### PR TITLE
Add PerformanceResourceTiming tracking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Context } from "./core/context";
 import { loggerModule, LogLevel } from "./core/logger";
 import { initMonitoring, monitor } from "./core/monitoring";
 import { errorCollectionModule } from "./errorCollection/errorCollection";
+import { rumModule } from "./rum/rum";
 
 declare global {
   interface Window {
@@ -53,5 +54,6 @@ function makeInit(configuration: Configuration) {
     configuration.apply(override);
     const logger = loggerModule(configuration);
     errorCollectionModule(configuration, logger);
+    rumModule(logger);
   });
 }

--- a/src/rum/rum.ts
+++ b/src/rum/rum.ts
@@ -1,0 +1,18 @@
+import { Logger } from "../core/logger";
+import { monitor } from "../core/monitoring";
+
+export function rumModule(logger: Logger) {
+  trackPerformanceResourceTiming(logger);
+}
+
+function trackPerformanceResourceTiming(logger: Logger) {
+  if (PerformanceObserver) {
+    const observer = new PerformanceObserver(
+      monitor((list: PerformanceObserverEntryList) => {
+        const data = list.getEntries().map(e => e.toJSON());
+        logger.log("[RUM Event] PerformanceResourceTiming", { data });
+      })
+    );
+    observer.observe({ entryTypes: ["resource"] });
+  }
+}


### PR DESCRIPTION
Use `PerformanceObserver` to track PerformanceResourceTiming.

[Browser support](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver#Browser_compatibility) - [Log example](https://app.datadoghq.com/logs?cols=%22%5B%5C%22log_severity%5C%22%5D%22&event=AAAAAWkltx7yTQVxtQAAAABBV2tsdHlQTlpQUVNWenc3VlVXQw&from_ts=1551115940742&index=main&live=false&query=source%3Abrowser-agent&saved_view=11417&stream_sort=desc&to_ts=1551116020381)

Send everything for now, add filtering when we will know what we need.