### PR TITLE
Send page duration

### DIFF
--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,7 +1,7 @@
 import { Configuration } from './configuration'
 import { addGlobalContext, getCommonContext, getGlobalContext, setGlobalContext } from './context'
 import { monitored } from './monitoring'
-import { Batch, flushOnPageHide, HttpRequest } from './transport'
+import { Batch, flushOnVisibilityHidden, HttpRequest } from './transport'
 
 export interface Message {
   message: string
@@ -27,7 +27,7 @@ export function loggerModule(configuration: Configuration) {
     ...getCommonContext(),
     ...getGlobalContext(),
   }))
-  flushOnPageHide(batch)
+  flushOnVisibilityHidden(batch)
 
   const logger = new Logger(batch)
   window.Datadog.setGlobalContext = setGlobalContext

--- a/src/rum/rum.ts
+++ b/src/rum/rum.ts
@@ -1,5 +1,6 @@
 import { Logger } from '../core/logger'
 import { monitor } from '../core/monitoring'
+import { beforeFlushOnUnload } from '../core/transport'
 
 type RequestIdleCallbackHandle = number
 
@@ -149,16 +150,12 @@ function trackInputDelay(logger: Logger) {
   }
 }
 
-/**
- * Data batch is flushed on visibility change event
- * page hide guarantee that this event is pushed before the flush
- */
 function trackPageDuration(logger: Logger) {
-  window.addEventListener('pagehide', () => {
-    logger.log(`${RUM_EVENT_PREFIX} page hide`, {
+  beforeFlushOnUnload(() => {
+    logger.log(`${RUM_EVENT_PREFIX} page unload`, {
       data: {
         duration: performance.now(),
-        entryType: 'page hide',
+        entryType: 'page unload',
       },
     })
   })

--- a/tslint.json
+++ b/tslint.json
@@ -21,6 +21,7 @@
     "no-implicit-dependencies": [true, "dev"],
     "no-null-keyword": true,
     "object-literal-sort-keys": [true, "shorthand-first"],
+    "prefer-array-literal": [true, { "allow-type-parameters": true }],
     "ter-computed-property-spacing": false
   },
   "rulesDirectory": []


### PR DESCRIPTION
@sdeprez after some tests, safari does not want to send XHR (sync or async) during the unload  phase, so I find another approach.