### PR TITLE
Send a RUM event for the display

### DIFF
--- a/src/rum/rum.ts
+++ b/src/rum/rum.ts
@@ -25,10 +25,20 @@ declare global {
 const RUM_EVENT_PREFIX = `[RUM Event]`
 
 export function rumModule(logger: Logger) {
+  trackDisplay(logger)
   trackPerformanceTiming(logger)
   trackFirstIdle(logger)
   trackFirstInput(logger)
   trackInputDelay(logger)
+}
+
+function trackDisplay(logger: Logger) {
+  logger.log(`${RUM_EVENT_PREFIX} display`, {
+    data: {
+      entryType: 'display',
+      startTime: performance.now(),
+    },
+  })
 }
 
 function trackPerformanceTiming(logger: Logger) {


### PR DESCRIPTION
[display event example](https://app.datadoghq.com/logs?cols=%22%5B%5C%22log_severity%5C%22%5D%22&event=AAAAAWlIVVAx2dTnQgAAAABBV2xJVlZnQ2Zzdkw4NjNQTDhqcA&from_ts=1551696735332&index=main&live=false&query=source%3Abrowser-agent&saved_view=11417&stream_sort=desc&to_ts=1551696750035)