### PR TITLE
error collection: prefix console message

### DIFF
--- a/src/core/errorCollection.ts
+++ b/src/core/errorCollection.ts
@@ -48,7 +48,7 @@ export function startConsoleTracking(errorObservable: ErrorObservable) {
   console.error = (message?: any, ...optionalParams: any[]) => {
     originalConsoleError.apply(console, [message, ...optionalParams])
     errorObservable.notify({
-      message: [message, ...optionalParams]
+      message: ['console error:', message, ...optionalParams]
         .map((param: any) => (typeof param === 'string' ? param : jsonStringify(param, undefined, 2)))
         .join(' '),
     })

--- a/src/core/tests/errorCollection.spec.ts
+++ b/src/core/tests/errorCollection.spec.ts
@@ -45,12 +45,12 @@ describe('console tracker', () => {
 
   it('should notify error', () => {
     console.error('foo', 'bar')
-    expect(notifyError).calledWithExactly({ message: 'foo bar' })
+    expect(notifyError).calledWithExactly({ message: 'console error: foo bar' })
   })
 
   it('should stringify object parameters', () => {
     console.error('Hello', { foo: 'bar' })
-    expect(notifyError).calledWithExactly({ message: 'Hello {\n  "foo": "bar"\n}' })
+    expect(notifyError).calledWithExactly({ message: 'console error: Hello {\n  "foo": "bar"\n}' })
   })
 })
 

--- a/test/e2e/agents.scenario.ts
+++ b/test/e2e/agents.scenario.ts
@@ -34,7 +34,7 @@ describe('logs', () => {
     })
     flushEvents()
     const logs = await retrieveLogsMessages()
-    expect(logs).to.contain('oh snap')
+    expect(logs).to.contain('console error: oh snap')
     const browserLogs = await browser.getLogs('browser')
     expect(browserLogs.length).to.equal(1)
   })


### PR DESCRIPTION
avoid empty message in the UI when console argument is an object

<img width="722" alt="Capture d’écran 2019-06-04 à 14 21 36" src="https://user-images.githubusercontent.com/1331991/58878912-b20e9680-86d4-11e9-989e-6fd2adede50f.png">
