### PR TITLE
[RUM] fix IE 11 unavailable API

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -150,3 +150,7 @@ function hasToJSON(value: unknown): value is ObjectWithToJSON {
 export function startsWith(candidate: string, search: string) {
   return candidate.indexOf(search) === 0
 }
+
+export function includes(candidate: unknown[], search: unknown) {
+  return candidate.indexOf(search) !== -1
+}

--- a/src/rum/resourceUtils.ts
+++ b/src/rum/resourceUtils.ts
@@ -1,6 +1,6 @@
 import { Configuration } from '../core/configuration'
 import { addMonitoringMessage } from '../core/internalMonitoring'
-import { msToNs, ResourceKind, startsWith } from '../core/utils'
+import { includes, msToNs, ResourceKind, startsWith } from '../core/utils'
 import { PerformanceResourceDetails } from './rum'
 
 const RESOURCE_TYPES: Array<[ResourceKind, (initiatorType: string, path: string) => boolean]> = [
@@ -12,13 +12,13 @@ const RESOURCE_TYPES: Array<[ResourceKind, (initiatorType: string, path: string)
   [
     ResourceKind.IMAGE,
     (initiatorType: string, path: string) =>
-      ['image', 'img', 'icon'].includes(initiatorType) || path.match(/\.(gif|jpg|jpeg|tiff|png|svg)$/i) !== null,
+      includes(['image', 'img', 'icon'], initiatorType) || path.match(/\.(gif|jpg|jpeg|tiff|png|svg)$/i) !== null,
   ],
   [ResourceKind.FONT, (_: string, path: string) => path.match(/\.(woff|eot|woff2|ttf)$/i) !== null],
   [
     ResourceKind.MEDIA,
     (initiatorType: string, path: string) =>
-      ['audio', 'video'].includes(initiatorType) || path.match(/\.(mp3|mp4)$/i) !== null,
+      includes(['audio', 'video'], initiatorType) || path.match(/\.(mp3|mp4)$/i) !== null,
   ],
 ]
 

--- a/src/rum/rum.ts
+++ b/src/rum/rum.ts
@@ -3,7 +3,7 @@ import { ErrorContext, ErrorMessage, ErrorObservable, HttpContext } from '../cor
 import { monitor } from '../core/internalMonitoring'
 import { RequestDetails, RequestObservable, RequestType } from '../core/requestCollection'
 import { Batch, HttpRequest } from '../core/transport'
-import { generateUUID, msToNs, ResourceKind, withSnakeCaseKeys } from '../core/utils'
+import { generateUUID, includes, msToNs, ResourceKind, withSnakeCaseKeys } from '../core/utils'
 import { matchRequestTiming } from './matchRequestTiming'
 import { computePerformanceResourceDetails, computeResourceKind, computeSize, isValidResource } from './resourceUtils'
 import { RumSession } from './rumSession'
@@ -286,7 +286,7 @@ export function handleResourceEntry(
     return
   }
   const resourceKind = computeResourceKind(entry)
-  if ([ResourceKind.XHR, ResourceKind.FETCH].includes(resourceKind)) {
+  if (includes([ResourceKind.XHR, ResourceKind.FETCH], resourceKind)) {
     return
   }
   addRumEvent({


### PR DESCRIPTION
cf [log explorer](https://app.datadoghq.com/logs?agg_m=count&agg_t=count&cols=core_host%2Ccore_service&event&from_ts=1569224833282&index=main&live=false&messageDisplay=inline&query=source%3Abrowser-agent-internal-monitoring+-%28%22Not+enough+storage+is+available+to+complete+this+operation%22+OR+%22Not+enough+memory+resources+are+available+to+complete+this+operation%22+OR+%22Uncaught+%7B%7D%22+OR+%22Failed+to+construct+%27URL%27%3A+Invalid+URL%22+OR+%22Attempt+to+use%22+OR+%22cannot+be+created+in+a+document+with+origin%22+OR+%22ns.GetCommandSrc+is+not+a+function%22%29&stream_sort=desc&to_ts=1569225733282)