### PR TITLE
[LOGS] use screen.url for log and internal monitoring messages

### DIFF
--- a/src/core/internalMonitoring.ts
+++ b/src/core/internalMonitoring.ts
@@ -39,8 +39,8 @@ export function startInternalMonitoring(configuration: Configuration) {
     configuration.flushTimeout,
     () => ({
       date: new Date().getTime(),
-      http: {
-        referer: window.location.href,
+      screen: {
+        url: window.location.href,
       },
     }),
     utils.withSnakeCaseKeys

--- a/src/core/tests/internalMonitoring.spec.ts
+++ b/src/core/tests/internalMonitoring.spec.ts
@@ -175,10 +175,10 @@ describe('internal monitoring', () => {
         date: FAKE_DATE,
         entry_type: 'internal',
         error: jasmine.anything(),
-        http: {
-          referer: window.location.href,
-        },
         message: 'message',
+        screen: {
+          url: window.location.href,
+        },
         status: 'error',
       })
     })

--- a/src/logs/logger.ts
+++ b/src/logs/logger.ts
@@ -42,7 +42,11 @@ export function startLogger(errorObservable: ErrorObservable, configuration: Con
         {
           date: new Date().getTime(),
           http: {
+            // screen.url is preferred, but keep http.referer for retro-compatibility
             referer: window.location.href,
+          },
+          screen: {
+            url: window.location.href,
           },
           sessionId: session.getId(),
         },

--- a/src/logs/tests/logger.spec.ts
+++ b/src/logs/tests/logger.spec.ts
@@ -54,6 +54,9 @@ describe('logger module', () => {
           referer: window.location.href,
         },
         message: 'message',
+        screen: {
+          url: window.location.href,
+        },
         status: StatusType.warn,
       })
     })


### PR DESCRIPTION
In the log case, keep the previous `http.referer` entry for retro-compatibility during migration.