### PR TITLE
[RUM] view measures and user action renamings

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -40,10 +40,10 @@ contains all the public APIs.
   setRumGlobalContext (context: Context)  # entirely replace the default context
   ```
 
-- Add custom event
+- Add user action
 
   ```
-  addCustomEvent (name: string, context: Context)
+  addUserAction (name: string, context: Context)
   ```
 
 - Get internal context

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,10 +1,10 @@
 import { ErrorMessage, RequestDetails } from '@browser-agent/core'
-import { RawCustomEvent } from './rum'
+import { UserAction } from './rum'
 
 export enum LifeCycleEventType {
   error,
   performance,
-  customEvent,
+  userAction,
   request,
 }
 
@@ -14,7 +14,7 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.error, data: ErrorMessage): void
   notify(eventType: LifeCycleEventType.performance, data: PerformanceEntry): void
   notify(eventType: LifeCycleEventType.request, data: RequestDetails): void
-  notify(eventType: LifeCycleEventType.customEvent, data: RawCustomEvent): void
+  notify(eventType: LifeCycleEventType.userAction, data: UserAction): void
   notify(eventType: LifeCycleEventType, data: any) {
     const eventCallbacks = this.callbacks[eventType]
     if (eventCallbacks) {
@@ -25,7 +25,7 @@ export class LifeCycle {
   subscribe(eventType: LifeCycleEventType.error, callback: (data: ErrorMessage) => void): void
   subscribe(eventType: LifeCycleEventType.performance, callback: (data: PerformanceEntry) => void): void
   subscribe(eventType: LifeCycleEventType.request, callback: (data: RequestDetails) => void): void
-  subscribe(eventType: LifeCycleEventType.customEvent, callback: (data: RawCustomEvent) => void): void
+  subscribe(eventType: LifeCycleEventType.userAction, callback: (data: UserAction) => void): void
   subscribe(eventType: LifeCycleEventType, callback: (data: any) => void) {
     const eventCallbacks = this.callbacks[eventType]
     if (eventCallbacks) {

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -42,6 +42,9 @@ const STUBBED_RUM = {
   addCustomEvent(name: string, context: Context) {
     makeStub('addCustomEvent')
   },
+  addUserAction(name: string, context: Context) {
+    makeStub('addUserAction')
+  },
   getInternalContext(): InternalContext | undefined {
     makeStub('getInternalContext')
     return undefined

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -33,13 +33,13 @@ export interface PerformancePaintTiming extends PerformanceEntry {
 
 export type PerformanceLongTaskTiming = PerformanceEntry
 
-export interface RawCustomEvent {
+export interface UserAction {
   name: string
   context?: Context
 }
 
 export enum RumEventCategory {
-  CUSTOM = 'custom',
+  USER_ACTION = 'user_action',
   ERROR = 'error',
   LONG_TASK = 'long_task',
   VIEW = 'view',
@@ -139,9 +139,9 @@ export interface RumLongTaskEvent {
   }
 }
 
-export interface RumCustomEvent {
+export interface RumUserAction {
   evt: {
-    category: RumEventCategory.CUSTOM
+    category: RumEventCategory.USER_ACTION
     name: string
   }
   [key: string]: ContextValue
@@ -153,7 +153,7 @@ export type RumEvent =
   | RumResourceEvent
   | RumViewEvent
   | RumLongTaskEvent
-  | RumCustomEvent
+  | RumUserAction
 
 export function startRum(
   applicationId: string,
@@ -201,14 +201,18 @@ export function startRum(
   trackErrors(lifeCycle, addRumEvent)
   trackRequests(configuration, lifeCycle, session, addRumEvent)
   trackPerformanceTiming(configuration, lifeCycle, addRumEvent)
-  trackCustomEvent(lifeCycle, addRumEvent)
+  trackUserAction(lifeCycle, addRumEvent)
 
   return {
+    // Cleanup after migration
     addCustomEvent: monitor((name: string, context?: Context) => {
-      lifeCycle.notify(LifeCycleEventType.customEvent, { name, context })
+      lifeCycle.notify(LifeCycleEventType.userAction, { name, context })
     }),
     addRumGlobalContext: monitor((key: string, value: ContextValue) => {
       globalContext[key] = value
+    }),
+    addUserAction: monitor((name: string, context?: Context) => {
+      lifeCycle.notify(LifeCycleEventType.userAction, { name, context })
     }),
     getInternalContext: monitor(() => {
       return {
@@ -239,13 +243,13 @@ function trackErrors(lifeCycle: LifeCycle, addRumEvent: (event: RumEvent) => voi
   })
 }
 
-function trackCustomEvent(lifeCycle: LifeCycle, addRumEvent: (event: RumEvent) => void) {
-  lifeCycle.subscribe(LifeCycleEventType.customEvent, ({ name, context }) => {
+function trackUserAction(lifeCycle: LifeCycle, addRumEvent: (event: RumEvent) => void) {
+  lifeCycle.subscribe(LifeCycleEventType.userAction, ({ name, context }) => {
     addRumEvent({
       ...context,
       evt: {
         name,
-        category: RumEventCategory.CUSTOM,
+        category: RumEventCategory.USER_ACTION,
       },
     })
   })

--- a/packages/rum/src/viewTracker.ts
+++ b/packages/rum/src/viewTracker.ts
@@ -9,7 +9,7 @@ export interface ViewMeasures {
   domContentLoaded?: number
   domComplete?: number
   loadEventEnd?: number
-  customEventCount: number
+  userActionCount: number
   errorCount: number
   longTaskCount: number
 }
@@ -46,9 +46,9 @@ function newView(location: Location, addRumEvent: (event: RumEvent) => void) {
   startOrigin = performance.now()
   documentVersion = 1
   viewMeasures = {
-    customEventCount: 0,
     errorCount: 0,
     longTaskCount: 0,
+    userActionCount: 0,
   }
   activeLocation = { ...location }
   addViewEvent(addRumEvent)
@@ -133,8 +133,8 @@ function trackMeasures(lifeCycle: LifeCycle, scheduleViewUpdate: () => void) {
     viewMeasures.errorCount += 1
     scheduleViewUpdate()
   })
-  lifeCycle.subscribe(LifeCycleEventType.customEvent, () => {
-    viewMeasures.customEventCount += 1
+  lifeCycle.subscribe(LifeCycleEventType.userAction, () => {
+    viewMeasures.userActionCount += 1
     scheduleViewUpdate()
   })
   lifeCycle.subscribe(LifeCycleEventType.performance, (entry) => {

--- a/packages/rum/test/viewTracker.spec.ts
+++ b/packages/rum/test/viewTracker.spec.ts
@@ -1,7 +1,7 @@
 import { Batch } from '@browser-agent/core'
 
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
-import { PerformanceLongTaskTiming, PerformancePaintTiming, RawCustomEvent, RumEvent, RumViewEvent } from '../src/rum'
+import { PerformanceLongTaskTiming, PerformancePaintTiming, UserAction, RumEvent, RumViewEvent } from '../src/rum'
 import { trackView, viewId } from '../src/viewTracker'
 
 function setup({
@@ -59,7 +59,7 @@ describe('rum view measures', () => {
     entryType: 'longtask',
     startTime: 456,
   }
-  const FAKE_CUSTOM_EVENT = {
+  const FAKE_USER_ACTION = {
     context: {
       bar: 123,
     },
@@ -122,19 +122,19 @@ describe('rum view measures', () => {
     expect(getViewEvent(2).view.measures.longTaskCount).toEqual(0)
   })
 
-  it('should track custom event count', () => {
+  it('should track user action count', () => {
     const lifeCycle = new LifeCycle()
     setup({ addRumEvent, lifeCycle })
 
     expect(getEventCount()).toEqual(1)
-    expect(getViewEvent(0).view.measures.customEventCount).toEqual(0)
+    expect(getViewEvent(0).view.measures.userActionCount).toEqual(0)
 
-    lifeCycle.notify(LifeCycleEventType.customEvent, FAKE_CUSTOM_EVENT as RawCustomEvent)
+    lifeCycle.notify(LifeCycleEventType.userAction, FAKE_USER_ACTION as UserAction)
     history.pushState({}, '', '/bar')
 
     expect(getEventCount()).toEqual(3)
-    expect(getViewEvent(1).view.measures.customEventCount).toEqual(1)
-    expect(getViewEvent(2).view.measures.customEventCount).toEqual(0)
+    expect(getViewEvent(1).view.measures.userActionCount).toEqual(1)
+    expect(getViewEvent(2).view.measures.userActionCount).toEqual(0)
   })
 
   it('should track performance timings', () => {
@@ -143,9 +143,9 @@ describe('rum view measures', () => {
 
     expect(getEventCount()).toEqual(1)
     expect(getViewEvent(0).view.measures).toEqual({
-      customEventCount: 0,
       errorCount: 0,
       longTaskCount: 0,
+      userActionCount: 0,
     })
 
     lifeCycle.notify(LifeCycleEventType.performance, FAKE_PAINT_ENTRY as PerformancePaintTiming)
@@ -154,7 +154,6 @@ describe('rum view measures', () => {
 
     expect(getEventCount()).toEqual(3)
     expect(getViewEvent(1).view.measures).toEqual({
-      customEventCount: 0,
       domComplete: 456e6,
       domContentLoaded: 345e6,
       domInteractive: 234e6,
@@ -162,11 +161,12 @@ describe('rum view measures', () => {
       firstContentfulPaint: 123e6,
       loadEventEnd: 567e6,
       longTaskCount: 0,
+      userActionCount: 0,
     })
     expect(getViewEvent(2).view.measures).toEqual({
-      customEventCount: 0,
       errorCount: 0,
       longTaskCount: 0,
+      userActionCount: 0,
     })
   })
 })

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -109,13 +109,13 @@ describe('rum', () => {
 
     expect(viewEvent as any).not.toBe(undefined)
     expect(viewEvent.view.measures).toEqual({
-      custom_event_count: 0,
       dom_complete: strictlyPositiveNumber(),
       dom_content_loaded: strictlyPositiveNumber(),
       dom_interactive: strictlyPositiveNumber(),
       error_count: 0,
       load_event_end: strictlyPositiveNumber(),
       long_task_count: 0,
+      user_action_count: 0,
     } as any)
   })
 })


### PR DESCRIPTION
keep `addCustomEvent` API to avoid web-ui errors during the migration

RUMF-72
RUMF-74