### PR TITLE
Enforces lint and typechecking in all .ts files

### DIFF
--- a/packages/core/test/internalMonitoring.spec.ts
+++ b/packages/core/test/internalMonitoring.spec.ts
@@ -176,11 +176,11 @@ describe('internal monitoring', () => {
         entry_type: 'internal',
         error: jasmine.anything(),
         message: 'message',
+        status: 'error',
         view: {
           referrer: document.referrer,
           url: window.location.href,
         },
-        status: 'error',
       })
     })
 

--- a/packages/logs/test/logger.spec.ts
+++ b/packages/logs/test/logger.spec.ts
@@ -50,11 +50,11 @@ describe('logger module', () => {
           referer: window.location.href,
         },
         message: 'message',
+        status: StatusType.warn,
         view: {
           referrer: document.referrer,
           url: window.location.href,
         },
-        status: StatusType.warn,
       })
     })
   })

--- a/packages/logs/test/logs.entry.spec.ts
+++ b/packages/logs/test/logs.entry.spec.ts
@@ -5,6 +5,7 @@ describe('logs entry', () => {
   let logsGlobal: LogsGlobal
 
   beforeEach(() => {
+    // tslint:disable-next-line: no-unsafe-any
     logsGlobal = require('../src/logs.entry').datadogLogs
     delete (require.cache as any)[require.resolve('../src/logs.entry')]
   })

--- a/packages/logs/tsconfig.json
+++ b/packages/logs/tsconfig.json
@@ -8,5 +8,5 @@
       "@browser-agent/core": ["../core/src"]
     }
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["./**/*.ts"]
 }

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -9,6 +9,7 @@ describe('rum entry', () => {
     if (isIE()) {
       pending('no full rum support')
     }
+    // tslint:disable-next-line: no-unsafe-any
     rumGlobal = require('../src/rum.entry').datadogRum
     delete (require.cache as any)[require.resolve('../src/rum.entry')]
   })

--- a/packages/rum/test/viewTracker.spec.ts
+++ b/packages/rum/test/viewTracker.spec.ts
@@ -1,7 +1,7 @@
 import { Batch } from '@browser-agent/core'
 
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
-import { PerformanceLongTaskTiming, PerformancePaintTiming, UserAction, RumEvent, RumViewEvent } from '../src/rum'
+import { PerformanceLongTaskTiming, PerformancePaintTiming, RumEvent, RumViewEvent, UserAction } from '../src/rum'
 import { trackView, viewId } from '../src/viewTracker'
 
 function setup({

--- a/packages/rum/tsconfig.json
+++ b/packages/rum/tsconfig.json
@@ -8,5 +8,5 @@
       "@browser-agent/core": ["../core/src"]
     }
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["./**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
     "baseUrl": ".",
     "module": "es6"
   },
-  "include": ["./packages/*/src/**/*.ts"]
+  "include": ["./packages/**/*.ts"]
 }


### PR DESCRIPTION
Previously, linting was executed only on 'src' files, so test files were not linted.  This change makes the `yarn lint` more general by taking every ts files into account.

This change does not impact NPM packages since they are using `tsconfig.{esm,cjs}.json` configuration files, specifying custom 'include' configuration those use cases.