### PR TITLE
🐛[core] ensure that document.cookie is not null

### DIFF
--- a/packages/core/src/cookie.ts
+++ b/packages/core/src/cookie.ts
@@ -48,7 +48,7 @@ export function getCookie(name: string) {
 }
 
 export function areCookiesAuthorized(): boolean {
-  if (document.cookie === undefined) {
+  if (document.cookie === undefined || document.cookie === null) {
     return false
   }
   try {


### PR DESCRIPTION
try to to fix internal monitoring error "Cannot read property 'match' of null"