### PR TITLE
🔊🐛 [RUMF-201] add internal logs for buggy load event measures

### DIFF
--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -29,7 +29,7 @@ export class HttpRequest {
 
 const isObject = (o: unknown): o is { [k: string]: unknown } => typeof o === 'object' && o !== null
 
-function reportAdbnormalMeasure(contextualizedMessage: Context) {
+function reportAbnormalMeasure(contextualizedMessage: Context) {
   if (
     isObject(contextualizedMessage.view) &&
     isObject(contextualizedMessage.view.measures) &&
@@ -101,7 +101,7 @@ export class Batch<T> {
 
   private process(message: T) {
     const contextualizedMessage = lodashMerge({}, this.contextProvider(), message) as Context
-    reportAdbnormalMeasure(contextualizedMessage)
+    reportAbnormalMeasure(contextualizedMessage)
     const processedMessage = jsonStringify(contextualizedMessage)!
     const messageBytesSize = this.sizeInBytes(processedMessage)
     return { processedMessage, messageBytesSize }


### PR DESCRIPTION
To help debug the weird measure values shown in the View Explorer, this adds debug logs when the SDK sends abnormal load event duration (above one day). This is intentionaly at the lowest level possible (right before serialization) to make sure we have the final value transmited to the backend.