### PR TITLE
 🐛[types] do not globally override ts types

### DIFF
--- a/packages/core/src/tracekit.ts
+++ b/packages/core/src/tracekit.ts
@@ -2,14 +2,12 @@
 
 import { monitor } from './internalMonitoring'
 
-declare global {
-  interface Error {
-    sourceURL?: string
-    fileName?: string
-    line?: string | number
-    lineNumber?: string | number
-    description?: string
-  }
+export interface BrowserError extends Error {
+  sourceURL?: string
+  fileName?: string
+  line?: string | number
+  lineNumber?: string | number
+  description?: string
 }
 
 export type Handler = (...params: any[]) => any
@@ -816,7 +814,7 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
    * @return {StackTrace} Stack trace information.
    * @memberof computeStackTrace
    */
-  function computeStackTraceByWalkingCallerChain(ex: Error, depth: number) {
+  function computeStackTraceByWalkingCallerChain(ex: BrowserError, depth: number) {
     const functionName = /function\s+([_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*)?\s*\(/i
     const stack = []
     const funcs: any = {}

--- a/packages/core/test/parser.spec.ts
+++ b/packages/core/test/parser.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable no-unsafe-any
 
 import { isSafari } from '../src/specHelper'
-import { computeStackTrace } from '../src/tracekit'
+import { BrowserError, computeStackTrace } from '../src/tracekit'
 import * as CapturedExceptions from './fixtures/capturedExceptions'
 
 describe('Parser', () => {
@@ -30,7 +30,7 @@ describe('Parser', () => {
   })
 
   it('should parse Safari 6 error', () => {
-    const stackFrames = computeStackTrace(CapturedExceptions.SAFARI_6 as Error)
+    const stackFrames = computeStackTrace(CapturedExceptions.SAFARI_6 as BrowserError)
 
     expect(stackFrames.stack.length).toEqual(4)
     expect(stackFrames.stack[0]).toEqual({
@@ -202,7 +202,7 @@ describe('Parser', () => {
   })
 
   it('should parse Firefox 7 error', () => {
-    const stackFrames = computeStackTrace(CapturedExceptions.FIREFOX_7 as Error)
+    const stackFrames = computeStackTrace(CapturedExceptions.FIREFOX_7 as BrowserError)
 
     expect(stackFrames.stack.length).toEqual(7)
     expect(stackFrames.stack[0]).toEqual({
@@ -257,7 +257,7 @@ describe('Parser', () => {
   })
 
   it('should parse Firefox 14 error', () => {
-    const stackFrames = computeStackTrace(CapturedExceptions.FIREFOX_14 as Error)
+    const stackFrames = computeStackTrace(CapturedExceptions.FIREFOX_14 as BrowserError)
 
     expect(stackFrames.stack.length).toEqual(3)
     expect(stackFrames.stack[0]).toEqual({
@@ -542,7 +542,7 @@ describe('Parser', () => {
   })
 
   it('should parse empty IE 9 error', () => {
-    const stackFrames = computeStackTrace(CapturedExceptions.IE_9 as Error)
+    const stackFrames = computeStackTrace(CapturedExceptions.IE_9 as BrowserError)
 
     if (stackFrames.stack) {
       expect(stackFrames.stack.length).toEqual(0)

--- a/packages/logs/src/logs.entry.ts
+++ b/packages/logs/src/logs.entry.ts
@@ -113,10 +113,8 @@ function canInitLogs(userConfiguration: LogsUserConfiguration) {
   return true
 }
 
-declare global {
-  interface Window {
-    DD_LOGS?: LogsGlobal
-  }
+interface BrowserWindow extends Window {
+  DD_LOGS?: LogsGlobal
 }
 
-window.DD_LOGS = datadogLogs
+;(window as BrowserWindow).DD_LOGS = datadogLogs

--- a/packages/rum/src/performanceCollection.ts
+++ b/packages/rum/src/performanceCollection.ts
@@ -3,10 +3,8 @@ import { getRelativeTime, monitor } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RumSession } from './rumSession'
 
-declare global {
-  interface Window {
-    PerformanceObserver?: PerformanceObserver
-  }
+interface BrowserWindow extends Window {
+  PerformanceObserver?: PerformanceObserver
 }
 
 function supportPerformanceObject() {
@@ -15,7 +13,7 @@ function supportPerformanceObject() {
 
 function supportPerformanceNavigationTimingEvent() {
   return (
-    window.PerformanceObserver &&
+    (window as BrowserWindow).PerformanceObserver &&
     PerformanceObserver.supportedEntryTypes !== undefined &&
     PerformanceObserver.supportedEntryTypes.includes('navigation')
   )
@@ -25,7 +23,7 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, session: RumSes
   if (supportPerformanceObject()) {
     handlePerformanceEntries(session, lifeCycle, performance.getEntries())
   }
-  if (window.PerformanceObserver) {
+  if ((window as BrowserWindow).PerformanceObserver) {
     const observer = new PerformanceObserver(
       monitor((entries) => handlePerformanceEntries(session, lifeCycle, entries.getEntries()))
     )

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -102,10 +102,8 @@ function canInitRum(userConfiguration: RumUserConfiguration) {
   return true
 }
 
-declare global {
-  interface Window {
-    DD_RUM?: RumGlobal
-  }
+interface BrowserWindow extends Window {
+  DD_RUM?: RumGlobal
 }
 
-window.DD_RUM = datadogRum
+;(window as BrowserWindow).DD_RUM = datadogRum

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -13,6 +13,10 @@ import { startPerformanceCollection } from '../src/performanceCollection'
 import { handleResourceEntry, RumEvent, RumResourceEvent, startRum, UserAction } from '../src/rum'
 import { RumGlobal } from '../src/rum.entry'
 
+interface BrowserWindow extends Window {
+  PerformanceObserver?: PerformanceObserver
+}
+
 function getEntry(addRumEvent: (event: RumEvent) => void, index: number) {
   return (addRumEvent as jasmine.Spy).calls.argsFor(index)[0] as RumEvent
 }
@@ -163,6 +167,7 @@ describe('rum session', () => {
   const FAKE_RESOURCE: Partial<PerformanceEntry> = { name: 'http://foo.com', entryType: 'resource' }
   const FAKE_REQUEST: Partial<RequestDetails> = { url: 'http://foo.com' }
   const FAKE_USER_ACTION: UserAction = { name: 'action', context: { foo: 'bar' } }
+  const browserWindow = window as BrowserWindow
   let server: sinon.SinonFakeServer
   let original: PerformanceObserver | undefined
   let stubBuilder: PerformanceObserverStubBuilder
@@ -172,14 +177,14 @@ describe('rum session', () => {
       pending('no full rum support')
     }
     server = sinon.fakeServer.create()
-    original = window.PerformanceObserver
+    original = browserWindow.PerformanceObserver
     stubBuilder = new PerformanceObserverStubBuilder()
-    window.PerformanceObserver = stubBuilder.getStub()
+    browserWindow.PerformanceObserver = stubBuilder.getStub()
   })
 
   afterEach(() => {
     server.restore()
-    window.PerformanceObserver = original
+    browserWindow.PerformanceObserver = original
   })
 
   it('when tracked with resources should enable full tracking', () => {


### PR DESCRIPTION
in order to avoid types conflict when the library is compiled alongside other libraries/projects