### PR TITLE
🐛 [RUMF-201] use timing.navigationStart to compute fake timings

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -178,8 +178,12 @@ export function isPercentage(value: unknown) {
   return typeof value === 'number' && value >= 0 && value <= 100
 }
 
+/**
+ * Get the time since the navigation was started.
+ *
+ * Note: this does not use `performance.timeOrigin` because it doesn't seem to reflect the actual
+ * time on which the navigation has started: it may be much farther in the past, at least in Firefox 71.
+ */
 export function getRelativeTime(timestamp: number) {
-  // performance.timeOrigin is undefined in WebKit, see https://bugs.webkit.org/show_bug.cgi?id=174862
-  const timeOrigin = performance.timeOrigin !== undefined ? performance.timeOrigin : performance.timing.navigationStart
-  return timestamp - timeOrigin
+  return timestamp - performance.timing.navigationStart
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -183,6 +183,7 @@ export function isPercentage(value: unknown) {
  *
  * Note: this does not use `performance.timeOrigin` because it doesn't seem to reflect the actual
  * time on which the navigation has started: it may be much farther in the past, at least in Firefox 71.
+ * Related issue in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1429926
  */
 export function getRelativeTime(timestamp: number) {
   return timestamp - performance.timing.navigationStart

--- a/packages/rum/src/performanceCollection.ts
+++ b/packages/rum/src/performanceCollection.ts
@@ -1,8 +1,7 @@
-import { addMonitoringMessage, getRelativeTime, monitor } from '@datadog/browser-core'
+import { getRelativeTime, monitor } from '@datadog/browser-core'
 
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RumSession } from './rumSession'
-import { viewContext } from './viewTracker'
 
 interface BrowserWindow extends Window {
   PerformanceObserver?: PerformanceObserver
@@ -52,23 +51,8 @@ interface FakePerformanceNavigationTiming {
   loadEventEnd: number
 }
 
-function reportAbnormalTimeOrigin() {
-  if (getRelativeTime(performance.timing.loadEventEnd) > 86400e3 /* 1 day in ms */) {
-    addMonitoringMessage(
-      `Got an abnormal loadEventEnd timing
-Session Id: ${viewContext.sessionId}
-View Id: ${viewContext.id}
-timeOrigin: ${performance.timeOrigin}
-navigationStart: ${performance.timing.navigationStart}
-loadEventEnd: ${performance.timing.loadEventEnd}
-timing: ${getRelativeTime(performance.timing.loadEventEnd)}`
-    )
-  }
-}
-
 function retrieveNavigationTimingWhenLoaded(callback: (timing: PerformanceNavigationTiming) => void) {
   function sendFakeTiming() {
-    reportAbnormalTimeOrigin()
     const timing: FakePerformanceNavigationTiming = {
       domComplete: getRelativeTime(performance.timing.domComplete),
       domContentLoadedEventEnd: getRelativeTime(performance.timing.domContentLoadedEventEnd),


### PR DESCRIPTION
Using `performance.timing.navigationStart` instead of `performance.timeOrigin` has several advantages:

* it is defined on more browsers ;
* it produces timings closer to the real PerformanceNavigationTiming
event ;
* performance.timeOrigin may be far in the past for some reason, causing
abnormal timings.

More context in https://datadoghq.atlassian.net/jira/software/projects/RUMF/boards/119?selectedIssue=RUMF-201