### PR TITLE
✅ fix e2e cbt tests on Edge

### DIFF
--- a/test/e2e/scenario/helpers.ts
+++ b/test/e2e/scenario/helpers.ts
@@ -153,6 +153,7 @@ async function deleteAllCookies() {
 }
 
 async function findSessionCookie() {
+  const cookies = (await browser.getCookies()) || []
   // tslint:disable-next-line: no-unsafe-any
-  return ((await browser.getCookies()) as any[]).find((cookie: any) => cookie.name === '_dd')
+  return cookies.find((cookie: any) => cookie.name === '_dd')
 }


### PR DESCRIPTION
Since a few days, a change from the cross-browser-testing side breaks our E2E tests on Edge.  It seems `browser.getCookies()` can return `null` now.  Let's fallback on an empty array in this case.