### PR TITLE
⚡️[batch] limit view update events

### DIFF
--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -59,6 +59,15 @@ export class Batch<T> {
     }
   }
 
+  remove(index: number) {
+    const [removedMessage] = this.buffer.splice(index, 1)
+    const messageBytesSize = this.sizeInBytes(removedMessage)
+    this.bufferBytesSize -= messageBytesSize
+    if (this.buffer.length > 0) {
+      this.bufferBytesSize -= 1
+    }
+  }
+
   beforeFlushOnUnload(handler: () => void) {
     this.beforeFlushOnUnloadHandlers.push(handler)
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -188,3 +188,11 @@ export function isPercentage(value: unknown) {
 export function getRelativeTime(timestamp: number) {
   return timestamp - performance.timing.navigationStart
 }
+
+export function objectValues(object: { [key: string]: unknown }) {
+  const values: unknown[] = []
+  Object.keys(object).forEach((key) => {
+    values.push(object[key])
+  })
+  return values
+}

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -181,4 +181,25 @@ describe('batch', () => {
       jasmine.any(Number)
     )
   })
+
+  it('should upsert a message for a given key', () => {
+    batch.upsert({ message: '1' }, 'a')
+    batch.upsert({ message: '2' }, 'a')
+    batch.upsert({ message: '3' }, 'b')
+    batch.upsert({ message: '4' }, 'c')
+
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"foo":"bar","message":"2"}\n{"foo":"bar","message":"3"}\n{"foo":"bar","message":"4"}',
+      jasmine.any(Number)
+    )
+
+    batch.upsert({ message: '5' }, 'c')
+    batch.upsert({ message: '6' }, 'b')
+    batch.upsert({ message: '7' }, 'a')
+
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"foo":"bar","message":"5"}\n{"foo":"bar","message":"6"}\n{"foo":"bar","message":"7"}',
+      jasmine.any(Number)
+    )
+  })
 })

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -162,4 +162,23 @@ describe('batch', () => {
     expect(transport.send).not.toHaveBeenCalled()
     warnStub.restore()
   })
+
+  it('should remove a message', () => {
+    batch.add({ message: '1' })
+    const firstMessageSize = (batch as any).bufferBytesSize
+
+    batch.add({ message: '2' })
+    batch.remove(1)
+
+    expect((batch as any).bufferBytesSize).toBe(firstMessageSize)
+
+    batch.add({ message: '3' })
+    expect(transport.send).not.toHaveBeenCalled()
+
+    batch.add({ message: '4' })
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"foo":"bar","message":"1"}\n{"foo":"bar","message":"3"}\n{"foo":"bar","message":"4"}',
+      jasmine.any(Number)
+    )
+  })
 })

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -163,25 +163,6 @@ describe('batch', () => {
     warnStub.restore()
   })
 
-  it('should remove a message', () => {
-    batch.add({ message: '1' })
-    const firstMessageSize = (batch as any).bufferBytesSize
-
-    batch.add({ message: '2' })
-    batch.remove(1)
-
-    expect((batch as any).bufferBytesSize).toBe(firstMessageSize)
-
-    batch.add({ message: '3' })
-    expect(transport.send).not.toHaveBeenCalled()
-
-    batch.add({ message: '4' })
-    expect(transport.send).toHaveBeenCalledWith(
-      '{"foo":"bar","message":"1"}\n{"foo":"bar","message":"3"}\n{"foo":"bar","message":"4"}',
-      jasmine.any(Number)
-    )
-  })
-
   it('should upsert a message for a given key', () => {
     batch.upsert({ message: '1' }, 'a')
     batch.upsert({ message: '2' }, 'a')
@@ -199,6 +180,17 @@ describe('batch', () => {
 
     expect(transport.send).toHaveBeenCalledWith(
       '{"foo":"bar","message":"5"}\n{"foo":"bar","message":"6"}\n{"foo":"bar","message":"7"}',
+      jasmine.any(Number)
+    )
+
+    batch.upsert({ message: '8' }, 'a')
+    batch.upsert({ message: '9' }, 'b')
+    batch.upsert({ message: '10' }, 'a')
+    batch.upsert({ message: '11' }, 'b')
+    batch.flush()
+
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"foo":"bar","message":"10"}\n{"foo":"bar","message":"11"}',
       jasmine.any(Number)
     )
   })

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon'
 
 import { Batch, HttpRequest } from '../src/transport'
-import { Context, noop } from '../src/utils'
+import { noop } from '../src/utils'
 
 describe('request', () => {
   const ENDPOINT_URL = 'http://my.website'

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -149,7 +149,7 @@ export function startRum(
     () => globalContext
   )
 
-  trackView(window.location, lifeCycle, session, batch.addRumEvent, batch.beforeFlushOnUnload)
+  trackView(window.location, lifeCycle, session, batch.upsertRumEvent, batch.beforeFlushOnUnload)
   trackErrors(lifeCycle, batch.addRumEvent)
   trackRequests(configuration, lifeCycle, session, batch.addRumEvent)
   trackPerformanceTiming(configuration, lifeCycle, batch.addRumEvent)
@@ -203,6 +203,11 @@ function startRumBatch(
       }
     },
     beforeFlushOnUnload: (handler: () => void) => batch.beforeFlushOnUnload(handler),
+    upsertRumEvent: (event: RumEvent, key: string) => {
+      if (session.isTracked()) {
+        batch.upsert(withSnakeCaseKeys(event as Context), key)
+      }
+    },
   }
 }
 

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -1,17 +1,16 @@
 import { LogsGlobal } from '@datadog/browser-logs'
-import { RumEvent, RumEventCategory, RumResourceEvent, RumViewEvent } from '@datadog/browser-rum'
+import { RumEvent, RumEventCategory, RumResourceEvent } from '@datadog/browser-rum'
 import {
   browserExecute,
   browserExecuteAsync,
-  findLastEvent,
   flushBrowserLogs,
   flushEvents,
   renewSession,
-  retrieveInitialViewEvents,
   retrieveLogs,
   retrieveLogsMessages,
   retrieveRumEvents,
   retrieveRumEventsTypes,
+  retrieveViewEvents,
   sortByMessage,
   tearDown,
   withBrowserLogs,
@@ -103,9 +102,7 @@ describe('rum', () => {
 
   it('should send performance timings along the view events', async () => {
     await flushEvents()
-    const events = await retrieveRumEvents()
-
-    const viewEvent = findLastEvent(events, (event) => event.evt.category === 'view') as RumViewEvent
+    const viewEvent = (await retrieveViewEvents())[0]
 
     expect(viewEvent as any).not.toBe(undefined)
     const measures = viewEvent.view.measures
@@ -119,7 +116,7 @@ describe('rum', () => {
     await renewSession()
     await flushEvents()
 
-    const viewEvents = await retrieveInitialViewEvents()
+    const viewEvents = await retrieveViewEvents()
 
     expect(viewEvents.length).toBe(2)
     expect(viewEvents[0].session_id).not.toBe(viewEvents[1].session_id)

--- a/test/e2e/scenario/helpers.ts
+++ b/test/e2e/scenario/helpers.ts
@@ -94,11 +94,9 @@ export async function retrieveMonitoringErrors() {
   return fetch('/monitoring').then((monitoringErrors: string) => JSON.parse(monitoringErrors) as MonitoringMessage[])
 }
 
-export async function retrieveInitialViewEvents() {
+export async function retrieveViewEvents() {
   const events = await retrieveRumEvents()
-  return events.filter(
-    (event) => event.evt.category === 'view' && (event as ServerRumViewEvent).rum.document_version === 1
-  ) as ServerRumViewEvent[]
+  return events.filter((event) => event.evt.category === 'view') as ServerRumViewEvent[]
 }
 
 export async function resetServerState() {
@@ -124,10 +122,6 @@ export function sortByMessage(a: { message: string }, b: { message: string }) {
     return 1
   }
   return 0
-}
-
-export function findLastEvent(events: RumEvent[], predicate: (event: RumEvent) => boolean) {
-  return events.reduce<RumEvent | undefined>((olderEvent, event) => (predicate(event) ? event : olderEvent), undefined)
 }
 
 export async function renewSession() {


### PR DESCRIPTION
Limit the number of view events to process on the backend by ensuring that there is only one view event by view id by batch.