### PR TITLE
♻️[e2e] wait request to reach server before assertions

### DIFF
--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -102,7 +102,7 @@ describe('rum', () => {
     await flushEvents()
     const events = await waitServerRumEvents()
 
-    const viewEvent = events.filter((event) => event.evt.category === 'view')[0] as RumViewEvent
+    const viewEvent = events.find((event) => event.evt.category === 'view') as RumViewEvent
 
     expect(viewEvent as any).not.toBe(undefined)
     const measures = viewEvent.view.measures

--- a/test/e2e/scenario/helpers.ts
+++ b/test/e2e/scenario/helpers.ts
@@ -100,10 +100,10 @@ async function fetch(url: string): Promise<string> {
 }
 
 export async function fetchWhile(url: string, conditionFn: (body: any) => boolean, timeout = 10000) {
-  const threshold = new Date().getTime() + timeout
+  const threshold = Date.now() + timeout
   let body: string = await fetch(url)
   while (conditionFn(JSON.parse(body))) {
-    if (new Date().getTime() > threshold) {
+    if (Date.now() > threshold) {
       throw new Error(`fetchWhile promise rejected because of timeout (${timeout / 1000}s)
             Body: ${body}
             conditionFn: ${conditionFn.toString()}


### PR DESCRIPTION
Some logs/rum requests were handled by the server after the end of the test.

Before:
```
GET /logs 
[]
GET /reset
POST /logs 
XXX
YYY
```

After:
```
GET /logs 
[]
POST /logs 
XXX
YYY
GET /logs 
[XXX,YYY]
GET /reset
```