### PR TITLE
🔊[e2e] add extra logging

### DIFF
--- a/test/server/server.js
+++ b/test/server/server.js
@@ -19,7 +19,7 @@ const stream = fs.createWriteStream(path.join(__dirname, 'test-server.log'))
 
 const app = express()
 app.use(cors())
-app.use(morgan(':method :url :body', { stream }))
+app.use(morgan(':method :url :status :body', { stream }))
 app.use(express.static(path.join(__dirname, '../static')))
 app.use(express.static(path.join(__dirname, '../app/dist')))
 


### PR DESCRIPTION
Debug case:

```
undefined is not an object (evaluating 'window.DD_LOGS.logger')
```

[gitlab job](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/23762559)

Info so far:
- Webdriver navigates to `/bundle-e2e-page.html`
- logs and rum files are not downloaded from the server.

Add:

- logging for html download
- status code for all requests