### PR TITLE
🔊 [RUM-257] add more abnormal info

### DIFF
--- a/packages/rum/src/viewTracker.ts
+++ b/packages/rum/src/viewTracker.ts
@@ -25,6 +25,7 @@ interface ViewContext {
 export let viewContext: ViewContext
 
 const THROTTLE_VIEW_UPDATE_PERIOD = 3000
+const pageOrigin = Date.now()
 let startTimestamp: number
 let startOrigin: number
 let documentVersion: number
@@ -128,6 +129,7 @@ function reportAbnormalLoadEvent(navigationEntry: PerformanceNavigationTiming) {
 Session Id: ${viewContext.sessionId}
 View Id: ${viewContext.id}
 Load event: ${navigationEntry.loadEventEnd}
+Page start date: ${pageOrigin}
 View start date: ${startTimestamp}
 Page duration: ${performance.now()}
 View duration: ${performance.now() - startOrigin}

--- a/packages/rum/src/viewTracker.ts
+++ b/packages/rum/src/viewTracker.ts
@@ -26,6 +26,7 @@ export let viewContext: ViewContext
 
 const THROTTLE_VIEW_UPDATE_PERIOD = 3000
 const pageOrigin = Date.now()
+const navigationEntries: PerformanceNavigationTiming[] = []
 let startTimestamp: number
 let startOrigin: number
 let documentVersion: number
@@ -135,6 +136,7 @@ Page duration: ${performance.now()}
 View duration: ${performance.now() - startOrigin}
 Document Version: ${documentVersion}
 Entry: ${JSON.stringify(navigationEntry)}
+Previous navigation entries: ${JSON.stringify(navigationEntries)}
 Perf timing: ${JSON.stringify(performance.timing)}
 Previous measures: ${JSON.stringify(viewMeasures)}`
     )
@@ -154,6 +156,7 @@ function trackMeasures(lifeCycle: LifeCycle, scheduleViewUpdate: () => void) {
         loadEventEnd: msToNs(navigationEntry.loadEventEnd),
       }
       scheduleViewUpdate()
+      navigationEntries.push(navigationEntry)
     } else if (entry.entryType === 'paint' && entry.name === 'first-contentful-paint') {
       const paintEntry = entry as PerformancePaintTiming
       viewMeasures = {


### PR DESCRIPTION
## Reasoning
### page origin

observed performance.now() older than the deployment date
=> page origin will give us the timestamp of the sdk execution

### previous navigation entries

in abnormal load event, domComplete and loadEvent are close to a new view creation (< 1min) whereas other timings are very old (> 1 day)
**hypothesis**: a "situation" that create a new view also generate a new navigation entry with a refresh of dom complete + load event
