### PR TITLE
✅[e2e] wait for browser url loaded

### DIFF
--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -14,9 +14,9 @@ import {
   withBrowserLogs,
 } from './helpers'
 
-beforeEach(() => {
+beforeEach(async () => {
   // tslint:disable-next-line: no-unsafe-any
-  browser.url(`/${(browser as any).config.e2eMode}-e2e-page.html`)
+  await browser.url(`/${(browser as any).config.e2eMode}-e2e-page.html`)
 })
 
 afterEach(tearDown)


### PR DESCRIPTION
try to fix e2e issue:
`Unable to get property 'logger' of undefined or null reference`
calls to load the page url from the server are not in server.log