### PR TITLE
🔊[RUMF-257] report abnormal performance.now()

### DIFF
--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -1,4 +1,5 @@
 import {
+  addMonitoringMessage,
   Batch,
   Configuration,
   Context,
@@ -143,6 +144,8 @@ export function startRum(
       globalContext
     )
   )
+
+  reportAbnormalPerformanceNow()
 
   const batch = startRumBatch(
     configuration,
@@ -342,4 +345,14 @@ export function handleLongTaskEntry(entry: PerformanceLongTaskTiming, addRumEven
       category: RumEventCategory.LONG_TASK,
     },
   })
+}
+
+function reportAbnormalPerformanceNow() {
+  if (performance.now() > 300e3 /* 5 min in ms*/) {
+    addMonitoringMessage(`Abnormal performance.now()
+performance.now(): ${performance.now()}
+Date.now(): ${Date.now()}
+Navigation entries: ${JSON.stringify(performance.getEntriesByType('navigation'), undefined, 2)}
+`)
+  }
 }


### PR DESCRIPTION
**Reasoning**

Reported abnormal navigation entries had a performance.now() in the past.
Let's see how many cases we have in the wild.