### PR TITLE
✨[RUMF-342] use startTime for events timestamp

### DIFF
--- a/packages/core/src/errorCollection.ts
+++ b/packages/core/src/errorCollection.ts
@@ -13,6 +13,7 @@ import { computeStackTrace, Handler, report, StackFrame, StackTrace } from './tr
 import { jsonStringify, ONE_MINUTE } from './utils'
 
 export interface ErrorMessage {
+  startTime: number
   message: string
   context: {
     error: ErrorContext
@@ -73,6 +74,7 @@ export function filterErrors(configuration: Configuration, errorObservable: Obse
           },
         },
         message: `Reached max number of errors by minute: ${configuration.maxErrorsByMinute}`,
+        startTime: performance.now(),
       })
     }
   })
@@ -93,6 +95,7 @@ export function startConsoleTracking(errorObservable: ErrorObservable) {
         },
       },
       message: ['console error:', message, ...optionalParams].map(formatConsoleParameters).join(' '),
+      startTime: performance.now(),
     })
   })
 }
@@ -143,6 +146,7 @@ export function formatRuntimeError(stackTrace: StackTrace, errorObject: any) {
         origin: ErrorOrigin.SOURCE,
       },
     },
+    startTime: performance.now(),
   }
 }
 
@@ -178,6 +182,7 @@ export function trackNetworkError(
           },
         },
         message: `${format(request.type)} error ${request.method} ${request.url}`,
+        startTime: request.startTime,
       })
     }
   })

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -193,6 +193,10 @@ export function getRelativeTime(timestamp: number) {
   return timestamp - performance.timing.navigationStart
 }
 
+export function getTimestamp(relativeTime: number) {
+  return Math.floor(performance.timing.navigationStart + relativeTime)
+}
+
 export function objectValues(object: { [key: string]: unknown }) {
   const values: unknown[] = []
   Object.keys(object).forEach((key) => {

--- a/packages/core/test/errorCollection.spec.ts
+++ b/packages/core/test/errorCollection.spec.ts
@@ -45,7 +45,11 @@ describe('console tracker', () => {
 
   it('should notify error', () => {
     console.error('foo', 'bar')
-    expect(notifyError).toHaveBeenCalledWith({ ...CONSOLE_CONTEXT, message: 'console error: foo bar' })
+    expect(notifyError).toHaveBeenCalledWith({
+      ...CONSOLE_CONTEXT,
+      message: 'console error: foo bar',
+      startTime: jasmine.any(Number),
+    })
   })
 
   it('should stringify object parameters', () => {
@@ -53,6 +57,7 @@ describe('console tracker', () => {
     expect(notifyError).toHaveBeenCalledWith({
       ...CONSOLE_CONTEXT,
       message: 'console error: Hello {\n  "foo": "bar"\n}',
+      startTime: jasmine.any(Number),
     })
   })
 
@@ -212,6 +217,7 @@ describe('network error tracker', () => {
         http: { method: 'GET', status_code: 503, url: 'http://fake.com' },
       },
       message: 'XHR error GET http://fake.com',
+      startTime: jasmine.any(Number),
     })
   })
 
@@ -270,49 +276,50 @@ describe('error limitation', () => {
   })
 
   it('should stop send errors if threshold is exceeded', () => {
-    errorObservable.notify({ message: '1', ...CONTEXT })
-    errorObservable.notify({ message: '2', ...CONTEXT })
-    errorObservable.notify({ message: '3', ...CONTEXT })
+    errorObservable.notify({ message: '1', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '2', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '3', startTime: 100, ...CONTEXT })
 
-    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '1', ...CONTEXT })
-    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '2', ...CONTEXT })
-    expect(filteredSubscriber).not.toHaveBeenCalledWith({ message: '3', ...CONTEXT })
+    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '1', startTime: 100, ...CONTEXT })
+    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '2', startTime: 100, ...CONTEXT })
+    expect(filteredSubscriber).not.toHaveBeenCalledWith({ message: '3', startTime: 100, ...CONTEXT })
   })
 
   it('should send a threshold reached message', () => {
-    errorObservable.notify({ message: '1', ...CONTEXT })
-    errorObservable.notify({ message: '2', ...CONTEXT })
-    errorObservable.notify({ message: '3', ...CONTEXT })
+    errorObservable.notify({ message: '1', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '2', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '3', startTime: 100, ...CONTEXT })
 
     expect(filteredSubscriber).toHaveBeenCalledWith({
       context: { error: { origin: ErrorOrigin.AGENT } },
       message: 'Reached max number of errors by minute: 2',
+      startTime: jasmine.any(Number),
     })
   })
 
   it('should reset error count every each minute', () => {
-    errorObservable.notify({ message: '1', ...CONTEXT })
-    errorObservable.notify({ message: '2', ...CONTEXT })
-    errorObservable.notify({ message: '3', ...CONTEXT })
-    errorObservable.notify({ message: '4', ...CONTEXT })
+    errorObservable.notify({ message: '1', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '2', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '3', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '4', startTime: 100, ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(3)
 
     jasmine.clock().tick(ONE_MINUTE - 1)
 
-    errorObservable.notify({ message: '5', ...CONTEXT })
+    errorObservable.notify({ message: '5', startTime: 100, ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(3)
 
     jasmine.clock().tick(1)
 
-    errorObservable.notify({ message: '6', ...CONTEXT })
-    errorObservable.notify({ message: '7', ...CONTEXT })
-    errorObservable.notify({ message: '8', ...CONTEXT })
-    errorObservable.notify({ message: '9', ...CONTEXT })
+    errorObservable.notify({ message: '6', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '7', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '8', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '9', startTime: 100, ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(6)
 
     jasmine.clock().tick(ONE_MINUTE)
 
-    errorObservable.notify({ message: '10', ...CONTEXT })
+    errorObservable.notify({ message: '10', startTime: 100, ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(7)
   })
 })

--- a/packages/core/test/errorCollection.spec.ts
+++ b/packages/core/test/errorCollection.spec.ts
@@ -260,6 +260,7 @@ describe('error limitation', () => {
         origin: ErrorOrigin.SOURCE,
       },
     },
+    startTime: 100,
   }
 
   beforeEach(() => {
@@ -276,19 +277,19 @@ describe('error limitation', () => {
   })
 
   it('should stop send errors if threshold is exceeded', () => {
-    errorObservable.notify({ message: '1', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '2', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '3', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '1', ...CONTEXT })
+    errorObservable.notify({ message: '2', ...CONTEXT })
+    errorObservable.notify({ message: '3', ...CONTEXT })
 
-    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '1', startTime: 100, ...CONTEXT })
-    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '2', startTime: 100, ...CONTEXT })
-    expect(filteredSubscriber).not.toHaveBeenCalledWith({ message: '3', startTime: 100, ...CONTEXT })
+    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '1', ...CONTEXT })
+    expect(filteredSubscriber).toHaveBeenCalledWith({ message: '2', ...CONTEXT })
+    expect(filteredSubscriber).not.toHaveBeenCalledWith({ message: '3', ...CONTEXT })
   })
 
   it('should send a threshold reached message', () => {
-    errorObservable.notify({ message: '1', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '2', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '3', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '1', ...CONTEXT })
+    errorObservable.notify({ message: '2', ...CONTEXT })
+    errorObservable.notify({ message: '3', ...CONTEXT })
 
     expect(filteredSubscriber).toHaveBeenCalledWith({
       context: { error: { origin: ErrorOrigin.AGENT } },
@@ -298,28 +299,28 @@ describe('error limitation', () => {
   })
 
   it('should reset error count every each minute', () => {
-    errorObservable.notify({ message: '1', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '2', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '3', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '4', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '1', ...CONTEXT })
+    errorObservable.notify({ message: '2', ...CONTEXT })
+    errorObservable.notify({ message: '3', ...CONTEXT })
+    errorObservable.notify({ message: '4', ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(3)
 
     jasmine.clock().tick(ONE_MINUTE - 1)
 
-    errorObservable.notify({ message: '5', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '5', ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(3)
 
     jasmine.clock().tick(1)
 
-    errorObservable.notify({ message: '6', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '7', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '8', startTime: 100, ...CONTEXT })
-    errorObservable.notify({ message: '9', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '6', ...CONTEXT })
+    errorObservable.notify({ message: '7', ...CONTEXT })
+    errorObservable.notify({ message: '8', ...CONTEXT })
+    errorObservable.notify({ message: '9', ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(6)
 
     jasmine.clock().tick(ONE_MINUTE)
 
-    errorObservable.notify({ message: '10', startTime: 100, ...CONTEXT })
+    errorObservable.notify({ message: '10', ...CONTEXT })
     expect(filteredSubscriber).toHaveBeenCalledTimes(7)
   })
 })

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -6,6 +6,7 @@ import {
   ErrorMessage,
   ErrorObservable,
   ErrorOrigin,
+  getTimestamp,
   HttpRequest,
   InternalMonitoring,
   monitored,
@@ -91,7 +92,9 @@ export function startLogger(
   }
   const logger = new Logger(session, handlers)
   customLoggers = {}
-  errorObservable.subscribe((e: ErrorMessage) => logger.error(e.message, e.context))
+  errorObservable.subscribe((e: ErrorMessage) =>
+    logger.error(e.message, { date: getTimestamp(e.startTime), ...e.context })
+  )
 
   const globalApi: Partial<LogsGlobal> = {}
   globalApi.setLoggerGlobalContext = (context: Context) => {

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -5,6 +5,7 @@ import {
   ContextValue,
   ErrorContext,
   ErrorMessage,
+  getTimestamp,
   HttpContext,
   HttpRequest,
   includes,
@@ -263,6 +264,7 @@ export function trackRequests(
     const timing = matchRequestTiming(requestDetails)
     const kind = requestDetails.type === RequestType.XHR ? ResourceKind.XHR : ResourceKind.FETCH
     addRumEvent({
+      date: getTimestamp(timing ? timing.startTime : requestDetails.startTime),
       duration: msToNs(timing ? timing.duration : requestDetails.duration),
       evt: {
         category: RumEventCategory.RESOURCE,
@@ -318,6 +320,7 @@ export function handleResourceEntry(
     return
   }
   addRumEvent({
+    date: getTimestamp(entry.startTime),
     duration: msToNs(entry.duration),
     evt: {
       category: RumEventCategory.RESOURCE,
@@ -338,6 +341,7 @@ export function handleResourceEntry(
 
 export function handleLongTaskEntry(entry: PerformanceLongTaskTiming, addRumEvent: (event: RumEvent) => void) {
   addRumEvent({
+    date: getTimestamp(entry.startTime),
     duration: msToNs(entry.duration),
     evt: {
       category: RumEventCategory.LONG_TASK,

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -223,9 +223,10 @@ function startRumBatch(
 }
 
 function trackErrors(lifeCycle: LifeCycle, addRumEvent: (event: RumEvent) => void) {
-  lifeCycle.subscribe(LifeCycleEventType.ERROR_COLLECTED, ({ message, context }: ErrorMessage) => {
+  lifeCycle.subscribe(LifeCycleEventType.ERROR_COLLECTED, ({ message, startTime, context }: ErrorMessage) => {
     addRumEvent({
       message,
+      date: getTimestamp(startTime),
       evt: {
         category: RumEventCategory.ERROR,
       },

--- a/packages/rum/src/viewTracker.ts
+++ b/packages/rum/src/viewTracker.ts
@@ -25,7 +25,6 @@ interface ViewContext {
 export let viewContext: ViewContext
 
 const THROTTLE_VIEW_UPDATE_PERIOD = 3000
-let isInitialView = true
 let startOrigin: number
 let documentVersion: number
 let viewMeasures: ViewMeasures
@@ -50,12 +49,12 @@ export function trackView(
 }
 
 function newView(location: Location, session: RumSession, upsertRumEvent: (event: RumEvent, key: string) => void) {
+  startOrigin = !viewContext ? 0 : performance.now()
   viewContext = {
     id: generateUUID(),
     location: { ...location },
     sessionId: session.getId(),
   }
-  startOrigin = isInitialView ? 0 : performance.now()
   documentVersion = 1
   viewMeasures = {
     errorCount: 0,
@@ -64,7 +63,6 @@ function newView(location: Location, session: RumSession, upsertRumEvent: (event
     userActionCount: 0,
   }
   upsertViewEvent(upsertRumEvent)
-  isInitialView = false
 }
 
 function updateView(upsertRumEvent: (event: RumEvent, key: string) => void) {


### PR DESCRIPTION
Use startTime instead of collection time in order to have a more accurate date for events.