### PR TITLE
🐛[RUMF-266] fix xhr incorrect status reported on late abortion

### DIFF
--- a/packages/core/src/requestCollection.ts
+++ b/packages/core/src/requestCollection.ts
@@ -72,7 +72,17 @@ export function trackXhr(observable: RequestObservable) {
       })
     }
 
-    this.addEventListener('loadend', monitor(reportXhr))
+    const originalOnreadystatechange = this.onreadystatechange
+
+    this.onreadystatechange = function() {
+      if (this.readyState === XMLHttpRequest.DONE) {
+        monitor(reportXhr)()
+      }
+
+      if (originalOnreadystatechange) {
+        originalOnreadystatechange.apply(this, arguments as any)
+      }
+    }
 
     return originalSend.apply(this, arguments as any)
   }

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -175,55 +175,6 @@ describe('rum', () => {
 })
 
 describe('error collection', () => {
-  it('should track xhr error', async () => {
-    await browserExecuteAsync(
-      (baseUrl, unreachableUrl, done) => {
-        let count = 0
-        let xhr = new XMLHttpRequest()
-        xhr.addEventListener('load', () => (count += 1))
-        xhr.open('GET', `${baseUrl}/throw`)
-        xhr.send()
-
-        xhr = new XMLHttpRequest()
-        xhr.addEventListener('load', () => (count += 1))
-        xhr.open('GET', `${baseUrl}/unknown`)
-        xhr.send()
-
-        xhr = new XMLHttpRequest()
-        xhr.addEventListener('error', () => (count += 1))
-        xhr.open('GET', unreachableUrl)
-        xhr.send()
-
-        xhr = new XMLHttpRequest()
-        xhr.addEventListener('load', () => (count += 1))
-        xhr.open('GET', `${baseUrl}/ok`)
-        xhr.send()
-
-        const interval = setInterval(() => {
-          if (count === 4) {
-            clearInterval(interval)
-            done(undefined)
-          }
-        }, 500)
-      },
-      browser.options.baseUrl!,
-      UNREACHABLE_URL
-    )
-    await flushBrowserLogs()
-    await flushEvents()
-    const logs = (await waitServerLogs()).sort(sortByMessage)
-
-    expect(logs.length).toEqual(2)
-
-    expect(logs[0].message).toEqual(`XHR error GET ${browser.options.baseUrl}/throw`)
-    expect(logs[0].http.status_code).toEqual(500)
-    expect(logs[0].error.stack).toMatch(/Server error/)
-
-    expect(logs[1].message).toEqual(`XHR error GET ${UNREACHABLE_URL}`)
-    expect(logs[1].http.status_code).toEqual(0)
-    expect(logs[1].error.stack).toEqual('Failed to load')
-  })
-
   it('should track fetch error', async () => {
     await browserExecuteAsync(
       (baseUrl, unreachableUrl, done) => {

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -31,9 +31,9 @@ if (process.env.ENV === 'development') {
   // e2e tests
   app.use(express.static(path.join(__dirname, '../../packages/logs/bundle')))
   app.use(express.static(path.join(__dirname, '../../packages/rum/bundle')))
-  app.use(bodyParser.text())
-  fakeBackend(app)
 }
+app.use(bodyParser.text())
+fakeBackend(app)
 
 app.listen(port, () => console.log(`server listening on port ${port}.`))
 

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -30,4 +30,19 @@ module.exports = {
     stats: 'errors-only',
     logLevel: 'warn',
   },
+  beforeMiddleware: ['custom'],
+  plugins: ['karma-*', { 'middleware:custom': ['factory', CustomMiddlewareFactory] }],
+}
+
+function CustomMiddlewareFactory() {
+  return function(request, response, next) {
+    if (request.url === '/ok') {
+      response.writeHead(200)
+      return response.end('ok')
+    }
+    if (request.url === '/throw') {
+      throw 'expected server error'
+    }
+    return next()
+  }
 }

--- a/test/unit/karma.cbt.conf.js
+++ b/test/unit/karma.cbt.conf.js
@@ -11,7 +11,7 @@ const ONE_MINUTE = 60000
 module.exports = function(config) {
   config.set({
     ...karmaBaseConf,
-    plugins: ['karma-*', 'karma-cbt-launcher'],
+    plugins: [...karmaBaseConf.plugins, 'karma-cbt-launcher'],
     reporters: [...karmaBaseConf.reporters, 'CrossBrowserTesting'],
     browsers: Object.keys(browsers),
     concurrency: 1,


### PR DESCRIPTION
An xhr request can be [aborted](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/abort) after completion, overriding its original status by an aborted one (ie. statusCode: 0).
Use [onreadystatechange](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/onreadystatechange) in order to retrieve xhr status as soon as possible.

Convert existing xhr e2e tests to unit tests.

closes #257 