### PR TITLE
🐛[RUMF-320] Remove url-polyfill dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,7 +2,6 @@ Component,Origin,License,Copyright
 require,lodash.assign,MIT,Copyright jQuery Foundation and other contributors
 require,lodash.merge,MIT,Copyright OpenJS Foundation and other contributors
 require,tslib,Apache-2.0,Copyright Microsoft Corporation
-require,url-polyfill,MIT,Copyright 2017 Valentin Richard
 file,tracekit,MIT,Copyright 2013 Onur Can Cakmak and all TraceKit contributors
 dev,@types/jasmine,MIT,Copyright Microsoft Corporation
 dev,@types/lodash.assign,MIT,Copyright Microsoft Corporation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "lodash.assign": "4.2.0",
     "lodash.merge": "4.6.2",
-    "tslib": "1.10.0",
-    "url-polyfill": "1.1.7"
+    "tslib": "1.10.0"
   },
   "devDependencies": {
     "@types/lodash.assign": "4.2.6",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   stopSessionManagement,
 } from './sessionManagement'
 export { HttpRequest, Batch } from './transport'
+export * from './urlPolyfill'
 export * from './utils'
 export { areCookiesAuthorized, getCookie, setCookie, COOKIE_ACCESS_DELAY } from './cookie'
 

--- a/packages/core/src/requestCollection.ts
+++ b/packages/core/src/requestCollection.ts
@@ -4,6 +4,7 @@ import { toStackTraceString } from './errorCollection'
 import { monitor } from './internalMonitoring'
 import { Observable } from './observable'
 import { computeStackTrace } from './tracekit'
+import { normalizeUrl } from './urlPolyfill'
 import { ResourceKind } from './utils'
 
 export enum RequestType {
@@ -143,10 +144,6 @@ export function trackFetch(observable: RequestObservable) {
     responsePromise.then(monitor(reportFetch), monitor(reportFetch))
     return responsePromise
   })
-}
-
-export function normalizeUrl(url: string) {
-  return new URL(url, window.location.origin).href
 }
 
 export function isRejected(request: RequestDetails) {

--- a/packages/core/src/requestCollection.ts
+++ b/packages/core/src/requestCollection.ts
@@ -1,5 +1,3 @@
-import 'url-polyfill'
-
 import { toStackTraceString } from './errorCollection'
 import { monitor } from './internalMonitoring'
 import { Observable } from './observable'

--- a/packages/core/src/urlPolyfill.ts
+++ b/packages/core/src/urlPolyfill.ts
@@ -1,5 +1,7 @@
+import { getLinkElementOrigin, getLocationOrigin } from './utils'
+
 export function normalizeUrl(url: string) {
-  return buildUrl(url, window.location.origin).href
+  return buildUrl(url, getLocationOrigin()).href
 }
 
 export function isValidUrl(url: string) {
@@ -15,11 +17,12 @@ export function haveSameOrigin(url1: string, url2: string) {
 }
 
 export function getOrigin(url: string) {
-  return buildUrl(url).origin
+  return getLinkElementOrigin(buildUrl(url))
 }
 
 export function getPathName(url: string) {
-  return buildUrl(url).pathname
+  const pathname = buildUrl(url).pathname
+  return pathname[0] === '/' ? pathname : `/${pathname}`
 }
 
 export function getSearch(url: string) {

--- a/packages/core/src/urlPolyfill.ts
+++ b/packages/core/src/urlPolyfill.ts
@@ -1,10 +1,10 @@
 export function normalizeUrl(url: string) {
-  return new URL(url, window.location.origin).href
+  return buildUrl(url, window.location.origin).href
 }
 
 export function isValidUrl(url: string) {
   try {
-    return !!new URL(url)
+    return !!buildUrl(url)
   } catch {
     return false
   }
@@ -15,17 +15,34 @@ export function haveSameOrigin(url1: string, url2: string) {
 }
 
 export function getOrigin(url: string) {
-  return new URL(url).origin
+  return buildUrl(url).origin
 }
 
 export function getPathName(url: string) {
-  return new URL(url).pathname
+  return buildUrl(url).pathname
 }
 
 export function getSearch(url: string) {
-  return new URL(url).search
+  return buildUrl(url).search
 }
 
 export function getHash(url: string) {
-  return new URL(url).hash
+  return buildUrl(url).hash
+}
+
+function buildUrl(url: string, base?: string) {
+  if (base === undefined && !/:/.test(url)) {
+    throw new Error(`Invalid URL: '${url}'`)
+  }
+  let doc = document
+  const anchorElement = doc.createElement('a')
+  if (base !== undefined) {
+    doc = document.implementation.createHTMLDocument('')
+    const baseElement = doc.createElement('base')
+    baseElement.href = base
+    doc.head.appendChild(baseElement)
+    doc.body.appendChild(anchorElement)
+  }
+  anchorElement.href = url
+  return anchorElement
 }

--- a/packages/core/src/urlPolyfill.ts
+++ b/packages/core/src/urlPolyfill.ts
@@ -1,0 +1,31 @@
+export function normalizeUrl(url: string) {
+  return new URL(url, window.location.origin).href
+}
+
+export function isValidUrl(url: string) {
+  try {
+    return !!new URL(url)
+  } catch {
+    return false
+  }
+}
+
+export function haveSameOrigin(url1: string, url2: string) {
+  return getOrigin(url1) === getOrigin(url2)
+}
+
+export function getOrigin(url: string) {
+  return new URL(url).origin
+}
+
+export function getPathName(url: string) {
+  return new URL(url).pathname
+}
+
+export function getSearch(url: string) {
+  return new URL(url).search
+}
+
+export function getHash(url: string) {
+  return new URL(url).hash
+}

--- a/packages/core/src/urlPolyfill.ts
+++ b/packages/core/src/urlPolyfill.ts
@@ -34,6 +34,9 @@ export function getHash(url: string) {
 }
 
 function buildUrl(url: string, base?: string) {
+  if (checkURLSupported()) {
+    return new URL(url, base)
+  }
   if (base === undefined && !/:/.test(url)) {
     throw new Error(`Invalid URL: '${url}'`)
   }
@@ -48,4 +51,18 @@ function buildUrl(url: string, base?: string) {
   }
   anchorElement.href = url
   return anchorElement
+}
+
+let isURLSupported: boolean | undefined
+function checkURLSupported() {
+  if (isURLSupported !== undefined) {
+    return isURLSupported
+  }
+  try {
+    const url = new URL('http://test')
+    return url.href === 'http://test'
+  } catch {
+    isURLSupported = false
+  }
+  return isURLSupported
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -219,7 +219,7 @@ export function getLocationOrigin() {
  * IE fallback
  * https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/origin
  */
-export function getLinkElementOrigin(element: Location | HTMLAnchorElement) {
+export function getLinkElementOrigin(element: Location | HTMLAnchorElement | URL) {
   if (element.origin) {
     return element.origin
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -210,3 +210,19 @@ export function getGlobalObject<T>(): T {
   // tslint:disable-next-line: function-constructor no-function-constructor-with-string-args
   return (typeof globalThis === 'object' ? globalThis : Function('return this')()) as T
 }
+
+export function getLocationOrigin() {
+  return getLinkElementOrigin(window.location)
+}
+
+/**
+ * IE fallback
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/origin
+ */
+export function getLinkElementOrigin(element: Location | HTMLAnchorElement) {
+  if (element.origin) {
+    return element.origin
+  }
+  const sanitizedHost = element.host.replace(/(:80|:443)$/, '')
+  return `${element.protocol}//${sanitizedHost}`
+}

--- a/packages/core/test/requestCollection.spec.ts
+++ b/packages/core/test/requestCollection.spec.ts
@@ -1,13 +1,5 @@
 import { Observable } from '../src/observable'
-import {
-  isRejected,
-  isServerError,
-  normalizeUrl,
-  RequestDetails,
-  RequestType,
-  trackFetch,
-  trackXhr,
-} from '../src/requestCollection'
+import { isRejected, isServerError, RequestDetails, RequestType, trackFetch, trackXhr } from '../src/requestCollection'
 import { FetchStub, FetchStubBuilder, FetchStubPromise, isFirefox, isIE } from '../src/specHelper'
 
 describe('fetch tracker', () => {
@@ -171,27 +163,6 @@ describe('fetch tracker', () => {
       expect(spy).toHaveBeenCalled()
       done()
     })
-  })
-})
-
-describe('normalize url', () => {
-  it('should add origin to relative path', () => {
-    expect(normalizeUrl('/my/path')).toEqual(`${window.location.origin}/my/path`)
-  })
-
-  it('should add protocol to relative url', () => {
-    expect(normalizeUrl('//foo.com:9876/my/path')).toEqual('http://foo.com:9876/my/path')
-  })
-
-  it('should keep full url unchanged', () => {
-    expect(normalizeUrl('https://foo.com/my/path')).toEqual('https://foo.com/my/path')
-  })
-
-  it('should keep non http url unchanged', () => {
-    if (isFirefox()) {
-      pending('https://bugzilla.mozilla.org/show_bug.cgi?id=1578787')
-    }
-    expect(normalizeUrl('file://foo.com/my/path')).toEqual('file://foo.com/my/path')
   })
 })
 

--- a/packages/core/test/urlPolyfill.spec.ts
+++ b/packages/core/test/urlPolyfill.spec.ts
@@ -1,0 +1,61 @@
+import { getHash, getOrigin, getPathName, getSearch, isFirefox, isValidUrl, normalizeUrl } from '../src'
+
+describe('normalize url', () => {
+  it('should add origin to relative path', () => {
+    expect(normalizeUrl('/my/path')).toEqual(`${window.location.origin}/my/path`)
+  })
+
+  it('should add protocol to relative url', () => {
+    expect(normalizeUrl('//foo.com:9876/my/path')).toEqual('http://foo.com:9876/my/path')
+  })
+
+  it('should keep full url unchanged', () => {
+    expect(normalizeUrl('https://foo.com/my/path')).toEqual('https://foo.com/my/path')
+  })
+
+  it('should keep non http url unchanged', () => {
+    if (isFirefox()) {
+      pending('https://bugzilla.mozilla.org/show_bug.cgi?id=1578787')
+    }
+    expect(normalizeUrl('file://foo.com/my/path')).toEqual('file://foo.com/my/path')
+  })
+})
+
+describe('isValidUrl', () => {
+  it('should ensure url is valid', () => {
+    expect(isValidUrl('http://www.datadoghq.com')).toBe(true)
+    expect(isValidUrl('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe(true)
+    expect(isValidUrl('file://www.datadoghq.com')).toBe(true)
+    expect(isValidUrl('/plop')).toBe(false)
+    expect(isValidUrl('')).toBe(false)
+  })
+})
+
+describe('getOrigin', () => {
+  it('should retrieve url origin', () => {
+    expect(getOrigin('http://www.datadoghq.com')).toBe('http://www.datadoghq.com')
+    expect(getOrigin('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe('http://www.datadoghq.com')
+    expect(getOrigin('http://localhost:8080')).toBe('http://localhost:8080')
+  })
+})
+
+describe('getPathName', () => {
+  it('should retrieve url path name', () => {
+    expect(getPathName('http://www.datadoghq.com')).toBe('/')
+    expect(getPathName('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe('/foo/bar')
+  })
+})
+
+describe('getSearch', () => {
+  it('should retrieve url search', () => {
+    expect(getSearch('http://www.datadoghq.com')).toBe('')
+    expect(getSearch('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe('?a=b')
+  })
+})
+
+describe('getHash', () => {
+  it('should retrieve url hash', () => {
+    expect(getHash('http://www.datadoghq.com')).toBe('')
+    expect(getHash('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe('#hello')
+  })
+})

--- a/packages/core/test/urlPolyfill.spec.ts
+++ b/packages/core/test/urlPolyfill.spec.ts
@@ -1,8 +1,17 @@
-import { getHash, getOrigin, getPathName, getSearch, isFirefox, isValidUrl, normalizeUrl } from '../src'
+import {
+  getHash,
+  getLocationOrigin,
+  getOrigin,
+  getPathName,
+  getSearch,
+  isFirefox,
+  isValidUrl,
+  normalizeUrl,
+} from '../src'
 
 describe('normalize url', () => {
   it('should add origin to relative path', () => {
-    expect(normalizeUrl('/my/path')).toEqual(`${window.location.origin}/my/path`)
+    expect(normalizeUrl('/my/path')).toEqual(`${getLocationOrigin()}/my/path`)
   })
 
   it('should add protocol to relative url', () => {

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -64,6 +64,7 @@ export interface PerformanceResourceDetails {
 }
 
 export interface RumResourceEvent {
+  date: number
   duration: number
   evt: {
     category: RumEventCategory.RESOURCE
@@ -309,7 +310,7 @@ function trackPerformanceTiming(
 export function handleResourceEntry(
   configuration: Configuration,
   entry: PerformanceResourceTiming,
-  addRumEvent: (event: RumEvent) => void,
+  addRumEvent: (event: RumResourceEvent) => void,
   lifeCycle: LifeCycle
 ) {
   if (!isValidResource(entry.name, configuration)) {

--- a/packages/rum/test/viewTracker.spec.ts
+++ b/packages/rum/test/viewTracker.spec.ts
@@ -1,3 +1,5 @@
+import { getHash, getPathName, getSearch } from '@datadog/browser-core'
+
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
 import { PerformanceLongTaskTiming, PerformancePaintTiming, RumEvent, RumViewEvent, UserAction } from '../src/rum'
 import { RumSession } from '../src/rumSession'
@@ -11,10 +13,10 @@ function setup({
   lifeCycle?: LifeCycle
 } = {}) {
   spyOn(history, 'pushState').and.callFake((_: any, __: string, pathname: string) => {
-    const url = new URL(pathname, 'http://localhost')
-    fakeLocation.pathname = url.pathname
-    fakeLocation.search = url.search
-    fakeLocation.hash = url.hash
+    const url = `http://localhost${pathname}`
+    fakeLocation.pathname = getPathName(url)
+    fakeLocation.search = getSearch(url)
+    fakeLocation.hash = getHash(url)
   })
   const fakeLocation: Partial<Location> = { pathname: '/foo' }
   const fakeSession = {

--- a/test/app/yarn.lock
+++ b/test/app/yarn.lock
@@ -2,26 +2,25 @@
 # yarn lockfile v1
 
 
-"@datadog/browser-core@1.4.1", "@datadog/browser-core@file:../../packages/core":
-  version "1.4.1"
+"@datadog/browser-core@1.7.0", "@datadog/browser-core@file:../../packages/core":
+  version "1.7.0"
   dependencies:
     lodash.assign "4.2.0"
     lodash.merge "4.6.2"
     tslib "1.10.0"
-    url-polyfill "1.1.7"
 
 "@datadog/browser-logs@file:../../packages/logs":
-  version "1.4.1"
+  version "1.7.0"
   dependencies:
-    "@datadog/browser-core" "1.4.1"
+    "@datadog/browser-core" "1.7.0"
     lodash.assign "4.2.0"
     lodash.merge "4.6.2"
     tslib "1.10.0"
 
 "@datadog/browser-rum@file:../../packages/rum":
-  version "1.4.1"
+  version "1.7.0"
   dependencies:
-    "@datadog/browser-core" "1.4.1"
+    "@datadog/browser-core" "1.7.0"
     lodash.assign "4.2.0"
     lodash.merge "4.6.2"
     tslib "1.10.0"
@@ -2235,11 +2234,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-polyfill@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.7.tgz#402ee84360eb549bbeb585f4c7971e79a31de9e3"
-  integrity sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA==
 
 url@^0.11.0:
   version "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9713,11 +9713,6 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-polyfill@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.7.tgz#402ee84360eb549bbeb585f4c7971e79a31de9e3"
-  integrity sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA==
-
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
The dependency used to polyfill URL API is modifying the global scope which caused an issue for a customer.
Since we don't use a lot of URL features, replace this polyfill by a simple implementation that support only our current needs.