### PR TITLE
🐛[RUMF-396] try to fix view date shift

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -191,11 +191,22 @@ export function isNumber(value: unknown): value is number {
  * Related issue in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1429926
  */
 export function getRelativeTime(timestamp: number) {
-  return timestamp - performance.timing.navigationStart
+  return timestamp - getNavigationStart()
 }
 
 export function getTimestamp(relativeTime: number) {
-  return Math.floor(performance.timing.navigationStart + relativeTime)
+  return Math.floor(getNavigationStart() + relativeTime)
+}
+
+/**
+ * Navigation start slightly change on some rare cases
+ */
+let navigationStart: number | undefined
+export function getNavigationStart() {
+  if (navigationStart === undefined) {
+    navigationStart = performance.timing.navigationStart
+  }
+  return navigationStart
 }
 
 export function objectValues(object: { [key: string]: unknown }) {


### PR DESCRIPTION
In some rare cases, view date change over the time which break the backend aggregation.
performance.timing.navigationStart seems to be the culprit.