### PR TITLE
🐛[RUMF-403] fix checkURLSupported 

### DIFF
--- a/packages/core/src/urlPolyfill.ts
+++ b/packages/core/src/urlPolyfill.ts
@@ -35,7 +35,7 @@ export function getHash(url: string) {
 
 function buildUrl(url: string, base?: string) {
   if (checkURLSupported()) {
-    return new URL(url, base)
+    return base !== undefined ? new URL(url, base) : new URL(url)
   }
   if (base === undefined && !/:/.test(url)) {
     throw new Error(`Invalid URL: '${url}'`)
@@ -59,8 +59,9 @@ function checkURLSupported() {
     return isURLSupported
   }
   try {
-    const url = new URL('http://test')
-    return url.href === 'http://test'
+    const url = new URL('http://test/path')
+    isURLSupported = url.href === 'http://test/path'
+    return isURLSupported
   } catch {
     isURLSupported = false
   }

--- a/test/static/async-e2e-page.html
+++ b/test/static/async-e2e-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="base-uri 'none';" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/empty.css" />
     <title>async tests page</title>

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="base-uri 'none';" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/empty.css" />
     <title>bundle tests page</title>

--- a/test/static/npm-e2e-page.html
+++ b/test/static/npm-e2e-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="base-uri 'none';" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/empty.css" />
     <title>npm tests page</title>


### PR DESCRIPTION
URL api was never used and for customer with base-uri csp restrictions, the polyfill raised an exception.
cf [bug report](https://github.com/DataDog/browser-sdk/pull/294#issuecomment-598279956)

Add similar restrictions to e2e pages.