### PR TITLE
🐛 replace console.error by console.warn when cookies are not supported

### DIFF
--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -45,7 +45,7 @@ export function commonInit(userConfiguration: UserConfiguration, buildEnv: Build
 
 export function checkCookiesAuthorized() {
   if (!areCookiesAuthorized()) {
-    console.error('Cookies are not authorized, we will not send any data.')
+    console.warn('Cookies are not authorized, we will not send any data.');
     return false
   }
   return true

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -45,7 +45,7 @@ export function commonInit(userConfiguration: UserConfiguration, buildEnv: Build
 
 export function checkCookiesAuthorized() {
   if (!areCookiesAuthorized()) {
-    console.warn('Cookies are not authorized, we will not send any data.');
+    console.warn('Cookies are not authorized, we will not send any data.')
     return false
   }
   return true


### PR DESCRIPTION
What it does
replace
![Capture d’écran 2020-03-17 à 16 52 04](https://user-images.githubusercontent.com/6943103/76875064-55015d00-6870-11ea-9869-aeb6227fad74.png)

by
![Capture d’écran 2020-03-17 à 16 52 17](https://user-images.githubusercontent.com/6943103/76875094-5e8ac500-6870-11ea-97e9-aea4e05125a3.png)

Context
[https://github.com/DataDog/browser-sdk/issues/288](https://github.com/DataDog/browser-sdk/issues/288)
[RUMF-376](https://datadoghq.atlassian.net/browse/RUMF-376)

Changes
- replace console.error by console.warn