### PR TITLE
✨add an option to silent multiple Init errors

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CONFIGURATION = {
   maxInternalMonitoringMessagesPerPage: 15,
   resourceSampleRate: 100,
   sampleRate: 100,
+  silentMultipleInit: false,
 
   /**
    * arbitrary value, byte precision not needed
@@ -42,6 +43,7 @@ export interface UserConfiguration {
   resourceSampleRate?: number
   datacenter?: Datacenter
   enableExperimentalFeatures?: boolean
+  silentMultipleInit?: boolean
 
   // Below is only taken into account for e2e-test bundle.
   internalMonitoringEndpoint?: string

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -41,13 +41,15 @@ What we call `Context` is a map `{key: value}` that will be added to the message
   - `isCollectingError`: when truthy, we'll automatically forward `console.error` logs, uncaught exceptions and network errors.
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send logs.
   - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
+  - `silentMultipleInit`: prevent logging errors while having multiple Init
 
   ```
   init(configuration: {
       clientToken: string,
       datacenter?: string,
       isCollectingError?: boolean,
-      sampleRate?: number
+      sampleRate?: number,
+      silentMultipleInit?: boolean
   })
   ```
 

--- a/packages/logs/src/logs.entry.ts
+++ b/packages/logs/src/logs.entry.ts
@@ -99,7 +99,7 @@ datadogLogs.init = monitor((userConfiguration: LogsUserConfiguration) => {
 })
 
 function canInitLogs(userConfiguration: LogsUserConfiguration) {
-  if (isAlreadyInitialized) {
+  if (isAlreadyInitialized && !userConfiguration.silentMultipleInit) {
     console.error('DD_LOGS is already initialized.')
     return false
   }

--- a/packages/logs/src/logs.entry.ts
+++ b/packages/logs/src/logs.entry.ts
@@ -99,8 +99,10 @@ datadogLogs.init = monitor((userConfiguration: LogsUserConfiguration) => {
 })
 
 function canInitLogs(userConfiguration: LogsUserConfiguration) {
-  if (isAlreadyInitialized && !userConfiguration.silentMultipleInit) {
-    console.error('DD_LOGS is already initialized.')
+  if (isAlreadyInitialized) {
+    if (!userConfiguration.silentMultipleInit) {
+      console.error('DD_LOGS is already initialized.')
+    }
     return false
   }
   if (!userConfiguration || (!userConfiguration.publicApiKey && !userConfiguration.clientToken)) {

--- a/packages/logs/test/logs.entry.spec.ts
+++ b/packages/logs/test/logs.entry.spec.ts
@@ -76,6 +76,23 @@ describe('logs entry', () => {
     expect(errorSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('should not log an error if init is called several times and silentMultipleInit is true', () => {
+    const errorSpy = spyOn(console, 'error')
+    logsGlobal.init({
+      clientToken: 'yes',
+      sampleRate: 1,
+      silentMultipleInit: true,
+    })
+    expect(errorSpy).toHaveBeenCalledTimes(0)
+
+    logsGlobal.init({
+      clientToken: 'yes',
+      sampleRate: 1,
+      silentMultipleInit: true,
+    })
+    expect(errorSpy).toHaveBeenCalledTimes(0)
+  })
+
   it("shouldn't trigger any console.log if the configuration is correct", () => {
     const errorSpy = spyOn(console, 'error')
     logsGlobal.init({ clientToken: 'yes', sampleRate: 1 })

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -39,6 +39,7 @@ datadogRum.init({
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send rum events.
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
   - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
+  - `silentMultipleInit`: prevent logging errors while having multiple Init
 
   ```
   init(configuration: {
@@ -46,7 +47,8 @@ datadogRum.init({
       clientToken: string,
       datacenter?: string,
       resourceSampleRate?: number
-      sampleRate?: number
+      sampleRate?: number,
+      silentMultipleInit?: boolean
   })
   ```
 

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -82,8 +82,10 @@ datadogRum.init = monitor((userConfiguration: RumUserConfiguration) => {
 })
 
 function canInitRum(userConfiguration: RumUserConfiguration) {
-  if (isAlreadyInitialized && !userConfiguration.silentMultipleInit) {
-    console.error('DD_RUM is already initialized.')
+  if (isAlreadyInitialized) {
+    if (!userConfiguration.silentMultipleInit) {
+      console.error('DD_RUM is already initialized.')
+    }
     return false
   }
   if (!userConfiguration || (!userConfiguration.clientToken && !userConfiguration.publicApiKey)) {

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -82,7 +82,7 @@ datadogRum.init = monitor((userConfiguration: RumUserConfiguration) => {
 })
 
 function canInitRum(userConfiguration: RumUserConfiguration) {
-  if (isAlreadyInitialized) {
+  if (isAlreadyInitialized && !userConfiguration.silentMultipleInit) {
     console.error('DD_RUM is already initialized.')
     return false
   }

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -55,6 +55,27 @@ describe('rum entry', () => {
     expect(errorSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('should not log an error if init is called several times and silentMultipleInit is true', () => {
+    const errorSpy = spyOn(console, 'error')
+    rumGlobal.init({
+      clientToken: 'yes',
+      applicationId: 'yes',
+      sampleRate: 1,
+      resourceSampleRate: 1,
+      silentMultipleInit: true,
+    })
+    expect(errorSpy).toHaveBeenCalledTimes(0)
+
+    rumGlobal.init({
+      clientToken: 'yes',
+      applicationId: 'yes',
+      sampleRate: 1,
+      resourceSampleRate: 1,
+      silentMultipleInit: true,
+    })
+    expect(errorSpy).toHaveBeenCalledTimes(0)
+  })
+
   it("shouldn't trigger any console.log if the configuration is correct", () => {
     const errorSpy = spyOn(console, 'error')
     rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1, resourceSampleRate: 1 })

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -58,19 +58,19 @@ describe('rum entry', () => {
   it('should not log an error if init is called several times and silentMultipleInit is true', () => {
     const errorSpy = spyOn(console, 'error')
     rumGlobal.init({
-      clientToken: 'yes',
       applicationId: 'yes',
-      sampleRate: 1,
+      clientToken: 'yes',
       resourceSampleRate: 1,
+      sampleRate: 1,
       silentMultipleInit: true,
     })
     expect(errorSpy).toHaveBeenCalledTimes(0)
 
     rumGlobal.init({
-      clientToken: 'yes',
       applicationId: 'yes',
-      sampleRate: 1,
+      clientToken: 'yes',
       resourceSampleRate: 1,
+      sampleRate: 1,
       silentMultipleInit: true,
     })
     expect(errorSpy).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
What it does
Add a new and optional init option : `silentMultipleInit?: boolean`

Context
[https://github.com/DataDog/browser-sdk/issues/280](https://github.com/DataDog/browser-sdk/issues/280)

Changes
- Update README files
- Add the new `silentMultipleInit?: boolean` property to the `UserConfiguration` type
- Check the boolean while being already initialized