### PR TITLE
[RUMF-407] improve resource timings collection

### DIFF
--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -22,7 +22,13 @@ import lodashMerge from 'lodash.merge'
 
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { matchRequestTiming } from './matchRequestTiming'
-import { computePerformanceResourceDetails, computeResourceKind, computeSize, isValidResource } from './resourceUtils'
+import {
+  computePerformanceResourceDetails,
+  computePerformanceResourceDuration,
+  computeResourceKind,
+  computeSize,
+  isValidResource,
+} from './resourceUtils'
 import { RumGlobal } from './rum.entry'
 import { RumSession } from './rumSession'
 import { trackView, viewContext, ViewMeasures } from './viewTracker'
@@ -266,18 +272,18 @@ export function trackRequests(
     const kind = requestDetails.type === RequestType.XHR ? ResourceKind.XHR : ResourceKind.FETCH
     addRumEvent({
       date: getTimestamp(timing ? timing.startTime : requestDetails.startTime),
-      duration: msToNs(timing ? timing.duration : requestDetails.duration),
+      duration: timing ? computePerformanceResourceDuration(timing) : msToNs(requestDetails.duration),
       evt: {
         category: RumEventCategory.RESOURCE,
       },
       http: {
         method: requestDetails.method,
-        performance: computePerformanceResourceDetails(timing),
+        performance: timing ? computePerformanceResourceDetails(timing) : undefined,
         statusCode: requestDetails.status,
         url: requestDetails.url,
       },
       network: {
-        bytesWritten: computeSize(timing),
+        bytesWritten: timing ? computeSize(timing) : undefined,
       },
       resource: {
         kind,
@@ -322,7 +328,7 @@ export function handleResourceEntry(
   }
   addRumEvent({
     date: getTimestamp(entry.startTime),
-    duration: msToNs(entry.duration),
+    duration: computePerformanceResourceDuration(entry),
     evt: {
       category: RumEventCategory.RESOURCE,
     },

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -176,10 +176,17 @@ describe('rum handle performance entry', () => {
       const entry: Partial<PerformanceResourceTiming> = {
         connectEnd: 10,
         connectStart: -3,
+        domainLookupEnd: 10,
+        domainLookupStart: 10,
         entryType: 'resource',
+        fetchStart: 10,
         name: 'http://localhost/test',
+        redirectEnd: 0,
+        redirectStart: 0,
+        requestStart: 10,
         responseEnd: 100,
         responseStart: 25,
+        secureConnectionStart: 0,
       }
 
       handleResourceEntry(

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -74,45 +74,45 @@ describe('rum', () => {
   })
 
   it('should track xhr timings', async () => {
-    const timing = await makeXHRAndCollectEvent(`${serverUrl.sameOrigin}/ok`)
+    const timing = (await makeXHRAndCollectEvent(`${serverUrl.sameOrigin}/ok`))!
     expect(timing).not.toBeUndefined()
-    expect(timing!.http.method).toEqual('GET')
-    expect((timing!.http as any).status_code).toEqual(200)
-    expectToHaveValidTimings(timing!)
+    expect(timing.http.method).toEqual('GET')
+    expect((timing.http as any).status_code).toEqual(200)
+    expectToHaveValidTimings(timing)
   })
 
   it('should track redirect xhr timings', async () => {
-    const timing = await makeXHRAndCollectEvent(`${serverUrl.sameOrigin}/redirect/1`)
-    expect(timing!).not.toBeUndefined()
-    expect(timing!.http.method).toEqual('GET')
-    expect((timing!.http as any).status_code).toEqual(200)
-    expectToHaveValidTimings(timing!)
-    expect(timing!.http.performance!.redirect).not.toBeUndefined()
-    expect(timing!.http.performance!.redirect!.duration).toBeGreaterThan(0)
+    const timing = (await makeXHRAndCollectEvent(`${serverUrl.sameOrigin}/redirect/1`))!
+    expect(timing).not.toBeUndefined()
+    expect(timing.http.method).toEqual('GET')
+    expect((timing.http as any).status_code).toEqual(200)
+    expectToHaveValidTimings(timing)
+    expect(timing.http.performance!.redirect).not.toBeUndefined()
+    expect(timing.http.performance!.redirect!.duration).toBeGreaterThan(0)
   })
 
   it('should not track disallowed cross origin xhr timings', async () => {
-    const timing = await makeXHRAndCollectEvent(`${serverUrl.crossOrigin}/ok`)
+    const timing = (await makeXHRAndCollectEvent(`${serverUrl.crossOrigin}/ok`))!
     expect(timing).not.toBeUndefined()
-    expect(timing!.http.method).toEqual('GET')
-    expect((timing!.http as any).status_code).toEqual(200)
-    expect(timing!.duration).toBeGreaterThan(0)
+    expect(timing.http.method).toEqual('GET')
+    expect((timing.http as any).status_code).toEqual(200)
+    expect(timing.duration).toBeGreaterThan(0)
 
     // Edge 18 seems to have valid timings even on cross browser requests ¯\_ツ_/¯ It doesn't matter
     // too much.
     if (browser.capabilities.browserName === 'MicrosoftEdge' && browser.capabilities.browserVersion === '18') {
-      expectToHaveValidTimings(timing!)
+      expectToHaveValidTimings(timing)
     } else {
-      expect(timing!.http.performance).toBeUndefined()
+      expect(timing.http.performance).toBeUndefined()
     }
   })
 
   it('should track allowed cross origin xhr timings', async () => {
-    const timing = await makeXHRAndCollectEvent(`${serverUrl.crossOrigin}/ok?timing-allow-origin=true`)
+    const timing = (await makeXHRAndCollectEvent(`${serverUrl.crossOrigin}/ok?timing-allow-origin=true`))!
     expect(timing).not.toBeUndefined()
-    expect(timing!.http.method).toEqual('GET')
-    expect((timing!.http as any).status_code).toEqual(200)
-    expectToHaveValidTimings(timing!)
+    expect(timing.http.method).toEqual('GET')
+    expect((timing.http as any).status_code).toEqual(200)
+    expectToHaveValidTimings(timing)
   })
 
   it('should send performance timings along the view events', async () => {

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -81,6 +81,16 @@ describe('rum', () => {
     expectToHaveValidTimings(timing!)
   })
 
+  it('should track redirect xhr timings', async () => {
+    const timing = await makeXHRAndCollectEvent(`${serverUrl.sameOrigin}/redirect/1`)
+    expect(timing!).not.toBeUndefined()
+    expect(timing!.http.method).toEqual('GET')
+    expect((timing!.http as any).status_code).toEqual(200)
+    expectToHaveValidTimings(timing!)
+    expect(timing!.http.performance!.redirect).not.toBeUndefined()
+    expect(timing!.http.performance!.redirect!.duration).toBeGreaterThan(0)
+  })
+
   it('should not track disallowed cross origin xhr timings', async () => {
     const timing = await makeXHRAndCollectEvent(`${serverUrl.crossOrigin}/ok`)
     expect(timing).not.toBeUndefined()

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -98,7 +98,7 @@ describe('rum', () => {
     expect((timing.http as any).status_code).toEqual(200)
     expect(timing.duration).toBeGreaterThan(0)
 
-    // Edge 18 seems to have valid timings even on cross browser requests ¯\_ツ_/¯ It doesn't matter
+    // Edge 18 seems to have valid timings even on cross origin requests ¯\_ツ_/¯ It doesn't matter
     // too much.
     if (browser.capabilities.browserName === 'MicrosoftEdge' && browser.capabilities.browserVersion === '18') {
       expectToHaveValidTimings(timing)

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -82,7 +82,7 @@ describe('rum', () => {
   })
 
   it('should track redirect xhr timings', async () => {
-    const timing = (await makeXHRAndCollectEvent(`${serverUrl.sameOrigin}/redirect/1`))!
+    const timing = (await makeXHRAndCollectEvent(`${serverUrl.sameOrigin}/redirect`))!
     expect(timing).not.toBeUndefined()
     expect(timing.http.method).toEqual('GET')
     expect((timing.http as any).status_code).toEqual(200)

--- a/test/e2e/scenario/helpers.ts
+++ b/test/e2e/scenario/helpers.ts
@@ -25,6 +25,13 @@ export interface ServerRumViewEvent extends RumViewEvent {
   }
 }
 
+const { hostname } = new URL(browser.config.baseUrl!)
+
+export const serverUrl = {
+  crossOrigin: `http://${hostname}:3001`,
+  sameOrigin: browser.config.baseUrl!,
+}
+
 const intakeRequest = request.defaults({ baseUrl: 'http://localhost:4000' })
 
 export async function flushEvents() {

--- a/test/e2e/wdio.base.conf.js
+++ b/test/e2e/wdio.base.conf.js
@@ -1,6 +1,5 @@
 const { exec } = require('child_process')
-let appProcess
-let intakeProcess
+let servers
 
 module.exports = {
   runner: 'local',
@@ -17,8 +16,14 @@ module.exports = {
   },
   e2eMode: process.env.E2E_MODE || 'bundle',
   onPrepare: function() {
-    appProcess = exec('PORT=3000 node test/server/server')
-    intakeProcess = exec('PORT=4000 node test/server/server')
+    servers = [
+      // Test server same origin
+      exec('PORT=3000 node test/server/server'),
+      // Test server cross origin
+      exec('PORT=3001 node test/server/server'),
+      // Intake server
+      exec('PORT=4000 node test/server/server'),
+    ]
   },
   before: function() {
     require('ts-node').register({
@@ -27,7 +32,6 @@ module.exports = {
     })
   },
   onComplete: function() {
-    appProcess.kill()
-    intakeProcess.kill()
+    servers.forEach((server) => server.kill())
   },
 }

--- a/test/server/fake-backend.js
+++ b/test/server/fake-backend.js
@@ -38,6 +38,15 @@ module.exports = (app) => {
     }
     res.send('ok')
   })
+
+  app.get('/redirect/:n', (req, res) => {
+    const n = Number(req.params.n)
+    if (!isNaN(n) && n > 1) {
+      res.redirect(`${n - 1}`)
+    } else {
+      res.redirect('../ok')
+    }
+  })
 }
 
 function send(res, data) {

--- a/test/server/fake-backend.js
+++ b/test/server/fake-backend.js
@@ -33,6 +33,9 @@ module.exports = (app) => {
   })
 
   app.get('/ok', (req, res) => {
+    if (req.query['timing-allow-origin'] === 'true') {
+      res.set('Timing-Allow-Origin', '*')
+    }
     res.send('ok')
   })
 }

--- a/test/server/fake-backend.js
+++ b/test/server/fake-backend.js
@@ -39,13 +39,8 @@ module.exports = (app) => {
     res.send('ok')
   })
 
-  app.get('/redirect/:n', (req, res) => {
-    const n = Number(req.params.n)
-    if (!isNaN(n) && n > 1) {
-      res.redirect(`${n - 1}`)
-    } else {
-      res.redirect('../ok')
-    }
+  app.get('/redirect', (req, res) => {
+    res.redirect('ok')
   })
 }
 


### PR DESCRIPTION
With this PR, we try to improve the resources timing collection in different ways:

* Better cross browser support:
  * If `timing.duration` isn't available or 0, use `responseEnd - startTime` instead, if available (Safari)
  * If `redirectStart` isn't available, use `startTime` instead (Firefox)
  * If `redirectEnd` isn't available, use `fetchStart` instead (Firefox)

* Change how the timings `start` are computed: use difference (in nanosecond) between the request `startTime` and the timing start, so we can build reliable timings diagram.
  * Discard any timing lower than `startTime` instead of 0 since it should not happen and would provide negative timings `start`.

* Report timings for all cached resources, as we've seen that we can't accurately know if a resource is cached or not (timings may not be 0 when cached)