### PR TITLE
🐛[RUMF-431] fix CSP issue with global object strategy

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -237,9 +237,20 @@ export function getGlobalObject<T>(): T {
     configurable: true,
   })
   // @ts-ignore
-  const globalObject = _dd_temp_
+  let globalObject: unknown = _dd_temp_
   // @ts-ignore
   delete Object.prototype._dd_temp_
+  if (typeof globalObject !== 'object') {
+    // on safari _dd_temp_ is available on window but not globally
+    // fallback on other browser globals check
+    if (typeof self === 'object') {
+      globalObject = self
+    } else if (typeof window === 'object') {
+      globalObject = window
+    } else {
+      globalObject = {}
+    }
+  }
   return globalObject as T
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -223,9 +223,24 @@ export function objectEntries(object: { [key: string]: unknown }) {
   return Object.keys(object).map((key) => [key, object[key]])
 }
 
+/**
+ * inspired by https://mathiasbynens.be/notes/globalthis
+ */
 export function getGlobalObject<T>(): T {
-  // tslint:disable-next-line: function-constructor no-function-constructor-with-string-args
-  return (typeof globalThis === 'object' ? globalThis : Function('return this')()) as T
+  if (typeof globalThis === 'object') {
+    return (globalThis as unknown) as T
+  }
+  Object.defineProperty(Object.prototype, '_dd_temp_', {
+    get() {
+      return this
+    },
+    configurable: true,
+  })
+  // @ts-ignore
+  const globalObject = _dd_temp_
+  // @ts-ignore
+  delete Object.prototype._dd_temp_
+  return globalObject as T
 }
 
 export function getLocationOrigin() {

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="base-uri 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="base-uri 'none'; script-src 'self' 'unsafe-inline'" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/empty.css" />
     <title>bundle tests page</title>


### PR DESCRIPTION
Unless adding `unsafe-eval`, Function is blocked by CSP restriction on older browsers.
Use black magic instead 🙈

fixes #328