### PR TITLE
[RUM] User action collection adjustements

### DIFF
--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -135,6 +135,7 @@ export interface RumViewEvent {
 }
 
 export interface RumLongTaskEvent {
+  date: number
   duration: number
   evt: {
     category: RumEventCategory.LONG_TASK
@@ -257,7 +258,7 @@ function startRumBatch(
   }
 }
 
-function trackErrors(lifeCycle: LifeCycle, addRumEvent: (event: RumEvent) => void) {
+function trackErrors(lifeCycle: LifeCycle, addRumEvent: (event: RumErrorEvent) => void) {
   lifeCycle.subscribe(LifeCycleEventType.ERROR_COLLECTED, ({ message, startTime, context }: ErrorMessage) => {
     addRumEvent({
       message,
@@ -401,14 +402,13 @@ export function handleResourceEntry(
   lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
 }
 
-export function handleLongTaskEntry(entry: PerformanceLongTaskTiming, addRumEvent: (event: RumEvent) => void) {
+export function handleLongTaskEntry(entry: PerformanceLongTaskTiming, addRumEvent: (event: RumLongTaskEvent) => void) {
   addRumEvent({
     date: getTimestamp(entry.startTime),
     duration: msToNs(entry.duration),
     evt: {
       category: RumEventCategory.LONG_TASK,
     },
-    startTime: entry.startTime,
     userAction: getUserActionReference(entry.startTime),
   })
 }

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -31,7 +31,7 @@ import {
 } from './resourceUtils'
 import { RumGlobal } from './rum.entry'
 import { RumSession } from './rumSession'
-import { getUserActionId } from './userActionCollection'
+import { getUserActionReference, UserActionReference } from './userActionCollection'
 import { trackView, viewContext, ViewMeasures } from './viewTracker'
 
 export interface PerformancePaintTiming extends PerformanceEntry {
@@ -106,17 +106,18 @@ export interface RumResourceEvent {
     kind: ResourceKind
   }
   traceId?: number
-  userActionId?: string
+  userAction?: UserActionReference
 }
 
 export interface RumErrorEvent {
+  date: number
   http?: HttpContext
   error: ErrorContext
   evt: {
     category: RumEventCategory.ERROR
   }
   message: string
-  userActionId?: string
+  userAction?: UserActionReference
 }
 
 export interface RumViewEvent {
@@ -138,7 +139,7 @@ export interface RumLongTaskEvent {
   evt: {
     category: RumEventCategory.LONG_TASK
   }
-  userActionId?: string
+  userAction?: UserActionReference
 }
 
 export interface RumUserActionEvent {
@@ -264,7 +265,7 @@ function trackErrors(lifeCycle: LifeCycle, addRumEvent: (event: RumEvent) => voi
       evt: {
         category: RumEventCategory.ERROR,
       },
-      userActionId: getUserActionId(startTime),
+      userAction: getUserActionReference(startTime),
       ...context,
     })
   })
@@ -341,7 +342,7 @@ export function trackRequests(
         kind,
       },
       traceId: request.traceId,
-      userActionId: getUserActionId(startTime),
+      userAction: getUserActionReference(startTime),
     })
     lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
   })
@@ -395,7 +396,7 @@ export function handleResourceEntry(
     resource: {
       kind: resourceKind,
     },
-    userActionId: getUserActionId(entry.startTime),
+    userAction: getUserActionReference(entry.startTime),
   })
   lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
 }
@@ -408,6 +409,6 @@ export function handleLongTaskEntry(entry: PerformanceLongTaskTiming, addRumEven
       category: RumEventCategory.LONG_TASK,
     },
     startTime: entry.startTime,
-    userActionId: getUserActionId(entry.startTime),
+    userAction: getUserActionReference(entry.startTime),
   })
 }

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -292,7 +292,7 @@ function trackAutoUserAction(lifeCycle: LifeCycle, addRumEvent: (event: RumUserA
     if (userAction.type !== UserActionType.CUSTOM) {
       addRumEvent({
         date: getTimestamp(userAction.startTime),
-        duration: userAction.duration,
+        duration: msToNs(userAction.duration),
         evt: {
           category: RumEventCategory.USER_ACTION,
           name: userAction.name,

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -71,9 +71,12 @@ export function startUserActionCollection(lifeCycle: LifeCycle) {
 
 let currentUserAction: { id: string; startTime: number } | undefined
 
-export function getUserActionId(time: number): string | undefined {
+export interface UserActionReference {
+  id: string
+}
+export function getUserActionReference(time: number): UserActionReference | undefined {
   if (currentUserAction && time >= currentUserAction.startTime) {
-    return currentUserAction.id
+    return { id: currentUserAction.id }
   }
   return undefined
 }

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -3,7 +3,7 @@ import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
 import { UserActionType } from '../src/rum'
 import {
   $$tests,
-  getUserActionId,
+  getUserActionReference,
   PageActivityEvent,
   startUserActionCollection,
   USER_ACTION_MAX_DURATION,
@@ -165,42 +165,42 @@ describe('newUserAction', () => {
   })
 })
 
-describe('getUserActionId', () => {
+describe('getUserActionReference', () => {
   const clock = mockClock()
 
   beforeEach(() => {
     resetUserAction()
   })
 
-  it('returns the current user action id', (done) => {
-    expect(getUserActionId(Date.now())).toBeUndefined()
+  it('returns the current user action reference', (done) => {
+    expect(getUserActionReference(Date.now())).toBeUndefined()
     const activityObservable = new Observable<PageActivityEvent>()
     newUserAction(activityObservable, (userAction) => {
-      expect(userAction!.id).toBe(userActionId)
-      expect(getUserActionId(Date.now())).toBeUndefined()
+      expect(userAction!.id).toBe(userActionReference.id)
+      expect(getUserActionReference(Date.now())).toBeUndefined()
       done()
     })
 
-    const userActionId = getUserActionId(Date.now())!
+    const userActionReference = getUserActionReference(Date.now())!
 
-    expect(userActionId).toBeDefined()
+    expect(userActionReference).toBeDefined()
 
     clock.tick(80)
     activityObservable.notify({ isBusy: false })
 
-    expect(getUserActionId(Date.now())).toBeDefined()
+    expect(getUserActionReference(Date.now())).toBeDefined()
 
     clock.expire()
   })
 
-  it('do not return the user action id for events occuring before the start of the user action', (done) => {
+  it('do not return the user action reference for events occuring before the start of the user action', (done) => {
     const activityObservable = new Observable<PageActivityEvent>()
     const time = Date.now()
     clock.tick(50)
     newUserAction(activityObservable, done)
 
     clock.tick(50)
-    expect(getUserActionId(time)).toBeUndefined()
+    expect(getUserActionReference(time)).toBeUndefined()
 
     clock.expire()
   })

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -252,6 +252,6 @@ describe('user action collection', () => {
     expect(userActionEvents[0].duration).toBeGreaterThan(0)
 
     expect(resourceEvents.length).toBe(1)
-    expect(resourceEvents[0].user_action_id).toBe(userActionEvents[0].user_action.id)
+    expect(resourceEvents[0].user_action!.id).toBe(userActionEvents[0].user_action.id!)
   })
 })

--- a/test/e2e/scenario/serverTypes.ts
+++ b/test/e2e/scenario/serverTypes.ts
@@ -50,7 +50,9 @@ export interface ServerRumResourceEvent extends ServerRumEvent {
     kind: 'fetch' | 'xhr' | 'document'
   }
   duration: number
-  user_action_id?: string
+  user_action?: {
+    id: string
+  }
 }
 
 export function isRumResourceEvent(event: ServerRumEvent): event is ServerRumResourceEvent {


### PR DESCRIPTION
After a few tests on staging, user actions needs two adjustments:

* change the data model so `user_action_id` becomes `user_action.id` on all RUM events
* convert the duration in nanoseconds to be in line with other rum events