### PR TITLE
👷 add a typecheck job to the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,12 +39,21 @@ lint:
     - yarn
     - yarn lint
 
+typecheck:
+  stage: test
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  script:
+    - yarn
+    - yarn typecheck
+
 build:
   stage: test
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
   script:
     - yarn
+    - yarn typecheck
     - yarn build
 
 compatibility:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,6 @@ build:
   image: $CI_IMAGE
   script:
     - yarn
-    - yarn typecheck
     - yarn build
 
 compatibility:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:bundle": "lerna run build:bundle --stream",
     "format": "prettier --check \"**/*.{ts,js,json,md,yml,html}\"",
     "lint": "tslint -c ./tslint.json -p ./tsconfig.json && tslint -c ./tslint.json -p ./test/e2e/scenario/tsconfig.json",
+    "typecheck": "tsc -p . --noEmit true",
     "dev": "ENV=development node test/server/server.js",
     "release": "lerna version --exact",
     "version": "node ./scripts/generate-changelog.js",


### PR DESCRIPTION
Other jobs are not typechecking all TS source files, or at least not failing when there is a TS error:

* `yarn run build`: will fail if there is an typecheck error on files included in the bundle, but not on test files
* `yarn run test` (and any test executed by karma): karma will not fail if there is a typecheck error in files, and I didn't find a way to configure it otherwise
* `yarn run lint`: tslint does not typecheck the code