### PR TITLE
✨[RUMF-43] add proxyHost init option

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -43,6 +43,7 @@ export interface UserConfiguration {
   datacenter?: Datacenter
   enableExperimentalFeatures?: string[]
   silentMultipleInit?: boolean
+  proxyHost?: string
 
   // Below is only taken into account for e2e-test bundle.
   internalMonitoringEndpoint?: string
@@ -64,6 +65,7 @@ interface TransportConfiguration {
   datacenter: Datacenter
   env: Environment
   version: string
+  proxyHost?: string
 }
 
 export function buildConfiguration(userConfiguration: UserConfiguration, buildEnv: BuildEnv): Configuration {
@@ -71,6 +73,7 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
     clientToken: userConfiguration.clientToken,
     datacenter: userConfiguration.datacenter || buildEnv.datacenter,
     env: buildEnv.env,
+    proxyHost: userConfiguration.proxyHost,
     version: buildEnv.version,
   }
 
@@ -126,6 +129,9 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
   const tld = conf.datacenter === 'us' ? 'com' : 'eu'
   const domain = conf.env === 'production' ? `datadoghq.${tld}` : `datad0g.${tld}`
   const tags = `version:${conf.version}`
-  return `https://${type}-http-intake.logs.${domain}/v1/input/${conf.clientToken}?ddsource=${source ||
-    'browser'}&ddtags=${tags}`
+  const datadogHost = `${type}-http-intake.logs.${domain}`
+  const host = conf.proxyHost ? conf.proxyHost : datadogHost
+  const proxyParameter = conf.proxyHost ? `dd-host=${datadogHost}&` : ''
+
+  return `https://${host}/v1/input/${conf.clientToken}?${proxyParameter}ddsource=${source || 'browser'}&ddtags=${tags}`
 }

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -131,7 +131,7 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
   const tags = `version:${conf.version}`
   const datadogHost = `${type}-http-intake.logs.${domain}`
   const host = conf.proxyHost ? conf.proxyHost : datadogHost
-  const proxyParameter = conf.proxyHost ? `dd-host=${datadogHost}&` : ''
+  const proxyParameter = conf.proxyHost ? `ddhost=${datadogHost}&` : ''
 
   return `https://${host}/v1/input/${conf.clientToken}?${proxyParameter}ddsource=${source || 'browser'}&ddtags=${tags}`
 }

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -70,4 +70,12 @@ describe('configuration', () => {
       expect(configuration.rumEndpoint).toContain('datadoghq.eu')
     })
   })
+
+  describe('proxyHost', () => {
+    it('should replace endpoint host add set it as a query parameter', () => {
+      const configuration = buildConfiguration({ clientToken, proxyHost: 'proxy.io' }, prodEnv)
+      expect(configuration.rumEndpoint).toMatch(/^https:\/\/proxy\.io\//)
+      expect(configuration.rumEndpoint).toContain('?dd-host=rum-http-intake.logs.datadoghq.com&')
+    })
+  })
 })

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -75,7 +75,7 @@ describe('configuration', () => {
     it('should replace endpoint host add set it as a query parameter', () => {
       const configuration = buildConfiguration({ clientToken, proxyHost: 'proxy.io' }, prodEnv)
       expect(configuration.rumEndpoint).toMatch(/^https:\/\/proxy\.io\//)
-      expect(configuration.rumEndpoint).toContain('?dd-host=rum-http-intake.logs.datadoghq.com&')
+      expect(configuration.rumEndpoint).toContain('?ddhost=rum-http-intake.logs.datadoghq.com&')
     })
   })
 })


### PR DESCRIPTION
Send data through a proxy before sending it to datadog servers.
Correct datadog host to forward the data is added to requests in the `ddhost` query parameter

Ex:
By setting `proxyHost` init option to `my.proxy.io`
Requests URL will look like:

https://my.proxy.io/some/path/token?ddhost=service.datadog-domain.com&some=parameters

And must be forwarded to:

https://service.datadog-domain.com/some/path/token?some=parameters