### PR TITLE
🐛 [RUM] fix view update after its end

### DIFF
--- a/packages/core/src/sessionManagement.ts
+++ b/packages/core/src/sessionManagement.ts
@@ -34,7 +34,7 @@ export function startSessionManagement<Type extends string>(
   const renewObservable = new Observable<void>()
   let currentSessionId = retrieveActiveSession(sessionCookie).id
 
-  const expandOrRenewSession = utils.throttle(() => {
+  const { throttled: expandOrRenewSession } = utils.throttle(() => {
     const session = retrieveActiveSession(sessionCookie)
     const { type, isTracked } = computeSessionState(session[sessionTypeKey])
     session[sessionTypeKey] = type

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -4,6 +4,7 @@ describe('utils', () => {
   describe('throttle', () => {
     let spy: jasmine.Spy
     let throttled: () => void
+    let stop: () => void
 
     beforeEach(() => {
       jasmine.clock().install()
@@ -17,7 +18,7 @@ describe('utils', () => {
 
     describe('when {leading: false, trailing:false}', () => {
       beforeEach(() => {
-        throttled = throttle(spy, 2, { leading: false, trailing: false })
+        throttled = throttle(spy, 2, { leading: false, trailing: false }).throttled
       })
 
       it('should not call throttled function', () => {
@@ -61,7 +62,7 @@ describe('utils', () => {
 
     describe('when {leading: false, trailing:true}', () => {
       beforeEach(() => {
-        throttled = throttle(spy, 2, { leading: false })
+        throttled = throttle(spy, 2, { leading: false }).throttled
       })
 
       it('should call throttled function after the wait period', () => {
@@ -105,7 +106,7 @@ describe('utils', () => {
 
     describe('when {leading: true, trailing:false}', () => {
       beforeEach(() => {
-        throttled = throttle(spy, 2, { trailing: false })
+        throttled = throttle(spy, 2, { trailing: false }).throttled
       })
 
       it('should call throttled function immediately', () => {
@@ -149,7 +150,7 @@ describe('utils', () => {
 
     describe('when {leading: true, trailing:true}', () => {
       beforeEach(() => {
-        throttled = throttle(spy, 2)
+        throttled = throttle(spy, 2).throttled
       })
 
       it('should call throttled function immediately', () => {
@@ -188,6 +189,32 @@ describe('utils', () => {
         throttled()
         jasmine.clock().tick(2)
         expect(spy).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    describe('stop', () => {
+      beforeEach(() => {
+        const result = throttle(spy, 2)
+        stop = result.stop
+        throttled = result.throttled
+      })
+
+      it('should abort pending execution', () => {
+        throttled()
+        throttled()
+        expect(spy).toHaveBeenCalledTimes(1)
+
+        stop()
+
+        jasmine.clock().tick(2)
+        expect(spy).toHaveBeenCalledTimes(1)
+      })
+
+      it('should dismiss future calls', () => {
+        stop()
+        throttled()
+        jasmine.clock().tick(2)
+        expect(spy).toHaveBeenCalledTimes(0)
       })
     })
   })

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -82,7 +82,7 @@ function newView(
   viewContext = { id, location, sessionId: session.getId() }
 
   // Update the view every time the measures are changing
-  const scheduleViewUpdate = throttle(
+  const { throttled: scheduleViewUpdate } = throttle(
     monitor(() => {
       if (shouldIgnoreScheduledViewUpdate) {
         // The view update may come after the view has ended when the throttled scheduleViewUpdate

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -95,6 +95,12 @@ function newView(
   updateView()
 
   function updateView() {
+    if (viewContext.id !== id) {
+      // The view update may come after the view has ended when the throttled scheduleViewUpdate
+      // function is called right before ending the view.  In this case, we should not send the
+      // updated view event.
+      return
+    }
     documentVersion += 1
     lifeCycle.notify(LifeCycleEventType.VIEW_COLLECTED, {
       documentVersion,

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -297,4 +297,25 @@ describe('rum view measures', () => {
       userActionCount: 0,
     })
   })
+
+  it('should not update measures after ending a view', () => {
+    jasmine.clock().install()
+    expect(getRumEventCount()).toEqual(1)
+
+    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+
+    expect(getRumEventCount()).toEqual(1)
+
+    history.pushState({}, '', '/bar')
+
+    expect(getRumEventCount()).toEqual(3)
+    expect(getViewEvent(1).id).toEqual(getViewEvent(0).id)
+    expect(getViewEvent(2).id).not.toEqual(getViewEvent(0).id)
+
+    jasmine.clock().tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+    expect(getRumEventCount()).toEqual(3)
+
+    jasmine.clock().uninstall()
+  })
 })


### PR DESCRIPTION
With the last release (v1.11.0), we have seen a lot of "duplicated" views, meaning view events with the same id but a different date. This is likely caused by the throttled `updateView` function, sending a view update after the view ends when a timing or a event count have changed right before the view end.

This fixes the issue by ensuring that the view sending an update is still the current view.