### PR TITLE
reduce getElementContent truncate to 100 chars

### DIFF
--- a/packages/rum/src/getElementContent.ts
+++ b/packages/rum/src/getElementContent.ts
@@ -1,5 +1,5 @@
 function truncate(s: string) {
-  return s.length > 200 ? `${s.slice(0, 200)} [...]` : s
+  return s.length > 100 ? `${s.slice(0, 100)} [...]` : s
 }
 
 const candidates: Array<(element: Element) => string | null> = [

--- a/packages/rum/test/getElementContent.spec.ts
+++ b/packages/rum/test/getElementContent.spec.ts
@@ -48,7 +48,7 @@ describe('getElementContent', () => {
       )
     ).toBe(
       // tslint:disable-next-line max-line-length
-      'Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]'
+      'Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]'
     )
   })
 })


### PR DESCRIPTION
### What it does
reduce the maximum content length from 200 to 100 characters

### Context
[RUMF-467](https://datadoghq.atlassian.net/browse/RUMF-467)

### Change
- update the truncate function
- add ✅