### PR TITLE
🐛 prevent runtime error in static test files

### DIFF
--- a/test/static/async-e2e-page.html
+++ b/test/static/async-e2e-page.html
@@ -12,7 +12,7 @@
     <script type="text/javascript">
       window.addEventListener('load', () => {
         const intakeOrigin = `http://${window.location.hostname}:4000`
-        const specIdParam = /spec-id=\d+/.exec(window.location.search)[0]
+        const specIdParam = window.location.search ? /spec-id=\d+/.exec(window.location.search)[0] : ''
         const logs = document.createElement('script')
         logs.src = './datadog-logs-us.js'
         logs.onload = () => {

--- a/test/static/async-e2e-page.html
+++ b/test/static/async-e2e-page.html
@@ -12,7 +12,7 @@
     <script type="text/javascript">
       window.addEventListener('load', () => {
         const intakeOrigin = `http://${window.location.hostname}:4000`
-        const specIdParam = window.location.search ? /spec-id=\d+/.exec(window.location.search)[0] : ''
+        const specIdParam = /spec-id=\d+/.exec(window.location.search) && /spec-id=\d+/.exec(window.location.search)[0]
         const logs = document.createElement('script')
         logs.src = './datadog-logs-us.js'
         logs.onload = () => {

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="./datadog-logs-us.js"></script>
     <script type="text/javascript">
       const intakeOrigin = `http://${window.location.hostname}:4000`
-      const specIdParam = /spec-id=\d+/.exec(window.location.search)[0]
+      const specIdParam = window.location.search ? /spec-id=\d+/.exec(window.location.search)[0] : ''
       window.DD_LOGS &&
         window.DD_LOGS.init({
           clientToken: 'key',

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="./datadog-logs-us.js"></script>
     <script type="text/javascript">
       const intakeOrigin = `http://${window.location.hostname}:4000`
-      const specIdParam = window.location.search ? /spec-id=\d+/.exec(window.location.search)[0] : ''
+      const specIdParam = /spec-id=\d+/.exec(window.location.search) && /spec-id=\d+/.exec(window.location.search)[0]
       window.DD_LOGS &&
         window.DD_LOGS.init({
           clientToken: 'key',


### PR DESCRIPTION
Fix runtime error occurring in `async-e2e-page.html` and `bundle-e2e-page.html` static test files