### PR TITLE
✨[RUMF-465] collect client service, env and version

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -141,10 +141,9 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 function getEndpoint(type: string, conf: TransportConfiguration, source?: string) {
   const tld = conf.datacenter === 'us' ? 'com' : 'eu'
   const domain = conf.sdkEnv === 'production' ? `datadoghq.${tld}` : `datad0g.${tld}`
-  const tags = `sdk_version:${conf.sdkVersion}
-    ${conf.clientEnv ? `,env:${conf.clientEnv}` : ''}
-    ${conf.clientService ? `,service:${conf.clientService}` : ''}
-    ${conf.clientVersion ? `,version:${conf.clientVersion}` : ''}`
+  const tags = `sdk_version:${conf.sdkVersion}${conf.clientEnv ? `,env:${conf.clientEnv}` : ''}${
+    conf.clientService ? `,service:${conf.clientService}` : ''
+  }${conf.clientVersion ? `,version:${conf.clientVersion}` : ''}`
   const datadogHost = `${type}-http-intake.logs.${domain}`
   const host = conf.proxyHost ? conf.proxyHost : datadogHost
   const proxyParameter = conf.proxyHost ? `ddhost=${datadogHost}&` : ''

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -141,9 +141,11 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 function getEndpoint(type: string, conf: TransportConfiguration, source?: string) {
   const tld = conf.datacenter === 'us' ? 'com' : 'eu'
   const domain = conf.sdkEnv === 'production' ? `datadoghq.${tld}` : `datad0g.${tld}`
-  const tags = `sdk_version:${conf.sdkVersion}${conf.env ? `,env:${conf.env}` : ''}${
-    conf.service ? `,service:${conf.service}` : ''
-  }${conf.version ? `,version:${conf.version}` : ''}`
+  const tags =
+    `sdk_version:${conf.sdkVersion}` +
+    `${conf.env ? `,env:${conf.env}` : ''}` +
+    `${conf.service ? `,service:${conf.service}` : ''}` +
+    `${conf.version ? `,version:${conf.version}` : ''}`
   const datadogHost = `${type}-http-intake.logs.${domain}`
   const host = conf.proxyHost ? conf.proxyHost : datadogHost
   const proxyParameter = conf.proxyHost ? `ddhost=${datadogHost}&` : ''

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -45,14 +45,14 @@ export interface UserConfiguration {
   silentMultipleInit?: boolean
   proxyHost?: string
 
+  service?: string
+  env?: string
+  version?: string
+
   // Below is only taken into account for e2e-test build mode.
   internalMonitoringEndpoint?: string
   logsEndpoint?: string
   rumEndpoint?: string
-
-  clientService?: string
-  clientEnv?: string
-  clientVersion?: string
 }
 
 export type Configuration = typeof DEFAULT_CONFIGURATION & {
@@ -72,22 +72,22 @@ interface TransportConfiguration {
   sdkVersion: string
   proxyHost?: string
 
-  clientService?: string
-  clientEnv?: string
-  clientVersion?: string
+  service?: string
+  env?: string
+  version?: string
 }
 
 export function buildConfiguration(userConfiguration: UserConfiguration, buildEnv: BuildEnv): Configuration {
   const transportConfiguration: TransportConfiguration = {
     buildMode: buildEnv.buildMode,
-    clientEnv: userConfiguration.clientEnv,
-    clientService: userConfiguration.clientService,
     clientToken: userConfiguration.clientToken,
-    clientVersion: userConfiguration.clientVersion,
     datacenter: userConfiguration.datacenter || buildEnv.datacenter,
+    env: userConfiguration.env,
     proxyHost: userConfiguration.proxyHost,
     sdkEnv: buildEnv.sdkEnv,
     sdkVersion: buildEnv.sdkVersion,
+    service: userConfiguration.service,
+    version: userConfiguration.version,
   }
 
   const enableExperimentalFeatures = Array.isArray(userConfiguration.enableExperimentalFeatures)
@@ -141,9 +141,9 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 function getEndpoint(type: string, conf: TransportConfiguration, source?: string) {
   const tld = conf.datacenter === 'us' ? 'com' : 'eu'
   const domain = conf.sdkEnv === 'production' ? `datadoghq.${tld}` : `datad0g.${tld}`
-  const tags = `sdk_version:${conf.sdkVersion}${conf.clientEnv ? `,env:${conf.clientEnv}` : ''}${
-    conf.clientService ? `,service:${conf.clientService}` : ''
-  }${conf.clientVersion ? `,version:${conf.clientVersion}` : ''}`
+  const tags = `sdk_version:${conf.sdkVersion}${conf.env ? `,env:${conf.env}` : ''}${
+    conf.service ? `,service:${conf.service}` : ''
+  }${conf.version ? `,version:${conf.version}` : ''}`
   const datadogHost = `${type}-http-intake.logs.${domain}`
   const host = conf.proxyHost ? conf.proxyHost : datadogHost
   const proxyParameter = conf.proxyHost ? `ddhost=${datadogHost}&` : ''

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -28,7 +28,7 @@ export type BuildMode = 'release' | 'staging' | 'e2e-test'
 
 export interface BuildEnv {
   datacenter: Datacenter
-  env: Environment
+  sdkEnv: Environment
   buildMode: BuildMode
   sdkVersion: string
 }

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -81,8 +81,20 @@ describe('configuration', () => {
     })
   })
 
-  describe('env, version and service', () => {
-    it('should set the env, version and services tags in the logs and rum endpoints', () => {
+  describe('sdk_version, env, version and service', () => {
+    it('should not modify the logs and rum endpoints tags when not defined', () => {
+      const configuration = buildConfiguration({ clientToken }, prodEnv)
+      expect(configuration.rumEndpoint).toContain(`&ddtags=sdk_version:${prodEnv.sdkVersion}`)
+
+      expect(configuration.rumEndpoint).not.toContain(',env:')
+      expect(configuration.rumEndpoint).not.toContain(',service:')
+      expect(configuration.rumEndpoint).not.toContain(',version:')
+      expect(configuration.logsEndpoint).not.toContain(',env:')
+      expect(configuration.logsEndpoint).not.toContain(',service:')
+      expect(configuration.logsEndpoint).not.toContain(',version:')
+    })
+
+    it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = buildConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' }, prodEnv)
       expect(configuration.rumEndpoint).toContain(
         `&ddtags=sdk_version:${prodEnv.sdkVersion},env:foo,service:bar,version:baz`

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -5,7 +5,7 @@ describe('configuration', () => {
   const prodEnv = {
     buildMode: 'release' as 'release',
     datacenter: 'us' as 'us',
-    env: 'production' as 'production',
+    sdkEnv: 'production' as 'production',
     sdkVersion: 'some_version',
   }
 
@@ -36,7 +36,7 @@ describe('configuration', () => {
       const e2eEnv = {
         buildMode: 'e2e-test' as 'e2e-test',
         datacenter: 'us' as 'us',
-        env: 'staging' as 'staging',
+        sdkEnv: 'staging' as 'staging',
         sdkVersion: 'some_version',
       }
       const configuration = buildConfiguration(
@@ -78,6 +78,18 @@ describe('configuration', () => {
       const configuration = buildConfiguration({ clientToken, proxyHost: 'proxy.io' }, prodEnv)
       expect(configuration.rumEndpoint).toMatch(/^https:\/\/proxy\.io\//)
       expect(configuration.rumEndpoint).toContain('?ddhost=rum-http-intake.logs.datadoghq.com&')
+    })
+  })
+
+  describe('env, version and service', () => {
+    it('should set the env, version and services tags in the logs and rum endpoints', () => {
+      const configuration = buildConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' }, prodEnv)
+      expect(configuration.rumEndpoint).toContain(
+        `&ddtags=sdk_version:${prodEnv.sdkVersion},env:foo,service:bar,version:baz`
+      )
+      expect(configuration.logsEndpoint).toContain(
+        `&ddtags=sdk_version:${prodEnv.sdkVersion},env:foo,service:bar,version:baz`
+      )
     })
   })
 })

--- a/packages/logs/src/buildEnv.ts
+++ b/packages/logs/src/buildEnv.ts
@@ -3,6 +3,6 @@ import { BuildEnv, Datacenter, Environment } from '@datadog/browser-core'
 export const buildEnv: BuildEnv = {
   buildMode: '<<< BUILD_MODE >>>' as BuildEnv['buildMode'],
   datacenter: '<<< TARGET_DATACENTER >>>' as Datacenter,
-  env: '<<< TARGET_ENV >>>' as Environment,
+  sdkEnv: '<<< TARGET_ENV >>>' as Environment,
   sdkVersion: '<<< SDK_VERSION >>>',
 }

--- a/packages/rum/src/buildEnv.ts
+++ b/packages/rum/src/buildEnv.ts
@@ -3,6 +3,6 @@ import { BuildEnv } from '@datadog/browser-core'
 export const buildEnv: BuildEnv = {
   buildMode: '<<< BUILD_MODE >>>' as BuildEnv['buildMode'],
   datacenter: '<<< TARGET_DATACENTER >>>' as BuildEnv['datacenter'],
-  env: '<<< TARGET_ENV >>>' as BuildEnv['env'],
+  sdkEnv: '<<< TARGET_ENV >>>' as BuildEnv['sdkEnv'],
   sdkVersion: '<<< SDK_VERSION >>>',
 }


### PR DESCRIPTION
## Motivation
Allows users to configure optional fields that tag their RUM events and logs with a specific service, environment and version.

## Changes
New optional configuration options have been added to the log, rum init process. If define, these new fields will then create new tags for each of the logs and RUM events send to the intake.

## Testing
1. add the optional `clientService, clientEnv, clientVersion` fields to the `window.DD_RUM.init and window.DD_LOGS.init`
2. check in the network tab that the intake URL carries the new tags ex: `&ddtags=sdk_version:dev,env:envaaa,service:serviceaaa,version:versionaaa`
