### PR TITLE
👷[RUMF-453] remove IE10 from tested browsers

### DIFF
--- a/test/browsers.conf.js
+++ b/test/browsers.conf.js
@@ -47,11 +47,4 @@ module.exports = {
     os: 'Windows',
     os_version: '10',
   },
-  IE_10: {
-    base: 'BrowserStack',
-    browser: 'IE',
-    browser_version: '10.0',
-    os: 'Windows',
-    os_version: '7',
-  },
 }

--- a/test/unit/karma.bs.conf.js
+++ b/test/unit/karma.bs.conf.js
@@ -7,8 +7,6 @@ const { getBuildInfos, getIp } = require('../utils')
 // https://github.com/sinonjs/sinon/blob/894951c/package.json#L113
 karmaBaseConf.webpack.resolve.mainFields = ['cdn', 'main']
 
-const ONE_MINUTE = 60000
-
 module.exports = function(config) {
   config.set({
     ...karmaBaseConf,


### PR DESCRIPTION
## Motivation

Microsoft drop the support this year: https://betanews.com/2020/03/04/ends-ie10-support-windows-server-2012/

## Changes

Remove IE10 from tested browsers.
All polyfills are still used for IE11.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
