### PR TITLE
📝 [RUMF-465] add service, env, version to API docs

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -42,6 +42,9 @@ What we call `Context` is a map `{key: value}` that will be added to the message
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send logs.
   - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
+  - `service`: defined the service name
+  - `env`: defined the environment of the service
+  - `version`: defined the version of the service
 
   ```
   init(configuration: {
@@ -49,7 +52,10 @@ What we call `Context` is a map `{key: value}` that will be added to the message
       datacenter?: string,
       isCollectingError?: boolean,
       sampleRate?: number,
-      silentMultipleInit?: boolean
+      silentMultipleInit?: boolean,
+      service?: string,
+      env?: string,
+      version?: string,
   })
   ```
 

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -42,9 +42,9 @@ What we call `Context` is a map `{key: value}` that will be added to the message
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send logs.
   - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
-  - `service`: defined the service name
-  - `env`: defined the environment of the service
-  - `version`: defined the version of the service
+  - `service`: name of the corresponding service
+  - `env`: environment of the service
+  - `version`: version of the service
 
   ```
   init(configuration: {

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -40,6 +40,9 @@ datadogRum.init({
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
   - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
+  - `service`: defined the service name
+  - `env`: defined the environment of the service
+  - `version`: defined the version of the service
 
   ```
   init(configuration: {
@@ -48,7 +51,10 @@ datadogRum.init({
       datacenter?: string,
       resourceSampleRate?: number
       sampleRate?: number,
-      silentMultipleInit?: boolean
+      silentMultipleInit?: boolean,
+      service?: string,
+      env?: string,
+      version?: string,
   })
   ```
 

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -40,9 +40,9 @@ datadogRum.init({
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
   - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
-  - `service`: defined the service name
-  - `env`: defined the environment of the service
-  - `version`: defined the version of the service
+  - `service`: name of the corresponding service
+  - `env`: environment of the service
+  - `version`: version of the service
 
   ```
   init(configuration: {


### PR DESCRIPTION
## Motivation

Missing documentation for service, env, version in `init` API

## Changes

Add documentation

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
