### PR TITLE
✨ [RUMF-385] improve click action naming

### DIFF
--- a/packages/rum/src/getActionNameFromElement.ts
+++ b/packages/rum/src/getActionNameFromElement.ts
@@ -1,14 +1,14 @@
-export function getElementContent(element: Element): string {
+export function getActionNameFromElement(element: Element): string {
   return (
-    getElementContentForGetters(element, priorityGetters) || getElementContentForGetters(element, fallbackGetters) || ''
+    getActionNameFromElementForGetters(element, priorityGetters) ||
+    getActionNameFromElementForGetters(element, fallbackGetters) ||
+    ''
   )
 }
 
-type ContentGetter = (
-  element: Element | HTMLElement | HTMLInputElement | HTMLSelectElement
-) => string | undefined | null
+type NameGetter = (element: Element | HTMLElement | HTMLInputElement | HTMLSelectElement) => string | undefined | null
 
-const priorityGetters: ContentGetter[] = [
+const priorityGetters: NameGetter[] = [
   // associated LABEL text
   (element) => {
     // IE does not support element.labels, so we fallback to a CSS selector based on the element id
@@ -69,14 +69,14 @@ const priorityGetters: ContentGetter[] = [
   },
 ]
 
-const fallbackGetters: ContentGetter[] = [
+const fallbackGetters: NameGetter[] = [
   // element text
   (element) => {
     return getTextualContent(element)
   },
 ]
 
-function getElementContentForGetters(targetElement: Element, getters: ContentGetter[]) {
+function getActionNameFromElementForGetters(targetElement: Element, getters: NameGetter[]) {
   let element: Element | null = targetElement
   let recursionCounter = 0
   while (
@@ -87,11 +87,11 @@ function getElementContentForGetters(targetElement: Element, getters: ContentGet
     element.nodeName !== 'HEAD'
   ) {
     for (const getter of getters) {
-      const content = getter(element)
-      if (typeof content === 'string') {
-        const trimedContent = content.trim()
-        if (trimedContent) {
-          return truncate(normalizeWhitespace(trimedContent))
+      const name = getter(element)
+      if (typeof name === 'string') {
+        const trimedName = name.trim()
+        if (trimedName) {
+          return truncate(normalizeWhitespace(trimedName))
         }
       }
     }

--- a/packages/rum/src/getElementContent.ts
+++ b/packages/rum/src/getElementContent.ts
@@ -1,35 +1,176 @@
+export function getElementContent(element: Element): string {
+  return (
+    getElementContentForGetters(element, priorityGetters) || getElementContentForGetters(element, fallbackGetters) || ''
+  )
+}
+
+type ContentGetter = (
+  element: Element | HTMLElement | HTMLInputElement | HTMLSelectElement
+) => string | undefined | null
+
+const priorityGetters: ContentGetter[] = [
+  // associated LABEL text
+  (element) => {
+    // IE does not support element.labels, so we fallback to a CSS selector based on the element id
+    // instead
+    if (supportsLabelProperty()) {
+      if ('labels' in element && element.labels && element.labels.length > 0) {
+        return getTextualContent(element.labels[0])
+      }
+    } else if (element.id) {
+      const label =
+        element.ownerDocument && element.ownerDocument.querySelector(`label[for="${element.id.replace('"', '\\"')}"]`)
+      return label && getTextualContent(label)
+    }
+  },
+  // INPUT button (and associated) value
+  (element) => {
+    if (element.nodeName === 'INPUT') {
+      const input = element as HTMLInputElement
+      const type = input.getAttribute('type')
+      if (type === 'button' || type === 'submit' || type === 'reset') {
+        return input.value
+      }
+    }
+  },
+  // BUTTON, LABEL or button-like element text
+  (element) => {
+    if (element.nodeName === 'BUTTON' || element.nodeName === 'LABEL' || element.getAttribute('role') === 'button') {
+      return getTextualContent(element)
+    }
+  },
+  // aria-label attribute value
+  (element) => element.getAttribute('aria-label'),
+  // associated element text designated by the aria-labelledby attribute
+  (element) => {
+    const labelledByAttribute = element.getAttribute('aria-labelledby')
+    if (labelledByAttribute) {
+      return labelledByAttribute
+        .split(/\s+/)
+        .map((id) => getElementById(element, id))
+        .filter((label): label is HTMLElement => Boolean(label))
+        .map(getTextualContent)
+        .join(' ')
+    }
+  },
+  // alt attribute value
+  (element) => element.getAttribute('alt'),
+  // name attribute value
+  (element) => element.getAttribute('name'),
+  // title attribute value
+  (element) => element.getAttribute('title'),
+  // placeholder attribute value
+  (element) => element.getAttribute('placeholder'),
+  // SELECT first OPTION text
+  (element) => {
+    if ('options' in element && element.options.length > 0) {
+      return getTextualContent(element.options[0])
+    }
+  },
+]
+
+const fallbackGetters: ContentGetter[] = [
+  // element text
+  (element) => {
+    return getTextualContent(element)
+  },
+]
+
+function getElementContentForGetters(targetElement: Element, getters: ContentGetter[]) {
+  let element: Element | null = targetElement
+  let recursionCounter = 0
+  while (
+    recursionCounter <= 10 &&
+    element &&
+    element.nodeName !== 'BODY' &&
+    element.nodeName !== 'HTML' &&
+    element.nodeName !== 'HEAD'
+  ) {
+    for (const getter of getters) {
+      const content = getter(element)
+      if (typeof content === 'string') {
+        const trimedContent = content.trim()
+        if (trimedContent) {
+          return truncate(normalizeWhitespace(trimedContent))
+        }
+      }
+    }
+    // Don't consider parents of FORM elements
+    if (element.nodeName === 'FORM') {
+      break
+    }
+    element = element.parentElement
+    recursionCounter += 1
+  }
+}
+
+function normalizeWhitespace(s: string) {
+  return s.replace(/\s+/g, ' ')
+}
+
 function truncate(s: string) {
   return s.length > 100 ? `${s.slice(0, 100)} [...]` : s
 }
 
-const candidates: Array<(element: Element) => string | null> = [
-  (element) => element.textContent,
-  (element) => {
-    if (element.tagName === 'INPUT') {
-      const input = element as HTMLInputElement
-      const type = input.getAttribute('type')
-      if (type === 'button' || type === 'submit') {
-        return input.value
-      }
-    }
-    // tslint:disable-next-line no-null-keyword
-    return null
-  },
-  (element) => element.getAttribute('aria-label'),
-  (element) => element.getAttribute('alt'),
-  (element) => element.getAttribute('title'),
-  (element) => element.getAttribute('placeholder'),
-]
+function getElementById(refElement: Element, id: string) {
+  // tslint:disable-next-line: no-null-keyword
+  return refElement.ownerDocument ? refElement.ownerDocument.getElementById(id) : null
+}
 
-export function getElementContent(element: Element): string {
-  for (const candidate of candidates) {
-    const content = candidate(element)
-    if (typeof content === 'string') {
-      const trimedContent = content.trim()
-      if (trimedContent) {
-        return truncate(trimedContent)
+function getTextualContent(element: Element | HTMLElement) {
+  if ((element as HTMLElement).isContentEditable) {
+    return
+  }
+
+  if ('innerText' in element) {
+    let text = element.innerText
+    if (!supportsInnerTextScriptAndStyleRemoval()) {
+      // remove the inner text of SCRIPT and STYLES from the result. This is a bit dirty, but should
+      // be relatively fast and work in most cases.
+      const elementsToRemove: NodeListOf<HTMLElement> = element.querySelectorAll('script, style')
+      // tslint:disable-next-line: prefer-for-of
+      for (let i = 0; i < elementsToRemove.length; i += 1) {
+        const innerText = elementsToRemove[i].innerText
+        if (innerText.trim().length > 0) {
+          text = text.replace(innerText, '')
+        }
       }
     }
+    return text
   }
-  return element.parentElement ? getElementContent(element.parentElement) : ''
+
+  return element.textContent
+}
+
+/**
+ * Returns true if element.innerText excludes the text from inline SCRIPT and STYLE element.  This
+ * should be the case everywhere except on some version of Internet Explorer.
+ * See http://perfectionkills.com/the-poor-misunderstood-innerText/#diff-with-textContent
+ */
+let supportsInnerTextScriptAndStyleRemovalResult: boolean | undefined
+function supportsInnerTextScriptAndStyleRemoval() {
+  if (supportsInnerTextScriptAndStyleRemovalResult === undefined) {
+    const style = document.createElement('style')
+    style.textContent = '*'
+    const div = document.createElement('div')
+    div.appendChild(style)
+    document.body.appendChild(div)
+    supportsInnerTextScriptAndStyleRemovalResult = div.innerText === ''
+    document.body.removeChild(div)
+  }
+  return supportsInnerTextScriptAndStyleRemovalResult
+}
+
+/**
+ * Returns true if the browser supports the element.labels property.  This should be the case
+ * everywhere except on Internet Explorer.
+ * Note: The result is computed lazily, because we don't want any DOM access when the SDK is
+ * evaluated.
+ */
+let supportsLabelPropertyResult: boolean | undefined
+function supportsLabelProperty() {
+  if (supportsLabelPropertyResult === undefined) {
+    supportsLabelPropertyResult = 'labels' in HTMLInputElement.prototype
+  }
+  return supportsLabelPropertyResult
 }

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -1,5 +1,5 @@
 import { Context, DOM_EVENT, generateUUID } from '@datadog/browser-core'
-import { getElementContent } from './getElementContent'
+import { getActionNameFromElement } from './getActionNameFromElement'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { trackEventCounts } from './trackEventCounts'
 import { waitIdlePageActivity } from './trackPageActivities'
@@ -45,11 +45,11 @@ export function startUserActionCollection(lifeCycle: LifeCycle) {
     if (!(event.target instanceof Element)) {
       return
     }
-    const content = getElementContent(event.target)
-    if (!content) {
+    const name = getActionNameFromElement(event.target)
+    if (!name) {
       return
     }
-    newUserAction(lifeCycle, UserActionType.CLICK, content)
+    newUserAction(lifeCycle, UserActionType.CLICK, name)
   }
 
   // New views trigger the cancellation of the current pending User Action

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -45,7 +45,11 @@ export function startUserActionCollection(lifeCycle: LifeCycle) {
     if (!(event.target instanceof Element)) {
       return
     }
-    newUserAction(lifeCycle, UserActionType.CLICK, getElementContent(event.target))
+    const content = getElementContent(event.target)
+    if (!content) {
+      return
+    }
+    newUserAction(lifeCycle, UserActionType.CLICK, content)
   }
 
   // New views trigger the cancellation of the current pending User Action

--- a/packages/rum/test/getActionNameFromElement.spec.ts
+++ b/packages/rum/test/getActionNameFromElement.spec.ts
@@ -1,6 +1,6 @@
-import { getElementContent } from '../src/getElementContent'
+import { getActionNameFromElement } from '../src/getActionNameFromElement'
 
-describe('getElementContent', () => {
+describe('getActionNameFromElement', () => {
   const iframes: HTMLIFrameElement[] = []
 
   function element(s: TemplateStringsArray) {
@@ -23,41 +23,41 @@ describe('getElementContent', () => {
     iframes.length = 0
   })
 
-  it('extracts the text content of an element', () => {
-    expect(getElementContent(element`<div>Foo <div>bar</div></div>`)).toBe('Foo bar')
+  it('extracts the textual content of an element', () => {
+    expect(getActionNameFromElement(element`<div>Foo <div>bar</div></div>`)).toBe('Foo bar')
   })
 
   it('extracts the text of an input button', () => {
-    expect(getElementContent(element`<input type="button" value="Click" />`)).toBe('Click')
+    expect(getActionNameFromElement(element`<input type="button" value="Click" />`)).toBe('Click')
   })
 
   it('extracts the alt text of an image', () => {
-    expect(getElementContent(element`<img title="foo" alt="bar" />`)).toBe('bar')
+    expect(getActionNameFromElement(element`<img title="foo" alt="bar" />`)).toBe('bar')
   })
 
   it('extracts the title text of an image', () => {
-    expect(getElementContent(element`<img title="foo" />`)).toBe('foo')
+    expect(getActionNameFromElement(element`<img title="foo" />`)).toBe('foo')
   })
 
   it('extracts the text of an aria-label attribute', () => {
-    expect(getElementContent(element`<span aria-label="Foo" />`)).toBe('Foo')
+    expect(getActionNameFromElement(element`<span aria-label="Foo" />`)).toBe('Foo')
   })
 
-  it('gets the parent element content if everything else fails', () => {
-    expect(getElementContent(element`<div>Foo <img target /></div>`)).toBe('Foo')
+  it('gets the parent element textual content if everything else fails', () => {
+    expect(getActionNameFromElement(element`<div>Foo <img target /></div>`)).toBe('Foo')
   })
 
   it("doesn't get the value of a text input", () => {
-    expect(getElementContent(element`<input type="text" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(element`<input type="text" value="foo" />`)).toBe('')
   })
 
   it("doesn't get the value of a password input", () => {
-    expect(getElementContent(element`<input type="password" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(element`<input type="password" value="foo" />`)).toBe('')
   })
 
-  it('limits the content length to a reasonable size', () => {
+  it('limits the name length to a reasonable size', () => {
     expect(
-      getElementContent(
+      getActionNameFromElement(
         // tslint:disable-next-line max-line-length
         element`<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>`
       )
@@ -68,20 +68,20 @@ describe('getElementContent', () => {
   })
 
   it('normalize white spaces', () => {
-    expect(getElementContent(element`<div>foo\tbar\n\n  baz</div>`)).toBe('foo bar baz')
+    expect(getActionNameFromElement(element`<div>foo\tbar\n\n  baz</div>`)).toBe('foo bar baz')
   })
 
-  it('ignores the inline script content', () => {
-    expect(getElementContent(element`<div><script>console.log('toto')</script>b</div>`)).toBe('b')
+  it('ignores the inline script textual content', () => {
+    expect(getActionNameFromElement(element`<div><script>console.log('toto')</script>b</div>`)).toBe('b')
   })
 
   it('extracts text from SVG elements', () => {
-    expect(getElementContent(element`<svg><text>foo  bar</text></svg>`)).toBe('foo bar')
+    expect(getActionNameFromElement(element`<svg><text>foo  bar</text></svg>`)).toBe('foo bar')
   })
 
   it('extracts text from an associated label', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <label for="toto">label text</label>
           <div>ignored</div>
@@ -93,7 +93,7 @@ describe('getElementContent', () => {
 
   it('extracts text from a parent label', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <label>
           foo
           <div>
@@ -107,7 +107,7 @@ describe('getElementContent', () => {
 
   it('extracts text from the first OPTION element when clicking on a SELECT', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <select>
           <option>foo</option>
           <option>bar</option>
@@ -118,7 +118,7 @@ describe('getElementContent', () => {
 
   it('extracts text from a aria-labelledby associated element', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <label id="toto">label text</label>
           <div>ignored</div>
@@ -130,7 +130,7 @@ describe('getElementContent', () => {
 
   it('extracts text from multiple aria-labelledby associated elements', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <label id="toto1">label</label>
           <div>ignored</div>
@@ -144,7 +144,7 @@ describe('getElementContent', () => {
 
   it('extracts text from a BUTTON element', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <div>ignored</div>
           <button target>foo</button>
@@ -155,7 +155,7 @@ describe('getElementContent', () => {
 
   it('extracts text from a role=button element', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <div>ignored</div>
           <div role="button" target>foo</div>
@@ -166,7 +166,7 @@ describe('getElementContent', () => {
 
   it('limits the recursion to the 10th parent', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <div>ignored</div>
           <i><i><i><i><i><i><i><i><i><i>
@@ -179,7 +179,7 @@ describe('getElementContent', () => {
 
   it('limits the recursion to the BODY element', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>ignored</div>
         <i target></i>
       `)
@@ -188,7 +188,7 @@ describe('getElementContent', () => {
 
   it('limits the recursion to a FORM element', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <div>ignored</div>
           <form>
@@ -201,7 +201,7 @@ describe('getElementContent', () => {
 
   it('extracts the name from a parent FORM element', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div>
           <div>ignored</div>
           <form title="foo">
@@ -212,9 +212,9 @@ describe('getElementContent', () => {
     ).toBe('foo')
   })
 
-  it('extracts the whole content of a button', () => {
+  it('extracts the whole textual content of a button', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <button>
           foo
           <i target>bar</i>
@@ -223,9 +223,9 @@ describe('getElementContent', () => {
     ).toBe('foo bar')
   })
 
-  it('ignores the content of contenteditable elements', () => {
+  it('ignores the textual content of contenteditable elements', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div contenteditable>
           <i target>ignored</i>
           ignored
@@ -234,9 +234,9 @@ describe('getElementContent', () => {
     ).toBe('')
   })
 
-  it('extracts the content from attributes of contenteditable elements', () => {
+  it('extracts the name from attributes of contenteditable elements', () => {
     expect(
-      getElementContent(element`
+      getActionNameFromElement(element`
         <div contenteditable>
           <i aria-label="foo" target>ignored</i>
           ignored


### PR DESCRIPTION
## Motivation

Improve the name of click actions.

## Changes

* Improve the name extraction from elements by adding different strategies and adjusting priorities.
* Don't collect actions if a name cannot be found.

## Testing

This should be left on staging for a little while to verify that it does not break thing, and indeed improve the action names.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
