### PR TITLE
👷 [changelog] ensure to retrieve latest tags

### DIFF
--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -61,6 +61,7 @@ async function getEmojisLegend() {
 }
 
 async function getChangesList() {
+  await executeCommand('git fetch --tags')
   const lastTagHash = await executeCommand('git rev-list --tags --max-count=1')
   const lastTagName = await executeCommand(`git describe --tags ${lastTagHash}`)
 


### PR DESCRIPTION
## Motivation

Avoid commits already released when generating the changelog

## Changes

fecth tag from remote before retrieving commits

## Testing

issue reproduced locally with missing tags, let's see how it behaves in next release

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
