### PR TITLE
⚡️[RUMF-510] Improve sizeInByte calculation performance

### DIFF
--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -133,7 +133,7 @@ export class Batch<T> {
 
   private maxSizeInBytes(candidate: string) {
     // the candidate byte size, once URI encoded can be maximized by 4 time its length
-    // Using this maximized value prevent any costly calculation while checking the byte size requirement
+    // Using this maximized value prevent any costly calculation while validating the byte size requirement
     return candidate.length * 4
   }
 

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -2,7 +2,7 @@ import { monitor } from './internalMonitoring'
 import { Context, deepMerge, DOM_EVENT, jsonStringify, noop, objectValues } from './utils'
 
 // https://en.wikipedia.org/wiki/UTF-8
-const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/g
+const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/
 
 /**
  * Use POST request without content type to:
@@ -81,12 +81,7 @@ export class Batch<T> {
       return new TextEncoder().encode(candidate).length
     }
 
-    if (window.Blob !== undefined) {
-      return new Blob([candidate]).size
-    }
-
-    // tslint:disable-next-line no-bitwise
-    return ~-encodeURI(candidate).split(/%..|./).length
+    return new Blob([candidate]).size
   }
 
   private addOrUpdate(message: T, key?: string) {

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -1,4 +1,3 @@
-import { isIE } from '@datadog/browser-core'
 import { monitor } from './internalMonitoring'
 import { Context, deepMerge, DOM_EVENT, HAS_MULTI_BYTES_CHARACTERS, jsonStringify, noop, objectValues } from './utils'
 
@@ -75,11 +74,16 @@ export class Batch<T> {
       return candidate.length
     }
 
-    if (isIE()) {
+    if (window.TextDecoder !== undefined) {
+      return new TextEncoder().encode(candidate).length
+    }
+
+    if (window.Blob !== undefined) {
       return new Blob([candidate]).size
     }
 
-    return new TextEncoder().encode(candidate).length
+    // tslint:disable-next-line no-bitwise
+    return ~-encodeURI(candidate).split(/%..|./).length
   }
 
   private addOrUpdate(message: T, key?: string) {

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -74,7 +74,7 @@ export class Batch<T> {
       return candidate.length
     }
 
-    if (window.TextDecoder !== undefined) {
+    if (window.TextEncoder !== undefined) {
       return new TextEncoder().encode(candidate).length
     }
 

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -1,5 +1,8 @@
 import { monitor } from './internalMonitoring'
-import { Context, deepMerge, DOM_EVENT, HAS_MULTI_BYTES_CHARACTERS, jsonStringify, noop, objectValues } from './utils'
+import { Context, deepMerge, DOM_EVENT, jsonStringify, noop, objectValues } from './utils'
+
+// https://en.wikipedia.org/wiki/UTF-8
+const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/g
 
 /**
  * Use POST request without content type to:

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -35,7 +35,7 @@ export class Batch<T> {
   private upsertBuffer: { [key: string]: string } = {}
   private bufferBytesSize = 0
   private bufferMessageCount = 0
-  private biggerThanOneByteRegex = /([^\u0000-\u007F])/
+  private biggerThanOneByteRegex = /[^\u0000-\u007F]/g
 
   constructor(
     private request: HttpRequest,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,9 +5,6 @@ export const ONE_MINUTE = 60 * ONE_SECOND
 export const ONE_HOUR = 60 * ONE_MINUTE
 export const ONE_KILO_BYTE = 1024
 
-// https://en.wikipedia.org/wiki/UTF-8
-export const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/g
-
 export enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
   CLICK = 'click',

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,6 +5,7 @@ export const ONE_MINUTE = 60 * ONE_SECOND
 export const ONE_HOUR = 60 * ONE_MINUTE
 export const ONE_KILO_BYTE = 1024
 
+// https://en.wikipedia.org/wiki/UTF-8
 export const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/g
 
 export enum DOM_EVENT {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,6 +5,8 @@ export const ONE_MINUTE = 60 * ONE_SECOND
 export const ONE_HOUR = 60 * ONE_MINUTE
 export const ONE_KILO_BYTE = 1024
 
+export const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/g
+
 export enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
   CLICK = 'click',

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -122,17 +122,20 @@ describe('batch', () => {
   })
 
   it('should consider separator size when computing the size', () => {
-    batch.add({ message: '30 b' }) // batch: 30 sep: 0
-    batch.add({ message: '30 b' }) // batch: 60 sep: 1
-    batch.add({ message: '39 bytes - xx' }) // batch: 99 sep: 2
+    batch.add({ message: '67 bytes - 🪐🪐🪐' }) // batch: 67 sep: 0
+    batch.add({ message: '30 b' }) // batch: 97 sep: 1
+    batch.add({ message: '39 bytes - xx' }) // batch: 39 sep: 2
 
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"30 b"}\n{"foo":"bar","message":"30 b"}', 61)
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"foo":"bar","message":"67 bytes - 🪐🪐🪐"}\n{"foo":"bar","message":"30 b"}',
+      98
+    )
   })
 
   it('should call send one time when the size is too high and the batch is empty', () => {
-    const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    const message = '111 bytes - 🪐🪐xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     batch.add({ message })
-    expect(transport.send).toHaveBeenCalledWith(`{"foo":"bar","message":"${message}"}`, 101)
+    expect(transport.send).toHaveBeenCalledWith(`{"foo":"bar","message":"${message}"}`, 111)
   })
 
   it('should flush the batch and send the message when the message is too heavy', () => {

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -5,7 +5,7 @@ import { noop } from '../src/utils'
 
 describe('request', () => {
   const ENDPOINT_URL = 'http://my.website'
-  const BATCH_BYTES_LIMIT = 100
+  const BATCH_BYTES_LIMIT = 400
   let server: sinon.SinonFakeServer
   let request: HttpRequest
 
@@ -56,7 +56,7 @@ describe('request', () => {
 
 describe('batch', () => {
   const MAX_SIZE = 3
-  const BATCH_BYTES_LIMIT = 100
+  const BATCH_BYTES_LIMIT = 400
   const MESSAGE_BYTES_LIMIT = 50 * 1024
   let CONTEXT: { foo: string }
   const FLUSH_TIMEOUT = 60 * 1000
@@ -115,24 +115,27 @@ describe('batch', () => {
     expect(transport.send).not.toHaveBeenCalled()
 
     batch.add({ message: '60 bytes - xxxxxxxxxxxxxxxxxxxxxxx' })
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"50 bytes - xxxxxxxxxxxxx"}', 50)
+    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"50 bytes - xxxxxxxxxxxxx"}', 200)
 
     batch.flush()
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxx"}', 60)
+    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxx"}', 240)
   })
 
   it('should consider separator size when computing the size', () => {
-    batch.add({ message: '30 b' }) // batch: 30 sep: 0
-    batch.add({ message: '30 b' }) // batch: 60 sep: 1
-    batch.add({ message: '39 bytes - xx' }) // batch: 99 sep: 2
+    batch.add({ message: '39 bytes - xx' }) // batch: 156 (39*4) sep: 0
+    batch.add({ message: '60 bytes - xxxxxxxxxxxxxxxxxxxxxxx' }) // batch: 396 (39*4 + 60*4) sep: 1
+    batch.add({ message: '39 bytes - xx' }) // batch: 156 (39*4) sep: 2
 
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"30 b"}\n{"foo":"bar","message":"30 b"}', 61)
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"foo":"bar","message":"39 bytes - xx"}\n{"foo":"bar","message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxx"}',
+      397
+    )
   })
 
   it('should call send one time when the size is too high and the batch is empty', () => {
     const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     batch.add({ message })
-    expect(transport.send).toHaveBeenCalledWith(`{"foo":"bar","message":"${message}"}`, 101)
+    expect(transport.send).toHaveBeenCalledWith(`{"foo":"bar","message":"${message}"}`, 404)
   })
 
   it('should flush the batch and send the message when the message is too heavy', () => {


### PR DESCRIPTION
### What it does
Improve RUM and Log SDK performance when numerous console.error occur.

## Before
1000 console error loaded in 15000ms 
<img width="617" alt="Capture d’écran 2020-06-03 à 08 59 11" src="https://user-images.githubusercontent.com/6943103/83605654-91438000-a578-11ea-8980-bd96620c2455.png">

## After
1000 console error loaded in 7000ms 
<img width="617" alt="Capture d’écran 2020-06-03 à 09 01 51" src="https://user-images.githubusercontent.com/6943103/83605845-ed0e0900-a578-11ea-9904-0e20ffacea1d.png">

### Changes
- ⚡️ improve sizeInByte calculation
