### PR TITLE
✨ [RUMF-549] add an option to enable the user interaction tracking

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CONFIGURATION = {
   resourceSampleRate: 100,
   sampleRate: 100,
   silentMultipleInit: false,
+  trackInteractions: false,
 
   /**
    * arbitrary value, byte precision not needed
@@ -44,6 +45,7 @@ export interface UserConfiguration {
   datacenter?: Datacenter
   enableExperimentalFeatures?: string[]
   silentMultipleInit?: boolean
+  trackInteractions?: boolean
   proxyHost?: string
 
   service?: string
@@ -124,6 +126,10 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 
   if ('resourceSampleRate' in userConfiguration) {
     configuration.resourceSampleRate = userConfiguration.resourceSampleRate!
+  }
+
+  if ('trackInteractions' in userConfiguration) {
+    configuration.trackInteractions = !!userConfiguration.trackInteractions
   }
 
   if (transportConfiguration.buildMode === 'e2e-test') {

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -40,6 +40,7 @@ datadogRum.init({
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
   - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
+  - `trackInteractions`: collect actions initiated by user interactions
   - `service`: name of the corresponding service
   - `env`: environment of the service
   - `version`: version of the service
@@ -52,6 +53,7 @@ datadogRum.init({
       resourceSampleRate?: number
       sampleRate?: number,
       silentMultipleInit?: boolean,
+      trackInteractions?: boolean,
       service?: string,
       env?: string,
       version?: string,

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -77,7 +77,7 @@ datadogRum.init = monitor((userConfiguration: RumUserConfiguration) => {
   const [requestStartObservable, requestCompleteObservable] = startRequestCollection()
   startPerformanceCollection(lifeCycle, session)
   startDOMMutationCollection(lifeCycle)
-  if (configuration.isEnabled('collect-user-actions')) {
+  if (configuration.trackInteractions) {
     startUserActionCollection(lifeCycle)
   }
 

--- a/test/app/app.ts
+++ b/test/app/app.ts
@@ -18,8 +18,9 @@ datadogLogs.init({
 datadogRum.init({
   applicationId: 'rum',
   clientToken: 'key',
-  enableExperimentalFeatures: ['collect-user-actions'],
+  enableExperimentalFeatures: [],
   internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
   logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
   rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
+  trackInteractions: true,
 })

--- a/test/static/async-e2e-page.html
+++ b/test/static/async-e2e-page.html
@@ -37,7 +37,8 @@
               internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
               logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
               rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
-              enableExperimentalFeatures: ['collect-user-actions'],
+              enableExperimentalFeatures: [],
+              trackInteractions: true,
             })
         }
         document.getElementsByTagName('head')[0].appendChild(rum)

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -29,7 +29,8 @@
           internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
           logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
           rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
-          enableExperimentalFeatures: ['collect-user-actions'],
+          enableExperimentalFeatures: [],
+          trackInteractions: true,
         })
     </script>
   </head>


### PR DESCRIPTION
## Motivation

Let the user chose if they want to track user interactions. This replaces the 'collect-user-actions' FF.

## Changes

Add a `trackInteractions` flag for the RUM init options.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
