### PR TITLE
👷[codeowners] use rum-browser

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @Datadog/rum
+*   @Datadog/rum-browser


### PR DESCRIPTION
## Motivation

Stop using global @DataDog/rum team

## Changes

Use @DataDog/rum-browser instead


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
