### PR TITLE
👷[build] allow sideEffects optimization on core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "run-p build:cjs build:esm",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json",


### PR DESCRIPTION
## Motivation

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
core package should not contain side effect, a few functions can then be safely removed while building target files

## Changes

mark core package as side effect free

## Testing

automated tests

- rum: 44k -> 42k
- logs: 30k -> 29k

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
