### PR TITLE
[RUMF-559] debug undefined sessionId

### DIFF
--- a/packages/core/src/internalMonitoring.ts
+++ b/packages/core/src/internalMonitoring.ts
@@ -93,10 +93,11 @@ export function monitor<T extends Function>(fn: T): T {
   } as unknown) as T // consider output type has input type
 }
 
-export function addMonitoringMessage(message: string) {
+export function addMonitoringMessage(message: string, context?: utils.Context) {
   logMessageIfDebug(message)
   addToMonitoringBatch({
     message,
+    ...context,
     status: StatusType.info,
   })
 }


### PR DESCRIPTION
## Motivation

Investigate event without sessionId

## Changes

Add internal log when detecting one


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
