### PR TITLE
[RUM] Customize error collection

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -44,6 +44,9 @@ datadogRum.init({
   - `service`: name of the corresponding service
   - `env`: environment of the service
   - `version`: version of the service
+  - `isCollectingError`: if RUM should collect errors. Default is `true`
+  - `collectErrorMessage`: when collecting errors, if RUM should collect error message. Default is `true`. Depends on `isCollectingError`.
+  - `collectErrorStack`: when collecting errors, if RUM should collect error stack trace. Default is `true`. Depends on `isCollectingError`.
 
   ```
   init(configuration: {
@@ -57,6 +60,9 @@ datadogRum.init({
       service?: string,
       env?: string,
       version?: string,
+      isCollectingError?: boolean,
+      collectErrorMessage?: boolean,
+      collectErrorStack?: boolean
   })
   ```
 

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -26,8 +26,10 @@ import { startViewCollection } from './viewCollection'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string,
-  collectErrorMessage?: boolean, //default behavior as if true
-  collectErrorStack?: boolean, //default behavior as if true
+  //default behavior as if true
+  collectErrorMessage?: boolean,
+  collectErrorStack?: boolean,
+  isCollectingError?: boolean
 }
 
 export interface InternalContext {
@@ -69,7 +71,7 @@ datadogRum.init = monitor((userConfiguration: RumUserConfiguration) => {
   if (userConfiguration.publicApiKey) {
     userConfiguration.clientToken = userConfiguration.publicApiKey
   }
-  const rumUserConfiguration = { ...userConfiguration, isCollectingError: true }
+  const rumUserConfiguration = { isCollectingError: true, ...userConfiguration }
   const lifeCycle = new LifeCycle()
 
   const { errorObservable, configuration, internalMonitoring } = commonInit(rumUserConfiguration, buildEnv)


### PR DESCRIPTION
## Motivation
Hello! As my organization begins to explore adopting Datadog RUM, we're realizing that we'd like to be able to better configure some of the data that is being sent to Datadog. In this PR, I expose `collectErrorMessage`, `collectErrorStack`, && `isCollectingError` as options when configuring the client. In our experience, PII can sometimes be surfaced in error messages and error stack traces, so we'd like to avoid collecting that. If other organizations want to eliminate error collection completely, they have the option of configuring `isCollectingError` to be `false`.

I'm also curious if there are any other recommended approaches for a similar result?  

## Changes

- Expose `collectErrorMessage`, `collectErrorStack`, `isCollectingError` as optional arguments to fine tune the error collection. 
- This change is backwards compatible. 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

`isCollectingError` is covered by tests in the core lib since it's already an exposed arg in the log lib. I'm happy to add a few more tests as well, but want to focus on soliciting feedback re: if the idea itself is something that's worth entertaining and can be merged. 

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
