### PR TITLE
🐛[RUMF-559] prevent event without sessionId

### DIFF
--- a/packages/core/test/sessionManagement.spec.ts
+++ b/packages/core/test/sessionManagement.spec.ts
@@ -198,6 +198,22 @@ describe('startSessionManagement', () => {
       expectSessionIdToBeDefined(session)
       expectTrackingTypeToBe(session, FIRST_PRODUCT_KEY, FakeTrackingType.TRACKED)
     })
+
+    it('should not renew on visibility after expiration', () => {
+      const session = startSessionManagement(FIRST_PRODUCT_KEY, () => ({
+        isTracked: true,
+        trackingType: FakeTrackingType.TRACKED,
+      }))
+      const renewSessionSpy = jasmine.createSpy()
+      session.renewObservable.subscribe(renewSessionSpy)
+
+      expireSession()
+
+      jasmine.clock().tick(VISIBILITY_CHECK_DELAY)
+
+      expect(renewSessionSpy).not.toHaveBeenCalled()
+      expectSessionIdToNotBeDefined(session)
+    })
   })
 
   describe('multiple startSessionManagement calls', () => {

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -56,7 +56,7 @@ export interface TestIO {
 
 export function setup(): TestSetupBuilder {
   let session = {
-    getId: () => undefined as string | undefined,
+    getId: () => '1234' as string | undefined,
     isTracked: () => true,
     isTrackedWithResource: () => true,
   }


### PR DESCRIPTION
## Motivation

Some events are sent to the intake without a session id.

Scenario to reproduce:

- sdk initialized with a session not tracked on two different tabs
- session expiration
- one tab renew the session in a tracked state
- generate some events on the second tab without interacting with it

then the second tab still considers to be on the last view of the first session, so `viewContext.sessionId = undefined`.
Events can be added to the batch because `session.isTracked() = true` due to the value of the cookie.

No matter what is the visibility state of the second tab, we don't want to create a new view and  collect the associated events before any real user action on this tab.

## Changes

Ensure that `viewContext.sessionId` is defined to allow events to be added to the batch.


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
