### PR TITLE
👷[RUMF-528] allow dual shipping in staging

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -53,7 +53,7 @@ export interface UserConfiguration {
   version?: string
 
   // only on staging build mode
-  slave?: SlaveUserConfiguration
+  replica?: ReplicaUserConfiguration
 
   // only on e2e-test build mode
   internalMonitoringEndpoint?: string
@@ -61,7 +61,7 @@ export interface UserConfiguration {
   rumEndpoint?: string
 }
 
-interface SlaveUserConfiguration {
+interface ReplicaUserConfiguration {
   applicationId?: string
   clientToken: string
 }
@@ -75,10 +75,10 @@ export type Configuration = typeof DEFAULT_CONFIGURATION & {
   isEnabled: (feature: string) => boolean
 
   // only on staging build mode
-  slave?: SlaveConfiguration
+  replica?: ReplicaConfiguration
 }
 
-interface SlaveConfiguration {
+interface ReplicaConfiguration {
   applicationId?: string
   logsEndpoint: string
   rumEndpoint: string
@@ -163,22 +163,22 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
   }
 
   if (transportConfiguration.buildMode === BuildMode.STAGING) {
-    if (userConfiguration.slave !== undefined) {
-      const slaveTransportConfiguration = {
+    if (userConfiguration.replica !== undefined) {
+      const replicaTransportConfiguration = {
         ...transportConfiguration,
-        applicationId: userConfiguration.slave.applicationId,
-        clientToken: userConfiguration.slave.clientToken,
+        applicationId: userConfiguration.replica.applicationId,
+        clientToken: userConfiguration.replica.clientToken,
         sdkEnv: SdkEnv.PRODUCTION,
       }
-      configuration.slave = {
-        applicationId: userConfiguration.slave.applicationId,
+      configuration.replica = {
+        applicationId: userConfiguration.replica.applicationId,
         internalMonitoringEndpoint: getEndpoint(
           'browser',
-          slaveTransportConfiguration,
+          replicaTransportConfiguration,
           'browser-agent-internal-monitoring'
         ),
-        logsEndpoint: getEndpoint('browser', slaveTransportConfiguration),
-        rumEndpoint: getEndpoint('rum', slaveTransportConfiguration),
+        logsEndpoint: getEndpoint('browser', replicaTransportConfiguration),
+        rumEndpoint: getEndpoint('rum', replicaTransportConfiguration),
       }
     }
   }

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -1,4 +1,4 @@
-import { BuildEnv, BuildMode, Datacenter, Environment } from './init'
+import { BuildEnv, BuildMode, Datacenter, SdkEnv } from './init'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from './utils'
 
 export const DEFAULT_CONFIGURATION = {
@@ -88,7 +88,7 @@ interface SlaveConfiguration {
 interface TransportConfiguration {
   clientToken: string
   datacenter: Datacenter
-  sdkEnv: Environment
+  sdkEnv: SdkEnv
   buildMode: BuildMode
   sdkVersion: string
   applicationId?: string
@@ -150,7 +150,7 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
     configuration.trackInteractions = !!userConfiguration.trackInteractions
   }
 
-  if (transportConfiguration.buildMode === 'e2e-test') {
+  if (transportConfiguration.buildMode === BuildMode.E2E_TEST) {
     if (userConfiguration.internalMonitoringEndpoint !== undefined) {
       configuration.internalMonitoringEndpoint = userConfiguration.internalMonitoringEndpoint
     }
@@ -162,13 +162,13 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
     }
   }
 
-  if (transportConfiguration.buildMode === 'staging') {
+  if (transportConfiguration.buildMode === BuildMode.STAGING) {
     if (userConfiguration.slave !== undefined) {
       const slaveTransportConfiguration = {
         ...transportConfiguration,
         applicationId: userConfiguration.slave.applicationId,
         clientToken: userConfiguration.slave.clientToken,
-        sdkEnv: 'production' as Environment,
+        sdkEnv: SdkEnv.PRODUCTION,
       }
       configuration.slave = {
         applicationId: userConfiguration.slave.applicationId,
@@ -187,8 +187,8 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 }
 
 function getEndpoint(type: string, conf: TransportConfiguration, source?: string) {
-  const tld = conf.datacenter === 'us' ? 'com' : 'eu'
-  const domain = conf.sdkEnv === 'production' ? `datadoghq.${tld}` : `datad0g.${tld}`
+  const tld = conf.datacenter === Datacenter.US ? 'com' : 'eu'
+  const domain = conf.sdkEnv === SdkEnv.PRODUCTION ? `datadoghq.${tld}` : `datad0g.${tld}`
   const tags =
     `sdk_version:${conf.sdkVersion}` +
     `${conf.env ? `,env:${conf.env}` : ''}` +

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,9 @@ export { DEFAULT_CONFIGURATION, Configuration, UserConfiguration } from './confi
 export { ErrorMessage, ErrorContext, HttpContext, ErrorOrigin, ErrorObservable } from './errorCollection'
 export {
   BuildEnv,
+  BuildMode,
   Datacenter,
-  Environment,
+  SdkEnv,
   makeStub,
   makeGlobal,
   commonInit,

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -22,13 +22,23 @@ export function makeGlobal<T>(stub: T): T {
   return global
 }
 
-export type Datacenter = 'eu' | 'us'
-export type Environment = 'production' | 'staging'
-export type BuildMode = 'release' | 'staging' | 'e2e-test'
+export enum Datacenter {
+  US = 'us',
+  EU = 'eu',
+}
+export enum SdkEnv {
+  PRODUCTION = 'production',
+  STAGING = 'staging',
+}
+export enum BuildMode {
+  RELEASE = 'release',
+  STAGING = 'staging',
+  E2E_TEST = 'e2e-test',
+}
 
 export interface BuildEnv {
   datacenter: Datacenter
-  sdkEnv: Environment
+  sdkEnv: SdkEnv
   buildMode: BuildMode
   sdkVersion: string
 }

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -1,11 +1,12 @@
+import { BuildMode, Datacenter, SdkEnv } from '../src'
 import { buildConfiguration } from '../src/configuration'
 
 describe('configuration', () => {
   const clientToken = 'some_client_token'
   const prodEnv = {
-    buildMode: 'release' as 'release',
-    datacenter: 'us' as 'us',
-    sdkEnv: 'production' as 'production',
+    buildMode: BuildMode.RELEASE,
+    datacenter: Datacenter.US,
+    sdkEnv: SdkEnv.PRODUCTION,
     sdkVersion: 'some_version',
   }
 
@@ -34,9 +35,9 @@ describe('configuration', () => {
     it('should be available for e2e-test build mode', () => {
       const endpoint = 'bbbbbbbbbbbbbbb'
       const e2eEnv = {
-        buildMode: 'e2e-test' as 'e2e-test',
-        datacenter: 'us' as 'us',
-        sdkEnv: 'staging' as 'staging',
+        buildMode: BuildMode.E2E_TEST,
+        datacenter: Datacenter.US,
+        sdkEnv: SdkEnv.STAGING,
         sdkVersion: 'some_version',
       }
       const configuration = buildConfiguration(
@@ -68,7 +69,7 @@ describe('configuration', () => {
     })
 
     it('should use user value when set', () => {
-      const configuration = buildConfiguration({ clientToken, datacenter: 'eu' }, prodEnv)
+      const configuration = buildConfiguration({ clientToken, datacenter: Datacenter.EU }, prodEnv)
       expect(configuration.rumEndpoint).toContain('datadoghq.eu')
     })
   })

--- a/packages/logs/src/buildEnv.ts
+++ b/packages/logs/src/buildEnv.ts
@@ -1,8 +1,8 @@
-import { BuildEnv, Datacenter, Environment } from '@datadog/browser-core'
+import { BuildEnv, BuildMode, Datacenter, SdkEnv } from '@datadog/browser-core'
 
 export const buildEnv: BuildEnv = {
-  buildMode: '<<< BUILD_MODE >>>' as BuildEnv['buildMode'],
+  buildMode: '<<< BUILD_MODE >>>' as BuildMode,
   datacenter: '<<< TARGET_DATACENTER >>>' as Datacenter,
-  sdkEnv: '<<< TARGET_ENV >>>' as Environment,
+  sdkEnv: '<<< TARGET_ENV >>>' as SdkEnv,
   sdkVersion: '<<< SDK_VERSION >>>',
 }

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -65,26 +65,7 @@ export function startLogger(
     () => deepMerge({ session_id: session.getId() }, globalContext, getRUMInternalContext() as Context) as Context
   )
 
-  const batch = new Batch<LogsMessage>(
-    new HttpRequest(configuration.logsEndpoint, configuration.batchBytesLimit),
-    configuration.maxBatchSize,
-    configuration.batchBytesLimit,
-    configuration.maxMessageSize,
-    configuration.flushTimeout,
-    () =>
-      deepMerge(
-        {
-          date: new Date().getTime(),
-          session_id: session.getId(),
-          view: {
-            referrer: document.referrer,
-            url: window.location.href,
-          },
-        },
-        globalContext,
-        getRUMInternalContext() as Context
-      ) as Context
-  )
+  const batch = startLoggerBatch(configuration, session, () => globalContext)
   const handlers = {
     [HandlerType.console]: (message: LogsMessage) => console.log(`${message.status}: ${message.message}`),
     [HandlerType.http]: (message: LogsMessage) => batch.add(message),
@@ -107,6 +88,48 @@ export function startLogger(
   globalApi.getLogger = getLogger
   globalApi.logger = logger
   return globalApi
+}
+
+function startLoggerBatch(configuration: Configuration, session: LoggerSession, globalContextProvider: () => Context) {
+  const masterBatch = createLoggerBatch(configuration.logsEndpoint)
+
+  let slaveBatch: Batch<LogsMessage>
+  if (configuration.slave !== undefined) {
+    slaveBatch = createLoggerBatch(configuration.slave.logsEndpoint)
+  } else {
+    slaveBatch = ({
+      add: noop,
+    } as unknown) as Batch<LogsMessage>
+  }
+
+  function createLoggerBatch(endpointUrl: string) {
+    return new Batch<LogsMessage>(
+      new HttpRequest(endpointUrl, configuration.batchBytesLimit),
+      configuration.maxBatchSize,
+      configuration.batchBytesLimit,
+      configuration.maxMessageSize,
+      configuration.flushTimeout,
+      () =>
+        deepMerge(
+          {
+            date: new Date().getTime(),
+            session_id: session.getId(),
+            view: {
+              referrer: document.referrer,
+              url: window.location.href,
+            },
+          },
+          globalContextProvider(),
+          getRUMInternalContext() as Context
+        ) as Context
+    )
+  }
+  return {
+    add(message: LogsMessage) {
+      masterBatch.add(message)
+      slaveBatch.add(message)
+    },
+  }
 }
 
 let customLoggers: { [name: string]: Logger }


### PR DESCRIPTION
## Motivation

Allow to analyze staging events in prod environment

## Changes

**Constraint**
For RUM, we need to have different application id when sending events.

**Strategy**
For each event source (rum, logs, internal monitoring), instantiate a primary and a replica batch. Each event is added to both.

**Extra configuration**
```
{
  replica?: {
    applicationId?: string
    clientToken: string
  }
}
```

## Testing

Manual test

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
