### PR TITLE
Classify favicons (and icons in general) as resources of image kind

### DIFF
--- a/packages/rum/src/resourceUtils.ts
+++ b/packages/rum/src/resourceUtils.ts
@@ -23,7 +23,7 @@ const RESOURCE_TYPES: Array<[ResourceKind, (initiatorType: string, path: string)
   [
     ResourceKind.IMAGE,
     (initiatorType: string, path: string) =>
-      includes(['image', 'img', 'icon'], initiatorType) || path.match(/\.(gif|jpg|jpeg|tiff|png|svg)$/i) !== null,
+      includes(['image', 'img', 'icon'], initiatorType) || path.match(/\.(gif|jpg|jpeg|tiff|png|svg|ico)$/i) !== null,
   ],
   [ResourceKind.FONT, (_: string, path: string) => path.match(/\.(woff|eot|woff2|ttf)$/i) !== null],
   [


### PR DESCRIPTION
## Motivation

I've notice favicon and other .ico files are not classified as images.

## Changes

Add `ico` to the list of file extensions considered for resources of image kind.

## Testing

Using a local built of this SDK classifies .ico files properly.