### PR TITLE
✨[RUMF-594] specify same site attribute on cookies

### DIFF
--- a/packages/core/src/cookie.ts
+++ b/packages/core/src/cookie.ts
@@ -39,7 +39,7 @@ export function setCookie(name: string, value: string, expireDelay: number) {
   const date = new Date()
   date.setTime(date.getTime() + expireDelay)
   const expires = `expires=${date.toUTCString()}`
-  document.cookie = `${name}=${value};${expires};path=/`
+  document.cookie = `${name}=${value};${expires};path=/;samesite=strict`
 }
 
 export function getCookie(name: string) {

--- a/packages/core/src/specHelper.ts
+++ b/packages/core/src/specHelper.ts
@@ -23,7 +23,7 @@ export function isIE() {
 
 export function clearAllCookies() {
   document.cookie.split(';').forEach((c) => {
-    document.cookie = c.replace(/=.*/, `=;expires=${new Date().toUTCString()};path=/`)
+    document.cookie = c.replace(/=.*/, `=;expires=${new Date().toUTCString()};path=/;samesite=strict`)
   })
 }
 

--- a/test/e2e/scenario/helpers.ts
+++ b/test/e2e/scenario/helpers.ts
@@ -152,7 +152,7 @@ async function deleteAllCookies() {
     for (const cookie of cookies) {
       const eqPos = cookie.indexOf('=')
       const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie
-      document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`
+      document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;samesite=strict`
     }
   })
 }


### PR DESCRIPTION
## Motivation

Firefox has started to display a warning for all used cookies that don't specify a same site attribute.
Let's specify one to get rid of it.
fixes #430 

## Changes

Specify `samesite=strict` on all our cookies updates, we don't need to pass cookies to server requests, so let's use the more restrictive option.
cf https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#Write_a_new_cookie

## Testing

Tested in dev, warning has disappeared in firefox.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
