### PR TITLE
🐛 use Datacenter enum in setup doc

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -9,10 +9,11 @@ Datadog browser logs library.
 ### NPM
 
 ```
+import { Datacenter } from '@datadog/browser-core'
 import { datadogLogs } from '@datadog/browser-logs'
 datadogLogs.init({
   clientToken: 'XXX',
-  datacenter: 'us',
+  datacenter: Datacenter.US,
   forwardErrorsToLogs: true,
   sampleRate: 100
 })

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -7,11 +7,12 @@ Datadog browser rum library.
 ### NPM
 
 ```
+import { Datacenter } from '@datadog/browser-core'
 import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: 'XXX',
   clientToken: 'XXX',
-  datacenter: 'us',
+  datacenter: Datacenter.US,
   resourceSampleRate: 100,
   sampleRate: 100
 })


### PR DESCRIPTION
## Motivation

Datacenter values are now exposed in an enum.
In a typescript setup, it is required to use it to avoid compilation issues.
fix #434 

## Changes

Update setup instructions to retrieve Datacenter enum.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
