### PR TITLE
✨[RUMF-609] export Datacenter enum from logs and rum

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -9,8 +9,7 @@ Datadog browser logs library.
 ### NPM
 
 ```
-import { Datacenter } from '@datadog/browser-core'
-import { datadogLogs } from '@datadog/browser-logs'
+import { Datacenter, datadogLogs } from '@datadog/browser-logs'
 datadogLogs.init({
   clientToken: 'XXX',
   datacenter: Datacenter.US,

--- a/packages/logs/src/index.ts
+++ b/packages/logs/src/index.ts
@@ -1,2 +1,3 @@
+export { Datacenter } from '@datadog/browser-core'
 export { StatusType, HandlerType, LoggerConfiguration, Logger, LogsMessage } from './logger'
 export { LogsUserConfiguration, Status, LogsGlobal, datadogLogs } from './logs.entry'

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -7,8 +7,7 @@ Datadog browser rum library.
 ### NPM
 
 ```
-import { Datacenter } from '@datadog/browser-core'
-import { datadogRum } from '@datadog/browser-rum'
+import { Datacenter, datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: 'XXX',
   clientToken: 'XXX',

--- a/packages/rum/src/index.ts
+++ b/packages/rum/src/index.ts
@@ -1,2 +1,3 @@
+export { Datacenter } from '@datadog/browser-core'
 export { RumUserConfiguration, RumGlobal, datadogRum, InternalContext } from './rum.entry'
 export { RumEventCategory, RumEvent, RumResourceEvent, RumViewEvent, RumUserActionEvent } from './rum'


### PR DESCRIPTION
## Motivation

Avoid to add browser-core in dependencies

## Changes

export Datacenter enum from logs and rum


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
