### PR TITLE
✨[RUMF-603] Introduce and use new lifecycle events

### DIFF
--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -5,8 +5,11 @@ import { View } from './viewCollection'
 export enum LifeCycleEventType {
   ERROR_COLLECTED,
   PERFORMANCE_ENTRY_COLLECTED,
-  USER_ACTION_COLLECTED,
-  VIEW_COLLECTED,
+  ACTION_CREATED,
+  ACTION_COMPLETED,
+  ACTION_DISCARDED,
+  VIEW_CREATED,
+  VIEW_UPDATED,
   REQUEST_STARTED,
   REQUEST_COMPLETED,
   SESSION_RENEWED,
@@ -26,14 +29,17 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, data: PerformanceEntry): void
   notify(eventType: LifeCycleEventType.REQUEST_STARTED, data: RequestStartEvent): void
   notify(eventType: LifeCycleEventType.REQUEST_COMPLETED, data: RequestCompleteEvent): void
-  notify(eventType: LifeCycleEventType.USER_ACTION_COLLECTED, data: UserAction): void
-  notify(eventType: LifeCycleEventType.VIEW_COLLECTED, data: View): void
+  notify(eventType: LifeCycleEventType.ACTION_COMPLETED, data: UserAction): void
+  notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: View): void
   notify(
     eventType:
       | LifeCycleEventType.SESSION_RENEWED
       | LifeCycleEventType.RESOURCE_ADDED_TO_BATCH
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
+      | LifeCycleEventType.ACTION_CREATED
+      | LifeCycleEventType.ACTION_DISCARDED
+      | LifeCycleEventType.VIEW_CREATED
   ): void
   notify(eventType: LifeCycleEventType, data?: any) {
     const eventCallbacks = this.callbacks[eventType]
@@ -52,14 +58,17 @@ export class LifeCycle {
     eventType: LifeCycleEventType.REQUEST_COMPLETED,
     callback: (data: RequestCompleteEvent) => void
   ): Subscription
-  subscribe(eventType: LifeCycleEventType.USER_ACTION_COLLECTED, callback: (data: UserAction) => void): Subscription
-  subscribe(eventType: LifeCycleEventType.VIEW_COLLECTED, callback: (data: View) => void): Subscription
+  subscribe(eventType: LifeCycleEventType.ACTION_COMPLETED, callback: (data: UserAction) => void): Subscription
+  subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription
   subscribe(
     eventType:
       | LifeCycleEventType.SESSION_RENEWED
       | LifeCycleEventType.RESOURCE_ADDED_TO_BATCH
       | LifeCycleEventType.DOM_MUTATED
-      | LifeCycleEventType.BEFORE_UNLOAD,
+      | LifeCycleEventType.BEFORE_UNLOAD
+      | LifeCycleEventType.ACTION_CREATED
+      | LifeCycleEventType.ACTION_DISCARDED
+      | LifeCycleEventType.VIEW_CREATED,
     callback: () => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType, callback: (data?: any) => void) {

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,6 +1,6 @@
 import { ErrorMessage, RequestCompleteEvent, RequestStartEvent } from '@datadog/browser-core'
 import { UserAction } from './userActionCollection'
-import { View } from './viewCollection'
+import { View, ViewContext } from './viewCollection'
 
 export enum LifeCycleEventType {
   ERROR_COLLECTED,
@@ -30,6 +30,7 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.REQUEST_STARTED, data: RequestStartEvent): void
   notify(eventType: LifeCycleEventType.REQUEST_COMPLETED, data: RequestCompleteEvent): void
   notify(eventType: LifeCycleEventType.ACTION_COMPLETED, data: UserAction): void
+  notify(eventType: LifeCycleEventType.VIEW_CREATED, data: ViewContext): void
   notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: View): void
   notify(
     eventType:
@@ -59,6 +60,7 @@ export class LifeCycle {
     callback: (data: RequestCompleteEvent) => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType.ACTION_COMPLETED, callback: (data: UserAction) => void): Subscription
+  subscribe(eventType: LifeCycleEventType.VIEW_CREATED, callback: (data: ViewContext) => void): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription
   subscribe(
     eventType:
@@ -67,8 +69,7 @@ export class LifeCycle {
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.ACTION_CREATED
-      | LifeCycleEventType.ACTION_DISCARDED
-      | LifeCycleEventType.VIEW_CREATED,
+      | LifeCycleEventType.ACTION_DISCARDED,
     callback: () => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType, callback: (data?: any) => void) {

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -201,7 +201,7 @@ export function startRum(
       globalContext[key] = value
     }),
     addUserAction: monitor((name: string, context?: Context) => {
-      lifeCycle.notify(LifeCycleEventType.USER_ACTION_COLLECTED, { context, name, type: UserActionType.CUSTOM })
+      lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, { context, name, type: UserActionType.CUSTOM })
     }),
     getInternalContext: monitor(
       (): InternalContext => {
@@ -282,7 +282,7 @@ function startRumBatch(
 }
 
 function trackView(lifeCycle: LifeCycle, upsertRumEvent: (event: RumViewEvent, key: string) => void) {
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_COLLECTED, (view) => {
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, (view) => {
     upsertRumEvent(
       {
         date: getTimestamp(view.startTime),
@@ -322,7 +322,7 @@ function trackCustomUserAction(
   lifeCycle: LifeCycle,
   addRumEvent: (event: RumUserActionEvent, context?: Context) => void
 ) {
-  lifeCycle.subscribe(LifeCycleEventType.USER_ACTION_COLLECTED, (userAction) => {
+  lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, (userAction) => {
     if (userAction.type === UserActionType.CUSTOM) {
       addRumEvent(
         {
@@ -341,7 +341,7 @@ function trackCustomUserAction(
 }
 
 function trackAutoUserAction(lifeCycle: LifeCycle, addRumEvent: (event: RumUserActionEvent) => void) {
-  lifeCycle.subscribe(LifeCycleEventType.USER_ACTION_COLLECTED, (userAction) => {
+  lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, (userAction) => {
     if (userAction.type !== UserActionType.CUSTOM) {
       addRumEvent({
         date: getTimestamp(userAction.startTime),

--- a/packages/rum/src/trackEventCounts.ts
+++ b/packages/rum/src/trackEventCounts.ts
@@ -24,7 +24,7 @@ export function trackEventCounts(lifeCycle: LifeCycle, callback: (eventCounts: E
     })
   )
   subscriptions.push(
-    lifeCycle.subscribe(LifeCycleEventType.USER_ACTION_COLLECTED, () => {
+    lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, () => {
       eventCounts.userActionCount += 1
       callback(eventCounts)
     })

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -53,7 +53,7 @@ export function startUserActionCollection(lifeCycle: LifeCycle) {
   }
 
   // New views trigger the cancellation of the current pending User Action
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_COLLECTED, () => {
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, () => {
     if (pendingAutoUserAction) {
       pendingAutoUserAction.stop()
     }
@@ -78,11 +78,13 @@ function newUserAction(lifeCycle: LifeCycle, type: UserActionType, name: string)
   const id = generateUUID()
   const startTime = performance.now()
 
+  lifeCycle.notify(LifeCycleEventType.ACTION_CREATED)
+
   const { eventCounts, stop: stopEventCountsTracking } = trackEventCounts(lifeCycle)
 
   const { stop: stopWaitIdlePageActivity } = waitIdlePageActivity(lifeCycle, (hadActivity, endTime) => {
     if (hadActivity) {
-      lifeCycle.notify(LifeCycleEventType.USER_ACTION_COLLECTED, {
+      lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, {
         id,
         name,
         startTime,
@@ -94,6 +96,8 @@ function newUserAction(lifeCycle: LifeCycle, type: UserActionType, name: string)
           resourceCount: eventCounts.resourceCount,
         },
       })
+    } else {
+      lifeCycle.notify(LifeCycleEventType.ACTION_DISCARDED)
     }
 
     stopEventCountsTracking()

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -109,6 +109,8 @@ function newView(
 
   viewContext = { id, location, sessionId: session.getId() }
 
+  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED)
+
   // Update the view every time the measures are changing
   const { throttled: scheduleViewUpdate, stop: stopScheduleViewUpdate } = throttle(
     monitor(updateView),
@@ -135,7 +137,7 @@ function newView(
 
   function updateView() {
     documentVersion += 1
-    lifeCycle.notify(LifeCycleEventType.VIEW_COLLECTED, {
+    lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, {
       documentVersion,
       id,
       loadingTime,

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -81,7 +81,7 @@ export function startViewCollection(location: Location, lifeCycle: LifeCycle, se
   }
 }
 
-interface ViewContext {
+export interface ViewContext {
   id: string
   location: Location
   sessionId: string | undefined
@@ -109,7 +109,7 @@ function newView(
 
   viewContext = { id, location, sessionId: session.getId() }
 
-  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED)
+  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, viewContext)
 
   // Update the view every time the measures are changing
   const { throttled: scheduleViewUpdate, stop: stopScheduleViewUpdate } = throttle(

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -260,7 +260,7 @@ describe('rum session', () => {
     stubBuilder.fakeEntry(FAKE_RESOURCE as PerformanceEntry, 'resource')
     lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
     lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, FAKE_REQUEST as RequestCompleteEvent)
-    lifeCycle.notify(LifeCycleEventType.USER_ACTION_COLLECTED, FAKE_USER_ACTION)
+    lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, FAKE_USER_ACTION)
 
     expect(server.requests.length).toEqual(4)
   })
@@ -303,7 +303,7 @@ describe('rum session', () => {
     stubBuilder.fakeEntry(FAKE_RESOURCE as PerformanceEntry, 'resource')
     lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, FAKE_REQUEST as RequestCompleteEvent)
     lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-    lifeCycle.notify(LifeCycleEventType.USER_ACTION_COLLECTED, FAKE_USER_ACTION)
+    lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, FAKE_USER_ACTION)
 
     expect(server.requests.length).toEqual(0)
   })
@@ -550,7 +550,7 @@ describe('rum user action', () => {
     const { server, lifeCycle } = setupBuilder.build()
     server.requests = []
 
-    lifeCycle.notify(LifeCycleEventType.USER_ACTION_COLLECTED, {
+    lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, {
       context: { fooBar: 'foo' },
       name: 'hello',
       type: UserActionType.CUSTOM,

--- a/packages/rum/test/trackEventCounts.spec.ts
+++ b/packages/rum/test/trackEventCounts.spec.ts
@@ -34,7 +34,7 @@ describe('trackEventCounts', () => {
   it('tracks user actions', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
     const userAction = {}
-    lifeCycle.notify(LifeCycleEventType.USER_ACTION_COLLECTED, userAction as UserAction)
+    lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, userAction as UserAction)
     expect(eventCounts.userActionCount).toBe(1)
   })
 

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -8,7 +8,6 @@ import {
   UserAction,
   UserActionType,
 } from '../src/userActionCollection'
-import { View } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 const { resetUserAction, newUserAction } = $$tests
@@ -62,7 +61,7 @@ describe('startUserActionCollection', () => {
     setupBuilder = setup()
       .withFakeClock()
       .withUserActionCollection()
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.USER_ACTION_COLLECTED, pushEvent))
+      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, pushEvent))
   })
 
   afterEach(() => {
@@ -75,8 +74,7 @@ describe('startUserActionCollection', () => {
     const { lifeCycle, clock } = setupBuilder.build()
     mockValidatedClickUserAction(lifeCycle, clock, button)
 
-    const fakeView = {}
-    lifeCycle.notify(LifeCycleEventType.VIEW_COLLECTED, fakeView as View)
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED)
     clock.tick(EXPIRE_DELAY)
 
     expect(events).toEqual([])
@@ -137,7 +135,7 @@ describe('getUserActionReference', () => {
     const { clock } = setupBuilder.build()
     expect(getUserActionReference()).toBeUndefined()
     const lifeCycle = new LifeCycle()
-    lifeCycle.subscribe(LifeCycleEventType.USER_ACTION_COLLECTED, pushEvent)
+    lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, pushEvent)
 
     newUserAction(lifeCycle, UserActionType.CLICK, 'test')
 
@@ -158,7 +156,7 @@ describe('getUserActionReference', () => {
     expect(userAction.id).toBe(userActionReference.id)
   })
 
-  it('do not return the user action reference for events occuring before the start of the user action', () => {
+  it('do not return the user action reference for events occurring before the start of the user action', () => {
     const { clock } = setupBuilder.build()
     const timeBeforeStartingUserAction = Date.now()
 
@@ -191,7 +189,7 @@ describe('newUserAction', () => {
 
   it('cancels any starting user action while another one is happening', () => {
     const { lifeCycle, clock } = setupBuilder.build()
-    lifeCycle.subscribe(LifeCycleEventType.USER_ACTION_COLLECTED, pushEvent)
+    lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, pushEvent)
 
     newUserAction(lifeCycle, UserActionType.CLICK, 'test-1')
     newUserAction(lifeCycle, UserActionType.CLICK, 'test-2')
@@ -204,10 +202,10 @@ describe('newUserAction', () => {
     expect(events[0].name).toBe('test-1')
   })
 
-  it('counts errors occuring during the user action', () => {
+  it('counts errors occurring during the user action', () => {
     const { lifeCycle, clock } = setupBuilder.build()
     const error = {}
-    lifeCycle.subscribe(LifeCycleEventType.USER_ACTION_COLLECTED, pushEvent)
+    lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, pushEvent)
 
     newUserAction(lifeCycle, UserActionType.CLICK, 'test-1')
 

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -1,4 +1,4 @@
-import { getHash, getPathName, getSearch, msToNs } from '@datadog/browser-core'
+import { getHash, getPathName, getSearch } from '@datadog/browser-core'
 
 import { LifeCycleEventType } from '../src/lifeCycle'
 import { PerformanceLongTaskTiming, PerformancePaintTiming } from '../src/rum'
@@ -132,7 +132,7 @@ describe('rum track renew session', () => {
     mockHistory(fakeLocation)
     setupBuilder = setup()
       .withViewCollection(fakeLocation)
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_COLLECTED, addRumEvent))
+      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent))
   })
 
   afterEach(() => {
@@ -170,14 +170,14 @@ describe('rum track load duration', () => {
     setupBuilder = setup()
       .withFakeClock()
       .withViewCollection(fakeLocation)
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_COLLECTED, addRumEvent))
+      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent))
   })
 
   afterEach(() => {
     setupBuilder.cleanup()
   })
 
-  it('should collect intital view type as "initial_load"', () => {
+  it('should collect initial view type as "initial_load"', () => {
     setupBuilder.build()
     expect(getViewEvent(0).loadingType).toEqual(ViewLoadingType.INITIAL_LOAD)
   })
@@ -207,7 +207,7 @@ describe('rum track loading time', () => {
     setupBuilder = setup()
       .withFakeClock()
       .withViewCollection(fakeLocation)
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_COLLECTED, addRumEvent))
+      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent))
   })
 
   afterEach(() => {
@@ -302,7 +302,7 @@ describe('rum view measures', () => {
     mockHistory(fakeLocation)
     setupBuilder = setup()
       .withViewCollection(fakeLocation)
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_COLLECTED, addRumEvent))
+      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent))
   })
 
   afterEach(() => {
@@ -354,7 +354,7 @@ describe('rum view measures', () => {
     expect(getRumEventCount()).toEqual(1)
     expect(getViewEvent(0).measures.userActionCount).toEqual(0)
 
-    lifeCycle.notify(LifeCycleEventType.USER_ACTION_COLLECTED, FAKE_USER_ACTION as UserAction)
+    lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, FAKE_USER_ACTION as UserAction)
     history.pushState({}, '', '/bar')
 
     expect(getRumEventCount()).toEqual(3)

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -164,12 +164,14 @@ describe('rum track renew session', () => {
 
   it('should create new view on renew session', () => {
     const { lifeCycle } = setupBuilder.build()
-
-    lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (viewContext) => {
-      expect(viewContext.id).not.toEqual(initialViewId)
-    })
+    const createSpy = jasmine.createSpy('create')
+    lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
 
     lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+
+    expect(createSpy).toHaveBeenCalled()
+    const viewContext = createSpy.calls.argsFor(0)[0] as ViewContext
+    expect(viewContext.id).not.toEqual(initialViewId)
   })
 
   it('should send a final view event when the session is renewed', () => {


### PR DESCRIPTION
## Motivation

Prepare future work on associate events with its parents based on start time
Fix discard user action on view created instead of view update

## Changes

Introduce new events:
- VIEW_CREATED: when a view is created
- VIEW_UPDATED: when a view is updated
- ACTION_CREATED: when an action is created
- ACTION_COMPLETED: when an action is completed
- ACTION_DISCARDED: when an action is discarded

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
