### PR TITLE
♻️ [RUMF-604] introduce parentContexts to return current contexts

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -104,6 +104,12 @@ export function deepMerge(destination: ContextValue, ...toMerge: ContextValue[])
   }, destination)
 }
 
+export function combine<A, B, C>(a: A, b: B, c: C): A & B & C
+export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D
+export function combine(a: Context, ...b: Context[]): Context {
+  return deepMerge(a, ...b) as Context
+}
+
 interface Assignable {
   [key: string]: any
 }

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -74,7 +74,13 @@ export function startLogger(
   const logger = new Logger(session, handlers)
   customLoggers = {}
   errorObservable.subscribe((e: ErrorMessage) =>
-    logger.error(e.message, { date: getTimestamp(e.startTime), ...e.context })
+    logger.error(
+      e.message,
+      deepMerge(
+        ({ date: getTimestamp(e.startTime), ...e.context } as unknown) as Context,
+        getRUMInternalContext(e.startTime)
+      )
+    )
   )
 
   const globalApi: Partial<LogsGlobal> = {}
@@ -205,10 +211,10 @@ export class Logger {
 }
 
 interface Rum {
-  getInternalContext: () => object
+  getInternalContext: (startTime?: number) => Context
 }
 
-function getRUMInternalContext(): object | undefined {
+function getRUMInternalContext(startTime?: number): Context | undefined {
   const rum = (window as any).DD_RUM as Rum
-  return rum && rum.getInternalContext ? rum.getInternalContext() : undefined
+  return rum && rum.getInternalContext ? rum.getInternalContext(startTime) : undefined
 }

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,6 +1,7 @@
 import { ErrorMessage, RequestCompleteEvent, RequestStartEvent } from '@datadog/browser-core'
+import { ActionContext, ViewContext } from './parentContexts'
 import { UserAction } from './userActionCollection'
-import { View, ViewContext } from './viewCollection'
+import { View } from './viewCollection'
 
 export enum LifeCycleEventType {
   ERROR_COLLECTED,
@@ -30,7 +31,14 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.REQUEST_STARTED, data: RequestStartEvent): void
   notify(eventType: LifeCycleEventType.REQUEST_COMPLETED, data: RequestCompleteEvent): void
   notify(eventType: LifeCycleEventType.ACTION_COMPLETED, data: UserAction): void
-  notify(eventType: LifeCycleEventType.VIEW_CREATED, data: ViewContext): void
+  notify(
+    eventType: LifeCycleEventType.ACTION_CREATED,
+    { actionContext, startTime }: { actionContext: ActionContext; startTime: number }
+  ): void
+  notify(
+    eventType: LifeCycleEventType.VIEW_CREATED,
+    { viewContext, startTime }: { viewContext: ViewContext; startTime: number }
+  ): void
   notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: View): void
   notify(
     eventType:
@@ -38,9 +46,7 @@ export class LifeCycle {
       | LifeCycleEventType.RESOURCE_ADDED_TO_BATCH
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
-      | LifeCycleEventType.ACTION_CREATED
       | LifeCycleEventType.ACTION_DISCARDED
-      | LifeCycleEventType.VIEW_CREATED
   ): void
   notify(eventType: LifeCycleEventType, data?: any) {
     const eventCallbacks = this.callbacks[eventType]
@@ -60,7 +66,14 @@ export class LifeCycle {
     callback: (data: RequestCompleteEvent) => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType.ACTION_COMPLETED, callback: (data: UserAction) => void): Subscription
-  subscribe(eventType: LifeCycleEventType.VIEW_CREATED, callback: (data: ViewContext) => void): Subscription
+  subscribe(
+    eventType: LifeCycleEventType.ACTION_CREATED,
+    callback: ({ actionContext, startTime }: { actionContext: ActionContext; startTime: number }) => void
+  ): Subscription
+  subscribe(
+    eventType: LifeCycleEventType.VIEW_CREATED,
+    callback: ({ viewContext, startTime }: { viewContext: ViewContext; startTime: number }) => void
+  ): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription
   subscribe(
     eventType:
@@ -68,7 +81,6 @@ export class LifeCycle {
       | LifeCycleEventType.RESOURCE_ADDED_TO_BATCH
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
-      | LifeCycleEventType.ACTION_CREATED
       | LifeCycleEventType.ACTION_DISCARDED,
     callback: () => void
   ): Subscription

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,5 +1,4 @@
 import { ErrorMessage, RequestCompleteEvent, RequestStartEvent } from '@datadog/browser-core'
-import { ActionContext, ViewContext } from './parentContexts'
 import { UserAction } from './userActionCollection'
 import { View } from './viewCollection'
 
@@ -32,12 +31,8 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.REQUEST_COMPLETED, data: RequestCompleteEvent): void
   notify(eventType: LifeCycleEventType.ACTION_COMPLETED, data: UserAction): void
   notify(
-    eventType: LifeCycleEventType.ACTION_CREATED,
-    { actionContext, startTime }: { actionContext: ActionContext; startTime: number }
-  ): void
-  notify(
-    eventType: LifeCycleEventType.VIEW_CREATED,
-    { viewContext, startTime }: { viewContext: ViewContext; startTime: number }
+    eventType: LifeCycleEventType.ACTION_CREATED | LifeCycleEventType.VIEW_CREATED,
+    { id, startTime }: { id: string; startTime: number }
   ): void
   notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: View): void
   notify(
@@ -67,12 +62,8 @@ export class LifeCycle {
   ): Subscription
   subscribe(eventType: LifeCycleEventType.ACTION_COMPLETED, callback: (data: UserAction) => void): Subscription
   subscribe(
-    eventType: LifeCycleEventType.ACTION_CREATED,
-    callback: ({ actionContext, startTime }: { actionContext: ActionContext; startTime: number }) => void
-  ): Subscription
-  subscribe(
-    eventType: LifeCycleEventType.VIEW_CREATED,
-    callback: ({ viewContext, startTime }: { viewContext: ViewContext; startTime: number }) => void
+    eventType: LifeCycleEventType.ACTION_CREATED | LifeCycleEventType.VIEW_CREATED,
+    callback: ({ id, startTime }: { id: string; startTime: number }) => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription
   subscribe(

--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -26,7 +26,7 @@ export interface ParentContexts {
 }
 
 export function startParentContexts(lifeCycle: LifeCycle): ParentContexts {
-  let currentView: InternalViewContext
+  let currentView: InternalViewContext | undefined
   let currentAction: InternalActionContext | undefined
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (data) => {

--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -1,14 +1,19 @@
+import { Context } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RumSession } from './rumSession'
 
-export interface ViewContext {
-  id: string
+export interface ViewContext extends Context {
   sessionId: string | undefined
-  url: string
+  view: {
+    id: string
+    url: string
+  }
 }
 
-export interface ActionContext {
-  id: string
+export interface ActionContext extends Context {
+  userAction: {
+    id: string
+  }
 }
 
 interface InternalContext {
@@ -48,8 +53,8 @@ export function startParentContexts(location: Location, lifeCycle: LifeCycle, se
       if (!currentAction || (startTime !== undefined && startTime < currentAction.startTime)) {
         return undefined
       }
-      return { id: currentAction.id }
+      return { userAction: { id: currentAction.id } }
     },
-    findView: () => currentView && { sessionId: currentSessionId, id: currentView.id, url: location.href },
+    findView: () => currentView && { sessionId: currentSessionId, view: { id: currentView.id, url: location.href } },
   }
 }

--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -1,0 +1,57 @@
+import { LifeCycle, LifeCycleEventType } from './lifeCycle'
+
+export interface ViewContext {
+  id: string
+  sessionId: string | undefined
+  location: Location
+}
+
+export interface ActionContext {
+  id: string
+}
+
+interface InternalViewContext {
+  viewContext: ViewContext
+  startTime: number
+}
+
+interface InternalActionContext {
+  actionContext: ActionContext
+  startTime: number
+}
+
+export interface ParentContexts {
+  findAction: (startTime?: number) => ActionContext | undefined
+  findView: (startTime?: number) => ViewContext | undefined
+}
+
+export function startParentContexts(lifeCycle: LifeCycle): ParentContexts {
+  let currentView: InternalViewContext
+  let currentAction: InternalActionContext | undefined
+
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (data) => {
+    currentView = data
+  })
+
+  lifeCycle.subscribe(LifeCycleEventType.ACTION_CREATED, (data) => {
+    currentAction = data
+  })
+
+  lifeCycle.subscribe(LifeCycleEventType.ACTION_COMPLETED, () => {
+    currentAction = undefined
+  })
+
+  lifeCycle.subscribe(LifeCycleEventType.ACTION_DISCARDED, () => {
+    currentAction = undefined
+  })
+
+  return {
+    findAction: (startTime) => {
+      if (!currentAction || (startTime !== undefined && startTime < currentAction.startTime)) {
+        return undefined
+      }
+      return currentAction.actionContext
+    },
+    findView: () => currentView && currentView.viewContext,
+  }
+}

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -20,7 +20,7 @@ import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { startPerformanceCollection } from './performanceCollection'
 import { startRum } from './rum'
 import { startRumSession } from './rumSession'
-import { startUserActionCollection, UserActionReference } from './userActionCollection'
+import { startUserActionCollection } from './userActionCollection'
 import { startViewCollection } from './viewCollection'
 
 export interface RumUserConfiguration extends UserConfiguration {
@@ -33,7 +33,9 @@ export interface InternalContext {
   view: {
     id: string
   }
-  user_action?: UserActionReference
+  user_action?: {
+    id: string
+  }
 }
 
 const STUBBED_RUM = {

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -73,9 +73,16 @@ datadogRum.init = monitor((userConfiguration: RumUserConfiguration) => {
 
   const { errorObservable, configuration, internalMonitoring } = commonInit(rumUserConfiguration, buildEnv)
   const session = startRumSession(configuration, lifeCycle)
-  const globalApi = startRum(rumUserConfiguration.applicationId, lifeCycle, configuration, session, internalMonitoring)
+  const globalApi = startRum(
+    rumUserConfiguration.applicationId,
+    location,
+    lifeCycle,
+    configuration,
+    session,
+    internalMonitoring
+  )
 
-  startViewCollection(location, lifeCycle, session)
+  startViewCollection(location, lifeCycle)
   const [requestStartObservable, requestCompleteObservable] = startRequestCollection()
   startPerformanceCollection(lifeCycle, session)
   startDOMMutationCollection(lifeCycle)

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -21,7 +21,6 @@ import { startPerformanceCollection } from './performanceCollection'
 import { startRum } from './rum'
 import { startRumSession } from './rumSession'
 import { startUserActionCollection } from './userActionCollection'
-import { startViewCollection } from './viewCollection'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string
@@ -83,7 +82,6 @@ datadogRum.init = monitor((userConfiguration: RumUserConfiguration) => {
     internalMonitoring
   )
 
-  startViewCollection(location, lifeCycle)
   const [requestStartObservable, requestCompleteObservable] = startRequestCollection()
   startPerformanceCollection(lifeCycle, session)
   startDOMMutationCollection(lifeCycle)

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -30,7 +30,7 @@ export interface RumUserConfiguration extends UserConfiguration {
 export interface InternalContext {
   application_id: string
   session_id: string | undefined
-  view: {
+  view?: {
     id: string
     url: string
   }

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -32,6 +32,7 @@ export interface InternalContext {
   session_id: string | undefined
   view: {
     id: string
+    url: string
   }
   user_action?: {
     id: string

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -144,6 +144,7 @@ enum SessionType {
 
 export function startRum(
   applicationId: string,
+  location: Location,
   lifeCycle: LifeCycle,
   configuration: Configuration,
   session: RumSession,
@@ -151,7 +152,7 @@ export function startRum(
 ): Omit<RumGlobal, 'init'> {
   let globalContext: Context = {}
 
-  const parentContexts = startParentContexts(lifeCycle)
+  const parentContexts = startParentContexts(window.location, lifeCycle, session)
 
   internalMonitoring.setExternalContextProvider(() => {
     const parentView = parentContexts.findView()!
@@ -185,7 +186,7 @@ export function startRum(
         view: {
           id: parentView.id,
           referrer: document.referrer,
-          url: parentView.location.href,
+          url: parentView.url,
         },
       }
     },

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -80,7 +80,7 @@ function newUserAction(lifeCycle: LifeCycle, type: UserActionType, name: string)
   const id = generateUUID()
   const startTime = performance.now()
 
-  lifeCycle.notify(LifeCycleEventType.ACTION_CREATED)
+  lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { startTime, actionContext: { id } })
 
   const { eventCounts, stop: stopEventCountsTracking } = trackEventCounts(lifeCycle)
 

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -79,8 +79,7 @@ function newUserAction(lifeCycle: LifeCycle, type: UserActionType, name: string)
 
   const id = generateUUID()
   const startTime = performance.now()
-
-  lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { startTime, actionContext: { id } })
+  lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { id, startTime })
 
   const { eventCounts, stop: stopEventCountsTracking } = trackEventCounts(lifeCycle)
 

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -125,20 +125,6 @@ function newUserAction(lifeCycle: LifeCycle, type: UserActionType, name: string)
   }
 }
 
-export interface UserActionReference {
-  id: string
-}
-export function getUserActionReference(time?: number): UserActionReference | undefined {
-  if (!pendingAutoUserAction || (time !== undefined && time < pendingAutoUserAction.startTime)) {
-    return undefined
-  }
-
-  return { id: pendingAutoUserAction.id }
-}
-
 export const $$tests = {
   newUserAction,
-  resetUserAction() {
-    pendingAutoUserAction = undefined
-  },
 }

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -1,9 +1,7 @@
 import { DOM_EVENT, generateUUID, monitor, msToNs, noop, ONE_MINUTE, throttle } from '@datadog/browser-core'
 
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
-import { ViewContext } from './parentContexts'
 import { PerformancePaintTiming } from './rum'
-import { RumSession } from './rumSession'
 import { trackEventCounts } from './trackEventCounts'
 import { waitIdlePageActivity } from './trackPageActivities'
 
@@ -38,10 +36,10 @@ export enum ViewLoadingType {
 export const THROTTLE_VIEW_UPDATE_PERIOD = 3000
 export const SESSION_KEEP_ALIVE_INTERVAL = 5 * ONE_MINUTE
 
-export function startViewCollection(location: Location, lifeCycle: LifeCycle, session: RumSession) {
+export function startViewCollection(location: Location, lifeCycle: LifeCycle) {
   let currentLocation = { ...location }
   const startOrigin = 0
-  let currentView = newView(lifeCycle, currentLocation, session, ViewLoadingType.INITIAL_LOAD, startOrigin)
+  let currentView = newView(lifeCycle, currentLocation, ViewLoadingType.INITIAL_LOAD, startOrigin)
 
   // Renew view on history changes
   trackHistory(() => {
@@ -49,7 +47,7 @@ export function startViewCollection(location: Location, lifeCycle: LifeCycle, se
       currentLocation = { ...location }
       currentView.triggerUpdate()
       currentView.end()
-      currentView = newView(lifeCycle, currentLocation, session, ViewLoadingType.ROUTE_CHANGE)
+      currentView = newView(lifeCycle, currentLocation, ViewLoadingType.ROUTE_CHANGE)
     }
   })
 
@@ -57,7 +55,7 @@ export function startViewCollection(location: Location, lifeCycle: LifeCycle, se
   lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
     // do not trigger view update to avoid wrong data
     currentView.end()
-    currentView = newView(lifeCycle, currentLocation, session, ViewLoadingType.ROUTE_CHANGE)
+    currentView = newView(lifeCycle, currentLocation, ViewLoadingType.ROUTE_CHANGE)
   })
 
   // End the current view on page unload
@@ -85,7 +83,6 @@ export function startViewCollection(location: Location, lifeCycle: LifeCycle, se
 function newView(
   lifeCycle: LifeCycle,
   location: Location,
-  session: RumSession,
   loadingType: ViewLoadingType,
   startTime: number = performance.now()
 ) {
@@ -100,9 +97,7 @@ function newView(
   let documentVersion = 0
   let loadingTime: number | undefined
 
-  const viewContext = { id, location, sessionId: session.getId() }
-
-  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext, startTime })
+  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id, startTime })
 
   // Update the view every time the measures are changing
   const { throttled: scheduleViewUpdate, stop: stopScheduleViewUpdate } = throttle(

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -82,8 +82,6 @@ export function startViewCollection(location: Location, lifeCycle: LifeCycle, se
   }
 }
 
-export let viewContext: ViewContext
-
 function newView(
   lifeCycle: LifeCycle,
   location: Location,
@@ -102,7 +100,7 @@ function newView(
   let documentVersion = 0
   let loadingTime: number | undefined
 
-  viewContext = { id, location, sessionId: session.getId() }
+  const viewContext = { id, location, sessionId: session.getId() }
 
   lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext, startTime })
 

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -1,0 +1,68 @@
+import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
+import { ParentContexts, startParentContexts } from '../src/parentContexts'
+
+describe('parentContexts', () => {
+  const actionContext = { id: 'fake' }
+  const viewContext = { location, id: 'fake', sessionId: 'fake' }
+  const startTime = 10
+
+  let parentContexts: ParentContexts
+  let lifeCycle: LifeCycle
+
+  beforeEach(() => {
+    lifeCycle = new LifeCycle()
+    parentContexts = startParentContexts(lifeCycle)
+  })
+
+  describe('findView', () => {
+    it('should return undefined if there is no current view', () => {
+      expect(parentContexts.findView()).toBeUndefined()
+    })
+
+    it('should return the current view context', () => {
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext, startTime })
+
+      expect(parentContexts.findView()).toBe(viewContext)
+    })
+
+    it('should replace the current view context on VIEW_CREATED', () => {
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext, startTime })
+      const newViewContext = { ...viewContext, id: 'fake2' }
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext: newViewContext, startTime })
+
+      expect(parentContexts.findView()).toBe(newViewContext)
+    })
+  })
+
+  describe('findAction', () => {
+    it('should return undefined if there is no current action', () => {
+      expect(parentContexts.findAction()).toBeUndefined()
+    })
+
+    it('should return the current action context', () => {
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+
+      expect(parentContexts.findAction()).toBe(actionContext)
+    })
+
+    it('should return undefined if startTime is before the start of the current action', () => {
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+
+      expect(parentContexts.findAction(startTime - 1)).toBeUndefined()
+    })
+
+    it('should clear the current action on ACTION_DISCARDED', () => {
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+      lifeCycle.notify(LifeCycleEventType.ACTION_DISCARDED)
+
+      expect(parentContexts.findAction()).toBeUndefined()
+    })
+
+    it('should clear the current action on ACTION_COMPLETED', () => {
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+      lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, undefined as any)
+
+      expect(parentContexts.findAction()).toBeUndefined()
+    })
+  })
+})

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -40,7 +40,7 @@ describe('parentContexts', () => {
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
 
       expect(parentContexts.findView()).toBeDefined()
-      expect(parentContexts.findView()!.id).toEqual(FAKE_ID)
+      expect(parentContexts.findView()!.view.id).toEqual(FAKE_ID)
     })
 
     it('should replace the current view context on VIEW_CREATED', () => {
@@ -50,18 +50,18 @@ describe('parentContexts', () => {
       const newViewId = 'fake 2'
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: newViewId })
 
-      expect(parentContexts.findView()!.id).toEqual(newViewId)
+      expect(parentContexts.findView()!.view.id).toEqual(newViewId)
     })
 
     it('should return the current url with the current view', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
-      expect(parentContexts.findView()!.url).toBe('fake-url')
+      expect(parentContexts.findView()!.view.url).toBe('fake-url')
 
       fakeUrl = 'other-url'
 
-      expect(parentContexts.findView()!.url).toBe('other-url')
+      expect(parentContexts.findView()!.view.url).toBe('other-url')
     })
 
     it('should update session id only on VIEW_CREATED', () => {
@@ -91,7 +91,7 @@ describe('parentContexts', () => {
       lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { startTime, id: FAKE_ID })
 
       expect(parentContexts.findAction()).toBeDefined()
-      expect(parentContexts.findAction()!.id).toBe(FAKE_ID)
+      expect(parentContexts.findAction()!.userAction.id).toBe(FAKE_ID)
     })
 
     it('should return undefined if startTime is before the start of the current action', () => {

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -1,65 +1,120 @@
-import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
-import { ParentContexts, startParentContexts } from '../src/parentContexts'
+import { LifeCycleEventType } from '../src/lifeCycle'
+import { setup, TestSetupBuilder } from './specHelper'
 
 describe('parentContexts', () => {
-  const actionContext = { id: 'fake' }
-  const viewContext = { location, id: 'fake', sessionId: 'fake' }
+  const FAKE_ID = 'fake'
   const startTime = 10
 
-  let parentContexts: ParentContexts
-  let lifeCycle: LifeCycle
+  let fakeUrl: string
+  let sessionId: string
+  let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    lifeCycle = new LifeCycle()
-    parentContexts = startParentContexts(lifeCycle)
+    fakeUrl = 'fake-url'
+    sessionId = 'fake-session'
+    const fakeLocation = {
+      get href() {
+        return fakeUrl
+      },
+    }
+    setupBuilder = setup()
+      .withFakeLocation(fakeLocation)
+      .withSession({
+        getId: () => sessionId,
+        isTracked: () => true,
+        isTrackedWithResource: () => true,
+      })
+      .withParentContexts()
   })
 
   describe('findView', () => {
     it('should return undefined if there is no current view', () => {
+      const { parentContexts } = setupBuilder.build()
+
       expect(parentContexts.findView()).toBeUndefined()
     })
 
     it('should return the current view context', () => {
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext, startTime })
+      const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      expect(parentContexts.findView()).toBe(viewContext)
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+
+      expect(parentContexts.findView()).toBeDefined()
+      expect(parentContexts.findView()!.id).toEqual(FAKE_ID)
     })
 
     it('should replace the current view context on VIEW_CREATED', () => {
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext, startTime })
-      const newViewContext = { ...viewContext, id: 'fake2' }
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext: newViewContext, startTime })
+      const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      expect(parentContexts.findView()).toBe(newViewContext)
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      const newViewId = 'fake 2'
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: newViewId })
+
+      expect(parentContexts.findView()!.id).toEqual(newViewId)
+    })
+
+    it('should return the current url with the current view', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      expect(parentContexts.findView()!.url).toBe('fake-url')
+
+      fakeUrl = 'other-url'
+
+      expect(parentContexts.findView()!.url).toBe('other-url')
+    })
+
+    it('should update session id only on VIEW_CREATED', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      expect(parentContexts.findView()!.sessionId).toBe('fake-session')
+
+      sessionId = 'other-session'
+      expect(parentContexts.findView()!.sessionId).toBe('fake-session')
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: 'fake 2' })
+      expect(parentContexts.findView()!.sessionId).toBe('other-session')
     })
   })
 
   describe('findAction', () => {
     it('should return undefined if there is no current action', () => {
+      const { parentContexts } = setupBuilder.build()
+
       expect(parentContexts.findAction()).toBeUndefined()
     })
 
     it('should return the current action context', () => {
-      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+      const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      expect(parentContexts.findAction()).toBe(actionContext)
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { startTime, id: FAKE_ID })
+
+      expect(parentContexts.findAction()).toBeDefined()
+      expect(parentContexts.findAction()!.id).toBe(FAKE_ID)
     })
 
     it('should return undefined if startTime is before the start of the current action', () => {
-      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { startTime, id: FAKE_ID })
 
       expect(parentContexts.findAction(startTime - 1)).toBeUndefined()
     })
 
     it('should clear the current action on ACTION_DISCARDED', () => {
-      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { startTime, id: FAKE_ID })
       lifeCycle.notify(LifeCycleEventType.ACTION_DISCARDED)
 
       expect(parentContexts.findAction()).toBeUndefined()
     })
 
     it('should clear the current action on ACTION_COMPLETED', () => {
-      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { actionContext, startTime })
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.ACTION_CREATED, { startTime, id: FAKE_ID })
       lifeCycle.notify(LifeCycleEventType.ACTION_COMPLETED, undefined as any)
 
       expect(parentContexts.findAction()).toBeUndefined()

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -9,13 +9,13 @@ import {
 import sinon from 'sinon'
 
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
-import { handleResourceEntry, RumEvent, RumResourceEvent } from '../src/rum'
+import { handleResourceEntry, RawRumEvent, RumEvent, RumResourceEvent } from '../src/rum'
 import { UserAction, UserActionType } from '../src/userActionCollection'
-import { SESSION_KEEP_ALIVE_INTERVAL } from '../src/viewCollection'
+import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
-function getEntry(addRumEvent: (startTime: number, event: RumEvent) => void, index: number) {
-  return (addRumEvent as jasmine.Spy).calls.argsFor(index)[1] as RumEvent
+function getEntry(handler: (startTime: number, event: RumEvent) => void, index: number) {
+  return (handler as jasmine.Spy).calls.argsFor(index)[1] as RumEvent
 }
 
 function getServerRequestBodies<T>(server: sinon.SinonFakeServer) {
@@ -33,23 +33,26 @@ function getRumMessage(server: sinon.SinonFakeServer, index: number) {
 }
 
 interface ExpectedRequestBody {
+  application_id: string
+  date: number
   evt: {
     category: string
   }
   session_id: string
   view: {
     id: string
+    referrer: string
   }
 }
 
 describe('rum handle performance entry', () => {
-  let addRumEvent: (startTime: number, event: RumEvent) => void
+  let handler: (startTime: number, event: RawRumEvent) => void
 
   beforeEach(() => {
     if (isIE()) {
       pending('no full rum support')
     }
-    addRumEvent = jasmine.createSpy()
+    handler = jasmine.createSpy()
   })
   ;[
     {
@@ -91,10 +94,10 @@ describe('rum handle performance entry', () => {
         handleResourceEntry(
           configuration as Configuration,
           entry as PerformanceResourceTiming,
-          addRumEvent,
+          handler,
           new LifeCycle()
         )
-        const entryAdded = (addRumEvent as jasmine.Spy).calls.all().length !== 0
+        const entryAdded = (handler as jasmine.Spy).calls.all().length !== 0
         expect(entryAdded).toEqual(expectEntryToBeAdded)
       })
     }
@@ -139,10 +142,10 @@ describe('rum handle performance entry', () => {
         handleResourceEntry(
           configuration as Configuration,
           entry as PerformanceResourceTiming,
-          addRumEvent,
+          handler,
           new LifeCycle()
         )
-        const resourceEvent = getEntry(addRumEvent, 0) as RumResourceEvent
+        const resourceEvent = getEntry(handler, 0) as RumResourceEvent
         expect(resourceEvent.resource.kind).toEqual(expected)
       })
     }
@@ -164,13 +167,8 @@ describe('rum handle performance entry', () => {
       secureConnectionStart: 0,
     }
 
-    handleResourceEntry(
-      configuration as Configuration,
-      entry as PerformanceResourceTiming,
-      addRumEvent,
-      new LifeCycle()
-    )
-    const resourceEvent = getEntry(addRumEvent, 0) as RumResourceEvent
+    handleResourceEntry(configuration as Configuration, entry as PerformanceResourceTiming, handler, new LifeCycle())
+    const resourceEvent = getEntry(handler, 0) as RumResourceEvent
     expect(resourceEvent.http.performance!.connect!.duration).toEqual(7 * 1e6)
     expect(resourceEvent.http.performance!.download!.duration).toEqual(75 * 1e6)
   })
@@ -193,13 +191,8 @@ describe('rum handle performance entry', () => {
         secureConnectionStart: 0,
       }
 
-      handleResourceEntry(
-        configuration as Configuration,
-        entry as PerformanceResourceTiming,
-        addRumEvent,
-        new LifeCycle()
-      )
-      const resourceEvent = getEntry(addRumEvent, 0) as RumResourceEvent
+      handleResourceEntry(configuration as Configuration, entry as PerformanceResourceTiming, handler, new LifeCycle())
+      const resourceEvent = getEntry(handler, 0) as RumResourceEvent
       expect(resourceEvent.http.performance).toBe(undefined)
     })
 
@@ -211,13 +204,8 @@ describe('rum handle performance entry', () => {
         responseStart: 100,
       }
 
-      handleResourceEntry(
-        configuration as Configuration,
-        entry as PerformanceResourceTiming,
-        addRumEvent,
-        new LifeCycle()
-      )
-      const resourceEvent = getEntry(addRumEvent, 0) as RumResourceEvent
+      handleResourceEntry(configuration as Configuration, entry as PerformanceResourceTiming, handler, new LifeCycle())
+      const resourceEvent = getEntry(handler, 0) as RumResourceEvent
       expect(resourceEvent.http.performance).toBe(undefined)
     })
   })
@@ -251,7 +239,6 @@ describe('rum session', () => {
   it('when tracked with resources should enable full tracking', () => {
     const { server, stubBuilder, lifeCycle } = setupBuilder
       .withPerformanceObserverStubBuilder()
-      .withViewCollection()
       .withPerformanceCollection()
       .build()
 
@@ -273,7 +260,6 @@ describe('rum session', () => {
         isTrackedWithResource: () => false,
       })
       .withPerformanceObserverStubBuilder()
-      .withViewCollection()
       .withPerformanceCollection()
       .build()
 
@@ -317,7 +303,6 @@ describe('rum session', () => {
         isTrackedWithResource: () => isTracked,
       })
       .withPerformanceObserverStubBuilder()
-      .withViewCollection()
       .withPerformanceCollection()
       .build()
 
@@ -343,7 +328,6 @@ describe('rum session', () => {
         isTracked: () => true,
         isTrackedWithResource: () => isTrackedWithResource,
       })
-      .withViewCollection()
       .withPerformanceCollection()
       .build()
 
@@ -369,7 +353,6 @@ describe('rum session', () => {
         isTracked: () => true,
         isTrackedWithResource: () => true,
       })
-      .withViewCollection()
       .build()
 
     const initialRequests = getServerRequestBodies<ExpectedRequestBody>(server)
@@ -399,7 +382,6 @@ describe('rum session', () => {
         isTracked: () => isTracked,
         isTrackedWithResource: () => false,
       })
-      .withViewCollection()
       .build()
 
     server.requests = []
@@ -434,7 +416,6 @@ describe('rum session keep alive', () => {
         isTrackedWithResource: () => true,
       })
       .withRum()
-      .withViewCollection()
   })
 
   afterEach(() => {
@@ -490,7 +471,6 @@ describe('rum global context', () => {
     setupBuilder = setup()
       .withFakeServer()
       .withRum()
-      .withViewCollection()
   })
 
   afterEach(() => {
@@ -539,7 +519,6 @@ describe('rum user action', () => {
     setupBuilder = setup()
       .withFakeServer()
       .withRum()
-      .withViewCollection()
   })
 
   afterEach(() => {
@@ -557,5 +536,50 @@ describe('rum user action', () => {
     })
 
     expect((getRumMessage(server, 0) as any).fooBar).toEqual('foo')
+  })
+})
+
+describe('rum context', () => {
+  const FAKE_ERROR: Partial<ErrorMessage> = { message: 'test' }
+  let setupBuilder: TestSetupBuilder
+
+  beforeEach(() => {
+    setupBuilder = setup()
+      .withFakeServer()
+      .withRum()
+  })
+
+  afterEach(() => {
+    setupBuilder.cleanup()
+  })
+
+  it('should be snake cased and added to request', () => {
+    const { server } = setupBuilder.build()
+    const initialRequests = getServerRequestBodies<ExpectedRequestBody>(server)
+    expect(initialRequests[0].application_id).toEqual('appId')
+  })
+
+  it('should be merge with event attributes', () => {
+    const { server } = setupBuilder.build()
+    const initialRequests = getServerRequestBodies<ExpectedRequestBody>(server)
+    expect(initialRequests[0].view.referrer).toBeDefined()
+    expect(initialRequests[0].view.id).toBeDefined()
+  })
+
+  it('should be overwritten by event attributes', () => {
+    const { server, lifeCycle, clock } = setupBuilder.withFakeClock().build()
+
+    const initialRequests = getServerRequestBodies<ExpectedRequestBody>(server)
+    expect(initialRequests[0].evt.category).toEqual('view')
+    const initialViewDate = initialRequests[0].date
+
+    // generate view update
+    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
+    server.requests = []
+    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+    const subsequentRequests = getServerRequestBodies<ExpectedRequestBody>(server)
+    expect(subsequentRequests[0].evt.category).toEqual('view')
+    expect(subsequentRequests[0].date).toEqual(initialViewDate)
   })
 })

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -14,8 +14,8 @@ import { UserAction, UserActionType } from '../src/userActionCollection'
 import { SESSION_KEEP_ALIVE_INTERVAL } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
-function getEntry(addRumEvent: (event: RumEvent) => void, index: number) {
-  return (addRumEvent as jasmine.Spy).calls.argsFor(index)[0] as RumEvent
+function getEntry(addRumEvent: (startTime: number, event: RumEvent) => void, index: number) {
+  return (addRumEvent as jasmine.Spy).calls.argsFor(index)[1] as RumEvent
 }
 
 function getServerRequestBodies<T>(server: sinon.SinonFakeServer) {
@@ -43,7 +43,7 @@ interface ExpectedRequestBody {
 }
 
 describe('rum handle performance entry', () => {
-  let addRumEvent: (event: RumEvent) => void
+  let addRumEvent: (startTime: number, event: RumEvent) => void
 
   beforeEach(() => {
     if (isIE()) {

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -145,7 +145,8 @@ describe('newUserAction', () => {
   })
 
   afterEach(() => {
-    document.getElementById('root')!.remove()
+    const root = document.getElementById('root')!
+    root.parentNode!.removeChild(root)
     setupBuilder.cleanup()
   })
 

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -1,6 +1,5 @@
 import { DOM_EVENT, ErrorMessage } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
-import { ViewContext } from '../src/parentContexts'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../src/trackPageActivities'
 import { $$tests, AutoUserAction, UserAction, UserActionType } from '../src/userActionCollection'
 import { setup, TestSetupBuilder } from './specHelper'
@@ -79,8 +78,7 @@ describe('startUserActionCollection', () => {
     mockValidatedClickUserAction(lifeCycle, clock, button)
     expect(createSpy).toHaveBeenCalled()
 
-    const fakeViewContext = {}
-    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext: fakeViewContext as ViewContext, startTime: 0 })
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id: 'fake', startTime: 0 })
     clock.tick(EXPIRE_DELAY)
 
     expect(events).toEqual([])

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -1,5 +1,6 @@
 import { DOM_EVENT, ErrorMessage } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
+import { ViewContext } from '../src/parentContexts'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../src/trackPageActivities'
 import {
   $$tests,
@@ -84,7 +85,8 @@ describe('startUserActionCollection', () => {
     mockValidatedClickUserAction(lifeCycle, clock, button)
     expect(createSpy).toHaveBeenCalled()
 
-    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED)
+    const fakeViewContext = {}
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { viewContext: fakeViewContext as ViewContext, startTime: 0 })
     clock.tick(EXPIRE_DELAY)
 
     expect(events).toEqual([])

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -83,18 +83,17 @@ function spyOnViews() {
 describe('rum track url change', () => {
   let setupBuilder: TestSetupBuilder
   let initialViewId: string
-  let initialLocation: Location
   let createSpy: jasmine.Spy
 
   beforeEach(() => {
     const fakeLocation: Partial<Location> = { pathname: '/foo' }
     mockHistory(fakeLocation)
     setupBuilder = setup()
-      .withViewCollection(fakeLocation)
+      .withFakeLocation(fakeLocation)
+      .withViewCollection()
       .beforeBuild((lifeCycle) => {
-        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ viewContext }) => {
-          initialViewId = viewContext.id
-          initialLocation = viewContext.location
+        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
+          initialViewId = id
           subscription.unsubscribe()
         })
       })
@@ -112,9 +111,8 @@ describe('rum track url change', () => {
     history.pushState({}, '', '/bar')
 
     expect(createSpy).toHaveBeenCalled()
-    const viewContext = (createSpy.calls.argsFor(0)[0] as { viewContext: ViewContext }).viewContext
+    const viewContext = createSpy.calls.argsFor(0)[0] as ViewContext
     expect(viewContext.id).not.toEqual(initialViewId)
-    expect(viewContext.location).not.toEqual(initialLocation)
   })
 
   it('should not create new view on search change', () => {
@@ -149,11 +147,12 @@ describe('rum track renew session', () => {
     const fakeLocation: Partial<Location> = { pathname: '/foo' }
     mockHistory(fakeLocation)
     setupBuilder = setup()
-      .withViewCollection(fakeLocation)
+      .withFakeLocation(fakeLocation)
+      .withViewCollection()
       .beforeBuild((lifeCycle) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent)
-        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ viewContext }) => {
-          initialViewId = viewContext.id
+        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
+          initialViewId = id
           subscription.unsubscribe()
         })
       })
@@ -197,7 +196,8 @@ describe('rum track load duration', () => {
     mockHistory(fakeLocation)
     setupBuilder = setup()
       .withFakeClock()
-      .withViewCollection(fakeLocation)
+      .withFakeLocation(fakeLocation)
+      .withViewCollection()
       .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent))
   })
 
@@ -234,7 +234,8 @@ describe('rum track loading time', () => {
     mockHistory(fakeLocation)
     setupBuilder = setup()
       .withFakeClock()
-      .withViewCollection(fakeLocation)
+      .withFakeLocation(fakeLocation)
+      .withViewCollection()
       .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent))
   })
 
@@ -329,7 +330,8 @@ describe('rum view measures', () => {
     const fakeLocation: Partial<Location> = { pathname: '/foo' }
     mockHistory(fakeLocation)
     setupBuilder = setup()
-      .withViewCollection(fakeLocation)
+      .withFakeLocation(fakeLocation)
+      .withViewCollection()
       .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent))
   })
 

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -1,6 +1,7 @@
 import { getHash, getPathName, getSearch } from '@datadog/browser-core'
 
 import { LifeCycleEventType } from '../src/lifeCycle'
+import { ViewContext } from '../src/parentContexts'
 import { PerformanceLongTaskTiming, PerformancePaintTiming } from '../src/rum'
 
 import {
@@ -9,7 +10,7 @@ import {
   PAGE_ACTIVITY_VALIDATION_DELAY,
 } from '../src/trackPageActivities'
 import { UserAction, UserActionType } from '../src/userActionCollection'
-import { THROTTLE_VIEW_UPDATE_PERIOD, View, ViewContext, ViewLoadingType } from '../src/viewCollection'
+import { THROTTLE_VIEW_UPDATE_PERIOD, View, ViewLoadingType } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 const AFTER_PAGE_ACTIVITY_MAX_DURATION = PAGE_ACTIVITY_MAX_DURATION * 1.1
@@ -91,7 +92,7 @@ describe('rum track url change', () => {
     setupBuilder = setup()
       .withViewCollection(fakeLocation)
       .beforeBuild((lifeCycle) => {
-        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (viewContext) => {
+        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ viewContext }) => {
           initialViewId = viewContext.id
           initialLocation = viewContext.location
           subscription.unsubscribe()
@@ -111,7 +112,7 @@ describe('rum track url change', () => {
     history.pushState({}, '', '/bar')
 
     expect(createSpy).toHaveBeenCalled()
-    const viewContext = createSpy.calls.argsFor(0)[0] as ViewContext
+    const viewContext = (createSpy.calls.argsFor(0)[0] as { viewContext: ViewContext }).viewContext
     expect(viewContext.id).not.toEqual(initialViewId)
     expect(viewContext.location).not.toEqual(initialLocation)
   })
@@ -151,7 +152,7 @@ describe('rum track renew session', () => {
       .withViewCollection(fakeLocation)
       .beforeBuild((lifeCycle) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, addRumEvent)
-        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (viewContext) => {
+        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ viewContext }) => {
           initialViewId = viewContext.id
           subscription.unsubscribe()
         })


### PR DESCRIPTION
## Motivation

Following #438, prepare future work on associate events with its parents based on start time.

## Changes

- introduce parentContexts
- use parentContexts
- handle view url & session in parentContexts
- return structured context
- prepare usage with startTime
- rework userActionCollection

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
