### PR TITLE
🐛 fix dual shipping

### DIFF
--- a/packages/core/src/internalMonitoring.ts
+++ b/packages/core/src/internalMonitoring.ts
@@ -24,7 +24,7 @@ export interface MonitoringMessage extends utils.Context {
 }
 
 const monitoringConfiguration: {
-  batch?: Batch<MonitoringMessage>
+  batch?: Batch
   debugMode?: boolean
   maxMessagesPerPage: number
   sentMessageCount: number
@@ -51,38 +51,41 @@ export function startInternalMonitoring(configuration: Configuration): InternalM
 
 function startMonitoringBatch(configuration: Configuration) {
   const primaryBatch = createMonitoringBatch(configuration.internalMonitoringEndpoint!)
-  let replicaBatch: Batch<MonitoringMessage> | undefined
+  let replicaBatch: Batch | undefined
   if (configuration.replica !== undefined) {
     replicaBatch = createMonitoringBatch(configuration.replica.internalMonitoringEndpoint)
   }
 
   function createMonitoringBatch(endpointUrl: string) {
-    return new Batch<MonitoringMessage>(
+    return new Batch(
       new HttpRequest(endpointUrl, configuration.batchBytesLimit),
       configuration.maxBatchSize,
       configuration.batchBytesLimit,
       configuration.maxMessageSize,
-      configuration.flushTimeout,
-      (message: utils.Context) =>
-        utils.deepMerge(
-          {
-            date: new Date().getTime(),
-            view: {
-              referrer: document.referrer,
-              url: window.location.href,
-            },
-          },
-          externalContextProvider !== undefined ? externalContextProvider() : {},
-          message
-        ) as utils.Context
+      configuration.flushTimeout
     )
+  }
+
+  function withContext(message: MonitoringMessage) {
+    return utils.deepMerge(
+      {
+        date: new Date().getTime(),
+        view: {
+          referrer: document.referrer,
+          url: window.location.href,
+        },
+      },
+      externalContextProvider !== undefined ? externalContextProvider() : {},
+      message
+    ) as utils.Context
   }
 
   return {
     add(message: MonitoringMessage) {
-      primaryBatch.add(message)
+      const contextualizedMessage = withContext(message)
+      primaryBatch.add(contextualizedMessage)
       if (replicaBatch) {
-        replicaBatch.add(message)
+        replicaBatch.add(contextualizedMessage)
       }
     },
   }

--- a/packages/core/src/internalMonitoring.ts
+++ b/packages/core/src/internalMonitoring.ts
@@ -14,7 +14,7 @@ export interface InternalMonitoring {
   setExternalContextProvider: (provider: () => utils.Context) => void
 }
 
-export interface MonitoringMessage {
+export interface MonitoringMessage extends utils.Context {
   message: string
   status: StatusType
   error?: {
@@ -63,7 +63,7 @@ function startMonitoringBatch(configuration: Configuration) {
       configuration.batchBytesLimit,
       configuration.maxMessageSize,
       configuration.flushTimeout,
-      () =>
+      (message: utils.Context) =>
         utils.deepMerge(
           {
             date: new Date().getTime(),
@@ -72,7 +72,8 @@ function startMonitoringBatch(configuration: Configuration) {
               url: window.location.href,
             },
           },
-          externalContextProvider !== undefined ? externalContextProvider() : {}
+          externalContextProvider !== undefined ? externalContextProvider() : {},
+          message
         ) as utils.Context
     )
   }

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -1,5 +1,5 @@
 import { monitor } from './internalMonitoring'
-import { Context, DOM_EVENT, identity, jsonStringify, noop, objectValues } from './utils'
+import { Context, DOM_EVENT, jsonStringify, noop, objectValues } from './utils'
 
 // https://en.wikipedia.org/wiki/UTF-8
 const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/
@@ -33,7 +33,7 @@ function addBatchTime(url: string) {
   return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}`
 }
 
-export class Batch<T extends Context> {
+export class Batch {
   private pushOnlyBuffer: string[] = []
   private upsertBuffer: { [key: string]: string } = {}
   private bufferBytesSize = 0
@@ -45,18 +45,17 @@ export class Batch<T extends Context> {
     private bytesLimit: number,
     private maxMessageSize: number,
     private flushTimeout: number,
-    private processor: (message: Context) => Context = identity,
     private beforeUnloadCallback: () => void = noop
   ) {
     this.flushOnVisibilityHidden()
     this.flushPeriodically()
   }
 
-  add(message: T) {
+  add(message: Context) {
     this.addOrUpdate(message)
   }
 
-  upsert(message: T, key: string) {
+  upsert(message: Context, key: string) {
     this.addOrUpdate(message, key)
   }
 
@@ -84,7 +83,7 @@ export class Batch<T extends Context> {
     return new Blob([candidate]).size
   }
 
-  private addOrUpdate(message: T, key?: string) {
+  private addOrUpdate(message: Context, key?: string) {
     const { processedMessage, messageBytesSize } = this.process(message)
     if (messageBytesSize >= this.maxMessageSize) {
       console.warn(`Discarded a message whose size was bigger than the maximum allowed size ${this.maxMessageSize}KB.`)
@@ -102,8 +101,8 @@ export class Batch<T extends Context> {
     }
   }
 
-  private process(message: T) {
-    const processedMessage = jsonStringify(this.processor(message))!
+  private process(message: Context) {
+    const processedMessage = jsonStringify(message)!
     const messageBytesSize = this.sizeInBytes(processedMessage)
     return { processedMessage, messageBytesSize }
   }

--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -1,5 +1,5 @@
 import { monitor } from './internalMonitoring'
-import { Context, deepMerge, DOM_EVENT, jsonStringify, noop, objectValues } from './utils'
+import { Context, DOM_EVENT, identity, jsonStringify, noop, objectValues } from './utils'
 
 // https://en.wikipedia.org/wiki/UTF-8
 const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/
@@ -33,7 +33,7 @@ function addBatchTime(url: string) {
   return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}`
 }
 
-export class Batch<T> {
+export class Batch<T extends Context> {
   private pushOnlyBuffer: string[] = []
   private upsertBuffer: { [key: string]: string } = {}
   private bufferBytesSize = 0
@@ -45,7 +45,7 @@ export class Batch<T> {
     private bytesLimit: number,
     private maxMessageSize: number,
     private flushTimeout: number,
-    private contextProvider: () => Context,
+    private processor: (message: Context) => Context = identity,
     private beforeUnloadCallback: () => void = noop
   ) {
     this.flushOnVisibilityHidden()
@@ -103,8 +103,7 @@ export class Batch<T> {
   }
 
   private process(message: T) {
-    const contextualizedMessage = deepMerge({}, this.contextProvider(), (message as unknown) as Context) as Context
-    const processedMessage = jsonStringify(contextualizedMessage)!
+    const processedMessage = jsonStringify(this.processor(message))!
     const messageBytesSize = this.sizeInBytes(processedMessage)
     return { processedMessage, messageBytesSize }
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -189,6 +189,10 @@ export function toSnakeCase(word: string) {
 // tslint:disable-next-line:no-empty
 export function noop() {}
 
+export function identity<T>(a: T): T {
+  return a
+}
+
 interface ObjectWithToJSON {
   toJSON: (() => object) | undefined
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -189,10 +189,6 @@ export function toSnakeCase(word: string) {
 // tslint:disable-next-line:no-empty
 export function noop() {}
 
-export function identity<T>(a: T): T {
-  return a
-}
-
 interface ObjectWithToJSON {
   toJSON: (() => object) | undefined
 }

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon'
 
 import { Batch, HttpRequest } from '../src/transport'
-import { Context, deepMerge, noop } from '../src/utils'
+import { noop } from '../src/utils'
 
 describe('request', () => {
   const ENDPOINT_URL = 'http://my.website'
@@ -58,23 +58,14 @@ describe('batch', () => {
   const MAX_SIZE = 3
   const BATCH_BYTES_LIMIT = 100
   const MESSAGE_BYTES_LIMIT = 50 * 1024
-  let CONTEXT: { foo: string }
   const FLUSH_TIMEOUT = 60 * 1000
-  let batch: Batch<{ message: string; foo?: any }>
+  let batch: Batch
   let transport: HttpRequest
 
   beforeEach(() => {
-    CONTEXT = { foo: 'bar' }
     transport = ({ send: noop } as unknown) as HttpRequest
     spyOn(transport, 'send')
-    batch = new Batch(
-      transport,
-      MAX_SIZE,
-      BATCH_BYTES_LIMIT,
-      MESSAGE_BYTES_LIMIT,
-      FLUSH_TIMEOUT,
-      (message: Context) => deepMerge(CONTEXT, message) as Context
-    )
+    batch = new Batch(transport, MAX_SIZE, BATCH_BYTES_LIMIT, MESSAGE_BYTES_LIMIT, FLUSH_TIMEOUT)
   })
 
   it('should add context to message', () => {
@@ -82,19 +73,7 @@ describe('batch', () => {
 
     batch.flush()
 
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"hello"}', jasmine.any(Number))
-  })
-
-  it('should deep merge contexts', () => {
-    CONTEXT.foo = { bar: 'qux' } as any
-    batch.add({ message: 'hello', foo: { hello: 'qix' } })
-
-    batch.flush()
-
-    expect(transport.send).toHaveBeenCalledWith(
-      '{"foo":{"bar":"qux","hello":"qix"},"message":"hello"}',
-      jasmine.any(Number)
-    )
+    expect(transport.send).toHaveBeenCalledWith('{"message":"hello"}', jasmine.any(Number))
   })
 
   it('should empty the batch after a flush', () => {
@@ -120,48 +99,48 @@ describe('batch', () => {
     batch.add({ message: '2' })
     batch.add({ message: '3' })
     expect(transport.send).toHaveBeenCalledWith(
-      '{"foo":"bar","message":"1"}\n{"foo":"bar","message":"2"}\n{"foo":"bar","message":"3"}',
+      '{"message":"1"}\n{"message":"2"}\n{"message":"3"}',
       jasmine.any(Number)
     )
   })
 
   it('should flush when new message will overflow bytes limit', () => {
-    batch.add({ message: '50 bytes - xxxxxxxxxxxxx' })
+    batch.add({ message: '50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx' })
     expect(transport.send).not.toHaveBeenCalled()
 
-    batch.add({ message: '60 bytes - xxxxxxxxxxxxxxxxxxxxxxx' })
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"50 bytes - xxxxxxxxxxxxx"}', 50)
+    batch.add({ message: '60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' })
+    expect(transport.send).toHaveBeenCalledWith('{"message":"50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx"}', 50)
 
     batch.flush()
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxx"}', 60)
+    expect(transport.send).toHaveBeenCalledWith('{"message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}', 60)
   })
 
   it('should consider separator size when computing the size', () => {
-    batch.add({ message: '30 b' }) // batch: 30 sep: 0
-    batch.add({ message: '30 b' }) // batch: 60 sep: 1
-    batch.add({ message: '39 bytes - xx' }) // batch: 99 sep: 2
+    batch.add({ message: '30 bytes - xxxxx' }) // batch: 30 sep: 0
+    batch.add({ message: '30 bytes - xxxxx' }) // batch: 60 sep: 1
+    batch.add({ message: '39 bytes - xxxxxxxxxxxxxx' }) // batch: 99 sep: 2
 
-    expect(transport.send).toHaveBeenCalledWith('{"foo":"bar","message":"30 b"}\n{"foo":"bar","message":"30 b"}', 61)
+    expect(transport.send).toHaveBeenCalledWith('{"message":"30 bytes - xxxxx"}\n{"message":"30 bytes - xxxxx"}', 61)
   })
 
   it('should call send one time when the size is too high and the batch is empty', () => {
-    const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     batch.add({ message })
-    expect(transport.send).toHaveBeenCalledWith(`{"foo":"bar","message":"${message}"}`, 101)
+    expect(transport.send).toHaveBeenCalledWith(`{"message":"${message}"}`, 101)
   })
 
   it('should flush the batch and send the message when the message is too heavy', () => {
-    const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 
-    batch.add({ message: '50 bytes - xxxxxxxxxxxxx' })
+    batch.add({ message: '50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx' })
     batch.add({ message })
     expect(transport.send).toHaveBeenCalledTimes(2)
   })
 
   it('should flush after timeout', () => {
     const clock = sinon.useFakeTimers()
-    batch = new Batch(transport, MAX_SIZE, BATCH_BYTES_LIMIT, MESSAGE_BYTES_LIMIT, 10, () => CONTEXT)
-    batch.add({ message: '50 bytes - xxxxxxxxxxxxx' })
+    batch = new Batch(transport, MAX_SIZE, BATCH_BYTES_LIMIT, MESSAGE_BYTES_LIMIT, 10)
+    batch.add({ message: '50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx' })
     clock.tick(100)
 
     expect(transport.send).toHaveBeenCalled()
@@ -171,7 +150,7 @@ describe('batch', () => {
 
   it('should not send a message with a size above the limit', () => {
     const warnStub = sinon.stub(console, 'warn')
-    batch = new Batch(transport, MAX_SIZE, BATCH_BYTES_LIMIT, 50, FLUSH_TIMEOUT, () => CONTEXT)
+    batch = new Batch(transport, MAX_SIZE, BATCH_BYTES_LIMIT, 50, FLUSH_TIMEOUT)
     batch.add({ message: '50 bytes - xxxxxxxxxxxxx' })
 
     expect(transport.send).not.toHaveBeenCalled()
@@ -185,7 +164,7 @@ describe('batch', () => {
     batch.upsert({ message: '4' }, 'c')
 
     expect(transport.send).toHaveBeenCalledWith(
-      '{"foo":"bar","message":"2"}\n{"foo":"bar","message":"3"}\n{"foo":"bar","message":"4"}',
+      '{"message":"2"}\n{"message":"3"}\n{"message":"4"}',
       jasmine.any(Number)
     )
 
@@ -194,7 +173,7 @@ describe('batch', () => {
     batch.upsert({ message: '7' }, 'a')
 
     expect(transport.send).toHaveBeenCalledWith(
-      '{"foo":"bar","message":"5"}\n{"foo":"bar","message":"6"}\n{"foo":"bar","message":"7"}',
+      '{"message":"5"}\n{"message":"6"}\n{"message":"7"}',
       jasmine.any(Number)
     )
 
@@ -204,9 +183,6 @@ describe('batch', () => {
     batch.upsert({ message: '11' }, 'b')
     batch.flush()
 
-    expect(transport.send).toHaveBeenCalledWith(
-      '{"foo":"bar","message":"10"}\n{"foo":"bar","message":"11"}',
-      jasmine.any(Number)
-    )
+    expect(transport.send).toHaveBeenCalledWith('{"message":"10"}\n{"message":"11"}', jasmine.any(Number))
   })
 })

--- a/packages/core/test/transport.spec.ts
+++ b/packages/core/test/transport.spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon'
 
 import { Batch, HttpRequest } from '../src/transport'
-import { noop } from '../src/utils'
+import { Context, deepMerge, noop } from '../src/utils'
 
 describe('request', () => {
   const ENDPOINT_URL = 'http://my.website'
@@ -67,7 +67,14 @@ describe('batch', () => {
     CONTEXT = { foo: 'bar' }
     transport = ({ send: noop } as unknown) as HttpRequest
     spyOn(transport, 'send')
-    batch = new Batch(transport, MAX_SIZE, BATCH_BYTES_LIMIT, MESSAGE_BYTES_LIMIT, FLUSH_TIMEOUT, () => CONTEXT)
+    batch = new Batch(
+      transport,
+      MAX_SIZE,
+      BATCH_BYTES_LIMIT,
+      MESSAGE_BYTES_LIMIT,
+      FLUSH_TIMEOUT,
+      (message: Context) => deepMerge(CONTEXT, message) as Context
+    )
   })
 
   it('should add context to message', () => {

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -111,7 +111,7 @@ function startLoggerBatch(configuration: Configuration, session: LoggerSession, 
       configuration.batchBytesLimit,
       configuration.maxMessageSize,
       configuration.flushTimeout,
-      () =>
+      (message: Context) =>
         deepMerge(
           {
             date: new Date().getTime(),
@@ -122,7 +122,8 @@ function startLoggerBatch(configuration: Configuration, session: LoggerSession, 
             },
           },
           globalContextProvider(),
-          getRUMInternalContext() as Context
+          getRUMInternalContext() as Context,
+          message
         ) as Context
     )
   }


### PR DESCRIPTION
## Motivation

Following #440, dual shipping was broken due to wrong application id being associated with replica events.
This was due to an incorrect merge order.

## Changes

Remove context provider from Batch and let the caller process him self the message before passing it to the batch.

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
