### PR TITLE
✨ [RUMF-605] associate event to parent context by start date (behind flag)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
 } from './requestCollection'
 export {
   startSessionManagement,
+  SESSION_TIME_OUT_DELAY,
   // Exposed for tests
   SESSION_COOKIE_NAME,
   stopSessionManagement,

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -51,7 +51,7 @@ const STUBBED_RUM = {
   addUserAction(name: string, context: Context) {
     makeStub('addUserAction')
   },
-  getInternalContext(): InternalContext | undefined {
+  getInternalContext(startTime?: number): InternalContext | undefined {
     makeStub('getInternalContext')
     return undefined
   },

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -170,7 +170,12 @@ export function startRum(
 ): Omit<RumGlobal, 'init'> {
   let globalContext: Context = {}
 
-  const parentContexts = startParentContexts(window.location, lifeCycle, session)
+  const parentContexts = startParentContexts(
+    window.location,
+    lifeCycle,
+    session,
+    configuration.isEnabled('context-history')
+  )
 
   internalMonitoring.setExternalContextProvider(() => {
     return deepMerge(

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -32,8 +32,6 @@ export interface AutoUserAction {
   measures: UserActionMeasures
 }
 
-export type UserAction = CustomUserAction | AutoUserAction
-
 export function startUserActionCollection(lifeCycle: LifeCycle) {
   const userAction = startUserActionManagement(lifeCycle)
 

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -1,7 +1,13 @@
 import { LifeCycleEventType } from '../src/lifeCycle'
+import { AutoUserAction } from '../src/userActionCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
-describe('parentContexts', () => {
+function stubActionWithDuration(duration: number): AutoUserAction {
+  const action: Partial<AutoUserAction> = { duration }
+  return action as AutoUserAction
+}
+
+describe('parentContexts (only current)', () => {
   const FAKE_ID = 'fake'
   const startTime = 10
 
@@ -24,7 +30,7 @@ describe('parentContexts', () => {
         isTracked: () => true,
         isTrackedWithResource: () => true,
       })
-      .withParentContexts()
+      .withParentContexts(false)
   })
 
   describe('findView', () => {
@@ -116,6 +122,168 @@ describe('parentContexts', () => {
 
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, undefined as any)
+
+      expect(parentContexts.findAction()).toBeUndefined()
+    })
+  })
+})
+
+describe('parentContexts (with context history)', () => {
+  const FAKE_ID = 'fake'
+  const startTime = 10
+
+  let fakeUrl: string
+  let sessionId: string
+  let setupBuilder: TestSetupBuilder
+
+  beforeEach(() => {
+    fakeUrl = 'fake-url'
+    sessionId = 'fake-session'
+    const fakeLocation = {
+      get href() {
+        return fakeUrl
+      },
+    }
+    setupBuilder = setup()
+      .withFakeLocation(fakeLocation)
+      .withSession({
+        getId: () => sessionId,
+        isTracked: () => true,
+        isTrackedWithResource: () => true,
+      })
+      .withParentContexts(true)
+  })
+
+  describe('findView', () => {
+    it('should return undefined when there is no current view and no startTime', () => {
+      const { parentContexts } = setupBuilder.build()
+
+      expect(parentContexts.findView()).toBeUndefined()
+    })
+
+    it('should return the current view context when there is no start time', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+
+      expect(parentContexts.findView()).toBeDefined()
+      expect(parentContexts.findView()!.view.id).toEqual(FAKE_ID)
+    })
+
+    it('should return the view context corresponding to startTime', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 10, id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 20, id: 'view 2' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 30, id: 'view 3' })
+
+      expect(parentContexts.findView(15)!.view.id).toEqual('view 1')
+      expect(parentContexts.findView(20)!.view.id).toEqual('view 2')
+      expect(parentContexts.findView(40)!.view.id).toEqual('view 3')
+    })
+
+    it('should return undefined when no view context corresponding to startTime', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 10, id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 20, id: 'view 2' })
+
+      expect(parentContexts.findView(5)).not.toBeDefined()
+    })
+
+    it('should replace the current view context on VIEW_CREATED', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      const newViewId = 'fake 2'
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: newViewId })
+
+      expect(parentContexts.findView()!.view.id).toEqual(newViewId)
+    })
+
+    it('should return the current url with the current view', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      expect(parentContexts.findView()!.view.url).toBe('fake-url')
+
+      fakeUrl = 'other-url'
+
+      expect(parentContexts.findView()!.view.url).toBe('other-url')
+    })
+
+    it('should update session id only on VIEW_CREATED', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      expect(parentContexts.findView()!.sessionId).toBe('fake-session')
+
+      sessionId = 'other-session'
+      expect(parentContexts.findView()!.sessionId).toBe('fake-session')
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: 'fake 2' })
+      expect(parentContexts.findView()!.sessionId).toBe('other-session')
+    })
+  })
+
+  describe('findAction', () => {
+    it('should return undefined when there is no current action and no startTime', () => {
+      const { parentContexts } = setupBuilder.build()
+
+      expect(parentContexts.findAction()).toBeUndefined()
+    })
+
+    it('should return the current action context when no startTime', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
+
+      expect(parentContexts.findAction()).toBeDefined()
+      expect(parentContexts.findAction()!.userAction.id).toBe(FAKE_ID)
+    })
+
+    it('should return the action context corresponding to startTime', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10, id: 'action 1' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 30, id: 'action 2' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 50, id: 'action 3' })
+
+      expect(parentContexts.findAction(15)!.userAction.id).toBe('action 1')
+      expect(parentContexts.findAction(20)!.userAction.id).toBe('action 1')
+      expect(parentContexts.findAction(30)!.userAction.id).toBe('action 2')
+      expect(parentContexts.findAction(55)!.userAction.id).toBe('action 3')
+    })
+
+    it('should return undefined if no action context corresponding to startTime', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10, id: 'action 1' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_DISCARDED)
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 20, id: 'action 2' })
+
+      expect(parentContexts.findAction(10)).toBeUndefined()
+    })
+
+    it('should clear the current action on ACTION_DISCARDED', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_DISCARDED)
+
+      expect(parentContexts.findAction()).toBeUndefined()
+    })
+
+    it('should clear the current action on ACTION_COMPLETED', () => {
+      const { lifeCycle, parentContexts } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
 
       expect(parentContexts.findAction()).toBeUndefined()
     })

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -120,6 +120,9 @@ export function setup(): TestSetupBuilder {
     withParentContexts(withContextHistory: boolean) {
       buildTasks.push(() => {
         parentContexts = startParentContexts(fakeLocation as Location, lifeCycle, session, withContextHistory)
+        cleanupTasks.push(() => {
+          parentContexts.stop()
+        })
       })
       return setupBuilder
     },

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -39,7 +39,7 @@ export interface TestSetupBuilder {
   withViewCollection: () => TestSetupBuilder
   withUserActionCollection: () => TestSetupBuilder
   withPerformanceCollection: () => TestSetupBuilder
-  withParentContexts: () => TestSetupBuilder
+  withParentContexts: (withContextHistory: boolean) => TestSetupBuilder
   withFakeClock: () => TestSetupBuilder
   withFakeServer: () => TestSetupBuilder
   withPerformanceObserverStubBuilder: () => TestSetupBuilder
@@ -117,9 +117,9 @@ export function setup(): TestSetupBuilder {
       buildTasks.push(() => startPerformanceCollection(lifeCycle, session))
       return setupBuilder
     },
-    withParentContexts() {
+    withParentContexts(withContextHistory: boolean) {
       buildTasks.push(() => {
-        parentContexts = startParentContexts(fakeLocation as Location, lifeCycle, session)
+        parentContexts = startParentContexts(fakeLocation as Location, lifeCycle, session, withContextHistory)
       })
       return setupBuilder
     },

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -1,7 +1,7 @@
 import { DOM_EVENT, ErrorMessage } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../src/trackPageActivities'
-import { AutoUserAction, UserAction, UserActionType } from '../src/userActionCollection'
+import { AutoUserAction, UserActionType } from '../src/userActionCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 // Used to wait some time after the creation of a user action
@@ -126,7 +126,7 @@ describe('startUserActionCollection', () => {
 
 describe('newUserAction', () => {
   let setupBuilder: TestSetupBuilder
-  const { events, pushEvent } = eventsCollector<UserAction>()
+  const { events, pushEvent } = eventsCollector<AutoUserAction>()
 
   function newClick(name: string) {
     const button = document.createElement('button')

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -29,7 +29,7 @@
           internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
           logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
           rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
-          enableExperimentalFeatures: [],
+          enableExperimentalFeatures: ['context-history'],
           trackInteractions: true,
         })
     </script>


### PR DESCRIPTION
## Motivation

Events were attached to parent view or action when we received them. It caused some issues in the waterfall display where we could see events starting before the start of the view (or the action) which were very confusing.

## Changes

Keep an history of parent contexts to retrieve the one (if any) corresponding to the start time of the event.
Clear automatically old context on session renew or after a time out delay.

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
