### PR TITLE
refact message format, tabState by tagID,  add auto refresh and init

### DIFF
--- a/extension/src/contentscript/listenRumEvents.ts
+++ b/extension/src/contentscript/listenRumEvents.ts
@@ -1,4 +1,4 @@
-import { addOrUpdateViews, LifeCycleEventType, View } from '../lib/rumEvents'
+import { LifeCycleEventType, View } from '../lib/rumEvents'
 
 const ROOT_TAG: HTMLCollection | null = document.getElementsByTagName('html')
 const CUSTOM_EVENT_NAME = 'custom-rum-event'
@@ -12,7 +12,7 @@ interface CustomEventDetail {
 
 if (ROOT_TAG && ROOT_TAG.length) {
   ROOT_TAG[0].addEventListener(RUM_SDK_ON, () => {
-    chrome.runtime.sendMessage({ sdkEnabled: true })
+    chrome.runtime.sendMessage({ type: 'enableExtension' })
 
     ROOT_TAG[0].addEventListener(CUSTOM_EVENT_NAME, (customEvent: CustomEvent<CustomEventDetail>) => {
       if (
@@ -20,7 +20,7 @@ if (ROOT_TAG && ROOT_TAG.length) {
         (customEvent.detail.type === LifeCycleEventType[LifeCycleEventType.VIEW_CREATED] ||
           customEvent.detail.type === LifeCycleEventType[LifeCycleEventType.VIEW_UPDATED])
       ) {
-        chrome.runtime.sendMessage({ view: JSON.parse(customEvent.detail.content) as View })
+        chrome.runtime.sendMessage({ type: 'addOrUpdateViews', payload: JSON.parse(customEvent.detail.content) as View })
       }
     })
   })


### PR DESCRIPTION
## Motivation

Mieux comprendre vos 2 derniers commits et en jouant avec je voulais clean un peu pour mieux comprendre, une chose en entrainant une autre voila la PR.

![refact](https://user-images.githubusercontent.com/1764557/87726556-873fae80-c7bf-11ea-91f3-a31732489980.gif)

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

- message format `{ type: string, payload: any }`
- merge `tabsState` and `tabsViews` and send only views for the active tab
- init (to have some data when opening the popup)
- auto-refresh
- display documentVersion to see update

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
