### PR TITLE
✨ [RUMF-605] enable event association to parent context by start date

### DIFF
--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -38,12 +38,7 @@ export interface ParentContexts {
   stop: () => void
 }
 
-export function startParentContexts(
-  location: Location,
-  lifeCycle: LifeCycle,
-  session: RumSession,
-  withContextHistory: boolean
-): ParentContexts {
+export function startParentContexts(location: Location, lifeCycle: LifeCycle, session: RumSession): ParentContexts {
   let currentView: CurrentContext | undefined
   let currentAction: CurrentContext | undefined
   let currentSessionId: string | undefined
@@ -52,7 +47,7 @@ export function startParentContexts(
   let previousActions: Array<PreviousContext<ActionContext>> = []
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (currentContext) => {
-    if (currentView && withContextHistory) {
+    if (currentView) {
       previousViews.unshift({
         context: buildCurrentViewContext(),
         endTime: currentContext.startTime,
@@ -68,7 +63,7 @@ export function startParentContexts(
   })
 
   lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, (userAction: AutoUserAction) => {
-    if (currentAction && withContextHistory) {
+    if (currentAction) {
       previousActions.unshift({
         context: buildCurrentActionContext(),
         endTime: currentAction.startTime + userAction.duration,
@@ -123,9 +118,6 @@ export function startParentContexts(
     }
     if (currentContext && startTime >= currentContext.startTime) {
       return buildContext()
-    }
-    if (!withContextHistory) {
-      return undefined
     }
     for (const previousContext of previousContexts) {
       if (startTime > previousContext.endTime) {

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -170,12 +170,7 @@ export function startRum(
 ): Omit<RumGlobal, 'init'> {
   let globalContext: Context = {}
 
-  const parentContexts = startParentContexts(
-    window.location,
-    lifeCycle,
-    session,
-    configuration.isEnabled('context-history')
-  )
+  const parentContexts = startParentContexts(window.location, lifeCycle, session)
 
   internalMonitoring.setExternalContextProvider(() => {
     return deepMerge(

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -12,7 +12,7 @@ function stubActionWithDuration(duration: number): AutoUserAction {
   return action as AutoUserAction
 }
 
-describe('parentContexts (only current)', () => {
+describe('parentContexts', () => {
   const FAKE_ID = 'fake'
   const startTime = 10
 
@@ -35,128 +35,7 @@ describe('parentContexts (only current)', () => {
         isTracked: () => true,
         isTrackedWithResource: () => true,
       })
-      .withParentContexts(false)
-  })
-
-  describe('findView', () => {
-    it('should return undefined if there is no current view', () => {
-      const { parentContexts } = setupBuilder.build()
-
-      expect(parentContexts.findView()).toBeUndefined()
-    })
-
-    it('should return the current view context', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
-
-      expect(parentContexts.findView()).toBeDefined()
-      expect(parentContexts.findView()!.view.id).toEqual(FAKE_ID)
-    })
-
-    it('should replace the current view context on VIEW_CREATED', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
-      const newViewId = 'fake 2'
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: newViewId })
-
-      expect(parentContexts.findView()!.view.id).toEqual(newViewId)
-    })
-
-    it('should return the current url with the current view', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
-      expect(parentContexts.findView()!.view.url).toBe('fake-url')
-
-      fakeUrl = 'other-url'
-
-      expect(parentContexts.findView()!.view.url).toBe('other-url')
-    })
-
-    it('should update session id only on VIEW_CREATED', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
-      expect(parentContexts.findView()!.sessionId).toBe('fake-session')
-
-      sessionId = 'other-session'
-      expect(parentContexts.findView()!.sessionId).toBe('fake-session')
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: 'fake 2' })
-      expect(parentContexts.findView()!.sessionId).toBe('other-session')
-    })
-  })
-
-  describe('findAction', () => {
-    it('should return undefined if there is no current action', () => {
-      const { parentContexts } = setupBuilder.build()
-
-      expect(parentContexts.findAction()).toBeUndefined()
-    })
-
-    it('should return the current action context', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
-
-      expect(parentContexts.findAction()).toBeDefined()
-      expect(parentContexts.findAction()!.userAction.id).toBe(FAKE_ID)
-    })
-
-    it('should return undefined if startTime is before the start of the current action', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
-
-      expect(parentContexts.findAction(startTime - 1)).toBeUndefined()
-    })
-
-    it('should clear the current action on AUTO_ACTION_DISCARDED', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_DISCARDED)
-
-      expect(parentContexts.findAction()).toBeUndefined()
-    })
-
-    it('should clear the current action on AUTO_ACTION_COMPLETED', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime, id: FAKE_ID })
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, undefined as any)
-
-      expect(parentContexts.findAction()).toBeUndefined()
-    })
-  })
-})
-
-describe('parentContexts (with context history)', () => {
-  const FAKE_ID = 'fake'
-  const startTime = 10
-
-  let fakeUrl: string
-  let sessionId: string
-  let setupBuilder: TestSetupBuilder
-
-  beforeEach(() => {
-    fakeUrl = 'fake-url'
-    sessionId = 'fake-session'
-    const fakeLocation = {
-      get href() {
-        return fakeUrl
-      },
-    }
-    setupBuilder = setup()
-      .withFakeLocation(fakeLocation)
-      .withSession({
-        getId: () => sessionId,
-        isTracked: () => true,
-        isTrackedWithResource: () => true,
-      })
-      .withParentContexts(true)
+      .withParentContexts()
   })
 
   afterEach(() => {

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -39,7 +39,7 @@ export interface TestSetupBuilder {
   withViewCollection: () => TestSetupBuilder
   withUserActionCollection: () => TestSetupBuilder
   withPerformanceCollection: () => TestSetupBuilder
-  withParentContexts: (withContextHistory: boolean) => TestSetupBuilder
+  withParentContexts: () => TestSetupBuilder
   withFakeClock: () => TestSetupBuilder
   withFakeServer: () => TestSetupBuilder
   withPerformanceObserverStubBuilder: () => TestSetupBuilder
@@ -117,9 +117,9 @@ export function setup(): TestSetupBuilder {
       buildTasks.push(() => startPerformanceCollection(lifeCycle, session))
       return setupBuilder
     },
-    withParentContexts(withContextHistory: boolean) {
+    withParentContexts() {
       buildTasks.push(() => {
-        parentContexts = startParentContexts(fakeLocation as Location, lifeCycle, session, withContextHistory)
+        parentContexts = startParentContexts(fakeLocation as Location, lifeCycle, session)
         cleanupTasks.push(() => {
           parentContexts.stop()
         })

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -29,7 +29,7 @@
           internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
           logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
           rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
-          enableExperimentalFeatures: ['context-history'],
+          enableExperimentalFeatures: [],
           trackInteractions: true,
         })
     </script>


### PR DESCRIPTION
## Motivation

cf [✨ associate event to parent context by start date (behind flag)](https://github.com/DataDog/browser-sdk/pull/445)

## Changes

Remove flag

## Testing

Automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
