### PR TITLE
SDK: better support for SPA routing - STEP 1/2 : add hash tracking

### DIFF
--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -177,10 +177,11 @@ function trackHash(onHashChange: () => void) {
 function areDifferentViews(previous: Location, current: Location): boolean {
   return (
     previous.pathname !== current.pathname ||
-    // hash can be empty or undefined
-    // switching from undefined to empty does not mean different views
-    (previous.hash && current.hash && previous.hash !== current.hash) ||
-    Boolean(previous.hash && !current.hash) ||
+    // the views are different when:
+    //  switching from a defined hash to no hash ('')
+    //  switching from a defined hash to a different and defined hash
+    //  switching from no hash ('') to a defined hash
+    (previous.hash && previous.hash !== current.hash) ||
     Boolean(!previous.hash && current.hash)
   )
 }

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -58,7 +58,6 @@ export function startViewCollection(location: Location, lifeCycle: LifeCycle) {
   // Renew view on hash changes
   trackHash(() => {
     if (areDifferentViews(currentLocation, location)) {
-      console.log('trackHash areDifferentViews yes')
       onRouteChange()
     }
   })
@@ -110,8 +109,6 @@ function newView(
   let loadingTime: number | undefined
 
   lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id, startTime })
-
-  console.log('LifeCycleEventType.VIEW_CREATED notified', id, startTime)
 
   // Update the view every time the measures are changing
   const { throttled: scheduleViewUpdate, stop: stopScheduleViewUpdate } = throttle(

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -41,26 +41,20 @@ export function startViewCollection(location: Location, lifeCycle: LifeCycle) {
   const startOrigin = 0
   let currentView = newView(lifeCycle, currentLocation, ViewLoadingType.INITIAL_LOAD, startOrigin)
 
-  function onRouteChange() {
-    currentLocation = { ...location }
-    currentView.triggerUpdate()
-    currentView.end()
-    currentView = newView(lifeCycle, currentLocation, ViewLoadingType.ROUTE_CHANGE)
+  function renewViewOnChange() {
+    if (areDifferentViews(currentLocation, location)) {
+      currentLocation = { ...location }
+      currentView.triggerUpdate()
+      currentView.end()
+      currentView = newView(lifeCycle, currentLocation, ViewLoadingType.ROUTE_CHANGE)
+    }
   }
 
   // Renew view on history changes
-  trackHistory(() => {
-    if (areDifferentViews(currentLocation, location)) {
-      onRouteChange()
-    }
-  })
+  trackHistory(renewViewOnChange)
 
   // Renew view on hash changes
-  trackHash(() => {
-    if (areDifferentViews(currentLocation, location)) {
-      onRouteChange()
-    }
-  })
+  trackHash(renewViewOnChange)
 
   // Renew view on session renewal
   lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -175,15 +175,7 @@ function trackHash(onHashChange: () => void) {
 }
 
 function areDifferentViews(previous: Location, current: Location): boolean {
-  return (
-    previous.pathname !== current.pathname ||
-    // the views are different when:
-    //  switching from a defined hash to no hash ('')
-    //  switching from a defined hash to a different and defined hash
-    //  switching from no hash ('') to a defined hash
-    (previous.hash && previous.hash !== current.hash) ||
-    Boolean(!previous.hash && current.hash)
-  )
+  return previous.pathname !== current.pathname || previous.hash !== current.hash
 }
 
 interface Timings {

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -171,14 +171,7 @@ function trackHistory(onHistoryChange: () => void) {
 }
 
 function trackHash(onHashChange: () => void) {
-  function noAnchorNavHashChange() {
-    const cleanedHash = window.location.hash.replace(/#/g, '')
-    if (!document.getElementById(cleanedHash)) {
-      onHashChange()
-    }
-  }
-
-  window.addEventListener('hashchange', monitor(noAnchorNavHashChange))
+  window.addEventListener('hashchange', monitor(onHashChange))
 }
 
 function areDifferentViews(previous: Location, current: Location): boolean {

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -171,7 +171,14 @@ function trackHistory(onHistoryChange: () => void) {
 }
 
 function trackHash(onHashChange: () => void) {
-  window.addEventListener('hashchange', monitor(onHashChange))
+  function noAnchorNavHashChange() {
+    const cleanedHash = window.location.hash.replace(/#/g, '')
+    if (!document.getElementById(cleanedHash)) {
+      onHashChange()
+    }
+  }
+
+  window.addEventListener('hashchange', monitor(noAnchorNavHashChange))
 }
 
 function areDifferentViews(previous: Location, current: Location): boolean {

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -148,19 +148,17 @@ describe('rum track url change', () => {
     expect(createSpy).not.toHaveBeenCalled()
   })
 
-  fit('should create a new view on hash change', () => {
+  it('should create a new view on hash change', () => {
     const { lifeCycle } = setupBuilder.build()
     lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
 
-    lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id, startTime }) => {
-      console.log('LifeCycleEventType.VIEW_CREATED received', id, startTime)
+    window.addEventListener('hashchange', () => {
+      expect(createSpy).toHaveBeenCalled()
+      const viewContext = createSpy.calls.argsFor(0)[0] as ViewContext
+      expect(viewContext.id).not.toEqual(initialViewId)
     })
 
     window.location.hash = '#bar'
-
-    expect(createSpy).toHaveBeenCalled()
-    const viewContext = createSpy.calls.argsFor(0)[0] as ViewContext
-    expect(viewContext.id).not.toEqual(initialViewId)
   })
 
   it('should not create a new view when the hash has kept the same value', () => {
@@ -169,9 +167,11 @@ describe('rum track url change', () => {
     const { lifeCycle } = setupBuilder.build()
     lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
 
-    window.location.hash = '#bar'
+    window.addEventListener('hashchange', () => {
+      expect(createSpy).not.toHaveBeenCalled()
+    })
 
-    expect(createSpy).not.toHaveBeenCalled()
+    window.location.hash = '#bar'
   })
 
   it('should not create new view on search change', () => {

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -71,9 +71,6 @@ function mockHistory(location: Partial<Location>) {
 }
 
 function mockHash(location: Partial<Location>) {
-  // Reset previous tests value
-  window.location.hash = ''
-
   function hashchangeCallBack() {
     location.hash = window.location.hash
   }
@@ -82,6 +79,7 @@ function mockHash(location: Partial<Location>) {
 
   return () => {
     window.removeEventListener('hashchange', hashchangeCallBack)
+    window.location.hash = ''
   }
 }
 
@@ -137,7 +135,7 @@ describe('rum track url change', () => {
     expect(viewContext.id).not.toEqual(initialViewId)
   })
 
-  it('should create a new view on pushState hash change', () => {
+  it('should create a new view on hash change from history', () => {
     const { lifeCycle } = setupBuilder.build()
     lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
 
@@ -148,7 +146,7 @@ describe('rum track url change', () => {
     expect(viewContext.id).not.toEqual(initialViewId)
   })
 
-  it('should not create a new view on pushState when the hash has kept the same value', () => {
+  it('should not create a new view on hash change from history when the hash has kept the same value', () => {
     history.pushState({}, '', '/foo#bar')
 
     const { lifeCycle } = setupBuilder.build()

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -71,6 +71,8 @@ function mockHistory(location: Partial<Location>) {
 }
 
 function mockHash(location: Partial<Location>) {
+  // Reset previous tests value
+  window.location.hash = ''
   window.addEventListener('hashchange', () => {
     location.hash = window.location.hash
   })
@@ -100,6 +102,7 @@ describe('rum track url change', () => {
       window.addEventListener('hashchange', () => {
         resolve()
       })
+
       window.location.hash = hash
     })
   }

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -1,4 +1,4 @@
-import { getHash, getPathName, getSearch } from '@datadog/browser-core'
+import { getHash, getPathName, getSearch, isIE } from '@datadog/browser-core'
 
 import { LifeCycleEventType } from '../src/lifeCycle'
 import { ViewContext } from '../src/parentContexts'
@@ -98,6 +98,9 @@ describe('rum track url change', () => {
   let createSpy: jasmine.Spy
 
   async function asyncSetWindowLocationHash(hash: string) {
+    if (isIE()) {
+      pending('no Promise support')
+    }
     return new Promise((resolve) => {
       window.addEventListener('hashchange', () => {
         resolve()


### PR DESCRIPTION
## Motivation
**Given**
  startViewCollection
**When**
  on window.location.hash changes
**Then**
  check if the views are different. 
  If the hash fragment has changed, then the views are different.

## Changes
- ✨    add a `trackHash` function
- ✨    modify `areDifferentViews` to handle hash changes

## Testing

 ✅    hash changes tests have been added both for pushStates and window.location.hash window.location.hash
Test with the Vue router without `mode: 'history'`:

`const router = new VueRouter({
  routes
})`


### SHOULD NOT BE MERGE UNTIL STEP 2 is done
SDK: better support for SPA routing - STEP 2/2 : filter out html anchor tags changes