### PR TITLE
[RUMF-617] Extract XHR and Fetch proxies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tunnel.log
 local.log
 test-server.log
 /test-report/
+browserstack.err

--- a/packages/core/src/errorCollection.ts
+++ b/packages/core/src/errorCollection.ts
@@ -2,9 +2,8 @@ import { Configuration } from './configuration'
 import { FetchContext, startFetchProxy } from './fetchProxy'
 import { monitor } from './internalMonitoring'
 import { Observable } from './observable'
-import { RequestType } from './requestCollection'
 import { computeStackTrace, Handler, report, StackFrame, StackTrace } from './tracekit'
-import { jsonStringify, ONE_MINUTE } from './utils'
+import { jsonStringify, ONE_MINUTE, RequestType } from './utils'
 import { startXhrProxy, XhrContext } from './xhrProxy'
 
 export interface ErrorMessage {

--- a/packages/core/src/errorCollection.ts
+++ b/packages/core/src/errorCollection.ts
@@ -1,10 +1,10 @@
 import { Configuration } from './configuration'
-import { FetchContext, startFetchProxy } from './fetchProxy'
+import { FetchContext, resetFetchProxy, startFetchProxy } from './fetchProxy'
 import { monitor } from './internalMonitoring'
 import { Observable } from './observable'
 import { computeStackTrace, Handler, report, StackFrame, StackTrace } from './tracekit'
 import { jsonStringify, ONE_MINUTE, RequestType } from './utils'
-import { startXhrProxy, XhrContext } from './xhrProxy'
+import { resetXhrProxy, startXhrProxy, XhrContext } from './xhrProxy'
 
 export interface ErrorMessage {
   startTime: number
@@ -156,11 +156,8 @@ export function toStackTraceString(stack: StackTrace) {
 }
 
 export function trackNetworkError(configuration: Configuration, errorObservable: ErrorObservable) {
-  const xhrProxy = startXhrProxy()
-  const fetchProxy = startFetchProxy()
-
-  xhrProxy.onRequestComplete((context) => handleCompleteRequest(RequestType.XHR, context))
-  fetchProxy.onRequestComplete((context) => handleCompleteRequest(RequestType.FETCH, context))
+  startXhrProxy().onRequestComplete((context) => handleCompleteRequest(RequestType.XHR, context))
+  startFetchProxy().onRequestComplete((context) => handleCompleteRequest(RequestType.FETCH, context))
 
   function handleCompleteRequest(type: RequestType, request: XhrContext | FetchContext) {
     if (isRejected(request) || isServerError(request)) {
@@ -184,8 +181,8 @@ export function trackNetworkError(configuration: Configuration, errorObservable:
 
   return {
     stop() {
-      xhrProxy.reset()
-      fetchProxy.reset()
+      resetXhrProxy()
+      resetFetchProxy()
     },
   }
 }

--- a/packages/core/src/fetchProxy.ts
+++ b/packages/core/src/fetchProxy.ts
@@ -1,0 +1,95 @@
+import { toStackTraceString } from './errorCollection'
+import { monitor } from './internalMonitoring'
+import { computeStackTrace } from './tracekit'
+import { normalizeUrl } from './urlPolyfill'
+
+export interface FetchProxy {
+  beforeSend: (callback: (context: Partial<FetchContext>) => void) => void
+  onRequestComplete: (callback: (context: FetchContext) => void) => void
+  reset: () => void
+}
+
+export interface FetchContext {
+  method: string
+  startTime: number
+  duration: number
+  url: string
+  status: number
+  response: string
+  responseType?: string
+  [key: string]: unknown
+}
+
+let originalFetch: typeof window.fetch
+let hasBeenStarted = false
+const beforeSendCallbacks: Array<(xhr: Partial<FetchContext>) => void> = []
+const onRequestCompleteCallbacks: Array<(xhr: FetchContext) => void> = []
+
+export function startFetchProxy(): FetchProxy {
+  if (!hasBeenStarted) {
+    hasBeenStarted = true
+    proxyFetch()
+  }
+  return {
+    beforeSend(callback: (context: Partial<FetchContext>) => void) {
+      beforeSendCallbacks.push(callback)
+    },
+    onRequestComplete(callback: (context: FetchContext) => void) {
+      onRequestCompleteCallbacks.push(callback)
+    },
+    reset() {
+      hasBeenStarted = false
+      beforeSendCallbacks.splice(0, beforeSendCallbacks.length)
+      onRequestCompleteCallbacks.splice(0, onRequestCompleteCallbacks.length)
+      window.fetch = originalFetch
+    },
+  }
+}
+
+function proxyFetch() {
+  if (!window.fetch) {
+    return
+  }
+
+  originalFetch = window.fetch
+
+  // tslint:disable promise-function-async
+  window.fetch = monitor(function(this: WindowOrWorkerGlobalScope['fetch'], input: RequestInfo, init?: RequestInit) {
+    const method = (init && init.method) || (typeof input === 'object' && input.method) || 'GET'
+    const startTime = performance.now()
+
+    const context: Partial<FetchContext> = {
+      method,
+      startTime,
+    }
+
+    const reportFetch = async (response: Response | Error) => {
+      context.duration = performance.now() - context.startTime!
+      context.url = normalizeUrl((typeof input === 'object' && input.url) || (input as string))
+
+      if ('stack' in response || response instanceof Error) {
+        context.status = 0
+        context.response = toStackTraceString(computeStackTrace(response))
+
+        onRequestCompleteCallbacks.forEach((callback) => callback(context as FetchContext))
+      } else if ('status' in response) {
+        let text: string
+        try {
+          text = await response.clone().text()
+        } catch (e) {
+          text = `Unable to retrieve response: ${e}`
+        }
+        context.response = text
+        context.responseType = response.type
+        context.status = response.status
+
+        onRequestCompleteCallbacks.forEach((callback) => callback(context as FetchContext))
+      }
+    }
+    beforeSendCallbacks.forEach((callback) => callback(context))
+
+    const responsePromise = originalFetch.call(this, input, init)
+    responsePromise.then(monitor(reportFetch), monitor(reportFetch))
+    return responsePromise
+  })
+}

--- a/packages/core/src/fetchProxy.ts
+++ b/packages/core/src/fetchProxy.ts
@@ -17,6 +17,10 @@ export interface FetchContext {
   status: number
   response: string
   responseType?: string
+
+  /**
+   * allow clients to enhance the context
+   */
   [key: string]: unknown
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,13 +14,6 @@ export {
 export { InternalMonitoring, MonitoringMessage, monitored, monitor, addMonitoringMessage } from './internalMonitoring'
 export { Observable } from './observable'
 export {
-  RequestType,
-  RequestCompleteEvent,
-  RequestStartEvent,
-  startRequestCollection,
-  RequestObservables,
-} from './requestCollection'
-export {
   startSessionManagement,
   SESSION_TIME_OUT_DELAY,
   // Exposed for tests
@@ -31,5 +24,7 @@ export { HttpRequest, Batch } from './transport'
 export * from './urlPolyfill'
 export * from './utils'
 export { areCookiesAuthorized, getCookie, setCookie, COOKIE_ACCESS_DELAY } from './cookie'
+export { startXhrProxy, XhrContext, XhrProxy } from './xhrProxy'
+export { startFetchProxy, FetchContext, FetchProxy } from './fetchProxy'
 
 export * from './specHelper'

--- a/packages/core/src/requestCollection.ts
+++ b/packages/core/src/requestCollection.ts
@@ -116,11 +116,3 @@ function getTraceId(): number | undefined {
         .toTraceId()
     : undefined
 }
-
-export function isRejected(request: RequestCompleteEvent) {
-  return request.status === 0 && request.responseType !== 'opaque'
-}
-
-export function isServerError(request: RequestCompleteEvent) {
-  return request.status >= 500
-}

--- a/packages/core/src/specHelper.ts
+++ b/packages/core/src/specHelper.ts
@@ -197,6 +197,22 @@ export class PerformanceObserverStubBuilder {
   }
 }
 
+export function withXhr({
+  setup,
+  onComplete,
+}: {
+  setup: (xhr: XMLHttpRequest) => void
+  onComplete: (xhr: XMLHttpRequest) => void
+}) {
+  const xhr = new XMLHttpRequest()
+  xhr.addEventListener('loadend', () => {
+    setTimeout(() => {
+      onComplete(xhr)
+    })
+  })
+  setup(xhr)
+}
+
 export function setPageVisibility(visibility: 'visible' | 'hidden') {
   Object.defineProperty(document, 'visibilityState', {
     get() {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -29,6 +29,11 @@ export enum ResourceKind {
   OTHER = 'other',
 }
 
+export enum RequestType {
+  FETCH = ResourceKind.FETCH,
+  XHR = ResourceKind.XHR,
+}
+
 // use lodash API
 export function throttle(
   fn: () => void,

--- a/packages/core/src/xhrProxy.ts
+++ b/packages/core/src/xhrProxy.ts
@@ -18,6 +18,10 @@ export interface XhrContext {
   duration: number
   status: number
   response: string | undefined
+
+  /**
+   * allow clients to enhance the context
+   */
   [key: string]: unknown
 }
 

--- a/packages/core/src/xhrProxy.ts
+++ b/packages/core/src/xhrProxy.ts
@@ -1,0 +1,99 @@
+import { monitor } from './internalMonitoring'
+import { normalizeUrl } from './urlPolyfill'
+
+interface BrowserXHR extends XMLHttpRequest {
+  _datadog_xhr: Partial<XhrContext>
+}
+
+export interface XhrProxy {
+  beforeSend: (callback: (context: Partial<XhrContext>) => void) => void
+  onRequestComplete: (callback: (context: XhrContext) => void) => void
+  reset: () => void
+}
+
+export interface XhrContext {
+  method: string
+  url: string
+  startTime: number
+  duration: number
+  status: number
+  response: string | undefined
+  [key: string]: unknown
+}
+
+const beforeSendCallbacks: Array<(context: Partial<XhrContext>) => void> = []
+const onRequestCompleteCallbacks: Array<(context: XhrContext) => void> = []
+let hasBeenStarted = false
+let originalXhrOpen: typeof XMLHttpRequest.prototype.open
+let originalXhrSend: typeof XMLHttpRequest.prototype.send
+
+export function startXhrProxy(): XhrProxy {
+  if (!hasBeenStarted) {
+    hasBeenStarted = true
+    proxyXhr()
+  }
+  return {
+    beforeSend(callback: (context: Partial<XhrContext>) => void) {
+      beforeSendCallbacks.push(callback)
+    },
+    onRequestComplete(callback: (context: XhrContext) => void) {
+      onRequestCompleteCallbacks.push(callback)
+    },
+    reset() {
+      hasBeenStarted = false
+      beforeSendCallbacks.splice(0, beforeSendCallbacks.length)
+      onRequestCompleteCallbacks.splice(0, onRequestCompleteCallbacks.length)
+      XMLHttpRequest.prototype.open = originalXhrOpen
+      XMLHttpRequest.prototype.send = originalXhrSend
+    },
+  }
+}
+
+function proxyXhr() {
+  originalXhrOpen = XMLHttpRequest.prototype.open
+  originalXhrSend = XMLHttpRequest.prototype.send
+
+  XMLHttpRequest.prototype.open = monitor(function(this: BrowserXHR, method: string, url: string) {
+    this._datadog_xhr = {
+      method,
+      url: normalizeUrl(url),
+    }
+    return originalXhrOpen.apply(this, arguments as any)
+  })
+
+  XMLHttpRequest.prototype.send = function(this: BrowserXHR, body: unknown) {
+    this._datadog_xhr.startTime = performance.now()
+
+    const originalOnreadystatechange = this.onreadystatechange
+
+    this.onreadystatechange = function() {
+      if (this.readyState === XMLHttpRequest.DONE) {
+        monitor(reportXhr)()
+      }
+
+      if (originalOnreadystatechange) {
+        originalOnreadystatechange.apply(this, arguments as any)
+      }
+    }
+
+    let hasBeenReported = false
+    const reportXhr = () => {
+      if (hasBeenReported) {
+        return
+      }
+      hasBeenReported = true
+
+      this._datadog_xhr.duration = performance.now() - this._datadog_xhr.startTime!
+      this._datadog_xhr.response = this.response as string | undefined
+      this._datadog_xhr.status = this.status
+
+      onRequestCompleteCallbacks.forEach((callback) => callback(this._datadog_xhr as XhrContext))
+    }
+
+    this.addEventListener('loadend', monitor(reportXhr))
+
+    beforeSendCallbacks.forEach((callback) => callback(this._datadog_xhr))
+
+    return originalXhrSend.apply(this, arguments as any)
+  }
+}

--- a/packages/core/test/errorCollection.spec.ts
+++ b/packages/core/test/errorCollection.spec.ts
@@ -1,3 +1,4 @@
+import { FetchStub, FetchStubManager, isIE, stubFetch } from '../src'
 import { Configuration } from '../src/configuration'
 import {
   ErrorMessage,
@@ -11,7 +12,6 @@ import {
   trackNetworkError,
 } from '../src/errorCollection'
 import { Observable } from '../src/observable'
-import { RequestCompleteEvent, RequestType } from '../src/requestCollection'
 import { StackTrace } from '../src/tracekit'
 import { ONE_MINUTE } from '../src/utils'
 
@@ -189,66 +189,99 @@ describe('runtime error formatter', () => {
 
 describe('network error tracker', () => {
   let errorObservableSpy: jasmine.Spy
-  let requestObservable: Observable<RequestCompleteEvent>
+  let fetchStub: FetchStub
+  let fetchStubManager: FetchStubManager
+  let stopNetworkErrorTracking: () => void
+  const FAKE_URL = 'http://fake.com/'
   const DEFAULT_REQUEST = {
     duration: 10,
     method: 'GET',
-    requestId: 123,
-    response: 'Server error',
+    responseText: 'Server error',
     startTime: 0,
     status: 503,
-    type: RequestType.XHR,
-    url: 'http://fake.com',
+    url: FAKE_URL,
   }
 
   beforeEach(() => {
+    if (isIE()) {
+      pending('no fetch support')
+    }
     const errorObservable = new Observable<ErrorMessage>()
-    requestObservable = new Observable<RequestCompleteEvent>()
     errorObservableSpy = spyOn(errorObservable, 'notify')
     const configuration = { requestErrorResponseLengthLimit: 32 }
-    trackNetworkError(configuration as Configuration, errorObservable, requestObservable)
+
+    fetchStubManager = stubFetch()
+    ;({ stop: stopNetworkErrorTracking } = trackNetworkError(configuration as Configuration, errorObservable))
+    fetchStub = window.fetch as FetchStub
   })
 
-  it('should track server error', () => {
-    requestObservable.notify(DEFAULT_REQUEST)
+  afterEach(() => {
+    fetchStubManager.reset()
+    stopNetworkErrorTracking()
+  })
 
-    expect(errorObservableSpy).toHaveBeenCalledWith({
-      context: {
-        error: { origin: 'network', stack: 'Server error' },
-        http: { method: 'GET', status_code: 503, url: 'http://fake.com' },
-      },
-      message: 'XHR error GET http://fake.com',
-      startTime: jasmine.any(Number),
+  it('should track server error', (done) => {
+    fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).toHaveBeenCalledWith({
+        context: {
+          error: { origin: 'network', stack: 'Server error' },
+          http: { method: 'GET', status_code: 503, url: 'http://fake.com/' },
+        },
+        message: 'Fetch error GET http://fake.com/',
+        startTime: jasmine.any(Number),
+      })
+      done()
     })
   })
 
-  it('should track refused request', () => {
-    requestObservable.notify({ ...DEFAULT_REQUEST, status: 0 })
-    expect(errorObservableSpy).toHaveBeenCalled()
+  it('should track refused request', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 0 })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).toHaveBeenCalled()
+      done()
+    })
   })
 
-  it('should not track client error', () => {
-    requestObservable.notify({ ...DEFAULT_REQUEST, status: 400 })
-    expect(errorObservableSpy).not.toHaveBeenCalled()
+  it('should not track client error', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 400 })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).not.toHaveBeenCalled()
+      done()
+    })
   })
 
-  it('should not track successful request', () => {
-    requestObservable.notify({ ...DEFAULT_REQUEST, status: 200 })
-    expect(errorObservableSpy).not.toHaveBeenCalled()
+  it('should not track successful request', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 200 })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).not.toHaveBeenCalled()
+      done()
+    })
   })
 
-  it('should add a default error response', () => {
-    requestObservable.notify({ ...DEFAULT_REQUEST, response: undefined })
+  it('should add a default error response', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, responseText: undefined })
 
-    const stack = (errorObservableSpy.calls.mostRecent().args[0] as ErrorMessage).context.error.stack
-    expect(stack).toEqual('Failed to load')
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).toHaveBeenCalled()
+      const stack = (errorObservableSpy.calls.mostRecent().args[0] as ErrorMessage).context.error.stack
+      expect(stack).toEqual('Failed to load')
+      done()
+    })
   })
 
-  it('should truncate error response', () => {
-    requestObservable.notify({ ...DEFAULT_REQUEST, response: 'Lorem ipsum dolor sit amet orci aliquam.' })
+  it('should truncate error response', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, responseText: 'Lorem ipsum dolor sit amet orci aliquam.' })
 
-    const stack = (errorObservableSpy.calls.mostRecent().args[0] as ErrorMessage).context.error.stack
-    expect(stack).toEqual('Lorem ipsum dolor sit amet orci ...')
+    fetchStubManager.whenAllComplete(() => {
+      const stack = (errorObservableSpy.calls.mostRecent().args[0] as ErrorMessage).context.error.stack
+      expect(stack).toEqual('Lorem ipsum dolor sit amet orci ...')
+      done()
+    })
   })
 })
 

--- a/packages/core/test/errorCollection.spec.ts
+++ b/packages/core/test/errorCollection.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '../src/errorCollection'
 import { Observable } from '../src/observable'
 import { StackTrace } from '../src/tracekit'
-import { ONE_MINUTE } from '../src/utils'
+import { ONE_MINUTE, RequestType } from '../src/utils'
 
 describe('console tracker', () => {
   let consoleErrorStub: jasmine.Spy

--- a/packages/core/test/fetchProxy.spec.ts
+++ b/packages/core/test/fetchProxy.spec.ts
@@ -1,0 +1,162 @@
+import { FetchContext, FetchProxy, startFetchProxy } from '../src/fetchProxy'
+import { FetchStub, FetchStubManager, FetchStubPromise, isIE, stubFetch } from '../src/specHelper'
+
+describe('fetch proxy', () => {
+  const FAKE_URL = 'http://fake-url/'
+  let fetchStub: (input: RequestInfo, init?: RequestInit) => FetchStubPromise
+  let fetchStubManager: FetchStubManager
+  let completeSpy: jasmine.Spy
+  let fetchProxy: FetchProxy
+
+  function getRequest(index: number): FetchContext {
+    return completeSpy.calls.argsFor(index)[0] as FetchContext
+  }
+
+  beforeEach(() => {
+    if (isIE()) {
+      pending('no fetch support')
+    }
+    fetchStubManager = stubFetch()
+    fetchProxy = startFetchProxy()
+    completeSpy = jasmine.createSpy('requestComplete')
+    fetchProxy.onRequestComplete(completeSpy)
+    fetchStub = window.fetch as FetchStub
+  })
+
+  afterEach(() => {
+    fetchStubManager.reset()
+    fetchProxy.reset()
+  })
+
+  it('should track server error', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = getRequest(0)
+      expect(request.method).toEqual('GET')
+      expect(request.url).toEqual(FAKE_URL)
+      expect(request.status).toEqual(500)
+      expect(request.response).toEqual('fetch error')
+      done()
+    })
+  })
+
+  it('should track refused fetch', (done) => {
+    fetchStub(FAKE_URL).rejectWith(new Error('fetch error'))
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = getRequest(0)
+      expect(request.method).toEqual('GET')
+      expect(request.url).toEqual(FAKE_URL)
+      expect(request.status).toEqual(0)
+      expect(request.response).toMatch(/Error: fetch error/)
+      done()
+    })
+  })
+
+  // https://fetch.spec.whatwg.org/#concept-body-consume-body
+  it('should track fetch with response text error', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 200, responseTextError: new Error('locked') })
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = getRequest(0)
+      expect(request.method).toEqual('GET')
+      expect(request.url).toEqual(FAKE_URL)
+      expect(request.status).toEqual(200)
+      expect(request.response).toMatch(/Error: locked/)
+      done()
+    })
+  })
+
+  it('should track opaque fetch', (done) => {
+    // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
+    fetchStub(FAKE_URL).resolveWith({ status: 0, type: 'opaque' })
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = getRequest(0)
+      expect(request.method).toEqual('GET')
+      expect(request.url).toEqual(FAKE_URL)
+      expect(request.status).toEqual(0)
+      done()
+    })
+  })
+
+  it('should track client error', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 400, responseText: 'Not found' })
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = getRequest(0)
+      expect(request.method).toEqual('GET')
+      expect(request.url).toEqual(FAKE_URL)
+      expect(request.status).toEqual(400)
+      expect(request.response).toEqual('Not found')
+      done()
+    })
+  })
+
+  it('should get method from input', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 500 })
+    fetchStub(new Request(FAKE_URL)).resolveWith({ status: 500 })
+    fetchStub(new Request(FAKE_URL, { method: 'PUT' })).resolveWith({ status: 500 })
+    fetchStub(new Request(FAKE_URL, { method: 'PUT' }), { method: 'POST' }).resolveWith({ status: 500 })
+    fetchStub(new Request(FAKE_URL), { method: 'POST' }).resolveWith({ status: 500 })
+    fetchStub(FAKE_URL, { method: 'POST' }).resolveWith({ status: 500 })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(getRequest(0).method).toEqual('GET')
+      expect(getRequest(1).method).toEqual('GET')
+      expect(getRequest(2).method).toEqual('PUT')
+      expect(getRequest(3).method).toEqual('POST')
+      expect(getRequest(4).method).toEqual('POST')
+      expect(getRequest(5).method).toEqual('POST')
+      done()
+    })
+  })
+
+  it('should get url from input', (done) => {
+    fetchStub(FAKE_URL).rejectWith(new Error('fetch error'))
+    fetchStub(new Request(FAKE_URL)).rejectWith(new Error('fetch error'))
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(getRequest(0).url).toEqual(FAKE_URL)
+      expect(getRequest(1).url).toEqual(FAKE_URL)
+      done()
+    })
+  })
+
+  it('should keep promise resolved behavior', (done) => {
+    const fetchStubPromise = fetchStub(FAKE_URL)
+    const spy = jasmine.createSpy()
+    fetchStubPromise.then(spy)
+    fetchStubPromise.resolveWith({ status: 500 })
+
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should keep promise rejected behavior', (done) => {
+    const fetchStubPromise = fetchStub(FAKE_URL)
+    const spy = jasmine.createSpy()
+    fetchStubPromise.catch(spy)
+    fetchStubPromise.rejectWith(new Error('fetch error'))
+
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should allow to enhance the context', (done) => {
+    fetchProxy.beforeSend((context) => {
+      context.foo = 'bar'
+    })
+    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(getRequest(0).foo).toBe('bar')
+      done()
+    })
+  })
+})

--- a/packages/core/test/fetchProxy.spec.ts
+++ b/packages/core/test/fetchProxy.spec.ts
@@ -1,4 +1,4 @@
-import { FetchContext, FetchProxy, startFetchProxy } from '../src/fetchProxy'
+import { FetchContext, FetchProxy, resetFetchProxy, startFetchProxy } from '../src/fetchProxy'
 import { FetchStub, FetchStubManager, FetchStubPromise, isIE, stubFetch } from '../src/specHelper'
 
 describe('fetch proxy', () => {
@@ -25,7 +25,7 @@ describe('fetch proxy', () => {
 
   afterEach(() => {
     fetchStubManager.reset()
-    fetchProxy.reset()
+    resetFetchProxy()
   })
 
   it('should track server error', (done) => {

--- a/packages/core/test/fetchProxy.spec.ts
+++ b/packages/core/test/fetchProxy.spec.ts
@@ -5,11 +5,11 @@ describe('fetch proxy', () => {
   const FAKE_URL = 'http://fake-url/'
   let fetchStub: (input: RequestInfo, init?: RequestInit) => FetchStubPromise
   let fetchStubManager: FetchStubManager
-  let completeSpy: jasmine.Spy
+  let completeSpy: jasmine.Spy<(context: FetchContext) => void>
   let fetchProxy: FetchProxy
 
-  function getRequest(index: number): FetchContext {
-    return completeSpy.calls.argsFor(index)[0] as FetchContext
+  function getRequest(index: number) {
+    return completeSpy.calls.argsFor(index)[0]
   }
 
   beforeEach(() => {

--- a/packages/core/test/requestCollection.spec.ts
+++ b/packages/core/test/requestCollection.spec.ts
@@ -1,7 +1,6 @@
+import { FetchProxy } from '../src/fetchProxy'
 import { Observable } from '../src/observable'
 import {
-  isRejected,
-  isServerError,
   RequestCompleteEvent,
   RequestObservables,
   RequestStartEvent,
@@ -9,24 +8,30 @@ import {
   trackFetch,
   trackXhr,
 } from '../src/requestCollection'
-import { FetchStub, FetchStubBuilder, FetchStubPromise, isIE } from '../src/specHelper'
-import { find, includes } from '../src/utils'
+import { FetchStub, FetchStubManager, isIE, stubFetch, withXhr } from '../src/specHelper'
+import { XhrProxy } from '../src/xhrProxy'
 
-describe('fetch tracker', () => {
+describe('collect fetch', () => {
   const FAKE_URL = 'http://fake-url/'
-  let originalFetch: any
-  let fetchStubBuilder: FetchStubBuilder
-  let fetchStub: (input: RequestInfo, init?: RequestInit) => FetchStubPromise
+  let fetchStub: FetchStub
+  let fetchStubManager: FetchStubManager
+  let fetchProxy: FetchProxy
+  let startSpy: jasmine.Spy
+  let completeSpy: jasmine.Spy
 
   beforeEach(() => {
     if (isIE()) {
       pending('no fetch support')
     }
-    originalFetch = window.fetch
+    fetchStubManager = stubFetch()
+
     const requestObservables: RequestObservables = [new Observable(), new Observable()]
-    fetchStubBuilder = new FetchStubBuilder(requestObservables)
-    window.fetch = fetchStubBuilder.getStub()
-    trackFetch(requestObservables)
+    startSpy = jasmine.createSpy('requestStart')
+    completeSpy = jasmine.createSpy('requestComplete')
+    requestObservables[0].subscribe(startSpy)
+    requestObservables[1].subscribe(completeSpy)
+    fetchProxy = trackFetch(requestObservables)
+
     fetchStub = window.fetch as FetchStub
     window.onunhandledrejection = (ev: PromiseRejectionEvent) => {
       throw new Error(`unhandled rejected promise \n    ${ev.reason}`)
@@ -34,317 +39,115 @@ describe('fetch tracker', () => {
   })
 
   afterEach(() => {
-    window.fetch = originalFetch as any
+    fetchStubManager.reset()
+    fetchProxy.reset()
     // tslint:disable-next-line:no-null-keyword
     window.onunhandledrejection = null
   })
 
-  it('should track server error', (done) => {
+  it('should notify on request start', (done) => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
-    fetchStubBuilder.whenAllComplete((requests: RequestCompleteEvent[]) => {
-      const request = requests[0]
+    fetchStubManager.whenAllComplete(() => {
+      expect(startSpy).toHaveBeenCalledWith({ requestId: jasmine.any(Number) })
+      done()
+    })
+  })
+
+  it('should notify on request complete', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent
+
       expect(request.type).toEqual(RequestType.FETCH)
       expect(request.method).toEqual('GET')
       expect(request.url).toEqual(FAKE_URL)
       expect(request.status).toEqual(500)
       expect(request.response).toEqual('fetch error')
-      expect(isRejected(request)).toBe(false)
-      expect(isServerError(request)).toBe(true)
       done()
     })
   })
 
-  it('should track refused fetch', (done) => {
-    fetchStub(FAKE_URL).rejectWith(new Error('fetch error'))
+  it('should assign a request id', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
-    fetchStubBuilder.whenAllComplete((requests: RequestCompleteEvent[]) => {
-      const request = requests[0]
-      expect(request.type).toEqual(RequestType.FETCH)
-      expect(request.method).toEqual('GET')
-      expect(request.url).toEqual(FAKE_URL)
-      expect(request.status).toEqual(0)
-      expect(request.response).toMatch(/Error: fetch error/)
-      expect(isRejected(request)).toBe(true)
-      expect(isServerError(request)).toBe(false)
-      done()
-    })
-  })
+    fetchStubManager.whenAllComplete(() => {
+      const startRequestId = (startSpy.calls.argsFor(0)[0] as RequestStartEvent).requestId
+      const completeRequestId = (completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent).requestId
 
-  // https://fetch.spec.whatwg.org/#concept-body-consume-body
-  it('should track fetch with response text error', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 200, responseTextError: new Error('locked') })
-
-    fetchStubBuilder.whenAllComplete((requests: RequestCompleteEvent[]) => {
-      const request = requests[0]
-      expect(request.type).toEqual(RequestType.FETCH)
-      expect(request.method).toEqual('GET')
-      expect(request.url).toEqual(FAKE_URL)
-      expect(request.status).toEqual(200)
-      expect(request.response).toMatch(/Error: locked/)
-      expect(isRejected(request)).toBe(false)
-      expect(isServerError(request)).toBe(false)
-      done()
-    })
-  })
-
-  it('should track opaque fetch', (done) => {
-    // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
-    fetchStub(FAKE_URL).resolveWith({ status: 0, type: 'opaque' })
-
-    fetchStubBuilder.whenAllComplete((requests: RequestCompleteEvent[]) => {
-      const request = requests[0]
-      expect(request.type).toEqual(RequestType.FETCH)
-      expect(request.method).toEqual('GET')
-      expect(request.url).toEqual(FAKE_URL)
-      expect(request.status).toEqual(0)
-      expect(isRejected(request)).toBe(false)
-      expect(isServerError(request)).toBe(false)
-      done()
-    })
-  })
-
-  it('should track client error', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 400, responseText: 'Not found' })
-
-    fetchStubBuilder.whenAllComplete((requests: RequestCompleteEvent[]) => {
-      const request = requests[0]
-      expect(request.type).toEqual(RequestType.FETCH)
-      expect(request.method).toEqual('GET')
-      expect(request.url).toEqual(FAKE_URL)
-      expect(request.status).toEqual(400)
-      expect(request.response).toEqual('Not found')
-      expect(isRejected(request)).toBe(false)
-      expect(isServerError(request)).toBe(false)
-      done()
-    })
-  })
-
-  it('should get method from input', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL)).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL, { method: 'PUT' })).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL, { method: 'PUT' }), { method: 'POST' }).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL), { method: 'POST' }).resolveWith({ status: 500 })
-    fetchStub(FAKE_URL, { method: 'POST' }).resolveWith({ status: 500 })
-
-    fetchStubBuilder.whenAllComplete((requests: RequestCompleteEvent[]) => {
-      expect(requests[0].method).toEqual('GET')
-      expect(requests[1].method).toEqual('GET')
-      expect(requests[2].method).toEqual('PUT')
-      expect(requests[3].method).toEqual('POST')
-      expect(requests[4].method).toEqual('POST')
-      expect(requests[5].method).toEqual('POST')
-      done()
-    })
-  })
-
-  it('should get url from input', (done) => {
-    fetchStub(FAKE_URL).rejectWith(new Error('fetch error'))
-    fetchStub(new Request(FAKE_URL)).rejectWith(new Error('fetch error'))
-    fetchStubBuilder.whenAllComplete((requests: RequestCompleteEvent[]) => {
-      expect(requests[0].url).toEqual(FAKE_URL)
-      expect(requests[1].url).toEqual(FAKE_URL)
-      done()
-    })
-  })
-
-  it('should keep promise resolved behavior', (done) => {
-    const fetchStubPromise = fetchStub(FAKE_URL)
-    const spy = jasmine.createSpy()
-    fetchStubPromise.then(spy)
-    fetchStubPromise.resolveWith({ status: 500 })
-
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
-      done()
-    })
-  })
-
-  it('should keep promise rejected behavior', (done) => {
-    const fetchStubPromise = fetchStub(FAKE_URL)
-    const spy = jasmine.createSpy()
-    fetchStubPromise.catch(spy)
-    fetchStubPromise.rejectWith(new Error('fetch error'))
-
-    setTimeout(() => {
-      expect(spy).toHaveBeenCalled()
+      expect(completeRequestId).toBe(startRequestId)
       done()
     })
   })
 })
 
-describe('xhr tracker', () => {
-  let originalOpen: typeof XMLHttpRequest.prototype.open
-  let originalSend: typeof XMLHttpRequest.prototype.send
-  let requestStartObservable: Observable<RequestStartEvent>
-  let requestCompleteObservable: Observable<RequestCompleteEvent>
+describe('collect xhr', () => {
+  let xhrProxy: XhrProxy
   let startSpy: jasmine.Spy
   let completeSpy: jasmine.Spy
 
   beforeEach(() => {
-    originalOpen = XMLHttpRequest.prototype.open
-    originalSend = XMLHttpRequest.prototype.send
-    requestStartObservable = new Observable()
-    requestCompleteObservable = new Observable()
-    startSpy = spyOn(requestStartObservable, 'notify').and.callThrough()
-    completeSpy = spyOn(requestCompleteObservable, 'notify').and.callThrough()
-    trackXhr([requestStartObservable, requestCompleteObservable])
+    if (isIE()) {
+      pending('no fetch support')
+    }
+
+    const requestObservables: RequestObservables = [new Observable(), new Observable()]
+    startSpy = jasmine.createSpy('requestStart')
+    completeSpy = jasmine.createSpy('requestComplete')
+    requestObservables[0].subscribe(startSpy)
+    requestObservables[1].subscribe(completeSpy)
+    xhrProxy = trackXhr(requestObservables)
   })
 
   afterEach(() => {
-    XMLHttpRequest.prototype.open = originalOpen
-    XMLHttpRequest.prototype.send = originalSend
+    xhrProxy.reset()
   })
 
-  function xhrSpec({
-    done,
-    setup,
-    expectedMethod,
-    expectedResponse,
-    expectedStatus,
-    expectedURL,
-    expectXHR,
-  }: {
-    done: DoneFn
-    setup: (xhr: XMLHttpRequest) => void
-    expectedMethod: string | jasmine.Any
-    expectedStatus: number | jasmine.Any
-    expectedURL: string
-    expectedResponse?: string | jasmine.AsymmetricMatcher<string>
-    expectXHR?: (xhr: XMLHttpRequest) => void
-  }) {
-    const xhr = new XMLHttpRequest()
-    xhr.addEventListener('loadend', () => {
-      setTimeout(() => {
-        const requests = (completeSpy.calls.allArgs() as RequestCompleteEvent[][]).map((args) => args[0])
-        const request = find(requests, (d) => includes(d.url, expectedURL))!
-
-        expect(request).toEqual({
-          duration: (jasmine.any(Number) as unknown) as number,
-          method: expectedMethod as string,
-          requestId: (jasmine.any(Number) as unknown) as number,
-          response: expectedResponse as string,
-          startTime: (jasmine.any(Number) as unknown) as number,
-          status: expectedStatus as number,
-          traceId: undefined,
-          type: RequestType.XHR,
-          url: (jasmine.stringMatching(expectedURL) as unknown) as string,
-        })
-        expect(startSpy).toHaveBeenCalledWith({ requestId: request.requestId })
-
-        if (expectXHR) {
-          expectXHR(xhr)
-        }
-
+  it('should notify on request start', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/ok')
+        xhr.send()
+      },
+      onComplete() {
+        expect(startSpy).toHaveBeenCalledWith({ requestId: jasmine.any(Number) })
         done()
-      })
+      },
     })
-    setup(xhr)
-  }
+  })
 
-  it('should track successful request', (done) => {
-    xhrSpec({
-      done,
+  it('should notify on request complete', (done) => {
+    withXhr({
       setup(xhr) {
         xhr.open('GET', '/ok')
         xhr.send()
       },
-      expectedMethod: 'GET',
-      expectedResponse: 'ok',
-      expectedStatus: 200,
-      expectedURL: '/ok',
-    })
-  })
+      onComplete() {
+        const request = completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent
 
-  it('should track client error', (done) => {
-    xhrSpec({
-      done,
-      setup(xhr) {
-        xhr.open('GET', '/expected-404')
-        xhr.send()
-      },
-      expectedMethod: 'GET',
-      expectedResponse: 'NOT FOUND',
-      expectedStatus: 404,
-      expectedURL: '/expected-404',
-    })
-  })
-
-  it('should track server error', (done) => {
-    xhrSpec({
-      done,
-      setup(xhr) {
-        xhr.open('GET', '/throw')
-        xhr.send()
-      },
-      expectedMethod: 'GET',
-      expectedResponse: jasmine.stringMatching('expected server error'),
-      expectedStatus: 500,
-      expectedURL: '/throw',
-    })
-  })
-
-  it('should track network error', (done) => {
-    xhrSpec({
-      done,
-      setup(xhr) {
-        xhr.open('GET', 'http://foo.bar/qux')
-        xhr.send()
-      },
-      expectedMethod: 'GET',
-      expectedResponse: '',
-      expectedStatus: 0,
-      expectedURL: 'http://foo.bar/qux',
-    })
-  })
-
-  it('should track successful request aborted', (done) => {
-    const onReadyStateChange = jasmine.createSpy()
-    xhrSpec({
-      done,
-      setup(xhr) {
-        xhr.onreadystatechange = onReadyStateChange
-        xhr.addEventListener('load', () => xhr.abort())
-        xhr.open('GET', '/ok')
-        xhr.send()
-      },
-      expectedMethod: 'GET',
-      expectedResponse: 'ok',
-      expectedStatus: 200,
-      expectedURL: '/ok',
-      expectXHR(xhr) {
-        expect(xhr.status).toBe(0)
-        expect(onReadyStateChange).toHaveBeenCalled()
+        expect(request.type).toEqual(RequestType.XHR)
+        expect(request.method).toEqual('GET')
+        expect(request.url).toContain('/ok')
+        expect(request.status).toEqual(200)
+        expect(request.response).toEqual('ok')
+        done()
       },
     })
   })
 
-  it('should track successful sync request', (done) => {
-    xhrSpec({
-      done,
-      expectedMethod: 'GET',
-      expectedResponse: 'ok',
-      expectedStatus: 200,
-      expectedURL: '/ok',
-      setup(xhr) {
-        xhr.open('GET', '/ok', false)
-        xhr.send()
-      },
-    })
-  })
-
-  it('should track request with onreadystatechange overridden', (done) => {
-    xhrSpec({
-      done,
-      expectedMethod: 'GET',
-      expectedResponse: 'ok',
-      expectedStatus: 200,
-      expectedURL: '/ok',
+  it('should assign a request id', (done) => {
+    withXhr({
       setup(xhr) {
         xhr.open('GET', '/ok')
         xhr.send()
-        xhr.onreadystatechange = () => undefined
+      },
+      onComplete() {
+        const startRequestId = (startSpy.calls.argsFor(0)[0] as RequestStartEvent).requestId
+        const completeRequestId = (completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent).requestId
+
+        expect(completeRequestId).toBe(startRequestId)
+        done()
       },
     })
   })

--- a/packages/core/test/xhrProxy.spec.ts
+++ b/packages/core/test/xhrProxy.spec.ts
@@ -1,5 +1,5 @@
 import { withXhr } from '../src'
-import { startXhrProxy, XhrContext, XhrProxy } from '../src/xhrProxy'
+import { resetXhrProxy, startXhrProxy, XhrContext, XhrProxy } from '../src/xhrProxy'
 
 describe('xhr proxy', () => {
   let completeSpy: jasmine.Spy<(context: XhrContext) => void>
@@ -10,13 +10,13 @@ describe('xhr proxy', () => {
   }
 
   beforeEach(() => {
-    xhrProxy = startXhrProxy()
     completeSpy = jasmine.createSpy('complete')
+    xhrProxy = startXhrProxy()
     xhrProxy.onRequestComplete(completeSpy)
   })
 
   afterEach(() => {
-    xhrProxy.reset()
+    resetXhrProxy()
   })
 
   it('should track successful request', (done) => {

--- a/packages/core/test/xhrProxy.spec.ts
+++ b/packages/core/test/xhrProxy.spec.ts
@@ -1,0 +1,177 @@
+import { withXhr } from '../src'
+import { startXhrProxy, XhrContext, XhrProxy } from '../src/xhrProxy'
+
+describe('xhr proxy', () => {
+  let completeSpy: jasmine.Spy
+  let xhrProxy: XhrProxy
+
+  function getRequest(index: number): XhrContext {
+    return completeSpy.calls.argsFor(index)[0] as XhrContext
+  }
+
+  beforeEach(() => {
+    xhrProxy = startXhrProxy()
+    completeSpy = jasmine.createSpy('complete')
+    xhrProxy.onRequestComplete(completeSpy)
+  })
+
+  afterEach(() => {
+    xhrProxy.reset()
+  })
+
+  it('should track successful request', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/ok')
+        xhr.send()
+      },
+      onComplete() {
+        const request = getRequest(0)
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/ok')
+        expect(request.response).toBe('ok')
+        expect(request.status).toBe(200)
+        expect(request.startTime).toEqual(jasmine.any(Number))
+        expect(request.duration).toEqual(jasmine.any(Number))
+        done()
+      },
+    })
+  })
+
+  it('should track client error', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/expected-404')
+        xhr.send()
+      },
+      onComplete() {
+        const request = getRequest(0)
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/expected-404')
+        expect(request.response).toBe('NOT FOUND')
+        expect(request.status).toBe(404)
+        expect(request.startTime).toEqual(jasmine.any(Number))
+        expect(request.duration).toEqual(jasmine.any(Number))
+        done()
+      },
+    })
+  })
+
+  it('should track server error', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/throw')
+        xhr.send()
+      },
+      onComplete() {
+        const request = getRequest(0)
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/throw')
+        expect(request.response).toEqual(jasmine.stringMatching('expected server error'))
+        expect(request.status).toBe(500)
+        expect(request.startTime).toEqual(jasmine.any(Number))
+        expect(request.duration).toEqual(jasmine.any(Number))
+        done()
+      },
+    })
+  })
+
+  it('should track network error', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', 'http://foo.bar/qux')
+        xhr.send()
+      },
+      onComplete() {
+        const request = getRequest(0)
+        expect(request.method).toBe('GET')
+        expect(request.url).toBe('http://foo.bar/qux')
+        expect(request.response).toBe('')
+        expect(request.status).toBe(0)
+        expect(request.startTime).toEqual(jasmine.any(Number))
+        expect(request.duration).toEqual(jasmine.any(Number))
+        done()
+      },
+    })
+  })
+
+  it('should track successful request aborted', (done) => {
+    const onReadyStateChange = jasmine.createSpy()
+    withXhr({
+      setup(xhr) {
+        xhr.onreadystatechange = onReadyStateChange
+        xhr.addEventListener('load', () => xhr.abort())
+        xhr.open('GET', '/ok')
+        xhr.send()
+      },
+      onComplete(xhr) {
+        const request = getRequest(0)
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/ok')
+        expect(request.response).toBe('ok')
+        expect(request.status).toBe(200)
+        expect(request.startTime).toEqual(jasmine.any(Number))
+        expect(request.duration).toEqual(jasmine.any(Number))
+        expect(xhr.status).toBe(0)
+        expect(onReadyStateChange).toHaveBeenCalled()
+        done()
+      },
+    })
+  })
+
+  it('should track successful sync request', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/ok', false)
+        xhr.send()
+      },
+      onComplete() {
+        const request = getRequest(0)
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/ok')
+        expect(request.response).toBe('ok')
+        expect(request.status).toBe(200)
+        expect(request.startTime).toEqual(jasmine.any(Number))
+        expect(request.duration).toEqual(jasmine.any(Number))
+        done()
+      },
+    })
+  })
+
+  it('should track request with onreadystatechange overridden', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/ok')
+        xhr.send()
+        xhr.onreadystatechange = () => undefined
+      },
+      onComplete() {
+        const request = getRequest(0)
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/ok')
+        expect(request.response).toBe('ok')
+        expect(request.status).toBe(200)
+        expect(request.startTime).toEqual(jasmine.any(Number))
+        expect(request.duration).toEqual(jasmine.any(Number))
+        done()
+      },
+    })
+  })
+
+  it('should allow to enhance the context', (done) => {
+    xhrProxy.beforeSend((xhrContext) => {
+      xhrContext.foo = 'bar'
+    })
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/ok')
+        xhr.send()
+      },
+      onComplete() {
+        const request = getRequest(0)
+        expect(request.foo).toBe('bar')
+        done()
+      },
+    })
+  })
+})

--- a/packages/core/test/xhrProxy.spec.ts
+++ b/packages/core/test/xhrProxy.spec.ts
@@ -2,11 +2,11 @@ import { withXhr } from '../src'
 import { startXhrProxy, XhrContext, XhrProxy } from '../src/xhrProxy'
 
 describe('xhr proxy', () => {
-  let completeSpy: jasmine.Spy
+  let completeSpy: jasmine.Spy<(context: XhrContext) => void>
   let xhrProxy: XhrProxy
 
-  function getRequest(index: number): XhrContext {
-    return completeSpy.calls.argsFor(index)[0] as XhrContext
+  function getRequest(index: number) {
+    return completeSpy.calls.argsFor(index)[0]
   }
 
   beforeEach(() => {

--- a/packages/logs/test/logs.entry.spec.ts
+++ b/packages/logs/test/logs.entry.spec.ts
@@ -1,13 +1,12 @@
 import { monitor, stopSessionManagement } from '@datadog/browser-core'
 import { LogsGlobal } from '../src'
+import { makeLogsGlobal } from '../src/logs.entry'
 
 describe('logs entry', () => {
   let logsGlobal: LogsGlobal
 
   beforeEach(() => {
-    // tslint:disable-next-line: no-unsafe-any
-    logsGlobal = require('../src/logs.entry').datadogLogs
-    delete (require.cache as any)[require.resolve('../src/logs.entry')]
+    logsGlobal = makeLogsGlobal({} as any)
   })
 
   afterEach(() => {

--- a/packages/logs/test/logs.entry.spec.ts
+++ b/packages/logs/test/logs.entry.spec.ts
@@ -1,4 +1,5 @@
 import { monitor, stopSessionManagement } from '@datadog/browser-core'
+import { startXhrProxy } from '../../core/src/xhrProxy'
 import { LogsGlobal } from '../src'
 import { makeLogsGlobal } from '../src/logs.entry'
 
@@ -11,6 +12,7 @@ describe('logs entry', () => {
 
   afterEach(() => {
     stopSessionManagement()
+    startXhrProxy().reset()
   })
 
   it('should set global with init', () => {

--- a/packages/logs/test/logs.entry.spec.ts
+++ b/packages/logs/test/logs.entry.spec.ts
@@ -1,5 +1,5 @@
 import { monitor, stopSessionManagement } from '@datadog/browser-core'
-import { startXhrProxy } from '../../core/src/xhrProxy'
+import { resetXhrProxy } from '../../core/src/xhrProxy'
 import { LogsGlobal } from '../src'
 import { makeLogsGlobal } from '../src/logs.entry'
 
@@ -11,8 +11,10 @@ describe('logs entry', () => {
   })
 
   afterEach(() => {
+    // some tests can successfully start the tracking
+    // stop behaviors that can pollute following tests
     stopSessionManagement()
-    startXhrProxy().reset()
+    resetXhrProxy()
   })
 
   it('should set global with init', () => {

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,4 +1,5 @@
-import { ErrorMessage, RequestCompleteEvent, RequestStartEvent } from '@datadog/browser-core'
+import { ErrorMessage } from '@datadog/browser-core'
+import { RequestCompleteEvent, RequestStartEvent } from './requestCollection'
 import { AutoUserAction, CustomUserAction } from './userActionCollection'
 import { View } from './viewCollection'
 

--- a/packages/rum/src/matchRequestTiming.ts
+++ b/packages/rum/src/matchRequestTiming.ts
@@ -1,4 +1,4 @@
-import { RequestCompleteEvent } from '@datadog/browser-core'
+import { RequestCompleteEvent } from './requestCollection'
 
 interface Timing {
   startTime: number

--- a/packages/rum/src/requestCollection.ts
+++ b/packages/rum/src/requestCollection.ts
@@ -1,12 +1,4 @@
-import { startFetchProxy } from './fetchProxy'
-import { Observable } from './observable'
-import { ResourceKind } from './utils'
-import { startXhrProxy } from './xhrProxy'
-
-export enum RequestType {
-  FETCH = ResourceKind.FETCH,
-  XHR = ResourceKind.XHR,
-}
+import { Observable, RequestType, startFetchProxy, startXhrProxy } from '@datadog/browser-core'
 
 export interface RequestStartEvent {
   requestId: number

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -84,7 +84,7 @@ export function makeRumGlobal(stub: RumGlobal) {
 
     const { errorObservable, configuration, internalMonitoring } = commonInit(rumUserConfiguration, buildEnv)
     const session = startRumSession(configuration, lifeCycle)
-    const globalApi = startRum(
+    const { globalApi } = startRum(
       rumUserConfiguration.applicationId,
       location,
       lifeCycle,

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -10,7 +10,6 @@ import {
   makeGlobal,
   makeStub,
   monitor,
-  startRequestCollection,
   UserConfiguration,
 } from '@datadog/browser-core'
 
@@ -18,6 +17,7 @@ import { buildEnv } from './buildEnv'
 import { startDOMMutationCollection } from './domMutationCollection'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { startPerformanceCollection } from './performanceCollection'
+import { startRequestCollection } from './requestCollection'
 import { startRum } from './rum'
 import { startRumSession } from './rumSession'
 import { startUserActionCollection } from './userActionCollection'

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -59,72 +59,80 @@ const STUBBED_RUM = {
 
 export type RumGlobal = typeof STUBBED_RUM
 
-export const datadogRum = makeGlobal(STUBBED_RUM)
-let isAlreadyInitialized = false
-datadogRum.init = monitor((userConfiguration: RumUserConfiguration) => {
-  if (!checkCookiesAuthorized() || !checkIsNotLocalFile() || !canInitRum(userConfiguration)) {
-    return
-  }
-  if (userConfiguration.publicApiKey) {
-    userConfiguration.clientToken = userConfiguration.publicApiKey
-  }
-  const rumUserConfiguration = { ...userConfiguration, isCollectingError: true }
-  const lifeCycle = new LifeCycle()
-
-  const { errorObservable, configuration, internalMonitoring } = commonInit(rumUserConfiguration, buildEnv)
-  const session = startRumSession(configuration, lifeCycle)
-  const globalApi = startRum(
-    rumUserConfiguration.applicationId,
-    location,
-    lifeCycle,
-    configuration,
-    session,
-    internalMonitoring
-  )
-
-  const [requestStartObservable, requestCompleteObservable] = startRequestCollection()
-  startPerformanceCollection(lifeCycle, session)
-  startDOMMutationCollection(lifeCycle)
-  if (configuration.trackInteractions) {
-    startUserActionCollection(lifeCycle)
-  }
-
-  errorObservable.subscribe((errorMessage) => lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, errorMessage))
-  requestStartObservable.subscribe((startEvent) => lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, startEvent))
-  requestCompleteObservable.subscribe((request) => lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, request))
-
-  assign(datadogRum, globalApi)
-  isAlreadyInitialized = true
-})
-
-function canInitRum(userConfiguration: RumUserConfiguration) {
-  if (isAlreadyInitialized) {
-    if (!userConfiguration.silentMultipleInit) {
-      console.error('DD_RUM is already initialized.')
-    }
-    return false
-  }
-  if (!userConfiguration || (!userConfiguration.clientToken && !userConfiguration.publicApiKey)) {
-    console.error('Client Token is not configured, we will not send any data.')
-    return false
-  }
-  if (!userConfiguration.applicationId) {
-    console.error('Application ID is not configured, no RUM data will be collected.')
-    return false
-  }
-  if (userConfiguration.sampleRate !== undefined && !isPercentage(userConfiguration.sampleRate)) {
-    console.error('Sample Rate should be a number between 0 and 100')
-    return false
-  }
-  if (userConfiguration.resourceSampleRate !== undefined && !isPercentage(userConfiguration.resourceSampleRate)) {
-    console.error('Resource Sample Rate should be a number between 0 and 100')
-    return false
-  }
-  return true
-}
+export const datadogRum = makeRumGlobal(STUBBED_RUM)
 
 interface BrowserWindow extends Window {
   DD_RUM?: RumGlobal
 }
 
 getGlobalObject<BrowserWindow>().DD_RUM = datadogRum
+
+export function makeRumGlobal(stub: RumGlobal) {
+  const global = makeGlobal(stub)
+
+  let isAlreadyInitialized = false
+
+  global.init = monitor((userConfiguration: RumUserConfiguration) => {
+    if (!checkCookiesAuthorized() || !checkIsNotLocalFile() || !canInitRum(userConfiguration)) {
+      return
+    }
+    if (userConfiguration.publicApiKey) {
+      userConfiguration.clientToken = userConfiguration.publicApiKey
+    }
+    const rumUserConfiguration = { ...userConfiguration, isCollectingError: true }
+    const lifeCycle = new LifeCycle()
+
+    const { errorObservable, configuration, internalMonitoring } = commonInit(rumUserConfiguration, buildEnv)
+    const session = startRumSession(configuration, lifeCycle)
+    const globalApi = startRum(
+      rumUserConfiguration.applicationId,
+      location,
+      lifeCycle,
+      configuration,
+      session,
+      internalMonitoring
+    )
+
+    const [requestStartObservable, requestCompleteObservable] = startRequestCollection()
+    startPerformanceCollection(lifeCycle, session)
+    startDOMMutationCollection(lifeCycle)
+    if (configuration.trackInteractions) {
+      startUserActionCollection(lifeCycle)
+    }
+
+    errorObservable.subscribe((errorMessage) => lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, errorMessage))
+    requestStartObservable.subscribe((startEvent) => lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, startEvent))
+    requestCompleteObservable.subscribe((request) => lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, request))
+
+    assign(global, globalApi)
+    isAlreadyInitialized = true
+  })
+
+  function canInitRum(userConfiguration: RumUserConfiguration) {
+    if (isAlreadyInitialized) {
+      if (!userConfiguration.silentMultipleInit) {
+        console.error('DD_RUM is already initialized.')
+      }
+      return false
+    }
+    if (!userConfiguration || (!userConfiguration.clientToken && !userConfiguration.publicApiKey)) {
+      console.error('Client Token is not configured, we will not send any data.')
+      return false
+    }
+    if (!userConfiguration.applicationId) {
+      console.error('Application ID is not configured, no RUM data will be collected.')
+      return false
+    }
+    if (userConfiguration.sampleRate !== undefined && !isPercentage(userConfiguration.sampleRate)) {
+      console.error('Sample Rate should be a number between 0 and 100')
+      return false
+    }
+    if (userConfiguration.resourceSampleRate !== undefined && !isPercentage(userConfiguration.resourceSampleRate)) {
+      console.error('Resource Sample Rate should be a number between 0 and 100')
+      return false
+    }
+    return true
+  }
+
+  return global
+}

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -167,7 +167,7 @@ export function startRum(
   configuration: Configuration,
   session: RumSession,
   internalMonitoring: InternalMonitoring
-): Omit<RumGlobal, 'init'> {
+): { globalApi: Omit<RumGlobal, 'init'>; stop: () => void } {
   let globalContext: Context = {}
 
   const parentContexts = startParentContexts(window.location, lifeCycle, session)
@@ -205,29 +205,35 @@ export function startRum(
   startViewCollection(location, lifeCycle)
 
   return {
-    addRumGlobalContext: monitor((key: string, value: ContextValue) => {
-      globalContext[key] = value
-    }),
-    addUserAction: monitor((name: string, context?: Context) => {
-      lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { context, name, type: UserActionType.CUSTOM })
-    }),
-    getInternalContext: monitor(
-      (startTime?: number): InternalContext => {
-        return (withSnakeCaseKeys(deepMerge(
-          { applicationId },
-          parentContexts.findView(startTime),
-          parentContexts.findAction(startTime)
-        ) as Context) as unknown) as InternalContext
-      }
-    ),
-    setRumGlobalContext: monitor((context: Context) => {
-      globalContext = context
-    }),
+    globalApi: {
+      addRumGlobalContext: monitor((key: string, value: ContextValue) => {
+        globalContext[key] = value
+      }),
+      addUserAction: monitor((name: string, context?: Context) => {
+        lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { context, name, type: UserActionType.CUSTOM })
+      }),
+      getInternalContext: monitor(
+        (startTime?: number): InternalContext => {
+          return (withSnakeCaseKeys(deepMerge(
+            { applicationId },
+            parentContexts.findView(startTime),
+            parentContexts.findAction(startTime)
+          ) as Context) as unknown) as InternalContext
+        }
+      ),
+      setRumGlobalContext: monitor((context: Context) => {
+        globalContext = context
+      }),
+    },
+    stop: () => {
+      batch.stop()
+    },
   }
 }
 
 interface RumBatch {
   add: (message: Context) => void
+  stop: () => void
   upsert: (message: Context, key: string) => void
 }
 
@@ -255,14 +261,24 @@ function makeRumBatch(configuration: Configuration, lifeCycle: LifeCycle): RumBa
     return deepMerge(message, { application_id: replica!.applicationId }) as Context
   }
 
+  let stopped = false
   return {
     add: (message: Context) => {
+      if (stopped) {
+        return
+      }
       primaryBatch.add(message)
       if (replicaBatch) {
         replicaBatch.add(withReplicaApplicationId(message))
       }
     },
+    stop: () => {
+      stopped = true
+    },
     upsert: (message: Context, key: string) => {
+      if (stopped) {
+        return
+      }
       primaryBatch.upsert(message, key)
       if (replicaBatch) {
         replicaBatch.upsert(withReplicaApplicationId(message), key)

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -226,6 +226,8 @@ export function startRum(
       }),
     },
     stop: () => {
+      // prevent batch from previous tests to keep running and send unwanted requests
+      // could be replaced by stopping all the component when they will all have a stop method
       batch.stop()
     },
   }

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -15,7 +15,6 @@ import {
   monitor,
   msToNs,
   Omit,
-  RequestCompleteEvent,
   RequestType,
   ResourceKind,
   withSnakeCaseKeys,
@@ -24,6 +23,7 @@ import {
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { matchRequestTiming } from './matchRequestTiming'
 import { ActionContext, ParentContexts, startParentContexts, ViewContext } from './parentContexts'
+import { RequestCompleteEvent } from './requestCollection'
 import {
   computePerformanceResourceDetails,
   computePerformanceResourceDuration,

--- a/packages/rum/test/machRequestTiming.spec.ts
+++ b/packages/rum/test/machRequestTiming.spec.ts
@@ -1,6 +1,7 @@
-import { isIE, RequestCompleteEvent } from '@datadog/browser-core'
+import { isIE } from '@datadog/browser-core'
 
 import { matchRequestTiming } from '../src/matchRequestTiming'
+import { RequestCompleteEvent } from '../src/requestCollection'
 
 describe('matchRequestTiming', () => {
   const FAKE_REQUEST: Partial<RequestCompleteEvent> = { startTime: 100, duration: 500 }

--- a/packages/rum/test/requestCollection.spec.ts
+++ b/packages/rum/test/requestCollection.spec.ts
@@ -22,8 +22,8 @@ describe('collect fetch', () => {
   let fetchStub: FetchStub
   let fetchStubManager: FetchStubManager
   let fetchProxy: FetchProxy
-  let startSpy: jasmine.Spy
-  let completeSpy: jasmine.Spy
+  let startSpy: jasmine.Spy<(requestStartEvent: RequestStartEvent) => void>
+  let completeSpy: jasmine.Spy<(requestCompleteEvent: RequestCompleteEvent) => void>
 
   beforeEach(() => {
     if (isIE()) {
@@ -55,7 +55,7 @@ describe('collect fetch', () => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
-      expect(startSpy).toHaveBeenCalledWith({ requestId: jasmine.any(Number) })
+      expect(startSpy).toHaveBeenCalledWith({ requestId: (jasmine.any(Number) as unknown) as number })
       done()
     })
   })
@@ -64,7 +64,7 @@ describe('collect fetch', () => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
-      const request = completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent
+      const request = completeSpy.calls.argsFor(0)[0]
 
       expect(request.type).toEqual(RequestType.FETCH)
       expect(request.method).toEqual('GET')
@@ -79,8 +79,8 @@ describe('collect fetch', () => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
-      const startRequestId = (startSpy.calls.argsFor(0)[0] as RequestStartEvent).requestId
-      const completeRequestId = (completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent).requestId
+      const startRequestId = startSpy.calls.argsFor(0)[0].requestId
+      const completeRequestId = completeSpy.calls.argsFor(0)[0].requestId
 
       expect(completeRequestId).toBe(startRequestId)
       done()
@@ -90,8 +90,8 @@ describe('collect fetch', () => {
 
 describe('collect xhr', () => {
   let xhrProxy: XhrProxy
-  let startSpy: jasmine.Spy
-  let completeSpy: jasmine.Spy
+  let startSpy: jasmine.Spy<(requestStartEvent: RequestStartEvent) => void>
+  let completeSpy: jasmine.Spy<(requestCompleteEvent: RequestCompleteEvent) => void>
 
   beforeEach(() => {
     if (isIE()) {
@@ -117,7 +117,7 @@ describe('collect xhr', () => {
         xhr.send()
       },
       onComplete() {
-        expect(startSpy).toHaveBeenCalledWith({ requestId: jasmine.any(Number) })
+        expect(startSpy).toHaveBeenCalledWith({ requestId: (jasmine.any(Number) as unknown) as number })
         done()
       },
     })
@@ -130,7 +130,7 @@ describe('collect xhr', () => {
         xhr.send()
       },
       onComplete() {
-        const request = completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent
+        const request = completeSpy.calls.argsFor(0)[0]
 
         expect(request.type).toEqual(RequestType.XHR)
         expect(request.method).toEqual('GET')
@@ -149,8 +149,8 @@ describe('collect xhr', () => {
         xhr.send()
       },
       onComplete() {
-        const startRequestId = (startSpy.calls.argsFor(0)[0] as RequestStartEvent).requestId
-        const completeRequestId = (completeSpy.calls.argsFor(0)[0] as RequestCompleteEvent).requestId
+        const startRequestId = startSpy.calls.argsFor(0)[0].requestId
+        const completeRequestId = completeSpy.calls.argsFor(0)[0].requestId
 
         expect(completeRequestId).toBe(startRequestId)
         done()

--- a/packages/rum/test/requestCollection.spec.ts
+++ b/packages/rum/test/requestCollection.spec.ts
@@ -1,15 +1,21 @@
-import { FetchProxy } from '../src/fetchProxy'
-import { Observable } from '../src/observable'
+import {
+  FetchProxy,
+  FetchStub,
+  FetchStubManager,
+  isIE,
+  Observable,
+  RequestType,
+  stubFetch,
+  withXhr,
+  XhrProxy,
+} from '@datadog/browser-core'
 import {
   RequestCompleteEvent,
   RequestObservables,
   RequestStartEvent,
-  RequestType,
   trackFetch,
   trackXhr,
 } from '../src/requestCollection'
-import { FetchStub, FetchStubManager, isIE, stubFetch, withXhr } from '../src/specHelper'
-import { XhrProxy } from '../src/xhrProxy'
 
 describe('collect fetch', () => {
   const FAKE_URL = 'http://fake-url/'

--- a/packages/rum/test/requestCollection.spec.ts
+++ b/packages/rum/test/requestCollection.spec.ts
@@ -7,8 +7,9 @@ import {
   RequestType,
   stubFetch,
   withXhr,
-  XhrProxy,
 } from '@datadog/browser-core'
+import { resetFetchProxy } from '../../core/src/fetchProxy'
+import { resetXhrProxy } from '../../core/src/xhrProxy'
 import {
   RequestCompleteEvent,
   RequestObservables,
@@ -46,7 +47,7 @@ describe('collect fetch', () => {
 
   afterEach(() => {
     fetchStubManager.reset()
-    fetchProxy.reset()
+    resetFetchProxy()
     // tslint:disable-next-line:no-null-keyword
     window.onunhandledrejection = null
   })
@@ -89,7 +90,6 @@ describe('collect fetch', () => {
 })
 
 describe('collect xhr', () => {
-  let xhrProxy: XhrProxy
   let startSpy: jasmine.Spy<(requestStartEvent: RequestStartEvent) => void>
   let completeSpy: jasmine.Spy<(requestCompleteEvent: RequestCompleteEvent) => void>
 
@@ -103,11 +103,11 @@ describe('collect xhr', () => {
     completeSpy = jasmine.createSpy('requestComplete')
     requestObservables[0].subscribe(startSpy)
     requestObservables[1].subscribe(completeSpy)
-    xhrProxy = trackXhr(requestObservables)
+    trackXhr(requestObservables)
   })
 
   afterEach(() => {
-    xhrProxy.reset()
+    resetXhrProxy()
   })
 
   it('should notify on request start', (done) => {

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -1,4 +1,5 @@
 import { isIE, stopSessionManagement } from '@datadog/browser-core'
+import { startXhrProxy } from '../../core/src/xhrProxy'
 
 import { makeRumGlobal, RumGlobal, RumUserConfiguration } from '../src/rum.entry'
 
@@ -14,6 +15,7 @@ describe('rum entry', () => {
 
   afterEach(() => {
     stopSessionManagement()
+    startXhrProxy().reset()
   })
 
   it('init should log an error with no application id', () => {

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -1,5 +1,5 @@
 import { isIE, stopSessionManagement } from '@datadog/browser-core'
-import { startXhrProxy } from '../../core/src/xhrProxy'
+import { resetXhrProxy } from '../../core/src/xhrProxy'
 
 import { makeRumGlobal, RumGlobal, RumUserConfiguration } from '../src/rum.entry'
 
@@ -14,8 +14,10 @@ describe('rum entry', () => {
   })
 
   afterEach(() => {
+    // some tests can successfully start the tracking
+    // stop behaviors that can pollute following tests
     stopSessionManagement()
-    startXhrProxy().reset()
+    resetXhrProxy()
   })
 
   it('init should log an error with no application id', () => {

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -1,6 +1,6 @@
 import { isIE, stopSessionManagement } from '@datadog/browser-core'
 
-import { RumGlobal, RumUserConfiguration } from '../src/rum.entry'
+import { makeRumGlobal, RumGlobal, RumUserConfiguration } from '../src/rum.entry'
 
 describe('rum entry', () => {
   let rumGlobal: RumGlobal
@@ -9,9 +9,7 @@ describe('rum entry', () => {
     if (isIE()) {
       pending('no full rum support')
     }
-    // tslint:disable-next-line: no-unsafe-any
-    rumGlobal = require('../src/rum.entry').datadogRum
-    delete (require.cache as any)[require.resolve('../src/rum.entry')]
+    rumGlobal = makeRumGlobal({} as any)
   })
 
   afterEach(() => {

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -1,14 +1,8 @@
-import {
-  Configuration,
-  DEFAULT_CONFIGURATION,
-  ErrorMessage,
-  isIE,
-  RequestCompleteEvent,
-  SPEC_ENDPOINTS,
-} from '@datadog/browser-core'
+import { Configuration, DEFAULT_CONFIGURATION, ErrorMessage, isIE, SPEC_ENDPOINTS } from '@datadog/browser-core'
 import sinon from 'sinon'
 
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
+import { RequestCompleteEvent } from '../src/requestCollection'
 import { handleResourceEntry, RawRumEvent, RumEvent, RumResourceEvent } from '../src/rum'
 import { AutoUserAction, CustomUserAction, UserActionType } from '../src/userActionCollection'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD } from '../src/viewCollection'

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -86,17 +86,18 @@ export function setup(): TestSetupBuilder {
       return setupBuilder
     },
     withRum() {
-      buildTasks.push(
-        () =>
-          (rumApi = startRum(
-            'appId',
-            fakeLocation as Location,
-            lifeCycle,
-            configuration as Configuration,
-            session,
-            internalMonitoringStub
-          ))
-      )
+      buildTasks.push(() => {
+        let stopRum
+        ;({ globalApi: rumApi, stop: stopRum } = startRum(
+          'appId',
+          fakeLocation as Location,
+          lifeCycle,
+          configuration as Configuration,
+          session,
+          internalMonitoringStub
+        ))
+        cleanupTasks.push(stopRum)
+      })
       return setupBuilder
     },
     withViewCollection() {

--- a/packages/rum/test/trackPageActivities.spec.ts
+++ b/packages/rum/test/trackPageActivities.spec.ts
@@ -1,5 +1,6 @@
-import { noop, Observable, RequestCompleteEvent } from '@datadog/browser-core'
+import { noop, Observable } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
+import { RequestCompleteEvent } from '../src/requestCollection'
 import {
   PAGE_ACTIVITY_END_DELAY,
   PAGE_ACTIVITY_MAX_DURATION,


### PR DESCRIPTION
## Motivation

Current proxies of XHR and fetch were managed by request collection which was handled as a singleton to avoid to proxy XHR and fetch multiple times.
With the future integration of tracing inside the sdk (cf #461), we would want to collect request with trace id for rum but not for logs. 
In a npm setup this would be problematic since the request collection instance would be shared between rum and logs.

## Changes

1.  Extract XHR and Fetch proxies that:
    - instrument browser API only once
    - deal with request data, not with domain logic (request id, trace id, request type) 
    - provide hooks to attach/retrieve info during the request life cycle
2. Use proxies in request collection and error collection
3. Move request collection to rum package

## Testing

Automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
