### PR TITLE
[RUMF-625] make sure view url doesn't change

### DIFF
--- a/packages/core/src/urlPolyfill.ts
+++ b/packages/core/src/urlPolyfill.ts
@@ -33,7 +33,7 @@ export function getHash(url: string) {
   return buildUrl(url).hash
 }
 
-function buildUrl(url: string, base?: string) {
+export function buildUrl(url: string, base?: string) {
   if (checkURLSupported()) {
     return base !== undefined ? new URL(url, base) : new URL(url)
   }

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -32,10 +32,8 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.REQUEST_COMPLETED, data: RequestCompleteEvent): void
   notify(eventType: LifeCycleEventType.AUTO_ACTION_COMPLETED, data: AutoUserAction): void
   notify(eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED, data: CustomUserAction): void
-  notify(
-    eventType: LifeCycleEventType.AUTO_ACTION_CREATED | LifeCycleEventType.VIEW_CREATED,
-    { id, startTime }: { id: string; startTime: number }
-  ): void
+  notify(eventType: LifeCycleEventType.AUTO_ACTION_CREATED, data: { id: string; startTime: number }): void
+  notify(eventType: LifeCycleEventType.VIEW_CREATED, data: { id: string; startTime: number; location: Location }): void
   notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: View): void
   notify(
     eventType:
@@ -64,12 +62,16 @@ export class LifeCycle {
   ): Subscription
   subscribe(eventType: LifeCycleEventType.AUTO_ACTION_COMPLETED, callback: (data: AutoUserAction) => void): Subscription
   subscribe(
-    eventType: LifeCycleEventType.AUTO_ACTION_CREATED | LifeCycleEventType.VIEW_CREATED,
-    callback: ({ id, startTime }: { id: string; startTime: number }) => void
+    eventType: LifeCycleEventType.AUTO_ACTION_CREATED,
+    callback: (data: { id: string; startTime: number }) => void
   ): Subscription
   subscribe(
     eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED,
     callback: (data: CustomUserAction) => void
+  ): Subscription
+  subscribe(
+    eventType: LifeCycleEventType.VIEW_CREATED,
+    callback: (data: { id: string; startTime: number; location: Location }) => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription
   subscribe(

--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -24,6 +24,7 @@ export interface ActionContext extends Context {
 interface CurrentContext {
   id: string
   startTime: number
+  location?: Location
 }
 
 interface PreviousContext<T> {
@@ -56,6 +57,10 @@ export function startParentContexts(location: Location, lifeCycle: LifeCycle, se
     }
     currentView = currentContext
     currentSessionId = session.getId()
+  })
+
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, (currentContext) => {
+    currentView = currentContext
   })
 
   lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_CREATED, (currentContext) => {
@@ -100,7 +105,13 @@ export function startParentContexts(location: Location, lifeCycle: LifeCycle, se
   }
 
   function buildCurrentViewContext() {
-    return { sessionId: currentSessionId, view: { id: currentView!.id, url: location.href } }
+    return {
+      sessionId: currentSessionId,
+      view: {
+        id: currentView!.id,
+        url: (currentView!.location || location).href,
+      },
+    }
   }
 
   function buildCurrentActionContext() {

--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -21,10 +21,15 @@ export interface ActionContext extends Context {
   }
 }
 
-interface CurrentContext {
+interface CurrentViewContext {
   id: string
   startTime: number
-  location?: Location
+  location: Location
+}
+
+interface CurrentActionContext {
+  id: string
+  startTime: number
 }
 
 interface PreviousContext<T> {
@@ -39,9 +44,9 @@ export interface ParentContexts {
   stop: () => void
 }
 
-export function startParentContexts(location: Location, lifeCycle: LifeCycle, session: RumSession): ParentContexts {
-  let currentView: CurrentContext | undefined
-  let currentAction: CurrentContext | undefined
+export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): ParentContexts {
+  let currentView: CurrentViewContext | undefined
+  let currentAction: CurrentActionContext | undefined
   let currentSessionId: string | undefined
 
   let previousViews: Array<PreviousContext<ViewContext>> = []
@@ -109,7 +114,7 @@ export function startParentContexts(location: Location, lifeCycle: LifeCycle, se
       sessionId: currentSessionId,
       view: {
         id: currentView!.id,
-        url: (currentView!.location || location).href,
+        url: currentView!.location.href,
       },
     }
   }
@@ -121,7 +126,7 @@ export function startParentContexts(location: Location, lifeCycle: LifeCycle, se
   function findContext<T>(
     buildContext: () => T,
     previousContexts: Array<PreviousContext<T>>,
-    currentContext?: CurrentContext,
+    currentContext?: { startTime: number },
     startTime?: number
   ) {
     if (!startTime) {

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -170,7 +170,7 @@ export function startRum(
 ): Omit<RumGlobal, 'init'> {
   let globalContext: Context = {}
 
-  const parentContexts = startParentContexts(location, lifeCycle, session)
+  const parentContexts = startParentContexts(lifeCycle, session)
 
   internalMonitoring.setExternalContextProvider(() => {
     return deepMerge(

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -171,7 +171,7 @@ export function startRum(
 ): Omit<RumGlobal, 'init'> {
   let globalContext: Context = {}
 
-  const parentContexts = startParentContexts(window.location, lifeCycle, session)
+  const parentContexts = startParentContexts(location, lifeCycle, session)
 
   internalMonitoring.setExternalContextProvider(() => {
     return deepMerge(

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -111,7 +111,6 @@ export interface RumViewEvent {
     loadingTime?: number
     loadingType: ViewLoadingType
     measures: ViewMeasures
-    url: string
   }
 }
 
@@ -360,7 +359,6 @@ function trackView(lifeCycle: LifeCycle, handler: (startTime: number, event: Rum
         loadingTime: view.loadingTime ? msToNs(view.loadingTime) : undefined,
         loadingType: view.loadingType,
         measures: view.measures,
-        url: view.location.href,
       },
     })
   })

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -111,6 +111,7 @@ export interface RumViewEvent {
     loadingTime?: number
     loadingType: ViewLoadingType
     measures: ViewMeasures
+    url: string
   }
 }
 
@@ -359,6 +360,7 @@ function trackView(lifeCycle: LifeCycle, handler: (startTime: number, event: Rum
         loadingTime: view.loadingTime ? msToNs(view.loadingTime) : undefined,
         loadingType: view.loadingType,
         measures: view.measures,
+        url: view.location.href,
       },
     })
   })

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -99,7 +99,7 @@ function newView(
   let loadingTime: number | undefined
   let location: Location = { ...initialLocation }
 
-  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id, startTime })
+  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id, startTime, location })
 
   // Update the view every time the measures are changing
   const { throttled: scheduleViewUpdate, stop: stopScheduleViewUpdate } = throttle(

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -16,20 +16,13 @@ describe('parentContexts', () => {
   const FAKE_ID = 'fake'
   const startTime = 10
 
-  let fakeUrl: string
   let sessionId: string
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    fakeUrl = 'fake-url'
     sessionId = 'fake-session'
-    const fakeLocation = {
-      get href() {
-        return fakeUrl
-      },
-    }
     setupBuilder = setup()
-      .withFakeLocation(fakeLocation)
+      .withFakeLocation('http://fake-url.com')
       .withSession({
         getId: () => sessionId,
         isTracked: () => true,
@@ -93,11 +86,11 @@ describe('parentContexts', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
-      expect(parentContexts.findView()!.view.url).toBe('fake-url')
+      expect(parentContexts.findView()!.view.url).toBe('http://fake-url.com/')
 
-      fakeUrl = 'other-url'
+      history.pushState({}, '', '/foo')
 
-      expect(parentContexts.findView()!.view.url).toBe('other-url')
+      expect(parentContexts.findView()!.view.url).toBe('http://fake-url.com/foo')
     })
 
     it('should update session id only on VIEW_CREATED', () => {

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -5,6 +5,7 @@ import {
   VIEW_CONTEXT_TIME_OUT_DELAY,
 } from '../src/parentContexts'
 import { AutoUserAction } from '../src/userActionCollection'
+import { View } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 function stubActionWithDuration(duration: number): AutoUserAction {
@@ -45,7 +46,7 @@ describe('parentContexts', () => {
     it('should return the current view context when there is no start time', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime, id: FAKE_ID })
 
       expect(parentContexts.findView()).toBeDefined()
       expect(parentContexts.findView()!.view.id).toEqual(FAKE_ID)
@@ -54,9 +55,9 @@ describe('parentContexts', () => {
     it('should return the view context corresponding to startTime', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 10, id: 'view 1' })
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 20, id: 'view 2' })
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 30, id: 'view 3' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: 10, id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: 20, id: 'view 2' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: 30, id: 'view 3' })
 
       expect(parentContexts.findView(15)!.view.id).toEqual('view 1')
       expect(parentContexts.findView(20)!.view.id).toEqual('view 2')
@@ -66,8 +67,8 @@ describe('parentContexts', () => {
     it('should return undefined when no view context corresponding to startTime', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 10, id: 'view 1' })
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 20, id: 'view 2' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: 10, id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: 20, id: 'view 2' })
 
       expect(parentContexts.findView(5)).not.toBeDefined()
     })
@@ -75,17 +76,17 @@ describe('parentContexts', () => {
     it('should replace the current view context on VIEW_CREATED', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime, id: FAKE_ID })
       const newViewId = 'fake 2'
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: newViewId })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime, id: newViewId })
 
       expect(parentContexts.findView()!.view.id).toEqual(newViewId)
     })
 
     it('should return the current url with the current view', () => {
-      const { lifeCycle, parentContexts } = setupBuilder.build()
+      const { lifeCycle, parentContexts, fakeLocation } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID, location: fakeLocation as Location })
       expect(parentContexts.findView()!.view.url).toBe('http://fake-url.com/')
 
       history.pushState({}, '', '/foo')
@@ -96,13 +97,13 @@ describe('parentContexts', () => {
     it('should update session id only on VIEW_CREATED', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: FAKE_ID })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime, id: FAKE_ID })
       expect(parentContexts.findView()!.sessionId).toBe('fake-session')
 
       sessionId = 'other-session'
       expect(parentContexts.findView()!.sessionId).toBe('fake-session')
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime, id: 'fake 2' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime, id: 'fake 2' })
       expect(parentContexts.findView()!.sessionId).toBe('other-session')
     })
   })
@@ -174,8 +175,8 @@ describe('parentContexts', () => {
     it('should be cleared on SESSION_RENEWED', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 10, id: 'view 1' })
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: 20, id: 'view 2' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: 10, id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: 20, id: 'view 2' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10, id: 'action 1' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 20, id: 'action 2' })
@@ -199,10 +200,10 @@ describe('parentContexts', () => {
       const originalTime = performance.now()
       const targetTime = originalTime + 5
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: originalTime, id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: originalTime, id: 'view 1' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: originalTime, id: 'action 1' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { startTime: originalTime + 10, id: 'view 2' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, startTime: originalTime + 10, id: 'view 2' })
 
       clock.tick(10)
       expect(parentContexts.findView(targetTime)).toBeDefined()

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -58,6 +58,7 @@ export interface TestIO {
   rumApi: RumApi
   clock: jasmine.Clock
   parentContexts: ParentContexts
+  fakeLocation: Partial<Location>
 }
 
 export function setup(): TestSetupBuilder {
@@ -124,7 +125,7 @@ export function setup(): TestSetupBuilder {
     },
     withParentContexts() {
       buildTasks.push(() => {
-        parentContexts = startParentContexts(fakeLocation as Location, lifeCycle, session)
+        parentContexts = startParentContexts(lifeCycle, session)
         cleanupTasks.push(() => {
           parentContexts.stop()
         })
@@ -161,7 +162,7 @@ export function setup(): TestSetupBuilder {
     build() {
       beforeBuildTasks.forEach((task) => task(lifeCycle))
       buildTasks.forEach((task) => task())
-      return { server, lifeCycle, stubBuilder, rumApi, clock, parentContexts }
+      return { server, lifeCycle, stubBuilder, rumApi, clock, parentContexts, fakeLocation }
     },
     cleanup() {
       cleanupTasks.forEach((task) => task())

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -2,6 +2,7 @@ import { DOM_EVENT, ErrorMessage } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../src/trackPageActivities'
 import { AutoUserAction, UserActionType } from '../src/userActionCollection'
+import { View } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 // Used to wait some time after the creation of a user action
@@ -76,7 +77,7 @@ describe('startUserActionCollection', () => {
     mockValidatedClickUserAction(lifeCycle, clock, button)
     expect(createSpy).toHaveBeenCalled()
 
-    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id: 'fake', startTime: 0 })
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, id: 'fake', startTime: 0 })
     clock.tick(EXPIRE_DELAY)
 
     expect(events).toEqual([])

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -77,11 +77,10 @@ describe('rum track url change', () => {
   let setupBuilder: TestSetupBuilder
   let initialViewId: string
   let createSpy: jasmine.Spy
-  let updateSpy: jasmine.Spy<(view: View) => void>
 
   beforeEach(() => {
     setupBuilder = setup()
-      .withFakeLocation('http://foo.com/foo')
+      .withFakeLocation('/foo')
       .withViewCollection()
       .beforeBuild((lifeCycle) => {
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
@@ -90,7 +89,6 @@ describe('rum track url change', () => {
         })
       })
     createSpy = jasmine.createSpy('create')
-    updateSpy = jasmine.createSpy('update')
   })
 
   afterEach(() => {
@@ -124,28 +122,6 @@ describe('rum track url change', () => {
     history.pushState({}, '', '/foo#bar')
 
     expect(createSpy).not.toHaveBeenCalled()
-  })
-
-  it('should update current view on search change', () => {
-    const { lifeCycle } = setupBuilder.build()
-    lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, updateSpy)
-
-    history.pushState({}, '', '/foo?bar=qux')
-
-    expect(updateSpy).toHaveBeenCalled()
-    const view = updateSpy.calls.argsFor(0)[0]
-    expect(view.location.href).toBe('http://foo.com/foo?bar=qux')
-  })
-
-  it('should update current view on hash change', () => {
-    const { lifeCycle } = setupBuilder.build()
-    lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, updateSpy)
-
-    history.pushState({}, '', '/foo#bar')
-
-    expect(updateSpy).toHaveBeenCalled()
-    const view = updateSpy.calls.argsFor(0)[0]
-    expect(view.location.href).toBe('http://foo.com/foo#bar')
   })
 })
 

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -77,10 +77,11 @@ describe('rum track url change', () => {
   let setupBuilder: TestSetupBuilder
   let initialViewId: string
   let createSpy: jasmine.Spy
+  let updateSpy: jasmine.Spy<(view: View) => void>
 
   beforeEach(() => {
     setupBuilder = setup()
-      .withFakeLocation('/foo')
+      .withFakeLocation('http://foo.com/foo')
       .withViewCollection()
       .beforeBuild((lifeCycle) => {
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
@@ -89,6 +90,7 @@ describe('rum track url change', () => {
         })
       })
     createSpy = jasmine.createSpy('create')
+    updateSpy = jasmine.createSpy('update')
   })
 
   afterEach(() => {
@@ -122,6 +124,28 @@ describe('rum track url change', () => {
     history.pushState({}, '', '/foo#bar')
 
     expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  it('should update current view on search change', () => {
+    const { lifeCycle } = setupBuilder.build()
+    lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, updateSpy)
+
+    history.pushState({}, '', '/foo?bar=qux')
+
+    expect(updateSpy).toHaveBeenCalled()
+    const view = updateSpy.calls.argsFor(0)[0]
+    expect(view.location.href).toBe('http://foo.com/foo?bar=qux')
+  })
+
+  it('should update current view on hash change', () => {
+    const { lifeCycle } = setupBuilder.build()
+    lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, updateSpy)
+
+    history.pushState({}, '', '/foo#bar')
+
+    expect(updateSpy).toHaveBeenCalled()
+    const view = updateSpy.calls.argsFor(0)[0]
+    expect(view.location.href).toBe('http://foo.com/foo#bar')
   })
 })
 

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -1,5 +1,3 @@
-import { getHash, getPathName, getSearch } from '@datadog/browser-core'
-
 import { LifeCycleEventType } from '../src/lifeCycle'
 import { ViewContext } from '../src/parentContexts'
 import { PerformanceLongTaskTiming, PerformancePaintTiming } from '../src/rum'
@@ -61,15 +59,6 @@ const FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING = {
   loadEventEnd: BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY * 1.2,
 }
 
-function mockHistory(location: Partial<Location>) {
-  spyOn(history, 'pushState').and.callFake((_: any, __: string, pathname: string) => {
-    const url = `http://localhost${pathname}`
-    location.pathname = getPathName(url)
-    location.search = getSearch(url)
-    location.hash = getHash(url)
-  })
-}
-
 function spyOnViews() {
   const handler = jasmine.createSpy()
 
@@ -90,10 +79,8 @@ describe('rum track url change', () => {
   let createSpy: jasmine.Spy
 
   beforeEach(() => {
-    const fakeLocation: Partial<Location> = { pathname: '/foo' }
-    mockHistory(fakeLocation)
     setupBuilder = setup()
-      .withFakeLocation(fakeLocation)
+      .withFakeLocation('/foo')
       .withViewCollection()
       .beforeBuild((lifeCycle) => {
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
@@ -148,10 +135,8 @@ describe('rum track renew session', () => {
   beforeEach(() => {
     ;({ handler, getViewEvent, getHandledCount } = spyOnViews())
 
-    const fakeLocation: Partial<Location> = { pathname: '/foo' }
-    mockHistory(fakeLocation)
     setupBuilder = setup()
-      .withFakeLocation(fakeLocation)
+      .withFakeLocation('/foo')
       .withViewCollection()
       .beforeBuild((lifeCycle) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
@@ -196,11 +181,9 @@ describe('rum track load duration', () => {
   beforeEach(() => {
     ;({ handler, getViewEvent } = spyOnViews())
 
-    const fakeLocation: Partial<Location> = { pathname: '/foo' }
-    mockHistory(fakeLocation)
     setupBuilder = setup()
       .withFakeClock()
-      .withFakeLocation(fakeLocation)
+      .withFakeLocation('/foo')
       .withViewCollection()
       .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
   })
@@ -234,11 +217,9 @@ describe('rum track loading time', () => {
   beforeEach(() => {
     ;({ handler, getHandledCount, getViewEvent } = spyOnViews())
 
-    const fakeLocation: Partial<Location> = { pathname: '/foo' }
-    mockHistory(fakeLocation)
     setupBuilder = setup()
       .withFakeClock()
-      .withFakeLocation(fakeLocation)
+      .withFakeLocation('/foo')
       .withViewCollection()
       .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
   })
@@ -331,10 +312,8 @@ describe('rum view measures', () => {
   beforeEach(() => {
     ;({ handler, getViewEvent, getHandledCount } = spyOnViews())
 
-    const fakeLocation: Partial<Location> = { pathname: '/foo' }
-    mockHistory(fakeLocation)
     setupBuilder = setup()
-      .withFakeLocation(fakeLocation)
+      .withFakeLocation('/foo')
       .withViewCollection()
       .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
   })


### PR DESCRIPTION
## Motivation

When a SPA changes its URL, the ending view gets updated with the new URL. It should keep its initial URL no matter what.

See https://datadoghq.atlassian.net/browse/RUMF-625

## Changes

When formating a RumViewEvent, use the one from the collected View object instead of the ViewContext which already contains the new URL

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
