### PR TITLE
✨ [RUMF-626] use site configuration and deprecate suffixed bundle

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,11 +168,11 @@ deploy-staging:
   image: $CI_IMAGE
   script:
     - yarn
-    - WITH_SUFFIX=true TARGET_DATACENTER=eu TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=eu BUILD_MODE=staging yarn build:bundle
     - ./scripts/deploy.sh staging eu
-    - WITH_SUFFIX=true TARGET_DATACENTER=us TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=us BUILD_MODE=staging yarn build:bundle
     - ./scripts/deploy.sh staging us
-    - TARGET_DATACENTER=us TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
+    - TARGET_DATACENTER=us BUILD_MODE=staging yarn build:bundle
     - ./scripts/deploy.sh staging
 
 deploy-release:
@@ -186,11 +186,11 @@ deploy-release:
   image: $CI_IMAGE
   script:
     - yarn
-    - WITH_SUFFIX=true TARGET_DATACENTER=us TARGET_ENV=production BUILD_MODE=release yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=us BUILD_MODE=release yarn build:bundle
     - ./scripts/deploy.sh prod us
-    - WITH_SUFFIX=true TARGET_DATACENTER=eu TARGET_ENV=production BUILD_MODE=release yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=eu BUILD_MODE=release yarn build:bundle
     - ./scripts/deploy.sh prod eu
-    - TARGET_DATACENTER=us TARGET_ENV=production BUILD_MODE=release yarn build:bundle
+    - TARGET_DATACENTER=us BUILD_MODE=release yarn build:bundle
     - ./scripts/deploy.sh prod
 
 ########################################################################################################################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,10 +168,12 @@ deploy-staging:
   image: $CI_IMAGE
   script:
     - yarn
-    - TARGET_DATACENTER=eu TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=eu TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
     - ./scripts/deploy.sh staging eu
-    - TARGET_DATACENTER=us TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=us TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
     - ./scripts/deploy.sh staging us
+    - TARGET_DATACENTER=us TARGET_ENV=staging BUILD_MODE=staging yarn build:bundle
+    - ./scripts/deploy.sh staging
 
 deploy-release:
   only:
@@ -184,10 +186,12 @@ deploy-release:
   image: $CI_IMAGE
   script:
     - yarn
-    - TARGET_DATACENTER=us TARGET_ENV=production BUILD_MODE=release yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=us TARGET_ENV=production BUILD_MODE=release yarn build:bundle
     - ./scripts/deploy.sh prod us
-    - TARGET_DATACENTER=eu TARGET_ENV=production BUILD_MODE=release yarn build:bundle
+    - WITH_SUFFIX=true TARGET_DATACENTER=eu TARGET_ENV=production BUILD_MODE=release yarn build:bundle
     - ./scripts/deploy.sh prod eu
+    - TARGET_DATACENTER=us TARGET_ENV=production BUILD_MODE=release yarn build:bundle
+    - ./scripts/deploy.sh prod
 
 ########################################################################################################################
 # Notify

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The browser SDK is used to collect logs and RUM data from the browser.
 
 This repository contains several packages:
 
-| Package      | npm                      | size                     | cdn               | doc                                 |
-| ------------ | ------------------------ | ------------------------ | ----------------- | ----------------------------------- |
-| browser-logs | [![npm version][01]][02] | [![bundle size][03]][04] | [us][05] [eu][06] | [![API][1]][07] [![product][2]][08] |
-| browser-rum  | [![npm version][11]][12] | [![bundle size][13]][14] | [us][15] [eu][16] | [![API][1]][17] [![product][2]][18] |
-| browser-core | [![npm version][21]][22] | [![bundle size][23]][24] |                   |
+| Package      | npm                      | size                     | cdn                | doc                                 |
+| ------------ | ------------------------ | ------------------------ | ------------------ | ----------------------------------- |
+| browser-logs | [![npm version][01]][02] | [![bundle size][03]][04] | [datadog-logs][05] | [![API][1]][07] [![product][2]][08] |
+| browser-rum  | [![npm version][11]][12] | [![bundle size][13]][14] | [datadog-rum][15]  | [![API][1]][17] [![product][2]][18] |
+| browser-core | [![npm version][21]][22] | [![bundle size][23]][24] |                    |
 
 [1]: https://github.githubassets.com/favicons/favicon.png
 [2]: https://imgix.datadoghq.com/img/favicons/favicon-32x32.png
@@ -18,16 +18,14 @@ This repository contains several packages:
 [02]: https://badge.fury.io/js/%40datadog%2Fbrowser-logs
 [03]: https://badgen.net/bundlephobia/minzip/@datadog/browser-logs
 [04]: https://bundlephobia.com/result?p=@datadog/browser-logs
-[05]: https://www.datadoghq-browser-agent.com/datadog-logs-us.js
-[06]: https://www.datadoghq-browser-agent.com/datadog-logs-eu.js
+[05]: https://www.datadoghq-browser-agent.com/datadog-logs.js
 [07]: ./packages/logs/README.md
 [08]: https://docs.datadoghq.com/logs/log_collection/javascript/?tab=npm
 [11]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum.svg
 [12]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum
 [13]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum
 [14]: https://bundlephobia.com/result?p=@datadog/browser-rum
-[15]: https://www.datadoghq-browser-agent.com/datadog-rum-us.js
-[16]: https://www.datadoghq-browser-agent.com/datadog-rum-eu.js
+[15]: https://www.datadoghq-browser-agent.com/datadog-rum.js
 [17]: ./packages/rum/README.md
 [18]: https://docs.datadoghq.com/real_user_monitoring/
 [21]: https://badge.fury.io/js/%40datadog%2Fbrowser-core.svg

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "ENV=development node test/server/server.js",
     "release": "lerna version --exact",
     "version": "node ./scripts/generate-changelog.js",
-    "publish:npm": "TARGET_DATACENTER=us TARGET_ENV=production BUILD_MODE=release yarn build && lerna publish from-package",
+    "publish:npm": "TARGET_DATACENTER=us BUILD_MODE=release yarn build && lerna publish from-package",
     "fail": "./scripts/fail.sh",
     "test": "yarn test:unit",
     "test:unit": "karma start ./test/unit/karma.local.conf.js",

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -1,4 +1,4 @@
-import { BuildEnv, BuildMode, Datacenter, SdkEnv } from './init'
+import { BuildEnv, BuildMode, Datacenter, INTAKE_DOMAINS, SdkEnv } from './init'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from './utils'
 
 export const DEFAULT_CONFIGURATION = {
@@ -187,8 +187,7 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 }
 
 function getEndpoint(type: string, conf: TransportConfiguration, source?: string) {
-  const tld = conf.datacenter === Datacenter.US ? 'com' : 'eu'
-  const domain = conf.sdkEnv === SdkEnv.PRODUCTION ? `datadoghq.${tld}` : `datad0g.${tld}`
+  const domain = conf.sdkEnv === SdkEnv.STAGING ? INTAKE_DOMAINS[SdkEnv.STAGING] : INTAKE_DOMAINS[conf.datacenter]
   const tags =
     `sdk_version:${conf.sdkVersion}` +
     `${conf.env ? `,env:${conf.env}` : ''}` +

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,6 @@ export {
   BuildEnv,
   BuildMode,
   Datacenter,
-  SdkEnv,
   makeStub,
   makeGlobal,
   commonInit,

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -25,11 +25,21 @@ export function makeGlobal<T>(stub: T): T {
 export enum Datacenter {
   US = 'us',
   EU = 'eu',
+  GOV = 'gov',
 }
+
 export enum SdkEnv {
   PRODUCTION = 'production',
   STAGING = 'staging',
 }
+
+export const INTAKE_DOMAINS = {
+  [Datacenter.EU]: 'datadoghq.eu',
+  [Datacenter.US]: 'datadoghq.com',
+  [Datacenter.GOV]: 'ddog-gov.com',
+  [SdkEnv.STAGING]: 'datad0g.com',
+}
+
 export enum BuildMode {
   RELEASE = 'release',
   STAGING = 'staging',

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -25,19 +25,11 @@ export function makeGlobal<T>(stub: T): T {
 export enum Datacenter {
   US = 'us',
   EU = 'eu',
-  GOV = 'gov',
 }
 
-export enum SdkEnv {
-  PRODUCTION = 'production',
-  STAGING = 'staging',
-}
-
-export const INTAKE_DOMAINS = {
+export const INTAKE_SITE = {
   [Datacenter.EU]: 'datadoghq.eu',
   [Datacenter.US]: 'datadoghq.com',
-  [Datacenter.GOV]: 'ddog-gov.com',
-  [SdkEnv.STAGING]: 'datad0g.com',
 }
 
 export enum BuildMode {
@@ -48,7 +40,6 @@ export enum BuildMode {
 
 export interface BuildEnv {
   datacenter: Datacenter
-  sdkEnv: SdkEnv
   buildMode: BuildMode
   sdkVersion: string
 }

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -40,7 +40,7 @@ What we call `Context` is a map `{key: value}` that will be added to the message
 
   - `isCollectingError`: when truthy, we'll automatically forward `console.error` logs, uncaught exceptions and network errors.
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send logs.
-  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
+  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu' | 'gov')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
   - `service`: name of the corresponding service
   - `env`: environment of the service

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -40,7 +40,7 @@ What we call `Context` is a map `{key: value}` that will be added to the message
 
   - `isCollectingError`: when truthy, we'll automatically forward `console.error` logs, uncaught exceptions and network errors.
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send logs.
-  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu' | 'gov')
+  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
   - `service`: name of the corresponding service
   - `env`: environment of the service

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -9,10 +9,10 @@ Datadog browser logs library.
 ### NPM
 
 ```
-import { Datacenter, datadogLogs } from '@datadog/browser-logs'
+import { datadogLogs } from '@datadog/browser-logs'
 datadogLogs.init({
   clientToken: 'XXX',
-  datacenter: Datacenter.US,
+  site: 'datadoghq.com',
   forwardErrorsToLogs: true,
   sampleRate: 100
 })
@@ -25,7 +25,7 @@ datadogLogs.init({
 <script>
   window.DD_LOGS.init({
     clientToken: 'XXX',
-    datacenter: 'us',
+    site: 'datadoghq.com',
     forwardErrorsToLogs: true,
     sampleRate: 100
   });
@@ -40,7 +40,7 @@ What we call `Context` is a map `{key: value}` that will be added to the message
 
   - `isCollectingError`: when truthy, we'll automatically forward `console.error` logs, uncaught exceptions and network errors.
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send logs.
-  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
+  - `site`: The site of the Datadog intake to send SDK data to (default: 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site)
   - `silentMultipleInit`: prevent logging errors while having multiple Init
   - `service`: name of the corresponding service
   - `env`: environment of the service
@@ -49,7 +49,7 @@ What we call `Context` is a map `{key: value}` that will be added to the message
   ```
   init(configuration: {
       clientToken: string,
-      datacenter?: string,
+      site?: string,
       isCollectingError?: boolean,
       sampleRate?: number,
       silentMultipleInit?: boolean,
@@ -100,7 +100,7 @@ import '@datadog/browser-logs/bundle/datadog-logs';
 
 window.DD_LOGS.init({
   clientToken: 'XXX',
-  datacenter: 'us',
+  site: 'datadoghq.com',
   forwardErrorsToLogs: true,
   sampleRate: 100
 });

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -21,7 +21,7 @@ datadogLogs.init({
 ### Bundle
 
 ```
-<script src = 'https://www.datadoghq-browser-agent.com/datadog-logs-us.js'>
+<script src = 'https://www.datadoghq-browser-agent.com/datadog-logs.js'>
 <script>
   window.DD_LOGS.init({
     clientToken: 'XXX',
@@ -95,7 +95,7 @@ Types are compatible with TypeScript >= 3.0.
 For earlier version, you can import js sources and use global variable to avoid any compilation issue:
 
 ```
-import '@datadog/browser-logs/bundle/datadog-logs-us';
+import '@datadog/browser-logs/bundle/datadog-logs';
 
 window.DD_LOGS.init({
   clientToken: 'XXX',

--- a/packages/logs/src/buildEnv.ts
+++ b/packages/logs/src/buildEnv.ts
@@ -1,8 +1,7 @@
-import { BuildEnv, BuildMode, Datacenter, SdkEnv } from '@datadog/browser-core'
+import { BuildEnv, BuildMode, Datacenter } from '@datadog/browser-core'
 
 export const buildEnv: BuildEnv = {
   buildMode: '<<< BUILD_MODE >>>' as BuildMode,
   datacenter: '<<< TARGET_DATACENTER >>>' as Datacenter,
-  sdkEnv: '<<< TARGET_ENV >>>' as SdkEnv,
   sdkVersion: '<<< SDK_VERSION >>>',
 }

--- a/packages/logs/webpack.config.js
+++ b/packages/logs/webpack.config.js
@@ -3,6 +3,9 @@ const path = require('path')
 const webpackBase = require('../../webpack.base')
 
 const datacenter = process.env.TARGET_DATACENTER || 'us'
+const withSuffix = process.env.WITH_SUFFIX || false
+
+const suffix = withSuffix ? `-${datacenter}` : ''
 
 module.exports = (env, argv) => ({
   entry: {
@@ -10,7 +13,7 @@ module.exports = (env, argv) => ({
   },
   ...webpackBase(argv.mode),
   output: {
-    filename: `datadog-logs-${datacenter}.js`,
+    filename: `datadog-logs${suffix}.js`,
     path: path.resolve(__dirname, 'bundle'),
   },
 })

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -38,7 +38,7 @@ datadogRum.init({
 
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send rum events.
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
-  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu' | 'gov')
+  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
   - `trackInteractions`: collect actions initiated by user interactions
   - `service`: name of the corresponding service

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -20,7 +20,7 @@ datadogRum.init({
 ### Bundle
 
 ```
-<script src = 'https://www.datadoghq-browser-agent.com/datadog-rum-us.js'>
+<script src = 'https://www.datadoghq-browser-agent.com/datadog-rum.js'>
 <script>
   window.DD_RUM.init({
     applicationId: 'XXX',
@@ -99,7 +99,7 @@ Types are compatible with TypeScript >= 3.0.
 For earlier version, you can import js sources and use global variable to avoid any compilation issue:
 
 ```
-import '@datadog/browser-rum/bundle/datadog-rum-us';
+import '@datadog/browser-rum/bundle/datadog-rum';
 
 window.DD_RUM.init({
   applicationId: 'XXX',

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -38,7 +38,7 @@ datadogRum.init({
 
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send rum events.
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
-  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
+  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu' | 'gov')
   - `silentMultipleInit`: prevent logging errors while having multiple Init
   - `trackInteractions`: collect actions initiated by user interactions
   - `service`: name of the corresponding service

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -7,11 +7,11 @@ Datadog browser rum library.
 ### NPM
 
 ```
-import { Datacenter, datadogRum } from '@datadog/browser-rum'
+import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: 'XXX',
   clientToken: 'XXX',
-  datacenter: Datacenter.US,
+  site: 'datadoghq.com',
   resourceSampleRate: 100,
   sampleRate: 100
 })
@@ -25,7 +25,7 @@ datadogRum.init({
   window.DD_RUM.init({
     applicationId: 'XXX',
     clientToken: 'XXX',
-    datacenter: 'us',
+    site: 'datadoghq.com',
     resourceSampleRate: 100,
     sampleRate: 100
   });
@@ -38,7 +38,7 @@ datadogRum.init({
 
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send rum events.
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
-  - `datacenter`: defined to which datacenter we'll send collected data ('us' | 'eu')
+  - `site`: The site of the Datadog intake to send SDK data to (default: 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site)
   - `silentMultipleInit`: prevent logging errors while having multiple Init
   - `trackInteractions`: collect actions initiated by user interactions
   - `service`: name of the corresponding service
@@ -49,7 +49,7 @@ datadogRum.init({
   init(configuration: {
       applicationId: string,
       clientToken: string,
-      datacenter?: string,
+      site?: string,
       resourceSampleRate?: number
       sampleRate?: number,
       silentMultipleInit?: boolean,
@@ -104,7 +104,7 @@ import '@datadog/browser-rum/bundle/datadog-rum';
 window.DD_RUM.init({
   applicationId: 'XXX',
   clientToken: 'XXX',
-  datacenter: 'us',
+  site: 'datadoghq.com',
   resourceSampleRate: 100,
   sampleRate: 100
 });

--- a/packages/rum/src/buildEnv.ts
+++ b/packages/rum/src/buildEnv.ts
@@ -1,8 +1,7 @@
-import { BuildEnv } from '@datadog/browser-core'
+import { BuildEnv, BuildMode, Datacenter } from '@datadog/browser-core'
 
 export const buildEnv: BuildEnv = {
-  buildMode: '<<< BUILD_MODE >>>' as BuildEnv['buildMode'],
-  datacenter: '<<< TARGET_DATACENTER >>>' as BuildEnv['datacenter'],
-  sdkEnv: '<<< TARGET_ENV >>>' as BuildEnv['sdkEnv'],
+  buildMode: '<<< BUILD_MODE >>>' as BuildMode,
+  datacenter: '<<< TARGET_DATACENTER >>>' as Datacenter,
   sdkVersion: '<<< SDK_VERSION >>>',
 }

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -3,6 +3,9 @@ const path = require('path')
 const webpackBase = require('../../webpack.base')
 
 const datacenter = process.env.TARGET_DATACENTER || 'us'
+const withSuffix = process.env.WITH_SUFFIX || false
+
+const suffix = withSuffix ? `-${datacenter}` : ''
 
 module.exports = (env, argv) => ({
   entry: {
@@ -10,7 +13,7 @@ module.exports = (env, argv) => ({
   },
   ...webpackBase(argv.mode),
   output: {
-    filename: `datadog-rum-${datacenter}.js`,
+    filename: `datadog-rum${suffix}.js`,
     path: path.resolve(__dirname, 'bundle'),
   },
 })

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -22,4 +22,5 @@ module.exports = {
   TARGET_ENV: process.env.TARGET_ENV || 'staging',
   BUILD_MODE: process.env.BUILD_MODE,
   SDK_VERSION: sdkVersion,
+  WITH_SUFFIX: process.env.WITH_SUFFIX || false,
 }

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -19,7 +19,6 @@ switch (process.env.BUILD_MODE) {
 
 module.exports = {
   TARGET_DATACENTER: process.env.TARGET_DATACENTER || 'us',
-  TARGET_ENV: process.env.TARGET_ENV || 'staging',
   BUILD_MODE: process.env.BUILD_MODE,
   SDK_VERSION: sdkVersion,
   WITH_SUFFIX: process.env.WITH_SUFFIX || false,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,7 +17,7 @@ case "${env}" in
     DISTRIBUTION_ID="E2FP11ZSCFD3EU"
     ;;
 * )
-    echo "Usage: ./deploy.sh staging|prod eu|us"
+    echo "Usage: ./deploy.sh staging|prod [eu|us]"
     exit 1
     ;;
 esac
@@ -31,8 +31,12 @@ case "${datacenter}" in
     LOGS_FILE_NAME="datadog-logs-us.js"
     RUM_FILE_NAME="datadog-rum-us.js"
     ;;
+"")
+    LOGS_FILE_NAME="datadog-logs.js"
+    RUM_FILE_NAME="datadog-rum.js"
+    ;;
 * )
-    echo "Usage: ./deploy.sh staging|prod eu|us"
+    echo "Usage: ./deploy.sh staging|prod [eu|us]"
     exit 1
     ;;
 esac

--- a/scripts/replace-build-env.js
+++ b/scripts/replace-build-env.js
@@ -18,9 +18,27 @@ try {
     from: Object.keys(buildEnv).map((entry) => `<<< ${entry} >>>`),
     to: Object.values(buildEnv),
   })
+  if (buildEnv.WITH_SUFFIX) {
+    replace.sync({
+      files: `${buildDirectory}/**/*.js`,
+      from: /.*/,
+      to: (...args) =>
+        `${makeDeprecatedSuffixComment(args[args.length - 1])}\n${args[0]}\n${makeDeprecatedSuffixComment(
+          args[args.length - 1]
+        )}`,
+    })
+  }
   console.log('Changed files:', results.filter((entry) => entry.hasChanged).map((entry) => entry.file))
   process.exit(0)
 } catch (error) {
   console.error('Error occurred:', error)
   process.exit(1)
+}
+
+function makeDeprecatedSuffixComment(filePath) {
+  const fileName = filePath.split('/').pop()
+  const suffixRegExp = /-(us|eu)/
+  const env = fileName.match(suffixRegExp)[1]
+  const newFileName = fileName.replace(suffixRegExp, '')
+  return `/**\n * ${fileName} IS DEPRECATED, USE ${newFileName} WITH { datacenter: '${env}' } INIT CONFIGURATION INSTEAD\n */`
 }

--- a/scripts/replace-build-env.js
+++ b/scripts/replace-build-env.js
@@ -4,7 +4,7 @@ const buildEnv = require('./build-env')
 /**
  * Replace BuildEnv in build files
  * Usage:
- * TARGET_DATACENTER=xxx TARGET_ENV=yyy BUILD_MODE=zzz node replace-build-env.js /path/to/build/directory
+ * TARGET_DATACENTER=xxx BUILD_MODE=zzz node replace-build-env.js /path/to/build/directory
  */
 
 const buildDirectory = process.argv[2]
@@ -40,5 +40,7 @@ function makeDeprecatedSuffixComment(filePath) {
   const suffixRegExp = /-(us|eu)/
   const env = fileName.match(suffixRegExp)[1]
   const newFileName = fileName.replace(suffixRegExp, '')
-  return `/**\n * ${fileName} IS DEPRECATED, USE ${newFileName} WITH { datacenter: '${env}' } INIT CONFIGURATION INSTEAD\n */`
+  return `/**\n * ${fileName} IS DEPRECATED, USE ${newFileName} WITH { site: 'datadoghq.${
+    env === 'eu' ? 'eu' : 'com'
+  }' } INIT CONFIGURATION INSTEAD\n */`
 }

--- a/test/static/async-e2e-page.html
+++ b/test/static/async-e2e-page.html
@@ -17,7 +17,7 @@
         const intakeOrigin = `http://${window.location.hostname}:4000`
         const specIdParam = /spec-id=\d+/.exec(window.location.search) && /spec-id=\d+/.exec(window.location.search)[0]
         const logs = document.createElement('script')
-        logs.src = './datadog-logs-us.js'
+        logs.src = './datadog-logs.js'
         logs.onload = () => {
           window.DD_LOGS &&
             window.DD_LOGS.init({
@@ -31,7 +31,7 @@
         document.getElementsByTagName('head')[0].appendChild(logs)
 
         const rum = document.createElement('script')
-        rum.src = './datadog-rum-us.js'
+        rum.src = './datadog-rum.js'
         rum.onload = () => {
           window.DD_RUM &&
             window.DD_RUM.init({

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/empty.css" />
     <title>bundle tests page</title>
-    <script type="text/javascript" src="./datadog-logs-us.js"></script>
+    <script type="text/javascript" src="./datadog-logs.js"></script>
     <script type="text/javascript">
       const intakeOrigin = `http://${window.location.hostname}:4000`
       const specIdParam = /spec-id=\d+/.exec(window.location.search) && /spec-id=\d+/.exec(window.location.search)[0]
@@ -20,7 +20,7 @@
           enableExperimentalFeatures: [],
         })
     </script>
-    <script type="text/javascript" src="./datadog-rum-us.js"></script>
+    <script type="text/javascript" src="./datadog-rum.js"></script>
     <script type="text/javascript">
       window.DD_RUM &&
         window.DD_RUM.init({


### PR DESCRIPTION
## Motivation

Allow to easily support future datacenters and align configuration parameter with other libraries.

## Changes

- Support site configuration
- Build new bundle files without suffix: `datadog-rum.js` and `datadog-logs.js`
- Use new bundle files everywhere

## Testing

Automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
