### PR TITLE
✨ Update context api to include removeContext method

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -67,6 +67,7 @@ What we call `Context` is a map `{key: value}` that will be added to the message
   logger.setLevel (level?: 'debug' | 'info' | 'warn' | 'error')
   logger.setHandler (handler?: 'http' | 'console' | 'silent')
   logger.addContext (key: string, value: any)  # add one key-value to the logger context
+  logger.removeContext (key: string)  # remove one key from the logger context
   logger.setContext (context: Context)  # entirely replace the logger context
   ```
 

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -207,7 +207,7 @@ export class Logger {
   }
 
   removeContext(key: string) {
-    delete this.loggerContext[key];
+    delete this.loggerContext[key]
   }
 
   setHandler(handler: HandlerType) {

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -206,6 +206,10 @@ export class Logger {
     this.loggerContext[key] = value
   }
 
+  removeContext(key: string) {
+    delete this.loggerContext[key];
+  }
+
   setHandler(handler: HandlerType) {
     this.handler = this.handlers[handler]
   }

--- a/packages/logs/src/logs.entry.ts
+++ b/packages/logs/src/logs.entry.ts
@@ -44,6 +44,9 @@ const STUBBED_LOGGER = {
   addContext(key: string, value: ContextValue) {
     makeStub('logs.logger.addContext')
   },
+  removeContext(key: string) {
+    makeStub('logs.logger.removeContext')
+  },
   setHandler(handler: HandlerType) {
     makeStub('logs.logger.setHandler')
   },

--- a/packages/logs/test/logger.spec.ts
+++ b/packages/logs/test/logger.spec.ts
@@ -152,10 +152,10 @@ describe('logger module', () => {
     })
 
     it('should be able to be able to add and remove from context', () => {
-      LOGS.logger.setContext({});
-      LOGS.logger.addContext('foo', { bar: 'qux' });
+      LOGS.logger.setContext({})
+      LOGS.logger.addContext('foo', { bar: 'qux' })
       LOGS.logger.log('first')
-      LOGS.logger.removeContext('foo');
+      LOGS.logger.removeContext('foo')
       LOGS.logger.log('second')
       expect(getLoggedMessage(server, 0).foo).toEqual({
         bar: 'qux',

--- a/packages/logs/test/logger.spec.ts
+++ b/packages/logs/test/logger.spec.ts
@@ -150,6 +150,18 @@ describe('logger module', () => {
         qix: 'qux',
       })
     })
+
+    it('should be able to be able to add and remove from context', () => {
+      LOGS.logger.setContext({});
+      LOGS.logger.addContext('foo', { bar: 'qux' });
+      LOGS.logger.log('first')
+      LOGS.logger.removeContext('foo');
+      LOGS.logger.log('second')
+      expect(getLoggedMessage(server, 0).foo).toEqual({
+        bar: 'qux',
+      })
+      expect(getLoggedMessage(server, 1).foo).toEqual(undefined)
+    })
   })
 
   describe('log level', () => {


### PR DESCRIPTION
## Motivation

In issue #409 it was suggested updating the logger API to allow users to remove keys from the logger. 

## Changes

This PR updates the logger API to have a removeContext method that removes a key from the context object. No existing methods have been modified as part of this work.

## Testing

To test this new functionality, the user must call removeContext with an existing key. A unit test has been added to test the existing addContext function and the new removeContext function. 

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
