### PR TITLE
🐛[RUMF-639] xhr proxy: do not instrument xhr already opened

### DIFF
--- a/packages/core/src/xhrProxy.ts
+++ b/packages/core/src/xhrProxy.ts
@@ -67,39 +67,41 @@ function proxyXhr() {
     return originalXhrOpen.apply(this, arguments as any)
   })
 
-  XMLHttpRequest.prototype.send = function(this: BrowserXHR, body: unknown) {
-    this._datadog_xhr.startTime = performance.now()
+  XMLHttpRequest.prototype.send = monitor(function(this: BrowserXHR, body: unknown) {
+    if (this._datadog_xhr) {
+      this._datadog_xhr.startTime = performance.now()
 
-    const originalOnreadystatechange = this.onreadystatechange
+      const originalOnreadystatechange = this.onreadystatechange
 
-    this.onreadystatechange = function() {
-      if (this.readyState === XMLHttpRequest.DONE) {
-        monitor(reportXhr)()
+      this.onreadystatechange = function() {
+        if (this.readyState === XMLHttpRequest.DONE) {
+          monitor(reportXhr)()
+        }
+
+        if (originalOnreadystatechange) {
+          originalOnreadystatechange.apply(this, arguments as any)
+        }
       }
 
-      if (originalOnreadystatechange) {
-        originalOnreadystatechange.apply(this, arguments as any)
+      let hasBeenReported = false
+      const reportXhr = () => {
+        if (hasBeenReported) {
+          return
+        }
+        hasBeenReported = true
+
+        this._datadog_xhr.duration = performance.now() - this._datadog_xhr.startTime!
+        this._datadog_xhr.response = this.response as string | undefined
+        this._datadog_xhr.status = this.status
+
+        onRequestCompleteCallbacks.forEach((callback) => callback(this._datadog_xhr as XhrContext))
       }
+
+      this.addEventListener('loadend', monitor(reportXhr))
+
+      beforeSendCallbacks.forEach((callback) => callback(this._datadog_xhr))
     }
-
-    let hasBeenReported = false
-    const reportXhr = () => {
-      if (hasBeenReported) {
-        return
-      }
-      hasBeenReported = true
-
-      this._datadog_xhr.duration = performance.now() - this._datadog_xhr.startTime!
-      this._datadog_xhr.response = this.response as string | undefined
-      this._datadog_xhr.status = this.status
-
-      onRequestCompleteCallbacks.forEach((callback) => callback(this._datadog_xhr as XhrContext))
-    }
-
-    this.addEventListener('loadend', monitor(reportXhr))
-
-    beforeSendCallbacks.forEach((callback) => callback(this._datadog_xhr))
 
     return originalXhrSend.apply(this, arguments as any)
-  }
+  })
 }

--- a/packages/core/test/xhrProxy.spec.ts
+++ b/packages/core/test/xhrProxy.spec.ts
@@ -174,4 +174,19 @@ describe('xhr proxy', () => {
       },
     })
   })
+
+  it('should should not break xhr opened before the instrumentation', (done) => {
+    resetXhrProxy()
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/ok')
+        startXhrProxy()
+        xhr.send()
+      },
+      onComplete() {
+        expect(completeSpy.calls.count()).toBe(0)
+        done()
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Motivation

Issue raised by customer

## Changes

Check that xhr has been instrumented on `open` to instrument `send`

## Testing

Automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
