### PR TITLE
👷 relax tslib version for SDKs installed through npm

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
   },
   "dependencies": {
-    "tslib": "1.10.0"
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@types/sinon": "7.0.13",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "1.15.3",
-    "tslib": "1.10.0"
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@types/sinon": "7.0.13",

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "1.15.3",
-    "tslib": "1.10.0"
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@types/sinon": "7.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9487,15 +9487,15 @@ tsconfig-paths@^3.4.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.10.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-
 tslib@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
+
+tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslint-config-airbnb@5.11.1:
   version "5.11.1"


### PR DESCRIPTION

## Motivation

See #493 

To reduce the SDK cost when using it through NPM, we should accept any semver compatible tslib version, so it can use an already present tslib version if any.

The bundled SDK is still using tslib 1.10.0 as specified by yarn.lock

## Changes

Adjust the required tslib version in package.json

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
