### PR TITLE
[RUMF-620]: Send service as tag and attribute

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -96,6 +96,7 @@ interface TransportConfiguration {
   applicationId?: string
   proxyHost?: string
 
+  service?: string
   env?: string
   version?: string
 }
@@ -108,6 +109,7 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
     env: userConfiguration.env,
     proxyHost: userConfiguration.proxyHost,
     sdkVersion: buildEnv.sdkVersion,
+    service: userConfiguration.service,
     site: userConfiguration.site || INTAKE_SITE[userConfiguration.datacenter || buildEnv.datacenter],
     version: userConfiguration.version,
   }
@@ -189,6 +191,7 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
   const tags =
     `sdk_version:${conf.sdkVersion}` +
     `${conf.env ? `,env:${conf.env}` : ''}` +
+    `${conf.service ? `,service:${conf.service}` : ''}` +
     `${conf.version ? `,version:${conf.version}` : ''}`
   const datadogHost = `${type}-http-intake.logs.${conf.site}`
   const host = conf.proxyHost ? conf.proxyHost : datadogHost

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -100,8 +100,12 @@ describe('configuration', () => {
 
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = buildConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' }, usEnv)
-      expect(configuration.rumEndpoint).toContain(`&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,version:baz`)
-      expect(configuration.logsEndpoint).toContain(`&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,version:baz`)
+      expect(configuration.rumEndpoint).toContain(
+        `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
+      )
+      expect(configuration.logsEndpoint).toContain(
+        `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
+      )
     })
   })
 })


### PR DESCRIPTION
## Motivation
Using `service` as attribute only requires some UI and Facets changes.

## Changes
Dual ship `service` as tag and attribute while we make the required changes. 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
