### PR TITLE
Revert "[RUMF-620]: Send "service" as an attribute, not a tag (#494)"

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -96,6 +96,7 @@ interface TransportConfiguration {
   applicationId?: string
   proxyHost?: string
 
+  service?: string
   env?: string
   version?: string
 }
@@ -108,6 +109,7 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
     env: userConfiguration.env,
     proxyHost: userConfiguration.proxyHost,
     sdkVersion: buildEnv.sdkVersion,
+    service: userConfiguration.service,
     site: userConfiguration.site || INTAKE_SITE[userConfiguration.datacenter || buildEnv.datacenter],
     version: userConfiguration.version,
   }
@@ -189,6 +191,7 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
   const tags =
     `sdk_version:${conf.sdkVersion}` +
     `${conf.env ? `,env:${conf.env}` : ''}` +
+    `${conf.service ? `,service:${conf.service}` : ''}` +
     `${conf.version ? `,version:${conf.version}` : ''}`
   const datadogHost = `${type}-http-intake.logs.${conf.site}`
   const host = conf.proxyHost ? conf.proxyHost : datadogHost

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -100,8 +100,12 @@ describe('configuration', () => {
 
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = buildConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' }, usEnv)
-      expect(configuration.rumEndpoint).toContain(`&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,version:baz`)
-      expect(configuration.logsEndpoint).toContain(`&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,version:baz`)
+      expect(configuration.rumEndpoint).toContain(
+        `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
+      )
+      expect(configuration.logsEndpoint).toContain(
+        `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
+      )
     })
   })
 })

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -118,7 +118,6 @@ function startLoggerBatch(configuration: Configuration, session: LoggerSession, 
     return deepMerge(
       {
         date: new Date().getTime(),
-        service: configuration.service,
         session_id: session.getId(),
         view: {
           referrer: document.referrer,

--- a/packages/logs/test/logger.spec.ts
+++ b/packages/logs/test/logger.spec.ts
@@ -31,7 +31,6 @@ describe('logger module', () => {
     ...DEFAULT_CONFIGURATION,
     logsEndpoint: 'https://localhost/log',
     maxBatchSize: 1,
-    service: 'Service',
   }
   let LOGS: LogsApi
   let server: sinon.SinonFakeServer
@@ -58,7 +57,6 @@ describe('logger module', () => {
         date: FAKE_DATE,
         foo: 'bar',
         message: 'message',
-        service: 'Service',
         status: StatusType.warn,
         view: {
           referrer: document.referrer,

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -181,7 +181,6 @@ export function startRum(
     () => ({
       applicationId,
       date: new Date().getTime(),
-      service: configuration.service,
       session: {
         // must be computed on each event because synthetics instrumentation can be done after sdk execution
         // cf https://github.com/puppeteer/puppeteer/issues/3667


### PR DESCRIPTION


## Motivation

There is a few issues with #494 : 
* The corresponding facet hasn't been updated by the backend
* Mobile SDKs are still using the tag instead of the attribute
* The SidePanelHeader is using the tag, not the attribute https://github.com/DataDog/web-ui/blob/43b199c540d7b026bcb8b9f6a8cd191e36810a99/javascript/datadog/rum/components/side-panel/SidePanelHeader/EventContextRow/EventContextRow.tsx#L36
 
Those issues should be addressed before deploying #494 , maybe by dual shipping the service as a tag and an attribute #501 , but we should discuss about it a bit more.

## Changes

This reverts commit ff82247eb18a17568f3d3fb03293ed8dd2afe1ac.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
