### PR TITLE
🐛[RUMF-645] do not track intake request errors

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -1,4 +1,5 @@
 import { BuildEnv, BuildMode, Datacenter, INTAKE_SITE } from './init'
+import { haveSameOrigin } from './urlPolyfill'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from './utils'
 
 export const DEFAULT_CONFIGURATION = {
@@ -200,4 +201,13 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
   const parameters = `${applicationIdParameter}${proxyParameter}ddsource=${source || 'browser'}&ddtags=${tags}`
 
   return `https://${host}/v1/input/${conf.clientToken}?${parameters}`
+}
+
+export function isIntakeRequest(url: string, configuration: Configuration) {
+  return (
+    haveSameOrigin(url, configuration.logsEndpoint) ||
+    haveSameOrigin(url, configuration.rumEndpoint) ||
+    haveSameOrigin(url, configuration.traceEndpoint) ||
+    (configuration.internalMonitoringEndpoint && haveSameOrigin(url, configuration.internalMonitoringEndpoint))
+  )
 }

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -73,6 +73,7 @@ export type Configuration = typeof DEFAULT_CONFIGURATION & {
   rumEndpoint: string
   traceEndpoint: string
   internalMonitoringEndpoint?: string
+  proxyHost?: string
 
   service?: string
 
@@ -124,6 +125,7 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
       return includes(enableExperimentalFeatures, feature)
     },
     logsEndpoint: getEndpoint('browser', transportConfiguration),
+    proxyHost: userConfiguration.proxyHost,
     rumEndpoint: getEndpoint('rum', transportConfiguration),
     traceEndpoint: getEndpoint('public-trace', transportConfiguration),
     ...DEFAULT_CONFIGURATION,
@@ -208,6 +210,11 @@ export function isIntakeRequest(url: string, configuration: Configuration) {
     haveSameOrigin(url, configuration.logsEndpoint) ||
     haveSameOrigin(url, configuration.rumEndpoint) ||
     haveSameOrigin(url, configuration.traceEndpoint) ||
-    (configuration.internalMonitoringEndpoint && haveSameOrigin(url, configuration.internalMonitoringEndpoint))
+    (configuration.internalMonitoringEndpoint && haveSameOrigin(url, configuration.internalMonitoringEndpoint)) ||
+    (configuration.proxyHost && haveSameOrigin(url, configuration.proxyHost)) ||
+    (configuration.replica &&
+      (haveSameOrigin(url, configuration.replica.logsEndpoint) ||
+        haveSameOrigin(url, configuration.replica.rumEndpoint) ||
+        haveSameOrigin(url, configuration.replica.internalMonitoringEndpoint)))
   )
 }

--- a/packages/core/src/errorCollection.ts
+++ b/packages/core/src/errorCollection.ts
@@ -1,4 +1,4 @@
-import { Configuration } from './configuration'
+import { Configuration, isIntakeRequest } from './configuration'
 import { FetchContext, resetFetchProxy, startFetchProxy } from './fetchProxy'
 import { monitor } from './internalMonitoring'
 import { Observable } from './observable'
@@ -160,7 +160,7 @@ export function trackNetworkError(configuration: Configuration, errorObservable:
   startFetchProxy().onRequestComplete((context) => handleCompleteRequest(RequestType.FETCH, context))
 
   function handleCompleteRequest(type: RequestType, request: XhrContext | FetchContext) {
-    if (isRejected(request) || isServerError(request)) {
+    if (!isIntakeRequest(request.url, configuration) && (isRejected(request) || isServerError(request))) {
       errorObservable.notify({
         context: {
           error: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { DEFAULT_CONFIGURATION, Configuration, UserConfiguration } from './configuration'
+export { DEFAULT_CONFIGURATION, Configuration, UserConfiguration, isIntakeRequest } from './configuration'
 export { ErrorMessage, ErrorContext, HttpContext, ErrorOrigin, ErrorObservable } from './errorCollection'
 export {
   BuildEnv,

--- a/packages/core/test/errorCollection.spec.ts
+++ b/packages/core/test/errorCollection.spec.ts
@@ -1,4 +1,4 @@
-import { FetchStub, FetchStubManager, isIE, stubFetch } from '../src'
+import { FetchStub, FetchStubManager, isIE, SPEC_ENDPOINTS, stubFetch } from '../src'
 import { Configuration } from '../src/configuration'
 import {
   ErrorMessage,
@@ -13,7 +13,7 @@ import {
 } from '../src/errorCollection'
 import { Observable } from '../src/observable'
 import { StackTrace } from '../src/tracekit'
-import { ONE_MINUTE, RequestType } from '../src/utils'
+import { ONE_MINUTE } from '../src/utils'
 
 describe('console tracker', () => {
   let consoleErrorStub: jasmine.Spy
@@ -208,7 +208,7 @@ describe('network error tracker', () => {
     }
     const errorObservable = new Observable<ErrorMessage>()
     errorObservableSpy = spyOn(errorObservable, 'notify')
-    const configuration = { requestErrorResponseLengthLimit: 32 }
+    const configuration = { requestErrorResponseLengthLimit: 32, ...SPEC_ENDPOINTS }
 
     fetchStubManager = stubFetch()
     ;({ stop: stopNetworkErrorTracking } = trackNetworkError(configuration as Configuration, errorObservable))
@@ -232,6 +232,15 @@ describe('network error tracker', () => {
         message: 'Fetch error GET http://fake.com/',
         startTime: jasmine.any(Number),
       })
+      done()
+    })
+  })
+
+  it('should not track intake error', (done) => {
+    fetchStub('https://logs-intake.com/send?foo=bar').resolveWith(DEFAULT_REQUEST)
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).not.toHaveBeenCalled()
       done()
     })
   })

--- a/packages/rum/src/resourceUtils.ts
+++ b/packages/rum/src/resourceUtils.ts
@@ -2,8 +2,8 @@ import {
   addMonitoringMessage,
   Configuration,
   getPathName,
-  haveSameOrigin,
   includes,
+  isIntakeRequest,
   isValidUrl,
   msToNs,
   ResourceKind,
@@ -169,14 +169,5 @@ export function computeSize(entry: RumPerformanceResourceTiming) {
 }
 
 export function shouldTrackResource(url: string, configuration: Configuration, session: RumSession) {
-  return session.isTrackedWithResource() && url && !isBrowserAgentRequest(url, configuration)
-}
-
-function isBrowserAgentRequest(url: string, configuration: Configuration) {
-  return (
-    haveSameOrigin(url, configuration.logsEndpoint) ||
-    haveSameOrigin(url, configuration.rumEndpoint) ||
-    haveSameOrigin(url, configuration.traceEndpoint) ||
-    (configuration.internalMonitoringEndpoint && haveSameOrigin(url, configuration.internalMonitoringEndpoint))
-  )
+  return session.isTrackedWithResource() && url && !isIntakeRequest(url, configuration)
 }

--- a/packages/rum/src/resourceUtils.ts
+++ b/packages/rum/src/resourceUtils.ts
@@ -107,10 +107,10 @@ export function computePerformanceResourceDetails(
     return undefined
   }
 
-  // The only time fetchStart is different than startTime is if a redirection occured.
-  const hasRedirectionOccured = fetchStart !== startTime
+  // The only time fetchStart is different than startTime is if a redirection occurred.
+  const hasRedirectionOccurred = fetchStart !== startTime
 
-  if (hasRedirectionOccured) {
+  if (hasRedirectionOccurred) {
     // Firefox doesn't provide redirect timings on cross origin requests.  Provide a default for
     // those.
     if (redirectStart < startTime) {
@@ -131,22 +131,22 @@ export function computePerformanceResourceDetails(
     firstByte: formatTiming(startTime, requestStart, responseStart),
   }
 
-  // Make sure a connection occured
+  // Make sure a connection occurred
   if (connectEnd !== fetchStart) {
     details.connect = formatTiming(startTime, connectStart, connectEnd)
 
-    // Make sure a secure connection occured
+    // Make sure a secure connection occurred
     if (areInOrder(connectStart, secureConnectionStart, connectEnd)) {
       details.ssl = formatTiming(startTime, secureConnectionStart, connectEnd)
     }
   }
 
-  // Make sure a domain lookup occured
+  // Make sure a domain lookup occurred
   if (domainLookupEnd !== fetchStart) {
     details.dns = formatTiming(startTime, domainLookupStart, domainLookupEnd)
   }
 
-  if (hasRedirectionOccured) {
+  if (hasRedirectionOccurred) {
     details.redirect = formatTiming(startTime, redirectStart, redirectEnd)
   }
 
@@ -161,7 +161,7 @@ function formatTiming(origin: number, start: number, end: number) {
 }
 
 export function computeSize(entry: RumPerformanceResourceTiming) {
-  // Make sure a request actually occured
+  // Make sure a request actually occurred
   if (entry.startTime < entry.responseStart) {
     return entry.decodedBodySize
   }


### PR DESCRIPTION
## Motivation

Intake request errors are reported which cause a loop of errors 

## Changes

Exclude intake request errors like intake resource events

## Testing

Automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
