### PR TITLE
[RUMF-621] set view referrer to the previous view URL

### DIFF
--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,8 +1,8 @@
 import { ErrorMessage } from '@datadog/browser-core'
 import { RumPerformanceEntry } from './performanceCollection'
 import { RequestCompleteEvent, RequestStartEvent } from './requestCollection'
-import { AutoUserAction, CustomUserAction } from './userActionCollection'
-import { View } from './viewCollection'
+import { AutoActionCreatedEvent, AutoUserAction, CustomUserAction } from './userActionCollection'
+import { View, ViewCreatedEvent } from './viewCollection'
 
 export enum LifeCycleEventType {
   ERROR_COLLECTED,
@@ -34,8 +34,8 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.REQUEST_COMPLETED, data: RequestCompleteEvent): void
   notify(eventType: LifeCycleEventType.AUTO_ACTION_COMPLETED, data: AutoUserAction): void
   notify(eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED, data: CustomUserAction): void
-  notify(eventType: LifeCycleEventType.AUTO_ACTION_CREATED, data: { id: string; startTime: number }): void
-  notify(eventType: LifeCycleEventType.VIEW_CREATED, data: { id: string; startTime: number; location: Location }): void
+  notify(eventType: LifeCycleEventType.AUTO_ACTION_CREATED, data: AutoActionCreatedEvent): void
+  notify(eventType: LifeCycleEventType.VIEW_CREATED, data: ViewCreatedEvent): void
   notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: View): void
   notify(
     eventType:
@@ -65,16 +65,13 @@ export class LifeCycle {
   subscribe(eventType: LifeCycleEventType.AUTO_ACTION_COMPLETED, callback: (data: AutoUserAction) => void): Subscription
   subscribe(
     eventType: LifeCycleEventType.AUTO_ACTION_CREATED,
-    callback: (data: { id: string; startTime: number }) => void
+    callback: (data: AutoActionCreatedEvent) => void
   ): Subscription
   subscribe(
     eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED,
     callback: (data: CustomUserAction) => void
   ): Subscription
-  subscribe(
-    eventType: LifeCycleEventType.VIEW_CREATED,
-    callback: (data: { id: string; startTime: number; location: Location }) => void
-  ): Subscription
+  subscribe(eventType: LifeCycleEventType.VIEW_CREATED, callback: (data: ViewCreatedEvent) => void): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription
   subscribe(
     eventType:

--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -1,7 +1,8 @@
 import { Context, monitor, ONE_MINUTE, SESSION_TIME_OUT_DELAY } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RumSession } from './rumSession'
-import { AutoUserAction } from './userActionCollection'
+import { AutoActionCreatedEvent, AutoUserAction } from './userActionCollection'
+import { ViewCreatedEvent } from './viewCollection'
 
 export const VIEW_CONTEXT_TIME_OUT_DELAY = SESSION_TIME_OUT_DELAY
 export const ACTION_CONTEXT_TIME_OUT_DELAY = 5 * ONE_MINUTE // arbitrary
@@ -21,17 +22,6 @@ export interface ActionContext extends Context {
   }
 }
 
-interface CurrentViewContext {
-  id: string
-  startTime: number
-  location: Location
-}
-
-interface CurrentActionContext {
-  id: string
-  startTime: number
-}
-
 interface PreviousContext<T> {
   startTime: number
   endTime: number
@@ -45,8 +35,8 @@ export interface ParentContexts {
 }
 
 export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): ParentContexts {
-  let currentView: CurrentViewContext | undefined
-  let currentAction: CurrentActionContext | undefined
+  let currentView: ViewCreatedEvent | undefined
+  let currentAction: AutoActionCreatedEvent | undefined
   let currentSessionId: string | undefined
 
   let previousViews: Array<PreviousContext<ViewContext>> = []

--- a/packages/rum/src/parentContexts.ts
+++ b/packages/rum/src/parentContexts.ts
@@ -13,6 +13,7 @@ export interface ViewContext extends Context {
   view: {
     id: string
     url: string
+    referrer: string
   }
 }
 
@@ -108,6 +109,7 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
       sessionId: currentSessionId,
       view: {
         id: currentView!.id,
+        referrer: currentView!.referrer,
         url: currentView!.location.href,
       },
     }

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -32,6 +32,7 @@ export interface InternalContext {
   view?: {
     id: string
     url: string
+    referrer: string
   }
   user_action?: {
     id: string

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -202,14 +202,8 @@ export function startRum(
         const viewContext = parentContexts.findView(startTime)
         if (session.isTracked() && viewContext && viewContext.sessionId) {
           return (withSnakeCaseKeys(deepMerge(
-            {
-              applicationId,
-              sessionId: viewContext.sessionId,
-              view: {
-                id: viewContext.view.id,
-                url: viewContext.view.url,
-              },
-            },
+            { applicationId },
+            viewContext,
             parentContexts.findAction(startTime)
           ) as Context) as unknown) as InternalContext
         }

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -134,9 +134,6 @@ interface RumContext {
   session: {
     type: string
   }
-  view: {
-    referrer: string
-  }
 }
 
 export type RawRumEvent = RumErrorEvent | RumResourceEvent | RumViewEvent | RumLongTaskEvent | RumUserActionEvent
@@ -186,9 +183,6 @@ export function startRum(
         // cf https://github.com/puppeteer/puppeteer/issues/3667
         type: getSessionType(),
       },
-      view: {
-        referrer: document.referrer,
-      },
     }),
     () => globalContext
   )
@@ -205,11 +199,17 @@ export function startRum(
         lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { context, name, type: UserActionType.CUSTOM })
       }),
       getInternalContext: monitor((startTime?: number): InternalContext | undefined => {
-        const view = parentContexts.findView(startTime)
-        if (session.isTracked() && view && view.sessionId) {
+        const viewContext = parentContexts.findView(startTime)
+        if (session.isTracked() && viewContext && viewContext.sessionId) {
           return (withSnakeCaseKeys(deepMerge(
-            { applicationId },
-            view,
+            {
+              applicationId,
+              sessionId: viewContext.sessionId,
+              view: {
+                id: viewContext.view.id,
+                url: viewContext.view.url,
+              },
+            },
             parentContexts.findAction(startTime)
           ) as Context) as unknown) as InternalContext
         }

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -32,6 +32,11 @@ export interface AutoUserAction {
   measures: UserActionMeasures
 }
 
+export interface AutoActionCreatedEvent {
+  id: string
+  startTime: number
+}
+
 export function startUserActionCollection(lifeCycle: LifeCycle) {
   const userAction = startUserActionManagement(lifeCycle)
 

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -15,6 +15,12 @@ export interface View {
   loadingType: ViewLoadingType
 }
 
+export interface ViewCreatedEvent {
+  id: string
+  location: Location
+  startTime: number
+}
+
 interface Timings {
   firstContentfulPaint?: number
   domInteractive?: number

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -7,6 +7,7 @@ import { waitIdlePageActivity } from './trackPageActivities'
 export interface View {
   id: string
   location: Location
+  referrer: string
   measures: ViewMeasures
   documentVersion: number
   startTime: number
@@ -18,6 +19,7 @@ export interface View {
 export interface ViewCreatedEvent {
   id: string
   location: Location
+  referrer: string
   startTime: number
 }
 
@@ -113,8 +115,9 @@ function newView(
   let loadingTime: number | undefined
   let endTime: number | undefined
   let location: Location = { ...initialLocation }
+  const referrer = document.referrer
 
-  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id, startTime, location })
+  lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { id, startTime, location, referrer })
 
   // Update the view every time the measures are changing
   const { throttled: scheduleViewUpdate, cancel: cancelScheduleViewUpdate } = throttle(
@@ -148,6 +151,7 @@ function newView(
       loadingTime,
       loadingType,
       location,
+      referrer,
       startTime,
       duration: (endTime === undefined ? performance.now() : endTime) - startTime,
       measures: { ...timings, ...eventCounts },

--- a/packages/rum/src/viewCollection.ts
+++ b/packages/rum/src/viewCollection.ts
@@ -184,9 +184,10 @@ function newView(
     },
     updateLocation(newLocation: Location) {
       location = { ...newLocation }
-      this.url = location.href
     },
-    url: location.href,
+    get url() {
+      return location.href
+    },
   }
 }
 

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -5,7 +5,6 @@ import {
   VIEW_CONTEXT_TIME_OUT_DELAY,
 } from '../src/parentContexts'
 import { AutoUserAction } from '../src/userActionCollection'
-import { View } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 function stubActionWithDuration(duration: number): AutoUserAction {

--- a/packages/rum/test/parentContexts.spec.ts
+++ b/packages/rum/test/parentContexts.spec.ts
@@ -17,7 +17,7 @@ describe('parentContexts', () => {
   const FAKE_ID = 'fake'
   const startTime = 10
 
-  function createViewCreatedEvent(partialViewCreatedEvent: Partial<ViewCreatedEvent> = {}): ViewCreatedEvent {
+  function buildViewCreatedEvent(partialViewCreatedEvent: Partial<ViewCreatedEvent> = {}): ViewCreatedEvent {
     return { location, startTime, id: FAKE_ID, referrer: 'http://foo.com', ...partialViewCreatedEvent }
   }
 
@@ -50,7 +50,7 @@ describe('parentContexts', () => {
     it('should return the current view context when there is no start time', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent())
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent())
 
       expect(parentContexts.findView()).toBeDefined()
       expect(parentContexts.findView()!.view.id).toEqual(FAKE_ID)
@@ -59,9 +59,9 @@ describe('parentContexts', () => {
     it('should return the view context corresponding to startTime', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ startTime: 10, id: 'view 1' }))
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ startTime: 20, id: 'view 2' }))
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ startTime: 30, id: 'view 3' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 10, id: 'view 1' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 20, id: 'view 2' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 30, id: 'view 3' }))
 
       expect(parentContexts.findView(15)!.view.id).toEqual('view 1')
       expect(parentContexts.findView(20)!.view.id).toEqual('view 2')
@@ -71,8 +71,8 @@ describe('parentContexts', () => {
     it('should return undefined when no view context corresponding to startTime', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ startTime: 10, id: 'view 1' }))
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ startTime: 20, id: 'view 2' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 10, id: 'view 1' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 20, id: 'view 2' }))
 
       expect(parentContexts.findView(5)).not.toBeDefined()
     })
@@ -80,9 +80,9 @@ describe('parentContexts', () => {
     it('should replace the current view context on VIEW_CREATED', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent())
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent())
       const newViewId = 'fake 2'
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ id: newViewId }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ id: newViewId }))
 
       expect(parentContexts.findView()!.view.id).toEqual(newViewId)
     })
@@ -90,7 +90,7 @@ describe('parentContexts', () => {
     it('should return the current url with the current view', () => {
       const { lifeCycle, parentContexts, fakeLocation } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ location: fakeLocation as Location }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ location: fakeLocation as Location }))
       expect(parentContexts.findView()!.view.url).toBe('http://fake-url.com/')
 
       history.pushState({}, '', '/foo')
@@ -101,13 +101,13 @@ describe('parentContexts', () => {
     it('should update session id only on VIEW_CREATED', () => {
       const { lifeCycle, parentContexts } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent())
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent())
       expect(parentContexts.findView()!.sessionId).toBe('fake-session')
 
       sessionId = 'other-session'
       expect(parentContexts.findView()!.sessionId).toBe('fake-session')
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, createViewCreatedEvent({ id: 'fake 2' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ id: 'fake 2' }))
       expect(parentContexts.findView()!.sessionId).toBe('other-session')
     })
   })
@@ -181,14 +181,14 @@ describe('parentContexts', () => {
 
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
-        createViewCreatedEvent({
+        buildViewCreatedEvent({
           id: 'view 1',
           startTime: 10,
         })
       )
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
-        createViewCreatedEvent({
+        buildViewCreatedEvent({
           id: 'view 2',
           startTime: 20,
         })
@@ -218,7 +218,7 @@ describe('parentContexts', () => {
 
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
-        createViewCreatedEvent({
+        buildViewCreatedEvent({
           id: 'view 1',
           startTime: originalTime,
         })
@@ -227,7 +227,7 @@ describe('parentContexts', () => {
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
-        createViewCreatedEvent({ startTime: originalTime + 10, id: 'view 2' })
+        buildViewCreatedEvent({ startTime: originalTime + 10, id: 'view 2' })
       )
 
       clock.tick(10)

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -671,6 +671,7 @@ describe('rum internal context', () => {
       },
       view: {
         id: jasmine.any(String),
+        referrer: document.referrer,
         url: window.location.href,
       },
     })
@@ -705,6 +706,7 @@ describe('rum internal context', () => {
       },
       view: {
         id: jasmine.any(String),
+        referrer: document.referrer,
         url: window.location.href,
       },
     })

--- a/packages/rum/test/userActionCollection.spec.ts
+++ b/packages/rum/test/userActionCollection.spec.ts
@@ -77,7 +77,12 @@ describe('startUserActionCollection', () => {
     mockValidatedClickUserAction(lifeCycle, clock, button)
     expect(createSpy).toHaveBeenCalled()
 
-    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, { location, id: 'fake', startTime: 0 })
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      location,
+      id: 'fake',
+      referrer: 'http://foo.com',
+      startTime: 0,
+    })
     clock.tick(EXPIRE_DELAY)
 
     expect(events).toEqual([])

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -224,6 +224,68 @@ describe('rum track url change', () => {
   })
 })
 
+describe('rum view referrer', () => {
+  let setupBuilder: TestSetupBuilder
+  let initialViewCreatedEvent: ViewCreatedEvent
+  let createSpy: jasmine.Spy<(event: ViewCreatedEvent) => void>
+
+  beforeEach(() => {
+    setupBuilder = setup()
+      .withFakeLocation('/foo')
+      .withViewCollection()
+      .beforeBuild((lifeCycle) => {
+        const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (event) => {
+          initialViewCreatedEvent = event
+          subscription.unsubscribe()
+        })
+      })
+    createSpy = jasmine.createSpy('create')
+  })
+
+  afterEach(() => {
+    setupBuilder.cleanup()
+  })
+
+  it('should set the document referrer as referrer for the initial view', () => {
+    setupBuilder.build()
+    expect(initialViewCreatedEvent.referrer).toEqual(document.referrer)
+  })
+
+  it('should set the previous view URL as referrer when a route change occurs', () => {
+    const { lifeCycle } = setupBuilder.build()
+    lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
+
+    history.pushState({}, '', '/bar')
+
+    expect(createSpy).toHaveBeenCalled()
+    const viewContext = createSpy.calls.argsFor(0)[0]
+    expect(viewContext.referrer).toEqual(jasmine.stringMatching(/\/foo$/))
+  })
+
+  it('should set the previous view URL as referrer when a the session is renewed', () => {
+    const { lifeCycle } = setupBuilder.build()
+    lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
+
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+
+    expect(createSpy).toHaveBeenCalled()
+    const viewContext = createSpy.calls.argsFor(0)[0]
+    expect(viewContext.referrer).toEqual(jasmine.stringMatching(/\/foo$/))
+  })
+
+  it('should use the most up-to-date URL of the previous view as a referrer', () => {
+    const { lifeCycle } = setupBuilder.build()
+    lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
+
+    history.pushState({}, '', '/foo?a=b')
+    history.pushState({}, '', '/bar')
+
+    expect(createSpy).toHaveBeenCalled()
+    const viewContext = createSpy.calls.argsFor(0)[0]
+    expect(viewContext.referrer).toEqual(jasmine.stringMatching(/\/foo\?a=b$/))
+  })
+})
+
 describe('rum track renew session', () => {
   let setupBuilder: TestSetupBuilder
   let handler: jasmine.Spy


### PR DESCRIPTION
## Motivation

For `route_change` views, use the previous view URL as referrer.

## Changes

For the sake of simplicity, lifecycle types have been improved a bit so we can re-use them easily. Then, the referrer has been set to the View context so it can be used everywher the View context is used. Finally, the view collections is retrieving the previous view URL when creating the new view on URL change or session renew.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
