### PR TITLE
Correcting description of site field

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -38,7 +38,7 @@ datadogRum.init({
 
   - `sampleRate`: percentage of sessions to track. Only tracked sessions send rum events.
   - `resourceSampleRate`: percentage of tracked sessions with resources collection.
-  - `site`: The site of the Datadog intake to send SDK data to (default: 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site)
+  - `site`: The site of the Datadog intake to send SDK data to ('datadoghq.com' to send data to the US site; 'datadoghq.eu' to send data to the EU site)
   - `silentMultipleInit`: prevent logging errors while having multiple Init
   - `trackInteractions`: collect actions initiated by user interactions
   - `service`: name of the corresponding service


### PR DESCRIPTION
Removing the reference to site having a default value. This appears to have changed and the main docs at https://docs.datadoghq.com/real_user_monitoring/browser/ have been updated to reflect this.


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
