### PR TITLE
[RUMF-634] add resource id for traced request

### DIFF
--- a/packages/rum/src/requestCollection.ts
+++ b/packages/rum/src/requestCollection.ts
@@ -10,11 +10,11 @@ import {
 import { startTracer, TraceIdentifier, Tracer } from './tracer'
 
 export interface RequestStartEvent {
-  requestId: number
+  requestIndex: number
 }
 
 export interface RequestCompleteEvent {
-  requestId: number
+  requestIndex: number
   type: RequestType
   method: string
   url: string
@@ -29,7 +29,7 @@ export interface RequestCompleteEvent {
 
 export type RequestObservables = [Observable<RequestStartEvent>, Observable<RequestCompleteEvent>]
 
-let nextRequestId = 1
+let nextRequestIndex = 1
 
 export function startRequestCollection(configuration: Configuration) {
   const requestObservables: RequestObservables = [new Observable(), new Observable()]
@@ -42,7 +42,7 @@ export function startRequestCollection(configuration: Configuration) {
 interface CustomXhrContext extends XhrContext {
   traceId: TraceIdentifier | undefined
   spanId: TraceIdentifier | undefined
-  requestId: number
+  requestIndex: number
 }
 
 export function trackXhr([requestStartObservable, requestCompleteObservable]: RequestObservables, tracer: Tracer) {
@@ -53,17 +53,17 @@ export function trackXhr([requestStartObservable, requestCompleteObservable]: Re
       context.traceId = tracingResult.traceId
       context.spanId = tracingResult.spanId
     }
-    context.requestId = getNextRequestId()
+    context.requestIndex = getNextRequestIndex()
 
     requestStartObservable.notify({
-      requestId: context.requestId,
+      requestIndex: context.requestIndex,
     })
   })
   xhrProxy.onRequestComplete((context) => {
     requestCompleteObservable.notify({
       duration: context.duration,
       method: context.method,
-      requestId: context.requestId,
+      requestIndex: context.requestIndex,
       response: context.response,
       spanId: context.spanId,
       startTime: context.startTime,
@@ -79,7 +79,7 @@ export function trackXhr([requestStartObservable, requestCompleteObservable]: Re
 interface CustomFetchContext extends FetchContext {
   traceId: TraceIdentifier | undefined
   spanId: TraceIdentifier | undefined
-  requestId: number
+  requestIndex: number
 }
 
 export function trackFetch([requestStartObservable, requestCompleteObservable]: RequestObservables, tracer: Tracer) {
@@ -90,17 +90,17 @@ export function trackFetch([requestStartObservable, requestCompleteObservable]: 
       context.traceId = tracingResult.traceId
       context.spanId = tracingResult.spanId
     }
-    context.requestId = getNextRequestId()
+    context.requestIndex = getNextRequestIndex()
 
     requestStartObservable.notify({
-      requestId: context.requestId,
+      requestIndex: context.requestIndex,
     })
   })
   fetchProxy.onRequestComplete((context) => {
     requestCompleteObservable.notify({
       duration: context.duration,
       method: context.method,
-      requestId: context.requestId,
+      requestIndex: context.requestIndex,
       response: context.response,
       responseType: context.responseType,
       spanId: context.spanId,
@@ -114,8 +114,8 @@ export function trackFetch([requestStartObservable, requestCompleteObservable]: 
   return fetchProxy
 }
 
-function getNextRequestId() {
-  const result = nextRequestId
-  nextRequestId += 1
+function getNextRequestIndex() {
+  const result = nextRequestIndex
+  nextRequestIndex += 1
   return result
 }

--- a/packages/rum/src/trackPageActivities.ts
+++ b/packages/rum/src/trackPageActivities.ts
@@ -59,7 +59,7 @@ export function waitIdlePageActivity(
 export function trackPageActivities(lifeCycle: LifeCycle): { observable: Observable<PageActivityEvent>; stop(): void } {
   const observable = new Observable<PageActivityEvent>()
   const subscriptions: Subscription[] = []
-  let firstRequestId: undefined | number
+  let firstRequestIndex: undefined | number
   let pendingRequestsCount = 0
 
   subscriptions.push(lifeCycle.subscribe(LifeCycleEventType.DOM_MUTATED, () => notifyPageActivity()))
@@ -76,8 +76,8 @@ export function trackPageActivities(lifeCycle: LifeCycle): { observable: Observa
 
   subscriptions.push(
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, (startEvent) => {
-      if (firstRequestId === undefined) {
-        firstRequestId = startEvent.requestId
+      if (firstRequestIndex === undefined) {
+        firstRequestIndex = startEvent.requestIndex
       }
 
       pendingRequestsCount += 1
@@ -88,7 +88,7 @@ export function trackPageActivities(lifeCycle: LifeCycle): { observable: Observa
   subscriptions.push(
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, (request) => {
       // If the request started before the tracking start, ignore it
-      if (firstRequestId === undefined || request.requestId < firstRequestId) {
+      if (firstRequestIndex === undefined || request.requestIndex < firstRequestIndex) {
         return
       }
       pendingRequestsCount -= 1

--- a/packages/rum/test/requestCollection.spec.ts
+++ b/packages/rum/test/requestCollection.spec.ts
@@ -60,7 +60,7 @@ describe('collect fetch', () => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
-      expect(startSpy).toHaveBeenCalledWith({ requestId: (jasmine.any(Number) as unknown) as number })
+      expect(startSpy).toHaveBeenCalledWith({ requestIndex: (jasmine.any(Number) as unknown) as number })
       done()
     })
   })
@@ -84,10 +84,10 @@ describe('collect fetch', () => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
-      const startRequestId = startSpy.calls.argsFor(0)[0].requestId
-      const completeRequestId = completeSpy.calls.argsFor(0)[0].requestId
+      const startRequestIndex = startSpy.calls.argsFor(0)[0].requestIndex
+      const completeRequestIndex = completeSpy.calls.argsFor(0)[0].requestIndex
 
-      expect(completeRequestId).toBe(startRequestId)
+      expect(completeRequestIndex).toBe(startRequestIndex)
       done()
     })
   })
@@ -124,7 +124,7 @@ describe('collect xhr', () => {
         xhr.send()
       },
       onComplete() {
-        expect(startSpy).toHaveBeenCalledWith({ requestId: (jasmine.any(Number) as unknown) as number })
+        expect(startSpy).toHaveBeenCalledWith({ requestIndex: (jasmine.any(Number) as unknown) as number })
         done()
       },
     })
@@ -156,10 +156,10 @@ describe('collect xhr', () => {
         xhr.send()
       },
       onComplete() {
-        const startRequestId = startSpy.calls.argsFor(0)[0].requestId
-        const completeRequestId = completeSpy.calls.argsFor(0)[0].requestId
+        const startRequestIndex = startSpy.calls.argsFor(0)[0].requestIndex
+        const completeRequestIndex = completeSpy.calls.argsFor(0)[0].requestIndex
 
-        expect(completeRequestId).toBe(startRequestId)
+        expect(completeRequestIndex).toBe(startRequestIndex)
         done()
       },
     })

--- a/packages/rum/test/trackPageActivities.spec.ts
+++ b/packages/rum/test/trackPageActivities.spec.ts
@@ -102,14 +102,14 @@ describe('trackPagePageActivities', () => {
   })
 
   describe('requests', () => {
-    function makeFakeRequestCompleteEvent(requestId: number): RequestCompleteEvent {
-      return { requestId } as any
+    function makeFakeRequestCompleteEvent(requestIndex: number): RequestCompleteEvent {
+      return { requestIndex } as any
     }
     it('emits an activity event when a request starts', () => {
       const lifeCycle = new LifeCycle()
       trackPageActivities(lifeCycle).observable.subscribe(pushEvent)
       lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, {
-        requestId: 10,
+        requestIndex: 10,
       })
       expect(events).toEqual([{ isBusy: true }])
     })
@@ -118,7 +118,7 @@ describe('trackPagePageActivities', () => {
       const lifeCycle = new LifeCycle()
       trackPageActivities(lifeCycle).observable.subscribe(pushEvent)
       lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, {
-        requestId: 10,
+        requestIndex: 10,
       })
       lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, makeFakeRequestCompleteEvent(10))
       expect(events).toEqual([{ isBusy: true }, { isBusy: false }])
@@ -135,10 +135,10 @@ describe('trackPagePageActivities', () => {
       const lifeCycle = new LifeCycle()
       trackPageActivities(lifeCycle).observable.subscribe(pushEvent)
       lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, {
-        requestId: 10,
+        requestIndex: 10,
       })
       lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, {
-        requestId: 11,
+        requestIndex: 11,
       })
       lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, makeFakeRequestCompleteEvent(9))
       lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, makeFakeRequestCompleteEvent(11))

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -336,5 +336,6 @@ describe('tracing', () => {
     expect(requests.length).toBe(1)
     expect(requests[0]._dd!.trace_id).toMatch(/\d+/)
     expect(requests[0]._dd!.span_id).toMatch(/\d+/)
+    expect(requests[0].resource.id).toBeDefined()
   }
 })

--- a/test/e2e/scenario/serverTypes.ts
+++ b/test/e2e/scenario/serverTypes.ts
@@ -39,6 +39,7 @@ export interface ServerRumResourceEvent extends ServerRumEvent {
   }
   resource: {
     kind: 'fetch' | 'xhr' | 'document'
+    id?: string
   }
   duration: number
   _dd?: {


### PR DESCRIPTION
## Motivation

Allow future link from APM trace to corresponding RUM resource

## Changes

- rename requestId in requestIndex
- add resource id for traced request


## Testing

Traced requests are sent with a resource id

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
