### PR TITLE
🐛[RUMF-617] fix missing headers on traced requests

### DIFF
--- a/packages/rum/src/tracer.ts
+++ b/packages/rum/src/tracer.ts
@@ -19,11 +19,19 @@ export function startTracer(configuration: Configuration): Tracer {
     traceFetch: (context) =>
       injectHeadersIfTracingAllowed(configuration, context.url!, (tracingHeaders: TracingHeaders) => {
         context.init = { ...context.init }
-        const headers: { [key: string]: string } = {}
 
+        const headers: { [key: string]: string } = {}
         if (context.init.headers instanceof Headers) {
           context.init.headers.forEach((value, key) => {
             headers[key] = value
+          })
+        } else if (Array.isArray(context.init.headers)) {
+          context.init.headers.forEach(([key, value]) => {
+            headers[key] = value
+          })
+        } else if (context.init.headers) {
+          Object.keys(context.init.headers).forEach((key) => {
+            headers[key] = (context.init!.headers as Record<string, string>)[key]
           })
         }
 

--- a/packages/rum/src/tracer.ts
+++ b/packages/rum/src/tracer.ts
@@ -20,22 +20,11 @@ export function startTracer(configuration: Configuration): Tracer {
       injectHeadersIfTracingAllowed(configuration, context.url!, (tracingHeaders: TracingHeaders) => {
         context.init = { ...context.init }
 
-        const headers: { [key: string]: string } = {}
-        if (context.init.headers instanceof Headers) {
-          context.init.headers.forEach((value, key) => {
-            headers[key] = value
-          })
-        } else if (Array.isArray(context.init.headers)) {
-          context.init.headers.forEach(([key, value]) => {
-            headers[key] = value
-          })
-        } else if (context.init.headers) {
-          Object.keys(context.init.headers).forEach((key) => {
-            headers[key] = (context.init!.headers as Record<string, string>)[key]
-          })
-        }
-
-        context.init.headers = { ...headers, ...tracingHeaders }
+        const headers = new Headers(context.init.headers)
+        Object.keys(tracingHeaders).forEach((name) => {
+          headers.set(name, tracingHeaders[name])
+        })
+        context.init.headers = headers
       }),
     traceXhr: (context, xhr) =>
       injectHeadersIfTracingAllowed(configuration, context.url!, (tracingHeaders: TracingHeaders) => {

--- a/packages/rum/test/tracer.spec.ts
+++ b/packages/rum/test/tracer.spec.ts
@@ -83,11 +83,8 @@ describe('tracer', () => {
       expect(context.init!.headers).toEqual(tracingHeadersFor(tracingResult.traceId, tracingResult.spanId))
     })
 
-    it('should preserve original request init and headers', () => {
-      const headers = new Headers()
-      headers.set('foo', 'bar')
-
-      const init = { headers, method: 'POST' }
+    it('should preserve original request init', () => {
+      const init = { method: 'POST' }
       const context: Partial<FetchContext> = {
         ...ALLOWED_DOMAIN_CONTEXT,
         init,
@@ -98,6 +95,20 @@ describe('tracer', () => {
 
       expect(context.init).not.toBe(init)
       expect(context.init!.method).toBe('POST')
+      expect(context.init!.headers).toEqual(tracingHeadersFor(tracingResult.traceId, tracingResult.spanId))
+    })
+
+    it('should preserve original headers object', () => {
+      const headers = new Headers()
+      headers.set('foo', 'bar')
+
+      const context: Partial<FetchContext> = {
+        ...ALLOWED_DOMAIN_CONTEXT,
+        init: { headers, method: 'POST' },
+      }
+
+      const tracer = startTracer(configuration as Configuration)
+      const tracingResult = tracer.traceFetch(context)!
 
       expect(context.init!.headers).not.toBe(headers)
       expect(context.init!.headers).toEqual({
@@ -112,6 +123,48 @@ describe('tracer', () => {
       expect(originalHeadersPlainObject).toEqual({
         foo: 'bar',
       })
+    })
+
+    it('should preserve original headers plain object', () => {
+      const headers = { foo: 'bar' }
+
+      const context: Partial<FetchContext> = {
+        ...ALLOWED_DOMAIN_CONTEXT,
+        init: { headers, method: 'POST' },
+      }
+
+      const tracer = startTracer(configuration as Configuration)
+      const tracingResult = tracer.traceFetch(context)!
+
+      expect(context.init!.headers).not.toBe(headers)
+      expect(context.init!.headers).toEqual({
+        ...tracingHeadersFor(tracingResult.traceId, tracingResult.spanId),
+        foo: 'bar',
+      })
+
+      expect(headers).toEqual({
+        foo: 'bar',
+      })
+    })
+
+    it('should preserve original headers array', () => {
+      const headers = [['foo', 'bar']]
+
+      const context: Partial<FetchContext> = {
+        ...ALLOWED_DOMAIN_CONTEXT,
+        init: { headers, method: 'POST' },
+      }
+
+      const tracer = startTracer(configuration as Configuration)
+      const tracingResult = tracer.traceFetch(context)!
+
+      expect(context.init!.headers).not.toBe(headers)
+      expect(context.init!.headers).toEqual({
+        ...tracingHeadersFor(tracingResult.traceId, tracingResult.spanId),
+        foo: 'bar',
+      })
+
+      expect(headers).toEqual([['foo', 'bar']])
     })
 
     it('should not trace request on disallowed domain', () => {

--- a/packages/rum/test/tracer.spec.ts
+++ b/packages/rum/test/tracer.spec.ts
@@ -80,7 +80,9 @@ describe('tracer', () => {
       const tracingResult = tracer.traceFetch(context)!
 
       expect(tracingResult).toBeDefined()
-      expect(context.init!.headers).toEqual(tracingHeadersFor(tracingResult.traceId, tracingResult.spanId))
+      expect(toPlainObject(context.init!.headers as Headers)).toEqual(
+        tracingHeadersFor(tracingResult.traceId, tracingResult.spanId)
+      )
     })
 
     it('should preserve original request init', () => {
@@ -95,7 +97,9 @@ describe('tracer', () => {
 
       expect(context.init).not.toBe(init)
       expect(context.init!.method).toBe('POST')
-      expect(context.init!.headers).toEqual(tracingHeadersFor(tracingResult.traceId, tracingResult.spanId))
+      expect(toPlainObject(context.init!.headers as Headers)).toEqual(
+        tracingHeadersFor(tracingResult.traceId, tracingResult.spanId)
+      )
     })
 
     it('should preserve original headers object', () => {
@@ -111,16 +115,11 @@ describe('tracer', () => {
       const tracingResult = tracer.traceFetch(context)!
 
       expect(context.init!.headers).not.toBe(headers)
-      expect(context.init!.headers).toEqual({
+      expect(toPlainObject(context.init!.headers as Headers)).toEqual({
         ...tracingHeadersFor(tracingResult.traceId, tracingResult.spanId),
         foo: 'bar',
       })
-
-      const originalHeadersPlainObject: { [key: string]: string } = {}
-      headers.forEach((value, key) => {
-        originalHeadersPlainObject[key] = value
-      })
-      expect(originalHeadersPlainObject).toEqual({
+      expect(toPlainObject(headers)).toEqual({
         foo: 'bar',
       })
     })
@@ -137,7 +136,7 @@ describe('tracer', () => {
       const tracingResult = tracer.traceFetch(context)!
 
       expect(context.init!.headers).not.toBe(headers)
-      expect(context.init!.headers).toEqual({
+      expect(toPlainObject(context.init!.headers as Headers)).toEqual({
         ...tracingHeadersFor(tracingResult.traceId, tracingResult.spanId),
         foo: 'bar',
       })
@@ -148,7 +147,7 @@ describe('tracer', () => {
     })
 
     it('should preserve original headers array', () => {
-      const headers = [['foo', 'bar']]
+      const headers = [['foo', 'bar'], ['foo', 'baz']]
 
       const context: Partial<FetchContext> = {
         ...ALLOWED_DOMAIN_CONTEXT,
@@ -159,12 +158,12 @@ describe('tracer', () => {
       const tracingResult = tracer.traceFetch(context)!
 
       expect(context.init!.headers).not.toBe(headers)
-      expect(context.init!.headers).toEqual({
+      expect(toPlainObject(context.init!.headers as Headers)).toEqual({
         ...tracingHeadersFor(tracingResult.traceId, tracingResult.spanId),
-        foo: 'bar',
+        foo: 'bar, baz',
       })
 
-      expect(headers).toEqual([['foo', 'bar']])
+      expect(headers).toEqual([['foo', 'bar'], ['foo', 'baz']])
     })
 
     it('should not trace request on disallowed domain', () => {
@@ -200,6 +199,14 @@ describe('TraceIdentifier', () => {
     expect(traceIdentifier.toDecimalString()).toMatch(/^\d+$/)
   })
 })
+
+function toPlainObject(headers: Headers) {
+  const result: { [key: string]: string } = {}
+  headers.forEach((value, key) => {
+    result[key] = value
+  })
+  return result
+}
 
 function tracingHeadersFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
   return {

--- a/test/e2e/scenario/agents.scenario.ts
+++ b/test/e2e/scenario/agents.scenario.ts
@@ -308,14 +308,14 @@ describe('anchor navigation', () => {
 
 describe('tracing', () => {
   it('should trace xhr', async () => {
-    const rawHeaders = await sendXhr(`${serverUrl.sameOrigin}/headers`)
+    const rawHeaders = await sendXhr(`${serverUrl.sameOrigin}/headers`, [['x-foo', 'bar'], ['x-foo', 'baz']])
     checkRequestHeaders(rawHeaders)
     await flushEvents()
     await checkTraceAssociatedToRumEvent()
   })
 
   it('should trace fetch', async () => {
-    const rawHeaders = await sendFetch(`${serverUrl.sameOrigin}/headers`)
+    const rawHeaders = await sendFetch(`${serverUrl.sameOrigin}/headers`, [['x-foo', 'bar'], ['x-foo', 'baz']])
     checkRequestHeaders(rawHeaders)
     await flushEvents()
     await checkTraceAssociatedToRumEvent()
@@ -325,6 +325,7 @@ describe('tracing', () => {
     const headers: { [key: string]: string } = JSON.parse(rawHeaders) as any
     expect(headers['x-datadog-trace-id']).toMatch(/\d+/)
     expect(headers['x-datadog-origin']).toBe('rum')
+    expect(headers['x-foo']).toBe('bar, baz')
   }
 
   async function checkTraceAssociatedToRumEvent() {


### PR DESCRIPTION
## Motivation

some requests headers possible types were not copied with the tracing headers, resulting in some request failures due to missing headers.

## Changes

Handle other headers types

## Testing

Automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
