### PR TITLE
[RUMF-684] fix error collection configuration

### DIFF
--- a/packages/core/src/errorCollection.ts
+++ b/packages/core/src/errorCollection.ts
@@ -41,11 +41,9 @@ let filteredErrorsObservable: ErrorObservable
 export function startErrorCollection(configuration: Configuration) {
   if (!filteredErrorsObservable) {
     const errorObservable = new Observable<ErrorMessage>()
-    if (configuration.isCollectingError) {
-      trackNetworkError(configuration, errorObservable)
-      startConsoleTracking(errorObservable)
-      startRuntimeErrorTracking(errorObservable)
-    }
+    trackNetworkError(configuration, errorObservable)
+    startConsoleTracking(errorObservable)
+    startRuntimeErrorTracking(errorObservable)
     filteredErrorsObservable = filterErrors(configuration, errorObservable)
   }
   return filteredErrorsObservable

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -1,7 +1,8 @@
 import { buildConfiguration, UserConfiguration } from './configuration'
 import { areCookiesAuthorized } from './cookie'
-import { startErrorCollection } from './errorCollection'
+import { ErrorMessage, startErrorCollection } from './errorCollection'
 import { setDebugMode, startInternalMonitoring } from './internalMonitoring'
+import { Observable } from './observable'
 
 export function makeStub(methodName: string) {
   console.warn(`'${methodName}' not yet available, please call '.init()' first.`)
@@ -47,7 +48,9 @@ export interface BuildEnv {
 export function commonInit(userConfiguration: UserConfiguration, buildEnv: BuildEnv) {
   const configuration = buildConfiguration(userConfiguration, buildEnv)
   const internalMonitoring = startInternalMonitoring(configuration)
-  const errorObservable = startErrorCollection(configuration)
+  const errorObservable = configuration.isCollectingError
+    ? startErrorCollection(configuration)
+    : new Observable<ErrorMessage>()
 
   return {
     configuration,


### PR DESCRIPTION
## Motivation

Before this commit, the RUM and Logs were dependent:
* when initializing the RUM SDK first, setting `forwardErrorsToLogs: false` option was ignored;
* when initializing the Logs SDK first, and setting `forwardErrorsToLogs: false`, errors were not collected in RUM

## Changes

This fixes the issue by avoiding calling `startErrorCollection` if error collection is not needed.

## Testing

Setup both SDKs with NPM/webpack (the bundle version does not have this issue because the 'core' modules are not shared between logs and rum). Start by calling `init` for RUM, then on Logs with `forwardErrorsToLog: false`. Errors should not be forwarded to logs.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
