### PR TITLE
🐛 [RUMF-670] wait for the DOM to be ready before getting the trace id

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -14,6 +14,7 @@ export enum DOM_EVENT {
   SCROLL = 'scroll',
   TOUCH_START = 'touchstart',
   VISIBILITY_CHANGE = 'visibilitychange',
+  DOM_CONTENT_LOADED = 'DOMContentLoaded',
 }
 
 export enum ResourceKind {

--- a/packages/rum/src/performanceCollection.ts
+++ b/packages/rum/src/performanceCollection.ts
@@ -68,7 +68,7 @@ function supportPerformanceNavigationTimingEvent() {
 }
 
 export function startPerformanceCollection(lifeCycle: LifeCycle) {
-  retrieveInitialDocumentResourceTiming((timing) => {
+  retrieveInitialDocumentResourceTimingWhenDomReady((timing) => {
     handleRumPerformanceEntry(lifeCycle, timing)
   })
 
@@ -101,7 +101,9 @@ export function startPerformanceCollection(lifeCycle: LifeCycle) {
   }
 }
 
-export function retrieveInitialDocumentResourceTiming(callback: (timing: RumPerformanceResourceTiming) => void) {
+export function retrieveInitialDocumentResourceTimingWhenDomReady(
+  callback: (timing: RumPerformanceResourceTiming) => void
+) {
   runOnReadyState('interactive', () => {
     let timing: RumPerformanceResourceTiming
 

--- a/packages/rum/src/performanceCollection.ts
+++ b/packages/rum/src/performanceCollection.ts
@@ -68,7 +68,7 @@ function supportPerformanceNavigationTimingEvent() {
 }
 
 export function startPerformanceCollection(lifeCycle: LifeCycle) {
-  retrieveInitialDocumentResourceTimingWhenDomReady((timing) => {
+  retrieveInitialDocumentResourceTiming((timing) => {
     handleRumPerformanceEntry(lifeCycle, timing)
   })
 
@@ -95,15 +95,13 @@ export function startPerformanceCollection(lifeCycle: LifeCycle) {
     }
   }
   if (!supportPerformanceNavigationTimingEvent()) {
-    retrieveNavigationTimingWhenLoaded((timing) => {
+    retrieveNavigationTiming((timing) => {
       handleRumPerformanceEntry(lifeCycle, timing)
     })
   }
 }
 
-export function retrieveInitialDocumentResourceTimingWhenDomReady(
-  callback: (timing: RumPerformanceResourceTiming) => void
-) {
+export function retrieveInitialDocumentResourceTiming(callback: (timing: RumPerformanceResourceTiming) => void) {
   runOnReadyState('interactive', () => {
     let timing: RumPerformanceResourceTiming
 
@@ -130,7 +128,7 @@ export function retrieveInitialDocumentResourceTimingWhenDomReady(
   })
 }
 
-function retrieveNavigationTimingWhenLoaded(callback: (timing: RumPerformanceNavigationTiming) => void) {
+function retrieveNavigationTiming(callback: (timing: RumPerformanceNavigationTiming) => void) {
   function sendFakeTiming() {
     callback({
       ...computeRelativePerformanceTiming(),

--- a/packages/rum/src/performanceCollection.ts
+++ b/packages/rum/src/performanceCollection.ts
@@ -129,16 +129,16 @@ export function retrieveInitialDocumentResourceTiming(callback: (timing: RumPerf
 }
 
 function retrieveNavigationTimingWhenLoaded(callback: (timing: RumPerformanceNavigationTiming) => void) {
+  function sendFakeTiming() {
+    callback({
+      ...computeRelativePerformanceTiming(),
+      entryType: 'navigation',
+    })
+  }
+
   runOnReadyState('complete', () => {
     // Send it a bit after the actual load event, so the "loadEventEnd" timing is accurate
-    setTimeout(
-      monitor(() => {
-        callback({
-          ...computeRelativePerformanceTiming(),
-          entryType: 'navigation',
-        })
-      })
-    )
+    setTimeout(monitor(sendFakeTiming))
   })
 }
 

--- a/packages/rum/test/performanceCollection.spec.ts
+++ b/packages/rum/test/performanceCollection.spec.ts
@@ -1,7 +1,7 @@
 import { isIE } from '@datadog/browser-core'
 
 import { restorePageVisibility, setPageVisibility } from '../../core/src/specHelper'
-import { retrieveInitialDocumentResourceTimingWhenDomReady } from '../../rum/src/performanceCollection'
+import { retrieveInitialDocumentResourceTiming } from '../../rum/src/performanceCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 describe('rum first_contentful_paint', () => {
@@ -47,7 +47,7 @@ describe('rum initial document resource', () => {
   })
 
   it('creates a resource timing for the initial document', (done) => {
-    retrieveInitialDocumentResourceTimingWhenDomReady((timing) => {
+    retrieveInitialDocumentResourceTiming((timing) => {
       expect(timing.entryType).toBe('resource')
       expect(timing.duration).toBeGreaterThan(0)
       done()

--- a/packages/rum/test/performanceCollection.spec.ts
+++ b/packages/rum/test/performanceCollection.spec.ts
@@ -1,7 +1,7 @@
 import { isIE } from '@datadog/browser-core'
 
 import { restorePageVisibility, setPageVisibility } from '../../core/src/specHelper'
-import { retrieveInitialDocumentResourceTiming } from '../../rum/src/performanceCollection'
+import { retrieveInitialDocumentResourceTimingWhenDomReady } from '../../rum/src/performanceCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 
 describe('rum first_contentful_paint', () => {
@@ -47,7 +47,7 @@ describe('rum initial document resource', () => {
   })
 
   it('creates a resource timing for the initial document', (done) => {
-    retrieveInitialDocumentResourceTiming((timing) => {
+    retrieveInitialDocumentResourceTimingWhenDomReady((timing) => {
       expect(timing.entryType).toBe('resource')
       expect(timing.duration).toBeGreaterThan(0)
       done()

--- a/packages/rum/test/performanceCollection.spec.ts
+++ b/packages/rum/test/performanceCollection.spec.ts
@@ -46,9 +46,11 @@ describe('rum initial document resource', () => {
     setupBuilder.cleanup()
   })
 
-  it('creates a resource timing for the initial document', () => {
-    const timing = retrieveInitialDocumentResourceTiming()
-    expect(timing.entryType).toBe('resource')
-    expect(timing.duration).toBeGreaterThan(0)
+  it('creates a resource timing for the initial document', (done) => {
+    retrieveInitialDocumentResourceTiming((timing) => {
+      expect(timing.entryType).toBe('resource')
+      expect(timing.duration).toBeGreaterThan(0)
+      done()
+    })
   })
 })


### PR DESCRIPTION


## Motivation

Because the RUM SDK can be initialized synchronously when the document is loading, the DOM may not be fully accessible when getting the trace id set by APM. In particular, if meta tags are written after the SDK snippet, the SDK will not have access to them during init.

## Changes

Wait for DOM to be loaded before getting the trace id and generating the initial document resource.

## Testing

Tests have been written in the integration test POC PR https://github.com/DataDog/browser-sdk/pull/524

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
