### PR TITLE
[RUMF-699] isIntakeRequest: test the path as well

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -225,7 +225,7 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
 
 export function isIntakeRequest(url: string, configuration: Configuration) {
   return (
-    getPathName(url).startsWith('/v1/input/') &&
+    getPathName(url).indexOf('/v1/input/') === 0 &&
     (haveSameOrigin(url, configuration.logsEndpoint) ||
       haveSameOrigin(url, configuration.rumEndpoint) ||
       haveSameOrigin(url, configuration.traceEndpoint) ||

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -1,6 +1,6 @@
 import { CookieOptions, getCurrentSite } from './cookie'
 import { BuildEnv, BuildMode, Datacenter, INTAKE_SITE } from './init'
-import { haveSameOrigin } from './urlPolyfill'
+import { getPathName, haveSameOrigin } from './urlPolyfill'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from './utils'
 
 export const DEFAULT_CONFIGURATION = {
@@ -225,14 +225,15 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
 
 export function isIntakeRequest(url: string, configuration: Configuration) {
   return (
-    haveSameOrigin(url, configuration.logsEndpoint) ||
-    haveSameOrigin(url, configuration.rumEndpoint) ||
-    haveSameOrigin(url, configuration.traceEndpoint) ||
-    (!!configuration.internalMonitoringEndpoint && haveSameOrigin(url, configuration.internalMonitoringEndpoint)) ||
-    (!!configuration.replica &&
-      (haveSameOrigin(url, configuration.replica.logsEndpoint) ||
-        haveSameOrigin(url, configuration.replica.rumEndpoint) ||
-        haveSameOrigin(url, configuration.replica.internalMonitoringEndpoint)))
+    getPathName(url).startsWith('/v1/input/') &&
+    (haveSameOrigin(url, configuration.logsEndpoint) ||
+      haveSameOrigin(url, configuration.rumEndpoint) ||
+      haveSameOrigin(url, configuration.traceEndpoint) ||
+      (!!configuration.internalMonitoringEndpoint && haveSameOrigin(url, configuration.internalMonitoringEndpoint)) ||
+      (!!configuration.replica &&
+        (haveSameOrigin(url, configuration.replica.logsEndpoint) ||
+          haveSameOrigin(url, configuration.replica.rumEndpoint) ||
+          haveSameOrigin(url, configuration.replica.internalMonitoringEndpoint))))
   )
 }
 

--- a/packages/core/src/specHelper.ts
+++ b/packages/core/src/specHelper.ts
@@ -2,10 +2,10 @@ import { Configuration } from './configuration'
 import { noop } from './utils'
 
 export const SPEC_ENDPOINTS: Partial<Configuration> = {
-  internalMonitoringEndpoint: 'https://monitoring-intake.com/abcde?foo=bar',
-  logsEndpoint: 'https://logs-intake.com/abcde?foo=bar',
-  rumEndpoint: 'https://rum-intake.com/abcde?foo=bar',
-  traceEndpoint: 'https://trace-intake.com/abcde?foo=bar',
+  internalMonitoringEndpoint: 'https://monitoring-intake.com/v1/input/abcde?foo=bar',
+  logsEndpoint: 'https://logs-intake.com/v1/input/abcde?foo=bar',
+  rumEndpoint: 'https://rum-intake.com/v1/input/abcde?foo=bar',
+  traceEndpoint: 'https://trace-intake.com/v1/input/abcde?foo=bar',
 }
 
 export function isSafari() {

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -139,14 +139,21 @@ describe('configuration', () => {
 
     it('should detect intake request', () => {
       const configuration = buildConfiguration({ clientToken }, usEnv)
-      expect(isIntakeRequest('https://rum-http-intake.logs.datadoghq.com', configuration)).toBe(true)
-      expect(isIntakeRequest('https://browser-http-intake.logs.datadoghq.com', configuration)).toBe(true)
-      expect(isIntakeRequest('https://public-trace-http-intake.logs.datadoghq.com', configuration)).toBe(true)
+      expect(isIntakeRequest('https://rum-http-intake.logs.datadoghq.com/v1/input/xxx', configuration)).toBe(true)
+      expect(isIntakeRequest('https://browser-http-intake.logs.datadoghq.com/v1/input/xxx', configuration)).toBe(true)
+      expect(isIntakeRequest('https://public-trace-http-intake.logs.datadoghq.com/v1/input/xxx', configuration)).toBe(
+        true
+      )
     })
 
     it('should detect proxy intake request', () => {
       const configuration = buildConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, usEnv)
-      expect(isIntakeRequest('https://www.proxy.com', configuration)).toBe(true)
+      expect(isIntakeRequest('https://www.proxy.com/v1/input/xxx', configuration)).toBe(true)
+    })
+
+    it('should not detect request done on the same host as the proxy', () => {
+      const configuration = buildConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, usEnv)
+      expect(isIntakeRequest('https://www.proxy.com/foo', configuration)).toBe(false)
     })
 
     it('should detect replica intake request', () => {
@@ -154,12 +161,12 @@ describe('configuration', () => {
         { clientToken, site: 'foo.com', replica: { clientToken } },
         { ...usEnv, buildMode: BuildMode.STAGING }
       )
-      expect(isIntakeRequest('https://rum-http-intake.logs.foo.com', configuration)).toBe(true)
-      expect(isIntakeRequest('https://browser-http-intake.logs.foo.com', configuration)).toBe(true)
-      expect(isIntakeRequest('https://public-trace-http-intake.logs.foo.com', configuration)).toBe(true)
+      expect(isIntakeRequest('https://rum-http-intake.logs.foo.com/v1/input/xxx', configuration)).toBe(true)
+      expect(isIntakeRequest('https://browser-http-intake.logs.foo.com/v1/input/xxx', configuration)).toBe(true)
+      expect(isIntakeRequest('https://public-trace-http-intake.logs.foo.com/v1/input/xxx', configuration)).toBe(true)
 
-      expect(isIntakeRequest('https://rum-http-intake.logs.datadoghq.com', configuration)).toBe(true)
-      expect(isIntakeRequest('https://browser-http-intake.logs.datadoghq.com', configuration)).toBe(true)
+      expect(isIntakeRequest('https://rum-http-intake.logs.datadoghq.com/v1/input/xxx', configuration)).toBe(true)
+      expect(isIntakeRequest('https://browser-http-intake.logs.datadoghq.com/v1/input/xxx', configuration)).toBe(true)
     })
   })
 })

--- a/packages/core/test/errorCollection.spec.ts
+++ b/packages/core/test/errorCollection.spec.ts
@@ -237,7 +237,7 @@ describe('network error tracker', () => {
   })
 
   it('should not track intake error', (done) => {
-    fetchStub('https://logs-intake.com/send?foo=bar').resolveWith(DEFAULT_REQUEST)
+    fetchStub('https://logs-intake.com/v1/input/send?foo=bar').resolveWith(DEFAULT_REQUEST)
 
     fetchStubManager.whenAllComplete(() => {
       expect(errorObservableSpy).not.toHaveBeenCalled()

--- a/packages/logs/test/logger.spec.ts
+++ b/packages/logs/test/logger.spec.ts
@@ -29,7 +29,7 @@ describe('logger module', () => {
   const FAKE_DATE = 123456
   const configuration: Partial<Configuration> = {
     ...DEFAULT_CONFIGURATION,
-    logsEndpoint: 'https://localhost/log',
+    logsEndpoint: 'https://localhost/v1/input/log',
     maxBatchSize: 1,
   }
   let LOGS: LogsApi

--- a/packages/rum/test/resourceUtils.spec.ts
+++ b/packages/rum/test/resourceUtils.spec.ts
@@ -243,11 +243,15 @@ describe('shouldTrackResource', () => {
   }
 
   it('should exclude requests on intakes endpoints', () => {
-    expect(isAllowedRequestUrl(configuration as Configuration, 'https://rum-intake.com/abcde?foo=bar')).toBe(false)
+    expect(isAllowedRequestUrl(configuration as Configuration, 'https://rum-intake.com/v1/input/abcde?foo=bar')).toBe(
+      false
+    )
   })
 
   it('should exclude requests on intakes endpoints with different client parameters', () => {
-    expect(isAllowedRequestUrl(configuration as Configuration, 'https://rum-intake.com/wxyz?foo=qux')).toBe(false)
+    expect(isAllowedRequestUrl(configuration as Configuration, 'https://rum-intake.com/v1/input/wxyz?foo=qux')).toBe(
+      false
+    )
   })
 
   it('should allow requests on non intake domains', () => {

--- a/test/app/app.ts
+++ b/test/app/app.ts
@@ -12,9 +12,9 @@ const specIdParam = /spec-id=\d+/.exec(search)![0]
 datadogLogs.init({
   clientToken: 'key',
   forwardErrorsToLogs: true,
-  internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
-  logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
-  rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
+  internalMonitoringEndpoint: `${intakeOrigin}/v1/input/monitoring?${specIdParam}`,
+  logsEndpoint: `${intakeOrigin}/v1/input/logs?${specIdParam}`,
+  rumEndpoint: `${intakeOrigin}/v1/input/rum?${specIdParam}`,
 })
 
 datadogRum.init({
@@ -22,9 +22,9 @@ datadogRum.init({
   applicationId: 'rum',
   clientToken: 'key',
   enableExperimentalFeatures: [],
-  internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
-  logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
-  rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
+  internalMonitoringEndpoint: `${intakeOrigin}/v1/input/monitoring?${specIdParam}`,
+  logsEndpoint: `${intakeOrigin}/v1/input/logs?${specIdParam}`,
+  rumEndpoint: `${intakeOrigin}/v1/input/rum?${specIdParam}`,
   service: 'e2e',
   trackInteractions: true,
 })

--- a/test/server/fake-backend.js
+++ b/test/server/fake-backend.js
@@ -2,19 +2,19 @@ const url = require('url')
 const { clean } = require('./spec-contexts')
 
 module.exports = (app) => {
-  app.post('/logs', (req, res) => {
+  app.post('/v1/input/logs', (req, res) => {
     req.body.split('\n').forEach((log) => req.specContext.logs.push(JSON.parse(log)))
     res.send('ok')
   })
   app.get('/logs', (req, res) => send(res, req.specContext.logs))
 
-  app.post('/rum', (req, res) => {
+  app.post('/v1/input/rum', (req, res) => {
     req.body.split('\n').forEach((rumEvent) => req.specContext.rum.push(JSON.parse(rumEvent)))
     res.send('ok')
   })
   app.get('/rum', (req, res) => send(res, req.specContext.rum))
 
-  app.post('/monitoring', (req, res) => {
+  app.post('/v1/input/monitoring', (req, res) => {
     req.specContext.monitoring.push(JSON.parse(req.body))
     res.send('ok')
   })

--- a/test/static/async-e2e-page.html
+++ b/test/static/async-e2e-page.html
@@ -22,9 +22,9 @@
           window.DD_LOGS &&
             window.DD_LOGS.init({
               clientToken: 'key',
-              internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
-              logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
-              rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
+              internalMonitoringEndpoint: `${intakeOrigin}/v1/input/monitoring?${specIdParam}`,
+              logsEndpoint: `${intakeOrigin}/v1/input/logs?${specIdParam}`,
+              rumEndpoint: `${intakeOrigin}/v1/input/rum?${specIdParam}`,
               forwardErrorsToLogs: true,
             })
         }
@@ -39,9 +39,9 @@
               applicationId: 'rum',
               clientToken: 'key',
               enableExperimentalFeatures: [],
-              internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
-              logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
-              rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
+              internalMonitoringEndpoint: `${intakeOrigin}/v1/input/monitoring?${specIdParam}`,
+              logsEndpoint: `${intakeOrigin}/v1/input/logs?${specIdParam}`,
+              rumEndpoint: `${intakeOrigin}/v1/input/rum?${specIdParam}`,
               service: 'e2e',
               trackInteractions: true,
             })

--- a/test/static/bundle-e2e-page.html
+++ b/test/static/bundle-e2e-page.html
@@ -13,9 +13,9 @@
       window.DD_LOGS &&
         window.DD_LOGS.init({
           clientToken: 'key',
-          internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
-          logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
-          rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
+          internalMonitoringEndpoint: `${intakeOrigin}/v1/input/monitoring?${specIdParam}`,
+          logsEndpoint: `${intakeOrigin}/v1/input/logs?${specIdParam}`,
+          rumEndpoint: `${intakeOrigin}/v1/input/rum?${specIdParam}`,
           forwardErrorsToLogs: true,
           enableExperimentalFeatures: [],
         })
@@ -28,9 +28,9 @@
           applicationId: 'rum',
           clientToken: 'key',
           enableExperimentalFeatures: [],
-          internalMonitoringEndpoint: `${intakeOrigin}/monitoring?${specIdParam}`,
-          logsEndpoint: `${intakeOrigin}/logs?${specIdParam}`,
-          rumEndpoint: `${intakeOrigin}/rum?${specIdParam}`,
+          internalMonitoringEndpoint: `${intakeOrigin}/v1/input/monitoring?${specIdParam}`,
+          logsEndpoint: `${intakeOrigin}/v1/input/logs?${specIdParam}`,
+          rumEndpoint: `${intakeOrigin}/v1/input/rum?${specIdParam}`,
           service: 'e2e',
           trackInteractions: true,
         })


### PR DESCRIPTION
## Motivation

When using a proxy on the same origin than the current page, some resources may be incorrectly filtered out.

## Changes

Test the beginning of the path to make sure this is a intake url.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
