### PR TITLE
[RUM] 🐛 call previously installed onunhandledrejection handler

### DIFF
--- a/packages/core/src/tracekit.ts
+++ b/packages/core/src/tracekit.ts
@@ -278,6 +278,9 @@ export const report = (function reportModuleWrapper() {
     const reason = e.reason || 'Empty reason'
     const stack = computeStackTrace(reason)
     notifyHandlers(stack, true, reason)
+    if (oldOnunhandledrejectionHandler) {
+      return oldOnunhandledrejectionHandler.apply(arguments as any)
+    }
   }
 
   /**

--- a/packages/core/test/tracekit.spec.ts
+++ b/packages/core/test/tracekit.spec.ts
@@ -117,18 +117,20 @@ Error: foo
 
     describe('onunhandledrejection handler', () => {
       it('should call the previously installed handler', (done) => {
-        window.onunhandledrejection = function(e: PromiseRejectionEvent) {
+        window.onunhandledrejection = (e: PromiseRejectionEvent) => {
           report.unsubscribe(subscriptionHandler!)
           done()
-        };
-  
-        subscriptionHandler = (stack) => {}
+        }
+
+        subscriptionHandler = (stack) => {
+          return
+        }
         report.subscribe(subscriptionHandler)
-        const error = new Error('I am unhandled');
-        Promise.reject(error);
+        const error = new Error('I am unhandled')
+        Promise.reject(error)
       })
     })
-    
+
     describe('with undefined arguments', () => {
       it('should pass undefined:undefined', (done) => {
         // this is probably not good behavior;  just writing this test to verify

--- a/packages/core/test/tracekit.spec.ts
+++ b/packages/core/test/tracekit.spec.ts
@@ -115,6 +115,20 @@ Error: foo
       window.onerror = jasmine.createSpy()
     })
 
+    describe('onunhandledrejection handler', () => {
+      it('should call the previously installed handler', (done) => {
+        window.onunhandledrejection = function(e: PromiseRejectionEvent) {
+          report.unsubscribe(subscriptionHandler!)
+          done()
+        };
+  
+        subscriptionHandler = (stack) => {}
+        report.subscribe(subscriptionHandler)
+        const error = new Error('I am unhandled');
+        Promise.reject(error);
+      })
+    })
+    
     describe('with undefined arguments', () => {
       it('should pass undefined:undefined', (done) => {
         // this is probably not good behavior;  just writing this test to verify


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/browser-sdk/issues/541 confirmed that the existing behavior of ignoring the previously installed `onunhandledrejection` handler is a bug; this PR fixes it

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

I tested this out against my project (that first raised the issue) as well as added an unit test to `tracekit.spec.ts`.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
