### PR TITLE
[RUMF-620]: Dual-ship "service" as tag and attribute

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -83,6 +83,8 @@ export type Configuration = typeof DEFAULT_CONFIGURATION & {
   internalMonitoringEndpoint?: string
   proxyHost?: string
 
+  service?: string
+
   isEnabled: (feature: string) => boolean
 
   // only on staging build mode
@@ -134,6 +136,7 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
     logsEndpoint: getEndpoint('browser', transportConfiguration),
     proxyHost: userConfiguration.proxyHost,
     rumEndpoint: getEndpoint('rum', transportConfiguration),
+    service: userConfiguration.service,
     traceEndpoint: getEndpoint('public-trace', transportConfiguration),
     ...DEFAULT_CONFIGURATION,
   }

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -121,6 +121,7 @@ function startLoggerBatch(configuration: Configuration, session: LoggerSession, 
     return deepMerge(
       {
         date: new Date().getTime(),
+        service: configuration.service,
         session_id: session.getId(),
         view: {
           referrer: document.referrer,

--- a/packages/logs/test/logger.spec.ts
+++ b/packages/logs/test/logger.spec.ts
@@ -31,6 +31,7 @@ describe('logger module', () => {
     ...DEFAULT_CONFIGURATION,
     logsEndpoint: 'https://localhost/v1/input/log',
     maxBatchSize: 1,
+    service: 'Service',
   }
   let LOGS: LogsApi
   let server: sinon.SinonFakeServer
@@ -57,6 +58,7 @@ describe('logger module', () => {
         date: FAKE_DATE,
         foo: 'bar',
         message: 'message',
+        service: 'Service',
         status: StatusType.warn,
         view: {
           referrer: document.referrer,

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -182,6 +182,7 @@ export function startRum(
     () => ({
       applicationId,
       date: new Date().getTime(),
+      service: configuration.service,
       session: {
         // must be computed on each event because synthetics instrumentation can be done after sdk execution
         // cf https://github.com/puppeteer/puppeteer/issues/3667


### PR DESCRIPTION
## Motivation
The move of `service` from tag to attribute must be done in two steps to ease the transition.

## Changes
Send `service` as attribute as well as tag.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.

Closes #501 