### PR TITLE
✨ [RUMF-709][core] support 'null' as a context value 

### DIFF
--- a/packages/core/src/internalMonitoring.ts
+++ b/packages/core/src/internalMonitoring.ts
@@ -67,7 +67,7 @@ function startMonitoringBatch(configuration: Configuration) {
   }
 
   function withContext(message: MonitoringMessage) {
-    return utils.deepMerge(
+    return utils.combine(
       {
         date: new Date().getTime(),
         view: {
@@ -77,7 +77,7 @@ function startMonitoringBatch(configuration: Configuration) {
       },
       externalContextProvider !== undefined ? externalContextProvider() : {},
       message
-    ) as utils.Context
+    )
   }
 
   return {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -76,7 +76,8 @@ export function throttle(
 }
 
 const isContextArray = (value: ContextValue): value is ContextArray => Array.isArray(value)
-const isContext = (value: ContextValue): value is Context => !Array.isArray(value) && typeof value === 'object'
+const isContext = (value: ContextValue): value is Context =>
+  !Array.isArray(value) && typeof value === 'object' && value !== null
 
 /**
  * Performs a deep merge of objects and arrays
@@ -162,7 +163,7 @@ export interface Context {
   [x: string]: ContextValue
 }
 
-export type ContextValue = string | number | boolean | Context | ContextArray | undefined
+export type ContextValue = string | number | boolean | Context | ContextArray | undefined | null
 
 export interface ContextArray extends Array<ContextValue> {}
 
@@ -178,7 +179,7 @@ export function deepSnakeCase(candidate: ContextValue): ContextValue {
   if (Array.isArray(candidate)) {
     return candidate.map((value: ContextValue) => deepSnakeCase(value))
   }
-  if (typeof candidate === 'object') {
+  if (typeof candidate === 'object' && candidate !== null) {
     return withSnakeCaseKeys(candidate)
   }
   return candidate

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -88,7 +88,7 @@ const isContext = (value: ContextValue): value is Context =>
  * ⚠️ this method does not prevent infinite loops while merging circular references ⚠️
  *
  */
-export function deepMerge(destination: ContextValue, ...toMerge: ContextValue[]): ContextValue {
+function deepMerge(destination: ContextValue, ...toMerge: ContextValue[]): ContextValue {
   return toMerge.reduce((value1: ContextValue, value2: ContextValue): ContextValue => {
     if (isContextArray(value1) && isContextArray(value2)) {
       return [...Array(Math.max(value1.length, value2.length))].map((_, index) =>

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -107,6 +107,7 @@ export function deepMerge(destination: ContextValue, ...toMerge: ContextValue[])
   }, destination)
 }
 
+export function combine<A, B>(a: A, b: B): A & B
 export function combine<A, B, C>(a: A, b: B, c: C): A & B & C
 export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D
 export function combine(a: Context, ...b: Context[]): Context {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -111,8 +111,8 @@ function deepMerge(destination: ContextValue, ...toMerge: ContextValue[]): Conte
 export function combine<A, B>(a: A, b: B): A & B
 export function combine<A, B, C>(a: A, b: B, c: C): A & B & C
 export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D
-export function combine(a: Context, ...b: Context[]): Context {
-  return deepMerge(a, ...b) as Context
+export function combine(destination: Context, ...toMerge: Array<Context | null>): Context {
+  return deepMerge(destination, ...toMerge.filter((object) => object !== null)) as Context
 }
 
 interface Assignable {

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -21,6 +21,11 @@ describe('utils', () => {
       expect(deepMerge({ a: 1 }, { a: undefined })).toEqual({ a: 1 })
     })
 
+    it('should support null values', () => {
+      // tslint:disable-next-line: no-null-keyword
+      expect(deepMerge({ a: {} }, { a: null })).toEqual({ a: null })
+    })
+
     it('should merge arrays', () => {
       const target = [{ a: 'target' }, 'extraString']
       const source = [{ b: 'source' }]
@@ -259,10 +264,14 @@ describe('utils', () => {
         withSnakeCaseKeys({
           camelCase: 1,
           nestedKey: { 'kebab-case': 'helloWorld', array: [{ camelCase: 1 }, { camelCase: 2 }] },
+          // tslint:disable-next-line: no-null-keyword
+          nullValue: null,
         })
       ).toEqual({
         camel_case: 1,
         nested_key: { kebab_case: 'helloWorld', array: [{ camel_case: 1 }, { camel_case: 2 }] },
+        // tslint:disable-next-line: no-null-keyword
+        null_value: null,
       })
     })
   })

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -21,9 +21,14 @@ describe('utils', () => {
       expect(combine({ a: 1 }, { a: undefined as number | undefined })).toEqual({ a: 1 })
     })
 
-    it('should support null values', () => {
+    it('should replace a sub-value with null', () => {
       // tslint:disable-next-line: no-null-keyword
       expect(combine({ a: {} }, { a: null as any })).toEqual({ a: null })
+    })
+
+    it('should ignore null arguments', () => {
+      // tslint:disable-next-line: no-null-keyword
+      expect(combine({ a: 1 }, null)).toEqual({ a: 1 })
     })
 
     it('should merge arrays', () => {

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -1,5 +1,5 @@
 import {
-  deepMerge,
+  combine,
   findCommaSeparatedValue,
   jsonStringify,
   performDraw,
@@ -10,26 +10,26 @@ import {
 } from '../src/utils'
 
 describe('utils', () => {
-  describe('deepMerge', () => {
+  describe('combine', () => {
     it('should deeply add and replace keys', () => {
       const target = { a: { b: 'toBeReplaced', c: 'target' } }
       const source = { a: { b: 'replaced', d: 'source' } }
-      expect(deepMerge(target, source)).toEqual({ a: { b: 'replaced', c: 'target', d: 'source' } })
+      expect(combine(target, source)).toEqual({ a: { b: 'replaced', c: 'target', d: 'source' } })
     })
 
     it('should not replace with undefined', () => {
-      expect(deepMerge({ a: 1 }, { a: undefined })).toEqual({ a: 1 })
+      expect(combine({ a: 1 }, { a: undefined as number | undefined })).toEqual({ a: 1 })
     })
 
     it('should support null values', () => {
       // tslint:disable-next-line: no-null-keyword
-      expect(deepMerge({ a: {} }, { a: null })).toEqual({ a: null })
+      expect(combine({ a: {} }, { a: null as any })).toEqual({ a: null })
     })
 
     it('should merge arrays', () => {
-      const target = [{ a: 'target' }, 'extraString']
-      const source = [{ b: 'source' }]
-      expect(deepMerge(target, source)).toEqual([{ a: 'target', b: 'source' }, 'extraString'])
+      const target = [{ a: 'target' }, 'extraString'] as any
+      const source = [{ b: 'source' }] as any
+      expect(combine(target, source)).toEqual([{ a: 'target', b: 'source' }, 'extraString'])
     })
   })
 

--- a/packages/logs/src/logger.ts
+++ b/packages/logs/src/logger.ts
@@ -175,25 +175,25 @@ export class Logger {
   }
 
   @monitored
-  log(message: string, messageContext = {}, status = StatusType.info) {
+  log(message: string, messageContext?: Context, status = StatusType.info) {
     if (this.session.isTracked() && STATUS_PRIORITIES[status] >= STATUS_PRIORITIES[this.level]) {
       this.handler({ message, status, ...(deepMerge({}, this.loggerContext, messageContext) as Context) })
     }
   }
 
-  debug(message: string, messageContext = {}) {
+  debug(message: string, messageContext?: Context) {
     this.log(message, messageContext, StatusType.debug)
   }
 
-  info(message: string, messageContext = {}) {
+  info(message: string, messageContext?: Context) {
     this.log(message, messageContext, StatusType.info)
   }
 
-  warn(message: string, messageContext = {}) {
+  warn(message: string, messageContext?: Context) {
     this.log(message, messageContext, StatusType.warn)
   }
 
-  error(message: string, messageContext = {}) {
+  error(message: string, messageContext?: Context) {
     const errorOrigin = {
       error: {
         origin: ErrorOrigin.LOGGER,


### PR DESCRIPTION
## Motivation

Ensure that nothing breaks when the user unexpectedly pass `null` for values that end up in a `Context`.

## Changes

Add proper support for `null` value in context.

## Testing

Unit tests have been upgraded. You can test it manually by calling `DD_RUM.init({ service: null, clientToken: 'xxx', applicationId: 'xxx' })`

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
