### PR TITLE
[RUMF-553] add dummy events format validation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,14 @@ check-licenses:
   script:
     - node --no-warnings scripts/check-licenses.js
 
+events-format:
+  stage: test
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  script:
+    - yarn
+    - yarn test:events-format
+
 unit-bs:
   except:
     refs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rum-events-format"]
+	path = rum-events-format
+	url = https://github.com/DataDog/rum-events-format

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -12,6 +12,7 @@ dev,@wdio/local-runner,MIT,Copyright JS Foundation and other contributors
 dev,@wdio/selenium-standalone-service,MIT,Copyright JS Foundation and other contributors
 dev,@wdio/spec-reporter,MIT,Copyright JS Foundation and other contributors
 dev,@wdio/sync,MIT,Copyright JS Foundation and other contributors
+dev,ajv,MIT,Copyright 2015-2017 Evgeny Poberezkin
 dev,body-parser,MIT,Copyright 2014 Jonathan Ong 2014-2015 Douglas Christopher Wilson
 dev,browserstack-local,MIT,Copyright 2016 BrowserStack
 dev,codecov,MIT,Copyright 2014 Gregg Caines

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:e2e:async": "BUILD_MODE=e2e-test yarn build && E2E_MODE=async wdio test/e2e/wdio.local.conf.js",
     "test:e2e:bs": "BUILD_MODE=e2e-test yarn build && node ./scripts/bs-wrapper.js wdio test/e2e/wdio.bs.conf.js",
     "test:compat:tsc": "yarn build && (cd test/app && rm -rf node_modules && yarn && yarn compat:tsc) || yarn fail 'typescript 3.0 compatibility broken'",
-    "test:compat:ssr": "yarn build && (cd test/app && rm -rf node_modules && yarn && yarn compat:ssr) || yarn fail 'server side rendering compatibility broken'"
+    "test:compat:ssr": "yarn build && (cd test/app && rm -rf node_modules && yarn && yarn compat:ssr) || yarn fail 'server side rendering compatibility broken'",
+    "test:events-format": "git submodule update --init && node test/schema/dummy-validation.js"
   },
   "devDependencies": {
     "@types/jasmine": "3.5.10",
@@ -38,6 +39,7 @@
     "@wdio/selenium-standalone-service": "6.0.16",
     "@wdio/spec-reporter": "6.0.16",
     "@wdio/sync": "6.1.0",
+    "ajv": "6.12.5",
     "body-parser": "1.19.0",
     "browserstack-local": "1.4.5",
     "codecov": "3.7.1",

--- a/test/schema/dummy-validation.js
+++ b/test/schema/dummy-validation.js
@@ -1,0 +1,60 @@
+const Ajv = require('ajv')
+const viewEvent = {
+  type: 'view',
+  date: 1591283924940,
+  application: {
+    id: 'ac8218cf-498b-4d33-bd44-151095959547',
+  },
+  session: {
+    id: 'cacbf45c-3a05-48ce-b066-d76349460599',
+    type: 'user',
+  },
+  view: {
+    id: '623d50fd-75cf-4025-97d2-e51ff94171f6',
+    referrer: '',
+    url: 'https://app.datadoghq.com/rum/explorer?live=1h&query=&tab=view',
+    loading_time: 4115295000,
+    loading_type: 'initial_load',
+    time_spent: 245512755000,
+    first_contentful_paint: 420725000,
+    dom_complete: 2144660000,
+    dom_content_loaded: 951715000,
+    dom_interactive: 906695000,
+    load_event: 2154370000,
+    action: {
+      count: 0,
+    },
+    error: {
+      count: 2,
+    },
+    long_task: {
+      count: 5,
+    },
+    resource: {
+      count: 9,
+    },
+  },
+  _dd: {
+    document_version: 9,
+    format_version: 2,
+  },
+}
+
+const ajv = new Ajv()
+const valid = ajv
+  // TODO improve me
+  .addSchema(require('../../rum-events-format/schemas/_common-schema.json'), 'schemas/_common-schema.json')
+  .addSchema(require('../../rum-events-format/schemas/view-schema.json'), 'schemas/view-schema.json')
+  .addSchema(require('../../rum-events-format/schemas/action-schema.json'), 'schemas/action-schema.json')
+  .addSchema(require('../../rum-events-format/schemas/resource-schema.json'), 'schemas/resource-schema.json')
+  .addSchema(require('../../rum-events-format/schemas/long_task-schema.json'), 'schemas/long_task-schema.json')
+  .addSchema(require('../../rum-events-format/schemas/error-schema.json'), 'schemas/error-schema.json')
+  .addSchema(require('../../rum-events-format/rum-events-format.json'), 'rum-events-format.json')
+  .validate('rum-events-format.json', viewEvent)
+
+if (!valid) {
+  console.error('❌')
+  console.error(ajv.errorsText())
+  process.exit(1)
+}
+console.log('✅')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,6 +1549,16 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
+ajv@6.12.5:
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^5.0.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -3928,6 +3938,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^2.2.6:
   version "2.2.7"


### PR DESCRIPTION
## Motivation

Test link with rum-events-format and validation tool.


## Changes

- rum-events-format as git submodule
- simple validation test ran from ci

## Testing

cf ci step events-format

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
