### PR TITLE
🐛 consider proxy host with custom path request as intake request

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -222,7 +222,7 @@ function getEndpoint(type: string, conf: TransportConfiguration, source?: string
 
 export function isIntakeRequest(url: string, configuration: Configuration) {
   return (
-    getPathName(url).indexOf('/v1/input/') === 0 &&
+    getPathName(url).indexOf('/v1/input/') !== -1 &&
     (haveSameOrigin(url, configuration.logsEndpoint) ||
       haveSameOrigin(url, configuration.rumEndpoint) ||
       haveSameOrigin(url, configuration.traceEndpoint) ||

--- a/packages/core/test/configuration.spec.ts
+++ b/packages/core/test/configuration.spec.ts
@@ -135,8 +135,10 @@ describe('configuration', () => {
     })
 
     it('should detect proxy intake request', () => {
-      const configuration = buildConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, usEnv)
+      let configuration = buildConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, usEnv)
       expect(isIntakeRequest('https://www.proxy.com/v1/input/xxx', configuration)).toBe(true)
+      configuration = buildConfiguration({ clientToken, proxyHost: 'www.proxy.com/custom/path' }, usEnv)
+      expect(isIntakeRequest('https://www.proxy.com/custom/path/v1/input/xxx', configuration)).toBe(true)
     })
 
     it('should not detect request done on the same host as the proxy', () => {

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -99,7 +99,7 @@ The following parameters are available:
 | `resourceSampleRate`    | Number  | No       | `100`           | The percentage of tracked sessions with resources collection: `100` for all, `0` for none.               |
 | `sampleRate`            | Number  | No       | `100`           | The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send rum events. |
 | `silentMultipleInit`    | Boolean | No       | `false`         | Initialization fails silently if Datadog's RUM is already initialized on the page.                       |
-| `proxyHost`             | String  | No       |                 | Optional proxy URL, see the full [proxy setup guide][7] for more information.                            |
+| `proxyHost`             | String  | No       |                 | Optional proxy host (ex: www.proxy.com), see the full [proxy setup guide][7] for more information.       |
 | `allowedTracingOrigins` | List    | No       |                 | A list of request origins used to inject tracing headers.                                                |
 
 Options that must have matching configuration when also using `logs` SDK:


### PR DESCRIPTION
## Motivation

Some customers hi-jack the host to also have a path.
Since it is working, ensure that it is fully supported.

## Changes

- check that request contain `v1/input`, not only start with it
- doc: replace proxy url by proxy host with an example to avoid confusion

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
