### PR TITLE
✨ [RUMF-530][RUM] allow using RUM API before init 

### DIFF
--- a/packages/core/src/contextManager.ts
+++ b/packages/core/src/contextManager.ts
@@ -1,0 +1,23 @@
+import { Context, ContextValue } from './utils'
+
+export function createContextManager() {
+  let context: Context = {}
+
+  return {
+    get() {
+      return context
+    },
+
+    add(key: string, value: ContextValue) {
+      context[key] = value
+    },
+
+    remove(key: string) {
+      delete context[key]
+    },
+
+    set(newContext: Context) {
+      context = newContext
+    },
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,6 @@ export {
   BuildEnv,
   BuildMode,
   Datacenter,
-  makeStub,
   makeGlobal,
   commonInit,
   checkCookiesAuthorized,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,5 +31,6 @@ export { areCookiesAuthorized, getCookie, setCookie, COOKIE_ACCESS_DELAY } from 
 export { startXhrProxy, XhrCompleteContext, XhrStartContext, XhrProxy } from './xhrProxy'
 export { startFetchProxy, FetchCompleteContext, FetchStartContext, FetchProxy } from './fetchProxy'
 export { BoundedBuffer } from './boundedBuffer'
+export { createContextManager } from './contextManager'
 
 export * from './specHelper'

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -4,10 +4,6 @@ import { ErrorMessage, startErrorCollection } from './errorCollection'
 import { setDebugMode, startInternalMonitoring } from './internalMonitoring'
 import { Observable } from './observable'
 
-export function makeStub(methodName: string) {
-  console.warn(`'${methodName}' not yet available, please call '.init()' first.`)
-}
-
 export function makeGlobal<T>(stub: T): T {
   const global = { ...stub }
 

--- a/packages/core/test/contextManager.spec.ts
+++ b/packages/core/test/contextManager.spec.ts
@@ -1,0 +1,42 @@
+import { createContextManager } from '../src/contextManager'
+
+describe('createContextManager', () => {
+  it('starts with an empty context', () => {
+    const manager = createContextManager()
+    expect(manager.get()).toEqual({})
+  })
+
+  it('updates the context', () => {
+    const manager = createContextManager()
+    manager.set({ bar: 'foo' })
+    expect(manager.get()).toEqual({ bar: 'foo' })
+  })
+
+  it('updates the context without copy', () => {
+    const manager = createContextManager()
+    const context = {}
+    manager.set(context)
+    expect(manager.get()).toBe(context)
+  })
+
+  it('completely replaces the context', () => {
+    const manager = createContextManager()
+    manager.set({ a: 'foo' })
+    expect(manager.get()).toEqual({ a: 'foo' })
+    manager.set({ b: 'foo' })
+    expect(manager.get()).toEqual({ b: 'foo' })
+  })
+
+  it('sets a context value', () => {
+    const manager = createContextManager()
+    manager.add('foo', 'bar')
+    expect(manager.get()).toEqual({ foo: 'bar' })
+  })
+
+  it('removes a context value', () => {
+    const manager = createContextManager()
+    manager.set({ a: 'foo', b: 'bar' })
+    manager.remove('a')
+    expect(manager.get()).toEqual({ b: 'bar' })
+  })
+})

--- a/packages/logs/test/logger.spec.ts
+++ b/packages/logs/test/logger.spec.ts
@@ -37,17 +37,6 @@ describe('Logger', () => {
       expect(getLoggedMessage(0).bar).toEqual('foo')
     })
 
-    it('should be updatable', () => {
-      logger.setContext({ bar: 'foo' })
-      logger.log('first')
-      logger.setContext({ foo: 'bar' })
-      logger.log('second')
-
-      expect(getLoggedMessage(0).bar).toEqual('foo')
-      expect(getLoggedMessage(1).foo).toEqual('bar')
-      expect(getLoggedMessage(1).bar).toBeUndefined()
-    })
-
     it('should be deep merged', () => {
       logger.setContext({ foo: { qix: 'qux' } })
       logger.log('message', { foo: { qux: 'qux' } })
@@ -61,18 +50,6 @@ describe('Logger', () => {
         hello: 'hi',
         qix: 'qux',
       })
-    })
-
-    it('should be able to be able to add and remove from context', () => {
-      logger.setContext({})
-      logger.addContext('foo', { bar: 'qux' })
-      logger.log('first')
-      logger.removeContext('foo')
-      logger.log('second')
-      expect(getLoggedMessage(0).foo).toEqual({
-        bar: 'qux',
-      })
-      expect(getLoggedMessage(1).foo).toEqual(undefined)
     })
   })
 

--- a/packages/logs/test/logs.entry.spec.ts
+++ b/packages/logs/test/logs.entry.spec.ts
@@ -173,7 +173,7 @@ describe('logs entry', () => {
         expect(getLoggedMessage(0).context.view!.url).toEqual(initialLocation)
       })
 
-      it('saves the global context', () => {
+      it('stores a deep copy of the global context', () => {
         LOGS.addLoggerGlobalContext('foo', 'bar')
         LOGS.logger.log('message')
         LOGS.addLoggerGlobalContext('foo', 'baz')
@@ -181,6 +181,16 @@ describe('logs entry', () => {
         LOGS.init(DEFAULT_INIT_CONFIGURATION)
 
         expect(getLoggedMessage(0).context.foo).toEqual('bar')
+      })
+
+      it('stores a deep copy of the log context', () => {
+        const context = { foo: 'bar' }
+        LOGS.logger.log('message', context)
+        context.foo = 'baz'
+
+        LOGS.init(DEFAULT_INIT_CONFIGURATION)
+
+        expect(getLoggedMessage(0).message.foo).toEqual('bar')
       })
     })
   })
@@ -217,27 +227,6 @@ describe('logs entry', () => {
         LOGS.logger.log('message')
 
         expect(getLoggedMessage(0).context.bar).toEqual('foo')
-      })
-
-      it('should be updatable', () => {
-        LOGS.setLoggerGlobalContext({ bar: 'foo' })
-        LOGS.logger.log('first')
-        LOGS.setLoggerGlobalContext({ foo: 'bar' })
-        LOGS.logger.log('second')
-
-        expect(getLoggedMessage(0).context.bar).toEqual('foo')
-        expect(getLoggedMessage(1).context.foo).toEqual('bar')
-        expect(getLoggedMessage(1).context.bar).toBeUndefined()
-      })
-
-      it('should be removable', () => {
-        LOGS.addLoggerGlobalContext('bar', 'foo')
-        LOGS.logger.log('first')
-        LOGS.removeLoggerGlobalContext('bar')
-        LOGS.logger.log('second')
-
-        expect(getLoggedMessage(0).context.bar).toEqual('foo')
-        expect(getLoggedMessage(1).context.bar).toBeUndefined()
       })
 
       it('should be used by all loggers', () => {

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage } from '@datadog/browser-core'
+import { Context, ErrorMessage } from '@datadog/browser-core'
 import { RumPerformanceEntry } from './performanceCollection'
 import { RequestCompleteEvent, RequestStartEvent } from './requestCollection'
 import { AutoActionCreatedEvent, AutoUserAction, CustomUserAction } from './userActionCollection'
@@ -33,7 +33,10 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.REQUEST_STARTED, data: RequestStartEvent): void
   notify(eventType: LifeCycleEventType.REQUEST_COMPLETED, data: RequestCompleteEvent): void
   notify(eventType: LifeCycleEventType.AUTO_ACTION_COMPLETED, data: AutoUserAction): void
-  notify(eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED, data: CustomUserAction): void
+  notify(
+    eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED,
+    data: { action: CustomUserAction; context: Context }
+  ): void
   notify(eventType: LifeCycleEventType.AUTO_ACTION_CREATED, data: AutoActionCreatedEvent): void
   notify(eventType: LifeCycleEventType.VIEW_CREATED, data: ViewCreatedEvent): void
   notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: View): void
@@ -69,7 +72,7 @@ export class LifeCycle {
   ): Subscription
   subscribe(
     eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED,
-    callback: (data: CustomUserAction) => void
+    callback: (data: { action: CustomUserAction; context: Context }) => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_CREATED, callback: (data: ViewCreatedEvent) => void): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -35,7 +35,7 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.AUTO_ACTION_COMPLETED, data: AutoUserAction): void
   notify(
     eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED,
-    data: { action: CustomUserAction; context: Context }
+    data: { action: CustomUserAction; context?: Context }
   ): void
   notify(eventType: LifeCycleEventType.AUTO_ACTION_CREATED, data: AutoActionCreatedEvent): void
   notify(eventType: LifeCycleEventType.VIEW_CREATED, data: ViewCreatedEvent): void
@@ -72,7 +72,7 @@ export class LifeCycle {
   ): Subscription
   subscribe(
     eventType: LifeCycleEventType.CUSTOM_ACTION_COLLECTED,
-    callback: (data: { action: CustomUserAction; context: Context }) => void
+    callback: (data: { action: CustomUserAction; context?: Context }) => void
   ): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_CREATED, callback: (data: ViewCreatedEvent) => void): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: View) => void): Subscription

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -49,7 +49,7 @@ export function makeRumGlobal(startRumImpl: StartRum) {
   let globalContext: Context = {}
 
   let getInternalContextStrategy: ReturnType<StartRum>['getInternalContext'] = () => {
-    throw new Error('TODO')
+    return undefined
   }
   let addUserActionStrategy: ReturnType<StartRum>['addUserAction'] = () => {
     throw new Error('TODO')

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -1,27 +1,18 @@
 import {
-  assign,
   checkCookiesAuthorized,
   checkIsNotLocalFile,
-  commonInit,
   Context,
   ContextValue,
   getGlobalObject,
   isPercentage,
   makeGlobal,
-  makeStub,
   monitor,
   mustUseSecureCookie,
   UserConfiguration,
 } from '@datadog/browser-core'
 
-import { buildEnv } from './buildEnv'
-import { startDOMMutationCollection } from './domMutationCollection'
-import { LifeCycle, LifeCycleEventType } from './lifeCycle'
-import { startPerformanceCollection } from './performanceCollection'
-import { startRequestCollection } from './requestCollection'
 import { startRum } from './rum'
-import { startRumSession } from './rumSession'
-import { startUserActionCollection } from './userActionCollection'
+import { UserActionType } from './userActionCollection'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string
@@ -40,31 +31,9 @@ export interface InternalContext {
   }
 }
 
-const STUBBED_RUM = {
-  init(userConfiguration: RumUserConfiguration) {
-    makeStub('core.init')
-  },
-  addRumGlobalContext(key: string, value: ContextValue) {
-    makeStub('addRumGlobalContext')
-  },
-  removeRumGlobalContext(key: string) {
-    makeStub('removeRumGlobalContext')
-  },
-  setRumGlobalContext(context: Context) {
-    makeStub('setRumGlobalContext')
-  },
-  addUserAction(name: string, context: Context) {
-    makeStub('addUserAction')
-  },
-  getInternalContext(startTime?: number): InternalContext | undefined {
-    makeStub('getInternalContext')
-    return undefined
-  },
-}
+export type RumGlobal = ReturnType<typeof makeRumGlobal>
 
-export type RumGlobal = typeof STUBBED_RUM
-
-export const datadogRum = makeRumGlobal(STUBBED_RUM)
+export const datadogRum = makeRumGlobal(startRum)
 
 interface BrowserWindow extends Window {
   DD_RUM?: RumGlobal
@@ -72,53 +41,60 @@ interface BrowserWindow extends Window {
 
 getGlobalObject<BrowserWindow>().DD_RUM = datadogRum
 
-export function makeRumGlobal(stub: RumGlobal) {
-  const global = makeGlobal(stub)
+export type StartRum = typeof startRum
 
+export function makeRumGlobal(startRumImpl: StartRum) {
   let isAlreadyInitialized = false
 
-  global.init = monitor((userConfiguration: RumUserConfiguration) => {
-    if (
-      !checkCookiesAuthorized(mustUseSecureCookie(userConfiguration)) ||
-      !checkIsNotLocalFile() ||
-      !canInitRum(userConfiguration)
-    ) {
-      return
-    }
-    if (userConfiguration.publicApiKey) {
-      userConfiguration.clientToken = userConfiguration.publicApiKey
-    }
-    const lifeCycle = new LifeCycle()
+  let globalContext: Context = {}
 
-    const isCollectingError = true
-    const { errorObservable, configuration, internalMonitoring } = commonInit(
-      userConfiguration,
-      buildEnv,
-      isCollectingError
-    )
-    const session = startRumSession(configuration, lifeCycle)
-    const { globalApi } = startRum(
-      userConfiguration.applicationId,
-      location,
-      lifeCycle,
-      configuration,
-      session,
-      internalMonitoring
-    )
+  let getInternalContextStrategy: ReturnType<StartRum>['getInternalContext'] = () => {
+    throw new Error('TODO')
+  }
+  let addUserActionStrategy: ReturnType<StartRum>['addUserAction'] = () => {
+    throw new Error('TODO')
+  }
 
-    const [requestStartObservable, requestCompleteObservable] = startRequestCollection(configuration)
-    startPerformanceCollection(lifeCycle, configuration)
-    startDOMMutationCollection(lifeCycle)
-    if (configuration.trackInteractions) {
-      startUserActionCollection(lifeCycle)
-    }
+  return makeGlobal({
+    init: monitor((userConfiguration: RumUserConfiguration) => {
+      if (
+        !checkCookiesAuthorized(mustUseSecureCookie(userConfiguration)) ||
+        !checkIsNotLocalFile() ||
+        !canInitRum(userConfiguration)
+      ) {
+        return
+      }
+      if (userConfiguration.publicApiKey) {
+        userConfiguration.clientToken = userConfiguration.publicApiKey
+      }
 
-    errorObservable.subscribe((errorMessage) => lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, errorMessage))
-    requestStartObservable.subscribe((startEvent) => lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, startEvent))
-    requestCompleteObservable.subscribe((request) => lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, request))
+      ;({ getInternalContext: getInternalContextStrategy, addUserAction: addUserActionStrategy } = startRumImpl(
+        userConfiguration,
+        () => globalContext
+      ))
 
-    assign(global, globalApi)
-    isAlreadyInitialized = true
+      isAlreadyInitialized = true
+    }),
+
+    addRumGlobalContext: monitor((key: string, value: ContextValue) => {
+      globalContext[key] = value
+    }),
+
+    removeRumGlobalContext: monitor((key: string) => {
+      delete globalContext[key]
+    }),
+
+    setRumGlobalContext: monitor((context: Context) => {
+      globalContext = context
+    }),
+
+    getInternalContext: monitor((startTime?: number) => {
+      return getInternalContextStrategy(startTime)
+    }),
+
+    addUserAction: monitor((name: string, context?: Context) => {
+      addUserActionStrategy({ name, context, type: UserActionType.CUSTOM })
+    }),
   })
 
   function canInitRum(userConfiguration: RumUserConfiguration) {
@@ -154,6 +130,4 @@ export function makeRumGlobal(stub: RumGlobal) {
     }
     return true
   }
-
-  return global
 }

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -55,8 +55,8 @@ export function makeRumGlobal(startRumImpl: StartRum) {
     return undefined
   }
   const beforeInitAddUserAction = new BoundedBuffer<[CustomUserAction, Context]>()
-  let addUserActionStrategy: ReturnType<StartRum>['addUserAction'] = (action, context) => {
-    beforeInitAddUserAction.add([action, context])
+  let addUserActionStrategy: ReturnType<StartRum>['addUserAction'] = (action) => {
+    beforeInitAddUserAction.add([action, combine({}, globalContextManager.get())])
   }
 
   return makeGlobal({
@@ -92,15 +92,12 @@ export function makeRumGlobal(startRumImpl: StartRum) {
     }),
 
     addUserAction: monitor((name: string, context?: Context) => {
-      addUserActionStrategy(
-        {
-          name,
-          context: combine({}, context),
-          startTime: performance.now(),
-          type: UserActionType.CUSTOM,
-        },
-        combine({}, globalContextManager.get())
-      )
+      addUserActionStrategy({
+        name,
+        context: combine({}, context),
+        startTime: performance.now(),
+        type: UserActionType.CUSTOM,
+      })
     }),
   })
 

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -99,7 +99,8 @@ export function makeRumGlobal(startRumImpl: StartRum) {
     addUserAction: monitor((name: string, context?: Context) => {
       addUserActionStrategy({
         name,
-        context: combine({}, globalContext, context),
+        context: combine({}, context),
+        globalContext: combine({}, globalContext),
         startTime: performance.now(),
         type: UserActionType.CUSTOM,
       })

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -199,8 +199,8 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
       return doGetInternalContext(parentContexts, userConfiguration.applicationId, session, startTime)
     },
 
-    addUserAction(userAction: CustomUserAction) {
-      lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, userAction)
+    addUserAction(action: CustomUserAction, context: Context) {
+      lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { action, context })
     },
   }
 }
@@ -433,7 +433,7 @@ function trackCustomUserAction(
 ) {
   lifeCycle.subscribe(
     LifeCycleEventType.CUSTOM_ACTION_COLLECTED,
-    ({ name, type, context, globalContext, startTime }) => {
+    ({ action: { name, type, context: customerContext, startTime }, context: savedGlobalContext }) => {
       handler(
         startTime,
         {
@@ -446,8 +446,8 @@ function trackCustomUserAction(
             type,
           },
         },
-        globalContext,
-        context
+        savedGlobalContext,
+        customerContext
       )
     }
   )

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -185,7 +185,7 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
     getGlobalContext
   )
 
-  const [requestStartObservable, requestCompleteObservable] = startRequestCollection(configuration)
+  startRequestCollection(lifeCycle, configuration)
   startPerformanceCollection(lifeCycle, configuration)
   startDOMMutationCollection(lifeCycle)
   if (configuration.trackInteractions) {
@@ -193,8 +193,6 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
   }
 
   errorObservable.subscribe((errorMessage) => lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, errorMessage))
-  requestStartObservable.subscribe((startEvent) => lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, startEvent))
-  requestCompleteObservable.subscribe((request) => lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, request))
 
   return {
     getInternalContext(startTime?: number) {

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -346,7 +346,7 @@ function makeRumEventHandler(
       if (session.isTracked() && view && view.sessionId) {
         const action = parentContexts.findAction(startTime)
         const rumEvent = assemble(event, { action, view, rum: rumContextProvider() })
-        const message = combine(globalContextProvider(), customerContext, withSnakeCaseKeys(rumEvent))
+        const message = combine(customerContext || globalContextProvider(), withSnakeCaseKeys(rumEvent))
         callback(message, rumEvent)
       }
     }
@@ -424,19 +424,20 @@ function trackCustomUserAction(
   lifeCycle: LifeCycle,
   handler: (startTime: number, event: RumUserActionEvent, customerContext?: Context) => void
 ) {
-  lifeCycle.subscribe(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, (userAction) => {
+  lifeCycle.subscribe(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, ({ name, type, context, startTime }) => {
     handler(
-      performance.now(),
+      startTime,
       {
+        date: getTimestamp(startTime),
         evt: {
+          name,
           category: RumEventCategory.USER_ACTION,
-          name: userAction.name,
         },
         userAction: {
-          type: userAction.type,
+          type,
         },
       },
-      userAction.context
+      context
     )
   })
 }

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -199,7 +199,7 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
       return doGetInternalContext(parentContexts, userConfiguration.applicationId, session, startTime)
     },
 
-    addUserAction(action: CustomUserAction, context: Context) {
+    addUserAction(action: CustomUserAction, context?: Context) {
       lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { action, context })
     },
   }

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -21,7 +21,8 @@ export interface CustomUserAction {
   type: UserActionType.CUSTOM
   name: string
   startTime: number
-  context?: Context
+  context: Context
+  globalContext: Context
 }
 
 export interface AutoUserAction {

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -22,7 +22,6 @@ export interface CustomUserAction {
   name: string
   startTime: number
   context: Context
-  globalContext: Context
 }
 
 export interface AutoUserAction {

--- a/packages/rum/src/userActionCollection.ts
+++ b/packages/rum/src/userActionCollection.ts
@@ -20,6 +20,7 @@ export interface UserActionMeasures {
 export interface CustomUserAction {
   type: UserActionType.CUSTOM
   name: string
+  startTime: number
   context?: Context
 }
 

--- a/packages/rum/test/requestCollection.spec.ts
+++ b/packages/rum/test/requestCollection.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '@datadog/browser-core'
 import { resetFetchProxy } from '../../core/src/fetchProxy'
 import { resetXhrProxy } from '../../core/src/xhrProxy'
+import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
 import {
   RequestCompleteEvent,
   RequestObservables,
@@ -42,15 +43,15 @@ describe('collect fetch', () => {
     }
     fetchStubManager = stubFetch()
 
-    const requestObservables: RequestObservables = [new Observable(), new Observable()]
     startSpy = jasmine.createSpy('requestStart')
     completeSpy = jasmine.createSpy('requestComplete')
-    requestObservables[0].subscribe(startSpy)
-    requestObservables[1].subscribe(completeSpy)
+    const lifeCycle = new LifeCycle()
+    lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, startSpy)
+    lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, completeSpy)
     const tracerStub: Partial<Tracer> = {
       traceFetch: () => undefined,
     }
-    fetchProxy = trackFetch(configuration as Configuration, requestObservables, tracerStub as Tracer)
+    fetchProxy = trackFetch(lifeCycle, configuration as Configuration, tracerStub as Tracer)
 
     fetchStub = window.fetch as FetchStub
     window.onunhandledrejection = (ev: PromiseRejectionEvent) => {
@@ -121,15 +122,15 @@ describe('collect xhr', () => {
       pending('no fetch support')
     }
 
-    const requestObservables: RequestObservables = [new Observable(), new Observable()]
     startSpy = jasmine.createSpy('requestStart')
     completeSpy = jasmine.createSpy('requestComplete')
-    requestObservables[0].subscribe(startSpy)
-    requestObservables[1].subscribe(completeSpy)
+    const lifeCycle = new LifeCycle()
+    lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, startSpy)
+    lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, completeSpy)
     const tracerStub: Partial<Tracer> = {
       traceXhr: () => undefined,
     }
-    trackXhr(configuration as Configuration, requestObservables, tracerStub as Tracer)
+    trackXhr(lifeCycle, configuration as Configuration, tracerStub as Tracer)
   })
 
   afterEach(() => {

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -1,25 +1,17 @@
-import { isIE, stopSessionManagement } from '@datadog/browser-core'
-import { resetXhrProxy } from '../../core/src/xhrProxy'
-
 import { makeRumGlobal, RumGlobal, RumUserConfiguration } from '../src/rum.entry'
+
+const noopStartRum = () => ({
+  addUserAction: () => undefined,
+  getInternalContext: () => undefined,
+})
 
 describe('rum entry', () => {
   let rumGlobal: RumGlobal
   let errorSpy: jasmine.Spy
 
   beforeEach(() => {
-    if (isIE()) {
-      pending('no full rum support')
-    }
     errorSpy = spyOn(console, 'error')
-    rumGlobal = makeRumGlobal({} as any)
-  })
-
-  afterEach(() => {
-    // some tests can successfully start the tracking
-    // stop behaviors that can pollute following tests
-    stopSessionManagement()
-    resetXhrProxy()
+    rumGlobal = makeRumGlobal(noopStartRum)
   })
 
   it('init should log an error with no application id', () => {
@@ -59,7 +51,7 @@ describe('rum entry', () => {
     rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', allowedTracingOrigins: [] })
     expect(errorSpy).toHaveBeenCalledTimes(0)
 
-    makeRumGlobal({} as any).init({
+    makeRumGlobal(noopStartRum).init({
       allowedTracingOrigins: ['foo.bar'],
       applicationId: 'yes',
       clientToken: 'yes',
@@ -67,7 +59,11 @@ describe('rum entry', () => {
     })
     expect(errorSpy).toHaveBeenCalledTimes(0)
 
-    makeRumGlobal({} as any).init({ clientToken: 'yes', applicationId: 'yes', allowedTracingOrigins: ['foo.bar'] })
+    makeRumGlobal(noopStartRum).init({
+      allowedTracingOrigins: ['foo.bar'],
+      applicationId: 'yes',
+      clientToken: 'yes',
+    })
     expect(errorSpy).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -162,24 +162,12 @@ describe('rum entry', () => {
       expect(addUserActionSpy.calls.argsFor(0)).toEqual([
         {
           context: { bar: 'baz' },
+          globalContext: {},
           name: 'foo',
           startTime: jasmine.any(Number),
           type: UserActionType.CUSTOM,
         },
       ])
-    })
-
-    it('combines the global context and user action context', () => {
-      rumGlobal.addRumGlobalContext('foo', 'from-global-context')
-      rumGlobal.addRumGlobalContext('bar', 'from-global-context')
-      rumGlobal.addUserAction('message', { bar: 'from-action-context' })
-
-      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(addUserActionSpy.calls.argsFor(0)[0].context).toEqual({
-        bar: 'from-action-context',
-        foo: 'from-global-context',
-      })
     })
 
     describe('save context when sending a user action', () => {
@@ -195,10 +183,22 @@ describe('rum entry', () => {
         expect(addUserActionSpy.calls.argsFor(0)[0].startTime).toEqual(ONE_SECOND)
       })
 
-      it('saves the global context', () => {
+      it('stores a deep copy of the global context', () => {
         rumGlobal.addRumGlobalContext('foo', 'bar')
         rumGlobal.addUserAction('message')
         rumGlobal.addRumGlobalContext('foo', 'baz')
+
+        rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+
+        expect(addUserActionSpy.calls.argsFor(0)[0].globalContext).toEqual({
+          foo: 'bar',
+        })
+      })
+
+      it('stores a deep copy of the action context', () => {
+        const context = { foo: 'bar' }
+        rumGlobal.addUserAction('message', context)
+        context.foo = 'baz'
 
         rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
 

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -118,7 +118,7 @@ describe('rum entry', () => {
       expect(getInternalContextSpy).not.toHaveBeenCalled()
     })
 
-    it('returns the global context after init', () => {
+    it('returns the internal context after init', () => {
       rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
 
       expect(rumGlobal.getInternalContext()).toEqual({ application_id: '123', session_id: '123' })

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -1,94 +1,133 @@
-import { makeRumGlobal, RumGlobal, RumUserConfiguration } from '../src/rum.entry'
+import { makeRumGlobal, RumGlobal, RumUserConfiguration, StartRum } from '../src/rum.entry'
 
 const noopStartRum = () => ({
   addUserAction: () => undefined,
   getInternalContext: () => undefined,
 })
+const DEFAULT_INIT_CONFIGURATION = { applicationId: 'xxx', clientToken: 'xxx' }
 
 describe('rum entry', () => {
-  let rumGlobal: RumGlobal
-  let errorSpy: jasmine.Spy
+  describe('configuration validation', () => {
+    let rumGlobal: RumGlobal
+    let errorSpy: jasmine.Spy
 
-  beforeEach(() => {
-    errorSpy = spyOn(console, 'error')
-    rumGlobal = makeRumGlobal(noopStartRum)
-  })
-
-  it('init should log an error with no application id', () => {
-    const invalidConfiguration = { clientToken: 'yes' }
-    rumGlobal.init(invalidConfiguration as RumUserConfiguration)
-    expect(console.error).toHaveBeenCalledTimes(1)
-
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes' })
-    expect(errorSpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('init should log an error if sampleRate is invalid', () => {
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 'foo' as any })
-    expect(errorSpy).toHaveBeenCalledTimes(1)
-
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 200 })
-    expect(errorSpy).toHaveBeenCalledTimes(2)
-  })
-
-  it('init should log an error if resourceSampleRate is invalid', () => {
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', resourceSampleRate: 'foo' as any })
-    expect(errorSpy).toHaveBeenCalledTimes(1)
-
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', resourceSampleRate: 200 })
-    expect(errorSpy).toHaveBeenCalledTimes(2)
-  })
-
-  it('should log an error if init is called several times', () => {
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1, resourceSampleRate: 1 })
-    expect(errorSpy).toHaveBeenCalledTimes(0)
-
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1, resourceSampleRate: 1 })
-    expect(errorSpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('should log an error if tracing is enabled without a service configured', () => {
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', allowedTracingOrigins: [] })
-    expect(errorSpy).toHaveBeenCalledTimes(0)
-
-    makeRumGlobal(noopStartRum).init({
-      allowedTracingOrigins: ['foo.bar'],
-      applicationId: 'yes',
-      clientToken: 'yes',
-      service: 'foo',
+    beforeEach(() => {
+      errorSpy = spyOn(console, 'error')
+      rumGlobal = makeRumGlobal(noopStartRum)
     })
-    expect(errorSpy).toHaveBeenCalledTimes(0)
 
-    makeRumGlobal(noopStartRum).init({
-      allowedTracingOrigins: ['foo.bar'],
-      applicationId: 'yes',
-      clientToken: 'yes',
+    it('init should log an error with no application id', () => {
+      const invalidConfiguration = { clientToken: 'yes' }
+      rumGlobal.init(invalidConfiguration as RumUserConfiguration)
+      expect(console.error).toHaveBeenCalledTimes(1)
+
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes' })
+      expect(errorSpy).toHaveBeenCalledTimes(1)
     })
-    expect(errorSpy).toHaveBeenCalledTimes(1)
+
+    it('init should log an error if sampleRate is invalid', () => {
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 'foo' as any })
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 200 })
+      expect(errorSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('init should log an error if resourceSampleRate is invalid', () => {
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', resourceSampleRate: 'foo' as any })
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', resourceSampleRate: 200 })
+      expect(errorSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should log an error if init is called several times', () => {
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1, resourceSampleRate: 1 })
+      expect(errorSpy).toHaveBeenCalledTimes(0)
+
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1, resourceSampleRate: 1 })
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should log an error if tracing is enabled without a service configured', () => {
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', allowedTracingOrigins: [] })
+      expect(errorSpy).toHaveBeenCalledTimes(0)
+
+      makeRumGlobal(noopStartRum).init({
+        allowedTracingOrigins: ['foo.bar'],
+        applicationId: 'yes',
+        clientToken: 'yes',
+        service: 'foo',
+      })
+      expect(errorSpy).toHaveBeenCalledTimes(0)
+
+      makeRumGlobal(noopStartRum).init({
+        allowedTracingOrigins: ['foo.bar'],
+        applicationId: 'yes',
+        clientToken: 'yes',
+      })
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not log an error if init is called several times and silentMultipleInit is true', () => {
+      rumGlobal.init({
+        applicationId: 'yes',
+        clientToken: 'yes',
+        resourceSampleRate: 1,
+        sampleRate: 1,
+        silentMultipleInit: true,
+      })
+      expect(errorSpy).toHaveBeenCalledTimes(0)
+
+      rumGlobal.init({
+        applicationId: 'yes',
+        clientToken: 'yes',
+        resourceSampleRate: 1,
+        sampleRate: 1,
+        silentMultipleInit: true,
+      })
+      expect(errorSpy).toHaveBeenCalledTimes(0)
+    })
+
+    it("shouldn't trigger any console.log if the configuration is correct", () => {
+      rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1, resourceSampleRate: 1 })
+      expect(errorSpy).toHaveBeenCalledTimes(0)
+    })
   })
 
-  it('should not log an error if init is called several times and silentMultipleInit is true', () => {
-    rumGlobal.init({
-      applicationId: 'yes',
-      clientToken: 'yes',
-      resourceSampleRate: 1,
-      sampleRate: 1,
-      silentMultipleInit: true,
-    })
-    expect(errorSpy).toHaveBeenCalledTimes(0)
+  describe('getInternalContext', () => {
+    let getInternalContextSpy: jasmine.Spy<ReturnType<StartRum>['getInternalContext']>
+    let rumGlobal: RumGlobal
 
-    rumGlobal.init({
-      applicationId: 'yes',
-      clientToken: 'yes',
-      resourceSampleRate: 1,
-      sampleRate: 1,
-      silentMultipleInit: true,
+    beforeEach(() => {
+      getInternalContextSpy = jasmine.createSpy().and.callFake(() => ({
+        application_id: '123',
+        session_id: '123',
+      }))
+      rumGlobal = makeRumGlobal(() => ({
+        ...noopStartRum(),
+        getInternalContext: getInternalContextSpy,
+      }))
     })
-    expect(errorSpy).toHaveBeenCalledTimes(0)
-  })
 
-  it("shouldn't trigger any console.log if the configuration is correct", () => {
-    rumGlobal.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1, resourceSampleRate: 1 })
-    expect(errorSpy).toHaveBeenCalledTimes(0)
+    it('returns undefined before init', () => {
+      expect(rumGlobal.getInternalContext()).toBe(undefined)
+      expect(getInternalContextSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns the global context after init', () => {
+      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+
+      expect(rumGlobal.getInternalContext()).toEqual({ application_id: '123', session_id: '123' })
+      expect(getInternalContextSpy).toHaveBeenCalled()
+    })
+
+    it('uses the startTime if specified', () => {
+      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+
+      const startTime = 234832890
+      expect(rumGlobal.getInternalContext(startTime)).toEqual({ application_id: '123', session_id: '123' })
+      expect(getInternalContextSpy).toHaveBeenCalledWith(startTime)
+    })
   })
 })

--- a/packages/rum/test/rum.entry.spec.ts
+++ b/packages/rum/test/rum.entry.spec.ts
@@ -162,11 +162,11 @@ describe('rum entry', () => {
       expect(addUserActionSpy.calls.argsFor(0)).toEqual([
         {
           context: { bar: 'baz' },
-          globalContext: {},
           name: 'foo',
           startTime: jasmine.any(Number),
           type: UserActionType.CUSTOM,
         },
+        {},
       ])
     })
 
@@ -190,7 +190,7 @@ describe('rum entry', () => {
 
         rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
 
-        expect(addUserActionSpy.calls.argsFor(0)[0].globalContext).toEqual({
+        expect(addUserActionSpy.calls.argsFor(0)[1]).toEqual({
           foo: 'bar',
         })
       })

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -558,6 +558,23 @@ describe('rum user action', () => {
 
     expect((getRumMessage(server, 0) as any).fooBar).toEqual('foo')
   })
+
+  it('should ignore the global context', () => {
+    const { setGlobalContext, server, lifeCycle } = setupBuilder.build()
+    server.requests = []
+
+    setGlobalContext({ replacedContext: 'b', addedContext: 'x' })
+
+    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
+      context: { replacedContext: 'a' },
+      name: 'hello',
+      startTime: 123,
+      type: UserActionType.CUSTOM,
+    })
+
+    expect((getRumMessage(server, 0) as any).replacedContext).toEqual('a')
+    expect((getRumMessage(server, 0) as any).addedContext).toEqual(undefined)
+  })
 })
 
 describe('rum context', () => {

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -1,4 +1,4 @@
-import { Configuration, DEFAULT_CONFIGURATION, ErrorMessage, isIE, SPEC_ENDPOINTS } from '@datadog/browser-core'
+import { ErrorMessage, isIE } from '@datadog/browser-core'
 import sinon from 'sinon'
 
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
@@ -16,12 +16,6 @@ function getEntry(handler: (startTime: number, event: RumEvent) => void, index: 
 
 function getServerRequestBodies<T>(server: sinon.SinonFakeServer) {
   return server.requests.map((r) => JSON.parse(r.requestBody) as T)
-}
-
-const configuration = {
-  ...DEFAULT_CONFIGURATION,
-  ...SPEC_ENDPOINTS,
-  maxBatchSize: 1,
 }
 
 function getRumMessage(server: sinon.SinonFakeServer, index: number) {
@@ -62,13 +56,7 @@ describe('rum handle performance entry', () => {
     const entry = { entryType: 'resource' as const, name: 'https://resource.com/valid' }
     const session = createMockSession()
 
-    handleResourceEntry(
-      configuration as Configuration,
-      new LifeCycle(),
-      session,
-      handler,
-      entry as RumPerformanceResourceTiming
-    )
+    handleResourceEntry(new LifeCycle(), session, handler, entry as RumPerformanceResourceTiming)
 
     expect(handler).toHaveBeenCalled()
   })
@@ -78,13 +66,7 @@ describe('rum handle performance entry', () => {
     const session = createMockSession()
     session.isTrackedWithResource = () => false
 
-    handleResourceEntry(
-      configuration as Configuration,
-      new LifeCycle(),
-      session,
-      handler,
-      entry as RumPerformanceResourceTiming
-    )
+    handleResourceEntry(new LifeCycle(), session, handler, entry as RumPerformanceResourceTiming)
 
     expect(handler).not.toHaveBeenCalled()
   })
@@ -125,13 +107,7 @@ describe('rum handle performance entry', () => {
       it(`should compute resource kind: ${description}`, () => {
         const entry: Partial<RumPerformanceResourceTiming> = { initiatorType, name: url, entryType: 'resource' }
 
-        handleResourceEntry(
-          configuration as Configuration,
-          new LifeCycle(),
-          createMockSession(),
-          handler,
-          entry as RumPerformanceResourceTiming
-        )
+        handleResourceEntry(new LifeCycle(), createMockSession(), handler, entry as RumPerformanceResourceTiming)
         const resourceEvent = getEntry(handler, 0) as RumResourceEvent
         expect(resourceEvent.resource.kind).toEqual(expected)
       })
@@ -154,13 +130,7 @@ describe('rum handle performance entry', () => {
       secureConnectionStart: 0,
     }
 
-    handleResourceEntry(
-      configuration as Configuration,
-      new LifeCycle(),
-      createMockSession(),
-      handler,
-      entry as RumPerformanceResourceTiming
-    )
+    handleResourceEntry(new LifeCycle(), createMockSession(), handler, entry as RumPerformanceResourceTiming)
     const resourceEvent = getEntry(handler, 0) as RumResourceEvent
     expect(resourceEvent.http.performance!.connect!.duration).toEqual(7 * 1e6)
     expect(resourceEvent.http.performance!.download!.duration).toEqual(75 * 1e6)
@@ -184,13 +154,7 @@ describe('rum handle performance entry', () => {
         secureConnectionStart: 0,
       }
 
-      handleResourceEntry(
-        configuration as Configuration,
-        new LifeCycle(),
-        createMockSession(),
-        handler,
-        entry as RumPerformanceResourceTiming
-      )
+      handleResourceEntry(new LifeCycle(), createMockSession(), handler, entry as RumPerformanceResourceTiming)
       const resourceEvent = getEntry(handler, 0) as RumResourceEvent
       expect(resourceEvent.http.performance).toBe(undefined)
     })
@@ -203,13 +167,7 @@ describe('rum handle performance entry', () => {
         responseStart: 100,
       }
 
-      handleResourceEntry(
-        configuration as Configuration,
-        new LifeCycle(),
-        createMockSession(),
-        handler,
-        entry as RumPerformanceResourceTiming
-      )
+      handleResourceEntry(new LifeCycle(), createMockSession(), handler, entry as RumPerformanceResourceTiming)
       const resourceEvent = getEntry(handler, 0) as RumResourceEvent
       expect(resourceEvent.http.performance).toBe(undefined)
     })
@@ -222,13 +180,7 @@ describe('rum handle performance entry', () => {
       traceId: '123',
     }
 
-    handleResourceEntry(
-      configuration as Configuration,
-      new LifeCycle(),
-      createMockSession(),
-      handler,
-      entry as RumPerformanceResourceTiming
-    )
+    handleResourceEntry(new LifeCycle(), createMockSession(), handler, entry as RumPerformanceResourceTiming)
     const resourceEvent = getEntry(handler, 0) as RumResourceEvent
     expect(resourceEvent._dd!.traceId).toBe('123')
   })

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -551,7 +551,7 @@ describe('rum user action', () => {
     expect((getRumMessage(server, 0) as any).fooBar).toEqual('foo')
   })
 
-  it('should ignore the current global context', () => {
+  it('should ignore the current global context when a saved global context is provided', () => {
     const { setGlobalContext, server, lifeCycle } = setupBuilder.build()
     server.requests = []
 

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -508,7 +508,7 @@ describe('rum global context', () => {
     expect((getRumMessage(server, 1) as any).bar).toBeUndefined()
   })
 
-  it('should be removable', () => {
+  it('should ignore subsequent context mutation', () => {
     const { server, lifeCycle, setGlobalContext } = setupBuilder.build()
     server.requests = []
 

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -222,6 +222,7 @@ describe('rum session', () => {
   const FAKE_REQUEST: Partial<RequestCompleteEvent> = { url: 'http://foo.com' }
   const FAKE_CUSTOM_USER_ACTION: CustomUserAction = {
     context: { foo: 'bar' },
+    globalContext: {},
     name: 'action',
     startTime: 123,
     type: UserActionType.CUSTOM,
@@ -551,6 +552,7 @@ describe('rum user action', () => {
 
     lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
       context: { fooBar: 'foo' },
+      globalContext: {},
       name: 'hello',
       startTime: 123,
       type: UserActionType.CUSTOM,
@@ -559,14 +561,15 @@ describe('rum user action', () => {
     expect((getRumMessage(server, 0) as any).fooBar).toEqual('foo')
   })
 
-  it('should ignore the global context', () => {
+  it('should ignore the current global context', () => {
     const { setGlobalContext, server, lifeCycle } = setupBuilder.build()
     server.requests = []
 
     setGlobalContext({ replacedContext: 'b', addedContext: 'x' })
 
     lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
-      context: { replacedContext: 'a' },
+      context: {},
+      globalContext: { replacedContext: 'a' },
       name: 'hello',
       startTime: 123,
       type: UserActionType.CUSTOM,

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -223,6 +223,7 @@ describe('rum session', () => {
   const FAKE_CUSTOM_USER_ACTION: CustomUserAction = {
     context: { foo: 'bar' },
     name: 'action',
+    startTime: 123,
     type: UserActionType.CUSTOM,
   }
   let setupBuilder: TestSetupBuilder
@@ -551,6 +552,7 @@ describe('rum user action', () => {
     lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
       context: { fooBar: 'foo' },
       name: 'hello',
+      startTime: 123,
       type: UserActionType.CUSTOM,
     })
 

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -494,20 +494,6 @@ describe('rum global context', () => {
     expect((getRumMessage(server, 0) as any).bar).toEqual('foo')
   })
 
-  it('should be updatable', () => {
-    const { server, lifeCycle, setGlobalContext } = setupBuilder.build()
-    server.requests = []
-
-    setGlobalContext({ bar: 'foo' })
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-    setGlobalContext({ foo: 'bar' })
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-
-    expect((getRumMessage(server, 0) as any).bar).toEqual('foo')
-    expect((getRumMessage(server, 1) as any).foo).toEqual('bar')
-    expect((getRumMessage(server, 1) as any).bar).toBeUndefined()
-  })
-
   it('should ignore subsequent context mutation', () => {
     const { server, lifeCycle, setGlobalContext } = setupBuilder.build()
     server.requests = []

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -220,12 +220,14 @@ describe('rum session', () => {
   const FAKE_ERROR: Partial<ErrorMessage> = { message: 'test' }
   const FAKE_RESOURCE: Partial<RumPerformanceResourceTiming> = { name: 'http://foo.com', entryType: 'resource' }
   const FAKE_REQUEST: Partial<RequestCompleteEvent> = { url: 'http://foo.com' }
-  const FAKE_CUSTOM_USER_ACTION: CustomUserAction = {
-    context: { foo: 'bar' },
-    globalContext: {},
-    name: 'action',
-    startTime: 123,
-    type: UserActionType.CUSTOM,
+  const FAKE_CUSTOM_USER_ACTION_EVENT = {
+    action: {
+      context: { foo: 'bar' },
+      name: 'action',
+      startTime: 123,
+      type: UserActionType.CUSTOM as const,
+    },
+    context: {},
   }
   let setupBuilder: TestSetupBuilder
 
@@ -254,7 +256,7 @@ describe('rum session', () => {
     stubBuilder.fakeEntry(FAKE_RESOURCE as PerformanceEntry, 'resource')
     lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
     lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, FAKE_REQUEST as RequestCompleteEvent)
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, FAKE_CUSTOM_USER_ACTION)
+    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, FAKE_CUSTOM_USER_ACTION_EVENT)
 
     expect(server.requests.length).toEqual(4)
   })
@@ -296,7 +298,7 @@ describe('rum session', () => {
     stubBuilder.fakeEntry(FAKE_RESOURCE as PerformanceEntry, 'resource')
     lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, FAKE_REQUEST as RequestCompleteEvent)
     lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, FAKE_CUSTOM_USER_ACTION)
+    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, FAKE_CUSTOM_USER_ACTION_EVENT)
 
     expect(server.requests.length).toEqual(0)
   })
@@ -537,11 +539,13 @@ describe('rum user action', () => {
     server.requests = []
 
     lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
-      context: { fooBar: 'foo' },
-      globalContext: {},
-      name: 'hello',
-      startTime: 123,
-      type: UserActionType.CUSTOM,
+      action: {
+        context: { fooBar: 'foo' },
+        name: 'hello',
+        startTime: 123,
+        type: UserActionType.CUSTOM,
+      },
+      context: {},
     })
 
     expect((getRumMessage(server, 0) as any).fooBar).toEqual('foo')
@@ -554,11 +558,13 @@ describe('rum user action', () => {
     setGlobalContext({ replacedContext: 'b', addedContext: 'x' })
 
     lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
-      context: {},
-      globalContext: { replacedContext: 'a' },
-      name: 'hello',
-      startTime: 123,
-      type: UserActionType.CUSTOM,
+      action: {
+        context: {},
+        name: 'hello',
+        startTime: 123,
+        type: UserActionType.CUSTOM,
+      },
+      context: { replacedContext: 'a' },
     })
 
     expect((getRumMessage(server, 0) as any).replacedContext).toEqual('a')

--- a/packages/rum/test/trackEventCounts.spec.ts
+++ b/packages/rum/test/trackEventCounts.spec.ts
@@ -39,7 +39,10 @@ describe('trackEventCounts', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
     const userAction = {}
     lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, userAction as AutoUserAction)
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, userAction as CustomUserAction)
+    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
+      action: userAction as CustomUserAction,
+      context: {},
+    })
     expect(eventCounts.userActionCount).toBe(2)
   })
 

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -30,6 +30,7 @@ const FAKE_CUSTOM_USER_ACTION: CustomUserAction = {
     bar: 123,
   },
   name: 'foo',
+  startTime: 123,
   type: UserActionType.CUSTOM,
 }
 const FAKE_AUTO_USER_ACTION: Partial<AutoUserAction> = {

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -29,6 +29,7 @@ const FAKE_CUSTOM_USER_ACTION: CustomUserAction = {
   context: {
     bar: 123,
   },
+  globalContext: {},
   name: 'foo',
   startTime: 123,
   type: UserActionType.CUSTOM,

--- a/packages/rum/test/viewCollection.spec.ts
+++ b/packages/rum/test/viewCollection.spec.ts
@@ -29,7 +29,6 @@ const FAKE_CUSTOM_USER_ACTION: CustomUserAction = {
   context: {
     bar: 123,
   },
-  globalContext: {},
   name: 'foo',
   startTime: 123,
   type: UserActionType.CUSTOM,
@@ -527,7 +526,7 @@ describe('rum view measures', () => {
     expect(getHandledCount()).toEqual(1)
     expect(getViewEvent(0).measures.userActionCount).toEqual(0)
 
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, FAKE_CUSTOM_USER_ACTION)
+    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { action: FAKE_CUSTOM_USER_ACTION, context: {} })
     lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, FAKE_AUTO_USER_ACTION as AutoUserAction)
     history.pushState({}, '', '/bar')
 


### PR DESCRIPTION
## Motivation

We want to allow using RUM APIs before initialising the SDK. (see #545 for the Logs side)

## Changes

* Remove stubs and regroup the public API implementation
* Use a bounded buffer to collect pre-init user actions and send them at init
* Make `getInternalContext` return `undefined` before init

## Testing

Unit tests have been updated. Manual testing can be done by running some `DD_RUM.addUserAction('foo')` or `DD_RUM.getInternalContext()` before `DD_RUM.init()`.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
