### PR TITLE
doc: fix wrong option name

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -104,11 +104,11 @@ The following parameters are available:
 
 Options that must have matching configuration when also using `logs` SDK:
 
-| Parameter                         | Type    | Required | Default | Description                                                                                                                                                  |
-| --------------------------------- | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `trackSessionAcrossSubdomains`    | Boolean | No       | `false` | Preserve the session across subdomains for the same site.                                                                                                    |
-| `useSecureSessionCookie`          | Boolean | No       | `false` | Use a secure session cookie. This disables RUM events sent on insecure (non-HTTPS) connections.                                                              |
-| `allowThirdPartyContextExecution` | Boolean | No       | `false` | Use a secure cross-site session cookie. This allows the logs SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`. |
+| Parameter                      | Type    | Required | Default | Description                                                                                                                                                  |
+| ------------------------------ | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `trackSessionAcrossSubdomains` | Boolean | No       | `false` | Preserve the session across subdomains for the same site.                                                                                                    |
+| `useSecureSessionCookie`       | Boolean | No       | `false` | Use a secure session cookie. This disables RUM events sent on insecure (non-HTTPS) connections.                                                              |
+| `useCrossSiteSessionCookie`    | Boolean | No       | `false` | Use a secure cross-site session cookie. This allows the logs SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`. |
 
 #### Example
 


### PR DESCRIPTION
## Motivation

Wrong option name in doc

## Changes

Use right option name

## Testing

none

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
