### PR TITLE
🐛[RUMF-716] fix invalid action name

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -372,3 +372,16 @@ export function findCommaSeparatedValue(rawString: string, name: string) {
   const matches = rawString.match(`(?:^|;)\\s*${name}\\s*=\\s*([^;]+)`)
   return matches ? matches[1] : undefined
 }
+
+export function safeTruncate(candidate: string, length: number) {
+  const slice = candidate.slice(0, length)
+  try {
+    // throw if attempt to encode a surrogate
+    // which is not part of a high-low pair
+    encodeURIComponent(slice)
+    return slice
+  } catch {
+    // add the missing part
+    return slice + candidate.charAt(length)
+  }
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -374,14 +374,10 @@ export function findCommaSeparatedValue(rawString: string, name: string) {
 }
 
 export function safeTruncate(candidate: string, length: number) {
-  const slice = candidate.slice(0, length)
-  try {
-    // throw if attempt to encode a surrogate
-    // which is not part of a high-low pair
-    encodeURIComponent(slice)
-    return slice
-  } catch {
-    // add the missing part
-    return slice + candidate.charAt(length)
+  const lastChar = candidate.charCodeAt(length - 1)
+  // check if it is the high part of a surrogate pair
+  if (lastChar >= 0xd800 && lastChar <= 0xdbff) {
+    return candidate.slice(0, length + 1)
   }
+  return candidate.slice(0, length)
 }

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -4,6 +4,7 @@ import {
   jsonStringify,
   performDraw,
   round,
+  safeTruncate,
   throttle,
   toSnakeCase,
   withSnakeCaseKeys,
@@ -317,6 +318,20 @@ describe('utils', () => {
       ;(circularReference as any).myself = circularReference
 
       expect(jsonStringify(circularReference)).toEqual('<error: unable to serialize object>')
+    })
+  })
+
+  describe('safeTruncate', () => {
+    it('should truncate a string', () => {
+      const truncated = safeTruncate('1234567890', 4)
+      expect(truncated.length).toBe(4)
+      expect(truncated).toBe('1234')
+    })
+
+    it('should not break a surrogate characters pair', () => {
+      const truncated = safeTruncate('12345😎890', 6)
+      expect(truncated.length).toBe(7)
+      expect(truncated).toBe('12345😎')
     })
   })
 

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -323,9 +323,9 @@ describe('utils', () => {
 
   describe('safeTruncate', () => {
     it('should truncate a string', () => {
-      const truncated = safeTruncate('1234567890', 4)
-      expect(truncated.length).toBe(4)
-      expect(truncated).toBe('1234')
+      const truncated = safeTruncate('1234😎7890', 6)
+      expect(truncated.length).toBe(6)
+      expect(truncated).toBe('1234😎')
     })
 
     it('should not break a surrogate characters pair', () => {

--- a/packages/rum/src/getActionNameFromElement.ts
+++ b/packages/rum/src/getActionNameFromElement.ts
@@ -1,3 +1,5 @@
+import { safeTruncate } from '@datadog/browser-core'
+
 export function getActionNameFromElement(element: Element): string {
   // Proceed to get the action name in two steps:
   // * first, get the name programmatically, explicitly defined by the user.
@@ -146,7 +148,7 @@ function normalizeWhitespace(s: string) {
 }
 
 function truncate(s: string) {
-  return s.length > 100 ? `${s.slice(0, 100)} [...]` : s
+  return s.length > 100 ? `${safeTruncate(s, 100)} [...]` : s
 }
 
 function getElementById(refElement: Element, id: string) {


### PR DESCRIPTION
## Motivation

Some UTF-8 characters can be composed of a pair of "surrogate" characters.

more details:  [MDN#encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)

## Changes

Ensure that our string truncate don't make invalid string by keeping only the first part of the pair.

## Testing

unit test

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
