### PR TITLE
♻️[RUMF-725] Extract RUM assembly and batch logic 

### DIFF
--- a/packages/rum/src/assembly.ts
+++ b/packages/rum/src/assembly.ts
@@ -1,0 +1,96 @@
+import { combine, Configuration, Context, withSnakeCaseKeys } from '@datadog/browser-core'
+import { LifeCycle, LifeCycleEventType } from './lifeCycle'
+import { ActionContext, ParentContexts, ViewContext } from './parentContexts'
+import {
+  RawRumEvent,
+  RumErrorEvent,
+  RumEventCategory,
+  RumLongTaskEvent,
+  RumResourceEvent,
+  RumUserActionEvent,
+  RumViewEvent,
+} from './rum'
+import { RumSession } from './rumSession'
+
+interface BrowserWindow extends Window {
+  _DATADOG_SYNTHETICS_BROWSER?: unknown
+}
+
+interface RumContext {
+  applicationId: string
+  date: number
+  service?: string
+  session: {
+    type: string
+  }
+}
+
+export type RumEvent =
+  | RumErrorEvent & ActionContext & ViewContext & RumContext
+  | RumResourceEvent & ActionContext & ViewContext & RumContext
+  | RumViewEvent & ViewContext & RumContext
+  | RumLongTaskEvent & ActionContext & ViewContext & RumContext
+  | RumUserActionEvent & ViewContext & RumContext
+
+enum SessionType {
+  SYNTHETICS = 'synthetics',
+  USER = 'user',
+}
+
+export function startRumAssembly(
+  applicationId: string,
+  configuration: Configuration,
+  lifeCycle: LifeCycle,
+  session: RumSession,
+  parentContexts: ParentContexts,
+  getGlobalContext: () => Context
+) {
+  lifeCycle.subscribe(
+    LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
+    ({
+      startTime,
+      rawRumEvent,
+      savedGlobalContext,
+      customerContext,
+    }: {
+      startTime: number
+      rawRumEvent: RawRumEvent
+      savedGlobalContext?: Context
+      customerContext?: Context
+    }) => {
+      const viewContext = parentContexts.findView(startTime)
+      if (session.isTracked() && viewContext && viewContext.sessionId) {
+        const actionContext = parentContexts.findAction(startTime)
+        const rumContext: RumContext = {
+          applicationId,
+          date: new Date().getTime(),
+          service: configuration.service,
+          session: {
+            // must be computed on each event because synthetics instrumentation can be done after sdk execution
+            // cf https://github.com/puppeteer/puppeteer/issues/3667
+            type: getSessionType(),
+          },
+        }
+        const rumEvent = needToAssembleWithAction(rawRumEvent)
+          ? combine(rumContext, viewContext, actionContext, rawRumEvent)
+          : combine(rumContext, viewContext, rawRumEvent)
+        const serverRumEvent = combine(
+          savedGlobalContext || getGlobalContext(),
+          customerContext,
+          withSnakeCaseKeys(rumEvent)
+        )
+        lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { rumEvent, serverRumEvent })
+      }
+    }
+  )
+}
+
+function needToAssembleWithAction(event: RawRumEvent): event is RumErrorEvent | RumResourceEvent | RumLongTaskEvent {
+  return (
+    [RumEventCategory.ERROR, RumEventCategory.RESOURCE, RumEventCategory.LONG_TASK].indexOf(event.evt.category) !== -1
+  )
+}
+
+function getSessionType() {
+  return (window as BrowserWindow)._DATADOG_SYNTHETICS_BROWSER === undefined ? SessionType.USER : SessionType.SYNTHETICS
+}

--- a/packages/rum/src/batch.ts
+++ b/packages/rum/src/batch.ts
@@ -1,6 +1,7 @@
 import { Batch, combine, Configuration, Context, HttpRequest } from '@datadog/browser-core'
+import { RumEvent } from './assembly'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
-import { RumEvent, RumEventCategory } from './rum'
+import { RumEventCategory } from './rum'
 
 export function startRumBatch(configuration: Configuration, lifeCycle: LifeCycle) {
   const batch = makeRumBatch(configuration, lifeCycle)

--- a/packages/rum/src/batch.ts
+++ b/packages/rum/src/batch.ts
@@ -1,0 +1,81 @@
+import { Batch, combine, Configuration, Context, HttpRequest } from '@datadog/browser-core'
+import { LifeCycle, LifeCycleEventType } from './lifeCycle'
+import { RumEvent, RumEventCategory } from './rum'
+
+export function startRumBatch(configuration: Configuration, lifeCycle: LifeCycle) {
+  const batch = makeRumBatch(configuration, lifeCycle)
+
+  lifeCycle.subscribe(
+    LifeCycleEventType.RUM_EVENT_COLLECTED,
+    ({ rumEvent, serverRumEvent }: { rumEvent: RumEvent; serverRumEvent: Context }) => {
+      if (rumEvent.evt.category === RumEventCategory.VIEW) {
+        batch.upsert(serverRumEvent, rumEvent.view.id)
+      } else {
+        batch.add(serverRumEvent)
+      }
+    }
+  )
+
+  return {
+    stop() {
+      batch.stop()
+    },
+  }
+}
+
+interface RumBatch {
+  add: (message: Context) => void
+  stop: () => void
+  upsert: (message: Context, key: string) => void
+}
+
+function makeRumBatch(configuration: Configuration, lifeCycle: LifeCycle): RumBatch {
+  const primaryBatch = createRumBatch(configuration.rumEndpoint)
+
+  let replicaBatch: Batch | undefined
+  const replica = configuration.replica
+  if (replica !== undefined) {
+    replicaBatch = createRumBatch(replica.rumEndpoint)
+  }
+
+  function createRumBatch(endpointUrl: string) {
+    return new Batch(
+      new HttpRequest(endpointUrl, configuration.batchBytesLimit, true),
+      configuration.maxBatchSize,
+      configuration.batchBytesLimit,
+      configuration.maxMessageSize,
+      configuration.flushTimeout,
+      // FIXME before unload is called twice when replica
+      () => lifeCycle.notify(LifeCycleEventType.BEFORE_UNLOAD)
+    )
+  }
+
+  function withReplicaApplicationId(message: Context) {
+    return combine(message, { application_id: replica!.applicationId })
+  }
+
+  let stopped = false
+  return {
+    add: (message: Context) => {
+      if (stopped) {
+        return
+      }
+      primaryBatch.add(message)
+      if (replicaBatch) {
+        replicaBatch.add(withReplicaApplicationId(message))
+      }
+    },
+    stop: () => {
+      stopped = true
+    },
+    upsert: (message: Context, key: string) => {
+      if (stopped) {
+        return
+      }
+      primaryBatch.upsert(message, key)
+      if (replicaBatch) {
+        replicaBatch.upsert(withReplicaApplicationId(message), key)
+      }
+    },
+  }
+}

--- a/packages/rum/src/index.ts
+++ b/packages/rum/src/index.ts
@@ -1,3 +1,4 @@
 export { Datacenter } from '@datadog/browser-core'
 export { RumUserConfiguration, RumGlobal, datadogRum, InternalContext } from './rum.entry'
-export { RumEventCategory, RumEvent, RumResourceEvent, RumViewEvent, RumUserActionEvent } from './rum'
+export { RumEventCategory, RumResourceEvent, RumViewEvent, RumUserActionEvent } from './rum'
+export { RumEvent } from './assembly'

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -54,22 +54,14 @@ export class LifeCycle {
   ): void
   notify(
     eventType: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
-    {
-      startTime,
-      rawRumEvent,
-      savedGlobalContext,
-      customerContext,
-    }: {
+    data: {
       startTime: number
       rawRumEvent: RawRumEvent
       savedGlobalContext?: Context
       customerContext?: Context
     }
   ): void
-  notify(
-    eventType: LifeCycleEventType.RUM_EVENT_COLLECTED,
-    { rumEvent, serverRumEvent }: { rumEvent: RumEvent; serverRumEvent: Context }
-  ): void
+  notify(eventType: LifeCycleEventType.RUM_EVENT_COLLECTED, data: { rumEvent: RumEvent; serverRumEvent: Context }): void
   notify(eventType: LifeCycleEventType, data?: any) {
     const eventCallbacks = this.callbacks[eventType]
     if (eventCallbacks) {
@@ -109,12 +101,7 @@ export class LifeCycle {
   ): Subscription
   subscribe(
     eventType: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
-    callback: ({
-      startTime,
-      rawRumEvent,
-      savedGlobalContext,
-      customerContext,
-    }: {
+    callback: (data: {
       startTime: number
       rawRumEvent: RawRumEvent
       savedGlobalContext?: Context
@@ -123,7 +110,7 @@ export class LifeCycle {
   ): void
   subscribe(
     eventType: LifeCycleEventType.RUM_EVENT_COLLECTED,
-    callback: ({ rumEvent, serverRumEvent }: { rumEvent: RumEvent; serverRumEvent: Context }) => void
+    callback: (data: { rumEvent: RumEvent; serverRumEvent: Context }) => void
   ): void
   subscribe(eventType: LifeCycleEventType, callback: (data?: any) => void) {
     if (!this.callbacks[eventType]) {

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,7 +1,8 @@
 import { Context, ErrorMessage } from '@datadog/browser-core'
+import { RumEvent } from './assembly'
 import { RumPerformanceEntry } from './performanceCollection'
 import { RequestCompleteEvent, RequestStartEvent } from './requestCollection'
-import { RumEvent } from './rum'
+import { RawRumEvent } from './rum'
 import { AutoActionCreatedEvent, AutoUserAction, CustomUserAction } from './userActionCollection'
 import { View, ViewCreatedEvent } from './viewCollection'
 
@@ -20,6 +21,7 @@ export enum LifeCycleEventType {
   RESOURCE_ADDED_TO_BATCH,
   DOM_MUTATED,
   BEFORE_UNLOAD,
+  RAW_RUM_EVENT_COLLECTED,
   RUM_EVENT_COLLECTED,
 }
 
@@ -49,6 +51,20 @@ export class LifeCycle {
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED
+  ): void
+  notify(
+    eventType: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
+    {
+      startTime,
+      rawRumEvent,
+      savedGlobalContext,
+      customerContext,
+    }: {
+      startTime: number
+      rawRumEvent: RawRumEvent
+      savedGlobalContext?: Context
+      customerContext?: Context
+    }
   ): void
   notify(
     eventType: LifeCycleEventType.RUM_EVENT_COLLECTED,
@@ -91,6 +107,20 @@ export class LifeCycle {
       | LifeCycleEventType.AUTO_ACTION_DISCARDED,
     callback: () => void
   ): Subscription
+  subscribe(
+    eventType: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
+    callback: ({
+      startTime,
+      rawRumEvent,
+      savedGlobalContext,
+      customerContext,
+    }: {
+      startTime: number
+      rawRumEvent: RawRumEvent
+      savedGlobalContext?: Context
+      customerContext?: Context
+    }) => void
+  ): void
   subscribe(
     eventType: LifeCycleEventType.RUM_EVENT_COLLECTED,
     callback: ({ rumEvent, serverRumEvent }: { rumEvent: RumEvent; serverRumEvent: Context }) => void

--- a/packages/rum/src/lifeCycle.ts
+++ b/packages/rum/src/lifeCycle.ts
@@ -1,6 +1,7 @@
 import { Context, ErrorMessage } from '@datadog/browser-core'
 import { RumPerformanceEntry } from './performanceCollection'
 import { RequestCompleteEvent, RequestStartEvent } from './requestCollection'
+import { RumEvent } from './rum'
 import { AutoActionCreatedEvent, AutoUserAction, CustomUserAction } from './userActionCollection'
 import { View, ViewCreatedEvent } from './viewCollection'
 
@@ -19,6 +20,7 @@ export enum LifeCycleEventType {
   RESOURCE_ADDED_TO_BATCH,
   DOM_MUTATED,
   BEFORE_UNLOAD,
+  RUM_EVENT_COLLECTED,
 }
 
 export interface Subscription {
@@ -47,6 +49,10 @@ export class LifeCycle {
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED
+  ): void
+  notify(
+    eventType: LifeCycleEventType.RUM_EVENT_COLLECTED,
+    { rumEvent, serverRumEvent }: { rumEvent: RumEvent; serverRumEvent: Context }
   ): void
   notify(eventType: LifeCycleEventType, data?: any) {
     const eventCallbacks = this.callbacks[eventType]
@@ -85,6 +91,10 @@ export class LifeCycle {
       | LifeCycleEventType.AUTO_ACTION_DISCARDED,
     callback: () => void
   ): Subscription
+  subscribe(
+    eventType: LifeCycleEventType.RUM_EVENT_COLLECTED,
+    callback: ({ rumEvent, serverRumEvent }: { rumEvent: RumEvent; serverRumEvent: Context }) => void
+  ): void
   subscribe(eventType: LifeCycleEventType, callback: (data?: any) => void) {
     if (!this.callbacks[eventType]) {
       this.callbacks[eventType] = []

--- a/packages/rum/src/rum.ts
+++ b/packages/rum/src/rum.ts
@@ -14,13 +14,14 @@ import {
   ResourceKind,
   withSnakeCaseKeys,
 } from '@datadog/browser-core'
+import { startRumAssembly } from './assembly'
 import { startRumBatch } from './batch'
 
 import { buildEnv } from './buildEnv'
 import { startDOMMutationCollection } from './domMutationCollection'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { matchRequestTiming } from './matchRequestTiming'
-import { ActionContext, ParentContexts, startParentContexts, ViewContext } from './parentContexts'
+import { ParentContexts, startParentContexts } from './parentContexts'
 import {
   RumPerformanceLongTaskTiming,
   RumPerformanceResourceTiming,
@@ -133,26 +134,7 @@ export interface RumUserActionEvent {
   }
 }
 
-interface RumContext {
-  applicationId: string
-  date: number
-  session: {
-    type: string
-  }
-}
-
 export type RawRumEvent = RumErrorEvent | RumResourceEvent | RumViewEvent | RumLongTaskEvent | RumUserActionEvent
-export type RumEvent =
-  | RumErrorEvent & ActionContext & ViewContext & RumContext
-  | RumResourceEvent & ActionContext & ViewContext & RumContext
-  | RumViewEvent & ViewContext & RumContext
-  | RumLongTaskEvent & ActionContext & ViewContext & RumContext
-  | RumUserActionEvent & ViewContext & RumContext
-
-enum SessionType {
-  SYNTHETICS = 'synthetics',
-  USER = 'user',
-}
 
 export function startRum(userConfiguration: RumUserConfiguration, getGlobalContext: () => Context) {
   const lifeCycle = new LifeCycle()
@@ -228,23 +210,8 @@ export function startRumEventCollection(
 ) {
   const parentContexts = startParentContexts(lifeCycle, session)
   const batch = startRumBatch(configuration, lifeCycle)
-  const handler = makeRumEventHandler(
-    parentContexts,
-    session,
-    () => ({
-      applicationId,
-      date: new Date().getTime(),
-      service: configuration.service,
-      session: {
-        // must be computed on each event because synthetics instrumentation can be done after sdk execution
-        // cf https://github.com/puppeteer/puppeteer/issues/3667
-        type: getSessionType(),
-      },
-    }),
-    getGlobalContext
-  )
-
-  trackRumEvents(lifeCycle, session, handler)
+  startRumAssembly(applicationId, configuration, lifeCycle, session, parentContexts, getGlobalContext)
+  trackRumEvents(lifeCycle, session)
   startViewCollection(location, lifeCycle)
 
   return {
@@ -258,70 +225,26 @@ export function startRumEventCollection(
   }
 }
 
-interface AssembleWithoutAction {
-  view: ViewContext
-  rum: RumContext
-}
+export function trackRumEvents(lifeCycle: LifeCycle, session: RumSession) {
+  const handler = (
+    startTime: number,
+    rawRumEvent: RawRumEvent,
+    savedGlobalContext?: Context,
+    customerContext?: Context
+  ) =>
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+      customerContext,
+      rawRumEvent,
+      savedGlobalContext,
+      startTime,
+    })
 
-interface AssembleWithAction extends AssembleWithoutAction {
-  action?: ActionContext
-}
-
-type RumEventHandler = <T extends RawRumEvent>(
-  assemble: (event: T, { view, action, rum }: AssembleWithAction) => RumEvent,
-  callback: (message: Context, event: RumEvent) => void
-) => (startTime: number, event: T, customerContext?: Context) => void
-
-function makeRumEventHandler(
-  parentContexts: ParentContexts,
-  session: RumSession,
-  rumContextProvider: () => RumContext,
-  globalContextProvider: () => Context
-): RumEventHandler {
-  return function rumEventHandler<T extends RawRumEvent>(
-    assemble: (event: T, { view, action, rum }: AssembleWithAction) => RumEvent,
-    callback: (message: Context, event: RumEvent) => void
-  ) {
-    return (startTime: number, event: T, savedGlobalContext?: Context, customerContext?: Context) => {
-      const view = parentContexts.findView(startTime)
-      if (session.isTracked() && view && view.sessionId) {
-        const action = parentContexts.findAction(startTime)
-        const rumEvent = assemble(event, { action, view, rum: rumContextProvider() })
-        const message = combine(
-          savedGlobalContext || globalContextProvider(),
-          customerContext,
-          withSnakeCaseKeys(rumEvent)
-        )
-        callback(message, rumEvent)
-      }
-    }
-  }
-}
-
-interface BrowserWindow extends Window {
-  _DATADOG_SYNTHETICS_BROWSER?: unknown
-}
-
-function getSessionType() {
-  return (window as BrowserWindow)._DATADOG_SYNTHETICS_BROWSER === undefined ? SessionType.USER : SessionType.SYNTHETICS
-}
-
-export function trackRumEvents(lifeCycle: LifeCycle, session: RumSession, handler: RumEventHandler) {
-  const onHandledEvent = (serverRumEvent: Context, rumEvent: RumEvent) =>
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { rumEvent, serverRumEvent })
-  const assembleWithoutAction = (event: RumViewEvent | RumUserActionEvent, { view, rum }: AssembleWithoutAction) =>
-    combine(rum, view, event)
-  const assembleWithAction = (
-    event: RumErrorEvent | RumResourceEvent | RumLongTaskEvent,
-    { view, action, rum }: AssembleWithAction
-  ) => combine(rum, view, action, event)
-
-  trackView(lifeCycle, handler(assembleWithoutAction, onHandledEvent))
-  trackErrors(lifeCycle, handler(assembleWithAction, onHandledEvent))
-  trackRequests(lifeCycle, session, handler(assembleWithAction, onHandledEvent))
-  trackPerformanceTiming(lifeCycle, session, handler(assembleWithAction, onHandledEvent))
-  trackCustomUserAction(lifeCycle, handler(assembleWithoutAction, onHandledEvent))
-  trackAutoUserAction(lifeCycle, handler(assembleWithoutAction, onHandledEvent))
+  trackView(lifeCycle, handler)
+  trackErrors(lifeCycle, handler)
+  trackRequests(lifeCycle, session, handler)
+  trackPerformanceTiming(lifeCycle, session, handler)
+  trackCustomUserAction(lifeCycle, handler)
+  trackAutoUserAction(lifeCycle, handler)
 }
 
 export function trackView(lifeCycle: LifeCycle, handler: (startTime: number, event: RumViewEvent) => void) {

--- a/packages/rum/test/assembly.spec.ts
+++ b/packages/rum/test/assembly.spec.ts
@@ -1,0 +1,170 @@
+import { Context } from '@datadog/browser-core'
+import { RumEventCategory } from '../src'
+import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
+import { RawRumEvent } from '../src/rum'
+import { setup, TestSetupBuilder } from './specHelper'
+
+interface ServerRumEvents {
+  application_id: string
+  user_action: {
+    id: string
+  }
+  date: number
+  evt: {
+    category: string
+  }
+  session_id: string
+  view: {
+    id: string
+    referrer: string
+  }
+  network?: {
+    bytes_written: number
+  }
+}
+
+describe('rum assembly', () => {
+  let setupBuilder: TestSetupBuilder
+  let lifeCycle: LifeCycle
+  let setGlobalContext: (context: Context) => void
+  let serverRumEvents: ServerRumEvents[]
+
+  function generateRawRumEvent(
+    category: RumEventCategory,
+    properties?: Partial<RawRumEvent>,
+    savedGlobalContext?: Context,
+    customerContext?: Context
+  ) {
+    const viewEvent = { evt: { category }, ...properties }
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+      customerContext,
+      savedGlobalContext,
+      rawRumEvent: viewEvent as RawRumEvent,
+      startTime: 0,
+    })
+  }
+
+  beforeEach(() => {
+    setupBuilder = setup()
+      .withParentContexts({
+        findAction: () => ({
+          userAction: {
+            id: '7890',
+          },
+        }),
+        findView: () => ({
+          sessionId: '1234',
+          view: {
+            id: 'abcde',
+            referrer: 'url',
+            url: 'url',
+          },
+        }),
+      })
+      .withAssembly()
+    ;({ lifeCycle, setGlobalContext } = setupBuilder.build())
+
+    serverRumEvents = []
+    lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, ({ serverRumEvent }) =>
+      serverRumEvents.push((serverRumEvent as unknown) as ServerRumEvents)
+    )
+  })
+
+  afterEach(() => {
+    setupBuilder.cleanup()
+  })
+
+  describe('events', () => {
+    it('should have snake cased attributes', () => {
+      generateRawRumEvent(RumEventCategory.RESOURCE, { network: { bytesWritten: 2 } })
+
+      expect(serverRumEvents[0].network!.bytes_written).toBe(2)
+    })
+  })
+
+  describe('rum context', () => {
+    it('should be merged with event attributes', () => {
+      generateRawRumEvent(RumEventCategory.VIEW)
+
+      expect(serverRumEvents[0].view.id).toBeDefined()
+      expect(serverRumEvents[0].date).toBeDefined()
+    })
+
+    it('should be snake cased', () => {
+      generateRawRumEvent(RumEventCategory.VIEW)
+
+      expect(serverRumEvents[0].application_id).toBe('appId')
+    })
+
+    it('should be overwritten by event attributes', () => {
+      generateRawRumEvent(RumEventCategory.VIEW, { date: 10 })
+
+      expect(serverRumEvents[0].date).toBe(10)
+    })
+  })
+
+  describe('rum global context', () => {
+    it('should be merged with event attributes', () => {
+      setGlobalContext({ bar: 'foo' })
+      generateRawRumEvent(RumEventCategory.VIEW)
+
+      expect((serverRumEvents[0] as any).bar).toEqual('foo')
+    })
+
+    it('should ignore subsequent context mutation', () => {
+      const globalContext = { bar: 'foo' }
+      setGlobalContext(globalContext)
+      generateRawRumEvent(RumEventCategory.VIEW)
+      delete globalContext.bar
+      generateRawRumEvent(RumEventCategory.VIEW)
+
+      expect((serverRumEvents[0] as any).bar).toEqual('foo')
+      expect((serverRumEvents[1] as any).bar).toBeUndefined()
+    })
+
+    it('should not be automatically snake cased', () => {
+      setGlobalContext({ fooBar: 'foo' })
+      generateRawRumEvent(RumEventCategory.VIEW)
+
+      expect(((serverRumEvents[0] as any) as any).fooBar).toEqual('foo')
+    })
+
+    it('should ignore the current global context when a saved global context is provided', () => {
+      setGlobalContext({ replacedContext: 'b', addedContext: 'x' })
+
+      generateRawRumEvent(RumEventCategory.VIEW, undefined, { replacedContext: 'a' })
+
+      expect((serverRumEvents[0] as any).replacedContext).toEqual('a')
+      expect((serverRumEvents[0] as any).addedContext).toEqual(undefined)
+    })
+  })
+
+  describe('customer context', () => {
+    it('should be merged with event attributes', () => {
+      generateRawRumEvent(RumEventCategory.VIEW, undefined, undefined, { foo: 'bar' })
+
+      expect((serverRumEvents[0] as any).foo).toEqual('bar')
+    })
+
+    it('should not be automatically snake cased', () => {
+      generateRawRumEvent(RumEventCategory.VIEW, undefined, undefined, { fooBar: 'foo' })
+
+      expect(((serverRumEvents[0] as any) as any).fooBar).toEqual('foo')
+    })
+  })
+
+  describe('action context', () => {
+    it('should be added on some event categories', () => {
+      ;[RumEventCategory.RESOURCE, RumEventCategory.LONG_TASK, RumEventCategory.ERROR].forEach((category) => {
+        generateRawRumEvent(category)
+        expect(serverRumEvents[0].user_action.id).toBeDefined()
+        serverRumEvents = []
+      })
+      ;[RumEventCategory.VIEW, RumEventCategory.USER_ACTION].forEach((category) => {
+        generateRawRumEvent(category)
+        expect(serverRumEvents[0].user_action).not.toBeDefined()
+        serverRumEvents = []
+      })
+    })
+  })
+})

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -472,151 +472,6 @@ describe('rum session keep alive', () => {
   })
 })
 
-describe('rum global context', () => {
-  const FAKE_ERROR: Partial<ErrorMessage> = { message: 'test' }
-  let setupBuilder: TestSetupBuilder
-
-  beforeEach(() => {
-    setupBuilder = setup()
-      .withFakeServer()
-      .withRum()
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
-  it('should be added to the request', () => {
-    const { server, lifeCycle, setGlobalContext } = setupBuilder.build()
-    server.requests = []
-
-    setGlobalContext({ bar: 'foo' })
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-
-    expect((getRumMessage(server, 0) as any).bar).toEqual('foo')
-  })
-
-  it('should ignore subsequent context mutation', () => {
-    const { server, lifeCycle, setGlobalContext } = setupBuilder.build()
-    server.requests = []
-
-    const globalContext = { bar: 'foo' }
-    setGlobalContext(globalContext)
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-    delete globalContext.bar
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-
-    expect((getRumMessage(server, 0) as any).bar).toEqual('foo')
-    expect((getRumMessage(server, 1) as any).bar).toBeUndefined()
-  })
-
-  it('should not be automatically snake cased', () => {
-    const { server, lifeCycle, setGlobalContext } = setupBuilder.build()
-    server.requests = []
-
-    setGlobalContext({ fooBar: 'foo' })
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-
-    expect((getRumMessage(server, 0) as any).fooBar).toEqual('foo')
-  })
-})
-
-describe('rum user action', () => {
-  let setupBuilder: TestSetupBuilder
-
-  beforeEach(() => {
-    setupBuilder = setup()
-      .withFakeServer()
-      .withRum()
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
-  it('should not be automatically snake cased', () => {
-    const { server, lifeCycle } = setupBuilder.build()
-    server.requests = []
-
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
-      action: {
-        context: { fooBar: 'foo' },
-        name: 'hello',
-        startTime: 123,
-        type: UserActionType.CUSTOM,
-      },
-      context: {},
-    })
-
-    expect((getRumMessage(server, 0) as any).fooBar).toEqual('foo')
-  })
-
-  it('should ignore the current global context when a saved global context is provided', () => {
-    const { setGlobalContext, server, lifeCycle } = setupBuilder.build()
-    server.requests = []
-
-    setGlobalContext({ replacedContext: 'b', addedContext: 'x' })
-
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
-      action: {
-        context: {},
-        name: 'hello',
-        startTime: 123,
-        type: UserActionType.CUSTOM,
-      },
-      context: { replacedContext: 'a' },
-    })
-
-    expect((getRumMessage(server, 0) as any).replacedContext).toEqual('a')
-    expect((getRumMessage(server, 0) as any).addedContext).toEqual(undefined)
-  })
-})
-
-describe('rum context', () => {
-  const FAKE_ERROR: Partial<ErrorMessage> = { message: 'test' }
-  let setupBuilder: TestSetupBuilder
-
-  beforeEach(() => {
-    setupBuilder = setup()
-      .withFakeServer()
-      .withRum()
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
-  it('should be snake cased and added to request', () => {
-    const { server } = setupBuilder.build()
-    const initialRequests = getServerRequestBodies<ExpectedRequestBody>(server)
-    expect(initialRequests[0].application_id).toEqual('appId')
-  })
-
-  it('should be merge with event attributes', () => {
-    const { server } = setupBuilder.build()
-    const initialRequests = getServerRequestBodies<ExpectedRequestBody>(server)
-    expect(initialRequests[0].view.referrer).toBeDefined()
-    expect(initialRequests[0].view.id).toBeDefined()
-  })
-
-  it('should be overwritten by event attributes', () => {
-    const { server, lifeCycle, clock } = setupBuilder.withFakeClock().build()
-
-    const initialRequests = getServerRequestBodies<ExpectedRequestBody>(server)
-    expect(initialRequests[0].evt.category).toEqual('view')
-    const initialViewDate = initialRequests[0].date
-
-    // generate view update
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-    server.requests = []
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-
-    const subsequentRequests = getServerRequestBodies<ExpectedRequestBody>(server)
-    expect(subsequentRequests[0].evt.category).toEqual('view')
-    expect(subsequentRequests[0].date).toEqual(initialViewDate)
-  })
-})
-
 describe('rum internal context', () => {
   let setupBuilder: TestSetupBuilder
 
@@ -683,7 +538,7 @@ describe('rum internal context', () => {
   })
 })
 
-describe('rum event assembly', () => {
+describe('rum view url', () => {
   const FAKE_ERROR: Partial<ErrorMessage> = { message: 'test' }
   const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
     domComplete: 456,
@@ -706,7 +561,7 @@ describe('rum event assembly', () => {
     setupBuilder.cleanup()
   })
 
-  it('should sets the view URL on long task events', () => {
+  it('should sets the view URL on events', () => {
     const { server, lifeCycle } = setupBuilder.withFakeLocation('http://foo.com/').build()
 
     server.requests = []

--- a/packages/rum/test/rum.spec.ts
+++ b/packages/rum/test/rum.spec.ts
@@ -1,5 +1,6 @@
 import { ErrorMessage, isIE } from '@datadog/browser-core'
 import sinon from 'sinon'
+import { RumEvent } from '../src'
 
 import { LifeCycle, LifeCycleEventType } from '../src/lifeCycle'
 import { RumPerformanceNavigationTiming, RumPerformanceResourceTiming } from '../src/performanceCollection'
@@ -8,13 +9,12 @@ import {
   doGetInternalContext,
   handleResourceEntry,
   RawRumEvent,
-  RumEvent,
   RumResourceEvent,
   RumViewEvent,
   trackView,
 } from '../src/rum'
 import { RumSession } from '../src/rumSession'
-import { AutoUserAction, CustomUserAction, UserActionType } from '../src/userActionCollection'
+import { AutoUserAction, UserActionType } from '../src/userActionCollection'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD, View } from '../src/viewCollection'
 import { setup, TestSetupBuilder } from './specHelper'
 

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -8,11 +8,11 @@ import {
   SPEC_ENDPOINTS,
 } from '@datadog/browser-core'
 import sinon from 'sinon'
+import { startRumAssembly } from '../src/assembly'
 import { LifeCycle } from '../src/lifeCycle'
 import { ParentContexts, startParentContexts } from '../src/parentContexts'
 import { startPerformanceCollection } from '../src/performanceCollection'
 import { startRumEventCollection } from '../src/rum'
-import { InternalContext } from '../src/rum.entry'
 import { RumSession } from '../src/rumSession'
 import { startUserActionCollection } from '../src/userActionCollection'
 import { startViewCollection } from '../src/viewCollection'
@@ -28,7 +28,8 @@ export interface TestSetupBuilder {
   withViewCollection: () => TestSetupBuilder
   withUserActionCollection: () => TestSetupBuilder
   withPerformanceCollection: () => TestSetupBuilder
-  withParentContexts: () => TestSetupBuilder
+  withParentContexts: (stub?: Partial<ParentContexts>) => TestSetupBuilder
+  withAssembly: () => TestSetupBuilder
   withFakeClock: () => TestSetupBuilder
   withFakeServer: () => TestSetupBuilder
   withPerformanceObserverStubBuilder: () => TestSetupBuilder
@@ -72,6 +73,7 @@ export function setup(): TestSetupBuilder {
     isEnabled: () => true,
     maxBatchSize: 1,
   }
+  const FAKE_APP_ID = 'appId'
 
   const setupBuilder = {
     withFakeLocation(initialUrl: string) {
@@ -101,7 +103,7 @@ export function setup(): TestSetupBuilder {
       buildTasks.push(() => {
         let stopRum
         ;({ parentContexts, stop: stopRum } = startRumEventCollection(
-          'appId',
+          FAKE_APP_ID,
           fakeLocation as Location,
           lifeCycle,
           configuration as Configuration,
@@ -111,6 +113,19 @@ export function setup(): TestSetupBuilder {
         cleanupTasks.push(stopRum)
       })
 
+      return setupBuilder
+    },
+    withAssembly() {
+      buildTasks.push(() => {
+        startRumAssembly(
+          FAKE_APP_ID,
+          configuration as Configuration,
+          lifeCycle,
+          session,
+          parentContexts,
+          () => globalContext
+        )
+      })
       return setupBuilder
     },
     withViewCollection() {
@@ -131,7 +146,11 @@ export function setup(): TestSetupBuilder {
       buildTasks.push(() => startPerformanceCollection(lifeCycle, configuration as Configuration))
       return setupBuilder
     },
-    withParentContexts() {
+    withParentContexts(stub?: Partial<ParentContexts>) {
+      if (stub) {
+        parentContexts = stub as ParentContexts
+        return setupBuilder
+      }
       buildTasks.push(() => {
         parentContexts = startParentContexts(lifeCycle, session)
         cleanupTasks.push(() => {


### PR DESCRIPTION
## Motivation

Split responsibilities, preliminary work for v2 format

## Changes

- trackRumEvents send `RAW_RUM_EVENT_COLLECTED` life cycle events
- assembly listen `RAW_RUM_EVENT_COLLECTED` and send `RUM_EVENT_COLLECTED`
- batch listen `RUM_EVENT_COLLECTED`

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
