### PR TITLE
✅[RUMF-732] e2e:bs add spec file retries

### DIFF
--- a/test/e2e/wdio.bs.conf.js
+++ b/test/e2e/wdio.bs.conf.js
@@ -1,12 +1,13 @@
 const baseConf = require('./wdio.base.conf')
 const browsers = require('./browsers.conf')
-const { getBuildInfos, getIp } = require('../utils')
+const { getBuildInfos } = require('../utils')
 
 exports.config = {
   ...baseConf,
 
   capabilities: Object.values(browsers).map((browser) => ({
     ...browser,
+    browserName: `${browser.browser} ${browser.browser_version || ''}`,
     'browserstack.video': false,
     'browserstack.local': true,
     project: 'browser sdk e2e',

--- a/test/e2e/wdio.bs.conf.js
+++ b/test/e2e/wdio.bs.conf.js
@@ -5,6 +5,8 @@ const { getBuildInfos } = require('../utils')
 exports.config = {
   ...baseConf,
 
+  specFileRetries: 1,
+
   capabilities: Object.values(browsers).map((browser) => ({
     ...browser,
     browserName: `${browser.browser} ${browser.browser_version || ''}`,


### PR DESCRIPTION
## Motivation

Stabilise bs e2e tests

## Changes

- add 1 spec file retries
- add browser name to differentiate runner logs

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
