### PR TITLE
 ✨ [RUMF-534] implement logs.onReady and rum.onReady 

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   BuildEnv,
   BuildMode,
   Datacenter,
+  defineGlobal,
   makeGlobal,
   commonInit,
   checkCookiesAuthorized,

--- a/packages/logs/src/logs.entry.ts
+++ b/packages/logs/src/logs.entry.ts
@@ -5,6 +5,7 @@ import {
   Context,
   ContextValue,
   createContextManager,
+  defineGlobal,
   getGlobalObject,
   isPercentage,
   makeGlobal,
@@ -33,8 +34,7 @@ export const datadogLogs = makeLogsGlobal(startLogs)
 interface BrowserWindow extends Window {
   DD_LOGS?: LogsGlobal
 }
-
-getGlobalObject<BrowserWindow>().DD_LOGS = datadogLogs
+defineGlobal(getGlobalObject<BrowserWindow>(), 'DD_LOGS', datadogLogs)
 
 export type StartLogs = typeof startLogs
 

--- a/packages/rum/src/rum.entry.ts
+++ b/packages/rum/src/rum.entry.ts
@@ -7,6 +7,7 @@ import {
   ContextValue,
   createContextManager,
   deepClone,
+  defineGlobal,
   getGlobalObject,
   isPercentage,
   makeGlobal,
@@ -42,8 +43,7 @@ export const datadogRum = makeRumGlobal(startRum)
 interface BrowserWindow extends Window {
   DD_RUM?: RumGlobal
 }
-
-getGlobalObject<BrowserWindow>().DD_RUM = datadogRum
+defineGlobal(getGlobalObject<BrowserWindow>(), 'DD_RUM', datadogRum)
 
 export type StartRum = typeof startRum
 

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -31,22 +31,18 @@ export const DEFAULT_SETUPS = [
 export function asyncSetup(options: SetupOptions) {
   let body = options.body || ''
 
+  function formatSnippet(url: string, globalName: string) {
+    return `(function(r,a,w,l,s) {
+r=r[s]=r[s]||{q:[],onReady:function(c){r.q.push(c)}}
+s=a.createElement(w);s.async=1;s.src=l
+l=a.getElementsByTagName(w)[0];l.parentNode.insertBefore(s,l)
+})(window,document,'script','${url}','${globalName}')`
+  }
+
   if (options.logs) {
     body += html`
-      <script type="text/javascript">
-        window.addEventListener('load', () => {
-          const logs = document.createElement('script')
-          logs.src = './datadog-logs.js'
-          document.getElementsByTagName('head')[0].appendChild(logs)
-        })
-
-        window.DD_LOGS = window.DD_LOGS || {
-          onReady: function(c) {
-            DD_LOGS.q.push(c)
-          },
-          q: [],
-        }
-
+      <script>
+        ${formatSnippet('./datadog-logs.js', 'DD_LOGS')}
         DD_LOGS.onReady(function() {
           DD_LOGS.init(${formatLogsOptions(options.logs)})
         })
@@ -57,19 +53,7 @@ export function asyncSetup(options: SetupOptions) {
   if (options.rum) {
     body += html`
       <script type="text/javascript">
-        window.addEventListener('load', () => {
-          const logs = document.createElement('script')
-          logs.src = './datadog-rum.js'
-          document.getElementsByTagName('head')[0].appendChild(logs)
-        })
-
-        window.DD_RUM = window.DD_RUM || {
-          onReady: function(c) {
-            DD_RUM.q.push(c)
-          },
-          q: [],
-        }
-
+        ${formatSnippet('./datadog-rum.js', 'DD_RUM')}
         DD_RUM.onReady(function() {
           DD_RUM.init(${formatRumOptions(options.rum)})
         })

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -37,10 +37,18 @@ export function asyncSetup(options: SetupOptions) {
         window.addEventListener('load', () => {
           const logs = document.createElement('script')
           logs.src = './datadog-logs.js'
-          logs.onload = () => {
-            DD_LOGS.init(${formatLogsOptions(options.logs)})
-          }
           document.getElementsByTagName('head')[0].appendChild(logs)
+        })
+
+        window.DD_LOGS = window.DD_LOGS || {
+          onReady: function(c) {
+            DD_LOGS.q.push(c)
+          },
+          q: [],
+        }
+
+        DD_LOGS.onReady(function() {
+          DD_LOGS.init(${formatLogsOptions(options.logs)})
         })
       </script>
     `
@@ -52,10 +60,18 @@ export function asyncSetup(options: SetupOptions) {
         window.addEventListener('load', () => {
           const logs = document.createElement('script')
           logs.src = './datadog-rum.js'
-          logs.onload = () => {
-            DD_RUM.init(${formatRumOptions(options.rum)})
-          }
           document.getElementsByTagName('head')[0].appendChild(logs)
+        })
+
+        window.DD_RUM = window.DD_RUM || {
+          onReady: function(c) {
+            DD_RUM.q.push(c)
+          },
+          q: [],
+        }
+
+        DD_RUM.onReady(function() {
+          DD_RUM.init(${formatRumOptions(options.rum)})
         })
       </script>
     `

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -32,10 +32,10 @@ export function asyncSetup(options: SetupOptions) {
   let body = options.body || ''
 
   function formatSnippet(url: string, globalName: string) {
-    return `(function(r,a,w,l,s) {
-r=r[s]=r[s]||{q:[],onReady:function(c){r.q.push(c)}}
-s=a.createElement(w);s.async=1;s.src=l
-l=a.getElementsByTagName(w)[0];l.parentNode.insertBefore(s,l)
+    return `(function(h,o,u,n,d) {
+h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+d=o.createElement(u);d.async=1;d.src=n
+n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
 })(window,document,'script','${url}','${globalName}')`
   }
 


### PR DESCRIPTION
## Motivation

Have a proper way to execute code when the SDK is ready.

## Changes

* Implement `logs.onReady` and `rum.onReady` to execute previously stored callbacks
* Change the e2e tests async setup to use the new official async snippet

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
