### PR TITLE
✅[RUMF-732] use stub instead or real xhr in unit test

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -27,6 +27,7 @@ dev,karma-chrome-launcher,MIT,Copyright 2011-2013 Google Inc.
 dev,karma-coverage-istanbul-reporter,MIT,Copyright 2017 Matt Lewis
 dev,karma-jasmine,MIT,Copyright 2011-2013 Google Inc.
 dev,karma-junit-reporter,MIT,Copyright (C) 2011-2013 Google, Inc.
+dev,karma-jasmine-seed-reporter,MIT,Copyright 2018 ThoughtWorks, Inc.
 dev,karma-spec-reporter,MIT,Copyright 2015 Michael Lex
 dev,karma-webpack,MIT,Copyright JS Foundation and other contributors
 dev,lerna,MIT,Copyright 2015-present Lerna Contributors

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage-istanbul-reporter": "2.1.1",
     "karma-jasmine": "3.1.1",
+    "karma-jasmine-seed-reporter": "0.2.0",
     "karma-junit-reporter": "2.0.1",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "4.0.2",

--- a/packages/core/src/specHelper.ts
+++ b/packages/core/src/specHelper.ts
@@ -168,17 +168,28 @@ class StubXhr {
     this.readyState = XMLHttpRequest.DONE
     this.onreadystatechange()
     if (status >= 200 && status < 500) {
-      this.element.dispatchEvent(new Event('load'))
+      this.element.dispatchEvent(createNewEvent('load'))
     }
     if (status >= 500) {
-      this.element.dispatchEvent(new Event('error'))
+      this.element.dispatchEvent(createNewEvent('error'))
     }
-    this.element.dispatchEvent(new Event('loadend'))
+    this.element.dispatchEvent(createNewEvent('loadend'))
   }
 
   addEventListener(name: string, callback: () => void) {
     this.element.addEventListener(name, callback)
   }
+}
+
+function createNewEvent(eventName: string) {
+  let event
+  if (typeof Event === 'function') {
+    event = new Event(eventName)
+  } else {
+    event = document.createEvent('Event')
+    event.initEvent(eventName, true, true)
+  }
+  return event
 }
 
 export function stubXhr() {

--- a/packages/core/src/specHelper.ts
+++ b/packages/core/src/specHelper.ts
@@ -147,10 +147,10 @@ class StubXhr {
   public readyState: number = XMLHttpRequest.UNSENT
   public onreadystatechange: () => void = noop
 
-  private element: HTMLDivElement
+  private fakeEventTarget: HTMLDivElement
 
   constructor() {
-    this.element = document.createElement('div')
+    this.fakeEventTarget = document.createElement('div')
   }
 
   // tslint:disable:no-empty
@@ -168,16 +168,20 @@ class StubXhr {
     this.readyState = XMLHttpRequest.DONE
     this.onreadystatechange()
     if (status >= 200 && status < 500) {
-      this.element.dispatchEvent(createNewEvent('load'))
+      this.dispatchEvent('load')
     }
     if (status >= 500) {
-      this.element.dispatchEvent(createNewEvent('error'))
+      this.dispatchEvent('error')
     }
-    this.element.dispatchEvent(createNewEvent('loadend'))
+    this.dispatchEvent('loadend')
   }
 
   addEventListener(name: string, callback: () => void) {
-    this.element.addEventListener(name, callback)
+    this.fakeEventTarget.addEventListener(name, callback)
+  }
+
+  private dispatchEvent(name: string) {
+    this.fakeEventTarget.dispatchEvent(createNewEvent(name))
   }
 }
 

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -41,19 +41,5 @@ module.exports = {
     stats: 'errors-only',
     logLevel: 'warn',
   },
-  beforeMiddleware: ['custom'],
-  plugins: ['karma-*', { 'middleware:custom': ['factory', CustomMiddlewareFactory] }],
-}
-
-function CustomMiddlewareFactory() {
-  return function(request, response, next) {
-    if (request.url === '/ok') {
-      response.writeHead(200)
-      return response.end('ok')
-    }
-    if (request.url === '/throw') {
-      throw 'expected server error'
-    }
-    return next()
-  }
+  plugins: ['karma-*'],
 }

--- a/test/unit/karma.bs.conf.js
+++ b/test/unit/karma.bs.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
   config.set({
     ...karmaBaseConf,
     plugins: [...karmaBaseConf.plugins, 'karma-browserstack-launcher'],
-    reporters: [...karmaBaseConf.reporters, 'BrowserStack'],
+    reporters: [...karmaBaseConf.reporters, 'BrowserStack', 'jasmine-seed'],
     browsers: Object.keys(browsers),
     concurrency: 5,
     hostname: getIp(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5591,6 +5591,11 @@ karma-coverage-istanbul-reporter@2.1.1:
     istanbul-api "^2.1.6"
     minimatch "^3.0.4"
 
+karma-jasmine-seed-reporter@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/karma-jasmine-seed-reporter/-/karma-jasmine-seed-reporter-0.2.0.tgz#a8f7d4c66d23d756deb63cb8dac88e0e058958b9"
+  integrity sha512-15d6kNFakKfqNnCNQoRzJpivwbaAjaEdOBfBf4lojLUyLDRkSKhFEujL/kPI4eqM4XtYzHGpuxh3M+MSTBQBjA==
+
 karma-jasmine@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-3.1.1.tgz#f592b253e7619a8d84559d7daf473a647498ade8"


### PR DESCRIPTION
## Motivation

unit test on bs are brittle because requests to karma middleware are randomly not completing

## Changes

- use xhr stub to avoid any issue with real requests during unit tests
- add seed reporter to ease ci failure reproduction

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
