### PR TITLE
:bug: [RUMF-742] fix cookie creation domain when trackSessionAcrossSubdomains: true

### DIFF
--- a/packages/core/src/cookie.ts
+++ b/packages/core/src/cookie.ts
@@ -1,4 +1,4 @@
-import { findCommaSeparatedValue, ONE_SECOND } from './utils'
+import { findCommaSeparatedValue, generateUUID, ONE_SECOND } from './utils'
 
 export const COOKIE_ACCESS_DELAY = ONE_SECOND
 
@@ -80,7 +80,9 @@ export function areCookiesAuthorized(options: CookieOptions): boolean {
 let getCurrentSiteCache: string | undefined
 export function getCurrentSite() {
   if (getCurrentSiteCache === undefined) {
-    const testCookieName = 'dd_site_test'
+    // Use a unique cookie name to avoid issues when the SDK is initialized multiple times during
+    // the test cookie lifetime
+    const testCookieName = `dd_site_test_${generateUUID()}`
     const testCookieValue = 'test'
 
     const domainLevels = window.location.hostname.split('.')

--- a/packages/core/src/cookie.ts
+++ b/packages/core/src/cookie.ts
@@ -77,15 +77,19 @@ export function areCookiesAuthorized(options: CookieOptions): boolean {
  * strategy: find the minimal domain on which cookies are allowed to be set
  * https://web.dev/same-site-same-origin/#site
  */
+let getCurrentSiteCache: string | undefined
 export function getCurrentSite() {
-  const testCookieName = 'dd_site_test'
-  const testCookieValue = 'test'
+  if (getCurrentSiteCache === undefined) {
+    const testCookieName = 'dd_site_test'
+    const testCookieValue = 'test'
 
-  const domainLevels = window.location.hostname.split('.')
-  let candidateDomain = domainLevels.pop()
-  while (domainLevels.length && !getCookie(testCookieName)) {
-    candidateDomain = `${domainLevels.pop()}.${candidateDomain}`
-    setCookie(testCookieName, testCookieValue, ONE_SECOND, { domain: candidateDomain })
+    const domainLevels = window.location.hostname.split('.')
+    let candidateDomain = domainLevels.pop()
+    while (domainLevels.length && !getCookie(testCookieName)) {
+      candidateDomain = `${domainLevels.pop()}.${candidateDomain}`
+      setCookie(testCookieName, testCookieValue, ONE_SECOND, { domain: candidateDomain })
+    }
+    getCurrentSiteCache = candidateDomain
   }
-  return candidateDomain
+  return getCurrentSiteCache
 }

--- a/packages/core/src/cookie.ts
+++ b/packages/core/src/cookie.ts
@@ -62,7 +62,9 @@ export function areCookiesAuthorized(options: CookieOptions): boolean {
     return false
   }
   try {
-    const testCookieName = 'dd_cookie_test'
+    // Use a unique cookie name to avoid issues when the SDK is initialized multiple times during
+    // the test cookie lifetime
+    const testCookieName = `dd_cookie_test_${generateUUID()}`
     const testCookieValue = 'test'
     setCookie(testCookieName, testCookieValue, ONE_SECOND, options)
     return getCookie(testCookieName) === testCookieValue


### PR DESCRIPTION
## Motivation

The function `getCurrentSite` can yield invalid result when a SDK is initialized multiple times within 1 second.

## Changes

* Cache `getCurrentSite` result
* Use an unique cookie name for `getCurrentSite`

## Testing

Setup the RUM SDK on a test page, and print its internal context. Beforehand, clear any cookie on the current domain. Then, refresh the page quickly 2 times: the session should stay the same, and the cookie should be created with a valid domain.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
