### PR TITLE
🐛 [RUMF-745] fix V2 context

### DIFF
--- a/packages/rum/src/domain/assemblyV2.spec.ts
+++ b/packages/rum/src/domain/assemblyV2.spec.ts
@@ -10,6 +10,7 @@ interface ServerRumEvents {
   action: {
     id: string
   }
+  context: any
   date: number
   type: string
   session: {
@@ -114,7 +115,7 @@ describe('rum assembly v2', () => {
       setGlobalContext({ bar: 'foo' })
       generateRawRumEvent(RumEventType.VIEW)
 
-      expect((serverRumEvents[0] as any).bar).toEqual('foo')
+      expect((serverRumEvents[0].context as any).bar).toEqual('foo')
     })
 
     it('should ignore subsequent context mutation', () => {
@@ -124,15 +125,15 @@ describe('rum assembly v2', () => {
       delete globalContext.bar
       generateRawRumEvent(RumEventType.VIEW)
 
-      expect((serverRumEvents[0] as any).bar).toEqual('foo')
-      expect((serverRumEvents[1] as any).bar).toBeUndefined()
+      expect((serverRumEvents[0].context as any).bar).toEqual('foo')
+      expect((serverRumEvents[1].context as any).bar).toBeUndefined()
     })
 
     it('should not be automatically snake cased', () => {
       setGlobalContext({ fooBar: 'foo' })
       generateRawRumEvent(RumEventType.VIEW)
 
-      expect(((serverRumEvents[0] as any) as any).fooBar).toEqual('foo')
+      expect((serverRumEvents[0].context as any).fooBar).toEqual('foo')
     })
 
     it('should ignore the current global context when a saved global context is provided', () => {
@@ -140,8 +141,8 @@ describe('rum assembly v2', () => {
 
       generateRawRumEvent(RumEventType.VIEW, undefined, { replacedContext: 'a' })
 
-      expect((serverRumEvents[0] as any).replacedContext).toEqual('a')
-      expect((serverRumEvents[0] as any).addedContext).toEqual(undefined)
+      expect((serverRumEvents[0].context as any).replacedContext).toEqual('a')
+      expect((serverRumEvents[0].context as any).addedContext).toEqual(undefined)
     })
   })
 
@@ -149,13 +150,13 @@ describe('rum assembly v2', () => {
     it('should be merged with event attributes', () => {
       generateRawRumEvent(RumEventType.VIEW, undefined, undefined, { foo: 'bar' })
 
-      expect((serverRumEvents[0] as any).foo).toEqual('bar')
+      expect((serverRumEvents[0].context as any).foo).toEqual('bar')
     })
 
     it('should not be automatically snake cased', () => {
       generateRawRumEvent(RumEventType.VIEW, undefined, undefined, { fooBar: 'foo' })
 
-      expect(((serverRumEvents[0] as any) as any).fooBar).toEqual('foo')
+      expect(((serverRumEvents[0].context as any) as any).fooBar).toEqual('foo')
     })
   })
 

--- a/packages/rum/src/domain/assemblyV2.spec.ts
+++ b/packages/rum/src/domain/assemblyV2.spec.ts
@@ -156,7 +156,7 @@ describe('rum assembly v2', () => {
     it('should not be automatically snake cased', () => {
       generateRawRumEvent(RumEventType.VIEW, undefined, undefined, { fooBar: 'foo' })
 
-      expect(((serverRumEvents[0].context as any) as any).fooBar).toEqual('foo')
+      expect((serverRumEvents[0].context as any).fooBar).toEqual('foo')
     })
   })
 

--- a/packages/rum/src/domain/assemblyV2.ts
+++ b/packages/rum/src/domain/assemblyV2.ts
@@ -62,11 +62,8 @@ export function startRumAssemblyV2(
         const rumEvent = needToAssembleWithAction(rawRumEvent)
           ? combine(rumContext, viewContext, actionContext, rawRumEvent)
           : combine(rumContext, viewContext, rawRumEvent)
-        const serverRumEvent = combine(
-          { context: savedGlobalContext || getGlobalContext() },
-          { context: customerContext },
-          withSnakeCaseKeys(rumEvent)
-        )
+        const serverRumEvent = withSnakeCaseKeys(rumEvent)
+        serverRumEvent.context = combine(savedGlobalContext || getGlobalContext(), customerContext)
         lifeCycle.notify(LifeCycleEventType.RUM_EVENT_V2_COLLECTED, { rumEvent, serverRumEvent })
       }
     }

--- a/packages/rum/src/domain/assemblyV2.ts
+++ b/packages/rum/src/domain/assemblyV2.ts
@@ -63,8 +63,8 @@ export function startRumAssemblyV2(
           ? combine(rumContext, viewContext, actionContext, rawRumEvent)
           : combine(rumContext, viewContext, rawRumEvent)
         const serverRumEvent = combine(
-          savedGlobalContext || getGlobalContext(),
-          customerContext,
+          { context: savedGlobalContext || getGlobalContext() },
+          { context: customerContext },
           withSnakeCaseKeys(rumEvent)
         )
         lifeCycle.notify(LifeCycleEventType.RUM_EVENT_V2_COLLECTED, { rumEvent, serverRumEvent })


### PR DESCRIPTION
## Motivation

in v2, customer attributes are encapsulated in a context attribute

## Changes

move customer attribute to context

## Testing

unit tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
