### PR TITLE
👷 [RUMF-750] add the resource_group gitlab option to browserstack tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,7 @@ unit-bs:
       - master
       - tags
   stage: browserstack
+  resource_group: browserstack
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
   artifacts:
@@ -119,6 +120,7 @@ e2e-bs:
       - master
       - tags
   stage: browserstack
+  resource_group: browserstack
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
   artifacts:


### PR DESCRIPTION
## Motivation

Avoid running multiple browserstack CI jobs in parallel to comply to the parallel test quota.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

CI only

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
