### PR TITLE
👷 [RUMF-751] only use the 'bundle' setup on BS by default

### DIFF
--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -22,11 +22,17 @@ export interface SetupOptions {
 
 export type SetupFactory = (options: SetupOptions) => string
 
-export const DEFAULT_SETUPS = [
-  { name: 'async', factory: asyncSetup },
-  { name: 'npm', factory: npmSetup },
-  { name: 'bundle', factory: bundleSetup },
-]
+const isBrowserStack =
+  browser.config.services &&
+  browser.config.services.some((service) => (Array.isArray(service) ? service[0] : service) === 'browserstack')
+
+export const DEFAULT_SETUPS = isBrowserStack
+  ? [{ name: 'bundle', factory: bundleSetup }]
+  : [
+      { name: 'async', factory: asyncSetup },
+      { name: 'npm', factory: npmSetup },
+      { name: 'bundle', factory: bundleSetup },
+    ]
 
 export function asyncSetup(options: SetupOptions) {
   let body = options.body || ''


### PR DESCRIPTION
## Motivation

Limit e2e-bs job flakiness.

## Changes

By default, only run tests with the 'bundle' setup on BS

## Testing

CI only

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
