### PR TITLE
[RUMF-752] restore retry strategy on session creation failure

### DIFF
--- a/scripts/bs-wrapper.js
+++ b/scripts/bs-wrapper.js
@@ -1,14 +1,36 @@
 'use strict'
 
-const execSync = require('child_process').execSync
+const exec = require('child_process').exec
 const request = require('request')
 
 const AVAILABILITY_CHECK_DELAY = 30_000
 const RUNNING_BUILDS_API = `https://${process.env.BS_USERNAME}:${process.env.BS_ACCESS_KEY}@api.browserstack.com/automate/builds.json?status=running`
+const COMMAND = `yarn ${process.argv.slice(2).join(' ')}`
+const RETRY_DELAY = 30_000
+const MAX_RETRY_COUNT = 3
+
+const TEST_STATUS_DEFINITIVE_FAILURE = 'definitive_failure'
+const TEST_STATUS_RECOVERABLE_FAILURE = 'recoverable_failure'
+const TEST_STATUS_SUCCESS = 'success'
+
+main()
+  .then((status) => process.exit(status === TEST_STATUS_SUCCESS ? 0 : 1))
+  .catch((error) => {
+    console.log(error)
+    process.exit(1)
+  })
 
 async function main() {
-  await waitForAvailability()
-  execSync(`yarn ${process.argv.slice(2).join(' ')}`, { stdio: 'inherit' })
+  for (let retryCount = 0; retryCount < MAX_RETRY_COUNT; retryCount += 1) {
+    await waitForAvailability()
+    const status = await runTests()
+    if (status !== TEST_STATUS_RECOVERABLE_FAILURE) {
+      return status
+    }
+    console.log('tests failed, waiting to retry...')
+    await timeout(RETRY_DELAY)
+  }
+  return TEST_STATUS_DEFINITIVE_FAILURE
 }
 
 async function waitForAvailability() {
@@ -29,10 +51,35 @@ function hasRunningBuild() {
   })
 }
 
+function runTests() {
+  return new Promise((resolve) => {
+    let logs = ''
+    const current = exec(COMMAND)
+    current.stdout.pipe(process.stdout)
+    current.stdout.on('data', (data) => {
+      logs += data
+
+      if (hasSessionCreationFailure(logs)) {
+        current.kill('SIGTERM')
+      }
+    })
+
+    current.on('exit', (code) => {
+      if (code === 0) {
+        resolve(TEST_STATUS_SUCCESS)
+      } else if (hasSessionCreationFailure(logs)) {
+        resolve(TEST_STATUS_RECOVERABLE_FAILURE)
+      } else {
+        resolve(TEST_STATUS_DEFINITIVE_FAILURE)
+      }
+    })
+  })
+}
+
+function hasSessionCreationFailure(logs) {
+  return logs.includes('@wdio/runner: Error: Failed to create session')
+}
+
 function timeout(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
-
-main()
-  .then(() => process.exit(0))
-  .catch(() => process.exit(1))

--- a/scripts/bs-wrapper.js
+++ b/scripts/bs-wrapper.js
@@ -77,7 +77,7 @@ function runTests() {
 }
 
 function hasSessionCreationFailure(logs) {
-  return logs.includes('@wdio/runner: Error: Failed to create session')
+  return logs.includes('Failed to create session.')
 }
 
 function timeout(ms) {


### PR DESCRIPTION
## Motivation

Retry e2e-bs test when wdio fails to create the browserstack session

## Changes

Restore the retry strategy by checking the test stdout to look for specific error messages.

## Testing

CI only

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
