### PR TITLE
[RUMF-753] ✅ bump BrowserStack Edge version

### DIFF
--- a/test/browsers.conf.js
+++ b/test/browsers.conf.js
@@ -1,10 +1,10 @@
-// Capabilities `curl -u "user:key" https://api.browserstack.com/automate/browsers.json`
+// Capabilities: https://www.browserstack.com/automate/capabilities
 
 module.exports = {
   EDGE: {
     base: 'BrowserStack',
     browser: 'Edge',
-    browser_version: '18.0',
+    browser_version: '86',
     os: 'Windows',
     os_version: '10',
   },

--- a/test/e2e/browsers.conf.js
+++ b/test/e2e/browsers.conf.js
@@ -2,7 +2,14 @@ const browsers = require('../browsers.conf')
 
 module.exports = [
   browsers['SAFARI'],
-  browsers['EDGE'],
+  {
+    ...browsers['EDGE'],
+    // Without this specific version, execute and executeAsync fails on Edge.
+    'browserstack.selenium_version': '3.5.2',
+    // Note: more recent versions of selenium 3 have the same issue, but selenium 4 seems to be
+    // fine:
+    // 'browserstack.selenium_version': '4.0.0-alpha-6',
+  },
   browsers['FIREFOX'],
   {
     ...browsers['CHROME_MOBILE'],

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -35,9 +35,6 @@ describe('rum resources', () => {
   createTest("don't track disallowed cross origin xhr timings")
     .withRum()
     .run(async ({ crossOriginUrl, events }) => {
-      if (browser.capabilities.browserName === 'MicrosoftEdge') {
-        pending('Edge 18 seems to track cross origin xhr timings anyway')
-      }
       await sendXhr(`${crossOriginUrl}/ok?duration=${REQUEST_DURATION}`)
       await flushEvents()
       const resourceEvent = events.rumResources.find((r) => r.http.url.includes('/ok'))!


### PR DESCRIPTION
## Motivation

Mitigation for https://datadoghq.atlassian.net/browse/RUMF-753. Edge 18 is outdated and have a tiny market share, let's support the last version of Edge instead.

## Changes

Update Edge version to 86 in BrowserStack tests

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
