### PR TITLE
✨[RUMF-740] migrate error to v2 format (experimental)

### DIFF
--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -1,6 +1,6 @@
 import { areCookiesAuthorized, CookieOptions } from '../browser/cookie'
 import { buildConfiguration, UserConfiguration } from '../domain/configuration'
-import { ErrorMessage, startErrorCollection } from '../domain/errorCollection'
+import { RawError, startErrorCollection } from '../domain/errorCollection'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
 import { Observable } from '../tools/observable'
 
@@ -61,7 +61,7 @@ export interface BuildEnv {
 export function commonInit(userConfiguration: UserConfiguration, buildEnv: BuildEnv, isCollectingError: boolean) {
   const configuration = buildConfiguration(userConfiguration, buildEnv)
   const internalMonitoring = startInternalMonitoring(configuration)
-  const errorObservable = isCollectingError ? startErrorCollection(configuration) : new Observable<ErrorMessage>()
+  const errorObservable = isCollectingError ? startErrorCollection(configuration) : new Observable<RawError>()
 
   return {
     configuration,

--- a/packages/core/src/domain/errorCollection.spec.ts
+++ b/packages/core/src/domain/errorCollection.spec.ts
@@ -219,12 +219,14 @@ describe('network error tracker', () => {
     fetchStubManager.whenAllComplete(() => {
       expect(errorObservableSpy).toHaveBeenCalledWith({
         message: 'Fetch error GET http://fake.com/',
-        method: 'GET',
+        resource: {
+          method: 'GET',
+          statusCode: 503,
+          url: 'http://fake.com/',
+        },
         source: 'network',
         stack: 'Server error',
         startTime: jasmine.any(Number),
-        statusCode: 503,
-        url: 'http://fake.com/',
       })
       done()
     })

--- a/packages/core/src/domain/errorCollection.ts
+++ b/packages/core/src/domain/errorCollection.ts
@@ -12,9 +12,11 @@ export interface RawError {
   type?: string
   stack?: string
   source: ErrorSource
-  url?: string
-  statusCode?: number
-  method?: string
+  resource?: {
+    url: string
+    statusCode: number
+    method: string
+  }
 }
 
 export enum ErrorSource {
@@ -144,12 +146,14 @@ export function trackNetworkError(configuration: Configuration, errorObservable:
     if (!isIntakeRequest(request.url, configuration) && (isRejected(request) || isServerError(request))) {
       errorObservable.notify({
         message: `${format(type)} error ${request.method} ${request.url}`,
-        method: request.method,
+        resource: {
+          method: request.method,
+          statusCode: request.status,
+          url: request.url,
+        },
         source: ErrorSource.NETWORK,
         stack: truncateResponse(request.response, configuration) || 'Failed to load',
         startTime: request.startTime,
-        statusCode: request.status,
-        url: request.url,
       })
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,14 +5,7 @@ export {
   isIntakeRequest,
   buildCookieOptions,
 } from './domain/configuration'
-export {
-  ErrorMessage,
-  ErrorContext,
-  HttpContext,
-  ErrorSource,
-  ErrorObservable,
-  formatUnknownError,
-} from './domain/errorCollection'
+export { ErrorSource, ErrorObservable, formatUnknownError, RawError } from './domain/errorCollection'
 export { computeStackTrace } from './domain/tracekit'
 export {
   BuildEnv,

--- a/packages/logs/src/boot/logs.spec.ts
+++ b/packages/logs/src/boot/logs.spec.ts
@@ -2,11 +2,11 @@ import {
   Configuration,
   Context,
   DEFAULT_CONFIGURATION,
-  ErrorMessage,
   ErrorObservable,
   ErrorSource,
   noop,
   Observable,
+  RawError,
 } from '@datadog/browser-core'
 import sinon from 'sinon'
 
@@ -65,7 +65,7 @@ describe('logs', () => {
 
   beforeEach(() => {
     sessionIsTracked = true
-    errorObservable = new Observable<ErrorMessage>()
+    errorObservable = new Observable<RawError>()
     server = sinon.fakeServer.create()
   })
 
@@ -217,16 +217,17 @@ describe('logs', () => {
       startLogs({ errorLogger: new Logger(sendLogSpy) })
 
       errorObservable.notify({
-        context: { error: { origin: ErrorSource.SOURCE, kind: 'Error' } },
         message: 'error!',
+        source: ErrorSource.SOURCE,
         startTime: 1234,
+        type: 'Error',
       })
 
       expect(sendLogSpy).toHaveBeenCalled()
       expect(sendLogSpy.calls.first().args).toEqual([
         {
           date: jasmine.any(Number),
-          error: { origin: ErrorSource.SOURCE, kind: 'Error' },
+          error: { origin: ErrorSource.SOURCE, kind: 'Error', stack: undefined },
           message: 'error!',
           status: StatusType.error,
         },
@@ -245,9 +246,10 @@ describe('logs', () => {
       startLogs({ errorLogger: new Logger(sendLogSpy) })
 
       errorObservable.notify({
-        context: { error: { origin: ErrorSource.SOURCE, kind: 'Error' } },
         message: 'error!',
+        source: ErrorSource.SOURCE,
         startTime: 1234,
+        type: 'Error',
       })
 
       expect(sendLogSpy).toHaveBeenCalled()

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -46,28 +46,28 @@ export function doStartLogs(
 
   const batch = startLoggerBatch(configuration, session)
 
-  errorObservable.subscribe((e: RawError) => {
+  errorObservable.subscribe((error: RawError) => {
     errorLogger.error(
-      e.message,
+      error.message,
       combine(
         {
-          date: getTimestamp(e.startTime),
+          date: getTimestamp(error.startTime),
           error: {
-            kind: e.type,
-            origin: e.source,
-            stack: e.stack,
+            kind: error.type,
+            origin: error.source,
+            stack: error.stack,
           },
         },
-        e.source === ErrorSource.NETWORK
+        error.resource
           ? {
               http: {
-                method: e.method,
-                status_code: e.statusCode,
-                url: e.url,
+                method: error.resource.method,
+                status_code: error.resource.statusCode,
+                url: error.resource.url,
               },
             }
           : undefined,
-        getRUMInternalContext(e.startTime)
+        getRUMInternalContext(error.startTime)
       )
     )
   })

--- a/packages/rum/src/boot/rum.spec.ts
+++ b/packages/rum/src/boot/rum.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage, isIE } from '@datadog/browser-core'
+import { isIE } from '@datadog/browser-core'
 import sinon from 'sinon'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { RumPerformanceNavigationTiming } from '../browser/performanceCollection'
@@ -35,7 +35,6 @@ interface ExpectedRequestBody {
 }
 
 describe('rum session', () => {
-  const FAKE_ERROR: Partial<ErrorMessage> = { message: 'test' }
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
@@ -109,29 +108,6 @@ describe('rum session', () => {
     expect(subsequentRequests[0].type).toEqual('view')
     expect(subsequentRequests[0].session.id).toEqual('43')
     expect(subsequentRequests[0].view.id).not.toEqual(initialRequests[0].view.id)
-  })
-
-  it('when switching from not tracked to tracked, it should not send events without sessionId', () => {
-    let sessionId = undefined as string | undefined
-    let isTracked = false
-    const { server, lifeCycle } = setupBuilder
-      .withSession({
-        getId: () => sessionId,
-        isTracked: () => isTracked,
-        isTrackedWithResource: () => false,
-      })
-      .build()
-
-    server.requests = []
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-    expect(getServerRequestBodies<ExpectedRequestBody>(server).length).toEqual(0)
-
-    // it can happen without a renew session if the session is renewed on another tab
-    isTracked = true
-    sessionId = '1234'
-
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, FAKE_ERROR as ErrorMessage)
-    expect(getServerRequestBodies<ExpectedRequestBody>(server).length).toEqual(0)
   })
 })
 

--- a/packages/rum/src/domain/assembly.spec.ts
+++ b/packages/rum/src/domain/assembly.spec.ts
@@ -30,6 +30,7 @@ describe('rum assembly', () => {
   let setGlobalContext: (context: Context) => void
   let serverRumEvents: ServerRumEvents[]
   let isTracked: boolean
+  let viewSessionId: string | undefined
 
   function generateRawRumEvent(
     category: RumEventCategory,
@@ -48,6 +49,7 @@ describe('rum assembly', () => {
 
   beforeEach(() => {
     isTracked = true
+    viewSessionId = '1234'
     setupBuilder = setup()
       .withSession({
         getId: () => '1234',
@@ -61,7 +63,7 @@ describe('rum assembly', () => {
           },
         }),
         findView: () => ({
-          sessionId: '1234',
+          sessionId: viewSessionId,
           view: {
             id: 'abcde',
             referrer: 'url',
@@ -190,15 +192,29 @@ describe('rum assembly', () => {
   })
 
   describe('session', () => {
-    it('when tracked, it should generate event ', () => {
+    it('when tracked, it should generate event', () => {
       isTracked = true
 
       generateRawRumEvent(RumEventCategory.VIEW)
       expect(serverRumEvents.length).toBe(1)
     })
 
-    it('when not tracked, it should not generate event ', () => {
+    it('when not tracked, it should not generate event', () => {
       isTracked = false
+
+      generateRawRumEvent(RumEventCategory.VIEW)
+      expect(serverRumEvents.length).toBe(0)
+    })
+
+    it('when view context has session id, it should generate event', () => {
+      viewSessionId = '1234'
+
+      generateRawRumEvent(RumEventCategory.VIEW)
+      expect(serverRumEvents.length).toBe(1)
+    })
+
+    it('when view context has no session id, it should not generate event', () => {
+      viewSessionId = undefined
 
       generateRawRumEvent(RumEventCategory.VIEW)
       expect(serverRumEvents.length).toBe(0)

--- a/packages/rum/src/domain/assemblyV2.spec.ts
+++ b/packages/rum/src/domain/assemblyV2.spec.ts
@@ -1,6 +1,5 @@
 import { Context } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
-import { RumEventCategory } from '../types'
 import { RawRumEventV2, RumEventType } from '../typesV2'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 
@@ -36,6 +35,7 @@ describe('rum assembly v2', () => {
   let setGlobalContext: (context: Context) => void
   let serverRumEvents: ServerRumEvents[]
   let isTracked: boolean
+  let viewSessionId: string | undefined
 
   function generateRawRumEvent(
     type: RumEventType,
@@ -54,6 +54,7 @@ describe('rum assembly v2', () => {
 
   beforeEach(() => {
     isTracked = true
+    viewSessionId = '1234'
     setupBuilder = setup()
       .withSession({
         getId: () => '1234',
@@ -68,7 +69,7 @@ describe('rum assembly v2', () => {
         }),
         findViewV2: () => ({
           session: {
-            id: '1234',
+            id: viewSessionId,
           },
           view: {
             id: 'abcde',
@@ -197,15 +198,29 @@ describe('rum assembly v2', () => {
   })
 
   describe('session', () => {
-    it('when tracked, it should generate event ', () => {
+    it('when tracked, it should generate event', () => {
       isTracked = true
 
       generateRawRumEvent(RumEventType.VIEW)
       expect(serverRumEvents.length).toBe(1)
     })
 
-    it('when not tracked, it should not generate event ', () => {
+    it('when not tracked, it should not generate event', () => {
       isTracked = false
+
+      generateRawRumEvent(RumEventType.VIEW)
+      expect(serverRumEvents.length).toBe(0)
+    })
+
+    it('when view context has session id, it should generate event', () => {
+      viewSessionId = '1234'
+
+      generateRawRumEvent(RumEventType.VIEW)
+      expect(serverRumEvents.length).toBe(1)
+    })
+
+    it('when view context has no session id, it should not generate event', () => {
+      viewSessionId = undefined
 
       generateRawRumEvent(RumEventType.VIEW)
       expect(serverRumEvents.length).toBe(0)

--- a/packages/rum/src/domain/lifeCycle.ts
+++ b/packages/rum/src/domain/lifeCycle.ts
@@ -1,4 +1,4 @@
-import { Context, ErrorMessage } from '@datadog/browser-core'
+import { Context, RawError } from '@datadog/browser-core'
 import { RumPerformanceEntry } from '../browser/performanceCollection'
 import { RawRumEvent, RumEvent } from '../types'
 import { RawRumEventV2, RumEventV2 } from '../typesV2'
@@ -36,7 +36,7 @@ export interface Subscription {
 export class LifeCycle {
   private callbacks: { [key in LifeCycleEventType]?: Array<(data: any) => void> } = {}
 
-  notify(eventType: LifeCycleEventType.ERROR_COLLECTED, data: ErrorMessage): void
+  notify(eventType: LifeCycleEventType.ERROR_COLLECTED, data: RawError): void
   notify(eventType: LifeCycleEventType.ERROR_PROVIDED, data: { error: ProvidedError; context?: Context }): void
   notify(eventType: LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, data: RumPerformanceEntry): void
   notify(eventType: LifeCycleEventType.REQUEST_STARTED, data: RequestStartEvent): void
@@ -84,7 +84,7 @@ export class LifeCycle {
     }
   }
 
-  subscribe(eventType: LifeCycleEventType.ERROR_COLLECTED, callback: (data: ErrorMessage) => void): Subscription
+  subscribe(eventType: LifeCycleEventType.ERROR_COLLECTED, callback: (data: RawError) => void): Subscription
   subscribe(
     eventType: LifeCycleEventType.ERROR_PROVIDED,
     callback: (data: { error: ProvidedError; context?: Context }) => void

--- a/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -1,4 +1,4 @@
-import { DOM_EVENT, ErrorMessage } from '@datadog/browser-core'
+import { DOM_EVENT, RawError } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
@@ -177,13 +177,13 @@ describe('newAction', () => {
 
     newClick('test-1')
 
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as ErrorMessage)
+    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
     lifeCycle.notify(LifeCycleEventType.DOM_MUTATED)
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as ErrorMessage)
+    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
 
     clock.tick(EXPIRE_DELAY)
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as ErrorMessage)
+    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
 
     expect(events.length).toBe(1)
     const action = events[0] as AutoAction

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -2,15 +2,15 @@ import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { ErrorSource, RumEventCategory } from '../../../index'
 import { RumEventType } from '../../../typesV2'
 import { LifeCycleEventType } from '../../lifeCycle'
-import { startProvidedErrorCollection } from './errorCollection'
+import { startErrorCollection } from './errorCollection'
 
-describe('provided error collection', () => {
+describe('error collection', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
     setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
       configuration.isEnabled = () => false
-      startProvidedErrorCollection(lifeCycle, configuration)
+      startErrorCollection(lifeCycle, configuration)
     })
   })
 
@@ -18,74 +18,117 @@ describe('provided error collection', () => {
     setupBuilder.cleanup()
   })
 
-  it('notifies a raw rum error event', () => {
-    const { lifeCycle, rawRumEvents } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
-      error: {
-        error: new Error('foo'),
-        source: ErrorSource.CUSTOM,
+  describe('provided', () => {
+    it('notifies a raw rum error event', () => {
+      const { lifeCycle, rawRumEvents } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
+        error: {
+          error: new Error('foo'),
+          source: ErrorSource.CUSTOM,
+          startTime: 12,
+        },
+      })
+
+      expect(rawRumEvents.length).toBe(1)
+      expect(rawRumEvents[0]).toEqual({
+        customerContext: undefined,
+        rawRumEvent: {
+          date: jasmine.any(Number),
+          error: {
+            kind: 'Error',
+            origin: ErrorSource.CUSTOM,
+            stack: jasmine.stringMatching('Error: foo'),
+          },
+          evt: {
+            category: RumEventCategory.ERROR,
+          },
+          message: 'foo',
+        },
+        savedGlobalContext: undefined,
         startTime: 12,
-      },
+      })
     })
 
-    expect(rawRumEvents.length).toBe(1)
-    expect(rawRumEvents[0]).toEqual({
-      customerContext: undefined,
-      rawRumEvent: {
+    it('should save the specified customer context', () => {
+      const { lifeCycle, rawRumEvents } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
+        error: {
+          context: { foo: 'bar' },
+          error: new Error('foo'),
+          source: ErrorSource.CUSTOM,
+          startTime: 12,
+        },
+      })
+      expect(rawRumEvents[0].customerContext).toEqual({
+        foo: 'bar',
+      })
+    })
+
+    it('should save the global context', () => {
+      const { lifeCycle, rawRumEvents } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
+        context: { foo: 'bar' },
+        error: {
+          error: new Error('foo'),
+          source: ErrorSource.CUSTOM,
+          startTime: 12,
+        },
+      })
+      expect(rawRumEvents[0].savedGlobalContext).toEqual({
+        foo: 'bar',
+      })
+    })
+  })
+
+  describe('auto', () => {
+    it('should create error event from collected error', () => {
+      const { lifeCycle, rawRumEvents } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
+        context: {
+          error: {
+            kind: 'foo',
+            origin: ErrorSource.SOURCE,
+            stack: 'bar',
+          },
+          http: {
+            method: 'GET',
+            status_code: 500,
+            url: 'url',
+          },
+        },
+        message: 'hello',
+        startTime: 1234,
+      })
+
+      expect(rawRumEvents[0].startTime).toBe(1234)
+      expect(rawRumEvents[0].rawRumEvent).toEqual({
         date: jasmine.any(Number),
         error: {
-          kind: 'Error',
-          origin: ErrorSource.CUSTOM,
-          stack: jasmine.stringMatching('Error: foo'),
+          kind: 'foo',
+          origin: ErrorSource.SOURCE,
+          stack: 'bar',
         },
         evt: {
           category: RumEventCategory.ERROR,
         },
-        message: 'foo',
-      },
-      savedGlobalContext: undefined,
-      startTime: 12,
-    })
-  })
-
-  it('should save the specified customer context', () => {
-    const { lifeCycle, rawRumEvents } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
-      error: {
-        context: { foo: 'bar' },
-        error: new Error('foo'),
-        source: ErrorSource.CUSTOM,
-        startTime: 12,
-      },
-    })
-    expect(rawRumEvents[0].customerContext).toEqual({
-      foo: 'bar',
-    })
-  })
-
-  it('should save the global context', () => {
-    const { lifeCycle, rawRumEvents } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
-      context: { foo: 'bar' },
-      error: {
-        error: new Error('foo'),
-        source: ErrorSource.CUSTOM,
-        startTime: 12,
-      },
-    })
-    expect(rawRumEvents[0].savedGlobalContext).toEqual({
-      foo: 'bar',
+        http: {
+          method: 'GET',
+          status_code: 500,
+          url: 'url',
+        },
+        message: 'hello',
+      })
     })
   })
 })
 
-describe('provided error collection v2', () => {
+describe('error collection v2', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
     setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
       configuration.isEnabled = () => true
-      startProvidedErrorCollection(lifeCycle, configuration)
+      startErrorCollection(lifeCycle, configuration)
     })
   })
 
@@ -93,61 +136,102 @@ describe('provided error collection v2', () => {
     setupBuilder.cleanup()
   })
 
-  it('notifies a raw rum error event', () => {
-    const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
-      error: {
-        error: new Error('foo'),
-        source: ErrorSource.CUSTOM,
+  describe('provided', () => {
+    it('notifies a raw rum error event', () => {
+      const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
+        error: {
+          error: new Error('foo'),
+          source: ErrorSource.CUSTOM,
+          startTime: 12,
+        },
+      })
+
+      expect(rawRumEventsV2.length).toBe(1)
+      expect(rawRumEventsV2[0]).toEqual({
+        customerContext: undefined,
+        rawRumEvent: {
+          date: jasmine.any(Number),
+          error: {
+            message: 'foo',
+            source: ErrorSource.CUSTOM,
+            stack: jasmine.stringMatching('Error: foo'),
+            type: 'Error',
+          },
+          type: RumEventType.ERROR,
+        },
+        savedGlobalContext: undefined,
         startTime: 12,
-      },
+      })
     })
 
-    expect(rawRumEventsV2.length).toBe(1)
-    expect(rawRumEventsV2[0]).toEqual({
-      customerContext: undefined,
-      rawRumEvent: {
+    it('should save the specified customer context', () => {
+      const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
+        error: {
+          context: { foo: 'bar' },
+          error: new Error('foo'),
+          source: ErrorSource.CUSTOM,
+          startTime: 12,
+        },
+      })
+      expect(rawRumEventsV2[0].customerContext).toEqual({
+        foo: 'bar',
+      })
+    })
+
+    it('should save the global context', () => {
+      const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
+        context: { foo: 'bar' },
+        error: {
+          error: new Error('foo'),
+          source: ErrorSource.CUSTOM,
+          startTime: 12,
+        },
+      })
+      expect(rawRumEventsV2[0].savedGlobalContext).toEqual({
+        foo: 'bar',
+      })
+    })
+  })
+
+  describe('auto', () => {
+    it('should create error event from collected error', () => {
+      const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
+      lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
+        context: {
+          error: {
+            kind: 'foo',
+            origin: ErrorSource.SOURCE,
+            stack: 'bar',
+          },
+          http: {
+            method: 'GET',
+            status_code: 500,
+            url: 'url',
+          },
+        },
+        message: 'hello',
+        startTime: 1234,
+      })
+
+      expect(rawRumEventsV2[0].startTime).toBe(1234)
+      expect(rawRumEventsV2[0].rawRumEvent).toEqual({
         date: jasmine.any(Number),
         error: {
-          message: 'foo',
-          source: ErrorSource.CUSTOM,
-          stack: jasmine.stringMatching('Error: foo'),
-          type: 'Error',
+          message: 'hello',
+          resource: {
+            method: 'GET',
+            status_code: 500,
+            url: 'url',
+          },
+          source: ErrorSource.SOURCE,
+          stack: 'bar',
+          type: 'foo',
         },
         type: RumEventType.ERROR,
-      },
-      savedGlobalContext: undefined,
-      startTime: 12,
-    })
-  })
-
-  it('should save the specified customer context', () => {
-    const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
-      error: {
-        context: { foo: 'bar' },
-        error: new Error('foo'),
-        source: ErrorSource.CUSTOM,
-        startTime: 12,
-      },
-    })
-    expect(rawRumEventsV2[0].customerContext).toEqual({
-      foo: 'bar',
-    })
-  })
-
-  it('should save the global context', () => {
-    const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, {
-      context: { foo: 'bar' },
-      error: {
-        error: new Error('foo'),
-        source: ErrorSource.CUSTOM,
-        startTime: 12,
-      },
-    })
-    expect(rawRumEventsV2[0].savedGlobalContext).toEqual({
-      foo: 'bar',
+      })
     })
   })
 })

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -85,13 +85,15 @@ describe('error collection', () => {
       const { lifeCycle, rawRumEvents } = setupBuilder.build()
       lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
         message: 'hello',
-        method: 'GET',
+        resource: {
+          method: 'GET',
+          statusCode: 500,
+          url: 'url',
+        },
         source: ErrorSource.NETWORK,
         stack: 'bar',
         startTime: 1234,
-        statusCode: 500,
         type: 'foo',
-        url: 'url',
       })
 
       expect(rawRumEvents[0].startTime).toBe(1234)
@@ -148,6 +150,7 @@ describe('error collection v2', () => {
           date: jasmine.any(Number),
           error: {
             message: 'foo',
+            resource: undefined,
             source: ErrorSource.CUSTOM,
             stack: jasmine.stringMatching('Error: foo'),
             type: 'Error',
@@ -195,13 +198,15 @@ describe('error collection v2', () => {
       const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
       lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
         message: 'hello',
-        method: 'GET',
+        resource: {
+          method: 'GET',
+          statusCode: 500,
+          url: 'url',
+        },
         source: ErrorSource.NETWORK,
         stack: 'bar',
         startTime: 1234,
-        statusCode: 500,
         type: 'foo',
-        url: 'url',
       })
 
       expect(rawRumEventsV2[0].startTime).toBe(1234)

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -84,20 +84,14 @@ describe('error collection', () => {
     it('should create error event from collected error', () => {
       const { lifeCycle, rawRumEvents } = setupBuilder.build()
       lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
-        context: {
-          error: {
-            kind: 'foo',
-            origin: ErrorSource.SOURCE,
-            stack: 'bar',
-          },
-          http: {
-            method: 'GET',
-            status_code: 500,
-            url: 'url',
-          },
-        },
         message: 'hello',
+        method: 'GET',
+        source: ErrorSource.NETWORK,
+        stack: 'bar',
         startTime: 1234,
+        statusCode: 500,
+        type: 'foo',
+        url: 'url',
       })
 
       expect(rawRumEvents[0].startTime).toBe(1234)
@@ -105,7 +99,7 @@ describe('error collection', () => {
         date: jasmine.any(Number),
         error: {
           kind: 'foo',
-          origin: ErrorSource.SOURCE,
+          origin: ErrorSource.NETWORK,
           stack: 'bar',
         },
         evt: {
@@ -200,20 +194,14 @@ describe('error collection v2', () => {
     it('should create error event from collected error', () => {
       const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
       lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
-        context: {
-          error: {
-            kind: 'foo',
-            origin: ErrorSource.SOURCE,
-            stack: 'bar',
-          },
-          http: {
-            method: 'GET',
-            status_code: 500,
-            url: 'url',
-          },
-        },
         message: 'hello',
+        method: 'GET',
+        source: ErrorSource.NETWORK,
+        stack: 'bar',
         startTime: 1234,
+        statusCode: 500,
+        type: 'foo',
+        url: 'url',
       })
 
       expect(rawRumEventsV2[0].startTime).toBe(1234)
@@ -223,10 +211,10 @@ describe('error collection v2', () => {
           message: 'hello',
           resource: {
             method: 'GET',
-            status_code: 500,
+            statusCode: 500,
             url: 'url',
           },
-          source: ErrorSource.SOURCE,
+          source: ErrorSource.NETWORK,
           stack: 'bar',
           type: 'foo',
         },

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -64,12 +64,12 @@ function processError(error: RawError) {
       },
       message: error.message,
     },
-    error.source === ErrorSource.NETWORK
+    error.resource
       ? {
           http: {
-            method: error.method,
-            status_code: error.statusCode,
-            url: error.url,
+            method: error.resource.method,
+            status_code: error.resource.statusCode,
+            url: error.resource.url,
           },
         }
       : undefined
@@ -81,29 +81,18 @@ function processError(error: RawError) {
 }
 
 function processErrorV2(error: RawError) {
-  const rawRumEvent: RumErrorEventV2 = combine(
-    {
-      date: getTimestamp(error.startTime),
-      error: {
-        message: error.message,
-        source: error.source,
-        stack: error.stack,
-        type: error.type,
-      },
-      type: RumEventType.ERROR as const,
+  const rawRumEvent: RumErrorEventV2 = {
+    date: getTimestamp(error.startTime),
+    error: {
+      message: error.message,
+      resource: error.resource,
+      source: error.source,
+      stack: error.stack,
+      type: error.type,
     },
-    error.source === ErrorSource.NETWORK
-      ? {
-          error: {
-            resource: {
-              method: error.method,
-              statusCode: error.statusCode,
-              url: error.url,
-            },
-          },
-        }
-      : undefined
-  )
+    type: RumEventType.ERROR as const,
+  }
+
   return {
     rawRumEvent,
     startTime: error.startTime,

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -1,11 +1,12 @@
 import {
+  combine,
   computeStackTrace,
   Configuration,
   Context,
-  ErrorMessage,
   ErrorSource,
   formatUnknownError,
   getTimestamp,
+  RawError,
 } from '@datadog/browser-core'
 import { RumErrorEvent, RumEventCategory } from '../../../types'
 import { RumErrorEventV2, RumEventType } from '../../../typesV2'
@@ -22,81 +23,89 @@ export function startErrorCollection(lifeCycle: LifeCycle, configuration: Config
   lifeCycle.subscribe(
     LifeCycleEventType.ERROR_PROVIDED,
     ({ error: { error, startTime, context: customerContext, source }, context: savedGlobalContext }) => {
-      const stackTrace = error instanceof Error ? computeStackTrace(error) : undefined
-      const { message, stack, kind } = formatUnknownError(stackTrace, error, 'Provided')
+      const rawError = computeRawError(error, startTime, source)
 
-      if (configuration.isEnabled('v2_format')) {
-        const rawRumEvent: RumErrorEventV2 = {
-          date: getTimestamp(startTime),
-          error: {
-            message,
-            source,
-            stack,
-            type: kind,
-          },
-          type: RumEventType.ERROR,
-        }
-
-        lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, {
-          customerContext,
-          rawRumEvent,
-          savedGlobalContext,
-          startTime,
-        })
-      } else {
-        const rawRumEvent: RumErrorEvent = {
-          message,
-          date: getTimestamp(startTime),
-          error: {
-            kind,
-            stack,
-            origin: source,
-          },
-          evt: {
-            category: RumEventCategory.ERROR,
-          },
-        }
-
-        lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-          customerContext,
-          rawRumEvent,
-          savedGlobalContext,
-          startTime,
-        })
-      }
+      configuration.isEnabled('v2_format')
+        ? lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, {
+            customerContext,
+            savedGlobalContext,
+            ...processErrorV2(rawError),
+          })
+        : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+            customerContext,
+            savedGlobalContext,
+            ...processError(rawError),
+          })
     }
   )
-  lifeCycle.subscribe(LifeCycleEventType.ERROR_COLLECTED, ({ startTime, context, message }: ErrorMessage) => {
-    if (configuration.isEnabled('v2_format')) {
-      const rawRumEvent: RumErrorEventV2 = {
-        date: getTimestamp(startTime),
-        error: {
-          message,
-          resource: context.http,
-          source: context.error.origin,
-          stack: context.error.stack,
-          type: context.error.kind,
-        },
-        type: RumEventType.ERROR,
-      }
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, {
-        rawRumEvent,
-        startTime,
-      })
-    } else {
-      const rawRumEvent: RumErrorEvent = {
-        message,
-        date: getTimestamp(startTime),
-        error: context.error,
-        evt: {
-          category: RumEventCategory.ERROR,
-        },
-        http: context.http,
-      }
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent,
-        startTime,
-      })
-    }
+  lifeCycle.subscribe(LifeCycleEventType.ERROR_COLLECTED, (error: RawError) => {
+    configuration.isEnabled('v2_format')
+      ? lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, processErrorV2(error))
+      : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processError(error))
   })
+}
+
+function computeRawError(error: unknown, startTime: number, source: ErrorSource): RawError {
+  const stackTrace = error instanceof Error ? computeStackTrace(error) : undefined
+  return { startTime, source, ...formatUnknownError(stackTrace, error, 'Provided') }
+}
+
+function processError(error: RawError) {
+  const rawRumEvent: RumErrorEvent = combine(
+    {
+      date: getTimestamp(error.startTime),
+      error: {
+        kind: error.type,
+        origin: error.source,
+        stack: error.stack,
+      },
+      evt: {
+        category: RumEventCategory.ERROR as const,
+      },
+      message: error.message,
+    },
+    error.source === ErrorSource.NETWORK
+      ? {
+          http: {
+            method: error.method,
+            status_code: error.statusCode,
+            url: error.url,
+          },
+        }
+      : undefined
+  )
+  return {
+    rawRumEvent,
+    startTime: error.startTime,
+  }
+}
+
+function processErrorV2(error: RawError) {
+  const rawRumEvent: RumErrorEventV2 = combine(
+    {
+      date: getTimestamp(error.startTime),
+      error: {
+        message: error.message,
+        source: error.source,
+        stack: error.stack,
+        type: error.type,
+      },
+      type: RumEventType.ERROR as const,
+    },
+    error.source === ErrorSource.NETWORK
+      ? {
+          error: {
+            resource: {
+              method: error.method,
+              statusCode: error.statusCode,
+              url: error.url,
+            },
+          },
+        }
+      : undefined
+  )
+  return {
+    rawRumEvent,
+    startTime: error.startTime,
+  }
 }

--- a/packages/rum/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum/src/domain/trackEventCounts.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage, objectValues } from '@datadog/browser-core'
+import { objectValues, RawError } from '@datadog/browser-core'
 import { RumPerformanceLongTaskTiming, RumPerformanceNavigationTiming } from '../browser/performanceCollection'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { AutoAction, CustomAction } from './rumEventsCollection/action/trackActions'
@@ -14,7 +14,7 @@ describe('trackEventCounts', () => {
   it('tracks errors', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
     const error = {}
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as ErrorMessage)
+    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
     expect(eventCounts.errorCount).toBe(1)
   })
 

--- a/packages/rum/src/types.ts
+++ b/packages/rum/src/types.ts
@@ -1,4 +1,4 @@
-import { Context, ErrorContext, ErrorSource, HttpContext, ResourceType } from '@datadog/browser-core'
+import { Context, ErrorSource, ResourceType } from '@datadog/browser-core'
 import { ActionCounts, ActionType } from './domain/rumEventsCollection/action/trackActions'
 import { PerformanceResourceDetails } from './domain/rumEventsCollection/resource/resourceUtils'
 import { Timings, ViewLoadingType } from './domain/rumEventsCollection/view/trackViews'
@@ -39,8 +39,16 @@ export interface RumResourceEvent {
 
 export interface RumErrorEvent {
   date: number
-  http?: HttpContext
-  error: ErrorContext
+  http?: {
+    url: string
+    status_code: number
+    method: string
+  }
+  error: {
+    kind?: string
+    stack?: string
+    origin: ErrorSource
+  }
   evt: {
     category: RumEventCategory.ERROR
   }

--- a/packages/rum/src/typesV2.ts
+++ b/packages/rum/src/typesV2.ts
@@ -1,4 +1,4 @@
-import { Context, ErrorSource, HttpContext, ResourceType } from '@datadog/browser-core'
+import { Context, ErrorSource, ResourceType } from '@datadog/browser-core'
 import { ActionType } from './domain/rumEventsCollection/action/trackActions'
 import { PerformanceResourceDetailsElement } from './domain/rumEventsCollection/resource/resourceUtils'
 import { ViewLoadingType } from './domain/rumEventsCollection/view/trackViews'
@@ -39,7 +39,11 @@ export interface RumErrorEventV2 {
   date: number
   type: RumEventType.ERROR
   error: {
-    resource?: HttpContext
+    resource?: {
+      url: string
+      statusCode: number
+      method: string
+    }
     type?: string
     stack?: string
     source: ErrorSource


### PR DESCRIPTION
## Motivation

Following #570, migrating error to v2 format

## Changes

- mutualize collection start for provided and auto error
- handle error in v2
- use internal unstructured error format to ease usage across logs, rum V1 and rum v2

## Testing

unit tests, staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
