### PR TITLE
✨[RUMF-518] migrate internal context to v2 format (experimental)

### DIFF
--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -128,5 +128,18 @@ interface Rum {
 
 function getRUMInternalContext(startTime?: number): Context | undefined {
   const rum = (window as any).DD_RUM as Rum
-  return rum && rum.getInternalContext ? rum.getInternalContext(startTime) : undefined
+  const context = rum && rum.getInternalContext ? rum.getInternalContext(startTime) : undefined
+  if (!context || !context.session) {
+    return context
+  }
+  // TODO settle on integration strategy
+  // tslint:disable:no-unsafe-any
+  const v2context = context as any
+  v2context.session_id = v2context.session.id
+  v2context.application_id = v2context.application.id
+  if (v2context.action) {
+    v2context.user_action = { id: v2context.action.id }
+  }
+  // tslint:enable:no-unsafe-any
+  return v2context as Context
 }

--- a/packages/rum/src/boot/rum.ts
+++ b/packages/rum/src/boot/rum.ts
@@ -1,10 +1,11 @@
-import { combine, commonInit, Configuration, Context, withSnakeCaseKeys } from '@datadog/browser-core'
+import { combine, commonInit, Configuration, Context } from '@datadog/browser-core'
 import { startDOMMutationCollection } from '../browser/domMutationCollection'
 import { startPerformanceCollection } from '../browser/performanceCollection'
 import { startRumAssembly } from '../domain/assembly'
 import { startRumAssemblyV2 } from '../domain/assemblyV2'
+import { startInternalContext } from '../domain/internalContext'
 import { LifeCycle, LifeCycleEventType } from '../domain/lifeCycle'
-import { ParentContexts, startParentContexts } from '../domain/parentContexts'
+import { startParentContexts } from '../domain/parentContexts'
 import { startRequestCollection } from '../domain/requestCollection'
 import { startActionCollection } from '../domain/rumEventsCollection/action/actionCollection'
 import { CustomAction } from '../domain/rumEventsCollection/action/trackActions'
@@ -14,7 +15,6 @@ import { startResourceCollection } from '../domain/rumEventsCollection/resource/
 import { startViewCollection } from '../domain/rumEventsCollection/view/viewCollection'
 import { RumSession, startRumSession } from '../domain/rumSession'
 import { startRumBatch } from '../transport/batch'
-import { InternalContext } from '../types'
 
 import { buildEnv } from './buildEnv'
 import { RumUserConfiguration } from './rum.entry'
@@ -53,12 +53,12 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
   startPerformanceCollection(lifeCycle, configuration)
   startDOMMutationCollection(lifeCycle)
 
+  const internalContext = startInternalContext(userConfiguration.applicationId, session, parentContexts)
+
   errorObservable.subscribe((errorMessage) => lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, errorMessage))
 
   return {
-    getInternalContext(startTime?: number) {
-      return doGetInternalContext(parentContexts, userConfiguration.applicationId, session, startTime)
-    },
+    getInternalContext: internalContext.get,
 
     addAction(action: CustomAction, context?: Context) {
       lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { action, context })
@@ -67,20 +67,6 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
     addError(error: ProvidedError, context?: Context) {
       lifeCycle.notify(LifeCycleEventType.ERROR_PROVIDED, { error, context })
     },
-  }
-}
-
-export function doGetInternalContext(
-  parentContexts: ParentContexts,
-  applicationId: string,
-  session: RumSession,
-  startTime?: number
-) {
-  const viewContext = parentContexts.findView(startTime)
-  if (session.isTracked() && viewContext && viewContext.sessionId) {
-    return (withSnakeCaseKeys(
-      combine({ applicationId }, viewContext, parentContexts.findAction(startTime))
-    ) as unknown) as InternalContext
   }
 }
 

--- a/packages/rum/src/boot/rum.ts
+++ b/packages/rum/src/boot/rum.ts
@@ -53,7 +53,7 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
   startPerformanceCollection(lifeCycle, configuration)
   startDOMMutationCollection(lifeCycle)
 
-  const internalContext = startInternalContext(userConfiguration.applicationId, session, parentContexts)
+  const internalContext = startInternalContext(userConfiguration.applicationId, session, parentContexts, configuration)
 
   errorObservable.subscribe((errorMessage) => lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, errorMessage))
 

--- a/packages/rum/src/domain/internalContext.spec.ts
+++ b/packages/rum/src/domain/internalContext.spec.ts
@@ -1,8 +1,9 @@
 import { setup, TestSetupBuilder } from '../../test/specHelper'
+import { ParentContexts } from './parentContexts'
 
 describe('internal context', () => {
   let setupBuilder: TestSetupBuilder
-  let parentContextsStub: { findAction: jasmine.Spy; findView: jasmine.Spy }
+  let parentContextsStub: Partial<ParentContexts>
 
   beforeEach(() => {
     parentContextsStub = {
@@ -23,6 +24,9 @@ describe('internal context', () => {
     setupBuilder = setup()
       .withParentContexts(parentContextsStub)
       .withInternalContext()
+      .beforeBuild((_, configuration) => {
+        configuration.isEnabled = () => false
+      })
   })
 
   afterEach(() => {
@@ -65,5 +69,79 @@ describe('internal context', () => {
 
     expect(parentContextsStub.findView).toHaveBeenCalledWith(123)
     expect(parentContextsStub.findAction).toHaveBeenCalledWith(123)
+  })
+})
+
+describe('internal context v2', () => {
+  let setupBuilder: TestSetupBuilder
+  let parentContextsStub: Partial<ParentContexts>
+
+  beforeEach(() => {
+    parentContextsStub = {
+      findActionV2: jasmine.createSpy('findAction').and.returnValue({
+        action: {
+          id: '7890',
+        },
+      }),
+      findViewV2: jasmine.createSpy('findView').and.returnValue({
+        session: {
+          id: '1234',
+        },
+        view: {
+          id: 'abcde',
+          referrer: 'referrer',
+          url: 'url',
+        },
+      }),
+    }
+    setupBuilder = setup()
+      .withParentContexts(parentContextsStub)
+      .withInternalContext()
+  })
+
+  afterEach(() => {
+    setupBuilder.cleanup()
+  })
+
+  it('should return current internal context', () => {
+    const { internalContext } = setupBuilder.build()
+
+    expect(internalContext.get()).toEqual({
+      action: {
+        id: '7890',
+      },
+      application: {
+        id: 'appId',
+      },
+      session: {
+        id: '1234',
+      },
+      view: {
+        id: 'abcde',
+        referrer: 'referrer',
+        url: 'url',
+      },
+    })
+  })
+
+  it("should return undefined if the session isn't tracked", () => {
+    const { internalContext } = setupBuilder
+      .withSession({
+        getId: () => '1234',
+        isTracked: () => false,
+        isTrackedWithResource: () => false,
+      })
+      .build()
+
+    expect(internalContext.get()).toEqual(undefined)
+  })
+
+  it('should return internal context corresponding to startTime', () => {
+    const { internalContext } = setupBuilder.build()
+
+    internalContext.get(123)
+
+    expect(parentContextsStub.findViewV2).toHaveBeenCalledWith(123)
+    expect(parentContextsStub.findActionV2).toHaveBeenCalledWith(123)
   })
 })

--- a/packages/rum/src/domain/internalContext.spec.ts
+++ b/packages/rum/src/domain/internalContext.spec.ts
@@ -1,0 +1,69 @@
+import { setup, TestSetupBuilder } from '../../test/specHelper'
+
+describe('internal context', () => {
+  let setupBuilder: TestSetupBuilder
+  let parentContextsStub: { findAction: jasmine.Spy; findView: jasmine.Spy }
+
+  beforeEach(() => {
+    parentContextsStub = {
+      findAction: jasmine.createSpy('findAction').and.returnValue({
+        userAction: {
+          id: '7890',
+        },
+      }),
+      findView: jasmine.createSpy('findView').and.returnValue({
+        sessionId: '1234',
+        view: {
+          id: 'abcde',
+          referrer: 'referrer',
+          url: 'url',
+        },
+      }),
+    }
+    setupBuilder = setup()
+      .withParentContexts(parentContextsStub)
+      .withInternalContext()
+  })
+
+  afterEach(() => {
+    setupBuilder.cleanup()
+  })
+
+  it('should return current internal context', () => {
+    const { internalContext } = setupBuilder.build()
+
+    expect(internalContext.get()).toEqual({
+      application_id: 'appId',
+      session_id: '1234',
+      user_action: {
+        id: '7890',
+      },
+      view: {
+        id: 'abcde',
+        referrer: 'referrer',
+        url: 'url',
+      },
+    })
+  })
+
+  it("should return undefined if the session isn't tracked", () => {
+    const { internalContext } = setupBuilder
+      .withSession({
+        getId: () => '1234',
+        isTracked: () => false,
+        isTrackedWithResource: () => false,
+      })
+      .build()
+
+    expect(internalContext.get()).toEqual(undefined)
+  })
+
+  it('should return internal context corresponding to startTime', () => {
+    const { internalContext } = setupBuilder.build()
+
+    internalContext.get(123)
+
+    expect(parentContextsStub.findView).toHaveBeenCalledWith(123)
+    expect(parentContextsStub.findAction).toHaveBeenCalledWith(123)
+  })
+})

--- a/packages/rum/src/domain/internalContext.ts
+++ b/packages/rum/src/domain/internalContext.ts
@@ -1,16 +1,39 @@
-import { combine, withSnakeCaseKeys } from '@datadog/browser-core'
+import { combine, Configuration, withSnakeCaseKeys } from '@datadog/browser-core'
 import { InternalContext } from '../types'
+import { InternalContextV2 } from '../typesV2'
 import { ParentContexts } from './parentContexts'
 import { RumSession } from './rumSession'
 
-export function startInternalContext(applicationId: string, session: RumSession, parentContexts: ParentContexts) {
+export function startInternalContext(
+  applicationId: string,
+  session: RumSession,
+  parentContexts: ParentContexts,
+  configuration: Configuration
+) {
   return {
     get: (startTime?: number) => {
-      const viewContext = parentContexts.findView(startTime)
-      if (session.isTracked() && viewContext && viewContext.sessionId) {
-        return (withSnakeCaseKeys(
-          combine({ applicationId }, viewContext, parentContexts.findAction(startTime))
-        ) as unknown) as InternalContext
+      if (configuration.isEnabled('v2_format')) {
+        const viewContext = parentContexts.findViewV2(startTime)
+        if (session.isTracked() && viewContext && viewContext.session.id) {
+          return (withSnakeCaseKeys(
+            combine(
+              {
+                application: {
+                  id: applicationId,
+                },
+              },
+              viewContext,
+              parentContexts.findActionV2(startTime)
+            )
+          ) as unknown) as InternalContextV2
+        }
+      } else {
+        const viewContext = parentContexts.findView(startTime)
+        if (session.isTracked() && viewContext && viewContext.sessionId) {
+          return (withSnakeCaseKeys(
+            combine({ applicationId }, viewContext, parentContexts.findAction(startTime))
+          ) as unknown) as InternalContext
+        }
       }
     },
   }

--- a/packages/rum/src/domain/internalContext.ts
+++ b/packages/rum/src/domain/internalContext.ts
@@ -1,0 +1,17 @@
+import { combine, withSnakeCaseKeys } from '@datadog/browser-core'
+import { InternalContext } from '../types'
+import { ParentContexts } from './parentContexts'
+import { RumSession } from './rumSession'
+
+export function startInternalContext(applicationId: string, session: RumSession, parentContexts: ParentContexts) {
+  return {
+    get: (startTime?: number) => {
+      const viewContext = parentContexts.findView(startTime)
+      if (session.isTracked() && viewContext && viewContext.sessionId) {
+        return (withSnakeCaseKeys(
+          combine({ applicationId }, viewContext, parentContexts.findAction(startTime))
+        ) as unknown) as InternalContext
+      }
+    },
+  }
+}

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -180,7 +180,7 @@ export function setup(): TestSetupBuilder {
     },
     withInternalContext() {
       buildTasks.push(() => {
-        internalContext = startInternalContext(FAKE_APP_ID, session, parentContexts)
+        internalContext = startInternalContext(FAKE_APP_ID, session, parentContexts, configuration as Configuration)
       })
       return setupBuilder
     },


### PR DESCRIPTION
## Motivation

Following #570, migrating internal context to v2 format

## Changes

- extract to dedicated file
- handle v2
- keep v1 properties for logs for now

## Testing

unit tests, staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
