### PR TITLE
[RUMF-756] cyclic reference support in Context

### DIFF
--- a/packages/core/src/domain/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring.ts
@@ -1,4 +1,5 @@
 // tslint:disable ban-types
+import { combine, Context } from '../tools/context'
 import * as utils from '../tools/utils'
 import { Batch, HttpRequest } from '../transport/transport'
 import { Configuration } from './configuration'
@@ -11,10 +12,10 @@ enum StatusType {
 }
 
 export interface InternalMonitoring {
-  setExternalContextProvider: (provider: () => utils.Context) => void
+  setExternalContextProvider: (provider: () => Context) => void
 }
 
-export interface MonitoringMessage extends utils.Context {
+export interface MonitoringMessage extends Context {
   message: string
   status: StatusType
   error?: {
@@ -30,7 +31,7 @@ const monitoringConfiguration: {
   sentMessageCount: number
 } = { maxMessagesPerPage: 0, sentMessageCount: 0 }
 
-let externalContextProvider: () => utils.Context
+let externalContextProvider: () => Context
 
 export function startInternalMonitoring(configuration: Configuration): InternalMonitoring {
   if (configuration.internalMonitoringEndpoint) {
@@ -43,7 +44,7 @@ export function startInternalMonitoring(configuration: Configuration): InternalM
     })
   }
   return {
-    setExternalContextProvider: (provider: () => utils.Context) => {
+    setExternalContextProvider: (provider: () => Context) => {
       externalContextProvider = provider
     },
   }
@@ -67,7 +68,7 @@ function startMonitoringBatch(configuration: Configuration) {
   }
 
   function withContext(message: MonitoringMessage) {
-    return utils.combine(
+    return combine(
       {
         date: new Date().getTime(),
         view: {
@@ -118,7 +119,7 @@ export function monitor<T extends Function>(fn: T): T {
   } as unknown) as T // consider output type has input type
 }
 
-export function addMonitoringMessage(message: string, context?: utils.Context) {
+export function addMonitoringMessage(message: string, context?: Context) {
   logMessageIfDebug(message)
   addToMonitoringBatch({
     message,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
 export { HttpRequest, Batch } from './transport/transport'
 export * from './tools/urlPolyfill'
 export * from './tools/utils'
+export { combine, Context, ContextArray, ContextValue, deepClone, withSnakeCaseKeys } from './tools/context'
 export { areCookiesAuthorized, getCookie, setCookie, COOKIE_ACCESS_DELAY } from './browser/cookie'
 export { startXhrProxy, XhrCompleteContext, XhrStartContext, XhrProxy, resetXhrProxy } from './browser/xhrProxy'
 export {

--- a/packages/core/src/tools/context.spec.ts
+++ b/packages/core/src/tools/context.spec.ts
@@ -1,4 +1,4 @@
-import { combine, deepClone, toSnakeCase, withSnakeCaseKeys } from './context'
+import { combine, deepClone, mergeInto, toSnakeCase, withSnakeCaseKeys } from './context'
 
 describe('context', () => {
   describe('combine', () => {
@@ -67,6 +67,67 @@ describe('context', () => {
       const value = { a: [1] }
       const clonedValue = deepClone(value)
       expect(clonedValue.a).not.toBe(value.a)
+    })
+  })
+
+  describe('mergeInto', () => {
+    describe('source is not an object or array', () => {
+      it('should ignore undefined sources', () => {
+        const destination = {}
+        expect(mergeInto(destination, undefined)).toBe(destination)
+      })
+
+      it('should ignore undefined destination', () => {
+        expect(mergeInto(undefined, 1)).toBe(1)
+      })
+
+      it('should ignore destinations with a different type', () => {
+        expect(mergeInto({}, 1)).toBe(1)
+      })
+    })
+
+    describe('source is an array', () => {
+      it('should create a new array if destination is undefined', () => {
+        const source = [1]
+        const result = mergeInto(undefined, source)
+        expect(result).not.toBe(source)
+        expect(result).toEqual(source)
+      })
+
+      it('should return the source if the destination is not an array', () => {
+        const source = [1]
+        expect(mergeInto({}, source)).toBe(source)
+      })
+
+      it('should mutate and return destination if it is an array', () => {
+        const destination = ['destination']
+        const source = ['source']
+        const result = mergeInto(destination, source)
+        expect(result).toBe(destination)
+        expect(result).toEqual(source)
+      })
+    })
+
+    describe('source is an object', () => {
+      it('should create a new object if destination is undefined', () => {
+        const source = {}
+        const result = mergeInto(undefined, source)
+        expect(result).not.toBe(source)
+        expect(result).toEqual(source)
+      })
+
+      it('should return the source if the destination is not an object', () => {
+        const source = { a: 1 }
+        expect(mergeInto([], source)).toBe(source)
+      })
+
+      it('should mutate and return destination if it is an object', () => {
+        const destination = {}
+        const source = { a: 'b' }
+        const result = mergeInto(destination, source)
+        expect(result).toBe(destination)
+        expect(result).toEqual(source)
+      })
     })
   })
 

--- a/packages/core/src/tools/context.spec.ts
+++ b/packages/core/src/tools/context.spec.ts
@@ -1,4 +1,11 @@
-import { combine, createStack, deepClone, mergeInto, toSnakeCase, withSnakeCaseKeys } from './context'
+import {
+  combine,
+  createCircularReferenceChecker,
+  deepClone,
+  mergeInto,
+  toSnakeCase,
+  withSnakeCaseKeys,
+} from './context'
 
 describe('context', () => {
   describe('combine', () => {
@@ -86,35 +93,35 @@ describe('context', () => {
     describe('source is not an object or array', () => {
       it('should ignore undefined sources', () => {
         const destination = {}
-        expect(mergeInto(destination, undefined, createStack())).toBe(destination)
+        expect(mergeInto(destination, undefined, createCircularReferenceChecker())).toBe(destination)
       })
 
       it('should ignore undefined destination', () => {
-        expect(mergeInto(undefined, 1, createStack())).toBe(1)
+        expect(mergeInto(undefined, 1, createCircularReferenceChecker())).toBe(1)
       })
 
       it('should ignore destinations with a different type', () => {
-        expect(mergeInto({}, 1, createStack())).toBe(1)
+        expect(mergeInto({}, 1, createCircularReferenceChecker())).toBe(1)
       })
     })
 
     describe('source is an array', () => {
       it('should create a new array if destination is undefined', () => {
         const source = [1]
-        const result = mergeInto(undefined, source, createStack())
+        const result = mergeInto(undefined, source, createCircularReferenceChecker())
         expect(result).not.toBe(source)
         expect(result).toEqual(source)
       })
 
       it('should return the source if the destination is not an array', () => {
         const source = [1]
-        expect(mergeInto({}, source, createStack())).toBe(source)
+        expect(mergeInto({}, source, createCircularReferenceChecker())).toBe(source)
       })
 
       it('should mutate and return destination if it is an array', () => {
         const destination = ['destination']
         const source = ['source']
-        const result = mergeInto(destination, source, createStack())
+        const result = mergeInto(destination, source, createCircularReferenceChecker())
         expect(result).toBe(destination)
         expect(result).toEqual(source)
       })
@@ -123,30 +130,30 @@ describe('context', () => {
     describe('source is an object', () => {
       it('should create a new object if destination is undefined', () => {
         const source = {}
-        const result = mergeInto(undefined, source, createStack())
+        const result = mergeInto(undefined, source, createCircularReferenceChecker())
         expect(result).not.toBe(source)
         expect(result).toEqual(source)
       })
 
       it('should return the source if the destination is not an object', () => {
         const source = { a: 1 }
-        expect(mergeInto([], source, createStack())).toBe(source)
+        expect(mergeInto([], source, createCircularReferenceChecker())).toBe(source)
       })
 
       it('should mutate and return destination if it is an object', () => {
         const destination = {}
         const source = { a: 'b' }
-        const result = mergeInto(destination, source, createStack())
+        const result = mergeInto(destination, source, createCircularReferenceChecker())
         expect(result).toBe(destination)
         expect(result).toEqual(source)
       })
     })
 
-    it('should return undefined if the source is in the stack', () => {
+    it('should return undefined if the source has already been seen', () => {
       const source = {}
-      const stack = createStack()
-      stack.add(source)
-      expect(mergeInto({}, source, stack)).toBe(undefined)
+      const circularReferenceChecker = createCircularReferenceChecker()
+      circularReferenceChecker.hasAlreadyBeenSeen(source)
+      expect(mergeInto({}, source, circularReferenceChecker)).toBe(undefined)
     })
   })
 

--- a/packages/core/src/tools/context.spec.ts
+++ b/packages/core/src/tools/context.spec.ts
@@ -1,0 +1,96 @@
+import { combine, deepClone, toSnakeCase, withSnakeCaseKeys } from './context'
+
+describe('context', () => {
+  describe('combine', () => {
+    it('should deeply add and replace keys', () => {
+      const sourceA = { a: { b: 'toBeReplaced', c: 'source a' } }
+      const sourceB = { a: { b: 'replaced', d: 'source b' } }
+      expect(combine(sourceA, sourceB)).toEqual({ a: { b: 'replaced', c: 'source a', d: 'source b' } })
+    })
+
+    it('should not replace with undefined', () => {
+      expect(combine({ a: 1 }, { a: undefined as number | undefined })).toEqual({ a: 1 })
+    })
+
+    it('should replace a sub-value with null', () => {
+      // tslint:disable-next-line: no-null-keyword
+      expect(combine({ a: {} }, { a: null as any })).toEqual({ a: null })
+    })
+
+    it('should ignore null arguments', () => {
+      // tslint:disable-next-line: no-null-keyword
+      expect(combine({ a: 1 }, null)).toEqual({ a: 1 })
+    })
+
+    it('should merge arrays', () => {
+      const sourceA = [{ a: 'source a' }, 'extraString'] as any
+      const sourceB = [{ b: 'source b' }] as any
+      expect(combine(sourceA, sourceB)).toEqual([{ a: 'source a', b: 'source b' }, 'extraString'])
+    })
+
+    it('should merge multiple objects', () => {
+      expect(combine({ a: 1 }, { b: 2 }, { c: 3 })).toEqual({ a: 1, b: 2, c: 3 })
+    })
+
+    it('should not keep references on objects', () => {
+      const source = { a: { b: 1 } }
+      const result = combine({}, source)
+      expect(result.a).not.toBe(source.a)
+    })
+
+    it('should not keep references on arrays', () => {
+      const source = { a: [1] }
+      const result = combine({}, source)
+      expect(result.a).not.toBe(source.a)
+    })
+  })
+
+  describe('deepClone', () => {
+    it('should return a result deeply equal to the source', () => {
+      const clonedValue = deepClone({ a: 1 })
+      expect(clonedValue).toEqual({ a: 1 })
+    })
+
+    it('should return a different reference', () => {
+      const value = { a: 1 }
+      const clonedValue = deepClone(value)
+      expect(clonedValue).not.toBe(value)
+    })
+
+    it('should return different references for objects sub values', () => {
+      const value = { a: { b: 1 } }
+      const clonedValue = deepClone(value)
+      expect(clonedValue.a).not.toBe(value.a)
+    })
+
+    it('should return different references for arrays items', () => {
+      const value = { a: [1] }
+      const clonedValue = deepClone(value)
+      expect(clonedValue.a).not.toBe(value.a)
+    })
+  })
+
+  describe('format', () => {
+    it('should format a string to snake case', () => {
+      expect(toSnakeCase('camelCaseWord')).toEqual('camel_case_word')
+      expect(toSnakeCase('PascalCase')).toEqual('pascal_case')
+      expect(toSnakeCase('kebab-case')).toEqual('kebab_case')
+    })
+
+    it('should format object keys in snake case', () => {
+      expect(
+        withSnakeCaseKeys({
+          camelCase: 1,
+          nestedKey: { 'kebab-case': 'helloWorld', array: [{ camelCase: 1 }, { camelCase: 2 }] },
+          // tslint:disable-next-line: no-null-keyword
+          nullValue: null,
+        })
+      ).toEqual({
+        camel_case: 1,
+        nested_key: { kebab_case: 'helloWorld', array: [{ camel_case: 1 }, { camel_case: 2 }] },
+        // tslint:disable-next-line: no-null-keyword
+        null_value: null,
+      })
+    })
+  })
+})

--- a/packages/core/src/tools/context.ts
+++ b/packages/core/src/tools/context.ts
@@ -1,0 +1,105 @@
+export interface Context {
+  [x: string]: ContextValue
+}
+
+export type ContextValue = string | number | boolean | Context | ContextArray | undefined | null
+
+export interface ContextArray extends Array<ContextValue> {}
+
+export function withSnakeCaseKeys(candidate: Context): Context {
+  const result: Context = {}
+  Object.keys(candidate as Context).forEach((key: string) => {
+    result[toSnakeCase(key)] = deepSnakeCase(candidate[key])
+  })
+  return result as Context
+}
+
+export function deepSnakeCase(candidate: ContextValue): ContextValue {
+  if (Array.isArray(candidate)) {
+    return candidate.map((value: ContextValue) => deepSnakeCase(value))
+  }
+  if (typeof candidate === 'object' && candidate !== null) {
+    return withSnakeCaseKeys(candidate)
+  }
+  return candidate
+}
+
+export function toSnakeCase(word: string) {
+  return word
+    .replace(
+      /[A-Z]/g,
+      (uppercaseLetter: string, index: number) => `${index !== 0 ? '_' : ''}${uppercaseLetter.toLowerCase()}`
+    )
+    .replace(/-/g, '_')
+}
+
+const isContextArray = (value: ContextValue): value is ContextArray => Array.isArray(value)
+const isContext = (value: ContextValue): value is Context =>
+  !Array.isArray(value) && typeof value === 'object' && value !== null
+
+/**
+ * Performs a deep merge of objects and arrays.
+ * - Sources won't be mutated
+ * - Object and arrays in the output value are dereferenced ("deep cloned")
+ * - Arrays values are merged index by index
+ * - Objects are merged by keys
+ * - Values get replaced, unless undefined
+ *
+ * ⚠️ This function does not prevent infinite loops while merging circular references
+ */
+function deepMerge(...sources: ContextValue[]): ContextValue {
+  let destination: ContextValue
+
+  for (let i = sources.length - 1; i >= 0; i -= 1) {
+    const source = sources[i]
+
+    if (source === undefined) {
+      // Ignore any undefined source.
+      continue
+    }
+
+    if (destination === undefined) {
+      // This is the first defined source.  If it is "mergeable" (array or object), initialize the
+      // destination with an empty value that will be populated with all sources sub values.  Else,
+      // just return its value.
+      if (isContext(source)) {
+        destination = {}
+      } else if (isContextArray(source)) {
+        destination = []
+      } else {
+        destination = source
+        break
+      }
+    }
+
+    // At this point, 'destination' is either an array or an object.  If the current 'source' has
+    // the same type we can merge it.  Else, don't try to merge it or any other source.
+    if (isContext(destination) && isContext(source)) {
+      for (const key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          destination[key] = deepMerge(source[key], destination[key])
+        }
+      }
+    } else if (isContextArray(destination) && isContextArray(source)) {
+      destination.length = Math.max(destination.length, source.length)
+      for (let index = 0; index < source.length; index += 1) {
+        destination[index] = deepMerge(source[index], destination[index])
+      }
+    } else {
+      break
+    }
+  }
+
+  return destination
+}
+
+export function combine<A, B>(a: A, b: B): A & B
+export function combine<A, B, C>(a: A, b: B, c: C): A & B & C
+export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D
+export function combine(destination: Context, ...toMerge: Array<Context | null>): Context {
+  return deepMerge(destination, ...toMerge.filter((object) => object !== null)) as Context
+}
+
+export function deepClone<T extends ContextValue>(context: T): T {
+  return deepMerge(context) as T
+}

--- a/packages/core/src/tools/context.ts
+++ b/packages/core/src/tools/context.ts
@@ -37,69 +37,78 @@ const isContextArray = (value: ContextValue): value is ContextArray => Array.isA
 const isContext = (value: ContextValue): value is Context =>
   !Array.isArray(value) && typeof value === 'object' && value !== null
 
-/**
+/*
  * Performs a deep merge of objects and arrays.
- * - Sources won't be mutated
+ * - Arguments won't be mutated
  * - Object and arrays in the output value are dereferenced ("deep cloned")
  * - Arrays values are merged index by index
  * - Objects are merged by keys
  * - Values get replaced, unless undefined
- *
- * ⚠️ This function does not prevent infinite loops while merging circular references
+ * - Circular references are replaced by 'undefined'
  */
-function deepMerge(...sources: ContextValue[]): ContextValue {
+export function combine<A, B>(a: A, b: B): A & B
+export function combine<A, B, C>(a: A, b: B, c: C): A & B & C
+export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D
+export function combine(...sources: ContextValue[]): ContextValue {
   let destination: ContextValue
 
-  for (let i = sources.length - 1; i >= 0; i -= 1) {
-    const source = sources[i]
-
-    if (source === undefined) {
-      // Ignore any undefined source.
+  for (const source of sources) {
+    // Ignore any undefined or null sources.
+    if (source === undefined || source === null) {
       continue
     }
 
-    if (destination === undefined) {
-      // This is the first defined source.  If it is "mergeable" (array or object), initialize the
-      // destination with an empty value that will be populated with all sources sub values.  Else,
-      // just return its value.
-      if (isContext(source)) {
-        destination = {}
-      } else if (isContextArray(source)) {
-        destination = []
-      } else {
-        destination = source
-        break
-      }
-    }
-
-    // At this point, 'destination' is either an array or an object.  If the current 'source' has
-    // the same type we can merge it.  Else, don't try to merge it or any other source.
-    if (isContext(destination) && isContext(source)) {
-      for (const key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-          destination[key] = deepMerge(source[key], destination[key])
-        }
-      }
-    } else if (isContextArray(destination) && isContextArray(source)) {
-      destination.length = Math.max(destination.length, source.length)
-      for (let index = 0; index < source.length; index += 1) {
-        destination[index] = deepMerge(source[index], destination[index])
-      }
-    } else {
-      break
-    }
+    destination = mergeInto(destination, source)
   }
 
   return destination
 }
 
-export function combine<A, B>(a: A, b: B): A & B
-export function combine<A, B, C>(a: A, b: B, c: C): A & B & C
-export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D
-export function combine(destination: Context, ...toMerge: Array<Context | null>): Context {
-  return deepMerge(destination, ...toMerge.filter((object) => object !== null)) as Context
+/*
+ * Performs a deep clone of objects and arrays.
+ * - Circular references are replaced by 'undefined'
+ */
+export function deepClone<T extends ContextValue>(context: T): T {
+  return mergeInto(undefined, context) as T
 }
 
-export function deepClone<T extends ContextValue>(context: T): T {
-  return deepMerge(context) as T
+/**
+ * Iterate over 'source' and affect its subvalues into 'destination', recursively.  If the 'source'
+ * and 'destination' can't be merged, return 'source'.
+ */
+export function mergeInto(destination: ContextValue, source: ContextValue) {
+  // Ignore the 'source' if it is undefined
+  if (source === undefined) {
+    return destination
+  }
+
+  // If the 'source' is not an object or array, it can't be merged with 'destination' in any way, so
+  // return it directly.
+  if (!isContext(source) && !isContextArray(source)) {
+    return source
+  }
+
+  // 'source' and 'destination' are objects, merge them together
+  if (isContext(source) && (destination === undefined || isContext(destination))) {
+    const finalDestination = destination || {}
+    for (const key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        finalDestination[key] = mergeInto(finalDestination[key], source[key])
+      }
+    }
+    return finalDestination
+  }
+
+  // 'source' and 'destination' are arrays, merge them together
+  if (isContextArray(source) && (destination === undefined || isContextArray(destination))) {
+    const finalDestination = destination || []
+    finalDestination.length = Math.max(finalDestination.length, source.length)
+    for (let index = 0; index < source.length; index += 1) {
+      finalDestination[index] = mergeInto(finalDestination[index], source[index])
+    }
+    return finalDestination
+  }
+
+  // The destination in not an array nor an object, so we can't merge it
+  return source
 }

--- a/packages/core/src/tools/context.ts
+++ b/packages/core/src/tools/context.ts
@@ -77,7 +77,7 @@ interface CircularReferenceChecker {
   hasAlreadyBeenSeen(value: Context | ContextArray): boolean
 }
 export function createCircularReferenceChecker(): CircularReferenceChecker {
-  if (typeof WeakSet !== undefined) {
+  if (typeof WeakSet !== 'undefined') {
     const set: WeakSet<Context | ContextArray> = new WeakSet()
     return {
       hasAlreadyBeenSeen(value) {

--- a/packages/core/src/tools/context.ts
+++ b/packages/core/src/tools/context.ts
@@ -77,8 +77,8 @@ interface Stack {
   add(value: Context | ContextArray): boolean
 }
 export function createStack(): Stack {
-  if (typeof Set !== undefined) {
-    const set: Set<Context | ContextArray> = new Set()
+  if (typeof WeakSet !== undefined) {
+    const set: WeakSet<Context | ContextArray> = new WeakSet()
     return {
       add(value) {
         const has = set.has(value)

--- a/packages/core/src/tools/contextManager.ts
+++ b/packages/core/src/tools/contextManager.ts
@@ -1,4 +1,4 @@
-import { Context, ContextValue } from './utils'
+import { Context, ContextValue } from './context'
 
 export function createContextManager() {
   let context: Context = {}

--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -1,86 +1,6 @@
-import {
-  combine,
-  deepClone,
-  findCommaSeparatedValue,
-  jsonStringify,
-  performDraw,
-  round,
-  safeTruncate,
-  throttle,
-  toSnakeCase,
-  withSnakeCaseKeys,
-} from './utils'
+import { findCommaSeparatedValue, jsonStringify, performDraw, round, safeTruncate, throttle } from './utils'
 
 describe('utils', () => {
-  describe('combine', () => {
-    it('should deeply add and replace keys', () => {
-      const sourceA = { a: { b: 'toBeReplaced', c: 'source a' } }
-      const sourceB = { a: { b: 'replaced', d: 'source b' } }
-      expect(combine(sourceA, sourceB)).toEqual({ a: { b: 'replaced', c: 'source a', d: 'source b' } })
-    })
-
-    it('should not replace with undefined', () => {
-      expect(combine({ a: 1 }, { a: undefined as number | undefined })).toEqual({ a: 1 })
-    })
-
-    it('should replace a sub-value with null', () => {
-      // tslint:disable-next-line: no-null-keyword
-      expect(combine({ a: {} }, { a: null as any })).toEqual({ a: null })
-    })
-
-    it('should ignore null arguments', () => {
-      // tslint:disable-next-line: no-null-keyword
-      expect(combine({ a: 1 }, null)).toEqual({ a: 1 })
-    })
-
-    it('should merge arrays', () => {
-      const sourceA = [{ a: 'source a' }, 'extraString'] as any
-      const sourceB = [{ b: 'source b' }] as any
-      expect(combine(sourceA, sourceB)).toEqual([{ a: 'source a', b: 'source b' }, 'extraString'])
-    })
-
-    it('should merge multiple objects', () => {
-      expect(combine({ a: 1 }, { b: 2 }, { c: 3 })).toEqual({ a: 1, b: 2, c: 3 })
-    })
-
-    it('should not keep references on objects', () => {
-      const source = { a: { b: 1 } }
-      const result = combine({}, source)
-      expect(result.a).not.toBe(source.a)
-    })
-
-    it('should not keep references on arrays', () => {
-      const source = { a: [1] }
-      const result = combine({}, source)
-      expect(result.a).not.toBe(source.a)
-    })
-  })
-
-  describe('deepClone', () => {
-    it('should return a result deeply equal to the source', () => {
-      const clonedValue = deepClone({ a: 1 })
-      expect(clonedValue).toEqual({ a: 1 })
-    })
-
-    it('should return a different reference', () => {
-      const value = { a: 1 }
-      const clonedValue = deepClone(value)
-      expect(clonedValue).not.toBe(value)
-    })
-
-    it('should return different references for objects sub values', () => {
-      const value = { a: { b: 1 } }
-      const clonedValue = deepClone(value)
-      expect(clonedValue.a).not.toBe(value.a)
-    })
-
-    it('should return different references for arrays items', () => {
-      const value = { a: [1] }
-      const clonedValue = deepClone(value)
-      expect(clonedValue.a).not.toBe(value.a)
-    })
-  })
-
   describe('throttle', () => {
     let spy: jasmine.Spy
     let throttled: () => void
@@ -296,30 +216,6 @@ describe('utils', () => {
         expect(spy).toHaveBeenCalledTimes(1)
         jasmine.clock().tick(2)
         expect(spy).toHaveBeenCalledTimes(1)
-      })
-    })
-  })
-
-  describe('format', () => {
-    it('should format a string to snake case', () => {
-      expect(toSnakeCase('camelCaseWord')).toEqual('camel_case_word')
-      expect(toSnakeCase('PascalCase')).toEqual('pascal_case')
-      expect(toSnakeCase('kebab-case')).toEqual('kebab_case')
-    })
-
-    it('should format object keys in snake case', () => {
-      expect(
-        withSnakeCaseKeys({
-          camelCase: 1,
-          nestedKey: { 'kebab-case': 'helloWorld', array: [{ camelCase: 1 }, { camelCase: 2 }] },
-          // tslint:disable-next-line: no-null-keyword
-          nullValue: null,
-        })
-      ).toEqual({
-        camel_case: 1,
-        nested_key: { kebab_case: 'helloWorld', array: [{ camel_case: 1 }, { camel_case: 2 }] },
-        // tslint:disable-next-line: no-null-keyword
-        null_value: null,
       })
     })
   })

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -73,77 +73,6 @@ export function throttle(
   }
 }
 
-const isContextArray = (value: ContextValue): value is ContextArray => Array.isArray(value)
-const isContext = (value: ContextValue): value is Context =>
-  !Array.isArray(value) && typeof value === 'object' && value !== null
-
-/**
- * Performs a deep merge of objects and arrays.
- * - Sources won't be mutated
- * - Object and arrays in the output value are dereferenced ("deep cloned")
- * - Arrays values are merged index by index
- * - Objects are merged by keys
- * - Values get replaced, unless undefined
- *
- * ⚠️ This function does not prevent infinite loops while merging circular references
- */
-function deepMerge(...sources: ContextValue[]): ContextValue {
-  let destination: ContextValue
-
-  for (let i = sources.length - 1; i >= 0; i -= 1) {
-    const source = sources[i]
-
-    if (source === undefined) {
-      // Ignore any undefined source.
-      continue
-    }
-
-    if (destination === undefined) {
-      // This is the first defined source.  If it is "mergeable" (array or object), initialize the
-      // destination with an empty value that will be populated with all sources sub values.  Else,
-      // just return its value.
-      if (isContext(source)) {
-        destination = {}
-      } else if (isContextArray(source)) {
-        destination = []
-      } else {
-        destination = source
-        break
-      }
-    }
-
-    // At this point, 'destination' is either an array or an object.  If the current 'source' has
-    // the same type we can merge it.  Else, don't try to merge it or any other source.
-    if (isContext(destination) && isContext(source)) {
-      for (const key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-          destination[key] = deepMerge(source[key], destination[key])
-        }
-      }
-    } else if (isContextArray(destination) && isContextArray(source)) {
-      destination.length = Math.max(destination.length, source.length)
-      for (let index = 0; index < source.length; index += 1) {
-        destination[index] = deepMerge(source[index], destination[index])
-      }
-    } else {
-      break
-    }
-  }
-
-  return destination
-}
-
-export function combine<A, B>(a: A, b: B): A & B
-export function combine<A, B, C>(a: A, b: B, c: C): A & B & C
-export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D
-export function combine(destination: Context, ...toMerge: Array<Context | null>): Context {
-  return deepMerge(destination, ...toMerge.filter((object) => object !== null)) as Context
-}
-
-export function deepClone<T extends ContextValue>(context: T): T {
-  return deepMerge(context) as T
-}
-
 interface Assignable {
   [key: string]: any
 }
@@ -186,41 +115,6 @@ export function msToNs<T>(duration: number | T): number | T {
     return duration
   }
   return round(duration * 1e6, 0)
-}
-
-export interface Context {
-  [x: string]: ContextValue
-}
-
-export type ContextValue = string | number | boolean | Context | ContextArray | undefined | null
-
-export interface ContextArray extends Array<ContextValue> {}
-
-export function withSnakeCaseKeys(candidate: Context): Context {
-  const result: Context = {}
-  Object.keys(candidate as Context).forEach((key: string) => {
-    result[toSnakeCase(key)] = deepSnakeCase(candidate[key])
-  })
-  return result as Context
-}
-
-export function deepSnakeCase(candidate: ContextValue): ContextValue {
-  if (Array.isArray(candidate)) {
-    return candidate.map((value: ContextValue) => deepSnakeCase(value))
-  }
-  if (typeof candidate === 'object' && candidate !== null) {
-    return withSnakeCaseKeys(candidate)
-  }
-  return candidate
-}
-
-export function toSnakeCase(word: string) {
-  return word
-    .replace(
-      /[A-Z]/g,
-      (uppercaseLetter: string, index: number) => `${index !== 0 ? '_' : ''}${uppercaseLetter.toLowerCase()}`
-    )
-    .replace(/-/g, '_')
 }
 
 // tslint:disable-next-line:no-empty

--- a/packages/core/src/transport/transport.ts
+++ b/packages/core/src/transport/transport.ts
@@ -1,5 +1,6 @@
 import { monitor } from '../domain/internalMonitoring'
-import { Context, DOM_EVENT, jsonStringify, noop, objectValues } from '../tools/utils'
+import { Context } from '../tools/context'
+import { DOM_EVENT, jsonStringify, noop, objectValues } from '../tools/utils'
 
 // https://en.wikipedia.org/wiki/UTF-8
 const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/


### PR DESCRIPTION
## Motivation

Support cyclic references in various Context manipulations.

Related issue: #587

## Changes

The cyclic references are set to 'undefined', and will be skipped in JSON serialization.

## Testing

* Simple test: `a = { b: 1 }; a.c = a; DD_LOGS.logger.log('foo', a)` should not fail, and 'c' should not appear in log context
* CI tests have been added

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
