### PR TITLE
[RUMF-748] use RAW_RUM_EVENT_COLLECTED to compute event counts

### DIFF
--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -1,8 +1,6 @@
 import { areCookiesAuthorized, CookieOptions } from '../browser/cookie'
 import { buildConfiguration, UserConfiguration } from '../domain/configuration'
-import { RawError, startErrorCollection } from '../domain/errorCollection'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
-import { Observable } from '../tools/observable'
 
 export function makeGlobal<T>(stub: T): T & { onReady(callback: () => void): void } {
   const global = {
@@ -58,14 +56,12 @@ export interface BuildEnv {
   sdkVersion: string
 }
 
-export function commonInit(userConfiguration: UserConfiguration, buildEnv: BuildEnv, isCollectingError: boolean) {
+export function commonInit(userConfiguration: UserConfiguration, buildEnv: BuildEnv) {
   const configuration = buildConfiguration(userConfiguration, buildEnv)
   const internalMonitoring = startInternalMonitoring(configuration)
-  const errorObservable = isCollectingError ? startErrorCollection(configuration) : new Observable<RawError>()
 
   return {
     configuration,
-    errorObservable,
     internalMonitoring,
   }
 }

--- a/packages/core/src/browser/fetchProxy.ts
+++ b/packages/core/src/browser/fetchProxy.ts
@@ -1,6 +1,6 @@
-import { toStackTraceString } from '../domain/automaticErrorCollection'
 import { monitor } from '../domain/internalMonitoring'
 import { computeStackTrace } from '../domain/tracekit'
+import { toStackTraceString } from '../tools/error'
 import { normalizeUrl } from '../tools/urlPolyfill'
 
 export interface FetchProxy<

--- a/packages/core/src/browser/fetchProxy.ts
+++ b/packages/core/src/browser/fetchProxy.ts
@@ -1,4 +1,4 @@
-import { toStackTraceString } from '../domain/errorCollection'
+import { toStackTraceString } from '../domain/automaticErrorCollection'
 import { monitor } from '../domain/internalMonitoring'
 import { computeStackTrace } from '../domain/tracekit'
 import { normalizeUrl } from '../tools/urlPolyfill'

--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -1,11 +1,9 @@
+import { ErrorSource, RawError } from '../tools/error'
 import { Observable } from '../tools/observable'
 import { FetchStub, FetchStubManager, isIE, SPEC_ENDPOINTS, stubFetch } from '../tools/specHelper'
 import { ONE_MINUTE } from '../tools/utils'
 import {
-  ErrorSource,
   filterErrors,
-  formatUnknownError,
-  RawError,
   startConsoleTracking,
   startRuntimeErrorTracking,
   stopConsoleTracking,
@@ -13,7 +11,6 @@ import {
   trackNetworkError,
 } from './automaticErrorCollection'
 import { Configuration } from './configuration'
-import { StackTrace } from './tracekit'
 
 describe('console tracker', () => {
   let consoleErrorStub: jasmine.Spy
@@ -106,77 +103,6 @@ describe('runtime error tracker', () => {
       expect((notifyError.calls.mostRecent().args[0] as RawError).message).toEqual(ERROR_MESSAGE)
       done()
     }, 100)
-  })
-})
-
-describe('formatUnknownError', () => {
-  const NOT_COMPUTED_STACK_TRACE: StackTrace = { name: undefined, message: undefined, stack: [] } as any
-
-  it('should format an error', () => {
-    const stack: StackTrace = {
-      message: 'oh snap!',
-      name: 'TypeError',
-      stack: [
-        {
-          args: ['1', 'bar'],
-          column: 15,
-          func: 'foo',
-          line: 52,
-          url: 'http://path/to/file.js',
-        },
-        {
-          args: [],
-          column: undefined,
-          func: '?',
-          line: 12,
-          url: 'http://path/to/file.js',
-        },
-        {
-          args: ['baz'],
-          column: undefined,
-          func: '?',
-          line: undefined,
-          url: 'http://path/to/file.js',
-        },
-      ],
-    }
-
-    const formatted = formatUnknownError(stack, undefined, 'Uncaught')
-
-    expect(formatted.message).toEqual('oh snap!')
-    expect(formatted.type).toEqual('TypeError')
-    expect(formatted.stack).toEqual(`TypeError: oh snap!
-  at foo(1, bar) @ http://path/to/file.js:52:15
-  at <anonymous> @ http://path/to/file.js:12
-  at <anonymous>(baz) @ http://path/to/file.js`)
-  })
-
-  it('should format an error with an empty message', () => {
-    const stack: StackTrace = {
-      message: '',
-      name: 'TypeError',
-      stack: [],
-    }
-
-    const formatted = formatUnknownError(stack, undefined, 'Uncaught')
-
-    expect(formatted.message).toEqual('Empty message')
-  })
-
-  it('should format a string error', () => {
-    const errorObject = 'oh snap!'
-
-    const formatted = formatUnknownError(NOT_COMPUTED_STACK_TRACE, errorObject, 'Uncaught')
-
-    expect(formatted.message).toEqual('Uncaught "oh snap!"')
-  })
-
-  it('should format an object error', () => {
-    const errorObject = { foo: 'bar' }
-
-    const formatted = formatUnknownError(NOT_COMPUTED_STACK_TRACE, errorObject, 'Uncaught')
-
-    expect(formatted.message).toEqual('Uncaught {"foo":"bar"}')
   })
 })
 

--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -1,7 +1,6 @@
 import { Observable } from '../tools/observable'
 import { FetchStub, FetchStubManager, isIE, SPEC_ENDPOINTS, stubFetch } from '../tools/specHelper'
 import { ONE_MINUTE } from '../tools/utils'
-import { Configuration } from './configuration'
 import {
   ErrorSource,
   filterErrors,
@@ -12,7 +11,8 @@ import {
   stopConsoleTracking,
   stopRuntimeErrorTracking,
   trackNetworkError,
-} from './errorCollection'
+} from './automaticErrorCollection'
+import { Configuration } from './configuration'
 import { StackTrace } from './tracekit'
 
 describe('console tracker', () => {

--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -31,7 +31,7 @@ export enum ErrorSource {
 export type ErrorObservable = Observable<RawError>
 let filteredErrorsObservable: ErrorObservable
 
-export function startErrorCollection(configuration: Configuration) {
+export function startAutomaticErrorCollection(configuration: Configuration) {
   if (!filteredErrorsObservable) {
     const errorObservable = new Observable<RawError>()
     trackNetworkError(configuration, errorObservable)

--- a/packages/core/src/domain/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring.ts
@@ -2,8 +2,8 @@
 import { combine, Context } from '../tools/context'
 import * as utils from '../tools/utils'
 import { Batch, HttpRequest } from '../transport/transport'
+import { toStackTraceString } from './automaticErrorCollection'
 import { Configuration } from './configuration'
-import { toStackTraceString } from './errorCollection'
 import { computeStackTrace } from './tracekit'
 
 enum StatusType {

--- a/packages/core/src/domain/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring.ts
@@ -1,8 +1,8 @@
 // tslint:disable ban-types
 import { combine, Context } from '../tools/context'
+import { toStackTraceString } from '../tools/error'
 import * as utils from '../tools/utils'
 import { Batch, HttpRequest } from '../transport/transport'
-import { toStackTraceString } from './automaticErrorCollection'
 import { Configuration } from './configuration'
 import { computeStackTrace } from './tracekit'
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,13 +5,7 @@ export {
   isIntakeRequest,
   buildCookieOptions,
 } from './domain/configuration'
-export {
-  startAutomaticErrorCollection,
-  ErrorSource,
-  ErrorObservable,
-  formatUnknownError,
-  RawError,
-} from './domain/automaticErrorCollection'
+export { startAutomaticErrorCollection, ErrorObservable } from './domain/automaticErrorCollection'
 export { computeStackTrace } from './domain/tracekit'
 export {
   BuildEnv,
@@ -41,6 +35,7 @@ export {
 export { HttpRequest, Batch } from './transport/transport'
 export * from './tools/urlPolyfill'
 export * from './tools/utils'
+export { ErrorSource, formatUnknownError, RawError } from './tools/error'
 export { combine, Context, ContextArray, ContextValue, deepClone, withSnakeCaseKeys } from './tools/context'
 export { areCookiesAuthorized, getCookie, setCookie, COOKIE_ACCESS_DELAY } from './browser/cookie'
 export { startXhrProxy, XhrCompleteContext, XhrStartContext, XhrProxy, resetXhrProxy } from './browser/xhrProxy'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,12 +6,12 @@ export {
   buildCookieOptions,
 } from './domain/configuration'
 export {
-  startErrorCollection,
+  startAutomaticErrorCollection,
   ErrorSource,
   ErrorObservable,
   formatUnknownError,
   RawError,
-} from './domain/errorCollection'
+} from './domain/automaticErrorCollection'
 export { computeStackTrace } from './domain/tracekit'
 export {
   BuildEnv,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,13 @@ export {
   isIntakeRequest,
   buildCookieOptions,
 } from './domain/configuration'
-export { ErrorSource, ErrorObservable, formatUnknownError, RawError } from './domain/errorCollection'
+export {
+  startErrorCollection,
+  ErrorSource,
+  ErrorObservable,
+  formatUnknownError,
+  RawError,
+} from './domain/errorCollection'
 export { computeStackTrace } from './domain/tracekit'
 export {
   BuildEnv,

--- a/packages/core/src/tools/error.spec.ts
+++ b/packages/core/src/tools/error.spec.ts
@@ -1,0 +1,73 @@
+import { StackTrace } from '../domain/tracekit'
+import { formatUnknownError } from './error'
+
+describe('formatUnknownError', () => {
+  const NOT_COMPUTED_STACK_TRACE: StackTrace = { name: undefined, message: undefined, stack: [] } as any
+
+  it('should format an error', () => {
+    const stack: StackTrace = {
+      message: 'oh snap!',
+      name: 'TypeError',
+      stack: [
+        {
+          args: ['1', 'bar'],
+          column: 15,
+          func: 'foo',
+          line: 52,
+          url: 'http://path/to/file.js',
+        },
+        {
+          args: [],
+          column: undefined,
+          func: '?',
+          line: 12,
+          url: 'http://path/to/file.js',
+        },
+        {
+          args: ['baz'],
+          column: undefined,
+          func: '?',
+          line: undefined,
+          url: 'http://path/to/file.js',
+        },
+      ],
+    }
+
+    const formatted = formatUnknownError(stack, undefined, 'Uncaught')
+
+    expect(formatted.message).toEqual('oh snap!')
+    expect(formatted.type).toEqual('TypeError')
+    expect(formatted.stack).toEqual(`TypeError: oh snap!
+  at foo(1, bar) @ http://path/to/file.js:52:15
+  at <anonymous> @ http://path/to/file.js:12
+  at <anonymous>(baz) @ http://path/to/file.js`)
+  })
+
+  it('should format an error with an empty message', () => {
+    const stack: StackTrace = {
+      message: '',
+      name: 'TypeError',
+      stack: [],
+    }
+
+    const formatted = formatUnknownError(stack, undefined, 'Uncaught')
+
+    expect(formatted.message).toEqual('Empty message')
+  })
+
+  it('should format a string error', () => {
+    const errorObject = 'oh snap!'
+
+    const formatted = formatUnknownError(NOT_COMPUTED_STACK_TRACE, errorObject, 'Uncaught')
+
+    expect(formatted.message).toEqual('Uncaught "oh snap!"')
+  })
+
+  it('should format an object error', () => {
+    const errorObject = { foo: 'bar' }
+
+    const formatted = formatUnknownError(NOT_COMPUTED_STACK_TRACE, errorObject, 'Uncaught')
+
+    expect(formatted.message).toEqual('Uncaught {"foo":"bar"}')
+  })
+})

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -1,0 +1,52 @@
+import { StackTrace } from '../domain/tracekit'
+import { jsonStringify } from './utils'
+
+export interface RawError {
+  startTime: number
+  message: string
+  type?: string
+  stack?: string
+  source: ErrorSource
+  resource?: {
+    url: string
+    statusCode: number
+    method: string
+  }
+}
+
+export enum ErrorSource {
+  AGENT = 'agent',
+  CONSOLE = 'console',
+  NETWORK = 'network',
+  SOURCE = 'source',
+  LOGGER = 'logger',
+  CUSTOM = 'custom',
+}
+
+export function formatUnknownError(stackTrace: StackTrace | undefined, errorObject: any, nonErrorPrefix: string) {
+  if (!stackTrace || (stackTrace.message === undefined && !(errorObject instanceof Error))) {
+    return {
+      message: `${nonErrorPrefix} ${jsonStringify(errorObject)}`,
+      stack: 'No stack, consider using an instance of Error',
+      type: stackTrace && stackTrace.name,
+    }
+  }
+
+  return {
+    message: stackTrace.message || 'Empty message',
+    stack: toStackTraceString(stackTrace),
+    type: stackTrace.name,
+  }
+}
+
+export function toStackTraceString(stack: StackTrace) {
+  let result = `${stack.name || 'Error'}: ${stack.message}`
+  stack.stack.forEach((frame) => {
+    const func = frame.func === '?' ? '<anonymous>' : frame.func
+    const args = frame.args && frame.args.length > 0 ? `(${frame.args.join(', ')})` : ''
+    const line = frame.line ? `:${frame.line}` : ''
+    const column = frame.line && frame.column ? `:${frame.column}` : ''
+    result += `\n  at ${func}${args} @ ${frame.url}${line}${column}`
+  })
+  return result
+}

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -6,11 +6,12 @@ import {
   Configuration,
   Context,
   ErrorObservable,
-  ErrorSource,
   getTimestamp,
   HttpRequest,
   InternalMonitoring,
+  Observable,
   RawError,
+  startErrorCollection,
 } from '@datadog/browser-core'
 import { Logger, LogsMessage } from '../domain/logger'
 import { LoggerSession, startLoggerSession } from '../domain/loggerSession'
@@ -22,12 +23,9 @@ export function startLogs(
   errorLogger: Logger,
   getGlobalContext: () => Context
 ) {
-  const isCollectingError = userConfiguration.forwardErrorsToLogs !== false
-  const { configuration, internalMonitoring, errorObservable } = commonInit(
-    userConfiguration,
-    buildEnv,
-    isCollectingError
-  )
+  const { configuration, internalMonitoring } = commonInit(userConfiguration, buildEnv)
+  const errorObservable =
+    userConfiguration.forwardErrorsToLogs !== false ? startErrorCollection(configuration) : new Observable<RawError>()
   const session = startLoggerSession(configuration, areCookiesAuthorized(configuration.cookieOptions))
   return doStartLogs(configuration, errorObservable, internalMonitoring, session, errorLogger, getGlobalContext)
 }

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -11,7 +11,7 @@ import {
   InternalMonitoring,
   Observable,
   RawError,
-  startErrorCollection,
+  startAutomaticErrorCollection,
 } from '@datadog/browser-core'
 import { Logger, LogsMessage } from '../domain/logger'
 import { LoggerSession, startLoggerSession } from '../domain/loggerSession'
@@ -25,7 +25,9 @@ export function startLogs(
 ) {
   const { configuration, internalMonitoring } = commonInit(userConfiguration, buildEnv)
   const errorObservable =
-    userConfiguration.forwardErrorsToLogs !== false ? startErrorCollection(configuration) : new Observable<RawError>()
+    userConfiguration.forwardErrorsToLogs !== false
+      ? startAutomaticErrorCollection(configuration)
+      : new Observable<RawError>()
   const session = startLoggerSession(configuration, areCookiesAuthorized(configuration.cookieOptions))
   return doStartLogs(configuration, errorObservable, internalMonitoring, session, errorLogger, getGlobalContext)
 }

--- a/packages/rum/src/boot/rum.ts
+++ b/packages/rum/src/boot/rum.ts
@@ -22,12 +22,7 @@ import { RumUserConfiguration } from './rum.entry'
 export function startRum(userConfiguration: RumUserConfiguration, getGlobalContext: () => Context) {
   const lifeCycle = new LifeCycle()
 
-  const isCollectingError = true
-  const { errorObservable, configuration, internalMonitoring } = commonInit(
-    userConfiguration,
-    buildEnv,
-    isCollectingError
-  )
+  const { configuration, internalMonitoring } = commonInit(userConfiguration, buildEnv)
   const session = startRumSession(configuration, lifeCycle)
 
   internalMonitoring.setExternalContextProvider(() => {
@@ -54,8 +49,6 @@ export function startRum(userConfiguration: RumUserConfiguration, getGlobalConte
   startDOMMutationCollection(lifeCycle)
 
   const internalContext = startInternalContext(userConfiguration.applicationId, session, parentContexts, configuration)
-
-  errorObservable.subscribe((errorMessage) => lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, errorMessage))
 
   return {
     getInternalContext: internalContext.get,

--- a/packages/rum/src/domain/lifeCycle.ts
+++ b/packages/rum/src/domain/lifeCycle.ts
@@ -126,7 +126,7 @@ export class LifeCycle {
       savedGlobalContext?: Context
       customerContext?: Context
     }) => void
-  ): void
+  ): Subscription
   subscribe(
     eventType: LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED,
     callback: (data: {
@@ -135,15 +135,15 @@ export class LifeCycle {
       savedGlobalContext?: Context
       customerContext?: Context
     }) => void
-  ): void
+  ): Subscription
   subscribe(
     eventType: LifeCycleEventType.RUM_EVENT_COLLECTED,
     callback: (data: { rumEvent: RumEvent; serverRumEvent: Context }) => void
-  ): void
+  ): Subscription
   subscribe(
     eventType: LifeCycleEventType.RUM_EVENT_V2_COLLECTED,
     callback: (data: { rumEvent: RumEventV2; serverRumEvent: Context }) => void
-  ): void
+  ): Subscription
   subscribe(eventType: LifeCycleEventType, callback: (data?: any) => void) {
     if (!this.callbacks[eventType]) {
       this.callbacks[eventType] = []

--- a/packages/rum/src/domain/lifeCycle.ts
+++ b/packages/rum/src/domain/lifeCycle.ts
@@ -8,7 +8,6 @@ import { ProvidedError } from './rumEventsCollection/error/errorCollection'
 import { View, ViewCreatedEvent } from './rumEventsCollection/view/trackViews'
 
 export enum LifeCycleEventType {
-  ERROR_COLLECTED,
   ERROR_PROVIDED,
   PERFORMANCE_ENTRY_COLLECTED,
   CUSTOM_ACTION_COLLECTED,
@@ -35,7 +34,6 @@ export interface Subscription {
 export class LifeCycle {
   private callbacks: { [key in LifeCycleEventType]?: Array<(data: any) => void> } = {}
 
-  notify(eventType: LifeCycleEventType.ERROR_COLLECTED, data: RawError): void
   notify(eventType: LifeCycleEventType.ERROR_PROVIDED, data: { error: ProvidedError; context?: Context }): void
   notify(eventType: LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, data: RumPerformanceEntry): void
   notify(eventType: LifeCycleEventType.REQUEST_STARTED, data: RequestStartEvent): void
@@ -82,7 +80,6 @@ export class LifeCycle {
     }
   }
 
-  subscribe(eventType: LifeCycleEventType.ERROR_COLLECTED, callback: (data: RawError) => void): Subscription
   subscribe(
     eventType: LifeCycleEventType.ERROR_PROVIDED,
     callback: (data: { error: ProvidedError; context?: Context }) => void

--- a/packages/rum/src/domain/lifeCycle.ts
+++ b/packages/rum/src/domain/lifeCycle.ts
@@ -20,7 +20,6 @@ export enum LifeCycleEventType {
   REQUEST_STARTED,
   REQUEST_COMPLETED,
   SESSION_RENEWED,
-  RESOURCE_ADDED_TO_BATCH,
   DOM_MUTATED,
   BEFORE_UNLOAD,
   RAW_RUM_EVENT_COLLECTED,
@@ -49,7 +48,6 @@ export class LifeCycle {
   notify(
     eventType:
       | LifeCycleEventType.SESSION_RENEWED
-      | LifeCycleEventType.RESOURCE_ADDED_TO_BATCH
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED
@@ -112,7 +110,6 @@ export class LifeCycle {
   subscribe(
     eventType:
       | LifeCycleEventType.SESSION_RENEWED
-      | LifeCycleEventType.RESOURCE_ADDED_TO_BATCH
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED,

--- a/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -1,6 +1,7 @@
 import { DOM_EVENT } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumErrorEvent, RumEventCategory } from '../../../types'
+import { RumErrorEventV2, RumEventType } from '../../../typesV2'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
 import { ActionType, AutoAction } from './trackActions'
@@ -188,6 +189,33 @@ describe('newAction', () => {
 
     clock.tick(EXPIRE_DELAY)
     lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, collectedRawRumEvent)
+
+    expect(events.length).toBe(1)
+    const action = events[0] as AutoAction
+    expect(action.counts).toEqual({
+      errorCount: 2,
+      longTaskCount: 0,
+      resourceCount: 0,
+    })
+  })
+
+  it('counts errors occurring during the action v2', () => {
+    const { lifeCycle, clock } = setupBuilder.build()
+    const collectedRawRumEvent = {
+      rawRumEvent: ({ type: RumEventType.ERROR } as unknown) as RumErrorEventV2,
+      startTime: 0,
+    }
+    lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, pushEvent)
+
+    newClick('test-1')
+
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, collectedRawRumEvent)
+    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
+    lifeCycle.notify(LifeCycleEventType.DOM_MUTATED)
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, collectedRawRumEvent)
+
+    clock.tick(EXPIRE_DELAY)
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, collectedRawRumEvent)
 
     expect(events.length).toBe(1)
     const action = events[0] as AutoAction

--- a/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -1,5 +1,6 @@
-import { DOM_EVENT, RawError } from '@datadog/browser-core'
+import { DOM_EVENT } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
+import { RumErrorEvent, RumEventCategory } from '../../../types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
 import { ActionType, AutoAction } from './trackActions'
@@ -172,18 +173,21 @@ describe('newAction', () => {
 
   it('counts errors occurring during the action', () => {
     const { lifeCycle, clock } = setupBuilder.build()
-    const error = {}
+    const collectedRawRumEvent = {
+      rawRumEvent: ({ evt: { category: RumEventCategory.ERROR } } as unknown) as RumErrorEvent,
+      startTime: 0,
+    }
     lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, pushEvent)
 
     newClick('test-1')
 
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, collectedRawRumEvent)
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
     lifeCycle.notify(LifeCycleEventType.DOM_MUTATED)
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, collectedRawRumEvent)
 
     clock.tick(EXPIRE_DELAY)
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, collectedRawRumEvent)
 
     expect(events.length).toBe(1)
     const action = events[0] as AutoAction

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -1,16 +1,18 @@
+import { Observable, RawError } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { ErrorSource, RumEventCategory } from '../../../index'
 import { RumEventType } from '../../../typesV2'
 import { LifeCycleEventType } from '../../lifeCycle'
-import { startErrorCollection } from './errorCollection'
+import { doStartErrorCollection } from './errorCollection'
 
 describe('error collection', () => {
   let setupBuilder: TestSetupBuilder
+  const errorObservable = new Observable<RawError>()
 
   beforeEach(() => {
     setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
       configuration.isEnabled = () => false
-      startErrorCollection(lifeCycle, configuration)
+      doStartErrorCollection(lifeCycle, configuration, errorObservable)
     })
   })
 
@@ -82,8 +84,8 @@ describe('error collection', () => {
 
   describe('auto', () => {
     it('should create error event from collected error', () => {
-      const { lifeCycle, rawRumEvents } = setupBuilder.build()
-      lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
+      const { rawRumEvents } = setupBuilder.build()
+      errorObservable.notify({
         message: 'hello',
         resource: {
           method: 'GET',
@@ -120,11 +122,12 @@ describe('error collection', () => {
 
 describe('error collection v2', () => {
   let setupBuilder: TestSetupBuilder
+  const errorObservable = new Observable<RawError>()
 
   beforeEach(() => {
     setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
       configuration.isEnabled = () => true
-      startErrorCollection(lifeCycle, configuration)
+      doStartErrorCollection(lifeCycle, configuration, errorObservable)
     })
   })
 
@@ -195,8 +198,8 @@ describe('error collection v2', () => {
 
   describe('auto', () => {
     it('should create error event from collected error', () => {
-      const { lifeCycle, rawRumEventsV2 } = setupBuilder.build()
-      lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {
+      const { rawRumEventsV2 } = setupBuilder.build()
+      errorObservable.notify({
         message: 'hello',
         resource: {
           method: 'GET',

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -8,7 +8,7 @@ import {
   getTimestamp,
   Observable,
   RawError,
-  startErrorCollection as startRawErrorCollection,
+  startAutomaticErrorCollection,
 } from '@datadog/browser-core'
 import { RumErrorEvent, RumEventCategory } from '../../../types'
 import { RumErrorEventV2, RumEventType } from '../../../typesV2'
@@ -22,7 +22,7 @@ export interface ProvidedError {
 }
 
 export function startErrorCollection(lifeCycle: LifeCycle, configuration: Configuration) {
-  doStartErrorCollection(lifeCycle, configuration, startRawErrorCollection(configuration))
+  doStartErrorCollection(lifeCycle, configuration, startAutomaticErrorCollection(configuration))
 }
 
 export function doStartErrorCollection(

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -6,7 +6,9 @@ import {
   ErrorSource,
   formatUnknownError,
   getTimestamp,
+  Observable,
   RawError,
+  startErrorCollection as startRawErrorCollection,
 } from '@datadog/browser-core'
 import { RumErrorEvent, RumEventCategory } from '../../../types'
 import { RumErrorEventV2, RumEventType } from '../../../typesV2'
@@ -20,6 +22,14 @@ export interface ProvidedError {
 }
 
 export function startErrorCollection(lifeCycle: LifeCycle, configuration: Configuration) {
+  doStartErrorCollection(lifeCycle, configuration, startRawErrorCollection(configuration))
+}
+
+export function doStartErrorCollection(
+  lifeCycle: LifeCycle,
+  configuration: Configuration,
+  observable: Observable<RawError>
+) {
   lifeCycle.subscribe(
     LifeCycleEventType.ERROR_PROVIDED,
     ({ error: { error, startTime, context: customerContext, source }, context: savedGlobalContext }) => {
@@ -38,7 +48,8 @@ export function startErrorCollection(lifeCycle: LifeCycle, configuration: Config
           })
     }
   )
-  lifeCycle.subscribe(LifeCycleEventType.ERROR_COLLECTED, (error: RawError) => {
+
+  observable.subscribe((error) => {
     configuration.isEnabled('v2_format')
       ? lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, processErrorV2(error))
       : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processError(error))

--- a/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -28,7 +28,6 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Con
       configuration.isEnabled('v2_format')
         ? lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, processRequestV2(request))
         : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processRequest(request))
-      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
     }
   })
 
@@ -37,7 +36,6 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Con
       configuration.isEnabled('v2_format')
         ? lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, processResourceEntryV2(entry))
         : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processResourceEntry(entry))
-      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
     }
   })
 }

--- a/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -554,15 +554,10 @@ describe('rum view measures', () => {
     expect(getViewEvent(4).eventCounts.resourceCount).toEqual(0)
   })
 
-  it('should update eventCounts when notified with a PERFORMANCE_ENTRY_COLLECTED event (throttled)', () => {
+  it('should update timings when notified with a PERFORMANCE_ENTRY_COLLECTED event (throttled)', () => {
     const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
     expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 0,
-      userActionCount: 0,
-    })
+    expect(getViewEvent(0).timings).toEqual({})
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_NAVIGATION_ENTRY)
 
@@ -571,11 +566,11 @@ describe('rum view measures', () => {
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
     expect(getHandledCount()).toEqual(2)
-    expect(getViewEvent(1).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 0,
-      userActionCount: 0,
+    expect(getViewEvent(1).timings).toEqual({
+      domComplete: 456,
+      domContentLoaded: 345,
+      domInteractive: 234,
+      loadEventEnd: 567,
     })
   })
 
@@ -604,15 +599,10 @@ describe('rum view measures', () => {
     })
   })
 
-  it('should update eventCounts when ending a view', () => {
+  it('should update timings when ending a view', () => {
     const { lifeCycle } = setupBuilder.build()
     expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 0,
-      userActionCount: 0,
-    })
+    expect(getViewEvent(0).timings).toEqual({})
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_PAINT_ENTRY)
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_NAVIGATION_ENTRY)
@@ -621,18 +611,14 @@ describe('rum view measures', () => {
     history.pushState({}, '', '/bar')
 
     expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 0,
-      userActionCount: 0,
+    expect(getViewEvent(1).timings).toEqual({
+      domComplete: 456,
+      domContentLoaded: 345,
+      domInteractive: 234,
+      firstContentfulPaint: 123,
+      loadEventEnd: 567,
     })
-    expect(getViewEvent(2).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 0,
-      userActionCount: 0,
-    })
+    expect(getViewEvent(2).timings).toEqual({})
   })
 
   it('should not update eventCounts after ending a view', () => {

--- a/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -479,223 +479,227 @@ describe('rum view measures', () => {
     setupBuilder.cleanup()
   })
 
-  it('should track error count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts.errorCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {} as any)
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {} as any)
-    history.pushState({}, '', '/bar')
-
-    expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).eventCounts.errorCount).toEqual(2)
-    expect(getViewEvent(2).eventCounts.errorCount).toEqual(0)
-  })
-
-  it('should track long task count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts.longTaskCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_LONG_TASK)
-    history.pushState({}, '', '/bar')
-
-    expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).eventCounts.longTaskCount).toEqual(1)
-    expect(getViewEvent(2).eventCounts.longTaskCount).toEqual(0)
-  })
-
-  it('should track resource count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts.resourceCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
-    history.pushState({}, '', '/bar')
-
-    expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).eventCounts.resourceCount).toEqual(1)
-    expect(getViewEvent(2).eventCounts.resourceCount).toEqual(0)
-  })
-
-  it('should track action count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts.userActionCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { action: FAKE_CUSTOM_USER_ACTION, context: {} })
-    lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, FAKE_AUTO_USER_ACTION as AutoAction)
-    history.pushState({}, '', '/bar')
-
-    expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).eventCounts.userActionCount).toEqual(2)
-    expect(getViewEvent(2).eventCounts.userActionCount).toEqual(0)
-  })
-
-  it('should reset event count when the view changes', () => {
-    const { lifeCycle } = setupBuilder.build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts.resourceCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
-    history.pushState({}, '', '/bar')
-
-    expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).eventCounts.resourceCount).toEqual(1)
-    expect(getViewEvent(2).eventCounts.resourceCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
-    history.pushState({}, '', '/baz')
-
-    expect(getHandledCount()).toEqual(5)
-    expect(getViewEvent(3).eventCounts.resourceCount).toEqual(2)
-    expect(getViewEvent(4).eventCounts.resourceCount).toEqual(0)
-  })
-
-  it('should update timings when notified with a PERFORMANCE_ENTRY_COLLECTED event (throttled)', () => {
-    const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).timings).toEqual({})
-
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_NAVIGATION_ENTRY)
-
-    expect(getHandledCount()).toEqual(1)
-
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-
-    expect(getHandledCount()).toEqual(2)
-    expect(getViewEvent(1).timings).toEqual({
-      domComplete: 456,
-      domContentLoaded: 345,
-      domInteractive: 234,
-      loadEventEnd: 567,
-    })
-  })
-
-  it('should update eventCounts when notified with a RESOURCE_ADDED_TO_BATCH event (throttled)', () => {
-    const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 0,
-      userActionCount: 0,
-    })
-
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
-
-    expect(getHandledCount()).toEqual(1)
-
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-
-    expect(getHandledCount()).toEqual(2)
-    expect(getViewEvent(1).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 1,
-      userActionCount: 0,
-    })
-  })
-
-  it('should update timings when ending a view', () => {
-    const { lifeCycle } = setupBuilder.build()
-    expect(getHandledCount()).toEqual(1)
-    expect(getViewEvent(0).timings).toEqual({})
-
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_PAINT_ENTRY)
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_NAVIGATION_ENTRY)
-    expect(getHandledCount()).toEqual(1)
-
-    history.pushState({}, '', '/bar')
-
-    expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).timings).toEqual({
-      domComplete: 456,
-      domContentLoaded: 345,
-      domInteractive: 234,
-      firstContentfulPaint: 123,
-      loadEventEnd: 567,
-    })
-    expect(getViewEvent(2).timings).toEqual({})
-  })
-
-  it('should not update eventCounts after ending a view', () => {
-    const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    expect(getHandledCount()).toEqual(1)
-
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
-
-    expect(getHandledCount()).toEqual(1)
-
-    history.pushState({}, '', '/bar')
-
-    expect(getHandledCount()).toEqual(3)
-    expect(getViewEvent(1).id).toEqual(getViewEvent(0).id)
-    expect(getViewEvent(2).id).not.toEqual(getViewEvent(0).id)
-
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-
-    expect(getHandledCount()).toEqual(3)
-  })
-
-  describe('load event happening after initial view end', () => {
-    let initialView: { init: View; end: View; last: View }
-    let secondView: { init: View; last: View }
-    const VIEW_DURATION = 100
-
-    beforeEach(() => {
+  describe('timings', () => {
+    it('should update timings when notified with a PERFORMANCE_ENTRY_COLLECTED event (throttled)', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).timings).toEqual({})
 
-      clock.tick(VIEW_DURATION)
-
-      history.pushState({}, '', '/bar')
-
-      clock.tick(VIEW_DURATION)
-
-      expect(getHandledCount()).toEqual(3)
-
-      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_PAINT_ENTRY)
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_NAVIGATION_ENTRY)
+
+      expect(getHandledCount()).toEqual(1)
 
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
-      expect(getHandledCount()).toEqual(4)
-
-      initialView = {
-        end: getViewEvent(1),
-        init: getViewEvent(0),
-        last: getViewEvent(3),
-      }
-      secondView = {
-        init: getViewEvent(2),
-        last: getViewEvent(2),
-      }
+      expect(getHandledCount()).toEqual(2)
+      expect(getViewEvent(1).timings).toEqual({
+        domComplete: 456,
+        domContentLoaded: 345,
+        domInteractive: 234,
+        loadEventEnd: 567,
+      })
     })
 
-    it('should not set timings to the second view', () => {
-      expect(secondView.last.timings).toEqual({})
-    })
+    it('should update timings when ending a view', () => {
+      const { lifeCycle } = setupBuilder.build()
+      expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).timings).toEqual({})
 
-    it('should set timings only on the initial view', () => {
-      expect(initialView.last.timings).toEqual({
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_PAINT_ENTRY)
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_NAVIGATION_ENTRY)
+      expect(getHandledCount()).toEqual(1)
+
+      history.pushState({}, '', '/bar')
+
+      expect(getHandledCount()).toEqual(3)
+      expect(getViewEvent(1).timings).toEqual({
         domComplete: 456,
         domContentLoaded: 345,
         domInteractive: 234,
         firstContentfulPaint: 123,
         loadEventEnd: 567,
       })
+      expect(getViewEvent(2).timings).toEqual({})
     })
 
-    it('should not update the initial view duration when updating it with new timings', () => {
-      expect(initialView.end.duration).toBe(VIEW_DURATION)
-      expect(initialView.last.duration).toBe(VIEW_DURATION)
+    describe('load event happening after initial view end', () => {
+      let initialView: { init: View; end: View; last: View }
+      let secondView: { init: View; last: View }
+      const VIEW_DURATION = 100
+
+      beforeEach(() => {
+        const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+        expect(getHandledCount()).toEqual(1)
+
+        clock.tick(VIEW_DURATION)
+
+        history.pushState({}, '', '/bar')
+
+        clock.tick(VIEW_DURATION)
+
+        expect(getHandledCount()).toEqual(3)
+
+        lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_PAINT_ENTRY)
+        lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_NAVIGATION_ENTRY)
+
+        clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+        expect(getHandledCount()).toEqual(4)
+
+        initialView = {
+          end: getViewEvent(1),
+          init: getViewEvent(0),
+          last: getViewEvent(3),
+        }
+        secondView = {
+          init: getViewEvent(2),
+          last: getViewEvent(2),
+        }
+      })
+
+      it('should not set timings to the second view', () => {
+        expect(secondView.last.timings).toEqual({})
+      })
+
+      it('should set timings only on the initial view', () => {
+        expect(initialView.last.timings).toEqual({
+          domComplete: 456,
+          domContentLoaded: 345,
+          domInteractive: 234,
+          firstContentfulPaint: 123,
+          loadEventEnd: 567,
+        })
+      })
+
+      it('should not update the initial view duration when updating it with new timings', () => {
+        expect(initialView.end.duration).toBe(VIEW_DURATION)
+        expect(initialView.last.duration).toBe(VIEW_DURATION)
+      })
+
+      it('should update the initial view loadingTime following the loadEventEnd value', () => {
+        expect(initialView.last.loadingTime).toBe(FAKE_NAVIGATION_ENTRY.loadEventEnd)
+      })
+    })
+  })
+
+  describe('event counts', () => {
+    it('should track error count', () => {
+      const { lifeCycle } = setupBuilder.build()
+      expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).eventCounts.errorCount).toEqual(0)
+
+      lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {} as any)
+      lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, {} as any)
+      history.pushState({}, '', '/bar')
+
+      expect(getHandledCount()).toEqual(3)
+      expect(getViewEvent(1).eventCounts.errorCount).toEqual(2)
+      expect(getViewEvent(2).eventCounts.errorCount).toEqual(0)
     })
 
-    it('should update the initial view loadingTime following the loadEventEnd value', () => {
-      expect(initialView.last.loadingTime).toBe(FAKE_NAVIGATION_ENTRY.loadEventEnd)
+    it('should track long task count', () => {
+      const { lifeCycle } = setupBuilder.build()
+      expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).eventCounts.longTaskCount).toEqual(0)
+
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_LONG_TASK)
+      history.pushState({}, '', '/bar')
+
+      expect(getHandledCount()).toEqual(3)
+      expect(getViewEvent(1).eventCounts.longTaskCount).toEqual(1)
+      expect(getViewEvent(2).eventCounts.longTaskCount).toEqual(0)
+    })
+
+    it('should track resource count', () => {
+      const { lifeCycle } = setupBuilder.build()
+      expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).eventCounts.resourceCount).toEqual(0)
+
+      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+      history.pushState({}, '', '/bar')
+
+      expect(getHandledCount()).toEqual(3)
+      expect(getViewEvent(1).eventCounts.resourceCount).toEqual(1)
+      expect(getViewEvent(2).eventCounts.resourceCount).toEqual(0)
+    })
+
+    it('should track action count', () => {
+      const { lifeCycle } = setupBuilder.build()
+      expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).eventCounts.userActionCount).toEqual(0)
+
+      lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, { action: FAKE_CUSTOM_USER_ACTION, context: {} })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, FAKE_AUTO_USER_ACTION as AutoAction)
+      history.pushState({}, '', '/bar')
+
+      expect(getHandledCount()).toEqual(3)
+      expect(getViewEvent(1).eventCounts.userActionCount).toEqual(2)
+      expect(getViewEvent(2).eventCounts.userActionCount).toEqual(0)
+    })
+
+    it('should reset event count when the view changes', () => {
+      const { lifeCycle } = setupBuilder.build()
+      expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).eventCounts.resourceCount).toEqual(0)
+
+      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+      history.pushState({}, '', '/bar')
+
+      expect(getHandledCount()).toEqual(3)
+      expect(getViewEvent(1).eventCounts.resourceCount).toEqual(1)
+      expect(getViewEvent(2).eventCounts.resourceCount).toEqual(0)
+
+      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+      history.pushState({}, '', '/baz')
+
+      expect(getHandledCount()).toEqual(5)
+      expect(getViewEvent(3).eventCounts.resourceCount).toEqual(2)
+      expect(getViewEvent(4).eventCounts.resourceCount).toEqual(0)
+    })
+
+    it('should update eventCounts when notified with a RESOURCE_ADDED_TO_BATCH event (throttled)', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+      expect(getHandledCount()).toEqual(1)
+      expect(getViewEvent(0).eventCounts).toEqual({
+        errorCount: 0,
+        longTaskCount: 0,
+        resourceCount: 0,
+        userActionCount: 0,
+      })
+
+      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+
+      expect(getHandledCount()).toEqual(1)
+
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+      expect(getHandledCount()).toEqual(2)
+      expect(getViewEvent(1).eventCounts).toEqual({
+        errorCount: 0,
+        longTaskCount: 0,
+        resourceCount: 1,
+        userActionCount: 0,
+      })
+    })
+
+    it('should not update eventCounts after ending a view', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+      expect(getHandledCount()).toEqual(1)
+
+      lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+
+      expect(getHandledCount()).toEqual(1)
+
+      history.pushState({}, '', '/bar')
+
+      expect(getHandledCount()).toEqual(3)
+      expect(getViewEvent(1).id).toEqual(getViewEvent(0).id)
+      expect(getViewEvent(2).id).not.toEqual(getViewEvent(0).id)
+
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+      expect(getHandledCount()).toEqual(3)
     })
   })
 })

--- a/packages/rum/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum/src/domain/trackEventCounts.spec.ts
@@ -1,7 +1,6 @@
-import { objectValues, RawError } from '@datadog/browser-core'
-import { RumPerformanceLongTaskTiming, RumPerformanceNavigationTiming } from '../browser/performanceCollection'
+import { objectValues } from '@datadog/browser-core'
+import { RawRumEvent, RumEventCategory } from '../types'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
-import { AutoAction, CustomAction } from './rumEventsCollection/action/trackActions'
 import { EventCounts, trackEventCounts } from './trackEventCounts'
 
 describe('trackEventCounts', () => {
@@ -11,53 +10,49 @@ describe('trackEventCounts', () => {
     lifeCycle = new LifeCycle()
   })
 
+  function notifyCollectedRawRumEvent(category: RumEventCategory) {
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+      rawRumEvent: ({ evt: { category } } as unknown) as RawRumEvent,
+      startTime: 0,
+    })
+  }
+
   it('tracks errors', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    const error = {}
-    lifeCycle.notify(LifeCycleEventType.ERROR_COLLECTED, error as RawError)
+    notifyCollectedRawRumEvent(RumEventCategory.ERROR)
     expect(eventCounts.errorCount).toBe(1)
   })
 
   it('tracks long tasks', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    const performanceTiming = { entryType: 'longtask' }
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, performanceTiming as RumPerformanceLongTaskTiming)
+    notifyCollectedRawRumEvent(RumEventCategory.LONG_TASK)
     expect(eventCounts.longTaskCount).toBe(1)
   })
 
-  it("doesn't track navigation entries", () => {
+  it("doesn't track views", () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    const performanceTiming = { entryType: 'navigation' }
-    lifeCycle.notify(
-      LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED,
-      performanceTiming as RumPerformanceNavigationTiming
-    )
+    notifyCollectedRawRumEvent(RumEventCategory.VIEW)
     expect(objectValues(eventCounts).every((value) => value === 0)).toBe(true)
   })
 
   it('tracks actions', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    const action = {}
-    lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, action as AutoAction)
-    lifeCycle.notify(LifeCycleEventType.CUSTOM_ACTION_COLLECTED, {
-      action: action as CustomAction,
-      context: {},
-    })
-    expect(eventCounts.userActionCount).toBe(2)
+    notifyCollectedRawRumEvent(RumEventCategory.USER_ACTION)
+    expect(eventCounts.userActionCount).toBe(1)
   })
 
   it('tracks resources', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+    notifyCollectedRawRumEvent(RumEventCategory.RESOURCE)
     expect(eventCounts.resourceCount).toBe(1)
   })
 
   it('stops tracking when stop is called', () => {
     const { eventCounts, stop } = trackEventCounts(lifeCycle)
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+    notifyCollectedRawRumEvent(RumEventCategory.RESOURCE)
     expect(eventCounts.resourceCount).toBe(1)
     stop()
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+    notifyCollectedRawRumEvent(RumEventCategory.RESOURCE)
     expect(eventCounts.resourceCount).toBe(1)
   })
 
@@ -65,11 +60,11 @@ describe('trackEventCounts', () => {
     const spy = jasmine.createSpy<(eventCounts: EventCounts) => void>()
     trackEventCounts(lifeCycle, spy)
 
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+    notifyCollectedRawRumEvent(RumEventCategory.RESOURCE)
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(1)
 
-    lifeCycle.notify(LifeCycleEventType.RESOURCE_ADDED_TO_BATCH)
+    notifyCollectedRawRumEvent(RumEventCategory.RESOURCE)
     expect(spy).toHaveBeenCalledTimes(2)
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(2)
   })

--- a/packages/rum/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum/src/domain/trackEventCounts.spec.ts
@@ -1,5 +1,6 @@
 import { objectValues } from '@datadog/browser-core'
 import { RawRumEvent, RumEventCategory } from '../types'
+import { RawRumEventV2, RumEventType } from '../typesV2'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { EventCounts, trackEventCounts } from './trackEventCounts'
 
@@ -65,6 +66,73 @@ describe('trackEventCounts', () => {
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(1)
 
     notifyCollectedRawRumEvent(RumEventCategory.RESOURCE)
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.calls.mostRecent().args[0].resourceCount).toBe(2)
+  })
+})
+
+describe('trackEventCounts v2', () => {
+  let lifeCycle: LifeCycle
+
+  beforeEach(() => {
+    lifeCycle = new LifeCycle()
+  })
+
+  function notifyCollectedRawRumEvent(type: RumEventType) {
+    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, {
+      rawRumEvent: ({ type } as unknown) as RawRumEventV2,
+      startTime: 0,
+    })
+  }
+
+  it('tracks errors', () => {
+    const { eventCounts } = trackEventCounts(lifeCycle)
+    notifyCollectedRawRumEvent(RumEventType.ERROR)
+    expect(eventCounts.errorCount).toBe(1)
+  })
+
+  it('tracks long tasks', () => {
+    const { eventCounts } = trackEventCounts(lifeCycle)
+    notifyCollectedRawRumEvent(RumEventType.LONG_TASK)
+    expect(eventCounts.longTaskCount).toBe(1)
+  })
+
+  it("doesn't track views", () => {
+    const { eventCounts } = trackEventCounts(lifeCycle)
+    notifyCollectedRawRumEvent(RumEventType.VIEW)
+    expect(objectValues(eventCounts).every((value) => value === 0)).toBe(true)
+  })
+
+  it('tracks actions', () => {
+    const { eventCounts } = trackEventCounts(lifeCycle)
+    notifyCollectedRawRumEvent(RumEventType.ACTION)
+    expect(eventCounts.userActionCount).toBe(1)
+  })
+
+  it('tracks resources', () => {
+    const { eventCounts } = trackEventCounts(lifeCycle)
+    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    expect(eventCounts.resourceCount).toBe(1)
+  })
+
+  it('stops tracking when stop is called', () => {
+    const { eventCounts, stop } = trackEventCounts(lifeCycle)
+    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    expect(eventCounts.resourceCount).toBe(1)
+    stop()
+    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    expect(eventCounts.resourceCount).toBe(1)
+  })
+
+  it('invokes a potential callback when a count is increased', () => {
+    const spy = jasmine.createSpy<(eventCounts: EventCounts) => void>()
+    trackEventCounts(lifeCycle, spy)
+
+    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.calls.mostRecent().args[0].resourceCount).toBe(1)
+
+    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
     expect(spy).toHaveBeenCalledTimes(2)
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(2)
   })

--- a/packages/rum/src/domain/trackEventCounts.ts
+++ b/packages/rum/src/domain/trackEventCounts.ts
@@ -1,5 +1,6 @@
 import { noop } from '@datadog/browser-core'
 import { RumEventCategory } from '../types'
+import { RumEventType } from '../typesV2'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 
 export interface EventCounts {
@@ -38,9 +39,31 @@ export function trackEventCounts(lifeCycle: LifeCycle, callback: (eventCounts: E
     }
   })
 
+  const subscriptionV2 = lifeCycle.subscribe(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, ({ rawRumEvent }): void => {
+    switch (rawRumEvent.type) {
+      case RumEventType.ERROR:
+        eventCounts.errorCount += 1
+        callback(eventCounts)
+        break
+      case RumEventType.ACTION:
+        eventCounts.userActionCount += 1
+        callback(eventCounts)
+        break
+      case RumEventType.LONG_TASK:
+        eventCounts.longTaskCount += 1
+        callback(eventCounts)
+        break
+      case RumEventType.RESOURCE:
+        eventCounts.resourceCount += 1
+        callback(eventCounts)
+        break
+    }
+  })
+
   return {
     stop() {
       subscription.unsubscribe()
+      subscriptionV2.unsubscribe()
     },
     eventCounts,
   }


### PR DESCRIPTION
## Motivation

The recent introduction of RAW_RUM_EVENT_COLLECTED lifecycle events allows to simplify the event counts tracking.

## Changes

* Adjust view measures tests a bit
* Use RAW_RUM_EVENT_COLLECTED and RAW_RUM_EVENT_V2_COLLECTED instead of various events in trackEventCounts
* Remove the now unused RESOURCE_ADDED_TO_BATCH event
* Replace the ERROR_COLLECTED event by listening directly to the raw error observable.

## Testing

Unit and e2e tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
