### PR TITLE
[RUMF-766] prevent request duration override by wrong matching timing

### DIFF
--- a/packages/rum/src/domain/assemblyV2.spec.ts
+++ b/packages/rum/src/domain/assemblyV2.spec.ts
@@ -1,5 +1,5 @@
 import { Context } from '@datadog/browser-core'
-import { createRawRumEvent } from '../../test/createRawRumEvent'
+import { createRawRumEvent } from '../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { RumEventType } from '../typesV2'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'

--- a/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -1,5 +1,5 @@
 import { DOM_EVENT } from '@datadog/browser-core'
-import { createRawRumEvent } from '../../../../test/createRawRumEvent'
+import { createRawRumEvent } from '../../../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumErrorEvent, RumEventCategory } from '../../../types'
 import { RumEventType } from '../../../typesV2'

--- a/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
@@ -1,4 +1,5 @@
 import { isIE } from '@datadog/browser-core'
+import { createResourceEntry } from '../../../../test/fixtures'
 import { RumPerformanceResourceTiming } from '../../../browser/performanceCollection'
 import { RequestCompleteEvent } from '../../requestCollection'
 
@@ -17,17 +18,17 @@ describe('matchRequestTiming', () => {
   })
 
   it('should match single timing nested in the request ', () => {
-    const match: Partial<RumPerformanceResourceTiming> = { startTime: 200, duration: 300 }
-    entries.push(match as RumPerformanceResourceTiming)
+    const match = createResourceEntry({ startTime: 200, duration: 300 })
+    entries.push(match)
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(match as RumPerformanceResourceTiming)
+    expect(timing).toEqual(match)
   })
 
   it('should not match single timing outside the request ', () => {
-    const match: Partial<RumPerformanceResourceTiming> = { startTime: 0, duration: 300 }
-    entries.push(match as RumPerformanceResourceTiming)
+    const match = createResourceEntry({ startTime: 0, duration: 300 })
+    entries.push(match)
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
@@ -35,19 +36,19 @@ describe('matchRequestTiming', () => {
   })
 
   it('should match two following timings nested in the request ', () => {
-    const optionsTiming: Partial<RumPerformanceResourceTiming> = { startTime: 200, duration: 50 }
-    const actualTiming: Partial<RumPerformanceResourceTiming> = { startTime: 300, duration: 100 }
-    entries.push(optionsTiming as RumPerformanceResourceTiming, actualTiming as RumPerformanceResourceTiming)
+    const optionsTiming = createResourceEntry({ startTime: 150, duration: 50 })
+    const actualTiming = createResourceEntry({ startTime: 200, duration: 100 })
+    entries.push(optionsTiming, actualTiming)
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(actualTiming as RumPerformanceResourceTiming)
+    expect(timing).toEqual(actualTiming)
   })
 
   it('should not match two not following timings nested in the request ', () => {
-    const match1: Partial<RumPerformanceResourceTiming> = { startTime: 200, duration: 100 }
-    const match2: Partial<RumPerformanceResourceTiming> = { startTime: 250, duration: 100 }
-    entries.push(match1 as RumPerformanceResourceTiming, match2 as RumPerformanceResourceTiming)
+    const match1 = createResourceEntry({ startTime: 150, duration: 100 })
+    const match2 = createResourceEntry({ startTime: 200, duration: 100 })
+    entries.push(match1, match2)
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
@@ -55,14 +56,23 @@ describe('matchRequestTiming', () => {
   })
 
   it('should not match multiple timings nested in the request', () => {
-    const match1: Partial<RumPerformanceResourceTiming> = { startTime: 100, duration: 100 }
-    const match2: Partial<RumPerformanceResourceTiming> = { startTime: 200, duration: 100 }
-    const match3: Partial<RumPerformanceResourceTiming> = { startTime: 300, duration: 100 }
-    entries.push(
-      match1 as RumPerformanceResourceTiming,
-      match2 as RumPerformanceResourceTiming,
-      match3 as RumPerformanceResourceTiming
-    )
+    const match1 = createResourceEntry({ startTime: 100, duration: 50 })
+    const match2 = createResourceEntry({ startTime: 150, duration: 50 })
+    const match3 = createResourceEntry({ startTime: 200, duration: 50 })
+    entries.push(match1, match2, match3)
+
+    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+
+    expect(timing).toEqual(undefined)
+  })
+
+  it('should match invalid timing nested in the request ', () => {
+    const match = createResourceEntry({
+      duration: 100,
+      fetchStart: 0,
+      startTime: 200,
+    })
+    entries.push(match)
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 

--- a/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -1,6 +1,6 @@
 import { RequestType, ResourceType } from '@datadog/browser-core'
+import { createResourceEntry } from '../../../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
-import { RumPerformanceResourceTiming } from '../../../browser/performanceCollection'
 import { RumEventCategory, RumResourceEvent } from '../../../types'
 import { RumEventType, RumResourceEventV2 } from '../../../typesV2'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -423,29 +423,6 @@ describe('resourceCollection V2', () => {
     })
   })
 })
-
-function createResourceEntry(details?: Partial<RumPerformanceResourceTiming>): RumPerformanceResourceTiming {
-  const entry: Partial<RumPerformanceResourceTiming> = {
-    connectEnd: 0,
-    connectStart: 0,
-    decodedBodySize: 0,
-    domainLookupEnd: 0,
-    domainLookupStart: 0,
-    duration: 100,
-    entryType: 'resource',
-    fetchStart: 0,
-    name: 'https://resource.com/valid',
-    redirectEnd: 0,
-    redirectStart: 0,
-    requestStart: 0,
-    responseEnd: 0,
-    responseStart: 0,
-    secureConnectionStart: 0,
-    startTime: 1234,
-    ...details,
-  }
-  return entry as RumPerformanceResourceTiming
-}
 
 function createCompletedRequest(details?: Partial<RequestCompleteEvent>): RequestCompleteEvent {
   const request: Partial<RequestCompleteEvent> = {

--- a/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -1,4 +1,4 @@
-import { createRawRumEvent } from '../../../../test/createRawRumEvent'
+import { createRawRumEvent } from '../../../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumPerformanceNavigationTiming, RumPerformancePaintTiming } from '../../../browser/performanceCollection'
 

--- a/packages/rum/test/fixtures.ts
+++ b/packages/rum/test/fixtures.ts
@@ -1,4 +1,5 @@
 import { combine, Context, ErrorSource, ResourceType } from '@datadog/browser-core'
+import { RumPerformanceResourceTiming } from '../src/browser/performanceCollection'
 import { ActionType } from '../src/domain/rumEventsCollection/action/trackActions'
 import { ViewLoadingType } from '../src/domain/rumEventsCollection/view/trackViews'
 import { RawRumEventV2, RumEventType } from '../src/typesV2'
@@ -75,4 +76,30 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
         overrides
       )
   }
+}
+
+export function createResourceEntry(
+  overrides?: Partial<RumPerformanceResourceTiming>
+): RumPerformanceResourceTiming & PerformanceResourceTiming {
+  const entry: Partial<RumPerformanceResourceTiming & PerformanceResourceTiming> = {
+    connectEnd: 200,
+    connectStart: 200,
+    decodedBodySize: 200,
+    domainLookupEnd: 200,
+    domainLookupStart: 200,
+    duration: 100,
+    entryType: 'resource',
+    fetchStart: 200,
+    name: 'https://resource.com/valid',
+    redirectEnd: 200,
+    redirectStart: 200,
+    requestStart: 200,
+    responseEnd: 300,
+    responseStart: 200,
+    secureConnectionStart: 200,
+    startTime: 200,
+    ...overrides,
+  }
+  entry.toJSON = () => entry
+  return entry as RumPerformanceResourceTiming & PerformanceResourceTiming
 }


### PR DESCRIPTION
## Motivation

Quick fix to see if demo website shorter browser spans could be related to wrong timing association.
Since TAO is not enabled on shopist, we should observe a duration increase for RUM fetch events.

## Changes

Do not consider invalid or incomplete timing in match request timing.

## Testing

unit test, manual tests on DD + demo

## Next steps

if hypothesis is confirmed, discuss proper strategies. 

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
