### PR TITLE
✅ [RUMF-759] cleanup RUM unit tests specHelper

### DIFF
--- a/packages/core/src/tools/specHelper.ts
+++ b/packages/core/src/tools/specHelper.ts
@@ -100,47 +100,6 @@ export interface FetchStubPromise extends Promise<Response> {
   rejectWith: (error: Error) => Promise<Error>
 }
 
-export class PerformanceObserverStubBuilder {
-  public instance: any
-
-  getEntryTypes() {
-    // tslint:disable-next-line: no-unsafe-any
-    return this.instance.entryTypes
-  }
-
-  fakeEntry(entry: PerformanceEntry, entryType: string) {
-    const asEntryList = () => [entry]
-    // tslint:disable-next-line: no-unsafe-any
-    this.instance.callback({
-      getEntries: asEntryList,
-      getEntriesByName: asEntryList,
-      getEntriesByType: (type: string) => {
-        if (type === entryType) {
-          return asEntryList()
-        }
-        return []
-      },
-    })
-  }
-
-  getStub(): PerformanceObserver {
-    // tslint:disable-next-line:no-this-assignment
-    const builder = this
-    return (class {
-      static supportedEntryTypes = ['navigation']
-      constructor(public callback: PerformanceObserverCallback) {
-        builder.instance = this
-      }
-      observe(options?: PerformanceObserverInit) {
-        if (options) {
-          // tslint:disable-next-line: no-unsafe-any
-          builder.instance.entryTypes = options.entryTypes
-        }
-      }
-    } as unknown) as PerformanceObserver
-  }
-}
-
 class StubXhr {
   public response: string | undefined = undefined
   public status: number | undefined = undefined

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -17,9 +17,7 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@types/sinon": "7.0.13",
-    "ajv": "6.12.6",
-    "sinon": "7.3.2"
+    "ajv": "6.12.6"
   },
   "repository": {
     "type": "git",

--- a/packages/rum/src/boot/rum.spec.ts
+++ b/packages/rum/src/boot/rum.spec.ts
@@ -62,8 +62,8 @@ describe('rum session', () => {
         isTracked: () => true,
         isTrackedWithResource: () => true,
       })
-      .beforeBuild((_, configuration) => {
-        configuration.isEnabled = () => false
+      .withConfiguration({
+        isEnabled: () => false,
       })
       .build()
 
@@ -137,8 +137,8 @@ describe('rum session keep alive', () => {
 
   it('should send a view update regularly (v1)', () => {
     const { clock } = setupBuilder
-      .beforeBuild((_, configuration) => {
-        configuration.isEnabled = () => false
+      .withConfiguration({
+        isEnabled: () => false,
       })
       .build()
 

--- a/packages/rum/src/boot/rum.spec.ts
+++ b/packages/rum/src/boot/rum.spec.ts
@@ -46,8 +46,7 @@ describe('rum session', () => {
 
     setupBuilder = setup().beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
       serverRumEvents = collectServerEvents(lifeCycle)
-      const { stop } = startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
-      return stop
+      return startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
     })
   })
 
@@ -128,8 +127,7 @@ describe('rum session keep alive', () => {
       })
       .beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
-        const { stop } = startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
-        return stop
+        return startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
       })
   })
 
@@ -213,8 +211,7 @@ describe('rum view url', () => {
   beforeEach(() => {
     setupBuilder = setup().beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
       serverRumEvents = collectServerEvents(lifeCycle)
-      const { stop } = startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
-      return stop
+      return startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
     })
   })
 

--- a/packages/rum/src/boot/rum.spec.ts
+++ b/packages/rum/src/boot/rum.spec.ts
@@ -4,6 +4,7 @@ import { RumPerformanceNavigationTiming } from '../browser/performanceCollection
 
 import { LifeCycle, LifeCycleEventType } from '../domain/lifeCycle'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD } from '../domain/rumEventsCollection/view/trackViews'
+import { startRumEventCollection } from './rum'
 
 interface ServerRumEvent {
   application_id: string
@@ -43,11 +44,11 @@ describe('rum session', () => {
       pending('no full rum support')
     }
 
-    setupBuilder = setup()
-      .withRum()
-      .beforeBuild(({ lifeCycle }) => {
-        serverRumEvents = collectServerEvents(lifeCycle)
-      })
+    setupBuilder = setup().beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
+      serverRumEvents = collectServerEvents(lifeCycle)
+      const { stop } = startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
+      return stop
+    })
   })
 
   afterEach(() => {
@@ -125,9 +126,10 @@ describe('rum session keep alive', () => {
         isTracked: () => isSessionTracked,
         isTrackedWithResource: () => true,
       })
-      .withRum()
-      .beforeBuild(({ lifeCycle }) => {
+      .beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
+        const { stop } = startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
+        return stop
       })
   })
 
@@ -209,11 +211,11 @@ describe('rum view url', () => {
   let serverRumEvents: ServerRumEvent[]
 
   beforeEach(() => {
-    setupBuilder = setup()
-      .withRum()
-      .beforeBuild(({ lifeCycle }) => {
-        serverRumEvents = collectServerEvents(lifeCycle)
-      })
+    setupBuilder = setup().beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
+      serverRumEvents = collectServerEvents(lifeCycle)
+      const { stop } = startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({}))
+      return stop
+    })
   })
 
   afterEach(() => {

--- a/packages/rum/src/boot/rum.spec.ts
+++ b/packages/rum/src/boot/rum.spec.ts
@@ -45,7 +45,7 @@ describe('rum session', () => {
 
     setupBuilder = setup()
       .withRum()
-      .beforeBuild((lifeCycle) => {
+      .beforeBuild(({ lifeCycle }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
       })
   })
@@ -126,7 +126,7 @@ describe('rum session keep alive', () => {
         isTrackedWithResource: () => true,
       })
       .withRum()
-      .beforeBuild((lifeCycle) => {
+      .beforeBuild(({ lifeCycle }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
       })
   })
@@ -211,7 +211,7 @@ describe('rum view url', () => {
   beforeEach(() => {
     setupBuilder = setup()
       .withRum()
-      .beforeBuild((lifeCycle) => {
+      .beforeBuild(({ lifeCycle }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
       })
   })

--- a/packages/rum/src/browser/performanceCollection.spec.ts
+++ b/packages/rum/src/browser/performanceCollection.spec.ts
@@ -5,14 +5,15 @@ import { retrieveInitialDocumentResourceTiming } from './performanceCollection'
 
 describe('rum first_contentful_paint', () => {
   let setupBuilder: TestSetupBuilder
+  let performanceObserverObserveSpy: jasmine.Spy<(options?: PerformanceObserverInit | undefined) => void>
+
   beforeEach(() => {
     if (isIE()) {
       pending('no full rum support')
     }
 
-    setupBuilder = setup()
-      .withPerformanceObserverStubBuilder()
-      .withPerformanceCollection()
+    performanceObserverObserveSpy = spyOn(PerformanceObserver.prototype, 'observe')
+    setupBuilder = setup().withPerformanceCollection()
   })
 
   afterEach(() => {
@@ -22,16 +23,16 @@ describe('rum first_contentful_paint', () => {
 
   it('should not be collected when page starts not visible', () => {
     setPageVisibility('hidden')
-    const { stubBuilder } = setupBuilder.build()
+    setupBuilder.build()
 
-    expect(stubBuilder.getEntryTypes()).not.toContain('paint')
+    expect(performanceObserverObserveSpy.calls.argsFor(0)[0]!.entryTypes).not.toContain('paint')
   })
 
   it('should be collected when page starts visible', () => {
     setPageVisibility('visible')
-    const { stubBuilder } = setupBuilder.build()
+    setupBuilder.build()
 
-    expect(stubBuilder.getEntryTypes()).toContain('paint')
+    expect(performanceObserverObserveSpy.calls.argsFor(0)[0]!.entryTypes).toContain('paint')
   })
 })
 

--- a/packages/rum/src/browser/performanceCollection.spec.ts
+++ b/packages/rum/src/browser/performanceCollection.spec.ts
@@ -1,7 +1,7 @@
 import { isIE, restorePageVisibility, setPageVisibility } from '@datadog/browser-core'
 
 import { setup, TestSetupBuilder } from '../../test/specHelper'
-import { retrieveInitialDocumentResourceTiming } from './performanceCollection'
+import { retrieveInitialDocumentResourceTiming, startPerformanceCollection } from './performanceCollection'
 
 describe('rum first_contentful_paint', () => {
   let setupBuilder: TestSetupBuilder
@@ -13,7 +13,9 @@ describe('rum first_contentful_paint', () => {
     }
 
     performanceObserverObserveSpy = spyOn(PerformanceObserver.prototype, 'observe')
-    setupBuilder = setup().withPerformanceCollection()
+    setupBuilder = setup().beforeBuild(({ lifeCycle, configuration }) => {
+      startPerformanceCollection(lifeCycle, configuration)
+    })
   })
 
   afterEach(() => {
@@ -39,7 +41,9 @@ describe('rum first_contentful_paint', () => {
 describe('rum initial document resource', () => {
   let setupBuilder: TestSetupBuilder
   beforeEach(() => {
-    setupBuilder = setup().withPerformanceCollection()
+    setupBuilder = setup().beforeBuild(({ lifeCycle, configuration }) => {
+      startPerformanceCollection(lifeCycle, configuration)
+    })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/internalContext.spec.ts
+++ b/packages/rum/src/domain/internalContext.spec.ts
@@ -24,8 +24,8 @@ describe('internal context', () => {
     setupBuilder = setup()
       .withParentContexts(parentContextsStub)
       .withInternalContext()
-      .beforeBuild((_, configuration) => {
-        configuration.isEnabled = () => false
+      .withConfiguration({
+        isEnabled: () => false,
       })
   })
 

--- a/packages/rum/src/domain/internalContext.spec.ts
+++ b/packages/rum/src/domain/internalContext.spec.ts
@@ -1,9 +1,11 @@
 import { setup, TestSetupBuilder } from '../../test/specHelper'
+import { startInternalContext } from './internalContext'
 import { ParentContexts } from './parentContexts'
 
 describe('internal context', () => {
   let setupBuilder: TestSetupBuilder
   let parentContextsStub: Partial<ParentContexts>
+  let internalContext: ReturnType<typeof startInternalContext>
 
   beforeEach(() => {
     parentContextsStub = {
@@ -23,9 +25,11 @@ describe('internal context', () => {
     }
     setupBuilder = setup()
       .withParentContexts(parentContextsStub)
-      .withInternalContext()
       .withConfiguration({
         isEnabled: () => false,
+      })
+      .beforeBuild(({ applicationId, session, parentContexts, configuration }) => {
+        internalContext = startInternalContext(applicationId, session, parentContexts, configuration)
       })
   })
 
@@ -34,7 +38,7 @@ describe('internal context', () => {
   })
 
   it('should return current internal context', () => {
-    const { internalContext } = setupBuilder.build()
+    setupBuilder.build()
 
     expect(internalContext.get()).toEqual({
       application_id: 'appId',
@@ -51,7 +55,7 @@ describe('internal context', () => {
   })
 
   it("should return undefined if the session isn't tracked", () => {
-    const { internalContext } = setupBuilder
+    setupBuilder
       .withSession({
         getId: () => '1234',
         isTracked: () => false,
@@ -63,7 +67,7 @@ describe('internal context', () => {
   })
 
   it('should return internal context corresponding to startTime', () => {
-    const { internalContext } = setupBuilder.build()
+    setupBuilder.build()
 
     internalContext.get(123)
 
@@ -75,6 +79,7 @@ describe('internal context', () => {
 describe('internal context v2', () => {
   let setupBuilder: TestSetupBuilder
   let parentContextsStub: Partial<ParentContexts>
+  let internalContext: ReturnType<typeof startInternalContext>
 
   beforeEach(() => {
     parentContextsStub = {
@@ -96,7 +101,9 @@ describe('internal context v2', () => {
     }
     setupBuilder = setup()
       .withParentContexts(parentContextsStub)
-      .withInternalContext()
+      .beforeBuild(({ applicationId, session, parentContexts, configuration }) => {
+        internalContext = startInternalContext(applicationId, session, parentContexts, configuration)
+      })
   })
 
   afterEach(() => {
@@ -104,7 +111,7 @@ describe('internal context v2', () => {
   })
 
   it('should return current internal context', () => {
-    const { internalContext } = setupBuilder.build()
+    setupBuilder.build()
 
     expect(internalContext.get()).toEqual({
       action: {
@@ -125,7 +132,7 @@ describe('internal context v2', () => {
   })
 
   it("should return undefined if the session isn't tracked", () => {
-    const { internalContext } = setupBuilder
+    setupBuilder
       .withSession({
         getId: () => '1234',
         isTracked: () => false,
@@ -137,7 +144,7 @@ describe('internal context v2', () => {
   })
 
   it('should return internal context corresponding to startTime', () => {
-    const { internalContext } = setupBuilder.build()
+    setupBuilder.build()
 
     internalContext.get(123)
 

--- a/packages/rum/src/domain/parentContexts.spec.ts
+++ b/packages/rum/src/domain/parentContexts.spec.ts
@@ -38,7 +38,7 @@ describe('parentContexts', () => {
       })
       .beforeBuild(({ lifeCycle, session }) => {
         parentContexts = startParentContexts(lifeCycle, session)
-        return parentContexts.stop
+        return parentContexts
       })
   })
 

--- a/packages/rum/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -13,7 +13,7 @@ describe('actionCollection', () => {
       .withConfiguration({
         isEnabled: () => false,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         startActionCollection(lifeCycle, configuration)
       })
   })
@@ -88,7 +88,7 @@ describe('actionCollection v2', () => {
       .withConfiguration({
         isEnabled: () => true,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         startActionCollection(lifeCycle, configuration)
       })
   })

--- a/packages/rum/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -9,10 +9,13 @@ describe('actionCollection', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => false
-      startActionCollection(lifeCycle, configuration)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => false,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        startActionCollection(lifeCycle, configuration)
+      })
   })
 
   afterEach(() => {
@@ -81,10 +84,13 @@ describe('actionCollection v2', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => true
-      startActionCollection(lifeCycle, configuration)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => true,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        startActionCollection(lifeCycle, configuration)
+      })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -5,7 +5,7 @@ import { RumErrorEvent, RumEventCategory } from '../../../types'
 import { RumEventType } from '../../../typesV2'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
-import { ActionType, AutoAction } from './trackActions'
+import { ActionType, AutoAction, trackActions } from './trackActions'
 
 // Used to wait some time after the creation of a action
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = PAGE_ACTIVITY_VALIDATION_DELAY * 0.8
@@ -60,11 +60,12 @@ describe('trackActions', () => {
 
     setupBuilder = setup()
       .withFakeClock()
-      .withActionCollection()
       .beforeBuild(({ lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_CREATED, createSpy)
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, pushEvent)
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_DISCARDED, discardSpy)
+        const { stop } = trackActions(lifeCycle)
+        return stop
       })
   })
 
@@ -149,7 +150,10 @@ describe('newAction', () => {
     document.body.appendChild(root)
     setupBuilder = setup()
       .withFakeClock()
-      .withActionCollection()
+      .beforeBuild(({ lifeCycle }) => {
+        const { stop } = trackActions(lifeCycle)
+        return stop
+      })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -64,8 +64,7 @@ describe('trackActions', () => {
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_CREATED, createSpy)
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, pushEvent)
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_DISCARDED, discardSpy)
-        const { stop } = trackActions(lifeCycle)
-        return stop
+        return trackActions(lifeCycle)
       })
   })
 
@@ -151,8 +150,7 @@ describe('newAction', () => {
     setupBuilder = setup()
       .withFakeClock()
       .beforeBuild(({ lifeCycle }) => {
-        const { stop } = trackActions(lifeCycle)
-        return stop
+        return trackActions(lifeCycle)
       })
   })
 

--- a/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -61,7 +61,7 @@ describe('trackActions', () => {
     setupBuilder = setup()
       .withFakeClock()
       .withActionCollection()
-      .beforeBuild((lifeCycle) => {
+      .beforeBuild(({ lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_CREATED, createSpy)
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, pushEvent)
         lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_DISCARDED, discardSpy)

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -10,10 +10,13 @@ describe('error collection', () => {
   const errorObservable = new Observable<RawError>()
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => false
-      doStartErrorCollection(lifeCycle, configuration, errorObservable)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => false,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        doStartErrorCollection(lifeCycle, configuration, errorObservable)
+      })
   })
 
   afterEach(() => {
@@ -125,10 +128,13 @@ describe('error collection v2', () => {
   const errorObservable = new Observable<RawError>()
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => true
-      doStartErrorCollection(lifeCycle, configuration, errorObservable)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => true,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        doStartErrorCollection(lifeCycle, configuration, errorObservable)
+      })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -14,7 +14,7 @@ describe('error collection', () => {
       .withConfiguration({
         isEnabled: () => false,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         doStartErrorCollection(lifeCycle, configuration, errorObservable)
       })
   })
@@ -132,7 +132,7 @@ describe('error collection v2', () => {
       .withConfiguration({
         isEnabled: () => true,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         doStartErrorCollection(lifeCycle, configuration, errorObservable)
       })
   })

--- a/packages/rum/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -9,10 +9,13 @@ describe('long task collection', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => false
-      startLongTaskCollection(lifeCycle, configuration)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => false,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        startLongTaskCollection(lifeCycle, configuration)
+      })
   })
 
   afterEach(() => {
@@ -55,10 +58,13 @@ describe('long task collection v2', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => true
-      startLongTaskCollection(lifeCycle, configuration)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => true,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        startLongTaskCollection(lifeCycle, configuration)
+      })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -13,7 +13,7 @@ describe('long task collection', () => {
       .withConfiguration({
         isEnabled: () => false,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         startLongTaskCollection(lifeCycle, configuration)
       })
   })
@@ -62,7 +62,7 @@ describe('long task collection v2', () => {
       .withConfiguration({
         isEnabled: () => true,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         startLongTaskCollection(lifeCycle, configuration)
       })
   })

--- a/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -20,8 +20,10 @@ describe('resourceCollection', () => {
           isTracked: () => true,
           isTrackedWithResource: () => true,
         })
+        .withConfiguration({
+          isEnabled: () => false,
+        })
         .beforeBuild((lifeCycle, configuration, session: RumSession) => {
-          configuration.isEnabled = () => false
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -102,8 +104,10 @@ describe('resourceCollection', () => {
           isTracked: () => true,
           isTrackedWithResource: () => false,
         })
+        .withConfiguration({
+          isEnabled: () => false,
+        })
         .beforeBuild((lifeCycle, configuration, session: RumSession) => {
-          configuration.isEnabled = () => false
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -137,8 +141,10 @@ describe('resourceCollection', () => {
           isTracked: () => true,
           isTrackedWithResource: () => isTrackedWithResource,
         })
+        .withConfiguration({
+          isEnabled: () => false,
+        })
         .beforeBuild((lifeCycle, configuration, session: RumSession) => {
-          configuration.isEnabled = () => false
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -180,10 +186,13 @@ describe('resourceCollection', () => {
 
   describe('tracing info', () => {
     beforeEach(() => {
-      setupBuilder = setup().beforeBuild((lifeCycle, configuration, session: RumSession) => {
-        configuration.isEnabled = () => false
-        startResourceCollection(lifeCycle, configuration, session)
-      })
+      setupBuilder = setup()
+        .withConfiguration({
+          isEnabled: () => false,
+        })
+        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+          startResourceCollection(lifeCycle, configuration, session)
+        })
     })
 
     afterEach(() => {
@@ -233,8 +242,10 @@ describe('resourceCollection V2', () => {
           isTracked: () => true,
           isTrackedWithResource: () => true,
         })
+        .withConfiguration({
+          isEnabled: () => true,
+        })
         .beforeBuild((lifeCycle, configuration, session: RumSession) => {
-          configuration.isEnabled = () => true
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -304,8 +315,10 @@ describe('resourceCollection V2', () => {
           isTracked: () => true,
           isTrackedWithResource: () => false,
         })
+        .withConfiguration({
+          isEnabled: () => true,
+        })
         .beforeBuild((lifeCycle, configuration, session: RumSession) => {
-          configuration.isEnabled = () => true
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -339,8 +352,10 @@ describe('resourceCollection V2', () => {
           isTracked: () => true,
           isTrackedWithResource: () => isTrackedWithResource,
         })
+        .withConfiguration({
+          isEnabled: () => true,
+        })
         .beforeBuild((lifeCycle, configuration, session: RumSession) => {
-          configuration.isEnabled = () => true
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -382,10 +397,13 @@ describe('resourceCollection V2', () => {
 
   describe('tracing info', () => {
     beforeEach(() => {
-      setupBuilder = setup().beforeBuild((lifeCycle, configuration, session: RumSession) => {
-        configuration.isEnabled = () => true
-        startResourceCollection(lifeCycle, configuration, session)
-      })
+      setupBuilder = setup()
+        .withConfiguration({
+          isEnabled: () => true,
+        })
+        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+          startResourceCollection(lifeCycle, configuration, session)
+        })
     })
 
     afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -23,7 +23,7 @@ describe('resourceCollection', () => {
         .withConfiguration({
           isEnabled: () => false,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -107,7 +107,7 @@ describe('resourceCollection', () => {
         .withConfiguration({
           isEnabled: () => false,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -144,7 +144,7 @@ describe('resourceCollection', () => {
         .withConfiguration({
           isEnabled: () => false,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -190,7 +190,7 @@ describe('resourceCollection', () => {
         .withConfiguration({
           isEnabled: () => false,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -245,7 +245,7 @@ describe('resourceCollection V2', () => {
         .withConfiguration({
           isEnabled: () => true,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -318,7 +318,7 @@ describe('resourceCollection V2', () => {
         .withConfiguration({
           isEnabled: () => true,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -355,7 +355,7 @@ describe('resourceCollection V2', () => {
         .withConfiguration({
           isEnabled: () => true,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })
@@ -401,7 +401,7 @@ describe('resourceCollection V2', () => {
         .withConfiguration({
           isEnabled: () => true,
         })
-        .beforeBuild((lifeCycle, configuration, session: RumSession) => {
+        .beforeBuild(({ lifeCycle, configuration, session }) => {
           startResourceCollection(lifeCycle, configuration, session)
         })
     })

--- a/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -78,8 +78,7 @@ describe('rum track url change', () => {
           initialViewId = id
           subscription.unsubscribe()
         })
-        const { stop } = trackViews(location, lifeCycle)
-        return stop
+        return trackViews(location, lifeCycle)
       })
     createSpy = jasmine.createSpy('create')
   })
@@ -217,8 +216,7 @@ describe('rum view referrer', () => {
           initialViewCreatedEvent = event
           subscription.unsubscribe()
         })
-        const { stop } = trackViews(location, lifeCycle)
-        return stop
+        return trackViews(location, lifeCycle)
       })
     createSpy = jasmine.createSpy('create')
   })
@@ -285,8 +283,7 @@ describe('rum track renew session', () => {
           initialViewId = id
           subscription.unsubscribe()
         })
-        const { stop } = trackViews(location, lifeCycle)
-        return stop
+        return trackViews(location, lifeCycle)
       })
   })
 
@@ -329,8 +326,7 @@ describe('rum track loading type', () => {
       .withFakeLocation('/foo')
       .beforeBuild(({ location, lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
-        const { stop } = trackViews(location, lifeCycle)
-        return stop
+        return trackViews(location, lifeCycle)
       })
   })
 
@@ -368,8 +364,7 @@ describe('rum track loading time', () => {
       .withFakeLocation('/foo')
       .beforeBuild(({ location, lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
-        const { stop } = trackViews(location, lifeCycle)
-        return stop
+        return trackViews(location, lifeCycle)
       })
   })
 
@@ -462,8 +457,7 @@ describe('rum view measures', () => {
       .withFakeLocation('/foo')
       .beforeBuild(({ location, lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
-        const { stop } = trackViews(location, lifeCycle)
-        return stop
+        return trackViews(location, lifeCycle)
       })
   })
 

--- a/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -10,7 +10,7 @@ import {
   PAGE_ACTIVITY_MAX_DURATION,
   PAGE_ACTIVITY_VALIDATION_DELAY,
 } from '../../trackPageActivities'
-import { THROTTLE_VIEW_UPDATE_PERIOD, View, ViewCreatedEvent, ViewLoadingType } from './trackViews'
+import { THROTTLE_VIEW_UPDATE_PERIOD, trackViews, View, ViewCreatedEvent, ViewLoadingType } from './trackViews'
 
 const AFTER_PAGE_ACTIVITY_MAX_DURATION = PAGE_ACTIVITY_MAX_DURATION * 1.1
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = PAGE_ACTIVITY_VALIDATION_DELAY * 0.8
@@ -73,12 +73,13 @@ describe('rum track url change', () => {
   beforeEach(() => {
     setupBuilder = setup()
       .withFakeLocation('/foo')
-      .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => {
+      .beforeBuild(({ location, lifeCycle }) => {
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
           initialViewId = id
           subscription.unsubscribe()
         })
+        const { stop } = trackViews(location, lifeCycle)
+        return stop
       })
     createSpy = jasmine.createSpy('create')
   })
@@ -211,12 +212,13 @@ describe('rum view referrer', () => {
   beforeEach(() => {
     setupBuilder = setup()
       .withFakeLocation('/foo')
-      .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => {
+      .beforeBuild(({ location, lifeCycle }) => {
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (event) => {
           initialViewCreatedEvent = event
           subscription.unsubscribe()
         })
+        const { stop } = trackViews(location, lifeCycle)
+        return stop
       })
     createSpy = jasmine.createSpy('create')
   })
@@ -277,13 +279,14 @@ describe('rum track renew session', () => {
 
     setupBuilder = setup()
       .withFakeLocation('/foo')
-      .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => {
+      .beforeBuild(({ lifeCycle, location }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
           initialViewId = id
           subscription.unsubscribe()
         })
+        const { stop } = trackViews(location, lifeCycle)
+        return stop
       })
   })
 
@@ -324,9 +327,10 @@ describe('rum track loading type', () => {
     setupBuilder = setup()
       .withFakeClock()
       .withFakeLocation('/foo')
-      .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => {
+      .beforeBuild(({ location, lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
+        const { stop } = trackViews(location, lifeCycle)
+        return stop
       })
   })
 
@@ -362,9 +366,10 @@ describe('rum track loading time', () => {
     setupBuilder = setup()
       .withFakeClock()
       .withFakeLocation('/foo')
-      .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => {
+      .beforeBuild(({ location, lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
+        const { stop } = trackViews(location, lifeCycle)
+        return stop
       })
   })
 
@@ -455,9 +460,10 @@ describe('rum view measures', () => {
 
     setupBuilder = setup()
       .withFakeLocation('/foo')
-      .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => {
+      .beforeBuild(({ location, lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
+        const { stop } = trackViews(location, lifeCycle)
+        return stop
       })
   })
 

--- a/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -325,7 +325,9 @@ describe('rum track loading type', () => {
       .withFakeClock()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
+      .beforeBuild(({ lifeCycle }) => {
+        lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
+      })
   })
 
   afterEach(() => {
@@ -361,7 +363,9 @@ describe('rum track loading time', () => {
       .withFakeClock()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
+      .beforeBuild(({ lifeCycle }) => {
+        lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
+      })
   })
 
   afterEach(() => {
@@ -452,7 +456,9 @@ describe('rum view measures', () => {
     setupBuilder = setup()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild(({ lifeCycle }) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
+      .beforeBuild(({ lifeCycle }) => {
+        lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
+      })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -74,7 +74,7 @@ describe('rum track url change', () => {
     setupBuilder = setup()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild((lifeCycle) => {
+      .beforeBuild(({ lifeCycle }) => {
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
           initialViewId = id
           subscription.unsubscribe()
@@ -212,7 +212,7 @@ describe('rum view referrer', () => {
     setupBuilder = setup()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild((lifeCycle) => {
+      .beforeBuild(({ lifeCycle }) => {
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (event) => {
           initialViewCreatedEvent = event
           subscription.unsubscribe()
@@ -278,7 +278,7 @@ describe('rum track renew session', () => {
     setupBuilder = setup()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild((lifeCycle) => {
+      .beforeBuild(({ lifeCycle }) => {
         lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler)
         const subscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, ({ id }) => {
           initialViewId = id
@@ -325,7 +325,7 @@ describe('rum track loading type', () => {
       .withFakeClock()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
+      .beforeBuild(({ lifeCycle }) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
   })
 
   afterEach(() => {
@@ -361,7 +361,7 @@ describe('rum track loading time', () => {
       .withFakeClock()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
+      .beforeBuild(({ lifeCycle }) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
   })
 
   afterEach(() => {
@@ -452,7 +452,7 @@ describe('rum view measures', () => {
     setupBuilder = setup()
       .withFakeLocation('/foo')
       .withViewCollection()
-      .beforeBuild((lifeCycle) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
+      .beforeBuild(({ lifeCycle }) => lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, handler))
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -13,7 +13,7 @@ describe('viewCollection', () => {
       .withConfiguration({
         isEnabled: () => false,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         startViewCollection(lifeCycle, configuration, location)
       })
   })
@@ -86,7 +86,7 @@ describe('viewCollection V2', () => {
       .withConfiguration({
         isEnabled: () => true,
       })
-      .beforeBuild((lifeCycle, configuration) => {
+      .beforeBuild(({ lifeCycle, configuration }) => {
         startViewCollection(lifeCycle, configuration, location)
       })
   })

--- a/packages/rum/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -9,10 +9,13 @@ describe('viewCollection', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => false
-      startViewCollection(lifeCycle, configuration, location)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => false,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        startViewCollection(lifeCycle, configuration, location)
+      })
   })
 
   afterEach(() => {
@@ -79,10 +82,13 @@ describe('viewCollection V2', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild((lifeCycle, configuration) => {
-      configuration.isEnabled = () => true
-      startViewCollection(lifeCycle, configuration, location)
-    })
+    setupBuilder = setup()
+      .withConfiguration({
+        isEnabled: () => true,
+      })
+      .beforeBuild((lifeCycle, configuration) => {
+        startViewCollection(lifeCycle, configuration, location)
+      })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -11,7 +11,7 @@ export function startViewCollection(lifeCycle: LifeCycle, configuration: Configu
       : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processViewUpdate(view))
   })
 
-  trackViews(location, lifeCycle)
+  return trackViews(location, lifeCycle)
 }
 
 function processViewUpdate(view: View) {

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -31,6 +31,7 @@ interface BrowserWindow extends Window {
 export interface TestSetupBuilder {
   withFakeLocation: (initialUrl: string) => TestSetupBuilder
   withSession: (session: RumSession) => TestSetupBuilder
+  withConfiguration: (overrides: Partial<Configuration>) => TestSetupBuilder
   withRum: () => TestSetupBuilder
   withViewCollection: () => TestSetupBuilder
   withActionCollection: () => TestSetupBuilder
@@ -42,7 +43,7 @@ export interface TestSetupBuilder {
   withFakeClock: () => TestSetupBuilder
   withPerformanceObserverStubBuilder: () => TestSetupBuilder
   beforeBuild: (
-    callback: (lifeCycle: LifeCycle, configuration: Configuration, session: RumSession) => void
+    callback: (lifeCycle: LifeCycle, configuration: Readonly<Configuration>, session: RumSession) => void
   ) => TestSetupBuilder
 
   cleanup: () => void
@@ -138,6 +139,10 @@ export function setup(): TestSetupBuilder {
     },
     withSession(sessionStub: RumSession) {
       session = sessionStub
+      return setupBuilder
+    },
+    withConfiguration(overrides: Partial<Configuration>) {
+      assign(configuration, overrides)
       return setupBuilder
     },
     withRum() {

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -14,7 +14,7 @@ import { startRumAssembly } from '../src/domain/assembly'
 import { startRumAssemblyV2 } from '../src/domain/assemblyV2'
 import { startInternalContext } from '../src/domain/internalContext'
 import { LifeCycle, LifeCycleEventType } from '../src/domain/lifeCycle'
-import { ParentContexts, startParentContexts } from '../src/domain/parentContexts'
+import { ParentContexts } from '../src/domain/parentContexts'
 import { RumSession } from '../src/domain/rumSession'
 import { RawRumEvent } from '../src/types'
 import { RawRumEventV2, RumContextV2, ViewContextV2 } from '../src/typesV2'
@@ -25,7 +25,7 @@ export interface TestSetupBuilder {
   withSession: (session: RumSession) => TestSetupBuilder
   withConfiguration: (overrides: Partial<Configuration>) => TestSetupBuilder
   withRum: () => TestSetupBuilder
-  withParentContexts: (stub?: Partial<ParentContexts>) => TestSetupBuilder
+  withParentContexts: (stub: Partial<ParentContexts>) => TestSetupBuilder
   withInternalContext: () => TestSetupBuilder
   withAssembly: () => TestSetupBuilder
   withAssemblyV2: () => TestSetupBuilder
@@ -47,7 +47,6 @@ interface BuildContext {
 export interface TestIO {
   lifeCycle: LifeCycle
   clock: jasmine.Clock
-  parentContexts: ParentContexts
   internalContext: ReturnType<typeof startInternalContext>
   fakeLocation: Partial<Location>
   setGlobalContext: (context: Context) => void
@@ -185,17 +184,8 @@ export function setup(): TestSetupBuilder {
       })
       return setupBuilder
     },
-    withParentContexts(stub?: Partial<ParentContexts>) {
-      if (stub) {
-        parentContexts = stub as ParentContexts
-        return setupBuilder
-      }
-      buildTasks.push(() => {
-        parentContexts = startParentContexts(lifeCycle, session)
-        cleanupTasks.push(() => {
-          parentContexts.stop()
-        })
-      })
+    withParentContexts(stub: Partial<ParentContexts>) {
+      parentContexts = stub as ParentContexts
       return setupBuilder
     },
     withFakeClock() {
@@ -229,7 +219,6 @@ export function setup(): TestSetupBuilder {
         fakeLocation,
         internalContext,
         lifeCycle,
-        parentContexts,
         rawRumEvents,
         rawRumEventsV2,
         session,

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -10,7 +10,6 @@ import {
   SPEC_ENDPOINTS,
   withSnakeCaseKeys,
 } from '@datadog/browser-core'
-import sinon from 'sinon'
 import { startRumEventCollection } from '../src/boot/rum'
 import { startPerformanceCollection } from '../src/browser/performanceCollection'
 import { startRumAssembly } from '../src/domain/assembly'
@@ -41,7 +40,6 @@ export interface TestSetupBuilder {
   withAssembly: () => TestSetupBuilder
   withAssemblyV2: () => TestSetupBuilder
   withFakeClock: () => TestSetupBuilder
-  withFakeServer: () => TestSetupBuilder
   withPerformanceObserverStubBuilder: () => TestSetupBuilder
   beforeBuild: (
     callback: (lifeCycle: LifeCycle, configuration: Configuration, session: RumSession) => void
@@ -53,7 +51,6 @@ export interface TestSetupBuilder {
 
 export interface TestIO {
   lifeCycle: LifeCycle
-  server: sinon.SinonFakeServer
   stubBuilder: PerformanceObserverStubBuilder
   clock: jasmine.Clock
   parentContexts: ParentContexts
@@ -100,7 +97,6 @@ export function setup(): TestSetupBuilder {
   }> = []
 
   let globalContext: Context
-  let server: sinon.SinonFakeServer
   let clock: jasmine.Clock
   let stubBuilder: PerformanceObserverStubBuilder
   let fakeLocation: Partial<Location> = location
@@ -110,7 +106,6 @@ export function setup(): TestSetupBuilder {
     ...DEFAULT_CONFIGURATION,
     ...SPEC_ENDPOINTS,
     isEnabled: () => true,
-    maxBatchSize: 1,
   }
   const FAKE_APP_ID = 'appId'
 
@@ -233,11 +228,6 @@ export function setup(): TestSetupBuilder {
       cleanupClock = () => jasmine.clock().uninstall()
       return setupBuilder
     },
-    withFakeServer() {
-      server = sinon.fakeServer.create()
-      cleanupTasks.push(() => server.restore())
-      return setupBuilder
-    },
     withPerformanceObserverStubBuilder() {
       const browserWindow = window as BrowserWindow
       const original = browserWindow.PerformanceObserver
@@ -261,7 +251,6 @@ export function setup(): TestSetupBuilder {
         parentContexts,
         rawRumEvents,
         rawRumEventsV2,
-        server,
         session,
         stubBuilder,
         setGlobalContext(context: Context) {

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -16,7 +16,6 @@ import { startRumAssemblyV2 } from '../src/domain/assemblyV2'
 import { startInternalContext } from '../src/domain/internalContext'
 import { LifeCycle, LifeCycleEventType } from '../src/domain/lifeCycle'
 import { ParentContexts, startParentContexts } from '../src/domain/parentContexts'
-import { trackActions } from '../src/domain/rumEventsCollection/action/trackActions'
 import { RumSession } from '../src/domain/rumSession'
 import { RawRumEvent } from '../src/types'
 import { RawRumEventV2, RumContextV2, ViewContextV2 } from '../src/typesV2'
@@ -27,7 +26,6 @@ export interface TestSetupBuilder {
   withSession: (session: RumSession) => TestSetupBuilder
   withConfiguration: (overrides: Partial<Configuration>) => TestSetupBuilder
   withRum: () => TestSetupBuilder
-  withActionCollection: () => TestSetupBuilder
   withPerformanceCollection: () => TestSetupBuilder
   withParentContexts: (stub?: Partial<ParentContexts>) => TestSetupBuilder
   withInternalContext: () => TestSetupBuilder
@@ -186,13 +184,6 @@ export function setup(): TestSetupBuilder {
     withInternalContext() {
       buildTasks.push(() => {
         internalContext = startInternalContext(FAKE_APP_ID, session, parentContexts, configuration as Configuration)
-      })
-      return setupBuilder
-    },
-    withActionCollection() {
-      buildTasks.push(() => {
-        const { stop } = trackActions(lifeCycle)
-        cleanupTasks.push(stop)
       })
       return setupBuilder
     },

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -10,7 +10,6 @@ import {
   withSnakeCaseKeys,
 } from '@datadog/browser-core'
 import { startRumEventCollection } from '../src/boot/rum'
-import { startPerformanceCollection } from '../src/browser/performanceCollection'
 import { startRumAssembly } from '../src/domain/assembly'
 import { startRumAssemblyV2 } from '../src/domain/assemblyV2'
 import { startInternalContext } from '../src/domain/internalContext'
@@ -26,7 +25,6 @@ export interface TestSetupBuilder {
   withSession: (session: RumSession) => TestSetupBuilder
   withConfiguration: (overrides: Partial<Configuration>) => TestSetupBuilder
   withRum: () => TestSetupBuilder
-  withPerformanceCollection: () => TestSetupBuilder
   withParentContexts: (stub?: Partial<ParentContexts>) => TestSetupBuilder
   withInternalContext: () => TestSetupBuilder
   withAssembly: () => TestSetupBuilder
@@ -185,10 +183,6 @@ export function setup(): TestSetupBuilder {
       buildTasks.push(() => {
         internalContext = startInternalContext(FAKE_APP_ID, session, parentContexts, configuration as Configuration)
       })
-      return setupBuilder
-    },
-    withPerformanceCollection() {
-      buildTasks.push(() => startPerformanceCollection(lifeCycle, configuration as Configuration))
       return setupBuilder
     },
     withParentContexts(stub?: Partial<ParentContexts>) {

--- a/packages/rum/test/specHelper.ts
+++ b/packages/rum/test/specHelper.ts
@@ -28,7 +28,7 @@ export interface TestSetupBuilder {
   build: () => TestIO
 }
 
-type BeforeBuildCallback = (buildContext: BuildContext) => void | (() => void)
+type BeforeBuildCallback = (buildContext: BuildContext) => void | ({ stop?(): void })
 interface BuildContext {
   lifeCycle: LifeCycle
   configuration: Readonly<Configuration>
@@ -144,7 +144,7 @@ export function setup(): TestSetupBuilder {
     },
     build() {
       beforeBuildTasks.forEach((task) => {
-        const cleanup = task({
+        const result = task({
           lifeCycle,
           parentContexts,
           session,
@@ -152,8 +152,8 @@ export function setup(): TestSetupBuilder {
           configuration: configuration as Configuration,
           location: fakeLocation as Location,
         })
-        if (cleanup) {
-          cleanupTasks.push(cleanup)
+        if (result && result.stop) {
+          cleanupTasks.push(result.stop)
         }
       })
       return {

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -15,7 +15,7 @@ module.exports = {
   client: {
     jasmine: {
       random: true,
-      oneFailurePerSpec: false,
+      oneFailurePerSpec: true,
     },
   },
   preprocessors: {


### PR DESCRIPTION
## Motivation

The line between what should be in specHelper and what should not is blurry. Most of domain-related `withXXX` methods are only used by the related domain spec file. It seems that `beforeBuild` is a good way to start a given function based on a testing context (session, configuration, etc.).

## Changes

This PR tries to simplify the unit test specHelper by reducing its responsabilities:
* the `withFakeServer` is replaced with a spy on `RUM_EVENT_COLLECTED` lifecycle events
* a `withConfiguration` method has been added to the spec helper to allow modifying the configuration before any `beforeBuild` call
* the `beforeBuild` method has been extended to expose more context to the callback, and allow to specify a cleanup function
* domain-specific `withXXX` methods have been inlined to their related spec by using `beforeBuild`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
