### PR TITLE
⚗️[RUMF-766] add match request timing debug infos (experimental)

### DIFF
--- a/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
@@ -23,7 +23,7 @@ describe('matchRequestTiming', () => {
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(match)
+    expect(timing.candidate).toEqual(match)
   })
 
   it('should not match single timing outside the request ', () => {
@@ -32,7 +32,7 @@ describe('matchRequestTiming', () => {
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(undefined)
+    expect(timing.candidate).toEqual(undefined)
   })
 
   it('should match two following timings nested in the request ', () => {
@@ -42,7 +42,7 @@ describe('matchRequestTiming', () => {
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(actualTiming)
+    expect(timing.candidate).toEqual(actualTiming)
   })
 
   it('should not match two not following timings nested in the request ', () => {
@@ -52,7 +52,7 @@ describe('matchRequestTiming', () => {
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(undefined)
+    expect(timing.candidate).toEqual(undefined)
   })
 
   it('should not match multiple timings nested in the request', () => {
@@ -63,7 +63,7 @@ describe('matchRequestTiming', () => {
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(undefined)
+    expect(timing.candidate).toEqual(undefined)
   })
 
   it('should match invalid timing nested in the request ', () => {
@@ -76,6 +76,6 @@ describe('matchRequestTiming', () => {
 
     const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(undefined)
+    expect(timing.candidate).toEqual(undefined)
   })
 })

--- a/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
@@ -22,7 +22,7 @@ interface Timing {
  */
 export function matchRequestTiming(request: RequestCompleteEvent) {
   if (!performance || !('getEntriesByName' in performance)) {
-    return
+    return {}
   }
   const candidates = performance
     .getEntriesByName(request.url, 'resource')
@@ -30,15 +30,26 @@ export function matchRequestTiming(request: RequestCompleteEvent) {
     .filter(toValidEntry)
     .filter((entry) => isBetween(entry, request.startTime, endTime(request)))
 
+  let result
+
   if (candidates.length === 1) {
-    return candidates[0]
+    result = candidates[0]
   }
 
   if (candidates.length === 2 && firstCanBeOptionRequest(candidates)) {
-    return candidates[1]
+    result = candidates[1]
   }
 
-  return
+  return {
+    candidate: result,
+    debug: {
+      candidates: candidates.map((c) => ({ startTime: c.startTime, duration: c.duration })),
+      matchesNb: candidates.length,
+      request: { startTime: request.startTime, duration: request.duration },
+      result: result && { startTime: result.startTime, duration: result.duration },
+      resultDiff: result && request.duration - result.duration,
+    },
+  }
 }
 
 function firstCanBeOptionRequest(correspondingEntries: RumPerformanceResourceTiming[]) {

--- a/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -295,6 +295,7 @@ describe('resourceCollection V2', () => {
       expect(rawRumEventsV2[0].startTime).toBe(1234)
       expect(rawRumEventsV2[0].rawRumEvent).toEqual({
         date: (jasmine.any(Number) as unknown) as number,
+        debug: jasmine.anything(),
         resource: {
           duration: 100 * 1e6,
           method: 'GET',

--- a/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -26,8 +26,8 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Con
   lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, (request: RequestCompleteEvent) => {
     if (session.isTrackedWithResource()) {
       configuration.isEnabled('v2_format')
-        ? lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, processRequestV2(request))
-        : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processRequest(request))
+        ? lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_V2_COLLECTED, processRequestV2(request, configuration))
+        : lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processRequest(request, configuration))
     }
   })
 
@@ -40,12 +40,14 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Con
   })
 }
 
-function processRequest(request: RequestCompleteEvent) {
+function processRequest(request: RequestCompleteEvent, configuration: Configuration) {
   const kind = request.type === RequestType.XHR ? ResourceType.XHR : ResourceType.FETCH
 
   const matchingTiming = matchRequestTiming(request)
-  const startTime = matchingTiming ? matchingTiming.startTime : request.startTime
-  const correspondingTimingOverrides = matchingTiming ? computePerformanceEntryMetrics(matchingTiming) : undefined
+  const startTime = matchingTiming.candidate ? matchingTiming.candidate.startTime : request.startTime
+  const correspondingTimingOverrides = matchingTiming.candidate
+    ? computePerformanceEntryMetrics(matchingTiming.candidate)
+    : undefined
 
   const tracingInfo = computeRequestTracingInfo(request)
 
@@ -66,17 +68,24 @@ function processRequest(request: RequestCompleteEvent) {
       },
     },
     tracingInfo,
-    correspondingTimingOverrides
+    correspondingTimingOverrides,
+    configuration.isEnabled('match-debug')
+      ? {
+          debug: matchingTiming.debug,
+        }
+      : undefined
   )
   return { startTime, rawRumEvent: resourceEvent }
 }
 
-function processRequestV2(request: RequestCompleteEvent) {
+function processRequestV2(request: RequestCompleteEvent, configuration: Configuration) {
   const type = request.type === RequestType.XHR ? ResourceType.XHR : ResourceType.FETCH
 
   const matchingTiming = matchRequestTiming(request)
-  const startTime = matchingTiming ? matchingTiming.startTime : request.startTime
-  const correspondingTimingOverrides = matchingTiming ? computePerformanceEntryMetricsV2(matchingTiming) : undefined
+  const startTime = matchingTiming.candidate ? matchingTiming.candidate.startTime : request.startTime
+  const correspondingTimingOverrides = matchingTiming.candidate
+    ? computePerformanceEntryMetricsV2(matchingTiming.candidate)
+    : undefined
 
   const tracingInfo = computeRequestTracingInfo(request)
 
@@ -93,7 +102,12 @@ function processRequestV2(request: RequestCompleteEvent) {
       type: RumEventType.RESOURCE,
     },
     tracingInfo,
-    correspondingTimingOverrides
+    correspondingTimingOverrides,
+    configuration.isEnabled('match-debug')
+      ? {
+          debug: matchingTiming.debug,
+        }
+      : undefined
   )
   return { startTime, rawRumEvent: resourceEvent as RumResourceEventV2 }
 }

--- a/packages/rum/src/typesV2.ts
+++ b/packages/rum/src/typesV2.ts
@@ -13,6 +13,7 @@ export enum RumEventType {
 
 export interface RumResourceEventV2 {
   date: number
+  debug?: any
   type: RumEventType.RESOURCE
   resource: {
     type: ResourceType


### PR DESCRIPTION
## Motivation

Allow to debug match request timing on real data
Should be reverted after the analysis

## Changes

when `'match-debug'` enabled, add debug infos to resource events

## Testing

tested locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
