### PR TITLE
✨ [RUMF-762] include the context when using console handler

### DIFF
--- a/packages/logs/src/boot/logs.entry.spec.ts
+++ b/packages/logs/src/boot/logs.entry.spec.ts
@@ -271,7 +271,10 @@ describe('logs entry', () => {
         logger.error('message')
 
         expect(sendLogsSpy).not.toHaveBeenCalled()
-        expect(console.log).toHaveBeenCalledWith('error: message')
+        expect(console.log).toHaveBeenCalledWith('error: message', {
+          error: { origin: 'logger' },
+          logger: { name: 'foo' },
+        })
       })
 
       it('should have their name in their context', () => {

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -83,11 +83,16 @@ describe('Logger', () => {
 
     it('should be configurable to "console"', () => {
       logger.setHandler(HandlerType.console)
+      logger.setContext({ foo: 'bar' })
 
-      logger.error('message')
+      logger.error('message', { lorem: 'ipsum' })
 
       expect(sendLogSpy).not.toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledWith('error: message')
+      expect(console.log).toHaveBeenCalledWith('error: message', {
+        error: { origin: 'logger' },
+        foo: 'bar',
+        lorem: 'ipsum',
+      })
     })
 
     it('should be configurable to "silent"', () => {

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -52,7 +52,7 @@ export class Logger {
           })
           break
         case HandlerType.console:
-          console.log(`${status}: ${message}`)
+          console.log(`${status}: ${message}`, combine(this.contextManager.get(), messageContext))
           break
         case HandlerType.silent:
           break


### PR DESCRIPTION
## Motivation

Fixing https://github.com/DataDog/browser-sdk/issues/589

## Changes

The context is now included when using the `console` handler. It's passed as the second parameter to `console.log` call instead of calling it twice.

## Testing

I updated the logs unit tests to check that the context is included.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
