### PR TITLE
✨ [RUMF-771] Add getLoggerGlobalContext and getRumGlobalContext

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -356,7 +356,7 @@ datadogLogs.setLoggerGlobalContext("{'env': 'staging'}")
 
 datadogLogs.addLoggerGlobalContext('referrer', document.referrer)
 
-datadogLogs.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
+const context = datadogLogs.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
 ```
 
 #### CDN async
@@ -372,7 +372,9 @@ DD_LOGS.onReady(function() {
   window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('referrer', document.referrer)
 })
 
-window.DD_LOGS && DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
+DD_LOGS.onReady(function() {
+  var context = window.DD_LOGS && DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
+})
 ```
 
 **Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
@@ -386,7 +388,7 @@ window.DD_LOGS && DD_LOGS.setLoggerGlobalContext({ env: 'staging' })
 
 window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('referrer', document.referrer)
 
-window.DD_LOGS && DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
+var context = window.DD_LOGS && DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
 ```
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -343,6 +343,7 @@ After the Datadog browser log library is initialized, it is possible to:
 
 - Set the entire context for all your loggers with the `setLoggerGlobalContext (context: Context)` API.
 - Add a context to all your loggers with `addLoggerGlobalContext (key: string, value: any)` API.
+- Get the entire global context with `getLoggerGlobalContext ()` API.
 
 ##### NPM
 
@@ -354,6 +355,8 @@ import { datadogLogs } from '@datadog/browser-logs'
 datadogLogs.setLoggerGlobalContext("{'env': 'staging'}")
 
 datadogLogs.addLoggerGlobalContext('referrer', document.referrer)
+
+datadogLogs.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
 ```
 
 #### CDN async
@@ -368,6 +371,8 @@ DD_LOGS.onReady(function() {
 DD_LOGS.onReady(function() {
   window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('referrer', document.referrer)
 })
+
+window.DD_LOGS && DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
 ```
 
 **Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
@@ -380,6 +385,8 @@ For CDN sync, use:
 window.DD_LOGS && DD_LOGS.setLoggerGlobalContext({ env: 'staging' })
 
 window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('referrer', document.referrer)
+
+window.DD_LOGS && DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
 ```
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the library.

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -70,6 +70,7 @@ export function makeLogsGlobal(startLogsImpl: StartLogs) {
     }),
 
     setLoggerGlobalContext: monitor(globalContextManager.set),
+    getLoggerGlobalContext: monitor(globalContextManager.get),
 
     addLoggerGlobalContext: monitor(globalContextManager.add),
 

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -3,7 +3,6 @@ import {
   checkIsNotLocalFile,
   combine,
   Context,
-  ContextValue,
   createContextManager,
   defineGlobal,
   getGlobalObject,

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -69,8 +69,8 @@ export function makeLogsGlobal(startLogsImpl: StartLogs) {
       isAlreadyInitialized = true
     }),
 
-    setLoggerGlobalContext: monitor(globalContextManager.set),
     getLoggerGlobalContext: monitor(globalContextManager.get),
+    setLoggerGlobalContext: monitor(globalContextManager.set),
 
     addLoggerGlobalContext: monitor(globalContextManager.add),
 

--- a/packages/logs/src/domain/loggerSession.ts
+++ b/packages/logs/src/domain/loggerSession.ts
@@ -29,7 +29,7 @@ export function startLoggerSession(configuration: Configuration, areCookieAuthor
   }
 }
 
-function computeTrackingType(configuration: Configuration): LoggerTrackingType {
+function computeTrackingType(configuration: Configuration) {
   if (!performDraw(configuration.sampleRate)) {
     return LoggerTrackingType.NOT_TRACKED
   }

--- a/packages/logs/src/domain/loggerSession.ts
+++ b/packages/logs/src/domain/loggerSession.ts
@@ -29,7 +29,7 @@ export function startLoggerSession(configuration: Configuration, areCookieAuthor
   }
 }
 
-function computeTrackingType(configuration: Configuration): string {
+function computeTrackingType(configuration: Configuration): LoggerTrackingType {
   if (!performDraw(configuration.sampleRate)) {
     return LoggerTrackingType.NOT_TRACKED
   }

--- a/packages/rum/src/boot/rum.entry.ts
+++ b/packages/rum/src/boot/rum.entry.ts
@@ -80,8 +80,8 @@ export function makeRumGlobal(startRumImpl: StartRum) {
 
     removeRumGlobalContext: monitor(globalContextManager.remove),
 
-    setRumGlobalContext: monitor(globalContextManager.set),
     getRumGlobalContext: monitor(globalContextManager.get),
+    setRumGlobalContext: monitor(globalContextManager.set),
 
     getInternalContext: monitor((startTime?: number) => {
       return getInternalContextStrategy(startTime)

--- a/packages/rum/src/boot/rum.entry.ts
+++ b/packages/rum/src/boot/rum.entry.ts
@@ -81,6 +81,7 @@ export function makeRumGlobal(startRumImpl: StartRum) {
     removeRumGlobalContext: monitor(globalContextManager.remove),
 
     setRumGlobalContext: monitor(globalContextManager.set),
+    getRumGlobalContext: monitor(globalContextManager.get),
 
     getInternalContext: monitor((startTime?: number) => {
       return getInternalContextStrategy(startTime)


### PR DESCRIPTION
## Motivation

Simply debugging by providing getters for global contexts.

## Changes

- Couple of small changes (correcting return type and removing unused import).
- Added `getLoggerGlobalContext` and `getRumGlobalContext`
- Updated README

## Testing

No new tests were added since the contextManager methods are already tested and those getters are just aliases of `contextManager.get`.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
