### PR TITLE
✨ [RUMF-758] keep internal context in v1 format (experimental)

### DIFF
--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -128,18 +128,5 @@ interface Rum {
 
 function getRUMInternalContext(startTime?: number): Context | undefined {
   const rum = (window as any).DD_RUM as Rum
-  const context = rum && rum.getInternalContext ? rum.getInternalContext(startTime) : undefined
-  if (!context || !context.session) {
-    return context
-  }
-  // TODO settle on integration strategy
-  // tslint:disable:no-unsafe-any
-  const v2context = context as any
-  v2context.session_id = v2context.session.id
-  v2context.application_id = v2context.application.id
-  if (v2context.action) {
-    v2context.user_action = { id: v2context.action.id }
-  }
-  // tslint:enable:no-unsafe-any
-  return v2context as Context
+  return rum && rum.getInternalContext ? rum.getInternalContext(startTime) : undefined
 }

--- a/packages/rum/src/domain/internalContext.spec.ts
+++ b/packages/rum/src/domain/internalContext.spec.ts
@@ -114,14 +114,10 @@ describe('internal context v2', () => {
     setupBuilder.build()
 
     expect(internalContext.get()).toEqual({
-      action: {
+      application_id: 'appId',
+      session_id: '1234',
+      user_action: {
         id: '7890',
-      },
-      application: {
-        id: 'appId',
-      },
-      session: {
-        id: '1234',
       },
       view: {
         id: 'abcde',

--- a/packages/rum/src/typesV2.ts
+++ b/packages/rum/src/typesV2.ts
@@ -145,20 +145,3 @@ export type RumEventV2 =
   | RumViewEventV2 & ViewContextV2 & RumContextV2
   | RumLongTaskEventV2 & ActionContextV2 & ViewContextV2 & RumContextV2
   | RumActionEventV2 & ViewContextV2 & RumContextV2
-
-export interface InternalContextV2 {
-  application: {
-    id: string
-  }
-  session: {
-    id: string | undefined
-  }
-  view?: {
-    id: string
-    url: string
-    referrer: string
-  }
-  action?: {
-    id: string
-  }
-}


### PR DESCRIPTION
## Motivation

Following #593, keep compatibility with logs data format

## Changes

in v2, internal context still returns v1 format

## Testing

unit, staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
