### PR TITLE
🐛 [RUMF-791] prevent IE11 performance entry error

### DIFF
--- a/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
@@ -24,8 +24,13 @@ export function matchRequestTiming(request: RequestCompleteEvent) {
   if (!performance || !('getEntriesByName' in performance)) {
     return
   }
-  const candidates = performance
-    .getEntriesByName(request.url, 'resource')
+  const sameNameEntries = performance.getEntriesByName(request.url, 'resource')
+
+  if (!(sameNameEntries.length > 0 && 'toJSON' in sameNameEntries[0])) {
+    return
+  }
+
+  const candidates = sameNameEntries
     .map((entry) => entry.toJSON() as RumPerformanceResourceTiming)
     .filter(toValidEntry)
     .filter((entry) => isBetween(entry, request.startTime, endTime(request)))

--- a/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
+++ b/packages/rum/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
@@ -26,7 +26,7 @@ export function matchRequestTiming(request: RequestCompleteEvent) {
   }
   const sameNameEntries = performance.getEntriesByName(request.url, 'resource')
 
-  if (!(sameNameEntries.length > 0 && 'toJSON' in sameNameEntries[0])) {
+  if (!sameNameEntries.length || !('toJSON' in sameNameEntries[0])) {
     return
   }
 


### PR DESCRIPTION
## Motivation

toJSON is not available in IE11, prevent execution error

## Changes

check if toJSON available before using it

## Testing

manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
