### PR TITLE
✨ [RUMF-770] Disable tracing for cancelled requests

### DIFF
--- a/packages/rum/src/domain/requestCollection.spec.ts
+++ b/packages/rum/src/domain/requestCollection.spec.ts
@@ -84,6 +84,18 @@ describe('collect fetch', () => {
     })
   })
 
+  it('should not trace cancelled requests', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 0, responseText: 'fetch cancelled' })
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = completeSpy.calls.argsFor(0)[0]
+
+      expect(request.status).toEqual(0)
+      expect(request.traceId).toEqual(undefined)
+      done()
+    })
+  })
+
   it('should assign a request id', (done) => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
@@ -194,6 +206,22 @@ describe('collect xhr', () => {
       onComplete() {
         expect(startSpy).not.toHaveBeenCalled()
         expect(completeSpy).not.toHaveBeenCalled()
+        done()
+      },
+    })
+  })
+
+  it('should not trace cancelled requests', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', '/ok')
+        xhr.send()
+        xhr.complete(0)
+      },
+      onComplete() {
+        const request = completeSpy.calls.argsFor(0)[0]
+        expect(request.status).toEqual(0)
+        expect(request.traceId).toEqual(undefined)
         done()
       },
     })

--- a/packages/rum/src/domain/requestCollection.spec.ts
+++ b/packages/rum/src/domain/requestCollection.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RequestCompleteEvent, RequestStartEvent, trackFetch, trackXhr } from './requestCollection'
-import { Tracer } from './tracing/tracer'
+import { clearTracingIfCancelled, Tracer } from './tracing/tracer'
 
 const configuration = {
   ...DEFAULT_CONFIGURATION,
@@ -43,6 +43,7 @@ describe('collect fetch', () => {
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, startSpy)
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, completeSpy)
     const tracerStub: Partial<Tracer> = {
+      clearTracingIfCancelled,
       traceFetch: () => undefined,
     }
     fetchProxy = trackFetch(lifeCycle, configuration as Configuration, tracerStub as Tracer)
@@ -135,6 +136,7 @@ describe('collect xhr', () => {
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, startSpy)
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, completeSpy)
     const tracerStub: Partial<Tracer> = {
+      clearTracingIfCancelled,
       traceXhr: () => undefined,
     }
     trackXhr(lifeCycle, configuration as Configuration, tracerStub as Tracer)

--- a/packages/rum/src/domain/requestCollection.ts
+++ b/packages/rum/src/domain/requestCollection.ts
@@ -15,10 +15,6 @@ export interface RequestStartEvent {
   requestIndex: number
 }
 
-interface CustomContext {
-  requestIndex: number
-}
-
 export interface RequestCompleteEvent {
   requestIndex: number
   type: RequestType
@@ -44,7 +40,7 @@ export function startRequestCollection(lifeCycle: LifeCycle, configuration: Conf
 }
 
 export function trackXhr(lifeCycle: LifeCycle, configuration: Configuration, tracer: Tracer) {
-  const xhrProxy = startXhrProxy<CustomContext & TracedXhrStartContext, CustomContext & TracedXhrCompleteContext>()
+  const xhrProxy = startXhrProxy<TracedXhrStartContext, TracedXhrCompleteContext>()
   xhrProxy.beforeSend((context, xhr) => {
     if (isAllowedRequestUrl(configuration, context.url)) {
       tracer.traceXhr(context, xhr)
@@ -76,10 +72,7 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: Configuration, tra
 }
 
 export function trackFetch(lifeCycle: LifeCycle, configuration: Configuration, tracer: Tracer) {
-  const fetchProxy = startFetchProxy<
-    CustomContext & TracedFetchStartContext,
-    CustomContext & TracedFetchCompleteContext
-  >()
+  const fetchProxy = startFetchProxy<TracedFetchStartContext, TracedFetchCompleteContext>()
   fetchProxy.beforeSend((context) => {
     if (isAllowedRequestUrl(configuration, context.url)) {
       tracer.traceFetch(context)
@@ -102,7 +95,7 @@ export function trackFetch(lifeCycle: LifeCycle, configuration: Configuration, t
         spanId: context.spanId,
         startTime: context.startTime,
         status: context.status,
-        traceId: context.status === 0 ? undefined : context.traceId,
+        traceId: context.traceId,
         type: RequestType.FETCH,
         url: context.url,
       })

--- a/packages/rum/src/domain/requestCollection.ts
+++ b/packages/rum/src/domain/requestCollection.ts
@@ -1,15 +1,27 @@
-import { Configuration, Observable, RequestType, startFetchProxy, startXhrProxy } from '@datadog/browser-core'
+import {
+  Configuration,
+  FetchCompleteContext,
+  FetchStartContext,
+  Observable,
+  RequestType,
+  startFetchProxy,
+  startXhrProxy,
+  XhrCompleteContext,
+  XhrStartContext,
+} from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { isAllowedRequestUrl } from './rumEventsCollection/resource/resourceUtils'
-import {
-  startTracer,
-  TracedFetchCompleteContext,
-  TracedFetchStartContext,
-  TracedXhrCompleteContext,
-  TracedXhrStartContext,
-  TraceIdentifier,
-  Tracer,
-} from './tracing/tracer'
+import { startTracer, TraceIdentifier, Tracer } from './tracing/tracer'
+
+export interface CustomContext {
+  requestIndex: number
+  spanId?: TraceIdentifier
+  traceId?: TraceIdentifier
+}
+export interface RumFetchStartContext extends FetchStartContext, CustomContext {}
+export interface RumFetchCompleteContext extends FetchCompleteContext, CustomContext {}
+export interface RumXhrStartContext extends XhrStartContext, CustomContext {}
+export interface RumXhrCompleteContext extends XhrCompleteContext, CustomContext {}
 
 export interface RequestStartEvent {
   requestIndex: number
@@ -40,7 +52,7 @@ export function startRequestCollection(lifeCycle: LifeCycle, configuration: Conf
 }
 
 export function trackXhr(lifeCycle: LifeCycle, configuration: Configuration, tracer: Tracer) {
-  const xhrProxy = startXhrProxy<TracedXhrStartContext, TracedXhrCompleteContext>()
+  const xhrProxy = startXhrProxy<RumXhrStartContext, RumXhrCompleteContext>()
   xhrProxy.beforeSend((context, xhr) => {
     if (isAllowedRequestUrl(configuration, context.url)) {
       tracer.traceXhr(context, xhr)
@@ -72,7 +84,7 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: Configuration, tra
 }
 
 export function trackFetch(lifeCycle: LifeCycle, configuration: Configuration, tracer: Tracer) {
-  const fetchProxy = startFetchProxy<TracedFetchStartContext, TracedFetchCompleteContext>()
+  const fetchProxy = startFetchProxy<RumFetchStartContext, RumFetchCompleteContext>()
   fetchProxy.beforeSend((context) => {
     if (isAllowedRequestUrl(configuration, context.url)) {
       tracer.traceFetch(context)

--- a/packages/rum/src/domain/requestCollection.ts
+++ b/packages/rum/src/domain/requestCollection.ts
@@ -73,7 +73,7 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: Configuration, tra
         spanId: context.spanId,
         startTime: context.startTime,
         status: context.status,
-        traceId: context.traceId,
+        traceId: context.status === 0 ? undefined : context.traceId,
         type: RequestType.XHR,
         url: context.url,
       })
@@ -109,7 +109,7 @@ export function trackFetch(lifeCycle: LifeCycle, configuration: Configuration, t
         spanId: context.spanId,
         startTime: context.startTime,
         status: context.status,
-        traceId: context.traceId,
+        traceId: context.status === 0 ? undefined : context.traceId,
         type: RequestType.FETCH,
         url: context.url,
       })

--- a/packages/rum/src/domain/tracing/tracer.ts
+++ b/packages/rum/src/domain/tracing/tracer.ts
@@ -1,34 +1,22 @@
+import { Configuration, getOrigin, objectEntries } from '@datadog/browser-core'
 import {
-  Configuration,
-  FetchCompleteContext,
-  FetchStartContext,
-  getOrigin,
-  objectEntries,
-  XhrCompleteContext,
-  XhrStartContext,
-} from '@datadog/browser-core'
-
-export interface TracingContext {
-  requestIndex: number
-  spanId?: TraceIdentifier
-  traceId?: TraceIdentifier
-}
-export interface TracedFetchStartContext extends FetchStartContext, TracingContext {}
-export interface TracedFetchCompleteContext extends FetchCompleteContext, TracingContext {}
-export interface TracedXhrStartContext extends XhrStartContext, TracingContext {}
-export interface TracedXhrCompleteContext extends XhrCompleteContext, TracingContext {}
+  RumFetchCompleteContext,
+  RumFetchStartContext,
+  RumXhrCompleteContext,
+  RumXhrStartContext,
+} from '../requestCollection'
 
 export interface Tracer {
-  traceFetch: (context: Partial<TracedFetchStartContext>) => void
-  traceXhr: (context: Partial<TracedXhrStartContext>, xhr: XMLHttpRequest) => void
-  clearTracingIfCancelled: (context: TracedFetchCompleteContext | TracedXhrCompleteContext) => void
+  traceFetch: (context: Partial<RumFetchStartContext>) => void
+  traceXhr: (context: Partial<RumXhrStartContext>, xhr: XMLHttpRequest) => void
+  clearTracingIfCancelled: (context: RumFetchCompleteContext | RumXhrCompleteContext) => void
 }
 
 interface TracingHeaders {
   [key: string]: string
 }
 
-export function clearTracingIfCancelled(context: TracedFetchCompleteContext | TracedXhrCompleteContext) {
+export function clearTracingIfCancelled(context: RumFetchCompleteContext | RumXhrCompleteContext) {
   if (context.status === 0) {
     context.traceId = undefined
     context.spanId = undefined
@@ -68,7 +56,7 @@ export function startTracer(configuration: Configuration): Tracer {
 
 function injectHeadersIfTracingAllowed(
   configuration: Configuration,
-  context: Partial<TracedFetchStartContext | TracedXhrStartContext>,
+  context: Partial<RumFetchStartContext | RumXhrStartContext>,
   inject: (tracingHeaders: TracingHeaders) => void
 ) {
   if (!isTracingSupported() || !isAllowedUrl(configuration, context.url!)) {

--- a/packages/rum/src/domain/tracing/tracer.ts
+++ b/packages/rum/src/domain/tracing/tracer.ts
@@ -67,7 +67,7 @@ export function startTracer(configuration: Configuration): Tracer {
 
 function injectHeadersIfTracingAllowed(
   configuration: Configuration,
-  context: Partial<TracedFetchStartContext | TracedXhrCompleteContext>,
+  context: Partial<TracedFetchStartContext | TracedXhrStartContext>,
   inject: (tracingHeaders: TracingHeaders) => void
 ) {
   if (!isTracingSupported() || !isAllowedUrl(configuration, context.url!)) {
@@ -76,7 +76,7 @@ function injectHeadersIfTracingAllowed(
 
   context.traceId = new TraceIdentifier()
   context.spanId = new TraceIdentifier()
-  inject(makeTracingHeaders(context.traceId!, context.spanId))
+  inject(makeTracingHeaders(context.traceId, context.spanId))
 }
 
 function isAllowedUrl(configuration: Configuration, requestUrl: string) {

--- a/packages/rum/src/domain/tracing/tracer.ts
+++ b/packages/rum/src/domain/tracing/tracer.ts
@@ -9,6 +9,7 @@ import {
 } from '@datadog/browser-core'
 
 export interface TracingContext {
+  requestIndex: number
   spanId?: TraceIdentifier
   traceId?: TraceIdentifier
 }


### PR DESCRIPTION
## Motivation

Do not trace cancelled requests because they lack backend information.

## Changes

Set `request.traceId` to `undefined` if the request was cancelled.

## Testing

Added unit tests to ensure that `traceId` is removed from the `LifeCycleEventType.REQUEST_COMPLETED` event when the `request.status == 0`.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
