### PR TITLE
🐛 fix tracekit handling of exotic errors

### DIFF
--- a/packages/core/src/domain/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring.ts
@@ -98,14 +98,14 @@ export function resetInternalMonitoring() {
 
 export function monitored(_: any, __: string, descriptor: PropertyDescriptor) {
   const originalMethod = descriptor.value
-  descriptor.value = function() {
+  descriptor.value = function () {
     const decorated = (monitoringConfiguration.batch ? monitor(originalMethod) : originalMethod) as Function
     return decorated.apply(this, arguments)
   }
 }
 
 export function monitor<T extends Function>(fn: T): T {
-  return (function(this: any) {
+  return (function (this: any) {
     try {
       return fn.apply(this, arguments)
     } catch (e) {

--- a/packages/core/src/domain/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring.ts
@@ -98,14 +98,14 @@ export function resetInternalMonitoring() {
 
 export function monitored(_: any, __: string, descriptor: PropertyDescriptor) {
   const originalMethod = descriptor.value
-  descriptor.value = function () {
+  descriptor.value = function() {
     const decorated = (monitoringConfiguration.batch ? monitor(originalMethod) : originalMethod) as Function
     return decorated.apply(this, arguments)
   }
 }
 
 export function monitor<T extends Function>(fn: T): T {
-  return (function (this: any) {
+  return (function(this: any) {
     try {
       return fn.apply(this, arguments)
     } catch (e) {
@@ -154,7 +154,7 @@ function formatError(e: unknown) {
         kind: stackTrace.name,
         stack: toStackTraceString(stackTrace),
       },
-      message: stackTrace.message,
+      message: stackTrace.message!,
     }
   }
   return {

--- a/packages/core/src/domain/tracekit.spec.ts
+++ b/packages/core/src/domain/tracekit.spec.ts
@@ -102,6 +102,13 @@ Error: foo
 
       expect(stackFrames.stack[0].url).toEqual('<anonymous>')
     })
+
+    it('should ensure that message and name are string', () => {
+      const ex = { message: { foo: 'bar' }, name: { bar: 'qux' } }
+      const stack = computeStackTrace(ex)
+      expect(stack.message).toEqual('{"foo":"bar"}')
+      expect(stack.name).toEqual('{"bar":"qux"}')
+    })
   })
 
   describe('error notifications', () => {

--- a/packages/core/src/domain/tracekit.spec.ts
+++ b/packages/core/src/domain/tracekit.spec.ts
@@ -103,11 +103,14 @@ Error: foo
       expect(stackFrames.stack[0].url).toEqual('<anonymous>')
     })
 
-    it('should ensure that message and name are string', () => {
-      const ex = { message: { foo: 'bar' }, name: { bar: 'qux' } }
-      const stack = computeStackTrace(ex)
-      expect(stack.message).toEqual('{"foo":"bar"}')
-      expect(stack.name).toEqual('{"bar":"qux"}')
+    it('should handle edge case values', () => {
+      expect(computeStackTrace({ message: { foo: 'bar' } }).message).toBeUndefined()
+      expect(computeStackTrace({ name: { foo: 'bar' } }).name).toBeUndefined()
+      expect(computeStackTrace(2).message).toBeUndefined()
+      expect(computeStackTrace({ foo: 'bar' }).message).toBeUndefined()
+      expect(computeStackTrace(undefined).message).toBeUndefined()
+      // tslint:disable-next-line:no-null-keyword
+      expect(computeStackTrace(null).message).toBeUndefined()
     })
   })
 

--- a/packages/core/src/domain/tracekit.ts
+++ b/packages/core/src/domain/tracekit.ts
@@ -43,7 +43,7 @@ export interface StackFrame {
  */
 export interface StackTrace {
   name?: string
-  message: string
+  message?: string
   url?: string
   stack: StackFrame[]
   incomplete?: boolean
@@ -931,14 +931,18 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
     }
 
     return {
-      message: forceString((ex as any).message),
-      name: forceString((ex as any).name),
+      message: tryToGetString(ex, 'message'),
+      name: tryToGetString(ex, 'name'),
       stack: [],
     }
   }
 
-  function forceString(candidate: unknown) {
-    return typeof candidate !== 'string' ? JSON.stringify(candidate) : candidate
+  function tryToGetString(candidate: unknown, property: string) {
+    if (typeof candidate !== 'object' || !candidate || !(property in candidate)) {
+      return undefined
+    }
+    const value = (candidate as { [k: string]: unknown })[property]
+    return typeof value === 'string' ? value : undefined
   }
 
   /**

--- a/packages/core/src/domain/tracekit.ts
+++ b/packages/core/src/domain/tracekit.ts
@@ -879,7 +879,7 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
    * @param {(string|number)=} depth
    * @memberof computeStackTrace
    */
-  function doComputeStackTrace(ex: Error, depth?: string | number): StackTrace {
+  function doComputeStackTrace(ex: unknown, depth?: string | number): StackTrace {
     let stack
     const normalizedDepth = depth === undefined ? 0 : +depth
 
@@ -887,7 +887,7 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
       // This must be tried first because Opera 10 *destroys*
       // its stacktrace property if you try to access the stack
       // property first!!
-      stack = computeStackTraceFromStacktraceProp(ex)
+      stack = computeStackTraceFromStacktraceProp(ex as Error)
       if (stack) {
         return stack
       }
@@ -898,7 +898,7 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
     }
 
     try {
-      stack = computeStackTraceFromStackProp(ex)
+      stack = computeStackTraceFromStackProp(ex as Error)
       if (stack) {
         return stack
       }
@@ -909,7 +909,7 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
     }
 
     try {
-      stack = computeStackTraceFromOperaMultiLineMessage(ex)
+      stack = computeStackTraceFromOperaMultiLineMessage(ex as Error)
       if (stack) {
         return stack
       }
@@ -920,7 +920,7 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
     }
 
     try {
-      stack = computeStackTraceByWalkingCallerChain(ex, normalizedDepth + 1)
+      stack = computeStackTraceByWalkingCallerChain(ex as Error, normalizedDepth + 1)
       if (stack) {
         return stack
       }
@@ -931,10 +931,14 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
     }
 
     return {
-      message: ex.message,
-      name: ex.name,
+      message: forceString((ex as any).message),
+      name: forceString((ex as any).name),
       stack: [],
     }
+  }
+
+  function forceString(candidate: unknown) {
+    return typeof candidate !== 'string' ? JSON.stringify(candidate) : candidate
   }
 
   /**


### PR DESCRIPTION
## Motivation

Object thrown with an object message instead of a string is forwarded as is, which is not compatible with our backend and our UI.
ex:
```js
throw { message: { foo: 'bar' }}
```
sent:
```json
{ "message": { "foo": "bar" }, "stack": "Error: { \"foo\": \"bar\" }"}
```
expected:
```json
{ "message": "Uncaught { \"foo\": \"bar\" }", "stack": "'No stack, consider using an instance of Error'"}
```

## Changes

- Check inside tracekit that StackTrace message and name are string
- allow `StackTrace.message = undefined` which was already checked in the code

## Testing

automated tests + sandbox

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
