### PR TITLE
🐛 handle direct onerror calls with objects

### DIFF
--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -104,6 +104,19 @@ describe('runtime error tracker', () => {
       done()
     }, 100)
   })
+
+  it('should handle direct onerror calls with objects', (done) => {
+    setTimeout(() => {
+      window.onerror!({ foo: 'bar' } as any)
+    }, 10)
+
+    setTimeout(() => {
+      const collectedError = notifyError.calls.mostRecent().args[0] as RawError
+      expect(collectedError.message).toEqual('Uncaught {"foo":"bar"}')
+      expect(collectedError.stack).toEqual('No stack, consider using an instance of Error')
+      done()
+    }, 100)
+  })
 })
 
 describe('network error tracker', () => {

--- a/packages/core/src/domain/tracekit.spec.ts
+++ b/packages/core/src/domain/tracekit.spec.ts
@@ -208,6 +208,17 @@ Error: foo
           testLineNo
         )
       })
+
+      it('should handle object message passed through onerror', (done) => {
+        subscriptionHandler = (stack, _, error) => {
+          expect(stack.message).toBeUndefined()
+          expect(error).toEqual({ foo: 'bar' }) // consider the message as initial error
+          report.unsubscribe(subscriptionHandler!)
+          done()
+        }
+        report.subscribe(subscriptionHandler)
+        report.traceKitWindowOnError({ foo: 'bar' } as any)
+      })
     })
 
     function testErrorNotification(callOnError: boolean, numReports: number, done: DoneFn) {

--- a/packages/core/src/domain/tracekit.ts
+++ b/packages/core/src/domain/tracekit.ts
@@ -253,11 +253,11 @@ export const report = (function reportModuleWrapper() {
 
       stack = {
         name,
-        message: msg as string,
+        message: typeof msg === 'string' ? msg : undefined,
         stack: [location],
       }
 
-      notifyHandlers(stack, true)
+      notifyHandlers(stack, true, message)
     }
 
     if (oldOnerrorHandler) {


### PR DESCRIPTION
## Motivation

Following #651 and #655, we still observed malformed errors with object messages and stack:
```
Error: [object Object]
at undefined @ undefined
```
That seems related to tracekit handling of `window.onerror` direct calls.

## Changes

Update tracekit direct calls strategy to endup on the case where we advise to use an instance of Error.

## Testing

automated tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
