### PR TITLE
[RUMF-807] Export types used in API

### DIFF
--- a/packages/logs/src/index.ts
+++ b/packages/logs/src/index.ts
@@ -1,3 +1,3 @@
-export { Logger, LogsMessage } from './domain/logger'
+export { Logger, LogsMessage, StatusType, HandlerType } from './domain/logger'
 export { LogsUserConfiguration, LoggerConfiguration, LogsGlobal, datadogLogs } from './boot/logs.entry'
 export { LogsEvent } from './logsEvent.types'

--- a/packages/rum/src/index.ts
+++ b/packages/rum/src/index.ts
@@ -1,4 +1,5 @@
 export { RumUserConfiguration, RumGlobal, datadogRum } from './boot/rum.entry'
+export { ProvidedSource } from './domain/rumEventsCollection/error/errorCollection'
 export {
   RumEvent,
   RumActionEvent,


### PR DESCRIPTION
## Motivation

fix #654 

## Changes

Add in exports:

- rum: ProvidedSource
- logs: StatusType, HandlerType

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
