### PR TITLE
[RUMF-807] Broaden context types in APIs

### DIFF
--- a/packages/core/src/tools/contextManager.ts
+++ b/packages/core/src/tools/contextManager.ts
@@ -8,16 +8,16 @@ export function createContextManager() {
       return context
     },
 
-    add(key: string, value: ContextValue) {
-      context[key] = value
+    add(key: string, value: any) {
+      context[key] = value as ContextValue
     },
 
     remove(key: string) {
       delete context[key]
     },
 
-    set(newContext: Context) {
-      context = newContext
+    set(newContext: object) {
+      context = newContext as Context
     },
   }
 }

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -23,7 +23,7 @@ export interface LogsUserConfiguration extends UserConfiguration {
 export interface LoggerConfiguration {
   level?: StatusType
   handler?: HandlerType
-  context?: Context
+  context?: object
 }
 
 export type LogsGlobal = ReturnType<typeof makeLogsGlobal>

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -45,7 +45,7 @@ export class Logger {
   }
 
   @monitored
-  log(message: string, messageContext?: Context, status: StatusType = StatusType.info) {
+  log(message: string, messageContext?: object, status: StatusType = StatusType.info) {
     if (STATUS_PRIORITIES[status] >= STATUS_PRIORITIES[this.level]) {
       switch (this.handlerType) {
         case HandlerType.http:
@@ -64,19 +64,19 @@ export class Logger {
     }
   }
 
-  debug(message: string, messageContext?: Context) {
+  debug(message: string, messageContext?: object) {
     this.log(message, messageContext, StatusType.debug)
   }
 
-  info(message: string, messageContext?: Context) {
+  info(message: string, messageContext?: object) {
     this.log(message, messageContext, StatusType.info)
   }
 
-  warn(message: string, messageContext?: Context) {
+  warn(message: string, messageContext?: object) {
     this.log(message, messageContext, StatusType.warn)
   }
 
-  error(message: string, messageContext?: Context) {
+  error(message: string, messageContext?: object) {
     const errorOrigin = {
       error: {
         origin: ErrorSource.LOGGER,
@@ -85,11 +85,11 @@ export class Logger {
     this.log(message, combine(errorOrigin, messageContext), StatusType.error)
   }
 
-  setContext(context: Context) {
+  setContext(context: object) {
     this.contextManager.set(context)
   }
 
-  addContext(key: string, value: ContextValue) {
+  addContext(key: string, value: any) {
     this.contextManager.add(key, value)
   }
 

--- a/packages/rum/src/boot/rum.entry.ts
+++ b/packages/rum/src/boot/rum.entry.ts
@@ -101,10 +101,10 @@ export function makeRumGlobal(startRumImpl: StartRum) {
       return getInternalContextStrategy(startTime)
     }),
 
-    addAction: monitor((name: string, context?: Context) => {
+    addAction: monitor((name: string, context?: object) => {
       addActionStrategy({
         name,
-        context: deepClone(context),
+        context: deepClone(context as Context),
         startTime: performance.now(),
         type: ActionType.CUSTOM,
       })
@@ -114,11 +114,11 @@ export function makeRumGlobal(startRumImpl: StartRum) {
      * @deprecated
      * @see addAction
      */
-    addUserAction: (name: string, context?: Context) => {
-      rumGlobal.addAction(name, context)
+    addUserAction: (name: string, context?: object) => {
+      rumGlobal.addAction(name, context as Context)
     },
 
-    addError: monitor((error: unknown, context?: Context, source: ProvidedSource = ErrorSource.CUSTOM) => {
+    addError: monitor((error: unknown, context?: object, source: ProvidedSource = ErrorSource.CUSTOM) => {
       let checkedSource: ProvidedSource
       if (source === ErrorSource.CUSTOM || source === ErrorSource.NETWORK || source === ErrorSource.SOURCE) {
         checkedSource = source
@@ -128,7 +128,7 @@ export function makeRumGlobal(startRumImpl: StartRum) {
       }
       addErrorStrategy({
         error,
-        context: deepClone(context),
+        context: deepClone(context as Context),
         source: checkedSource,
         startTime: performance.now(),
       })


### PR DESCRIPTION
## Motivation

Using Context or ContextValue in our APIs is not convenient for typescript customers since customer interfaces won't be compatible with them due to [index signature missing on interfaces](https://github.com/microsoft/TypeScript/issues/15300).

## Changes

Replace Context by object and ContextValue by any in APIs
Keep using Context and ContextValue internally.

fix #603 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
