### PR TITLE
🐛 [CDN cache] remove stale-while-revalidate

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,7 +41,7 @@ case "${datacenter}" in
     ;;
 esac
 
-CACHE_CONTROL='max-age=900, s-maxage=60, stale-while-revalidate=31536000'
+CACHE_CONTROL='max-age=900, s-maxage=60'
 LOGS_BUNDLE_PATH="packages/logs/bundle"
 RUM_BUNDLE_PATH="packages/rum/bundle"
 declare -A paths


### PR DESCRIPTION
## Motivation

By keeping an outdated version while revalidating the sdk version, usage of new APIs can lead to undefined functions error.

## Changes

Remove stale-while-revalidate from cache options

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
