### PR TITLE
👷 fix build bundle

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,14 @@ build:
     - scripts/cli lint test/app
     - scripts/cli typecheck test/app
 
+build-bundle:
+  stage: test
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  script:
+    - yarn
+    - yarn build:bundle
+
 compatibility:
   stage: test
   tags: ['runner:main', 'size:large']

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/logs/tsconfig.esm.json
+++ b/packages/logs/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/logs/tsconfig.json
+++ b/packages/logs/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./bundle/",
-    "module": "es6",
-    "paths": {
-      "@datadog/browser-core": ["../core/src"]
-    }
+    "module": "es6"
   },
   "include": ["src", "test"]
 }

--- a/packages/logs/tsconfig.json
+++ b/packages/logs/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "./bundle/",
-    "module": "es6"
-  },
-  "include": ["src", "test"]
-}

--- a/packages/rum-core/tsconfig.cjs.json
+++ b/packages/rum-core/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/rum-core/tsconfig.esm.json
+++ b/packages/rum-core/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/rum-core/tsconfig.json
+++ b/packages/rum-core/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./bundle/",
-    "module": "es6",
-    "paths": {
-      "@datadog/browser-core": ["../core/src"]
-    }
+    "module": "es6"
   },
   "include": ["src", "test"]
 }

--- a/packages/rum-core/tsconfig.json
+++ b/packages/rum-core/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "./bundle/",
-    "module": "es6"
-  },
-  "include": ["src", "test"]
-}

--- a/packages/rum-recorder/tsconfig.cjs.json
+++ b/packages/rum-recorder/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/rum-recorder/tsconfig.esm.json
+++ b/packages/rum-recorder/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/rum-recorder/tsconfig.json
+++ b/packages/rum-recorder/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "./bundle/",
-    "module": "es6"
-  },
-  "include": ["src", "test"]
-}

--- a/packages/rum-recorder/tsconfig.json
+++ b/packages/rum-recorder/tsconfig.json
@@ -3,11 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./bundle/",
-    "module": "es6",
-    "paths": {
-      "@datadog/browser-core": ["../core/src"],
-      "@datadog/browser-rum": ["../rum/src"]
-    }
+    "module": "es6"
   },
   "include": ["src", "test"]
 }

--- a/packages/rum/tsconfig.cjs.json
+++ b/packages/rum/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/rum/tsconfig.esm.json
+++ b/packages/rum/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/rum/tsconfig.json
+++ b/packages/rum/tsconfig.json
@@ -3,11 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./bundle/",
-    "module": "es6",
-    "paths": {
-      "@datadog/browser-core": ["../core/src"],
-      "@datadog/browser-rum-core": ["../rum-core/src"]
-    }
+    "module": "es6"
   },
   "include": ["src", "test"]
 }

--- a/packages/rum/tsconfig.json
+++ b/packages/rum/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "./bundle/",
-    "module": "es6"
-  },
-  "include": ["src", "test"]
-}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "importHelpers": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,15 +9,18 @@
     "strict": true,
     "target": "es5",
     "sourceMap": true,
+
     "plugins": [
       {
         "name": "typescript-tslint-plugin"
       }
     ],
+
     "paths": {
       "@datadog/browser-core": ["./packages/core/src"],
       "@datadog/browser-rum-core": ["./packages/rum-core/src"],
-      "@datadog/browser-rum": ["./packages/rum/src"]
+      "@datadog/browser-rum": ["./packages/rum/src"],
+      "@datadog/browser-rum-recorder": ["./packages/rum-recorder/src"]
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,8 +19,7 @@
     "paths": {
       "@datadog/browser-core": ["./packages/core/src"],
       "@datadog/browser-rum-core": ["./packages/rum-core/src"],
-      "@datadog/browser-rum": ["./packages/rum/src"],
-      "@datadog/browser-rum-recorder": ["./packages/rum-recorder/src"]
+      "@datadog/browser-rum": ["./packages/rum/src"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
+// This tsconfig is only used for tooling (ex: typecheck in code editors)
 {
   "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "module": "es6"
-  },
   "include": ["./packages/**/src/**/*.ts", "./packages/**/test/**/*.ts"]
 }

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 
 module.exports = (mode) => ({
@@ -14,6 +15,6 @@ module.exports = (mode) => ({
   },
   resolve: {
     extensions: ['.ts', '.js'],
-    plugins: [new TsconfigPathsPlugin()],
+    plugins: [new TsconfigPathsPlugin({ configFile: path.join(__dirname, 'tsconfig.base.json') })],
   },
 })

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -1,6 +1,8 @@
 const path = require('path')
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 
+const tsconfigPath = path.join(__dirname, 'tsconfig.base.json')
+
 module.exports = (mode) => ({
   mode,
   devtool: mode === 'development' ? 'inline-source-map' : 'false',
@@ -10,11 +12,18 @@ module.exports = (mode) => ({
         test: /\.ts$/,
         loader: 'ts-loader',
         exclude: /node_modules/,
+        options: {
+          configFile: tsconfigPath,
+          onlyCompileBundledFiles: true,
+          compilerOptions: {
+            module: 'es6',
+          },
+        },
       },
     ],
   },
   resolve: {
     extensions: ['.ts', '.js'],
-    plugins: [new TsconfigPathsPlugin({ configFile: path.join(__dirname, 'tsconfig.base.json') })],
+    plugins: [new TsconfigPathsPlugin({ configFile: tsconfigPath })],
   },
 })


### PR DESCRIPTION
## Motivation

The staging build is broken: `yarn build:bundle` fails because the rum-recorder webpack build can't find the `@datadog/browser-rum-core` package (transitive dependency).

For some reason, `yarn build` works though.

## Changes

* read paths from `tsconfig.base.json` when building with webpack: this avoids having to redeclare paths in each packages
* add a ci job to check for `yarn build:bundle`

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
