### PR TITLE
👷 fix build bundle (continuation)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,11 +150,7 @@ deploy-staging:
   image: $CI_IMAGE
   script:
     - yarn
-    - WITH_SUFFIX=true TARGET_DATACENTER=eu BUILD_MODE=staging yarn build:bundle
-    - ./scripts/deploy.sh staging eu
-    - WITH_SUFFIX=true TARGET_DATACENTER=us BUILD_MODE=staging yarn build:bundle
-    - ./scripts/deploy.sh staging us
-    - TARGET_DATACENTER=us BUILD_MODE=staging yarn build:bundle
+    - BUILD_MODE=staging yarn build:bundle
     - ./scripts/deploy.sh staging
 
 deploy-release:
@@ -168,11 +164,7 @@ deploy-release:
   image: $CI_IMAGE
   script:
     - yarn
-    - WITH_SUFFIX=true TARGET_DATACENTER=us BUILD_MODE=release yarn build:bundle
-    - ./scripts/deploy.sh prod us
-    - WITH_SUFFIX=true TARGET_DATACENTER=eu BUILD_MODE=release yarn build:bundle
-    - ./scripts/deploy.sh prod eu
-    - TARGET_DATACENTER=us BUILD_MODE=release yarn build:bundle
+    - BUILD_MODE=release yarn build:bundle
     - ./scripts/deploy.sh prod
 
 ########################################################################################################################

--- a/packages/logs/.npmignore
+++ b/packages/logs/.npmignore
@@ -1,5 +1,5 @@
 *
-!/bundle/**/*
+!/bundle/datadog-logs.js
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -7,7 +7,7 @@
   "types": "cjs/index.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rm -rf bundle && webpack --config webpack.config.js --mode=production && yarn replace-build-env bundle",
+    "build:bundle": "rm -rf bundle && webpack --mode=production",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
     "replace-build-env": "node ../../scripts/replace-build-env.js"

--- a/packages/logs/webpack.config.js
+++ b/packages/logs/webpack.config.js
@@ -2,18 +2,10 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-const datacenter = process.env.TARGET_DATACENTER || 'us'
-const withSuffix = process.env.WITH_SUFFIX || false
+const entry = path.resolve(__dirname, 'src/boot/logs.entry.ts')
 
-const suffix = withSuffix ? `-${datacenter}` : ''
-
-module.exports = (env, argv) => ({
-  entry: {
-    logs: path.resolve(__dirname, 'src/boot/logs.entry.ts'),
-  },
-  ...webpackBase(argv.mode),
-  output: {
-    filename: `datadog-logs${suffix}.js`,
-    path: path.resolve(__dirname, 'bundle'),
-  },
-})
+module.exports = (env, argv) => [
+  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-logs.js' }),
+  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-logs-us.js' }),
+  webpackBase({ mode: argv.mode, entry, datacenter: 'eu', filename: 'datadog-logs-eu.js' }),
+]

--- a/packages/rum-recorder/package.json
+++ b/packages/rum-recorder/package.json
@@ -7,10 +7,9 @@
   "types": "cjs/index.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rm -rf bundle && webpack --config webpack.config.js --mode=production && yarn replace-build-env bundle",
-    "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
-    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
-    "replace-build-env": "node ../../scripts/replace-build-env.js"
+    "build:bundle": "rm -rf bundle && webpack --mode=production",
+    "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json",
+    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
   },
   "dependencies": {
     "@datadog/browser-core": "2.1.2",

--- a/packages/rum-recorder/package.json
+++ b/packages/rum-recorder/package.json
@@ -7,7 +7,7 @@
   "types": "cjs/index.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "if [[ $WITH_SUFFIX != true ]]; then rm -rf bundle && webpack --config webpack.config.js --mode=production && yarn replace-build-env bundle; fi",
+    "build:bundle": "rm -rf bundle && webpack --config webpack.config.js --mode=production && yarn replace-build-env bundle",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
     "replace-build-env": "node ../../scripts/replace-build-env.js"

--- a/packages/rum-recorder/package.json
+++ b/packages/rum-recorder/package.json
@@ -7,7 +7,7 @@
   "types": "cjs/index.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rm -rf bundle && webpack --config webpack.config.js --mode=production && yarn replace-build-env bundle",
+    "build:bundle": "if [[ $WITH_SUFFIX != true ]]; then rm -rf bundle && webpack --config webpack.config.js --mode=production && yarn replace-build-env bundle; fi",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
     "replace-build-env": "node ../../scripts/replace-build-env.js"

--- a/packages/rum-recorder/webpack.config.js
+++ b/packages/rum-recorder/webpack.config.js
@@ -2,13 +2,9 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-module.exports = (env, argv) => ({
-  entry: {
-    rum: path.resolve(__dirname, 'src/boot/recorder.entry.ts'),
-  },
-  ...webpackBase(argv.mode),
-  output: {
+module.exports = (env, argv) =>
+  webpackBase({
+    mode: argv.mode,
+    entry: path.resolve(__dirname, 'src/boot/recorder.entry.ts'),
     filename: 'datadog-rum-recorder.js',
-    path: path.resolve(__dirname, 'bundle'),
-  },
-})
+  })

--- a/packages/rum/.npmignore
+++ b/packages/rum/.npmignore
@@ -1,5 +1,5 @@
 *
-!/bundle/**/*
+!/bundle/datadog-rum.js
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -7,10 +7,9 @@
   "types": "cjs/index.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rm -rf bundle && webpack --config webpack.config.js --mode=production && yarn replace-build-env bundle",
+    "build:bundle": "rm -rf bundle && webpack --mode=production",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json",
-    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json",
-    "replace-build-env": "node ../../scripts/replace-build-env.js"
+    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
   },
   "dependencies": {
     "@datadog/browser-core": "2.1.2",

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -2,18 +2,10 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-const datacenter = process.env.TARGET_DATACENTER || 'us'
-const withSuffix = process.env.WITH_SUFFIX || false
+const entry = path.resolve(__dirname, 'src/boot/rum.entry.ts')
 
-const suffix = withSuffix ? `-${datacenter}` : ''
-
-module.exports = (env, argv) => ({
-  entry: {
-    rum: path.resolve(__dirname, 'src/boot/rum.entry.ts'),
-  },
-  ...webpackBase(argv.mode),
-  output: {
-    filename: `datadog-rum${suffix}.js`,
-    path: path.resolve(__dirname, 'bundle'),
-  },
-})
+module.exports = (env, argv) => [
+  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-rum.js' }),
+  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-rum-us.js' }),
+  webpackBase({ mode: argv.mode, entry, datacenter: 'eu', filename: 'datadog-rum-eu.js' }),
+]

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -19,5 +19,4 @@ module.exports = {
   TARGET_DATACENTER: process.env.TARGET_DATACENTER || 'us',
   BUILD_MODE: process.env.BUILD_MODE,
   SDK_VERSION: sdkVersion,
-  WITH_SUFFIX: process.env.WITH_SUFFIX || '',
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,6 @@
 set -ex
 
 env=$1
-datacenter=$2
 
 case "${env}" in
 "prod")
@@ -17,36 +16,20 @@ case "${env}" in
     DISTRIBUTION_ID="E2FP11ZSCFD3EU"
     ;;
 * )
-    echo "Usage: ./deploy.sh staging|prod [eu|us]"
+    echo "Usage: ./deploy.sh staging|prod"
     exit 1
     ;;
 esac
 
-case "${datacenter}" in
-"eu")
-    FILE_PATHS=(
-      "packages/logs/bundle/datadog-logs-eu.js"
-      "packages/rum/bundle/datadog-rum-eu.js"
-    )
-    ;;
-"us")
-    FILE_PATHS=(
-      "packages/logs/bundle/datadog-logs-us.js"
-      "packages/rum/bundle/datadog-rum-us.js"
-    )
-    ;;
-"")
-    FILE_PATHS=(
-      "packages/logs/bundle/datadog-logs.js"
-      "packages/rum/bundle/datadog-rum.js"
-      "packages/rum-recorder/bundle/datadog-rum-recorder.js"
-    )
-    ;;
-* )
-    echo "Usage: ./deploy.sh staging|prod [eu|us]"
-    exit 1
-    ;;
-esac
+FILE_PATHS=(
+  "packages/logs/bundle/datadog-logs-eu.js"
+  "packages/logs/bundle/datadog-logs-us.js"
+  "packages/logs/bundle/datadog-logs.js"
+  "packages/rum-recorder/bundle/datadog-rum-recorder.js"
+  "packages/rum/bundle/datadog-rum-eu.js"
+  "packages/rum/bundle/datadog-rum-us.js"
+  "packages/rum/bundle/datadog-rum.js"
+)
 
 CACHE_CONTROL='max-age=900, s-maxage=60'
 

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -6,32 +6,13 @@ const path = require('path')
 const logsConfig = require('../packages/logs/webpack.config')
 const rumConfig = require('../packages/rum/webpack.config')
 const rumRecorderConfig = require('../packages/rum-recorder/webpack.config')
-const buildEnv = require('./build-env')
 
 const app = express()
 
 app.use(express.static(path.join(__dirname, '../sandbox')))
 for (const config of [rumConfig, logsConfig, rumRecorderConfig]) {
-  app.use(middleware(webpack(withBuildEnv(config(null, { mode: 'development' })))))
+  app.use(middleware(webpack(config(null, { mode: 'development' }))))
 }
 
 const port = 8080
 app.listen(port, () => console.log(`server listening on port ${port}.`))
-
-function withBuildEnv(webpackConf) {
-  webpackConf.module = {
-    ...webpackConf.module,
-    rules: [
-      ...webpackConf.module.rules,
-      ...Object.keys(buildEnv).map((key) => ({
-        test: /\.ts$/,
-        loader: 'string-replace-loader',
-        options: {
-          search: `<<< ${key} >>>`,
-          replace: buildEnv[key],
-        },
-      })),
-    ],
-  }
-  return webpackConf
-}

--- a/scripts/replace-build-env.js
+++ b/scripts/replace-build-env.js
@@ -18,16 +18,6 @@ try {
     from: Object.keys(buildEnv).map((entry) => `<<< ${entry} >>>`),
     to: Object.values(buildEnv),
   })
-  if (buildEnv.WITH_SUFFIX) {
-    replace.sync({
-      files: `${buildDirectory}/**/*.js`,
-      from: /.*/,
-      to: (...args) =>
-        `${makeDeprecatedSuffixComment(args[args.length - 1])}\n${args[0]}\n${makeDeprecatedSuffixComment(
-          args[args.length - 1]
-        )}`,
-    })
-  }
   console.log(
     'Changed files:',
     results.filter((entry) => entry.hasChanged).map((entry) => entry.file)
@@ -36,14 +26,4 @@ try {
 } catch (error) {
   console.error('Error occurred:', error)
   process.exit(1)
-}
-
-function makeDeprecatedSuffixComment(filePath) {
-  const fileName = filePath.split('/').pop()
-  const suffixRegExp = /-(us|eu)/
-  const env = fileName.match(suffixRegExp)[1]
-  const newFileName = fileName.replace(suffixRegExp, '')
-  return `/**\n * ${fileName} IS DEPRECATED, USE ${newFileName} WITH { site: 'datadoghq.${
-    env === 'eu' ? 'eu' : 'com'
-  }' } INIT CONFIGURATION INSTEAD\n */`
 }


### PR DESCRIPTION

## Motivation

Since `rum-recorder` is a new bundle, we don't have to support the legacy bundle with a suffix, so I didn't add the extra logic to generate it in the webpack configuration. The deploy job expect to have it though, and tries to add a comment banner on a non-suffixed file, which is unexpected and fails.

## Changes

Don't build rum-recorder bundle with a suffix.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
