### PR TITLE
👷 [RUMF-818] fix unit tests code coverage

### DIFF
--- a/scripts/codecov.sh
+++ b/scripts/codecov.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
+if ! grep -q '"s":{[^}]\+}' coverage/coverage-final.json; then
+  echo "Error: empty code coverage"
+  exit 1
+fi
+
 export CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.browser-sdk.codecov_token --with-decryption --query "Parameter.Value" --out text)
 yarn codecov -t "${CODECOV_TOKEN}" -f coverage/coverage-final.json

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -18,6 +18,18 @@ module.exports = ({ entry, mode, filename, datacenter }) => ({
     rules: [
       {
         test: /\.ts$/,
+        loader: 'string-replace-loader',
+        options: {
+          multiple: [
+            { search: '<<< TARGET_DATACENTER >>>', replace: datacenter || 'us' },
+            { search: '<<< SDK_VERSION >>>', replace: buildEnv.SDK_VERSION },
+            { search: '<<< BUILD_MODE >>>', replace: buildEnv.BUILD_MODE },
+          ],
+        },
+      },
+
+      {
+        test: /\.ts$/,
         loader: 'ts-loader',
         exclude: /node_modules/,
         options: {
@@ -26,18 +38,6 @@ module.exports = ({ entry, mode, filename, datacenter }) => ({
           compilerOptions: {
             module: 'es6',
           },
-        },
-      },
-
-      {
-        test: /\.ts$/,
-        loader: 'string-replace-loader',
-        options: {
-          multiple: [
-            { search: '<<< TARGET_DATACENTER >>>', replace: datacenter || 'us' },
-            { search: '<<< SDK_VERSION >>>', replace: buildEnv.SDK_VERSION },
-            { search: '<<< BUILD_MODE >>>', replace: buildEnv.BUILD_MODE },
-          ],
         },
       },
     ],


### PR DESCRIPTION
## Motivation

Code coverage have been broken since 8a55636ed3d8d8bb7e79a23a05696c60667db665.

## Changes

Invert ts and string-replace loaders in webpack configuration. Changing the loader order fixes the code coverage during unit tests.  I investigated deeply into istanbul and string-replace-loader,  I have a gut feeling that it is because string-replace-loader does not support source maps, but can't confirm it.

## Testing

CI, https://codecov.io/gh/DataDog/browser-sdk/tree/546c12eaf46d48f9f802dbf62458c249b34331f4/packages

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
