### PR TITLE
📝 [RUMF-792] add RUM browser support

### DIFF
--- a/packages/logs/BROWSER_SUPPORT.md
+++ b/packages/logs/BROWSER_SUPPORT.md
@@ -1,14 +1,14 @@
 # Browser Support
 
-| Feature        | Chrome | Firefox | Safari | Edge | Chrome Android | Safari iOS | Android Browser (4.4) | IE11 | IE10 | IE9 | IE8 | Opera |
-| -------------- | ------ | ------- | ------ | ---- | -------------- | ---------- | --------------------- | ---- | ---- | --- | --- | ----- |
-| loading        | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✓                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| init           | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✓                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| global context | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| logs request   | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| flush on hide  | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✗    | ✗    | ✗   | ✗   | ✓     |
-| console error  | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| network error  | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| runtime error  | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| custom logger  | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✓    | ✓    | ✗   | ✗   | ✓     |
-| handler        | ✓      | ✓       | ✓      | ✓    | ✓              | ✓          | ✗                     | ✓    | ✓    | ✗   | ✗   | ✓     |
+| Feature        | Chrome | Firefox | Safari | Edge | Chrome Android | Safari iOS | IE11 | < IE11 | Opera |
+| -------------- | ------ | ------- | ------ | ---- | -------------- | ---------- | ---- | ------ | ----- |
+| loading        | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| init           | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| global context | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| logs request   | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| flush on hide  | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ❌   | ❌     | ✅    |
+| console error  | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| network error  | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| runtime error  | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| custom logger  | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |
+| handler        | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅   | ❌     | ✅    |

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -17,7 +17,7 @@ With the browser logs SDK, you can send logs directly to Datadog from JS clients
 
 **Datadog browser logs SDK**: Configure the SDK through [NPM](#npm) or use the [CDN async](#cdn-async) or [CDN sync](#cdn-sync) code snippets in the head tag.
 
-**Supported browsers**: The browser logs SDK supports all modern desktop and mobile browsers including IE10 and IE11. See the [browser support][4] table.
+**Supported browsers**: The browser logs SDK supports all modern desktop and mobile browsers including IE11. See the [browser support][4] table.
 
 ### Choose the right installation method
 

--- a/packages/rum/BROWSER_SUPPORT.md
+++ b/packages/rum/BROWSER_SUPPORT.md
@@ -1,0 +1,25 @@
+# Browser Support
+
+| Feature           | Chrome | Firefox | Safari | Edge | Chrome Android | Safari iOS | IE11  | < IE11 | Opera |
+| ----------------- | ------ | ------- | ------ | ---- | -------------- | ---------- | ----- | ------ | ----- |
+| loading           | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| init              | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| rum request       | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| flush on hide     | ✅     | ✅      | ✅     | ✅   | ✅             | ❌         | ❌    | ❌     | ✅    |
+| console error     | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| network error     | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| runtime error     | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| auto action       | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| custom action     | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| long task         | ✅     | ❌      | ❌     | ✅   | ✅             | ❌         | ❌    | ❌     | ✅    |
+| tracing           | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| route change      | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| loading time      | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| resource timing   | ✅     | ✅      | ⚠️(2)  | ✅   | ✅             | ⚠️(2)      | ⚠️(3) | ❌     | ✅    |
+| navigation timing | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
+| web vitals        | ✅     | ⚠️(1)   | ⚠️(1)  | ✅   | ✅             | ⚠️(1)      | ❌    | ❌     | ✅    |
+| FCP               | ✅     | ❌      | ❌     | ✅   | ✅             | ❌         | ❌    | ❌     | ✅    |
+
+1. FID only
+2. size information not available
+3. firstByte and download only

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -16,6 +16,8 @@ To set up Datadog RUM browser monitoring:
 
 **Note**: Your application shows up on the application list page as "pending" until Datadog starts receiving data.
 
+**Supported browsers**: The RUM SDK supports all modern desktop and mobile browsers including IE11. See the [browser support][8] table.
+
 ### Choose the right installation method
 
 | Installation method        | Use case                                                                                                                                                                                                                                                                                                                                                           |
@@ -178,3 +180,4 @@ init(configuration: {
 [5]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [6]: https://docs.datadoghq.com/real_user_monitoring/data_collected/user_action/#automatic-collection-of-user-actions
 [7]: https://docs.datadoghq.com/real_user_monitoring/faq/proxy_rum_data/
+[8]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum/BROWSER_SUPPORT.md


### PR DESCRIPTION
## Motivation

Document RUM features support by main browsers.

## Changes

Similar to [logs/BROWSER_SUPPORT.md](https://github.com/DataDog/browser-sdk/blob/master/packages/logs/BROWSER_SUPPORT.md), add a browser support doc for RUM features.

## Testing

NA

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
