### PR TITLE
[RUMF-824] support Request instances in tracing

### DIFF
--- a/packages/core/src/browser/fetchProxy.ts
+++ b/packages/core/src/browser/fetchProxy.ts
@@ -14,6 +14,7 @@ export interface FetchProxy<
 export interface FetchStartContext {
   method: string
   startTime: number
+  input: RequestInfo
   init?: RequestInit
   url: string
 
@@ -77,6 +78,7 @@ function proxyFetch() {
 
     const context: FetchStartContext = {
       init,
+      input,
       method,
       startTime,
       url,

--- a/packages/core/src/browser/fetchProxy.ts
+++ b/packages/core/src/browser/fetchProxy.ts
@@ -108,7 +108,7 @@ function proxyFetch() {
     }
     beforeSendCallbacks.forEach((callback) => callback(context))
 
-    const responsePromise = originalFetch.call(this, input, context.init)
+    const responsePromise = originalFetch.call(this, context.input, context.init)
     responsePromise.then(monitor(reportFetch), monitor(reportFetch))
     return responsePromise
   })

--- a/packages/core/src/tools/specHelper.ts
+++ b/packages/core/src/tools/specHelper.ts
@@ -61,8 +61,8 @@ export function stubFetch(): FetchStubManager {
       resolve = res
       reject = rej
     })
-    ;(promise as FetchStubPromise).resolveWith = async (response: ResponseStub) => {
-      const resolved = resolve({
+    ;(promise as FetchStubPromise).resolveWith = (response: ResponseStub) => {
+      resolve({
         ...response,
         clone: () => {
           const cloned = {
@@ -75,14 +75,12 @@ export function stubFetch(): FetchStubManager {
           }
           return cloned as Response
         },
-      }) as Promise<ResponseStub>
+      })
       onRequestEnd()
-      return resolved
     }
-    ;(promise as FetchStubPromise).rejectWith = async (error: Error) => {
-      const rejected = reject(error) as Promise<Error>
+    ;(promise as FetchStubPromise).rejectWith = (error: Error) => {
+      reject(error)
       onRequestEnd()
-      return rejected
     }
     return promise
   }) as typeof window.fetch
@@ -106,8 +104,8 @@ export interface ResponseStub extends Partial<Response> {
 export type FetchStub = (input: RequestInfo, init?: RequestInit) => FetchStubPromise
 
 export interface FetchStubPromise extends Promise<Response> {
-  resolveWith: (response: ResponseStub) => Promise<ResponseStub>
-  rejectWith: (error: Error) => Promise<Error>
+  resolveWith: (response: ResponseStub) => void
+  rejectWith: (error: Error) => void
 }
 
 class StubXhr {

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -204,12 +204,12 @@ describe('tracer', () => {
       const tracer = startTracer(configuration as Configuration)
       tracer.traceFetch(context)
 
-      expect(context.init!.headers).toEqual([
+      expect(context.init).toBe(undefined)
+      expect(context.input).not.toBe(request)
+      expect(headersAsArray((context.input as Request).headers)).toEqual([
         ['foo', 'bar'],
         ...tracingHeadersAsArrayFor(context.traceId!, context.spanId!),
       ])
-
-      expect(context.input).toBe(request)
       expect(headersAsArray(request.headers)).toEqual([['foo', 'bar']])
     })
 
@@ -319,7 +319,7 @@ function tracingHeadersFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
 }
 
 function tracingHeadersAsArrayFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
-  return objectEntries(tracingHeadersFor(traceId, spanId)) as string[][]
+  return objectEntries(tracingHeadersFor(traceId, spanId)) as Array<[string, string]>
 }
 
 function headersAsArray(headers: Headers) {

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -189,30 +189,6 @@ describe('tracer', () => {
       ])
     })
 
-    it('should preserve original headers contained in a Request instance', () => {
-      const request = new Request(document.location.origin, {
-        headers: {
-          foo: 'bar',
-        },
-      })
-
-      const context: Partial<RumFetchCompleteContext> = {
-        ...ALLOWED_DOMAIN_CONTEXT,
-        init: request,
-      }
-
-      const tracer = startTracer(configuration as Configuration)
-      tracer.traceFetch(context)
-
-      expect(context.init).not.toBe(request)
-      expect(headersAsArray((context.init as Request).headers)).toEqual([
-        ['foo', 'bar'],
-        ...tracingHeadersAsArrayFor(context.traceId!, context.spanId!),
-      ])
-
-      expect(headersAsArray(request.headers)).toEqual([['foo', 'bar']])
-    })
-
     it('should not trace request on disallowed domain', () => {
       const context: Partial<RumFetchCompleteContext> = { ...DISALLOWED_DOMAIN_CONTEXT }
 
@@ -301,13 +277,5 @@ function tracingHeadersFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
 }
 
 function tracingHeadersAsArrayFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
-  return objectEntries(tracingHeadersFor(traceId, spanId)) as Array<[string, string]>
-}
-
-function headersAsArray(headers: Headers) {
-  const result: Array<[string, string]> = []
-  headers.forEach((value, key) => {
-    result.push([key, value])
-  })
-  return result
+  return objectEntries(tracingHeadersFor(traceId, spanId)) as string[][]
 }

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -189,6 +189,30 @@ describe('tracer', () => {
       ])
     })
 
+    it('should preserve original headers contained in a Request instance', () => {
+      const request = new Request(document.location.origin, {
+        headers: {
+          foo: 'bar',
+        },
+      })
+
+      const context: Partial<RumFetchCompleteContext> = {
+        ...ALLOWED_DOMAIN_CONTEXT,
+        init: request,
+      }
+
+      const tracer = startTracer(configuration as Configuration)
+      tracer.traceFetch(context)
+
+      expect(context.init).not.toBe(request)
+      expect(headersAsArray((context.init as Request).headers)).toEqual([
+        ['foo', 'bar'],
+        ...tracingHeadersAsArrayFor(context.traceId!, context.spanId!),
+      ])
+
+      expect(headersAsArray(request.headers)).toEqual([['foo', 'bar']])
+    })
+
     it('should not trace request on disallowed domain', () => {
       const context: Partial<RumFetchCompleteContext> = { ...DISALLOWED_DOMAIN_CONTEXT }
 
@@ -277,5 +301,13 @@ function tracingHeadersFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
 }
 
 function tracingHeadersAsArrayFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
-  return objectEntries(tracingHeadersFor(traceId, spanId)) as string[][]
+  return objectEntries(tracingHeadersFor(traceId, spanId)) as Array<[string, string]>
+}
+
+function headersAsArray(headers: Headers) {
+  const result: Array<[string, string]> = []
+  headers.forEach((value, key) => {
+    result.push([key, value])
+  })
+  return result
 }

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -42,6 +42,10 @@ export function startTracer(configuration: Configuration): Tracer {
           Object.keys(context.init.headers).forEach((key) => {
             headers.push([key, (context.init!.headers as Record<string, string>)[key]])
           })
+        } else if (context.input instanceof Request) {
+          context.input.headers.forEach((value, key) => {
+            headers.push([key, value])
+          })
         }
         context.init.headers = headers.concat(objectEntries(tracingHeaders) as string[][])
       }),

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -28,22 +28,29 @@ export function startTracer(configuration: Configuration): Tracer {
     clearTracingIfCancelled,
     traceFetch: (context) =>
       injectHeadersIfTracingAllowed(configuration, context, (tracingHeaders: TracingHeaders) => {
-        context.init = { ...context.init }
-        const headers: string[][] = []
-        if (context.init.headers instanceof Headers) {
-          context.init.headers.forEach((value, key) => {
-            headers.push([key, value])
+        if (context.init instanceof Request) {
+          context.init = context.init.clone()
+          Object.keys(tracingHeaders).forEach((name) => {
+            ;(context.init as Request).headers.append(name, tracingHeaders[name])
           })
-        } else if (Array.isArray(context.init.headers)) {
-          context.init.headers.forEach((header) => {
-            headers.push(header)
-          })
-        } else if (context.init.headers) {
-          Object.keys(context.init.headers).forEach((key) => {
-            headers.push([key, (context.init!.headers as Record<string, string>)[key]])
-          })
+        } else {
+          context.init = { ...context.init }
+          const headers: string[][] = []
+          if (context.init.headers instanceof Headers) {
+            context.init.headers.forEach((value, key) => {
+              headers.push([key, value])
+            })
+          } else if (Array.isArray(context.init!.headers)) {
+            context.init.headers.forEach((header) => {
+              headers.push(header)
+            })
+          } else if (context.init.headers) {
+            Object.keys(context.init.headers).forEach((key) => {
+              headers.push([key, (context.init!.headers as Record<string, string>)[key]])
+            })
+          }
+          context.init.headers = headers.concat(objectEntries(tracingHeaders) as string[][])
         }
-        context.init.headers = headers.concat(objectEntries(tracingHeaders) as string[][])
       }),
     traceXhr: (context, xhr) =>
       injectHeadersIfTracingAllowed(configuration, context, (tracingHeaders: TracingHeaders) => {

--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -71,17 +71,3 @@ export async function sendXhr(url: string, headers: string[][] = []): Promise<st
   }
   return result.response
 }
-
-export async function sendFetch(url: string, headers: string[][] = []): Promise<string> {
-  return browserExecuteAsync(
-    // tslint:disable-next-line: no-shadowed-variable
-    (url, headers, done) => {
-      window
-        .fetch(url, { headers })
-        .then((response) => response.text())
-        .then(done)
-    },
-    url,
-    headers
-  )
-}


### PR DESCRIPTION
## Motivation

Support `Request` instances in tracing
```js
fetch(
  new Request('http://localhost:3000', {
    headers: {
      'x-foo': 'bar',
    },
  })
)
```

## Changes

Clone instance and add trace headers if the fetch init argument is a `Request`.

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
