### PR TITLE
✨[RUMF-802] add support for iOS capacitor app stack traces

### DIFF
--- a/packages/core/src/domain/tracekit.ts
+++ b/packages/core/src/domain/tracekit.ts
@@ -502,7 +502,7 @@ export const computeStackTrace = (function computeStackTraceWrapper() {
     // tslint:disable-next-line max-line-length
     const chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i
     // tslint:disable-next-line max-line-length
-    const gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i
+    const gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|capacitor|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i
     // tslint:disable-next-line max-line-length
     const winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i
 

--- a/packages/core/src/domain/tracekitParser.spec.ts
+++ b/packages/core/src/domain/tracekitParser.spec.ts
@@ -1151,4 +1151,24 @@ describe('Parser', () => {
       url: '[native code]',
     })
   })
+
+  it('should parse iOS capacitor', () => {
+    const stackFrames = computeStackTrace(CapturedExceptions.IOS_CAPACITOR)
+
+    expect(stackFrames.stack.length).toEqual(2)
+    expect(stackFrames.stack[0]).toEqual({
+      args: [],
+      column: 99546,
+      func: '?',
+      line: 34,
+      url: 'capacitor://localhost/media/dist/bundle.js',
+    })
+    expect(stackFrames.stack[1]).toEqual({
+      args: [],
+      column: 47950,
+      func: 'r',
+      line: 34,
+      url: 'capacitor://localhost/media/dist/bundle.js',
+    })
+  })
 })

--- a/packages/core/test/capturedExceptions.ts
+++ b/packages/core/test/capturedExceptions.ts
@@ -440,3 +440,8 @@ value@index.android.bundle:29:2417
 value@index.android.bundle:29:927
 [native code]`,
 }
+
+export const IOS_CAPACITOR = {
+  stack: `capacitor://localhost/media/dist/bundle.js:34:99546
+r@capacitor://localhost/media/dist/bundle.js:34:47950`,
+}


### PR DESCRIPTION
## Motivation

iOS capacitor app stack traces are not correctly parsed.
fixes #645

## Changes

Test case corresponding to [this error](https://github.com/getsentry/sentry-javascript/issues/1863#issuecomment-562910174).
Similar modifications in tracekit than the [one in sentry](https://github.com/mrlowe/sentry-javascript/commit/3a09f918e0cbadfdbc1c11d6d779d4718d597fb0)

## Testing

Unit test only

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
