### PR TITLE
[RUM] add session.has_replay

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,7 +1,7 @@
-import { Context, DEFAULT_CONFIGURATION, noop } from '@datadog/browser-core'
+import { DEFAULT_CONFIGURATION, noop } from '@datadog/browser-core'
 import { createRawRumEvent } from '../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
-import { RumEventType, User } from '../rawRumEvent.types'
+import { CommonContext, RumEventType } from '../rawRumEvent.types'
 import { RumActionEvent, RumEvent, RumLongTaskEvent } from '../rumEvent.types'
 import { startRumAssembly } from './assembly'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
@@ -9,8 +9,7 @@ import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 describe('rum assembly', () => {
   let setupBuilder: TestSetupBuilder
   let lifeCycle: LifeCycle
-  let globalContext: Context
-  let user: User
+  let commonContext: CommonContext
   let serverRumEvents: RumEvent[]
   let isTracked: boolean
   let viewSessionId: string | undefined
@@ -19,8 +18,10 @@ describe('rum assembly', () => {
   beforeEach(() => {
     isTracked = true
     viewSessionId = '1234'
-    globalContext = {}
-    user = {}
+    commonContext = {
+      context: {},
+      user: {},
+    }
     beforeSend = noop
     setupBuilder = setup()
       .withSession({
@@ -50,10 +51,7 @@ describe('rum assembly', () => {
         }),
       })
       .beforeBuild(({ applicationId, configuration, lifeCycle: localLifeCycle, session, parentContexts }) => {
-        startRumAssembly(applicationId, configuration, localLifeCycle, session, parentContexts, () => ({
-          user,
-          context: globalContext,
-        }))
+        startRumAssembly(applicationId, configuration, localLifeCycle, session, parentContexts, () => commonContext)
       })
     ;({ lifeCycle } = setupBuilder.build())
 
@@ -134,7 +132,7 @@ describe('rum assembly', () => {
 
   describe('rum global context', () => {
     it('should be merged with event attributes', () => {
-      globalContext = { bar: 'foo' }
+      commonContext.context = { bar: 'foo' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
@@ -144,7 +142,7 @@ describe('rum assembly', () => {
     })
 
     it('should not be included if empty', () => {
-      globalContext = {}
+      commonContext.context = {}
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
@@ -154,12 +152,12 @@ describe('rum assembly', () => {
     })
 
     it('should ignore subsequent context mutation', () => {
-      globalContext = { bar: 'foo', baz: 'foz' }
+      commonContext.context = { bar: 'foo', baz: 'foz' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
       })
-      delete globalContext.bar
+      delete commonContext.context.bar
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
@@ -170,7 +168,7 @@ describe('rum assembly', () => {
     })
 
     it('should not be automatically snake cased', () => {
-      globalContext = { fooBar: 'foo' }
+      commonContext.context = { fooBar: 'foo' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
@@ -180,7 +178,7 @@ describe('rum assembly', () => {
     })
 
     it('should ignore the current global context when a saved global context is provided', () => {
-      globalContext = { replacedContext: 'b', addedContext: 'x' }
+      commonContext.context = { replacedContext: 'b', addedContext: 'x' }
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
@@ -198,7 +196,7 @@ describe('rum assembly', () => {
 
   describe('rum user', () => {
     it('should be included in event attributes', () => {
-      user = { id: 'foo' }
+      commonContext.user = { id: 'foo' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
@@ -208,7 +206,7 @@ describe('rum assembly', () => {
     })
 
     it('should not be included if empty', () => {
-      user = {}
+      commonContext.user = {}
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
@@ -218,7 +216,7 @@ describe('rum assembly', () => {
     })
 
     it('should not be automatically snake cased', () => {
-      user = { fooBar: 'foo' }
+      commonContext.user = { fooBar: 'foo' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         startTime: 0,
@@ -228,7 +226,7 @@ describe('rum assembly', () => {
     })
 
     it('should ignore the current user when a saved common context user is provided', () => {
-      user = { replacedAttribute: 'b', addedAttribute: 'x' }
+      commonContext.user = { replacedAttribute: 'b', addedAttribute: 'x' }
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
@@ -308,7 +306,7 @@ describe('rum assembly', () => {
     })
   })
 
-  describe('session', () => {
+  describe('event generation condition', () => {
     it('when tracked, it should generate event', () => {
       isTracked = true
 
@@ -347,6 +345,30 @@ describe('rum assembly', () => {
         startTime: 0,
       })
       expect(serverRumEvents.length).toBe(0)
+    })
+  })
+
+  describe('session context', () => {
+    it('should include the session type and id', () => {
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+        startTime: 0,
+      })
+      expect(serverRumEvents[0].session).toEqual({
+        has_replay: undefined,
+        id: '1234',
+        type: 'user',
+      })
+    })
+
+    it('should set the session.has_replay attribute if it is defined in the common context', () => {
+      commonContext.hasReplay = true
+
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+        startTime: 0,
+      })
+      expect(serverRumEvents[0].session.has_replay).toBe(true)
     })
   })
 })

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -54,6 +54,7 @@ export function startRumAssembly(
       const viewContext = parentContexts.findView(startTime)
       if (session.isTracked() && viewContext && viewContext.session.id) {
         const actionContext = parentContexts.findAction(startTime)
+        const commonContext = savedCommonContext || getCommonContext()
         const rumContext: RumContext = {
           _dd: {
             formatVersion: 2,
@@ -64,6 +65,7 @@ export function startRumAssembly(
           date: new Date().getTime(),
           service: configuration.service,
           session: {
+            has_replay: commonContext.hasReplay,
             // must be computed on each event because synthetics instrumentation can be done after sdk execution
             // cf https://github.com/puppeteer/puppeteer/issues/3667
             type: getSessionType(),
@@ -73,7 +75,6 @@ export function startRumAssembly(
           ? combine(rumContext, viewContext, actionContext, rawRumEvent)
           : combine(rumContext, viewContext, rawRumEvent)
         const serverRumEvent = withSnakeCaseKeys(assembledRumEvent) as RumEvent & Context
-        const commonContext = savedCommonContext || getCommonContext()
 
         const context = combine(commonContext.context, customerContext)
         if (!isEmptyObject(context)) {

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -122,6 +122,7 @@ export interface RumContext {
   service?: string
   session: {
     type: string
+    has_replay?: boolean
   }
   _dd: {
     formatVersion: 2

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -568,6 +568,10 @@ export interface CommonProperties {
      * Type of the session
      */
     readonly type: 'user' | 'synthetics'
+    /**
+     * Whether this session has a replay
+     */
+    readonly has_replay?: boolean
     [k: string]: unknown
   }
   /**


### PR DESCRIPTION
## Motivation

Following #670 , I forgot to add the `session.has_replay` flag during event assembly. It will be used to filter events that have a session replay in web-ui. Its backend support (facet and merge on Session events) are being implemented.

## Changes

* add `session.has_replay` on events

## Testing

Unit tests, manual testing

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
