### PR TITLE
🐛[RUMF-809] URL encode tags in intake requests

### DIFF
--- a/packages/core/src/domain/configuration.spec.ts
+++ b/packages/core/src/domain/configuration.spec.ts
@@ -83,6 +83,13 @@ describe('configuration', () => {
     })
   })
 
+  describe('tags', () => {
+    it('should be encoded', () => {
+      const configuration = buildConfiguration({ clientToken, service: 'bar+foo' }, usEnv)
+      expect(configuration.rumEndpoint).toContain(`ddtags=sdk_version%3Asome_version%2Cservice%3Abar%2Bfoo`)
+    })
+  })
+
   describe('cookie options', () => {
     it('should not be secure nor crossSite by default', () => {
       const configuration = buildConfiguration({ clientToken }, usEnv)

--- a/packages/core/src/domain/configuration.spec.ts
+++ b/packages/core/src/domain/configuration.spec.ts
@@ -62,22 +62,22 @@ describe('configuration', () => {
   describe('sdk_version, env, version and service', () => {
     it('should not modify the logs and rum endpoints tags when not defined', () => {
       const configuration = buildConfiguration({ clientToken }, usEnv)
-      expect(configuration.rumEndpoint).toContain(`&ddtags=sdk_version:${usEnv.sdkVersion}`)
+      expect(decodeURIComponent(configuration.rumEndpoint)).toContain(`&ddtags=sdk_version:${usEnv.sdkVersion}`)
 
-      expect(configuration.rumEndpoint).not.toContain(',env:')
-      expect(configuration.rumEndpoint).not.toContain(',service:')
-      expect(configuration.rumEndpoint).not.toContain(',version:')
-      expect(configuration.logsEndpoint).not.toContain(',env:')
-      expect(configuration.logsEndpoint).not.toContain(',service:')
-      expect(configuration.logsEndpoint).not.toContain(',version:')
+      expect(decodeURIComponent(configuration.rumEndpoint)).not.toContain(',env:')
+      expect(decodeURIComponent(configuration.rumEndpoint)).not.toContain(',service:')
+      expect(decodeURIComponent(configuration.rumEndpoint)).not.toContain(',version:')
+      expect(decodeURIComponent(configuration.logsEndpoint)).not.toContain(',env:')
+      expect(decodeURIComponent(configuration.logsEndpoint)).not.toContain(',service:')
+      expect(decodeURIComponent(configuration.logsEndpoint)).not.toContain(',version:')
     })
 
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = buildConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' }, usEnv)
-      expect(configuration.rumEndpoint).toContain(
+      expect(decodeURIComponent(configuration.rumEndpoint)).toContain(
         `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
       )
-      expect(configuration.logsEndpoint).toContain(
+      expect(decodeURIComponent(configuration.logsEndpoint)).toContain(
         `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
       )
     })

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -246,7 +246,9 @@ function getEndpoint(
   const host = conf.proxyHost ? conf.proxyHost : datadogHost
   const proxyParameter = conf.proxyHost ? `ddhost=${datadogHost}&` : ''
   const applicationIdParameter = conf.applicationId ? `_dd.application_id=${conf.applicationId}&` : ''
-  const parameters = `${applicationIdParameter}${proxyParameter}ddsource=${source || 'browser'}&ddtags=${tags}`
+  const parameters = `${applicationIdParameter}${proxyParameter}ddsource=${
+    source || 'browser'
+  }&ddtags=${encodeURIComponent(tags)}`
 
   return `https://${host}/v1/input/${conf.clientToken}?${parameters}`
 }


### PR DESCRIPTION
## Motivation

Ensure that tags value are properly interpreted on backend side.
Note: most of the special characters are converted to underscore anyway, cf [tags doc](https://docs.datadoghq.com/getting_started/tagging/#defining-tags).

## Changes

URL encode value of `tags` query param in intake requests 

## Testing

Unit + manual test

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
