### PR TITLE
[RUMF-813] take full snapshots when the view changes or the session is renewed

### DIFF
--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -135,6 +135,35 @@ describe('startRecording', () => {
       expectNoExtraRequest(done)
     })
   })
+
+  it('takes a full snapshot when the view changes', (done) => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {} as any)
+
+    flushSegment(lifeCycle)
+
+    waitRequests(2, (requests) => {
+      expect(requests[0].data.get('has_full_snapshot')).toBe('true')
+      expect(requests[1].data.get('has_full_snapshot')).toBe('true')
+      expectNoExtraRequest(done)
+    })
+  })
+
+  it('takes a full snapshot when the session is renewed', (done) => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+
+    flushSegment(lifeCycle)
+
+    waitRequests(2, (requests) => {
+      expect(requests.length).toBe(2)
+      expect(requests[0].data.get('has_full_snapshot')).toBe('true')
+      expect(requests[1].data.get('has_full_snapshot')).toBe('true')
+      expectNoExtraRequest(done)
+    })
+  })
 })
 
 function flushSegment(lifeCycle: LifeCycle) {

--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -144,7 +144,6 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequests(2, (requests) => {
-      expect(requests[0].data.get('has_full_snapshot')).toBe('true')
       expect(requests[1].data.get('has_full_snapshot')).toBe('true')
       expectNoExtraRequest(done)
     })
@@ -158,8 +157,6 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequests(2, (requests) => {
-      expect(requests.length).toBe(2)
-      expect(requests[0].data.get('has_full_snapshot')).toBe('true')
       expect(requests[1].data.get('has_full_snapshot')).toBe('true')
       expectNoExtraRequest(done)
     })

--- a/packages/rum-recorder/src/boot/recorder.ts
+++ b/packages/rum-recorder/src/boot/recorder.ts
@@ -1,5 +1,5 @@
 import { Configuration } from '@datadog/browser-core'
-import { LifeCycle, ParentContexts, RumSession } from '@datadog/browser-rum-core'
+import { LifeCycle, LifeCycleEventType, ParentContexts, RumSession } from '@datadog/browser-rum-core'
 
 import { record } from '../domain/rrweb'
 import { startSegmentCollection } from '../domain/segmentCollection'
@@ -23,6 +23,9 @@ export function startRecording(
   const { stop: stopRecording, takeFullSnapshot } = record({
     emit: addRecord,
   })!
+
+  lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, takeFullSnapshot)
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
 
   return {
     stop() {

--- a/packages/rum-recorder/src/boot/recorder.ts
+++ b/packages/rum-recorder/src/boot/recorder.ts
@@ -20,7 +20,7 @@ export function startRecording(
     (data, meta) => send(configuration.sessionReplayEndpoint, data, meta)
   )
 
-  const stopRecording = record({
+  const { stop: stopRecording, takeFullSnapshot } = record({
     emit: addRecord,
   })!
 

--- a/packages/rum-recorder/src/domain/rrweb/record.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.spec.ts
@@ -24,7 +24,7 @@ describe('record', () => {
 
   it('will only have one full snapshot without checkout config', () => {
     const emit = jasmine.createSpy<(event: Event) => void>()
-    stop = record<Event>({ emit })
+    stop = record<Event>({ emit })?.stop
 
     const count = 30
     for (let i = 0; i < count; i += 1) {

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-null-keyword */
 import { MaskInputOptions, SlimDOMOptions, snapshot } from 'rrweb-snapshot'
 import { initObservers, mutationBuffer } from './observer'
-import { Event, EventType, EventWithTime, IncrementalSource, ListenerHandler, RecordOptions } from './types'
+import { Event, EventType, EventWithTime, IncrementalSource, ListenerHandler, RecordAPI, RecordOptions } from './types'
 import { getWindowHeight, getWindowWidth, mirror, on, polyfill } from './utils'
 
 function wrapEvent(e: Event): EventWithTime {
@@ -13,7 +13,7 @@ function wrapEvent(e: Event): EventWithTime {
 
 let wrappedEmit!: (e: EventWithTime, isCheckout?: boolean) => void
 
-function record<T = EventWithTime>(options: RecordOptions<T> = {}): ListenerHandler | undefined {
+function record<T = EventWithTime>(options: RecordOptions<T> = {}): RecordAPI | undefined {
   const {
     emit,
     checkoutEveryNms,
@@ -326,8 +326,11 @@ function record<T = EventWithTime>(options: RecordOptions<T> = {}): ListenerHand
         )
       )
     }
-    return () => {
-      handlers.forEach((h) => h())
+    return {
+      stop() {
+        handlers.forEach((h) => h())
+      },
+      takeFullSnapshot,
     }
   } catch (error) {
     // TODO: handle internal error

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -177,6 +177,11 @@ export interface RecordOptions<T> {
   mousemoveWait?: number
 }
 
+export interface RecordAPI {
+  stop: ListenerHandler
+  takeFullSnapshot(): void
+}
+
 export interface ObserverParam {
   mutationCb: MutationCallBack
   mousemoveCb: MousemoveCallBack


### PR DESCRIPTION
## Motivation

* Replays are watched by session. If a session doesn’t start with a full snapshot, it cannot be played from the start.

* Records can happen in multiple tabs simultatenously. This causes an issue during replay, because the player gets incremental snapshot but doesn’t know on which fullsnapshot it should apply. By starting all views with a full snapshot, the player can drop segments with a different view from the previous one but without full snapshot. This an easy workaround that can be improved in the future. 

## Changes

* Add the ability to manually trigger full snapshots in RRWeb
* Use it via LifeCycle events

## Testing

Unit + manual
 
---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
