### PR TITLE
✨ [RUMF-826] Allow classic intake only for us and eu

### DIFF
--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -1,6 +1,7 @@
 import { areCookiesAuthorized, CookieOptions } from '../browser/cookie'
 import { buildConfiguration, UserConfiguration } from '../domain/configuration'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
+import { Datacenter } from '../domain/transportConfiguration'
 
 export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): void } {
   const publicApi = {
@@ -32,18 +33,6 @@ export function defineGlobal<Global, Name extends keyof Global>(global: Global, 
   if (existingGlobalVariable && existingGlobalVariable.q) {
     existingGlobalVariable.q.forEach((fn) => fn())
   }
-}
-
-export const Datacenter = {
-  EU: 'eu',
-  US: 'us',
-} as const
-
-export type Datacenter = typeof Datacenter[keyof typeof Datacenter]
-
-export const INTAKE_SITE = {
-  [Datacenter.EU]: 'datadoghq.eu',
-  [Datacenter.US]: 'datadoghq.com',
 }
 
 export enum BuildMode {

--- a/packages/core/src/domain/configuration.spec.ts
+++ b/packages/core/src/domain/configuration.spec.ts
@@ -1,5 +1,6 @@
-import { BuildEnv, BuildMode, Datacenter } from '../boot/init'
+import { BuildEnv, BuildMode } from '../boot/init'
 import { buildConfiguration } from './configuration'
+import { Datacenter } from './transportConfiguration'
 
 describe('configuration', () => {
   const clientToken = 'some_client_token'

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -1,7 +1,7 @@
-import { BuildEnv, Datacenter } from '../boot/init'
+import { BuildEnv } from '../boot/init'
 import { CookieOptions, getCurrentSite } from '../browser/cookie'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from '../tools/utils'
-import { computeTransportConfiguration } from './transportConfiguration'
+import { computeTransportConfiguration, Datacenter } from './transportConfiguration'
 
 export const DEFAULT_CONFIGURATION = {
   allowedTracingOrigins: [] as Array<string | RegExp>,

--- a/packages/core/src/domain/transportConfiguration.ts
+++ b/packages/core/src/domain/transportConfiguration.ts
@@ -1,4 +1,4 @@
-import { BuildEnv, BuildMode, Datacenter, INTAKE_SITE } from '../boot/init'
+import { BuildEnv, BuildMode } from '../boot/init'
 import { includes } from '../tools/utils'
 import { TransportConfiguration, UserConfiguration } from './configuration'
 
@@ -18,7 +18,19 @@ const ENDPOINTS = {
   },
 }
 
-const CLASSIC_ALLOWED_SITES = ['datadoghq.com', 'datadoghq.eu']
+export const Datacenter = {
+  EU: 'eu',
+  US: 'us',
+} as const
+
+export type Datacenter = typeof Datacenter[keyof typeof Datacenter]
+
+export const INTAKE_SITE = {
+  [Datacenter.EU]: 'datadoghq.eu',
+  [Datacenter.US]: 'datadoghq.com',
+}
+
+const CLASSIC_ALLOWED_SITES = [INTAKE_SITE[Datacenter.US], INTAKE_SITE[Datacenter.EU]]
 
 type IntakeType = keyof typeof ENDPOINTS
 type EndpointType = keyof typeof ENDPOINTS[IntakeType]

--- a/packages/core/src/domain/transportConfiguration.ts
+++ b/packages/core/src/domain/transportConfiguration.ts
@@ -1,4 +1,5 @@
 import { BuildEnv, BuildMode, Datacenter, INTAKE_SITE } from '../boot/init'
+import { includes } from '../tools/utils'
 import { TransportConfiguration, UserConfiguration } from './configuration'
 
 const ENDPOINTS = {
@@ -16,6 +17,9 @@ const ENDPOINTS = {
     trace: 'public-trace',
   },
 }
+
+const CLASSIC_ALLOWED_SITES = ['datadoghq.com', 'datadoghq.eu']
+
 type IntakeType = keyof typeof ENDPOINTS
 type EndpointType = keyof typeof ENDPOINTS[IntakeType]
 
@@ -98,8 +102,7 @@ export function computeTransportConfiguration(userConfiguration: UserConfigurati
 }
 
 function getIntakeType(site: string, userConfiguration: UserConfiguration) {
-  // TODO when new intake will be available for gov, only allow classic intake for us and eu
-  return userConfiguration.useAlternateIntakeDomains || site === 'us3.datadoghq.com' ? 'alternate' : 'classic'
+  return !userConfiguration.useAlternateIntakeDomains && includes(CLASSIC_ALLOWED_SITES, site) ? 'classic' : 'alternate'
 }
 
 function getIntakeUrls(intakeType: IntakeType, settings: TransportSettings, withReplica: boolean) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,6 @@ export { computeStackTrace } from './domain/tracekit'
 export {
   BuildEnv,
   BuildMode,
-  Datacenter,
   defineGlobal,
   makePublicApi,
   commonInit,
@@ -46,3 +45,4 @@ export { createContextManager } from './tools/contextManager'
 export { limitModification } from './tools/limitModification'
 
 export * from './tools/specHelper'
+export { Datacenter } from './domain/transportConfiguration'


### PR DESCRIPTION
## Motivation

Alternate govcloud intake has replaced the classic one, only us and eu can use classic intakes now.

## Changes

- Update `getIntakeType` logic to only support classic for us and eu
- move INTAKE_SITE and Datacenter to avoid tooling issue

## Testing

unit + manual on gov app

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
