### PR TITLE
👷 Update test app lockfile on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "scripts/cli typecheck . && scripts/cli typecheck test/e2e",
     "dev": "node scripts/dev-server.js",
     "release": "lerna version --exact",
-    "version": "node ./scripts/generate-changelog.js",
+    "version": "scripts/cli version",
     "publish:npm": "TARGET_DATACENTER=us BUILD_MODE=release yarn build && lerna publish from-package",
     "fail": "./scripts/fail.sh",
     "test": "yarn test:unit",

--- a/scripts/cli
+++ b/scripts/cli
@@ -50,4 +50,10 @@ cmd_build_json2type () {
   set -e
 }
 
+cmd_version () {
+  node ./scripts/generate-changelog.js
+  # keep test app lockfile up to date
+  cd test/app && yarn
+}
+
 main "$@"


### PR DESCRIPTION
## Motivation

Avoid to manually update/revert it 

## Changes

- extract version cli command
- update test app lockfile before making the version commit

## Testing

next release

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
