### PR TITLE
[recorder] set 'hasReplay' to undefined by default

### DIFF
--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -176,5 +176,5 @@ export interface User {
 export interface CommonContext {
   user: User
   context: Context
-  hasReplay?: boolean
+  hasReplay?: true
 }

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
@@ -70,7 +70,7 @@ describe('makeRumRecorderPublicApi', () => {
     it('if enabled, commonContext.hasReplay should be true only if startSessionRecord is called', () => {
       enabledFlags = ['postpone_start_recording']
       rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-      expect(getCommonContext().hasReplay).toBe(false)
+      expect(getCommonContext().hasReplay).toBeUndefined()
       rumGlobal.startSessionRecord!()
       expect(getCommonContext().hasReplay).toBe(true)
     })

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
@@ -7,7 +7,7 @@ export type StartRecording = typeof startRecording
 
 export function makeRumRecorderPublicApi(startRumImpl: StartRum, startRecordingImpl: StartRecording) {
   const rumRecorderGlobal = makeRumPublicApi((userConfiguration, getCommonContext) => {
-    let isRecording = false
+    let isRecording: true | undefined
 
     const startRumResult = startRumImpl(userConfiguration, () => ({
       ...getCommonContext(),


### PR DESCRIPTION


## Motivation

`session.has_replay` should not be set if the record has not been started, to be consistent with the RUM bundle without recorder.

This change only affects the recorder with flag `postpone_start_recording`.

## Changes

Set hasReplay to undefined by default.
Adjust typings to enforce this.

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
