### PR TITLE
[RUMF-814] extract the "waitRequests" pattern as a util function

### DIFF
--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -3,7 +3,7 @@ import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
 
 import { setup, TestSetupBuilder } from '../../../rum-core/test/specHelper'
 
-import { expectNoExtraCall, waitCalls } from '../../test/utils'
+import { collectAsyncCalls } from '../../test/utils'
 import { startRecording } from './recorder'
 
 describe('startRecording', () => {
@@ -40,8 +40,10 @@ describe('startRecording', () => {
       )
 
     const requestSendSpy = spyOn(HttpRequest.prototype, 'send')
-    expectNoExtraRequestSendCalls = expectNoExtraCall.bind(null, requestSendSpy)
-    waitRequestSendCalls = waitCalls.bind(null, requestSendSpy)
+    ;({
+      waitAsyncCalls: waitRequestSendCalls,
+      expectNoExtraAsyncCall: expectNoExtraRequestSendCalls,
+    } = collectAsyncCalls(requestSendSpy))
   })
 
   afterEach(() => {

--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -3,16 +3,17 @@ import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
 
 import { setup, TestSetupBuilder } from '../../../rum-core/test/specHelper'
 
+import { expectNoExtraCall, waitCalls } from '../../test/utils'
 import { startRecording } from './recorder'
 
 describe('startRecording', () => {
   let setupBuilder: TestSetupBuilder
   let sessionId: string | undefined
-  let waitRequests: (
-    expectedRequestCount: number,
-    callback: (requests: ReadonlyArray<{ data: FormData; size: number }>) => void
+  let waitRequestSendCalls: (
+    expectedCallsCount: number,
+    callback: (calls: jasmine.Calls<HttpRequest['send']>) => void
   ) => void
-  let expectNoExtraRequest: (callback: () => void) => void
+  let expectNoExtraRequestSendCalls: (done: () => void) => void
 
   beforeEach(() => {
     if (isIE()) {
@@ -39,22 +40,8 @@ describe('startRecording', () => {
       )
 
     const requestSendSpy = spyOn(HttpRequest.prototype, 'send')
-
-    waitRequests = (expectedRequestCount, callback) => {
-      const requests: Array<{ data: FormData; size: number }> = []
-      requestSendSpy.and.callFake((data, size) => {
-        if (requests.push({ size, data: data as FormData }) === expectedRequestCount) {
-          callback(requests)
-        }
-      })
-    }
-
-    expectNoExtraRequest = (done) => {
-      requestSendSpy.and.callFake(() => {
-        fail('Unexpected request received')
-      })
-      setTimeout(done, 300)
-    }
+    expectNoExtraRequestSendCalls = expectNoExtraCall.bind(null, requestSendSpy)
+    waitRequestSendCalls = waitCalls.bind(null, requestSendSpy)
   })
 
   afterEach(() => {
@@ -65,9 +52,9 @@ describe('startRecording', () => {
     const { lifeCycle } = setupBuilder.build()
     flushSegment(lifeCycle)
 
-    waitRequests(1, (requests) => {
-      expect(requests).toEqual([{ data: jasmine.any(FormData), size: jasmine.any(Number) }])
-      expect(formDataAsObject(requests[0].data)).toEqual({
+    waitRequestSendCalls(1, (calls) => {
+      expect(calls.first().args).toEqual([jasmine.any(FormData), jasmine.any(Number)])
+      expect(getRequestData(calls.first())).toEqual({
         'application.id': 'appId',
         creation_reason: 'init',
         end: jasmine.stringMatching(/^\d{13}$/),
@@ -78,7 +65,7 @@ describe('startRecording', () => {
         start: jasmine.stringMatching(/^\d{13}$/),
         'view.id': 'view-id',
       })
-      expectNoExtraRequest(done)
+      expectNoExtraRequestSendCalls(done)
     })
   })
 
@@ -94,9 +81,9 @@ describe('startRecording', () => {
       document.body.dispatchEvent(inputEvent)
     }
 
-    waitRequests(1, (requests) => {
-      expect(requests[0].data.get('records_count')).toBe(String(inputCount + 2))
-      expectNoExtraRequest(done)
+    waitRequestSendCalls(1, (calls) => {
+      expect(getRequestData(calls.first()).records_count).toBe(String(inputCount + 2))
+      expectNoExtraRequestSendCalls(done)
     })
   })
 
@@ -111,9 +98,9 @@ describe('startRecording', () => {
 
     flushSegment(lifeCycle)
 
-    waitRequests(1, (requests) => {
-      expect(requests[0].data.get('records_count')).toBe('3')
-      expectNoExtraRequest(done)
+    waitRequestSendCalls(1, (calls) => {
+      expect(getRequestData(calls.first()).records_count).toBe('3')
+      expectNoExtraRequestSendCalls(done)
     })
   })
 
@@ -129,10 +116,11 @@ describe('startRecording', () => {
 
     flushSegment(lifeCycle)
 
-    waitRequests(1, (requests) => {
-      expect(requests[0].data.get('records_count')).toBe('1')
-      expect(requests[0].data.get('session.id')).toBe('new-session-id')
-      expectNoExtraRequest(done)
+    waitRequestSendCalls(1, (calls) => {
+      const data = getRequestData(calls.first())
+      expect(data.records_count).toBe('1')
+      expect(data['session.id']).toBe('new-session-id')
+      expectNoExtraRequestSendCalls(done)
     })
   })
 
@@ -143,9 +131,9 @@ describe('startRecording', () => {
 
     flushSegment(lifeCycle)
 
-    waitRequests(2, (requests) => {
-      expect(requests[1].data.get('has_full_snapshot')).toBe('true')
-      expectNoExtraRequest(done)
+    waitRequestSendCalls(2, (calls) => {
+      expect(getRequestData(calls.mostRecent()).has_full_snapshot).toBe('true')
+      expectNoExtraRequestSendCalls(done)
     })
   })
 
@@ -156,9 +144,9 @@ describe('startRecording', () => {
 
     flushSegment(lifeCycle)
 
-    waitRequests(2, (requests) => {
-      expect(requests[1].data.get('has_full_snapshot')).toBe('true')
-      expectNoExtraRequest(done)
+    waitRequestSendCalls(2, (calls) => {
+      expect(getRequestData(calls.mostRecent()).has_full_snapshot).toBe('true')
+      expectNoExtraRequestSendCalls(done)
     })
   })
 })
@@ -167,9 +155,11 @@ function flushSegment(lifeCycle: LifeCycle) {
   lifeCycle.notify(LifeCycleEventType.BEFORE_UNLOAD)
 }
 
-function formDataAsObject(data: FormData) {
+function getRequestData(call: jasmine.CallInfo<HttpRequest['send']>) {
+  const data = call.args[0]
+  expect(data).toEqual(jasmine.any(FormData))
   const result: { [key: string]: unknown } = {}
-  data.forEach((value, key) => {
+  ;(data as FormData).forEach((value, key) => {
     result[key] = value
   })
   return result

--- a/packages/rum-recorder/test/utils.ts
+++ b/packages/rum-recorder/test/utils.ts
@@ -51,3 +51,26 @@ export class MockWorker implements DeflateWorker {
     this.pendingMessages.length = 0
   }
 }
+
+export function waitCalls<F extends jasmine.Func>(
+  spy: jasmine.Spy<F>,
+  expectedCallsCount: number,
+  callback: (calls: jasmine.Calls<F>) => void
+) {
+  if (spy.calls.count() === expectedCallsCount) {
+    callback(spy.calls)
+  } else {
+    spy.and.callFake((() => {
+      if (spy.calls.count() === expectedCallsCount) {
+        callback(spy.calls)
+      }
+    }) as F)
+  }
+}
+
+export function expectNoExtraCall(spy: jasmine.Spy<any>, done: () => void) {
+  spy.and.callFake(() => {
+    fail('Unexpected extra call')
+  })
+  setTimeout(done, 300)
+}

--- a/packages/rum-recorder/test/utils.ts
+++ b/packages/rum-recorder/test/utils.ts
@@ -52,25 +52,24 @@ export class MockWorker implements DeflateWorker {
   }
 }
 
-export function waitCalls<F extends jasmine.Func>(
-  spy: jasmine.Spy<F>,
-  expectedCallsCount: number,
-  callback: (calls: jasmine.Calls<F>) => void
-) {
-  if (spy.calls.count() === expectedCallsCount) {
-    callback(spy.calls)
-  } else {
-    spy.and.callFake((() => {
+export function collectAsyncCalls<F extends jasmine.Func>(spy: jasmine.Spy<F>) {
+  return {
+    waitAsyncCalls: (expectedCallsCount: number, callback: (calls: jasmine.Calls<F>) => void) => {
       if (spy.calls.count() === expectedCallsCount) {
         callback(spy.calls)
+      } else {
+        spy.and.callFake((() => {
+          if (spy.calls.count() === expectedCallsCount) {
+            callback(spy.calls)
+          }
+        }) as F)
       }
-    }) as F)
+    },
+    expectNoExtraAsyncCall: (done: () => void) => {
+      spy.and.callFake((() => {
+        fail('Unexpected extra call')
+      }) as F)
+      setTimeout(done, 300)
+    },
   }
-}
-
-export function expectNoExtraCall(spy: jasmine.Spy<any>, done: () => void) {
-  spy.and.callFake(() => {
-    fail('Unexpected extra call')
-  })
-  setTimeout(done, 300)
 }


### PR DESCRIPTION
## Motivation

I want to abstract the pattern [introduced while working on the recorder tests](https://github.com/DataDog/browser-sdk/pull/670/commits/0dbceac30bdad343aced91277a9792280ad55877) to be used in other test specs. Since there is many ways of implementing this, I'd like to share this beforehand so we can agree on the best way of doing so.

## Changes

* define `expectNoExtraCalls` and `waitCalls` in the recorder `test/utils`
* use it in `recorder.spec.ts`. Because now only `jasmine.Calls` objects are exposed instead of transformed `{ data: FormData, size: number }` objects, a `getRequestData` helper  has been introduced locally.


## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
