### PR TITLE
🐛[RUMF-836] sanitize unsupported characters in timing name

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -911,4 +911,16 @@ describe('rum track custom timings', () => {
       foo: 1234,
     })
   })
+
+  it('should sanitized timing name', () => {
+    setupBuilder.build()
+    const warnSpy = spyOn(console, 'warn')
+
+    addTiming('foo bar-qux.@zip_21%$*€👋', 1234)
+
+    expect(getViewEvent(1).customTimings).toEqual({
+      'foo_bar-qux.@zip_21_$____': 1234,
+    })
+    expect(warnSpy).toHaveBeenCalled()
+  })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -205,7 +205,7 @@ function newView(
       }
     },
     addTiming(name: string, time: number) {
-      customTimings[name] = time - startTime
+      customTimings[sanitizeTiming(name)] = time - startTime
     },
     updateLocation(newLocation: Location) {
       location = { ...newLocation }
@@ -311,4 +311,15 @@ function trackLayoutShift(lifeCycle: LifeCycle, callback: (layoutShift: number) 
  */
 function isLayoutShiftSupported() {
   return supportPerformanceTimingEvent('layout-shift')
+}
+
+/**
+ * Timing name is used as facet path that must contain only letters, digits, or the characters - _ . @ $
+ */
+function sanitizeTiming(name: string) {
+  const sanitized = name.replace(/[^a-zA-Z0-9-_.@$]/g, '_')
+  if (sanitized !== name) {
+    console.warn(`Invalid timing name: ${name}, sanitized to: ${sanitized}`)
+  }
+  return sanitized
 }


### PR DESCRIPTION
## Motivation

Timing name is used as facet path, use of unsupported characters can then prevent the measure creation:

![image-20210127-103109 (1)](https://user-images.githubusercontent.com/1331991/106175017-e67e7280-6195-11eb-8870-2c7cba488c3b.png)


## Changes

- Sanitize timing name by replacing unsupported characters by `_`
- Warn when a sanitization is performed

## Testing

unit + manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
