### PR TITLE
[REPLAY-164] track Focus records

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -21,6 +21,8 @@ export enum DOM_EVENT {
   HASH_CHANGE = 'hashchange',
   PAGE_HIDE = 'pagehide',
   MOUSE_DOWN = 'mousedown',
+  FOCUS = 'focus',
+  BLUR = 'blur',
 }
 
 export enum ResourceType {

--- a/packages/rum-recorder/src/boot/recorder.ts
+++ b/packages/rum-recorder/src/boot/recorder.ts
@@ -4,6 +4,7 @@ import { LifeCycle, LifeCycleEventType, ParentContexts, RumSession } from '@data
 import { record } from '../domain/rrweb'
 import { startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'
+import { RawRecord } from '../types'
 
 export function startRecording(
   lifeCycle: LifeCycle,
@@ -20,8 +21,12 @@ export function startRecording(
     (data, meta) => send(configuration.sessionReplayEndpoint, data, meta)
   )
 
+  function addRawRecord(rawRecord: RawRecord) {
+    addRecord({ ...rawRecord, timestamp: Date.now() })
+  }
+
   const { stop: stopRecording, takeFullSnapshot } = record({
-    emit: addRecord,
+    emit: addRawRecord,
   })!
 
   lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, takeFullSnapshot)

--- a/packages/rum-recorder/src/domain/rrweb/record.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.spec.ts
@@ -23,7 +23,7 @@ describe('record', () => {
   })
 
   it('will only have one full snapshot without checkout config', () => {
-    const emit = jasmine.createSpy<(event: Record) => void>()
+    const emit = jasmine.createSpy<(record: Record) => void>()
     stop = record<Record>({ emit })?.stop
 
     const count = 30
@@ -32,9 +32,9 @@ describe('record', () => {
       input.dispatchEvent(createNewEvent('input', {}))
     }
 
-    const events = emit.calls.allArgs().map(([event]) => event)
+    const events = emit.calls.allArgs().map(([record]) => record)
     expect(events.length).toEqual(count + 2)
-    expect(events.filter((event) => event.type === RecordType.Meta).length).toEqual(1)
-    expect(events.filter((event) => event.type === RecordType.FullSnapshot).length).toEqual(1)
+    expect(events.filter((record) => record.type === RecordType.Meta).length).toEqual(1)
+    expect(events.filter((record) => record.type === RecordType.FullSnapshot).length).toEqual(1)
   })
 })

--- a/packages/rum-recorder/src/domain/rrweb/record.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.spec.ts
@@ -1,6 +1,6 @@
 import { createNewEvent, isIE } from '@datadog/browser-core'
+import { RecordType, Record } from '../../types'
 import { record } from './record'
-import { Event, EventType } from './types'
 
 describe('record', () => {
   let input: HTMLInputElement
@@ -23,8 +23,8 @@ describe('record', () => {
   })
 
   it('will only have one full snapshot without checkout config', () => {
-    const emit = jasmine.createSpy<(event: Event) => void>()
-    stop = record<Event>({ emit })?.stop
+    const emit = jasmine.createSpy<(event: Record) => void>()
+    stop = record<Record>({ emit })?.stop
 
     const count = 30
     for (let i = 0; i < count; i += 1) {
@@ -34,7 +34,7 @@ describe('record', () => {
 
     const events = emit.calls.allArgs().map(([event]) => event)
     expect(events.length).toEqual(count + 2)
-    expect(events.filter((event) => event.type === EventType.Meta).length).toEqual(1)
-    expect(events.filter((event) => event.type === EventType.FullSnapshot).length).toEqual(1)
+    expect(events.filter((event) => event.type === RecordType.Meta).length).toEqual(1)
+    expect(events.filter((event) => event.type === RecordType.FullSnapshot).length).toEqual(1)
   })
 })

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -1,5 +1,5 @@
 import { idNodeMap, INode, MaskInputOptions, serializedNodeWithId, SlimDOMOptions } from 'rrweb-snapshot'
-import type { Record } from '../../types'
+import type { RawRecord } from '../../types'
 
 export enum IncrementalSource {
   Mutation,
@@ -106,7 +106,7 @@ export interface RecordOptions<T> {
   slimDOMOptions?: SlimDOMOptions | 'all' | true
   inlineStylesheet?: boolean
   hooks?: HooksParam
-  packFn?: (record: Record) => Record
+  packFn?: (record: RawRecord) => RawRecord
   sampling?: SamplingStrategy
   recordCanvas?: boolean
   collectFonts?: boolean

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -1,56 +1,6 @@
 import { idNodeMap, INode, MaskInputOptions, serializedNodeWithId, SlimDOMOptions } from 'rrweb-snapshot'
+import type { Record } from '../../types'
 
-export enum EventType {
-  DomContentLoaded,
-  Load,
-  FullSnapshot,
-  IncrementalSnapshot,
-  Meta,
-  Custom,
-}
-
-export interface DomContentLoadedEvent {
-  type: EventType.DomContentLoaded
-  data: object
-}
-
-export interface LoadedEvent {
-  type: EventType.Load
-  data: object
-}
-
-export interface FullSnapshotEvent {
-  type: EventType.FullSnapshot
-  data: {
-    node: serializedNodeWithId
-    initialOffset: {
-      top: number
-      left: number
-    }
-  }
-}
-
-export interface IncrementalSnapshotEvent {
-  type: EventType.IncrementalSnapshot
-  data: IncrementalData
-}
-
-export interface MetaEvent {
-  type: EventType.Meta
-  data: {
-    href: string
-    width: number
-    height: number
-  }
-}
-
-export interface CustomEvent<T = unknown> {
-  type: EventType.Custom
-  data: {
-    tag: string
-    payload: T
-  }
-}
 export enum IncrementalSource {
   Mutation,
   MouseMove,
@@ -119,19 +69,6 @@ export type IncrementalData =
   | CanvasMutationData
   | FontData
 
-export type Event =
-  | DomContentLoadedEvent
-  | LoadedEvent
-  | FullSnapshotEvent
-  | IncrementalSnapshotEvent
-  | MetaEvent
-  | CustomEvent
-
-export type EventWithTime = Event & {
-  timestamp: number
-  delay?: number
-}
-
 export type BlockClass = string | RegExp
 
 export type SamplingStrategy = Partial<{
@@ -144,7 +81,7 @@ export type SamplingStrategy = Partial<{
    * false means not to record mouse interaction events
    * can also specify record some kinds of mouse interactions
    */
-  mouseInteraction: boolean | Record<string, boolean | undefined>
+  mouseInteraction: boolean | { [key: string]: boolean | undefined }
   /**
    * number is the throttle threshold of recording scroll
    */
@@ -169,7 +106,7 @@ export interface RecordOptions<T> {
   slimDOMOptions?: SlimDOMOptions | 'all' | true
   inlineStylesheet?: boolean
   hooks?: HooksParam
-  packFn?: (event: Event) => Event
+  packFn?: (record: Record) => Record
   sampling?: SamplingStrategy
   recordCanvas?: boolean
   collectFonts?: boolean

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -1,12 +1,7 @@
-// Alias EventWithTime to Record, to avoid naming clash between RRWeb events and RUM events
-import {
-  EventType as RecordType,
-  EventWithTime as Record,
-  IncrementalSource,
-  MousePosition,
-} from './domain/rrweb/types'
+import { serializedNodeWithId } from 'rrweb-snapshot'
+import type { IncrementalSource, MousePosition, IncrementalData } from './domain/rrweb/types'
 
-export { Record, RecordType, IncrementalSource, MousePosition }
+export { IncrementalSource, MousePosition }
 
 export interface MouseMoveRecord {
   type: RecordType.IncrementalSnapshot
@@ -43,3 +38,68 @@ export type CreationReason =
   | 'session_renewed'
   | 'before_unload'
   | 'visibility_hidden'
+
+export type RawRecord =
+  | DomContentLoadedRecord
+  | LoadedRecord
+  | FullSnapshotRecord
+  | IncrementalSnapshotRecord
+  | MetaRecord
+  | CustomRecord
+
+export type Record = RawRecord & {
+  timestamp: number
+  delay?: number
+}
+
+export enum RecordType {
+  DomContentLoaded,
+  Load,
+  FullSnapshot,
+  IncrementalSnapshot,
+  Meta,
+  Custom,
+}
+
+export interface DomContentLoadedRecord {
+  type: RecordType.DomContentLoaded
+  data: object
+}
+
+export interface LoadedRecord {
+  type: RecordType.Load
+  data: object
+}
+
+export interface FullSnapshotRecord {
+  type: RecordType.FullSnapshot
+  data: {
+    node: serializedNodeWithId
+    initialOffset: {
+      top: number
+      left: number
+    }
+  }
+}
+
+export interface IncrementalSnapshotRecord {
+  type: RecordType.IncrementalSnapshot
+  data: IncrementalData
+}
+
+export interface MetaRecord {
+  type: RecordType.Meta
+  data: {
+    href: string
+    width: number
+    height: number
+  }
+}
+
+export interface CustomRecord<T = unknown> {
+  type: RecordType.Custom
+  data: {
+    tag: string
+    payload: T
+  }
+}

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -35,6 +35,7 @@ export type RawRecord =
   | IncrementalSnapshotRecord
   | MetaRecord
   | CustomRecord
+  | FocusRecord
 
 export type Record = RawRecord & {
   timestamp: number
@@ -48,6 +49,7 @@ export enum RecordType {
   IncrementalSnapshot,
   Meta,
   Custom,
+  Focus,
 }
 
 export interface DomContentLoadedRecord {
@@ -90,5 +92,12 @@ export interface CustomRecord<T = unknown> {
   data: {
     tag: string
     payload: T
+  }
+}
+
+export interface FocusRecord {
+  type: RecordType.Focus
+  data: {
+    has_focus: boolean
   }
 }

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -1,6 +1,8 @@
 import { serializedNodeWithId } from 'rrweb-snapshot'
 import type { IncrementalData } from './domain/rrweb/types'
 
+export { IncrementalSource } from './domain/rrweb/types'
+
 export interface Segment extends SegmentMeta {
   records: Record[]
 }

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -1,16 +1,5 @@
 import { serializedNodeWithId } from 'rrweb-snapshot'
-import type { IncrementalSource, MousePosition, IncrementalData } from './domain/rrweb/types'
-
-export { IncrementalSource, MousePosition }
-
-export interface MouseMoveRecord {
-  type: RecordType.IncrementalSnapshot
-  timestamp: number
-  data: {
-    source: IncrementalSource.TouchMove | IncrementalSource.MouseMove
-    positions: MousePosition[]
-  }
-}
+import type { IncrementalData } from './domain/rrweb/types'
 
 export interface Segment extends SegmentMeta {
   records: Record[]


### PR DESCRIPTION
## Motivation

Add focus information to always show the currently focused view during replay

## Changes

* adjust types
* adjust rrweb architecture a bit to externalize records generation: the goal is to avoid implementing new records in the RRWeb codebase, to be more modular and easier to test. In a future PR, I'll remove some records from RRWeb, limiting its usage to recording DOM changes.
* add Focus records tracking

## Testing

Unit tests, manual tests

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
