### PR TITLE
🔧 [RUMF-825] restrict which types are used depending on the context

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ build-and-lint:
     - yarn build
     - yarn lint
     - scripts/cli typecheck test/app
+    - scripts/cli typecheck test/e2e
 
 build-bundle:
   stage: test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:bundle": "lerna run build:bundle --stream",
     "format": "prettier --check .",
     "lint": "scripts/cli lint .",
-    "typecheck": "scripts/cli typecheck . && scripts/cli typecheck test/e2e",
+    "typecheck": "scripts/cli typecheck .",
     "dev": "node scripts/dev-server.js",
     "release": "lerna version --exact",
     "version": "scripts/cli version",

--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -20,8 +20,8 @@ export function cacheCookieAccess(name: string, options: CookieOptions): CookieC
 
   const cacheAccess = () => {
     hasCache = true
-    window.clearTimeout(timeout)
-    timeout = window.setTimeout(() => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => {
       hasCache = false
     }, COOKIE_ACCESS_DELAY)
   }

--- a/packages/core/src/domain/sessionManagement.ts
+++ b/packages/core/src/domain/sessionManagement.ts
@@ -157,7 +157,7 @@ function trackVisibility(expandSession: () => void) {
   const { stop } = utils.addEventListener(document, utils.DOM_EVENT.VISIBILITY_CHANGE, expandSessionWhenVisible)
   stopCallbacks.push(stop)
 
-  const visibilityCheckInterval = window.setInterval(expandSessionWhenVisible, VISIBILITY_CHECK_DELAY)
+  const visibilityCheckInterval = setInterval(expandSessionWhenVisible, VISIBILITY_CHECK_DELAY)
   stopCallbacks.push(() => {
     clearInterval(visibilityCheckInterval)
   })

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -61,7 +61,7 @@ export function throttle(fn: () => void, wait: number, options?: { leading?: boo
         hasPendingExecution = true
       }
       inWaitPeriod = true
-      pendingTimeoutId = window.setTimeout(() => {
+      pendingTimeoutId = setTimeout(() => {
         if (needTrailingExecution && hasPendingExecution) {
           fn()
         }
@@ -70,7 +70,7 @@ export function throttle(fn: () => void, wait: number, options?: { leading?: boo
       }, wait)
     },
     cancel: () => {
-      window.clearTimeout(pendingTimeoutId)
+      clearTimeout(pendingTimeoutId)
       inWaitPeriod = false
       hasPendingExecution = false
     },

--- a/packages/rum-core/src/domain/parentContexts.ts
+++ b/packages/rum-core/src/domain/parentContexts.ts
@@ -75,7 +75,7 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
     currentAction = undefined
   })
 
-  const clearOldContextsInterval = window.setInterval(
+  const clearOldContextsInterval = setInterval(
     monitor(() => {
       clearOldContexts(previousViews, VIEW_CONTEXT_TIME_OUT_DELAY)
       clearOldContexts(previousActions, ACTION_CONTEXT_TIME_OUT_DELAY)
@@ -134,7 +134,7 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
     findAction: (startTime) => findContext(buildCurrentActionContext, previousActions, currentAction, startTime),
     findView: (startTime) => findContext(buildCurrentViewContext, previousViews, currentView, startTime),
     stop: () => {
-      window.clearInterval(clearOldContextsInterval)
+      clearInterval(clearOldContextsInterval)
     },
   }
 }

--- a/packages/rum-core/src/domain/trackPageActivities.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.ts
@@ -115,7 +115,7 @@ export function waitPageActivitiesCompletion(
   stopPageActivitiesTracking: () => void,
   completionCallback: (hadActivity: boolean, endTime: number) => void
 ): { stop: () => void } {
-  let idleTimeoutId: ReturnType<typeof setTimeout>
+  let idleTimeoutId: number
   let hasCompleted = false
 
   const validationTimeoutId = setTimeout(

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -114,7 +114,7 @@ function getAbsoluteSrcsetString(doc: Document, attributeValue: string) {
   const resultingSrcsetString = srcsetValues
     .map((srcItem) => {
       // removing all but middle spaces
-      const trimmedSrcItem = srcItem.trimLeft().trimRight()
+      const trimmedSrcItem = srcItem.replace(/^\s+/, '').replace(/\s+$/, '')
       const urlAndSize = trimmedSrcItem.split(' ')
       // this means we have both 0:url and 1:size
       if (urlAndSize.length === 2) {

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -47,13 +47,13 @@ export function throttle<T>(func: (arg: T) => void, wait: number, options: Throt
     const args = (arguments as unknown) as [T]
     if (remaining <= 0 || remaining > wait) {
       if (timeout) {
-        window.clearTimeout(timeout)
+        clearTimeout(timeout)
         timeout = undefined
       }
       previous = now
       func.apply(this, args)
     } else if (!timeout && options.trailing !== false) {
-      timeout = window.setTimeout(() => {
+      timeout = setTimeout(() => {
         previous = options.leading === false ? 0 : Date.now()
         timeout = undefined
         func.apply(this, args)

--- a/packages/rum-recorder/src/domain/segmentCollection.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection.ts
@@ -114,7 +114,7 @@ export function doStartSegmentCollection(
         }
 
         currentSegment = new Segment(writer, context, nextSegmentCreationReason, record)
-        currentSegmentExpirationTimeoutId = window.setTimeout(
+        currentSegmentExpirationTimeoutId = setTimeout(
           monitor(() => {
             flushSegment('max_duration')
           }),

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -8,11 +8,11 @@
     "target": "es5",
     "types": ["node", "webdriverio", "jasmine", "ajv"],
     "paths": {
-      "@datadog/browser-logs": ["../../packages/logs/src"],
-      "@datadog/browser-rum-core": ["../../packages/rum-core/src"],
-      "@datadog/browser-rum": ["../../packages/rum/src"],
-      "@datadog/browser-rum-recorder": ["../../packages/rum-recorder/src"],
-      "@datadog/browser-core": ["../../packages/core/src"]
+      "@datadog/browser-logs": ["../../packages/logs/cjs"],
+      "@datadog/browser-rum-core": ["../../packages/rum-core/cjs"],
+      "@datadog/browser-rum": ["../../packages/rum/cjs"],
+      "@datadog/browser-rum-recorder": ["../../packages/rum-recorder/cjs"],
+      "@datadog/browser-core": ["../../packages/core/cjs"]
     }
   }
 }

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack')
-const webpackConfig = require('../../webpack.base')('development')
+const webpackConfig = require('../../webpack.base')({ mode: 'development', types: ['jasmine'] })
 const getTestReportDirectory = require('../getTestReportDirectory')
 const jasmineSeedReporterPlugin = require('./jasmineSeedReporterPlugin')
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,9 @@
     "target": "es5",
     "sourceMap": true,
 
+    "types": [],
+    "lib": ["ES2016", "DOM"],
+
     "plugins": [
       {
         "name": "typescript-tslint-plugin"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
-// This tsconfig is only used for tooling (ex: typecheck in code editors)
+// This tsconfig is only used for tooling (ex: typecheck in code editors / lint)
 {
   "extends": "./tsconfig.base.json",
-  "include": [".", ".eslintrc.js"],
-  "exclude": ["./test/e2e", "./test/app"]
+  "compilerOptions": {
+    "types": ["jasmine"]
+  },
+  "include": ["packages", "scripts", "test", ".eslintrc.js"],
+  "exclude": ["packages/*/cjs", "packages/*/esm", "packages/*/bundle", "test/e2e", "test/app"]
 }

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -6,7 +6,7 @@ const buildEnv = require('./scripts/build-env')
 const tsconfigPath = path.join(__dirname, 'tsconfig.base.json')
 const SUFFIX_REGEXP = /-(us|eu)/
 
-module.exports = ({ entry, mode, filename, datacenter }) => ({
+module.exports = ({ entry, mode, filename, datacenter, types }) => ({
   entry,
   mode,
   output: {
@@ -38,6 +38,7 @@ module.exports = ({ entry, mode, filename, datacenter }) => ({
           compilerOptions: {
             module: 'es6',
             allowJs: true,
+            types: types || [],
           },
         },
       },


### PR DESCRIPTION
## Motivation

All types present in node_modules are used for every type of compilations (typecheck, bundle, ...) which can then lead to some type ambiguity.

ex: setTimeout defined by DOM and node

## Changes

- list needed types depending on the context
- used compiled sources in e2e compilation to avoid ambiguity, move typecheck e2e to build-and-lint accordingly
- simplify code used to avoid previous ambiguities

## Testing

ci / editor

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
