### PR TITLE
[REPLAY-149] implement ViewEnd record

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,6 +1,6 @@
 Component,Origin,License,Copyright
 require,tslib,Apache-2.0,Copyright Microsoft Corporation
-file,pako,MIT,(C) 2014-2017 Vitaly Puzrin and Andrey Tupitsin 
+file,pako,MIT,(C) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
 file,rrweb,MIT,Copyright (c) 2018 Contributors (https://github.com/rrweb-io/rrweb/graphs/contributors) and SmartX Inc.
 file,tracekit,MIT,Copyright 2013 Onur Can Cakmak and all TraceKit contributors
 prod,rrweb-snapshot,MIT,Copyright (c) 2018 Contributors (https://github.com/rrweb-io/rrweb-snapshot/graphs/contributors) and SmartX Inc.
@@ -8,6 +8,7 @@ dev,@types/connect-busboy,MIT,Copyright Microsoft Corporation
 dev,@types/cors,MIT,Copyright Microsoft Corporation
 dev,@types/express,MIT,Copyright Microsoft Corporation
 dev,@types/jasmine,MIT,Copyright Microsoft Corporation
+dev,@types/pako,MIT,Copyright Microsoft Corporation
 dev,@types/sinon,MIT,Copyright Microsoft Corporation
 dev,@typescript-eslint/eslint-plugin,MIT,Copyright JS Foundation and other contributors
 dev,@typescript-eslint/parser,MIT,Copyright JS Foundation and other contributors
@@ -47,6 +48,7 @@ dev,karma-spec-reporter,MIT,Copyright 2015 Michael Lex
 dev,karma-webpack,MIT,Copyright JS Foundation and other contributors
 dev,lerna,MIT,Copyright 2015-present Lerna Contributors
 dev,npm-run-all,MIT,Copyright 2015 Toru Nagashima
+dev,pako,MIT,(C) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
 dev,prettier,MIT,Copyright James Long and contributors
 dev,replace-in-file,MIT,Copyright 2015-2019 Adam Reis
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen

--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -13,6 +13,7 @@ export enum LifeCycleEventType {
   AUTO_ACTION_DISCARDED,
   VIEW_CREATED,
   VIEW_UPDATED,
+  VIEW_ENDED,
   REQUEST_STARTED,
   REQUEST_COMPLETED,
   SESSION_RENEWED,
@@ -42,6 +43,7 @@ export class LifeCycle {
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED
+      | LifeCycleEventType.VIEW_ENDED
   ): void
   notify(
     eventType: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
@@ -81,7 +83,8 @@ export class LifeCycle {
       | LifeCycleEventType.SESSION_RENEWED
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
-      | LifeCycleEventType.AUTO_ACTION_DISCARDED,
+      | LifeCycleEventType.AUTO_ACTION_DISCARDED
+      | LifeCycleEventType.VIEW_ENDED,
     callback: () => void
   ): Subscription
   subscribe(

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -186,6 +186,7 @@ function newView(
       stopEventCountsTracking()
       stopActivityLoadingTimeTracking()
       stopCLSTracking()
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED)
     },
     isDifferentView(otherLocation: Location) {
       return (

--- a/packages/rum-recorder/package.json
+++ b/packages/rum-recorder/package.json
@@ -21,5 +21,9 @@
     "type": "git",
     "url": "https://github.com/DataDog/browser-sdk.git",
     "directory": "packages/rum-recorder"
+  },
+  "devDependencies": {
+    "@types/pako": "1.0.1",
+    "pako": "2.0.3"
   }
 }

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -38,6 +38,7 @@ export type RawRecord =
   | MetaRecord
   | CustomRecord
   | FocusRecord
+  | ViewEndRecord
 
 export type Record = RawRecord & {
   timestamp: number
@@ -52,6 +53,7 @@ export enum RecordType {
   Meta,
   Custom,
   Focus,
+  ViewEnd,
 }
 
 export interface DomContentLoadedRecord {
@@ -102,4 +104,8 @@ export interface FocusRecord {
   data: {
     has_focus: boolean
   }
+}
+
+export interface ViewEndRecord {
+  type: RecordType.ViewEnd
 }

--- a/packages/rum-recorder/test/utils.ts
+++ b/packages/rum-recorder/test/utils.ts
@@ -69,6 +69,8 @@ export function collectAsyncCalls<F extends jasmine.Func>(spy: jasmine.Spy<F>) {
       spy.and.callFake((() => {
         fail('Unexpected extra call')
       }) as F)
+      // make sure the "setTimeout" is not mocked
+      jasmine.clock().uninstall()
       setTimeout(done, 300)
     },
   }

--- a/packages/rum-recorder/test/utils.ts
+++ b/packages/rum-recorder/test/utils.ts
@@ -69,8 +69,6 @@ export function collectAsyncCalls<F extends jasmine.Func>(spy: jasmine.Spy<F>) {
       spy.and.callFake((() => {
         fail('Unexpected extra call')
       }) as F)
-      // make sure the "setTimeout" is not mocked
-      jasmine.clock().uninstall()
       setTimeout(done, 300)
     },
   }

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -47,6 +47,10 @@ module.exports = ({ entry, mode, filename, datacenter }) => ({
   resolve: {
     extensions: ['.ts', '.js'],
     plugins: [new TsconfigPathsPlugin({ configFile: tsconfigPath })],
+    alias: {
+      // The default "pako.esm.js" build is not transpiled to es5
+      pako: 'pako/dist/pako.es5.js',
+    },
   },
 
   plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,6 +1303,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/pako@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.1.tgz#33b237f3c9aff44d0f82fe63acffa4a365ef4a61"
+  integrity sha512-GdZbRSJ3Cv5fiwT6I0SQ3ckeN2PWNqxd26W9Z2fCK1tGrrasGy4puvNFtnddqH9UJFMQYXxEuuB7B8UK+LLwSg==
+
 "@types/qs@*":
   version "6.9.5"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
@@ -7977,6 +7982,11 @@ p-waterfall@^1.0.0:
   integrity sha1-ftlLPOszMngjU69qrhGqn8I1uwA=
   dependencies:
     p-reduce "^1.0.0"
+
+pako@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
 
 pako@~1.0.5:
   version "1.0.10"


### PR DESCRIPTION
## Motivation

This is part of multitab tracking strategy. To let the player know a view has ended, a new record is added when the view ends or before unloading the page.

## Note

There is some limitations with this strategy:

* there may be multiple ViewEnd per view because a ViewEnd record is added even if the "beforeunload" event gets cancelled. We may add a way to detect "beforeunload" cancellations in the future
* there may be no ViewEnd for a view: if the browser fails to send the segment for whatever reason (sendBeacon limitations, connection issues, ...)
* there may be records or segments added after the ViewEnd record: the "beforeunload" event is triggered when the page starts to unload, and it can take a moment (the browser is waiting for the first byte of the next page response to actually leave the current page)

The player will need to be aware of this and handle it gracefully.

## Changes

* Adapt the recorder "flush" strategy to avoid sideeffects
* Add a ViewEnd record at the end of views

## Testing

Unit + Manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
