### PR TITLE
⚡️ [RUMF-841] remove session renew support in rum recorder

### DIFF
--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -139,19 +139,6 @@ describe('startRecording', () => {
       expectNoExtraRequestSendCalls(done)
     })
   })
-
-  it('takes a full snapshot when the session is renewed', (done) => {
-    const { lifeCycle } = setupBuilder.build()
-
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-
-    flushSegment(lifeCycle)
-
-    waitRequestSendCalls(2, (calls) => {
-      expect(getRequestData(calls.mostRecent()).has_full_snapshot).toBe('true')
-      expectNoExtraRequestSendCalls(done)
-    })
-  })
 })
 
 describe('trackFocusRecords', () => {

--- a/packages/rum-recorder/src/boot/recorder.ts
+++ b/packages/rum-recorder/src/boot/recorder.ts
@@ -29,7 +29,6 @@ export function startRecording(
     emit: addRawRecord,
   })!
 
-  lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, takeFullSnapshot)
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
   const { stop: stopTrackingFocusRecords } = trackFocusRecords(lifeCycle, addRawRecord)
 

--- a/packages/rum-recorder/src/domain/segmentCollection.spec.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection.spec.ts
@@ -87,12 +87,6 @@ describe('startSegmentCollection', () => {
       expect(sendCurrentSegment().creation_reason).toBe('view_change')
     })
 
-    it('flushes segment on session renew', () => {
-      const { lifeCycle, sendCurrentSegment } = startSegmentCollection(CONTEXT)
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-      expect(sendCurrentSegment().creation_reason).toBe('session_renewed')
-    })
-
     it('flushes segment when the page become hidden', () => {
       setPageVisibility('hidden')
       const { eventEmitter, sendCurrentSegment } = startSegmentCollection(CONTEXT)

--- a/packages/rum-recorder/src/domain/segmentCollection.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection.ts
@@ -76,10 +76,6 @@ export function doStartSegmentCollection(
     flushSegment('view_change')
   })
 
-  const { unsubscribe: unsubscribeSessionRenewed } = lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-    flushSegment('session_renewed')
-  })
-
   const { unsubscribe: unsubscribeBeforeUnload } = lifeCycle.subscribe(LifeCycleEventType.BEFORE_UNLOAD, () => {
     flushSegment('before_unload')
   })
@@ -128,7 +124,6 @@ export function doStartSegmentCollection(
       unsubscribeViewCreated()
       unsubscribeBeforeUnload()
       unsubscribeVisibilityChange()
-      unsubscribeSessionRenewed()
       worker.terminate()
     },
   }

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -26,7 +26,6 @@ export type CreationReason =
   | 'max_duration'
   | 'max_size'
   | 'view_change'
-  | 'session_renewed'
   | 'before_unload'
   | 'visibility_hidden'
 


### PR DESCRIPTION


## Motivation


When the session is renewed, a new View is created. In the RUM recorder, we are subscribing to both events, so we run the same action twice when a session is renewed.

## Changes

This commit removes unneeded callbacks invoked when the session is renewed, since they are already triggered when a view is created.

## Testing

Manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
