### PR TITLE
🐛 [RUMF-834] fix loop direction

### DIFF
--- a/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
@@ -1,0 +1,100 @@
+import { serializeNodeWithId, SerializedNodeWithId, IdNodeMap } from '../rrweb-snapshot'
+import { MutationBuffer } from './mutation'
+import { MutationCallBack } from './types'
+
+const DEFAULT_OPTIONS = {
+  blockClass: 'dd-block',
+  blockSelector: null,
+  inlineStylesheet: false,
+  skipChild: true,
+  slimDOMOptions: {},
+  recordCanvas: false,
+  maskInputOptions: {},
+}
+
+describe('MutationBuffer', () => {
+  let sandbox: HTMLElement
+  let mutationBuffer: MutationBuffer
+  let mutationCallbackSpy: jasmine.Spy<MutationCallBack>
+
+  beforeEach(() => {
+    sandbox = document.createElement('div')
+    sandbox.appendChild(document.createElement('div'))
+    mutationCallbackSpy = jasmine.createSpy<MutationCallBack>()
+    mutationBuffer = new MutationBuffer()
+    mutationBuffer.init(
+      mutationCallbackSpy,
+      DEFAULT_OPTIONS.blockClass,
+      DEFAULT_OPTIONS.blockSelector,
+      DEFAULT_OPTIONS.inlineStylesheet,
+      DEFAULT_OPTIONS.maskInputOptions,
+      DEFAULT_OPTIONS.recordCanvas,
+      DEFAULT_OPTIONS.slimDOMOptions
+    )
+  })
+
+  afterEach(() => {
+    sandbox.remove()
+  })
+
+  it('generates a mutation when a node is appended to a known node', () => {
+    addNodeToMap(sandbox, {})
+
+    mutationBuffer.processMutations([
+      {
+        type: 'childList',
+        target: sandbox,
+        addedNodes: createNodeList([sandbox.firstChild!]),
+        removedNodes: createNodeList([]),
+        oldValue: null,
+        attributeName: null,
+      },
+    ])
+
+    expect(mutationCallbackSpy).toHaveBeenCalledTimes(1)
+    expect(mutationCallbackSpy).toHaveBeenCalledWith({
+      texts: [],
+      attributes: [],
+      removes: [],
+      adds: [
+        {
+          parentId: 1,
+          nextId: null,
+          node: (jasmine.objectContaining({
+            tagName: 'div',
+          }) as unknown) as SerializedNodeWithId,
+        },
+      ],
+    })
+  })
+
+  it('does not generate a mutation when a node is appended to a unknown node', () => {
+    mutationBuffer.processMutations([
+      {
+        type: 'childList',
+        target: sandbox,
+        addedNodes: createNodeList([sandbox.firstChild!]),
+        removedNodes: createNodeList([]),
+        oldValue: null,
+        attributeName: null,
+      },
+    ])
+    expect(mutationCallbackSpy).not.toHaveBeenCalled()
+  })
+})
+
+function addNodeToMap(node: Node, map: IdNodeMap) {
+  serializeNodeWithId(node, {
+    doc: document,
+    map,
+    ...DEFAULT_OPTIONS,
+  })
+}
+
+function createNodeList(nodes: Node[]): NodeList {
+  return (Object.assign(nodes.slice(), {
+    item(this: Node[], index: number) {
+      return this[index]
+    },
+  }) as unknown) as NodeList
+}

--- a/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
@@ -1,3 +1,4 @@
+import { isIE } from '@datadog/browser-core'
 import { serializeNodeWithId, SerializedNodeWithId, IdNodeMap } from '../rrweb-snapshot'
 import { MutationBuffer } from './mutation'
 import { MutationCallBack } from './types'
@@ -18,6 +19,10 @@ describe('MutationBuffer', () => {
   let mutationCallbackSpy: jasmine.Spy<MutationCallBack>
 
   beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+
     sandbox = document.createElement('div')
     sandbox.appendChild(document.createElement('div'))
     mutationCallbackSpy = jasmine.createSpy<MutationCallBack>()

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -281,7 +281,7 @@ export class MutationBuffer {
         }
       }
       if (!node) {
-        for (let index = addList.length - 1; index >= 0; index += 1) {
+        for (let index = addList.length - 1; index >= 0; index -= 1) {
           const nodeCandidate = addList.get(index)!
           const parentId = mirror.getId((nodeCandidate.value.parentNode as Node) as INode)
           const nextId = getNextId(nodeCandidate.value)


### PR DESCRIPTION

## Motivation

When importing rrweb code, I made a typo and `index--` became `index +=
1`.

https://github.com/DataDog/browser-sdk/pull/658/commits/ecc09e7fe83407f003097f23ca2b277d0bdc5436#diff-7e32def6242fea74b49dc8381d38f18941e632957f7cea33951a0ecb07597705L280-R281

It should fix the "Cannot read property 'value' of null" and "Position outside of list" errors

## Changes

Restore loop direction!

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
