### PR TITLE
replay: add dd-privacy attribute for obfuscation & ignoring input

### DIFF
--- a/packages/rum-recorder/src/domain/privacy.spec.ts
+++ b/packages/rum-recorder/src/domain/privacy.spec.ts
@@ -1,0 +1,114 @@
+import { isIE } from '@datadog/browser-core'
+import {
+  nodeIsHidden,
+  nodeOrAncestorsAreHidden,
+  nodeHasInputIngored,
+  nodeOrAncestorsHaveInputIngnored,
+} from './privacy'
+
+describe('privacy helpers', () => {
+  beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+  })
+
+  describe('for hiding blocks', () => {
+    it('considers a normal DOM Element as not hidden', () => {
+      const node = document.createElement('p')
+      expect(nodeIsHidden(node)).toBeFalsy()
+    })
+    it('considers a DOM Element with a data-dd-privacy="hidden" attribute as hidden', () => {
+      const node = document.createElement('p')
+      node.setAttribute('data-dd-privacy', 'hidden')
+      expect(nodeIsHidden(node)).toBeTruthy()
+    })
+    it('considers a DOM Element with a data-dd-privacy="foo" attribute as not hidden', () => {
+      const node = document.createElement('p')
+      node.setAttribute('data-dd-privacy', 'foo')
+      expect(nodeIsHidden(node)).toBeFalsy()
+    })
+    it('considers a DOM Element with a dd-privacy-hidden class as hidden', () => {
+      const node = document.createElement('p')
+      node.className = 'dd-privacy-hidden'
+      expect(nodeIsHidden(node)).toBeTruthy()
+    })
+    it('considers a normal DOM Element with a normal parent as not hidden', () => {
+      const node = document.createElement('p')
+      const parent = document.createElement('div')
+      parent.appendChild(node)
+      expect(nodeOrAncestorsAreHidden(node)).toBeFalsy()
+    })
+    it('considers a DOM Element with a parent node with a dd-privacy="hidden" attribute as hidden', () => {
+      const node = document.createElement('p')
+      const parent = document.createElement('div')
+      parent.setAttribute('data-dd-privacy', 'hidden')
+      parent.appendChild(node)
+      expect(nodeOrAncestorsAreHidden(node)).toBeTruthy()
+    })
+    it('considers a DOM Element with a parent node with a dd-privacy-hidden class as hidden', () => {
+      const node = document.createElement('p')
+      const parent = document.createElement('div')
+      parent.className = 'dd-privacy-hidden'
+      parent.appendChild(node)
+      expect(nodeOrAncestorsAreHidden(node)).toBeTruthy()
+    })
+    it('considers a DOM Document as not hidden', () => {
+      expect(nodeOrAncestorsAreHidden(document)).toBeFalsy()
+    })
+  })
+  describe('for ignoring input events', () => {
+    it('considers a normal DOM Element as not to be ignored', () => {
+      const node = document.createElement('input')
+      expect(nodeHasInputIngored(node)).toBeFalsy()
+    })
+    it('considers a DOM Element with a data-dd-privacy="input-ignored" attribute to be ignored', () => {
+      const node = document.createElement('input')
+      node.setAttribute('data-dd-privacy', 'input-ignored')
+      expect(nodeHasInputIngored(node)).toBeTruthy()
+    })
+    it('considers a DOM Element with a data-dd-privacy="foo" attribute as not to be ignored', () => {
+      const node = document.createElement('input')
+      node.setAttribute('data-dd-privacy', 'foo')
+      expect(nodeHasInputIngored(node)).toBeFalsy()
+    })
+    it('considers a DOM Element with a dd-privacy-input-ignored class to be ignored', () => {
+      const node = document.createElement('input')
+      node.className = 'dd-privacy-input-ignored'
+      expect(nodeHasInputIngored(node)).toBeTruthy()
+    })
+    it('considers a DOM HTMLInputElement with a type of "password" to be ignored', () => {
+      const node = document.createElement('input')
+      node.type = 'password'
+      expect(nodeHasInputIngored(node)).toBeTruthy()
+    })
+    it('considers a DOM HTMLInputElement with a type of "text" as not to be ignored', () => {
+      const node = document.createElement('input')
+      node.type = 'text'
+      expect(nodeHasInputIngored(node)).toBeFalse()
+    })
+    it('considers a normal DOM Element with a normal parent as not to be ignored', () => {
+      const node = document.createElement('input')
+      const parent = document.createElement('form')
+      parent.appendChild(node)
+      expect(nodeOrAncestorsHaveInputIngnored(node)).toBeFalsy()
+    })
+    it('considers a DOM Element with a parent node with a dd-privacy="input-ignored" attribute to be ignored', () => {
+      const node = document.createElement('input')
+      const parent = document.createElement('form')
+      parent.setAttribute('data-dd-privacy', 'input-ignored')
+      parent.appendChild(node)
+      expect(nodeOrAncestorsHaveInputIngnored(node)).toBeTruthy()
+    })
+    it('considers a DOM Element with a parent node with a dd-privacy-input-ignored class to be ignored', () => {
+      const node = document.createElement('input')
+      const parent = document.createElement('form')
+      parent.className = 'dd-privacy-input-ignored'
+      parent.appendChild(node)
+      expect(nodeOrAncestorsHaveInputIngnored(node)).toBeTruthy()
+    })
+    it('considers a DOM Document as not to be ignored', () => {
+      expect(nodeOrAncestorsHaveInputIngnored(document)).toBeFalsy()
+    })
+  })
+})

--- a/packages/rum-recorder/src/domain/privacy.spec.ts
+++ b/packages/rum-recorder/src/domain/privacy.spec.ts
@@ -1,9 +1,9 @@
 import { isIE } from '@datadog/browser-core'
 import {
-  nodeIsHidden,
-  nodeOrAncestorsAreHidden,
-  nodeHasInputIngored,
-  nodeOrAncestorsHaveInputIngnored,
+  nodeShouldBeHidden,
+  nodeOrAncestorsShouldBeHidden,
+  nodeShouldHaveInputIgnored,
+  nodeOrAncestorsShouldHaveInputIgnored,
 } from './privacy'
 
 describe('privacy helpers', () => {
@@ -16,99 +16,99 @@ describe('privacy helpers', () => {
   describe('for hiding blocks', () => {
     it('considers a normal DOM Element as not hidden', () => {
       const node = document.createElement('p')
-      expect(nodeIsHidden(node)).toBeFalsy()
+      expect(nodeShouldBeHidden(node)).toBeFalsy()
     })
     it('considers a DOM Element with a data-dd-privacy="hidden" attribute as hidden', () => {
       const node = document.createElement('p')
       node.setAttribute('data-dd-privacy', 'hidden')
-      expect(nodeIsHidden(node)).toBeTruthy()
+      expect(nodeShouldBeHidden(node)).toBeTruthy()
     })
     it('considers a DOM Element with a data-dd-privacy="foo" attribute as not hidden', () => {
       const node = document.createElement('p')
       node.setAttribute('data-dd-privacy', 'foo')
-      expect(nodeIsHidden(node)).toBeFalsy()
+      expect(nodeShouldBeHidden(node)).toBeFalsy()
     })
     it('considers a DOM Element with a dd-privacy-hidden class as hidden', () => {
       const node = document.createElement('p')
       node.className = 'dd-privacy-hidden'
-      expect(nodeIsHidden(node)).toBeTruthy()
+      expect(nodeShouldBeHidden(node)).toBeTruthy()
     })
     it('considers a normal DOM Element with a normal parent as not hidden', () => {
       const node = document.createElement('p')
       const parent = document.createElement('div')
       parent.appendChild(node)
-      expect(nodeOrAncestorsAreHidden(node)).toBeFalsy()
+      expect(nodeOrAncestorsShouldBeHidden(node)).toBeFalsy()
     })
     it('considers a DOM Element with a parent node with a dd-privacy="hidden" attribute as hidden', () => {
       const node = document.createElement('p')
       const parent = document.createElement('div')
       parent.setAttribute('data-dd-privacy', 'hidden')
       parent.appendChild(node)
-      expect(nodeOrAncestorsAreHidden(node)).toBeTruthy()
+      expect(nodeOrAncestorsShouldBeHidden(node)).toBeTruthy()
     })
     it('considers a DOM Element with a parent node with a dd-privacy-hidden class as hidden', () => {
       const node = document.createElement('p')
       const parent = document.createElement('div')
       parent.className = 'dd-privacy-hidden'
       parent.appendChild(node)
-      expect(nodeOrAncestorsAreHidden(node)).toBeTruthy()
+      expect(nodeOrAncestorsShouldBeHidden(node)).toBeTruthy()
     })
     it('considers a DOM Document as not hidden', () => {
-      expect(nodeOrAncestorsAreHidden(document)).toBeFalsy()
+      expect(nodeOrAncestorsShouldBeHidden(document)).toBeFalsy()
     })
   })
   describe('for ignoring input events', () => {
     it('considers a normal DOM Element as not to be ignored', () => {
       const node = document.createElement('input')
-      expect(nodeHasInputIngored(node)).toBeFalsy()
+      expect(nodeShouldHaveInputIgnored(node)).toBeFalsy()
     })
     it('considers a DOM Element with a data-dd-privacy="input-ignored" attribute to be ignored', () => {
       const node = document.createElement('input')
       node.setAttribute('data-dd-privacy', 'input-ignored')
-      expect(nodeHasInputIngored(node)).toBeTruthy()
+      expect(nodeShouldHaveInputIgnored(node)).toBeTruthy()
     })
     it('considers a DOM Element with a data-dd-privacy="foo" attribute as not to be ignored', () => {
       const node = document.createElement('input')
       node.setAttribute('data-dd-privacy', 'foo')
-      expect(nodeHasInputIngored(node)).toBeFalsy()
+      expect(nodeShouldHaveInputIgnored(node)).toBeFalsy()
     })
     it('considers a DOM Element with a dd-privacy-input-ignored class to be ignored', () => {
       const node = document.createElement('input')
       node.className = 'dd-privacy-input-ignored'
-      expect(nodeHasInputIngored(node)).toBeTruthy()
+      expect(nodeShouldHaveInputIgnored(node)).toBeTruthy()
     })
     it('considers a DOM HTMLInputElement with a type of "password" to be ignored', () => {
       const node = document.createElement('input')
       node.type = 'password'
-      expect(nodeHasInputIngored(node)).toBeTruthy()
+      expect(nodeShouldHaveInputIgnored(node)).toBeTruthy()
     })
     it('considers a DOM HTMLInputElement with a type of "text" as not to be ignored', () => {
       const node = document.createElement('input')
       node.type = 'text'
-      expect(nodeHasInputIngored(node)).toBeFalse()
+      expect(nodeShouldHaveInputIgnored(node)).toBeFalse()
     })
     it('considers a normal DOM Element with a normal parent as not to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
       parent.appendChild(node)
-      expect(nodeOrAncestorsHaveInputIngnored(node)).toBeFalsy()
+      expect(nodeOrAncestorsShouldHaveInputIgnored(node)).toBeFalsy()
     })
     it('considers a DOM Element with a parent node with a dd-privacy="input-ignored" attribute to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
       parent.setAttribute('data-dd-privacy', 'input-ignored')
       parent.appendChild(node)
-      expect(nodeOrAncestorsHaveInputIngnored(node)).toBeTruthy()
+      expect(nodeOrAncestorsShouldHaveInputIgnored(node)).toBeTruthy()
     })
     it('considers a DOM Element with a parent node with a dd-privacy-input-ignored class to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
       parent.className = 'dd-privacy-input-ignored'
       parent.appendChild(node)
-      expect(nodeOrAncestorsHaveInputIngnored(node)).toBeTruthy()
+      expect(nodeOrAncestorsShouldHaveInputIgnored(node)).toBeTruthy()
     })
     it('considers a DOM Document as not to be ignored', () => {
-      expect(nodeOrAncestorsHaveInputIngnored(document)).toBeFalsy()
+      expect(nodeOrAncestorsShouldHaveInputIgnored(document)).toBeFalsy()
     })
   })
 })

--- a/packages/rum-recorder/src/domain/privacy.ts
+++ b/packages/rum-recorder/src/domain/privacy.ts
@@ -1,7 +1,15 @@
 const PRIVACY_ATTR_NAME = 'data-dd-privacy'
 const PRIVACY_ATTR_VALUE_HIDDEN = 'hidden'
+const PRIVACY_ATTR_VALUE_INPUT_IGNORED = 'input-ignored'
 
 const PRIVACY_CLASS_HIDDEN = 'dd-privacy-hidden'
+const PRIVACY_CLASS_INPUT_IGNORED = 'dd-privacy-input-ignored'
+
+// PRIVACY_INPUT_TYPES_TO_IGNORE defines the input types whose input
+// events we want to ignore by default, as they often contain PII.
+// TODO: We might want to differentiate types to fully ignore vs types
+// to obfuscate.
+const PRIVACY_INPUT_TYPES_TO_IGNORE = ['email', 'password', 'tel']
 
 // Returns true if the given DOM node should be hidden. Ancestors
 // are not checked.
@@ -27,6 +35,36 @@ export function nodeOrAncestorsAreHidden(node: Node | null): boolean {
   return nodeOrAncestorsAreHidden(node.parentNode)
 }
 
+// Returns true if the given DOM node should have it's input events
+// ignored. Ancestors are not checked.
+export function nodeHasInputIngored(node: Node): boolean {
+  return (
+    isElement(node) &&
+    (node.getAttribute(PRIVACY_ATTR_NAME) === PRIVACY_ATTR_VALUE_INPUT_IGNORED ||
+      node.classList.contains(PRIVACY_CLASS_INPUT_IGNORED) ||
+      // if element is an HTMLInputElement, check the type is not to be ignored by default
+      (isInputElement(node) && PRIVACY_INPUT_TYPES_TO_IGNORE.includes(node.type)))
+  )
+}
+
+// Returns true if the given DOM node should have it's input events
+// ignored, recursively checking its ancestors.
+export function nodeOrAncestorsHaveInputIngnored(node: Node | null): boolean {
+  if (!node) {
+    return false
+  }
+
+  if (nodeHasInputIngored(node)) {
+    return true
+  }
+
+  return nodeOrAncestorsHaveInputIngnored(node.parentNode)
+}
+
 function isElement(node: Node): node is Element {
   return node.nodeType === node.ELEMENT_NODE
+}
+
+function isInputElement(elem: Element): elem is HTMLInputElement {
+  return elem.tagName === 'INPUT'
 }

--- a/packages/rum-recorder/src/domain/privacy.ts
+++ b/packages/rum-recorder/src/domain/privacy.ts
@@ -13,7 +13,7 @@ const PRIVACY_INPUT_TYPES_TO_IGNORE = ['email', 'password', 'tel']
 
 // Returns true if the given DOM node should be hidden. Ancestors
 // are not checked.
-export function nodeIsHidden(node: Node): boolean {
+export function nodeShouldBeHidden(node: Node): boolean {
   return (
     isElement(node) &&
     (node.getAttribute(PRIVACY_ATTR_NAME) === PRIVACY_ATTR_VALUE_HIDDEN ||
@@ -23,21 +23,21 @@ export function nodeIsHidden(node: Node): boolean {
 
 // Returns true if the given DOM node should be hidden, recursively
 // checking its ancestors.
-export function nodeOrAncestorsAreHidden(node: Node | null): boolean {
+export function nodeOrAncestorsShouldBeHidden(node: Node | null): boolean {
   if (!node) {
     return false
   }
 
-  if (nodeIsHidden(node)) {
+  if (nodeShouldBeHidden(node)) {
     return true
   }
 
-  return nodeOrAncestorsAreHidden(node.parentNode)
+  return nodeOrAncestorsShouldBeHidden(node.parentNode)
 }
 
 // Returns true if the given DOM node should have it's input events
 // ignored. Ancestors are not checked.
-export function nodeHasInputIngored(node: Node): boolean {
+export function nodeShouldHaveInputIgnored(node: Node): boolean {
   return (
     isElement(node) &&
     (node.getAttribute(PRIVACY_ATTR_NAME) === PRIVACY_ATTR_VALUE_INPUT_IGNORED ||
@@ -49,16 +49,16 @@ export function nodeHasInputIngored(node: Node): boolean {
 
 // Returns true if the given DOM node should have it's input events
 // ignored, recursively checking its ancestors.
-export function nodeOrAncestorsHaveInputIngnored(node: Node | null): boolean {
+export function nodeOrAncestorsShouldHaveInputIgnored(node: Node | null): boolean {
   if (!node) {
     return false
   }
 
-  if (nodeHasInputIngored(node)) {
+  if (nodeShouldHaveInputIgnored(node)) {
     return true
   }
 
-  return nodeOrAncestorsHaveInputIngnored(node.parentNode)
+  return nodeOrAncestorsShouldHaveInputIgnored(node.parentNode)
 }
 
 function isElement(node: Node): node is Element {

--- a/packages/rum-recorder/src/domain/privacy.ts
+++ b/packages/rum-recorder/src/domain/privacy.ts
@@ -1,0 +1,32 @@
+const PRIVACY_ATTR_NAME = 'data-dd-privacy'
+const PRIVACY_ATTR_VALUE_HIDDEN = 'hidden'
+
+const PRIVACY_CLASS_HIDDEN = 'dd-privacy-hidden'
+
+// Returns true if the given DOM node should be hidden. Ancestors
+// are not checked.
+export function nodeIsHidden(node: Node): boolean {
+  return (
+    isElement(node) &&
+    (node.getAttribute(PRIVACY_ATTR_NAME) === PRIVACY_ATTR_VALUE_HIDDEN ||
+      node.classList.contains(PRIVACY_CLASS_HIDDEN))
+  )
+}
+
+// Returns true if the given DOM node should be hidden, recursively
+// checking its ancestors.
+export function nodeOrAncestorsAreHidden(node: Node | null): boolean {
+  if (!node) {
+    return false
+  }
+
+  if (nodeIsHidden(node)) {
+    return true
+  }
+
+  return nodeOrAncestorsAreHidden(node.parentNode)
+}
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === node.ELEMENT_NODE
+}

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -183,7 +183,7 @@ function serializeNode(
         systemId: (n as DocumentType).systemId,
       }
     case n.ELEMENT_NODE:
-      const needBlock = nodeIsHidden(n)
+      const needBlock = nodeShouldBeHidden(n)
       const tagName = getValidTagName((n as HTMLElement).tagName)
       let attributes: Attributes = {}
       for (const { name, value } of Array.from((n as HTMLElement).attributes)) {

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { forEach } from '../rrweb/utils'
+import { nodeShouldBeHidden } from '../privacy'
 import {
   SerializedNode,
   SerializedNodeWithId,
@@ -159,29 +159,6 @@ export function transformAttribute(doc: Document, name: string, value: string): 
   return value
 }
 
-export function isBlockedElement(
-  element: HTMLElement,
-  blockClass: string | RegExp,
-  blockSelector: string | null
-): boolean {
-  if (typeof blockClass === 'string') {
-    if (element.classList.contains(blockClass)) {
-      return true
-    }
-  } else {
-    forEach(element.classList, (className: string) => {
-      if (blockClass.test(className)) {
-        return true
-      }
-    })
-  }
-  if (blockSelector) {
-    return element.matches(blockSelector)
-  }
-
-  return false
-}
-
 function serializeNode(
   n: Node,
   options: {
@@ -208,7 +185,7 @@ function serializeNode(
         systemId: (n as DocumentType).systemId,
       }
     case n.ELEMENT_NODE:
-      const needBlock = isBlockedElement(n as HTMLElement, blockClass, blockSelector)
+      const needBlock = nodeIsHidden(n)
       const tagName = getValidTagName((n as HTMLElement).tagName)
       let attributes: Attributes = {}
       for (const { name, value } of Array.from((n as HTMLElement).attributes)) {

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -183,7 +183,7 @@ function serializeNode(
         systemId: (n as DocumentType).systemId,
       }
     case n.ELEMENT_NODE:
-      const needBlock = nodeShouldBeHidden(n)
+      const shouldBeHidden = nodeShouldBeHidden(n)
       const tagName = getValidTagName((n as HTMLElement).tagName)
       let attributes: Attributes = {}
       for (const { name, value } of Array.from((n as HTMLElement).attributes)) {
@@ -251,7 +251,7 @@ function serializeNode(
       if ((n as HTMLElement).scrollTop) {
         attributes.rr_scrollTop = (n as HTMLElement).scrollTop
       }
-      if (needBlock) {
+      if (shouldBeHidden) {
         const { width, height } = (n as HTMLElement).getBoundingClientRect()
         attributes = {
           class: attributes.class,
@@ -265,7 +265,7 @@ function serializeNode(
         attributes,
         childNodes: [],
         isSVG: isSVGElement(n as Element) || undefined,
-        needBlock,
+        shouldBeHidden,
       }
     case n.TEXT_NODE:
       // The parent node may not be a html element which has a tagName attribute.
@@ -435,9 +435,9 @@ export function serializeNodeWithId(
   map[id] = n as INode
   let recordChild = !skipChild
   if (serializedNode.type === NodeType.Element) {
-    recordChild = recordChild && !serializedNode.needBlock
+    recordChild = recordChild && !serializedNode.shouldBeHidden
     // this property was not needed in replay side
-    delete serializedNode.needBlock
+    delete serializedNode.shouldBeHidden
   }
   if ((serializedNode.type === NodeType.Document || serializedNode.type === NodeType.Element) && recordChild) {
     if (

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -163,14 +163,12 @@ function serializeNode(
   n: Node,
   options: {
     doc: Document
-    blockClass: string | RegExp
-    blockSelector: string | null
     inlineStylesheet: boolean
     maskInputOptions: MaskInputOptions
     recordCanvas: boolean
   }
 ): SerializedNode | false {
-  const { doc, blockClass, blockSelector, inlineStylesheet, maskInputOptions = {}, recordCanvas } = options
+  const { doc, inlineStylesheet, maskInputOptions = {}, recordCanvas } = options
   switch (n.nodeType) {
     case n.DOCUMENT_NODE:
       return {
@@ -384,8 +382,6 @@ export function serializeNodeWithId(
   options: {
     doc: Document
     map: IdNodeMap
-    blockClass: string | RegExp
-    blockSelector: string | null
     skipChild: boolean
     inlineStylesheet: boolean
     maskInputOptions?: MaskInputOptions
@@ -397,8 +393,6 @@ export function serializeNodeWithId(
   const {
     doc,
     map,
-    blockClass,
-    blockSelector,
     skipChild = false,
     inlineStylesheet = true,
     maskInputOptions = {},
@@ -408,8 +402,6 @@ export function serializeNodeWithId(
   let { preserveWhiteSpace = true } = options
   const _serializedNode = serializeNode(n, {
     doc,
-    blockClass,
-    blockSelector,
     inlineStylesheet,
     maskInputOptions,
     recordCanvas,
@@ -460,8 +452,6 @@ export function serializeNodeWithId(
       const serializedChildNode = serializeNodeWithId(childN, {
         doc,
         map,
-        blockClass,
-        blockSelector,
         skipChild,
         inlineStylesheet,
         maskInputOptions,
@@ -480,22 +470,13 @@ export function serializeNodeWithId(
 export function snapshot(
   n: Document,
   options?: {
-    blockClass?: string | RegExp
     inlineStylesheet?: boolean
     maskAllInputs?: boolean | MaskInputOptions
     slimDOM?: boolean | SlimDOMOptions
     recordCanvas?: boolean
-    blockSelector?: string | null
   }
 ): [SerializedNodeWithId | null, IdNodeMap] {
-  const {
-    blockClass = 'rr-block',
-    inlineStylesheet = true,
-    recordCanvas = false,
-    blockSelector = null,
-    maskAllInputs = false,
-    slimDOM = false,
-  } = options || {}
+  const { inlineStylesheet = true, recordCanvas = false, maskAllInputs = false, slimDOM = false } = options || {}
   const idNodeMap: IdNodeMap = {}
   const maskInputOptions: MaskInputOptions =
     maskAllInputs === true
@@ -542,8 +523,6 @@ export function snapshot(
     serializeNodeWithId(n, {
       doc: n,
       map: idNodeMap,
-      blockClass,
-      blockSelector,
       skipChild: false,
       inlineStylesheet,
       maskInputOptions,

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/types.ts
@@ -28,7 +28,7 @@ export type ElementNode = {
   attributes: Attributes
   childNodes: SerializedNodeWithId[]
   isSVG?: true
-  needBlock?: boolean
+  shouldBeHidden?: boolean
 }
 
 export type TextNode = {

--- a/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
@@ -29,8 +29,6 @@ describe('MutationBuffer', () => {
     mutationBuffer = new MutationBuffer()
     mutationBuffer.init(
       mutationCallbackSpy,
-      DEFAULT_OPTIONS.blockClass,
-      DEFAULT_OPTIONS.blockSelector,
       DEFAULT_OPTIONS.inlineStylesheet,
       DEFAULT_OPTIONS.maskInputOptions,
       DEFAULT_OPTIONS.recordCanvas,

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -10,7 +10,6 @@ import { nodeOrAncestorsAreHidden } from '../privacy'
 import {
   AddedNodeMutation,
   AttributeCursor,
-  BlockClass,
   MutationCallBack,
   MutationRecord,
   RemovedNodeMutation,
@@ -149,10 +148,6 @@ export class MutationBuffer {
   // @ts-ignore Allows creating an instance without initializing all fields
   private emissionCallback: MutationCallBack
   // @ts-ignore Allows creating an instance without initializing all fields
-  private blockClass: BlockClass
-  // @ts-ignore Allows creating an instance without initializing all fields
-  private blockSelector: string | null
-  // @ts-ignore Allows creating an instance without initializing all fields
   private inlineStylesheet: boolean
   // @ts-ignore Allows creating an instance without initializing all fields
   private maskInputOptions: MaskInputOptions
@@ -163,15 +158,11 @@ export class MutationBuffer {
 
   public init(
     cb: MutationCallBack,
-    blockClass: BlockClass,
-    blockSelector: string | null,
     inlineStylesheet: boolean,
     maskInputOptions: MaskInputOptions,
     recordCanvas: boolean,
     slimDOMOptions: SlimDOMOptions
   ) {
-    this.blockClass = blockClass
-    this.blockSelector = blockSelector
     this.inlineStylesheet = inlineStylesheet
     this.maskInputOptions = maskInputOptions
     this.recordCanvas = recordCanvas
@@ -231,8 +222,6 @@ export class MutationBuffer {
         return addList.addNode(n)
       }
       const sn = serializeNodeWithId(n, {
-        blockClass: this.blockClass,
-        blockSelector: this.blockSelector,
         doc: document,
         inlineStylesheet: this.inlineStylesheet,
         map: mirror.map,

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -6,7 +6,7 @@ import {
   SlimDOMOptions,
   transformAttribute,
 } from '../rrweb-snapshot'
-import { nodeOrAncestorsAreHidden } from '../privacy'
+import { nodeOrAncestorsShouldBeHidden } from '../privacy'
 import {
   AddedNodeMutation,
   AttributeCursor,
@@ -207,7 +207,7 @@ export class MutationBuffer {
         ns = ns && ns.nextSibling
         nextId = ns && mirror.getId((ns as unknown) as INode)
       }
-      if (nextId === -1 && nodeOrAncestorsAreHidden(n.nextSibling)) {
+      if (nextId === -1 && nodeOrAncestorsShouldBeHidden(n.nextSibling)) {
         nextId = null
       }
       return nextId
@@ -336,7 +336,7 @@ export class MutationBuffer {
     switch (m.type) {
       case 'characterData': {
         const value = m.target.textContent
-        if (!nodeOrAncestorsAreHidden(m.target) && value !== m.oldValue) {
+        if (!nodeOrAncestorsShouldBeHidden(m.target) && value !== m.oldValue) {
           this.texts.push({
             value,
             node: m.target,
@@ -346,7 +346,7 @@ export class MutationBuffer {
       }
       case 'attributes': {
         const value = (m.target as HTMLElement).getAttribute(m.attributeName!)
-        if (nodeOrAncestorsAreHidden(m.target) || value === m.oldValue) {
+        if (nodeOrAncestorsShouldBeHidden(m.target) || value === m.oldValue) {
           return
         }
         let item: AttributeCursor | undefined = this.attributes.find((a) => a.node === m.target)
@@ -366,7 +366,7 @@ export class MutationBuffer {
         forEach(m.removedNodes, (n: Node) => {
           const nodeId = mirror.getId(n as INode)
           const parentId = mirror.getId(m.target as INode)
-          if (nodeOrAncestorsAreHidden(n) || nodeOrAncestorsAreHidden(m.target) || isIgnored(n)) {
+          if (nodeOrAncestorsShouldBeHidden(n) || nodeOrAncestorsShouldBeHidden(m.target) || isIgnored(n)) {
             return
           }
           // removed node has not been serialized yet, just remove it from the Set
@@ -406,7 +406,7 @@ export class MutationBuffer {
   }
 
   private genAdds = (n: Node | INode, target?: Node | INode) => {
-    if (nodeOrAncestorsAreHidden(n)) {
+    if (nodeOrAncestorsShouldBeHidden(n)) {
       return
     }
     if (isINode(n)) {

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -1,6 +1,6 @@
 import { noop, monitor, callMonitored } from '@datadog/browser-core'
 import { INode, MaskInputOptions, SlimDOMOptions } from '../rrweb-snapshot'
-import { nodeOrAncestorsAreHidden, nodeOrAncestorsHaveInputIngnored } from '../privacy'
+import { nodeOrAncestorsShouldBeHidden, nodeOrAncestorsShouldHaveInputIgnored } from '../privacy'
 import { MutationBuffer } from './mutation'
 import {
   Arguments,
@@ -101,7 +101,7 @@ function initMouseInteractionObserver(cb: MouseInteractionCallBack, sampling: Sa
 
   const handlers: ListenerHandler[] = []
   const getHandler = (eventKey: keyof typeof MouseInteractions) => (event: MouseEvent | TouchEvent) => {
-    if (nodeOrAncestorsAreHidden(event.target as Node)) {
+    if (nodeOrAncestorsShouldBeHidden(event.target as Node)) {
       return
     }
     const id = mirror.getId(event.target as INode)
@@ -128,7 +128,7 @@ function initMouseInteractionObserver(cb: MouseInteractionCallBack, sampling: Sa
 function initScrollObserver(cb: ScrollCallback, sampling: SamplingStrategy): ListenerHandler {
   const updatePosition = throttle<UIEvent>(
     monitor((evt) => {
-      if (!evt.target || nodeOrAncestorsAreHidden(evt.target as Node)) {
+      if (!evt.target || nodeOrAncestorsShouldBeHidden(evt.target as Node)) {
         return
       }
       const id = mirror.getId(evt.target as INode)
@@ -182,8 +182,8 @@ function initInputObserver(
       !target ||
       !(target as Element).tagName ||
       INPUT_TAGS.indexOf((target as Element).tagName) < 0 ||
-      nodeOrAncestorsAreHidden(target as Node) ||
-      nodeOrAncestorsHaveInputIngnored(target as Node)
+      nodeOrAncestorsShouldBeHidden(target as Node) ||
+      nodeOrAncestorsShouldHaveInputIgnored(target as Node)
     ) {
       return
     }
@@ -300,7 +300,7 @@ function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHandler {
 function initMediaInteractionObserver(mediaInteractionCb: MediaInteractionCallback): ListenerHandler {
   const handler = (type: 'play' | 'pause') => (event: Event) => {
     const { target } = event
-    if (!target || nodeOrAncestorsAreHidden(target as Node)) {
+    if (!target || nodeOrAncestorsShouldBeHidden(target as Node)) {
       return
     }
     mediaInteractionCb({
@@ -328,7 +328,7 @@ function initCanvasMutationObserver(cb: CanvasMutationCallback): ListenerHandler
         (original: (...args: unknown[]) => unknown) =>
           function (this: CanvasRenderingContext2D, ...args: unknown[]) {
             callMonitored(() => {
-              if (!nodeOrAncestorsAreHidden(this.canvas)) {
+              if (!nodeOrAncestorsShouldBeHidden(this.canvas)) {
                 setTimeout(
                   monitor(() => {
                     const recordArgs = [...args]

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -11,9 +11,6 @@ function record(options: RecordOptions = {}): RecordAPI {
     emit,
     checkoutEveryNms,
     checkoutEveryNth,
-    blockClass = 'rr-block',
-    blockSelector = null,
-    ignoreClass = 'rr-ignore',
     inlineStylesheet = true,
     maskAllInputs,
     maskInputOptions: maskInputOptionsArg,
@@ -122,8 +119,6 @@ function record(options: RecordOptions = {}): RecordAPI {
     const wasFrozen = mutationBuffer.isFrozen()
     mutationBuffer.freeze() // don't allow any mirror modifications during snapshotting
     const [node, idNodeMap] = snapshot(document, {
-      blockClass,
-      blockSelector,
       inlineStylesheet,
       recordCanvas,
       maskAllInputs: maskInputOptions,
@@ -170,10 +165,7 @@ function record(options: RecordOptions = {}): RecordAPI {
     handlers.push(
       initObservers(
         {
-          blockClass,
-          blockSelector,
           collectFonts,
-          ignoreClass,
           inlineStylesheet,
           maskInputFn,
           maskInputOptions,

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -69,8 +69,6 @@ export type IncrementalData =
   | CanvasMutationData
   | FontData
 
-export type BlockClass = string | RegExp
-
 export type SamplingStrategy = Partial<{
   /**
    * false means not to record mouse/touch move events
@@ -97,9 +95,6 @@ export interface RecordOptions {
   emit?: (record: RawRecord, isCheckout?: boolean) => void
   checkoutEveryNth?: number
   checkoutEveryNms?: number
-  blockClass?: BlockClass
-  blockSelector?: string
-  ignoreClass?: string
   maskAllInputs?: boolean
   maskInputOptions?: MaskInputOptions
   maskInputFn?: MaskInputFn
@@ -127,9 +122,6 @@ export interface ObserverParam {
   viewportResizeCb: ViewportResizeCallback
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
-  blockClass: BlockClass
-  blockSelector: string | null
-  ignoreClass: string
   maskInputOptions: MaskInputOptions
   maskInputFn?: MaskInputFn
   inlineStylesheet: boolean

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -140,30 +140,6 @@ export function getWindowWidth(): number {
   )
 }
 
-export function isBlocked(node: Node | null, blockClass: BlockClass): boolean {
-  if (!node) {
-    return false
-  }
-  if (node.nodeType === node.ELEMENT_NODE) {
-    let needBlock = false
-    if (typeof blockClass === 'string') {
-      needBlock = (node as HTMLElement).classList.contains(blockClass)
-    } else {
-      forEach((node as HTMLElement).classList, (className: string) => {
-        if (blockClass.test(className)) {
-          needBlock = true
-        }
-      })
-    }
-    return needBlock || isBlocked(node.parentNode, blockClass)
-  }
-  if (node.nodeType === node.TEXT_NODE) {
-    // check parent node since text node do not have class name
-    return isBlocked(node.parentNode, blockClass)
-  }
-  return isBlocked(node.parentNode, blockClass)
-}
-
 export function isIgnored(n: Node | INode): boolean {
   if ('__sn' in n) {
     return n.__sn.id === IGNORED_NODE // eslint-disable-line no-underscore-dangle

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -1,6 +1,6 @@
 import { noop, monitor } from '@datadog/browser-core'
 import { IGNORED_NODE, INode } from '../rrweb-snapshot'
-import { BlockClass, HookResetter, ListenerHandler, Mirror, ThrottleOptions } from './types'
+import { HookResetter, ListenerHandler, Mirror, ThrottleOptions } from './types'
 
 export function on(type: string, fn: (event: any) => void, target: Document | Window = document): ListenerHandler {
   const monitoredFn = monitor(fn)

--- a/test/e2e/browsers.conf.js
+++ b/test/e2e/browsers.conf.js
@@ -14,7 +14,7 @@ module.exports = [
   {
     ...browsers.CHROME_MOBILE,
     // cf https://github.com/webdriverio/webdriverio/issues/3264,
-    'browserstack.appium_version': '1.9.1',
+    'browserstack.appium_version': '1.17.0',
   },
   // Safari mobile on iOS 12.0 does not support
   // the way we flush events on page change

--- a/test/e2e/lib/helpers/recorder.ts
+++ b/test/e2e/lib/helpers/recorder.ts
@@ -1,0 +1,80 @@
+import {
+  NodeType,
+  SerializedNode,
+  DocumentNode,
+  ElementNode,
+  TextNode,
+} from '@datadog/browser-rum-recorder/cjs/domain/rrweb-snapshot/types'
+import {
+  Segment,
+  RecordType,
+  FullSnapshotRecord,
+  MetaRecord,
+  IncrementalSnapshotRecord,
+  IncrementalSource,
+} from '@datadog/browser-rum-recorder/cjs/types'
+
+// Returns this first MetaRecord in a Segment, if any.
+export function findMeta(segment: Segment): MetaRecord | null {
+  return segment.records.find((record) => record.type === RecordType.Meta) as MetaRecord
+}
+
+// Returns this first FullSnapshotRecord in a Segment, if any.
+export function findFullSnapshot(segment: Segment): FullSnapshotRecord | null {
+  return segment.records.find((record) => record.type === RecordType.FullSnapshot) as FullSnapshotRecord
+}
+
+// Returns the first IncrementalSnapshotRecord of a given source in a
+// Segment, if any.
+export function findIncrementalSnapshot(segment: Segment, source: IncrementalSource): IncrementalSnapshotRecord | null {
+  return segment.records.find(
+    (record) => record.type === RecordType.IncrementalSnapshot && record.data.source === source
+  ) as IncrementalSnapshotRecord
+}
+
+// Returns all the IncrementalSnapshotRecord of a given source in a
+// Segment, if any.
+export function findAllIncrementalSnapshots(segment: Segment, source: IncrementalSource): IncrementalSnapshotRecord[] {
+  return segment.records.filter(
+    (record) => record.type === RecordType.IncrementalSnapshot && record.data.source === source
+  ) as IncrementalSnapshotRecord[]
+}
+
+// Retrns the textContent of a ElementNode, if any.
+export function findTextContent(elem: ElementNode): string | null {
+  const text = elem.childNodes.find((child) => child.type === NodeType.Text) as TextNode
+  return text ? text.textContent : null
+}
+
+// Returns the first ElementNode with the given ID from a
+// FullSnapshotRecord, if any.
+export function findNodeWithId(fullSnapshot: FullSnapshotRecord, id: string): ElementNode | null {
+  return recFindNodeWithId(fullSnapshot.data.node as DocumentNode, id)
+}
+
+function isElementNode(node: SerializedNode): node is ElementNode {
+  return node.type === NodeType.Element
+}
+
+function recFindNodeWithId(node: DocumentNode | ElementNode | null, id: string): ElementNode | null {
+  if (node === null) {
+    return null
+  }
+
+  if (isElementNode(node) && node.attributes.id === id) {
+    return node
+  }
+
+  for (const child of node.childNodes) {
+    if (!isElementNode(child)) {
+      continue
+    }
+
+    const node = recFindNodeWithId(child, id)
+    if (node !== null) {
+      return node
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
Following up on https://github.com/DataDog/browser-sdk/pull/692 we figured it was best to expose privacy controls leveraging both classes & data attributes. Data attributes are used by other places of the SDK, and it made sense to show consistency.

This PR introduces the "privacy.ts" file with various helpers used by rrweb & rrweb-snapshot. This results in the recorder:
- ignoring the content of an element (obfuscation) if it has the attribute `data-dd-privacy` set to `hidden` or a class of `dd-privacy-hidden` 
- ignoring input events of an element if it has the attribute `data-dd-privacy` set to `input-ignored` or a class of `dd-privacy-input-ignored`, or if it is an input of type "password", "email" or "tel"

Further work could be done to offer a third strategy for inputs, obfuscating with asterisks instead of completely ignoring the input. Another idea would be to make the set of input types configurable. Finally, we could investigate automatic obfuscation of text node if matching regexps.
