### PR TITLE
👷 Lint improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,7 @@ module.exports = {
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/promise-function-async': 'off',
     '@typescript-eslint/quotes': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   env: {
     browser: true,
+    jasmine: true,
   },
   extends: [
     'plugin:@typescript-eslint/recommended',
@@ -15,6 +16,7 @@ module.exports = {
   },
   plugins: [
     'eslint-plugin-import',
+    'jasmine',
     'eslint-plugin-jsdoc',
     'eslint-plugin-prefer-arrow',
     'eslint-plugin-unicorn',
@@ -127,6 +129,7 @@ module.exports = {
     'id-match': 'error',
     'import/no-default-export': 'error',
     'import/order': 'error',
+    'jasmine/no-focused-tests': 'error',
     'jsdoc/check-alignment': 'error',
     'jsdoc/check-indentation': 'error',
     'jsdoc/newline-after-description': 'off',

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -30,6 +30,7 @@ dev,eslint,MIT,Copyright JS Foundation and other contributors
 dev,eslint-config-prettier,MIT,Copyright (c) 2017, 2018, 2019, 2020 Simon Lydell and contributors
 dev,eslint-plugin-import,MIT,Copyright (c) 2015 Ben Mosher
 dev,eslint-plugin-jsdoc,BSD-3-Clause,Copyright (c) 2018, Gajus Kuizinas (http://gajus.com/)
+dev,eslint-plugin-jasmine,MIT,Copyright (c) 2021 Tom Vincent
 dev,eslint-plugin-prefer-arrow,MIT,Copyright (c) 2018 Triston Jones
 dev,eslint-plugin-unicorn,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 dev,express,MIT,Copyright 2009-2014 TJ Holowaychuk 2013-2014 Roman Shtylman 2014-2015 Douglas Christopher Wilson

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint": "7.17.0",
     "eslint-config-prettier": "7.1.0",
     "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-jasmine": "4.1.2",
     "eslint-plugin-jsdoc": "30.7.13",
     "eslint-plugin-prefer-arrow": "1.2.2",
     "eslint-plugin-unicorn": "25.0.1",

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -1,6 +1,5 @@
 import {
   BoundedBuffer,
-  checkIsNotLocalFile,
   combine,
   Context,
   createContextManager,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,6 +4271,11 @@ eslint-plugin-import@2.22.1:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-jasmine@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-4.1.2.tgz#50cc20d603b02b37727f8d174d4b83b9b8ef25a5"
+  integrity sha512-Jr52EBi6Ql5WVDvRCKBID9kRD6/CaObvCWmgHpqobczX2Mzt8/QMu9vpgx6q/O5jyQ9CIGrKaEbPuEfHRf8guw==
+
 eslint-plugin-jsdoc@30.7.13:
   version "30.7.13"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz#52e5c74fb806d3bbeb51d04a0c829508c3c6b563"


### PR DESCRIPTION
## Motivation

1. Avoid to merge `fit` or `fdescribe`
2. Current warn on master 

## Changes

1. install [eslint-plugin-jasmine](https://github.com/tlvince/eslint-plugin-jasmine#rules), I have not spotted other must have rules but open to suggestion
2. @typescript-eslint/no-unused-vars seems to be the only "warn" rule, promote it to error and fix the current issue

## Testing

ci

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
