### PR TITLE
🔥[RUMF-821] remove unused record types

### DIFF
--- a/packages/rum-recorder/src/domain/rrweb/record.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.spec.ts
@@ -1,5 +1,5 @@
 import { createNewEvent, isIE } from '@datadog/browser-core'
-import { RecordType, Record } from '../../types'
+import { RecordType, RawRecord } from '../../types'
 import { record } from './record'
 
 describe('record', () => {
@@ -23,8 +23,8 @@ describe('record', () => {
   })
 
   it('will only have one full snapshot without checkout config', () => {
-    const emit = jasmine.createSpy<(record: Record) => void>()
-    stop = record<Record>({ emit })?.stop
+    const emit = jasmine.createSpy<(record: RawRecord) => void>()
+    stop = record({ emit })?.stop
 
     const count = 30
     for (let i = 0; i < count; i += 1) {

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -167,14 +167,6 @@ function record<T = RawRecord>(options: RecordOptions<T> = {}): RecordAPI | unde
 
   try {
     const handlers: ListenerHandler[] = []
-    handlers.push(
-      on('DOMContentLoaded', () => {
-        wrappedEmit({
-          data: {},
-          type: RecordType.DomContentLoaded,
-        })
-      })
-    )
     const init = () => {
       takeFullSnapshot()
 
@@ -279,19 +271,7 @@ function record<T = RawRecord>(options: RecordOptions<T> = {}): RecordAPI | unde
     if (document.readyState === 'interactive' || document.readyState === 'complete') {
       init()
     } else {
-      handlers.push(
-        on(
-          'load',
-          () => {
-            wrappedEmit({
-              data: {},
-              type: RecordType.Load,
-            })
-            init()
-          },
-          window
-        )
-      )
+      handlers.push(on('load', init, window))
     }
     return {
       stop: () => {
@@ -303,19 +283,6 @@ function record<T = RawRecord>(options: RecordOptions<T> = {}): RecordAPI | unde
     // TODO: handle internal error
     console.warn(error)
   }
-}
-
-record.addCustomRecord = <T>(tag: string, payload: T) => {
-  if (!wrappedEmit) {
-    throw new Error('please add custom record after start recording')
-  }
-  wrappedEmit({
-    data: {
-      payload,
-      tag,
-    },
-    type: RecordType.Custom,
-  })
 }
 
 record.freezePage = () => {

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -6,7 +6,7 @@ import { getWindowHeight, getWindowWidth, mirror, on, polyfill } from './utils'
 
 let wrappedEmit!: (record: RawRecord, isCheckout?: boolean) => void
 
-function record<T = RawRecord>(options: RecordOptions<T> = {}): RecordAPI | undefined {
+function record(options: RecordOptions = {}): RecordAPI | undefined {
   const {
     emit,
     checkoutEveryNms,
@@ -94,7 +94,7 @@ function record<T = RawRecord>(options: RecordOptions<T> = {}): RecordAPI | unde
       mutationBuffer.unfreeze()
     }
 
-    emit(((packFn ? packFn(record) : record) as unknown) as T, isCheckout)
+    emit(((packFn ? packFn(record) : record) as unknown) as RawRecord, isCheckout)
     if (record.type === RecordType.FullSnapshot) {
       lastFullSnapshotRecordTimestamp = Date.now()
       incrementalSnapshotCount = 0

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -93,8 +93,8 @@ export type SamplingStrategy = Partial<{
   input: 'all' | 'last'
 }>
 
-export interface RecordOptions<T> {
-  emit?: (e: T, isCheckout?: boolean) => void
+export interface RecordOptions {
+  emit?: (record: RawRecord, isCheckout?: boolean) => void
   checkoutEveryNth?: number
   checkoutEveryNms?: number
   blockClass?: BlockClass

--- a/packages/rum-recorder/src/domain/segmentCollection.spec.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection.spec.ts
@@ -7,7 +7,7 @@ import { Segment } from './segment'
 import { computeSegmentContext, doStartSegmentCollection, MAX_SEGMENT_DURATION } from './segmentCollection'
 
 const CONTEXT: SegmentContext = { application: { id: 'a' }, view: { id: 'b' }, session: { id: 'c' } }
-const RECORD: Record = { type: RecordType.Load, timestamp: 10, data: {} }
+const RECORD: Record = { type: RecordType.ViewEnd, timestamp: 10 }
 
 const BEFORE_MAX_SEGMENT_DURATION = MAX_SEGMENT_DURATION * 0.9
 
@@ -49,7 +49,7 @@ describe('startSegmentCollection', () => {
     const { addRecord, worker, segmentFlushSpy, sendCurrentSegment } = startSegmentCollection(CONTEXT)
     expect(worker.pendingData).toBe('')
     addRecord(RECORD)
-    expect(worker.pendingData).toBe('{"records":[{"type":1,"timestamp":10,"data":{}}')
+    expect(worker.pendingData).toBe('{"records":[{"type":7,"timestamp":10}')
     expect(segmentFlushSpy).not.toHaveBeenCalled()
     expect(sendCurrentSegment().creation_reason).toBe('init')
   })

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -37,14 +37,11 @@ export type Record = RawRecord & {
 }
 
 export enum RecordType {
-  _0, // previously DomContentLoaded
-  _1, // previously Load
-  FullSnapshot,
-  IncrementalSnapshot,
-  Meta,
-  _2, // previously Custom
-  Focus,
-  ViewEnd,
+  FullSnapshot = 2,
+  IncrementalSnapshot = 3,
+  Meta = 4,
+  Focus = 6,
+  ViewEnd = 7,
 }
 
 export interface FullSnapshotRecord {

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -29,15 +29,7 @@ export type CreationReason =
   | 'before_unload'
   | 'visibility_hidden'
 
-export type RawRecord =
-  | DomContentLoadedRecord
-  | LoadedRecord
-  | FullSnapshotRecord
-  | IncrementalSnapshotRecord
-  | MetaRecord
-  | CustomRecord
-  | FocusRecord
-  | ViewEndRecord
+export type RawRecord = FullSnapshotRecord | IncrementalSnapshotRecord | MetaRecord | FocusRecord | ViewEndRecord
 
 export type Record = RawRecord & {
   timestamp: number
@@ -45,24 +37,14 @@ export type Record = RawRecord & {
 }
 
 export enum RecordType {
-  DomContentLoaded,
-  Load,
+  _0, // previously DomContentLoaded
+  _1, // previously Load
   FullSnapshot,
   IncrementalSnapshot,
   Meta,
-  Custom,
+  _2, // previously Custom
   Focus,
   ViewEnd,
-}
-
-export interface DomContentLoadedRecord {
-  type: RecordType.DomContentLoaded
-  data: object
-}
-
-export interface LoadedRecord {
-  type: RecordType.Load
-  data: object
 }
 
 export interface FullSnapshotRecord {
@@ -87,14 +69,6 @@ export interface MetaRecord {
     href: string
     width: number
     height: number
-  }
-}
-
-export interface CustomRecord<T = unknown> {
-  type: RecordType.Custom
-  data: {
-    tag: string
-    payload: T
   }
 }
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Sandbox</title>
-    <script src="http://localhost:8080/datadog-rum.js"></script>
+    <script src="http://localhost:8080/datadog-rum-recorder.js"></script>
     <script src="http://localhost:8080/datadog-logs.js"></script>
     <script>
       DD_RUM.init({


### PR DESCRIPTION
## Motivation

Player does not use `DomContentLoaded`, `Load` or `Custom` record type.

## Changes

- Remove related code
- Do not mess with RecordType enum indexes

## Testing

ci + manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
