### PR TITLE
🔥 recorder: remove forEach polyfills

### DIFF
--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import { forEach } from '../rrweb/utils'
 import {
   SerializedNode,
   SerializedNodeWithId,
@@ -168,7 +169,7 @@ export function isBlockedElement(
       return true
     }
   } else {
-    element.classList.forEach((className) => {
+    forEach(element.classList, (className: string) => {
       if (blockClass.test(className)) {
         return true
       }
@@ -574,15 +575,4 @@ export function snapshot(
     }),
     idNodeMap,
   ]
-}
-
-export function visitSnapshot(node: SerializedNodeWithId, onVisit: (node: SerializedNodeWithId) => unknown) {
-  function walk(current: SerializedNodeWithId) {
-    onVisit(current)
-    if (current.type === NodeType.Document || current.type === NodeType.Element) {
-      current.childNodes.forEach(walk)
-    }
-  }
-
-  walk(node)
 }

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -15,7 +15,7 @@ import {
   RemovedNodeMutation,
   TextCursor,
 } from './types'
-import { isAncestorRemoved, isBlocked, isIgnored, mirror } from './utils'
+import { forEach, isAncestorRemoved, isBlocked, isIgnored, mirror } from './utils'
 
 interface DoubleLinkedListNode {
   previous: DoubleLinkedListNode | null
@@ -372,8 +372,8 @@ export class MutationBuffer {
         break
       }
       case 'childList': {
-        m.addedNodes.forEach((n) => this.genAdds(n, m.target))
-        m.removedNodes.forEach((n) => {
+        forEach(m.addedNodes, (n: Node) => this.genAdds(n, m.target))
+        forEach(m.removedNodes, (n: Node) => {
           const nodeId = mirror.getId(n as INode)
           const parentId = mirror.getId(m.target as INode)
           if (isBlocked(n, this.blockClass) || isBlocked(m.target, this.blockClass) || isIgnored(n)) {
@@ -436,7 +436,7 @@ export class MutationBuffer {
       this.addedSet.add(n)
       this.droppedSet.delete(n)
     }
-    n.childNodes.forEach((childN) => this.genAdds(childN))
+    forEach(n.childNodes, (childN: ChildNode) => this.genAdds(childN))
   }
 }
 
@@ -448,7 +448,7 @@ export class MutationBuffer {
  */
 function deepDelete(addsSet: Set<Node>, n: Node) {
   addsSet.delete(n)
-  n.childNodes.forEach((childN) => deepDelete(addsSet, childN))
+  forEach(n.childNodes, (childN: ChildNode) => deepDelete(addsSet, childN))
 }
 
 function isParentRemoved(removes: RemovedNodeMutation[], n: Node): boolean {

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -28,6 +28,7 @@ import {
   ViewportResizeCallback,
 } from './types'
 import {
+  forEach,
   getWindowHeight,
   getWindowWidth,
   hookSetter,
@@ -206,7 +207,7 @@ function initInputObserver(
     // the other radios with the same name attribute will be unchecked.
     const name: string | undefined = (target as HTMLInputElement).name
     if (type === 'radio' && name && isChecked) {
-      document.querySelectorAll(`input[type="radio"][name="${name}"]`).forEach((el) => {
+      forEach(document.querySelectorAll(`input[type="radio"][name="${name}"]`), (el: Element) => {
         if (el !== target) {
           cbWithDedup(el, {
             isChecked: !isChecked,

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -2,7 +2,7 @@ import { MaskInputOptions, SlimDOMOptions, snapshot } from '../rrweb-snapshot'
 import { RawRecord, RecordType } from '../../types'
 import { initObservers, mutationBuffer } from './observer'
 import { IncrementalSource, ListenerHandler, RecordAPI, RecordOptions } from './types'
-import { getWindowHeight, getWindowWidth, mirror, on, polyfill } from './utils'
+import { getWindowHeight, getWindowWidth, mirror, on } from './utils'
 
 let wrappedEmit!: (record: RawRecord, isCheckout?: boolean) => void
 
@@ -77,8 +77,6 @@ function record(options: RecordOptions = {}): RecordAPI | undefined {
       : slimDOMOptionsArg
       ? slimDOMOptionsArg
       : {}
-
-  polyfill()
 
   let lastFullSnapshotRecordTimestamp: number
   let incrementalSnapshotCount = 0

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -26,7 +26,7 @@ export const mirror: Mirror = {
     const id = n.__sn && n.__sn.id // eslint-disable-line no-underscore-dangle
     delete mirror.map[id]
     if (n.childNodes) {
-      n.childNodes.forEach((child) => mirror.removeNodeFromMap((child as Node) as INode))
+      forEach(n.childNodes, (child: ChildNode) => mirror.removeNodeFromMap((child as Node) as INode))
     }
   },
   has(id) {
@@ -148,7 +148,7 @@ export function isBlocked(node: Node | null, blockClass: BlockClass): boolean {
     if (typeof blockClass === 'string') {
       needBlock = (node as HTMLElement).classList.contains(blockClass)
     } else {
-      ;(node as HTMLElement).classList.forEach((className) => {
+      forEach((node as HTMLElement).classList, (className: string) => {
         if (blockClass.test(className)) {
           needBlock = true
         }
@@ -191,14 +191,6 @@ export function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEven
   return Boolean((event as TouchEvent).changedTouches)
 }
 
-export function polyfill(win = window) {
-  if ('NodeList' in win && !win.NodeList.prototype.forEach) {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    win.NodeList.prototype.forEach = (Array.prototype.forEach as unknown) as NodeList['forEach']
-  }
-
-  if ('DOMTokenList' in win && !win.DOMTokenList.prototype.forEach) {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    win.DOMTokenList.prototype.forEach = (Array.prototype.forEach as unknown) as DOMTokenList['forEach']
-  }
+export function forEach<List, Element>(list: List, callback: (value: Element, index: number, parent: List) => void) {
+  Array.prototype.forEach.call(list, (callback as unknown) as (value: any, index: number, parent: any[]) => void)
 }

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -191,6 +191,9 @@ export function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEven
   return Boolean((event as TouchEvent).changedTouches)
 }
 
-export function forEach<List, Element>(list: List, callback: (value: Element, index: number, parent: List) => void) {
-  Array.prototype.forEach.call(list, (callback as unknown) as (value: any, index: number, parent: any[]) => void)
+export function forEach<List extends { [index: number]: any }>(
+  list: List,
+  callback: (value: List[number], index: number, parent: List) => void
+) {
+  Array.prototype.forEach.call(list, callback as any)
 }

--- a/test/e2e/lib/types/serverEvents.ts
+++ b/test/e2e/lib/types/serverEvents.ts
@@ -1,5 +1,5 @@
 import { RumActionEvent, RumErrorEvent, RumEvent, RumResourceEvent, RumViewEvent } from '@datadog/browser-rum'
-import { Segment } from '../../../../packages/rum-recorder/src/types'
+import { Segment } from '@datadog/browser-rum-recorder/cjs/types'
 
 export interface ServerInternalMonitoringMessage {
   message: string

--- a/test/e2e/scenario/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder.scenario.ts
@@ -1,4 +1,4 @@
-import { CreationReason, IncrementalSource, RecordType } from '../../../packages/rum-recorder/src/types'
+import { CreationReason, IncrementalSource, RecordType } from '@datadog/browser-rum-recorder/cjs/types'
 
 import { createTest } from '../lib/framework'
 import { browserExecute } from '../lib/helpers/browser'

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -6,13 +6,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "target": "es5",
-    "types": ["node", "webdriverio", "jasmine", "ajv"],
-    "paths": {
-      "@datadog/browser-logs": ["../../packages/logs/cjs"],
-      "@datadog/browser-rum-core": ["../../packages/rum-core/cjs"],
-      "@datadog/browser-rum": ["../../packages/rum/cjs"],
-      "@datadog/browser-rum-recorder": ["../../packages/rum-recorder/cjs"],
-      "@datadog/browser-core": ["../../packages/core/cjs"]
-    }
+    "types": ["node", "webdriverio", "jasmine", "ajv"]
   }
 }


### PR DESCRIPTION
## Motivation

Avoid to touch shared API if it is not needed

## Changes

Replace `forEach` polyfills by a forEach utility function

## Testing

ci

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
