### PR TITLE
⚗ [RUMF-823] monitor deflate worker

### DIFF
--- a/packages/core/src/domain/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring.ts
@@ -132,7 +132,7 @@ export function addMonitoringMessage(message: string, context?: Context) {
   })
 }
 
-function addErrorToMonitoringBatch(e: unknown) {
+export function addErrorToMonitoringBatch(e: unknown) {
   addToMonitoringBatch({
     ...formatError(e),
     status: StatusType.error,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
   monitored,
   monitor,
   addMonitoringMessage,
+  addErrorToMonitoringBatch,
   setDebugMode,
 } from './domain/internalMonitoring'
 export { Observable } from './tools/observable'

--- a/packages/rum-recorder/src/domain/deflateSegmentWriter.ts
+++ b/packages/rum-recorder/src/domain/deflateSegmentWriter.ts
@@ -1,4 +1,4 @@
-import { addMonitoringMessage } from '@datadog/browser-core'
+import { addMonitoringMessage, addErrorToMonitoringBatch, monitor } from '@datadog/browser-core'
 import { SegmentMeta } from '../types'
 import { DeflateWorker } from './deflateWorker'
 import { SegmentWriter } from './segment'
@@ -12,28 +12,33 @@ export class DeflateSegmentWriter implements SegmentWriter {
     private onWrote: (size: number) => void,
     private onFlushed: (data: Uint8Array, meta: SegmentMeta) => void
   ) {
-    worker.addEventListener('message', ({ data }) => {
-      if ('result' in data) {
-        let pendingMeta = this.pendingMeta.shift()!
+    worker.addEventListener(
+      'message',
+      monitor(({ data }) => {
+        if ('error' in data) {
+          addErrorToMonitoringBatch(data.error)
+        } else if ('result' in data) {
+          let pendingMeta = this.pendingMeta.shift()!
 
-        // Messages should be received in the same order as they are sent, so the first
-        // 'pendingMeta' of the list should be the one corresponding to the handled message.
-        // But if something goes wrong in the worker and a response is lost, we need to avoid
-        // associating an incorrect meta to the flushed segment. Remove any pending meta with an id
-        // inferior to the one being waited for.
-        if (pendingMeta.id !== data.id) {
-          let lostCount = 0
-          while (pendingMeta.id !== data.id) {
-            pendingMeta = this.pendingMeta.shift()!
-            lostCount += 1
+          // Messages should be received in the same order as they are sent, so the first
+          // 'pendingMeta' of the list should be the one corresponding to the handled message.
+          // But if something goes wrong in the worker and a response is lost, we need to avoid
+          // associating an incorrect meta to the flushed segment. Remove any pending meta with an id
+          // inferior to the one being waited for.
+          if (pendingMeta.id !== data.id) {
+            let lostCount = 0
+            while (pendingMeta.id !== data.id) {
+              pendingMeta = this.pendingMeta.shift()!
+              lostCount += 1
+            }
+            addMonitoringMessage(`${lostCount} deflate worker responses have been lost`)
           }
-          addMonitoringMessage(`${lostCount} deflate worker responses have been lost`)
+          this.onFlushed(data.result, pendingMeta.meta)
+        } else {
+          this.onWrote(data.size)
         }
-        this.onFlushed(data.result, pendingMeta.meta)
-      } else {
-        this.onWrote(data.size)
-      }
-    })
+      })
+    )
   }
 
   write(data: string): void {

--- a/packages/rum-recorder/src/domain/deflateWorker.d.ts
+++ b/packages/rum-recorder/src/domain/deflateWorker.d.ts
@@ -30,3 +30,4 @@ export type DeflateWorkerResponse =
       id: number
       result: Uint8Array
     }
+  | { error: Error | string }


### PR DESCRIPTION
## Motivation

Keep an eye on worker execution

## Changes

- try/catch worker execution
- new `DeflateWorkerResponse` for error

## Testing

manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
