### PR TITLE
e2e: 🔼 Chrome version to 88

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
   APP: 'browser-sdk'
-  CURRENT_CI_IMAGE: 19
+  CURRENT_CI_IMAGE: 20
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
 
 # Download and install Chrome
 # Debian taken from https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-RUN curl --silent --show-error --fail http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_86.0.4240.75-1_amd64.deb --output google-chrome.deb \
+RUN curl --silent --show-error --fail http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_88.0.4324.150-1_amd64.deb --output google-chrome.deb \
     && dpkg -i google-chrome.deb \
     && rm google-chrome.deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -y -q --no-install-recommends python
 
 # Install pip
 RUN set -x \
- && curl -OL https://bootstrap.pypa.io/get-pip.py \
+ && curl -OL https://bootstrap.pypa.io/2.7/get-pip.py \
  && python get-pip.py \
  && rm get-pip.py
 

--- a/test/e2e/wdio.local.conf.js
+++ b/test/e2e/wdio.local.conf.js
@@ -1,7 +1,7 @@
 const baseConf = require('./wdio.base.conf')
 
 // https://sites.google.com/a/chromium.org/chromedriver/downloads
-const CHROME_DRIVER_VERSION = '86.0.4240.22'
+const CHROME_DRIVER_VERSION = '88.0.4324.96'
 
 exports.config = {
   ...baseConf,


### PR DESCRIPTION
## Motivation

To allow e2e with local chrome 88

## Changes

Bump chrome driver + chrome installed in docker

## Testing

ci + local

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
