### PR TITLE
🔼 Bump TypeScript to 4.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ts-loader": "6.2.2",
     "ts-node": "9.1.1",
     "tsconfig-paths-webpack-plugin": "3.2.0",
-    "typescript": "3.8.3",
+    "typescript": "4.1.5",
     "webdriverio": "6.1.4",
     "webpack": "4.42.1",
     "webpack-cli": "3.3.11",

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -12,10 +12,6 @@ import { FAKE_INITIAL_DOCUMENT, isAllowedRequestUrl } from '../domain/rumEventsC
 
 import { getDocumentTraceId } from '../domain/tracing/getDocumentTraceId'
 
-interface BrowserWindow extends Window {
-  PerformanceObserver?: PerformanceObserver
-}
-
 export interface RumPerformanceResourceTiming {
   entryType: 'resource'
   initiatorType: string
@@ -89,7 +85,7 @@ function supportPerformanceObject() {
 
 export function supportPerformanceTimingEvent(entryType: string) {
   return (
-    (window as BrowserWindow).PerformanceObserver &&
+    window.PerformanceObserver &&
     PerformanceObserver.supportedEntryTypes !== undefined &&
     PerformanceObserver.supportedEntryTypes.includes(entryType)
   )
@@ -103,7 +99,7 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: 
   if (supportPerformanceObject()) {
     handlePerformanceEntries(lifeCycle, configuration, performance.getEntries())
   }
-  if ((window as BrowserWindow).PerformanceObserver) {
+  if (window.PerformanceObserver) {
     const observer = new PerformanceObserver(
       monitor((entries: PerformanceObserverEntryList) =>
         handlePerformanceEntries(lifeCycle, configuration, entries.getEntries())

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -263,7 +263,7 @@ describe('getActionNameFromElement', () => {
         </form>
       `
       // Set the attribute on the <HTML> element
-      target.ownerDocument!.documentElement.setAttribute('data-dd-action-name', 'foo')
+      target.ownerDocument.documentElement.setAttribute('data-dd-action-name', 'foo')
       expect(getActionNameFromElement(target)).toBe('foo')
     })
 

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -99,7 +99,7 @@ class DoubleLinkedList {
     }
     /* eslint-disable no-underscore-dangle */
     if (n.__ln) {
-      delete n.__ln
+      delete (n as any).__ln
     }
     /* eslint-enable no-underscore-dangle */
     this.length -= 1

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -270,7 +270,7 @@ function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHandler {
   const insertRule = CSSStyleSheet.prototype.insertRule
   CSSStyleSheet.prototype.insertRule = function (this: CSSStyleSheet, rule: string, index?: number) {
     callMonitored(() => {
-      const id = mirror.getId(this.ownerNode as INode)
+      const id = mirror.getId((this.ownerNode as unknown) as INode)
       if (id !== -1) {
         cb({
           id,
@@ -285,7 +285,7 @@ function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHandler {
   const deleteRule = CSSStyleSheet.prototype.deleteRule
   CSSStyleSheet.prototype.deleteRule = function (this: CSSStyleSheet, index: number) {
     callMonitored(() => {
-      const id = mirror.getId(this.ownerNode as INode)
+      const id = mirror.getId((this.ownerNode as unknown) as INode)
       if (id !== -1) {
         cb({
           id,

--- a/packages/rum-recorder/test/forEach.spec.ts
+++ b/packages/rum-recorder/test/forEach.spec.ts
@@ -1,15 +1,12 @@
-import { INode } from '../src/domain/rrweb-snapshot/types'
-import { NodeInLinkedList } from '../src/domain/rrweb/mutation'
-
 afterEach(() => {
   cleanupRRWebReferencesFromNodes()
 })
 
 function cleanupRRWebReferencesFromNodes(node: Node = document.documentElement) {
   // eslint-disable-next-line no-underscore-dangle
-  delete (node as INode).__sn
+  delete (node as any).__sn
   // eslint-disable-next-line no-underscore-dangle
-  delete (node as NodeInLinkedList).__ln
+  delete (node as any).__ln
   for (let i = 0; i < node.childNodes.length; i += 1) {
     cleanupRRWebReferencesFromNodes(node.childNodes[i])
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10130,10 +10130,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 ua-parser-js@^0.7.21:
   version "0.7.21"


### PR DESCRIPTION
## Motivation

TS 4.x needed to update wdio dependencies

## Changes

- Bump ts version
- Remove useless BrowserWindow
- Tweak some casts for INode and NodeInLinkedList 😕

## Testing

ci

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
