### PR TITLE
Readme: add missing rum-core package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains several packages:
 | browser-logs         | [![npm version][01]][02] | [![bundle size][03]][04] | [datadog-logs][05]         | [![API][1]][07] [![product][2]][08] |
 | browser-rum          | [![npm version][11]][12] | [![bundle size][13]][14] | [datadog-rum][15]          | [![API][1]][17] [![product][2]][18] |
 | browser-rum-recorder | [![npm version][21]][22] | [![bundle size][23]][24] | [datadog-rum-recorder][25] | [![API][1]][27] [![product][2]][28] |
+| browser-rum-core     | [![npm version][41]][42] | [![bundle size][43]][44] |                            |
 | browser-core         | [![npm version][31]][32] | [![bundle size][33]][34] |                            |
 
 [1]: https://github.githubassets.com/favicons/favicon.png
@@ -40,3 +41,7 @@ This repository contains several packages:
 [32]: https://badge.fury.io/js/%40datadog%2Fbrowser-core
 [33]: https://badgen.net/bundlephobia/minzip/@datadog/browser-core
 [34]: https://bundlephobia.com/result?p=@datadog/browser-core
+[41]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-core.svg
+[42]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-core
+[43]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum-core
+[44]: https://bundlephobia.com/result?p=@datadog/browser-rum-core


### PR DESCRIPTION
## Motivation

`rum-core` is missing in packages list

## Changes

add `rum-core`

## Testing

NA

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
