### PR TITLE
✨ [RUMF-854] Enable beforeSend to dismiss events

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -75,7 +75,7 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
     cookieOptions: CookieOptions
 
     service?: string
-    beforeSend?: (event: any) => void | boolean
+    beforeSend?: (event: any) => unknown
 
     isEnabled: (feature: string) => boolean
   }

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -75,7 +75,7 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
     cookieOptions: CookieOptions
 
     service?: string
-    beforeSend?: (event: any) => void
+    beforeSend?: (event: any) => void | boolean
 
     isEnabled: (feature: string) => boolean
   }

--- a/packages/core/src/tools/limitModification.spec.ts
+++ b/packages/core/src/tools/limitModification.spec.ts
@@ -78,7 +78,7 @@ describe('limitModification', () => {
     })
   })
 
-  it('should return the return of the modifier', () => {
+  it('should return the result of the modifier', () => {
     const object = { foo: { bar: 'bar' } }
     const modifier = (candidate: any) => {
       candidate.foo.bar = 'qux'

--- a/packages/core/src/tools/limitModification.spec.ts
+++ b/packages/core/src/tools/limitModification.spec.ts
@@ -8,9 +8,9 @@ describe('limitModification', () => {
       candidate.qux = 'modified2'
     }
 
-    const result = limitModification(object, ['foo.bar', 'qux'], modifier)
+    limitModification(object, ['foo.bar', 'qux'], modifier)
 
-    expect(result).toEqual({
+    expect(object).toEqual({
       foo: { bar: 'modified1' },
       qux: 'modified2',
     })
@@ -23,9 +23,9 @@ describe('limitModification', () => {
       candidate.qux = 'modified2'
     }
 
-    const result = limitModification(object, ['foo.bar'], modifier)
+    limitModification(object, ['foo.bar'], modifier)
 
-    expect(result).toEqual({
+    expect(object).toEqual({
       foo: { bar: 'modified1' },
       qux: 'qux',
     })
@@ -39,9 +39,9 @@ describe('limitModification', () => {
       candidate.qix = 'modified3'
     }
 
-    const result = limitModification(object, ['foo.bar', 'qux', 'qix'], modifier)
+    limitModification(object, ['foo.bar', 'qux', 'qix'], modifier)
 
-    expect(result).toEqual({
+    expect(object).toEqual({
       foo: { bar: 'modified1' },
       qux: 'modified2',
     })
@@ -54,9 +54,9 @@ describe('limitModification', () => {
       candidate.qux = 1234
     }
 
-    const result = limitModification(object, ['foo.bar', 'qux'], modifier)
+    limitModification(object, ['foo.bar', 'qux'], modifier)
 
-    expect(result).toEqual({
+    expect(object).toEqual({
       foo: { bar: 'bar' },
       qux: 'qux',
     })
@@ -70,11 +70,26 @@ describe('limitModification', () => {
       delete candidate.qux
     }
 
-    const result = limitModification(object, ['foo.bar', 'qux'], modifier)
+    limitModification(object, ['foo.bar', 'qux'], modifier)
 
-    expect(result).toEqual({
+    expect(object).toEqual({
       foo: { bar: 'bar' },
       qux: 'qux',
+    })
+  })
+
+  it('should return the return of the modifier', () => {
+    const object = { foo: { bar: 'bar' } }
+    const modifier = (candidate: any) => {
+      candidate.foo.bar = 'qux'
+      return false
+    }
+
+    const result = limitModification(object, ['foo.bar', 'qux'], modifier)
+
+    expect(result).toBe(false)
+    expect(object).toEqual({
+      foo: { bar: 'qux' },
     })
   })
 
@@ -86,10 +101,10 @@ describe('limitModification', () => {
     }
     const errorSpy = spyOn(console, 'error')
 
-    const result = limitModification(object, ['foo.bar', 'qux'], modifier)
+    limitModification(object, ['foo.bar', 'qux'], modifier)
 
     expect(errorSpy).toHaveBeenCalled()
-    expect(result).toEqual({
+    expect(object).toEqual({
       foo: { bar: 'bar' },
       qux: 'qux',
     })

--- a/packages/core/src/tools/limitModification.ts
+++ b/packages/core/src/tools/limitModification.ts
@@ -5,11 +5,11 @@ import { Context, deepClone } from './context'
  * - field path do not support array, 'a.b.c' only
  * - modifiable fields type must be string
  */
-export function limitModification<T extends Context>(
+export function limitModification<T extends Context, Result>(
   object: T,
   modifiableFieldPaths: string[],
-  modifier: (object: T) => boolean | void
-): boolean | void {
+  modifier: (object: T) => Result
+): Result | undefined {
   const clone = deepClone(object)
   let result
   try {

--- a/packages/core/src/tools/limitModification.ts
+++ b/packages/core/src/tools/limitModification.ts
@@ -8,14 +8,15 @@ import { Context, deepClone } from './context'
 export function limitModification<T extends Context>(
   object: T,
   modifiableFieldPaths: string[],
-  modifier: (object: T) => void
-): T {
+  modifier: (object: T) => boolean | void
+): boolean | void {
   const clone = deepClone(object)
+  let result
   try {
-    modifier(clone)
+    result = modifier(clone)
   } catch (e) {
     console.error(e)
-    return object
+    return
   }
   modifiableFieldPaths.forEach((path) => {
     const originalValue = get(object, path)
@@ -24,7 +25,7 @@ export function limitModification<T extends Context>(
       set(object, path, newValue)
     }
   })
-  return object
+  return result
 }
 
 function get(object: unknown, path: string) {

--- a/packages/logs/src/boot/logs.spec.ts
+++ b/packages/logs/src/boot/logs.spec.ts
@@ -193,7 +193,9 @@ describe('logs', () => {
     })
 
     it('should allow modification on sensitive field', () => {
-      beforeSend = (event: LogsEvent) => (event.message = 'modified')
+      beforeSend = (event: LogsEvent) => {
+        event.message = 'modified'
+      }
 
       const assembledMessage = assemble(DEFAULT_MESSAGE, {})
 
@@ -201,7 +203,9 @@ describe('logs', () => {
     })
 
     it('should reject modification on non sensitive field', () => {
-      beforeSend = (event: LogsEvent) => ((event.service as any) = 'modified')
+      beforeSend = (event: LogsEvent) => {
+        ;(event.service as any) = 'modified'
+      }
 
       const assembledMessage = assemble(DEFAULT_MESSAGE, {})
 

--- a/packages/logs/src/boot/logs.spec.ts
+++ b/packages/logs/src/boot/logs.spec.ts
@@ -129,7 +129,7 @@ describe('logs', () => {
 
   describe('assemble', () => {
     let assemble: (message: LogsMessage, currentContext: Context) => Context | undefined
-    let beforeSend: (event: LogsEvent) => void
+    let beforeSend: (event: LogsEvent) => void | boolean
 
     beforeEach(() => {
       beforeSend = noop
@@ -145,6 +145,11 @@ describe('logs', () => {
     it('should not assemble when session is not tracked', () => {
       sessionIsTracked = false
 
+      expect(assemble(DEFAULT_MESSAGE, { foo: 'from-current-context' })).toBeUndefined()
+    })
+
+    it('should not assemble if beforeSend returned false', () => {
+      beforeSend = () => false
       expect(assemble(DEFAULT_MESSAGE, { foo: 'from-current-context' })).toBeUndefined()
     })
 

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -130,12 +130,12 @@ export function buildAssemble(session: LoggerSession, configuration: Configurati
       message
     )
     if (configuration.beforeSend) {
-      const result = limitModification(
+      const shouldSend = limitModification(
         contextualizedMessage as LogsEvent & Context,
         FIELDS_WITH_SENSITIVE_DATA,
         configuration.beforeSend
       )
-      if (result === false) {
+      if (shouldSend === false) {
         return undefined
       }
     }

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -130,11 +130,14 @@ export function buildAssemble(session: LoggerSession, configuration: Configurati
       message
     )
     if (configuration.beforeSend) {
-      limitModification(
+      const result = limitModification(
         contextualizedMessage as LogsEvent & Context,
         FIELDS_WITH_SENSITIVE_DATA,
         configuration.beforeSend
       )
+      if (result === false) {
+        return undefined
+      }
     }
     return contextualizedMessage as Context
   }

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -22,7 +22,7 @@ import { buildEnv } from './buildEnv'
 
 export interface LogsUserConfiguration extends UserConfiguration {
   forwardErrorsToLogs?: boolean
-  beforeSend?: (event: LogsEvent) => void
+  beforeSend?: (event: LogsEvent) => void | boolean
 }
 
 const FIELDS_WITH_SENSITIVE_DATA = ['view.url', 'view.referrer', 'message', 'error.stack', 'http.url']

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -20,7 +20,7 @@ import { startRum } from './rum'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string
-  beforeSend?: (event: RumEvent) => void
+  beforeSend?: (event: RumEvent) => void | boolean
 }
 
 export type RumPublicApi = ReturnType<typeof makeRumPublicApi>

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -89,6 +89,56 @@ describe('rum assembly', () => {
 
       expect(serverRumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
     })
+
+    it('should allow dismissing events other than views', () => {
+      beforeSend = () => false
+
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION, {
+          view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+        }),
+        startTime: 0,
+      })
+
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.ERROR, {
+          view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+        }),
+        startTime: 0,
+      })
+
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK, {
+          view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+        }),
+        startTime: 0,
+      })
+
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, {
+          view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+        }),
+        startTime: 0,
+      })
+
+      expect(serverRumEvents.length).toBe(0)
+    })
+
+    it('should not allow dismissing view events', () => {
+      beforeSend = () => false
+      const consoleWarnSpy = spyOn(console, 'warn')
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW, {
+          view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+        }),
+        startTime: 0,
+      })
+
+      expect(serverRumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        `Can't dismiss view events using beforeSend, use onNewLocation instead!`
+      )
+    })
   })
 
   describe('rum context', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -85,7 +85,7 @@ export function startRumAssembly(
   )
 }
 
-function shouldSend(event: RumEvent & Context, beforeSend?: (event: any) => any) {
+function shouldSend(event: RumEvent & Context, beforeSend?: (event: any) => unknown) {
   if (beforeSend) {
     const result = limitModification(event, FIELDS_WITH_SENSITIVE_DATA, beforeSend)
     if (result === false && event.type !== RumEventType.VIEW) {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -78,8 +78,15 @@ export function startRumAssembly(
           ;(serverRumEvent.usr as RumEvent['usr']) = commonContext.user as User & Context
         }
 
+        let beforeSendResult
         if (configuration.beforeSend) {
-          limitModification(serverRumEvent, FIELDS_WITH_SENSITIVE_DATA, configuration.beforeSend)
+          beforeSendResult = limitModification(serverRumEvent, FIELDS_WITH_SENSITIVE_DATA, configuration.beforeSend)
+        }
+        if (beforeSendResult === false && serverRumEvent.type !== RumEventType.VIEW) {
+          return
+        }
+        if (beforeSendResult === false) {
+          console.warn(`Can't dismiss view events using beforeSend, use onNewLocation instead!`)
         }
         lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, serverRumEvent)
       }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -1,5 +1,5 @@
-import { DOM_EVENT } from '@datadog/browser-core'
-import { createRawRumEvent } from '../../../../test/fixtures'
+import { Context, DOM_EVENT } from '@datadog/browser-core'
+import { RumEvent } from '../../../../../rum/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType, ActionType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
@@ -174,21 +174,18 @@ describe('newAction', () => {
 
   it('counts errors occurring during the action', () => {
     const { lifeCycle, clock } = setupBuilder.build()
-    const collectedRawRumEvent = {
-      rawRumEvent: createRawRumEvent(RumEventType.ERROR),
-      startTime: 0,
-    }
+    const collectedRumEvent = { type: RumEventType.ERROR } as RumEvent & Context
     lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, pushEvent)
 
     newClick('test-1')
 
-    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, collectedRawRumEvent)
+    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, collectedRumEvent)
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
     lifeCycle.notify(LifeCycleEventType.DOM_MUTATED)
-    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, collectedRawRumEvent)
+    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, collectedRumEvent)
 
     clock.tick(EXPIRE_DELAY)
-    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, collectedRawRumEvent)
+    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, collectedRumEvent)
 
     expect(events.length).toBe(1)
     const action = events[0]

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -1,4 +1,5 @@
-import { createRawRumEvent } from '../../../../test/fixtures'
+import { Context } from '../../../../../core/src'
+import { RumEvent } from '../../../../../rum/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { NewLocationListener } from '../../../boot/rum'
 import {
@@ -767,14 +768,8 @@ describe('rum view measures', () => {
       expect(getHandledCount()).toEqual(1)
       expect(getViewEvent(0).eventCounts.errorCount).toEqual(0)
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.ERROR),
-        startTime: 0,
-      })
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.ERROR),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.ERROR } as RumEvent & Context)
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.ERROR } as RumEvent & Context)
       history.pushState({}, '', '/bar')
 
       expect(getHandledCount()).toEqual(3)
@@ -787,10 +782,7 @@ describe('rum view measures', () => {
       expect(getHandledCount()).toEqual(1)
       expect(getViewEvent(0).eventCounts.longTaskCount).toEqual(0)
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.LONG_TASK } as RumEvent & Context)
       history.pushState({}, '', '/bar')
 
       expect(getHandledCount()).toEqual(3)
@@ -803,10 +795,7 @@ describe('rum view measures', () => {
       expect(getHandledCount()).toEqual(1)
       expect(getViewEvent(0).eventCounts.resourceCount).toEqual(0)
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.RESOURCE } as RumEvent & Context)
       history.pushState({}, '', '/bar')
 
       expect(getHandledCount()).toEqual(3)
@@ -819,10 +808,7 @@ describe('rum view measures', () => {
       expect(getHandledCount()).toEqual(1)
       expect(getViewEvent(0).eventCounts.userActionCount).toEqual(0)
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.ACTION } as RumEvent & Context)
       history.pushState({}, '', '/bar')
 
       expect(getHandledCount()).toEqual(3)
@@ -835,24 +821,15 @@ describe('rum view measures', () => {
       expect(getHandledCount()).toEqual(1)
       expect(getViewEvent(0).eventCounts.resourceCount).toEqual(0)
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.RESOURCE } as RumEvent & Context)
       history.pushState({}, '', '/bar')
 
       expect(getHandledCount()).toEqual(3)
       expect(getViewEvent(1).eventCounts.resourceCount).toEqual(1)
       expect(getViewEvent(2).eventCounts.resourceCount).toEqual(0)
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
-        startTime: 0,
-      })
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.RESOURCE } as RumEvent & Context)
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.RESOURCE } as RumEvent & Context)
       history.pushState({}, '', '/baz')
 
       expect(getHandledCount()).toEqual(5)
@@ -870,10 +847,7 @@ describe('rum view measures', () => {
         userActionCount: 0,
       })
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.RESOURCE } as RumEvent & Context)
 
       expect(getHandledCount()).toEqual(1)
 
@@ -892,10 +866,7 @@ describe('rum view measures', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       expect(getHandledCount()).toEqual(1)
 
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
-        startTime: 0,
-      })
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.RESOURCE } as RumEvent & Context)
 
       expect(getHandledCount()).toEqual(1)
 

--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -1,5 +1,6 @@
-import { objectValues } from '@datadog/browser-core'
-import { RawRumEvent, RumEventType } from '../rawRumEvent.types'
+import { Context, objectValues } from '@datadog/browser-core'
+import { RumEvent } from '../../../rum/src'
+import { RumEventType } from '../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { EventCounts, trackEventCounts } from './trackEventCounts'
 
@@ -11,10 +12,7 @@ describe('trackEventCounts', () => {
   })
 
   function notifyCollectedRawRumEvent(type: RumEventType) {
-    lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-      rawRumEvent: ({ type } as unknown) as RawRumEvent,
-      startTime: 0,
-    })
+    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type } as RumEvent & Context)
   }
 
   it('tracks errors', () => {

--- a/packages/rum-core/src/domain/trackEventCounts.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.ts
@@ -17,8 +17,8 @@ export function trackEventCounts(lifeCycle: LifeCycle, callback: (eventCounts: E
     userActionCount: 0,
   }
 
-  const subscription = lifeCycle.subscribe(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, ({ rawRumEvent }): void => {
-    switch (rawRumEvent.type) {
+  const subscription = lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, ({ type }): void => {
+    switch (type) {
       case RumEventType.ERROR:
         eventCounts.errorCount += 1
         callback(eventCounts)


### PR DESCRIPTION
## Motivation

Allow customers to dismiss RUM events.

## Changes

- Use `RUM_EVENT_COLLECTED` event to update event counts.
- Dismiss the event if `beforeSend` returned `false` and it's not a view event.
- Show a warning if `beforeSend` returned `false` for a view event.

## Testing

- unit tests
- manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
