### PR TITLE
📝 Doc: remove resourceSampleRate

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -43,7 +43,7 @@ export interface UserConfiguration {
   internalMonitoringApiKey?: string
   allowedTracingOrigins?: Array<string | RegExp>
   sampleRate?: number
-  resourceSampleRate?: number
+  resourceSampleRate?: number // deprecated
   datacenter?: Datacenter // deprecated
   site?: string
   enableExperimentalFeatures?: string[]

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -116,7 +116,6 @@ window.DD_RUM.init({
   applicationId: 'XXX',
   clientToken: 'XXX',
   site: 'datadoghq.com',
-  resourceSampleRate: 100,
   sampleRate: 100,
 })
 ```
@@ -136,7 +135,6 @@ The following parameters are available:
 | `env`                   | String  | No       |                 | The application’s environment, for example: prod, pre-prod, staging, etc.                                |
 | `version`               | String  | No       |                 | The application’s version, for example: 1.2.3, 6c44da20, 2020.02.13, etc.                                |
 | `trackInteractions`     | Boolean | No       | `false`         | Enables [automatic collection of users actions][6].                                                      |
-| `resourceSampleRate`    | Number  | No       | `100`           | The percentage of tracked sessions with resources collection: `100` for all, `0` for none.               |
 | `sampleRate`            | Number  | No       | `100`           | The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send rum events. |
 | `silentMultipleInit`    | Boolean | No       | `false`         | Initialization fails silently if Datadog's RUM is already initialized on the page.                       |
 | `proxyHost`             | String  | No       |                 | Optional proxy host (ex: www.proxy.com), see the full [proxy setup guide][7] for more information.       |
@@ -159,7 +157,6 @@ init(configuration: {
     applicationId: string,
     clientToken: string,
     site?: string,
-    resourceSampleRate?: number
     sampleRate?: number,
     silentMultipleInit?: boolean,
     trackInteractions?: boolean,


### PR DESCRIPTION
## Motivation

No reason to promote this configuration parameter since it is not aligned with billing.
It only confuses customers and generate support questions.

## Changes

Remove resourceSampleRate from doc + add deprecated note in configuration

## Testing

NA

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
