### PR TITLE
[RUMF-845] use core throttle function in recorder

### DIFF
--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -218,6 +218,15 @@ describe('utils', () => {
         expect(spy).toHaveBeenCalledTimes(1)
       })
     })
+
+    it('passes last parameters as arguments', () => {
+      const throttled = throttle(spy, 2).throttled
+      throttled(1)
+      throttled(2)
+      throttled(3)
+      jasmine.clock().tick(2)
+      expect(spy.calls.allArgs()).toEqual([[1], [3]])
+    })
   })
 
   describe('jsonStringify', () => {

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -52,33 +52,33 @@ export function throttle<T extends (...args: any[]) => void>(
   const needLeadingExecution = options && options.leading !== undefined ? options.leading : true
   const needTrailingExecution = options && options.trailing !== undefined ? options.trailing : true
   let inWaitPeriod = false
-  let hasPendingExecutionWithParameters: Parameters<T> | undefined
+  let pendingExecutionWithParameters: Parameters<T> | undefined
   let pendingTimeoutId: number
 
   return {
     throttled: (...parameters: Parameters<T>) => {
       if (inWaitPeriod) {
-        hasPendingExecutionWithParameters = parameters
+        pendingExecutionWithParameters = parameters
         return
       }
       if (needLeadingExecution) {
         fn(...parameters)
       } else {
-        hasPendingExecutionWithParameters = parameters
+        pendingExecutionWithParameters = parameters
       }
       inWaitPeriod = true
       pendingTimeoutId = setTimeout(() => {
-        if (needTrailingExecution && hasPendingExecutionWithParameters) {
-          fn(...hasPendingExecutionWithParameters)
+        if (needTrailingExecution && pendingExecutionWithParameters) {
+          fn(...pendingExecutionWithParameters)
         }
         inWaitPeriod = false
-        hasPendingExecutionWithParameters = undefined
+        pendingExecutionWithParameters = undefined
       }, wait)
     },
     cancel: () => {
       clearTimeout(pendingTimeoutId)
       inWaitPeriod = false
-      hasPendingExecutionWithParameters = undefined
+      pendingExecutionWithParameters = undefined
     },
   }
 }

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -57,7 +57,6 @@ function initMoveObserver(cb: MousemoveCallBack, sampling: SamplingStrategy): Li
 
   const { throttled: updatePosition } = throttle(
     monitor((evt: MouseEvent | TouchEvent) => {
-      console.log(evt)
       const { target } = evt
       const { clientX, clientY } = isTouchEvent(evt) ? evt.changedTouches[0] : evt
       const position = {

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -323,11 +323,6 @@ export interface Mirror {
   has: (id: number) => boolean
 }
 
-export interface ThrottleOptions {
-  leading?: boolean
-  trailing?: boolean
-}
-
 export type ListenerHandler = () => void
 export type HookResetter = () => void
 export type Arguments<T> = T extends (...payload: infer U) => unknown ? U : unknown

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -1,6 +1,6 @@
 import { noop, monitor } from '@datadog/browser-core'
 import { IGNORED_NODE, INode } from '../rrweb-snapshot'
-import { HookResetter, ListenerHandler, Mirror, ThrottleOptions } from './types'
+import { HookResetter, ListenerHandler, Mirror } from './types'
 
 export function on(type: string, fn: (event: any) => void, target: Document | Window = document): ListenerHandler {
   const monitoredFn = monitor(fn)
@@ -33,34 +33,6 @@ export const mirror: Mirror = {
   has(id) {
     return mirror.map.hasOwnProperty(id)
   },
-}
-
-// copy from underscore and modified
-export function throttle<T>(func: (arg: T) => void, wait: number, options: ThrottleOptions = {}) {
-  let timeout: number | undefined
-  let previous = 0
-  return function (this: unknown) {
-    const now = Date.now()
-    if (!previous && options.leading === false) {
-      previous = now
-    }
-    const remaining = wait - (now - previous)
-    const args = (arguments as unknown) as [T]
-    if (remaining <= 0 || remaining > wait) {
-      if (timeout) {
-        clearTimeout(timeout)
-        timeout = undefined
-      }
-      previous = now
-      func.apply(this, args)
-    } else if (!timeout && options.trailing !== false) {
-      timeout = setTimeout(() => {
-        previous = options.leading === false ? 0 : Date.now()
-        timeout = undefined
-        func.apply(this, args)
-      }, remaining)
-    }
-  }
 }
 
 export function hookSetter<T>(


### PR DESCRIPTION
## Motivation

Remove duplicated code by re-using the core "throttle" function in rum-recorder

## Changes

* Adjust the "throttle" function so it keeps the function arguments 
* use it is RRWeb codebase
* remove RRWeb utils throttle

## Testing

Manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
