### PR TITLE
[RUMF-845] use core 'addEventListener' in recorder

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -5,7 +5,7 @@ export const ONE_MINUTE = 60 * ONE_SECOND
 export const ONE_HOUR = 60 * ONE_MINUTE
 export const ONE_KILO_BYTE = 1024
 
-export enum DOM_EVENT {
+export const enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
   CLICK = 'click',
   DBL_CLICK = 'dblclick',

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -397,6 +397,15 @@ export function addEventListeners(
   }
 }
 
+export function runOnReadyState(expectedReadyState: 'complete' | 'interactive', callback: () => void) {
+  if (document.readyState === expectedReadyState || document.readyState === 'complete') {
+    callback()
+  } else {
+    const eventName = expectedReadyState === 'complete' ? DOM_EVENT.LOAD : DOM_EVENT.DOM_CONTENT_LOADED
+    addEventListener(window, eventName, callback, { once: true })
+  }
+}
+
 // Define those types for TS 3.0 compatibility
 // https://www.typescriptlang.org/docs/handbook/utility-types.html#thisparametertypetype
 export type ThisParameterType<T> = T extends (this: infer U, ...args: any[]) => any ? U : unknown

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -8,11 +8,14 @@ export const ONE_KILO_BYTE = 1024
 export enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
   CLICK = 'click',
+  DBL_CLICK = 'dblclick',
   KEY_DOWN = 'keydown',
   LOAD = 'load',
   POP_STATE = 'popstate',
   SCROLL = 'scroll',
   TOUCH_START = 'touchstart',
+  TOUCH_END = 'touchend',
+  TOUCH_MOVE = 'touchmove',
   VISIBILITY_CHANGE = 'visibilitychange',
   DOM_CONTENT_LOADED = 'DOMContentLoaded',
   POINTER_DOWN = 'pointerdown',
@@ -21,8 +24,16 @@ export enum DOM_EVENT {
   HASH_CHANGE = 'hashchange',
   PAGE_HIDE = 'pagehide',
   MOUSE_DOWN = 'mousedown',
+  MOUSE_UP = 'mouseup',
+  MOUSE_MOVE = 'mousemove',
   FOCUS = 'focus',
   BLUR = 'blur',
+  CONTEXT_MENU = 'contextmenu',
+  RESIZE = 'resize',
+  CHANGE = 'change',
+  INPUT = 'input',
+  PLAY = 'play',
+  PAUSE = 'pause',
 }
 
 export enum ResourceType {

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -352,10 +352,10 @@ interface AddEventListenerOptions {
  *
  * * returns a `stop` function to remove the listener
  */
-export function addEventListener(
+export function addEventListener<E extends Event>(
   emitter: EventEmitter,
   event: DOM_EVENT,
-  listener: (event: Event) => void,
+  listener: (event: E) => void,
   options?: AddEventListenerOptions
 ) {
   return addEventListeners(emitter, [event], listener, options)
@@ -373,24 +373,24 @@ export function addEventListener(
  *
  * * with `once: true`, the listener will be called at most once, even if different events are listened
  */
-export function addEventListeners(
+export function addEventListeners<E extends Event>(
   emitter: EventEmitter,
   events: DOM_EVENT[],
-  listener: (event: Event) => void,
+  listener: (event: E) => void,
   { once, capture, passive }: { once?: boolean; capture?: boolean; passive?: boolean } = {}
 ) {
-  const wrapedListener = monitor(
+  const wrappedListener = monitor(
     once
       ? (event: Event) => {
           stop()
-          listener(event)
+          listener(event as E)
         }
-      : listener
+      : (listener as (event: Event) => void)
   )
 
   const options = passive ? { capture, passive } : capture
-  events.forEach((event) => emitter.addEventListener(event, wrapedListener, options))
-  const stop = () => events.forEach((event) => emitter.removeEventListener(event, wrapedListener, options))
+  events.forEach((event) => emitter.addEventListener(event, wrappedListener, options))
+  const stop = () => events.forEach((event) => emitter.removeEventListener(event, wrappedListener, options))
 
   return {
     stop,

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -1,11 +1,11 @@
 import {
-  addEventListener,
   addEventListeners,
   Configuration,
   DOM_EVENT,
   getRelativeTime,
   isNumber,
   monitor,
+  runOnReadyState,
 } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../domain/lifeCycle'
 import { FAKE_INITIAL_DOCUMENT, isAllowedRequestUrl } from '../domain/rumEventsCollection/resource/resourceUtils'
@@ -245,15 +245,6 @@ function retrieveFirstInputTiming(callback: (timing: RumFirstInputTiming) => voi
         callback(timing)
       }
     }
-  }
-}
-
-function runOnReadyState(expectedReadyState: 'complete' | 'interactive', callback: () => void) {
-  if (document.readyState === expectedReadyState || document.readyState === 'complete') {
-    callback()
-  } else {
-    const eventName = expectedReadyState === 'complete' ? DOM_EVENT.LOAD : DOM_EVENT.DOM_CONTENT_LOADED
-    addEventListener(window, eventName, callback, { once: true })
   }
 }
 

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -304,7 +304,7 @@ function initMediaInteractionObserver(mediaInteractionCb: MediaInteractionCallba
     }
     mediaInteractionCb({
       id: mirror.getId(target as INode),
-      type: event.type === 'play' ? MediaInteractions.Play : MediaInteractions.Pause,
+      type: event.type === DOM_EVENT.PLAY ? MediaInteractions.Play : MediaInteractions.Pause,
     })
   }
   return addEventListeners(document, [DOM_EVENT.PLAY, DOM_EVENT.PAUSE], handler, { capture: true, passive: true }).stop

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -1,8 +1,9 @@
+import { runOnReadyState } from '@datadog/browser-core'
 import { MaskInputOptions, SlimDOMOptions, snapshot } from '../rrweb-snapshot'
 import { RawRecord, RecordType } from '../../types'
 import { initObservers } from './observer'
 import { IncrementalSource, ListenerHandler, RecordAPI, RecordOptions } from './types'
-import { getWindowHeight, getWindowWidth, mirror, on } from './utils'
+import { getWindowHeight, getWindowWidth, mirror } from './utils'
 import { MutationController } from './mutation'
 
 let wrappedEmit!: (record: RawRecord, isCheckout?: boolean) => void
@@ -260,11 +261,9 @@ export function record(options: RecordOptions = {}): RecordAPI {
       )
     )
   }
-  if (document.readyState === 'interactive' || document.readyState === 'complete') {
-    init()
-  } else {
-    handlers.push(on('load', init, window))
-  }
+
+  runOnReadyState('complete', init)
+
   return {
     stop: () => {
       handlers.forEach((h) => h())

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -77,11 +77,6 @@ export type SamplingStrategy = Partial<{
    */
   mousemove: boolean | number
   /**
-   * false means not to record mouse interaction events
-   * can also specify record some kinds of mouse interactions
-   */
-  mouseInteraction: boolean | { [key: string]: boolean | undefined }
-  /**
    * number is the throttle threshold of recording scroll
    */
   scroll: number
@@ -216,16 +211,15 @@ export interface MousePosition {
 }
 
 export enum MouseInteractions {
-  MouseUp,
-  MouseDown,
-  Click,
-  ContextMenu,
-  DblClick,
-  Focus,
-  Blur,
-  TouchStart,
-  TouchMove_Departed, // we will start a separate observer for touch move event
-  TouchEnd,
+  MouseUp = 0,
+  MouseDown = 1,
+  Click = 2,
+  ContextMenu = 3,
+  DblClick = 4,
+  Focus = 5,
+  Blur = 6,
+  TouchStart = 7,
+  TouchEnd = 9,
 }
 
 interface MouseInteractionParam {

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -1,13 +1,6 @@
-import { noop, monitor } from '@datadog/browser-core'
+import { noop } from '@datadog/browser-core'
 import { IGNORED_NODE, INode } from '../rrweb-snapshot'
-import { HookResetter, ListenerHandler, Mirror } from './types'
-
-export function on(type: string, fn: (event: any) => void, target: Document | Window = document): ListenerHandler {
-  const monitoredFn = monitor(fn)
-  const options = { capture: true, passive: true }
-  target.addEventListener(type, monitoredFn, options)
-  return () => target.removeEventListener(type, monitoredFn, options)
-}
+import { HookResetter, Mirror } from './types'
 
 export const mirror: Mirror = {
   map: {},


### PR DESCRIPTION
## Motivation

Reduce duplicated logic in core/rrweb

## Changes

* Mutualize `runOnReadyState` (this function was using `addEventListeners`, so instead of re-implementing it in rrweb, just mutualize it)
* Adjust typings so the listener gets any event type as argument
* Replace `on` usages with `addEventListener`
* Make `DOM_EVENT` a `const enum`

## Testing

CI, manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
