### PR TITLE
[RUMF-846] remove unused rrweb parts

### DIFF
--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -155,10 +155,9 @@ function serializeNode(
   n: Node,
   options: {
     doc: Document
-    inlineStylesheet: boolean
   }
 ): SerializedNode | false {
-  const { doc, inlineStylesheet } = options
+  const { doc } = options
   switch (n.nodeType) {
     case n.DOCUMENT_NODE:
       return {
@@ -180,7 +179,7 @@ function serializeNode(
         attributes[name] = transformAttribute(doc, name, value)
       }
       // remote css
-      if (tagName === 'link' && inlineStylesheet) {
+      if (tagName === 'link') {
         const stylesheet = Array.from(doc.styleSheets).find((s) => s.href === (n as HTMLLinkElement).href)
         const cssText = getCssRulesString(stylesheet as CSSStyleSheet)
         if (cssText) {
@@ -367,16 +366,14 @@ export function serializeNodeWithId(
     doc: Document
     map: IdNodeMap
     skipChild: boolean
-    inlineStylesheet: boolean
     slimDOMOptions: SlimDOMOptions
     preserveWhiteSpace?: boolean
   }
 ): SerializedNodeWithId | null {
-  const { doc, map, skipChild = false, inlineStylesheet = true, slimDOMOptions } = options
+  const { doc, map, skipChild = false, slimDOMOptions } = options
   let { preserveWhiteSpace = true } = options
   const _serializedNode = serializeNode(n, {
     doc,
-    inlineStylesheet,
   })
   if (!_serializedNode) {
     // TODO: dev only
@@ -425,7 +422,6 @@ export function serializeNodeWithId(
         doc,
         map,
         skipChild,
-        inlineStylesheet,
         slimDOMOptions,
         preserveWhiteSpace,
       })
@@ -440,11 +436,10 @@ export function serializeNodeWithId(
 export function snapshot(
   n: Document,
   options?: {
-    inlineStylesheet?: boolean
     slimDOM?: boolean | SlimDOMOptions
   }
 ): [SerializedNodeWithId | null, IdNodeMap] {
-  const { inlineStylesheet = true, slimDOM = false } = options || {}
+  const { slimDOM = false } = options || {}
   const idNodeMap: IdNodeMap = {}
   const slimDOMOptions: SlimDOMOptions =
     slimDOM === true || slimDOM === 'all'
@@ -469,7 +464,6 @@ export function snapshot(
       doc: n,
       map: idNodeMap,
       skipChild: false,
-      inlineStylesheet,
       slimDOMOptions,
     }),
     idNodeMap,

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -166,10 +166,9 @@ function serializeNode(
     doc: Document
     inlineStylesheet: boolean
     maskInputOptions: MaskInputOptions
-    recordCanvas: boolean
   }
 ): SerializedNode | false {
-  const { doc, inlineStylesheet, maskInputOptions = {}, recordCanvas } = options
+  const { doc, inlineStylesheet, maskInputOptions = {} } = options
   switch (n.nodeType) {
     case n.DOCUMENT_NODE:
       return {
@@ -236,10 +235,6 @@ function serializeNode(
         if (attributes.value === (selectValue as HTMLSelectElement).value) {
           attributes.selected = (n as HTMLOptionElement).selected
         }
-      }
-      // canvas image data
-      if (tagName === 'canvas' && recordCanvas) {
-        attributes.rr_dataURL = (n as HTMLCanvasElement).toDataURL()
       }
       // media elements
       if (tagName === 'audio' || tagName === 'video') {
@@ -389,25 +384,15 @@ export function serializeNodeWithId(
     inlineStylesheet: boolean
     maskInputOptions?: MaskInputOptions
     slimDOMOptions: SlimDOMOptions
-    recordCanvas?: boolean
     preserveWhiteSpace?: boolean
   }
 ): SerializedNodeWithId | null {
-  const {
-    doc,
-    map,
-    skipChild = false,
-    inlineStylesheet = true,
-    maskInputOptions = {},
-    slimDOMOptions,
-    recordCanvas = false,
-  } = options
+  const { doc, map, skipChild = false, inlineStylesheet = true, maskInputOptions = {}, slimDOMOptions } = options
   let { preserveWhiteSpace = true } = options
   const _serializedNode = serializeNode(n, {
     doc,
     inlineStylesheet,
     maskInputOptions,
-    recordCanvas,
   })
   if (!_serializedNode) {
     // TODO: dev only
@@ -459,7 +444,6 @@ export function serializeNodeWithId(
         inlineStylesheet,
         maskInputOptions,
         slimDOMOptions,
-        recordCanvas,
         preserveWhiteSpace,
       })
       if (serializedChildNode) {
@@ -476,10 +460,9 @@ export function snapshot(
     inlineStylesheet?: boolean
     maskAllInputs?: boolean | MaskInputOptions
     slimDOM?: boolean | SlimDOMOptions
-    recordCanvas?: boolean
   }
 ): [SerializedNodeWithId | null, IdNodeMap] {
-  const { inlineStylesheet = true, recordCanvas = false, maskAllInputs = false, slimDOM = false } = options || {}
+  const { inlineStylesheet = true, maskAllInputs = false, slimDOM = false } = options || {}
   const idNodeMap: IdNodeMap = {}
   const maskInputOptions: MaskInputOptions =
     maskAllInputs === true
@@ -530,7 +513,6 @@ export function snapshot(
       inlineStylesheet,
       maskInputOptions,
       slimDOMOptions,
-      recordCanvas,
     }),
     idNodeMap,
   ]

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -1,16 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { nodeShouldBeHidden } from '../privacy'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_HIDDEN } from '../../constants'
-import {
-  SerializedNode,
-  SerializedNodeWithId,
-  NodeType,
-  Attributes,
-  INode,
-  IdNodeMap,
-  MaskInputOptions,
-  SlimDOMOptions,
-} from './types'
+import { SerializedNode, SerializedNodeWithId, NodeType, Attributes, INode, IdNodeMap, SlimDOMOptions } from './types'
 
 const tagNameRegex = /[^a-z1-6-_]/
 
@@ -165,10 +156,9 @@ function serializeNode(
   options: {
     doc: Document
     inlineStylesheet: boolean
-    maskInputOptions: MaskInputOptions
   }
 ): SerializedNode | false {
-  const { doc, inlineStylesheet, maskInputOptions = {} } = options
+  const { doc, inlineStylesheet } = options
   switch (n.nodeType) {
     case n.DOCUMENT_NODE:
       return {
@@ -221,11 +211,7 @@ function serializeNode(
           attributes.type !== 'button' &&
           value
         ) {
-          attributes.value =
-            maskInputOptions[attributes.type as keyof MaskInputOptions] ||
-            maskInputOptions[tagName as keyof MaskInputOptions]
-              ? '*'.repeat(value.length)
-              : value
+          attributes.value = value
         } else if ((n as HTMLInputElement).checked) {
           attributes.checked = (n as HTMLInputElement).checked
         }
@@ -382,17 +368,15 @@ export function serializeNodeWithId(
     map: IdNodeMap
     skipChild: boolean
     inlineStylesheet: boolean
-    maskInputOptions?: MaskInputOptions
     slimDOMOptions: SlimDOMOptions
     preserveWhiteSpace?: boolean
   }
 ): SerializedNodeWithId | null {
-  const { doc, map, skipChild = false, inlineStylesheet = true, maskInputOptions = {}, slimDOMOptions } = options
+  const { doc, map, skipChild = false, inlineStylesheet = true, slimDOMOptions } = options
   let { preserveWhiteSpace = true } = options
   const _serializedNode = serializeNode(n, {
     doc,
     inlineStylesheet,
-    maskInputOptions,
   })
   if (!_serializedNode) {
     // TODO: dev only
@@ -442,7 +426,6 @@ export function serializeNodeWithId(
         map,
         skipChild,
         inlineStylesheet,
-        maskInputOptions,
         slimDOMOptions,
         preserveWhiteSpace,
       })
@@ -458,35 +441,11 @@ export function snapshot(
   n: Document,
   options?: {
     inlineStylesheet?: boolean
-    maskAllInputs?: boolean | MaskInputOptions
     slimDOM?: boolean | SlimDOMOptions
   }
 ): [SerializedNodeWithId | null, IdNodeMap] {
-  const { inlineStylesheet = true, maskAllInputs = false, slimDOM = false } = options || {}
+  const { inlineStylesheet = true, slimDOM = false } = options || {}
   const idNodeMap: IdNodeMap = {}
-  const maskInputOptions: MaskInputOptions =
-    maskAllInputs === true
-      ? {
-          color: true,
-          date: true,
-          'datetime-local': true,
-          email: true,
-          month: true,
-          // eslint-disable-next-line id-blacklist
-          number: true,
-          range: true,
-          search: true,
-          tel: true,
-          text: true,
-          time: true,
-          url: true,
-          week: true,
-          textarea: true,
-          select: true,
-        }
-      : maskAllInputs === false
-      ? {}
-      : maskAllInputs
   const slimDOMOptions: SlimDOMOptions =
     slimDOM === true || slimDOM === 'all'
       ? // if true: set of sensible options that should not throw away any information
@@ -511,7 +470,6 @@ export function snapshot(
       map: idNodeMap,
       skipChild: false,
       inlineStylesheet,
-      maskInputOptions,
       slimDOMOptions,
     }),
     idNodeMap,

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/types.ts
@@ -59,26 +59,6 @@ export type IdNodeMap = {
   [key: number]: INode
 }
 
-export type MaskInputOptions = Partial<{
-  color: boolean
-  date: boolean
-  'datetime-local': boolean
-  email: boolean
-  month: boolean
-  // eslint-disable-next-line id-blacklist
-  number: boolean
-  range: boolean
-  search: boolean
-  tel: boolean
-  text: boolean
-  time: boolean
-  url: boolean
-  week: boolean
-  // unify textarea and select element with text input
-  textarea: boolean
-  select: boolean
-}>
-
 export type SlimDOMOptions = Partial<{
   script: boolean
   comment: boolean

--- a/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
@@ -9,7 +9,6 @@ const DEFAULT_OPTIONS = {
   inlineStylesheet: false,
   skipChild: true,
   slimDOMOptions: {},
-  maskInputOptions: {},
 }
 
 describe('MutationObserverWrapper', () => {
@@ -33,7 +32,6 @@ describe('MutationObserverWrapper', () => {
       mutationController,
       mutationCallbackSpy,
       DEFAULT_OPTIONS.inlineStylesheet,
-      DEFAULT_OPTIONS.maskInputOptions,
       DEFAULT_OPTIONS.slimDOMOptions
     )
   })

--- a/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
@@ -6,7 +6,6 @@ import { MutationCallBack } from './types'
 const DEFAULT_OPTIONS = {
   blockClass: 'dd-block',
   blockSelector: null,
-  inlineStylesheet: false,
   skipChild: true,
   slimDOMOptions: {},
 }
@@ -31,7 +30,6 @@ describe('MutationObserverWrapper', () => {
     mutationObserverWrapper = new MutationObserverWrapper(
       mutationController,
       mutationCallbackSpy,
-      DEFAULT_OPTIONS.inlineStylesheet,
       DEFAULT_OPTIONS.slimDOMOptions
     )
   })

--- a/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
@@ -9,7 +9,6 @@ const DEFAULT_OPTIONS = {
   inlineStylesheet: false,
   skipChild: true,
   slimDOMOptions: {},
-  recordCanvas: false,
   maskInputOptions: {},
 }
 
@@ -35,7 +34,6 @@ describe('MutationObserverWrapper', () => {
       mutationCallbackSpy,
       DEFAULT_OPTIONS.inlineStylesheet,
       DEFAULT_OPTIONS.maskInputOptions,
-      DEFAULT_OPTIONS.recordCanvas,
       DEFAULT_OPTIONS.slimDOMOptions
     )
   })

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -172,7 +172,6 @@ export class MutationObserverWrapper {
   public constructor(
     private controller: MutationController,
     private emissionCallback: MutationCallBack,
-    private inlineStylesheet: boolean,
     private slimDOMOptions: SlimDOMOptions
   ) {
     this.observer = new MutationObserver(monitor(this.processMutations))
@@ -233,7 +232,6 @@ export class MutationObserverWrapper {
       }
       const sn = serializeNodeWithId(n, {
         doc: document,
-        inlineStylesheet: this.inlineStylesheet,
         map: mirror.map,
         skipChild: true,
         slimDOMOptions: this.slimDOMOptions,

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -181,7 +181,6 @@ export class MutationObserverWrapper {
     private emissionCallback: MutationCallBack,
     private inlineStylesheet: boolean,
     private maskInputOptions: MaskInputOptions,
-    private recordCanvas: boolean,
     private slimDOMOptions: SlimDOMOptions
   ) {
     this.observer = new MutationObserver(monitor(this.processMutations))
@@ -245,7 +244,6 @@ export class MutationObserverWrapper {
         inlineStylesheet: this.inlineStylesheet,
         map: mirror.map,
         maskInputOptions: this.maskInputOptions,
-        recordCanvas: this.recordCanvas,
         skipChild: true,
         slimDOMOptions: this.slimDOMOptions,
       })

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -1,12 +1,5 @@
 import { monitor } from '@datadog/browser-core'
-import {
-  IGNORED_NODE,
-  INode,
-  MaskInputOptions,
-  serializeNodeWithId,
-  SlimDOMOptions,
-  transformAttribute,
-} from '../rrweb-snapshot'
+import { IGNORED_NODE, INode, serializeNodeWithId, SlimDOMOptions, transformAttribute } from '../rrweb-snapshot'
 import { nodeOrAncestorsShouldBeHidden } from '../privacy'
 import {
   AddedNodeMutation,
@@ -180,7 +173,6 @@ export class MutationObserverWrapper {
     private controller: MutationController,
     private emissionCallback: MutationCallBack,
     private inlineStylesheet: boolean,
-    private maskInputOptions: MaskInputOptions,
     private slimDOMOptions: SlimDOMOptions
   ) {
     this.observer = new MutationObserver(monitor(this.processMutations))
@@ -243,7 +235,6 @@ export class MutationObserverWrapper {
         doc: document,
         inlineStylesheet: this.inlineStylesheet,
         map: mirror.map,
-        maskInputOptions: this.maskInputOptions,
         skipChild: true,
         slimDOMOptions: this.slimDOMOptions,
       })

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -27,10 +27,9 @@ const SCROLL_OBSERVER_THRESHOLD = 100
 function initMutationObserver(
   mutationController: MutationController,
   cb: MutationCallBack,
-  inlineStylesheet: boolean,
   slimDOMOptions: SlimDOMOptions
 ) {
-  const mutationObserverWrapper = new MutationObserverWrapper(mutationController, cb, inlineStylesheet, slimDOMOptions)
+  const mutationObserverWrapper = new MutationObserverWrapper(mutationController, cb, slimDOMOptions)
   return () => mutationObserverWrapper.stop()
 }
 
@@ -272,7 +271,7 @@ function initMediaInteractionObserver(mediaInteractionCb: MediaInteractionCallba
 }
 
 export function initObservers(o: ObserverParam): ListenerHandler {
-  const mutationHandler = initMutationObserver(o.mutationController, o.mutationCb, o.inlineStylesheet, o.slimDOMOptions)
+  const mutationHandler = initMutationObserver(o.mutationController, o.mutationCb, o.slimDOMOptions)
   const mousemoveHandler = initMoveObserver(o.mousemoveCb)
   const mouseInteractionHandler = initMouseInteractionObserver(o.mouseInteractionCb)
   const scrollHandler = initScrollObserver(o.scrollCb)

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -11,13 +11,11 @@ import { INode, MaskInputOptions, SlimDOMOptions } from '../rrweb-snapshot'
 import { nodeOrAncestorsShouldBeHidden, nodeOrAncestorsShouldHaveInputIgnored } from '../privacy'
 import { MutationObserverWrapper, MutationController } from './mutation'
 import {
-  Arguments,
   CanvasMutationCallback,
   FontCallback,
   FontFaceDescriptors,
   FontParam,
   HookResetter,
-  HooksParam,
   IncrementalSource,
   InputCallback,
   InputValue,
@@ -431,83 +429,7 @@ function initFontObserver(cb: FontCallback): ListenerHandler {
   }
 }
 
-function mergeHooks(o: ObserverParam, hooks: HooksParam) {
-  const {
-    mutationCb,
-    mousemoveCb,
-    mouseInteractionCb,
-    scrollCb,
-    viewportResizeCb,
-    inputCb,
-    mediaInteractionCb,
-    styleSheetRuleCb,
-    canvasMutationCb,
-    fontCb,
-  } = o
-  o.mutationCb = (...p: Arguments<MutationCallBack>) => {
-    if (hooks.mutation) {
-      hooks.mutation(...p)
-    }
-    mutationCb(...p)
-  }
-  o.mousemoveCb = (...p: Arguments<MousemoveCallBack>) => {
-    if (hooks.mousemove) {
-      hooks.mousemove(...p)
-    }
-    mousemoveCb(...p)
-  }
-  o.mouseInteractionCb = (...p: Arguments<MouseInteractionCallBack>) => {
-    if (hooks.mouseInteraction) {
-      hooks.mouseInteraction(...p)
-    }
-    mouseInteractionCb(...p)
-  }
-  o.scrollCb = (...p: Arguments<ScrollCallback>) => {
-    if (hooks.scroll) {
-      hooks.scroll(...p)
-    }
-    scrollCb(...p)
-  }
-  o.viewportResizeCb = (...p: Arguments<ViewportResizeCallback>) => {
-    if (hooks.viewportResize) {
-      hooks.viewportResize(...p)
-    }
-    viewportResizeCb(...p)
-  }
-  o.inputCb = (...p: Arguments<InputCallback>) => {
-    if (hooks.input) {
-      hooks.input(...p)
-    }
-    inputCb(...p)
-  }
-  o.mediaInteractionCb = (...p: Arguments<MediaInteractionCallback>) => {
-    if (hooks.mediaInteaction) {
-      hooks.mediaInteaction(...p)
-    }
-    mediaInteractionCb(...p)
-  }
-  o.styleSheetRuleCb = (...p: Arguments<StyleSheetRuleCallback>) => {
-    if (hooks.styleSheetRule) {
-      hooks.styleSheetRule(...p)
-    }
-    styleSheetRuleCb(...p)
-  }
-  o.canvasMutationCb = (...p: Arguments<CanvasMutationCallback>) => {
-    if (hooks.canvasMutation) {
-      hooks.canvasMutation(...p)
-    }
-    canvasMutationCb(...p)
-  }
-  o.fontCb = (...p: Arguments<FontCallback>) => {
-    if (hooks.font) {
-      hooks.font(...p)
-    }
-    fontCb(...p)
-  }
-}
-
-export function initObservers(o: ObserverParam, hooks: HooksParam = {}): ListenerHandler {
-  mergeHooks(o, hooks)
+export function initObservers(o: ObserverParam): ListenerHandler {
   const mutationHandler = initMutationObserver(
     o.mutationController,
     o.mutationCb,

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -29,7 +29,7 @@ import {
   StyleSheetRuleCallback,
   ViewportResizeCallback,
 } from './types'
-import { forEach, getWindowHeight, getWindowWidth, hookSetter, isTouchEvent, mirror, patch } from './utils'
+import { forEach, getWindowHeight, getWindowWidth, hookSetter, isTouchEvent, mirror } from './utils'
 
 function initMutationObserver(
   mutationController: MutationController,

--- a/packages/rum-recorder/src/domain/rrweb/record.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.spec.ts
@@ -52,54 +52,11 @@ describe('record', () => {
     expect(records.filter((record) => record.type === RecordType.FullSnapshot).length).toEqual(1)
   })
 
-  it('can checkout full snapshot by number of records', () => {
-    stop = record({
-      emit: emitSpy,
-      checkoutEveryNth: 10,
-    }).stop
-
-    const inputEventCount = 30
-    dispatchInputEvents(inputEventCount)
-
-    const records = getEmittedRecords()
-    expect(records.length).toBe(inputEventCount + RECORDS_PER_FULL_SNAPSHOTS * 4)
-    expect(records.filter((record) => record.type === RecordType.Meta).length).toBe(4)
-    expect(records.filter((record) => record.type === RecordType.FullSnapshot).length).toBe(4)
-    expect(records[1].type).toBe(RecordType.FullSnapshot)
-    expect(records[13].type).toBe(RecordType.FullSnapshot)
-    expect(records[25].type).toBe(RecordType.FullSnapshot)
-    expect(records[37].type).toBe(RecordType.FullSnapshot)
-  })
-
-  it('can checkout full snapshot by time', () => {
-    jasmine.clock().install()
-    jasmine.clock().mockDate()
-    const checkoutDelay = 500
-    stop = record({ emit: emitSpy, checkoutEveryNms: checkoutDelay }).stop
-
-    let inputEventCount = 30
-    dispatchInputEvents(inputEventCount)
-    jasmine.clock().tick(checkoutDelay)
-
-    expect(getEmittedRecords().length).toBe(inputEventCount + RECORDS_PER_FULL_SNAPSHOTS)
-
-    jasmine.clock().tick(1)
-    inputEventCount += 1
-    dispatchInputEvents(1)
-
-    const records = getEmittedRecords()
-    expect(records.length).toBe(inputEventCount + RECORDS_PER_FULL_SNAPSHOTS * 2)
-    expect(records.filter((record) => record.type === RecordType.Meta).length).toBe(2)
-    expect(records.filter((record) => record.type === RecordType.FullSnapshot).length).toBe(2)
-    expect(records[1].type).toBe(RecordType.FullSnapshot)
-    expect(records[34].type).toBe(RecordType.FullSnapshot)
-  })
-
   it('is safe to checkout during async callbacks', (done) => {
-    stop = record({
+    const recordApi = record({
       emit: emitSpy,
-      checkoutEveryNth: 2,
-    }).stop
+    })
+    stop = recordApi.stop
 
     const p = document.createElement('p')
     const span = document.createElement('span')
@@ -112,6 +69,7 @@ describe('record', () => {
 
     setTimeout(() => {
       span.innerText = 'test'
+      recordApi.takeFullSnapshot()
     }, 10)
 
     setTimeout(() => {

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -19,16 +19,10 @@ export function record(options: RecordOptions = {}): RecordAPI {
     slimDOMOptions: slimDOMOptionsArg,
     maskInputFn,
     packFn,
-    sampling = {},
-    mousemoveWait,
   } = options
   // runtime checks for user options
   if (!emit) {
     throw new Error('emit function is required')
-  }
-  // move departed options to new options
-  if (mousemoveWait !== undefined && sampling.mousemove === undefined) {
-    sampling.mousemove = mousemoveWait
   }
 
   const maskInputOptions: MaskInputOptions =
@@ -167,7 +161,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
         inlineStylesheet,
         maskInputFn,
         maskInputOptions,
-        sampling,
         slimDOMOptions,
         inputCb: (v) =>
           wrappedEmit({

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -9,13 +9,7 @@ import { MutationController } from './mutation'
 let wrappedEmit!: (record: RawRecord, isCheckout?: boolean) => void
 
 export function record(options: RecordOptions = {}): RecordAPI {
-  const {
-    emit,
-    checkoutEveryNms,
-    checkoutEveryNth,
-    inlineStylesheet = true,
-    slimDOMOptions: slimDOMOptionsArg,
-  } = options
+  const { emit, checkoutEveryNms, checkoutEveryNth, slimDOMOptions: slimDOMOptionsArg } = options
   // runtime checks for user options
   if (!emit) {
     throw new Error('emit function is required')
@@ -87,7 +81,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
     )
 
     const [node, idNodeMap] = snapshot(document, {
-      inlineStylesheet,
       slimDOM: slimDOMOptions,
     })
 
@@ -130,7 +123,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
     handlers.push(
       initObservers({
         mutationController,
-        inlineStylesheet,
         slimDOMOptions,
         inputCb: (v) =>
           wrappedEmit({

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -15,7 +15,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
     checkoutEveryNth,
     inlineStylesheet = true,
     slimDOMOptions: slimDOMOptionsArg,
-    packFn,
   } = options
   // runtime checks for user options
   if (!emit) {
@@ -57,7 +56,7 @@ export function record(options: RecordOptions = {}): RecordAPI {
       mutationController.unfreeze()
     }
 
-    emit(((packFn ? packFn(record) : record) as unknown) as RawRecord, isCheckout)
+    emit(record, isCheckout)
     if (record.type === RecordType.FullSnapshot) {
       lastFullSnapshotRecordTimestamp = Date.now()
       incrementalSnapshotCount = 0

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -1,5 +1,5 @@
 import { runOnReadyState } from '@datadog/browser-core'
-import { MaskInputOptions, SlimDOMOptions, snapshot } from '../rrweb-snapshot'
+import { SlimDOMOptions, snapshot } from '../rrweb-snapshot'
 import { RawRecord, RecordType } from '../../types'
 import { initObservers } from './observer'
 import { IncrementalSource, ListenerHandler, RecordAPI, RecordOptions } from './types'
@@ -14,39 +14,13 @@ export function record(options: RecordOptions = {}): RecordAPI {
     checkoutEveryNms,
     checkoutEveryNth,
     inlineStylesheet = true,
-    maskAllInputs,
-    maskInputOptions: maskInputOptionsArg,
     slimDOMOptions: slimDOMOptionsArg,
-    maskInputFn,
     packFn,
   } = options
   // runtime checks for user options
   if (!emit) {
     throw new Error('emit function is required')
   }
-
-  const maskInputOptions: MaskInputOptions =
-    maskAllInputs === true
-      ? {
-          color: true,
-          date: true,
-          'datetime-local': true,
-          email: true,
-          month: true,
-          number: true, // eslint-disable-line id-blacklist
-          range: true,
-          search: true,
-          select: true,
-          tel: true,
-          text: true,
-          textarea: true,
-          time: true,
-          url: true,
-          week: true,
-        }
-      : maskInputOptionsArg !== undefined
-      ? maskInputOptionsArg
-      : {}
 
   const slimDOMOptions: SlimDOMOptions =
     slimDOMOptionsArg === true || slimDOMOptionsArg === 'all'
@@ -115,7 +89,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
 
     const [node, idNodeMap] = snapshot(document, {
       inlineStylesheet,
-      maskAllInputs: maskInputOptions,
       slimDOM: slimDOMOptions,
     })
 
@@ -159,8 +132,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
       initObservers({
         mutationController,
         inlineStylesheet,
-        maskInputFn,
-        maskInputOptions,
         slimDOMOptions,
         inputCb: (v) =>
           wrappedEmit({

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -18,7 +18,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
     maskInputOptions: maskInputOptionsArg,
     slimDOMOptions: slimDOMOptionsArg,
     maskInputFn,
-    hooks,
     packFn,
     sampling = {},
     mousemoveWait,
@@ -166,99 +165,96 @@ export function record(options: RecordOptions = {}): RecordAPI {
     takeFullSnapshot()
 
     handlers.push(
-      initObservers(
-        {
-          mutationController,
-          collectFonts,
-          inlineStylesheet,
-          maskInputFn,
-          maskInputOptions,
-          recordCanvas,
-          sampling,
-          slimDOMOptions,
-          canvasMutationCb: (p) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.CanvasMutation,
-                ...p,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          fontCb: (p) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.Font,
-                ...p,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          inputCb: (v) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.Input,
-                ...v,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          mediaInteractionCb: (p) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.MediaInteraction,
-                ...p,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          mouseInteractionCb: (d) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.MouseInteraction,
-                ...d,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          mousemoveCb: (positions, source) =>
-            wrappedEmit({
-              data: {
-                positions,
-                source,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          mutationCb: (m) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.Mutation,
-                ...m,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          scrollCb: (p) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.Scroll,
-                ...p,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          styleSheetRuleCb: (r) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.StyleSheetRule,
-                ...r,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-          viewportResizeCb: (d) =>
-            wrappedEmit({
-              data: {
-                source: IncrementalSource.ViewportResize,
-                ...d,
-              },
-              type: RecordType.IncrementalSnapshot,
-            }),
-        },
-        hooks
-      )
+      initObservers({
+        mutationController,
+        collectFonts,
+        inlineStylesheet,
+        maskInputFn,
+        maskInputOptions,
+        recordCanvas,
+        sampling,
+        slimDOMOptions,
+        canvasMutationCb: (p) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.CanvasMutation,
+              ...p,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        fontCb: (p) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.Font,
+              ...p,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        inputCb: (v) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.Input,
+              ...v,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        mediaInteractionCb: (p) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.MediaInteraction,
+              ...p,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        mouseInteractionCb: (d) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.MouseInteraction,
+              ...d,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        mousemoveCb: (positions, source) =>
+          wrappedEmit({
+            data: {
+              positions,
+              source,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        mutationCb: (m) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.Mutation,
+              ...m,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        scrollCb: (p) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.Scroll,
+              ...p,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        styleSheetRuleCb: (r) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.StyleSheetRule,
+              ...r,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+        viewportResizeCb: (d) =>
+          wrappedEmit({
+            data: {
+              source: IncrementalSource.ViewportResize,
+              ...d,
+            },
+            type: RecordType.IncrementalSnapshot,
+          }),
+      })
     )
   }
 

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -21,7 +21,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
     packFn,
     sampling = {},
     mousemoveWait,
-    recordCanvas = false,
     collectFonts = false,
   } = options
   // runtime checks for user options
@@ -123,7 +122,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
 
     const [node, idNodeMap] = snapshot(document, {
       inlineStylesheet,
-      recordCanvas,
       maskAllInputs: maskInputOptions,
       slimDOM: slimDOMOptions,
     })
@@ -171,17 +169,8 @@ export function record(options: RecordOptions = {}): RecordAPI {
         inlineStylesheet,
         maskInputFn,
         maskInputOptions,
-        recordCanvas,
         sampling,
         slimDOMOptions,
-        canvasMutationCb: (p) =>
-          wrappedEmit({
-            data: {
-              source: IncrementalSource.CanvasMutation,
-              ...p,
-            },
-            type: RecordType.IncrementalSnapshot,
-          }),
         fontCb: (p) =>
           wrappedEmit({
             data: {

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -21,7 +21,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
     packFn,
     sampling = {},
     mousemoveWait,
-    collectFonts = false,
   } = options
   // runtime checks for user options
   if (!emit) {
@@ -165,20 +164,11 @@ export function record(options: RecordOptions = {}): RecordAPI {
     handlers.push(
       initObservers({
         mutationController,
-        collectFonts,
         inlineStylesheet,
         maskInputFn,
         maskInputOptions,
         sampling,
         slimDOMOptions,
-        fontCb: (p) =>
-          wrappedEmit({
-            data: {
-              source: IncrementalSource.Font,
-              ...p,
-            },
-            type: RecordType.IncrementalSnapshot,
-          }),
         inputCb: (v) =>
           wrappedEmit({
             data: {

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -13,7 +13,7 @@ export enum IncrementalSource {
   MediaInteraction = 7,
   StyleSheetRule = 8,
   // CanvasMutation = 9,
-  Font = 10,
+  // Font = 10,
 }
 
 export type MutationData = {
@@ -50,10 +50,6 @@ export type StyleSheetRuleData = {
   source: IncrementalSource.StyleSheetRule
 } & StyleSheetRuleParam
 
-export type FontData = {
-  source: IncrementalSource.Font
-} & FontParam
-
 export type IncrementalData =
   | MutationData
   | MousemoveData
@@ -63,7 +59,6 @@ export type IncrementalData =
   | InputData
   | MediaInteractionData
   | StyleSheetRuleData
-  | FontData
 
 export type SamplingStrategy = Partial<{
   /**
@@ -93,7 +88,6 @@ export interface RecordOptions {
   inlineStylesheet?: boolean
   packFn?: (record: RawRecord) => RawRecord
   sampling?: SamplingStrategy
-  collectFonts?: boolean
   // departed, please use sampling options
   mousemoveWait?: number
 }
@@ -116,9 +110,7 @@ export interface ObserverParam {
   maskInputFn?: MaskInputFn
   inlineStylesheet: boolean
   styleSheetRuleCb: StyleSheetRuleCallback
-  fontCb: FontCallback
   sampling: SamplingStrategy
-  collectFonts: boolean
   slimDOMOptions: SlimDOMOptions
 }
 
@@ -233,24 +225,6 @@ export interface StyleSheetRuleParam {
 }
 
 export type StyleSheetRuleCallback = (s: StyleSheetRuleParam) => void
-
-export interface FontFaceDescriptors {
-  style?: string
-  weight?: string
-  stretch?: string
-  unicodeRange?: string
-  variant?: string
-  featureSettings?: string
-}
-
-export interface FontParam {
-  family: string
-  fontSource: string
-  buffer: boolean
-  descriptors?: FontFaceDescriptors
-}
-
-export type FontCallback = (p: FontParam) => void
 
 export interface ViewportResizeDimention {
   width: number

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -231,4 +231,3 @@ export interface Mirror {
 
 export type ListenerHandler = () => void
 export type HookResetter = () => void
-export type Arguments<T> = T extends (...payload: infer U) => unknown ? U : unknown

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -96,7 +96,6 @@ export interface RecordOptions {
   maskInputFn?: MaskInputFn
   slimDOMOptions?: SlimDOMOptions | 'all' | true
   inlineStylesheet?: boolean
-  hooks?: HooksParam
   packFn?: (record: RawRecord) => RawRecord
   sampling?: SamplingStrategy
   recordCanvas?: boolean
@@ -129,19 +128,6 @@ export interface ObserverParam {
   recordCanvas: boolean
   collectFonts: boolean
   slimDOMOptions: SlimDOMOptions
-}
-
-export interface HooksParam {
-  mutation?: MutationCallBack
-  mousemove?: MousemoveCallBack
-  mouseInteraction?: MouseInteractionCallBack
-  scroll?: ScrollCallback
-  viewportResize?: ViewportResizeCallback
-  input?: InputCallback
-  mediaInteaction?: MediaInteractionCallback
-  styleSheetRule?: StyleSheetRuleCallback
-  canvasMutation?: CanvasMutationCallback
-  font?: FontCallback
 }
 
 // https://dom.spec.whatwg.org/#interface-mutationrecord

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -1,4 +1,4 @@
-import { IdNodeMap, INode, MaskInputOptions, SerializedNodeWithId, SlimDOMOptions } from '../rrweb-snapshot/types'
+import { IdNodeMap, INode, SerializedNodeWithId, SlimDOMOptions } from '../rrweb-snapshot/types'
 import type { RawRecord } from '../../types'
 import { MutationController } from './mutation'
 
@@ -64,9 +64,6 @@ export interface RecordOptions {
   emit?: (record: RawRecord, isCheckout?: boolean) => void
   checkoutEveryNth?: number
   checkoutEveryNms?: number
-  maskAllInputs?: boolean
-  maskInputOptions?: MaskInputOptions
-  maskInputFn?: MaskInputFn
   slimDOMOptions?: SlimDOMOptions | 'all' | true
   inlineStylesheet?: boolean
   packFn?: (record: RawRecord) => RawRecord
@@ -86,8 +83,6 @@ export interface ObserverParam {
   viewportResizeCb: ViewportResizeCallback
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
-  maskInputOptions: MaskInputOptions
-  maskInputFn?: MaskInputFn
   inlineStylesheet: boolean
   styleSheetRuleCb: StyleSheetRuleCallback
   slimDOMOptions: SlimDOMOptions
@@ -242,5 +237,3 @@ export interface Mirror {
 export type ListenerHandler = () => void
 export type HookResetter = () => void
 export type Arguments<T> = T extends (...payload: infer U) => unknown ? U : unknown
-
-export type MaskInputFn = (text: string) => string

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -66,7 +66,6 @@ export interface RecordOptions {
   checkoutEveryNms?: number
   slimDOMOptions?: SlimDOMOptions | 'all' | true
   inlineStylesheet?: boolean
-  packFn?: (record: RawRecord) => RawRecord
 }
 
 export interface RecordAPI {

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -60,23 +60,6 @@ export type IncrementalData =
   | MediaInteractionData
   | StyleSheetRuleData
 
-export type SamplingStrategy = Partial<{
-  /**
-   * false means not to record mouse/touch move events
-   * number is the throttle threshold of recording mouse/touch move
-   */
-  mousemove: boolean | number
-  /**
-   * number is the throttle threshold of recording scroll
-   */
-  scroll: number
-  /**
-   * 'all' will record all the input events
-   * 'last' will only record the last input value while input a sequence of chars
-   */
-  input: 'all' | 'last'
-}>
-
 export interface RecordOptions {
   emit?: (record: RawRecord, isCheckout?: boolean) => void
   checkoutEveryNth?: number
@@ -87,9 +70,6 @@ export interface RecordOptions {
   slimDOMOptions?: SlimDOMOptions | 'all' | true
   inlineStylesheet?: boolean
   packFn?: (record: RawRecord) => RawRecord
-  sampling?: SamplingStrategy
-  // departed, please use sampling options
-  mousemoveWait?: number
 }
 
 export interface RecordAPI {
@@ -110,7 +90,6 @@ export interface ObserverParam {
   maskInputFn?: MaskInputFn
   inlineStylesheet: boolean
   styleSheetRuleCb: StyleSheetRuleCallback
-  sampling: SamplingStrategy
   slimDOMOptions: SlimDOMOptions
 }
 

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -65,7 +65,6 @@ export interface RecordOptions {
   checkoutEveryNth?: number
   checkoutEveryNms?: number
   slimDOMOptions?: SlimDOMOptions | 'all' | true
-  inlineStylesheet?: boolean
 }
 
 export interface RecordAPI {
@@ -82,7 +81,6 @@ export interface ObserverParam {
   viewportResizeCb: ViewportResizeCallback
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
-  inlineStylesheet: boolean
   styleSheetRuleCb: StyleSheetRuleCallback
   slimDOMOptions: SlimDOMOptions
 }

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -62,8 +62,6 @@ export type IncrementalData =
 
 export interface RecordOptions {
   emit?: (record: RawRecord, isCheckout?: boolean) => void
-  checkoutEveryNth?: number
-  checkoutEveryNms?: number
   slimDOMOptions?: SlimDOMOptions | 'all' | true
 }
 

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -3,17 +3,17 @@ import type { RawRecord } from '../../types'
 import { MutationController } from './mutation'
 
 export enum IncrementalSource {
-  Mutation,
-  MouseMove,
-  MouseInteraction,
-  Scroll,
-  ViewportResize,
-  Input,
-  TouchMove,
-  MediaInteraction,
-  StyleSheetRule,
-  CanvasMutation,
-  Font,
+  Mutation = 0,
+  MouseMove = 1,
+  MouseInteraction = 2,
+  Scroll = 3,
+  ViewportResize = 4,
+  Input = 5,
+  TouchMove = 6,
+  MediaInteraction = 7,
+  StyleSheetRule = 8,
+  // CanvasMutation = 9,
+  Font = 10,
 }
 
 export type MutationData = {
@@ -50,10 +50,6 @@ export type StyleSheetRuleData = {
   source: IncrementalSource.StyleSheetRule
 } & StyleSheetRuleParam
 
-export type CanvasMutationData = {
-  source: IncrementalSource.CanvasMutation
-} & CanvasMutationParam
-
 export type FontData = {
   source: IncrementalSource.Font
 } & FontParam
@@ -67,7 +63,6 @@ export type IncrementalData =
   | InputData
   | MediaInteractionData
   | StyleSheetRuleData
-  | CanvasMutationData
   | FontData
 
 export type SamplingStrategy = Partial<{
@@ -98,7 +93,6 @@ export interface RecordOptions {
   inlineStylesheet?: boolean
   packFn?: (record: RawRecord) => RawRecord
   sampling?: SamplingStrategy
-  recordCanvas?: boolean
   collectFonts?: boolean
   // departed, please use sampling options
   mousemoveWait?: number
@@ -122,10 +116,8 @@ export interface ObserverParam {
   maskInputFn?: MaskInputFn
   inlineStylesheet: boolean
   styleSheetRuleCb: StyleSheetRuleCallback
-  canvasMutationCb: CanvasMutationCallback
   fontCb: FontCallback
   sampling: SamplingStrategy
-  recordCanvas: boolean
   collectFonts: boolean
   slimDOMOptions: SlimDOMOptions
 }
@@ -241,15 +233,6 @@ export interface StyleSheetRuleParam {
 }
 
 export type StyleSheetRuleCallback = (s: StyleSheetRuleParam) => void
-
-export type CanvasMutationCallback = (p: CanvasMutationParam) => void
-
-export interface CanvasMutationParam {
-  id: number
-  property: string
-  args: unknown[]
-  setter?: true
-}
 
 export interface FontFaceDescriptors {
   style?: string

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -1,4 +1,3 @@
-import { noop } from '@datadog/browser-core'
 import { IGNORED_NODE, INode } from '../rrweb-snapshot'
 import { HookResetter, Mirror } from './types'
 
@@ -47,45 +46,6 @@ export function hookSetter<T>(
   })
   return () => {
     Object.defineProperty(target, key, original || {})
-  }
-}
-
-// eslint-disable-next-line max-len
-// copy from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts
-export function patch(
-  source: { [key: string]: any },
-  name: string,
-  replacement: (...args: any[]) => unknown
-): () => void {
-  try {
-    if (!(name in source)) {
-      return noop
-    }
-
-    const original = source[name] as () => unknown
-    const wrapped = replacement(original)
-
-    // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
-    // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
-    if (typeof wrapped === 'function') {
-      wrapped.prototype = wrapped.prototype || {}
-      Object.defineProperties(wrapped, {
-        __rrweb_original__: {
-          enumerable: false,
-          value: original,
-        },
-      })
-    }
-
-    source[name] = wrapped
-
-    return () => {
-      source[name] = original
-    }
-  } catch {
-    return noop
-    // This can throw if multiple fill happens on a global object like XMLHttpRequest
-    // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
   }
 }
 

--- a/packages/rum-recorder/src/internal.ts
+++ b/packages/rum-recorder/src/internal.ts
@@ -7,7 +7,6 @@ export {
   InputData,
   MediaInteractionData,
   StyleSheetRuleData,
-  FontData,
   MediaInteractions,
   MouseInteractions,
   AddedNodeMutation,

--- a/packages/rum-recorder/src/internal.ts
+++ b/packages/rum-recorder/src/internal.ts
@@ -7,7 +7,6 @@ export {
   InputData,
   MediaInteractionData,
   StyleSheetRuleData,
-  CanvasMutationData,
   FontData,
   MediaInteractions,
   MouseInteractions,


### PR DESCRIPTION
## Motivation

Lighter bundle, less code to maintain

## Changes

Removed options:
* inlineStylesheet
* packFn
* mask input
* sampling
* hooks
* checkoutEvery*

Removed recording strategies:
* fonts
* canvas

See commit messages for rationals.

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
