### PR TITLE
[RUMF-845] remove slimDOM option and enable strategies to ignore elements

### DIFF
--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+import { isIE } from '@datadog/browser-core'
 import { absoluteToStylesheet, IGNORED_NODE, serializeNodeWithId } from './snapshot'
 
 describe('absolute url to stylesheet', () => {
@@ -82,13 +83,19 @@ describe('serializeNodeWithId', () => {
       map: {},
     }
 
+    beforeEach(() => {
+      if (isIE()) {
+        pending('IE not supported')
+      }
+    })
+
     it('does not save ignored nodes in the map', () => {
       const map = {}
       serializeNodeWithId(document.createElement('script'), { ...defaultOptions, map })
       expect(map).toEqual({})
     })
 
-    it('sets the serialized node id to IGNORED_NODE', () => {
+    it('sets ignored serialized node id to IGNORED_NODE', () => {
       const scriptElement = document.createElement('script')
       serializeNodeWithId(scriptElement, defaultOptions)
       // eslint-disable-next-line no-underscore-dangle

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { absoluteToStylesheet } from './snapshot'
+import { absoluteToStylesheet, IGNORED_NODE, serializeNodeWithId } from './snapshot'
 
 describe('absolute url to stylesheet', () => {
   const href = 'http://localhost/css/style.css'
@@ -71,5 +71,54 @@ describe('absolute url to stylesheet', () => {
   })
   it('can handle empty path', () => {
     expect(absoluteToStylesheet(`url('')`, href)).toEqual(`url('')`)
+  })
+})
+
+describe('serializeNodeWithId', () => {
+  describe('ignores some nodes', () => {
+    const defaultOptions = {
+      doc: document,
+      skipChild: false,
+      map: {},
+    }
+
+    it('does not same ignored nodes in the map', () => {
+      const map = {}
+      serializeNodeWithId(document.createElement('script'), { ...defaultOptions, map })
+      expect(map).toEqual({})
+    })
+
+    it('sets the serialized node id to IGNORED_NODE', () => {
+      const scriptElement = document.createElement('script')
+      serializeNodeWithId(scriptElement, defaultOptions)
+      // eslint-disable-next-line no-underscore-dangle
+      expect((scriptElement as any).__sn).toEqual(jasmine.objectContaining({ id: IGNORED_NODE }))
+    })
+
+    it('ignores script tags', () => {
+      expect(serializeNodeWithId(document.createElement('script'), defaultOptions)).toEqual(null)
+    })
+
+    it('ignores comments', () => {
+      expect(serializeNodeWithId(document.createComment('foo'), defaultOptions)).toEqual(null)
+    })
+
+    it('ignores link favicons', () => {
+      const linkElement = document.createElement('link')
+      linkElement.setAttribute('rel', 'shortcut icon')
+      expect(serializeNodeWithId(linkElement, defaultOptions)).toEqual(null)
+    })
+
+    it('ignores meta keywords', () => {
+      const metaElement = document.createElement('meta')
+      metaElement.setAttribute('name', 'keywords')
+      expect(serializeNodeWithId(metaElement, defaultOptions)).toEqual(null)
+    })
+
+    it('ignores meta name attribute casing', () => {
+      const metaElement = document.createElement('meta')
+      metaElement.setAttribute('name', 'KeYwOrDs')
+      expect(serializeNodeWithId(metaElement, defaultOptions)).toEqual(null)
+    })
   })
 })

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
@@ -82,7 +82,7 @@ describe('serializeNodeWithId', () => {
       map: {},
     }
 
-    it('does not same ignored nodes in the map', () => {
+    it('does not save ignored nodes in the map', () => {
       const map = {}
       serializeNodeWithId(document.createElement('script'), { ...defaultOptions, map })
       expect(map).toEqual({})

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -301,11 +301,13 @@ function isNodeIgnored(sn: SerializedNode): boolean {
     }
 
     if (sn.tagName === 'link') {
+      const relAttribute = lowerIfExists(sn.attributes.rel)
       return (
         // Scripts
-        (sn.attributes.rel === 'preload' && sn.attributes.as === 'script') ||
+        (relAttribute === 'preload' && sn.attributes.as === 'script') ||
         // Favicons
-        sn.attributes.rel === 'shortcut icon'
+        relAttribute === 'shortcut icon' ||
+        relAttribute === 'icon'
       )
     }
 

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { nodeShouldBeHidden } from '../privacy'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_HIDDEN } from '../../constants'
-import { SerializedNode, SerializedNodeWithId, NodeType, Attributes, INode, IdNodeMap, SlimDOMOptions } from './types'
+import { SerializedNode, SerializedNodeWithId, NodeType, Attributes, INode, IdNodeMap } from './types'
 
 const tagNameRegex = /[^a-z1-6-_]/
 
@@ -289,69 +289,63 @@ function lowerIfExists(maybeAttr: string | number | boolean): string {
   return (maybeAttr as string).toLowerCase()
 }
 
-function slimDOMExcluded(sn: SerializedNode, slimDOMOptions: SlimDOMOptions): boolean {
-  if (slimDOMOptions.comment && sn.type === NodeType.Comment) {
+function slimDOMExcluded(sn: SerializedNode): boolean {
+  if (sn.type === NodeType.Comment) {
     // TODO: convert IE conditional comments to real nodes
     return true
   } else if (sn.type === NodeType.Element) {
     if (
-      slimDOMOptions.script &&
-      (sn.tagName === 'script' ||
-        (sn.tagName === 'link' && sn.attributes.rel === 'preload' && sn.attributes.as === 'script'))
+      sn.tagName === 'script' ||
+      (sn.tagName === 'link' && sn.attributes.rel === 'preload' && sn.attributes.as === 'script')
     ) {
       return true
     } else if (
-      slimDOMOptions.headFavicon &&
-      ((sn.tagName === 'link' && sn.attributes.rel === 'shortcut icon') ||
-        (sn.tagName === 'meta' &&
-          (/^msapplication-tile(image|color)$/.test(lowerIfExists(sn.attributes.name)) ||
-            lowerIfExists(sn.attributes.name) === 'application-name' ||
-            lowerIfExists(sn.attributes.rel) === 'icon' ||
-            lowerIfExists(sn.attributes.rel) === 'apple-touch-icon' ||
-            lowerIfExists(sn.attributes.rel) === 'shortcut icon')))
+      (sn.tagName === 'link' && sn.attributes.rel === 'shortcut icon') ||
+      (sn.tagName === 'meta' &&
+        (/^msapplication-tile(image|color)$/.test(lowerIfExists(sn.attributes.name)) ||
+          lowerIfExists(sn.attributes.name) === 'application-name' ||
+          lowerIfExists(sn.attributes.rel) === 'icon' ||
+          lowerIfExists(sn.attributes.rel) === 'apple-touch-icon' ||
+          lowerIfExists(sn.attributes.rel) === 'shortcut icon'))
     ) {
       return true
     } else if (sn.tagName === 'meta') {
-      if (slimDOMOptions.headMetaDescKeywords && /^description|keywords$/.test(lowerIfExists(sn.attributes.name))) {
+      if (/^description|keywords$/.test(lowerIfExists(sn.attributes.name))) {
         return true
       } else if (
-        slimDOMOptions.headMetaSocial &&
-        (/^(og|twitter|fb):/.test(lowerIfExists(sn.attributes.property)) || // og = opengraph (facebook)
-          /^(og|twitter):/.test(lowerIfExists(sn.attributes.name)) ||
-          lowerIfExists(sn.attributes.name) === 'pinterest')
+        /^(og|twitter|fb):/.test(lowerIfExists(sn.attributes.property)) || // og = opengraph (facebook)
+        /^(og|twitter):/.test(lowerIfExists(sn.attributes.name)) ||
+        lowerIfExists(sn.attributes.name) === 'pinterest'
       ) {
         return true
       } else if (
-        slimDOMOptions.headMetaRobots &&
-        (lowerIfExists(sn.attributes.name) === 'robots' ||
-          lowerIfExists(sn.attributes.name) === 'googlebot' ||
-          lowerIfExists(sn.attributes.name) === 'bingbot')
+        lowerIfExists(sn.attributes.name) === 'robots' ||
+        lowerIfExists(sn.attributes.name) === 'googlebot' ||
+        lowerIfExists(sn.attributes.name) === 'bingbot'
       ) {
         return true
-      } else if (slimDOMOptions.headMetaHttpEquiv && sn.attributes['http-equiv'] !== undefined) {
+      } else if (sn.attributes['http-equiv'] !== undefined) {
         // e.g. X-UA-Compatible, Content-Type, Content-Language,
         // cache-control, X-Translated-By
         return true
       } else if (
-        slimDOMOptions.headMetaAuthorship &&
-        (lowerIfExists(sn.attributes.name) === 'author' ||
-          lowerIfExists(sn.attributes.name) === 'generator' ||
-          lowerIfExists(sn.attributes.name) === 'framework' ||
-          lowerIfExists(sn.attributes.name) === 'publisher' ||
-          lowerIfExists(sn.attributes.name) === 'progid' ||
-          /^article:/.test(lowerIfExists(sn.attributes.property)) ||
-          /^product:/.test(lowerIfExists(sn.attributes.property)))
+        lowerIfExists(sn.attributes.name) === 'author' ||
+        lowerIfExists(sn.attributes.name) === 'generator' ||
+        lowerIfExists(sn.attributes.name) === 'framework' ||
+        lowerIfExists(sn.attributes.name) === 'publisher' ||
+        lowerIfExists(sn.attributes.name) === 'progid' ||
+        /^article:/.test(lowerIfExists(sn.attributes.property)) ||
+        /^product:/.test(lowerIfExists(sn.attributes.property))
       ) {
         return true
       } else if (
-        slimDOMOptions.headMetaVerification &&
-        (lowerIfExists(sn.attributes.name) === 'google-site-verification' ||
-          lowerIfExists(sn.attributes.name) === 'yandex-verification' ||
-          lowerIfExists(sn.attributes.name) === 'csrf-token' ||
-          lowerIfExists(sn.attributes.name) === 'p:domain_verify' ||
-          lowerIfExists(sn.attributes.name) === 'verify-v1' ||
-          lowerIfExists(sn.attributes.name) === 'verification' ||
-          lowerIfExists(sn.attributes.name) === 'shopify-checkout-api-token')
+        lowerIfExists(sn.attributes.name) === 'google-site-verification' ||
+        lowerIfExists(sn.attributes.name) === 'yandex-verification' ||
+        lowerIfExists(sn.attributes.name) === 'csrf-token' ||
+        lowerIfExists(sn.attributes.name) === 'p:domain_verify' ||
+        lowerIfExists(sn.attributes.name) === 'verify-v1' ||
+        lowerIfExists(sn.attributes.name) === 'verification' ||
+        lowerIfExists(sn.attributes.name) === 'shopify-checkout-api-token'
       ) {
         return true
       }
@@ -366,11 +360,10 @@ export function serializeNodeWithId(
     doc: Document
     map: IdNodeMap
     skipChild: boolean
-    slimDOMOptions: SlimDOMOptions
     preserveWhiteSpace?: boolean
   }
 ): SerializedNodeWithId | null {
-  const { doc, map, skipChild = false, slimDOMOptions } = options
+  const { doc, map, skipChild = false } = options
   let { preserveWhiteSpace = true } = options
   const _serializedNode = serializeNode(n, {
     doc,
@@ -386,7 +379,7 @@ export function serializeNodeWithId(
   if ('__sn' in n) {
     id = n.__sn.id
   } else if (
-    slimDOMExcluded(_serializedNode, slimDOMOptions) ||
+    slimDOMExcluded(_serializedNode) ||
     (!preserveWhiteSpace &&
       _serializedNode.type === NodeType.Text &&
       !_serializedNode.isStyle &&
@@ -399,7 +392,7 @@ export function serializeNodeWithId(
   const serializedNode = Object.assign(_serializedNode, { id })
   ;(n as INode).__sn = serializedNode
   if (id === IGNORED_NODE) {
-    return null // slimDOM
+    return null
   }
   map[id] = n as INode
   let recordChild = !skipChild
@@ -410,7 +403,6 @@ export function serializeNodeWithId(
   }
   if ((serializedNode.type === NodeType.Document || serializedNode.type === NodeType.Element) && recordChild) {
     if (
-      slimDOMOptions.headWhitespace &&
       _serializedNode.type === NodeType.Element &&
       _serializedNode.tagName === 'head'
       // would impede performance: || getComputedStyle(n)['white-space'] === 'normal'
@@ -422,7 +414,6 @@ export function serializeNodeWithId(
         doc,
         map,
         skipChild,
-        slimDOMOptions,
         preserveWhiteSpace,
       })
       if (serializedChildNode) {
@@ -433,38 +424,13 @@ export function serializeNodeWithId(
   return serializedNode
 }
 
-export function snapshot(
-  n: Document,
-  options?: {
-    slimDOM?: boolean | SlimDOMOptions
-  }
-): [SerializedNodeWithId | null, IdNodeMap] {
-  const { slimDOM = false } = options || {}
+export function snapshot(n: Document): [SerializedNodeWithId | null, IdNodeMap] {
   const idNodeMap: IdNodeMap = {}
-  const slimDOMOptions: SlimDOMOptions =
-    slimDOM === true || slimDOM === 'all'
-      ? // if true: set of sensible options that should not throw away any information
-        {
-          script: true,
-          comment: true,
-          headFavicon: true,
-          headWhitespace: true,
-          headMetaDescKeywords: slimDOM === 'all', // destructive
-          headMetaSocial: true,
-          headMetaRobots: true,
-          headMetaHttpEquiv: true,
-          headMetaAuthorship: true,
-          headMetaVerification: true,
-        }
-      : slimDOM === false
-      ? {}
-      : slimDOM
   return [
     serializeNodeWithId(n, {
       doc: n,
       map: idNodeMap,
       skipChild: false,
-      slimDOMOptions,
     }),
     idNodeMap,
   ]

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/types.ts
@@ -58,16 +58,3 @@ export interface INode extends Node {
 export type IdNodeMap = {
   [key: number]: INode
 }
-
-export type SlimDOMOptions = Partial<{
-  script: boolean
-  comment: boolean
-  headFavicon: boolean
-  headWhitespace: boolean
-  headMetaDescKeywords: boolean
-  headMetaSocial: boolean
-  headMetaRobots: boolean
-  headMetaHttpEquiv: boolean
-  headMetaAuthorship: boolean
-  headMetaVerification: boolean
-}>

--- a/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.spec.ts
@@ -7,7 +7,6 @@ const DEFAULT_OPTIONS = {
   blockClass: 'dd-block',
   blockSelector: null,
   skipChild: true,
-  slimDOMOptions: {},
 }
 
 describe('MutationObserverWrapper', () => {
@@ -27,11 +26,7 @@ describe('MutationObserverWrapper', () => {
     mutationController = new MutationController()
     MockMutationObserver.setup()
 
-    mutationObserverWrapper = new MutationObserverWrapper(
-      mutationController,
-      mutationCallbackSpy,
-      DEFAULT_OPTIONS.slimDOMOptions
-    )
+    mutationObserverWrapper = new MutationObserverWrapper(mutationController, mutationCallbackSpy)
   })
 
   afterEach(() => {

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -1,5 +1,5 @@
 import { monitor } from '@datadog/browser-core'
-import { IGNORED_NODE, INode, serializeNodeWithId, SlimDOMOptions, transformAttribute } from '../rrweb-snapshot'
+import { IGNORED_NODE, INode, serializeNodeWithId, transformAttribute } from '../rrweb-snapshot'
 import { nodeOrAncestorsShouldBeHidden } from '../privacy'
 import {
   AddedNodeMutation,
@@ -169,11 +169,7 @@ export class MutationObserverWrapper {
   private movedSet = new Set<Node>()
   private droppedSet = new Set<Node>()
 
-  public constructor(
-    private controller: MutationController,
-    private emissionCallback: MutationCallBack,
-    private slimDOMOptions: SlimDOMOptions
-  ) {
+  public constructor(private controller: MutationController, private emissionCallback: MutationCallBack) {
     this.observer = new MutationObserver(monitor(this.processMutations))
     this.observer.observe(document, {
       attributeOldValue: true,
@@ -211,7 +207,7 @@ export class MutationObserverWrapper {
     const addList = new DoubleLinkedList()
     const getNextId = (n: Node): number | null => {
       let ns: Node | null = n
-      let nextId: number | null = IGNORED_NODE // slimDOM: ignored
+      let nextId: number | null = IGNORED_NODE
       while (nextId === IGNORED_NODE) {
         ns = ns && ns.nextSibling
         nextId = ns && mirror.getId((ns as unknown) as INode)
@@ -234,7 +230,6 @@ export class MutationObserverWrapper {
         doc: document,
         map: mirror.map,
         skipChild: true,
-        slimDOMOptions: this.slimDOMOptions,
       })
       if (sn) {
         adds.push({

--- a/packages/rum-recorder/src/domain/rrweb/observer.ts
+++ b/packages/rum-recorder/src/domain/rrweb/observer.ts
@@ -1,5 +1,5 @@
 import { monitor, callMonitored, throttle, DOM_EVENT, addEventListeners, addEventListener } from '@datadog/browser-core'
-import { INode, SlimDOMOptions } from '../rrweb-snapshot'
+import { INode } from '../rrweb-snapshot'
 import { nodeOrAncestorsShouldBeHidden, nodeOrAncestorsShouldHaveInputIgnored } from '../privacy'
 import { MutationObserverWrapper, MutationController } from './mutation'
 import {
@@ -24,12 +24,8 @@ import { forEach, getWindowHeight, getWindowWidth, hookSetter, isTouchEvent, mir
 const MOUSE_MOVE_OBSERVER_THRESHOLD = 50
 const SCROLL_OBSERVER_THRESHOLD = 100
 
-function initMutationObserver(
-  mutationController: MutationController,
-  cb: MutationCallBack,
-  slimDOMOptions: SlimDOMOptions
-) {
-  const mutationObserverWrapper = new MutationObserverWrapper(mutationController, cb, slimDOMOptions)
+function initMutationObserver(mutationController: MutationController, cb: MutationCallBack) {
+  const mutationObserverWrapper = new MutationObserverWrapper(mutationController, cb)
   return () => mutationObserverWrapper.stop()
 }
 
@@ -271,7 +267,7 @@ function initMediaInteractionObserver(mediaInteractionCb: MediaInteractionCallba
 }
 
 export function initObservers(o: ObserverParam): ListenerHandler {
-  const mutationHandler = initMutationObserver(o.mutationController, o.mutationCb, o.slimDOMOptions)
+  const mutationHandler = initMutationObserver(o.mutationController, o.mutationCb)
   const mousemoveHandler = initMoveObserver(o.mousemoveCb)
   const mouseInteractionHandler = initMouseInteractionObserver(o.mouseInteractionCb)
   const scrollHandler = initScrollObserver(o.scrollCb)

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -1,5 +1,5 @@
 import { runOnReadyState } from '@datadog/browser-core'
-import { SlimDOMOptions, snapshot } from '../rrweb-snapshot'
+import { snapshot } from '../rrweb-snapshot'
 import { RawRecord, RecordType } from '../../types'
 import { initObservers } from './observer'
 import { IncrementalSource, ListenerHandler, RecordAPI, RecordOptions } from './types'
@@ -9,31 +9,11 @@ import { MutationController } from './mutation'
 let wrappedEmit!: (record: RawRecord, isCheckout?: boolean) => void
 
 export function record(options: RecordOptions = {}): RecordAPI {
-  const { emit, slimDOMOptions: slimDOMOptionsArg } = options
+  const { emit } = options
   // runtime checks for user options
   if (!emit) {
     throw new Error('emit function is required')
   }
-
-  const slimDOMOptions: SlimDOMOptions =
-    slimDOMOptionsArg === true || slimDOMOptionsArg === 'all'
-      ? {
-          comment: true,
-          headFavicon: true,
-          // the following are off for slimDOMOptions === true,
-          // as they destroy some (hidden) info:
-          headMetaAuthorship: slimDOMOptionsArg === 'all',
-          headMetaDescKeywords: slimDOMOptionsArg === 'all',
-          headMetaHttpEquiv: true,
-          headMetaRobots: true,
-          headMetaSocial: true,
-          headMetaVerification: true,
-          headWhitespace: true,
-          script: true,
-        }
-      : slimDOMOptionsArg
-      ? slimDOMOptionsArg
-      : {}
 
   const mutationController = new MutationController()
 
@@ -67,9 +47,7 @@ export function record(options: RecordOptions = {}): RecordAPI {
       isCheckout
     )
 
-    const [node, idNodeMap] = snapshot(document, {
-      slimDOM: slimDOMOptions,
-    })
+    const [node, idNodeMap] = snapshot(document)
 
     if (!node) {
       return console.warn('Failed to snapshot the document')
@@ -110,7 +88,6 @@ export function record(options: RecordOptions = {}): RecordAPI {
     handlers.push(
       initObservers({
         mutationController,
-        slimDOMOptions,
         inputCb: (v) =>
           wrappedEmit({
             data: {

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -1,4 +1,4 @@
-import { IdNodeMap, INode, SerializedNodeWithId, SlimDOMOptions } from '../rrweb-snapshot/types'
+import { IdNodeMap, INode, SerializedNodeWithId } from '../rrweb-snapshot/types'
 import type { RawRecord } from '../../types'
 import { MutationController } from './mutation'
 
@@ -62,7 +62,6 @@ export type IncrementalData =
 
 export interface RecordOptions {
   emit?: (record: RawRecord, isCheckout?: boolean) => void
-  slimDOMOptions?: SlimDOMOptions | 'all' | true
 }
 
 export interface RecordAPI {
@@ -80,7 +79,6 @@ export interface ObserverParam {
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
   styleSheetRuleCb: StyleSheetRuleCallback
-  slimDOMOptions: SlimDOMOptions
 }
 
 // https://dom.spec.whatwg.org/#interface-mutationrecord

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -69,8 +69,7 @@ export function isIgnored(n: Node | INode): boolean {
   if ('__sn' in n) {
     return n.__sn.id === IGNORED_NODE // eslint-disable-line no-underscore-dangle
   }
-  // The main part of the slimDOM check happens in
-  // rrweb-snapshot::serializeNodeWithId
+  // The ignored DOM logic happens in rrweb-snapshot::serializeNodeWithId
   return false
 }
 


### PR DESCRIPTION
## Motivation

A bit less code (removed option) and lighter snapshots ("slim DOM" option always enabled)

## Changes

* Remove the "slim DOM" option
* Always apply all "slim DOM" strategies
* Add some unit testings

## Testing

Unit, manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
