### PR TITLE
⚗ performance impact summary tool

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
       './test/app/tsconfig.json',
       './test/e2e/tsconfig.json',
       './developer-extension/tsconfig.json',
+      './performances/tsconfig.json',
     ],
     sourceType: 'module',
   },

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -60,6 +60,7 @@ dev,lerna,MIT,Copyright 2015-present Lerna Contributors
 dev,npm-run-all,MIT,Copyright 2015 Toru Nagashima
 dev,pako,MIT,(C) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
 dev,prettier,MIT,Copyright James Long and contributors
+dev,puppeteer,Apache-2.0,Copyright 2017 Google Inc.
 dev,replace-in-file,MIT,Copyright 2015-2019 Adam Reis
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen
 dev,string-replace-loader,MIT,Copyright 2015 Valentyn Barmashyn

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "workspaces": [
     "packages/*",
-    "developer-extension"
+    "developer-extension",
+    "performances"
   ],
   "scripts": {
     "postinstall": "scripts/cli update_submodule",

--- a/performances/README.md
+++ b/performances/README.md
@@ -1,0 +1,5 @@
+# Browser SDK performances impact estimation tool
+
+This tool will run various scenarios in a browser and profile the impact of the Browser SDK.
+
+Use `yarn start` to execute it.

--- a/performances/README.md
+++ b/performances/README.md
@@ -1,5 +1,5 @@
 # Browser SDK performances impact estimation tool
 
-This tool will run various scenarios in a browser and profile the impact of the Browser SDK.
+This tool runs various scenarios in a browser and profile the impact of the Browser SDK.
 
 Use `yarn start` to execute it.

--- a/performances/package.json
+++ b/performances/package.json
@@ -2,6 +2,9 @@
   "private": true,
   "name": "performances",
   "version": "0.0.0",
+  "scripts": {
+    "start": "ts-node ./src/main.ts"
+  },
   "dependencies": {
     "puppeteer": "8.0.0"
   }

--- a/performances/package.json
+++ b/performances/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "performances",
+  "version": "0.0.0",
+  "dependencies": {
+    "puppeteer": "8.0.0"
+  }
+}

--- a/performances/src/format.ts
+++ b/performances/src/format.ts
@@ -1,0 +1,18 @@
+import { ProfilingResult, ProfilingResults } from './types'
+
+export function formatProfilingResults(results: ProfilingResults) {
+  return `\
+Memory (median): ${formatNumber(results.memory.sdk)} bytes ${formatPercent(results.memory)}
+CPU: ${formatNumber(results.cpu.sdk)} microseconds ${formatPercent(results.cpu)}
+Bandwidth:
+  upload: ${formatNumber(results.upload.sdk)} bytes
+  download: ${formatNumber(results.download.sdk)} bytes`
+}
+
+function formatNumber(n: number) {
+  return new Intl.NumberFormat('en-US').format(n)
+}
+
+function formatPercent({ total, sdk }: ProfilingResult) {
+  return `(${formatNumber((sdk / total) * 100)}%)`
+}

--- a/performances/src/format.ts
+++ b/performances/src/format.ts
@@ -1,18 +1,33 @@
 import { ProfilingResult, ProfilingResults } from './types'
 
+const DURATION_UNITS = ['μs', 'ms', 's']
+
+const BYTES_UNITS = ['B', 'kB', 'MB']
+
 export function formatProfilingResults(results: ProfilingResults) {
   return `\
-Memory (median): ${formatNumber(results.memory.sdk)} bytes ${formatPercent(results.memory)}
-CPU: ${formatNumber(results.cpu.sdk)} microseconds ${formatPercent(results.cpu)}
+Memory (median): ${formatNumberWithUnit(results.memory.sdk, BYTES_UNITS)} ${formatPercent(results.memory)}
+CPU: ${formatNumberWithUnit(results.cpu.sdk, DURATION_UNITS)} ${formatPercent(results.cpu)}
 Bandwidth:
-  upload: ${formatNumber(results.upload.sdk)} bytes
-  download: ${formatNumber(results.download.sdk)} bytes`
+  upload: ${formatNumberWithUnit(results.upload.sdk, BYTES_UNITS)}
+  download: ${formatNumberWithUnit(results.download.sdk, BYTES_UNITS)}`
 }
 
-function formatNumber(n: number) {
-  return new Intl.NumberFormat('en-US').format(n)
+function formatNumberWithUnit(n: number, units: string[]) {
+  let unit: string
+  for (unit of units) {
+    if (n < 1000) {
+      break
+    }
+    n /= 1000
+  }
+  return `${formatNumber(n)} ${unit!}`
 }
 
 function formatPercent({ total, sdk }: ProfilingResult) {
   return `(${formatNumber((sdk / total) * 100)}%)`
+}
+
+function formatNumber(n: number) {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: n < 10 ? 2 : n < 100 ? 1 : 0 }).format(n)
 }

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -58,10 +58,20 @@ async function profileScenario(
 async function runWikipediaScenario(page: Page, takeMeasurements: () => Promise<void>) {
   await page.goto('https://en.wikipedia.org/wiki/Event_monitoring')
   await takeMeasurements()
+
   await page.goto('https://en.wikipedia.org/wiki/Datadog')
   await takeMeasurements()
+
+  await page.type('[type="search"]', 'median', {
+    // large delay to trigger the autocomplete menu at each key press
+    delay: 400,
+  })
+  await Promise.all([page.waitForNavigation(), page.keyboard.press('Enter')])
+  await takeMeasurements()
+
   await page.goto('https://en.wikipedia.org/wiki/Ubuntu')
   await takeMeasurements()
+
   await page.goto('about:blank')
 }
 

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -5,7 +5,10 @@ import { startProfiling } from './profiling'
 import { trackNetwork } from './trackNetwork'
 import { ProfilingResults, ProfilingOptions } from './types'
 
-main().catch(console.error)
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})
 
 async function main() {
   const options: ProfilingOptions = {

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -9,18 +9,21 @@ async function main() {
   try {
     const page = await browser.newPage()
     await setupSDK(page)
-    const stopProfiling = await startProfiling(page)
-    await runScenario(page)
+    const { stopProfiling, takeMeasurements } = await startProfiling(page)
+    await runScenario(page, takeMeasurements)
     await stopProfiling()
   } finally {
     await browser.close()
   }
 }
 
-async function runScenario(page: Page) {
-  await page.goto('https://en.wikipedia.org/wiki/Ubuntu')
-  await page.goto('https://en.wikipedia.org/wiki/Datadog')
+async function runScenario(page: Page, takeMeasurements: () => Promise<void>) {
   await page.goto('https://en.wikipedia.org/wiki/Event_monitoring')
+  await takeMeasurements()
+  await page.goto('https://en.wikipedia.org/wiki/Datadog')
+  await takeMeasurements()
+  await page.goto('https://en.wikipedia.org/wiki/Ubuntu')
+  await takeMeasurements()
   await page.goto('about:blank')
 }
 

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -17,17 +17,31 @@ async function main() {
   }
 
   const wikipediaResults = await profileScenario(options, runWikipediaScenario)
-
-  console.log('# Wikipedia:')
-  console.log()
-  console.log(formatProfilingResults(wikipediaResults))
-  console.log()
-
   const twitterResults = await profileScenario(options, runTwitterScenario)
 
-  console.log('# Twitter:')
-  console.log()
-  console.log(formatProfilingResults(twitterResults))
+  console.log(`
+# Wikipedia
+
+Illustrates a mostly static site scenario.
+
+* Navigate on three Wikipedia articles
+* Do a search (with dynamic autocompletion) and go to the first result
+
+${formatProfilingResults(wikipediaResults)}
+
+
+# Twitter
+
+Illustrates a SPA scenario.
+
+* Navigate to the top trending topics
+* Click on the first trending topic
+* Click on Top, Latest, People, Photos and Videos tabs
+* Navigate to the Settings page
+* Click on a few checkboxes
+
+${formatProfilingResults(twitterResults)}
+`)
 }
 
 async function profileScenario(

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -1,0 +1,39 @@
+import puppeteer, { Page } from 'puppeteer'
+
+import { startProfiling } from './profiling'
+
+main().catch(console.error)
+
+async function main() {
+  const browser = await puppeteer.launch({ defaultViewport: { width: 1366, height: 768 }, headless: true })
+  try {
+    const page = await browser.newPage()
+    await setupSDK(page)
+    const stopProfiling = await startProfiling(page)
+    await runScenario(page)
+    await stopProfiling()
+  } finally {
+    await browser.close()
+  }
+}
+
+async function runScenario(page: Page) {
+  await page.goto('https://en.wikipedia.org/wiki/Ubuntu')
+  await page.goto('https://en.wikipedia.org/wiki/Datadog')
+  await page.goto('https://en.wikipedia.org/wiki/Event_monitoring')
+  await page.goto('about:blank')
+}
+
+async function setupSDK(page: Page) {
+  await page.evaluateOnNewDocument(`
+    import('https://www.datadoghq-browser-agent.com/datadog-rum.js')
+      .then(() => {
+        window.DD_RUM.init({
+          clientToken: 'xxx',
+          applicationId: 'xxx',
+          site: 'localhost',
+          trackInteractions: true,
+        })
+      })
+  `)
+}

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -1,23 +1,35 @@
 import puppeteer, { Page } from 'puppeteer'
 
+import { formatProfilingResults } from './format'
 import { startProfiling } from './profiling'
+import { ProfilingResults } from './types'
 
 main().catch(console.error)
 
 async function main() {
+  const wikipediaResults = await profileScenario(runWikipediaScenario)
+
+  console.log('# Wikipedia:')
+  console.log()
+  console.log(formatProfilingResults(wikipediaResults))
+}
+
+async function profileScenario(runScenario: (page: Page, takeMeasurements: () => Promise<void>) => Promise<void>) {
   const browser = await puppeteer.launch({ defaultViewport: { width: 1366, height: 768 }, headless: true })
+  let result: ProfilingResults
   try {
     const page = await browser.newPage()
     await setupSDK(page)
     const { stopProfiling, takeMeasurements } = await startProfiling(page)
     await runScenario(page, takeMeasurements)
-    await stopProfiling()
+    result = await stopProfiling()
   } finally {
     await browser.close()
   }
+  return result
 }
 
-async function runScenario(page: Page, takeMeasurements: () => Promise<void>) {
+async function runWikipediaScenario(page: Page, takeMeasurements: () => Promise<void>) {
   await page.goto('https://en.wikipedia.org/wiki/Event_monitoring')
   await takeMeasurements()
   await page.goto('https://en.wikipedia.org/wiki/Datadog')
@@ -28,6 +40,7 @@ async function runScenario(page: Page, takeMeasurements: () => Promise<void>) {
 }
 
 async function setupSDK(page: Page) {
+  await page.setBypassCSP(true)
   await page.evaluateOnNewDocument(`
     if (location.href !== 'about:blank') {
       import('https://www.datadoghq-browser-agent.com/datadog-rum.js')

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -10,6 +10,7 @@ main().catch(console.error)
 async function main() {
   const options: ProfilingOptions = {
     bundleUrl: 'https://www.datadoghq-browser-agent.com/datadog-rum.js',
+    proxyHost: 'datadog-browser-sdk-profiling-proxy',
   }
 
   const wikipediaResults = await profileScenario(options, runWikipediaScenario)
@@ -105,8 +106,9 @@ async function setupSDK(page: Page, options: ProfilingOptions) {
           window.DD_RUM.init({
             clientToken: 'xxx',
             applicationId: 'xxx',
-            site: 'localhost',
+            site: 'datadoghq.com',
             trackInteractions: true,
+            proxyHost: ${JSON.stringify(options.proxyHost)}
           })
         })
     }

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -26,14 +26,16 @@ async function runScenario(page: Page) {
 
 async function setupSDK(page: Page) {
   await page.evaluateOnNewDocument(`
-    import('https://www.datadoghq-browser-agent.com/datadog-rum.js')
-      .then(() => {
-        window.DD_RUM.init({
-          clientToken: 'xxx',
-          applicationId: 'xxx',
-          site: 'localhost',
-          trackInteractions: true,
+    if (location.href !== 'about:blank') {
+      import('https://www.datadoghq-browser-agent.com/datadog-rum.js')
+        .then(() => {
+          window.DD_RUM.init({
+            clientToken: 'xxx',
+            applicationId: 'xxx',
+            site: 'localhost',
+            trackInteractions: true,
+          })
         })
-      })
+    }
   `)
 }

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -39,6 +39,9 @@ async function profileScenario(
   let result: ProfilingResults
   try {
     const page = await browser.newPage()
+    await page.setExtraHTTPHeaders({
+      'Accept-Language': 'en-US',
+    })
     await setupSDK(page, options)
     const { stopProfiling, takeMeasurements } = await startProfiling(options, page)
     await runScenario(page, takeMeasurements)

--- a/performances/src/profiling.ts
+++ b/performances/src/profiling.ts
@@ -98,10 +98,10 @@ async function startNetworkProfiling(options: ProfilingOptions, client: CDPSessi
 
   const sdkRequestIds = new Set<string>()
 
-  const requestListener = ({ initiator, request, requestId }: Protocol.Network.RequestWillBeSentEvent) => {
+  const requestListener = ({ request, requestId }: Protocol.Network.RequestWillBeSentEvent) => {
     const size = getRequestApproximateSize(request)
     totalUpload += size
-    if (isSdkUrl(options, request.url) || (initiator.stack && isSdkUrl(options, initiator.stack.callFrames[0].url))) {
+    if (isSdkUrl(options, request.url)) {
       sdkUpload += size
       sdkRequestIds.add(requestId)
     }
@@ -128,7 +128,7 @@ async function startNetworkProfiling(options: ProfilingOptions, client: CDPSessi
 }
 
 function isSdkUrl(options: ProfilingOptions, url: string) {
-  return url === options.bundleUrl
+  return url === options.bundleUrl || url.startsWith(`https://${options.proxyHost}/`)
 }
 
 function* iterNodes<N extends { children?: N[] }>(root: N): Generator<N> {

--- a/performances/src/profiling.ts
+++ b/performances/src/profiling.ts
@@ -1,0 +1,114 @@
+import { CDPSession, Page, Protocol } from 'puppeteer'
+
+export async function startProfiling(page: Page) {
+  const client = await page.target().createCDPSession()
+  const stopCPUProfiling = await startCPUProfiling(client)
+  const stopMemoryProfiling = await startMemoryProfiling(client)
+  const stopNetworkProfiling = await startNetworkProfiling(client)
+
+  return async () => {
+    await stopCPUProfiling()
+    await stopMemoryProfiling()
+    stopNetworkProfiling()
+  }
+}
+
+async function startCPUProfiling(client: CDPSession) {
+  await client.send('Profiler.enable')
+  await client.send('Profiler.start')
+
+  return async () => {
+    const { profile } = await client.send('Profiler.stop')
+
+    const timeDeltaForNodeId = new Map<number, number>()
+
+    for (let index = 0; index < profile.samples!.length; index += 1) {
+      const nodeId = profile.samples![index]
+      timeDeltaForNodeId.set(nodeId, (timeDeltaForNodeId.get(nodeId) || 0) + profile.timeDeltas![index])
+    }
+
+    let total = 0
+    for (const node of profile.nodes) {
+      if (isSDKCallFrame(node.callFrame)) {
+        total += timeDeltaForNodeId.get(node.id) || 0
+      }
+    }
+
+    console.log(`CPU: ${total} microseconds`)
+  }
+}
+
+async function startMemoryProfiling(client: CDPSession) {
+  await client.send('HeapProfiler.enable')
+  await client.send('HeapProfiler.startSampling', {
+    // Set a low sampling interval to have more precise measurement
+    samplingInterval: 1000,
+  })
+
+  return async () => {
+    await client.send('HeapProfiler.collectGarbage')
+    const { profile } = await client.send('HeapProfiler.stopSampling')
+
+    const sizeForNodeId = new Map<number, number>()
+
+    for (const sample of profile.samples) {
+      sizeForNodeId.set(sample.nodeId, (sizeForNodeId.get(sample.nodeId) || 0) + sample.size)
+    }
+
+    let total = 0
+    for (const node of iterNodes(profile.head)) {
+      if (isSDKCallFrame(node.callFrame)) {
+        total += sizeForNodeId.get(node.id) || 0
+      }
+    }
+
+    console.log(`Memory: ${total} bytes`)
+  }
+}
+
+async function startNetworkProfiling(client: CDPSession) {
+  await client.send('Network.enable')
+  let total = 0
+  const requestListener = (info: Protocol.Network.RequestWillBeSentEvent) => {
+    if (info.initiator.stack && isSDKCallFrame(info.initiator.stack.callFrames[0])) {
+      total += getRequestApproximateSize(info.request)
+    }
+  }
+  client.on('Network.requestWillBeSent', requestListener)
+  return () => {
+    client.off('Network.requestWillBeSent', requestListener)
+
+    console.log(`Bandwidth: ${total} bytes`)
+  }
+}
+
+function isSDKCallFrame(callFrame: Protocol.Runtime.CallFrame) {
+  return callFrame.url.startsWith('https://www.datadoghq-browser-agent.com/')
+}
+
+function* iterNodes<N extends { children?: N[] }>(root: N): Generator<N> {
+  yield root
+  if (root.children) {
+    for (const child of root.children) {
+      yield* iterNodes(child)
+    }
+  }
+}
+
+function getRequestApproximateSize(request: Protocol.Network.Request) {
+  let bodySize = 0
+  if (request.postDataEntries) {
+    for (const { bytes } of request.postDataEntries) {
+      if (bytes) {
+        bodySize += Buffer.from(bytes, 'base64').byteLength
+      }
+    }
+  }
+
+  let headerSize = 0
+  for (const [name, value] of Object.entries(request.headers)) {
+    headerSize += name.length + value.length
+  }
+
+  return bodySize + headerSize
+}

--- a/performances/src/profiling.ts
+++ b/performances/src/profiling.ts
@@ -8,9 +8,7 @@ export async function startProfiling(options: ProfilingOptions, page: Page) {
   const stopNetworkProfiling = await startNetworkProfiling(options, client)
 
   return {
-    takeMeasurements: async () => {
-      await takeMemoryMeasurements()
-    },
+    takeMeasurements: takeMemoryMeasurements,
     stopProfiling: async (): Promise<ProfilingResults> => ({
       memory: await stopMemoryProfiling(),
       cpu: await stopCPUProfiling(),

--- a/performances/src/trackNetwork.ts
+++ b/performances/src/trackNetwork.ts
@@ -1,0 +1,40 @@
+import { HTTPRequest, Page } from 'puppeteer'
+
+export function trackNetwork(page: Page) {
+  const pendingRequests = new Set<HTTPRequest>()
+
+  page.on('request', (request) => {
+    pendingRequests.add(request)
+  })
+  page.on('requestfailed', (request) => {
+    pendingRequests.delete(request)
+  })
+  page.on('requestfinished', (request) => {
+    pendingRequests.delete(request)
+  })
+
+  return {
+    waitForNetworkIdle: async () =>
+      new Promise<void>((resolve) => {
+        let timeoutId: NodeJS.Timeout
+
+        wake()
+
+        page.on('request', wake)
+        page.on('requestfinished', wake)
+        page.on('requestfailed', wake)
+
+        function wake() {
+          clearTimeout(timeoutId)
+          if (pendingRequests.size === 0) {
+            timeoutId = setTimeout(() => {
+              page.off('request', wake)
+              page.off('requestfinished', wake)
+              page.off('requestfailed', wake)
+              resolve()
+            }, 200)
+          }
+        }
+      }),
+  }
+}

--- a/performances/src/types.ts
+++ b/performances/src/types.ts
@@ -1,3 +1,7 @@
+export interface ProfilingOptions {
+  bundleUrl: string
+}
+
 export interface ProfilingResults {
   memory: ProfilingResult
   cpu: ProfilingResult

--- a/performances/src/types.ts
+++ b/performances/src/types.ts
@@ -1,0 +1,11 @@
+export interface ProfilingResults {
+  memory: ProfilingResult
+  cpu: ProfilingResult
+  download: ProfilingResult
+  upload: ProfilingResult
+}
+
+export interface ProfilingResult {
+  sdk: number
+  total: number
+}

--- a/performances/src/types.ts
+++ b/performances/src/types.ts
@@ -1,5 +1,6 @@
 export interface ProfilingOptions {
   bundleUrl: string
+  proxyHost: string
 }
 
 export interface ProfilingResults {

--- a/performances/tsconfig.json
+++ b/performances/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es6",
+    "lib": ["ES2019"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4180,6 +4180,11 @@ detect-libc@^1.0.2, detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+devtools-protocol@0.0.854822:
+  version "0.0.854822"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.854822.tgz#eac3a5260a6b3b4e729a09fdc0c77b0d322e777b"
+  integrity sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg==
+
 devtools@6.1.3:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/devtools/-/devtools-6.1.3.tgz#8f1791031523f52154ab8f61c9731872e33d6a77"
@@ -6102,6 +6107,14 @@ https-proxy-agent@^4.0.0:
   integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
   dependencies:
     agent-base "5"
+    debug "4"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
     debug "4"
 
 humanize-ms@^1.2.1:
@@ -8076,7 +8089,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -8878,7 +8891,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.1.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -8999,7 +9012,7 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -9091,6 +9104,24 @@ puppeteer-core@^3.0.0:
     mime-types "^2.1.25"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"
+    rimraf "^3.0.2"
+    tar-fs "^2.0.0"
+    unbzip2-stream "^1.3.3"
+    ws "^7.2.3"
+
+puppeteer@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-8.0.0.tgz#a236669118aa795331c2d0ca19877159e7664705"
+  integrity sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==
+  dependencies:
+    debug "^4.1.0"
+    devtools-protocol "0.0.854822"
+    extract-zip "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.1"
+    pkg-dir "^4.2.0"
+    progress "^2.0.1"
+    proxy-from-env "^1.1.0"
     rimraf "^3.0.2"
     tar-fs "^2.0.0"
     unbzip2-stream "^1.3.3"


### PR DESCRIPTION
## Motivation

Evaluate the Browser SDK performance impact on a given scenario

## Changes

Implement a tool to run various profilings with puppeteer. You can try it with:


## Testing


```
git checkout benoit/performance-doc
yarn
cd performances
yarn start
```

Example output:

```
# Wikipedia

Illustrates a mostly static site scenario.

* Navigate on three Wikipedia articles
* Do a search (with dynamic autocompletion) and go the first result

Memory (median): 294 kB (4.83%)
CPU: 258 ms (4.24%)
Bandwidth:
  upload: 116 kB
  download: 20.5 kB


# Twitter

Illustrates a SPA scenario.

* Navigate to the top trending topics
* Click on the first trending topic
* Click on Top, Latest, People, Photos and Videos tabs
* Navigate to the Settings page
* Click on a few checkboxes

Memory (median): 225 kB (0.51%)
CPU: 391 ms (1.01%)
Bandwidth:
  upload: 186 kB
  download: 20.5 kB
```

From my observations, results are quite stable in general.



---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
