### PR TITLE
🐛 [RUMF-855] discard negative first-input delays

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
@@ -222,4 +222,17 @@ describe('firstInputTimings', () => {
 
     expect(fitCallback).not.toHaveBeenCalled()
   })
+
+  it('should not be present if the first-input performance entry is invalid', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
+      entryType: 'first-input' as const,
+      // Invalid, because processingStart should be >= startTime
+      processingStart: 900 as RelativeTime,
+      startTime: 1000 as RelativeTime,
+    })
+
+    expect(fitCallback).not.toHaveBeenCalled()
+  })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
@@ -137,7 +137,13 @@ export function trackFirstInputTimings(
   const firstHidden = trackFirstHidden()
 
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
-    if (entry.entryType === 'first-input' && entry.startTime < firstHidden.timeStamp) {
+    if (
+      entry.entryType === 'first-input' &&
+      entry.startTime < firstHidden.timeStamp &&
+      // Discard invalid first-input entries, see
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1185815
+      entry.startTime <= entry.processingStart
+    ) {
       callback({
         firstInputDelay: elapsed(entry.startTime, entry.processingStart),
         firstInputTime: entry.startTime as Duration,


### PR DESCRIPTION
## Motivation

Sometimes, in Chrome Browser on Chrome OS or obscur browsers like [Puffin](https://www.puffin.com/), the first input delay timing is negative. Discard those invalid timings, since they are likely not representing a real value. 

The issue have been reported to the [chromium tracker](https://bugs.chromium.org/p/chromium/issues/detail?id=1185815)

## Changes

Discard negative FID values

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
