### PR TITLE
🔊 [RUMF-855] add negative FID monitoring

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -1,6 +1,7 @@
 import {
   addEventListeners,
   Configuration,
+  Context,
   DOM_EVENT,
   Duration,
   getRelativeTime,
@@ -67,6 +68,8 @@ export interface RumFirstInputTiming {
   entryType: 'first-input'
   startTime: RelativeTime
   processingStart: RelativeTime
+  name: string
+  toJSON?: () => Context
 }
 
 export interface RumLayoutShiftTiming {
@@ -206,6 +209,7 @@ function retrieveFirstInputTiming(callback: (timing: RumFirstInputTiming) => voi
         entryType: 'first-input',
         processingStart: relativeNow(),
         startTime: evt.timeStamp as RelativeTime,
+        name: `emulated ${evt.type}`,
       }
 
       if (evt.type === DOM_EVENT.POINTER_DOWN) {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
@@ -47,6 +47,7 @@ const FAKE_FIRST_INPUT_ENTRY: RumFirstInputTiming = {
   entryType: 'first-input',
   processingStart: 1100 as RelativeTime,
   startTime: 1000 as RelativeTime,
+  name: 'fake',
 }
 
 describe('trackTimings', () => {
@@ -231,6 +232,7 @@ describe('firstInputTimings', () => {
       // Invalid, because processingStart should be >= startTime
       processingStart: 900 as RelativeTime,
       startTime: 1000 as RelativeTime,
+      name: 'fake',
     })
 
     expect(fitCallback).not.toHaveBeenCalled()

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
@@ -156,6 +156,7 @@ export function trackFirstInputTimings(
       } else if (entry.toJSON) {
         addMonitoringMessage(`Negative FID for entry ${entry.name}`, {
           entry: { ...entry.toJSON(), target: undefined },
+          fid: entry.processingStart - entry.startTime,
         })
       }
     }


### PR DESCRIPTION
## Motivation

Help debug the negative FID, see comment 1 in https://bugs.chromium.org/p/chromium/issues/detail?id=1185815#c1

## Changes

Add internal monitoring log when the FID is negative

## Testing

Manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
