### PR TITLE
[RUMF-862] fix export MediaInteractions enum

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -231,5 +231,11 @@ module.exports = {
         'local-rules/disallow-side-effects': 'error',
       },
     },
+    {
+      files: ['packages/{rum,logs,rum-recorder}/src/index.ts', 'packages/rum-recorder/src/internal.ts'],
+      rules: {
+        'local-rules/disallow-const-enum-exports': 'error',
+      },
+    },
   ],
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -234,7 +234,7 @@ module.exports = {
     {
       files: ['packages/{rum,logs,rum-recorder}/src/index.ts', 'packages/rum-recorder/src/internal.ts'],
       rules: {
-        'local-rules/disallow-const-enum-exports': 'error',
+        'local-rules/disallow-enum-exports': 'error',
       },
     },
   ],

--- a/eslint-local-rules/disallowConstEnumExports.js
+++ b/eslint-local-rules/disallowConstEnumExports.js
@@ -1,0 +1,67 @@
+const { SymbolFlags } = require('typescript')
+
+/**
+ * This rule forbids exporting 'const enums'.
+ *
+ * 'const enums' are useful in TS to optimize the generated code, but they don't produce any JS code
+ * on their own[0].  So, exporting them in public packages entry points should be avoided, because
+ * we don't know how public packages are used: it could be used by other builders like babel which
+ * don't have access to the type definition, so won't be able to access the enum value.
+ *
+ * Exporting 'const enums' from internal modules to be consumed by internal modules is fine, because
+ * we know that everything will be handled by TypeScript.
+ *
+ * So, this rule should not be applied on all the source code, but only on entry points that will be
+ * used in the wild.
+ *
+ * In the future, this rule could be removed and the 'isolatedModules' TS option[1] could be used
+ * instead. This way, TS output 'const enum' the same way it does for standard 'enum'. But this
+ * option adds a few more requirements, like exporting type with `export type` statements, which is
+ * not possible before TS 3.8[2]. Since we support all TS 3.x versions, it is not currently possible
+ * to enable this option.
+ *
+ * [0]: https://github.com/microsoft/TypeScript/issues/16671
+ * [1]: https://www.typescriptlang.org/tsconfig#isolatedModules
+ * [2]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
+ */
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow export of const enums.',
+      recommended: false,
+    },
+    schema: [],
+  },
+  create(context) {
+    const parserServices = context.parserServices
+    const checker = parserServices.program.getTypeChecker()
+
+    return {
+      ExportNamedDeclaration(node) {
+        for (const specifier of node.specifiers) {
+          const originalNode = parserServices.esTreeNodeToTSNodeMap.get(specifier)
+          const type = checker.getTypeAtLocation(originalNode)
+          if (type.symbol && isConstEnum(type.symbol)) {
+            context.report(specifier, 'Cannot export const enum')
+          }
+        }
+      },
+      ExportAllDeclaration(node) {
+        const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node)
+        const moduleSymbol = checker.getSymbolAtLocation(originalNode.moduleSpecifier)
+        const moduleExports = checker.getExportsOfModule(moduleSymbol)
+
+        for (const symbol of moduleExports) {
+          if (isConstEnum(symbol)) {
+            context.report(node, `Cannot export const enum ${symbol.getName()}`)
+          }
+        }
+      },
+    }
+  },
+}
+
+function isConstEnum(symbol) {
+  // eslint-disable-next-line no-bitwise
+  return symbol.getFlags() & SymbolFlags.ConstEnum
+}

--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -1,39 +1,28 @@
-/* eslint-disable unicorn/filename-case */
 const path = require('path')
 
-// Declare the local rules used by the Browser SDK
-//
-// See https://eslint.org/docs/developer-guide/working-with-rules for documentation on how to write
-// rules.
-//
-// You can use https://astexplorer.net/ to explore the parsed data structure of a code snippet.
-// Choose '@typescript-eslint/parser' as a parser to have the exact same structure as our ESLint
-// parser.
 module.exports = {
-  'disallow-side-effects': {
-    meta: {
-      docs: {
-        description:
-          'Disallow potential side effects when evaluating modules, to ensure modules content are tree-shakable.',
-        recommended: false,
+  meta: {
+    docs: {
+      description:
+        'Disallow potential side effects when evaluating modules, to ensure modules content are tree-shakable.',
+      recommended: false,
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.getFilename()
+    if (pathsWithSideEffect.has(filename)) {
+      return {}
+    }
+    return {
+      Program(node) {
+        reportPotentialSideEffect(context, node)
       },
-      schema: [],
-    },
-    create(context) {
-      const filename = context.getFilename()
-      if (pathsWithSideEffect.has(filename)) {
-        return {}
-      }
-      return {
-        Program(node) {
-          reportPotentialSideEffect(context, node)
-        },
-      }
-    },
+    }
   },
 }
 
-const packagesRoot = `${__dirname}/packages`
+const packagesRoot = path.resolve(__dirname, '..', 'packages')
 
 // Those modules are known to have side effects when evaluated
 const pathsWithSideEffect = new Set([

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -8,5 +8,5 @@
 // parser.
 module.exports = {
   'disallow-side-effects': require('./disallowSideEffects'),
-  'disallow-const-enum-exports': require('./disallowConstEnumExports'),
+  'disallow-enum-exports': require('./disallowEnumExports'),
 }

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -1,0 +1,11 @@
+// Declare the local rules used by the Browser SDK
+//
+// See https://eslint.org/docs/developer-guide/working-with-rules for documentation on how to write
+// rules.
+//
+// You can use https://astexplorer.net/ to explore the parsed data structure of a code snippet.
+// Choose '@typescript-eslint/parser' as a parser to have the exact same structure as our ESLint
+// parser.
+module.exports = {
+  'disallow-side-effects': require('./disallowSideEffects'),
+}

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -8,4 +8,5 @@
 // parser.
 module.exports = {
   'disallow-side-effects': require('./disallowSideEffects'),
+  'disallow-const-enum-exports': require('./disallowConstEnumExports'),
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jasmine": "4.1.2",
     "eslint-plugin-jsdoc": "32.0.0",
-    "eslint-plugin-local-rules": "1.0.1",
+    "eslint-plugin-local-rules": "1.1.0",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-unicorn": "28.0.0",
     "express": "4.17.1",

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -147,17 +147,19 @@ export interface MousePosition {
   timeOffset: number
 }
 
-export enum MouseInteractions {
-  MouseUp = 0,
-  MouseDown = 1,
-  Click = 2,
-  ContextMenu = 3,
-  DblClick = 4,
-  Focus = 5,
-  Blur = 6,
-  TouchStart = 7,
-  TouchEnd = 9,
+export const MouseInteractions = {
+  MouseUp: 0 as const,
+  MouseDown: 1 as const,
+  Click: 2 as const,
+  ContextMenu: 3 as const,
+  DblClick: 4 as const,
+  Focus: 5 as const,
+  Blur: 6 as const,
+  TouchStart: 7 as const,
+  TouchEnd: 9 as const,
 }
+
+export type MouseInteractions = typeof MouseInteractions[keyof typeof MouseInteractions]
 
 interface MouseInteractionParam {
   type: MouseInteractions
@@ -207,10 +209,12 @@ export interface InputValue {
 
 export type InputCallback = (v: InputValue & { id: number }) => void
 
-export enum MediaInteractions {
-  Play,
-  Pause,
+export const MediaInteractions = {
+  Play: 0 as const,
+  Pause: 1 as const,
 }
+
+export type MediaInteractions = typeof MediaInteractions[keyof typeof MediaInteractions]
 
 export interface MediaInteractionParam {
   type: MediaInteractions

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -207,7 +207,7 @@ export interface InputValue {
 
 export type InputCallback = (v: InputValue & { id: number }) => void
 
-export const enum MediaInteractions {
+export enum MediaInteractions {
   Play,
   Pause,
 }

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -148,16 +148,16 @@ export interface MousePosition {
 }
 
 export const MouseInteractions = {
-  MouseUp: 0 as const,
-  MouseDown: 1 as const,
-  Click: 2 as const,
-  ContextMenu: 3 as const,
-  DblClick: 4 as const,
-  Focus: 5 as const,
-  Blur: 6 as const,
-  TouchStart: 7 as const,
-  TouchEnd: 9 as const,
-}
+  MouseUp: 0,
+  MouseDown: 1,
+  Click: 2,
+  ContextMenu: 3,
+  DblClick: 4,
+  Focus: 5,
+  Blur: 6,
+  TouchStart: 7,
+  TouchEnd: 9,
+} as const
 
 export type MouseInteractions = typeof MouseInteractions[keyof typeof MouseInteractions]
 
@@ -210,9 +210,9 @@ export interface InputValue {
 export type InputCallback = (v: InputValue & { id: number }) => void
 
 export const MediaInteractions = {
-  Play: 0 as const,
-  Pause: 1 as const,
-}
+  Play: 0,
+  Pause: 1,
+} as const
 
 export type MediaInteractions = typeof MediaInteractions[keyof typeof MediaInteractions]
 

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -37,12 +37,12 @@ export type Record = RawRecord & {
 }
 
 export const RecordType = {
-  FullSnapshot: 2 as const,
-  IncrementalSnapshot: 3 as const,
-  Meta: 4 as const,
-  Focus: 6 as const,
-  ViewEnd: 7 as const,
-}
+  FullSnapshot: 2,
+  IncrementalSnapshot: 3,
+  Meta: 4,
+  Focus: 6,
+  ViewEnd: 7,
+} as const
 
 export type RecordType = typeof RecordType[keyof typeof RecordType]
 

--- a/packages/rum-recorder/src/types.ts
+++ b/packages/rum-recorder/src/types.ts
@@ -36,16 +36,18 @@ export type Record = RawRecord & {
   delay?: number
 }
 
-export enum RecordType {
-  FullSnapshot = 2,
-  IncrementalSnapshot = 3,
-  Meta = 4,
-  Focus = 6,
-  ViewEnd = 7,
+export const RecordType = {
+  FullSnapshot: 2 as const,
+  IncrementalSnapshot: 3 as const,
+  Meta: 4 as const,
+  Focus: 6 as const,
+  ViewEnd: 7 as const,
 }
 
+export type RecordType = typeof RecordType[keyof typeof RecordType]
+
 export interface FullSnapshotRecord {
-  type: RecordType.FullSnapshot
+  type: typeof RecordType.FullSnapshot
   data: {
     node: SerializedNodeWithId
     initialOffset: {
@@ -56,12 +58,12 @@ export interface FullSnapshotRecord {
 }
 
 export interface IncrementalSnapshotRecord {
-  type: RecordType.IncrementalSnapshot
+  type: typeof RecordType.IncrementalSnapshot
   data: IncrementalData
 }
 
 export interface MetaRecord {
-  type: RecordType.Meta
+  type: typeof RecordType.Meta
   data: {
     href: string
     width: number
@@ -70,12 +72,12 @@ export interface MetaRecord {
 }
 
 export interface FocusRecord {
-  type: RecordType.Focus
+  type: typeof RecordType.Focus
   data: {
     has_focus: boolean
   }
 }
 
 export interface ViewEndRecord {
-  type: RecordType.ViewEnd
+  type: typeof RecordType.ViewEnd
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "types": ["jasmine"]
   },
-  "include": ["packages", "scripts", "test", ".eslintrc.js", "eslint-local-rules.js"],
+  "include": ["packages", "scripts", "test", ".eslintrc.js", "eslint-local-rules"],
   "exclude": ["packages/*/cjs", "packages/*/esm", "packages/*/bundle", "test/e2e", "test/app", "developer-extension"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4748,10 +4748,10 @@ eslint-plugin-jsdoc@32.0.0:
     semver "^7.3.4"
     spdx-expression-parse "^3.0.1"
 
-eslint-plugin-local-rules@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.0.1.tgz#1a1f2659ad9297ea82a469d1f5b92b26d90ea3b0"
-  integrity sha512-spxkMBos6/ekNxO7khP2zj0j+tdNIhc3GWjXX397L/5R4ZM5huAIks6ADlZVRyiyUKbo/ABJgH/iP6cu9YYnyg==
+eslint-plugin-local-rules@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.1.0.tgz#5f934f685b08c96eed40b92aee7b02f03cf55f7b"
+  integrity sha512-FdPyzxakUKgZkeNM3x/vvRcB6nCjTNbui5gWALhvcaH1R6aCiD37fWtdesagcyBpEe9S9XRHAJ8CJ4rUJ3K9tQ==
 
 eslint-plugin-prefer-arrow@1.2.3:
   version "1.2.3"


### PR DESCRIPTION
## Motivation

Exporting `const enum` values only works if the user builds their package with TypeScript. Other bundlers don't use type informations, so can't use `const enum` values.

## Changes

* Change `MediaInteractions` to a standard enum
* Add an ESLint rule to avoid this kind of issue in the future

## Testing

Manually

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
