### PR TITLE
⚗ [RUMF-863] rework console error calls containing error instances

### DIFF
--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -58,7 +58,9 @@ describe('console tracker (console-stack disabled)', () => {
 
   it('should format error instance', () => {
     console.error(new TypeError('hello'))
-    expect((notifyError.calls.mostRecent().args[0] as RawError).message).toContain('console error: TypeError: hello')
+    expect((notifyError.calls.mostRecent().args[0] as RawError).message).toMatch(
+      /^console error: TypeError: hello\s+at/
+    )
   })
 })
 
@@ -92,6 +94,7 @@ describe('console tracker (console-stack enabled)', () => {
     expect(notifyError).toHaveBeenCalledWith({
       ...CONSOLE_CONTEXT,
       message: 'console error: foo bar',
+      stack: undefined,
       startTime: jasmine.any(Number),
     })
   })
@@ -101,13 +104,19 @@ describe('console tracker (console-stack enabled)', () => {
     expect(notifyError).toHaveBeenCalledWith({
       ...CONSOLE_CONTEXT,
       message: 'console error: Hello {\n  "foo": "bar"\n}',
+      stack: undefined,
       startTime: jasmine.any(Number),
     })
   })
 
   it('should format error instance', () => {
     console.error(new TypeError('hello'))
-    expect((notifyError.calls.mostRecent().args[0] as RawError).message).toContain('console error: TypeError: hello')
+    expect((notifyError.calls.mostRecent().args[0] as RawError).message).toBe('console error: TypeError: hello')
+  })
+
+  it('should extract stack from first error', () => {
+    console.error(new TypeError('foo'), new TypeError('bar'))
+    expect((notifyError.calls.mostRecent().args[0] as RawError).stack).toMatch(/^TypeError: foo\s+at/)
   })
 })
 

--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -58,9 +58,12 @@ describe('console tracker (console-stack disabled)', () => {
 
   it('should format error instance', () => {
     console.error(new TypeError('hello'))
-    expect((notifyError.calls.mostRecent().args[0] as RawError).message).toMatch(
-      /^console error: TypeError: hello\s+at/
-    )
+    const message = (notifyError.calls.mostRecent().args[0] as RawError).message
+    if (!isIE()) {
+      expect(message).toMatch(/^console error: TypeError: hello\s+at/)
+    } else {
+      expect(message).toContain('console error: TypeError: hello')
+    }
   })
 })
 
@@ -116,7 +119,12 @@ describe('console tracker (console-stack enabled)', () => {
 
   it('should extract stack from first error', () => {
     console.error(new TypeError('foo'), new TypeError('bar'))
-    expect((notifyError.calls.mostRecent().args[0] as RawError).stack).toMatch(/^TypeError: foo\s+at/)
+    const stack = (notifyError.calls.mostRecent().args[0] as RawError).stack
+    if (!isIE()) {
+      expect(stack).toMatch(/^TypeError: foo\s+at/)
+    } else {
+      expect(stack).toContain('TypeError: foo')
+    }
   })
 })
 

--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -58,7 +58,7 @@ export function startConsoleTracking(configuration: Configuration, errorObservab
 
 function buildErrorFromParams(configuration: Configuration, params: unknown[]) {
   if (configuration.isEnabled('console-stack')) {
-    const firstErrorParam = find(params, (param: unknown) => param instanceof Error) as Error
+    const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
     return {
       message: ['console error:', ...params]
         .map((param) => formatConsoleParameters(formatErrorMessage, param))

--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -60,27 +60,29 @@ function buildErrorFromParams(configuration: Configuration, params: unknown[]) {
   if (configuration.isEnabled('console-stack')) {
     const firstErrorParam = find(params, (param: unknown) => param instanceof Error) as Error
     return {
-      message: ['console error:', ...params].map(formatConsoleParameters(formatErrorMessage)).join(' '),
+      message: ['console error:', ...params]
+        .map((param) => formatConsoleParameters(formatErrorMessage, param))
+        .join(' '),
       stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,
     }
   }
-  return { message: ['console error:', ...params].map(formatConsoleParameters(toStackTraceString)).join(' ') }
+  return {
+    message: ['console error:', ...params].map((param) => formatConsoleParameters(toStackTraceString, param)).join(' '),
+  }
 }
 
 export function stopConsoleTracking() {
   console.error = originalConsoleError
 }
 
-function formatConsoleParameters(stackTraceFormatter: (stack: StackTrace) => string) {
-  return (param: unknown) => {
-    if (typeof param === 'string') {
-      return param
-    }
-    if (param instanceof Error) {
-      return stackTraceFormatter(computeStackTrace(param))
-    }
-    return jsonStringify(param, undefined, 2)
+function formatConsoleParameters(stackTraceFormatter: (stack: StackTrace) => string, param: unknown) {
+  if (typeof param === 'string') {
+    return param
   }
+  if (param instanceof Error) {
+    return stackTraceFormatter(computeStackTrace(param))
+  }
+  return jsonStringify(param, undefined, 2)
 }
 
 let traceKitReportHandler: (stack: StackTrace, isWindowError: boolean, errorObject?: any) => void

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -43,7 +43,7 @@ export function formatUnknownError(stackTrace: StackTrace | undefined, errorObje
 }
 
 export function toStackTraceString(stack: StackTrace) {
-  let result = `${stack.name || 'Error'}: ${stack.message!}`
+  let result = formatErrorMessage(stack)
   stack.stack.forEach((frame) => {
     const func = frame.func === '?' ? '<anonymous>' : frame.func
     const args = frame.args && frame.args.length > 0 ? `(${frame.args.join(', ')})` : ''
@@ -52,4 +52,8 @@ export function toStackTraceString(stack: StackTrace) {
     result += `\n  at ${func!}${args} @ ${frame.url!}${line}${column}`
   })
   return result
+}
+
+export function formatErrorMessage(stack: StackTrace) {
+  return `${stack.name || 'Error'}: ${stack.message!}`
 }

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -197,7 +197,10 @@ export function includes(candidate: string | unknown[], search: any) {
   return candidate.indexOf(search) !== -1
 }
 
-export function find<T>(array: T[], predicate: (item: T, index: number, array: T[]) => unknown): T | undefined {
+export function find<T, S extends T>(
+  array: T[],
+  predicate: (item: T, index: number, array: T[]) => item is S
+): S | undefined {
   for (let i = 0; i < array.length; i += 1) {
     const item = array[i]
     if (predicate(item, i, array)) {

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -1,4 +1,3 @@
-import { setDebugMode } from '@datadog/browser-core'
 import { clearAllCookies } from '../src/tools/specHelper'
 
 beforeEach(() => {
@@ -8,11 +7,8 @@ beforeEach(() => {
   ;(window as any).DD_RUM = {}
   // prevent 'Some of your tests did a full page reload!' issue
   window.onbeforeunload = () => 'stop'
-  // useful to debug monitored functions spec
-  setDebugMode(true)
 })
 
 afterEach(() => {
-  setDebugMode(false)
   clearAllCookies()
 })

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -1,3 +1,4 @@
+import { setDebugMode } from '@datadog/browser-core'
 import { clearAllCookies } from '../src/tools/specHelper'
 
 beforeEach(() => {
@@ -7,8 +8,11 @@ beforeEach(() => {
   ;(window as any).DD_RUM = {}
   // prevent 'Some of your tests did a full page reload!' issue
   window.onbeforeunload = () => 'stop'
+  // useful to debug monitored functions spec
+  setDebugMode(true)
 })
 
 afterEach(() => {
+  setDebugMode(false)
   clearAllCookies()
 })


### PR DESCRIPTION
## Motivation

Ease Error Tracking grouping

## Changes

behind `console-stack` FF:

- remove error stack from raw error message
- set raw error stack to first error instance stack

## Testing

unit tests + manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
