### PR TITLE
[RUMF-866] adjust postpone start recording

### DIFF
--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
@@ -6,7 +6,7 @@ import { makeRumRecorderPublicApi, StartRecording } from './rumRecorderPublicApi
 const DEFAULT_INIT_CONFIGURATION = { applicationId: 'xxx', clientToken: 'xxx' }
 
 describe('makeRumRecorderPublicApi', () => {
-  let rumGlobal: RumPublicApi & { startSessionRecord?(): void }
+  let rumGlobal: RumPublicApi & { startSessionReplayRecording?(): void }
   let startRecordingSpy: jasmine.Spy<StartRecording>
   let startRumSpy: jasmine.Spy<StartRum>
   let enabledFlags: string[] = []
@@ -49,10 +49,10 @@ describe('makeRumRecorderPublicApi', () => {
   })
 
   describe('experimental flag postpone_start_recording', () => {
-    it('if disabled, startSessionRecord should not be defined', () => {
-      expect(rumGlobal.startSessionRecord).toBeUndefined()
+    it('if disabled, startSessionReplayRecording should not be defined', () => {
+      expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
       rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-      expect(rumGlobal.startSessionRecord).toBeUndefined()
+      expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
     })
 
     it('if enabled, recording should not start when calling init()', () => {
@@ -61,27 +61,27 @@ describe('makeRumRecorderPublicApi', () => {
       expect(startRecordingSpy).not.toHaveBeenCalled()
     })
 
-    it('if enabled, startSessionRecord should be defined', () => {
+    it('if enabled, startSessionReplayRecording should be defined', () => {
       enabledFlags = ['postpone_start_recording']
-      expect(rumGlobal.startSessionRecord).toBeUndefined()
+      expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
       rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-      expect(rumGlobal.startSessionRecord).toEqual(jasmine.any(Function))
+      expect(rumGlobal.startSessionReplayRecording).toEqual(jasmine.any(Function))
     })
 
-    it('if enabled, commonContext.hasReplay should be true only if startSessionRecord is called', () => {
+    it('if enabled, commonContext.hasReplay should be true only if startSessionReplayRecording is called', () => {
       enabledFlags = ['postpone_start_recording']
       rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
       expect(getCommonContext().hasReplay).toBeUndefined()
-      rumGlobal.startSessionRecord!()
+      rumGlobal.startSessionReplayRecording!()
       expect(getCommonContext().hasReplay).toBe(true)
     })
 
-    it('if enabled, calling startSessionRecord multiple times should only start recording once', () => {
+    it('if enabled, calling startSessionReplayRecording multiple times should only start recording once', () => {
       enabledFlags = ['postpone_start_recording']
       rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-      rumGlobal.startSessionRecord!()
-      rumGlobal.startSessionRecord!()
-      rumGlobal.startSessionRecord!()
+      rumGlobal.startSessionReplayRecording!()
+      rumGlobal.startSessionReplayRecording!()
+      rumGlobal.startSessionReplayRecording!()
       expect(startRecordingSpy).toHaveBeenCalledTimes(1)
     })
   })

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
@@ -1,12 +1,17 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Configuration } from '@datadog/browser-core'
-import { RumPublicApi, StartRum } from '@datadog/browser-rum-core'
+import { RumPublicApi, RumUserConfiguration, StartRum } from '@datadog/browser-rum-core'
 import { makeRumRecorderPublicApi, StartRecording } from './rumRecorderPublicApi'
 
 const DEFAULT_INIT_CONFIGURATION = { applicationId: 'xxx', clientToken: 'xxx' }
 
 describe('makeRumRecorderPublicApi', () => {
-  let rumGlobal: RumPublicApi & { startSessionReplayRecording?(): void }
+  let rumGlobal: RumPublicApi & {
+    // TODO postpone_start_recording: those types will be included in rum-recorder public API when
+    // postpone_start_recording is stabilized.
+    startSessionReplayRecording?(): void
+    init(options: RumUserConfiguration & { manualSessionReplayRecordingStart?: boolean }): void
+  }
   let startRecordingSpy: jasmine.Spy<StartRecording>
   let startRumSpy: jasmine.Spy<StartRum>
   let enabledFlags: string[] = []
@@ -57,7 +62,7 @@ describe('makeRumRecorderPublicApi', () => {
 
     it('if enabled, recording should not start when calling init()', () => {
       enabledFlags = ['postpone_start_recording']
-      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+      rumGlobal.init({ ...DEFAULT_INIT_CONFIGURATION, manualSessionReplayRecordingStart: true })
       expect(startRecordingSpy).not.toHaveBeenCalled()
     })
 
@@ -70,7 +75,7 @@ describe('makeRumRecorderPublicApi', () => {
 
     it('if enabled, commonContext.hasReplay should be true only if startSessionReplayRecording is called', () => {
       enabledFlags = ['postpone_start_recording']
-      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+      rumGlobal.init({ ...DEFAULT_INIT_CONFIGURATION, manualSessionReplayRecordingStart: true })
       expect(getCommonContext().hasReplay).toBeUndefined()
       rumGlobal.startSessionReplayRecording!()
       expect(getCommonContext().hasReplay).toBe(true)

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
@@ -54,40 +54,56 @@ describe('makeRumRecorderPublicApi', () => {
   })
 
   describe('experimental flag postpone_start_recording', () => {
-    it('if disabled, startSessionReplayRecording should not be defined', () => {
-      expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
-      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-      expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
+    describe('if disabled', () => {
+      it('startSessionReplayRecording should not be defined', () => {
+        expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
+        rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+        expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
+      })
+
+      it('option manualSessionReplayRecordingStart should not be taken into account', () => {
+        rumGlobal.init({ ...DEFAULT_INIT_CONFIGURATION, manualSessionReplayRecordingStart: true })
+        expect(startRecordingSpy).toHaveBeenCalled()
+      })
     })
 
-    it('if enabled, recording should not start when calling init()', () => {
-      enabledFlags = ['postpone_start_recording']
-      rumGlobal.init({ ...DEFAULT_INIT_CONFIGURATION, manualSessionReplayRecordingStart: true })
-      expect(startRecordingSpy).not.toHaveBeenCalled()
-    })
+    describe('if enabled', () => {
+      beforeEach(() => {
+        enabledFlags = ['postpone_start_recording']
+      })
 
-    it('if enabled, startSessionReplayRecording should be defined', () => {
-      enabledFlags = ['postpone_start_recording']
-      expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
-      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-      expect(rumGlobal.startSessionReplayRecording).toEqual(jasmine.any(Function))
-    })
+      it('recording should start when calling init() with default options', () => {
+        rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+        expect(startRecordingSpy).toHaveBeenCalled()
+      })
 
-    it('if enabled, commonContext.hasReplay should be true only if startSessionReplayRecording is called', () => {
-      enabledFlags = ['postpone_start_recording']
-      rumGlobal.init({ ...DEFAULT_INIT_CONFIGURATION, manualSessionReplayRecordingStart: true })
-      expect(getCommonContext().hasReplay).toBeUndefined()
-      rumGlobal.startSessionReplayRecording!()
-      expect(getCommonContext().hasReplay).toBe(true)
-    })
+      it('startSessionReplayRecording should be defined', () => {
+        expect(rumGlobal.startSessionReplayRecording).toBeUndefined()
+        rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+        expect(rumGlobal.startSessionReplayRecording).toEqual(jasmine.any(Function))
+      })
 
-    it('if enabled, calling startSessionReplayRecording multiple times should only start recording once', () => {
-      enabledFlags = ['postpone_start_recording']
-      rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
-      rumGlobal.startSessionReplayRecording!()
-      rumGlobal.startSessionReplayRecording!()
-      rumGlobal.startSessionReplayRecording!()
-      expect(startRecordingSpy).toHaveBeenCalledTimes(1)
+      it('calling startSessionReplayRecording while recording is already start should be ignored', () => {
+        rumGlobal.init(DEFAULT_INIT_CONFIGURATION)
+        rumGlobal.startSessionReplayRecording!()
+        rumGlobal.startSessionReplayRecording!()
+        rumGlobal.startSessionReplayRecording!()
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
+      })
+
+      describe('with manualSessionReplayRecordingStart: true option', () => {
+        it('recording should not start when calling init() with option manualSessionReplayRecordingStart', () => {
+          rumGlobal.init({ ...DEFAULT_INIT_CONFIGURATION, manualSessionReplayRecordingStart: true })
+          expect(startRecordingSpy).not.toHaveBeenCalled()
+        })
+
+        it('commonContext.hasReplay should be true only if startSessionReplayRecording is called', () => {
+          rumGlobal.init({ ...DEFAULT_INIT_CONFIGURATION, manualSessionReplayRecordingStart: true })
+          expect(getCommonContext().hasReplay).toBeUndefined()
+          rumGlobal.startSessionReplayRecording!()
+          expect(getCommonContext().hasReplay).toBe(true)
+        })
+      })
     })
   })
 })

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
@@ -18,6 +18,9 @@ export function makeRumRecorderPublicApi(startRumImpl: StartRum, startRecordingI
 
     if (configuration.isEnabled('postpone_start_recording')) {
       ;(rumRecorderGlobal as any).startSessionReplayRecording = monitor(startSessionReplayRecording)
+      if (!(userConfiguration as any).manualSessionReplayRecordingStart) {
+        startSessionReplayRecording()
+      }
     } else {
       startSessionReplayRecording()
     }

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
@@ -17,12 +17,12 @@ export function makeRumRecorderPublicApi(startRumImpl: StartRum, startRecordingI
     const { lifeCycle, parentContexts, configuration, session } = startRumResult
 
     if (configuration.isEnabled('postpone_start_recording')) {
-      ;(rumRecorderGlobal as any).startSessionRecord = monitor(startSessionRecord)
+      ;(rumRecorderGlobal as any).startSessionReplayRecording = monitor(startSessionReplayRecording)
     } else {
-      startSessionRecord()
+      startSessionReplayRecording()
     }
 
-    function startSessionRecord() {
+    function startSessionReplayRecording() {
       if (isRecording) {
         return
       }


### PR DESCRIPTION
## Motivation

Adjust the way to postpone the recording start

## Note

This PR should not be merged before we adjust our internal usages of `postpone_start_recording`.

## Changes

* introduce the new `manualSessionReplayRecordingStart` option
* rename `startSessionRecord` to `startSessionReplayRecording`

Everything is still under the same `postpone_start_recording` flag


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
