### PR TITLE
[RUMF-857] round CLS to 4 decimals

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -127,7 +127,7 @@ export function performDraw(threshold: number): boolean {
   return threshold !== 0 && Math.random() * 100 <= threshold
 }
 
-export function round(num: number, decimals: 0 | 1 | 2 | 3) {
+export function round(num: number, decimals: 0 | 1 | 2 | 3 | 4) {
   return +num.toFixed(decimals)
 }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -907,7 +907,7 @@ describe('rum view measures', () => {
       expect(getViewEvent(0).cumulativeLayoutShift).toBe(undefined)
     })
 
-    it('should accmulate layout shift values', () => {
+    it('should accumulate layout shift values', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
@@ -925,7 +925,28 @@ describe('rum view measures', () => {
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       expect(getHandledCount()).toEqual(2)
-      expect(getViewEvent(1).cumulativeLayoutShift).toBe(0.1 + 0.2)
+      expect(getViewEvent(1).cumulativeLayoutShift).toBe(0.3)
+    })
+
+    it('should round the cumulative layout shift value to 4 decimals', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
+        entryType: 'layout-shift',
+        hadRecentInput: false,
+        value: 1.23456789,
+      })
+
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
+        entryType: 'layout-shift',
+        hadRecentInput: false,
+        value: 1.11111111111,
+      })
+
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+      expect(getHandledCount()).toEqual(2)
+      expect(getViewEvent(1).cumulativeLayoutShift).toBe(2.3457)
     })
 
     it('should ignore entries with recent input', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -9,6 +9,7 @@ import {
   ONE_MINUTE,
   relativeNow,
   RelativeTime,
+  round,
   throttle,
 } from '@datadog/browser-core'
 import { NewLocationListener } from '../../../boot/rum'
@@ -185,7 +186,7 @@ function newView(
   function triggerViewUpdate() {
     documentVersion += 1
     lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, {
-      cumulativeLayoutShift,
+      cumulativeLayoutShift: cumulativeLayoutShift && round(cumulativeLayoutShift, 4),
       customTimings,
       documentVersion,
       eventCounts,


### PR DESCRIPTION
## Motivation

Having more than 4 decimals to the cumulative layout shift score produce more noise than value. Since this score is compared to minimum `0.1`, the precision is still 3 orders of magnitude below, so it should be completly fine.

## Changes

Round the cumulative layout shift score to 4 decimals.

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
