### PR TITLE
Revert negative FID monitoring and adjust to 0

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -1,7 +1,6 @@
 import {
   addEventListeners,
   Configuration,
-  Context,
   DOM_EVENT,
   Duration,
   getRelativeTime,
@@ -68,8 +67,6 @@ export interface RumFirstInputTiming {
   entryType: 'first-input'
   startTime: RelativeTime
   processingStart: RelativeTime
-  name: string
-  toJSON?: () => Context
 }
 
 export interface RumLayoutShiftTiming {
@@ -209,7 +206,6 @@ function retrieveFirstInputTiming(callback: (timing: RumFirstInputTiming) => voi
         entryType: 'first-input',
         processingStart: relativeNow(),
         startTime: evt.timeStamp as RelativeTime,
-        name: `emulated ${evt.type}`,
       }
 
       if (evt.type === DOM_EVENT.POINTER_DOWN) {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
@@ -47,7 +47,6 @@ const FAKE_FIRST_INPUT_ENTRY: RumFirstInputTiming = {
   entryType: 'first-input',
   processingStart: 1100 as RelativeTime,
   startTime: 1000 as RelativeTime,
-  name: 'fake',
 }
 
 describe('trackTimings', () => {
@@ -232,7 +231,6 @@ describe('firstInputTimings', () => {
       // Invalid, because processingStart should be >= startTime
       processingStart: 900 as RelativeTime,
       startTime: 1000 as RelativeTime,
-      name: 'fake',
     })
 
     expect(fitCallback).not.toHaveBeenCalled()

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.spec.ts
@@ -223,16 +223,16 @@ describe('firstInputTimings', () => {
     expect(fitCallback).not.toHaveBeenCalled()
   })
 
-  it('should not be present if the first-input performance entry is invalid', () => {
+  it('should be adjusted to 0 if the computed value would be negative due to browser timings imprecisions', () => {
     const { lifeCycle } = setupBuilder.build()
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
       entryType: 'first-input' as const,
-      // Invalid, because processingStart should be >= startTime
       processingStart: 900 as RelativeTime,
       startTime: 1000 as RelativeTime,
     })
 
-    expect(fitCallback).not.toHaveBeenCalled()
+    expect(fitCallback).toHaveBeenCalledTimes(1)
+    expect(fitCallback).toHaveBeenCalledWith({ firstInputDelay: 0, firstInputTime: 1000 })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
@@ -1,12 +1,4 @@
-import {
-  addEventListeners,
-  addMonitoringMessage,
-  DOM_EVENT,
-  Duration,
-  elapsed,
-  EventEmitter,
-  RelativeTime,
-} from '@datadog/browser-core'
+import { addEventListeners, DOM_EVENT, Duration, elapsed, EventEmitter, RelativeTime } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { trackFirstHidden } from './trackFirstHidden'
 
@@ -145,20 +137,17 @@ export function trackFirstInputTimings(
   const firstHidden = trackFirstHidden()
 
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
-    if (entry.entryType === 'first-input' && entry.startTime < firstHidden.timeStamp) {
+    if (
+      entry.entryType === 'first-input' &&
+      entry.startTime < firstHidden.timeStamp &&
       // Discard invalid first-input entries, see
       // https://bugs.chromium.org/p/chromium/issues/detail?id=1185815
-      if (entry.startTime <= entry.processingStart) {
-        callback({
-          firstInputDelay: elapsed(entry.startTime, entry.processingStart),
-          firstInputTime: entry.startTime as Duration,
-        })
-      } else if (entry.toJSON) {
-        addMonitoringMessage(`Negative FID for entry ${entry.name}`, {
-          entry: { ...entry.toJSON(), target: undefined },
-          fid: entry.processingStart - entry.startTime,
-        })
-      }
+      entry.startTime <= entry.processingStart
+    ) {
+      callback({
+        firstInputDelay: elapsed(entry.startTime, entry.processingStart),
+        firstInputTime: entry.startTime as Duration,
+      })
     }
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackTimings.ts
@@ -137,15 +137,12 @@ export function trackFirstInputTimings(
   const firstHidden = trackFirstHidden()
 
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
-    if (
-      entry.entryType === 'first-input' &&
-      entry.startTime < firstHidden.timeStamp &&
-      // Discard invalid first-input entries, see
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=1185815
-      entry.startTime <= entry.processingStart
-    ) {
+    if (entry.entryType === 'first-input' && entry.startTime < firstHidden.timeStamp) {
+      const firstInputDelay = elapsed(entry.startTime, entry.processingStart)
       callback({
-        firstInputDelay: elapsed(entry.startTime, entry.processingStart),
+        // Ensure firstInputDelay to be positive, see
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=1185815
+        firstInputDelay: firstInputDelay >= 0 ? firstInputDelay : (0 as Duration),
         firstInputTime: entry.startTime as Duration,
       })
     }


### PR DESCRIPTION
## Motivation

We collected enough data to investigate the [Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1185815). Remove the monitoring, and adjust negative FID to 0 as per [Chromium developer recommendation](https://bugs.chromium.org/p/chromium/issues/detail?id=1185815#c5).

## Changes

* Revert #759 
* Adjust negative FID to 0

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
