### PR TITLE
[RUMF-853] introduce a feature flag for aborted network errors

### DIFF
--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -112,7 +112,7 @@ export function trackNetworkError(configuration: Configuration, errorObservable:
   function handleCompleteRequest(type: RequestType, request: XhrCompleteContext | FetchCompleteContext) {
     if (
       !configuration.isIntakeUrl(request.url) &&
-      !request.isAborted &&
+      (!configuration.isEnabled('remove-network-errors') || !request.isAborted) &&
       (isRejected(request) || isServerError(request))
     ) {
       errorObservable.notify({

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -193,7 +193,7 @@ describe('rum resources', () => {
 
         await flushEvents()
 
-        // Aborted XHR should be considered as errors for now
+        // Aborted fetch should be considered as errors for now
         expect(events.rumErrors.length).toBe(1)
 
         const resourceEvent = events.rumResources.find((event) => event.resource.type === 'fetch')

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -162,8 +162,8 @@ describe('rum resources', () => {
 
       return {
         toBeAborted() {
-          // Aborted XHR should not be considered as error
-          expect(events.rumErrors.length).toBe(0)
+          // Aborted XHR should be considered as errors for now
+          expect(events.rumErrors.length).toBe(1)
 
           expect(resourceEvent?.resource.status_code).toBe(0)
         },
@@ -193,8 +193,8 @@ describe('rum resources', () => {
 
         await flushEvents()
 
-        // Aborted fetch should not be considered as error
-        expect(events.rumErrors.length).toBe(0)
+        // Aborted XHR should be considered as errors for now
+        expect(events.rumErrors.length).toBe(1)
 
         const resourceEvent = events.rumResources.find((event) => event.resource.type === 'fetch')
         expect(resourceEvent).toBeTruthy()


### PR DESCRIPTION
## Motivation

Releasing #768 can lead to a big drop of network errors in some applications, and could impact some customer monitoring setup. We are planing to remove network errors entirely in the near future, so we decided to not release this publicly yet and wait for proper communication to be ready.

## Changes

Put #768 behind a experimental feature flag

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
