### PR TITLE
🐛 fix developer extension popup

### DIFF
--- a/developer-extension/webpack.config.js
+++ b/developer-extension/webpack.config.js
@@ -1,6 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const WebextensionPlugin = require('webpack-webextension-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
+const { DefinePlugin } = require('webpack')
 
 module.exports = (_env, argv) => {
   return [
@@ -28,6 +29,9 @@ module.exports = (_env, argv) => {
       plugins: [
         new HtmlWebpackPlugin({
           filename: 'popup.html',
+        }),
+        new DefinePlugin({
+          'process.env.BUMBAG_ENV': JSON.stringify('production'),
         }),
       ],
     }),


### PR DESCRIPTION


## Motivation

With the recent upgrade to Webpack 5, process.env is not defined by default, so bumbag crashes because it uses it to check if it is running in a test environment.

## Changes

Define `process.env.BUMBAG_ENV` to `"production"`. Bumbag only test if it is equal to `"test"`, so it doesn't matter too much if we set it to `"production"`, `"development"` or something else.

## Testing

Manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
