### PR TITLE
[RUMF-869] Ensure the "Focus" records are emited in the same segment as the "FullSnapshot"

### DIFF
--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -164,7 +164,7 @@ describe('startRecording', () => {
 
   // eslint-disable-next-line max-len
   it('does not split Meta, Focus and FullSnapshot records between multiple segments when taking a full snapshot', (done) => {
-    setMaxSegmentSize(10)
+    setMaxSegmentSize(0)
     setupBuilder.build()
 
     waitRequestSendCalls(1, (calls) => {

--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -5,8 +5,8 @@ import { inflate } from 'pako'
 import { setup, TestSetupBuilder } from '../../../rum-core/test/specHelper'
 import { collectAsyncCalls } from '../../test/utils'
 
-import { FocusRecord, RawRecord, Segment, RecordType } from '../types'
-import { startRecording, trackFocusRecords } from './recorder'
+import { Segment, RecordType } from '../types'
+import { startRecording } from './recorder'
 
 describe('startRecording', () => {
   let setupBuilder: TestSetupBuilder
@@ -158,60 +158,6 @@ describe('startRecording', () => {
         expectNoExtraRequestSendCalls(done)
       })
     })
-  })
-})
-
-describe('trackFocusRecords', () => {
-  let hasFocus: boolean
-  let addRecordSpy: jasmine.Spy<(rawRecord: RawRecord) => void>
-  let lifeCycle: LifeCycle
-
-  beforeEach(() => {
-    hasFocus = true
-    lifeCycle = new LifeCycle()
-    spyOn(Document.prototype, 'hasFocus').and.callFake(() => hasFocus)
-    addRecordSpy = jasmine.createSpy()
-  })
-
-  it('adds an initial Focus record', () => {
-    trackFocusRecords(lifeCycle, addRecordSpy)
-    expect(addRecordSpy).toHaveBeenCalled()
-  })
-
-  it('adds a Focus record on focus', () => {
-    trackFocusRecords(lifeCycle, addRecordSpy)
-    addRecordSpy.calls.reset()
-
-    window.dispatchEvent(createNewEvent('focus'))
-    expect(addRecordSpy).toHaveBeenCalled()
-  })
-
-  it('adds a Focus record on blur', () => {
-    trackFocusRecords(lifeCycle, addRecordSpy)
-    addRecordSpy.calls.reset()
-
-    window.dispatchEvent(createNewEvent('blur'))
-    expect(addRecordSpy).toHaveBeenCalled()
-  })
-
-  it('adds a Focus record on new view', () => {
-    trackFocusRecords(lifeCycle, addRecordSpy)
-    addRecordSpy.calls.reset()
-
-    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {} as any)
-    expect(addRecordSpy).toHaveBeenCalled()
-  })
-
-  it('set has_focus to true if the document has the focus', () => {
-    hasFocus = true
-    trackFocusRecords(lifeCycle, addRecordSpy)
-    expect((addRecordSpy.calls.mostRecent().args[0] as FocusRecord).data.has_focus).toBe(true)
-  })
-
-  it("set has_focus to false if the document doesn't have the focus", () => {
-    hasFocus = false
-    trackFocusRecords(lifeCycle, addRecordSpy)
-    expect((addRecordSpy.calls.mostRecent().args[0] as FocusRecord).data.has_focus).toBe(false)
   })
 })
 

--- a/packages/rum-recorder/src/boot/recorder.ts
+++ b/packages/rum-recorder/src/boot/recorder.ts
@@ -1,4 +1,4 @@
-import { Configuration, DOM_EVENT, addEventListeners } from '@datadog/browser-core'
+import { Configuration } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType, ParentContexts, RumSession } from '@datadog/browser-rum-core'
 
 import { record } from '../domain/rrweb'
@@ -30,30 +30,14 @@ export function startRecording(
   })
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
-  const { stop: stopTrackingFocusRecords } = trackFocusRecords(lifeCycle, addRawRecord)
   trackViewEndRecord(lifeCycle, (record) => addRawRecord(record))
 
   return {
     stop: () => {
       stopRecording()
       stopSegmentCollection()
-      stopTrackingFocusRecords()
     },
   }
-}
-
-export function trackFocusRecords(lifeCycle: LifeCycle, addRawRecord: (record: RawRecord) => void) {
-  function addFocusRecord() {
-    addRawRecord({
-      type: RecordType.Focus,
-      data: {
-        has_focus: document.hasFocus(),
-      },
-    })
-  }
-  addFocusRecord()
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, addFocusRecord)
-  return addEventListeners(window, [DOM_EVENT.FOCUS, DOM_EVENT.BLUR], addFocusRecord)
 }
 
 export function trackViewEndRecord(lifeCycle: LifeCycle, addRawRecord: (record: RawRecord) => void) {

--- a/packages/rum-recorder/src/domain/rrweb/record.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.spec.ts
@@ -7,13 +7,14 @@ import {
   FullSnapshotRecord,
   RawRecord,
   IncrementalSnapshotRecord,
+  FocusRecord,
 } from '../../types'
 import { SerializedNodeWithId, NodeType } from '../rrweb-snapshot/types'
 import { record } from './record'
 import { RecordAPI } from './types'
 
-// Each full snapshot is generating two records, a Meta record and a FullSnapshot record
-const RECORDS_PER_FULL_SNAPSHOTS = 2
+// Each full snapshot is generating three records: Meta, Focus and FullSnapshot
+const RECORDS_PER_FULL_SNAPSHOTS = 3
 
 describe('record', () => {
   let sandbox: HTMLElement
@@ -73,22 +74,23 @@ describe('record', () => {
       sandbox.appendChild(span)
     }, 10)
 
-    waitEmitCalls(7, () => {
+    waitEmitCalls(9, () => {
       const records = getEmittedRecords()
       const sandboxNode = findNode(
-        (records[1] as FullSnapshotRecord).data.node,
+        (records[2] as FullSnapshotRecord).data.node,
         (node) => node.type === NodeType.Element && node.attributes.id === 'sandbox'
       )!
       const inputId = findNode(sandboxNode, (node) => node.type === NodeType.Element && node.tagName === 'input')!.id
-      const paragraphId = ((records[2] as IncrementalSnapshotRecord).data as MutationData).adds[0].node.id
-      const spanId = ((records[2] as IncrementalSnapshotRecord).data as MutationData).adds[1].node.id
+      const paragraphId = ((records[3] as IncrementalSnapshotRecord).data as MutationData).adds[0].node.id
+      const spanId = ((records[3] as IncrementalSnapshotRecord).data as MutationData).adds[1].node.id
 
       expect(records[0].type).toBe(RecordType.Meta)
+      expect(records[1].type).toBe(RecordType.Focus)
 
-      expect(records[1].type).toBe(RecordType.FullSnapshot)
+      expect(records[2].type).toBe(RecordType.FullSnapshot)
 
-      expect(records[2].type).toBe(RecordType.IncrementalSnapshot)
-      expect((records[2] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[3].type).toBe(RecordType.IncrementalSnapshot)
+      expect((records[3] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.Mutation,
           adds: [
@@ -105,8 +107,8 @@ describe('record', () => {
         })
       )
 
-      expect(records[3].type).toBe(RecordType.IncrementalSnapshot)
-      expect((records[3] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[4].type).toBe(RecordType.IncrementalSnapshot)
+      expect((records[4] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.Mutation,
           adds: [
@@ -121,12 +123,13 @@ describe('record', () => {
         })
       )
 
-      expect(records[4].type).toBe(RecordType.Meta)
+      expect(records[5].type).toBe(RecordType.Meta)
+      expect(records[6].type).toBe(RecordType.Focus)
 
-      expect(records[5].type).toBe(RecordType.FullSnapshot)
+      expect(records[7].type).toBe(RecordType.FullSnapshot)
 
-      expect(records[6].type).toBe(RecordType.IncrementalSnapshot)
-      expect((records[6] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[8].type).toBe(RecordType.IncrementalSnapshot)
+      expect((records[8] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.Mutation,
           adds: [
@@ -171,31 +174,32 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    waitEmitCalls(6, () => {
+    waitEmitCalls(7, () => {
       const records = getEmittedRecords()
 
       expect(records[0].type).toEqual(RecordType.Meta)
-      expect(records[1].type).toEqual(RecordType.FullSnapshot)
-      expect(records[2].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[2] as IncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({ source: IncrementalSource.Mutation })
-      )
+      expect(records[1].type).toEqual(RecordType.Focus)
+      expect(records[2].type).toEqual(RecordType.FullSnapshot)
       expect(records[3].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[3] as IncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { color: #fff; }', index: undefined }],
-        })
+        jasmine.objectContaining({ source: IncrementalSource.Mutation })
       )
       expect(records[4].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[4] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
-          removes: [{ index: 0 }],
+          adds: [{ rule: 'body { color: #fff; }', index: undefined }],
         })
       )
       expect(records[5].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[5] as IncrementalSnapshotRecord).data).toEqual(
+        jasmine.objectContaining({
+          source: IncrementalSource.StyleSheetRule,
+          removes: [{ index: 0 }],
+        })
+      )
+      expect(records[6].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[6] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
           adds: [{ rule: 'body { color: #ccc; }', index: undefined }],
@@ -213,17 +217,74 @@ describe('record', () => {
 
     recordApi.takeFullSnapshot()
 
-    waitEmitCalls(5, () => {
+    waitEmitCalls(7, () => {
       const records = getEmittedRecords()
 
       expect(records[0].type).toEqual(RecordType.Meta)
-      expect(records[1].type).toEqual(RecordType.FullSnapshot)
-      expect(records[2].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[2] as IncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
-      expect(records[3].type).toEqual(RecordType.Meta)
-      expect(records[4].type).toEqual(RecordType.FullSnapshot)
+      expect(records[1].type).toEqual(RecordType.Focus)
+      expect(records[2].type).toEqual(RecordType.FullSnapshot)
+      expect(records[3].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[3] as IncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
+      expect(records[4].type).toEqual(RecordType.Meta)
+      expect(records[5].type).toEqual(RecordType.Focus)
+      expect(records[6].type).toEqual(RecordType.FullSnapshot)
 
       expectNoExtraEmitCalls(done)
+    })
+  })
+
+  describe('Focus records', () => {
+    let hasFocus: boolean
+
+    beforeEach(() => {
+      hasFocus = true
+      spyOn(Document.prototype, 'hasFocus').and.callFake(() => hasFocus)
+    })
+
+    it('adds an initial Focus record when starting to record', () => {
+      startRecording()
+      expect(getEmittedRecords()[1]).toEqual({
+        type: RecordType.Focus,
+        data: {
+          has_focus: true,
+        },
+      })
+    })
+
+    it('adds a Focus record on focus', () => {
+      startRecording()
+      emitSpy.calls.reset()
+
+      window.dispatchEvent(createNewEvent('focus'))
+      expect(getEmittedRecords()[0].type).toBe(RecordType.Focus)
+    })
+
+    it('adds a Focus record on blur', () => {
+      startRecording()
+      emitSpy.calls.reset()
+
+      window.dispatchEvent(createNewEvent('blur'))
+      expect(getEmittedRecords()[0].type).toBe(RecordType.Focus)
+    })
+
+    it('adds a Focus record on when taking a full snapshot', () => {
+      startRecording()
+      emitSpy.calls.reset()
+
+      recordApi.takeFullSnapshot()
+      expect(getEmittedRecords()[1].type).toBe(RecordType.Focus)
+    })
+
+    it('set has_focus to true if the document has the focus', () => {
+      hasFocus = true
+      startRecording()
+      expect((getEmittedRecords()[1] as FocusRecord).data.has_focus).toBe(true)
+    })
+
+    it("set has_focus to false if the document doesn't have the focus", () => {
+      hasFocus = false
+      startRecording()
+      expect((getEmittedRecords()[1] as FocusRecord).data.has_focus).toBe(false)
     })
   })
 

--- a/packages/rum-recorder/src/domain/rrweb/record.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.ts
@@ -47,6 +47,16 @@ export function record(options: RecordOptions = {}): RecordAPI {
       isCheckout
     )
 
+    wrappedEmit(
+      {
+        data: {
+          has_focus: document.hasFocus(),
+        },
+        type: RecordType.Focus,
+      },
+      isCheckout
+    )
+
     const [node, idNodeMap] = snapshot(document)
 
     if (!node) {
@@ -151,6 +161,11 @@ export function record(options: RecordOptions = {}): RecordAPI {
               ...d,
             },
             type: RecordType.IncrementalSnapshot,
+          }),
+        focusCb: (data) =>
+          wrappedEmit({
+            type: RecordType.Focus,
+            data,
           }),
       })
     )

--- a/packages/rum-recorder/src/domain/rrweb/types.ts
+++ b/packages/rum-recorder/src/domain/rrweb/types.ts
@@ -1,5 +1,5 @@
 import { IdNodeMap, INode, SerializedNodeWithId } from '../rrweb-snapshot/types'
-import type { RawRecord } from '../../types'
+import type { FocusRecord, RawRecord } from '../../types'
 import { MutationController } from './mutation'
 
 export enum IncrementalSource {
@@ -79,6 +79,7 @@ export interface ObserverParam {
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
   styleSheetRuleCb: StyleSheetRuleCallback
+  focusCb: FocusCallback
 }
 
 // https://dom.spec.whatwg.org/#interface-mutationrecord
@@ -222,6 +223,8 @@ export interface MediaInteractionParam {
 }
 
 export type MediaInteractionCallback = (p: MediaInteractionParam) => void
+
+export type FocusCallback = (data: FocusRecord['data']) => void
 
 export interface Mirror {
   map: IdNodeMap

--- a/packages/rum-recorder/src/domain/segment.spec.ts
+++ b/packages/rum-recorder/src/domain/segment.spec.ts
@@ -5,8 +5,6 @@ const CONTEXT: SegmentContext = { application: { id: 'a' }, view: { id: 'b' }, s
 
 const RECORD: Record = { type: RecordType.ViewEnd, timestamp: 10 }
 const FULL_SNAPSHOT_RECORD: Record = { type: RecordType.FullSnapshot, timestamp: 10, data: {} as any }
-const META_RECORD: Record = { type: RecordType.Meta, timestamp: 10, data: {} as any }
-const FOCUS_RECORD: Record = { type: RecordType.Focus, timestamp: 10, data: {} as any }
 
 describe('Segment', () => {
   it('writes a segment', () => {
@@ -59,27 +57,9 @@ describe('Segment', () => {
     })
   })
 
-  it("doesn't set has_full_snapshot to true if a FullSnapshot is the initial record", () => {
-    const writer = new StringWriter()
-    const segment = new Segment(writer, CONTEXT, 'init', FULL_SNAPSHOT_RECORD)
-    segment.flush()
-    expect(writer.flushed[0].meta.has_full_snapshot).toEqual(false)
-  })
-
-  // eslint-disable-next-line max-len
-  it("doesn't set has_full_snapshot to true if a FullSnapshot is not directly preceded by a Meta and Focus records", () => {
+  it('sets has_full_snapshot to true if a segment has a FullSnapshot', () => {
     const writer = new StringWriter()
     const segment = new Segment(writer, CONTEXT, 'init', RECORD)
-    segment.addRecord(FULL_SNAPSHOT_RECORD)
-    segment.flush()
-    expect(writer.flushed[0].meta.has_full_snapshot).toEqual(false)
-  })
-
-  it('sets has_full_snapshot to true if a FullSnapshot is preceded by a Meta and Focus records', () => {
-    const writer = new StringWriter()
-    const segment = new Segment(writer, CONTEXT, 'init', RECORD)
-    segment.addRecord(META_RECORD)
-    segment.addRecord(FOCUS_RECORD)
     segment.addRecord(FULL_SNAPSHOT_RECORD)
     segment.flush()
     expect(writer.flushed[0].meta.has_full_snapshot).toEqual(true)
@@ -88,8 +68,6 @@ describe('Segment', () => {
   it("doesn't overrides has_full_snapshot to false once it has been set to true", () => {
     const writer = new StringWriter()
     const segment = new Segment(writer, CONTEXT, 'init', RECORD)
-    segment.addRecord(META_RECORD)
-    segment.addRecord(FOCUS_RECORD)
     segment.addRecord(FULL_SNAPSHOT_RECORD)
     segment.addRecord(RECORD)
     segment.flush()

--- a/packages/rum-recorder/src/domain/segment.spec.ts
+++ b/packages/rum-recorder/src/domain/segment.spec.ts
@@ -6,6 +6,7 @@ const CONTEXT: SegmentContext = { application: { id: 'a' }, view: { id: 'b' }, s
 const RECORD: Record = { type: RecordType.ViewEnd, timestamp: 10 }
 const FULL_SNAPSHOT_RECORD: Record = { type: RecordType.FullSnapshot, timestamp: 10, data: {} as any }
 const META_RECORD: Record = { type: RecordType.Meta, timestamp: 10, data: {} as any }
+const FOCUS_RECORD: Record = { type: RecordType.Focus, timestamp: 10, data: {} as any }
 
 describe('Segment', () => {
   it('writes a segment', () => {
@@ -65,7 +66,8 @@ describe('Segment', () => {
     expect(writer.flushed[0].meta.has_full_snapshot).toEqual(false)
   })
 
-  it("doesn't set has_full_snapshot to true if a FullSnapshot is not directly preceded by a Meta record", () => {
+  // eslint-disable-next-line max-len
+  it("doesn't set has_full_snapshot to true if a FullSnapshot is not directly preceded by a Meta and Focus records", () => {
     const writer = new StringWriter()
     const segment = new Segment(writer, CONTEXT, 'init', RECORD)
     segment.addRecord(FULL_SNAPSHOT_RECORD)
@@ -73,10 +75,11 @@ describe('Segment', () => {
     expect(writer.flushed[0].meta.has_full_snapshot).toEqual(false)
   })
 
-  it('sets has_full_snapshot to true if a FullSnapshot is preceded by a Meta record', () => {
+  it('sets has_full_snapshot to true if a FullSnapshot is preceded by a Meta and Focus records', () => {
     const writer = new StringWriter()
     const segment = new Segment(writer, CONTEXT, 'init', RECORD)
     segment.addRecord(META_RECORD)
+    segment.addRecord(FOCUS_RECORD)
     segment.addRecord(FULL_SNAPSHOT_RECORD)
     segment.flush()
     expect(writer.flushed[0].meta.has_full_snapshot).toEqual(true)
@@ -86,6 +89,7 @@ describe('Segment', () => {
     const writer = new StringWriter()
     const segment = new Segment(writer, CONTEXT, 'init', RECORD)
     segment.addRecord(META_RECORD)
+    segment.addRecord(FOCUS_RECORD)
     segment.addRecord(FULL_SNAPSHOT_RECORD)
     segment.addRecord(RECORD)
     segment.flush()

--- a/packages/rum-recorder/src/domain/segment.ts
+++ b/packages/rum-recorder/src/domain/segment.ts
@@ -5,12 +5,18 @@ export interface SegmentWriter {
   flush(data: string, meta: SegmentMeta): void
 }
 
+const enum FullSnapshotState {
+  WaitingForMeta,
+  WaitingForFocus,
+  WaitingForFullSnapshot,
+  HasFullSnapshot,
+}
+
 export class Segment {
   private start: number
   private end: number
   private recordsCount: number
-  private hasFullSnapshot: boolean
-  private lastRecordType: RecordType
+  private fullSnapshotState: FullSnapshotState
 
   constructor(
     private writer: SegmentWriter,
@@ -20,22 +26,15 @@ export class Segment {
   ) {
     this.start = initialRecord.timestamp
     this.end = initialRecord.timestamp
-    this.lastRecordType = initialRecord.type
-    this.hasFullSnapshot = false
     this.recordsCount = 1
+    this.fullSnapshotState = reduceFullSnapshotState(FullSnapshotState.WaitingForMeta, initialRecord)
     this.writer.write(`{"records":[${JSON.stringify(initialRecord)}`)
   }
 
   addRecord(record: Record): void {
     this.end = record.timestamp
-    if (!this.hasFullSnapshot) {
-      // Note: to be exploitable by the replay, this field should be true only if the FullSnapshot
-      // is preceded by a Meta record. Because rrweb is emitting both records synchronously and
-      // contiguously, it should always be the case, but check it nonetheless.
-      this.hasFullSnapshot = record.type === RecordType.FullSnapshot && this.lastRecordType === RecordType.Meta
-    }
-    this.lastRecordType = record.type
     this.recordsCount += 1
+    this.fullSnapshotState = reduceFullSnapshotState(this.fullSnapshotState, record)
     this.writer.write(`,${JSON.stringify(record)}`)
   }
 
@@ -43,11 +42,34 @@ export class Segment {
     const meta: SegmentMeta = {
       creation_reason: this.creationReason,
       end: this.end,
-      has_full_snapshot: this.hasFullSnapshot,
+      has_full_snapshot: this.fullSnapshotState === FullSnapshotState.HasFullSnapshot,
       records_count: this.recordsCount,
       start: this.start,
       ...this.context,
     }
     this.writer.flush(`],${JSON.stringify(meta).slice(1)}\n`, meta)
+  }
+}
+
+function reduceFullSnapshotState(currentState: FullSnapshotState, record: Record): FullSnapshotState {
+  // Note: to be exploitable by the replay, we have to ensure that FullSnapshot record is
+  // preceded by a Meta and a Focus records.  Because the record logic is emitting both records
+  // synchronously and contiguously, it should always be the case, but check it nonetheless.
+  switch (currentState) {
+    case FullSnapshotState.WaitingForMeta:
+      return record.type === RecordType.Meta ? FullSnapshotState.WaitingForFocus : FullSnapshotState.WaitingForMeta
+
+    case FullSnapshotState.WaitingForFocus:
+      return record.type === RecordType.Focus
+        ? FullSnapshotState.WaitingForFullSnapshot
+        : FullSnapshotState.WaitingForMeta
+
+    case FullSnapshotState.WaitingForFullSnapshot:
+      return record.type === RecordType.FullSnapshot
+        ? FullSnapshotState.HasFullSnapshot
+        : FullSnapshotState.WaitingForMeta
+
+    default:
+      return currentState
   }
 }

--- a/packages/rum-recorder/src/domain/segmentCollection.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection.ts
@@ -7,6 +7,7 @@ import { createDeflateWorker, DeflateWorker } from './deflateWorker'
 import { Segment } from './segment'
 
 export const MAX_SEGMENT_DURATION = 30_000
+let MAX_SEGMENT_SIZE = SEND_BEACON_BYTE_LENGTH_LIMIT
 
 // Segments are the main data structure for session replays. They contain context information used
 // for indexing or UI needs, and a list of records (RRWeb 'events', renamed to avoid confusing
@@ -87,7 +88,7 @@ export function doStartSegmentCollection(
   const writer = new DeflateSegmentWriter(
     worker,
     (size) => {
-      if (size > SEND_BEACON_BYTE_LENGTH_LIMIT) {
+      if (size > MAX_SEGMENT_SIZE) {
         flushSegment('max_size')
       }
     },
@@ -187,4 +188,8 @@ export function computeSegmentContext(applicationId: string, session: RumSession
       id: viewContext.view.id,
     },
   }
+}
+
+export function setMaxSegmentSize(newSize: number = SEND_BEACON_BYTE_LENGTH_LIMIT) {
+  MAX_SEGMENT_SIZE = newSize
 }


### PR DESCRIPTION
## Motivation

Previously, the Focus record logic was uncorrelated with the FullSnapshot logic, and we have seen cases where Focus records where emited in a segment before the initial FullSnapshot record (because rrweb waits for `onload` before starting to generate records)

## Changes

This PR moves the Focus record logic to be closer to the FullSnapshot logic and uses the same guarantees as the Meta record to ensure all three events are correctly added in the same segment.

## Testing

Unit, manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
