### PR TITLE
✨ [RUMF-863] Enable console error with stack traces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,6 +178,7 @@ module.exports = {
     'no-trailing-spaces': 'off',
     'no-undef-init': 'error',
     'no-underscore-dangle': 'error',
+    'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
     'no-unused-labels': 'error',
     'no-unused-vars': 'off',

--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './automaticErrorCollection'
 import { Configuration } from './configuration'
 
-describe('console tracker (console-stack disabled)', () => {
+describe('console tracker', () => {
   let consoleErrorStub: jasmine.Spy
   let notifyError: jasmine.Spy
   const CONSOLE_CONTEXT = {
@@ -24,63 +24,8 @@ describe('console tracker (console-stack disabled)', () => {
     consoleErrorStub = spyOn(console, 'error')
     notifyError = jasmine.createSpy('notifyError')
     const errorObservable = new Observable<RawError>()
-    const configuration: Partial<Configuration> = { isEnabled: () => false }
     errorObservable.subscribe(notifyError)
-    startConsoleTracking(configuration as Configuration, errorObservable)
-  })
-
-  afterEach(() => {
-    stopConsoleTracking()
-  })
-
-  it('should keep original behavior', () => {
-    console.error('foo', 'bar')
-    expect(consoleErrorStub).toHaveBeenCalledWith('foo', 'bar')
-  })
-
-  it('should notify error', () => {
-    console.error('foo', 'bar')
-    expect(notifyError).toHaveBeenCalledWith({
-      ...CONSOLE_CONTEXT,
-      message: 'console error: foo bar',
-      startTime: jasmine.any(Number),
-    })
-  })
-
-  it('should stringify object parameters', () => {
-    console.error('Hello', { foo: 'bar' })
-    expect(notifyError).toHaveBeenCalledWith({
-      ...CONSOLE_CONTEXT,
-      message: 'console error: Hello {\n  "foo": "bar"\n}',
-      startTime: jasmine.any(Number),
-    })
-  })
-
-  it('should format error instance', () => {
-    console.error(new TypeError('hello'))
-    const message = (notifyError.calls.mostRecent().args[0] as RawError).message
-    if (!isIE()) {
-      expect(message).toMatch(/^console error: TypeError: hello\s+at/)
-    } else {
-      expect(message).toContain('console error: TypeError: hello')
-    }
-  })
-})
-
-describe('console tracker (console-stack enabled)', () => {
-  let consoleErrorStub: jasmine.Spy
-  let notifyError: jasmine.Spy
-  const CONSOLE_CONTEXT = {
-    source: ErrorSource.CONSOLE,
-  }
-
-  beforeEach(() => {
-    consoleErrorStub = spyOn(console, 'error')
-    notifyError = jasmine.createSpy('notifyError')
-    const errorObservable = new Observable<RawError>()
-    const configuration: Partial<Configuration> = { isEnabled: () => true }
-    errorObservable.subscribe(notifyError)
-    startConsoleTracking(configuration as Configuration, errorObservable)
+    startConsoleTracking(errorObservable)
   })
 
   afterEach(() => {

--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -62,9 +62,6 @@ function buildErrorFromParams(params: unknown[]) {
     message: ['console error:', ...params].map((param) => formatConsoleParameters(formatErrorMessage, param)).join(' '),
     stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,
   }
-  return {
-    message: ['console error:', ...params].map((param) => formatConsoleParameters(toStackTraceString, param)).join(' '),
-  }
 }
 
 export function stopConsoleTracking() {

--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -59,7 +59,7 @@ export function startConsoleTracking(errorObservable: ErrorObservable) {
 function buildErrorFromParams(params: unknown[]) {
   const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
   return {
-    message: ['console error:', ...params].map((param) => formatConsoleParameters(formatErrorMessage, param)).join(' '),
+    message: ['console error:', ...params].map((param) => formatConsoleParameters(param)).join(' '),
     stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,
   }
 }
@@ -68,12 +68,12 @@ export function stopConsoleTracking() {
   console.error = originalConsoleError
 }
 
-function formatConsoleParameters(stackTraceFormatter: (stack: StackTrace) => string, param: unknown) {
+function formatConsoleParameters(param: unknown) {
   if (typeof param === 'string') {
     return param
   }
   if (param instanceof Error) {
-    return stackTraceFormatter(computeStackTrace(param))
+    return formatErrorMessage(computeStackTrace(param))
   }
   return jsonStringify(param, undefined, 2)
 }

--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -15,7 +15,7 @@ export function startAutomaticErrorCollection(configuration: Configuration) {
   if (!filteredErrorsObservable) {
     const errorObservable = new Observable<RawError>()
     trackNetworkError(configuration, errorObservable)
-    startConsoleTracking(configuration, errorObservable)
+    startConsoleTracking(errorObservable)
     startRuntimeErrorTracking(errorObservable)
     filteredErrorsObservable = filterErrors(configuration, errorObservable)
   }
@@ -44,27 +44,23 @@ export function filterErrors(configuration: Configuration, errorObservable: Obse
 
 let originalConsoleError: (...params: unknown[]) => void
 
-export function startConsoleTracking(configuration: Configuration, errorObservable: ErrorObservable) {
+export function startConsoleTracking(errorObservable: ErrorObservable) {
   originalConsoleError = console.error
   console.error = monitor((...params: unknown[]) => {
     originalConsoleError.apply(console, params)
     errorObservable.notify({
-      ...buildErrorFromParams(configuration, params),
+      ...buildErrorFromParams(params),
       source: ErrorSource.CONSOLE,
       startTime: relativeNow(),
     })
   })
 }
 
-function buildErrorFromParams(configuration: Configuration, params: unknown[]) {
-  if (configuration.isEnabled('console-stack')) {
-    const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
-    return {
-      message: ['console error:', ...params]
-        .map((param) => formatConsoleParameters(formatErrorMessage, param))
-        .join(' '),
-      stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,
-    }
+function buildErrorFromParams(params: unknown[]) {
+  const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
+  return {
+    message: ['console error:', ...params].map((param) => formatConsoleParameters(formatErrorMessage, param)).join(' '),
+    stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,
   }
   return {
     message: ['console error:', ...params].map((param) => formatConsoleParameters(toStackTraceString, param)).join(' '),


### PR DESCRIPTION
## Motivation

cf #762:
* remove error stack from raw error message
* set raw error stack to first error instance stack 

## Changes

Remove feature flag + outdated tests

## Testing

unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
