### PR TITLE
[RUMF-886] don't start recording when 'postpone_start_recording' is enabled

### DIFF
--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.ts
@@ -1,4 +1,4 @@
-import { monitor, noop } from '@datadog/browser-core'
+import { Configuration, monitor, noop } from '@datadog/browser-core'
 import { LifeCycleEventType, makeRumPublicApi, RumUserConfiguration, StartRum } from '@datadog/browser-rum-core'
 
 import { startRecording } from './recorder'
@@ -67,13 +67,18 @@ export function makeRumRecorderPublicApi(startRumImpl: StartRum, startRecordingI
       lifeCycle.notify(LifeCycleEventType.RECORD_STOPPED)
     }
 
-    onInit(userConfiguration)
+    onInit(userConfiguration, configuration)
 
     return startRumResult
   })
 
-  let onInit = (userConfiguration: RumRecorderUserConfiguration) => {
-    if (!userConfiguration.manualSessionReplayRecordingStart) {
+  let onInit = (userConfiguration: RumRecorderUserConfiguration, configuration: Configuration) => {
+    if (
+      !userConfiguration.manualSessionReplayRecordingStart &&
+      // TODO: remove this when no snippets without manualSessionReplayRecordingStart are served in
+      // the Datadog app. See RUMF-886
+      !configuration.isEnabled('postpone_start_recording')
+    ) {
       startSessionReplayRecordingImpl()
     }
   }


### PR DESCRIPTION

## Motivation

Snippets, that are still using `postpone_start_recording` and aren't using `manualSessionReplayRecordingStart: false`, are problematic because the recording starts when using DD_RUM.init even if it should be postponed.


## Changes


Don't automatically start recording when `postpone_start_recording` experimental feature is enabled.

## Testing

CI, manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
