### PR TITLE
[RUMF-868] ignore paramaters stored in the hash

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackLocationChanges.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackLocationChanges.spec.ts
@@ -143,4 +143,17 @@ describe('rum track location change', () => {
 
     expect(createSpy).not.toHaveBeenCalled()
   })
+
+  it('should not create a new view when the search part of the hash changes', () => {
+    history.pushState({}, '', '/foo#bar')
+    const { lifeCycle } = setupBuilder.build()
+    lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, createSpy)
+
+    history.pushState({}, '', '/foo#bar?search=1')
+    history.pushState({}, '', '/foo#bar?search=2')
+    history.pushState({}, '', '/foo#bar?')
+    history.pushState({}, '', '/foo#bar')
+
+    expect(createSpy).not.toHaveBeenCalled()
+  })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackLocationChanges.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackLocationChanges.ts
@@ -15,7 +15,8 @@ export function trackLocationChanges(onLocationChange: () => void) {
 export function areDifferentLocation(currentLocation: Location, otherLocation: Location) {
   return (
     currentLocation.pathname !== otherLocation.pathname ||
-    (!isHashAnAnchor(otherLocation.hash) && otherLocation.hash !== currentLocation.hash)
+    (!isHashAnAnchor(otherLocation.hash) &&
+      getPathFromHash(otherLocation.hash) !== getPathFromHash(currentLocation.hash))
   )
 }
 
@@ -48,4 +49,9 @@ function trackHash(onHashChange: () => void) {
 function isHashAnAnchor(hash: string) {
   const correspondingId = hash.substr(1)
   return !!document.getElementById(correspondingId)
+}
+
+function getPathFromHash(hash: string) {
+  const index = hash.indexOf('?')
+  return index < 0 ? hash : hash.slice(0, index)
 }


### PR DESCRIPTION
## Motivation

Better support for hash routers.

## Changes

Do not take the "search" (anything starting from a `?`) part of a hash into account when comparing URLs to generate a new view.

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
