### PR TITLE
🐛 add missing monitoring wrappers

### DIFF
--- a/packages/core/src/domain/tracekit/report.ts
+++ b/packages/core/src/domain/tracekit/report.ts
@@ -74,11 +74,11 @@ export function report(ex: Error) {
   // this exception; otherwise, we will end up with an incomplete
   // stack trace
   setTimeout(
-    () => {
+    monitor(() => {
       if (lastException === ex) {
         processLastException()
       }
-    },
+    }),
     stack.incomplete ? 2000 : 0
   )
 

--- a/packages/core/src/transport/transport.ts
+++ b/packages/core/src/transport/transport.ts
@@ -1,6 +1,7 @@
 import { Context } from '../tools/context'
 import { getTimeStamp, relativeNow } from '../tools/timeUtils'
 import { addEventListener, DOM_EVENT, jsonStringify, noop, objectValues } from '../tools/utils'
+import { monitor } from '../domain/internalMonitoring'
 
 // https://en.wikipedia.org/wiki/UTF-8
 const HAS_MULTI_BYTES_CHARACTERS = /[^\u0000-\u007F]/
@@ -149,10 +150,13 @@ export class Batch {
   }
 
   private flushPeriodically() {
-    setTimeout(() => {
-      this.flush()
-      this.flushPeriodically()
-    }, this.flushTimeout)
+    setTimeout(
+      monitor(() => {
+        this.flush()
+        this.flushPeriodically()
+      }),
+      this.flushTimeout
+    )
   }
 
   private flushOnVisibilityHidden() {


### PR DESCRIPTION
## Motivation

Some execution errors were not caught by the internal monitoring, cf #794

## Changes

Add missing monitoring wrappers

## Testing

ci + manual (for flush)

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
