### PR TITLE
🐛 fallback to xhr when sendBeacon throws

### DIFF
--- a/packages/core/src/transport/transport.spec.ts
+++ b/packages/core/src/transport/transport.spec.ts
@@ -53,6 +53,17 @@ describe('request', () => {
     expect(navigator.sendBeacon).toHaveBeenCalled()
     expect(server.requests.length).toEqual(1)
   })
+
+  it('should fallback to xhr when sendBeacon throws', () => {
+    spyOn(navigator, 'sendBeacon').and.callFake(() => {
+      throw new TypeError()
+    })
+
+    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+    expect(navigator.sendBeacon).toHaveBeenCalled()
+    expect(server.requests.length).toEqual(1)
+  })
 })
 
 describe('batch', () => {

--- a/packages/core/src/transport/transport.ts
+++ b/packages/core/src/transport/transport.ts
@@ -26,7 +26,7 @@ export class HttpRequest {
           return
         }
       } catch (e) {
-        addErrorToMonitoringBatch(e)
+        reportBeaconError(e)
       }
     }
     const request = new XMLHttpRequest()
@@ -39,6 +39,14 @@ function addBatchTime(url: string) {
   return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}&m_time=${getTimeStamp(
     relativeNow()
   )}`
+}
+
+let hasReportedBeaconError = false
+function reportBeaconError(e: unknown) {
+  if (!hasReportedBeaconError) {
+    hasReportedBeaconError = true
+    addErrorToMonitoringBatch(e)
+  }
 }
 
 export class Batch {


### PR DESCRIPTION
## Motivation

From the spec, sendBeacon can throw TypeError.
cf #794 

## Changes

Fallback to xhr when sendBeacon throws

## Testing

unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
