### PR TITLE
⚗[RUMF-889] use preferred clock

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,17 @@ unit:
     - yarn test:unit
     - ./scripts/codecov.sh
 
+unit_system_clock:
+  stage: test
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  artifacts:
+    reports:
+      junit: test-report/unit/*.xml
+  script:
+    - yarn
+    - SYSTEM_CLOCK=true yarn test:unit
+
 e2e:
   stage: test
   tags: ['runner:main', 'size:large']
@@ -91,6 +102,20 @@ e2e:
   script:
     - yarn
     - yarn test:e2e
+
+e2e_system_clock:
+  stage: test
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  artifacts:
+    when: always
+    paths:
+      - test-report/e2e/specs.log
+    reports:
+      junit: test-report/e2e/*.xml
+  script:
+    - yarn
+    - SYSTEM_CLOCK=true yarn test:e2e
 
 check-licenses:
   stage: test

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,8 +8,9 @@
   "sideEffects": false,
   "scripts": {
     "build": "run-p build:cjs build:esm",
-    "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json",
-    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
+    "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
+    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
+    "replace-build-env": "node ../../scripts/replace-build-env.js"
   },
   "dependencies": {
     "tslib": "^1.10.0"

--- a/packages/core/src/boot/buildEnv.ts
+++ b/packages/core/src/boot/buildEnv.ts
@@ -1,0 +1,4 @@
+export const buildEnv = {
+  // @ts-ignore replaced at build time
+  systemClock: '<<< SYSTEM_CLOCK >>>' === 'true',
+}

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -3,6 +3,7 @@ import { buildConfiguration, UserConfiguration } from '../domain/configuration'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
 import { Datacenter } from '../domain/transportConfiguration'
 import { catchUserErrors } from '../tools/catchUserErrors'
+import { preferSystemClock } from '../tools/timeUtils'
 
 export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): void } {
   const publicApi = {
@@ -50,6 +51,9 @@ export interface BuildEnv {
 
 export function commonInit(userConfiguration: UserConfiguration, buildEnv: BuildEnv) {
   const configuration = buildConfiguration(userConfiguration, buildEnv)
+  if (configuration.isEnabled('system-clock')) {
+    preferSystemClock()
+  }
   const internalMonitoring = startInternalMonitoring(configuration)
 
   return {

--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -1,4 +1,4 @@
-import { RelativeTime } from '@datadog/browser-core'
+import { Time } from '@datadog/browser-core'
 import { ErrorSource, RawError } from '../tools/error'
 import { Observable } from '../tools/observable'
 import { FetchStub, FetchStubManager, isIE, SPEC_ENDPOINTS, stubFetch } from '../tools/specHelper'
@@ -283,7 +283,7 @@ describe('error limitation', () => {
   let filteredSubscriber: jasmine.Spy
   const CONTEXT = {
     source: ErrorSource.SOURCE,
-    startTime: 100 as RelativeTime,
+    startTime: 100 as Time,
   }
 
   beforeEach(() => {

--- a/packages/core/src/domain/automaticErrorCollection.ts
+++ b/packages/core/src/domain/automaticErrorCollection.ts
@@ -2,7 +2,7 @@ import { FetchCompleteContext, resetFetchProxy, startFetchProxy } from '../brows
 import { resetXhrProxy, startXhrProxy, XhrCompleteContext } from '../browser/xhrProxy'
 import { ErrorSource, formatUnknownError, RawError, toStackTraceString, formatErrorMessage } from '../tools/error'
 import { Observable } from '../tools/observable'
-import { relativeNow } from '../tools/timeUtils'
+import { preferredNow, preferredTime } from '../tools/timeUtils'
 import { jsonStringify, ONE_MINUTE, RequestType, find } from '../tools/utils'
 import { Configuration } from './configuration'
 import { monitor } from './internalMonitoring'
@@ -34,7 +34,7 @@ export function filterErrors(configuration: Configuration, errorObservable: Obse
       filteredErrorObservable.notify({
         message: `Reached max number of errors by minute: ${configuration.maxErrorsByMinute}`,
         source: ErrorSource.AGENT,
-        startTime: relativeNow(),
+        startTime: preferredNow(),
       })
     }
   })
@@ -51,7 +51,7 @@ export function startConsoleTracking(errorObservable: ErrorObservable) {
     errorObservable.notify({
       ...buildErrorFromParams(params),
       source: ErrorSource.CONSOLE,
-      startTime: relativeNow(),
+      startTime: preferredNow(),
     })
   })
 }
@@ -88,7 +88,7 @@ export function startRuntimeErrorTracking(errorObservable: ErrorObservable) {
       stack,
       type,
       source: ErrorSource.SOURCE,
-      startTime: relativeNow(),
+      startTime: preferredNow(),
     })
   }
   subscribe(traceKitReportHandler)
@@ -117,7 +117,7 @@ export function trackNetworkError(configuration: Configuration, errorObservable:
         },
         source: ErrorSource.NETWORK,
         stack: truncateResponse(request.response, configuration) || 'Failed to load',
-        startTime: request.startTime,
+        startTime: preferredTime(request.startTimeStamp, request.startTime),
       })
     }
   }

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -1,9 +1,9 @@
 import { StackTrace } from '../domain/tracekit'
-import { RelativeTime } from './timeUtils'
+import { Time } from './timeUtils'
 import { jsonStringify } from './utils'
 
 export interface RawError {
-  startTime: RelativeTime
+  startTime: Time
   message: string
   type?: string
   stack?: string

--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -1,4 +1,5 @@
-import { isNumber, round, ONE_SECOND } from './utils'
+import { buildEnv } from '../boot/buildEnv'
+import { isNumber, round } from './utils'
 
 export type Duration = number & { d: 'Duration in ms' }
 export type ServerDuration = number & { s: 'Duration in ns' }
@@ -6,7 +7,7 @@ export type TimeStamp = number & { t: 'Epoch time' }
 export type RelativeTime = number & { r: 'Time relative to navigation start' } & { d: 'Duration in ms' }
 export type Time = (TimeStamp | RelativeTime) & { p: 'preferred time' }
 
-let isSystemClockPreferred = false
+let isSystemClockPreferred = buildEnv.systemClock
 
 export function preferSystemClock() {
   isSystemClockPreferred = true
@@ -86,7 +87,7 @@ export function getTimeStamp(relativeTime: RelativeTime) {
  * Navigation start slightly change on some rare cases
  */
 let navigationStart: TimeStamp | undefined
-function getNavigationStart() {
+export function getNavigationStart() {
   if (navigationStart === undefined) {
     navigationStart = performance.timing.navigationStart as TimeStamp
   }

--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -93,3 +93,7 @@ export function getNavigationStart() {
   }
   return navigationStart
 }
+
+export function resetNavigationStart() {
+  navigationStart = undefined
+}

--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -1,9 +1,46 @@
-import { isNumber, round } from './utils'
+import { isNumber, round, ONE_SECOND } from './utils'
 
 export type Duration = number & { d: 'Duration in ms' }
 export type ServerDuration = number & { s: 'Duration in ns' }
 export type TimeStamp = number & { t: 'Epoch time' }
 export type RelativeTime = number & { r: 'Time relative to navigation start' } & { d: 'Duration in ms' }
+export type Time = (TimeStamp | RelativeTime) & { p: 'preferred time' }
+
+let isSystemClockPreferred = false
+
+export function preferSystemClock() {
+  isSystemClockPreferred = true
+}
+
+export function preferredNow(): Time {
+  return (isSystemClockPreferred ? timeStampNow() : relativeNow()) as Time
+}
+
+export function preferredTime(timestamp: TimeStamp, relativeTime: RelativeTime): Time {
+  return (isSystemClockPreferred ? timestamp : relativeTime) as Time
+}
+
+export function preferredTimeOrigin() {
+  return (isSystemClockPreferred ? getNavigationStart() : 0) as Time
+}
+
+export function preferredTimeStamp(time: Time) {
+  return isSystemClockPreferred ? (time as TimeStamp) : getTimeStamp(time as RelativeTime)
+}
+
+export function preferredRelativeTime(time: Time) {
+  return isSystemClockPreferred ? getRelativeTime(time as TimeStamp) : (time as RelativeTime)
+}
+
+// TODO test
+export function getCorrectedTimeStamp(relativeTime: RelativeTime) {
+  const correctedOrigin = Date.now() - performance.now()
+  if (isSystemClockPreferred && correctedOrigin > getNavigationStart()) {
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    return Math.floor(correctedOrigin + relativeTime) as TimeStamp
+  }
+  return getTimeStamp(relativeTime)
+}
 
 export function toServerDuration(duration: Duration): ServerDuration
 export function toServerDuration(duration: Duration | undefined): ServerDuration | undefined
@@ -22,6 +59,7 @@ export function relativeNow() {
   return performance.now() as RelativeTime
 }
 
+export function elapsed(start: Time, end: Time): Duration
 export function elapsed(start: TimeStamp, end: TimeStamp): Duration
 export function elapsed(start: RelativeTime, end: RelativeTime): Duration
 export function elapsed(start: number, end: number) {

--- a/packages/core/src/transport/transport.ts
+++ b/packages/core/src/transport/transport.ts
@@ -1,5 +1,5 @@
 import { Context } from '../tools/context'
-import { getTimeStamp, relativeNow } from '../tools/timeUtils'
+import { preferredTimeStamp, relativeNow, Time } from '../tools/timeUtils'
 import { addEventListener, DOM_EVENT, jsonStringify, noop, objectValues } from '../tools/utils'
 import { monitor, addErrorToMonitoringBatch } from '../domain/internalMonitoring'
 
@@ -36,8 +36,8 @@ export class HttpRequest {
 }
 
 function addBatchTime(url: string) {
-  return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}&m_time=${getTimeStamp(
-    relativeNow()
+  return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}&m_time=${preferredTimeStamp(
+    relativeNow() as Time
   )}`
 }
 

--- a/packages/logs/src/boot/logs.spec.ts
+++ b/packages/logs/src/boot/logs.spec.ts
@@ -8,6 +8,9 @@ import {
   Observable,
   RawError,
   Time,
+  preferredTime,
+  getTimeStamp,
+  RelativeTime,
 } from '@datadog/browser-core'
 import sinon from 'sinon'
 
@@ -283,7 +286,7 @@ describe('logs', () => {
       errorObservable.notify({
         message: 'error!',
         source: ErrorSource.SOURCE,
-        startTime: 1234 as Time,
+        startTime: preferredTime(getTimeStamp(1234 as RelativeTime), 1234 as RelativeTime),
         type: 'Error',
       })
 

--- a/packages/logs/src/boot/logs.spec.ts
+++ b/packages/logs/src/boot/logs.spec.ts
@@ -7,7 +7,7 @@ import {
   noop,
   Observable,
   RawError,
-  RelativeTime,
+  Time,
 } from '@datadog/browser-core'
 import sinon from 'sinon'
 
@@ -254,7 +254,7 @@ describe('logs', () => {
       errorObservable.notify({
         message: 'error!',
         source: ErrorSource.SOURCE,
-        startTime: 1234 as RelativeTime,
+        startTime: 1234 as Time,
         type: 'Error',
       })
 
@@ -283,7 +283,7 @@ describe('logs', () => {
       errorObservable.notify({
         message: 'error!',
         source: ErrorSource.SOURCE,
-        startTime: 1234 as RelativeTime,
+        startTime: 1234 as Time,
         type: 'Error',
       })
 

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -13,8 +13,9 @@ import {
   RawError,
   RelativeTime,
   startAutomaticErrorCollection,
-  getTimeStamp,
   UserConfiguration,
+  preferredTimeStamp,
+  preferredRelativeTime,
 } from '@datadog/browser-core'
 import { Logger, LogsMessage } from '../domain/logger'
 import { LoggerSession, startLoggerSession } from '../domain/loggerSession'
@@ -62,7 +63,7 @@ export function doStartLogs(
       error.message,
       combine(
         {
-          date: getTimeStamp(error.startTime),
+          date: preferredTimeStamp(error.startTime),
           error: {
             kind: error.type,
             origin: error.source,
@@ -78,7 +79,7 @@ export function doStartLogs(
               },
             }
           : undefined,
-        getRUMInternalContext(error.startTime)
+        getRUMInternalContext(preferredRelativeTime(error.startTime))
       )
     )
   })

--- a/packages/logs/src/boot/logs.ts
+++ b/packages/logs/src/boot/logs.ts
@@ -6,7 +6,6 @@ import {
   Configuration,
   Context,
   ErrorObservable,
-  getTimeStamp,
   HttpRequest,
   InternalMonitoring,
   limitModification,
@@ -14,6 +13,7 @@ import {
   RawError,
   RelativeTime,
   startAutomaticErrorCollection,
+  getTimeStamp,
   UserConfiguration,
 } from '@datadog/browser-core'
 import { Logger, LogsMessage } from '../domain/logger'

--- a/packages/rum-core/src/boot/rum.ts
+++ b/packages/rum-core/src/boot/rum.ts
@@ -1,4 +1,4 @@
-import { combine, commonInit, Configuration, preferSystemClock } from '@datadog/browser-core'
+import { combine, commonInit, Configuration } from '@datadog/browser-core'
 import { startDOMMutationCollection } from '../browser/domMutationCollection'
 import { startPerformanceCollection } from '../browser/performanceCollection'
 import { startRumAssembly } from '../domain/assembly'
@@ -22,9 +22,6 @@ export function startRum(userConfiguration: RumUserConfiguration, getCommonConte
   const lifeCycle = new LifeCycle()
 
   const { configuration, internalMonitoring } = commonInit(userConfiguration, buildEnv)
-  if (configuration.isEnabled('system-clock')) {
-    preferSystemClock()
-  }
   const session = startRumSession(configuration, lifeCycle)
 
   internalMonitoring.setExternalContextProvider(() =>

--- a/packages/rum-core/src/boot/rum.ts
+++ b/packages/rum-core/src/boot/rum.ts
@@ -1,4 +1,4 @@
-import { combine, commonInit, Configuration } from '@datadog/browser-core'
+import { combine, commonInit, Configuration, preferSystemClock } from '@datadog/browser-core'
 import { startDOMMutationCollection } from '../browser/domMutationCollection'
 import { startPerformanceCollection } from '../browser/performanceCollection'
 import { startRumAssembly } from '../domain/assembly'
@@ -22,6 +22,9 @@ export function startRum(userConfiguration: RumUserConfiguration, getCommonConte
   const lifeCycle = new LifeCycle()
 
   const { configuration, internalMonitoring } = commonInit(userConfiguration, buildEnv)
+  if (configuration.isEnabled('system-clock')) {
+    preferSystemClock()
+  }
   const session = startRumSession(configuration, lifeCycle)
 
   internalMonitoring.setExternalContextProvider(() =>

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorSource, ONE_SECOND, Time } from '@datadog/browser-core'
+import { ErrorSource, ONE_SECOND, getTimeStamp, preferredTime, RelativeTime } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { ActionType } from '../rawRumEvent.types'
 import { makeRumPublicApi, RumPublicApi, RumUserConfiguration, StartRum } from './rumPublicApi'
@@ -186,7 +186,9 @@ describe('rum entry', () => {
         clock.tick(ONE_SECOND)
         rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
-        expect(addActionSpy.calls.argsFor(0)[0].startTime as number).toEqual(ONE_SECOND)
+        expect(addActionSpy.calls.argsFor(0)[0].startTime as number).toEqual(
+          preferredTime(getTimeStamp(ONE_SECOND as RelativeTime), ONE_SECOND as RelativeTime)
+        )
       })
 
       it('stores a deep copy of the global context', () => {
@@ -288,7 +290,9 @@ describe('rum entry', () => {
         clock.tick(ONE_SECOND)
         rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
-        expect(addErrorSpy.calls.argsFor(0)[0].startTime as number).toEqual(ONE_SECOND)
+        expect(addErrorSpy.calls.argsFor(0)[0].startTime as number).toEqual(
+          preferredTime(getTimeStamp(ONE_SECOND as RelativeTime), ONE_SECOND as RelativeTime)
+        )
       })
 
       it('stores a deep copy of the global context', () => {
@@ -421,7 +425,9 @@ describe('rum entry', () => {
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
       expect(addTimingSpy.calls.argsFor(0)[0]).toEqual('foo')
-      expect(addTimingSpy.calls.argsFor(0)[1]).toEqual(10 as Time)
+      expect(addTimingSpy.calls.argsFor(0)[1]).toEqual(
+        preferredTime(getTimeStamp(10 as RelativeTime), 10 as RelativeTime)
+      )
     })
 
     it('should add custom timings', () => {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorSource, ONE_SECOND, RelativeTime } from '@datadog/browser-core'
+import { ErrorSource, ONE_SECOND, Time } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { ActionType } from '../rawRumEvent.types'
 import { makeRumPublicApi, RumPublicApi, RumUserConfiguration, StartRum } from './rumPublicApi'
@@ -421,7 +421,7 @@ describe('rum entry', () => {
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
       expect(addTimingSpy.calls.argsFor(0)[0]).toEqual('foo')
-      expect(addTimingSpy.calls.argsFor(0)[1]).toEqual(10 as RelativeTime)
+      expect(addTimingSpy.calls.argsFor(0)[1]).toEqual(10 as Time)
     })
 
     it('should add custom timings', () => {

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONFIGURATION, noop, RelativeTime } from '@datadog/browser-core'
+import { DEFAULT_CONFIGURATION, noop, Time } from '@datadog/browser-core'
 import { createRawRumEvent } from '../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { CommonContext, RumEventType } from '../rawRumEvent.types'
@@ -71,7 +71,7 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK, { view: { url: '/path?foo=bar' } }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].view.url).toBe('modified')
@@ -84,7 +84,7 @@ describe('rum assembly', () => {
         rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK, {
           view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
         }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
@@ -97,28 +97,28 @@ describe('rum assembly', () => {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION, {
           view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
         }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.ERROR, {
           view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
         }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK, {
           view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
         }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, {
           view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
         }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents.length).toBe(0)
@@ -131,7 +131,7 @@ describe('rum assembly', () => {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW, {
           view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
         }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
@@ -143,7 +143,7 @@ describe('rum assembly', () => {
     it('should be merged with event attributes', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW, undefined),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].view.id).toBeDefined()
@@ -153,7 +153,7 @@ describe('rum assembly', () => {
     it('should be overwritten by event attributes', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW, { date: 10 }),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].date).toBe(10)
@@ -165,7 +165,7 @@ describe('rum assembly', () => {
       commonContext.context = { bar: 'foo' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect((serverRumEvents[0].context as any).bar).toEqual('foo')
@@ -175,7 +175,7 @@ describe('rum assembly', () => {
       commonContext.context = {}
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].context).toBe(undefined)
@@ -185,12 +185,12 @@ describe('rum assembly', () => {
       commonContext.context = { bar: 'foo', baz: 'foz' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       delete commonContext.context.bar
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect((serverRumEvents[0].context as any).bar).toEqual('foo')
@@ -206,7 +206,7 @@ describe('rum assembly', () => {
           context: { replacedContext: 'a' },
           user: {},
         },
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect((serverRumEvents[0].context as any).replacedContext).toEqual('a')
@@ -219,7 +219,7 @@ describe('rum assembly', () => {
       commonContext.user = { id: 'foo' }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].usr!.id).toEqual('foo')
@@ -229,7 +229,7 @@ describe('rum assembly', () => {
       commonContext.user = {}
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].usr).toBe(undefined)
@@ -244,7 +244,7 @@ describe('rum assembly', () => {
           context: {},
           user: { replacedAttribute: 'a' },
         },
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect(serverRumEvents[0].usr!.replacedAttribute).toEqual('a')
@@ -257,7 +257,7 @@ describe('rum assembly', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         customerContext: { foo: 'bar' },
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
 
       expect((serverRumEvents[0].context as any).foo).toEqual('bar')
@@ -269,7 +269,7 @@ describe('rum assembly', () => {
       ;[RumEventType.RESOURCE, RumEventType.LONG_TASK, RumEventType.ERROR].forEach((category) => {
         lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
           rawRumEvent: createRawRumEvent(category),
-          startTime: 0 as RelativeTime,
+          startTime: 0 as Time,
         })
         expect(serverRumEvents[0].action).toEqual({ id: '7890' })
         serverRumEvents = []
@@ -277,14 +277,14 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents[0].action).not.toBeDefined()
       serverRumEvents = []
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect((serverRumEvents[0] as RumActionEvent).action.id).not.toBeDefined()
       serverRumEvents = []
@@ -295,7 +295,7 @@ describe('rum assembly', () => {
     it('should be merged with event attributes', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents[0].view).toEqual({
         id: 'abcde',
@@ -312,7 +312,7 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents.length).toBe(1)
     })
@@ -322,7 +322,7 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents.length).toBe(0)
     })
@@ -332,7 +332,7 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents.length).toBe(1)
     })
@@ -342,7 +342,7 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents.length).toBe(0)
     })
@@ -352,7 +352,7 @@ describe('rum assembly', () => {
     it('should include the session type and id', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents[0].session).toEqual({
         has_replay: undefined,
@@ -366,7 +366,7 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.ERROR),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents[0].session.has_replay).toBe(true)
     })
@@ -376,7 +376,7 @@ describe('rum assembly', () => {
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 0 as RelativeTime,
+        startTime: 0 as Time,
       })
       expect(serverRumEvents[0].session.has_replay).toBe(undefined)
     })

--- a/packages/rum-core/src/domain/internalContext.spec.ts
+++ b/packages/rum-core/src/domain/internalContext.spec.ts
@@ -1,3 +1,4 @@
+import { preferredTimeOrigin } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { startInternalContext } from './internalContext'
 import { ParentContexts } from './parentContexts'
@@ -70,8 +71,10 @@ describe('internal context', () => {
 
     internalContext.get(123)
 
-    expect(parentContextsStub.findView).toHaveBeenCalledWith(123)
-    expect(parentContextsStub.findAction).toHaveBeenCalledWith(123)
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    expect(parentContextsStub.findView).toHaveBeenCalledWith(preferredTimeOrigin() + 123)
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    expect(parentContextsStub.findAction).toHaveBeenCalledWith(preferredTimeOrigin() + 123)
   })
 
   it('should return current internal context', () => {

--- a/packages/rum-core/src/domain/internalContext.spec.ts
+++ b/packages/rum-core/src/domain/internalContext.spec.ts
@@ -73,4 +73,13 @@ describe('internal context', () => {
     expect(parentContextsStub.findView).toHaveBeenCalledWith(123)
     expect(parentContextsStub.findAction).toHaveBeenCalledWith(123)
   })
+
+  it('should return current internal context', () => {
+    setupBuilder.build()
+
+    internalContext.get()
+
+    expect(parentContextsStub.findView).toHaveBeenCalledWith(undefined)
+    expect(parentContextsStub.findAction).toHaveBeenCalledWith(undefined)
+  })
 })

--- a/packages/rum-core/src/domain/internalContext.ts
+++ b/packages/rum-core/src/domain/internalContext.ts
@@ -1,4 +1,4 @@
-import { RelativeTime } from '@datadog/browser-core'
+import { RelativeTime, preferredTime, getTimeStamp } from '@datadog/browser-core'
 import { InternalContext } from '../rawRumEvent.types'
 import { ParentContexts } from './parentContexts'
 import { RumSession } from './rumSession'
@@ -10,9 +10,14 @@ import { RumSession } from './rumSession'
 export function startInternalContext(applicationId: string, session: RumSession, parentContexts: ParentContexts) {
   return {
     get: (startTime?: number): InternalContext | undefined => {
-      const viewContext = parentContexts.findView(startTime as RelativeTime)
+      // no correction since relative time is computed from system clock
+      const time =
+        startTime !== undefined
+          ? preferredTime(getTimeStamp(startTime as RelativeTime), startTime as RelativeTime)
+          : undefined
+      const viewContext = parentContexts.findView(time)
       if (session.isTracked() && viewContext && viewContext.session.id) {
-        const actionContext = parentContexts.findAction(startTime as RelativeTime)
+        const actionContext = parentContexts.findAction(time)
         return {
           application_id: applicationId,
           session_id: viewContext.session.id,

--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -1,4 +1,4 @@
-import { Context, RelativeTime } from '@datadog/browser-core'
+import { Context, Time } from '@datadog/browser-core'
 import { RumPerformanceEntry } from '../browser/performanceCollection'
 import { CommonContext, RawRumEvent } from '../rawRumEvent.types'
 import { RumEvent } from '../rumEvent.types'
@@ -52,7 +52,7 @@ export class LifeCycle {
   notify(
     eventType: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
     data: {
-      startTime: RelativeTime
+      startTime: Time
       rawRumEvent: RawRumEvent
       savedCommonContext?: CommonContext
       customerContext?: Context
@@ -96,7 +96,7 @@ export class LifeCycle {
   subscribe(
     eventType: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
     callback: (data: {
-      startTime: RelativeTime
+      startTime: Time
       rawRumEvent: RawRumEvent
       savedCommonContext?: CommonContext
       customerContext?: Context

--- a/packages/rum-core/src/domain/parentContexts.spec.ts
+++ b/packages/rum-core/src/domain/parentContexts.spec.ts
@@ -1,4 +1,4 @@
-import { Duration, RelativeTime } from '@datadog/browser-core'
+import { Duration, Time } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { LifeCycleEventType } from './lifeCycle'
 import {
@@ -18,7 +18,7 @@ function stubActionWithDuration(duration: number): AutoAction {
 
 describe('parentContexts', () => {
   const FAKE_ID = 'fake'
-  const startTime = 10 as RelativeTime
+  const startTime = 10 as Time
 
   function buildViewCreatedEvent(partialViewCreatedEvent: Partial<ViewCreatedEvent> = {}): ViewCreatedEvent {
     return { location, startTime, id: FAKE_ID, referrer: 'http://foo.com', ...partialViewCreatedEvent }
@@ -66,37 +66,22 @@ describe('parentContexts', () => {
     it('should return the view context corresponding to startTime', () => {
       const { lifeCycle } = setupBuilder.build()
 
-      lifeCycle.notify(
-        LifeCycleEventType.VIEW_CREATED,
-        buildViewCreatedEvent({ startTime: 10 as RelativeTime, id: 'view 1' })
-      )
-      lifeCycle.notify(
-        LifeCycleEventType.VIEW_CREATED,
-        buildViewCreatedEvent({ startTime: 20 as RelativeTime, id: 'view 2' })
-      )
-      lifeCycle.notify(
-        LifeCycleEventType.VIEW_CREATED,
-        buildViewCreatedEvent({ startTime: 30 as RelativeTime, id: 'view 3' })
-      )
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 10 as Time, id: 'view 1' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 20 as Time, id: 'view 2' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 30 as Time, id: 'view 3' }))
 
-      expect(parentContexts.findView(15 as RelativeTime)!.view.id).toEqual('view 1')
-      expect(parentContexts.findView(20 as RelativeTime)!.view.id).toEqual('view 2')
-      expect(parentContexts.findView(40 as RelativeTime)!.view.id).toEqual('view 3')
+      expect(parentContexts.findView(15 as Time)!.view.id).toEqual('view 1')
+      expect(parentContexts.findView(20 as Time)!.view.id).toEqual('view 2')
+      expect(parentContexts.findView(40 as Time)!.view.id).toEqual('view 3')
     })
 
     it('should return undefined when no view context corresponding to startTime', () => {
       const { lifeCycle } = setupBuilder.build()
 
-      lifeCycle.notify(
-        LifeCycleEventType.VIEW_CREATED,
-        buildViewCreatedEvent({ startTime: 10 as RelativeTime, id: 'view 1' })
-      )
-      lifeCycle.notify(
-        LifeCycleEventType.VIEW_CREATED,
-        buildViewCreatedEvent({ startTime: 20 as RelativeTime, id: 'view 2' })
-      )
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 10 as Time, id: 'view 1' }))
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startTime: 20 as Time, id: 'view 2' }))
 
-      expect(parentContexts.findView(5 as RelativeTime)).not.toBeDefined()
+      expect(parentContexts.findView(5 as Time)).not.toBeDefined()
     })
 
     it('should replace the current view context on VIEW_CREATED', () => {
@@ -160,29 +145,29 @@ describe('parentContexts', () => {
     it('should return the action context corresponding to startTime', () => {
       const { lifeCycle } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10 as RelativeTime, id: 'action 1' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10 as Time, id: 'action 1' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
 
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 30 as RelativeTime, id: 'action 2' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 30 as Time, id: 'action 2' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
 
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 50 as RelativeTime, id: 'action 3' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 50 as Time, id: 'action 3' })
 
-      expect(parentContexts.findAction(15 as RelativeTime)!.action.id).toBe('action 1')
-      expect(parentContexts.findAction(20 as RelativeTime)!.action.id).toBe('action 1')
-      expect(parentContexts.findAction(30 as RelativeTime)!.action.id).toBe('action 2')
-      expect(parentContexts.findAction(55 as RelativeTime)!.action.id).toBe('action 3')
+      expect(parentContexts.findAction(15 as Time)!.action.id).toBe('action 1')
+      expect(parentContexts.findAction(20 as Time)!.action.id).toBe('action 1')
+      expect(parentContexts.findAction(30 as Time)!.action.id).toBe('action 2')
+      expect(parentContexts.findAction(55 as Time)!.action.id).toBe('action 3')
     })
 
     it('should return undefined if no action context corresponding to startTime', () => {
       const { lifeCycle } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10 as RelativeTime, id: 'action 1' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10 as Time, id: 'action 1' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_DISCARDED)
 
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 20 as RelativeTime, id: 'action 2' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 20 as Time, id: 'action 2' })
 
-      expect(parentContexts.findAction(10 as RelativeTime)).toBeUndefined()
+      expect(parentContexts.findAction(10 as Time)).toBeUndefined()
     })
 
     it('should clear the current action on ACTION_DISCARDED', () => {
@@ -212,54 +197,54 @@ describe('parentContexts', () => {
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({
           id: 'view 1',
-          startTime: 10 as RelativeTime,
+          startTime: 10 as Time,
         })
       )
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({
           id: 'view 2',
-          startTime: 20 as RelativeTime,
+          startTime: 20 as Time,
         })
       )
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10 as RelativeTime, id: 'action 1' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 10 as Time, id: 'action 1' })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
-      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 20 as RelativeTime, id: 'action 2' })
+      lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { startTime: 20 as Time, id: 'action 2' })
 
-      expect(parentContexts.findView(15 as RelativeTime)).toBeDefined()
-      expect(parentContexts.findAction(15 as RelativeTime)).toBeDefined()
-      expect(parentContexts.findView(25 as RelativeTime)).toBeDefined()
-      expect(parentContexts.findAction(25 as RelativeTime)).toBeDefined()
+      expect(parentContexts.findView(15 as Time)).toBeDefined()
+      expect(parentContexts.findAction(15 as Time)).toBeDefined()
+      expect(parentContexts.findView(25 as Time)).toBeDefined()
+      expect(parentContexts.findAction(25 as Time)).toBeDefined()
 
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
-      expect(parentContexts.findView(15 as RelativeTime)).toBeUndefined()
-      expect(parentContexts.findAction(15 as RelativeTime)).toBeUndefined()
-      expect(parentContexts.findView(25 as RelativeTime)).toBeUndefined()
-      expect(parentContexts.findAction(25 as RelativeTime)).toBeUndefined()
+      expect(parentContexts.findView(15 as Time)).toBeUndefined()
+      expect(parentContexts.findAction(15 as Time)).toBeUndefined()
+      expect(parentContexts.findView(25 as Time)).toBeUndefined()
+      expect(parentContexts.findAction(25 as Time)).toBeUndefined()
     })
 
     it('should be cleared when too old', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
 
       const originalTime = performance.now()
-      const targetTime = (originalTime + 5) as RelativeTime
+      const targetTime = (originalTime + 5) as Time
 
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({
           id: 'view 1',
-          startTime: originalTime as RelativeTime,
+          startTime: originalTime as Time,
         })
       )
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, {
-        startTime: originalTime as RelativeTime,
+        startTime: originalTime as Time,
         id: 'action 1',
       })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, stubActionWithDuration(10))
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
-        buildViewCreatedEvent({ startTime: (originalTime + 10) as RelativeTime, id: 'view 2' })
+        buildViewCreatedEvent({ startTime: (originalTime + 10) as Time, id: 'view 2' })
       )
 
       clock.tick(10)

--- a/packages/rum-core/src/domain/parentContexts.ts
+++ b/packages/rum-core/src/domain/parentContexts.ts
@@ -1,4 +1,4 @@
-import { monitor, ONE_MINUTE, RelativeTime, SESSION_TIME_OUT_DELAY } from '@datadog/browser-core'
+import { monitor, ONE_MINUTE, SESSION_TIME_OUT_DELAY, Time } from '@datadog/browser-core'
 import { ActionContext, ViewContext } from '../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { AutoAction, AutoActionCreatedEvent } from './rumEventsCollection/action/trackActions'
@@ -10,14 +10,14 @@ export const ACTION_CONTEXT_TIME_OUT_DELAY = 5 * ONE_MINUTE // arbitrary
 export const CLEAR_OLD_CONTEXTS_INTERVAL = ONE_MINUTE
 
 interface PreviousContext<T> {
-  startTime: RelativeTime
-  endTime: RelativeTime
+  startTime: Time
+  endTime: Time
   context: T
 }
 
 export interface ParentContexts {
-  findAction: (startTime?: RelativeTime) => ActionContext | undefined
-  findView: (startTime?: RelativeTime) => ViewContext | undefined
+  findAction: (startTime?: Time) => ActionContext | undefined
+  findView: (startTime?: Time) => ViewContext | undefined
   stop: () => void
 }
 
@@ -58,7 +58,7 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
       previousActions.unshift({
         context: buildCurrentActionContext(),
         // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        endTime: (currentAction.startTime + action.duration) as RelativeTime,
+        endTime: (currentAction.startTime + action.duration) as Time,
         startTime: currentAction.startTime,
       })
     }
@@ -112,8 +112,8 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
   function findContext<T>(
     buildContext: () => T,
     previousContexts: Array<PreviousContext<T>>,
-    currentContext?: { startTime: RelativeTime },
-    startTime?: RelativeTime
+    currentContext?: { startTime: Time },
+    startTime?: Time
   ) {
     if (startTime === undefined) {
       return currentContext ? buildContext() : undefined

--- a/packages/rum-core/src/domain/requestCollection.ts
+++ b/packages/rum-core/src/domain/requestCollection.ts
@@ -3,12 +3,13 @@ import {
   Duration,
   FetchCompleteContext,
   FetchStartContext,
-  RelativeTime,
   RequestType,
   startFetchProxy,
   startXhrProxy,
   XhrCompleteContext,
   XhrStartContext,
+  Time,
+  preferredTime,
 } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { isAllowedRequestUrl } from './rumEventsCollection/resource/resourceUtils'
@@ -36,7 +37,7 @@ export interface RequestCompleteEvent {
   status: number
   response?: string
   responseType?: string
-  startTime: RelativeTime
+  startTime: Time
   duration: Duration
   spanId?: TraceIdentifier
   traceId?: TraceIdentifier
@@ -71,7 +72,7 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: Configuration, tra
         requestIndex: context.requestIndex,
         response: context.response,
         spanId: context.spanId,
-        startTime: context.startTime,
+        startTime: preferredTime(context.startTimeStamp, context.startTime),
         status: context.status,
         traceId: context.traceId,
         type: RequestType.XHR,
@@ -104,7 +105,7 @@ export function trackFetch(lifeCycle: LifeCycle, configuration: Configuration, t
         response: context.response,
         responseType: context.responseType,
         spanId: context.spanId,
-        startTime: context.startTime,
+        startTime: preferredTime(context.startTimeStamp, context.startTime),
         status: context.status,
         traceId: context.traceId,
         type: RequestType.FETCH,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -1,4 +1,4 @@
-import { Duration, RelativeTime, ServerDuration } from '@datadog/browser-core'
+import { Duration, ServerDuration, Time } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType, ActionType } from '../../../rawRumEvent.types'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -32,7 +32,7 @@ describe('actionCollection', () => {
       duration: 100 as Duration,
       id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       name: 'foo',
-      startTime: 1234 as RelativeTime,
+      startTime: 1234 as Time,
       type: ActionType.CLICK,
     })
 
@@ -64,7 +64,7 @@ describe('actionCollection', () => {
     const { rawRumEvents } = setupBuilder.build()
     addAction({
       name: 'foo',
-      startTime: 1234 as RelativeTime,
+      startTime: 1234 as Time,
       type: ActionType.CUSTOM,
     })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -1,4 +1,4 @@
-import { combine, Configuration, getTimeStamp, toServerDuration } from '@datadog/browser-core'
+import { combine, Configuration, preferredTimeStamp, toServerDuration } from '@datadog/browser-core'
 import { ActionType, CommonContext, RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { AutoAction, CustomAction, trackActions } from './trackActions'
@@ -49,7 +49,7 @@ function processAction(action: AutoAction | CustomAction) {
         },
         type: action.type,
       },
-      date: getTimeStamp(action.startTime),
+      date: preferredTimeStamp(action.startTime),
       type: RumEventType.ACTION as const,
     },
     autoActionProperties

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -1,4 +1,4 @@
-import { Context, DOM_EVENT, RelativeTime } from '@datadog/browser-core'
+import { Context, DOM_EVENT, Time } from '@datadog/browser-core'
 import { RumEvent } from '../../../../../rum/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType, ActionType } from '../../../rawRumEvent.types'
@@ -82,7 +82,7 @@ describe('trackActions', () => {
       location,
       id: 'fake',
       referrer: 'http://foo.com',
-      startTime: 0 as RelativeTime,
+      startTime: 0 as Time,
     })
     clock.tick(EXPIRE_DELAY)
 

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorSource, Observable, RawError, RelativeTime } from '@datadog/browser-core'
+import { ErrorSource, Observable, RawError, Time } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType } from '../../../rawRumEvent.types'
 import { doStartErrorCollection } from './errorCollection'
@@ -28,7 +28,7 @@ describe('error collection', () => {
       addError({
         error: new Error('foo'),
         source: ErrorSource.CUSTOM,
-        startTime: 12 as RelativeTime,
+        startTime: 12 as Time,
       })
 
       expect(rawRumEvents.length).toBe(1)
@@ -56,7 +56,7 @@ describe('error collection', () => {
         context: { foo: 'bar' },
         error: new Error('foo'),
         source: ErrorSource.CUSTOM,
-        startTime: 12 as RelativeTime,
+        startTime: 12 as Time,
       })
       expect(rawRumEvents[0].customerContext).toEqual({
         foo: 'bar',
@@ -69,7 +69,7 @@ describe('error collection', () => {
         {
           error: new Error('foo'),
           source: ErrorSource.CUSTOM,
-          startTime: 12 as RelativeTime,
+          startTime: 12 as Time,
         },
         { context: { foo: 'bar' }, user: {} }
       )
@@ -84,7 +84,7 @@ describe('error collection', () => {
         {
           error: new Error('foo'),
           source: ErrorSource.CUSTOM,
-          startTime: 12 as RelativeTime,
+          startTime: 12 as Time,
         },
         { context: {}, user: { id: 'foo' } }
       )
@@ -106,7 +106,7 @@ describe('error collection', () => {
         },
         source: ErrorSource.NETWORK,
         stack: 'bar',
-        startTime: 1234 as RelativeTime,
+        startTime: 1234 as Time,
         type: 'foo',
       })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -5,16 +5,15 @@ import {
   formatUnknownError,
   Observable,
   RawError,
-  RelativeTime,
   startAutomaticErrorCollection,
-  getCorrectedTimeStamp,
-  preferredTime,
+  Time,
+  preferredTimeStamp,
 } from '@datadog/browser-core'
 import { CommonContext, RawRumErrorEvent, RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 
 export interface ProvidedError {
-  startTime: RelativeTime
+  startTime: Time
   error: unknown
   context?: Context
   source: ProvidedSource
@@ -44,15 +43,14 @@ export function doStartErrorCollection(lifeCycle: LifeCycle, observable: Observa
   }
 }
 
-function computeRawError(error: unknown, startTime: RelativeTime, source: ProvidedSource): RawError {
+function computeRawError(error: unknown, startTime: Time, source: ProvidedSource): RawError {
   const stackTrace = error instanceof Error ? computeStackTrace(error) : undefined
   return { startTime, source, ...formatUnknownError(stackTrace, error, 'Provided') }
 }
 
 function processError(error: RawError) {
-  const timeStamp = getCorrectedTimeStamp(error.startTime)
   const rawRumEvent: RawRumErrorEvent = {
-    date: timeStamp,
+    date: preferredTimeStamp(error.startTime),
     error: {
       message: error.message,
       resource: error.resource
@@ -71,6 +69,6 @@ function processError(error: RawError) {
 
   return {
     rawRumEvent,
-    startTime: preferredTime(timeStamp, error.startTime),
+    startTime: error.startTime,
   }
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -3,11 +3,12 @@ import {
   Configuration,
   Context,
   formatUnknownError,
-  getTimeStamp,
   Observable,
   RawError,
   RelativeTime,
   startAutomaticErrorCollection,
+  getCorrectedTimeStamp,
+  preferredTime,
 } from '@datadog/browser-core'
 import { CommonContext, RawRumErrorEvent, RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
@@ -49,8 +50,9 @@ function computeRawError(error: unknown, startTime: RelativeTime, source: Provid
 }
 
 function processError(error: RawError) {
+  const timeStamp = getCorrectedTimeStamp(error.startTime)
   const rawRumEvent: RawRumErrorEvent = {
-    date: getTimeStamp(error.startTime),
+    date: timeStamp,
     error: {
       message: error.message,
       resource: error.resource
@@ -69,6 +71,6 @@ function processError(error: RawError) {
 
   return {
     rawRumEvent,
-    startTime: error.startTime,
+    startTime: preferredTime(timeStamp, error.startTime),
   }
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -1,4 +1,4 @@
-import { Duration, RelativeTime, ServerDuration } from '@datadog/browser-core'
+import { Duration, getTimeStamp, preferredTime, RelativeTime, ServerDuration } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumPerformanceEntry } from '../../../browser/performanceCollection'
 import { RumEventType } from '../../../rawRumEvent.types'
@@ -10,6 +10,7 @@ describe('long task collection', () => {
 
   beforeEach(() => {
     setupBuilder = setup()
+      .withFakeClock()
       .withConfiguration({
         isEnabled: () => true,
       })
@@ -43,7 +44,7 @@ describe('long task collection', () => {
       startTime: 1234 as RelativeTime,
     })
 
-    expect(rawRumEvents[0].startTime).toBe(1234)
+    expect(rawRumEvents[0].startTime).toBe(preferredTime(getTimeStamp(1234 as RelativeTime), 1234 as RelativeTime))
     expect(rawRumEvents[0].rawRumEvent).toEqual({
       date: jasmine.any(Number),
       long_task: {

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
@@ -1,4 +1,4 @@
-import { getTimeStamp, toServerDuration } from '@datadog/browser-core'
+import { toServerDuration, getCorrectedTimeStamp, preferredTime } from '@datadog/browser-core'
 import { RawRumLongTaskEvent, RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 
@@ -7,8 +7,9 @@ export function startLongTaskCollection(lifeCycle: LifeCycle) {
     if (entry.entryType !== 'longtask') {
       return
     }
+    const timestamp = getCorrectedTimeStamp(entry.startTime)
     const rawRumEvent: RawRumLongTaskEvent = {
-      date: getTimeStamp(entry.startTime),
+      date: timestamp,
       long_task: {
         duration: toServerDuration(entry.duration),
       },
@@ -16,7 +17,7 @@ export function startLongTaskCollection(lifeCycle: LifeCycle) {
     }
     lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
       rawRumEvent,
-      startTime: entry.startTime,
+      startTime: preferredTime(timestamp, entry.startTime),
     })
   })
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
@@ -1,13 +1,15 @@
-import { Duration, isIE, RelativeTime, Time } from '@datadog/browser-core'
+import { Duration, isIE, RelativeTime, preferredTime, TimeStamp } from '@datadog/browser-core'
 import { createResourceEntry } from '../../../../test/fixtures'
 import { RumPerformanceResourceTiming } from '../../../browser/performanceCollection'
 import { RequestCompleteEvent } from '../../requestCollection'
 
+import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { matchRequestTiming } from './matchRequestTiming'
 
 describe('matchRequestTiming', () => {
-  const FAKE_REQUEST: Partial<RequestCompleteEvent> = { startTime: 100 as Time, duration: 500 as Duration }
+  let FAKE_REQUEST: Partial<RequestCompleteEvent>
   let entries: RumPerformanceResourceTiming[]
+  let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
     if (isIE()) {
@@ -15,6 +17,15 @@ describe('matchRequestTiming', () => {
     }
     entries = []
     spyOn(performance, 'getEntriesByName').and.returnValues((entries as unknown) as PerformanceResourceTiming[])
+    setupBuilder = setup().withFakeClock()
+    FAKE_REQUEST = {
+      startTime: preferredTime((Date.now() + 100) as TimeStamp, 100 as RelativeTime),
+      duration: 500 as Duration,
+    }
+  })
+
+  afterEach(() => {
+    setupBuilder.cleanup()
   })
 
   it('should match single timing nested in the request ', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
@@ -1,4 +1,4 @@
-import { Duration, isIE, RelativeTime } from '@datadog/browser-core'
+import { Duration, isIE, RelativeTime, Time } from '@datadog/browser-core'
 import { createResourceEntry } from '../../../../test/fixtures'
 import { RumPerformanceResourceTiming } from '../../../browser/performanceCollection'
 import { RequestCompleteEvent } from '../../requestCollection'
@@ -6,7 +6,7 @@ import { RequestCompleteEvent } from '../../requestCollection'
 import { matchRequestTiming } from './matchRequestTiming'
 
 describe('matchRequestTiming', () => {
-  const FAKE_REQUEST: Partial<RequestCompleteEvent> = { startTime: 100 as RelativeTime, duration: 500 as Duration }
+  const FAKE_REQUEST: Partial<RequestCompleteEvent> = { startTime: 100 as Time, duration: 500 as Duration }
   let entries: RumPerformanceResourceTiming[]
 
   beforeEach(() => {

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -1,4 +1,12 @@
-import { Duration, RelativeTime, RequestType, ResourceType, ServerDuration, TimeStamp } from '@datadog/browser-core'
+import {
+  Duration,
+  RelativeTime,
+  RequestType,
+  ResourceType,
+  ServerDuration,
+  TimeStamp,
+  Time,
+} from '@datadog/browser-core'
 import { createResourceEntry } from '../../../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RawRumResourceEvent, RumEventType } from '../../../rawRumEvent.types'
@@ -61,7 +69,7 @@ describe('resourceCollection', () => {
         createCompletedRequest({
           duration: 100 as Duration,
           method: 'GET',
-          startTime: 1234 as RelativeTime,
+          startTime: 1234 as Time,
           status: 200,
           type: RequestType.XHR,
           url: 'https://resource.com/valid',
@@ -220,7 +228,7 @@ function createCompletedRequest(details?: Partial<RequestCompleteEvent>): Reques
   const request: Partial<RequestCompleteEvent> = {
     duration: 100 as Duration,
     method: 'GET',
-    startTime: 1234 as RelativeTime,
+    startTime: 1234 as Time,
     status: 200,
     type: RequestType.XHR,
     url: 'https://resource.com/valid',

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -6,6 +6,8 @@ import {
   ServerDuration,
   TimeStamp,
   Time,
+  getTimeStamp,
+  preferredTime,
 } from '@datadog/browser-core'
 import { createResourceEntry } from '../../../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
@@ -21,6 +23,7 @@ describe('resourceCollection', () => {
   describe('when resource tracking is enabled', () => {
     beforeEach(() => {
       setupBuilder = setup()
+        .withFakeClock()
         .withSession({
           getId: () => '1234',
           isTracked: () => true,
@@ -49,7 +52,7 @@ describe('resourceCollection', () => {
         })
       )
 
-      expect(rawRumEvents[0].startTime).toBe(1234)
+      expect(rawRumEvents[0].startTime).toBe(preferredTime(getTimeStamp(1234 as RelativeTime), 1234 as RelativeTime))
       expect(rawRumEvents[0].rawRumEvent).toEqual({
         date: (jasmine.any(Number) as unknown) as TimeStamp,
         resource: {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -1,4 +1,4 @@
-import { Duration, noop, relativeNow, elapsed, round } from '@datadog/browser-core'
+import { Duration, noop, elapsed, round, preferredNow } from '@datadog/browser-core'
 import { EventCounts, trackEventCounts } from '../../trackEventCounts'
 import { ViewLoadingType } from '../../../rawRumEvent.types'
 import { waitIdlePageActivity } from '../../trackPageActivities'
@@ -85,10 +85,10 @@ function trackLoadingTime(loadType: ViewLoadingType, callback: (loadingTime: Dur
 }
 
 function trackActivityLoadingTime(lifeCycle: LifeCycle, callback: (loadingTimeValue: Duration | undefined) => void) {
-  const startTime = relativeNow()
-  const { stop: stopWaitIdlePageActivity } = waitIdlePageActivity(lifeCycle, (hadActivity, endTime) => {
-    if (hadActivity) {
-      callback(elapsed(startTime, endTime))
+  const startTime = preferredNow()
+  const { stop: stopWaitIdlePageActivity } = waitIdlePageActivity(lifeCycle, (params) => {
+    if (params.hadActivity) {
+      callback(elapsed(startTime, params.endTime))
     } else {
       callback(undefined)
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -1,4 +1,4 @@
-import { Duration, RelativeTime } from '../../../../../core/src'
+import { Duration, RelativeTime, Time } from '../../../../../core/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import {
   RumLargestContentfulPaintTiming,
@@ -357,7 +357,7 @@ describe('rum track custom timings', () => {
   let setupBuilder: TestSetupBuilder
   let handler: jasmine.Spy
   let getViewEvent: (index: number) => ViewEvent
-  let addTiming: (name: string, time?: RelativeTime) => void
+  let addTiming: (name: string, time?: Time) => void
 
   beforeEach(() => {
     ;({ handler, getViewEvent } = spyOnViews())
@@ -429,7 +429,7 @@ describe('rum track custom timings', () => {
   it('should add custom timing with a specific time', () => {
     setupBuilder.build()
 
-    addTiming('foo', 1234 as RelativeTime)
+    addTiming('foo', 1234 as Time)
 
     expect(getViewEvent(1).customTimings).toEqual({
       foo: 1234 as Duration,
@@ -440,7 +440,7 @@ describe('rum track custom timings', () => {
     setupBuilder.build()
     const warnSpy = spyOn(console, 'warn')
 
-    addTiming('foo bar-qux.@zip_21%$*€👋', 1234 as RelativeTime)
+    addTiming('foo bar-qux.@zip_21%$*€👋', 1234 as Time)
 
     expect(getViewEvent(1).customTimings).toEqual({
       'foo_bar-qux.@zip_21_$____': 1234 as Duration,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -1,4 +1,5 @@
-import { Duration, RelativeTime, Time } from '../../../../../core/src'
+import { getTimeStamp } from '@datadog/browser-core'
+import { Duration, RelativeTime, Time, preferredTime } from '../../../../../core/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import {
   RumLargestContentfulPaintTiming,
@@ -429,7 +430,7 @@ describe('rum track custom timings', () => {
   it('should add custom timing with a specific time', () => {
     setupBuilder.build()
 
-    addTiming('foo', 1234 as Time)
+    addTiming('foo', preferredTime(getTimeStamp(1234 as RelativeTime), 1234 as RelativeTime))
 
     expect(getViewEvent(1).customTimings).toEqual({
       foo: 1234 as Duration,
@@ -440,7 +441,7 @@ describe('rum track custom timings', () => {
     setupBuilder.build()
     const warnSpy = spyOn(console, 'warn')
 
-    addTiming('foo bar-qux.@zip_21%$*€👋', 1234 as Time)
+    addTiming('foo bar-qux.@zip_21%$*€👋', preferredTime(getTimeStamp(1234 as RelativeTime), 1234 as RelativeTime))
 
     expect(getViewEvent(1).customTimings).toEqual({
       'foo_bar-qux.@zip_21_$____': 1234 as Duration,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -1,4 +1,4 @@
-import { Duration, RelativeTime, ServerDuration } from '@datadog/browser-core'
+import { Duration, ServerDuration, Time } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType, ViewLoadingType } from '../../../rawRumEvent.types'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -47,7 +47,7 @@ describe('viewCollection', () => {
       loadingType: ViewLoadingType.INITIAL_LOAD,
       location: location as Location,
       referrer: '',
-      startTime: 1234 as RelativeTime,
+      startTime: 1234 as Time,
       timings: {
         domComplete: 10 as Duration,
         domContentLoaded: 10 as Duration,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -1,6 +1,6 @@
 import {
   Duration,
-  getTimeStamp,
+  preferredTimeStamp,
   isEmptyObject,
   mapValues,
   ServerDuration,
@@ -23,7 +23,7 @@ function processViewUpdate(view: ViewEvent) {
     _dd: {
       document_version: view.documentVersion,
     },
-    date: getTimeStamp(view.startTime),
+    date: preferredTimeStamp(view.startTime),
     type: RumEventType.VIEW,
     view: {
       action: {

--- a/packages/rum-core/src/domain/trackPageActivities.spec.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.spec.ts
@@ -1,4 +1,4 @@
-import { noop, Observable, RelativeTime } from '@datadog/browser-core'
+import { noop, Observable, Time } from '@datadog/browser-core'
 import { RumPerformanceNavigationTiming, RumPerformanceResourceTiming } from '../browser/performanceCollection'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RequestCompleteEvent } from './requestCollection'
@@ -152,9 +152,9 @@ describe('waitPageActivitiesCompletion', () => {
   const clock = mockClock()
 
   it('should not collect an event that is not followed by page activity', (done) => {
-    waitPageActivitiesCompletion(new Observable(), noop, (hadActivity, endTime) => {
-      expect(hadActivity).toBeFalse()
-      expect(endTime).toBeFalsy()
+    waitPageActivitiesCompletion(new Observable(), noop, (params) => {
+      expect(params.hadActivity).toBeFalse()
+      expect((params as any).endTime).toBeUndefined()
       done()
     })
 
@@ -165,9 +165,11 @@ describe('waitPageActivitiesCompletion', () => {
     const activityObservable = new Observable<PageActivityEvent>()
 
     const startTime = performance.now()
-    waitPageActivitiesCompletion(activityObservable, noop, (hadActivity, endTime) => {
-      expect(hadActivity).toBeTrue()
-      expect(endTime).toEqual((startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY) as RelativeTime)
+    waitPageActivitiesCompletion(activityObservable, noop, (params) => {
+      expect(params.hadActivity).toBeTrue()
+      expect((params as { hadActivity: true; endTime: Time }).endTime).toEqual(
+        (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY) as Time
+      )
       done()
     })
 
@@ -185,9 +187,11 @@ describe('waitPageActivitiesCompletion', () => {
       // Extend the action but stops before PAGE_ACTIVITY_MAX_DURATION
       const extendCount = Math.floor(PAGE_ACTIVITY_MAX_DURATION / BEFORE_PAGE_ACTIVITY_END_DELAY - 1)
 
-      waitPageActivitiesCompletion(activityObservable, noop, (hadActivity, endTime) => {
-        expect(hadActivity).toBeTrue()
-        expect(endTime).toBe((startTime + (extendCount + 1) * BEFORE_PAGE_ACTIVITY_END_DELAY) as RelativeTime)
+      waitPageActivitiesCompletion(activityObservable, noop, (params) => {
+        expect(params.hadActivity).toBeTrue()
+        expect((params as { hadActivity: true; endTime: Time }).endTime).toBe(
+          (startTime + (extendCount + 1) * BEFORE_PAGE_ACTIVITY_END_DELAY) as Time
+        )
         done()
       })
 
@@ -207,9 +211,11 @@ describe('waitPageActivitiesCompletion', () => {
       // Extend the action until it's more than PAGE_ACTIVITY_MAX_DURATION
       const extendCount = Math.ceil(PAGE_ACTIVITY_MAX_DURATION / BEFORE_PAGE_ACTIVITY_END_DELAY + 1)
 
-      waitPageActivitiesCompletion(activityObservable, noop, (hadActivity, endTime) => {
-        expect(hadActivity).toBeTrue()
-        expect(endTime).toBe((startTime + PAGE_ACTIVITY_MAX_DURATION) as RelativeTime)
+      waitPageActivitiesCompletion(activityObservable, noop, (params) => {
+        expect(params.hadActivity).toBeTrue()
+        expect((params as { hadActivity: true; endTime: Time }).endTime).toBe(
+          (startTime + PAGE_ACTIVITY_MAX_DURATION) as Time
+        )
         stop = true
         done()
       })
@@ -227,10 +233,10 @@ describe('waitPageActivitiesCompletion', () => {
     it('is extended while the page is busy', (done) => {
       const activityObservable = new Observable<PageActivityEvent>()
       const startTime = performance.now()
-      waitPageActivitiesCompletion(activityObservable, noop, (hadActivity, endTime) => {
-        expect(hadActivity).toBeTrue()
-        expect(endTime).toBe(
-          (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + PAGE_ACTIVITY_END_DELAY * 2) as RelativeTime
+      waitPageActivitiesCompletion(activityObservable, noop, (params) => {
+        expect(params.hadActivity).toBeTrue()
+        expect((params as { hadActivity: true; endTime: Time }).endTime).toBe(
+          (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + PAGE_ACTIVITY_END_DELAY * 2) as Time
         )
         done()
       })
@@ -247,9 +253,11 @@ describe('waitPageActivitiesCompletion', () => {
     it('expires is the page is busy for too long', (done) => {
       const activityObservable = new Observable<PageActivityEvent>()
       const startTime = performance.now()
-      waitPageActivitiesCompletion(activityObservable, noop, (hadActivity, endTime) => {
-        expect(hadActivity).toBeTrue()
-        expect(endTime).toBe((startTime + PAGE_ACTIVITY_MAX_DURATION) as RelativeTime)
+      waitPageActivitiesCompletion(activityObservable, noop, (params) => {
+        expect(params.hadActivity).toBeTrue()
+        expect((params as { hadActivity: true; endTime: Time }).endTime).toBe(
+          (startTime + PAGE_ACTIVITY_MAX_DURATION) as Time
+        )
         done()
       })
 

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -8,6 +8,7 @@ import {
   noop,
   SPEC_ENDPOINTS,
   TimeStamp,
+  resetNavigationStart,
 } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../src/domain/lifeCycle'
 import { ParentContexts } from '../src/domain/parentContexts'
@@ -120,8 +121,14 @@ export function setup(): TestSetupBuilder {
       jasmine.clock().mockDate()
       const start = Date.now()
       spyOn(performance, 'now').and.callFake(() => Date.now() - start)
+      resetNavigationStart()
+      Object.defineProperty(performance.timing, 'navigationStart', { value: start, configurable: true })
       clock = jasmine.clock()
-      cleanupClock = () => jasmine.clock().uninstall()
+      cleanupClock = () => {
+        jasmine.clock().uninstall()
+        delete (performance.timing as any).navigationStart
+        resetNavigationStart()
+      }
       return setupBuilder
     },
     beforeBuild(callback: BeforeBuildCallback) {

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -19,4 +19,5 @@ module.exports = {
   TARGET_DATACENTER: process.env.TARGET_DATACENTER || 'us',
   BUILD_MODE: process.env.BUILD_MODE,
   SDK_VERSION: sdkVersion,
+  SYSTEM_CLOCK: process.env.SYSTEM_CLOCK || 'false',
 }

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -26,6 +26,7 @@ module.exports = ({ entry, mode, filename, datacenter, types }) => ({
             { search: '<<< TARGET_DATACENTER >>>', replace: datacenter || 'us' },
             { search: '<<< SDK_VERSION >>>', replace: buildEnv.SDK_VERSION },
             { search: '<<< BUILD_MODE >>>', replace: buildEnv.BUILD_MODE },
+            { search: '<<< SYSTEM CLOCK >>>', replace: buildEnv.SYSTEM_CLOCK || 'false' },
           ],
         },
       },


### PR DESCRIPTION
## Motivation

Since we observed issues with monotonic clock values (mainly on chrome), experiment with consistently use system clock instead.

## Changes

Use system clock only behind a `system-clock` FF (RUM + logs).
Introduce a preferred time strategy to consistently use relative time or timestamp depending on the FF value.

Choices:
- replace relative time by timestamp when possible
- for requests keep both in context to not break xhr context sharing and keep consistent type signature
- for before init calls, save both times to be able to choose the right one at init depending on the FF value

- correct relative time with drift when we can't get a timestamp:
  - Long task start time
  - Performance resource start time 
  - Perf request timings during matching with request algo

- keep some relative timings without correction: 
  - Internal context, to not break the API
  - Initial view timings, they should mainly happen before any drift
  - Performance resource timings, they are relative to the start time

## Testing
Automated:
- [x] unit
- [ ] e2e

Manual:

- [x] check overall behavior disabled
- [x] check overall behavior enabled
- [x] check behavior when triggering a drift
- [x] check behavior when changing system clock => corrected by the backend in both cases

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
