### PR TITLE
🚨 remove ESLint rule "no-underscore-dangle"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,7 +177,6 @@ module.exports = {
     'no-throw-literal': 'error',
     'no-trailing-spaces': 'off',
     'no-undef-init': 'error',
-    'no-underscore-dangle': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
     'no-unused-labels': 'error',

--- a/packages/core/src/browser/xhrProxy.ts
+++ b/packages/core/src/browser/xhrProxy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import { monitor, callMonitored } from '../domain/internalMonitoring'
 import { Duration, elapsed, relativeNow, RelativeTime } from '../tools/timeUtils'
 import { normalizeUrl } from '../tools/urlPolyfill'

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -258,7 +258,7 @@ export function getGlobalObject<T>(): T {
   // @ts-ignore _dd_temp is defined using defineProperty
   let globalObject: unknown = _dd_temp_
   // @ts-ignore _dd_temp is defined using defineProperty
-  delete Object.prototype._dd_temp_ // eslint-disable-line no-underscore-dangle
+  delete Object.prototype._dd_temp_
   if (typeof globalObject !== 'object') {
     // on safari _dd_temp_ is available on window but not globally
     // fallback on other browser globals check

--- a/packages/logs/src/boot/logs.entry.spec.ts
+++ b/packages/logs/src/boot/logs.entry.spec.ts
@@ -62,7 +62,6 @@ describe('logs entry', () => {
     })
 
     it('should add a `_setDebug` that works', () => {
-      // eslint-disable-next-line no-underscore-dangle
       const setDebug: (debug: boolean) => void = (LOGS as any)._setDebug
       expect(!!setDebug).toEqual(true)
 

--- a/packages/rum-core/src/browser/domMutationCollection.ts
+++ b/packages/rum-core/src/browser/domMutationCollection.ts
@@ -26,7 +26,6 @@ function getMutationObserverConstructor(): MutationObserverConstructor | undefin
   // [1] https://github.com/angular/angular/issues/26948
   // [2] https://github.com/angular/angular/issues/31712
   if (browserWindow.Zone) {
-    // eslint-disable-next-line no-underscore-dangle
     const symbol = browserWindow.Zone.__symbol__('MutationObserver')
     constructor = browserWindow[symbol as any] as any
   }

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -108,6 +108,5 @@ function needToAssembleWithAction(
 }
 
 function getSessionType() {
-  // eslint-disable-next-line no-underscore-dangle
   return (window as BrowserWindow)._DATADOG_SYNTHETICS_BROWSER === undefined ? SessionType.USER : SessionType.SYNTHETICS
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -194,7 +194,6 @@ describe('resourceCollection', () => {
           traceId: '1234',
         })
       )
-      // eslint-disable-next-line no-underscore-dangle
       const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
       expect(traceInfo).toBeDefined()
       expect(traceInfo.trace_id).toBe('1234')
@@ -209,7 +208,6 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      // eslint-disable-next-line no-underscore-dangle
       const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
       expect(traceInfo).toBeDefined()
       expect(traceInfo.trace_id).toBeDefined()

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.spec.ts
@@ -98,7 +98,6 @@ describe('serializeNodeWithId', () => {
     it('sets ignored serialized node id to IGNORED_NODE', () => {
       const scriptElement = document.createElement('script')
       serializeNodeWithId(scriptElement, defaultOptions)
-      // eslint-disable-next-line no-underscore-dangle
       expect((scriptElement as any).__sn).toEqual(jasmine.objectContaining({ id: IGNORED_NODE }))
     })
 

--- a/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
+++ b/packages/rum-recorder/src/domain/rrweb-snapshot/snapshot.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import { nodeShouldBeHidden } from '../privacy'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_HIDDEN } from '../../constants'
 import { SerializedNode, SerializedNodeWithId, NodeType, Attributes, INode, IdNodeMap } from './types'

--- a/packages/rum-recorder/src/domain/rrweb/mutation.ts
+++ b/packages/rum-recorder/src/domain/rrweb/mutation.ts
@@ -45,7 +45,6 @@ class DoubleLinkedList {
       previous: null,
       value: n as NodeInLinkedList,
     }
-    /* eslint-disable no-underscore-dangle */
     ;(n as NodeInLinkedList).__ln = node
     if (n.previousSibling && isNodeInLinkedList(n.previousSibling)) {
       const current = n.previousSibling.__ln.next
@@ -60,7 +59,6 @@ class DoubleLinkedList {
       node.previous = current
       node.next = n.nextSibling.__ln
       n.nextSibling.__ln.previous = node
-      /* eslint-enable no-underscore-dangle */
       if (current) {
         current.next = node
       }
@@ -75,7 +73,7 @@ class DoubleLinkedList {
   }
 
   public removeNode(n: NodeInLinkedList) {
-    const current = n.__ln // eslint-disable-line no-underscore-dangle
+    const current = n.__ln
     if (!this.head) {
       return
     }
@@ -91,11 +89,9 @@ class DoubleLinkedList {
         current.next.previous = current.previous
       }
     }
-    /* eslint-disable no-underscore-dangle */
     if (n.__ln) {
       delete (n as any).__ln
     }
-    /* eslint-enable no-underscore-dangle */
     this.length -= 1
   }
 }
@@ -417,10 +413,9 @@ export class MutationObserverWrapper {
       this.movedSet.add(n)
       let targetId: number | null = null
       if (target && isINode(target)) {
-        targetId = target.__sn.id // eslint-disable-line no-underscore-dangle
+        targetId = target.__sn.id
       }
       if (targetId) {
-        // eslint-disable-next-line no-underscore-dangle
         this.movedMap[moveKey(n.__sn.id, targetId)] = true
       }
     } else {

--- a/packages/rum-recorder/src/domain/rrweb/utils.ts
+++ b/packages/rum-recorder/src/domain/rrweb/utils.ts
@@ -5,18 +5,17 @@ export const mirror: Mirror = {
   map: {},
   getId(n) {
     // if n is not a serialized INode, use -1 as its id.
-    // eslint-disable-next-line no-underscore-dangle
     if (!n.__sn) {
       return -1
     }
-    return n.__sn.id // eslint-disable-line no-underscore-dangle
+    return n.__sn.id
   },
   getNode(id) {
     return mirror.map[id] || null
   },
   // TODO: use a weakmap to get rid of manually memory management
   removeNodeFromMap(n) {
-    const id = n.__sn && n.__sn.id // eslint-disable-line no-underscore-dangle
+    const id = n.__sn && n.__sn.id
     delete mirror.map[id]
     if (n.childNodes) {
       forEach(n.childNodes, (child: ChildNode) => mirror.removeNodeFromMap((child as Node) as INode))
@@ -67,7 +66,7 @@ export function getWindowWidth(): number {
 
 export function isIgnored(n: Node | INode): boolean {
   if ('__sn' in n) {
-    return n.__sn.id === IGNORED_NODE // eslint-disable-line no-underscore-dangle
+    return n.__sn.id === IGNORED_NODE
   }
   // The ignored DOM logic happens in rrweb-snapshot::serializeNodeWithId
   return false

--- a/packages/rum-recorder/test/forEach.spec.ts
+++ b/packages/rum-recorder/test/forEach.spec.ts
@@ -3,9 +3,7 @@ afterEach(() => {
 })
 
 function cleanupRRWebReferencesFromNodes(node: Node = document.documentElement) {
-  // eslint-disable-next-line no-underscore-dangle
   delete (node as any).__sn
-  // eslint-disable-next-line no-underscore-dangle
   delete (node as any).__ln
   for (let i = 0; i < node.childNodes.length; i += 1) {
     cleanupRRWebReferencesFromNodes(node.childNodes[i])

--- a/test/e2e/scenario/rum/tracing.scenario.ts
+++ b/test/e2e/scenario/rum/tracing.scenario.ts
@@ -68,8 +68,8 @@ describe('tracing', () => {
       (event) => event.resource.type === 'xhr' || event.resource.type === 'fetch'
     )
     expect(requests.length).toBe(1)
-    expect(requests[0]._dd.trace_id).toMatch(/\d+/) // eslint-disable-line no-underscore-dangle
-    expect(requests[0]._dd.span_id).toMatch(/\d+/) // eslint-disable-line no-underscore-dangle
+    expect(requests[0]._dd.trace_id).toMatch(/\d+/)
+    expect(requests[0]._dd.span_id).toMatch(/\d+/)
     expect(requests[0].resource.id).toBeDefined()
   }
 })


### PR DESCRIPTION

## Motivation

This rule is a bit annoying for our codebase because we actually use "underscore dangles" in some of our variable/properties.


## Changes

Remove the rule from ESLint commit and all "disable" comments.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
