### PR TITLE
relax bundle URLs in the developer extension

### DIFF
--- a/developer-extension/src/background/domain/replaceBundles.ts
+++ b/developer-extension/src/background/domain/replaceBundles.ts
@@ -24,10 +24,9 @@ chrome.webRequest.onBeforeRequest.addListener(
   {
     types: ['script'],
     urls: [
-      // TODO: implement a configuration page to add more URLs in this list.
-      'https://www.datadoghq-browser-agent.com/datadog-logs.js',
-      'https://www.datadoghq-browser-agent.com/datadog-rum.js',
-      'https://www.datadoghq-browser-agent.com/datadog-rum-recorder.js',
+      'https://*/datadog-logs.js',
+      'https://*/datadog-rum.js',
+      'https://*/datadog-rum-recorder.js',
       'https://localhost:8443/static/datadog-rum-hotdog.js',
     ],
   },


### PR DESCRIPTION


## Motivation

This allows to use the extension in staging. I think the file name is explicit enough to prevent false positives.

## Changes

Relax bundle URLs in the developer extension

## Testing

Manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
