### PR TITLE
🐛[RUMF-900] prevent events to be sent from expired session

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -327,7 +327,7 @@ describe('rum assembly', () => {
       expect(serverRumEvents.length).toBe(0)
     })
 
-    it('when view context has session id, it should generate event', () => {
+    it('when view context has current session id, it should generate event', () => {
       viewSessionId = '1234'
 
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
@@ -335,6 +335,16 @@ describe('rum assembly', () => {
         startTime: 0 as RelativeTime,
       })
       expect(serverRumEvents.length).toBe(1)
+    })
+
+    it('when view context has not the current session id, it should not generate event', () => {
+      viewSessionId = '6789'
+
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+        startTime: 0 as RelativeTime,
+      })
+      expect(serverRumEvents.length).toBe(0)
     })
 
     it('when view context has no session id, it should not generate event', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -45,7 +45,7 @@ export function startRumAssembly(
     LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
     ({ startTime, rawRumEvent, savedCommonContext, customerContext }) => {
       const viewContext = parentContexts.findView(startTime)
-      if (session.isTracked() && viewContext && viewContext.session.id) {
+      if (session.isTracked() && viewContext && viewContext.session.id === session.getId()) {
         const actionContext = parentContexts.findAction(startTime)
         const commonContext = savedCommonContext || getCommonContext()
         const rumContext: RumContext = {

--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -40,6 +40,11 @@ describe('startRecording', () => {
           }
         },
       })
+      .withSession({
+        getId: () => sessionId,
+        isTracked: () => true,
+        isTrackedWithResource: () => true,
+      })
       .beforeBuild(({ lifeCycle, applicationId, configuration, parentContexts, session }) =>
         startRecording(lifeCycle, applicationId, configuration, session, parentContexts)
       )

--- a/packages/rum-recorder/src/domain/segmentCollection.spec.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection.spec.ts
@@ -213,7 +213,7 @@ describe('computeSegmentContext', () => {
   }
 
   const DEFAULT_SESSION: RumSession = {
-    getId: () => 'session-id',
+    getId: () => '456',
     isTracked: () => true,
     isTrackedWithResource: () => true,
   }
@@ -238,6 +238,19 @@ describe('computeSegmentContext', () => {
         mockParentContexts({
           ...DEFAULT_VIEW_CONTEXT,
           session: { id: undefined },
+        })
+      )
+    ).toBeUndefined()
+  })
+
+  it('returns undefined if the session id is not the one of the current session', () => {
+    expect(
+      computeSegmentContext(
+        'appid',
+        DEFAULT_SESSION,
+        mockParentContexts({
+          ...DEFAULT_VIEW_CONTEXT,
+          session: { id: 'expired-session' },
         })
       )
     ).toBeUndefined()

--- a/packages/rum-recorder/src/domain/segmentCollection.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection.ts
@@ -189,7 +189,7 @@ export function computeSegmentContext(applicationId: string, session: RumSession
     return undefined
   }
   const viewContext = parentContexts.findView()
-  if (!viewContext?.session.id) {
+  if (!viewContext?.session.id || viewContext.session.id !== session.getId()) {
     return undefined
   }
   return {


### PR DESCRIPTION
## Motivation

We have noticed that a tab in an expired session state can send events if another tab as an active session.

## Changes

Prevent to send event when current session id is not the same that the view context session id.

## Testing

unit + manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
