### PR TITLE
🐛 [RUMF-900] clear parent view context when view end

### DIFF
--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -4,7 +4,7 @@ import { CommonContext, RawRumEvent } from '../rawRumEvent.types'
 import { RumEvent } from '../rumEvent.types'
 import { RequestCompleteEvent, RequestStartEvent } from './requestCollection'
 import { AutoAction, AutoActionCreatedEvent } from './rumEventsCollection/action/trackActions'
-import { ViewEvent, ViewCreatedEvent } from './rumEventsCollection/view/trackViews'
+import { ViewEvent, ViewCreatedEvent, ViewEndedEvent } from './rumEventsCollection/view/trackViews'
 
 export enum LifeCycleEventType {
   PERFORMANCE_ENTRY_COLLECTED,
@@ -39,13 +39,13 @@ export class LifeCycle {
   notify(eventType: LifeCycleEventType.AUTO_ACTION_CREATED, data: AutoActionCreatedEvent): void
   notify(eventType: LifeCycleEventType.VIEW_CREATED, data: ViewCreatedEvent): void
   notify(eventType: LifeCycleEventType.VIEW_UPDATED, data: ViewEvent): void
+  notify(eventType: LifeCycleEventType.VIEW_ENDED, data: ViewEndedEvent): void
   notify(
     eventType:
       | LifeCycleEventType.SESSION_RENEWED
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED
-      | LifeCycleEventType.VIEW_ENDED
       | LifeCycleEventType.RECORD_STARTED
       | LifeCycleEventType.RECORD_STOPPED
   ): void
@@ -82,13 +82,13 @@ export class LifeCycle {
   ): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_CREATED, callback: (data: ViewCreatedEvent) => void): Subscription
   subscribe(eventType: LifeCycleEventType.VIEW_UPDATED, callback: (data: ViewEvent) => void): Subscription
+  subscribe(eventType: LifeCycleEventType.VIEW_ENDED, callback: (data: ViewEndedEvent) => void): Subscription
   subscribe(
     eventType:
       | LifeCycleEventType.SESSION_RENEWED
       | LifeCycleEventType.DOM_MUTATED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED
-      | LifeCycleEventType.VIEW_ENDED
       | LifeCycleEventType.RECORD_STARTED
       | LifeCycleEventType.RECORD_STOPPED,
     callback: () => void

--- a/packages/rum-core/src/domain/parentContexts.spec.ts
+++ b/packages/rum-core/src/domain/parentContexts.spec.ts
@@ -76,13 +76,13 @@ describe('parentContexts', () => {
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(10 as RelativeTime), id: 'view 1' })
       )
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime) })
 
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(20 as RelativeTime), id: 'view 2' })
       )
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(30 as RelativeTime), id: 'view 2' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(30 as RelativeTime) })
 
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
@@ -101,12 +101,12 @@ describe('parentContexts', () => {
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(10 as RelativeTime), id: 'view 1' })
       )
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime) })
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(20 as RelativeTime), id: 'view 2' })
       )
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime) })
 
       expect(parentContexts.findView(5 as RelativeTime)).not.toBeDefined()
     })
@@ -242,7 +242,7 @@ describe('parentContexts', () => {
           startClocks: relativeToClocks(10 as RelativeTime),
         })
       )
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime) })
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({
@@ -289,7 +289,6 @@ describe('parentContexts', () => {
       )
       lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
         endClocks: relativeToClocks((originalTime + 10) as RelativeTime),
-        id: 'view 1',
       })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, {
         startClocks: originalClocks,

--- a/packages/rum-core/src/domain/parentContexts.spec.ts
+++ b/packages/rum-core/src/domain/parentContexts.spec.ts
@@ -76,10 +76,14 @@ describe('parentContexts', () => {
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(10 as RelativeTime), id: 'view 1' })
       )
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
+
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(20 as RelativeTime), id: 'view 2' })
       )
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(30 as RelativeTime), id: 'view 2' })
+
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(30 as RelativeTime), id: 'view 3' })
@@ -97,15 +101,17 @@ describe('parentContexts', () => {
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(10 as RelativeTime), id: 'view 1' })
       )
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({ startClocks: relativeToClocks(20 as RelativeTime), id: 'view 2' })
       )
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
 
       expect(parentContexts.findView(5 as RelativeTime)).not.toBeDefined()
     })
 
-    it('should replace the current view context on VIEW_CREATED', () => {
+    it('should set the current view context on VIEW_CREATED', () => {
       const { lifeCycle } = setupBuilder.build()
 
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent())
@@ -236,6 +242,7 @@ describe('parentContexts', () => {
           startClocks: relativeToClocks(10 as RelativeTime),
         })
       )
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks: relativeToClocks(20 as RelativeTime), id: 'view 1' })
       lifeCycle.notify(
         LifeCycleEventType.VIEW_CREATED,
         buildViewCreatedEvent({
@@ -280,6 +287,10 @@ describe('parentContexts', () => {
           startClocks: originalClocks,
         })
       )
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
+        endClocks: relativeToClocks((originalTime + 10) as RelativeTime),
+        id: 'view 1',
+      })
       lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, {
         startClocks: originalClocks,
         id: 'action 1',

--- a/packages/rum-core/src/domain/parentContexts.ts
+++ b/packages/rum-core/src/domain/parentContexts.ts
@@ -37,13 +37,6 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
   let previousActions: Array<PreviousContext<ActionContext>> = []
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (currentContext) => {
-    if (currentView) {
-      previousViews.unshift({
-        context: buildCurrentViewContext(),
-        endTime: currentContext.startClocks.relative,
-        startTime: currentView.startClocks.relative,
-      })
-    }
     currentView = currentContext
     currentSessionId = session.getId()
   })
@@ -51,8 +44,19 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, (currentContext) => {
     // A view can be updated after its end.  We have to ensure that the view being updated is the
     // most recently created.
-    if (currentView!.id === currentContext.id) {
+    if (currentView && currentView.id === currentContext.id) {
       currentView = currentContext
+    }
+  })
+
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, ({ id, endClocks }) => {
+    if (currentView && currentView.id === id) {
+      previousViews.unshift({
+        endTime: endClocks.relative,
+        context: buildCurrentViewContext(),
+        startTime: currentView.startClocks.relative,
+      })
+      currentView = undefined
     }
   })
 

--- a/packages/rum-core/src/domain/parentContexts.ts
+++ b/packages/rum-core/src/domain/parentContexts.ts
@@ -49,8 +49,8 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
     }
   })
 
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, ({ id, endClocks }) => {
-    if (currentView && currentView.id === id) {
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, ({ endClocks }) => {
+    if (currentView) {
       previousViews.unshift({
         endTime: endClocks.relative,
         context: buildCurrentViewContext(),

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -45,7 +45,6 @@ export interface ViewCreatedEvent {
 }
 
 export interface ViewEndedEvent {
-  id: string
   endClocks: ClocksState
 }
 
@@ -195,7 +194,7 @@ function newView(
     end() {
       endClocks = clocksNow()
       stopViewMetricsTracking()
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { id, endClocks })
+      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks })
     },
     getLocation() {
       return location

--- a/packages/rum-recorder/src/boot/recorder.spec.ts
+++ b/packages/rum-recorder/src/boot/recorder.spec.ts
@@ -153,7 +153,7 @@ describe('startRecording', () => {
   it('adds a ViewEnd snapshot when the view ends', (done) => {
     const { lifeCycle } = setupBuilder.build()
 
-    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED)
+    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {} as any)
     viewId = 'view-id-2'
     lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {} as any)
     flushSegment(lifeCycle)


### PR DESCRIPTION
## Motivation

When a view is ended when changing page, some events can still be tracked and attached to the view after its end, which seems quite surprising.

## Changes

Clear current view context on view end

## Testing

unit + manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
