### PR TITLE
🐛 [RUMF-889] fix relative time rounding

### DIFF
--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -34,7 +34,7 @@ export function relativeToClocks(relative: RelativeTime) {
 function getCorrectedTimeStamp(relativeTime: RelativeTime) {
   const correctedOrigin = Date.now() - performance.now()
   // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  return Math.floor(correctedOrigin + relativeTime) as TimeStamp
+  return Math.round(correctedOrigin + relativeTime) as TimeStamp
 }
 
 export function toServerDuration(duration: Duration): ServerDuration
@@ -82,7 +82,7 @@ export function getRelativeTime(timestamp: TimeStamp) {
 
 export function getTimeStamp(relativeTime: RelativeTime) {
   // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  return Math.floor(getNavigationStart() + relativeTime) as TimeStamp
+  return Math.round(getNavigationStart() + relativeTime) as TimeStamp
 }
 
 /**


### PR DESCRIPTION
## Motivation

With #809 enabled, some documents start 1 ms before the start of the view.

Relative time can have sub milliseconds precision, taking the floor of the value can easily introduce a 1 ms error:

```
Request start               10.925
Navigation start            11
floor(Request start)        10   < Navigation start    
round(Request start)        11   = Navigation start
```

With some tests to compare rounding strategies:

0 ms: request start = navigation start
1 ms: request start < navigation start
-1 ms: request start > navigation start

<img width="300" alt="Capture d’écran 2021-04-29 à 15 00 18" src="https://user-images.githubusercontent.com/1331991/116554563-a006f400-a8fb-11eb-8c83-9e6621546f19.png">


Using round seems more accurate.

## Changes

Use round instead of floor.

## Testing

Manual


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
