### PR TITLE
🐛 allow 1 ms error for matching request

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
@@ -29,6 +29,15 @@ describe('matchRequestTiming', () => {
     expect(timing).toEqual(match)
   })
 
+  it('should match single timing nested in the request with error margin', () => {
+    const match = createResourceEntry({ startTime: 99 as RelativeTime, duration: 502 as Duration })
+    entries.push(match)
+
+    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+
+    expect(timing).toEqual(match)
+  })
+
   it('should not match single timing outside the request ', () => {
     const match = createResourceEntry({ startTime: 0 as RelativeTime, duration: 300 as Duration })
     entries.push(match)
@@ -69,7 +78,7 @@ describe('matchRequestTiming', () => {
     expect(timing).toEqual(undefined)
   })
 
-  it('should match invalid timing nested in the request ', () => {
+  it('should not match invalid timing nested in the request ', () => {
     const match = createResourceEntry({
       duration: 100 as Duration,
       fetchStart: 0 as RelativeTime,

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
@@ -13,10 +13,11 @@ interface Timing {
  *
  * Observations:
  * - Timing (start, end) are nested inside the request (start, end)
+ * - Some timing can be not exactly nested, being off by < 1 ms
  * - Browsers generate a timing entry for OPTIONS request
  *
  * Strategy:
- * - from valid nested entries
+ * - from valid nested entries (with 1 ms error margin)
  * - if a single timing match, return the timing
  * - if two following timings match (OPTIONS request), return the timing for the actual request
  * - otherwise we can't decide, return undefined
@@ -63,5 +64,7 @@ function endTime(timing: Timing) {
 }
 
 function isBetween(timing: Timing, start: RelativeTime, end: RelativeTime) {
-  return timing.startTime >= start && endTime(timing) <= end
+  const errorMargin = 1
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+  return timing.startTime >= start - errorMargin && endTime(timing) <= end + errorMargin
 }


### PR DESCRIPTION
## Motivation

Flaky e2e tests put in evidence that timing associated to an instrumented request can not alway be perfectly nested.
Observed case:
```
Req start     593.3949999
Timing start  593.5950000
Req end       799.3949999
Timing end    799.5550000

```
## Changes

Allow a 1 ms error margin in the matching condition.

## Testing

unit + ci

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
