### PR TITLE
✅ try to stabilise some e2e tests

### DIFF
--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -57,7 +57,9 @@ export async function sendXhr(url: string, headers: string[][] = []): Promise<st
     (url, headers, done) => {
       const xhr = new XMLHttpRequest()
       let state: State = { state: 'error' }
-      xhr.addEventListener('load', () => (state = { state: 'success', response: xhr.response as string }))
+      xhr.addEventListener('load', () => {
+        state = { state: 'success', response: xhr.response as string }
+      })
       xhr.addEventListener('loadend', () => done(state))
       xhr.open('GET', url)
       headers.forEach((header) => xhr.setRequestHeader(header[0], header[1]))

--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -56,8 +56,9 @@ export async function sendXhr(url: string, headers: string[][] = []): Promise<st
   const result: State = await browserExecuteAsync(
     (url, headers, done) => {
       const xhr = new XMLHttpRequest()
-      xhr.addEventListener('load', () => done({ state: 'success', response: xhr.response as string }))
-      xhr.addEventListener('error', () => done({ state: 'error' }))
+      let state: State = { state: 'error' }
+      xhr.addEventListener('load', () => (state = { state: 'success', response: xhr.response as string }))
+      xhr.addEventListener('loadend', () => done(state))
       xhr.open('GET', url)
       headers.forEach((header) => xhr.setRequestHeader(header[0], header[1]))
       xhr.send()


### PR DESCRIPTION
## Motivation

Fix flaky tests

## Changes

Use loadend event to consider e2e XHR done to be more aligned with SDK implementation.
(Not 100% sure that it improves the situation)

## Testing

ci

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
