### PR TITLE
👷 update default branch name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@
 
 ---
 
-I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
+I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,7 @@ check-licenses:
 unit-bs:
   except:
     refs:
-      - master
+      - main
       - tags
   stage: browserstack
   resource_group: browserstack
@@ -150,7 +150,7 @@ unit-bs:
 e2e-bs:
   except:
     refs:
-      - master
+      - main
       - tags
   stage: browserstack
   resource_group: browserstack
@@ -169,7 +169,7 @@ e2e-bs:
 deploy-staging:
   only:
     refs:
-      - master
+      - main
   stage: deploy
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
@@ -202,14 +202,14 @@ notify-feature-branch-failure:
   extends: .slack-notifier.on-failure
   except:
     refs:
-      - master
+      - main
       - tags
 
-notify-master-success:
+notify-main-success:
   extends: .slack-notifier-base
   only:
     refs:
-      - master
+      - main
   script:
     - COMMIT_MESSAGE=`git show-branch --no-name HEAD`
     - COMMIT_URL="$CI_PROJECT_URL/commits/$CI_COMMIT_SHA"
@@ -217,16 +217,16 @@ notify-master-success:
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"
     - postmessage "#rum-ops-stg" "$MESSAGE_TEXT"
 
-notify-master-failure:
+notify-main-failure:
   extends: .slack-notifier-base
   when: on_failure
   only:
     refs:
-      - master
+      - main
   script:
     - COMMIT_MESSAGE=`git show-branch --no-name HEAD`
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
-    - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME master pipeline for <$BUILD_URL|$COMMIT_MESSAGE> failed."'
+    - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME main pipeline for <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"
 
 notify-release-ready:

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -589,5 +589,5 @@ window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
 [1]: /account_management/api-app-keys/#api-keys
 [2]: /account_management/api-app-keys/#client-tokens
 [3]: https://www.npmjs.com/package/@datadog/browser-logs
-[4]: https://github.com/DataDog/browser-sdk/blob/master/packages/logs/BROWSER_SUPPORT.md
-[5]: https://github.com/DataDog/browser-sdk/blob/master/packages/logs/src/logsEvent.types.ts
+[4]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/BROWSER_SUPPORT.md
+[5]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/src/logsEvent.types.ts

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -177,4 +177,4 @@ init(configuration: {
 [5]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [6]: https://docs.datadoghq.com/real_user_monitoring/data_collected/user_action/#automatic-collection-of-user-actions
 [7]: https://docs.datadoghq.com/real_user_monitoring/faq/proxy_rum_data/
-[8]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum/BROWSER_SUPPORT.md
+[8]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/BROWSER_SUPPORT.md


### PR DESCRIPTION
## Motivation

Following #829, rename default branch

## Changes

Rename `master` to `main`

## Plan

- Rename default branch
- Merge PR
- Update [doc configuration](https://github.com/DataDog/documentation/blob/b4c8f125bae04235f44bfcb63529a33a28c8c93b/local/bin/py/build/configurations/pull_config.yaml#L413)



---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/master/CONTRIBUTING.md) documentation.
