### PR TITLE
✅ use `mockClock` everywhere

### DIFF
--- a/packages/core/src/domain/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring.spec.ts
@@ -1,4 +1,5 @@
 import sinon from 'sinon'
+import { Clock, mockClock } from '../../test/specHelper'
 
 import { Configuration } from './configuration'
 import {
@@ -173,18 +174,18 @@ describe('internal monitoring', () => {
   describe('request', () => {
     const FAKE_DATE = 123456
     let server: sinon.SinonFakeServer
+    let clock: Clock
 
     beforeEach(() => {
       startInternalMonitoring(configuration as Configuration)
       server = sinon.fakeServer.create()
-      jasmine.clock().install()
-      jasmine.clock().mockDate(new Date(FAKE_DATE))
+      clock = mockClock(new Date(FAKE_DATE))
     })
 
     afterEach(() => {
       resetInternalMonitoring()
       server.restore()
-      jasmine.clock().uninstall()
+      clock.cleanup()
     })
 
     it('should send the needed data', () => {

--- a/packages/core/src/tools/errorFilter.spec.ts
+++ b/packages/core/src/tools/errorFilter.spec.ts
@@ -1,5 +1,5 @@
 import { Configuration } from '../domain/configuration'
-import { mockClock } from '../../../core/test/specHelper'
+import { Clock, mockClock } from '../../../core/test/specHelper'
 import { RawError } from './error'
 import { createErrorFilter, ErrorFilter } from './errorFilter'
 import { RelativeTime, relativeToClocks, resetNavigationStart } from './timeUtils'
@@ -9,16 +9,15 @@ const CONFIGURATION = { maxErrorsByMinute: 1 } as Configuration
 
 describe('errorFilter.isLimitReached', () => {
   let errorFilter: ErrorFilter | undefined
-  let clock: jasmine.Clock
-  let cleanupClock: () => void
+  let clock: Clock
 
   beforeEach(() => {
-    ;({ clock, stop: cleanupClock } = mockClock())
+    clock = mockClock()
     resetNavigationStart()
   })
 
   afterEach(() => {
-    cleanupClock()
+    clock.cleanup()
   })
 
   it('returns false if the limit is not reached', () => {

--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -1,3 +1,4 @@
+import { Clock, mockClock } from '../../test/specHelper'
 import { findCommaSeparatedValue, jsonStringify, performDraw, round, safeTruncate, throttle } from './utils'
 
 describe('utils', () => {
@@ -5,15 +6,15 @@ describe('utils', () => {
     let spy: jasmine.Spy
     let throttled: () => void
     let cancel: () => void
+    let clock: Clock
 
     beforeEach(() => {
-      jasmine.clock().install()
-      jasmine.clock().mockDate()
+      clock = mockClock()
       spy = jasmine.createSpy()
     })
 
     afterEach(() => {
-      jasmine.clock().uninstall()
+      clock.cleanup()
     })
 
     describe('when {leading: false, trailing:false}', () => {
@@ -24,7 +25,7 @@ describe('utils', () => {
       it('should not call throttled function', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(0)
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(0)
       })
 
@@ -32,30 +33,30 @@ describe('utils', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(0)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(0)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(0)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(0)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(0)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(0)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(0)
       })
 
       it('should not called throttled function performed after the wait period', () => {
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(0)
       })
     })
@@ -68,7 +69,7 @@ describe('utils', () => {
       it('should call throttled function after the wait period', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(0)
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(1)
       })
 
@@ -76,30 +77,30 @@ describe('utils', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(0)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(0)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(0)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(1)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(1)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(2)
       })
 
       it('should perform calls made after the wait period', () => {
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(2)
       })
     })
@@ -112,7 +113,7 @@ describe('utils', () => {
       it('should call throttled function immediately', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(1)
       })
 
@@ -120,30 +121,30 @@ describe('utils', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(1)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(1)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(2)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(2)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(2)
       })
 
       it('should perform calls made after the wait period', () => {
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(2)
       })
     })
@@ -156,7 +157,7 @@ describe('utils', () => {
       it('should call throttled function immediately', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(1)
       })
 
@@ -164,30 +165,30 @@ describe('utils', () => {
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(1)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(2)
 
         throttled()
         expect(spy).toHaveBeenCalledTimes(3)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(3)
 
-        jasmine.clock().tick(1)
+        clock.tick(1)
         expect(spy).toHaveBeenCalledTimes(3)
       })
 
       it('should perform calls made after the wait period', () => {
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         throttled()
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(2)
       })
     })
@@ -206,7 +207,7 @@ describe('utils', () => {
 
         cancel()
 
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(1)
       })
 
@@ -214,7 +215,7 @@ describe('utils', () => {
         cancel()
         throttled()
         expect(spy).toHaveBeenCalledTimes(1)
-        jasmine.clock().tick(2)
+        clock.tick(2)
         expect(spy).toHaveBeenCalledTimes(1)
       })
     })
@@ -224,7 +225,7 @@ describe('utils', () => {
       throttled(1)
       throttled(2)
       throttled(3)
-      jasmine.clock().tick(2)
+      clock.tick(2)
       expect(spy.calls.allArgs()).toEqual([[1], [3]])
     })
   })

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -38,16 +38,18 @@ export function clearAllCookies() {
   })
 }
 
-export function mockClock() {
+export type Clock = ReturnType<typeof mockClock>
+
+export function mockClock(date?: Date) {
   jasmine.clock().install()
-  jasmine.clock().mockDate()
+  jasmine.clock().mockDate(date)
   const start = Date.now()
   spyOn(performance, 'now').and.callFake(() => Date.now() - start)
   spyOnProperty(performance.timing, 'navigationStart', 'get').and.callFake(() => start)
   resetNavigationStart()
   return {
-    clock: jasmine.clock(),
-    stop: () => {
+    tick: (ms: number) => jasmine.clock().tick(ms),
+    cleanup: () => {
       jasmine.clock().uninstall()
       resetNavigationStart()
     },

--- a/packages/logs/src/boot/logs.entry.spec.ts
+++ b/packages/logs/src/boot/logs.entry.spec.ts
@@ -1,4 +1,5 @@
 import { Context, monitor, ONE_SECOND } from '@datadog/browser-core'
+import { Clock, mockClock } from '../../../core/test/specHelper'
 
 import { HandlerType, LogsMessage, StatusType } from '../domain/logger'
 import { LogsPublicApi, makeLogsPublicApi, StartLogs } from './logs.entry'
@@ -124,15 +125,15 @@ describe('logs entry', () => {
 
   describe('pre-init API usages', () => {
     let LOGS: LogsPublicApi
+    let clock: Clock
 
     beforeEach(() => {
       LOGS = makeLogsPublicApi(startLogs)
-      jasmine.clock().install()
-      jasmine.clock().mockDate()
+      clock = mockClock()
     })
 
     afterEach(() => {
-      jasmine.clock().uninstall()
+      clock.cleanup()
     })
 
     it('allows sending logs', () => {
@@ -158,7 +159,7 @@ describe('logs entry', () => {
     describe('save context when submiting a log', () => {
       it('saves the date', () => {
         LOGS.logger.log('message')
-        jasmine.clock().tick(ONE_SECOND)
+        clock.tick(ONE_SECOND)
         LOGS.init(DEFAULT_INIT_CONFIGURATION)
 
         expect(getLoggedMessage(0).context.date).toEqual(Date.now() - ONE_SECOND)

--- a/packages/logs/src/boot/logs.spec.ts
+++ b/packages/logs/src/boot/logs.spec.ts
@@ -12,7 +12,7 @@ import {
   TimeStamp,
 } from '@datadog/browser-core'
 import sinon from 'sinon'
-import { mockClock } from '../../../core/test/specHelper'
+import { Clock, mockClock } from '../../../core/test/specHelper'
 
 import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LogsEvent } from '../logsEvent.types'
@@ -300,15 +300,14 @@ describe('logs', () => {
   })
 
   describe('error logs limitation', () => {
-    let clock: jasmine.Clock
-    let cleanupClock: () => void
+    let clock: Clock
 
     beforeEach(() => {
-      ;({ clock, stop: cleanupClock } = mockClock())
+      clock = mockClock()
     })
 
     afterEach(() => {
-      cleanupClock()
+      clock.cleanup()
     })
 
     it('stops sending error logs when reaching the limit', () => {

--- a/packages/logs/src/domain/loggerSession.spec.ts
+++ b/packages/logs/src/domain/loggerSession.spec.ts
@@ -6,6 +6,7 @@ import {
   setCookie,
   stopSessionManagement,
 } from '@datadog/browser-core'
+import { Clock, mockClock } from '../../../core/test/specHelper'
 
 import { LOGGER_SESSION_KEY, LoggerTrackingType, startLoggerSession } from './loggerSession'
 
@@ -13,19 +14,19 @@ describe('logger session', () => {
   const DURATION = 123456
   const configuration: Partial<Configuration> = { isEnabled: () => true, sampleRate: 0.5 }
   let tracked = true
+  let clock: Clock
 
   beforeEach(() => {
     spyOn(Math, 'random').and.callFake(() => (tracked ? 0 : 1))
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date())
+    clock = mockClock()
   })
 
   afterEach(() => {
     // remove intervals first
     stopSessionManagement()
     // flush pending callbacks to avoid random failures
-    jasmine.clock().tick(new Date().getTime())
-    jasmine.clock().uninstall()
+    clock.tick(new Date().getTime())
+    clock.cleanup()
   })
 
   it('when tracked should store tracking type and session id', () => {
@@ -68,7 +69,7 @@ describe('logger session', () => {
 
     setCookie(SESSION_COOKIE_NAME, '', DURATION)
     expect(getCookie(SESSION_COOKIE_NAME)).toBeUndefined()
-    jasmine.clock().tick(COOKIE_ACCESS_DELAY)
+    clock.tick(COOKIE_ACCESS_DELAY)
 
     tracked = true
     document.body.click()

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -1,4 +1,5 @@
 import { Context, DOM_EVENT, ClocksState } from '@datadog/browser-core'
+import { Clock } from '../../../../../core/test/specHelper'
 import { RumEvent } from '../../../../../rum/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType, ActionType } from '../../../rawRumEvent.types'
@@ -34,7 +35,7 @@ describe('trackActions', () => {
   let createSpy: jasmine.Spy
   let discardSpy: jasmine.Spy
 
-  function mockValidatedClickAction(lifeCycle: LifeCycle, clock: jasmine.Clock, target: HTMLElement) {
+  function mockValidatedClickAction(lifeCycle: LifeCycle, clock: Clock, target: HTMLElement) {
     target.addEventListener(DOM_EVENT.CLICK, () => {
       clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
       // Since we don't collect dom mutations for this test, manually dispatch one

--- a/packages/rum-core/src/domain/rumSession.spec.ts
+++ b/packages/rum-core/src/domain/rumSession.spec.ts
@@ -7,7 +7,7 @@ import {
   setCookie,
   stopSessionManagement,
 } from '@datadog/browser-core'
-import { isIE } from '../../../core/test/specHelper'
+import { Clock, isIE, mockClock } from '../../../core/test/specHelper'
 
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RUM_SESSION_KEY, RumTrackingType, startRumSession } from './rumSession'
@@ -26,13 +26,13 @@ describe('rum session', () => {
   }
   let lifeCycle: LifeCycle
   let renewSessionSpy: jasmine.Spy
+  let clock: Clock
 
   beforeEach(() => {
     if (isIE()) {
       pending('no full rum support')
     }
-    jasmine.clock().install()
-    jasmine.clock().mockDate(new Date())
+    clock = mockClock()
     renewSessionSpy = jasmine.createSpy('renewSessionSpy')
     lifeCycle = new LifeCycle()
     lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, renewSessionSpy)
@@ -42,8 +42,8 @@ describe('rum session', () => {
     // remove intervals first
     stopSessionManagement()
     // flush pending callbacks to avoid random failures
-    jasmine.clock().tick(new Date().getTime())
-    jasmine.clock().uninstall()
+    clock.tick(new Date().getTime())
+    clock.cleanup()
   })
 
   it('when tracked with resources should store session type and id', () => {
@@ -101,7 +101,7 @@ describe('rum session', () => {
     setCookie(SESSION_COOKIE_NAME, '', DURATION)
     expect(getCookie(SESSION_COOKIE_NAME)).toBeUndefined()
     expect(renewSessionSpy).not.toHaveBeenCalled()
-    jasmine.clock().tick(COOKIE_ACCESS_DELAY)
+    clock.tick(COOKIE_ACCESS_DELAY)
 
     setupDraws({ tracked: true, trackedWithResources: true })
     document.dispatchEvent(new CustomEvent('click'))

--- a/packages/rum-core/src/domain/trackPageActivities.spec.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.spec.ts
@@ -1,4 +1,4 @@
-import { noop, Observable, PreferredTime } from '@datadog/browser-core'
+import { noop, Observable, preferredNow, PreferredTime } from '@datadog/browser-core'
 import { Clock, mockClock } from '../../../core/test/specHelper'
 import { RumPerformanceNavigationTiming, RumPerformanceResourceTiming } from '../browser/performanceCollection'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
@@ -151,10 +151,11 @@ describe('waitPageActivitiesCompletion', () => {
   it('should collect an event that is followed by page activity', (done) => {
     const activityObservable = new Observable<PageActivityEvent>()
 
-    const startTime = performance.now()
+    const startTime = preferredNow()
     waitPageActivitiesCompletion(activityObservable, noop, (params) => {
       expect(params.hadActivity).toBeTrue()
       expect((params as { hadActivity: true; endTime: PreferredTime }).endTime).toEqual(
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
         (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY) as PreferredTime
       )
       done()
@@ -169,7 +170,7 @@ describe('waitPageActivitiesCompletion', () => {
   describe('extend with activities', () => {
     it('is extended while there is page activities', (done) => {
       const activityObservable = new Observable<PageActivityEvent>()
-      const startTime = performance.now()
+      const startTime = preferredNow()
 
       // Extend the action but stops before PAGE_ACTIVITY_MAX_DURATION
       const extendCount = Math.floor(PAGE_ACTIVITY_MAX_DURATION / BEFORE_PAGE_ACTIVITY_END_DELAY - 1)
@@ -177,6 +178,7 @@ describe('waitPageActivitiesCompletion', () => {
       waitPageActivitiesCompletion(activityObservable, noop, (params) => {
         expect(params.hadActivity).toBeTrue()
         expect((params as { hadActivity: true; endTime: PreferredTime }).endTime).toBe(
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
           (startTime + (extendCount + 1) * BEFORE_PAGE_ACTIVITY_END_DELAY) as PreferredTime
         )
         done()
@@ -193,7 +195,7 @@ describe('waitPageActivitiesCompletion', () => {
     it('expires after a limit', (done) => {
       const activityObservable = new Observable<PageActivityEvent>()
       let stop = false
-      const startTime = performance.now()
+      const startTime = preferredNow()
 
       // Extend the action until it's more than PAGE_ACTIVITY_MAX_DURATION
       const extendCount = Math.ceil(PAGE_ACTIVITY_MAX_DURATION / BEFORE_PAGE_ACTIVITY_END_DELAY + 1)
@@ -201,6 +203,7 @@ describe('waitPageActivitiesCompletion', () => {
       waitPageActivitiesCompletion(activityObservable, noop, (params) => {
         expect(params.hadActivity).toBeTrue()
         expect((params as { hadActivity: true; endTime: PreferredTime }).endTime).toBe(
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
           (startTime + PAGE_ACTIVITY_MAX_DURATION) as PreferredTime
         )
         stop = true
@@ -219,10 +222,11 @@ describe('waitPageActivitiesCompletion', () => {
   describe('busy activities', () => {
     it('is extended while the page is busy', (done) => {
       const activityObservable = new Observable<PageActivityEvent>()
-      const startTime = performance.now()
+      const startTime = preferredNow()
       waitPageActivitiesCompletion(activityObservable, noop, (params) => {
         expect(params.hadActivity).toBeTrue()
         expect((params as { hadActivity: true; endTime: PreferredTime }).endTime).toBe(
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
           (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + PAGE_ACTIVITY_END_DELAY * 2) as PreferredTime
         )
         done()
@@ -239,10 +243,11 @@ describe('waitPageActivitiesCompletion', () => {
 
     it('expires is the page is busy for too long', (done) => {
       const activityObservable = new Observable<PageActivityEvent>()
-      const startTime = performance.now()
+      const startTime = preferredNow()
       waitPageActivitiesCompletion(activityObservable, noop, (params) => {
         expect(params.hadActivity).toBeTrue()
         expect((params as { hadActivity: true; endTime: PreferredTime }).endTime).toBe(
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
           (startTime + PAGE_ACTIVITY_MAX_DURATION) as PreferredTime
         )
         done()

--- a/packages/rum-recorder/src/domain/rrweb/record.spec.ts
+++ b/packages/rum-recorder/src/domain/rrweb/record.spec.ts
@@ -1,4 +1,4 @@
-import { createNewEvent, isIE } from '../../../../core/test/specHelper'
+import { Clock, createNewEvent, isIE } from '../../../../core/test/specHelper'
 import { collectAsyncCalls, createMutationPayloadValidator } from '../../../test/utils'
 import {
   RecordType,
@@ -19,6 +19,7 @@ describe('record', () => {
   let emitSpy: jasmine.Spy<(record: RawRecord) => void>
   let waitEmitCalls: (expectedCallsCount: number, callback: () => void) => void
   let expectNoExtraEmitCalls: (done: () => void) => void
+  let clock: Clock | undefined
 
   beforeEach(() => {
     if (isIE()) {
@@ -31,7 +32,7 @@ describe('record', () => {
   })
 
   afterEach(() => {
-    jasmine.clock().uninstall()
+    clock?.cleanup()
     sandbox.remove()
     recordApi?.stop()
   })


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/browser-sdk/pull/828#discussion_r625591812

Our clock system is becoming a bit more complex. In #828, I introduced spec helper function to help mock the clock based on the rum-core spec helper. This PR slightly change the implementation and generalize its usage over all spec files.

## Changes

* Change the mock a bit to avoid having a destructuring assignement and using two distinct variables.
* Replace all `jasmine.Clock` usages by the new `mockClock` function.

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
