### PR TITLE
[RUMF-912] 📝 add a warning in the RUM-recorder readme

### DIFF
--- a/packages/rum-recorder/README.md
+++ b/packages/rum-recorder/README.md
@@ -1,5 +1,10 @@
 # RUM Browser Monitoring and Session Recording
 
+## Warning
+
+**This package is for the private beta of our Session Replay product. If you are not enrolled in our
+Session Replay private beta, please use the [RUM package](../rum) instead.**
+
 ## Overview
 
 This package is equivalent to the [RUM package](../rum), but will record the user session beside


### PR DESCRIPTION
## Motivation

Some customers seem to use the @datadog/browser-rum-recorder package even if they are not enrolled in our session replay beta.

## Changes

 Add a clear message to advise them to use the RUM-only package.

## Testing

Rendered: https://github.com/DataDog/browser-sdk/blob/e690632632769bc2320b658e320f377e8b921f4e/packages/rum-recorder/README.md#warning

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
