### PR TITLE
✨ Clear previously set user context

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -381,6 +381,18 @@ describe('rum public api', () => {
       expect(errorSpy).not.toHaveBeenCalled()
     })
 
+    it('should remove the user', () => {
+      const user = { id: 'foo', name: 'bar', email: 'qux' }
+      rumPublicApi.setUser(user)
+      rumPublicApi.removeUser()
+      rumPublicApi.addAction('message')
+
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+
+      expect(addActionSpy.calls.argsFor(0)[1]!.user).toEqual({})
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
     it('should reject non object input', () => {
       rumPublicApi.setUser(2 as any)
       rumPublicApi.setUser(null as any)

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -146,6 +146,10 @@ export function makeRumPublicApi<C extends RumUserConfiguration>(startRumImpl: S
         console.error('Unsupported user:', newUser)
       }
     }),
+
+    removeUser: monitor(() => {
+      user = {}
+    }),
   })
   return rumPublicApi
 


### PR DESCRIPTION
## Motivation

Provide an API to clear a previously set user without having to clear all its attributes.
#774

## Changes

Allows you to clear a  previously set user with the API `removeUser()`

## Testing

Unit, manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
