### PR TITLE
✨[RUMF-908] attach current drift value to events

### DIFF
--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -41,6 +41,11 @@ function getCorrectedTimeStamp(relativeTime: RelativeTime) {
   return getTimeStamp(relativeTime)
 }
 
+export function currentDrift() {
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+  return Math.round(Date.now() - (getNavigationStart() + performance.now()))
+}
+
 export function toServerDuration(duration: Duration): ServerDuration
 export function toServerDuration(duration: Duration | undefined): ServerDuration | undefined
 export function toServerDuration(duration: Duration | undefined) {

--- a/packages/core/src/transport/transport.ts
+++ b/packages/core/src/transport/transport.ts
@@ -1,5 +1,4 @@
 import { Context } from '../tools/context'
-import { getTimeStamp, relativeNow } from '../tools/timeUtils'
 import { addEventListener, DOM_EVENT, jsonStringify, noop, objectValues } from '../tools/utils'
 import { monitor, addErrorToMonitoringBatch } from '../domain/internalMonitoring'
 
@@ -36,9 +35,7 @@ export class HttpRequest {
 }
 
 function addBatchTime(url: string) {
-  return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}&m_time=${getTimeStamp(
-    relativeNow()
-  )}`
+  return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}`
 }
 
 let hasReportedBeaconError = false

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -7,6 +7,7 @@ import {
   isEmptyObject,
   limitModification,
   timeStampNow,
+  currentDrift,
 } from '@datadog/browser-core'
 import {
   CommonContext,
@@ -64,6 +65,7 @@ export function startRumAssembly(
         const rumContext: RumContext = {
           _dd: {
             format_version: 2,
+            drift: currentDrift(),
           },
           application: {
             id: applicationId,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -148,6 +148,7 @@ export interface RumContext {
   }
   _dd: {
     format_version: 2
+    drift: number
   }
 }
 

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -168,6 +168,7 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
   const fakeContext: RumContext & ViewContext = {
     _dd: {
       format_version: 2,
+      drift: 0,
     },
     application: {
       id: fakeId,


### PR DESCRIPTION
## Motivation

Provide extra context info for debugging

## Changes

- remove monotonic batch time from requests
- attach current drift in `_dd.drift` field

## Testing

ci, manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
