### PR TITLE
⚗ [RUMF-878] add startView API

### DIFF
--- a/packages/core/src/tools/boundedBuffer.spec.ts
+++ b/packages/core/src/tools/boundedBuffer.spec.ts
@@ -3,26 +3,28 @@ import { BoundedBuffer } from './boundedBuffer'
 describe('BoundedBuffer', () => {
   it('collect and drain the items', () => {
     const spy = jasmine.createSpy<(i: number) => void>()
-    const buffered = new BoundedBuffer<number>()
+    const buffered = new BoundedBuffer()
 
-    buffered.add(1)
-    buffered.drain(spy)
+    buffered.add<number>(1, spy)
+    expect(spy.calls.count()).toBe(0)
+
+    buffered.drain()
     expect(spy.calls.count()).toBe(1)
     expect(spy.calls.first().args).toEqual([1])
 
-    buffered.drain(spy)
+    buffered.drain()
     expect(spy.calls.count()).toBe(1)
   })
 
   it('store only the N last items', () => {
     const spy = jasmine.createSpy<(i: number) => void>()
-    const buffered = new BoundedBuffer<number>(5)
+    const buffered = new BoundedBuffer(5)
 
     for (let i = 0; i < 10; i += 1) {
-      buffered.add(i)
+      buffered.add<number>(i, spy)
     }
 
-    buffered.drain(spy)
+    buffered.drain()
     expect(spy.calls.allArgs()).toEqual([[5], [6], [7], [8], [9]])
   })
 })

--- a/packages/core/src/tools/boundedBuffer.spec.ts
+++ b/packages/core/src/tools/boundedBuffer.spec.ts
@@ -1,30 +1,29 @@
 import { BoundedBuffer } from './boundedBuffer'
 
 describe('BoundedBuffer', () => {
-  it('collect and drain the items', () => {
-    const spy = jasmine.createSpy<(i: number) => void>()
+  it('collect and drain the callbacks', () => {
+    const spy = jasmine.createSpy<() => void>()
     const buffered = new BoundedBuffer()
 
-    buffered.add<number>(1, spy)
+    buffered.add(spy)
     expect(spy.calls.count()).toBe(0)
 
     buffered.drain()
     expect(spy.calls.count()).toBe(1)
-    expect(spy.calls.first().args).toEqual([1])
 
     buffered.drain()
     expect(spy.calls.count()).toBe(1)
   })
 
-  it('store only the N last items', () => {
-    const spy = jasmine.createSpy<(i: number) => void>()
+  it('store only the N last callbacks', () => {
+    const spy = jasmine.createSpy<() => void>()
     const buffered = new BoundedBuffer(5)
 
     for (let i = 0; i < 10; i += 1) {
-      buffered.add<number>(i, spy)
+      buffered.add(spy)
     }
 
     buffered.drain()
-    expect(spy.calls.allArgs()).toEqual([[5], [6], [7], [8], [9]])
+    expect(spy.calls.count()).toEqual(5)
   })
 })

--- a/packages/core/src/tools/boundedBuffer.ts
+++ b/packages/core/src/tools/boundedBuffer.ts
@@ -1,19 +1,19 @@
 const DEFAULT_LIMIT = 10_000
 
 export class BoundedBuffer {
-  private buffer: Array<[any, (item: any) => void]> = []
+  private buffer: Array<() => void> = []
 
   constructor(private limit: number = DEFAULT_LIMIT) {}
 
-  add<T>(item: T, drainFn: (item: T) => void) {
-    const length = this.buffer.push([item, drainFn])
+  add(callback: () => void) {
+    const length = this.buffer.push(callback)
     if (length > this.limit) {
       this.buffer.splice(0, 1)
     }
   }
 
   drain() {
-    this.buffer.forEach(([item, drainFn]) => drainFn(item))
+    this.buffer.forEach((callback) => callback())
     this.buffer.length = 0
   }
 }

--- a/packages/core/src/tools/boundedBuffer.ts
+++ b/packages/core/src/tools/boundedBuffer.ts
@@ -1,19 +1,19 @@
 const DEFAULT_LIMIT = 10_000
 
-export class BoundedBuffer<T> {
-  private buffer: T[] = []
+export class BoundedBuffer {
+  private buffer: Array<[any, (item: any) => void]> = []
 
   constructor(private limit: number = DEFAULT_LIMIT) {}
 
-  add(item: T) {
-    const length = this.buffer.push(item)
+  add<T>(item: T, drainFn: (item: T) => void) {
+    const length = this.buffer.push([item, drainFn])
     if (length > this.limit) {
       this.buffer.splice(0, 1)
     }
   }
 
-  drain(fn: (item: T) => void) {
-    this.buffer.forEach((item) => fn(item))
+  drain() {
+    this.buffer.forEach(([item, drainFn]) => drainFn(item))
     this.buffer.length = 0
   }
 }

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -38,9 +38,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
 
   const beforeInitSendLog = new BoundedBuffer()
   let sendLogStrategy = (message: LogsMessage, currentContext: Context) => {
-    beforeInitSendLog.add<[LogsMessage, Context]>([message, currentContext], ([message, context]) =>
-      sendLogStrategy(message, context)
-    )
+    beforeInitSendLog.add(() => sendLogStrategy(message, currentContext))
   }
   const logger = new Logger(sendLog)
 

--- a/packages/rum-core/src/boot/rum.spec.ts
+++ b/packages/rum-core/src/boot/rum.spec.ts
@@ -1,10 +1,12 @@
-import { RelativeTime } from '@datadog/browser-core'
+import { RelativeTime, Configuration } from '@datadog/browser-core'
+import { RumSession } from '@datadog/browser-rum-core'
 import { isIE } from '../../../core/test/specHelper'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { RumPerformanceNavigationTiming } from '../browser/performanceCollection'
 
 import { LifeCycle, LifeCycleEventType } from '../domain/lifeCycle'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD } from '../domain/rumEventsCollection/view/trackViews'
+import { startViewCollection } from '../domain/rumEventsCollection/view/viewCollection'
 import { RumEvent } from '../rumEvent.types'
 import { startRumEventCollection } from './rum'
 
@@ -14,6 +16,32 @@ function collectServerEvents(lifeCycle: LifeCycle) {
     serverRumEvents.push(serverRumEvent)
   })
   return serverRumEvents
+}
+
+function startRum(
+  applicationId: string,
+  lifeCycle: LifeCycle,
+  configuration: Configuration,
+  session: RumSession,
+  location: Location
+) {
+  const { stop: rumEventCollectionStop } = startRumEventCollection(
+    applicationId,
+    lifeCycle,
+    configuration,
+    session,
+    () => ({
+      context: {},
+      user: {},
+    })
+  )
+  const { stop: viewCollectionStop } = startViewCollection(lifeCycle, location)
+  return {
+    stop: () => {
+      rumEventCollectionStop()
+      viewCollectionStop()
+    },
+  }
 }
 
 describe('rum session', () => {
@@ -27,10 +55,7 @@ describe('rum session', () => {
 
     setupBuilder = setup().beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
       serverRumEvents = collectServerEvents(lifeCycle)
-      return startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({
-        context: {},
-        user: {},
-      }))
+      return startRum(applicationId, lifeCycle, configuration, session, location)
     })
   })
 
@@ -83,10 +108,7 @@ describe('rum session keep alive', () => {
       })
       .beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
-        return startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({
-          context: {},
-          user: {},
-        }))
+        return startRum(applicationId, lifeCycle, configuration, session, location)
       })
   })
 
@@ -146,10 +168,7 @@ describe('rum view url', () => {
   beforeEach(() => {
     setupBuilder = setup().beforeBuild(({ applicationId, location, lifeCycle, configuration, session }) => {
       serverRumEvents = collectServerEvents(lifeCycle)
-      return startRumEventCollection(applicationId, location, lifeCycle, configuration, session, () => ({
-        context: {},
-        user: {},
-      }))
+      return startRum(applicationId, lifeCycle, configuration, session, location)
     })
   })
 

--- a/packages/rum-core/src/boot/rum.ts
+++ b/packages/rum-core/src/boot/rum.ts
@@ -44,7 +44,7 @@ export function startRum(userConfiguration: RumUserConfiguration, getCommonConte
 
   startLongTaskCollection(lifeCycle)
   startResourceCollection(lifeCycle, session)
-  const { addTiming } = startViewCollection(lifeCycle, location)
+  const { addTiming, startView } = startViewCollection(lifeCycle, location)
   const { addError } = startErrorCollection(lifeCycle, configuration)
   const { addAction } = startActionCollection(lifeCycle, configuration)
 
@@ -58,6 +58,7 @@ export function startRum(userConfiguration: RumUserConfiguration, getCommonConte
     addAction,
     addError,
     addTiming,
+    startView,
     configuration,
     lifeCycle,
     parentContexts,

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -98,6 +98,7 @@ export function makeRumPublicApi<C extends RumUserConfiguration>(startRumImpl: S
         user,
         context: globalContextManager.get(),
       })))
+      // TODO respect API order
       beforeInitAddAction.drain(([action, commonContext]) => addActionStrategy(action, commonContext))
       beforeInitAddError.drain(([error, commonContext]) => addErrorStrategy(error, commonContext))
       beforeInitAddTiming.drain(([name, time]) => addTimingStrategy(name, time))

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -125,7 +125,7 @@ export function trackViews(location: Location, lifeCycle: LifeCycle) {
       currentView.triggerUpdate()
     },
     startView: (name?: string, startClocks?: ClocksState) => {
-      currentView.end()
+      currentView.end(startClocks)
       currentView.triggerUpdate()
       currentView = trackViewChange(startClocks, name)
     },
@@ -197,8 +197,8 @@ function newView(
 
   return {
     scheduleUpdate: scheduleViewUpdate,
-    end() {
-      endClocks = clocksNow()
+    end(clocks = clocksNow()) {
+      endClocks = clocks
       stopViewMetricsTracking()
       lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks })
     },

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -115,14 +115,19 @@ export function trackViews(location: Location, lifeCycle: LifeCycle) {
     return { initialView, stop }
   }
 
-  function trackViewChange() {
-    return newView(lifeCycle, location, isRecording, ViewLoadingType.ROUTE_CHANGE, currentView.url)
+  function trackViewChange(startClocks?: ClocksState, name?: string) {
+    return newView(lifeCycle, location, isRecording, ViewLoadingType.ROUTE_CHANGE, currentView.url, startClocks, name)
   }
 
   return {
     addTiming: (name: string, endClocks = clocksNow()) => {
       currentView.addTiming(name, endClocks)
       currentView.triggerUpdate()
+    },
+    startView: (name?: string, startClocks?: ClocksState) => {
+      currentView.end()
+      currentView.triggerUpdate()
+      currentView = trackViewChange(startClocks, name)
     },
     stop: () => {
       stopInitialViewTracking()

--- a/test/app/app.ts
+++ b/test/app/app.ts
@@ -1,10 +1,10 @@
 import { datadogLogs, LogsUserConfiguration } from '@datadog/browser-logs'
-import { datadogRum, RumUserConfiguration } from '@datadog/browser-rum-recorder'
+import { datadogRum } from '@datadog/browser-rum-recorder'
 
 declare global {
   interface Window {
     LOGS_CONFIG?: LogsUserConfiguration
-    RUM_CONFIG?: RumUserConfiguration
+    RUM_INIT?: () => void
   }
 }
 
@@ -13,8 +13,8 @@ if (typeof window !== 'undefined') {
     datadogLogs.init(window.LOGS_CONFIG)
   }
 
-  if (window.RUM_CONFIG) {
-    datadogRum.init(window.RUM_CONFIG)
+  if (window.RUM_INIT) {
+    window.RUM_INIT()
   }
 } else {
   // compat test

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -1,21 +1,23 @@
+import { LogsUserConfiguration } from '@datadog/browser-logs'
+import { RumUserConfiguration } from '@datadog/browser-rum-core'
 import { deleteAllCookies, withBrowserLogs } from '../helpers/browser'
 import { flushEvents } from '../helpers/sdk'
 import { validateFormat } from '../helpers/validation'
 import { EventRegistry } from './eventsRegistry'
 import { getTestServers, Servers, waitForServersIdle } from './httpServers'
 import { log } from './logger'
-import { DEFAULT_SETUPS, LogsSetupOptions, RumSetupOptions, SetupFactory, SetupOptions } from './pageSetups'
+import { DEFAULT_SETUPS, SetupFactory, SetupOptions } from './pageSetups'
 import { Endpoints } from './sdkBuilds'
 import { createIntakeServerApp } from './serverApps/intake'
 import { createMockServerApp } from './serverApps/mock'
 
-const DEFAULT_RUM_OPTIONS = {
+const DEFAULT_RUM_CONFIGURATION = {
   applicationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   clientToken: 'token',
   enableExperimentalFeatures: [],
 }
 
-const DEFAULT_LOGS_OPTIONS = {
+const DEFAULT_LOGS_CONFIGURATION = {
   clientToken: 'token',
 }
 
@@ -33,32 +35,32 @@ interface TestContext {
 type TestRunner = (testContext: TestContext) => Promise<void>
 
 class TestBuilder {
-  private rumOptions: RumSetupOptions | undefined = undefined
-  private rumRecorderOptions: RumSetupOptions | undefined = undefined
-  private logsOptions: LogsSetupOptions | undefined = undefined
+  private rumConfiguration: RumUserConfiguration | undefined = undefined
+  private rumRecorderConfiguration: RumUserConfiguration | undefined = undefined
+  private logsConfiguration: LogsUserConfiguration | undefined = undefined
   private head = ''
   private body = ''
   private setups: Array<{ factory: SetupFactory; name?: string }> = []
 
   constructor(private title: string) {}
 
-  withRum(rumOptions?: RumSetupOptions) {
-    this.rumOptions = { ...DEFAULT_RUM_OPTIONS, ...rumOptions }
+  withRum(rumConfiguration?: Partial<RumUserConfiguration>) {
+    this.rumConfiguration = { ...DEFAULT_RUM_CONFIGURATION, ...rumConfiguration }
     return this
   }
 
-  withRumRecorder(rumRecorderOptions?: RumSetupOptions) {
-    this.rumRecorderOptions = { ...DEFAULT_RUM_OPTIONS, ...rumRecorderOptions }
+  withRumRecorder(rumRecorderConfiguration?: Partial<RumUserConfiguration>) {
+    this.rumRecorderConfiguration = { ...DEFAULT_RUM_CONFIGURATION, ...rumRecorderConfiguration }
     return this
   }
 
-  withRumInit(rumInit: (options: RumSetupOptions) => void) {
+  withRumInit(rumInit: (configuration: RumUserConfiguration) => void) {
     this.rumInit = rumInit
     return this
   }
 
-  withLogs(logsOptions?: LogsSetupOptions) {
-    this.logsOptions = { ...DEFAULT_LOGS_OPTIONS, ...logsOptions }
+  withLogs(logsConfiguration?: Partial<LogsUserConfiguration>) {
+    this.logsConfiguration = { ...DEFAULT_LOGS_CONFIGURATION, ...logsConfiguration }
     return this
   }
 
@@ -86,10 +88,10 @@ class TestBuilder {
     const setupOptions: SetupOptions = {
       body: this.body,
       head: this.head,
-      logs: this.logsOptions,
-      rum: this.rumOptions,
+      logs: this.logsConfiguration,
+      rum: this.rumConfiguration,
       rumInit: this.rumInit,
-      rumRecorder: this.rumRecorderOptions,
+      rumRecorder: this.rumRecorderConfiguration,
     }
 
     if (setups.length > 1) {
@@ -103,9 +105,8 @@ class TestBuilder {
     }
   }
 
-  private rumInit: (options: RumSetupOptions) => void = (options) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    ;(window.DD_RUM as any).init(options)
+  private rumInit: (configuration: RumUserConfiguration) => void = (configuration) => {
+    window.DD_RUM!.init(configuration)
   }
 }
 

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -52,6 +52,11 @@ class TestBuilder {
     return this
   }
 
+  withRumInit(rumInit: (options: RumSetupOptions) => void) {
+    this.rumInit = rumInit
+    return this
+  }
+
   withLogs(logsOptions?: LogsSetupOptions) {
     this.logsOptions = { ...DEFAULT_LOGS_OPTIONS, ...logsOptions }
     return this
@@ -83,6 +88,7 @@ class TestBuilder {
       head: this.head,
       logs: this.logsOptions,
       rum: this.rumOptions,
+      rumInit: this.rumInit,
       rumRecorder: this.rumRecorderOptions,
     }
 
@@ -95,6 +101,11 @@ class TestBuilder {
     } else {
       declareTest(this.title, setups[0].factory(setupOptions), runner)
     }
+  }
+
+  private rumInit: (options: RumSetupOptions) => void = (options) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    ;(window.DD_RUM as any).init(options)
   }
 }
 

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -123,7 +123,9 @@ export function npmSetup(options: SetupOptions) {
   if (rumOptions) {
     header += html`
       <script type="text/javascript">
-        window.RUM_CONFIG = ${formatRumOptions(rumOptions)}
+        window.RUM_INIT = () => {
+          ;(${options.rumInit.toString()})(${formatRumOptions(rumOptions)})
+        }
       </script>
     `
   }

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -1,24 +1,11 @@
-export interface RumSetupOptions {
-  clientToken?: string
-  applicationId?: string
-  internalMonitoringApiKey?: string
-  allowedTracingOrigins?: string[]
-  service?: string
-  trackInteractions?: boolean
-  enableExperimentalFeatures?: string[]
-}
-
-export interface LogsSetupOptions {
-  clientToken?: string
-  internalMonitoringApiKey?: string
-  forwardErrorsToLogs?: boolean
-}
+import { LogsUserConfiguration } from '@datadog/browser-logs'
+import { RumUserConfiguration } from '@datadog/browser-rum-core'
 
 export interface SetupOptions {
-  rum?: RumSetupOptions
-  rumRecorder?: RumSetupOptions
-  logs?: LogsSetupOptions
-  rumInit: (rumOptions: RumSetupOptions) => void
+  rum?: RumUserConfiguration
+  rumRecorder?: RumUserConfiguration
+  logs?: LogsUserConfiguration
+  rumInit: (configuration: RumUserConfiguration) => void
   head?: string
   body?: string
 }
@@ -53,19 +40,19 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       <script>
         ${formatSnippet('./datadog-logs.js', 'DD_LOGS')}
         DD_LOGS.onReady(function () {
-          DD_LOGS.init(${formatLogsOptions(options.logs)})
+          DD_LOGS.init(${formatLogsConfiguration(options.logs)})
         })
       </script>
     `
   }
 
-  const rumOptions = options.rumRecorder || options.rum
-  if (rumOptions) {
+  const rumConfiguration = options.rumRecorder || options.rum
+  if (rumConfiguration) {
     body += html`
       <script type="text/javascript">
         ${formatSnippet(options.rumRecorder ? './datadog-rum-recorder.js' : './datadog-rum.js', 'DD_RUM')}
         DD_RUM.onReady(function () {
-          ;(${options.rumInit.toString()})(${formatRumOptions(rumOptions)})
+          ;(${options.rumInit.toString()})(${formatRumConfiguration(rumConfiguration)})
         })
       </script>
     `
@@ -84,20 +71,20 @@ export function bundleSetup(options: SetupOptions) {
     header += html`
       <script type="text/javascript" src="./datadog-logs.js"></script>
       <script type="text/javascript">
-        DD_LOGS.init(${formatLogsOptions(options.logs)})
+        DD_LOGS.init(${formatLogsConfiguration(options.logs)})
       </script>
     `
   }
 
-  const rumOptions = options.rumRecorder || options.rum
-  if (rumOptions) {
+  const rumConfiguration = options.rumRecorder || options.rum
+  if (rumConfiguration) {
     header += html`
       <script
         type="text/javascript"
         src="${options.rumRecorder ? './datadog-rum-recorder.js' : './datadog-rum.js'}"
       ></script>
       <script type="text/javascript">
-        ;(${options.rumInit.toString()})(${formatRumOptions(rumOptions)})
+        ;(${options.rumInit.toString()})(${formatRumConfiguration(rumConfiguration)})
       </script>
     `
   }
@@ -114,17 +101,17 @@ export function npmSetup(options: SetupOptions) {
   if (options.logs) {
     header += html`
       <script type="text/javascript">
-        window.LOGS_CONFIG = ${formatLogsOptions(options.logs)}
+        window.LOGS_CONFIG = ${formatLogsConfiguration(options.logs)}
       </script>
     `
   }
 
-  const rumOptions = options.rumRecorder || options.rum
-  if (rumOptions) {
+  const rumConfiguration = options.rumRecorder || options.rum
+  if (rumConfiguration) {
     header += html`
       <script type="text/javascript">
         window.RUM_INIT = () => {
-          ;(${options.rumInit.toString()})(${formatRumOptions(rumOptions)})
+          ;(${options.rumInit.toString()})(${formatRumConfiguration(rumConfiguration)})
         }
       </script>
     `
@@ -157,10 +144,10 @@ export function html(parts: readonly string[], ...vars: string[]) {
   return parts.reduce((full, part, index) => full + vars[index - 1] + part)
 }
 
-function formatLogsOptions(options: LogsSetupOptions) {
-  return JSON.stringify(options)
+function formatLogsConfiguration(configuration: LogsUserConfiguration) {
+  return JSON.stringify(configuration)
 }
 
-function formatRumOptions(options: RumSetupOptions) {
-  return JSON.stringify(options).replace('"LOCATION_ORIGIN"', 'location.origin')
+function formatRumConfiguration(configuration: RumUserConfiguration) {
+  return JSON.stringify(configuration).replace('"LOCATION_ORIGIN"', 'location.origin')
 }

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -18,6 +18,7 @@ export interface SetupOptions {
   rum?: RumSetupOptions
   rumRecorder?: RumSetupOptions
   logs?: LogsSetupOptions
+  rumInit: (rumOptions: RumSetupOptions) => void
   head?: string
   body?: string
 }
@@ -64,7 +65,7 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       <script type="text/javascript">
         ${formatSnippet(options.rumRecorder ? './datadog-rum-recorder.js' : './datadog-rum.js', 'DD_RUM')}
         DD_RUM.onReady(function () {
-          DD_RUM.init(${formatRumOptions(rumOptions)})
+          ;(${options.rumInit.toString()})(${formatRumOptions(rumOptions)})
         })
       </script>
     `
@@ -96,7 +97,7 @@ export function bundleSetup(options: SetupOptions) {
         src="${options.rumRecorder ? './datadog-rum-recorder.js' : './datadog-rum.js'}"
       ></script>
       <script type="text/javascript">
-        DD_RUM.init(${formatRumOptions(rumOptions)})
+        ;(${options.rumInit.toString()})(${formatRumOptions(rumOptions)})
       </script>
     `
   }

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -1,24 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
 import { createTest } from '../../lib/framework'
 import { flushEvents } from '../../lib/helpers/sdk'
 
 describe('before init API calls', () => {
   createTest('should be associated to corresponding views')
     .withRum({ enableExperimentalFeatures: ['view-renaming'] })
-    .withRumInit((options) => {
-      ;(window.DD_RUM as any).addError('before manual view')
-      ;(window.DD_RUM as any).addAction('before manual view')
-      ;(window.DD_RUM as any).addTiming('before manual view')
+    .withRumInit((configuration) => {
+      window.DD_RUM!.addError('before manual view')
+      window.DD_RUM!.addAction('before manual view')
+      window.DD_RUM!.addTiming('before manual view')
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
       setTimeout(() => (window.DD_RUM as any).startView('manual view'), 10)
 
       setTimeout(() => {
-        ;(window.DD_RUM as any).addError('after manual view')
-        ;(window.DD_RUM as any).addAction('after manual view')
-        ;(window.DD_RUM as any).addTiming('after manual view')
+        window.DD_RUM!.addError('after manual view')
+        window.DD_RUM!.addAction('after manual view')
+        window.DD_RUM!.addTiming('after manual view')
       }, 20)
 
-      setTimeout(() => (window.DD_RUM as any).init(options), 30)
+      setTimeout(() => window.DD_RUM!.init(configuration), 30)
     })
     .run(async ({ events }) => {
       await flushEvents()

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+import { createTest, bundleSetup } from '../../lib/framework'
+import { asyncSetup } from '../../lib/framework/pageSetups'
+import { flushEvents } from '../../lib/helpers/sdk'
+
+describe('before init API calls', () => {
+  createTest('should be associated to corresponding views')
+    .withRum({ enableExperimentalFeatures: ['view-renaming'] })
+    .withRumInit((options) => {
+      ;(window.DD_RUM as any).addError('before manual view')
+      ;(window.DD_RUM as any).addAction('before manual view')
+      ;(window.DD_RUM as any).addTiming('before manual view')
+
+      setTimeout(() => (window.DD_RUM as any).startView('manual view'), 10)
+
+      setTimeout(() => {
+        ;(window.DD_RUM as any).addError('after manual view')
+        ;(window.DD_RUM as any).addAction('after manual view')
+        ;(window.DD_RUM as any).addTiming('after manual view')
+      }, 20)
+
+      setTimeout(() => (window.DD_RUM as any).init(options), 30)
+    })
+    .withSetup(bundleSetup, 'bundle')
+    .withSetup(asyncSetup, 'async')
+    .run(async ({ events }) => {
+      await flushEvents()
+
+      const initialView = events.rumViews[0]
+      expect(initialView.view.name).toBeUndefined()
+      expect(initialView.view.custom_timings).toEqual({
+        before_manual_view: jasmine.any(Number),
+      })
+
+      const manualView = events.rumViews[1]
+      expect(manualView.view.name).toBe('manual view')
+      expect(manualView.view.custom_timings).toEqual({
+        after_manual_view: jasmine.any(Number),
+      })
+
+      const documentEvent = events.rumResources.find((event) => event.resource.type === 'document')!
+      expect(documentEvent.view.id).toBe(initialView.view.id)
+
+      const beforeManualViewError = events.rumErrors[0]
+      expect(beforeManualViewError.error.message).toBe('Provided "before manual view"')
+      expect(beforeManualViewError.view.id).toBe(initialView.view.id)
+
+      const afterManualViewError = events.rumErrors[1]
+      expect(afterManualViewError.error.message).toBe('Provided "after manual view"')
+      expect(afterManualViewError.view.id).toBe(manualView.view.id)
+
+      const beforeManualViewAction = events.rumActions[0]
+      expect(beforeManualViewAction.action.target!.name).toBe('before manual view')
+      expect(beforeManualViewAction.view.id).toBe(initialView.view.id)
+
+      const afterManualViewAction = events.rumActions[1]
+      expect(afterManualViewAction.action.target!.name).toBe('after manual view')
+      expect(afterManualViewAction.view.id).toBe(manualView.view.id)
+    })
+})

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
-import { createTest, bundleSetup } from '../../lib/framework'
-import { asyncSetup } from '../../lib/framework/pageSetups'
+import { createTest } from '../../lib/framework'
 import { flushEvents } from '../../lib/helpers/sdk'
 
 describe('before init API calls', () => {
@@ -21,8 +20,6 @@ describe('before init API calls', () => {
 
       setTimeout(() => (window.DD_RUM as any).init(options), 30)
     })
-    .withSetup(bundleSetup, 'bundle')
-    .withSetup(asyncSetup, 'async')
     .run(async ({ events }) => {
       await flushEvents()
 


### PR DESCRIPTION
## Motivation

First step in the manual view naming strategy

## Changes

behind `view-renaming` flag, introduce new API:

```ts
DD_RUM.startView(name?: string)
```

Allowing to manually start a new view with an optional name

## Testing

unit / manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
