### PR TITLE
🐛 [logs] Fix IE11 console.log issue

### DIFF
--- a/packages/core/src/tools/display.ts
+++ b/packages/core/src/tools/display.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, local-rules/disallow-side-effects */
 /**
  * Keep references on console methods to avoid triggering patched behaviors
  *
@@ -7,7 +7,7 @@
  * but we should be safe from infinite loop nonetheless.
  */
 export const display: Pick<typeof console, 'log' | 'warn' | 'error'> = {
-  log: console.log,
-  warn: console.warn,
-  error: console.error,
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
 }


### PR DESCRIPTION
## Motivation

`Invalid calling object` errors reported since 2.9.0, related to #847.

Explanation: IE 11 console implementation has still some behavior differences when devtools are open or not

To reproduce:
- open the page with devtools closed
- open the devtools
- create a console logger and log a message

Result: `Invalid calling object` exception
Expected: message loged in console

## Changes

bind console object to function references

## Testing

manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
