### PR TITLE
✨ [RUMF-913] allow masking input values

### DIFF
--- a/packages/rum-recorder/src/constants.ts
+++ b/packages/rum-recorder/src/constants.ts
@@ -1,6 +1,14 @@
+export const enum InputPrivacyMode {
+  NONE = 1,
+  IGNORED,
+  MASKED,
+}
+
 export const PRIVACY_ATTR_NAME = 'data-dd-privacy'
 export const PRIVACY_ATTR_VALUE_HIDDEN = 'hidden'
 export const PRIVACY_ATTR_VALUE_INPUT_IGNORED = 'input-ignored'
+export const PRIVACY_ATTR_VALUE_INPUT_MASKED = 'input-masked'
 
 export const PRIVACY_CLASS_HIDDEN = 'dd-privacy-hidden'
 export const PRIVACY_CLASS_INPUT_IGNORED = 'dd-privacy-input-ignored'
+export const PRIVACY_CLASS_INPUT_MASKED = 'dd-privacy-input-masked'

--- a/packages/rum-recorder/src/domain/record/mutationBatch.spec.ts
+++ b/packages/rum-recorder/src/domain/record/mutationBatch.spec.ts
@@ -1,9 +1,10 @@
 import { collectAsyncCalls } from '../../../test/utils'
 import { createMutationBatch } from './mutationBatch'
+import { RumMutationRecord } from './types'
 
 describe('createMutationBatch', () => {
   let mutationBatch: ReturnType<typeof createMutationBatch>
-  let processMutationBatchSpy: jasmine.Spy<(mutations: MutationRecord[]) => void>
+  let processMutationBatchSpy: jasmine.Spy<(mutations: RumMutationRecord[]) => void>
 
   beforeEach(() => {
     processMutationBatchSpy = jasmine.createSpy()
@@ -15,7 +16,7 @@ describe('createMutationBatch', () => {
   })
 
   it('calls the callback asynchronously after adding a mutation', (done) => {
-    const mutation = { type: 'childList' } as MutationRecord
+    const mutation = { type: 'childList' } as RumMutationRecord
     mutationBatch.addMutations([mutation])
 
     const {
@@ -30,7 +31,7 @@ describe('createMutationBatch', () => {
   })
 
   it('calls the callback synchronously on flush', () => {
-    const mutation = { type: 'childList' } as MutationRecord
+    const mutation = { type: 'childList' } as RumMutationRecord
     mutationBatch.addMutations([mutation])
     mutationBatch.flush()
 
@@ -38,9 +39,9 @@ describe('createMutationBatch', () => {
   })
 
   it('appends mutations to the batch when adding more mutations', () => {
-    const mutation1 = { type: 'childList' } as MutationRecord
-    const mutation2 = { type: 'characterData' } as MutationRecord
-    const mutation3 = { type: 'attributes' } as MutationRecord
+    const mutation1 = { type: 'childList' } as RumMutationRecord
+    const mutation2 = { type: 'characterData' } as RumMutationRecord
+    const mutation3 = { type: 'attributes' } as RumMutationRecord
     mutationBatch.addMutations([mutation1])
     mutationBatch.addMutations([mutation2, mutation3])
     mutationBatch.flush()

--- a/packages/rum-recorder/src/domain/record/mutationBatch.ts
+++ b/packages/rum-recorder/src/domain/record/mutationBatch.ts
@@ -1,4 +1,5 @@
 import { monitor, noop } from '@datadog/browser-core'
+import { RumMutationRecord } from './types'
 
 /**
  * Maximum duration to wait before processing mutations. If the browser is idle, mutations will be
@@ -8,9 +9,9 @@ import { monitor, noop } from '@datadog/browser-core'
  */
 const MUTATION_PROCESS_MAX_DELAY = 100
 
-export function createMutationBatch(processMutationBatch: (mutations: MutationRecord[]) => void) {
+export function createMutationBatch(processMutationBatch: (mutations: RumMutationRecord[]) => void) {
   let cancelScheduledFlush = noop
-  let pendingMutations: MutationRecord[] = []
+  let pendingMutations: RumMutationRecord[] = []
 
   function flush() {
     cancelScheduledFlush()
@@ -19,7 +20,7 @@ export function createMutationBatch(processMutationBatch: (mutations: MutationRe
   }
 
   return {
-    addMutations: (mutations: MutationRecord[]) => {
+    addMutations: (mutations: RumMutationRecord[]) => {
       if (pendingMutations.length === 0) {
         cancelScheduledFlush = scheduleMutationFlush(flush)
       }

--- a/packages/rum-recorder/src/domain/record/mutationObserver.ts
+++ b/packages/rum-recorder/src/domain/record/mutationObserver.ts
@@ -11,11 +11,11 @@ import { serializeNodeWithId } from './serialize'
 import {
   AddedNodeMutation,
   AttributeMutation,
-  AttributesMutationRecord,
-  CharacterDataMutationRecord,
-  ChildListMutationRecord,
+  RumAttributesMutationRecord,
+  RumCharacterDataMutationRecord,
+  RumChildListMutationRecord,
   MutationCallBack,
-  MutationRecord,
+  RumMutationRecord,
   RemovedNodeMutation,
   TextMutation,
 } from './types'
@@ -29,10 +29,10 @@ type WithSerializedTarget<T> = T & { target: NodeWithSerializedNode }
  */
 export function startMutationObserver(controller: MutationController, mutationCallback: MutationCallBack) {
   const mutationBatch = createMutationBatch((mutations) => {
-    processMutations(mutations.concat(observer.takeRecords()), mutationCallback)
+    processMutations(mutations.concat(observer.takeRecords() as RumMutationRecord[]), mutationCallback)
   })
 
-  const observer = new MutationObserver(monitor(mutationBatch.addMutations))
+  const observer = new MutationObserver(monitor(mutationBatch.addMutations) as (callback: MutationRecord[]) => void)
 
   observer.observe(document, {
     attributeOldValue: true,
@@ -67,13 +67,13 @@ export class MutationController {
   }
 }
 
-function processMutations(mutations: MutationRecord[], mutationCallback: MutationCallBack) {
+function processMutations(mutations: RumMutationRecord[], mutationCallback: MutationCallBack) {
   // Discard any mutation with a 'target' node that:
   // * isn't injected in the current document or isn't known/serialized yet: those nodes are likely
   // part of a mutation occurring in a parent Node
   // * should be hidden or ignored
   const filteredMutations = mutations.filter(
-    (mutation): mutation is WithSerializedTarget<MutationRecord> =>
+    (mutation): mutation is WithSerializedTarget<RumMutationRecord> =>
       document.contains(mutation.target) &&
       nodeAndAncestorsHaveSerializedNode(mutation.target) &&
       !nodeOrAncestorsShouldBeHidden(mutation.target)
@@ -81,20 +81,20 @@ function processMutations(mutations: MutationRecord[], mutationCallback: Mutatio
 
   const { adds, removes, hasBeenSerialized } = processChildListMutations(
     filteredMutations.filter(
-      (mutation): mutation is WithSerializedTarget<ChildListMutationRecord> => mutation.type === 'childList'
+      (mutation): mutation is WithSerializedTarget<RumChildListMutationRecord> => mutation.type === 'childList'
     )
   )
 
   const texts = processCharacterDataMutations(
     filteredMutations.filter(
-      (mutation): mutation is WithSerializedTarget<CharacterDataMutationRecord> =>
+      (mutation): mutation is WithSerializedTarget<RumCharacterDataMutationRecord> =>
         mutation.type === 'characterData' && !hasBeenSerialized(mutation.target)
     )
   )
 
   const attributes = processAttributesMutations(
     filteredMutations.filter(
-      (mutation): mutation is WithSerializedTarget<AttributesMutationRecord> =>
+      (mutation): mutation is WithSerializedTarget<RumAttributesMutationRecord> =>
         mutation.type === 'attributes' && !hasBeenSerialized(mutation.target)
     )
   )
@@ -111,7 +111,7 @@ function processMutations(mutations: MutationRecord[], mutationCallback: Mutatio
   })
 }
 
-function processChildListMutations(mutations: Array<WithSerializedTarget<ChildListMutationRecord>>) {
+function processChildListMutations(mutations: Array<WithSerializedTarget<RumChildListMutationRecord>>) {
   // First, we iterate over mutations to collect:
   //
   // * nodes that have been added in the document and not removed by a subsequent mutation
@@ -202,7 +202,7 @@ function processChildListMutations(mutations: Array<WithSerializedTarget<ChildLi
   }
 }
 
-function processCharacterDataMutations(mutations: Array<WithSerializedTarget<CharacterDataMutationRecord>>) {
+function processCharacterDataMutations(mutations: Array<WithSerializedTarget<RumCharacterDataMutationRecord>>) {
   const textMutations: TextMutation[] = []
 
   // Deduplicate mutations based on their target node
@@ -230,18 +230,18 @@ function processCharacterDataMutations(mutations: Array<WithSerializedTarget<Cha
   return textMutations
 }
 
-function processAttributesMutations(mutations: Array<WithSerializedTarget<AttributesMutationRecord>>) {
+function processAttributesMutations(mutations: Array<WithSerializedTarget<RumAttributesMutationRecord>>) {
   const attributeMutations: AttributeMutation[] = []
 
   // Deduplicate mutations based on their target node and changed attribute
-  const handledNodes = new Map<Node, Set<string>>()
+  const handledElements = new Map<Element, Set<string>>()
   const filteredMutations = mutations.filter((mutation) => {
-    const handledAttributes = handledNodes.get(mutation.target)
+    const handledAttributes = handledElements.get(mutation.target)
     if (handledAttributes?.has(mutation.attributeName!)) {
       return false
     }
     if (!handledAttributes) {
-      handledNodes.set(mutation.target, new Set([mutation.attributeName!]))
+      handledElements.set(mutation.target, new Set([mutation.attributeName!]))
     } else {
       handledAttributes.add(mutation.attributeName!)
     }
@@ -249,9 +249,9 @@ function processAttributesMutations(mutations: Array<WithSerializedTarget<Attrib
   })
 
   // Emit mutations
-  const emittedMutations = new Map<Node, AttributeMutation>()
+  const emittedMutations = new Map<Element, AttributeMutation>()
   for (const mutation of filteredMutations) {
-    const value = ((mutation.target as unknown) as HTMLElement).getAttribute(mutation.attributeName!)
+    const value = mutation.target.getAttribute(mutation.attributeName!)
     if (value === mutation.oldValue) {
       continue
     }

--- a/packages/rum-recorder/src/domain/record/mutationObserver.ts
+++ b/packages/rum-recorder/src/domain/record/mutationObserver.ts
@@ -1,5 +1,5 @@
 import { monitor } from '@datadog/browser-core'
-import { nodeOrAncestorsShouldBeHidden } from './privacy'
+import { getNodeOrAncestorsInputPrivacyMode, nodeOrAncestorsShouldBeHidden } from './privacy'
 import {
   getSerializedNodeId,
   hasSerializedNode,
@@ -160,7 +160,11 @@ function processChildListMutations(mutations: Array<WithSerializedTarget<RumChil
       continue
     }
 
-    const serializedNode = serializeNodeWithId(node, { document, serializedNodeIds })
+    const serializedNode = serializeNodeWithId(node, {
+      document,
+      serializedNodeIds,
+      ancestorInputPrivacyMode: getNodeOrAncestorsInputPrivacyMode(node.parentNode!),
+    })
     if (!serializedNode) {
       continue
     }

--- a/packages/rum-recorder/src/domain/record/observer.spec.ts
+++ b/packages/rum-recorder/src/domain/record/observer.spec.ts
@@ -1,0 +1,62 @@
+import { createNewEvent, isIE } from '../../../../core/test/specHelper'
+import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_INPUT_MASKED } from '../../constants'
+import { initInputObserver } from './observer'
+import { serializeDocument } from './serialize'
+import { InputCallback } from './types'
+
+describe('initInputObserver', () => {
+  let stopInputObserver: () => void
+  let inputCallbackSpy: jasmine.Spy<InputCallback>
+  let sandbox: HTMLElement
+  let input: HTMLInputElement
+
+  beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+    inputCallbackSpy = jasmine.createSpy()
+    stopInputObserver = initInputObserver(inputCallbackSpy)
+
+    sandbox = document.createElement('div')
+    input = document.createElement('input')
+    sandbox.appendChild(input)
+    document.body.appendChild(sandbox)
+
+    serializeDocument(document)
+  })
+
+  afterEach(() => {
+    stopInputObserver()
+    sandbox.remove()
+  })
+
+  it('collects input values when an "input" event is dispatched', () => {
+    dispatchInputEvent('foo')
+
+    expect(inputCallbackSpy).toHaveBeenCalledOnceWith({
+      text: 'foo',
+      id: (jasmine.any(Number) as unknown) as number,
+    })
+  })
+
+  it('masks input values according to the element privacy mode', () => {
+    sandbox.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_INPUT_MASKED)
+
+    dispatchInputEvent('foo')
+
+    expect(inputCallbackSpy.calls.first().args[0].text).toBe('***')
+  })
+
+  it('masks input values according to a parent element privacy mode', () => {
+    input.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_INPUT_MASKED)
+
+    dispatchInputEvent('foo')
+
+    expect(inputCallbackSpy.calls.first().args[0].text).toBe('***')
+  })
+
+  function dispatchInputEvent(newValue: string) {
+    input.value = newValue
+    input.dispatchEvent(createNewEvent('input', { target: input }))
+  }
+})

--- a/packages/rum-recorder/src/domain/record/observer.spec.ts
+++ b/packages/rum-recorder/src/domain/record/observer.spec.ts
@@ -44,7 +44,7 @@ describe('initInputObserver', () => {
 
     dispatchInputEvent('foo')
 
-    expect(inputCallbackSpy.calls.first().args[0].text).toBe('***')
+    expect((inputCallbackSpy.calls.first().args[0] as { text?: string }).text).toBe('***')
   })
 
   it('masks input values according to a parent element privacy mode', () => {
@@ -52,7 +52,7 @@ describe('initInputObserver', () => {
 
     dispatchInputEvent('foo')
 
-    expect(inputCallbackSpy.calls.first().args[0].text).toBe('***')
+    expect((inputCallbackSpy.calls.first().args[0] as { text?: string }).text).toBe('***')
   })
 
   function dispatchInputEvent(newValue: string) {

--- a/packages/rum-recorder/src/domain/record/observer.ts
+++ b/packages/rum-recorder/src/domain/record/observer.ts
@@ -1,5 +1,6 @@
 import { monitor, callMonitored, throttle, DOM_EVENT, addEventListeners, addEventListener } from '@datadog/browser-core'
-import { nodeOrAncestorsShouldBeHidden, nodeOrAncestorsShouldHaveInputIgnored } from './privacy'
+import { InputPrivacyMode } from '../../constants'
+import { nodeOrAncestorsShouldBeHidden, getNodeOrAncestorsInputPrivacyMode } from './privacy'
 import { getSerializedNodeId, hasSerializedNode } from './serializationUtils'
 import {
   FocusCallback,
@@ -165,7 +166,7 @@ function initInputObserver(cb: InputCallback): ListenerHandler {
       !target.tagName ||
       INPUT_TAGS.indexOf(target.tagName) < 0 ||
       nodeOrAncestorsShouldBeHidden(target) ||
-      nodeOrAncestorsShouldHaveInputIgnored(target)
+      getNodeOrAncestorsInputPrivacyMode(target) === InputPrivacyMode.IGNORED
     ) {
       return
     }

--- a/packages/rum-recorder/src/domain/record/observer.ts
+++ b/packages/rum-recorder/src/domain/record/observer.ts
@@ -1,4 +1,12 @@
-import { monitor, callMonitored, throttle, DOM_EVENT, addEventListeners, addEventListener } from '@datadog/browser-core'
+import {
+  monitor,
+  callMonitored,
+  throttle,
+  DOM_EVENT,
+  addEventListeners,
+  addEventListener,
+  includes,
+} from '@datadog/browser-core'
 import { nodeOrAncestorsShouldBeHidden } from './privacy'
 import { getElementInputValue, getSerializedNodeId, hasSerializedNode } from './serializationUtils'
 import {
@@ -160,7 +168,7 @@ export function initInputObserver(cb: InputCallback): ListenerHandler {
   function eventHandler(event: { target: EventTarget | null }) {
     const target = event.target as HTMLInputElement | HTMLTextAreaElement
 
-    if (!target || !target.tagName || INPUT_TAGS.indexOf(target.tagName) < 0 || nodeOrAncestorsShouldBeHidden(target)) {
+    if (!target || !target.tagName || !includes(INPUT_TAGS, target.tagName) || nodeOrAncestorsShouldBeHidden(target)) {
       return
     }
 

--- a/packages/rum-recorder/src/domain/record/observer.ts
+++ b/packages/rum-recorder/src/domain/record/observer.ts
@@ -205,8 +205,8 @@ export function initInputObserver(cb: InputCallback): ListenerHandler {
     const lastInputState = lastInputStateMap.get(target)
     if (
       !lastInputState ||
-      lastInputState.text !== inputState.text ||
-      lastInputState.isChecked !== inputState.isChecked
+      (lastInputState as { text?: string }).text !== (inputState as { text?: string }).text ||
+      (lastInputState as { isChecked?: boolean }).isChecked !== (inputState as { isChecked?: boolean }).isChecked
     ) {
       lastInputStateMap.set(target, inputState)
       cb({

--- a/packages/rum-recorder/src/domain/record/privacy.spec.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.spec.ts
@@ -1,9 +1,10 @@
 import { isIE } from '../../../../core/test/specHelper'
+import { InputPrivacyMode } from '../../constants'
 import {
   nodeShouldBeHidden,
   nodeOrAncestorsShouldBeHidden,
-  nodeShouldHaveInputIgnored,
-  nodeOrAncestorsShouldHaveInputIgnored,
+  getNodeInputPrivacyMode,
+  getNodeOrAncestorsInputPrivacyMode,
 } from './privacy'
 
 describe('privacy helpers', () => {
@@ -57,58 +58,60 @@ describe('privacy helpers', () => {
       expect(nodeOrAncestorsShouldBeHidden(document)).toBeFalsy()
     })
   })
+
   describe('for ignoring input events', () => {
-    it('considers a normal DOM Element as not to be ignored', () => {
+    it('cannot determine the input privacy mode for a normal DOM Element', () => {
       const node = document.createElement('input')
-      expect(nodeShouldHaveInputIgnored(node)).toBeFalsy()
+      expect(getNodeInputPrivacyMode(node)).toBeUndefined()
     })
     it('considers a DOM Element with a data-dd-privacy="input-ignored" attribute to be ignored', () => {
       const node = document.createElement('input')
       node.setAttribute('data-dd-privacy', 'input-ignored')
-      expect(nodeShouldHaveInputIgnored(node)).toBeTruthy()
+      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
-    it('considers a DOM Element with a data-dd-privacy="foo" attribute as not to be ignored', () => {
+    it('cannot determine the input privacy mode for a DOM Element with a data-dd-privacy="foo" attribute', () => {
       const node = document.createElement('input')
       node.setAttribute('data-dd-privacy', 'foo')
-      expect(nodeShouldHaveInputIgnored(node)).toBeFalsy()
+      expect(getNodeInputPrivacyMode(node)).toBeUndefined()
     })
     it('considers a DOM Element with a dd-privacy-input-ignored class to be ignored', () => {
       const node = document.createElement('input')
       node.className = 'dd-privacy-input-ignored'
-      expect(nodeShouldHaveInputIgnored(node)).toBeTruthy()
+      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
     it('considers a DOM HTMLInputElement with a type of "password" to be ignored', () => {
       const node = document.createElement('input')
       node.type = 'password'
-      expect(nodeShouldHaveInputIgnored(node)).toBeTruthy()
+      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
-    it('considers a DOM HTMLInputElement with a type of "text" as not to be ignored', () => {
+    it('cannot determine the input privacy mode for a DOM HTMLInputElement with a type of "text"', () => {
       const node = document.createElement('input')
       node.type = 'text'
-      expect(nodeShouldHaveInputIgnored(node)).toBeFalse()
+      expect(getNodeInputPrivacyMode(node)).toBeUndefined()
     })
+
     it('considers a normal DOM Element with a normal parent as not to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
       parent.appendChild(node)
-      expect(nodeOrAncestorsShouldHaveInputIgnored(node)).toBeFalsy()
+      expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.NONE)
     })
     it('considers a DOM Element with a parent node with a dd-privacy="input-ignored" attribute to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
       parent.setAttribute('data-dd-privacy', 'input-ignored')
       parent.appendChild(node)
-      expect(nodeOrAncestorsShouldHaveInputIgnored(node)).toBeTruthy()
+      expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
     it('considers a DOM Element with a parent node with a dd-privacy-input-ignored class to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
       parent.className = 'dd-privacy-input-ignored'
       parent.appendChild(node)
-      expect(nodeOrAncestorsShouldHaveInputIgnored(node)).toBeTruthy()
+      expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
     it('considers a DOM Document as not to be ignored', () => {
-      expect(nodeOrAncestorsShouldHaveInputIgnored(document)).toBeFalsy()
+      expect(getNodeOrAncestorsInputPrivacyMode(document)).toBe(InputPrivacyMode.NONE)
     })
   })
 })

--- a/packages/rum-recorder/src/domain/record/privacy.spec.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.spec.ts
@@ -69,9 +69,10 @@ describe('privacy helpers', () => {
       node.setAttribute('data-dd-privacy', 'input-ignored')
       expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
-    it('cannot determine the input privacy mode for a DOM Element with a data-dd-privacy="foo" attribute', () => {
+    // eslint-disable-next-line max-len
+    it('cannot determine the input privacy mode for a DOM Element with a data-dd-privacy="unknown-mode" attribute', () => {
       const node = document.createElement('input')
-      node.setAttribute('data-dd-privacy', 'foo')
+      node.setAttribute('data-dd-privacy', 'unknown-mode')
       expect(getNodeInputPrivacyMode(node)).toBeUndefined()
     })
     it('considers a DOM Element with a dd-privacy-input-ignored class to be ignored', () => {

--- a/packages/rum-recorder/src/domain/record/privacy.spec.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.spec.ts
@@ -64,27 +64,39 @@ describe('privacy helpers', () => {
       const node = document.createElement('input')
       expect(getNodeInputPrivacyMode(node)).toBeUndefined()
     })
+
     it('considers a DOM Element with a data-dd-privacy="input-ignored" attribute to be ignored', () => {
       const node = document.createElement('input')
       node.setAttribute('data-dd-privacy', 'input-ignored')
       expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
+
     // eslint-disable-next-line max-len
     it('cannot determine the input privacy mode for a DOM Element with a data-dd-privacy="unknown-mode" attribute', () => {
       const node = document.createElement('input')
       node.setAttribute('data-dd-privacy', 'unknown-mode')
       expect(getNodeInputPrivacyMode(node)).toBeUndefined()
     })
+
     it('considers a DOM Element with a dd-privacy-input-ignored class to be ignored', () => {
       const node = document.createElement('input')
       node.className = 'dd-privacy-input-ignored'
       expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
+
+    it('consider a DOM Element to be ignored if both modes can apply', () => {
+      const node = document.createElement('input')
+      node.className = 'dd-privacy-input-ignored'
+      node.setAttribute('data-dd-privacy', 'input-masked')
+      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
+    })
+
     it('considers a DOM HTMLInputElement with a type of "password" to be ignored', () => {
       const node = document.createElement('input')
       node.type = 'password'
       expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
+
     it('cannot determine the input privacy mode for a DOM HTMLInputElement with a type of "text"', () => {
       const node = document.createElement('input')
       node.type = 'text'
@@ -97,6 +109,7 @@ describe('privacy helpers', () => {
       parent.appendChild(node)
       expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.NONE)
     })
+
     it('considers a DOM Element with a parent node with a dd-privacy="input-ignored" attribute to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
@@ -104,6 +117,7 @@ describe('privacy helpers', () => {
       parent.appendChild(node)
       expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
+
     it('considers a DOM Element with a parent node with a dd-privacy-input-ignored class to be ignored', () => {
       const node = document.createElement('input')
       const parent = document.createElement('form')
@@ -111,6 +125,7 @@ describe('privacy helpers', () => {
       parent.appendChild(node)
       expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
     })
+
     it('considers a DOM Document as not to be ignored', () => {
       expect(getNodeOrAncestorsInputPrivacyMode(document)).toBe(InputPrivacyMode.NONE)
     })

--- a/packages/rum-recorder/src/domain/record/privacy.spec.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.spec.ts
@@ -59,75 +59,106 @@ describe('privacy helpers', () => {
     })
   })
 
-  describe('for ignoring input events', () => {
-    it('cannot determine the input privacy mode for a normal DOM Element', () => {
+  describe('input privacy mode', () => {
+    it('use the ancestor privacy mode for a normal DOM Element', () => {
+      const node = document.createElement('div')
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.NONE)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.IGNORED)).toBe(InputPrivacyMode.IGNORED)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.MASKED)).toBe(InputPrivacyMode.MASKED)
+    })
+
+    it('use the ancestor privacy mode for a DOM Element with a data-dd-privacy="unknown-mode" attribute', () => {
       const node = document.createElement('input')
-      expect(getNodeInputPrivacyMode(node)).toBeUndefined()
+      node.setAttribute('data-dd-privacy', 'unknown-mode')
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.NONE)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.IGNORED)).toBe(InputPrivacyMode.IGNORED)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.MASKED)).toBe(InputPrivacyMode.MASKED)
+    })
+
+    it('use the ancestor privacy mode for a DOM HTMLInputElement with a type of "text"', () => {
+      const node = document.createElement('input')
+      node.type = 'text'
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.NONE)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.IGNORED)).toBe(InputPrivacyMode.IGNORED)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.MASKED)).toBe(InputPrivacyMode.MASKED)
+    })
+
+    it('considers a DOM Document as not to be ignored', () => {
+      expect(getNodeInputPrivacyMode(document, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.NONE)
     })
 
     it('considers a DOM Element with a data-dd-privacy="input-ignored" attribute to be ignored', () => {
       const node = document.createElement('input')
       node.setAttribute('data-dd-privacy', 'input-ignored')
-      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
-    })
-
-    // eslint-disable-next-line max-len
-    it('cannot determine the input privacy mode for a DOM Element with a data-dd-privacy="unknown-mode" attribute', () => {
-      const node = document.createElement('input')
-      node.setAttribute('data-dd-privacy', 'unknown-mode')
-      expect(getNodeInputPrivacyMode(node)).toBeUndefined()
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.IGNORED)
     })
 
     it('considers a DOM Element with a dd-privacy-input-ignored class to be ignored', () => {
       const node = document.createElement('input')
       node.className = 'dd-privacy-input-ignored'
-      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
-    })
-
-    it('consider a DOM Element to be ignored if both modes can apply', () => {
-      const node = document.createElement('input')
-      node.className = 'dd-privacy-input-ignored'
-      node.setAttribute('data-dd-privacy', 'input-masked')
-      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.IGNORED)
     })
 
     it('considers a DOM HTMLInputElement with a type of "password" to be ignored', () => {
       const node = document.createElement('input')
       node.type = 'password'
-      expect(getNodeInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
+      expect(getNodeInputPrivacyMode(node, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.IGNORED)
     })
 
-    it('cannot determine the input privacy mode for a DOM HTMLInputElement with a type of "text"', () => {
-      const node = document.createElement('input')
-      node.type = 'text'
-      expect(getNodeInputPrivacyMode(node)).toBeUndefined()
+    describe('input mode priority', () => {
+      it('consider a DOM Element to be ignored if both modes can apply', () => {
+        const node = document.createElement('input')
+        node.className = 'dd-privacy-input-ignored'
+        node.setAttribute('data-dd-privacy', 'input-masked')
+        expect(getNodeInputPrivacyMode(node, InputPrivacyMode.NONE)).toBe(InputPrivacyMode.IGNORED)
+      })
+
+      it('forces an element to be ignored if an ancestor is ignored', () => {
+        const node = document.createElement('input')
+        node.setAttribute('data-dd-privacy', 'input-masked')
+        expect(getNodeInputPrivacyMode(node, InputPrivacyMode.IGNORED)).toBe(InputPrivacyMode.IGNORED)
+      })
+
+      it('does not force an element to be masked if an ancestor is masked', () => {
+        const node = document.createElement('input')
+        node.setAttribute('data-dd-privacy', 'input-ignored')
+        expect(getNodeInputPrivacyMode(node, InputPrivacyMode.MASKED)).toBe(InputPrivacyMode.IGNORED)
+      })
     })
 
-    it('considers a normal DOM Element with a normal parent as not to be ignored', () => {
-      const node = document.createElement('input')
-      const parent = document.createElement('form')
-      parent.appendChild(node)
-      expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.NONE)
-    })
+    describe('walk through elements ancestors to determine the privacy mode', () => {
+      it('considers a normal DOM Element with a normal parent as not to be ignored', () => {
+        const node = document.createElement('input')
+        const parent = document.createElement('form')
+        parent.appendChild(node)
+        expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.NONE)
+      })
 
-    it('considers a DOM Element with a parent node with a dd-privacy="input-ignored" attribute to be ignored', () => {
-      const node = document.createElement('input')
-      const parent = document.createElement('form')
-      parent.setAttribute('data-dd-privacy', 'input-ignored')
-      parent.appendChild(node)
-      expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
-    })
+      it('considers a DOM Element with a parent node with a dd-privacy="input-ignored" attribute to be ignored', () => {
+        const node = document.createElement('input')
+        const parent = document.createElement('form')
+        parent.setAttribute('data-dd-privacy', 'input-ignored')
+        parent.appendChild(node)
+        expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
+      })
 
-    it('considers a DOM Element with a parent node with a dd-privacy-input-ignored class to be ignored', () => {
-      const node = document.createElement('input')
-      const parent = document.createElement('form')
-      parent.className = 'dd-privacy-input-ignored'
-      parent.appendChild(node)
-      expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
-    })
+      it('considers a DOM Element with a parent node with a dd-privacy-input-ignored class to be ignored', () => {
+        const node = document.createElement('input')
+        const parent = document.createElement('form')
+        parent.className = 'dd-privacy-input-ignored'
+        parent.appendChild(node)
+        expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
+      })
 
-    it('considers a DOM Document as not to be ignored', () => {
-      expect(getNodeOrAncestorsInputPrivacyMode(document)).toBe(InputPrivacyMode.NONE)
+      // eslint-disable-next-line max-len
+      it('considers a DOM Element with a "masked" privacy mode but within a parent with a "ignored" privacy mode to be ignored', () => {
+        const node = document.createElement('input')
+        const parent = document.createElement('form')
+        parent.setAttribute('data-dd-privacy', 'input-ignored')
+        parent.appendChild(node)
+        node.setAttribute('data-dd-privacy', 'input-masked')
+        expect(getNodeOrAncestorsInputPrivacyMode(node)).toBe(InputPrivacyMode.IGNORED)
+      })
     })
   })
 })

--- a/packages/rum-recorder/src/domain/record/privacy.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.ts
@@ -50,24 +50,16 @@ export function getNodeInputPrivacyMode(node: Node): InputPrivacyMode | undefine
   }
 
   const attribute = node.getAttribute(PRIVACY_ATTR_NAME)
-  if (attribute === PRIVACY_ATTR_VALUE_INPUT_IGNORED) {
+  if (
+    attribute === PRIVACY_ATTR_VALUE_INPUT_IGNORED ||
+    node.classList.contains(PRIVACY_CLASS_INPUT_IGNORED) ||
+    (isInputElement(node) && PRIVACY_INPUT_TYPES_TO_IGNORE.includes(node.type))
+  ) {
     return InputPrivacyMode.IGNORED
   }
 
-  if (attribute === PRIVACY_ATTR_VALUE_INPUT_MASKED) {
+  if (attribute === PRIVACY_ATTR_VALUE_INPUT_MASKED || node.classList.contains(PRIVACY_CLASS_INPUT_MASKED)) {
     return InputPrivacyMode.MASKED
-  }
-
-  if (node.classList.contains(PRIVACY_CLASS_INPUT_IGNORED)) {
-    return InputPrivacyMode.IGNORED
-  }
-
-  if (node.classList.contains(PRIVACY_CLASS_INPUT_MASKED)) {
-    return InputPrivacyMode.MASKED
-  }
-
-  if (isInputElement(node) && PRIVACY_INPUT_TYPES_TO_IGNORE.includes(node.type)) {
-    return InputPrivacyMode.IGNORED
   }
 }
 

--- a/packages/rum-recorder/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.spec.ts
@@ -178,7 +178,7 @@ describe('getElementInputValue', () => {
   it('does not return the value of a <input> with a IGNORED privacy mode', () => {
     const input = document.createElement('input')
     input.value = 'foo'
-    wrapInInputIgnored(input)
+    wrapInIgnoredParent(input)
     expect(getElementInputValue(input)).toBeUndefined()
   })
 
@@ -188,14 +188,14 @@ describe('getElementInputValue', () => {
     option.value = 'foo'
     select.appendChild(option)
     select.value = 'foo'
-    wrapInInputIgnored(select)
+    wrapInIgnoredParent(select)
     expect(getElementInputValue(select)).toBe('foo')
   })
 
   it('always returns the value of a <option>', () => {
     const option = document.createElement('option')
     option.value = 'foo'
-    wrapInInputIgnored(option)
+    wrapInIgnoredParent(option)
     expect(getElementInputValue(option)).toBe('foo')
   })
 
@@ -203,7 +203,7 @@ describe('getElementInputValue', () => {
     const input = document.createElement('input')
     input.value = 'foo'
     input.type = 'button'
-    wrapInInputIgnored(input)
+    wrapInIgnoredParent(input)
     expect(getElementInputValue(input)).toBe('foo')
   })
 
@@ -211,7 +211,7 @@ describe('getElementInputValue', () => {
     const input = document.createElement('input')
     input.value = 'foo'
     input.type = 'submit'
-    wrapInInputIgnored(input)
+    wrapInIgnoredParent(input)
     expect(getElementInputValue(input)).toBe('foo')
   })
 
@@ -219,7 +219,7 @@ describe('getElementInputValue', () => {
     const input = document.createElement('input')
     input.value = 'foo'
     input.type = 'reset'
-    wrapInInputIgnored(input)
+    wrapInIgnoredParent(input)
     expect(getElementInputValue(input)).toBe('foo')
   })
 
@@ -236,7 +236,7 @@ describe('getElementInputValue', () => {
     expect(getElementInputValue(input)).toBe('***')
   })
 
-  function wrapInInputIgnored(element: Element) {
+  function wrapInIgnoredParent(element: Element) {
     const parent = document.createElement('div')
     parent.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_INPUT_IGNORED)
     parent.appendChild(element)

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -105,7 +105,7 @@ export function getElementInputValue(element: Element, ancestorInputPrivacyMode?
   }
 
   const inputPrivacyMode = ancestorInputPrivacyMode
-    ? getNodeInputPrivacyMode(element) || ancestorInputPrivacyMode
+    ? getNodeInputPrivacyMode(element, ancestorInputPrivacyMode)
     : getNodeOrAncestorsInputPrivacyMode(element)
 
   if (

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -121,5 +121,5 @@ export function getElementInputValue(element: Element, ancestorInputPrivacyMode?
 }
 
 export function maskValue(value: string) {
-  return value.replace(/./g, () => '*')
+  return value.replace(/./g, '*')
 }

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -1,4 +1,6 @@
 import { buildUrl } from '@datadog/browser-core'
+import { InputPrivacyMode } from '../../constants'
+import { getNodeInputPrivacyMode, getNodeOrAncestorsInputPrivacyMode } from './privacy'
 import { SerializedNodeWithId } from './types'
 
 export interface NodeWithSerializedNode extends Node {
@@ -73,4 +75,51 @@ export function makeSrcsetUrlsAbsolute(attributeValue: string, baseUrl: string) 
 
 export function makeUrlAbsolute(url: string, baseUrl: string): string {
   return buildUrl(url.trim(), baseUrl).href
+}
+
+/**
+ * Get the element "value" to be serialized as an attribute or an input update record. It respects
+ * the input privacy mode of the element. An 'ancestorInputPrivacyMode' can be provided (if known)
+ * to avoid iterating over the element ancestors when looking for the input privacy mode.
+ */
+export function getElementInputValue(element: Element, ancestorInputPrivacyMode?: InputPrivacyMode) {
+  const tagName = element.tagName
+  if (tagName === 'OPTION' || tagName === 'SELECT') {
+    // Always use the option and select value, as they are useful to display the currently selected
+    // option during replay. They can still be hidden via the "hidden" privacy attribute or class
+    // name.
+    return (element as HTMLOptionElement | HTMLSelectElement).value
+  }
+
+  if (tagName !== 'INPUT' && tagName !== 'TEXTAREA') {
+    return
+  }
+
+  const value = (element as HTMLInputElement | HTMLTextAreaElement).value
+  const type = (element as HTMLInputElement | HTMLTextAreaElement).type
+
+  if (type === 'button' || type === 'submit' || type === 'reset') {
+    // Always use button-like element values, as they are used during replay to display their label.
+    // They can still be hidden via the "hidden" privacy attribute or class name.
+    return value
+  }
+
+  const inputPrivacyMode = ancestorInputPrivacyMode
+    ? getNodeInputPrivacyMode(element) || ancestorInputPrivacyMode
+    : getNodeOrAncestorsInputPrivacyMode(element)
+
+  if (
+    inputPrivacyMode === InputPrivacyMode.IGNORED ||
+    // Never use the radio and checkbox value, as they are not useful during replay.
+    type === 'radio' ||
+    type === 'checkbox'
+  ) {
+    return
+  }
+
+  return inputPrivacyMode === InputPrivacyMode.MASKED ? maskValue(value) : value
+}
+
+export function maskValue(value: string) {
+  return value.replace(/./g, () => '*')
 }

--- a/packages/rum-recorder/src/domain/record/serialize.ts
+++ b/packages/rum-recorder/src/domain/record/serialize.ts
@@ -184,8 +184,8 @@ function serializeElementNode(element: Element, options: SerializeOptions): Elem
       childNodesSerializationOptions = { ...childNodesSerializationOptions, ignoreWhiteSpace: true }
     }
 
-    const inputPrivacyMode = getNodeInputPrivacyMode(element)
-    if (inputPrivacyMode) {
+    const inputPrivacyMode = getNodeInputPrivacyMode(element, options.ancestorInputPrivacyMode)
+    if (inputPrivacyMode !== options.ancestorInputPrivacyMode) {
       childNodesSerializationOptions = { ...childNodesSerializationOptions, ancestorInputPrivacyMode: inputPrivacyMode }
     }
 

--- a/packages/rum-recorder/src/domain/record/types.ts
+++ b/packages/rum-recorder/src/domain/record/types.ts
@@ -82,27 +82,30 @@ export interface ObserverParam {
 }
 
 // https://dom.spec.whatwg.org/#interface-mutationrecord
-export interface CharacterDataMutationRecord {
+export interface RumCharacterDataMutationRecord {
   type: 'characterData'
   target: Node
   oldValue: string | null
 }
 
-export interface AttributesMutationRecord {
+export interface RumAttributesMutationRecord {
   type: 'attributes'
-  target: Node
+  target: Element
   oldValue: string | null
   attributeName: string | null
 }
 
-export interface ChildListMutationRecord {
+export interface RumChildListMutationRecord {
   type: 'childList'
   target: Node
   addedNodes: NodeList
   removedNodes: NodeList
 }
 
-export type MutationRecord = CharacterDataMutationRecord | AttributesMutationRecord | ChildListMutationRecord
+export type RumMutationRecord =
+  | RumCharacterDataMutationRecord
+  | RumAttributesMutationRecord
+  | RumChildListMutationRecord
 
 export interface TextCursor {
   node: Node

--- a/packages/rum-recorder/src/domain/record/types.ts
+++ b/packages/rum-recorder/src/domain/record/types.ts
@@ -216,8 +216,8 @@ export interface ViewportResizeDimention {
 export type ViewportResizeCallback = (d: ViewportResizeDimention) => void
 
 export interface InputValue {
-  text: string
-  isChecked: boolean
+  text?: string
+  isChecked?: boolean
 }
 
 export type InputCallback = (v: InputValue & { id: number }) => void

--- a/packages/rum-recorder/src/domain/record/types.ts
+++ b/packages/rum-recorder/src/domain/record/types.ts
@@ -39,7 +39,7 @@ export type ViewportResizeData = {
 export type InputData = {
   source: IncrementalSource.Input
   id: number
-} & InputValue
+} & InputState
 
 export type MediaInteractionData = {
   source: IncrementalSource.MediaInteraction
@@ -218,12 +218,12 @@ export interface ViewportResizeDimention {
 
 export type ViewportResizeCallback = (d: ViewportResizeDimention) => void
 
-export interface InputValue {
+export interface InputState {
   text?: string
   isChecked?: boolean
 }
 
-export type InputCallback = (v: InputValue & { id: number }) => void
+export type InputCallback = (v: InputState & { id: number }) => void
 
 export const MediaInteractions = {
   Play: 0,

--- a/packages/rum-recorder/src/domain/record/types.ts
+++ b/packages/rum-recorder/src/domain/record/types.ts
@@ -218,10 +218,7 @@ export interface ViewportResizeDimention {
 
 export type ViewportResizeCallback = (d: ViewportResizeDimention) => void
 
-export interface InputState {
-  text?: string
-  isChecked?: boolean
-}
+export type InputState = { text: string } | { isChecked: boolean }
 
 export type InputCallback = (v: InputState & { id: number }) => void
 

--- a/test/e2e/scenario/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder.scenario.ts
@@ -474,12 +474,12 @@ describe('recorder', () => {
 
         const radioInputRecords = filterRecordsByIdAttribute(segment, 'radio-input')
         expect(radioInputRecords.length).toBe(1)
-        expect(radioInputRecords[0].data.text).toBe('on')
+        expect(radioInputRecords[0].data.text).toBe(undefined)
         expect(radioInputRecords[0].data.isChecked).toBe(true)
 
         const checkboxInputRecords = filterRecordsByIdAttribute(segment, 'checkbox-input')
         expect(checkboxInputRecords.length).toBe(1)
-        expect(checkboxInputRecords[0].data.text).toBe('on')
+        expect(checkboxInputRecords[0].data.text).toBe(undefined)
         expect(checkboxInputRecords[0].data.isChecked).toBe(true)
 
         const textareaRecords = filterRecordsByIdAttribute(segment, 'textarea')

--- a/test/e2e/scenario/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder.scenario.ts
@@ -480,25 +480,25 @@ describe('recorder', () => {
 
         const textInputRecords = filterRecordsByIdAttribute(segment, 'text-input')
         expect(textInputRecords.length).toBeGreaterThanOrEqual(4)
-        expect(textInputRecords[textInputRecords.length - 1].data.text).toBe('test')
+        expect((textInputRecords[textInputRecords.length - 1].data as { text?: string }).text).toBe('test')
 
         const radioInputRecords = filterRecordsByIdAttribute(segment, 'radio-input')
         expect(radioInputRecords.length).toBe(1)
-        expect(radioInputRecords[0].data.text).toBe(undefined)
-        expect(radioInputRecords[0].data.isChecked).toBe(true)
+        expect((radioInputRecords[0].data as { text?: string }).text).toBe(undefined)
+        expect((radioInputRecords[0].data as { isChecked?: boolean }).isChecked).toBe(true)
 
         const checkboxInputRecords = filterRecordsByIdAttribute(segment, 'checkbox-input')
         expect(checkboxInputRecords.length).toBe(1)
-        expect(checkboxInputRecords[0].data.text).toBe(undefined)
-        expect(checkboxInputRecords[0].data.isChecked).toBe(true)
+        expect((checkboxInputRecords[0].data as { text?: string }).text).toBe(undefined)
+        expect((checkboxInputRecords[0].data as { isChecked?: boolean }).isChecked).toBe(true)
 
         const textareaRecords = filterRecordsByIdAttribute(segment, 'textarea')
         expect(textareaRecords.length).toBeGreaterThanOrEqual(4)
-        expect(textareaRecords[textareaRecords.length - 1].data.text).toBe('textarea test')
+        expect((textareaRecords[textareaRecords.length - 1].data as { text?: string }).text).toBe('textarea test')
 
         const selectRecords = filterRecordsByIdAttribute(segment, 'select')
         expect(selectRecords.length).toBe(1)
-        expect(selectRecords[0].data.text).toBe('2')
+        expect((selectRecords[0].data as { text?: string }).text).toBe('2')
 
         function filterRecordsByIdAttribute(segment: Segment, idAttribute: string) {
           const fullSnapshot = findFullSnapshot(segment)!
@@ -541,7 +541,7 @@ describe('recorder', () => {
         const inputRecords = findAllIncrementalSnapshots(segment, IncrementalSource.Input)
 
         expect(inputRecords.length).toBeGreaterThanOrEqual(3) // 4 on Safari, 3 on others
-        expect((inputRecords[inputRecords.length - 1].data as InputData).text).toBe('foo')
+        expect((inputRecords[inputRecords.length - 1].data as { text?: string }).text).toBe('foo')
       })
 
     createTest('replace masked values by asterisks')
@@ -570,7 +570,9 @@ describe('recorder', () => {
 
         expect(inputRecords.length).toBeGreaterThan(0)
 
-        expect(inputRecords.every((inputRecord) => /^\**$/.test((inputRecord.data as InputData).text!))).toBe(true)
+        expect(inputRecords.every((inputRecord) => /^\**$/.test((inputRecord.data as { text: string }).text))).toBe(
+          true
+        )
       })
   })
 


### PR DESCRIPTION
## Motivation

Let the user chose to mask input values (replacing the characters with asterisks) instead of completely ignoring them via a new privacy attribute value `data-dd-privacy="input-masked"` / `class="dd-privacy-input-masked"`.

## Changes

This PR removes the collection of some input values (radio/checkbox). Those values are likely to be useless during replay (note: if you think of a usecase, let me know). This way, we don't have to chose whether we should ignore/mask them.

It introduces an "input privacy mode", either computed by iterating over a node parent or propagated while serializing nodes.

It factorizes the input elements "value" computation by introducing a common function that will respect the "input privacy mode" and will be used while:
* the value is changed by the user, triggering an "input" event (`IncrementalSnapshot/Input`)
* the value is read from the element while serializing the node (`FullSnapshot`, `IncrementalSnapshot/Mutation` on child list)
* the value is programmatically set via `setAttribute` (`IncrementalSnapshot/Mutation` on attribute)

Note: those last two points where missing from the upstream rrweb-snapshot implementation.

## Testing

Manual, unit, e2e

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
