### PR TITLE
✨ track all programmatically-named-actions

### DIFF
--- a/packages/rum-core/src/domain/parentContexts.ts
+++ b/packages/rum-core/src/domain/parentContexts.ts
@@ -69,7 +69,7 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
       previousActions.unshift({
         context: buildCurrentActionContext(),
         // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        endTime: (currentAction.startClocks.relative + action.duration) as RelativeTime,
+        endTime: (currentAction.startClocks.relative + (action.duration ?? 0)) as RelativeTime,
         startTime: currentAction.startClocks.relative,
       })
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -21,6 +21,7 @@ describe('actionCollection', () => {
   afterEach(() => {
     setupBuilder.cleanup()
   })
+
   it('should create action from auto action', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
     lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, {
@@ -44,6 +45,44 @@ describe('actionCollection', () => {
         },
         id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
         loading_time: (100 * 1e6) as ServerDuration,
+        long_task: {
+          count: 10,
+        },
+        resource: {
+          count: 10,
+        },
+        target: {
+          name: 'foo',
+        },
+        type: ActionType.CLICK,
+      },
+      date: jasmine.any(Number),
+      type: RumEventType.ACTION,
+    })
+  })
+
+  it('should create action from programmatic auto action lacking a duration', () => {
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+    lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, {
+      counts: {
+        errorCount: 10,
+        longTaskCount: 10,
+        resourceCount: 10,
+      },
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      name: 'foo',
+      startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
+      type: ActionType.CLICK,
+    })
+
+    expect(rawRumEvents[0].startTime).toBe(1234)
+    expect(rawRumEvents[0].rawRumEvent).toEqual({
+      action: {
+        error: {
+          count: 10,
+        },
+        id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        loading_time: undefined,
         long_task: {
           count: 10,
         },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -30,7 +30,7 @@ function processAction(action: AutoAction | CustomAction) {
             count: action.counts.errorCount,
           },
           id: action.id,
-          loading_time: toServerDuration(action.duration),
+          loading_time: action.duration !== undefined ? toServerDuration(action.duration) : undefined,
           long_task: {
             count: action.counts.longTaskCount,
           },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -24,35 +24,35 @@ describe('getActionNameFromElement', () => {
   })
 
   it('extracts the textual content of an element', () => {
-    expect(getActionNameFromElement(element`<div>Foo <div>bar</div></div>`)).toBe('Foo bar')
+    expect(getActionNameFromElement(element`<div>Foo <div>bar</div></div>`)).toEqual(['Foo bar', 'inferred'])
   })
 
   it('extracts the text of an input button', () => {
-    expect(getActionNameFromElement(element`<input type="button" value="Click" />`)).toBe('Click')
+    expect(getActionNameFromElement(element`<input type="button" value="Click" />`)).toEqual(['Click', 'inferred'])
   })
 
   it('extracts the alt text of an image', () => {
-    expect(getActionNameFromElement(element`<img title="foo" alt="bar" />`)).toBe('bar')
+    expect(getActionNameFromElement(element`<img title="foo" alt="bar" />`)).toEqual(['bar', 'inferred'])
   })
 
   it('extracts the title text of an image', () => {
-    expect(getActionNameFromElement(element`<img title="foo" />`)).toBe('foo')
+    expect(getActionNameFromElement(element`<img title="foo" />`)).toEqual(['foo', 'inferred'])
   })
 
   it('extracts the text of an aria-label attribute', () => {
-    expect(getActionNameFromElement(element`<span aria-label="Foo" />`)).toBe('Foo')
+    expect(getActionNameFromElement(element`<span aria-label="Foo" />`)).toEqual(['Foo', 'inferred'])
   })
 
   it('gets the parent element textual content if everything else fails', () => {
-    expect(getActionNameFromElement(element`<div>Foo <img target /></div>`)).toBe('Foo')
+    expect(getActionNameFromElement(element`<div>Foo <img target /></div>`)).toEqual(['Foo', 'inferred'])
   })
 
   it("doesn't get the value of a text input", () => {
-    expect(getActionNameFromElement(element`<input type="text" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(element`<input type="text" value="foo" />`)).toEqual(['', 'inferred'])
   })
 
   it("doesn't get the value of a password input", () => {
-    expect(getActionNameFromElement(element`<input type="password" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(element`<input type="password" value="foo" />`)).toEqual(['', 'inferred'])
   })
 
   it('limits the name length to a reasonable size', () => {
@@ -61,22 +61,28 @@ describe('getActionNameFromElement', () => {
         // eslint-disable-next-line  max-len
         element`<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>`
       )
-    ).toBe(
+    ).toEqual(
       // eslint-disable-next-line  max-len
-      'Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]'
+      [
+        'Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]',
+        'inferred',
+      ]
     )
   })
 
   it('normalize white spaces', () => {
-    expect(getActionNameFromElement(element`<div>foo\tbar\n\n  baz</div>`)).toBe('foo bar baz')
+    expect(getActionNameFromElement(element`<div>foo\tbar\n\n  baz</div>`)).toEqual(['foo bar baz', 'inferred'])
   })
 
   it('ignores the inline script textual content', () => {
-    expect(getActionNameFromElement(element`<div><script>console.log('toto')</script>b</div>`)).toBe('b')
+    expect(getActionNameFromElement(element`<div><script>console.log('toto')</script>b</div>`)).toEqual([
+      'b',
+      'inferred',
+    ])
   })
 
   it('extracts text from SVG elements', () => {
-    expect(getActionNameFromElement(element`<svg><text>foo  bar</text></svg>`)).toBe('foo bar')
+    expect(getActionNameFromElement(element`<svg><text>foo  bar</text></svg>`)).toEqual(['foo bar', 'inferred'])
   })
 
   it('extracts text from an associated label', () => {
@@ -88,7 +94,7 @@ describe('getActionNameFromElement', () => {
           <input id="toto" target />
         </div>
       `)
-    ).toBe('label text')
+    ).toEqual(['label text', 'inferred'])
   })
 
   it('extracts text from a parent label', () => {
@@ -102,7 +108,7 @@ describe('getActionNameFromElement', () => {
           </div>
         </label>
       `)
-    ).toBe('foo bar')
+    ).toEqual(['foo bar', 'inferred'])
   })
 
   it('extracts text from the first OPTION element when clicking on a SELECT', () => {
@@ -113,7 +119,7 @@ describe('getActionNameFromElement', () => {
           <option>bar</option>
         </select>
       `)
-    ).toBe('foo')
+    ).toEqual(['foo', 'inferred'])
   })
 
   it('extracts text from a aria-labelledby associated element', () => {
@@ -125,7 +131,7 @@ describe('getActionNameFromElement', () => {
           <input aria-labelledby="toto" target />
         </div>
       `)
-    ).toBe('label text')
+    ).toEqual(['label text', 'inferred'])
   })
 
   it('extracts text from multiple aria-labelledby associated elements', () => {
@@ -139,7 +145,7 @@ describe('getActionNameFromElement', () => {
           <label id="toto2">text</label>
         </div>
       `)
-    ).toBe('label text')
+    ).toEqual(['label text', 'inferred'])
   })
 
   it('extracts text from a BUTTON element', () => {
@@ -150,7 +156,7 @@ describe('getActionNameFromElement', () => {
           <button target>foo</button>
         </div>
       `)
-    ).toBe('foo')
+    ).toEqual(['foo', 'inferred'])
   })
 
   it('extracts text from a role=button element', () => {
@@ -161,7 +167,7 @@ describe('getActionNameFromElement', () => {
           <div role="button" target>foo</div>
         </div>
       `)
-    ).toBe('foo')
+    ).toEqual(['foo', 'inferred'])
   })
 
   it('limits the recursion to the 10th parent', () => {
@@ -174,7 +180,7 @@ describe('getActionNameFromElement', () => {
           </i></i></i></i></i></i></i></i></i></i>
         </div>
       `)
-    ).toBe('')
+    ).toEqual(['', 'inferred'])
   })
 
   it('limits the recursion to the BODY element', () => {
@@ -183,7 +189,7 @@ describe('getActionNameFromElement', () => {
         <div>ignored</div>
         <i target></i>
       `)
-    ).toBe('')
+    ).toEqual(['', 'inferred'])
   })
 
   it('limits the recursion to a FORM element', () => {
@@ -196,7 +202,7 @@ describe('getActionNameFromElement', () => {
           </form>
         </div>
       `)
-    ).toBe('')
+    ).toEqual(['', 'inferred'])
   })
 
   it('extracts the name from a parent FORM element', () => {
@@ -209,7 +215,7 @@ describe('getActionNameFromElement', () => {
           </form>
         </div>
       `)
-    ).toBe('foo')
+    ).toEqual(['foo', 'inferred'])
   })
 
   it('extracts the whole textual content of a button', () => {
@@ -220,7 +226,7 @@ describe('getActionNameFromElement', () => {
           <i target>bar</i>
         </button>
       `)
-    ).toBe('foo bar')
+    ).toEqual(['foo bar', 'inferred'])
   })
 
   it('ignores the textual content of contenteditable elements', () => {
@@ -231,7 +237,7 @@ describe('getActionNameFromElement', () => {
           ignored
         </div>
       `)
-    ).toBe('')
+    ).toEqual(['', 'inferred'])
   })
 
   it('extracts the name from attributes of contenteditable elements', () => {
@@ -242,7 +248,7 @@ describe('getActionNameFromElement', () => {
           ignored
         </div>
       `)
-    ).toBe('foo')
+    ).toEqual(['foo', 'inferred'])
   })
 
   describe('programmatically declared action name', () => {
@@ -251,7 +257,7 @@ describe('getActionNameFromElement', () => {
         getActionNameFromElement(element`
           <div data-dd-action-name="foo">ignored</div>
         `)
-      ).toBe('foo')
+      ).toEqual(['foo', 'programmatic'])
     })
 
     it('considers any parent', () => {
@@ -264,7 +270,7 @@ describe('getActionNameFromElement', () => {
       `
       // Set the attribute on the <HTML> element
       target.ownerDocument.documentElement.setAttribute('data-dd-action-name', 'foo')
-      expect(getActionNameFromElement(target)).toBe('foo')
+      expect(getActionNameFromElement(target)).toEqual(['foo', 'programmatic'])
     })
 
     it('normalizes the value', () => {
@@ -272,7 +278,7 @@ describe('getActionNameFromElement', () => {
         getActionNameFromElement(element`
           <div data-dd-action-name="   foo  \t bar  ">ignored</div>
         `)
-      ).toBe('foo bar')
+      ).toEqual(['foo bar', 'programmatic'])
     })
 
     it('fallback on an automatic strategy if the attribute is empty', () => {
@@ -284,7 +290,7 @@ describe('getActionNameFromElement', () => {
             </div>
           </div>
       `)
-      ).toBe('foo')
+      ).toEqual(['foo', 'inferred'])
     })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
@@ -1,18 +1,25 @@
 import { safeTruncate } from '@datadog/browser-core'
+import { AutoActionNamingStrategy } from './trackActions'
 
-export function getActionNameFromElement(element: Element): string {
+export function getActionNameFromElement(element: Element): [string, AutoActionNamingStrategy] {
   // Proceed to get the action name in two steps:
   // * first, get the name programmatically, explicitly defined by the user.
   // * then, use strategies that are known to return good results. Those strategies will be used on
   //   the element and a few parents, but it's likely that they won't succeed at all.
   // * if no name is found this way, use strategies returning less accurate names as a fallback.
   //   Those are much likely to succeed.
-  return (
-    getActionNameFromElementProgrammatically(element) ||
+
+  const programmaticName = getActionNameFromElementProgrammatically(element)
+  if (programmaticName) {
+    return [programmaticName, 'programmatic']
+  }
+
+  const inferredName =
     getActionNameFromElementForStrategies(element, priorityStrategies) ||
     getActionNameFromElementForStrategies(element, fallbackStrategies) ||
     ''
-  )
+
+  return [inferredName, 'inferred']
 }
 
 /**

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -41,6 +41,34 @@ describe('action collection', () => {
       })
     })
 
+  createTest('track a named click action with no associated dom mutation')
+    .withRum({ trackInteractions: true })
+    .withBody(html` <button data-dd-action-name="thinger">click me</button> `)
+    .run(async ({ events }) => {
+      const button = await $('button')
+      await button.click()
+      await flushEvents()
+      const actionEvents = events.rumActions
+
+      expect(actionEvents.length).toBe(1)
+      expect(actionEvents[0].action).toEqual({
+        error: {
+          count: 0,
+        },
+        id: (jasmine.any(String) as unknown) as string,
+        long_task: {
+          count: (jasmine.any(Number) as unknown) as number,
+        },
+        resource: {
+          count: 0,
+        },
+        target: {
+          name: 'thinger',
+        },
+        type: 'click',
+      })
+    })
+
   createTest('associate a request to its action')
     .withRum({ trackInteractions: true })
     .withBody(


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

I am a developer on an Indeed platform team, and we have encountered unexpected behavior with the Datadog RUM [programmatically named user actions](https://docs.datadoghq.com/real_user_monitoring/browser/tracking_user_actions/?tab=npm#declaring-a-name-for-click-actions) feature.

#### Expectation

> User clicks on DOM elements that include the `data-dd-action-name` attribute are tracked.

#### Observed Behavior

> Some programmatically named user interactions are not tracked due to lack of a correlated DOM activity or network request.

The [automatic click tracking event filter rules](https://docs.datadoghq.com/real_user_monitoring/browser/tracking_user_actions/?tab=npm#what-interactions-are-being-tracked) are a perfectly sensible approach to determining which uninstrumented events are important enough to capture. Unfortunately, the activity detection requirement is also being applied to events which are being explicitly, programmatically instrumented using the `data-dd-action-name` attribute. The use of this attribute indicates that the event is important and signals developer intent to track all user click actions for the tagged element.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

The `getActionNameFromElement` user action tracking helper returns a tuple that includes metadata about whether the action name was found to be programmatically named or inferred by a fallback strategy. This information allows the action tracking management engine to `complete` rather than `discard` any programmatically named actions that lack a correlated DOM activity or network request.

This change will not affect the default automatic user interaction tracking behavior. Interactions which have been explicitly instrumented using the `data-dd-action-name` attribute will generate a higher number of RUM events. This is not expected to be a proportionally large increase compared to current behavior since most programmatically named actions already correlate with DOM / network activity. The new behavior is simply filling in gaps of missed data.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

Comprehensive unit and e2e tests have been added for all touched codepaths. Additionally, I was able to directly verify the changes in an internal branch build of the Indeed system that uses `@datadog/browser-rum` by locally building the package and directly installing from the tarball.

#### Generalized test steps

- In a sandbox environment, build a set of buttons with the following variations:
  1. `<button onclick="someDomMutation()">Auto With Action<button>`
  2. `<button>Auto No Action</button>`
  3. `<button data-dd-action-name="named with action" onclick="someDomMutation()">Named With Action</button>`
  4. `<button data-dd-action-name="named no action">Named No Action</button>`
- Load the environment in a browser.
- Click on each button.
- Open the [datadog rum explorer](https://app.datadoghq.com/rum/explorer) and look at actions filtered by the sandbox environment's app id.
- An action for variation 1 ("click on Auto With Action") should be logged.
- An action for variation 2 should not be logged.
- An action for variation 3 ("click on named with action") should be logged.
- An action for variation 4 ("click on named no action") should be logged. Note that it will not include an `Action Loading Time` property since no associated action was found.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
