### PR TITLE
🏷️ update events format

### DIFF
--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -83,6 +83,16 @@ export type RumActionEvent = CommonProperties & {
     }
     [k: string]: unknown
   }
+  /**
+   * View properties
+   */
+  readonly view?: {
+    /**
+     * Is the action starting in the foreground (focus in browser)
+     */
+    readonly in_foreground?: boolean
+    [k: string]: unknown
+  }
   [k: string]: unknown
 }
 /**
@@ -97,6 +107,10 @@ export type RumErrorEvent = CommonProperties & {
    * Error properties
    */
   readonly error: {
+    /**
+     * UUID of the error
+     */
+    readonly id?: string
     /**
      * Error message
      */
@@ -179,6 +193,16 @@ export type RumErrorEvent = CommonProperties & {
     readonly id: string
     [k: string]: unknown
   }
+  /**
+   * View properties
+   */
+  readonly view?: {
+    /**
+     * Is the error starting in the foreground (focus in browser)
+     */
+    readonly in_foreground?: boolean
+    [k: string]: unknown
+  }
   [k: string]: unknown
 }
 /**
@@ -193,6 +217,10 @@ export type RumLongTaskEvent = CommonProperties & {
    * Long Task properties
    */
   readonly long_task: {
+    /**
+     * UUID of the long task
+     */
+    readonly id?: string
     /**
      * Duration in ns of the long task
      */
@@ -523,6 +551,20 @@ export type RumViewEvent = CommonProperties & {
       readonly count: number
       [k: string]: unknown
     }
+    /**
+     * List of the periods of time the user had the view in foreground (focused in the browser)
+     */
+    readonly in_foreground_periods?: {
+      /**
+       * Duration in ns between start of the view and start of foreground period
+       */
+      readonly start: number
+      /**
+       * Duration in ns of the view foreground period
+       */
+      readonly duration: number
+      [k: string]: unknown
+    }[]
     [k: string]: unknown
   }
   /**
@@ -664,6 +706,12 @@ export interface CommonProperties {
      * Version of the RUM event format
      */
     readonly format_version: number
+    [k: string]: unknown
+  }
+  /**
+   * User provided context
+   */
+  context?: {
     [k: string]: unknown
   }
   [k: string]: unknown


### PR DESCRIPTION
## Motivation

We have multiple PRs in preparation that will need to update the `rum-events-format`. Let's udpate it on `main` to avoid potential conflicts.

## Changes

`yarn rum-events-format:sync`

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
