### PR TITLE
🐛 do not break the recorder when an URL fails to parse

### DIFF
--- a/packages/rum-recorder/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.spec.ts
@@ -149,6 +149,10 @@ describe('makeUrlAbsolute', () => {
   it('does not change data URIs', () => {
     expect(makeUrlAbsolute('data:image/gif;base64,ABC', 'http://example.org/foo/')).toBe('data:image/gif;base64,ABC')
   })
+
+  it('returns the original value if it fails to be parsed as an URL', () => {
+    expect(makeUrlAbsolute('http://', 'http://example.org/foo/')).toBe('http://')
+  })
 })
 
 describe('getElementInputValue', () => {

--- a/packages/rum-recorder/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.spec.ts
@@ -138,6 +138,12 @@ describe('makeSrcsetUrlsAbsolute', () => {
 })
 
 describe('makeUrlAbsolute', () => {
+  beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+  })
+
   it('makes an absolute URL from a relative path', () => {
     expect(makeUrlAbsolute('bar', 'http://example.org/foo/')).toBe('http://example.org/foo/bar')
   })

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -74,7 +74,11 @@ export function makeSrcsetUrlsAbsolute(attributeValue: string, baseUrl: string) 
 }
 
 export function makeUrlAbsolute(url: string, baseUrl: string): string {
-  return buildUrl(url.trim(), baseUrl).href
+  try {
+    return buildUrl(url.trim(), baseUrl).href
+  } catch (_) {
+    return url
+  }
 }
 
 /**


### PR DESCRIPTION
## Motivation

The RUM recorder tries to transform URLs in attributes or CSS to make them absolute. Sometimes, the value passed as an URL fails to parse, and an error is thrown. 

## Changes

Just return the original value in this case.

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
