### PR TITLE
Monitor potential invalid date

### DIFF
--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -9,6 +9,8 @@ import {
   timeStampNow,
   currentDrift,
   display,
+  addMonitoringMessage,
+  relativeNow,
 } from '@datadog/browser-core'
 import {
   CommonContext,
@@ -98,6 +100,18 @@ export function startRumAssembly(
           ;(serverRumEvent.usr as Mutable<RumEvent['usr']>) = commonContext.user as User & Context
         }
         if (shouldSend(serverRumEvent, configuration.beforeSend, errorFilter)) {
+          if (!Number.isInteger(serverRumEvent.date)) {
+            addMonitoringMessage('invalid date', {
+              debug: {
+                eventType: serverRumEvent.type,
+                eventTimeStamp: serverRumEvent.date,
+                eventRelativeTime: Math.round(startTime),
+                timeStampNow: timeStampNow(),
+                relativeNow: Math.round(relativeNow()),
+                drift: currentDrift(),
+              },
+            })
+          }
           lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, serverRumEvent)
         }
       }


### PR DESCRIPTION
## Motivation

Investigate some report of events with `date: {}`

## Changes

add monitoring log before adding event to batch when event date is not an integer

## Testing

manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
