### PR TITLE
👷 prevent release from main branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "scripts/cli lint .",
     "typecheck": "scripts/cli typecheck . && scripts/cli typecheck developer-extension",
     "dev": "node scripts/dev-server.js",
-    "release": "lerna version --exact",
+    "release": "scripts/cli release",
     "version": "scripts/cli version",
     "publish:npm": "TARGET_DATACENTER=us BUILD_MODE=release yarn build && lerna publish from-package",
     "test": "yarn test:unit:watch",

--- a/scripts/cli
+++ b/scripts/cli
@@ -50,6 +50,11 @@ cmd_build_json2type () {
   set -e
 }
 
+cmd_release () {
+  [[ `git branch --show-current` != "main" ]] || fail 'please do not release from `main` branch'
+  yarn lerna version --exact
+}
+
 cmd_version () {
   node ./scripts/generate-changelog.js
   # keep test app lockfile up to date


### PR DESCRIPTION
## Motivation

Add early check to prevent release from main branch by mistake.

## Changes

- introduce a `release` cli command
- check current branch with `git branch --show-current` (git >= 2.22)

## Testing

manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
