### PR TITLE
⚗ [RUMF-878] manual view tracking: create new view on renew session

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -103,6 +103,13 @@ export function trackViews(
   }
 
   function startViewLifeCycle() {
+    lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
+      // do not trigger view update to avoid wrong data
+      currentView.end()
+      // Renew view on session renewal
+      currentView = trackViewChange(undefined, currentView.name)
+    })
+
     // End the current view on page unload
     lifeCycle.subscribe(LifeCycleEventType.BEFORE_UNLOAD, () => {
       currentView.end()
@@ -134,13 +141,6 @@ export function trackViews(
   }
 
   function startAutomaticViewCollection() {
-    lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-      // do not trigger view update to avoid wrong data
-      currentView.end()
-      // Renew view on session renewal
-      currentView = trackViewChange()
-    })
-
     return trackLocationChanges(() => {
       if (areDifferentLocation(currentView.getLocation(), location)) {
         // Renew view on location changes
@@ -155,11 +155,6 @@ export function trackViews(
   }
 
   function startManualViewCollection() {
-    lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-      // do not trigger view update to avoid wrong data
-      currentView.end()
-    })
-
     return trackLocationChanges(() => {
       currentView.updateLocation(location)
       currentView.triggerUpdate()
@@ -246,6 +241,7 @@ function newView(
   }
 
   return {
+    name,
     scheduleUpdate: scheduleViewUpdate,
     end(clocks = clocksNow()) {
       endClocks = clocks


### PR DESCRIPTION
## Motivation

In case of renew session, restart tracking with a view name as soon as an user interaction occurs.

## Changes

Regardless of the view tracking mode:

- create a new view on renew session
- use current view name for the new view

## Testing

unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
