### PR TITLE
✨ [RUMF-920] keep trace id on aborted requests

### DIFF
--- a/packages/core/src/browser/fetchProxy.spec.ts
+++ b/packages/core/src/browser/fetchProxy.spec.ts
@@ -58,7 +58,7 @@ describe('fetch proxy', () => {
   })
 
   it('should track aborted fetch', (done) => {
-    fetchStub(FAKE_URL).rejectWith(new DOMException('The user aborted a request', 'AbortError'))
+    fetchStub(FAKE_URL).abort()
 
     fetchStubManager.whenAllComplete(() => {
       const request = getRequest(0)

--- a/packages/core/src/domain/automaticErrorCollection.spec.ts
+++ b/packages/core/src/domain/automaticErrorCollection.spec.ts
@@ -205,7 +205,7 @@ describe('network error tracker', () => {
   })
 
   it('should track aborted requests ', (done) => {
-    fetchStub(FAKE_URL).rejectWith(new DOMException('The user aborted a request', 'AbortError'))
+    fetchStub(FAKE_URL).abort()
 
     fetchStubManager.whenAllComplete(() => {
       expect(errorObservableSpy).toHaveBeenCalled()
@@ -270,7 +270,7 @@ describe('network error tracker', () => {
     })
 
     it('should not track aborted requests ', (done) => {
-      fetchStub(FAKE_URL).rejectWith(new DOMException('The user aborted a request', 'AbortError'))
+      fetchStub(FAKE_URL).abort()
 
       fetchStubManager.whenAllComplete(() => {
         expect(errorObservableSpy).not.toHaveBeenCalled()

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../core/test/specHelper'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { RequestCompleteEvent, RequestStartEvent, trackFetch, trackXhr } from './requestCollection'
-import { clearTracingIfCancelled, TraceIdentifier, Tracer } from './tracing/tracer'
+import { clearTracingIfNeeded, TraceIdentifier, Tracer } from './tracing/tracer'
 
 const configuration = {
   ...DEFAULT_CONFIGURATION,
@@ -43,7 +43,7 @@ describe('collect fetch', () => {
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, startSpy)
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, completeSpy)
     const tracerStub: Partial<Tracer> = {
-      clearTracingIfCancelled,
+      clearTracingIfNeeded,
       traceFetch: (context) => {
         context.traceId = new TraceIdentifier()
         context.spanId = new TraceIdentifier()
@@ -162,7 +162,7 @@ describe('collect xhr', () => {
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, startSpy)
     lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, completeSpy)
     const tracerStub: Partial<Tracer> = {
-      clearTracingIfCancelled,
+      clearTracingIfNeeded,
       traceXhr: (context) => {
         context.traceId = new TraceIdentifier()
         context.spanId = new TraceIdentifier()

--- a/packages/rum-core/src/domain/requestCollection.ts
+++ b/packages/rum-core/src/domain/requestCollection.ts
@@ -69,7 +69,7 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: Configuration, tra
   })
   xhrProxy.onRequestComplete((context) => {
     if (isAllowedRequestUrl(configuration, context.url)) {
-      tracer.clearTracingIfCancelled(context)
+      tracer.clearTracingIfNeeded(context)
       lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, {
         duration: context.duration,
         method: context.method,
@@ -102,7 +102,7 @@ export function trackFetch(lifeCycle: LifeCycle, configuration: Configuration, t
   })
   fetchProxy.onRequestComplete((context) => {
     if (isAllowedRequestUrl(configuration, context.url)) {
-      tracer.clearTracingIfCancelled(context)
+      tracer.clearTracingIfNeeded(context)
       lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, {
         duration: context.duration,
         method: context.method,

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -270,7 +270,7 @@ describe('tracer', () => {
         spanId: new TraceIdentifier(),
         traceId: new TraceIdentifier(),
       } as any
-      tracer.clearTracingIfCancelled(context)
+      tracer.clearTracingIfNeeded(context)
 
       expect(context.traceId).toBeUndefined()
       expect(context.spanId).toBeUndefined()
@@ -284,7 +284,7 @@ describe('tracer', () => {
         spanId: new TraceIdentifier(),
         traceId: new TraceIdentifier(),
       } as any
-      tracer.clearTracingIfCancelled(context)
+      tracer.clearTracingIfNeeded(context)
 
       expect(context.traceId).toBeDefined()
       expect(context.spanId).toBeDefined()

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -9,14 +9,14 @@ import {
 export interface Tracer {
   traceFetch: (context: Partial<RumFetchStartContext>) => void
   traceXhr: (context: Partial<RumXhrStartContext>, xhr: XMLHttpRequest) => void
-  clearTracingIfCancelled: (context: RumFetchCompleteContext | RumXhrCompleteContext) => void
+  clearTracingIfNeeded: (context: RumFetchCompleteContext | RumXhrCompleteContext) => void
 }
 
 interface TracingHeaders {
   [key: string]: string
 }
 
-export function clearTracingIfCancelled(context: RumFetchCompleteContext | RumXhrCompleteContext) {
+export function clearTracingIfNeeded(context: RumFetchCompleteContext | RumXhrCompleteContext) {
   if (context.status === 0 && !context.isAborted) {
     context.traceId = undefined
     context.spanId = undefined
@@ -25,7 +25,7 @@ export function clearTracingIfCancelled(context: RumFetchCompleteContext | RumXh
 
 export function startTracer(configuration: Configuration): Tracer {
   return {
-    clearTracingIfCancelled,
+    clearTracingIfNeeded,
     traceFetch: (context) =>
       injectHeadersIfTracingAllowed(configuration, context, (tracingHeaders: TracingHeaders) => {
         if (context.input instanceof Request && !context.init?.headers) {

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -17,7 +17,7 @@ interface TracingHeaders {
 }
 
 export function clearTracingIfCancelled(context: RumFetchCompleteContext | RumXhrCompleteContext) {
-  if (context.status === 0) {
+  if (context.status === 0 && !context.isAborted) {
     context.traceId = undefined
     context.spanId = undefined
   }

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -16,6 +16,23 @@ interface TracingHeaders {
   [key: string]: string
 }
 
+/**
+ * Clear tracing information to avoid incomplete traces. Ideally, we should do it when the the
+ * request did not reach the server, but we the browser does not expose this. So, we clear tracing
+ * information if the request ended with status 0 without being aborted by the application.
+ *
+ * Reasoning:
+ *
+ * * Applications are usually aborting requests after a bit of time, for example when the user is
+ * typing (autocompletion) or navigating away (in a SPA). With a performant device and good
+ * network conditions, the request is likely to reach the server before being canceled.
+ *
+ * * Requests aborted otherwise (ex: lack of internet, CORS issue, blocked by a privacy extension)
+ * are likely to finish quickly and without reaching the server.
+ *
+ * Of course it might not be the case every time, but it should limit having incomplete traces a
+ * bit..
+ * */
 export function clearTracingIfNeeded(context: RumFetchCompleteContext | RumXhrCompleteContext) {
   if (context.status === 0 && !context.isAborted) {
     context.traceId = undefined


### PR DESCRIPTION
## Motivation

Improve the chance to have a complete distributed trace on request resources: requests aborted by the application are likely to reach the server even if they ends up with a 0 status.

## Changes

Keep trace information for requests aborted by the application.

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
