### PR TITLE
✨ allow users to customize the attribute used to define the action name

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -82,6 +82,8 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
     service?: string
     beforeSend?: BeforeSendCallback
 
+    actionNameAttribute?: string
+
     isEnabled: (feature: string) => boolean
   }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -16,7 +16,7 @@ export function startActionCollection(
   )
 
   if (configuration.trackInteractions) {
-    trackActions(lifeCycle, domMutationObservable)
+    trackActions(lifeCycle, domMutationObservable, configuration)
   }
 
   return {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -286,5 +286,13 @@ describe('getActionNameFromElement', () => {
       `)
       ).toBe('foo')
     })
+
+    it('extracts the name from a user-configured attribute', () => {
+      expect(
+        getActionNameFromElement(element`
+          <div data-test-id="foo">ignored</div>
+        `, 'data-test-id')
+      ).toBe('foo')
+    })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -8,6 +8,7 @@ import {
   ClocksState,
   clocksNow,
   TimeStamp,
+  Configuration,
 } from '@datadog/browser-core'
 import { ActionType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
@@ -46,7 +47,11 @@ export interface AutoActionCreatedEvent {
   startClocks: ClocksState
 }
 
-export function trackActions(lifeCycle: LifeCycle, domMutationObservable: DOMMutationObservable) {
+export function trackActions(
+  lifeCycle: LifeCycle,
+  domMutationObservable: DOMMutationObservable,
+  {actionNameAttribute}: Configuration
+) {
   const action = startActionManagement(lifeCycle, domMutationObservable)
 
   // New views trigger the discard of the current pending Action
@@ -61,7 +66,7 @@ export function trackActions(lifeCycle: LifeCycle, domMutationObservable: DOMMut
       if (!(event.target instanceof Element)) {
         return
       }
-      const name = getActionNameFromElement(event.target)
+      const name = getActionNameFromElement(event.target, actionNameAttribute)
       if (!name) {
         return
       }


### PR DESCRIPTION
## Motivation

`data-test-id` and `data-testid` are the de-facto standard for consistent naming of actionable elements, used for both unit and integration testing. Being forced to duplicate these same names and introduce a vendor-specific attribute (`data-dd-action-name`) is not ideal. 

The reason why a custom attribute is preferred to the default fallback mechanisms is that localized applications will contain strings in different languages, splitting the same action into multiple ones. Additionally, this helps prevent leaking of personal data in case the action is personalized to the content only visible to the user.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

Adds the option to customize the attribute name.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

Uses the same code paths that already exist, but nonetheless added test cases for these new scenarios.

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
