### PR TITLE
✨ Privacy by Default POC

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -83,7 +83,7 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
     cookieOptions: CookieOptions
 
     service?: string
-    beforeSend?: BeforeSendCallback 
+    beforeSend?: BeforeSendCallback
     censorshipLevel?: CensorshipLevel
 
     isEnabled: (feature: string) => boolean

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -2,6 +2,7 @@ import { BuildEnv } from '../boot/init'
 import { CookieOptions, getCurrentSite } from '../browser/cookie'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from '../tools/utils'
+import { CensorshipLevel } from '../../../../packages/rum-recorder/src/constants'
 import { computeTransportConfiguration, Datacenter } from './transportConfiguration'
 
 export const DEFAULT_CONFIGURATION = {
@@ -13,6 +14,7 @@ export const DEFAULT_CONFIGURATION = {
   silentMultipleInit: false,
   trackInteractions: false,
   trackViewsManually: false,
+  censorshipLevel: CensorshipLevel.PRIVATE,
 
   /**
    * arbitrary value, byte precision not needed
@@ -54,6 +56,7 @@ export interface UserConfiguration {
   trackViewsManually?: boolean
   proxyHost?: string
   beforeSend?: BeforeSendCallback
+  censorshipLevel?: CensorshipLevel
 
   service?: string
   env?: string
@@ -80,7 +83,8 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
     cookieOptions: CookieOptions
 
     service?: string
-    beforeSend?: BeforeSendCallback
+    beforeSend?: BeforeSendCallback 
+    censorshipLevel?: CensorshipLevel
 
     isEnabled: (feature: string) => boolean
   }

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -24,11 +24,13 @@ import { ProvidedSource } from '../domain/rumEventsCollection/error/errorCollect
 import { RumEventDomainContext } from '../domainContext.types'
 import { CommonContext, User, ActionType } from '../rawRumEvent.types'
 import { RumEvent } from '../rumEvent.types'
+import { CensorshipLevel } from '../../../../packages/rum-recorder/src/constants'
 import { buildEnv } from './buildEnv'
 import { startRum } from './startRum'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string
+  censorshipLevel?: CensorshipLevel.PRIVATE,
   beforeSend?: (event: RumEvent, context: RumEventDomainContext) => void | boolean
 }
 
@@ -124,6 +126,10 @@ export function makeRumPublicApi<C extends RumUserConfiguration>(startRumImpl: S
         startViewStrategy = startView
       }
       bufferApiCalls.drain()
+    }
+    if (
+      configuration.isEnabled('privacy-by-default-poc')) {
+        (window as any).DD_RUM__PRIVATE = configuration
     }
   }
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -127,9 +127,9 @@ export function makeRumPublicApi<C extends RumUserConfiguration>(startRumImpl: S
       }
       bufferApiCalls.drain()
     }
-    if (configuration.isEnabled('privacy-by-default-poc')) {
-      ;(window as any).DD_RUM__PRIVATE = configuration
-    }
+    // if (configuration.isEnabled('privacy-by-default-poc')) {
+    //   ;(window as any).DD_RUM__PRIVATE = configuration
+    // }
   }
 
   const rumPublicApi = makePublicApi({

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -30,7 +30,7 @@ import { startRum } from './startRum'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string
-  censorshipLevel?: CensorshipLevel.PRIVATE,
+  censorshipLevel?: CensorshipLevel.PRIVATE
   beforeSend?: (event: RumEvent, context: RumEventDomainContext) => void | boolean
 }
 
@@ -127,9 +127,8 @@ export function makeRumPublicApi<C extends RumUserConfiguration>(startRumImpl: S
       }
       bufferApiCalls.drain()
     }
-    if (
-      configuration.isEnabled('privacy-by-default-poc')) {
-        (window as any).DD_RUM__PRIVATE = configuration
+    if (configuration.isEnabled('privacy-by-default-poc')) {
+      ;(window as any).DD_RUM__PRIVATE = configuration
     }
   }
 

--- a/packages/rum-recorder/src/boot/startRecording.ts
+++ b/packages/rum-recorder/src/boot/startRecording.ts
@@ -27,7 +27,8 @@ export function startRecording(
 
   const { stop: stopRecording, takeFullSnapshot } = record({
     emit: addRawRecord,
-  })
+  },
+  configuration)
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
   trackViewEndRecord(lifeCycle, (record) => addRawRecord(record))

--- a/packages/rum-recorder/src/boot/startRecording.ts
+++ b/packages/rum-recorder/src/boot/startRecording.ts
@@ -6,6 +6,8 @@ import { startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'
 import { RawRecord, RecordType } from '../types'
 
+let configurationProviderRef: Configuration | undefined;
+
 export function startRecording(
   lifeCycle: LifeCycle,
   applicationId: string,
@@ -13,6 +15,7 @@ export function startRecording(
   session: RumSession,
   parentContexts: ParentContexts
 ) {
+  configurationProviderRef = configuration;
   const { addRecord, stop: stopSegmentCollection } = startSegmentCollection(
     lifeCycle,
     applicationId,
@@ -27,8 +30,7 @@ export function startRecording(
 
   const { stop: stopRecording, takeFullSnapshot } = record({
     emit: addRawRecord,
-  },
-  configuration)
+  })
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
   trackViewEndRecord(lifeCycle, (record) => addRawRecord(record))
@@ -37,6 +39,7 @@ export function startRecording(
     stop: () => {
       stopRecording()
       stopSegmentCollection()
+      configurationProviderRef = undefined;
     },
   }
 }
@@ -47,4 +50,8 @@ export function trackViewEndRecord(lifeCycle: LifeCycle, addRawRecord: (record: 
       type: RecordType.ViewEnd,
     })
   })
+}
+
+export function getRumRecorderConfig (): Configuration | undefined {
+  return configurationProviderRef;
 }

--- a/packages/rum-recorder/src/constants.ts
+++ b/packages/rum-recorder/src/constants.ts
@@ -21,7 +21,7 @@ export const PRIVACY_CLASS_INPUT_MASKED = 'dd-privacy-input-masked'
 
 export const PRIVACY_INPUT_MASK = '*****'
 
-export const FORM_PRIVATE_TAG_NAMES: {[tagName: string]: true} = {
+export const FORM_PRIVATE_TAG_NAMES: { [tagName: string]: true } = {
   INPUT: true,
   LABEL: true,
   SELECT: true,
@@ -33,7 +33,7 @@ export const FORM_PRIVATE_TAG_NAMES: {[tagName: string]: true} = {
   OPTION: true,
   OPTGROUP: true,
   LEGEND: true,
-};
+}
 
 // export const FORM_PRIVATE_ATTRS = {
 //   alt: true,

--- a/packages/rum-recorder/src/constants.ts
+++ b/packages/rum-recorder/src/constants.ts
@@ -1,3 +1,9 @@
+export const enum CensorshipLevel {
+  PRIVATE = 'PRIVATE',
+  FORMS = 'FORMS',
+  PUBLIC = 'PUBLIC',
+}
+
 export const enum InputPrivacyMode {
   NONE = 1,
   IGNORED,
@@ -12,3 +18,43 @@ export const PRIVACY_ATTR_VALUE_INPUT_MASKED = 'input-masked'
 export const PRIVACY_CLASS_HIDDEN = 'dd-privacy-hidden'
 export const PRIVACY_CLASS_INPUT_IGNORED = 'dd-privacy-input-ignored'
 export const PRIVACY_CLASS_INPUT_MASKED = 'dd-privacy-input-masked'
+
+export const PRIVACY_INPUT_MASK = '*****'
+
+export const FORM_PRIVATE_TAG_NAMES: {[tagName: string]: true} = {
+  INPUT: true,
+  LABEL: true,
+  SELECT: true,
+  TEXTAREA: true,
+  BUTTON: true,
+  FIELDSET: true,
+  DATALIST: true,
+  OUPUT: true,
+  OPTION: true,
+  OPTGROUP: true,
+  LEGEND: true,
+};
+
+// export const FORM_PRIVATE_ATTRS = {
+//   alt: true,
+//   checked: true,
+//   data: true,
+//   placeholder: true,
+//   src: true,
+//   srcset: true,
+//   href: true,
+//   title: true,
+//   value: true,
+// }
+
+// export const DEFAULT_PRIVATE_ATTR = {
+//   // REMINDER: data-*
+//   alt: true,
+//   checked: true,
+//   placeholder: true,
+//   src: true,
+//   srcset: true,
+//   href: true,
+//   title: true,
+//   value: true,
+// }

--- a/packages/rum-recorder/src/domain/record/mutationObserver.ts
+++ b/packages/rum-recorder/src/domain/record/mutationObserver.ts
@@ -170,6 +170,7 @@ function processChildListMutations(mutations: Array<WithSerializedTarget<RumChil
       document,
       serializedNodeIds,
       ancestorInputPrivacyMode: getNodeOrAncestorsInputPrivacyMode(node.parentNode!),
+      // configuration: 99999999999999999
     })
     if (!serializedNode) {
       continue

--- a/packages/rum-recorder/src/domain/record/privacy.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.ts
@@ -101,19 +101,89 @@ export function isFormGroupElement(elem: Element): boolean {
   return FORM_PRIVATE_TAG_NAMES[elem.tagName]
 }
 
+
 /**
  * Scramble each "word" in a string, split by any whitespace character.
- * NOTE: This is not cryptographically secure, but a "happy medium" that maintains the layout of each HTML element.
- * @param text
- * @returns
+ * NOTE: This is not cryptographically secure, but a "happy medium" that maintains 
+ * the layout of each HTML element to handle UX usecases. for web elements that need
+ * strong level of privacy, they should be masked to fully block any recording on it.
+ * 
+ * ROUGH ALGORITHM:
+ * - reduce text charset: alphas are lowercased, numbers set to zero, others set to '*'
+ * - sort each word in the string
+ * - sort the characters of each word
+ * - words with <4 chars get replaced to asterisks
+ * - 10% chance of adding a letter
+ * - 10% chance of removing a letter
+ * - 10% chance of swapping a letter picked from the entire string
+ * - NOTE: Each transformation probability is independent
+ * 
+ * PITFALLS: Scrambling text provides little censorship for keywords/enums/options
+ * where there are only a handful of possible outcomes
+ * 
+ * FUTURE: We could modify Fisher-Yates Algorithm to first pass shuffle only the non-whitespace characters
+ * in an array to preserve the text breakpoints. This would provide strong word censorship while maintaining overall 
+ * text length, but would change the size of each word a little bit.
+ * 
+ * FUTURE: We split by any whitespace character and at the end replace with a space character. We should replace with
+ * the origional space character, such as a new line. The effect is that CSS `white-space: pre;` isn't preserved.
  */
-export const scrambleText = (text: string) =>
-  text
-    .split(/\s/)
-    .map((str) => shuffle(Array.from(str)).join('').toLowerCase())
-    .join(' ')
+export const scrambleText = (text: string) => {
+  const reducedText = text
+    .toLowerCase()
     .replace(/[0-9]/gi, '0')
+    .replace(/[^0-9a-u\s]/gi, '*')
+    // Drop letters vwxyz (no support for other unicode chars or other rare letters like j+k)
+  const words = reducedText.split(/\s/);
+  const censoredWords = shuffle(
+    words.map(word=>censorWord(word, reducedText))
+  );
+  
+  // Pad the string to handle losing some characters
+  const newLength = censoredWords.reduce((sum, word)=>sum+=word.length, 0);
+  if (newLength < text.length) {
+    censoredWords.push(''.repeat(text.length - newLength));
+  }
+  // Truncate the string to handle added characthers
+  return censoredWords.join(' ').slice(0, text.length);
+}
 
+
+/**
+ * Masks word by shuffling letters
+ * Masks short words by replacing entirely with '*' chars
+ * Masks length by possibly adding or removing one char
+ * Masks set of chars by possibly masking one char
+ * NOTE: Each transformation probability is independent
+ */
+function censorWord (word: string, text: string) {
+  if (word.length <=3) {
+    return word.replace(/./g, '*');
+  }
+  // Adding another char from the (parent) text increases entropy for large text bodies
+  if (Math.random() >= 0.9) {
+    const idx = Math.floor(text.length * Math.random());
+    const newChar = text[idx];
+    word += newChar
+  }
+  // Mask set of chars somewhat 
+  const letters = Array.from(word);
+  if (Math.random() >= 0.9) {
+    const fromIdx = Math.floor(text.length * Math.random());
+    const toIdx = Math.floor(word.length * Math.random());
+    letters[toIdx] = text[fromIdx];
+  }
+  let shuffledLetters = shuffle(letters);
+  if (Math.random() >= 0.9) {
+    shuffledLetters = shuffledLetters.slice(0,-1);
+  }
+  return shuffledLetters.join('');
+}
+
+/**
+ * Fisher-Yates Algorithm to shuffle an array.
+ * Unbiased, linear time efficiency, with constant space.
+ */
 function shuffle(array: string[]) {
   // COPYRIGHT: This function code from Mike Bostock https://bost.ocks.org/mike/shuffle/
   let m = array.length

--- a/packages/rum-recorder/src/domain/record/privacy.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.ts
@@ -1,5 +1,6 @@
 import {
   InputPrivacyMode,
+  CensorshipLevel,
   PRIVACY_ATTR_NAME,
   PRIVACY_ATTR_VALUE_HIDDEN,
   PRIVACY_ATTR_VALUE_INPUT_IGNORED,
@@ -7,7 +8,10 @@ import {
   PRIVACY_CLASS_HIDDEN,
   PRIVACY_CLASS_INPUT_IGNORED,
   PRIVACY_CLASS_INPUT_MASKED,
+  FORM_PRIVATE_TAG_NAMES,
 } from '../../constants'
+
+import {Configuration} from '../../../../../packages/core/src/domain/configuration'
 
 // PRIVACY_INPUT_TYPES_TO_IGNORE defines the input types whose input
 // events we want to ignore by default, as they often contain PII.
@@ -88,4 +92,38 @@ function isElement(node: Node): node is Element {
 
 function isInputElement(elem: Element): elem is HTMLInputElement {
   return elem.tagName === 'INPUT'
+}
+
+/**
+ * For CensorshipLevel=FORMS, we should block all form like elements
+ */
+export function isFormGroupElement (elem: Element): boolean {
+  return FORM_PRIVATE_TAG_NAMES[elem.tagName]
+}
+
+
+/**
+ * Scramble each "word" in a string, split by any whitespace character.
+ * NOTE: This is not cryptographically secure, but a "happy medium" that maintains the layout of each HTML element.
+ * @param text
+ * @returns
+ */
+export const scrambleText = (text: string) => text
+      .split(/\s/)
+      .map((str) => shuffle(Array.from(str)).join("").toLowerCase())
+      .join(" ")
+      .replace(/[0-9]/gi, '0')
+
+function shuffle(array: string[]) {
+  // COPYRIGHT: This function code from Mike Bostock https://bost.ocks.org/mike/shuffle/
+  let m = array.length;
+  let t: string;
+  let i: number;
+  while (m) {
+    i = Math.floor(Math.random() * m--);
+    t = array[m];
+    array[m] = array[i];
+    array[i] = t;
+  }
+  return array;
 }

--- a/packages/rum-recorder/src/domain/record/privacy.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.ts
@@ -11,7 +11,7 @@ import {
   FORM_PRIVATE_TAG_NAMES,
 } from '../../constants'
 
-import {Configuration} from '../../../../../packages/core/src/domain/configuration'
+import { Configuration } from '../../../../../packages/core/src/domain/configuration'
 
 // PRIVACY_INPUT_TYPES_TO_IGNORE defines the input types whose input
 // events we want to ignore by default, as they often contain PII.
@@ -97,10 +97,9 @@ function isInputElement(elem: Element): elem is HTMLInputElement {
 /**
  * For CensorshipLevel=FORMS, we should block all form like elements
  */
-export function isFormGroupElement (elem: Element): boolean {
+export function isFormGroupElement(elem: Element): boolean {
   return FORM_PRIVATE_TAG_NAMES[elem.tagName]
 }
-
 
 /**
  * Scramble each "word" in a string, split by any whitespace character.
@@ -108,22 +107,23 @@ export function isFormGroupElement (elem: Element): boolean {
  * @param text
  * @returns
  */
-export const scrambleText = (text: string) => text
-      .split(/\s/)
-      .map((str) => shuffle(Array.from(str)).join("").toLowerCase())
-      .join(" ")
-      .replace(/[0-9]/gi, '0')
+export const scrambleText = (text: string) =>
+  text
+    .split(/\s/)
+    .map((str) => shuffle(Array.from(str)).join('').toLowerCase())
+    .join(' ')
+    .replace(/[0-9]/gi, '0')
 
 function shuffle(array: string[]) {
   // COPYRIGHT: This function code from Mike Bostock https://bost.ocks.org/mike/shuffle/
-  let m = array.length;
-  let t: string;
-  let i: number;
+  let m = array.length
+  let t: string
+  let i: number
   while (m) {
-    i = Math.floor(Math.random() * m--);
-    t = array[m];
-    array[m] = array[i];
-    array[i] = t;
+    i = Math.floor(Math.random() * m--)
+    t = array[m]
+    array[m] = array[i]
+    array[i] = t
   }
-  return array;
+  return array
 }

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -1,7 +1,8 @@
 import { buildUrl } from '@datadog/browser-core'
-import { InputPrivacyMode, PRIVACY_INPUT_MASK } from '../../constants'
+import { CensorshipLevel, InputPrivacyMode, PRIVACY_INPUT_MASK } from '../../constants'
 import { getNodeInputPrivacyMode, getNodeOrAncestorsInputPrivacyMode } from './privacy'
 import { SerializedNodeWithId } from './types'
+import {getCensorshipLevel} from './serialize'
 
 export interface NodeWithSerializedNode extends Node {
   __sn: SerializedNodeWithId
@@ -87,6 +88,14 @@ export function makeUrlAbsolute(url: string, baseUrl: string): string {
  * to avoid iterating over the element ancestors when looking for the input privacy mode.
  */
 export function getElementInputValue(element: Element, ancestorInputPrivacyMode?: InputPrivacyMode) {
+  if (
+    getCensorshipLevel()===CensorshipLevel.PRIVATE ||
+    getCensorshipLevel()===CensorshipLevel.FORMS
+  ) {
+    const value = (element as HTMLOptionElement | HTMLSelectElement).value;
+    return maskValue(value);
+  }
+
   const tagName = element.tagName
   if (tagName === 'OPTION' || tagName === 'SELECT') {
     // Always use the option and select value, as they are useful to display the currently selected

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -1,5 +1,5 @@
 import { buildUrl } from '@datadog/browser-core'
-import { InputPrivacyMode } from '../../constants'
+import { InputPrivacyMode, PRIVACY_INPUT_MASK } from '../../constants'
 import { getNodeInputPrivacyMode, getNodeOrAncestorsInputPrivacyMode } from './privacy'
 import { SerializedNodeWithId } from './types'
 
@@ -125,5 +125,5 @@ export function getElementInputValue(element: Element, ancestorInputPrivacyMode?
 }
 
 export function maskValue(value: string) {
-  return value.replace(/./g, '*')
+  return value.replace(/.+/, PRIVACY_INPUT_MASK);
 }

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -125,5 +125,5 @@ export function getElementInputValue(element: Element, ancestorInputPrivacyMode?
 }
 
 export function maskValue(value: string) {
-  return value.replace(/.+/, PRIVACY_INPUT_MASK);
+  return value.replace(/.+/, PRIVACY_INPUT_MASK)
 }

--- a/packages/rum-recorder/src/domain/record/serialize.ts
+++ b/packages/rum-recorder/src/domain/record/serialize.ts
@@ -146,7 +146,11 @@ function serializeElementNode(element: Element, options: SerializeOptions): Elem
     }
   }
 
-  if (censorshipLevel === CensorshipLevel.FORMS && isFormGroupElement(element) && isEnabled('privacy-by-default-poc')) {
+  if (
+    (censorshipLevel === CensorshipLevel.PRIVATE || censorshipLevel === CensorshipLevel.FORMS) &&
+    isFormGroupElement(element) &&
+    isEnabled('privacy-by-default-poc')
+  ) {
     delete attributes.src
   }
 
@@ -376,6 +380,6 @@ function isEnabled(feature: string): boolean {
 
 function getCensorshipLevel(): CensorshipLevel {
   const configuration: Configuration = (window as any).DD_RUM__PRIVATE
-  const censorshipLevel: CensorshipLevel = configuration.censorshipLevel
-  return censorshipLevel
+  const level: CensorshipLevel = configuration.censorshipLevel
+  return level;
 }

--- a/packages/rum-recorder/src/domain/record/serialize.ts
+++ b/packages/rum-recorder/src/domain/record/serialize.ts
@@ -90,7 +90,7 @@ function serializeElementNode(element: Element, options: SerializeOptions): Elem
   const tagName = getValidTagName(element.tagName)
   const isSVG = isSVGElement(element) || undefined
   // const {censorshipLevel} = options.configuration;
-  const censorshipLevel = getCensorshipLevel();
+  const censorshipLevel = getCensorshipLevel()
 
   if (shouldIgnoreElement(element)) {
     return
@@ -135,30 +135,20 @@ function serializeElementNode(element: Element, options: SerializeOptions): Elem
     }
   }
 
-  if (
-    censorshipLevel===CensorshipLevel.PRIVATE
-    && tagName === 'img'
-    && isEnabled('privacy-by-default-poc')
-  ) {
+  if (censorshipLevel === CensorshipLevel.PRIVATE && tagName === 'img' && isEnabled('privacy-by-default-poc')) {
     if (attributes.src) {
       // TODO: For the POC for simplicity just demo with a placeholder
       const { width, height } = element.getBoundingClientRect()
-      attributes.rr_width = `${Math.round(width)}px`;
-      attributes.rr_height = `${Math.round(height)}px`;
+      attributes.rr_width = `${Math.round(width)}px`
+      attributes.rr_height = `${Math.round(height)}px`
       // delete attributes.src;
-      attributes.src = `https://via.placeholder.com/${width}x${height}`;
+      attributes.src = `https://via.placeholder.com/${width}x${height}`
     }
   }
 
-
-  if (
-    censorshipLevel===CensorshipLevel.FORMS
-    && isFormGroupElement(element)
-    && isEnabled('privacy-by-default-poc')
-  ) {
-    delete attributes.src;
+  if (censorshipLevel === CensorshipLevel.FORMS && isFormGroupElement(element) && isEnabled('privacy-by-default-poc')) {
+    delete attributes.src
   }
-
 
   // dynamic stylesheet
   if (
@@ -310,12 +300,8 @@ function serializeTextNode(text: Text, options: SerializeOptions): TextNode | un
     textContent = makeStylesheetUrlsAbsolute(textContent, location.href)
   } else if (options.ignoreWhiteSpace && !textContent.trim()) {
     return
-  } else if (
-    textContent
-    && parentTagName!=='HEAD'
-    && isEnabled('privacy-by-default-poc')
-  ) {
-    textContent = scrambleText(textContent);
+  } else if (textContent && parentTagName !== 'HEAD' && isEnabled('privacy-by-default-poc')) {
+    textContent = scrambleText(textContent)
   }
 
   return {
@@ -383,15 +369,13 @@ function isSVGElement(el: Element): boolean {
   return el.tagName === 'svg' || el instanceof SVGElement
 }
 
-
-
-function isEnabled (feature: string):boolean {
-  const configuration: Configuration = (window as any).DD_RUM__PRIVATE;
-  return configuration.isEnabled(feature);
+function isEnabled(feature: string): boolean {
+  const configuration: Configuration = (window as any).DD_RUM__PRIVATE
+  return configuration.isEnabled(feature)
 }
 
-function getCensorshipLevel ():CensorshipLevel {
-  const configuration: Configuration = (window as any).DD_RUM__PRIVATE;
-  const censorshipLevel: CensorshipLevel = configuration.censorshipLevel;
-  return censorshipLevel;
+function getCensorshipLevel(): CensorshipLevel {
+  const configuration: Configuration = (window as any).DD_RUM__PRIVATE
+  const censorshipLevel: CensorshipLevel = configuration.censorshipLevel
+  return censorshipLevel
 }


### PR DESCRIPTION
## Motivation

We want to implement "Privacy by Default". To derisk the project, here we test out censoring text nodes and certain HTML attributes for all nodes in order to get product feedback.
1. Text node has the non-destructively jumbled (preserving text breaks + length). We can go further if needed but this changes the size and shape of the replay so determine whatever the transformer is later
2. For `<img/>`, we hide the src attribute

NOTE:
1. No tests included until product gives the green light.
2. Will add a feature flag and cleanup if reviewers appreciate this draft.
    
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
