### PR TITLE
👷 Configure global dependencies cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ cache:
 
 stages:
   - ci-image
+  - install-dependencies
   - test
   - browserstack
   - pre-deploy-notify
@@ -26,6 +27,13 @@ ci-image:
   script:
     - docker build --tag $CI_IMAGE .
     - docker push $CI_IMAGE
+
+install-node-modules:
+  stage: install-dependencies
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  script:
+    - yarn
 
 format:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,11 @@ variables:
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
 
+cache:
+  key: '$CI_JOB_NAME-$CI_COMMIT_REF_SLUG'
+  paths:
+    - node_modules/
+
 stages:
   - ci-image
   - test


### PR DESCRIPTION
## Motivation

Speed up Gitlab pipeline

## Changes

Enable global cache for npm_modules

## Pipeline performance impact

Save ≈ **24 sec** per pipeline (will save 48 sec with the Canary version) 
Save ≈ **75 Mo** of network data transfert per pipeline

## Testing

Gitlab

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
