### PR TITLE
🐛 fix new view segment starting with an IncrementalSnapshot

### DIFF
--- a/packages/rum-recorder/src/boot/startRecording.spec.ts
+++ b/packages/rum-recorder/src/boot/startRecording.spec.ts
@@ -149,8 +149,7 @@ describe('startRecording', () => {
   it('takes a full snapshot when the view changes', (done) => {
     const { lifeCycle } = setupBuilder.build()
 
-    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {} as any)
-
+    changeView(lifeCycle)
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(2, (calls) => {
@@ -162,9 +161,7 @@ describe('startRecording', () => {
   it('adds a ViewEnd record when the view ends', (done) => {
     const { lifeCycle } = setupBuilder.build()
 
-    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {} as any)
-    viewId = 'view-id-2'
-    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {} as any)
+    changeView(lifeCycle)
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(2, (calls) => {
@@ -172,6 +169,26 @@ describe('startRecording', () => {
       readRequestSegment(calls.first(), (segment) => {
         expect(segment.records[segment.records.length - 1].type).toBe(RecordType.ViewEnd)
         expectNoExtraRequestSendCalls(done)
+      })
+    })
+  })
+
+  it('flushes pending mutations before ending the view', (done) => {
+    const { lifeCycle } = setupBuilder.build()
+
+    sandbox.appendChild(document.createElement('hr'))
+    changeView(lifeCycle)
+    flushSegment(lifeCycle)
+
+    waitRequestSendCalls(2, (calls) => {
+      readRequestSegment(calls.first(), (segment) => {
+        expect(segment.records[segment.records.length - 2].type).toBe(RecordType.IncrementalSnapshot)
+        expect(segment.records[segment.records.length - 1].type).toBe(RecordType.ViewEnd)
+
+        readRequestSegment(calls.mostRecent(), (segment) => {
+          expect(segment.records[0].type).toBe(RecordType.Meta)
+          expectNoExtraRequestSendCalls(done)
+        })
       })
     })
   })
@@ -190,6 +207,12 @@ describe('startRecording', () => {
       })
     })
   })
+
+  function changeView(lifeCycle: LifeCycle) {
+    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {} as any)
+    viewId = 'view-id-2'
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {} as any)
+  }
 })
 
 function flushSegment(lifeCycle: LifeCycle) {

--- a/packages/rum-recorder/src/boot/startRecording.ts
+++ b/packages/rum-recorder/src/boot/startRecording.ts
@@ -25,10 +25,11 @@ export function startRecording(
     addRecord({ ...rawRecord, timestamp: Date.now() })
   }
 
-  const { stop: stopRecording, takeFullSnapshot } = record({
+  const { stop: stopRecording, takeFullSnapshot, flush } = record({
     emit: addRawRecord,
   })
 
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, flush)
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
   trackViewEndRecord(lifeCycle, (record) => addRawRecord(record))
 

--- a/packages/rum-recorder/src/boot/startRecording.ts
+++ b/packages/rum-recorder/src/boot/startRecording.ts
@@ -25,11 +25,11 @@ export function startRecording(
     addRecord({ ...rawRecord, timestamp: Date.now() })
   }
 
-  const { stop: stopRecording, takeFullSnapshot, flush } = record({
+  const { stop: stopRecording, takeFullSnapshot, flushMutations } = record({
     emit: addRawRecord,
   })
 
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, flush)
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, flushMutations)
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
   trackViewEndRecord(lifeCycle, (record) => addRawRecord(record))
 

--- a/packages/rum-recorder/src/domain/record/record.ts
+++ b/packages/rum-recorder/src/domain/record/record.ts
@@ -135,5 +135,6 @@ export function record(options: RecordOptions): RecordAPI {
   return {
     stop: stopObservers,
     takeFullSnapshot,
+    flush: () => mutationController.flush(),
   }
 }

--- a/packages/rum-recorder/src/domain/record/record.ts
+++ b/packages/rum-recorder/src/domain/record/record.ts
@@ -135,6 +135,6 @@ export function record(options: RecordOptions): RecordAPI {
   return {
     stop: stopObservers,
     takeFullSnapshot,
-    flush: () => mutationController.flush(),
+    flushMutations: () => mutationController.flush(),
   }
 }

--- a/packages/rum-recorder/src/domain/record/types.ts
+++ b/packages/rum-recorder/src/domain/record/types.ts
@@ -66,6 +66,7 @@ export interface RecordOptions {
 export interface RecordAPI {
   stop: ListenerHandler
   takeFullSnapshot: () => void
+  flush: () => void
 }
 
 export interface ObserverParam {

--- a/packages/rum-recorder/src/domain/record/types.ts
+++ b/packages/rum-recorder/src/domain/record/types.ts
@@ -66,7 +66,7 @@ export interface RecordOptions {
 export interface RecordAPI {
   stop: ListenerHandler
   takeFullSnapshot: () => void
-  flush: () => void
+  flushMutations: () => void
 }
 
 export interface ObserverParam {


### PR DESCRIPTION



## Motivation

Pending mutations were flushed when a FullSnapshot was taken, but in this case the new view was already active, so pending mutations were incorrectly attributed to the new view.

## Changes


To fix this issue, we should flush pending mutations when the view ends.

## Testing

Manual testing, unit test.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
