### PR TITLE
✨ [RUMF-932] Allow context edition in logs beforeSend

### DIFF
--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -200,24 +200,26 @@ describe('logs', () => {
       expect(assembledMessage!.service).toBe('from-current-context')
     })
 
-    it('should allow modification on sensitive field', () => {
+    it('should allow modification of existing fields', () => {
       beforeSend = (event: LogsEvent) => {
-        event.message = 'modified'
+        event.message = 'modified message'
+        ;(event.service as any) = 'modified service'
       }
 
       const assembledMessage = assemble(DEFAULT_MESSAGE, {})
 
-      expect(assembledMessage!.message).toBe('modified')
+      expect(assembledMessage!.message).toBe('modified message')
+      expect(assembledMessage!.service).toBe('modified service')
     })
 
-    it('should reject modification on non sensitive field', () => {
+    it('should allow adding new fields', () => {
       beforeSend = (event: LogsEvent) => {
-        ;(event.service as any) = 'modified'
+        event.foo = 'bar'
       }
 
       const assembledMessage = assemble(DEFAULT_MESSAGE, {})
 
-      expect(assembledMessage!.service).toBe('Service')
+      expect(assembledMessage!.foo).toBe('bar')
     })
   })
 

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -145,13 +145,16 @@ export function html(parts: readonly string[], ...vars: string[]) {
 }
 
 function formatLogsConfiguration(configuration: LogsUserConfiguration) {
-  return JSON.stringify(configuration)
+  return formatConfiguration(configuration)
 }
 
 function formatRumConfiguration(configuration: RumUserConfiguration) {
+  return formatConfiguration(configuration).replace('"LOCATION_ORIGIN"', 'location.origin')
+}
+
+function formatConfiguration(configuration: LogsUserConfiguration | RumUserConfiguration) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   let result = JSON.stringify(configuration, (key, value) => (key === 'beforeSend' ? 'BEFORE_SEND' : value))
-  result = result.replace('"LOCATION_ORIGIN"', 'location.origin')
   if (configuration.beforeSend) {
     result = result.replace('"BEFORE_SEND"', configuration.beforeSend.toString())
   }

--- a/test/e2e/scenario/logs.scenario.ts
+++ b/test/e2e/scenario/logs.scenario.ts
@@ -84,4 +84,20 @@ describe('logs', () => {
       expect(unreachableRequest.http.status_code).toEqual(0)
       expect(unreachableRequest.error!.stack).toContain('TypeError')
     })
+
+  createTest('allow to modify events')
+    .withLogs({
+      beforeSend(event) {
+        event.foo = 'bar'
+      },
+    })
+    .run(async ({ events }) => {
+      await browserExecute(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        window.DD_LOGS!.logger.log('hello', {})
+      })
+      await flushEvents()
+      expect(events.logs.length).toBe(1)
+      expect(events.logs[0].foo).toBe('bar')
+    })
 })


### PR DESCRIPTION
## Motivation

This PR makes it possible to add custom attributes to logs event on `beforeSend` as requested here https://github.com/DataDog/browser-sdk/issues/896 

## Changes

- Allow modification of any field, not only sensitive fields.
- Allow addition of new fields.

## Testing

- unit
- e2e
- local

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
