### PR TITLE
👷 Enable cross pipeline Gitlab cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,13 +5,12 @@ variables:
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
 
 cache:
-  key: '$CI_JOB_NAME-$CI_COMMIT_REF_SLUG'
+  key: dependencies
   paths:
     - node_modules/
 
 stages:
   - ci-image
-  - install-dependencies
   - test
   - browserstack
   - pre-deploy-notify
@@ -29,13 +28,6 @@ ci-image:
   script:
     - docker build --tag $CI_IMAGE .
     - docker push $CI_IMAGE
-
-install-node-modules:
-  stage: install-dependencies
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
-  script:
-    - yarn
 
 format:
   stage: test


### PR DESCRIPTION
## Motivation

Speed up gitlab pipelines by enabling cross pipeline cache

## Changes

Change gitlab cache config

## Testing

Locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
