### PR TITLE
✨[REPLAY-336] Privacy by Default: MVP scaffold

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -13,7 +13,7 @@ export const DEFAULT_CONFIGURATION = {
   silentMultipleInit: false,
   trackInteractions: false,
   trackViewsManually: false,
-  censorshipLevel: 'PRIVATE',
+  censorshipLevel: 'PUBLIC',
 
   /**
    * arbitrary value, byte precision not needed
@@ -140,6 +140,10 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 
   if ('trackViewsManually' in userConfiguration) {
     configuration.trackViewsManually = !!userConfiguration.trackViewsManually
+  }
+
+  if ('censorshipLevel' in userConfiguration) {
+    configuration.censorshipLevel = userConfiguration.censorshipLevel ?? configuration.censorshipLevel
   }
 
   return configuration

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -2,6 +2,7 @@ import { BuildEnv } from '../boot/init'
 import { CookieOptions, getCurrentSite } from '../browser/cookie'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from '../tools/utils'
+import { CensorshipLevel } from '../../../../packages/rum-recorder/src/constants'
 import { computeTransportConfiguration, Datacenter } from './transportConfiguration'
 
 export const DEFAULT_CONFIGURATION = {
@@ -13,6 +14,7 @@ export const DEFAULT_CONFIGURATION = {
   silentMultipleInit: false,
   trackInteractions: false,
   trackViewsManually: false,
+  censorshipLevel: CensorshipLevel.PRIVATE,
 
   /**
    * arbitrary value, byte precision not needed
@@ -54,6 +56,7 @@ export interface UserConfiguration {
   trackViewsManually?: boolean
   proxyHost?: string
   beforeSend?: BeforeSendCallback
+  censorshipLevel?: CensorshipLevel
 
   service?: string
   env?: string
@@ -81,6 +84,7 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
 
     service?: string
     beforeSend?: BeforeSendCallback
+    censorshipLevel?: CensorshipLevel
 
     isEnabled: (feature: string) => boolean
   }

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -2,7 +2,6 @@ import { BuildEnv } from '../boot/init'
 import { CookieOptions, getCurrentSite } from '../browser/cookie'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from '../tools/utils'
-import { CensorshipLevel } from '../../../../packages/rum-recorder/src/constants'
 import { computeTransportConfiguration, Datacenter } from './transportConfiguration'
 
 export const DEFAULT_CONFIGURATION = {
@@ -14,7 +13,7 @@ export const DEFAULT_CONFIGURATION = {
   silentMultipleInit: false,
   trackInteractions: false,
   trackViewsManually: false,
-  censorshipLevel: CensorshipLevel.PRIVATE,
+  censorshipLevel: 'PRIVATE',
 
   /**
    * arbitrary value, byte precision not needed
@@ -56,7 +55,7 @@ export interface UserConfiguration {
   trackViewsManually?: boolean
   proxyHost?: string
   beforeSend?: BeforeSendCallback
-  censorshipLevel?: CensorshipLevel
+  censorshipLevel?: string
 
   service?: string
   env?: string
@@ -84,7 +83,7 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
 
     service?: string
     beforeSend?: BeforeSendCallback
-    censorshipLevel?: CensorshipLevel
+    censorshipLevel?: string
 
     isEnabled: (feature: string) => boolean
   }

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -24,14 +24,13 @@ import { ProvidedSource } from '../domain/rumEventsCollection/error/errorCollect
 import { RumEventDomainContext } from '../domainContext.types'
 import { CommonContext, User, ActionType } from '../rawRumEvent.types'
 import { RumEvent } from '../rumEvent.types'
-import { CensorshipLevel } from '../../../../packages/rum-recorder/src/constants'
 import { buildEnv } from './buildEnv'
 import { startRum } from './startRum'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string
   beforeSend?: (event: RumEvent, context: RumEventDomainContext) => void | boolean
-  censorshipLevel?: CensorshipLevel.PRIVATE
+  censorshipLevel?: string
 }
 
 export type RumPublicApi = ReturnType<typeof makeRumPublicApi>

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -24,12 +24,14 @@ import { ProvidedSource } from '../domain/rumEventsCollection/error/errorCollect
 import { RumEventDomainContext } from '../domainContext.types'
 import { CommonContext, User, ActionType } from '../rawRumEvent.types'
 import { RumEvent } from '../rumEvent.types'
+import { CensorshipLevel } from '../../../../packages/rum-recorder/src/constants'
 import { buildEnv } from './buildEnv'
 import { startRum } from './startRum'
 
 export interface RumUserConfiguration extends UserConfiguration {
   applicationId: string
   beforeSend?: (event: RumEvent, context: RumEventDomainContext) => void | boolean
+  censorshipLevel?: CensorshipLevel.PRIVATE
 }
 
 export type RumPublicApi = ReturnType<typeof makeRumPublicApi>

--- a/packages/rum-recorder/src/boot/startRecording.ts
+++ b/packages/rum-recorder/src/boot/startRecording.ts
@@ -6,6 +6,8 @@ import { startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'
 import { RawRecord, RecordType } from '../types'
 
+let configurationProviderRef: Configuration | undefined
+
 export function startRecording(
   lifeCycle: LifeCycle,
   applicationId: string,
@@ -13,6 +15,7 @@ export function startRecording(
   session: RumSession,
   parentContexts: ParentContexts
 ) {
+  configurationProviderRef = configuration
   const { addRecord, stop: stopSegmentCollection } = startSegmentCollection(
     lifeCycle,
     applicationId,
@@ -36,6 +39,7 @@ export function startRecording(
     stop: () => {
       stopRecording()
       stopSegmentCollection()
+      configurationProviderRef = undefined
     },
   }
 }
@@ -46,4 +50,8 @@ export function trackViewEndRecord(lifeCycle: LifeCycle, addRawRecord: (record: 
       type: RecordType.ViewEnd,
     })
   })
+}
+
+export function getRumRecorderConfig(): Configuration | undefined {
+  return configurationProviderRef
 }

--- a/packages/rum-recorder/src/constants.ts
+++ b/packages/rum-recorder/src/constants.ts
@@ -1,3 +1,9 @@
+export const enum CensorshipLevel {
+  PRIVATE = 'PRIVATE',
+  FORMS = 'FORMS',
+  PUBLIC = 'PUBLIC',
+}
+
 export const enum InputPrivacyMode {
   NONE = 1,
   IGNORED,
@@ -12,3 +18,19 @@ export const PRIVACY_ATTR_VALUE_INPUT_MASKED = 'input-masked'
 export const PRIVACY_CLASS_HIDDEN = 'dd-privacy-hidden'
 export const PRIVACY_CLASS_INPUT_IGNORED = 'dd-privacy-input-ignored'
 export const PRIVACY_CLASS_INPUT_MASKED = 'dd-privacy-input-masked'
+
+export const PRIVACY_INPUT_MASK = '*****'
+
+export const FORM_PRIVATE_TAG_NAMES: { [tagName: string]: true } = {
+  INPUT: true,
+  LABEL: true,
+  SELECT: true,
+  TEXTAREA: true,
+  BUTTON: true,
+  FIELDSET: true,
+  DATALIST: true,
+  OUPUT: true,
+  OPTION: true,
+  OPTGROUP: true,
+  LEGEND: true,
+}

--- a/packages/rum-recorder/src/domain/record/privacy.ts
+++ b/packages/rum-recorder/src/domain/record/privacy.ts
@@ -15,6 +15,8 @@ import {
 // to obfuscate.
 const PRIVACY_INPUT_TYPES_TO_IGNORE = ['email', 'password', 'tel']
 
+const MASKING_CHAR = '᙮'
+
 // Returns true if the given DOM node should be hidden. Ancestors
 // are not checked.
 export function nodeShouldBeHidden(node: Node): boolean {
@@ -89,3 +91,5 @@ function isElement(node: Node): node is Element {
 function isInputElement(elem: Element): elem is HTMLInputElement {
   return elem.tagName === 'INPUT'
 }
+
+export const censorText = (text: string) => text.replace(/[^\s]/g, MASKING_CHAR)

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -146,6 +146,7 @@ export function getCensorshipLevel(): CensorshipLevel {
     // Should never happen. Default to private
     return CensorshipLevel.PRIVATE
   }
-  const level: CensorshipLevel = configuration.censorshipLevel
+  // PENDING review from core package, core defines `censorshipLevel` as any string.
+  const level: CensorshipLevel = configuration.censorshipLevel as CensorshipLevel
   return level
 }

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -1,5 +1,6 @@
 import { buildUrl } from '@datadog/browser-core'
-import { InputPrivacyMode } from '../../constants'
+import { CensorshipLevel, InputPrivacyMode, PRIVACY_INPUT_MASK } from '../../constants'
+import { getRumRecorderConfig } from '../../boot/startRecording'
 import { getNodeInputPrivacyMode, getNodeOrAncestorsInputPrivacyMode } from './privacy'
 import { SerializedNodeWithId } from './types'
 
@@ -125,5 +126,23 @@ export function getElementInputValue(element: Element, ancestorInputPrivacyMode?
 }
 
 export function maskValue(value: string) {
-  return value.replace(/./g, '*')
+  return value.replace(/.+/, PRIVACY_INPUT_MASK)
+}
+
+export function isFlagEnabled(feature: string): boolean {
+  const configuration = getRumRecorderConfig()
+  if (!configuration) {
+    return false
+  }
+  return configuration.isEnabled(feature)
+}
+
+export function getCensorshipLevel(): CensorshipLevel {
+  const configuration = getRumRecorderConfig()
+  if (!configuration) {
+    // Should never happen. Default to private
+    return CensorshipLevel.PRIVATE
+  }
+  const level: CensorshipLevel = configuration.censorshipLevel
+  return level
 }

--- a/packages/rum-recorder/src/domain/record/serializationUtils.ts
+++ b/packages/rum-recorder/src/domain/record/serializationUtils.ts
@@ -126,7 +126,10 @@ export function getElementInputValue(element: Element, ancestorInputPrivacyMode?
 }
 
 export function maskValue(value: string) {
-  return value.replace(/.+/, PRIVACY_INPUT_MASK)
+  if (isFlagEnabled('privacy-by-default-poc')) {
+    return value.replace(/.+/, PRIVACY_INPUT_MASK)
+  }
+  return value.replace(/./g, '*')
 }
 
 export function isFlagEnabled(feature: string): boolean {

--- a/packages/rum-recorder/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection/segmentCollection.ts
@@ -153,7 +153,7 @@ export function doStartSegmentCollection(
     state = {
       status: SegmentCollectionStatus.SegmentPending,
       segment,
-      expirationTimeoutId: setTimeout(
+      expirationTimeoutId: window.setTimeout(
         monitor(() => {
           flushSegment('max_duration')
         }),


### PR DESCRIPTION
## Motivation

Part one of a series of PRs aimed at implementing privacy by default (REPLAY-336).
- This PR adds `censorshipLevel` config property to `rum-core` for use with `rum-recorder`
- Creates an importable reference to the global config object
- Exposes new methods `isFlagEnabled` and `getCensorshipLevel`
- Adds new helper method `censorText` for HTML text censorship that preserves whitespace
- Defines basic constants for all further PRs to build upon: `PRIVACY_INPUT_MASK` and `FORM_PRIVATE_TAG_NAMES`.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
