### PR TITLE
🏷️🐛 make logs event error.stack writable

### DIFF
--- a/packages/logs/src/logsEvent.types.ts
+++ b/packages/logs/src/logsEvent.types.ts
@@ -68,7 +68,7 @@ export interface LogsEvent {
     /**
      * Stacktrace of the error
      */
-    readonly stack?: string
+    stack?: string
 
     [k: string]: unknown
   }


### PR DESCRIPTION

## Motivation

Allows to scrub `error.stack` in logs `beforeSend`.

Fixes #917


## Changes

make logs event error.stack writable

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
