### PR TITLE
✨ [RUMF-945] allow users to customize the attribute used to define the action name

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -42,6 +42,7 @@ export interface UserConfiguration {
   publicApiKey?: string // deprecated
   clientToken: string
   applicationId?: string
+  actionNameAttribute?: string
   internalMonitoringApiKey?: string
   allowedTracingOrigins?: Array<string | RegExp>
   sampleRate?: number
@@ -139,6 +140,10 @@ export function buildConfiguration(userConfiguration: UserConfiguration, buildEn
 
   if ('trackViewsManually' in userConfiguration) {
     configuration.trackViewsManually = !!userConfiguration.trackViewsManually
+  }
+
+  if ('actionNameAttribute' in userConfiguration) {
+    configuration.actionNameAttribute = userConfiguration.actionNameAttribute
   }
 
   return configuration

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -82,6 +82,8 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
     service?: string
     beforeSend?: BeforeSendCallback
 
+    actionNameAttribute?: string
+
     isEnabled: (feature: string) => boolean
   }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -16,7 +16,7 @@ export function startActionCollection(
   )
 
   if (configuration.trackInteractions) {
-    trackActions(lifeCycle, domMutationObservable)
+    trackActions(lifeCycle, domMutationObservable, configuration)
   }
 
   return {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -286,5 +286,13 @@ describe('getActionNameFromElement', () => {
       `)
       ).toBe('foo')
     })
+
+    it('extracts the name from a user-configured attribute', () => {
+      expect(
+        getActionNameFromElement(element`
+          <div data-test-id="foo">ignored</div>
+        `, 'data-test-id')
+      ).toBe('foo')
+    })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -297,5 +297,16 @@ describe('getActionNameFromElement', () => {
         )
       ).toBe('foo')
     })
+
+    it('favors data-dd-action-name over user-configured attribute', () => {
+      expect(
+        getActionNameFromElement(
+          element`
+          <div data-test-id="foo" data-dd-action-name="bar">ignored</div>
+        `,
+          'data-test-id'
+        )
+      ).toBe('bar')
+    })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -289,9 +289,12 @@ describe('getActionNameFromElement', () => {
 
     it('extracts the name from a user-configured attribute', () => {
       expect(
-        getActionNameFromElement(element`
+        getActionNameFromElement(
+          element`
           <div data-test-id="foo">ignored</div>
-        `, 'data-test-id')
+        `,
+          'data-test-id'
+        )
       ).toBe('foo')
     })
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
@@ -6,7 +6,7 @@ import { safeTruncate } from '@datadog/browser-core'
  */
 const PROGRAMMATIC_ATTRIBUTE = 'data-dd-action-name'
 
-export function getActionNameFromElement(element: Element, actionNameAttribute?: string): string {
+export function getActionNameFromElement(element: Element, actionNameAttribute = PROGRAMMATIC_ATTRIBUTE): string {
   // Proceed to get the action name in two steps:
   // * first, get the name programmatically, explicitly defined by the user.
   // * then, use strategies that are known to return good results. Those strategies will be used on
@@ -21,10 +21,7 @@ export function getActionNameFromElement(element: Element, actionNameAttribute?:
   )
 }
 
-function getActionNameFromElementProgrammatically(
-  targetElement: Element,
-  programmaticAttribute = PROGRAMMATIC_ATTRIBUTE
-) {
+function getActionNameFromElementProgrammatically(targetElement: Element, programmaticAttribute: string) {
   let elementWithAttribute
   // We don't use getActionNameFromElementForStrategies here, because we want to consider all parents,
   // without limit. It is up to the user to declare a relevant naming strategy.

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
@@ -1,7 +1,8 @@
 import { safeTruncate } from '@datadog/browser-core'
 
 /**
- * Get the action name from the attribute 'data-dd-action-name' on the element or any of its parent. This can be customized by the setting the actionNameAttribute configuration option.
+ * Get the action name from the attribute 'data-dd-action-name' on the element or any of its parent.
+ * This can be customized by the setting the actionNameAttribute configuration option.
  */
 const PROGRAMMATIC_ATTRIBUTE = 'data-dd-action-name'
 
@@ -20,7 +21,10 @@ export function getActionNameFromElement(element: Element, actionNameAttribute?:
   )
 }
 
-function getActionNameFromElementProgrammatically(targetElement: Element, programmaticAttribute = PROGRAMMATIC_ATTRIBUTE) {
+function getActionNameFromElementProgrammatically(
+  targetElement: Element,
+  programmaticAttribute = PROGRAMMATIC_ATTRIBUTE
+) {
   let elementWithAttribute
   // We don't use getActionNameFromElementForStrategies here, because we want to consider all parents,
   // without limit. It is up to the user to declare a relevant naming strategy.

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
@@ -2,11 +2,11 @@ import { safeTruncate } from '@datadog/browser-core'
 
 /**
  * Get the action name from the attribute 'data-dd-action-name' on the element or any of its parent.
- * This can be customized by the setting the actionNameAttribute configuration option.
+ * It can also be retrieved from a user defined attribute.
  */
-const PROGRAMMATIC_ATTRIBUTE = 'data-dd-action-name'
+const DEFAULT_PROGRAMMATIC_ATTRIBUTE = 'data-dd-action-name'
 
-export function getActionNameFromElement(element: Element, actionNameAttribute = PROGRAMMATIC_ATTRIBUTE): string {
+export function getActionNameFromElement(element: Element, userProgrammaticAttribute?: string): string {
   // Proceed to get the action name in two steps:
   // * first, get the name programmatically, explicitly defined by the user.
   // * then, use strategies that are known to return good results. Those strategies will be used on
@@ -14,7 +14,8 @@ export function getActionNameFromElement(element: Element, actionNameAttribute =
   // * if no name is found this way, use strategies returning less accurate names as a fallback.
   //   Those are much likely to succeed.
   return (
-    getActionNameFromElementProgrammatically(element, actionNameAttribute) ||
+    getActionNameFromElementProgrammatically(element, DEFAULT_PROGRAMMATIC_ATTRIBUTE) ||
+    (userProgrammaticAttribute && getActionNameFromElementProgrammatically(element, userProgrammaticAttribute)) ||
     getActionNameFromElementForStrategies(element, priorityStrategies) ||
     getActionNameFromElementForStrategies(element, fallbackStrategies) ||
     ''

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -150,11 +150,9 @@ describe('newAction', () => {
     document.body.appendChild(root)
     setupBuilder = setup()
       .withFakeClock()
-      .beforeBuild(({
-        lifeCycle,
-        domMutationObservable,
-        configuration
-      }) => trackActions(lifeCycle, domMutationObservable, configuration))
+      .beforeBuild(({ lifeCycle, domMutationObservable, configuration }) =>
+        trackActions(lifeCycle, domMutationObservable, configuration)
+      )
   })
 
   afterEach(() => {
@@ -220,12 +218,10 @@ describe('newAction with a custom actionNameAttribute', () => {
     document.body.appendChild(root)
     setupBuilder = setup()
       .withFakeClock()
-      .withConfiguration({actionNameAttribute: 'data-my-custom-attribute'})
-      .beforeBuild(({
-        lifeCycle,
-        domMutationObservable,
-        configuration
-      }) => trackActions(lifeCycle, domMutationObservable, configuration))
+      .withConfiguration({ actionNameAttribute: 'data-my-custom-attribute' })
+      .beforeBuild(({ lifeCycle, domMutationObservable, configuration }) =>
+        trackActions(lifeCycle, domMutationObservable, configuration)
+      )
   })
 
   afterEach(() => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -137,9 +137,9 @@ describe('newAction', () => {
   let setupBuilder: TestSetupBuilder
   const { events, pushEvent } = eventsCollector<AutoAction>()
 
-  function newClick(name: string) {
+  function newClick(name: string, attribute = 'title') {
     const button = document.createElement('button')
-    button.setAttribute('title', name)
+    button.setAttribute(attribute, name)
     document.getElementById('root')!.appendChild(button)
     button.click()
   }
@@ -199,42 +199,14 @@ describe('newAction', () => {
       resourceCount: 0,
     })
   })
-})
 
-describe('newAction with a custom actionNameAttribute', () => {
-  let setupBuilder: TestSetupBuilder
-  const { events, pushEvent } = eventsCollector<AutoAction>()
-
-  function newClick(name: string) {
-    const button = document.createElement('button')
-    button.setAttribute('data-my-custom-attribute', name)
-    document.getElementById('root')!.appendChild(button)
-    button.click()
-  }
-
-  beforeEach(() => {
-    const root = document.createElement('root')
-    root.setAttribute('id', 'root')
-    document.body.appendChild(root)
-    setupBuilder = setup()
-      .withFakeClock()
+  it('should take the name from user-configured attribute', () => {
+    const { lifeCycle, domMutationObservable, clock } = setupBuilder
       .withConfiguration({ actionNameAttribute: 'data-my-custom-attribute' })
-      .beforeBuild(({ lifeCycle, domMutationObservable, configuration }) =>
-        trackActions(lifeCycle, domMutationObservable, configuration)
-      )
-  })
-
-  afterEach(() => {
-    const root = document.getElementById('root')!
-    root.parentNode!.removeChild(root)
-    setupBuilder.cleanup()
-  })
-
-  it('ignores any starting action while another one is happening', () => {
-    const { lifeCycle, domMutationObservable, clock } = setupBuilder.build()
+      .build()
     lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, pushEvent)
 
-    newClick('test-1')
+    newClick('test-1', 'data-my-custom-attribute')
 
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
     domMutationObservable.notify()

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -50,7 +50,7 @@ export interface AutoActionCreatedEvent {
 export function trackActions(
   lifeCycle: LifeCycle,
   domMutationObservable: DOMMutationObservable,
-  {actionNameAttribute}: Configuration
+  { actionNameAttribute }: Configuration
 ) {
   const action = startActionManagement(lifeCycle, domMutationObservable)
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -8,6 +8,7 @@ import {
   ClocksState,
   clocksNow,
   TimeStamp,
+  Configuration,
 } from '@datadog/browser-core'
 import { ActionType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
@@ -46,7 +47,11 @@ export interface AutoActionCreatedEvent {
   startClocks: ClocksState
 }
 
-export function trackActions(lifeCycle: LifeCycle, domMutationObservable: DOMMutationObservable) {
+export function trackActions(
+  lifeCycle: LifeCycle,
+  domMutationObservable: DOMMutationObservable,
+  {actionNameAttribute}: Configuration
+) {
   const action = startActionManagement(lifeCycle, domMutationObservable)
 
   // New views trigger the discard of the current pending Action
@@ -61,7 +66,7 @@ export function trackActions(lifeCycle: LifeCycle, domMutationObservable: DOMMut
       if (!(event.target instanceof Element)) {
         return
       }
-      const name = getActionNameFromElement(event.target)
+      const name = getActionNameFromElement(event.target, actionNameAttribute)
       if (!name) {
         return
       }


### PR DESCRIPTION
## Motivation

It can be useful to reuse existing tagging in the html to retrieve the action name rather than forcing customer to duplicate their tagging for every third party that need to retrieve this info.

take over of #903 

## Changes

Introduce new `actionNameAttribute` init configuration option

Usage:

```html

<script>
  DD_RUM.init({
    ...
    trackInteractions: true,
    actionNameAttribute: 'data-custom-name'
    ...
  })
</script>

<a onclick="triggerSomeRequestOrDomChange()" data-custom-name="Login button">Try it out!</a>
```

Both `data-dd-action-name` and configured attribute can be used, `data-dd-action-name` is favored when both are present on an element.

## Testing

unit, locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
