### PR TITLE
✨ [RUMF-928] enable manual view tracking

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -482,7 +482,7 @@ describe('rum public api', () => {
   })
 
   describe('trackViews mode', () => {
-    const AUTO_CONFIGURATION = { ...DEFAULT_INIT_CONFIGURATION, enableExperimentalFeatures: ['view-renaming'] }
+    const AUTO_CONFIGURATION = { ...DEFAULT_INIT_CONFIGURATION }
     const MANUAL_CONFIGURATION = { ...AUTO_CONFIGURATION, trackViewsManually: true }
 
     let startRumSpy: jasmine.Spy<StartRum>

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -520,8 +520,7 @@ describe('rum public api', () => {
         const { clock } = setupBuilder.withFakeClock().build()
 
         clock.tick(10)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumPublicApi as any).startView('foo')
+        rumPublicApi.startView('foo')
 
         expect(startViewSpy).not.toHaveBeenCalled()
 
@@ -539,8 +538,7 @@ describe('rum public api', () => {
       it('after init startView should be handle immediately', () => {
         rumPublicApi.init(AUTO_CONFIGURATION)
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumPublicApi as any).startView('foo')
+        rumPublicApi.startView('foo')
 
         expect(startViewSpy).toHaveBeenCalled()
         expect(startViewSpy.calls.argsFor(0)[0]).toEqual('foo')
@@ -557,8 +555,7 @@ describe('rum public api', () => {
       })
 
       it('before init startView should start rum', () => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumPublicApi as any).startView('foo')
+        rumPublicApi.startView('foo')
         expect(startRumSpy).not.toHaveBeenCalled()
         expect(startViewSpy).not.toHaveBeenCalled()
 
@@ -573,8 +570,7 @@ describe('rum public api', () => {
         expect(startRumSpy).not.toHaveBeenCalled()
         expect(startViewSpy).not.toHaveBeenCalled()
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumPublicApi as any).startView('foo')
+        rumPublicApi.startView('foo')
         expect(startRumSpy).toHaveBeenCalled()
         expect(startRumSpy.calls.argsFor(0)[4]).toEqual('foo')
         expect(startViewSpy).not.toHaveBeenCalled()
@@ -582,10 +578,8 @@ describe('rum public api', () => {
 
       it('after start rum startView should start view', () => {
         rumPublicApi.init(MANUAL_CONFIGURATION)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumPublicApi as any).startView('foo')
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumPublicApi as any).startView('bar')
+        rumPublicApi.startView('foo')
+        rumPublicApi.startView('bar')
 
         expect(startRumSpy).toHaveBeenCalled()
         expect(startRumSpy.calls.argsFor(0)[4]).toEqual('foo')
@@ -601,8 +595,7 @@ describe('rum public api', () => {
         rumPublicApi.addTiming('first')
 
         clock.tick(10)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumPublicApi as any).startView('foo')
+        rumPublicApi.startView('foo')
 
         clock.tick(10)
         rumPublicApi.addTiming('second')

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -197,9 +197,10 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
     removeUser: monitor(() => {
       user = {}
     }),
-  })
-  ;(rumPublicApi as any)['startView'] = monitor((name?: string) => {
-    startViewStrategy(name)
+
+    startView: monitor((name?: string) => {
+      startViewStrategy(name)
+    }),
   })
   return rumPublicApi
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -93,7 +93,7 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
     }
 
     const { configuration, internalMonitoring } = commonInit(initConfiguration, buildEnv)
-    if (!configuration.isEnabled('view-renaming') || !configuration.trackViewsManually) {
+    if (!configuration.trackViewsManually) {
       doStartRum()
     } else {
       // drain beforeInitCalls by buffering them until we start RUM
@@ -112,9 +112,8 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
     isAlreadyInitialized = true
 
     function doStartRum(initialViewName?: string) {
-      let startView
       ;({
-        startView,
+        startView: startViewStrategy,
         addAction: addActionStrategy,
         addError: addErrorStrategy,
         addTiming: addTimingStrategy,
@@ -129,9 +128,6 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
         }),
         initialViewName
       ))
-      if (configuration.isEnabled('view-renaming')) {
-        startViewStrategy = startView
-      }
       bufferApiCalls.drain()
     }
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -24,8 +24,7 @@ export function startViewCollection(
     lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processViewUpdate(view, foregroundContexts))
   )
 
-  const shouldTrackViewsAutomatically = !configuration.isEnabled('view-renaming') || !configuration.trackViewsManually
-  return trackViews(location, lifeCycle, domMutationObservable, shouldTrackViewsAutomatically, initialViewName)
+  return trackViews(location, lifeCycle, domMutationObservable, !configuration.trackViewsManually, initialViewName)
 }
 
 function processViewUpdate(

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
@@ -76,8 +76,7 @@ describe('makeRumRecorderPublicApi', () => {
         expect(startRumSpy).not.toHaveBeenCalled()
         rumRecorderPublicApi.init(MANUAL_VIEWS_CONFIGURATION)
         expect(startRumSpy).not.toHaveBeenCalled()
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumRecorderPublicApi as any).startView()
+        rumRecorderPublicApi.startView()
         expect(startRumSpy).toHaveBeenCalled()
       })
 
@@ -85,15 +84,13 @@ describe('makeRumRecorderPublicApi', () => {
         expect(startRecordingSpy).not.toHaveBeenCalled()
         rumRecorderPublicApi.init(MANUAL_VIEWS_CONFIGURATION)
         expect(startRecordingSpy).not.toHaveBeenCalled()
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumRecorderPublicApi as any).startView()
+        rumRecorderPublicApi.startView()
         expect(startRecordingSpy).toHaveBeenCalled()
       })
 
       it('does not start recording when initial view is started with manualSessionReplayRecordingStart: true', () => {
         rumRecorderPublicApi.init({ ...MANUAL_VIEWS_CONFIGURATION, manualSessionReplayRecordingStart: true })
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumRecorderPublicApi as any).startView()
+        rumRecorderPublicApi.startView()
         expect(startRecordingSpy).not.toHaveBeenCalled()
       })
 
@@ -102,16 +99,14 @@ describe('makeRumRecorderPublicApi', () => {
           ...MANUAL_VIEWS_CONFIGURATION,
           enableExperimentalFeatures: ['postpone_start_recording'],
         })
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumRecorderPublicApi as any).startView()
+        rumRecorderPublicApi.startView()
         expect(startRecordingSpy).not.toHaveBeenCalled()
       })
 
       it('does not start recording before the page "load"', () => {
         const { triggerOnLoad } = mockDocumentReadyState()
         rumRecorderPublicApi.init(MANUAL_VIEWS_CONFIGURATION)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(rumRecorderPublicApi as any).startView()
+        rumRecorderPublicApi.startView()
         expect(startRecordingSpy).not.toHaveBeenCalled()
         triggerOnLoad()
         expect(startRecordingSpy).toHaveBeenCalled()

--- a/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
+++ b/packages/rum-recorder/src/boot/rumRecorderPublicApi.spec.ts
@@ -70,7 +70,6 @@ describe('makeRumRecorderPublicApi', () => {
     describe('when tracking views manually', () => {
       const MANUAL_VIEWS_CONFIGURATION = {
         ...DEFAULT_INIT_CONFIGURATION,
-        enableExperimentalFeatures: ['view-renaming'],
         trackViewsManually: true,
       }
       it('starts RUM when initial view is started', () => {

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -3,7 +3,7 @@ import { flushEvents } from '../../lib/helpers/sdk'
 
 describe('API calls and events around init', () => {
   createTest('should be associated to corresponding views when views are automatically tracked')
-    .withRum({ enableExperimentalFeatures: ['view-renaming'] })
+    .withRum()
     .withRumInit((configuration) => {
       window.DD_RUM!.addError('before manual view')
       window.DD_RUM!.addAction('before manual view')
@@ -52,7 +52,7 @@ describe('API calls and events around init', () => {
     })
 
   createTest('should be associated to corresponding views when views are manually tracked')
-    .withRum({ trackViewsManually: true, enableExperimentalFeatures: ['view-renaming'] } as any)
+    .withRum({ trackViewsManually: true })
     .withRumInit((configuration) => {
       window.DD_RUM!.addError('before init')
       window.DD_RUM!.addAction('before init')

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -9,8 +9,7 @@ describe('API calls and events around init', () => {
       window.DD_RUM!.addAction('before manual view')
       window.DD_RUM!.addTiming('before manual view')
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
-      setTimeout(() => (window.DD_RUM as any).startView('manual view'), 10)
+      setTimeout(() => window.DD_RUM!.startView('manual view'), 10)
 
       setTimeout(() => {
         window.DD_RUM!.addError('after manual view')
@@ -66,8 +65,7 @@ describe('API calls and events around init', () => {
         window.DD_RUM!.addTiming('before manual view')
       }, 20)
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
-      setTimeout(() => (window.DD_RUM as any).startView('manual view'), 30)
+      setTimeout(() => window.DD_RUM!.startView('manual view'), 30)
 
       setTimeout(() => {
         window.DD_RUM!.addError('after manual view')


### PR DESCRIPTION
## Motivation

To better identify and group views, a `view.name` concept has been introduced.
In order to provide this `view.name` at the right time and to be sure that it will be include in children events: 
- allow customers to handle themselves the view creation lifecycle rather than relying on url changes
- allow customers to provide a name when starting a new view

Related PRs: #850, #867, #887

## Changes

### `startView` API

```ts
DD_RUM.startView(name?: string)
```

Allow to manually start a new view with an optional name

### `trackViewsManually` initialization parameter

when `trackViewsManually: true`:

- rum start is postponed until the first `startView` call
- on location change:
  -  no new views are created
  - current view location is still updated


## Testing

ci

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
