### PR TITLE
✨ [RUMF-938] add the session plan to RUM events

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export {
 export { Observable, Subscription } from './tools/observable'
 export {
   startSessionManagement,
+  Session,
   SESSION_TIME_OUT_DELAY,
   // Exposed for tests
   SESSION_COOKIE_NAME,

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -8,6 +8,7 @@ import { RumPerformanceNavigationTiming } from '../browser/performanceCollection
 import { LifeCycle, LifeCycleEventType } from '../domain/lifeCycle'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD } from '../domain/rumEventsCollection/view/trackViews'
 import { startViewCollection } from '../domain/rumEventsCollection/view/viewCollection'
+import { RumSessionPlan } from '../domain/rumSession'
 import { RumEvent } from '../rumEvent.types'
 import { startRumEventCollection } from './startRum'
 
@@ -78,6 +79,7 @@ describe('rum session', () => {
     const { lifeCycle } = setupBuilder
       .withSession({
         getId: () => sessionId,
+        getPlan: () => RumSessionPlan.REPLAY,
         isTracked: () => true,
         isTrackedWithResource: () => true,
       })
@@ -113,6 +115,7 @@ describe('rum session keep alive', () => {
       .withFakeClock()
       .withSession({
         getId: () => '1234',
+        getPlan: () => (isSessionTracked ? RumSessionPlan.REPLAY : undefined),
         isTracked: () => isSessionTracked,
         isTrackedWithResource: () => true,
       })

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -6,6 +6,7 @@ import { CommonContext, RawRumErrorEvent, RawRumEvent, RumEventType } from '../r
 import { RumActionEvent, RumErrorEvent, RumEvent } from '../rumEvent.types'
 import { startRumAssembly } from './assembly'
 import { LifeCycle, LifeCycleEventType, RawRumEventCollectedData } from './lifeCycle'
+import { RumSessionPlan } from './rumSession'
 
 describe('rum assembly', () => {
   let setupBuilder: TestSetupBuilder
@@ -449,6 +450,7 @@ describe('rum assembly', () => {
       const { lifeCycle } = setupBuilder
         .withSession({
           getId: () => '1234',
+          getPlan: () => undefined,
           isTracked: () => false,
           isTrackedWithResource: () => false,
         })
@@ -491,7 +493,7 @@ describe('rum assembly', () => {
   })
 
   describe('session context', () => {
-    it('should include the session type and id', () => {
+    it('should include the session type, id and plan', () => {
       const { lifeCycle } = setupBuilder.build()
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
@@ -500,6 +502,9 @@ describe('rum assembly', () => {
         has_replay: undefined,
         id: '1234',
         type: 'user',
+      })
+      expect(serverRumEvents[0]._dd.session).toEqual({
+        plan: RumSessionPlan.REPLAY,
       })
     })
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -73,13 +73,17 @@ export function startRumAssembly(
     LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
     ({ startTime, rawRumEvent, domainContext, savedCommonContext, customerContext }) => {
       const viewContext = parentContexts.findView(startTime)
-      if (session.isTracked() && viewContext && viewContext.session.id === session.getId()) {
+      const plan = session.getPlan()
+      if (plan && viewContext && viewContext.session.id === session.getId()) {
         const actionContext = parentContexts.findAction(startTime)
         const commonContext = savedCommonContext || getCommonContext()
         const rumContext: RumContext = {
           _dd: {
             format_version: 2,
             drift: currentDrift(),
+            session: {
+              plan,
+            },
           },
           application: {
             id: applicationId,

--- a/packages/rum-core/src/domain/internalContext.spec.ts
+++ b/packages/rum-core/src/domain/internalContext.spec.ts
@@ -57,6 +57,7 @@ describe('internal context', () => {
     setupBuilder
       .withSession({
         getId: () => '1234',
+        getPlan: () => undefined,
         isTracked: () => false,
         isTrackedWithResource: () => false,
       })

--- a/packages/rum-core/src/domain/parentContexts.spec.ts
+++ b/packages/rum-core/src/domain/parentContexts.spec.ts
@@ -10,6 +10,7 @@ import {
 } from './parentContexts'
 import { AutoAction } from './rumEventsCollection/action/trackActions'
 import { ViewCreatedEvent } from './rumEventsCollection/view/trackViews'
+import { RumSessionPlan } from './rumSession'
 
 function stubActionWithDuration(duration: number): AutoAction {
   const action: Partial<AutoAction> = { duration: duration as Duration }
@@ -40,6 +41,7 @@ describe('parentContexts', () => {
       .withFakeLocation('http://fake-url.com')
       .withSession({
         getId: () => sessionId,
+        getPlan: () => RumSessionPlan.REPLAY,
         isTracked: () => true,
         isTrackedWithResource: () => true,
       })

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -5,6 +5,7 @@ import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RawRumResourceEvent, RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycleEventType } from '../../lifeCycle'
 import { RequestCompleteEvent } from '../../requestCollection'
+import { RumSessionPlan } from '../../rumSession'
 import { TraceIdentifier } from '../../tracing/tracer'
 import { startResourceCollection } from './resourceCollection'
 
@@ -16,6 +17,7 @@ describe('resourceCollection', () => {
       setupBuilder = setup()
         .withSession({
           getId: () => '1234',
+          getPlan: () => RumSessionPlan.REPLAY,
           isTracked: () => true,
           isTrackedWithResource: () => true,
         })
@@ -158,6 +160,7 @@ describe('resourceCollection', () => {
       setupBuilder = setup()
         .withSession({
           getId: () => '1234',
+          getPlan: () => RumSessionPlan.REPLAY,
           isTracked: () => true,
           isTrackedWithResource: () => false,
         })
@@ -195,6 +198,7 @@ describe('resourceCollection', () => {
       setupBuilder = setup()
         .withSession({
           getId: () => '1234',
+          getPlan: () => RumSessionPlan.REPLAY,
           isTracked: () => true,
           isTrackedWithResource: () => isTrackedWithResource,
         })

--- a/packages/rum-core/src/domain/rumSession.spec.ts
+++ b/packages/rum-core/src/domain/rumSession.spec.ts
@@ -21,8 +21,8 @@ describe('rum session', () => {
   const configuration: Partial<Configuration> = {
     ...DEFAULT_CONFIGURATION,
     isEnabled: () => true,
-    resourceSampleRate: 0.5,
-    sampleRate: 0.5,
+    resourceSampleRate: 50,
+    sampleRate: 50,
   }
   let lifeCycle: LifeCycle
   let renewSessionSpy: jasmine.Spy
@@ -122,8 +122,10 @@ describe('rum session', () => {
       expect(rumSession.getId()).toBe('abcdef')
     })
 
-    it('should return undefined if there is no session yet', () => {
+    it('should return undefined if the session has expired', () => {
       const rumSession = startRumSession(configuration as Configuration, lifeCycle)
+      setCookie(SESSION_COOKIE_NAME, '', DURATION)
+      clock.tick(COOKIE_ACCESS_DELAY)
       expect(rumSession.getId()).toBe(undefined)
     })
   })
@@ -135,8 +137,10 @@ describe('rum session', () => {
       expect(rumSession.getPlan()).toBe(RumSessionPlan.REPLAY)
     })
 
-    it('should return undefined if there is no session yet', () => {
+    it('should return undefined if the session has expired', () => {
       const rumSession = startRumSession(configuration as Configuration, lifeCycle)
+      setCookie(SESSION_COOKIE_NAME, '', DURATION)
+      clock.tick(COOKIE_ACCESS_DELAY)
       expect(rumSession.getPlan()).toBe(undefined)
     })
 

--- a/packages/rum-core/src/domain/rumSession.ts
+++ b/packages/rum-core/src/domain/rumSession.ts
@@ -33,10 +33,21 @@ export function startRumSession(configuration: Configuration, lifeCycle: LifeCyc
   return {
     getId: session.getId,
     getPlan: () => getSessionPlan(session),
-    isTracked: () => getSessionPlan(session) !== undefined,
+    isTracked: () => isSessionTracked(session),
     isTrackedWithResource: () =>
       session.getId() !== undefined && session.getTrackingType() === RumTrackingType.TRACKED_WITH_RESOURCES,
   }
+}
+
+function isSessionTracked(session: Session<RumTrackingType>) {
+  return session.getId() !== undefined && isTypeTracked(session.getTrackingType())
+}
+
+function getSessionPlan(session: Session<RumTrackingType>) {
+  return isSessionTracked(session)
+    ? // TODO: return correct plan based on tracking type
+      RumSessionPlan.REPLAY
+    : undefined
 }
 
 function computeSessionState(configuration: Configuration, rawTrackingType?: string) {
@@ -52,7 +63,7 @@ function computeSessionState(configuration: Configuration, rawTrackingType?: str
   }
   return {
     trackingType,
-    isTracked: isTracked(trackingType),
+    isTracked: isTypeTracked(trackingType),
   }
 }
 
@@ -64,16 +75,9 @@ function hasValidRumSession(trackingType?: string): trackingType is RumTrackingT
   )
 }
 
-function isTracked(rumSessionType: RumTrackingType | undefined) {
+function isTypeTracked(rumSessionType: RumTrackingType | undefined) {
   return (
     rumSessionType === RumTrackingType.TRACKED_WITH_RESOURCES ||
     rumSessionType === RumTrackingType.TRACKED_WITHOUT_RESOURCES
   )
-}
-
-function getSessionPlan(session: Session<RumTrackingType>) {
-  return session.getId() !== undefined && isTracked(session.getTrackingType())
-    ? // TODO: return correct plan based on tracking type
-      RumSessionPlan.REPLAY
-    : undefined
 }

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -7,6 +7,7 @@ import {
   ServerDuration,
   TimeStamp,
 } from '@datadog/browser-core'
+import { RumSessionPlan } from './domain/rumSession'
 
 export enum RumEventType {
   ACTION = 'action',
@@ -173,6 +174,9 @@ export interface RumContext {
   _dd: {
     format_version: 2
     drift: number
+    session: {
+      plan: RumSessionPlan
+    }
   }
 }
 

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -13,7 +13,7 @@ import { ForegroundContexts } from '../src/domain/foregroundContexts'
 import { LifeCycle, LifeCycleEventType, RawRumEventCollectedData } from '../src/domain/lifeCycle'
 import { ParentContexts } from '../src/domain/parentContexts'
 import { trackViews, ViewEvent } from '../src/domain/rumEventsCollection/view/trackViews'
-import { RumSession } from '../src/domain/rumSession'
+import { RumSession, RumSessionPlan } from '../src/domain/rumSession'
 import { RawRumEvent, RumContext, ViewContext } from '../src/rawRumEvent.types'
 import { validateFormat } from './formatValidation'
 
@@ -52,8 +52,9 @@ export interface TestIO {
 }
 
 export function setup(): TestSetupBuilder {
-  let session = {
+  let session: RumSession = {
     getId: () => '1234' as string | undefined,
+    getPlan: () => RumSessionPlan.REPLAY,
     isTracked: () => true,
     isTrackedWithResource: () => true,
   }
@@ -179,6 +180,9 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
     _dd: {
       format_version: 2,
       drift: 0,
+      session: {
+        plan: RumSessionPlan.REPLAY,
+      },
     },
     application: {
       id: fakeId,

--- a/packages/rum-recorder/src/boot/startRecording.spec.ts
+++ b/packages/rum-recorder/src/boot/startRecording.spec.ts
@@ -1,5 +1,6 @@
 import { HttpRequest } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
+import { RumSessionPlan } from 'packages/rum-core/src/domain/rumSession'
 import { inflate } from 'pako'
 import { createNewEvent, isIE } from '../../../core/test/specHelper'
 
@@ -51,6 +52,7 @@ describe('startRecording', () => {
       })
       .withSession({
         getId: () => sessionId,
+        getPlan: () => RumSessionPlan.REPLAY,
         isTracked: () => true,
         isTrackedWithResource: () => true,
       })

--- a/packages/rum-recorder/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum-recorder/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -8,6 +8,7 @@ import {
   restorePageVisibility,
   setPageVisibility,
 } from '@datadog/browser-core/test/specHelper'
+import { RumSessionPlan } from 'packages/rum-core/src/domain/rumSession'
 import { Record, RecordType, SegmentContext, SegmentMeta } from '../../types'
 import { MockWorker } from '../../../test/utils'
 import { SEND_BEACON_BYTE_LENGTH_LIMIT } from '../../transport/send'
@@ -223,6 +224,7 @@ describe('computeSegmentContext', () => {
 
   const DEFAULT_SESSION: RumSession = {
     getId: () => '456',
+    getPlan: () => RumSessionPlan.REPLAY,
     isTracked: () => true,
     isTrackedWithResource: () => true,
   }


### PR DESCRIPTION


## Motivation

Send the session plan to the intake for each RUM events so they can apply specific rules to them.

## Changes

This commit introduces a new method to get the plan from a `RumSession`. For now, it is hardcoded to `REPLAY`, but in the future (RUMF-940) it will be defined by an `Configuration` option.

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
