### PR TITLE
💥 remove addError 'source' argument

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorSource, ONE_SECOND, RelativeTime, getTimeStamp, display, TimeStamp } from '@datadog/browser-core'
+import { ONE_SECOND, RelativeTime, getTimeStamp, display, TimeStamp } from '@datadog/browser-core'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { ActionType } from '../rawRumEvent.types'
 import { makeRumPublicApi, RumPublicApi, RumInitConfiguration, StartRum } from './rumPublicApi'
@@ -280,25 +280,10 @@ describe('rum public api', () => {
           context: undefined,
           error: new Error('foo'),
           handlingStack: jasmine.any(String),
-          source: ErrorSource.CUSTOM,
           startClocks: jasmine.any(Object),
         },
         { context: {}, user: {} },
       ])
-    })
-
-    it('allows setting an ErrorSource', () => {
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      rumPublicApi.addError(new Error('foo'), undefined, ErrorSource.SOURCE)
-      expect(addErrorSpy.calls.argsFor(0)[0].source).toBe(ErrorSource.SOURCE)
-    })
-
-    it('fallbacks to ErrorSource.CUSTOM if an invalid source is given', () => {
-      const displaySpy = spyOn(display, 'error')
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      rumPublicApi.addError(new Error('foo'), undefined, 'invalid' as any)
-      expect(addErrorSpy.calls.argsFor(0)[0].source).toBe(ErrorSource.CUSTOM)
-      expect(displaySpy).toHaveBeenCalledWith("DD_RUM.addError: Invalid source 'invalid'")
     })
 
     it('should generate a handling stack', () => {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -6,7 +6,6 @@ import {
   Context,
   createContextManager,
   deepClone,
-  ErrorSource,
   isPercentage,
   makePublicApi,
   monitor,
@@ -20,7 +19,6 @@ import {
   callMonitored,
   createHandlingStack,
 } from '@datadog/browser-core'
-import { ProvidedSource } from '../domain/rumEventsCollection/error/errorCollection'
 import { RumEventDomainContext } from '../domainContext.types'
 import { CommonContext, User, ActionType } from '../rawRumEvent.types'
 import { RumEvent } from '../rumEvent.types'
@@ -161,21 +159,13 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
       rumPublicApi.addAction(name, context as Context)
     },
 
-    addError: (error: unknown, context?: object, source: ProvidedSource = ErrorSource.CUSTOM) => {
+    addError: (error: unknown, context?: object) => {
       const handlingStack = createHandlingStack()
       callMonitored(() => {
-        let checkedSource: ProvidedSource
-        if (source === ErrorSource.CUSTOM || source === ErrorSource.NETWORK || source === ErrorSource.SOURCE) {
-          checkedSource = source
-        } else {
-          display.error(`DD_RUM.addError: Invalid source '${source as string}'`)
-          checkedSource = ErrorSource.CUSTOM
-        }
         addErrorStrategy({
           error,
           handlingStack,
           context: deepClone(context as Context),
-          source: checkedSource,
           startClocks: clocksNow(),
         })
       })

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -33,7 +33,6 @@ describe('error collection', () => {
       addError({
         error,
         handlingStack: 'Error: handling foo',
-        source: ErrorSource.CUSTOM,
         startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
       })
 
@@ -69,7 +68,6 @@ describe('error collection', () => {
         context: { foo: 'bar' },
         error: new Error('foo'),
         handlingStack: 'Error: handling foo',
-        source: ErrorSource.CUSTOM,
         startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
       })
       expect(rawRumEvents[0].customerContext).toEqual({
@@ -83,7 +81,6 @@ describe('error collection', () => {
         {
           error: new Error('foo'),
           handlingStack: 'Error: handling foo',
-          source: ErrorSource.CUSTOM,
           startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
         },
         { context: { foo: 'bar' }, user: {} }
@@ -99,7 +96,6 @@ describe('error collection', () => {
         {
           error: new Error('foo'),
           handlingStack: 'Error: handling foo',
-          source: ErrorSource.CUSTOM,
           startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
         },
         { context: {}, user: { id: 'foo' } }
@@ -113,7 +109,6 @@ describe('error collection', () => {
       const { rawRumEvents } = setupBuilder.build()
       addError({
         error: { foo: 'bar' },
-        source: ErrorSource.CUSTOM,
         handlingStack: 'Error: handling foo',
         startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
       })

--- a/packages/rum-core/src/index.ts
+++ b/packages/rum-core/src/index.ts
@@ -5,7 +5,6 @@ export {
   makeRumPublicApi,
   StartRum,
 } from './boot/rumPublicApi'
-export { ProvidedSource } from './domain/rumEventsCollection/error/errorCollection'
 export {
   RumEvent,
   RumActionEvent,

--- a/packages/rum-recorder/src/index.ts
+++ b/packages/rum-recorder/src/index.ts
@@ -2,7 +2,6 @@
 export { datadogRum } from './boot/recorder.entry'
 export {
   CommonProperties,
-  ProvidedSource,
   RumInitConfiguration,
   RumUserConfiguration,
   // Events

--- a/packages/rum/src/index.ts
+++ b/packages/rum/src/index.ts
@@ -2,7 +2,6 @@
 export { datadogRum } from './boot/rum.entry'
 export {
   CommonProperties,
-  ProvidedSource,
   RumPublicApi as RumGlobal,
   RumInitConfiguration,
   RumUserConfiguration,


### PR DESCRIPTION
## Motivation

In order to avoid any confusion on how to enrich RUM data, we advice user to use addError `context` attribut.
In that regard, all errors captured with addError are now classified as custom. 

## Changes

Remove addError 'source' argument

## Testing

Unit, Locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
