### PR TITLE
💥 enable network errors removal

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,6 @@ export {
   BeforeSendCallback,
 } from './domain/configuration'
 export { trackConsoleError } from './domain/error/trackConsoleError'
-export { trackNetworkError } from './domain/error/trackNetworkError'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'
 export { computeStackTrace, StackTrace } from './domain/tracekit'
 export {

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -43,7 +43,7 @@ export function startLogs(
   if (initConfiguration.forwardErrorsToLogs !== false) {
     trackConsoleError(errorObservable)
     trackRuntimeError(errorObservable)
-    trackNetworkError(configuration, errorObservable, configuration.isEnabled('remove-network-errors'))
+    trackNetworkError(configuration, errorObservable)
   }
 
   const session = startLoggerSession(configuration, areCookiesAuthorized(configuration.cookieOptions))

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -12,10 +12,10 @@ import {
   RawError,
   RelativeTime,
   InitConfiguration,
-  trackNetworkError,
   trackRuntimeError,
   trackConsoleError,
 } from '@datadog/browser-core'
+import { trackNetworkError } from '../domain/trackNetworkError'
 import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LoggerSession, startLoggerSession } from '../domain/loggerSession'
 import { LogsEvent } from '../logsEvent.types'

--- a/packages/logs/src/domain/trackNetworkError.spec.ts
+++ b/packages/logs/src/domain/trackNetworkError.spec.ts
@@ -1,7 +1,6 @@
-import { FetchStub, FetchStubManager, isIE, SPEC_ENDPOINTS, stubFetch } from '../../../test/specHelper'
-import { RawError } from '../../tools/error'
-import { Observable } from '../../tools/observable'
-import { Configuration } from '../configuration'
+import { Configuration, Observable, RawError } from '@datadog/browser-core'
+import { FetchStub, FetchStubManager, isIE, SPEC_ENDPOINTS, stubFetch } from '../../../core/test/specHelper'
+
 import { trackNetworkError } from './trackNetworkError'
 
 describe('network error tracker', () => {

--- a/packages/logs/src/domain/trackNetworkError.spec.ts
+++ b/packages/logs/src/domain/trackNetworkError.spec.ts
@@ -32,6 +32,8 @@ describe('network error tracker', () => {
     } as Configuration
 
     fetchStubManager = stubFetch()
+    ;({ stop: stopNetworkErrorTracking } = trackNetworkError(configuration, errorObservable))
+    fetchStub = window.fetch as FetchStub
   })
 
   afterEach(() => {
@@ -39,113 +41,91 @@ describe('network error tracker', () => {
     stopNetworkErrorTracking()
   })
 
-  describe('when default configuration', () => {
-    beforeEach(() => {
-      ;({ stop: stopNetworkErrorTracking } = trackNetworkError(configuration, errorObservable))
-      fetchStub = window.fetch as FetchStub
-    })
-    it('should track server error', (done) => {
-      fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
+  it('should track server error', (done) => {
+    fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
 
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).toHaveBeenCalledWith({
-          message: 'Fetch error GET http://fake.com/',
-          resource: {
-            method: 'GET',
-            statusCode: 503,
-            url: 'http://fake.com/',
-          },
-          source: 'network',
-          stack: 'Server error',
-          startClocks: jasmine.any(Object),
-        })
-        done()
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).toHaveBeenCalledWith({
+        message: 'Fetch error GET http://fake.com/',
+        resource: {
+          method: 'GET',
+          statusCode: 503,
+          url: 'http://fake.com/',
+        },
+        source: 'network',
+        stack: 'Server error',
+        startClocks: jasmine.any(Object),
       })
-    })
-
-    it('should not track intake error', (done) => {
-      fetchStub('https://logs-intake.com/v1/input/send?foo=bar').resolveWith(DEFAULT_REQUEST)
-
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).not.toHaveBeenCalled()
-        done()
-      })
-    })
-
-    it('should track aborted requests ', (done) => {
-      fetchStub(FAKE_URL).abort()
-
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).toHaveBeenCalled()
-        done()
-      })
-    })
-
-    it('should track refused request', (done) => {
-      fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 0 })
-
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).toHaveBeenCalled()
-        done()
-      })
-    })
-
-    it('should not track client error', (done) => {
-      fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 400 })
-
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).not.toHaveBeenCalled()
-        done()
-      })
-    })
-
-    it('should not track successful request', (done) => {
-      fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 200 })
-
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).not.toHaveBeenCalled()
-        done()
-      })
-    })
-
-    it('should add a default error response text', (done) => {
-      fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, responseText: undefined })
-
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).toHaveBeenCalled()
-        const stack = (errorObservableSpy.calls.mostRecent().args[0] as RawError).stack
-        expect(stack).toEqual('Failed to load')
-        done()
-      })
-    })
-
-    it('should truncate error response text', (done) => {
-      fetchStub(FAKE_URL).resolveWith({
-        ...DEFAULT_REQUEST,
-        responseText: 'Lorem ipsum dolor sit amet orci aliquam.',
-      })
-
-      fetchStubManager.whenAllComplete(() => {
-        const stack = (errorObservableSpy.calls.mostRecent().args[0] as RawError).stack
-        expect(stack).toEqual('Lorem ipsum dolor sit amet orci ...')
-        done()
-      })
+      done()
     })
   })
 
-  describe('when trackAbortedRequests param is false', () => {
-    beforeEach(() => {
-      ;({ stop: stopNetworkErrorTracking } = trackNetworkError(configuration, errorObservable, false))
-      fetchStub = window.fetch as FetchStub
+  it('should not track intake error', (done) => {
+    fetchStub('https://logs-intake.com/v1/input/send?foo=bar').resolveWith(DEFAULT_REQUEST)
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).not.toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should track aborted requests ', (done) => {
+    fetchStub(FAKE_URL).abort()
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should track refused request', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 0 })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should not track client error', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 400 })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).not.toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should not track successful request', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 200 })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).not.toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should add a default error response text', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, responseText: undefined })
+
+    fetchStubManager.whenAllComplete(() => {
+      expect(errorObservableSpy).toHaveBeenCalled()
+      const stack = (errorObservableSpy.calls.mostRecent().args[0] as RawError).stack
+      expect(stack).toEqual('Failed to load')
+      done()
+    })
+  })
+
+  it('should truncate error response text', (done) => {
+    fetchStub(FAKE_URL).resolveWith({
+      ...DEFAULT_REQUEST,
+      responseText: 'Lorem ipsum dolor sit amet orci aliquam.',
     })
 
-    it('should not track aborted requests ', (done) => {
-      fetchStub(FAKE_URL).abort()
-
-      fetchStubManager.whenAllComplete(() => {
-        expect(errorObservableSpy).not.toHaveBeenCalled()
-        done()
-      })
+    fetchStubManager.whenAllComplete(() => {
+      const stack = (errorObservableSpy.calls.mostRecent().args[0] as RawError).stack
+      expect(stack).toEqual('Lorem ipsum dolor sit amet orci ...')
+      done()
     })
   })
 })

--- a/packages/logs/src/domain/trackNetworkError.ts
+++ b/packages/logs/src/domain/trackNetworkError.ts
@@ -12,20 +12,12 @@ import {
   XhrCompleteContext,
 } from '@datadog/browser-core'
 
-export function trackNetworkError(
-  configuration: Configuration,
-  errorObservable: Observable<RawError>,
-  trackAbortedRequests = true
-) {
+export function trackNetworkError(configuration: Configuration, errorObservable: Observable<RawError>) {
   startXhrProxy().onRequestComplete((context) => handleCompleteRequest(RequestType.XHR, context))
   startFetchProxy().onRequestComplete((context) => handleCompleteRequest(RequestType.FETCH, context))
 
   function handleCompleteRequest(type: RequestType, request: XhrCompleteContext | FetchCompleteContext) {
-    if (
-      !configuration.isIntakeUrl(request.url) &&
-      (trackAbortedRequests || !request.isAborted) &&
-      (isRejected(request) || isServerError(request))
-    ) {
+    if (!configuration.isIntakeUrl(request.url) && (isRejected(request) || isServerError(request))) {
       errorObservable.notify({
         message: `${format(type)} error ${request.method} ${request.url}`,
         resource: {

--- a/packages/logs/src/domain/trackNetworkError.ts
+++ b/packages/logs/src/domain/trackNetworkError.ts
@@ -1,9 +1,16 @@
-import { FetchCompleteContext, resetFetchProxy, startFetchProxy } from '../../browser/fetchProxy'
-import { resetXhrProxy, startXhrProxy, XhrCompleteContext } from '../../browser/xhrProxy'
-import { ErrorSource, RawError } from '../../tools/error'
-import { Observable } from '../../tools/observable'
-import { RequestType } from '../../tools/utils'
-import { Configuration } from '../configuration'
+import {
+  Configuration,
+  ErrorSource,
+  FetchCompleteContext,
+  Observable,
+  RawError,
+  RequestType,
+  resetFetchProxy,
+  resetXhrProxy,
+  startFetchProxy,
+  startXhrProxy,
+  XhrCompleteContext,
+} from '@datadog/browser-core'
 
 export function trackNetworkError(
   configuration: Configuration,

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -56,7 +56,7 @@ export function startRum(
     foregroundContexts,
     initialViewName
   )
-  const { addError } = startErrorCollection(lifeCycle, configuration, foregroundContexts)
+  const { addError } = startErrorCollection(lifeCycle, foregroundContexts)
   const { addAction } = startActionCollection(lifeCycle, domMutationObservable, configuration, foregroundContexts)
 
   startRequestCollection(lifeCycle, configuration)

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -1,6 +1,5 @@
 import {
   computeStackTrace,
-  Configuration,
   Context,
   formatUnknownError,
   RawError,
@@ -10,7 +9,6 @@ import {
   Observable,
   trackConsoleError,
   trackRuntimeError,
-  trackNetworkError,
 } from '@datadog/browser-core'
 import { CommonContext, RawRumErrorEvent, RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType, RawRumEventCollectedData } from '../../lifeCycle'
@@ -26,17 +24,10 @@ export interface ProvidedError {
 
 export type ProvidedSource = 'custom' | 'network' | 'source'
 
-export function startErrorCollection(
-  lifeCycle: LifeCycle,
-  configuration: Configuration,
-  foregroundContexts: ForegroundContexts
-) {
+export function startErrorCollection(lifeCycle: LifeCycle, foregroundContexts: ForegroundContexts) {
   const errorObservable = new Observable<RawError>()
   trackConsoleError(errorObservable)
   trackRuntimeError(errorObservable)
-  if (!configuration.isEnabled('remove-network-errors')) {
-    trackNetworkError(configuration, errorObservable) // deprecated: to remove with version 3
-  }
 
   errorObservable.subscribe((error) => lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error }))
 

--- a/test/e2e/scenario/rum/errors.scenario.ts
+++ b/test/e2e/scenario/rum/errors.scenario.ts
@@ -1,7 +1,6 @@
-import { createTest, bundleSetup } from '../../lib/framework'
-import { browserExecute, browserExecuteAsync, withBrowserLogs } from '../../lib/helpers/browser'
+import { createTest } from '../../lib/framework'
+import { browserExecute, withBrowserLogs } from '../../lib/helpers/browser'
 import { flushEvents } from '../../lib/helpers/sdk'
-import { UNREACHABLE_URL } from '../../lib/helpers/constants'
 
 describe('rum errors', () => {
   createTest('send console.error errors')
@@ -16,61 +15,6 @@ describe('rum errors', () => {
       expect(events.rumErrors[0].error.source).toBe('console')
       await withBrowserLogs((browserLogs) => {
         expect(browserLogs.length).toEqual(1)
-      })
-    })
-
-  createTest('send XHR network errors')
-    .withRum()
-    .withSetup(bundleSetup)
-    .run(async ({ events }) => {
-      await browserExecuteAsync((unreachableUrl, done) => {
-        const xhr = new XMLHttpRequest()
-        xhr.addEventListener('error', () => done(undefined))
-        xhr.open('GET', unreachableUrl)
-        xhr.send()
-      }, UNREACHABLE_URL)
-
-      await flushEvents()
-      expect(events.rumErrors.length).toBe(1)
-      expect(events.rumErrors[0].error.message).toBe(`XHR error GET ${UNREACHABLE_URL}`)
-      expect(events.rumErrors[0].error.source).toBe('network')
-
-      const resourceEvent = events.rumResources.find((event) => event.resource.type === 'xhr')
-      expect(resourceEvent).toBeTruthy()
-      expect(resourceEvent?.resource.status_code).toBe(0)
-
-      await withBrowserLogs((browserLogs) => {
-        // Some browser report two errors:
-        // * failed to load resource
-        // * blocked by CORS policy
-        expect(browserLogs.length).toBeGreaterThanOrEqual(1)
-      })
-    })
-
-  createTest('send fetch network errors')
-    .withRum()
-    .withSetup(bundleSetup)
-    .run(async ({ events }) => {
-      await browserExecuteAsync((unreachableUrl, done) => {
-        fetch(unreachableUrl).catch(() => {
-          done(undefined)
-        })
-      }, UNREACHABLE_URL)
-
-      await flushEvents()
-      expect(events.rumErrors.length).toBe(1)
-      expect(events.rumErrors[0].error.message).toBe(`Fetch error GET ${UNREACHABLE_URL}`)
-      expect(events.rumErrors[0].error.source).toBe('network')
-
-      const resourceEvent = events.rumResources.find((event) => event.resource.type === 'fetch')
-      expect(resourceEvent).toBeTruthy()
-      expect(resourceEvent?.resource.status_code).toBe(0)
-
-      await withBrowserLogs((browserLogs) => {
-        // Some browser report two errors:
-        // * failed to load resource
-        // * blocked by CORS policy
-        expect(browserLogs.length).toBeGreaterThanOrEqual(1)
       })
     })
 })

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -162,9 +162,6 @@ describe('rum resources', () => {
 
       return {
         toBeAborted() {
-          // Aborted XHR should be considered as errors for now
-          expect(events.rumErrors.length).toBe(1)
-
           expect(resourceEvent?.resource.status_code).toBe(0)
         },
 
@@ -192,9 +189,6 @@ describe('rum resources', () => {
         })
 
         await flushEvents()
-
-        // Aborted fetch should be considered as errors for now
-        expect(events.rumErrors.length).toBe(1)
 
         const resourceEvent = events.rumResources.find((event) => event.resource.type === 'fetch')
         expect(resourceEvent).toBeTruthy()


### PR DESCRIPTION
## Motivation

RUM errors are not the best way to trigger attention for network requests with a bad status code. We already collect that information within RUM resources. By stopping the generation of RUM errors for these resources, we simplify the value proposition of RUM errors.

## Changes

- Remove the feature flag
- Move network error code in Logs

## Testing

Unit, Locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
