### PR TITLE
👷 [RUMF-954] remove deprecated bundles upload

### DIFF
--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -2,10 +2,11 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-const entry = path.resolve(__dirname, 'src/boot/rum.entry.ts')
-
 module.exports = (_env, argv) => [
-  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-rum.js' }),
-  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-rum-us.js' }),
-  webpackBase({ mode: argv.mode, entry, datacenter: 'eu', filename: 'datadog-rum-eu.js' }),
+  webpackBase({
+    mode: argv.mode,
+    entry: path.resolve(__dirname, 'src/boot/rum.entry.ts'),
+    datacenter: 'us',
+    filename: 'datadog-rum.js',
+  }),
 ]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,7 +29,6 @@ v[0-9]*) # if major version also update legacy files
     declare -A BUNDLES=(
       ["datadog-rum-${suffix}.js"]="packages/rum/bundle/datadog-rum.js"
       ["datadog-rum-slim-${suffix}.js"]="packages/rum-slim/bundle/datadog-rum-slim.js"
-      ["datadog-rum.js"]="packages/rum/bundle/datadog-rum.js" # deprecated: to remove with version 3
       ["datadog-rum-eu.js"]="packages/rum/bundle/datadog-rum-eu.js" # deprecated: to remove with version 3
       ["datadog-rum-us.js"]="packages/rum/bundle/datadog-rum-us.js" # deprecated: to remove with version 3
       ["datadog-logs.js"]="packages/logs/bundle/datadog-logs.js"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,8 +29,6 @@ v[0-9]*) # if major version also update legacy files
     declare -A BUNDLES=(
       ["datadog-rum-${suffix}.js"]="packages/rum/bundle/datadog-rum.js"
       ["datadog-rum-slim-${suffix}.js"]="packages/rum-slim/bundle/datadog-rum-slim.js"
-      ["datadog-rum-eu.js"]="packages/rum/bundle/datadog-rum-eu.js" # deprecated: to remove with version 3
-      ["datadog-rum-us.js"]="packages/rum/bundle/datadog-rum-us.js" # deprecated: to remove with version 3
       ["datadog-logs.js"]="packages/logs/bundle/datadog-logs.js"
       ["datadog-logs-eu.js"]="packages/logs/bundle/datadog-logs-eu.js"
       ["datadog-logs-us.js"]="packages/logs/bundle/datadog-logs-us.js" 


### PR DESCRIPTION
## Motivation

Don't build and upload unnecessary bundles anymore

## Changes

* remove unprefixed bundle upload
* remove -eu and -us bundles generation and upload

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
