### PR TITLE
Update computeStackTrace.ts

### DIFF
--- a/packages/core/src/domain/tracekit/computeStackTrace.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.ts
@@ -184,7 +184,7 @@ export function computeStackTraceFromStackProp(ex: unknown) {
   }
 
   // eslint-disable-next-line  max-len
-  const chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i
+  const chrome = /^\s*at (.*?) ?\(?((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i
   // eslint-disable-next-line  max-len
   const gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|capacitor|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i
   // eslint-disable-next-line  max-len

--- a/packages/core/src/domain/tracekit/parser.spec.ts
+++ b/packages/core/src/domain/tracekit/parser.spec.ts
@@ -359,7 +359,7 @@ describe('Parser', () => {
   it('should parse Chrome 15 error', () => {
     const stackFrames = computeStackTrace(CapturedExceptions.CHROME_15 as any)
 
-    expect(stackFrames.stack.length).toEqual(4)
+    expect(stackFrames.stack.length).toEqual(5)
     expect(stackFrames.stack[0]).toEqual({
       args: [],
       column: 17,
@@ -379,14 +379,21 @@ describe('Parser', () => {
       column: 5,
       func: 'foo',
       line: 20,
-      url: 'http://path/to/file.js',
+      url: 'chrome-extension://path/to/file.js',
     })
     expect(stackFrames.stack[3]).toEqual({
       args: [],
-      column: 4,
+      column: 5,
       func: '?',
       line: 24,
       url: 'http://path/to/file.js',
+    })
+    expect(stackFrames.stack[4]).toEqual({
+      args: [],
+      column: 4,
+      func: '?',
+      line: 28,
+      url: 'chrome-extension://path/to/file.js',
     })
   })
 

--- a/packages/core/test/capturedExceptions.ts
+++ b/packages/core/test/capturedExceptions.ts
@@ -158,8 +158,9 @@ export const CHROME_15 = {
   stack: `TypeError: Object #<Object> has no method 'undef'
     at bar (http://path/to/file.js:13:17)
     at bar (http://path/to/file.js:16:5)
-    at foo (http://path/to/file.js:20:5)
-    at http://path/to/file.js:24:4`,
+    at foo (chrome-extension://path/to/file.js:20:5)
+    at http://path/to/file.js:24:5)
+    at chrome-extension://path/to/file.js:28:4`,
 }
 
 export const CHROME_36 = {


### PR DESCRIPTION
The open parenthesis should be optional as it's not included in stack traces without a function name. The close parenthesis is already marked optional.

## Motivation

Formatting the stack trace is currently broken with stacks that don't include the function name.

Original stack trace:
```
Error: wow so broke
    at chrome-extension://<id>/content/index.js:85:37167
    at chrome-extension://<id>/content/index.js:85:37194
    at chrome-extension://<id>/content/index.js:85:37379
```

After parsing / without the fix (the function names here are wrong):
```
Error: wow so broke
at addError @ undefined
at <anonymous> @ undefined
at yt @ undefined
at addError @ undefined
```

After parsing / with the fix:
```
Error: wow so broke
at <anonymous> @ chrome-extension://<id>/content/index.js:85:37167
at <anonymous> @ chrome-extension://<id>/content/index.js:85:37194
at <anonymous> @ chrome-extension://<id>/content/index.js:85:37379
```

## Changes

Make the open parenthesis optional when parsing stack traces

## Testing

Throw an exception and see whether anonymous function calls are included correctly in the stack

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
