### PR TITLE
🐛 fix recording session renewal

### DIFF
--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -179,6 +179,7 @@ describe('makeRecorderApi', () => {
         session.setNotTracked()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
       })
     })
 
@@ -191,6 +192,7 @@ describe('makeRecorderApi', () => {
         recorderApi.start()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
       })
     })
 
@@ -203,7 +205,8 @@ describe('makeRecorderApi', () => {
         recorderApi.start()
         session.setLitePlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-        expect(startRecordingSpy).toHaveBeenCalled()
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
+        expect(stopRecordingSpy).toHaveBeenCalled()
       })
     })
 
@@ -216,6 +219,7 @@ describe('makeRecorderApi', () => {
         recorderApi.start()
         session.setNotTracked()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         expect(stopRecordingSpy).toHaveBeenCalled()
       })
     })

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -228,8 +228,8 @@ describe('makeRecorderApi', () => {
       it('keeps recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-        expect(stopRecordingSpy).not.toHaveBeenCalled()
-        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
+        expect(stopRecordingSpy).toHaveBeenCalled()
+        expect(startRecordingSpy).toHaveBeenCalledTimes(2)
       })
 
       it('does not starts recording if stopSessionReplayRecording was called', () => {

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -157,6 +157,7 @@ describe('makeRecorderApi', () => {
         session.setReplayPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
       })
 
       it('does not starts recording if stopSessionReplayRecording was called', () => {
@@ -178,6 +179,7 @@ describe('makeRecorderApi', () => {
         session.setReplayPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
       })
 
       it('does not starts recording if stopSessionReplayRecording was called', () => {
@@ -209,7 +211,7 @@ describe('makeRecorderApi', () => {
 
       it('stops recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        session.setNotTracked()
+        session.setLitePlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(stopRecordingSpy).toHaveBeenCalled()
       })

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -137,7 +137,7 @@ describe('makeRecorderApi', () => {
     })
   })
 
-  describe('session renewal', () => {
+  describe('when session renewal change the session plan', () => {
     let session: RumSessionMock
     let lifeCycle: LifeCycle
     beforeEach(() => {
@@ -147,29 +147,7 @@ describe('makeRecorderApi', () => {
       rumInit(DEFAULT_INIT_CONFIGURATION)
     })
 
-    describe('when an untracked session expires and the renewed session plan is REPLAY', () => {
-      beforeEach(() => {
-        session.setNotTracked()
-      })
-
-      it('starts recording if startSessionReplayRecording was called', () => {
-        recorderApi.start()
-        session.setReplayPlan()
-        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-        expect(startRecordingSpy).toHaveBeenCalled()
-        expect(stopRecordingSpy).not.toHaveBeenCalled()
-      })
-
-      it('does not starts recording if stopSessionReplayRecording was called', () => {
-        recorderApi.start()
-        recorderApi.stop()
-        session.setReplayPlan()
-        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-        expect(startRecordingSpy).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('when a LITE session expires and the renewed session plan is REPLAY', () => {
+    describe('from LITE to REPLAY', () => {
       beforeEach(() => {
         session.setLitePlan()
       })
@@ -191,7 +169,45 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('when a REPLAY session expires and the renewed session untracked', () => {
+    describe('from LITE to untracked', () => {
+      beforeEach(() => {
+        session.setLitePlan()
+      })
+
+      it('keeps not recording if startSessionReplayRecording was called', () => {
+        recorderApi.start()
+        session.setNotTracked()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('from LITE to LITE', () => {
+      beforeEach(() => {
+        session.setLitePlan()
+      })
+
+      it('keeps not recording if startSessionReplayRecording was called', () => {
+        recorderApi.start()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('from REPLAY to LITE', () => {
+      beforeEach(() => {
+        session.setReplayPlan()
+      })
+
+      it('stops recording if startSessionReplayRecording was called', () => {
+        recorderApi.start()
+        session.setLitePlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).toHaveBeenCalled()
+      })
+    })
+
+    describe('from REPLAY to untracked', () => {
       beforeEach(() => {
         session.setReplayPlan()
       })
@@ -204,16 +220,71 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('when a REPLAY session expires and the renewed session LITE', () => {
+    describe('from REPLAY to REPLAY', () => {
       beforeEach(() => {
         session.setReplayPlan()
       })
 
-      it('stops recording if startSessionReplayRecording was called', () => {
+      it('keeps recording if startSessionReplayRecording was called', () => {
+        recorderApi.start()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
+      })
+
+      it('does not starts recording if stopSessionReplayRecording was called', () => {
+        recorderApi.start()
+        recorderApi.stop()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
+        expect(stopRecordingSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('from untracked to REPLAY', () => {
+      beforeEach(() => {
+        session.setNotTracked()
+      })
+
+      it('starts recording if startSessionReplayRecording was called', () => {
+        recorderApi.start()
+        session.setReplayPlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
+      })
+
+      it('does not starts recording if stopSessionReplayRecording was called', () => {
+        recorderApi.start()
+        recorderApi.stop()
+        session.setReplayPlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('from untracked to LITE', () => {
+      beforeEach(() => {
+        session.setNotTracked()
+      })
+
+      it('keeps not recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         session.setLitePlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-        expect(stopRecordingSpy).toHaveBeenCalled()
+        expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('from untracked to untracked', () => {
+      beforeEach(() => {
+        session.setNotTracked()
+      })
+
+      it('keeps not recording if startSessionReplayRecording was called', () => {
+        recorderApi.start()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -60,13 +60,11 @@ export function makeRecorderApi(startRecordingImpl: StartRecording): RecorderApi
       parentContexts: ParentContexts
     ) => {
       lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-        if (state.status === RecorderStatus.IntentToStart) {
-          startStrategy()
-        }
+        const status = state.status
+        stopStrategy()
 
-        if (!session.hasReplayPlan() && state.status === RecorderStatus.Started) {
-          stopStrategy()
-          state = { status: RecorderStatus.IntentToStart }
+        if (status !== RecorderStatus.Stopped) {
+          startStrategy()
         }
       })
 

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -63,6 +63,11 @@ export function makeRecorderApi(startRecordingImpl: StartRecording): RecorderApi
         if (state.status === RecorderStatus.IntentToStart) {
           startStrategy()
         }
+
+        if (!session.hasReplayPlan() && state.status === RecorderStatus.Started) {
+          stopStrategy()
+          state = { status: RecorderStatus.IntentToStart }
+        }
       })
 
       startStrategy = () => {

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -60,10 +60,12 @@ export function makeRecorderApi(startRecordingImpl: StartRecording): RecorderApi
       parentContexts: ParentContexts
     ) => {
       lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-        const status = state.status
-        stopStrategy()
+        if (state.status === RecorderStatus.Started) {
+          stopStrategy()
+          state = { status: RecorderStatus.IntentToStart }
+        }
 
-        if (status !== RecorderStatus.Stopped) {
+        if (state.status === RecorderStatus.IntentToStart) {
           startStrategy()
         }
       })


### PR DESCRIPTION
## Motivation

Some LITE sessions have the replay enabled while they shouldn't. Using sample rates, it's possible to go from a REPLAY session to a LITE or an untracked session. In these cases, the recorder should stop recording.

## Changes

Stop recording when a new session with a LITE plan or untracked is started

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
