### PR TITLE
👷 npm log private

### DIFF
--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -2,6 +2,7 @@
   "name": "@datadog/browser-logs",
   "version": "3.0.0",
   "license": "Apache-2.0",
+  "private": true,
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",


### PR DESCRIPTION
## Motivation

In the context of RUM v3, we want to forbid Log from being updated in v3 before all changes are done.

## Changes

Update Log package.json

## Testing

None

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
