### PR TITLE
📝 update CDN URLs for V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ This repository contains several packages:
 [12]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum
 [13]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum
 [14]: https://bundlephobia.com/result?p=@datadog/browser-rum
-[15]: https://www.datadoghq-browser-agent.com/datadog-rum.js
+[15]: https://www.datadoghq-browser-agent.com/datadog-rum-v3.js
 [17]: ./packages/rum/README.md
 [18]: https://docs.datadoghq.com/real_user_monitoring/
 [21]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-slim.svg
 [22]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-slim
 [23]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum-slim
 [24]: https://bundlephobia.com/result?p=@datadog/browser-rum-slim
-[25]: https://www.datadoghq-browser-agent.com/datadog-rum-slim.js
+[25]: https://www.datadoghq-browser-agent.com/datadog-rum-slim-v3.js
 [27]: ./packages/rum-slim/README.md
 [28]: https://docs.datadoghq.com/real_user_monitoring/
 [41]: https://badge.fury.io/js/%40datadog%2Fbrowser-core.svg

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -61,7 +61,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
    d=o.createElement(u);d.async=1;d.src=n
    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-})(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum.js','DD_RUM')
+})(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v3.js','DD_RUM')
   DD_RUM.onReady(function() {
     DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
@@ -87,7 +87,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 Add the generated code snippet to the head tag (in front of any other script tags) of every HTML page you want to monitor in your application. Including the script tag higher and synchronized ensures Datadog RUM can collect all performance data and errors.
 
 ```html
-<script src="https://www.datadoghq-browser-agent.com/datadog-rum.js" type="text/javascript"></script>
+<script src="https://www.datadoghq-browser-agent.com/datadog-rum-v3.js" type="text/javascript"></script>
 <script>
   window.DD_RUM &&
     window.DD_RUM.init({

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -30,7 +30,7 @@ Options:
   const proxy = await startProxy()
 
   const options: ProfilingOptions = {
-    bundleUrl: 'https://www.datadoghq-browser-agent.com/datadog-rum.js',
+    bundleUrl: 'https://www.datadoghq-browser-agent.com/datadog-rum-v3.js',
     proxy,
     startRecording,
   }


### PR DESCRIPTION
## Motivation

The CDN URL changed for V3. This PR updates a few URLs in our codebase documentation.

## Changes

Add `-v3` to CDN URLs

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
