### PR TITLE
[RUMF-972] Revert "💥 always use alternative domains for RUM (#944)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,17 +39,6 @@ You can no longer change the source of error sent with `addError()`. All these e
 
 **New option**: If you used this feature to identify `network` and `source` errors, you can add context attributes with `addError()` instead.
 
-### New intake domains
-
-RUM now uses a new intake domain. Therefore the init options `useAlternateIntakeDomains` has been removed.
-
-| Old domains                        | New domains                      |
-| ---------------------------------- | -------------------------------- |
-| rum-http-intake.logs.datadoghq.com | rum.browser-intake-datadoghq.com |
-| rum-http-intake.logs.datadoghq.eu  | rum.browser-intake-datadoghq.eu  |
-
-> Warning: You have to update your content security policy, if you use one.
-
 ### Removed typescript types
 
 | Old types                    | New types                    |

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -29,11 +29,7 @@ import { RumEvent } from '../rumEvent.types'
 import { buildEnv } from './buildEnv'
 import { startRum } from './startRum'
 
-const droppedConfigurationOptions = [
-  'publicApiKey' as const,
-  'datacenter' as const,
-  'useAlternateIntakeDomains' as const,
-]
+const droppedConfigurationOptions = ['publicApiKey' as const, 'datacenter' as const]
 type DroppedConfigurationOptions = typeof droppedConfigurationOptions[number]
 
 export interface RumInitConfiguration extends Omit<InitConfiguration, DroppedConfigurationOptions> {
@@ -107,10 +103,7 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
 
     droppedConfigurationOptions.forEach((option) => delete (initConfiguration as InitConfiguration)[option])
 
-    const { configuration, internalMonitoring } = commonInit(
-      { ...initConfiguration, useAlternateIntakeDomains: true },
-      buildEnv
-    )
+    const { configuration, internalMonitoring } = commonInit(initConfiguration, buildEnv)
     if (!configuration.trackViewsManually) {
       doStartRum(initConfiguration, configuration, internalMonitoring)
     } else {


### PR DESCRIPTION


## Motivation

EU doesn't have the new intake domain available yet.

## Changes

This reverts commit 6fd361cf06d86cc07ce67a5f1f8a1a7b6dfc32a6.

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
