### PR TITLE
[RUMF-978][RUMF-980] adjust deploy for logs v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "node scripts/dev-server.js",
     "release": "scripts/cli release",
     "version": "scripts/cli version",
-    "publish:npm": "TARGET_DATACENTER=us BUILD_MODE=release yarn build && lerna publish from-package",
+    "publish:npm": "BUILD_MODE=release yarn build && lerna publish from-package",
     "test": "yarn test:unit:watch",
     "test:unit": "karma start ./test/unit/karma.local.conf.js",
     "test:unit:watch": "yarn test:unit --no-single-run",

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -1,7 +1,6 @@
 import { areCookiesAuthorized, CookieOptions } from '../browser/cookie'
 import { buildConfiguration, InitConfiguration } from '../domain/configuration'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
-import { Datacenter } from '../domain/transportConfiguration'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { display } from '../tools/display'
 
@@ -44,7 +43,6 @@ export enum BuildMode {
 }
 
 export interface BuildEnv {
-  datacenter: Datacenter
   buildMode: BuildMode
   sdkVersion: string
 }

--- a/packages/core/src/domain/configuration.spec.ts
+++ b/packages/core/src/domain/configuration.spec.ts
@@ -2,41 +2,39 @@ import { RumEvent } from '../../../rum/src'
 import { BuildEnv, BuildMode } from '../boot/init'
 import { display } from '../tools/display'
 import { buildConfiguration } from './configuration'
-import { Datacenter } from './transportConfiguration'
 
 describe('configuration', () => {
   const clientToken = 'some_client_token'
-  const usEnv: BuildEnv = {
+  const buildEnv: BuildEnv = {
     buildMode: BuildMode.RELEASE,
-    datacenter: Datacenter.US,
     sdkVersion: 'some_version',
   }
 
   describe('cookie options', () => {
     it('should not be secure nor crossSite by default', () => {
-      const configuration = buildConfiguration({ clientToken }, usEnv)
+      const configuration = buildConfiguration({ clientToken }, buildEnv)
       expect(configuration.cookieOptions).toEqual({ secure: false, crossSite: false })
     })
 
     it('should be secure when `useSecureSessionCookie` is truthy', () => {
-      const configuration = buildConfiguration({ clientToken, useSecureSessionCookie: true }, usEnv)
+      const configuration = buildConfiguration({ clientToken, useSecureSessionCookie: true }, buildEnv)
       expect(configuration.cookieOptions).toEqual({ secure: true, crossSite: false })
     })
 
     it('should be secure and crossSite when `useCrossSiteSessionCookie` is truthy', () => {
-      const configuration = buildConfiguration({ clientToken, useCrossSiteSessionCookie: true }, usEnv)
+      const configuration = buildConfiguration({ clientToken, useCrossSiteSessionCookie: true }, buildEnv)
       expect(configuration.cookieOptions).toEqual({ secure: true, crossSite: true })
     })
 
     it('should have domain when `trackSessionAcrossSubdomains` is truthy', () => {
-      const configuration = buildConfiguration({ clientToken, trackSessionAcrossSubdomains: true }, usEnv)
+      const configuration = buildConfiguration({ clientToken, trackSessionAcrossSubdomains: true }, buildEnv)
       expect(configuration.cookieOptions).toEqual({ secure: false, crossSite: false, domain: jasmine.any(String) })
     })
   })
 
   describe('beforeSend', () => {
     it('should be undefined when beforeSend is missing on user configuration', () => {
-      const configuration = buildConfiguration({ clientToken }, usEnv)
+      const configuration = buildConfiguration({ clientToken }, buildEnv)
       expect(configuration.beforeSend).toBeUndefined()
     })
 
@@ -46,7 +44,7 @@ describe('configuration', () => {
           return false
         }
       }
-      const configuration = buildConfiguration({ clientToken, beforeSend }, usEnv)
+      const configuration = buildConfiguration({ clientToken, beforeSend }, buildEnv)
       expect(configuration.beforeSend!({ view: { url: '/foo' } }, {})).toBeFalse()
       expect(configuration.beforeSend!({ view: { url: '/bar' } }, {})).toBeUndefined()
     })
@@ -56,7 +54,7 @@ describe('configuration', () => {
       const beforeSend = () => {
         throw myError
       }
-      const configuration = buildConfiguration({ clientToken, beforeSend }, usEnv)
+      const configuration = buildConfiguration({ clientToken, beforeSend }, buildEnv)
       const displaySpy = spyOn(display, 'error')
       expect(configuration.beforeSend!(null, {})).toBeUndefined()
       expect(displaySpy).toHaveBeenCalledWith('beforeSend threw an error:', myError)

--- a/packages/core/src/domain/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/transportConfiguration.spec.ts
@@ -3,18 +3,17 @@ import { computeTransportConfiguration } from './transportConfiguration'
 
 describe('transportConfiguration', () => {
   const clientToken = 'some_client_token'
-  const usEnv: BuildEnv = {
+  const buildEnv: BuildEnv = {
     buildMode: BuildMode.RELEASE,
-    datacenter: Datacenter.US,
     sdkVersion: 'some_version',
   }
 
   describe('internal monitoring endpoint', () => {
     it('should only be defined when api key is provided', () => {
-      let configuration = computeTransportConfiguration({ clientToken }, usEnv)
+      let configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.internalMonitoringEndpoint).toBeUndefined()
 
-      configuration = computeTransportConfiguration({ clientToken, internalMonitoringApiKey: clientToken }, usEnv)
+      configuration = computeTransportConfiguration({ clientToken, internalMonitoringApiKey: clientToken }, buildEnv)
       expect(configuration.internalMonitoringEndpoint).toContain(clientToken)
     })
   })
@@ -36,19 +35,19 @@ describe('transportConfiguration', () => {
 
   describe('site', () => {
     it('should use buildEnv value by default', () => {
-      const configuration = computeTransportConfiguration({ clientToken }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.rumEndpoint).toContain('datadoghq.com')
     })
 
     it('should use datacenter value when set', () => {
-      const configuration = computeTransportConfiguration({ clientToken, datacenter: Datacenter.EU }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken, datacenter: Datacenter.EU }, buildEnv)
       expect(configuration.rumEndpoint).toContain('datadoghq.eu')
     })
 
     it('should use site value when set', () => {
       const configuration = computeTransportConfiguration(
         { clientToken, datacenter: Datacenter.EU, site: 'foo.com' },
-        usEnv
+        buildEnv
       )
       expect(configuration.rumEndpoint).toContain('foo.com')
     })
@@ -58,7 +57,7 @@ describe('transportConfiguration', () => {
     it('should replace endpoint host add set it as a query parameter', () => {
       const configuration = computeTransportConfiguration(
         { clientToken, site: 'datadoghq.eu', proxyHost: 'proxy.io' },
-        usEnv
+        buildEnv
       )
       expect(configuration.rumEndpoint).toMatch(/^https:\/\/proxy\.io\//)
       expect(configuration.rumEndpoint).toContain('?ddhost=rum-http-intake.logs.datadoghq.eu&')
@@ -67,8 +66,8 @@ describe('transportConfiguration', () => {
 
   describe('sdk_version, env, version and service', () => {
     it('should not modify the logs and rum endpoints tags when not defined', () => {
-      const configuration = computeTransportConfiguration({ clientToken }, usEnv)
-      expect(decodeURIComponent(configuration.rumEndpoint)).toContain(`&ddtags=sdk_version:${usEnv.sdkVersion}`)
+      const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
+      expect(decodeURIComponent(configuration.rumEndpoint)).toContain(`&ddtags=sdk_version:${buildEnv.sdkVersion}`)
 
       expect(decodeURIComponent(configuration.rumEndpoint)).not.toContain(',env:')
       expect(decodeURIComponent(configuration.rumEndpoint)).not.toContain(',service:')
@@ -81,32 +80,32 @@ describe('transportConfiguration', () => {
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = computeTransportConfiguration(
         { clientToken, env: 'foo', service: 'bar', version: 'baz' },
-        usEnv
+        buildEnv
       )
       expect(decodeURIComponent(configuration.rumEndpoint)).toContain(
-        `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
+        `&ddtags=sdk_version:${buildEnv.sdkVersion},env:foo,service:bar,version:baz`
       )
       expect(decodeURIComponent(configuration.logsEndpoint)).toContain(
-        `&ddtags=sdk_version:${usEnv.sdkVersion},env:foo,service:bar,version:baz`
+        `&ddtags=sdk_version:${buildEnv.sdkVersion},env:foo,service:bar,version:baz`
       )
     })
   })
 
   describe('tags', () => {
     it('should be encoded', () => {
-      const configuration = computeTransportConfiguration({ clientToken, service: 'bar+foo' }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken, service: 'bar+foo' }, buildEnv)
       expect(configuration.rumEndpoint).toContain(`ddtags=sdk_version%3Asome_version%2Cservice%3Abar%2Bfoo`)
     })
   })
 
   describe('isIntakeUrl', () => {
     it('should not detect non intake request', () => {
-      const configuration = computeTransportConfiguration({ clientToken }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.isIntakeUrl('https://www.foo.com')).toBe(false)
     })
 
     it('should detect intake request for classic EU site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.eu' }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.eu' }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://public-trace-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
@@ -114,7 +113,7 @@ describe('transportConfiguration', () => {
     })
 
     it('should detect intake request for classic US site', () => {
-      const configuration = computeTransportConfiguration({ clientToken }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
 
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.com/v1/input/xxx')).toBe(true)
@@ -123,7 +122,7 @@ describe('transportConfiguration', () => {
     })
 
     it('should detect alternate intake domains for US site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://trace.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
@@ -131,7 +130,7 @@ describe('transportConfiguration', () => {
     })
 
     it('should detect alternate intake domains for EU site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://trace.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
@@ -141,21 +140,21 @@ describe('transportConfiguration', () => {
     it('should force alternate intake domains for other sites', () => {
       let configuration = computeTransportConfiguration(
         { clientToken, site: 'us3.datadoghq.com', useAlternateIntakeDomains: false },
-        usEnv
+        buildEnv
       )
       expect(configuration.isIntakeUrl('https://rum.browser-intake-us3-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.us3.datadoghq.com/v1/input/xxx')).toBe(false)
 
       configuration = computeTransportConfiguration(
         { clientToken, site: 'ddog-gov.com', useAlternateIntakeDomains: false },
-        usEnv
+        buildEnv
       )
       expect(configuration.isIntakeUrl('https://rum.browser-intake-ddog-gov.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.ddog-gov.com/v1/input/xxx')).toBe(false)
     })
 
     it('should handle sites with subdomains', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'foo.datadoghq.com' }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken, site: 'foo.datadoghq.com' }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum.browser-intake-foo-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-foo-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://trace.browser-intake-foo-datadoghq.com/v1/input/xxx')).toBe(true)
@@ -165,26 +164,26 @@ describe('transportConfiguration', () => {
     })
 
     it('should detect proxy intake request', () => {
-      let configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, usEnv)
+      let configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, buildEnv)
       expect(configuration.isIntakeUrl('https://www.proxy.com/v1/input/xxx')).toBe(true)
       configuration = computeTransportConfiguration(
         { clientToken, proxyHost: 'www.proxy.com', useAlternateIntakeDomains: true },
-        usEnv
+        buildEnv
       )
       expect(configuration.isIntakeUrl('https://www.proxy.com/v1/input/xxx')).toBe(true)
-      configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com/custom/path' }, usEnv)
+      configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com/custom/path' }, buildEnv)
       expect(configuration.isIntakeUrl('https://www.proxy.com/custom/path/v1/input/xxx')).toBe(true)
     })
 
     it('should not detect request done on the same host as the proxy', () => {
-      const configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, usEnv)
+      const configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, buildEnv)
       expect(configuration.isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
     })
 
     it('should detect replica intake request with classic intake domains', () => {
       const configuration = computeTransportConfiguration(
         { clientToken, site: 'datadoghq.eu', replica: { clientToken } },
-        { ...usEnv, buildMode: BuildMode.STAGING }
+        { ...buildEnv, buildMode: BuildMode.STAGING }
       )
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
@@ -198,7 +197,7 @@ describe('transportConfiguration', () => {
     it('should detect replica intake request with alternate intake domains', () => {
       const configuration = computeTransportConfiguration(
         { clientToken, site: 'foo.com', replica: { clientToken } },
-        { ...usEnv, buildMode: BuildMode.STAGING }
+        { ...buildEnv, buildMode: BuildMode.STAGING }
       )
       expect(configuration.isIntakeUrl('https://rum.browser-intake-foo.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-foo.com/v1/input/xxx')).toBe(true)

--- a/packages/core/src/domain/transportConfiguration.ts
+++ b/packages/core/src/domain/transportConfiguration.ts
@@ -58,7 +58,7 @@ export function computeTransportConfiguration(
     proxyHost: initConfiguration.proxyHost,
     sdkVersion: buildEnv.sdkVersion,
     service: initConfiguration.service,
-    site: initConfiguration.site || INTAKE_SITE[initConfiguration.datacenter || buildEnv.datacenter],
+    site: initConfiguration.site || INTAKE_SITE[initConfiguration.datacenter || Datacenter.US],
     version: initConfiguration.version,
   }
 

--- a/packages/logs/src/boot/buildEnv.ts
+++ b/packages/logs/src/boot/buildEnv.ts
@@ -1,7 +1,6 @@
-import { BuildEnv, BuildMode, Datacenter } from '@datadog/browser-core'
+import { BuildEnv, BuildMode } from '@datadog/browser-core'
 
 export const buildEnv: BuildEnv = {
   buildMode: '<<< BUILD_MODE >>>' as BuildMode,
-  datacenter: '<<< TARGET_DATACENTER >>>' as Datacenter,
   sdkVersion: '<<< SDK_VERSION >>>',
 }

--- a/packages/logs/webpack.config.js
+++ b/packages/logs/webpack.config.js
@@ -2,10 +2,11 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-const entry = path.resolve(__dirname, 'src/boot/logs.entry.ts')
-
 module.exports = (_env, argv) => [
-  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-logs.js' }),
-  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-logs-us.js' }),
-  webpackBase({ mode: argv.mode, entry, datacenter: 'eu', filename: 'datadog-logs-eu.js' }),
+  webpackBase({
+    mode: argv.mode,
+    entry: path.resolve(__dirname, 'src/boot/logs.entry.ts'),
+    datacenter: 'us',
+    filename: 'datadog-logs.js',
+  }),
 ]

--- a/packages/logs/webpack.config.js
+++ b/packages/logs/webpack.config.js
@@ -2,11 +2,9 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-module.exports = (_env, argv) => [
+module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
     entry: path.resolve(__dirname, 'src/boot/logs.entry.ts'),
-    datacenter: 'us',
     filename: 'datadog-logs.js',
-  }),
-]
+  })

--- a/packages/rum-core/src/boot/buildEnv.ts
+++ b/packages/rum-core/src/boot/buildEnv.ts
@@ -1,7 +1,6 @@
-import { BuildEnv, BuildMode, Datacenter } from '@datadog/browser-core'
+import { BuildEnv, BuildMode } from '@datadog/browser-core'
 
 export const buildEnv: BuildEnv = {
   buildMode: '<<< BUILD_MODE >>>' as BuildMode,
-  datacenter: '<<< TARGET_DATACENTER >>>' as Datacenter,
   sdkVersion: '<<< SDK_VERSION >>>',
 }

--- a/packages/rum-slim/webpack.config.js
+++ b/packages/rum-slim/webpack.config.js
@@ -2,8 +2,9 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-const entry = path.resolve(__dirname, 'src/boot/rumSlim.entry.ts')
-
-module.exports = (_env, argv) => [
-  webpackBase({ mode: argv.mode, entry, datacenter: 'us', filename: 'datadog-rum-slim.js' }),
-]
+module.exports = (_env, argv) =>
+  webpackBase({
+    mode: argv.mode,
+    entry: path.resolve(__dirname, 'src/boot/rumSlim.entry.ts'),
+    filename: 'datadog-rum-slim.js',
+  })

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -2,11 +2,9 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-module.exports = (_env, argv) => [
+module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
     entry: path.resolve(__dirname, 'src/boot/rum.entry.ts'),
-    datacenter: 'us',
     filename: 'datadog-rum.js',
-  }),
-]
+  })

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -16,7 +16,6 @@ switch (process.env.BUILD_MODE) {
 }
 
 module.exports = {
-  TARGET_DATACENTER: process.env.TARGET_DATACENTER || 'us',
   BUILD_MODE: process.env.BUILD_MODE,
   SDK_VERSION: sdkVersion,
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,22 +25,10 @@ case "${env}" in
 esac
 
 case "${suffix}" in
-v[0-9]*) # if major version also update legacy files
-    declare -A BUNDLES=(
-      ["datadog-rum-${suffix}.js"]="packages/rum/bundle/datadog-rum.js"
-      ["datadog-rum-slim-${suffix}.js"]="packages/rum-slim/bundle/datadog-rum-slim.js"
-      ["datadog-logs-${suffix}.js"]="packages/logs/bundle/datadog-logs.js"
-      ["datadog-logs-eu.js"]="packages/logs/bundle/datadog-logs-eu.js"
-      ["datadog-logs-us.js"]="packages/logs/bundle/datadog-logs-us.js" 
-    )
+v[0-9]*)
     CACHE_CONTROL='max-age=14400, s-maxage=60'
   ;;
 "canary" | "head")
-    declare -A BUNDLES=(
-      ["datadog-logs-${suffix}.js"]="packages/logs/bundle/datadog-logs.js"
-      ["datadog-rum-${suffix}.js"]="packages/rum/bundle/datadog-rum.js"
-      ["datadog-rum-slim-${suffix}.js"]="packages/rum-slim/bundle/datadog-rum-slim.js"
-    )
     CACHE_CONTROL='max-age=900, s-maxage=60'
   ;;
 * )
@@ -48,6 +36,12 @@ v[0-9]*) # if major version also update legacy files
     exit 1
   ;;
 esac
+
+declare -A BUNDLES=(
+  ["datadog-rum-${suffix}.js"]="packages/rum/bundle/datadog-rum.js"
+  ["datadog-rum-slim-${suffix}.js"]="packages/rum-slim/bundle/datadog-rum-slim.js"
+  ["datadog-logs-${suffix}.js"]="packages/logs/bundle/datadog-logs.js"
+)
 
 main() {
   in-isolation upload-to-s3

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,7 +29,7 @@ v[0-9]*) # if major version also update legacy files
     declare -A BUNDLES=(
       ["datadog-rum-${suffix}.js"]="packages/rum/bundle/datadog-rum.js"
       ["datadog-rum-slim-${suffix}.js"]="packages/rum-slim/bundle/datadog-rum-slim.js"
-      ["datadog-logs.js"]="packages/logs/bundle/datadog-logs.js"
+      ["datadog-logs-${suffix}.js"]="packages/logs/bundle/datadog-logs.js"
       ["datadog-logs-eu.js"]="packages/logs/bundle/datadog-logs-eu.js"
       ["datadog-logs-us.js"]="packages/logs/bundle/datadog-logs-us.js" 
     )

--- a/scripts/replace-build-env.js
+++ b/scripts/replace-build-env.js
@@ -4,7 +4,7 @@ const buildEnv = require('./build-env')
 /**
  * Replace BuildEnv in build files
  * Usage:
- * TARGET_DATACENTER=xxx BUILD_MODE=zzz node replace-build-env.js /path/to/build/directory
+ * BUILD_MODE=zzz node replace-build-env.js /path/to/build/directory
  */
 
 const buildDirectory = process.argv[2]

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -7,7 +7,7 @@ const buildEnv = require('./scripts/build-env')
 const tsconfigPath = path.join(__dirname, 'tsconfig.webpack.json')
 const SUFFIX_REGEXP = /-(us|eu)/
 
-module.exports = ({ entry, mode, filename, datacenter, types }) => ({
+module.exports = ({ entry, mode, filename, types }) => ({
   entry,
   mode,
   output: {
@@ -23,7 +23,6 @@ module.exports = ({ entry, mode, filename, datacenter, types }) => ({
         loader: 'string-replace-loader',
         options: {
           multiple: [
-            { search: '<<< TARGET_DATACENTER >>>', replace: datacenter || 'us' },
             { search: '<<< SDK_VERSION >>>', replace: buildEnv.SDK_VERSION },
             { search: '<<< BUILD_MODE >>>', replace: buildEnv.BUILD_MODE },
           ],

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -1,11 +1,9 @@
 const path = require('path')
-const { BannerPlugin } = require('webpack')
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 const buildEnv = require('./scripts/build-env')
 
 const tsconfigPath = path.join(__dirname, 'tsconfig.webpack.json')
-const SUFFIX_REGEXP = /-(us|eu)/
 
 module.exports = ({ entry, mode, filename, types }) => ({
   entry,
@@ -66,17 +64,4 @@ module.exports = ({ entry, mode, filename, types }) => ({
       }),
     ],
   },
-
-  plugins: [
-    new BannerPlugin({
-      banner({ filename }) {
-        const env = SUFFIX_REGEXP.exec(filename)[1]
-        const newFileName = filename.replace(SUFFIX_REGEXP, '')
-        return `\n${filename} IS DEPRECATED, USE ${newFileName} WITH { site: 'datadoghq.${
-          env === 'eu' ? 'eu' : 'com'
-        }' } INIT CONFIGURATION INSTEAD\n`
-      },
-      include: SUFFIX_REGEXP,
-    }),
-  ],
 })


### PR DESCRIPTION
## Motivation

Prepare for the Logs V3 release

## Changes


* Following the RUM pattern, suffix the Logs bundle with the major version
* Remove deprecated upload of eu and us bundles and do some related cleanup

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
