### PR TITLE
💥 [RUMF-981] remove deprecated logs options

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -2,7 +2,7 @@ import { BuildEnv } from '../boot/init'
 import { CookieOptions, getCurrentSite } from '../browser/cookie'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { includes, ONE_KILO_BYTE, ONE_SECOND } from '../tools/utils'
-import { computeTransportConfiguration, Datacenter } from './transportConfiguration'
+import { computeTransportConfiguration } from './transportConfiguration'
 
 export const DEFAULT_CONFIGURATION = {
   allowedTracingOrigins: [] as Array<string | RegExp>,
@@ -46,7 +46,6 @@ export interface InitConfiguration {
   allowedTracingOrigins?: Array<string | RegExp>
   sampleRate?: number
   replaySampleRate?: number
-  datacenter?: Datacenter // deprecated
   site?: string
   enableExperimentalFeatures?: string[]
   silentMultipleInit?: boolean

--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -39,7 +39,6 @@ export const DEFAULT_CONFIGURATION = {
 }
 
 export interface InitConfiguration {
-  publicApiKey?: string // deprecated
   clientToken: string
   applicationId?: string
   actionNameAttribute?: string

--- a/packages/core/src/domain/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/transportConfiguration.spec.ts
@@ -1,4 +1,4 @@
-import { BuildEnv, BuildMode, Datacenter } from '@datadog/browser-core'
+import { BuildEnv, BuildMode } from '@datadog/browser-core'
 import { computeTransportConfiguration } from './transportConfiguration'
 
 describe('transportConfiguration', () => {
@@ -22,7 +22,6 @@ describe('transportConfiguration', () => {
     it('should be available for e2e-test build mode', () => {
       const e2eEnv = {
         buildMode: BuildMode.E2E_TEST,
-        datacenter: Datacenter.US,
         sdkVersion: 'some_version',
       }
       const configuration = computeTransportConfiguration({ clientToken }, e2eEnv)
@@ -34,21 +33,13 @@ describe('transportConfiguration', () => {
   })
 
   describe('site', () => {
-    it('should use buildEnv value by default', () => {
+    it('should use US site by default', () => {
       const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.rumEndpoint).toContain('datadoghq.com')
     })
 
-    it('should use datacenter value when set', () => {
-      const configuration = computeTransportConfiguration({ clientToken, datacenter: Datacenter.EU }, buildEnv)
-      expect(configuration.rumEndpoint).toContain('datadoghq.eu')
-    })
-
     it('should use site value when set', () => {
-      const configuration = computeTransportConfiguration(
-        { clientToken, datacenter: Datacenter.EU, site: 'foo.com' },
-        buildEnv
-      )
+      const configuration = computeTransportConfiguration({ clientToken, site: 'foo.com' }, buildEnv)
       expect(configuration.rumEndpoint).toContain('foo.com')
     })
   })

--- a/packages/core/src/domain/transportConfiguration.ts
+++ b/packages/core/src/domain/transportConfiguration.ts
@@ -18,19 +18,10 @@ const ENDPOINTS = {
   },
 }
 
-export const Datacenter = {
-  EU: 'eu',
-  US: 'us',
-} as const
+const INTAKE_SITE_US = 'datadoghq.com'
+const INTAKE_SITE_EU = 'datadoghq.eu'
 
-export type Datacenter = typeof Datacenter[keyof typeof Datacenter]
-
-export const INTAKE_SITE = {
-  [Datacenter.EU]: 'datadoghq.eu',
-  [Datacenter.US]: 'datadoghq.com',
-}
-
-const CLASSIC_ALLOWED_SITES = [INTAKE_SITE[Datacenter.US], INTAKE_SITE[Datacenter.EU]]
+const CLASSIC_ALLOWED_SITES = [INTAKE_SITE_US, INTAKE_SITE_EU]
 
 type IntakeType = keyof typeof ENDPOINTS
 type EndpointType = keyof typeof ENDPOINTS[IntakeType]
@@ -58,7 +49,7 @@ export function computeTransportConfiguration(
     proxyHost: initConfiguration.proxyHost,
     sdkVersion: buildEnv.sdkVersion,
     service: initConfiguration.service,
-    site: initConfiguration.site || INTAKE_SITE[initConfiguration.datacenter || Datacenter.US],
+    site: initConfiguration.site || INTAKE_SITE_US,
     version: initConfiguration.version,
   }
 
@@ -95,7 +86,7 @@ export function computeTransportConfiguration(
         ...transportSettings,
         applicationId: initConfiguration.replica.applicationId,
         clientToken: initConfiguration.replica.clientToken,
-        site: INTAKE_SITE[Datacenter.US],
+        site: INTAKE_SITE_US,
       }
       configuration.replica = {
         applicationId: initConfiguration.replica.applicationId,
@@ -124,7 +115,7 @@ function getIntakeUrls(intakeType: IntakeType, settings: TransportSettings, with
   }
   const sites = [settings.site]
   if (settings.buildMode === BuildMode.STAGING && withReplica) {
-    sites.push(INTAKE_SITE[Datacenter.US])
+    sites.push(INTAKE_SITE_US)
   }
   const urls = []
   const endpointTypes = Object.keys(ENDPOINTS[intakeType]) as EndpointType[]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,5 +57,3 @@ export { BoundedBuffer } from './tools/boundedBuffer'
 export { catchUserErrors } from './tools/catchUserErrors'
 export { createContextManager } from './tools/contextManager'
 export { limitModification } from './tools/limitModification'
-
-export { Datacenter } from './domain/transportConfiguration'

--- a/packages/logs/src/boot/logs.entry.spec.ts
+++ b/packages/logs/src/boot/logs.entry.spec.ts
@@ -55,13 +55,6 @@ describe('logs entry', () => {
       expect(displaySpy).toHaveBeenCalledTimes(2)
     })
 
-    it('should warn if now deprecated publicApiKey is used', () => {
-      spyOn(display, 'warn')
-
-      LOGS.init({ publicApiKey: 'yo' } as any)
-      expect(display.warn).toHaveBeenCalledTimes(1)
-    })
-
     it('should add a `_setDebug` that works', () => {
       const setDebug: (debug: boolean) => void = (LOGS as any)._setDebug
       expect(!!setDebug).toEqual(true)

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -53,11 +53,6 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
         return
       }
 
-      if (initConfiguration.publicApiKey) {
-        initConfiguration.clientToken = initConfiguration.publicApiKey
-        display.warn('Public API Key is deprecated. Please use Client Token instead.')
-      }
-
       sendLogStrategy = startLogsImpl(initConfiguration, logger, globalContextManager.get)
       getInitConfigurationStrategy = () => deepClone(initConfiguration)
       beforeInitSendLog.drain()
@@ -92,7 +87,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       }
       return false
     }
-    if (!initConfiguration || (!initConfiguration.publicApiKey && !initConfiguration.clientToken)) {
+    if (!initConfiguration || !initConfiguration.clientToken) {
       display.error('Client Token is not configured, we will not send any data.')
       return false
     }

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -108,7 +108,7 @@ describe('rum public api', () => {
     })
 
     it('should ignore old configuration options', () => {
-      const oldConfigurationOptions = { publicApiKey: '', datacenter: 'us' }
+      const oldConfigurationOptions = { datacenter: 'us' }
       const initConfiguration = { ...DEFAULT_INIT_CONFIGURATION, ...oldConfigurationOptions }
       rumPublicApi.init(initConfiguration)
       expect(initConfiguration).not.toEqual(jasmine.objectContaining(oldConfigurationOptions))

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -106,13 +106,6 @@ describe('rum public api', () => {
       rumPublicApi.init({ clientToken: 'yes', applicationId: 'yes', sampleRate: 1 })
       expect(displaySpy).toHaveBeenCalledTimes(0)
     })
-
-    it('should ignore old configuration options', () => {
-      const oldConfigurationOptions = { datacenter: 'us' }
-      const initConfiguration = { ...DEFAULT_INIT_CONFIGURATION, ...oldConfigurationOptions }
-      rumPublicApi.init(initConfiguration)
-      expect(initConfiguration).not.toEqual(jasmine.objectContaining(oldConfigurationOptions))
-    })
   })
 
   describe('getInternalContext', () => {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -18,7 +18,6 @@ import {
   InternalMonitoring,
   callMonitored,
   createHandlingStack,
-  Omit,
 } from '@datadog/browser-core'
 import { LifeCycle } from '../domain/lifeCycle'
 import { ParentContexts } from '../domain/parentContexts'
@@ -29,10 +28,7 @@ import { RumEvent } from '../rumEvent.types'
 import { buildEnv } from './buildEnv'
 import { startRum } from './startRum'
 
-const droppedConfigurationOptions = ['datacenter' as const]
-type DroppedConfigurationOptions = typeof droppedConfigurationOptions[number]
-
-export interface RumInitConfiguration extends Omit<InitConfiguration, DroppedConfigurationOptions> {
+export interface RumInitConfiguration extends InitConfiguration {
   applicationId: string
   beforeSend?: (event: RumEvent, context: RumEventDomainContext) => void | boolean
 }
@@ -100,8 +96,6 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
     ) {
       return
     }
-
-    droppedConfigurationOptions.forEach((option) => delete (initConfiguration as InitConfiguration)[option])
 
     const { configuration, internalMonitoring } = commonInit(initConfiguration, buildEnv)
     if (!configuration.trackViewsManually) {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -29,7 +29,7 @@ import { RumEvent } from '../rumEvent.types'
 import { buildEnv } from './buildEnv'
 import { startRum } from './startRum'
 
-const droppedConfigurationOptions = ['publicApiKey' as const, 'datacenter' as const]
+const droppedConfigurationOptions = ['datacenter' as const]
 type DroppedConfigurationOptions = typeof droppedConfigurationOptions[number]
 
 export interface RumInitConfiguration extends Omit<InitConfiguration, DroppedConfigurationOptions> {


### PR DESCRIPTION
## Motivation

Prepare logs V3: remove deprecated options support

## Changes

* Remove `publicApiKey` and `datacenter` options
* Remove RUM support for omited options

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
