### PR TITLE
💥 [RUMF-982] remove deprecated LogsUserConfiguration type

### DIFF
--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -26,12 +26,6 @@ export interface LogsInitConfiguration extends InitConfiguration {
   beforeSend?: (event: LogsEvent) => void | boolean
 }
 
-/**
- * TODO: remove this type in the next major release
- * @deprecated Use LogsInitConfiguration instead
- */
-export type LogsUserConfiguration = LogsInitConfiguration
-
 export function startLogs(
   initConfiguration: LogsInitConfiguration,
   errorLogger: Logger,

--- a/packages/logs/src/index.ts
+++ b/packages/logs/src/index.ts
@@ -1,4 +1,4 @@
 export { Logger, LogsMessage, StatusType, HandlerType } from './domain/logger'
 export { LoggerConfiguration, LogsPublicApi as LogsGlobal, datadogLogs } from './boot/logs.entry'
-export { LogsInitConfiguration, LogsUserConfiguration } from './boot/startLogs'
+export { LogsInitConfiguration } from './boot/startLogs'
 export { LogsEvent } from './logsEvent.types'

--- a/test/app/app.ts
+++ b/test/app/app.ts
@@ -1,9 +1,9 @@
-import { datadogLogs, LogsUserConfiguration } from '@datadog/browser-logs'
+import { datadogLogs, LogsInitConfiguration } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 
 declare global {
   interface Window {
-    LOGS_CONFIG?: LogsUserConfiguration
+    LOGS_CONFIG?: LogsInitConfiguration
     RUM_INIT?: () => void
   }
 }


### PR DESCRIPTION
## Motivation

Prepare Logs V3: remove deprecated type

## Changes

* remove deprecated LogsUserConfiguration type

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
