### PR TITLE
✨ [RUMF-974] use user-agent to detect synthetics sessions

### DIFF
--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -270,3 +270,16 @@ export function setPageVisibility(visibility: 'visible' | 'hidden') {
 export function restorePageVisibility() {
   delete (document as any).visibilityState
 }
+
+export function setUserAgent(ua: string) {
+  Object.defineProperty(navigator, 'userAgent', {
+    get() {
+      return ua
+    },
+    configurable: true,
+  })
+}
+
+export function restoreUserAgent() {
+  delete (navigator as any).userAgent
+}

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,4 +1,5 @@
 import { ErrorSource, ONE_MINUTE, RawError, RelativeTime, display } from '@datadog/browser-core'
+import { setUserAgent, restoreUserAgent } from '@datadog/browser-core/test/specHelper'
 import { createRumSessionMock } from 'packages/rum-core/test/mockRumSession'
 import { createRawRumEvent } from '../../test/fixtures'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
@@ -500,6 +501,18 @@ describe('rum assembly', () => {
       expect(serverRumEvents[0]._dd.session).toEqual({
         plan: RumSessionPlan.REPLAY,
       })
+    })
+
+    it('should detect synthetics sessions', () => {
+      setUserAgent('foo DatadogSynthetics bar')
+
+      const { lifeCycle } = setupBuilder.build()
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+      })
+
+      expect(serverRumEvents[0].session.type).toEqual('synthetics')
+      restoreUserAgent()
     })
 
     it('should set the session.has_replay attribute if it is defined in the common context', () => {


### PR DESCRIPTION
## Motivation

Synthetics browser tests now add a specific value in the user agent to ease the identification, cf [doc](https://docs.datadoghq.com/synthetics/guide/identify_synthetics_bots/?tab=browsertests)

## Changes

- Check user agent instead of global variable
- Check only once

## Testing

unit test
Need to check on staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
