### PR TITLE
👷 dev server: redirect suffixed files

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -7,12 +7,22 @@ const logsConfig = require('../packages/logs/webpack.config')
 const rumSlimConfig = require('../packages/rum-slim/webpack.config')
 const rumConfig = require('../packages/rum/webpack.config')
 
+const port = 8080
 const app = express()
 
 app.use(express.static(path.join(__dirname, '../sandbox')))
 for (const config of [rumConfig, logsConfig, rumSlimConfig]) {
   app.use(middleware(webpack(config(null, { mode: 'development' }))))
 }
+app.use(redirectSuffixedFiles)
 
-const port = 8080
 app.listen(port, () => console.log(`server listening on port ${port}.`))
+
+function redirectSuffixedFiles(req, res, next) {
+  const matches = /(.*)-(canary|head)\.js/.exec(req.url)
+  if (matches) {
+    res.redirect(`${matches[1]}.js`)
+  } else {
+    next()
+  }
+}


### PR DESCRIPTION
## Motivation

allow to redirect canary or head files to files served by the dev server

## Changes

add some redirections in the dev server

## Testing

locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
