### PR TITLE
📝🗑 deprecate the XHR context, to be removed in V4

### DIFF
--- a/packages/core/src/browser/xhrProxy.ts
+++ b/packages/core/src/browser/xhrProxy.ts
@@ -3,6 +3,14 @@ import { Duration, elapsed, relativeNow, RelativeTime, ClocksState, clocksNow, t
 import { normalizeUrl } from '../tools/urlPolyfill'
 
 interface BrowserXHR<T extends XhrOpenContext> extends XMLHttpRequest {
+  /**
+   * @deprecated this property is shared by both logs and rum and can be used by different code
+   * versions depending on customer setup. To improve reliability and make SDKs independent, this
+   * property should be removed in the future, but this would be a breaking change since some
+   * customers are using it.
+   *
+   * TODO(v4): replace this property with a weakmap index
+   */
   _datadog_xhr?: T
 }
 


### PR DESCRIPTION
## Motivation

`xhr._datadog_xhr` is problematic because it is shared between SDKs

## Changes

Deprecate `xhr._datadog_xhr`. No replacement for now, but we might want to remove it in a future major version.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
