### PR TITLE
Revert "👷 npm log private (#959)"

### DIFF
--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -2,7 +2,6 @@
   "name": "@datadog/browser-logs",
   "version": "3.0.2",
   "license": "Apache-2.0",
-  "private": true,
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",


### PR DESCRIPTION


## Motivation

Logs V3 is almost ready, let's make it public again so it will be published on NPM

## Changes

This reverts commit 323db551d4a56c5cabcf2734cc87aa0ffe0ff0e3.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
