### PR TITLE
🔊 [RUMF-971] add some context on suspicious LCP and FCP monitoring

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -63,6 +63,7 @@ export interface RumPerformanceNavigationTiming {
 export interface RumLargestContentfulPaintTiming {
   entryType: 'largest-contentful-paint'
   startTime: RelativeTime
+  size: number
 }
 
 export interface RumFirstInputTiming {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
@@ -35,6 +35,7 @@ const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
 const FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY: RumLargestContentfulPaintTiming = {
   entryType: 'largest-contentful-paint',
   startTime: 789 as RelativeTime,
+  size: 10,
 }
 
 const FAKE_FIRST_INPUT_ENTRY: RumFirstInputTiming = {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
@@ -73,6 +73,7 @@ export function trackNavigationTimings(lifeCycle: LifeCycle, callback: (newTimin
 }
 
 export function trackFirstContentfulPaint(lifeCycle: LifeCycle, callback: (fcp: RelativeTime) => void) {
+  let fcpCount = 0
   const firstHidden = trackFirstHidden()
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
     if (
@@ -80,12 +81,14 @@ export function trackFirstContentfulPaint(lifeCycle: LifeCycle, callback: (fcp: 
       entry.name === 'first-contentful-paint' &&
       entry.startTime < firstHidden.timeStamp
     ) {
+      fcpCount += 1
       if (entry.startTime > ONE_DAY) {
         addMonitoringMessage('FCP > 1 day', {
           debug: {
             fcp: Math.round(entry.startTime),
             relativeNow: Math.round(relativeNow()),
             timeStampNow: timeStampNow(),
+            fcpCount,
           },
         })
       }
@@ -121,6 +124,8 @@ export function trackLargestContentfulPaint(
     { capture: true, once: true }
   )
 
+  const lcpSizes: number[] = []
+
   const { unsubscribe: unsubscribeLifeCycle } = lifeCycle.subscribe(
     LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED,
     (entry) => {
@@ -129,12 +134,14 @@ export function trackLargestContentfulPaint(
         entry.startTime < firstInteractionTimestamp &&
         entry.startTime < firstHidden.timeStamp
       ) {
+        lcpSizes.push(entry.size)
         if (entry.startTime > ONE_DAY) {
           addMonitoringMessage('LCP > 1 day', {
             debug: {
               lcp: Math.round(entry.startTime),
               relativeNow: Math.round(relativeNow()),
               timeStampNow: timeStampNow(),
+              lcpSizes,
             },
           })
         }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -17,6 +17,7 @@ const FAKE_PAINT_ENTRY: RumPerformancePaintTiming = {
 const FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY: RumLargestContentfulPaintTiming = {
   entryType: 'largest-contentful-paint',
   startTime: 789 as RelativeTime,
+  size: 10,
 }
 const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
   domComplete: 456 as RelativeTime,


### PR DESCRIPTION
## Motivation

Investigate suspicious LCP and FCP timings

## Changes

* Add a count of FCP to see if multiple FCP are sent on the same page
* Add a list of sizes for LCP to see if LCP are correctly sent with an ever-increasing size

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
