### PR TITLE
Configurable sessionUUID generator

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -80,6 +80,7 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
 
     service?: string
     beforeSend?: BeforeSendCallback
+    generateSessionUuid?: () => string,
 
     actionNameAttribute?: string
 

--- a/packages/logs/src/domain/loggerSession.ts
+++ b/packages/logs/src/domain/loggerSession.ts
@@ -38,7 +38,12 @@ function computeTrackingType(configuration: Configuration) {
 
 function computeSessionState(configuration: Configuration, rawSessionType?: string) {
   const trackingType = hasValidLoggerSession(rawSessionType) ? rawSessionType : computeTrackingType(configuration)
+
+  const id = (configuration.generateSessionUuid) ?
+    configuration.generateSessionUuid() : undefined
+
   return {
+    id,
     trackingType,
     isTracked: trackingType === LoggerTrackingType.TRACKED,
   }

--- a/packages/rum-core/src/domain/rumSession.spec.ts
+++ b/packages/rum-core/src/domain/rumSession.spec.ts
@@ -114,7 +114,7 @@ describe('rum session', () => {
   })
 
   describe('getId', () => {
-    it('should return the session id', () => {
+    it('should return the generated session id', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=1', DURATION)
       const rumSession = startRumSession(configuration as Configuration, lifeCycle)
       expect(rumSession.getId()).toBe('abcdef')
@@ -125,6 +125,18 @@ describe('rum session', () => {
       setCookie(SESSION_COOKIE_NAME, '', DURATION)
       clock.tick(COOKIE_ACCESS_DELAY)
       expect(rumSession.getId()).toBe(undefined)
+    })
+
+    it('should return the custom session id', () => {
+      // Must respect UUID format
+      const customSessionUuid = 'c610b260-edf5-48a4-b919-2ebc76f49393'
+
+      const rumSession = startRumSession({
+        ...configuration,
+        generateSessionUuid: () => customSessionUuid,
+      } as Configuration, lifeCycle)
+
+      expect(rumSession.getId()).toBe(customSessionUuid)
     })
   })
 

--- a/packages/rum-core/src/domain/rumSession.ts
+++ b/packages/rum-core/src/domain/rumSession.ts
@@ -56,7 +56,12 @@ function computeSessionState(configuration: Configuration, rawTrackingType?: str
   } else {
     trackingType = RumTrackingType.TRACKED_REPLAY
   }
+
+  const id = (configuration.generateSessionUuid) ?
+    configuration.generateSessionUuid() : undefined
+
   return {
+    id,
     trackingType,
     isTracked: isTypeTracked(trackingType),
   }


### PR DESCRIPTION
## Motivation

Allow to generate a custom session ID, so it can be consistent with logs/traces from other services (to correlate).

## Changes

- Add an optional new setting `generateSessionUuid: () => string` in `Configuration
- If the setting is specified, use it when starting session to generate the ID.

## Testing

Unit test for `rumSession` updated

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
