### PR TITLE
👷 update tar to fix vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8741,7 +8741,7 @@ tar@^4.4.12:
     yallist "^3.0.3"
 
 tar@^6.0.2, tar@^6.1.0:
-  version "6.1.0"
+  version "6.1.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
   integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
   dependencies:


### PR DESCRIPTION


## Motivation

https://github.com/advisories/GHSA-r628-mhmh-qjhw

## Changes

The [dependabot PR](https://github.com/DataDog/browser-sdk/pull/975 ) updated tar 4.x. This PR updates tar 6.x

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
