### PR TITLE
Get focus/blur event on capture instead of bubble

### DIFF
--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -89,11 +89,11 @@ function closeForegroundPeriod() {
 }
 
 function trackFocus(onFocusChange: () => void) {
-  return addEventListener(window, DOM_EVENT.FOCUS, () => onFocusChange())
+  return addEventListener(window, DOM_EVENT.FOCUS, () => onFocusChange(), { capture: true })
 }
 
 function trackBlur(onBlurChange: () => void) {
-  return addEventListener(window, DOM_EVENT.BLUR, () => onBlurChange())
+  return addEventListener(window, DOM_EVENT.BLUR, () => onBlurChange(), { capture: true })
 }
 
 function getInForeground(startTime: RelativeTime): boolean {

--- a/packages/rum/src/domain/record/observer.ts
+++ b/packages/rum/src/domain/record/observer.ts
@@ -301,7 +301,12 @@ function initMediaInteractionObserver(mediaInteractionCb: MediaInteractionCallba
 }
 
 function initFocusObserver(focusCb: FocusCallback): ListenerHandler {
-  return addEventListeners(window, [DOM_EVENT.FOCUS, DOM_EVENT.BLUR], () => {
-    focusCb({ has_focus: document.hasFocus() })
-  }).stop
+  return addEventListeners(
+    window,
+    [DOM_EVENT.FOCUS, DOM_EVENT.BLUR],
+    () => {
+      focusCb({ has_focus: document.hasFocus() })
+    },
+    { capture: true }
+  ).stop
 }


### PR DESCRIPTION
## Motivation

Avoid getting the focus or blur event propagation getting [stopped](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).

## Changes

- get blur/focus event on capture instead on bubble up phase

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
