### PR TITLE
Limit log monitoring + add more details

### DIFF
--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -71,6 +71,7 @@ function addNewForegroundPeriod() {
           count: foregroundPeriods.length,
           currentStart: currentForegroundPeriod.start,
           now,
+          diff: now - currentForegroundPeriod.start,
         },
       })
     }
@@ -96,6 +97,7 @@ function closeForegroundPeriod() {
           currentStart: currentForegroundPeriod.start,
           currentEnd: currentForegroundPeriod.end,
           now,
+          diff: now - currentForegroundPeriod.end,
         },
         now: relativeNow(),
       })


### PR DESCRIPTION
## Motivation

Too much logging in the foregroundContext manager

## Changes

- do not log error if two events are coming real close: https://bugs.chromium.org/p/chromium/issues/detail?id=1237904
- add now to extimate the user impact better
