### PR TITLE
Increase number of maximum periods

### DIFF
--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -13,7 +13,7 @@ import {
 import { InForegroundPeriod } from '../rawRumEvent.types'
 
 // Arbitrary value to cap number of element (mostly for backend)
-export const MAX_NUMBER_OF_FOCUSED_TIME = 500
+export const MAX_NUMBER_OF_FOCUSED_TIME = 1000
 
 export interface ForegroundContexts {
   getInForeground: (startTime: RelativeTime) => boolean | undefined


### PR DESCRIPTION
## Motivation

Avoid this [error](https://app.datadoghq.com/logs?query=source%3Abrowser-agent-internal-monitoring%20%20maximum%20of%20foreground&agg_m=count&agg_q=&agg_t=count&cols=%40view.url_details.host%2Csdk_version%2C%40http.useragent_details.browser.family&index=browser-agent-internal-monitoring&integration_id=&integration_short_name=&messageDisplay=inline&saved_view=64420&sort_m=&sort_t=&stream_sort=desc&top_n=&top_o=&viz=pattern&from_ts=1627738775248&to_ts=1627911575248&live=true):

> Reached maximum of foreground time


![image](https://user-images.githubusercontent.com/44997281/128738340-98273a6b-8a97-43d3-bc8e-433a89edf2ee.png)

It's a very naive solution. Once we tried it, if we still have issues, we can try to look into more complex solution like rotating the focus periods.

## Changes

- increase limit from 500 to 1000

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
