### PR TITLE
🗑️ Remove deprecated trace endpoint

### DIFF
--- a/packages/core/src/domain/configuration.ts
+++ b/packages/core/src/domain/configuration.ts
@@ -89,7 +89,6 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
 export interface TransportConfiguration {
   logsEndpoint: string
   rumEndpoint: string
-  traceEndpoint: string
   sessionReplayEndpoint: string
   internalMonitoringEndpoint?: string
   isIntakeUrl: (url: string) => boolean

--- a/packages/core/src/domain/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/transportConfiguration.spec.ts
@@ -99,7 +99,6 @@ describe('transportConfiguration', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.eu' }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://public-trace-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://session-replay.browser-intake-datadoghq.eu/v1/input/xxx')).toBe(true)
     })
 
@@ -108,7 +107,6 @@ describe('transportConfiguration', () => {
 
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.com/v1/input/xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://public-trace-http-intake.logs.datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://session-replay.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
     })
 
@@ -116,7 +114,6 @@ describe('transportConfiguration', () => {
       const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://trace.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://session-replay.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
     })
 
@@ -124,7 +121,6 @@ describe('transportConfiguration', () => {
       const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://trace.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://session-replay.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)
     })
 
@@ -148,7 +144,6 @@ describe('transportConfiguration', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'foo.datadoghq.com' }, buildEnv)
       expect(configuration.isIntakeUrl('https://rum.browser-intake-foo-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-foo-datadoghq.com/v1/input/xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://trace.browser-intake-foo-datadoghq.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://session-replay.browser-intake-foo-datadoghq.com/v1/input/xxx')).toBe(
         true
       )
@@ -178,7 +173,6 @@ describe('transportConfiguration', () => {
       )
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://public-trace-http-intake.logs.datadoghq.eu/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://session-replay.browser-intake-datadoghq.eu/v1/input/xxx')).toBe(true)
 
       expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.com/v1/input/xxx')).toBe(true)
@@ -192,7 +186,6 @@ describe('transportConfiguration', () => {
       )
       expect(configuration.isIntakeUrl('https://rum.browser-intake-foo.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://logs.browser-intake-foo.com/v1/input/xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://trace.browser-intake-foo.com/v1/input/xxx')).toBe(true)
       expect(configuration.isIntakeUrl('https://session-replay.browser-intake-foo.com/v1/input/xxx')).toBe(true)
 
       expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/v1/input/xxx')).toBe(true)

--- a/packages/core/src/domain/transportConfiguration.ts
+++ b/packages/core/src/domain/transportConfiguration.ts
@@ -7,14 +7,12 @@ const ENDPOINTS = {
     logs: 'logs',
     rum: 'rum',
     sessionReplay: 'session-replay',
-    trace: 'trace',
   },
   classic: {
     logs: 'browser',
     rum: 'rum',
     // session-replay has no classic endpoint
     sessionReplay: undefined,
-    trace: 'public-trace',
   },
 }
 
@@ -61,7 +59,6 @@ export function computeTransportConfiguration(
     logsEndpoint: getEndpoint(intakeType, 'logs', transportSettings),
     rumEndpoint: getEndpoint(intakeType, 'rum', transportSettings),
     sessionReplayEndpoint: getEndpoint(intakeType, 'sessionReplay', transportSettings),
-    traceEndpoint: getEndpoint(intakeType, 'trace', transportSettings),
   }
 
   if (initConfiguration.internalMonitoringApiKey) {

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -6,14 +6,12 @@ export const SPEC_ENDPOINTS: Partial<Configuration> = {
   internalMonitoringEndpoint: 'https://monitoring-intake.com/v1/input/abcde?foo=bar',
   logsEndpoint: 'https://logs-intake.com/v1/input/abcde?foo=bar',
   rumEndpoint: 'https://rum-intake.com/v1/input/abcde?foo=bar',
-  traceEndpoint: 'https://trace-intake.com/v1/input/abcde?foo=bar',
 
   isIntakeUrl: (url: string) => {
     const intakeUrls = [
       'https://monitoring-intake.com/v1/input/',
       'https://logs-intake.com/v1/input/',
       'https://rum-intake.com/v1/input/',
-      'https://trace-intake.com/v1/input/',
     ]
     return intakeUrls.some((intakeUrl) => url.indexOf(intakeUrl) === 0)
   },


### PR DESCRIPTION
## Motivation

Trace intake requests are emitted by deprecated beta of dd-trace-js.
We no longer need to exclude trace intake requests from RUM resource events.

## Changes

Remove trace endpoint

## Testing

Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
