### PR TITLE
[ci-app] [Proposal] Allow Other `window`

### DIFF
--- a/packages/core/src/browser/fetchProxy.ts
+++ b/packages/core/src/browser/fetchProxy.ts
@@ -43,9 +43,9 @@ const onRequestCompleteCallbacks: Array<(fetch: FetchCompleteContext) => void> =
 export function startFetchProxy<
   StartContext extends FetchStartContext = FetchStartContext,
   CompleteContext extends FetchCompleteContext = FetchCompleteContext
->(): FetchProxy<StartContext, CompleteContext> {
+>(myWindow?: Window): FetchProxy<StartContext, CompleteContext> {
   if (!fetchProxySingleton) {
-    proxyFetch()
+    proxyFetch(myWindow)
     fetchProxySingleton = {
       beforeSend(callback: (context: FetchStartContext) => void) {
         beforeSendCallbacks.push(callback)
@@ -67,14 +67,15 @@ export function resetFetchProxy() {
   }
 }
 
-function proxyFetch() {
-  if (!window.fetch) {
+function proxyFetch(myWindow?: Window) {
+  const finalWindow = myWindow || window
+  if (!finalWindow.fetch) {
     return
   }
 
-  originalFetch = window.fetch
+  originalFetch = finalWindow.fetch
 
-  window.fetch = function (this: WindowOrWorkerGlobalScope['fetch'], input: RequestInfo, init?: RequestInit) {
+  finalWindow.fetch = function (this: WindowOrWorkerGlobalScope['fetch'], input: RequestInfo, init?: RequestInit) {
     let responsePromise: Promise<Response>
 
     const context = callMonitored(beforeSend, null, [input, init])


### PR DESCRIPTION
## Motivation

In the context of CI visibility's effort to instrument `cypress`, we need a way to provide instrumentation for methods in a `window` other than the one in the global context. 

This is because `cypress` runs the app under test within an iframe, so the `window` we want to instrument is only available programmatically. 

https://docs.cypress.io/api/commands/window#Cypress-uses-2-different-windows

**Note**: this is just a dirty prototype to start the discussion.
**Note 2**: the same would have to be done for XHR. 

## Changes

* Allow `window` input to `startFetchProxy`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
