### PR TITLE
✨[RUMF-970] enable buffered PerformanceObserver

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -119,26 +119,21 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: 
     const mainEntries = ['resource', 'navigation', 'longtask', 'paint']
     const experimentalEntries = ['largest-contentful-paint', 'first-input', 'layout-shift']
 
-    if (!configuration.isEnabled('buffered-perf')) {
-      const observer = new PerformanceObserver(handlePerformanceEntryList)
-      observer.observe({ entryTypes: mainEntries.concat(experimentalEntries) })
-    } else {
-      try {
-        // Experimental entries are not retrieved by performance.getEntries()
-        // use a single PerformanceObserver with buffered flag by type
-        // to get values that could happen before SDK init
-        experimentalEntries.forEach((type) => {
-          const observer = new PerformanceObserver(handlePerformanceEntryList)
-          observer.observe({ type, buffered: true })
-        })
-      } catch (e) {
-        // Some old browser versions don't support PerformanceObserver without entryTypes option
-        mainEntries.push(...experimentalEntries)
-      }
-
-      const mainObserver = new PerformanceObserver(handlePerformanceEntryList)
-      mainObserver.observe({ entryTypes: mainEntries })
+    try {
+      // Experimental entries are not retrieved by performance.getEntries()
+      // use a single PerformanceObserver with buffered flag by type
+      // to get values that could happen before SDK init
+      experimentalEntries.forEach((type) => {
+        const observer = new PerformanceObserver(handlePerformanceEntryList)
+        observer.observe({ type, buffered: true })
+      })
+    } catch (e) {
+      // Some old browser versions don't support PerformanceObserver without entryTypes option
+      mainEntries.push(...experimentalEntries)
     }
+
+    const mainObserver = new PerformanceObserver(handlePerformanceEntryList)
+    mainObserver.observe({ entryTypes: mainEntries })
 
     if (supportPerformanceObject() && 'addEventListener' in performance) {
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1559377


### PR DESCRIPTION
## Motivation

Retrieve `largest-contentful-paint`, `first-input` and `layout-shift` values that could have been emitted before SDK init.

## Changes

Remove 'buffered-perf' flag

related PRs:
- #972  
- #978 

## Testing

Manual + DD app

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
