### PR TITLE
🐛[RUMF-990] restore global check to detect synthetics sessions

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -6,7 +6,7 @@ import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { RumEventDomainContext } from '../domainContext.types'
 import { CommonContext, RawRumErrorEvent, RawRumEvent, RumEventType } from '../rawRumEvent.types'
 import { RumActionEvent, RumErrorEvent, RumEvent } from '../rumEvent.types'
-import { startRumAssembly } from './assembly'
+import { BrowserWindow, startRumAssembly } from './assembly'
 import { LifeCycle, LifeCycleEventType, RawRumEventCollectedData } from './lifeCycle'
 import { RumSessionPlan } from './rumSession'
 
@@ -503,7 +503,7 @@ describe('rum assembly', () => {
       })
     })
 
-    it('should detect synthetics sessions', () => {
+    it('should detect synthetics sessions from UA', () => {
       setUserAgent('foo DatadogSynthetics bar')
 
       const { lifeCycle } = setupBuilder.build()
@@ -513,6 +513,19 @@ describe('rum assembly', () => {
 
       expect(serverRumEvents[0].session.type).toEqual('synthetics')
       restoreUserAgent()
+    })
+
+    it('should detect synthetics sessions from global', () => {
+      ;(window as BrowserWindow)._DATADOG_SYNTHETICS_BROWSER = true
+
+      const { lifeCycle } = setupBuilder.build()
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+      })
+
+      expect(serverRumEvents[0].session.type).toEqual('synthetics')
+
+      delete (window as BrowserWindow)._DATADOG_SYNTHETICS_BROWSER
     })
 
     it('should set the session.has_replay attribute if it is defined in the common context', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -29,6 +29,10 @@ import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import { ParentContexts } from './parentContexts'
 import { RumSession, RumSessionPlan } from './rumSession'
 
+export interface BrowserWindow extends Window {
+  _DATADOG_SYNTHETICS_BROWSER?: unknown
+}
+
 enum SessionType {
   SYNTHETICS = 'synthetics',
   USER = 'user',
@@ -61,8 +65,6 @@ export function startRumAssembly(
   parentContexts: ParentContexts,
   getCommonContext: () => CommonContext
 ) {
-  const sessionType = getSessionType()
-
   const errorFilter = createErrorFilter(configuration, (error) => {
     lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
   })
@@ -88,7 +90,8 @@ export function startRumAssembly(
           date: timeStampNow(),
           service: configuration.service,
           session: {
-            type: sessionType,
+            // must be computed on each event because synthetics instrumentation can be done after sdk execution
+            type: getSessionType(),
           },
         }
         const serverRumEvent = (needToAssembleWithAction(rawRumEvent)
@@ -159,5 +162,8 @@ function needToAssembleWithAction(
 }
 
 function getSessionType() {
-  return navigator.userAgent.indexOf('DatadogSynthetics') === -1 ? SessionType.USER : SessionType.SYNTHETICS
+  return navigator.userAgent.indexOf('DatadogSynthetics') === -1 &&
+    (window as BrowserWindow)._DATADOG_SYNTHETICS_BROWSER === undefined
+    ? SessionType.USER
+    : SessionType.SYNTHETICS
 }


### PR DESCRIPTION
## Motivation

User agent used by synthetics can be overwritten by the customer. So user agent check is not enough.

## Changes

Restore check on global. 
Previous PR:
#969 


## Testing

unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
