### PR TITLE
 ✨ [RUMF-996] set synthetics ids on RUM events 

### DIFF
--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -173,7 +173,7 @@ function getSyntheticsContext() {
   const testId = (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID
   const resultId = (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID
 
-  if (testId && resultId) {
+  if (typeof testId === 'string' && typeof resultId === 'string') {
     return {
       test_id: testId,
       result_id: resultId,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -179,6 +179,10 @@ export interface RumContext {
     type: string
     has_replay?: boolean
   }
+  synthetics?: {
+    test_id: string
+    result_id: string
+  }
   _dd: {
     format_version: 2
     drift: number

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -14,7 +14,7 @@ export type RumActionEvent = CommonProperties & {
   /**
    * RUM event type
    */
-  readonly type: string
+  readonly type: 'action'
   /**
    * Action properties
    */
@@ -102,7 +102,7 @@ export type RumErrorEvent = CommonProperties & {
   /**
    * RUM event type
    */
-  readonly type: string
+  readonly type: 'error'
   /**
    * Error properties
    */
@@ -220,7 +220,7 @@ export type RumLongTaskEvent = CommonProperties & {
   /**
    * RUM event type
    */
-  readonly type: string
+  readonly type: 'long_task'
   /**
    * Long Task properties
    */
@@ -233,6 +233,10 @@ export type RumLongTaskEvent = CommonProperties & {
      * Duration in ns of the long task
      */
     readonly duration: number
+    /**
+     * Whether this long task is considered a frozen frame
+     */
+    readonly is_frozen_frame?: boolean
     [k: string]: unknown
   }
   /**
@@ -254,7 +258,7 @@ export type RumResourceEvent = CommonProperties & {
   /**
    * RUM event type
    */
-  readonly type: string
+  readonly type: 'resource'
   /**
    * Resource properties
    */
@@ -438,7 +442,7 @@ export type RumViewEvent = CommonProperties & {
   /**
    * RUM event type
    */
-  readonly type: string
+  readonly type: 'view'
   /**
    * View properties
    */
@@ -510,6 +514,10 @@ export type RumViewEvent = CommonProperties & {
      */
     readonly is_active?: boolean
     /**
+     * Whether the View had a low average refresh rate
+     */
+    readonly is_slow_rendered?: boolean
+    /**
      * Properties of the actions of the view
      */
     readonly action: {
@@ -545,6 +553,16 @@ export type RumViewEvent = CommonProperties & {
     readonly long_task?: {
       /**
        * Number of long tasks that occurred on the view
+       */
+      readonly count: number
+      [k: string]: unknown
+    }
+    /**
+     * Properties of the frozen frames of the view
+     */
+    readonly frozen_frame?: {
+      /**
+       * Number of frozen frames that occurred on the view
        */
       readonly count: number
       [k: string]: unknown
@@ -731,13 +749,37 @@ export interface CommonProperties {
     [k: string]: unknown
   }
   /**
+   * Synthetics properties
+   */
+  readonly synthetics?: {
+    /**
+     * The identifier of the current Synthetics test
+     */
+    readonly test_id: string
+    /**
+     * The identifier of the current Synthetics test results
+     */
+    readonly result_id: string
+    [k: string]: unknown
+  }
+  /**
    * Internal properties
    */
   readonly _dd: {
     /**
      * Version of the RUM event format
      */
-    readonly format_version: number
+    readonly format_version: 2
+    /**
+     * Session-related internal properties
+     */
+    session?: {
+      /**
+       * Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+       */
+      plan: 1 | 2
+      [k: string]: unknown
+    }
     [k: string]: unknown
   }
   /**


### PR DESCRIPTION
## Motivation

Allow linking RUM to Synthetics tests

## Changes

Add Synthetics test id and result id to all RUM events based on global variables. In the future, it will also use cookies, but since we don't know yet how they will be defined, let's do only global variables first.

## Testing

Manual, Unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
