### PR TITLE
🐛 prevent recording to start when session renewed before onload

### DIFF
--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -208,6 +208,17 @@ describe('makeRecorderApi', () => {
         expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         expect(stopRecordingSpy).toHaveBeenCalled()
       })
+
+      it('prevents session recording to start if the session is renewed before onload', () => {
+        setupBuilder.build()
+        const { triggerOnLoad } = mockDocumentReadyState()
+        rumInit(DEFAULT_INIT_CONFIGURATION)
+        recorderApi.start()
+        session.setLitePlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        triggerOnLoad()
+        expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
     })
 
     describe('from REPLAY to untracked', () => {

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -63,7 +63,7 @@ export function makeRecorderApi(startRecordingImpl: StartRecording): RecorderApi
       parentContexts: ParentContexts
     ) => {
       lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-        if (state.status === RecorderStatus.Started) {
+        if (state.status === RecorderStatus.Starting || state.status === RecorderStatus.Started) {
           stopStrategy()
           state = { status: RecorderStatus.IntentToStart }
         }


### PR DESCRIPTION
## Motivation

When the session is renewed before onload, there may be a case where the recording is incorrectly started.
This shouldn't happen that often, but it bothered me.

## Changes

Stop the recording during session renew if it is `starting`.

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
