### PR TITLE
🐛 [RUMF-997]  dont take a FullSnapshot on view creation during session renew

### DIFF
--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -17,6 +17,19 @@ export enum LifeCycleEventType {
   VIEW_ENDED,
   REQUEST_STARTED,
   REQUEST_COMPLETED,
+
+  // The SESSION_EXPIRED lifecycle event has been introduced to represent when a session has expired
+  // and trigger cleanup tasks related to this, prior to renewing the session. Its implementation is
+  // slightly naive: it is not triggered as soon as the session is expired, but rather just before
+  // notifying that the session is renewed. Thus, the session id is already set to the newly renewed
+  // session.
+  //
+  // This implementation is "good enough" for our use-cases. Improving this is not trivial,
+  // primarily because multiple instances of the SDK may be managing the same session cookie at
+  // the same time, for example when using Logs and RUM on the same page, or opening multiple tabs
+  // on the same domain.
+  SESSION_EXPIRED,
+
   SESSION_RENEWED,
   BEFORE_UNLOAD,
   RAW_RUM_EVENT_COLLECTED,
@@ -41,6 +54,7 @@ export class LifeCycle {
   ): void
   notify(
     eventType:
+      | LifeCycleEventType.SESSION_EXPIRED
       | LifeCycleEventType.SESSION_RENEWED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED
@@ -77,6 +91,7 @@ export class LifeCycle {
   ): Subscription
   subscribe(
     eventType:
+      | LifeCycleEventType.SESSION_EXPIRED
       | LifeCycleEventType.SESSION_RENEWED
       | LifeCycleEventType.BEFORE_UNLOAD
       | LifeCycleEventType.AUTO_ACTION_DISCARDED,

--- a/packages/rum-core/src/domain/rumSession.ts
+++ b/packages/rum-core/src/domain/rumSession.ts
@@ -30,6 +30,7 @@ export function startRumSession(configuration: Configuration, lifeCycle: LifeCyc
   )
 
   session.renewObservable.subscribe(() => {
+    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
     lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
   })
 

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -155,6 +155,8 @@ describe('makeRecorderApi', () => {
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         session.setReplayPlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+        expect(startRecordingSpy).not.toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalled()
         expect(stopRecordingSpy).not.toHaveBeenCalled()
@@ -164,6 +166,7 @@ describe('makeRecorderApi', () => {
         recorderApi.start()
         recorderApi.stop()
         session.setReplayPlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
       })
@@ -177,6 +180,7 @@ describe('makeRecorderApi', () => {
       it('keeps not recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         session.setNotTracked()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
         expect(stopRecordingSpy).not.toHaveBeenCalled()
@@ -190,6 +194,7 @@ describe('makeRecorderApi', () => {
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
         expect(stopRecordingSpy).not.toHaveBeenCalled()
@@ -203,10 +208,12 @@ describe('makeRecorderApi', () => {
 
       it('stops recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         session.setLitePlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+        expect(stopRecordingSpy).toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalledTimes(1)
-        expect(stopRecordingSpy).toHaveBeenCalled()
       })
     })
 
@@ -217,10 +224,12 @@ describe('makeRecorderApi', () => {
 
       it('stops recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         session.setNotTracked()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+        expect(stopRecordingSpy).toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalledTimes(1)
-        expect(stopRecordingSpy).toHaveBeenCalled()
       })
     })
 
@@ -231,14 +240,19 @@ describe('makeRecorderApi', () => {
 
       it('keeps recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         expect(stopRecordingSpy).toHaveBeenCalled()
+        lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalledTimes(2)
       })
 
       it('does not starts recording if stopSessionReplayRecording was called', () => {
         recorderApi.start()
+        expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         recorderApi.stop()
+        expect(stopRecordingSpy).toHaveBeenCalledTimes(1)
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         expect(stopRecordingSpy).toHaveBeenCalledTimes(1)
@@ -253,6 +267,7 @@ describe('makeRecorderApi', () => {
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         session.setReplayPlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalled()
         expect(stopRecordingSpy).not.toHaveBeenCalled()
@@ -262,8 +277,10 @@ describe('makeRecorderApi', () => {
         recorderApi.start()
         recorderApi.stop()
         session.setReplayPlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
       })
     })
 
@@ -275,8 +292,10 @@ describe('makeRecorderApi', () => {
       it('keeps not recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         session.setLitePlan()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
       })
     })
 
@@ -287,8 +306,10 @@ describe('makeRecorderApi', () => {
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
+        lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
+        expect(stopRecordingSpy).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -62,12 +62,14 @@ export function makeRecorderApi(startRecordingImpl: StartRecording): RecorderApi
       session: RumSession,
       parentContexts: ParentContexts
     ) => {
-      lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
+      lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
         if (state.status === RecorderStatus.Started) {
           stopStrategy()
           state = { status: RecorderStatus.IntentToStart }
         }
+      })
 
+      lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
         if (state.status === RecorderStatus.IntentToStart) {
           startStrategy()
         }

--- a/test/e2e/scenario/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder.scenario.ts
@@ -1,10 +1,10 @@
-import { CreationReason, IncrementalSource, Segment } from '@datadog/browser-rum/cjs/types'
+import { CreationReason, IncrementalSource, RecordType, Segment } from '@datadog/browser-rum/cjs/types'
 import { InputData, StyleSheetRuleData, NodeType } from '@datadog/browser-rum/cjs/domain/record/types'
 import { RumInitConfiguration } from '@datadog/browser-rum-core'
 
 import { createTest, bundleSetup, html, EventRegistry } from '../lib/framework'
 import { browserExecute } from '../lib/helpers/browser'
-import { flushEvents } from '../lib/helpers/sdk'
+import { flushEvents, renewSession } from '../lib/helpers/sdk'
 import {
   findElement,
   findElementWithIdAttribute,
@@ -628,10 +628,35 @@ describe('recorder', () => {
         expect(styleSheetRules[1].data.adds).toEqual([{ rule: '.added {}', index: 0 }])
       })
   })
+
+  describe('session renewal', () => {
+    createTest('a single fullSnapshot is taken when the session is renewed')
+      .withRum()
+      .withRumInit(initRumAndStartRecording)
+      .withSetup(bundleSetup)
+      .run(async ({ events }) => {
+        await renewSession()
+
+        await flushEvents()
+
+        expect(events.sessionReplay.length).toBe(2)
+
+        const segment = getLastSegment(events)
+        expect(segment.creation_reason).toBe('init')
+        expect(segment.records[0].type).toBe(RecordType.Meta)
+        expect(segment.records[1].type).toBe(RecordType.Focus)
+        expect(segment.records[2].type).toBe(RecordType.FullSnapshot)
+        expect(segment.records.slice(3).every((record) => record.type !== RecordType.FullSnapshot)).toBe(true)
+      })
+  })
 })
 
 function getFirstSegment(events: EventRegistry) {
   return events.sessionReplay[0].segment.data
+}
+
+function getLastSegment(events: EventRegistry) {
+  return events.sessionReplay[events.sessionReplay.length - 1].segment.data
 }
 
 function initRumAndStartRecording(initConfiguration: RumInitConfiguration) {


### PR DESCRIPTION
## Motivation

When renewing the session from replay to lite (for example), a full snapshot was taken on the lite session, because the recording was stopped a tiny bit too late (after the new view creation)

## Changes

This PR introduces a new lifecycle event `SESSION_EXPIRED` to have a chance to do some cleanup before the session is renewed. It uses it to stop recording.

## Testing

Manual, e2e (no unit test because we don't have any test at this level: it involves the whole RUM and recording stack)

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
