### PR TITLE
✅ update chrome version for e2e local tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
   APP: 'browser-sdk'
-  CURRENT_CI_IMAGE: 24
+  CURRENT_CI_IMAGE: 25
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
 
 # Download and install Chrome
 # Debian taken from https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
-RUN curl --silent --show-error --fail http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_90.0.4430.85-1_amd64.deb --output google-chrome.deb \
+RUN curl --silent --show-error --fail http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_92.0.4515.107-1_amd64.deb --output google-chrome.deb \
     && dpkg -i google-chrome.deb \
     && rm google-chrome.deb
 

--- a/test/e2e/wdio.local.conf.js
+++ b/test/e2e/wdio.local.conf.js
@@ -1,7 +1,7 @@
 const baseConf = require('./wdio.base.conf')
 
 // https://sites.google.com/a/chromium.org/chromedriver/downloads
-const CHROME_DRIVER_VERSION = '90.0.4430.24'
+const CHROME_DRIVER_VERSION = '92.0.4515.107'
 
 exports.config = {
   ...baseConf,


### PR DESCRIPTION
## Motivation

Chrome was updated on our work laptop and the local e2e tests can't be run anymore.

## Changes

Update the chrome version for local e2e tests

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
