### PR TITLE
✨ [RUMF-993] New proxy strategy

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -59,7 +59,12 @@ export interface InitConfiguration {
   silentMultipleInit?: boolean
   trackInteractions?: boolean
   trackViewsManually?: boolean
+
+  /**
+   * @deprecated Favor proxyUrl option
+   */
   proxyHost?: string
+  proxyUrl?: string
   beforeSend?: BeforeSendCallback
   initialPrivacyLevel?: InitialPrivacyLevel
 

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -98,11 +98,6 @@ export function createEndpointBuilder(
 
     let parameters = `ddsource=${source || 'browser'}&ddtags=${encodeURIComponent(tags)}`
 
-    if (proxyHost) {
-      const datadogHost = buildHost(endpointType)
-      parameters += `&ddhost=${datadogHost}`
-    }
-
     if (shouldUseIntakeV2(endpointType)) {
       parameters +=
         `&dd-api-key=${clientToken}&` +

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -45,14 +45,32 @@ describe('transportConfiguration', () => {
     })
   })
 
+  describe('query parameters', () => {
+    it('should add new intake query parameters when "support-intake-v2" enabled', () => {
+      const configuration = computeTransportConfiguration({ clientToken, intakeApiVersion: 2 }, buildEnv, true)
+      expect(configuration.rumEndpoint).toMatch(
+        `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
+      )
+    })
+  })
+
   describe('proxyHost', () => {
-    it('should replace endpoint host add set it as a query parameter', () => {
+    it('should replace endpoint host and add set it as a query parameter', () => {
       const configuration = computeTransportConfiguration(
         { clientToken, site: 'datadoghq.eu', proxyHost: 'proxy.io' },
         buildEnv
       )
       expect(configuration.rumEndpoint).toMatch(/^https:\/\/proxy\.io\//)
       expect(configuration.rumEndpoint).toContain('&ddhost=rum-http-intake.logs.datadoghq.eu')
+    })
+  })
+
+  describe('proxyUrl', () => {
+    it('should replace the full endpoint by the proxyUrl and set it in the attribute ddforward', () => {
+      const configuration = computeTransportConfiguration({ clientToken, proxyUrl: 'https://proxy.io/path' }, buildEnv)
+      expect(configuration.rumEndpoint).toContain(
+        `https://proxy.io/path?ddforward=${encodeURIComponent('https://rum-http-intake.logs.datadoghq.com')}`
+      )
     })
   })
 

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -60,16 +60,19 @@ describe('transportConfiguration', () => {
         { clientToken, site: 'datadoghq.eu', proxyHost: 'proxy.io' },
         buildEnv
       )
-      expect(configuration.rumEndpoint).toMatch(/^https:\/\/proxy\.io\//)
-      expect(configuration.rumEndpoint).toContain('&ddhost=rum-http-intake.logs.datadoghq.eu')
+      expect(configuration.rumEndpoint).toMatch(
+        `https://proxy.io/v1/input/${clientToken}\\?ddhost=rum-http-intake.logs.datadoghq.eu&ddsource=(.*)&ddtags=(.*)`
+      )
     })
   })
 
   describe('proxyUrl', () => {
     it('should replace the full endpoint by the proxyUrl and set it in the attribute ddforward', () => {
       const configuration = computeTransportConfiguration({ clientToken, proxyUrl: 'https://proxy.io/path' }, buildEnv)
-      expect(configuration.rumEndpoint).toContain(
-        `https://proxy.io/path?ddforward=${encodeURIComponent('https://rum-http-intake.logs.datadoghq.com')}`
+      expect(configuration.rumEndpoint).toMatch(
+        `https://proxy.io/path\\?ddforward=${encodeURIComponent(
+          `https://rum-http-intake.logs.datadoghq.com/v1/input/${clientToken}?ddsource=(.*)&ddtags=(.*)`
+        )}`
       )
     })
   })


### PR DESCRIPTION
## Motivation

Some customer proxy configurations rely on the intake v1 path to root the requests. For instance they may use a wildcard to identify RUM like so `/v1/input/`. By enabling the intake version 2, the path would become `/api/v2/...` and these customers would break their proxy configuration.

In order to guarantee backward compatibility for future intake versions, we need to change our approach. 

## Changes

- Add a new **proxyUrl** option parameter
- Implement the new strategy

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
