### PR TITLE
🐛 [RUMF-1005] Fix dd-request-id endpoint query param

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -1,5 +1,5 @@
 import { BuildEnv } from '../../boot/init'
-import { generateUUID, includes } from '../../tools/utils'
+import { includes } from '../../tools/utils'
 import { InitConfiguration } from './configuration'
 
 export const ENDPOINTS = {
@@ -69,9 +69,8 @@ export function createEndpointBuilder(
     if (shouldUseIntakeV2(endpointType)) {
       parameters +=
         `&dd-api-key=${clientToken}&` +
-        `dd-evp-origin-version=${sdkVersion}&` +
-        `dd-evp-origin=browser&` +
-        `dd-request-id=${generateUUID()}`
+        `dd-evp-origin-version=${encodeURIComponent(sdkVersion)}&` +
+        `dd-evp-origin=browser`
     }
 
     return `${buildIntakeUrl(endpointType)}?${parameters}`

--- a/packages/core/src/domain/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring.spec.ts
@@ -194,7 +194,7 @@ describe('internal monitoring', () => {
       })
 
       expect(server.requests.length).toEqual(1)
-      expect(server.requests[0].url).toEqual(configuration.internalMonitoringEndpoint!)
+      expect(server.requests[0].url).toContain(configuration.internalMonitoringEndpoint!)
 
       expect(JSON.parse(server.requests[0].requestBody)).toEqual({
         date: FAKE_DATE,

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -86,6 +86,14 @@ describe('httpRequest parameters', () => {
     expect(sendBeaconSpy.calls.argsFor(0)[0]).toContain(`&batch_time=`)
   })
 
+  it('should not add batch_time', () => {
+    const request = new HttpRequest('https://my.website', BATCH_BYTES_LIMIT, false)
+
+    request.send('{"foo":"bar1"}', 10)
+
+    expect(sendBeaconSpy.calls.argsFor(0)[0]).not.toContain(`&batch_time=`)
+  })
+
   it('should have dd-request-id', () => {
     const request = new HttpRequest('https://my.website', BATCH_BYTES_LIMIT)
 

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import sinon from 'sinon'
+import { BuildEnv, BuildMode } from '../boot/init'
+import { createEndpointBuilder } from '../domain/configuration/endpointBuilder'
 import { HttpRequest } from './httpRequest'
 
 describe('httpRequest', () => {
@@ -61,5 +63,51 @@ describe('httpRequest', () => {
 
     expect(navigator.sendBeacon).toHaveBeenCalled()
     expect(server.requests.length).toEqual(1)
+  })
+})
+
+describe('httpRequest parameters', () => {
+  const BATCH_BYTES_LIMIT = 100
+  const clientToken = 'some_client_token'
+  const buildEnv: BuildEnv = {
+    buildMode: BuildMode.RELEASE,
+    sdkVersion: 'some_version',
+  }
+  let server: sinon.SinonFakeServer
+  let sendBeaconSpy: jasmine.Spy<(url: string, data?: BodyInit | null) => boolean>
+  beforeEach(() => {
+    server = sinon.fakeServer.create()
+    sendBeaconSpy = jasmine.createSpy()
+    navigator.sendBeacon = sendBeaconSpy
+  })
+
+  afterEach(() => {
+    server.restore()
+  })
+
+  it('should add batch_time', () => {
+    const request = new HttpRequest('https://my.website', BATCH_BYTES_LIMIT, true)
+
+    request.send('{"foo":"bar1"}', 10)
+
+    expect(sendBeaconSpy.calls.argsFor(0)[0]).toContain(`batch_time=`)
+  })
+
+  it('should add dd-request-id query attribute when the intake v2 enabled', () => {
+    const endpointBuilder = createEndpointBuilder({ clientToken, intakeApiVersion: 2 }, buildEnv, true)
+    const request = new HttpRequest(endpointBuilder.build('rum'), BATCH_BYTES_LIMIT)
+
+    request.send('{"foo":"bar1"}', 10)
+
+    expect(sendBeaconSpy.calls.argsFor(0)[0]).toContain(`&dd-request-id=`)
+  })
+
+  it('should not add dd-request-id query attribute when the intake v1 enabled', () => {
+    const endpointBuilder = createEndpointBuilder({ clientToken }, buildEnv, true)
+    const request = new HttpRequest(endpointBuilder.build('rum'), BATCH_BYTES_LIMIT)
+
+    request.send('{"foo":"bar1"}', 10)
+
+    expect(sendBeaconSpy.calls.argsFor(0)[0]).not.toContain(`&dd-request-id=`)
   })
 })

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -15,14 +15,9 @@ export class HttpRequest {
   constructor(private endpointUrl: string, private bytesLimit: number, private withBatchTime: boolean = false) {}
 
   send(data: string | FormData, size: number) {
-    let url = this.endpointUrl
-
-    if (isEndpointIntakeV2(url)) {
-      url = addRequestId(url)
-    }
-
+    let url = addQueryParameter(this.endpointUrl, 'dd-request-id', generateUUID())
     if (this.withBatchTime) {
-      url = addBatchTime(url)
+      url = addQueryParameter(url, 'batch_time', new Date().getTime().toString())
     }
 
     const tryBeacon = !!navigator.sendBeacon && size < this.bytesLimit
@@ -73,16 +68,8 @@ export class HttpRequest {
   }
 }
 
-function addBatchTime(url: string) {
-  return `${url}${url.indexOf('?') === -1 ? '?' : '&'}batch_time=${new Date().getTime()}`
-}
-
-function addRequestId(url: string) {
-  return `${url}${url.indexOf('?') === -1 ? '?' : '&'}dd-request-id=${generateUUID()}`
-}
-
-function isEndpointIntakeV2(url: string) {
-  return includes(url, '/api/v2')
+function addQueryParameter(url: string, key: string, value: string) {
+  return `${url}${includes(url, '?') ? '&' : '?'}${key}=${value}`
 }
 
 let hasReportedBeaconError = false

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -90,7 +90,7 @@ describe('logs', () => {
       )
 
       expect(server.requests.length).toEqual(1)
-      expect(server.requests[0].url).toEqual(baseConfiguration.logsEndpoint!)
+      expect(server.requests[0].url).toContain(baseConfiguration.logsEndpoint!)
       expect(getLoggedMessage(server, 0)).toEqual({
         date: FAKE_DATE,
         foo: 'bar',


### PR DESCRIPTION
## Motivation

Fix intake v2 `dd-request-id` to be unique per request

## Changes

Add dd-request-id  to HttpRequest 

## Testing

Locally, Unit
---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
