### PR TITLE
🐛[REPLAY-371] Truncate long "data:" URIs

### DIFF
--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -397,12 +397,14 @@ describe('shouldMaskNode', () => {
 })
 
 describe('serializeAttribute ', () => {
-  it('truncates "data:" URIs after 32,000 string length', () => {
+  it('truncates "data:" URIs after 100,000 string length', () => {
     const node = document.createElement('p')
 
-    const maxAttributeValue = `data:${'a'.repeat(32000 - 5)}`
-    const exceededAttributeValue = `data:${'a'.repeat(32001 - 5)}`
-    const ignoredAttributeValue = `foos:${'a'.repeat(32001 - 5)}`
+    const longString = new Array(100000 - 5).fill('a').join('');
+    const maxAttributeValue = `data:${(longString)}`
+    const exceededAttributeValue = `data:${(longString)}1`
+    const ignoredAttributeValue = `foos:${longString}`
+
     node.setAttribute('test-okay', maxAttributeValue)
     node.setAttribute('test-truncate', exceededAttributeValue)
     node.setAttribute('test-ignored', ignoredAttributeValue)

--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -400,9 +400,9 @@ describe('serializeAttribute ', () => {
   it('truncates "data:" URIs after 100,000 string length', () => {
     const node = document.createElement('p')
 
-    const longString = new Array(100000 - 5).fill('a').join('');
-    const maxAttributeValue = `data:${(longString)}`
-    const exceededAttributeValue = `data:${(longString)}1`
+    const longString = new Array(100000 - 5).fill('a').join('')
+    const maxAttributeValue = `data:${longString}`
+    const exceededAttributeValue = `data:${longString}1`
     const ignoredAttributeValue = `foos:${longString}`
 
     node.setAttribute('test-okay', maxAttributeValue)

--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -270,7 +270,7 @@ describe('Inherited Privacy Level  derivePrivacyLevelGivenParent() ... ', functi
 
   tests.forEach((test) => {
     it(`${test.msg}: ancestor(${test.args[0]}) to self(${test.args[1]}) should be (${test.expect})`, () => {
-      const inherited = reducePrivacyLevel(test.args[0] , test.args[1])
+      const inherited = reducePrivacyLevel(test.args[0] as NodePrivacyLevel, test.args[1] as NodePrivacyLevel)
       expect(inherited).toBe(test.expect)
     })
   })

--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -7,6 +7,7 @@ import {
   getNodePrivacyLevel,
   shouldMaskNode,
   serializeAttribute,
+  MAX_ATTRIBUTE_VALUE_CHAR_LENGTH,
 } from './privacy'
 import { ElementNode, NodeType, TextNode, SerializedNodeWithId } from './types'
 
@@ -397,10 +398,10 @@ describe('shouldMaskNode', () => {
 })
 
 describe('serializeAttribute ', () => {
-  it('truncates "data:" URIs after 100,000 string length', () => {
+  it('truncates "data:" URIs after long string length', () => {
     const node = document.createElement('p')
 
-    const longString = new Array(100000 + 1 - 5).join('a')
+    const longString = new Array(MAX_ATTRIBUTE_VALUE_CHAR_LENGTH + 1 - 5).join('a')
     const maxAttributeValue = `data:${longString}`
     const exceededAttributeValue = `data:${longString}1`
     const ignoredAttributeValue = `foos:${longString}`

--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -400,7 +400,7 @@ describe('serializeAttribute ', () => {
   it('truncates "data:" URIs after 100,000 string length', () => {
     const node = document.createElement('p')
 
-    const longString = new Array(100000 - 5).fill('a').join('')
+    const longString = new Array(100000 + 1 - 5).join('a')
     const maxAttributeValue = `data:${longString}`
     const exceededAttributeValue = `data:${longString}1`
     const ignoredAttributeValue = `foos:${longString}`
@@ -414,7 +414,7 @@ describe('serializeAttribute ', () => {
 
     expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'test-ignored')).toBe(ignoredAttributeValue)
 
-    expect(serializeAttribute(node, NodePrivacyLevel.ALLOW, 'test-truncate')).toBe('truncated')
-    expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'test-truncate')).toBe('truncated')
+    expect(serializeAttribute(node, NodePrivacyLevel.ALLOW, 'test-truncate')).toBe('data:truncated')
+    expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'test-truncate')).toBe('data:truncated')
   })
 })

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -187,10 +187,16 @@ export function serializeAttribute(
     }
   }
 
-  // Rebuild absolute URLs from relative (without using <base> tag)
   if (!attributeValue || typeof attributeValue !== 'string') {
     return attributeValue
   }
+
+  // Minimum Fix for customer.
+  if (attributeValue.length > 32_000 && attributeValue.slice(0, 5) === 'data:') {
+    return 'truncated'
+  }
+
+  // Rebuild absolute URLs from relative (without using <base> tag)
   const doc = element.ownerDocument
   switch (attributeName) {
     case 'src':

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -19,6 +19,8 @@ import {
   PRIVACY_ATTR_VALUE_INPUT_MASKED,
 } from '../../constants'
 
+export const MAX_ATTRIBUTE_VALUE_CHAR_LENGTH = 100_000
+
 import { makeStylesheetUrlsAbsolute, makeSrcsetUrlsAbsolute, makeUrlAbsolute } from './serializationUtils'
 
 import { shouldIgnoreElement } from './serialize'
@@ -192,7 +194,7 @@ export function serializeAttribute(
   }
 
   // Minimum Fix for customer.
-  if (attributeValue.length > 100_000 && attributeValue.slice(0, 5) === 'data:') {
+  if (attributeValue.length > MAX_ATTRIBUTE_VALUE_CHAR_LENGTH && attributeValue.slice(0, 5) === 'data:') {
     return 'data:truncated'
   }
 

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -193,7 +193,7 @@ export function serializeAttribute(
 
   // Minimum Fix for customer.
   if (attributeValue.length > 100_000 && attributeValue.slice(0, 5) === 'data:') {
-    return 'truncated'
+    return 'data:truncated'
   }
 
   // Rebuild absolute URLs from relative (without using <base> tag)

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -192,7 +192,7 @@ export function serializeAttribute(
   }
 
   // Minimum Fix for customer.
-  if (attributeValue.length > 32_000 && attributeValue.slice(0, 5) === 'data:') {
+  if (attributeValue.length > 100_000 && attributeValue.slice(0, 5) === 'data:') {
     return 'truncated'
   }
 


### PR DESCRIPTION
## Motivation
A customer is embedding a large "data:" URI resource. This impacts performance without sufficient corresponding benefit to this customer. As a general quick fix, we shall truncate this attribute value. We do not wish to generalise recorder limits at this time, so have specifically targeted only attributes starting with "data:" exceeding 100,000 length (somewhat arbitrarily chosen, but corresponds to 5*X < 1MB).

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing
New tests added.
<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
