### PR TITLE
📝[RUMF-1009] Rework logs beforeSend documentation

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -252,7 +252,7 @@ The placeholders in the examples above are described below:
 
 If your Browser logs contain sensitive information that needs redacting, configure the Browser SDK to scrub sensitive sequences by using the `beforeSend` callback when you initialize the Browser Log Collector.
 
-The `beforeSend` callback function gives you access to each log collected by the Browser SDK before it is sent to Datadog, and lets you update commonly redacted properties.
+The `beforeSend` callback function gives you access to each log collected by the Browser SDK before it is sent to Datadog, and lets you update any property.
 
 To redact email addresses from your web application URLs:
 
@@ -300,7 +300,6 @@ window.DD_LOGS &&
     });
 ```
 
-All logs properties are updatable.
 The following properties are automatically collected by the SDK and could contain sensitive data:
 
 | Attribute       | Type   | Description                                                                                      |

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -254,8 +254,6 @@ If your Browser logs contain sensitive information that needs redacting, configu
 
 The `beforeSend` callback function gives you access to each event collected by the Browser SDK before it is sent to Datadog, and lets you update commonly redacted properties.
 
-For examples of `beforeSend`, see [Enrich and control browser RUM data with beforeSend][5].
-
 To redact email addresses from your web application URLs:
 
 #### NPM
@@ -312,6 +310,62 @@ The following properties are automatically collected by the SDK and could contai
 | `message`       | String | The content of the log.                                                                          |
 | `error.stack`   | String | The stack trace or complementary information about the error.                                    |
 | `http.url`      | String | The HTTP URL.                                                                                    |
+
+### Discard specific logs
+
+The `beforeSend` callback function allows you to also discard a log before it is sent to Datadog.
+
+To discard network errors if their status is 404:
+
+#### NPM
+
+```javascript
+import { datadogLogs } from '@datadog/browser-logs'
+
+datadogLogs.init({
+    ...,
+    beforeSend: (event) => {
+        // discard 404 network errors
+        if (event.http && event.http.status_code === 404) {
+          return false
+        }
+    },
+    ...
+});
+```
+
+#### CDN Async
+
+```javascript
+DD_LOGS.onReady(function() {
+    DD_LOGS.init({
+        ...,
+        beforeSend: (event) => {
+          // discard 404 network errors
+          if (event.http && event.http.status_code === 404) {
+            return false
+          }
+        },
+        ...
+    })
+})
+```
+
+#### CDN Sync
+
+```javascript
+window.DD_LOGS &&
+    window.DD_LOGS.init({
+        ...,
+        beforeSend: (event) => {
+          // discard 404 network errors
+          if (event.http && event.http.status_code === 404) {
+            return false
+          }
+        },
+        ...
+    });
+```
 
 ### Define multiple loggers
 

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -252,7 +252,7 @@ The placeholders in the examples above are described below:
 
 If your Browser logs contain sensitive information that needs redacting, configure the Browser SDK to scrub sensitive sequences by using the `beforeSend` callback when you initialize the Browser Log Collector.
 
-The `beforeSend` callback function gives you access to each event collected by the Browser SDK before it is sent to Datadog, and lets you update commonly redacted properties.
+The `beforeSend` callback function gives you access to each log collected by the Browser SDK before it is sent to Datadog, and lets you update commonly redacted properties.
 
 To redact email addresses from your web application URLs:
 
@@ -263,9 +263,9 @@ import { datadogLogs } from '@datadog/browser-logs'
 
 datadogLogs.init({
     ...,
-    beforeSend: (event) => {
+    beforeSend: (log) => {
         // remove email from view url
-        event.view.url = event.view.url.replace(/email=[^&]*/, "email=REDACTED")
+        log.view.url = log.view.url.replace(/email=[^&]*/, "email=REDACTED")
     },
     ...
 });
@@ -277,9 +277,9 @@ datadogLogs.init({
 DD_LOGS.onReady(function() {
     DD_LOGS.init({
         ...,
-        beforeSend: (event) => {
+        beforeSend: (log) => {
             // remove email from view url
-            event.view.url = event.view.url.replace(/email=[^&]*/, "email=REDACTED")
+            log.view.url = log.view.url.replace(/email=[^&]*/, "email=REDACTED")
         },
         ...
     })
@@ -292,9 +292,9 @@ DD_LOGS.onReady(function() {
 window.DD_LOGS &&
     window.DD_LOGS.init({
         ...,
-        beforeSend: (event) => {
+        beforeSend: (log) => {
             // remove email from view url
-            event.view.url = event.view.url.replace(/email=[^&]*/, "email=REDACTED")
+            log.view.url = log.view.url.replace(/email=[^&]*/, "email=REDACTED")
         },
         ...
     });
@@ -324,9 +324,9 @@ import { datadogLogs } from '@datadog/browser-logs'
 
 datadogLogs.init({
     ...,
-    beforeSend: (event) => {
+    beforeSend: (log) => {
         // discard 404 network errors
-        if (event.http && event.http.status_code === 404) {
+        if (log.http && log.http.status_code === 404) {
           return false
         }
     },
@@ -340,9 +340,9 @@ datadogLogs.init({
 DD_LOGS.onReady(function() {
     DD_LOGS.init({
         ...,
-        beforeSend: (event) => {
+        beforeSend: (log) => {
           // discard 404 network errors
-          if (event.http && event.http.status_code === 404) {
+          if (log.http && log.http.status_code === 404) {
             return false
           }
         },
@@ -357,9 +357,9 @@ DD_LOGS.onReady(function() {
 window.DD_LOGS &&
     window.DD_LOGS.init({
         ...,
-        beforeSend: (event) => {
+        beforeSend: (log) => {
           // discard 404 network errors
-          if (event.http && event.http.status_code === 404) {
+          if (log.http && log.http.status_code === 404) {
             return false
           }
         },

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -302,7 +302,8 @@ window.DD_LOGS &&
     });
 ```
 
-You can update the following event properties:
+All logs properties are updatable.
+The following properties are automatically collected by the SDK and could contain sensitive data:
 
 | Attribute       | Type   | Description                                                                                      |
 | --------------- | ------ | ------------------------------------------------------------------------------------------------ |
@@ -311,7 +312,6 @@ You can update the following event properties:
 | `message`       | String | The content of the log.                                                                          |
 | `error.stack`   | String | The stack trace or complementary information about the error.                                    |
 | `http.url`      | String | The HTTP URL.                                                                                    |
-| `context`       | String | Extra contextual attributes added with the logger.                                               |
 
 ### Define multiple loggers
 


### PR DESCRIPTION
## Motivation

Clarify that:
- All properties are updatable 
- No context is available for logs
- Discard is possible

## Changes

- Update scrubbing section to reflect that all properties are updatable 
- Replace link to RUM guide by discard example
- Replace `event` occurrences by `log`

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
