### PR TITLE
👷⚗ [RUMF-991] add CURRENT_STAGING variable to .gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 variables:
+  CURRENT_STAGING: staging-35test
   APP: 'browser-sdk'
   CURRENT_CI_IMAGE: 25
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'


### PR DESCRIPTION


## Motivation

The goal of this PR is to allow testing the `to-staging` command. This
variable is required to be present on the main branch so `to-staging`
can do its magic.

## Changes

Add a dummy `CURRENT_STAGING` variable to `.gitlab-ci`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
