### PR TITLE
✨ [RUMF-992] New CLS implementation

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -74,6 +74,7 @@ export interface RumFirstInputTiming {
 
 export interface RumLayoutShiftTiming {
   entryType: 'layout-shift'
+  startTime: RelativeTime
   value: number
   hadRecentInput: boolean
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -1,4 +1,4 @@
-import { Context, RelativeTime, Duration } from '@datadog/browser-core'
+import { Context, RelativeTime, Duration, relativeNow } from '@datadog/browser-core'
 import { LifeCycleEventType, RumEvent } from '@datadog/browser-rum-core'
 import { TestSetupBuilder, setup, setupViewTest, ViewTest } from '../../../../test/specHelper'
 import { RumPerformanceNavigationTiming } from '../../../browser/performanceCollection'
@@ -311,15 +311,17 @@ describe('rum track view metrics', () => {
     it('should accumulate layout shift values', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
-
+      const now = relativeNow()
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
         entryType: 'layout-shift',
+        startTime: now,
         hadRecentInput: false,
         value: 0.1,
       })
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
         entryType: 'layout-shift',
+        startTime: (now + 100) as RelativeTime,
         hadRecentInput: false,
         value: 0.2,
       })
@@ -333,15 +335,18 @@ describe('rum track view metrics', () => {
     it('should round the cumulative layout shift value to 4 decimals', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
+      const now = relativeNow()
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
         entryType: 'layout-shift',
+        startTime: now,
         hadRecentInput: false,
         value: 1.23456789,
       })
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
         entryType: 'layout-shift',
+        startTime: (now + 100) as RelativeTime,
         hadRecentInput: false,
         value: 1.11111111111,
       })
@@ -358,6 +363,7 @@ describe('rum track view metrics', () => {
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
         entryType: 'layout-shift',
+        startTime: relativeNow(),
         hadRecentInput: true,
         value: 0.1,
       })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -352,5 +352,58 @@ describe('rum track view metrics', () => {
       expect(getViewUpdateCount()).toEqual(1)
       expect(getViewUpdate(0).cumulativeLayoutShift).toBe(0)
     })
+
+    it('should create a new session window if the gap is more than 1 second', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+      const { getViewUpdate, getViewUpdateCount } = viewTest
+      // first session window
+      newLayoutShift(lifeCycle, 0.1)
+      clock.tick(100)
+      newLayoutShift(lifeCycle, 0.2)
+      // second session window
+      clock.tick(1001)
+      newLayoutShift(lifeCycle, 0.1)
+
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+      expect(getViewUpdateCount()).toEqual(2)
+      expect(getViewUpdate(1).cumulativeLayoutShift).toBe(0.3)
+    })
+
+    it('should create a new session if the current session is more than 5 second', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+      const { getViewUpdate, getViewUpdateCount } = viewTest
+      // first session window
+      newLayoutShift(lifeCycle, 0.1)
+      clock.tick(4500)
+      newLayoutShift(lifeCycle, 0.2)
+      // second session window
+      clock.tick(501)
+      newLayoutShift(lifeCycle, 0.1)
+
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+      expect(getViewUpdateCount()).toEqual(3)
+      expect(getViewUpdate(2).cumulativeLayoutShift).toBe(0.3)
+    })
+
+    it('should get the max value sessions', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+      const { getViewUpdate, getViewUpdateCount } = viewTest
+      // first session window
+      newLayoutShift(lifeCycle, 0.1)
+      newLayoutShift(lifeCycle, 0.2)
+      // second session window
+      clock.tick(5001)
+      newLayoutShift(lifeCycle, 0.1)
+      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, 0.2)
+      // third session window
+      clock.tick(5001)
+      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, 0.2)
+
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+      expect(getViewUpdateCount()).toEqual(3)
+      expect(getViewUpdate(2).cumulativeLayoutShift).toBe(0.5)
+    })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -377,7 +377,7 @@ describe('rum track view metrics', () => {
       for (let i = 0; i < 6; i += 1) {
         clock.tick(999)
         newLayoutShift(lifeCycle, { value: 0.1 })
-      } //=> window 1: 0.5 | window 2: 0.1
+      } // window 1: 0.5 | window 2: 0.1
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
       expect(getViewUpdateCount()).toEqual(3)
       expect(getViewUpdate(2).cumulativeLayoutShift).toBe(0.5)

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -282,7 +282,7 @@ describe('rum track view metrics', () => {
 
   describe('cumulativeLayoutShift', () => {
     let isLayoutShiftSupported: boolean
-    const newLayoutShift = (lifeCycle: LifeCycle, value: number, hadRecentInput = false) => {
+    function newLayoutShift(lifeCycle: LifeCycle, value: number, hadRecentInput = false) {
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
         entryType: 'layout-shift',
         startTime: relativeNow(),
@@ -290,6 +290,7 @@ describe('rum track view metrics', () => {
         value,
       })
     }
+
     beforeEach(() => {
       if (!('PerformanceObserver' in window) || !('supportedEntryTypes' in PerformanceObserver)) {
         pending('No PerformanceObserver support')

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -370,20 +370,17 @@ describe('rum track view metrics', () => {
       expect(getViewUpdate(1).cumulativeLayoutShift).toBe(0.3)
     })
 
-    it('should create a new session if the current session is more than 5 second', () => {
+    it('should create a new session window if the current session window is more than 5 second', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
-      // first session window
-      newLayoutShift(lifeCycle, { value: 0.1 })
-      clock.tick(4500)
-      newLayoutShift(lifeCycle, { value: 0.2 })
-      // second session window
-      clock.tick(501)
-      newLayoutShift(lifeCycle, { value: 0.1 })
-
+      newLayoutShift(lifeCycle, { value: 0 })
+      for (let i = 0; i < 6; i += 1) {
+        clock.tick(999)
+        newLayoutShift(lifeCycle, { value: 0.1 })
+      } //=> window 1: 0.5 | window 2: 0.1
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
       expect(getViewUpdateCount()).toEqual(3)
-      expect(getViewUpdate(2).cumulativeLayoutShift).toBe(0.3)
+      expect(getViewUpdate(2).cumulativeLayoutShift).toBe(0.5)
     })
 
     it('should get the max value sessions', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -282,7 +282,7 @@ describe('rum track view metrics', () => {
 
   describe('cumulativeLayoutShift', () => {
     let isLayoutShiftSupported: boolean
-    function newLayoutShift(lifeCycle: LifeCycle, value: number, hadRecentInput = false) {
+    function newLayoutShift(lifeCycle: LifeCycle, { value = 0.1, hadRecentInput = false }) {
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
         entryType: 'layout-shift',
         startTime: relativeNow(),
@@ -321,9 +321,9 @@ describe('rum track view metrics', () => {
     it('should accumulate layout shift values for the first session window', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
-      newLayoutShift(lifeCycle, 0.1)
+      newLayoutShift(lifeCycle, { value: 0.1 })
       clock.tick(100)
-      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, { value: 0.2 })
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       expect(getViewUpdateCount()).toEqual(2)
@@ -333,9 +333,9 @@ describe('rum track view metrics', () => {
     it('should round the cumulative layout shift value to 4 decimals', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
-      newLayoutShift(lifeCycle, 1.23456789)
+      newLayoutShift(lifeCycle, { value: 1.23456789 })
       clock.tick(100)
-      newLayoutShift(lifeCycle, 1.11111111111)
+      newLayoutShift(lifeCycle, { value: 1.11111111111 })
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       expect(getViewUpdateCount()).toEqual(2)
@@ -346,7 +346,7 @@ describe('rum track view metrics', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
 
-      newLayoutShift(lifeCycle, 0.1, true)
+      newLayoutShift(lifeCycle, { value: 0.1, hadRecentInput: true })
 
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
@@ -358,12 +358,12 @@ describe('rum track view metrics', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
       // first session window
-      newLayoutShift(lifeCycle, 0.1)
+      newLayoutShift(lifeCycle, { value: 0.1 })
       clock.tick(100)
-      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, { value: 0.2 })
       // second session window
       clock.tick(1001)
-      newLayoutShift(lifeCycle, 0.1)
+      newLayoutShift(lifeCycle, { value: 0.1 })
 
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
       expect(getViewUpdateCount()).toEqual(2)
@@ -374,12 +374,12 @@ describe('rum track view metrics', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
       // first session window
-      newLayoutShift(lifeCycle, 0.1)
+      newLayoutShift(lifeCycle, { value: 0.1 })
       clock.tick(4500)
-      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, { value: 0.2 })
       // second session window
       clock.tick(501)
-      newLayoutShift(lifeCycle, 0.1)
+      newLayoutShift(lifeCycle, { value: 0.1 })
 
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
       expect(getViewUpdateCount()).toEqual(3)
@@ -390,17 +390,17 @@ describe('rum track view metrics', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
       // first session window
-      newLayoutShift(lifeCycle, 0.1)
-      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, { value: 0.1 })
+      newLayoutShift(lifeCycle, { value: 0.2 })
       // second session window
       clock.tick(5001)
-      newLayoutShift(lifeCycle, 0.1)
-      newLayoutShift(lifeCycle, 0.2)
-      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, { value: 0.1 })
+      newLayoutShift(lifeCycle, { value: 0.2 })
+      newLayoutShift(lifeCycle, { value: 0.2 })
       // third session window
       clock.tick(5001)
-      newLayoutShift(lifeCycle, 0.2)
-      newLayoutShift(lifeCycle, 0.2)
+      newLayoutShift(lifeCycle, { value: 0.2 })
+      newLayoutShift(lifeCycle, { value: 0.2 })
 
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
       expect(getViewUpdateCount()).toEqual(3)

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -57,7 +57,7 @@ export function trackViewMetrics(
   if (isLayoutShiftSupported()) {
     viewMetrics.cumulativeLayoutShift = 0
     ;({ stop: stopCLSTracking } = trackCumulativeLayoutShift(lifeCycle, (layoutShift) => {
-      viewMetrics.cumulativeLayoutShift = Math.max(viewMetrics.cumulativeLayoutShift!, round(layoutShift, 4))
+      viewMetrics.cumulativeLayoutShift = layoutShift
       scheduleViewUpdate()
     }))
   } else {
@@ -168,7 +168,7 @@ function trackCumulativeLayoutShift(lifeCycle: LifeCycle, callback: (layoutShift
       updateSessionWindow(entry)
       if (windowValue > clsValue) {
         clsValue = windowValue
-        callback(clsValue)
+        callback(round(clsValue, 4))
       }
     }
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -1,5 +1,14 @@
-import { Duration, noop, elapsed, round, timeStampNow, Configuration } from '@datadog/browser-core'
-import { supportPerformanceTimingEvent } from '../../../browser/performanceCollection'
+import {
+  Duration,
+  noop,
+  elapsed,
+  round,
+  timeStampNow,
+  Configuration,
+  RelativeTime,
+  ONE_SECOND,
+} from '@datadog/browser-core'
+import { RumLayoutShiftTiming, supportPerformanceTimingEvent } from '../../../browser/performanceCollection'
 import { ViewLoadingType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { EventCounts, trackEventCounts } from '../../trackEventCounts'
@@ -47,8 +56,8 @@ export function trackViewMetrics(
   let stopCLSTracking: () => void
   if (isLayoutShiftSupported()) {
     viewMetrics.cumulativeLayoutShift = 0
-    ;({ stop: stopCLSTracking } = trackLayoutShift(lifeCycle, (layoutShift) => {
-      viewMetrics.cumulativeLayoutShift = round(viewMetrics.cumulativeLayoutShift! + layoutShift, 4)
+    ;({ stop: stopCLSTracking } = trackCumulativeLayoutShift(lifeCycle, (layoutShift) => {
+      viewMetrics.cumulativeLayoutShift = Math.max(viewMetrics.cumulativeLayoutShift!, round(layoutShift, 4))
       scheduleViewUpdate()
     }))
   } else {
@@ -120,18 +129,47 @@ function trackActivityLoadingTime(
 }
 
 /**
- * Track layout shifts (LS) occurring during the Views.  This yields multiple values that can be
- * added up to compute the cumulated layout shift (CLS).
+ * Track the cumulative layout shifts (CLS).
+ * Layout shifts are grouped into session windows.
+ * The minimum gap between session windows is 1 second.
+ * The maximum duration of a session window is 5 second.
+ * The session window layout shift value is the sum of layout shifts inside it.
+ * The CLS value is the max of session windows values.
+ *
+ * This yields a new value whenever the CLS value is updated (a higher session window value is computed).
  *
  * See isLayoutShiftSupported to check for browser support.
  *
- * Documentation: https://web.dev/cls/
+ * Documentation:
+ * https://web.dev/cls/
+ * https://web.dev/evolving-cls/
  * Reference implementation: https://github.com/GoogleChrome/web-vitals/blob/master/src/getCLS.ts
  */
-function trackLayoutShift(lifeCycle: LifeCycle, callback: (layoutShift: number) => void) {
+function trackCumulativeLayoutShift(lifeCycle: LifeCycle, callback: (layoutShift: number) => void) {
+  let clsValue = 0
+  let windowValue = 0
+  let windowStartedAt = 0 as RelativeTime
+  let windowLastEntryAt = 0 as RelativeTime
+
+  const updateSessionWindow = (entry: RumLayoutShiftTiming) => {
+    const durationSinceStart = entry.startTime - windowStartedAt
+    const durationSinceLastEntry = entry.startTime - windowLastEntryAt
+    if (durationSinceLastEntry < 1 * ONE_SECOND && durationSinceStart < 5 * ONE_SECOND) {
+      windowValue += entry.value
+    } else {
+      windowValue = entry.value
+      windowStartedAt = entry.startTime
+    }
+    windowLastEntryAt = entry.startTime
+  }
+
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
     if (entry.entryType === 'layout-shift' && !entry.hadRecentInput) {
-      callback(entry.value)
+      updateSessionWindow(entry)
+      if (windowValue > clsValue) {
+        clsValue = windowValue
+        callback(clsValue)
+      }
     }
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -146,14 +146,14 @@ function trackActivityLoadingTime(
  * Reference implementation: https://github.com/GoogleChrome/web-vitals/blob/master/src/getCLS.ts
  */
 function trackCumulativeLayoutShift(lifeCycle: LifeCycle, callback: (layoutShift: number) => void) {
-  let clsValue = 0
+  let maxClsValue = 0
   const window = slidingSessionWindow()
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
     if (entry.entryType === 'layout-shift' && !entry.hadRecentInput) {
       window.update(entry)
-      if (window.value() > clsValue) {
-        clsValue = window.value()
-        callback(round(clsValue, 4))
+      if (window.value() > maxClsValue) {
+        maxClsValue = window.value()
+        callback(round(maxClsValue, 4))
       }
     }
   })


### PR DESCRIPTION
## Motivation

The strategy to compute CLS [has changed](https://web.dev/evolving-cls/). 

**Old strategy:** CLS is the sum of all layout shifts

**New strategy:**

- Layout shifts are grouped into session windows.
- A session window is a period that starts when a layout shift happens, and ends when no layout shift happens during 1 second or more. If a layout shift happens after that, it creates a new session window.
- A session window cannot be longer than 5 seconds. So if adding a layout shift to a session window would make it longer than 5 seconds, then a new session window is created with that layout shift.
- The value of CLS is max value of session windows

![illustration of session windows](https://web-dev.imgix.net/image/admin/JSBg0yF1fatrTDQSKiTW.webp?auto=format&w=1600)

## Changes

- Implement the new CLS strategy
- Add new unit tests

## Testing
unit, CI
---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
