### PR TITLE
Remove monitoring & ignore untrusted events

### DIFF
--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -57,7 +57,7 @@ export function startForegroundContexts(configuration: Configuration): Foregroun
   }
 }
 
-function addNewForegroundPeriod() {
+export function addNewForegroundPeriod() {
   if (foregroundPeriods.length > MAX_NUMBER_OF_FOCUSED_TIME) {
     addMonitoringMessage('Reached maximum of foreground time')
     return
@@ -82,7 +82,7 @@ function addNewForegroundPeriod() {
   })
 }
 
-function closeForegroundPeriod() {
+export function closeForegroundPeriod() {
   if (foregroundPeriods.length === 0) {
     addMonitoringMessage('No foreground period')
     return

--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -110,7 +110,7 @@ function closeForegroundPeriod() {
 function trackFocus(onFocusChange: () => void) {
   return addEventListener(window, DOM_EVENT.FOCUS, (event) => {
     if (!event.isTrusted) {
-      addMonitoringMessage('Event not trusted for foreground', { eventName: 'focus' })
+      return
     }
     onFocusChange()
   })
@@ -119,7 +119,7 @@ function trackFocus(onFocusChange: () => void) {
 function trackBlur(onBlurChange: () => void) {
   return addEventListener(window, DOM_EVENT.BLUR, (event) => {
     if (!event.isTrusted) {
-      addMonitoringMessage('Event not trusted for foreground', { eventName: 'blur' })
+      return
     }
     onBlurChange()
   })


### PR DESCRIPTION
## Motivation


[Only happened 32 times in two days](https://app.datadoghq.com/logs?query=source%3Abrowser-agent-internal-monitoring%20Event%20not%20trusted%20for%20foreground&agg_m=count&agg_q=&agg_t=count&cols=%40view.url_details.host%2Csdk_version%2C%40http.useragent_details.browser.family&index=browser-agent-internal-monitoring&integration_id=&integration_short_name=&messageDisplay=inline&saved_view=64420&sort_m=&sort_t=&stream_sort=desc&top_n=&top_o=&viz=stream&from_ts=1627738775248&to_ts=1627911575248&live=true)

## Changes

- Clean monitoring
- Ignore not trusted event

