### PR TITLE
🏷️ add InternalContext.view.name

### DIFF
--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -217,6 +217,7 @@ export interface InternalContext {
     id: string
     url: string
     referrer: string
+    name?: string
   }
   user_action?: {
     id: string


### PR DESCRIPTION
## Motivation

InternalContext `view.name` property is missing from the types.

## Changes

Add it

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
