### PR TITLE
Introducing new max for foreground periods

### DIFF
--- a/packages/rum-core/src/domain/foregroundContexts.spec.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.spec.ts
@@ -3,6 +3,7 @@ import { setup, TestSetupBuilder } from '../../test/specHelper'
 import {
   startForegroundContexts,
   ForegroundContexts,
+  MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW,
   MAX_NUMBER_OF_FOCUSED_TIME,
   closeForegroundPeriod,
   addNewForegroundPeriod,
@@ -171,6 +172,7 @@ describe('foreground context', () => {
 
     it('should not record anything after reaching the maximum number of focus periods', () => {
       const { clock } = setupBuilder.build()
+      const start = relativeNow()
       for (let i = 0; i < MAX_NUMBER_OF_FOCUSED_TIME + 1; i++) {
         addNewForegroundPeriod()
         clock.tick(FOCUS_PERIOD_LENGTH)
@@ -182,6 +184,9 @@ describe('foreground context', () => {
       clock.tick(FOCUS_PERIOD_LENGTH)
 
       expect(foregroundContext.getInForeground(relativeNow())).toEqual(false)
+      const duration = (((FOCUS_PERIOD_LENGTH as number) + (BLUR_PERIOD_LENGTH as number)) *
+        MAX_NUMBER_OF_FOCUSED_TIME) as Duration
+      expect(foregroundContext.getInForegroundPeriods(start, duration)).toHaveSize(MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW)
     })
 
     it('should not be in foreground, when the periods is closed twice', () => {

--- a/packages/rum-core/src/domain/foregroundContexts.spec.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.spec.ts
@@ -3,8 +3,8 @@ import { setup, TestSetupBuilder } from '../../test/specHelper'
 import {
   startForegroundContexts,
   ForegroundContexts,
-  MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW,
-  MAX_NUMBER_OF_FOCUSED_TIME,
+  MAX_NUMBER_OF_SELECTABLE_FOREGROUND_PERIODS,
+  MAX_NUMBER_OF_STORED_FOREGROUND_PERIODS,
   closeForegroundPeriod,
   addNewForegroundPeriod,
 } from './foregroundContexts'
@@ -35,23 +35,23 @@ describe('foreground context', () => {
       spyOn(Document.prototype, 'hasFocus').and.callFake(() => false)
     })
     describe('without any focus nor blur event', () => {
-      describe('getInForeground', () => {
+      describe('isInForegroundAt', () => {
         it('should return false', () => {
           const { clock } = setupBuilder.build()
 
           clock.tick(1_000)
 
-          expect(foregroundContext.getInForeground(relativeNow())).toEqual(false)
+          expect(foregroundContext.isInForegroundAt(relativeNow())).toEqual(false)
         })
       })
 
-      describe('getInForegroundPeriods', () => {
+      describe('selectInForegroundPeriodsFor', () => {
         it('should an empty array', () => {
           const { clock } = setupBuilder.build()
 
           clock.tick(1_000)
 
-          expect(foregroundContext.getInForegroundPeriods(relativeNow(), 0 as Duration)).toEqual([])
+          expect(foregroundContext.selectInForegroundPeriodsFor(relativeNow(), 0 as Duration)).toEqual([])
         })
       })
     })
@@ -77,29 +77,29 @@ describe('foreground context', () => {
         clock.tick(FOCUS_PERIOD_LENGTH)
       })
 
-      it('getInForeground should match the focused/burred period', () => {
+      it('isInForegroundAt should match the focused/burred period', () => {
         // first blurred period
-        expect(foregroundContext.getInForeground(2 as RelativeTime)).toEqual(false)
+        expect(foregroundContext.isInForegroundAt(2 as RelativeTime)).toEqual(false)
 
         // first focused period
-        expect(foregroundContext.getInForeground(10 as RelativeTime)).toEqual(true)
+        expect(foregroundContext.isInForegroundAt(10 as RelativeTime)).toEqual(true)
 
         // second blurred period
-        expect(foregroundContext.getInForeground(17 as RelativeTime)).toEqual(false)
+        expect(foregroundContext.isInForegroundAt(17 as RelativeTime)).toEqual(false)
 
         // second focused period
-        expect(foregroundContext.getInForeground(25 as RelativeTime)).toEqual(true)
+        expect(foregroundContext.isInForegroundAt(25 as RelativeTime)).toEqual(true)
 
         // third blurred period
-        expect(foregroundContext.getInForeground(32 as RelativeTime)).toEqual(false)
+        expect(foregroundContext.isInForegroundAt(32 as RelativeTime)).toEqual(false)
 
         // current focused periods
-        expect(foregroundContext.getInForeground(42 as RelativeTime)).toEqual(true)
+        expect(foregroundContext.isInForegroundAt(42 as RelativeTime)).toEqual(true)
       })
 
-      describe('getInForegroundPeriods', () => {
+      describe('selectInForegroundPeriodsFor', () => {
         it('should have 3 in foreground periods for the whole period', () => {
-          const periods = foregroundContext.getInForegroundPeriods(0 as RelativeTime, 50 as Duration)
+          const periods = foregroundContext.selectInForegroundPeriodsFor(0 as RelativeTime, 50 as Duration)
 
           expect(periods).toHaveSize(3)
           expect(periods![0]).toEqual({
@@ -117,7 +117,7 @@ describe('foreground context', () => {
         })
 
         it('should have 2 in foreground periods when in between the two full periods', () => {
-          const periods = foregroundContext.getInForegroundPeriods(10 as RelativeTime, 15 as Duration)
+          const periods = foregroundContext.selectInForegroundPeriodsFor(10 as RelativeTime, 15 as Duration)
 
           expect(periods).toHaveSize(2)
           expect(periods![0]).toEqual({
@@ -131,7 +131,7 @@ describe('foreground context', () => {
         })
 
         it('should have 2 periods, when in between the the full period and ongoing periods', () => {
-          const periods = foregroundContext.getInForegroundPeriods(25 as RelativeTime, 20 as Duration)
+          const periods = foregroundContext.selectInForegroundPeriodsFor(25 as RelativeTime, 20 as Duration)
 
           expect(periods).toHaveSize(2)
           expect(periods![0]).toEqual({
@@ -162,18 +162,18 @@ describe('foreground context', () => {
         closeForegroundPeriod()
         clock.tick(BLUR_PERIOD_LENGTH)
       })
-      it('getInForeground should match the focused/burred period', () => {
-        expect(foregroundContext.getInForeground(2 as RelativeTime)).toEqual(false)
-        expect(foregroundContext.getInForeground(10 as RelativeTime)).toEqual(true)
-        expect(foregroundContext.getInForeground(20 as RelativeTime)).toEqual(true)
-        expect(foregroundContext.getInForeground(30 as RelativeTime)).toEqual(false)
+      it('isInForegroundAt should match the focused/burred period', () => {
+        expect(foregroundContext.isInForegroundAt(2 as RelativeTime)).toEqual(false)
+        expect(foregroundContext.isInForegroundAt(10 as RelativeTime)).toEqual(true)
+        expect(foregroundContext.isInForegroundAt(20 as RelativeTime)).toEqual(true)
+        expect(foregroundContext.isInForegroundAt(30 as RelativeTime)).toEqual(false)
       })
     })
 
     it('should not record anything after reaching the maximum number of focus periods', () => {
       const { clock } = setupBuilder.build()
       const start = relativeNow()
-      for (let i = 0; i < MAX_NUMBER_OF_FOCUSED_TIME + 1; i++) {
+      for (let i = 0; i < MAX_NUMBER_OF_STORED_FOREGROUND_PERIODS + 1; i++) {
         addNewForegroundPeriod()
         clock.tick(FOCUS_PERIOD_LENGTH)
         closeForegroundPeriod()
@@ -183,10 +183,12 @@ describe('foreground context', () => {
       addNewForegroundPeriod()
       clock.tick(FOCUS_PERIOD_LENGTH)
 
-      expect(foregroundContext.getInForeground(relativeNow())).toEqual(false)
+      expect(foregroundContext.isInForegroundAt(relativeNow())).toEqual(false)
       const duration = (((FOCUS_PERIOD_LENGTH as number) + (BLUR_PERIOD_LENGTH as number)) *
-        MAX_NUMBER_OF_FOCUSED_TIME) as Duration
-      expect(foregroundContext.getInForegroundPeriods(start, duration)).toHaveSize(MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW)
+        MAX_NUMBER_OF_STORED_FOREGROUND_PERIODS) as Duration
+      expect(foregroundContext.selectInForegroundPeriodsFor(start, duration)).toHaveSize(
+        MAX_NUMBER_OF_SELECTABLE_FOREGROUND_PERIODS
+      )
     })
 
     it('should not be in foreground, when the periods is closed twice', () => {
@@ -197,14 +199,14 @@ describe('foreground context', () => {
       clock.tick(BLUR_PERIOD_LENGTH)
       closeForegroundPeriod()
 
-      expect(foregroundContext.getInForeground(relativeNow())).toEqual(false)
+      expect(foregroundContext.isInForegroundAt(relativeNow())).toEqual(false)
     })
 
     it('after starting with a blur even, should not be in foreground', () => {
       setupBuilder.build()
       closeForegroundPeriod()
 
-      expect(foregroundContext.getInForeground(relativeNow())).toEqual(false)
+      expect(foregroundContext.isInForegroundAt(relativeNow())).toEqual(false)
     })
   })
 
@@ -219,7 +221,7 @@ describe('foreground context', () => {
         clock.tick(FOCUS_PERIOD_LENGTH)
         closeForegroundPeriod()
 
-        expect(foregroundContext.getInForeground(2 as RelativeTime)).toEqual(true)
+        expect(foregroundContext.isInForegroundAt(2 as RelativeTime)).toEqual(true)
       })
 
       it('should return false after the first focused period', () => {
@@ -227,7 +229,7 @@ describe('foreground context', () => {
         clock.tick(FOCUS_PERIOD_LENGTH)
         closeForegroundPeriod()
 
-        expect(foregroundContext.getInForeground(12 as RelativeTime)).toEqual(false)
+        expect(foregroundContext.isInForegroundAt(12 as RelativeTime)).toEqual(false)
       })
     })
 
@@ -239,7 +241,7 @@ describe('foreground context', () => {
         clock.tick(FOCUS_PERIOD_LENGTH / 2)
         closeForegroundPeriod()
 
-        expect(foregroundContext.getInForeground(2 as RelativeTime)).toEqual(true)
+        expect(foregroundContext.isInForegroundAt(2 as RelativeTime)).toEqual(true)
       })
 
       it('should return false after the focused period', () => {
@@ -249,7 +251,7 @@ describe('foreground context', () => {
         clock.tick(FOCUS_PERIOD_LENGTH / 2)
         closeForegroundPeriod()
 
-        expect(foregroundContext.getInForeground(12 as RelativeTime)).toEqual(false)
+        expect(foregroundContext.isInForegroundAt(12 as RelativeTime)).toEqual(false)
       })
     })
   })

--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -148,11 +148,9 @@ function getInForegroundPeriods(eventStartTime: RelativeTime, duration: Duration
   const eventEndTime = (eventStartTime + duration) as RelativeTime
   const filteredForegroundPeriods: InForegroundPeriod[] = []
 
-  for (let i = foregroundPeriods.length - 1; i >= 0; i--) {
+  const earliestIndex = Math.max(0, foregroundPeriods.length - MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW)
+  for (let i = foregroundPeriods.length - 1; i >= earliestIndex; i--) {
     const foregroundPeriod = foregroundPeriods[i]
-    if (foregroundPeriods.length - i > MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW) {
-      break
-    }
     if (foregroundPeriod.end !== undefined && eventStartTime > foregroundPeriod.end) {
       // event starts after the end of the current focus period
       // since the array is sorted, we can stop looking for foreground periods

--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -13,16 +13,16 @@ import {
 import { InForegroundPeriod } from '../rawRumEvent.types'
 
 // Arbitrary value to cap number of element mostly for backend & to save bandwidth
-export const MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW = 500
+export const MAX_NUMBER_OF_SELECTABLE_FOREGROUND_PERIODS = 500
 // Arbitrary value to cap number of element mostly for memory consumption in the browser
-export const MAX_NUMBER_OF_FOCUSED_TIME = 2500
+export const MAX_NUMBER_OF_STORED_FOREGROUND_PERIODS = 2500
 // ignore duplicate focus & blur events if coming in the right after the previous one
 // chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1237904
 const MAX_TIME_TO_IGNORE_DUPLICATE = 10 as RelativeTime
 
 export interface ForegroundContexts {
-  getInForeground: (startTime: RelativeTime) => boolean | undefined
-  getInForegroundPeriods: (startTime: RelativeTime, duration: Duration) => InForegroundPeriod[] | undefined
+  isInForegroundAt: (startTime: RelativeTime) => boolean | undefined
+  selectInForegroundPeriodsFor: (startTime: RelativeTime, duration: Duration) => InForegroundPeriod[] | undefined
   stop: () => void
 }
 
@@ -36,8 +36,8 @@ let foregroundPeriods: ForegroundPeriod[] = []
 export function startForegroundContexts(configuration: Configuration): ForegroundContexts {
   if (!configuration.isEnabled('track-foreground')) {
     return {
-      getInForeground: () => undefined,
-      getInForegroundPeriods: () => undefined,
+      isInForegroundAt: () => undefined,
+      selectInForegroundPeriodsFor: () => undefined,
       stop: noop,
     }
   }
@@ -49,8 +49,8 @@ export function startForegroundContexts(configuration: Configuration): Foregroun
   const { stop: stopForegroundTracking } = trackFocus(addNewForegroundPeriod)
   const { stop: stopBlurTracking } = trackBlur(closeForegroundPeriod)
   return {
-    getInForeground,
-    getInForegroundPeriods,
+    isInForegroundAt,
+    selectInForegroundPeriodsFor,
     stop: () => {
       foregroundPeriods = []
       stopForegroundTracking()
@@ -60,7 +60,7 @@ export function startForegroundContexts(configuration: Configuration): Foregroun
 }
 
 export function addNewForegroundPeriod() {
-  if (foregroundPeriods.length > MAX_NUMBER_OF_FOCUSED_TIME) {
+  if (foregroundPeriods.length > MAX_NUMBER_OF_STORED_FOREGROUND_PERIODS) {
     addMonitoringMessage('Reached maximum of foreground time')
     return
   }
@@ -127,7 +127,7 @@ function trackBlur(onBlurChange: () => void) {
   })
 }
 
-function getInForeground(startTime: RelativeTime): boolean {
+function isInForegroundAt(startTime: RelativeTime): boolean {
   for (let i = foregroundPeriods.length - 1; i >= 0; i--) {
     const foregroundPeriod = foregroundPeriods[i]
     if (foregroundPeriod.end !== undefined && startTime > foregroundPeriod.end) {
@@ -143,12 +143,12 @@ function getInForeground(startTime: RelativeTime): boolean {
   return false
 }
 
-function getInForegroundPeriods(eventStartTime: RelativeTime, duration: Duration): InForegroundPeriod[] {
+function selectInForegroundPeriodsFor(eventStartTime: RelativeTime, duration: Duration): InForegroundPeriod[] {
   // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
   const eventEndTime = (eventStartTime + duration) as RelativeTime
   const filteredForegroundPeriods: InForegroundPeriod[] = []
 
-  const earliestIndex = Math.max(0, foregroundPeriods.length - MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW)
+  const earliestIndex = Math.max(0, foregroundPeriods.length - MAX_NUMBER_OF_SELECTABLE_FOREGROUND_PERIODS)
   for (let i = foregroundPeriods.length - 1; i >= earliestIndex; i--) {
     const foregroundPeriod = foregroundPeriods[i]
     if (foregroundPeriod.end !== undefined && eventStartTime > foregroundPeriod.end) {

--- a/packages/rum-core/src/domain/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/foregroundContexts.ts
@@ -12,8 +12,10 @@ import {
 } from '@datadog/browser-core'
 import { InForegroundPeriod } from '../rawRumEvent.types'
 
-// Arbitrary value to cap number of element (mostly for backend)
-export const MAX_NUMBER_OF_FOCUSED_TIME = 500
+// Arbitrary value to cap number of element mostly for backend & to save bandwidth
+export const MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW = 500
+// Arbitrary value to cap number of element mostly for memory consumption in the browser
+export const MAX_NUMBER_OF_FOCUSED_TIME = 2500
 // ignore duplicate focus & blur events if coming in the right after the previous one
 // chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1237904
 const MAX_TIME_TO_IGNORE_DUPLICATE = 10 as RelativeTime
@@ -148,6 +150,9 @@ function getInForegroundPeriods(eventStartTime: RelativeTime, duration: Duration
 
   for (let i = foregroundPeriods.length - 1; i >= 0; i--) {
     const foregroundPeriod = foregroundPeriods[i]
+    if (foregroundPeriods.length - i > MAX_NUMBER_OF_FOCUSED_TIME_PER_VIEW) {
+      break
+    }
     if (foregroundPeriod.end !== undefined && eventStartTime > foregroundPeriod.end) {
       // event starts after the end of the current focus period
       // since the array is sorted, we can stop looking for foreground periods

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -15,7 +15,7 @@ describe('actionCollection', () => {
         isEnabled: () => true,
       })
       .withForegroundContexts({
-        getInForeground: () => true,
+        isInForegroundAt: () => true,
       })
       .beforeBuild(({ lifeCycle, configuration, domMutationObservable, foregroundContexts }) => {
         ;({ addAction } = startActionCollection(lifeCycle, domMutationObservable, configuration, foregroundContexts))

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -65,7 +65,7 @@ function processAction(
     },
     autoActionProperties
   )
-  const inForeground = foregroundContexts.getInForeground(action.startClocks.relative)
+  const inForeground = foregroundContexts.isInForegroundAt(action.startClocks.relative)
   if (inForeground !== undefined) {
     actionEvent.view = { in_foreground: inForeground }
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -14,7 +14,7 @@ describe('error collection', () => {
         isEnabled: () => true,
       })
       .withForegroundContexts({
-        getInForeground: () => true,
+        isInForegroundAt: () => true,
       })
       .beforeBuild(({ lifeCycle, foregroundContexts }) => {
         ;({ addError } = doStartErrorCollection(lifeCycle, foregroundContexts))

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -91,7 +91,7 @@ function processError(
     },
     type: RumEventType.ERROR as const,
   }
-  const inForeground = foregroundContexts.getInForeground(error.startClocks.relative)
+  const inForeground = foregroundContexts.isInForegroundAt(error.startClocks.relative)
   if (inForeground !== undefined) {
     rawRumEvent.view = { in_foreground: inForeground }
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -50,7 +50,7 @@ describe('viewCollection', () => {
         isEnabled: () => true,
       })
       .withForegroundContexts({
-        getInForegroundPeriods: () => [{ start: 0 as ServerDuration, duration: 10 as ServerDuration }],
+        selectInForegroundPeriodsFor: () => [{ start: 0 as ServerDuration, duration: 10 as ServerDuration }],
       })
       .beforeBuild(({ lifeCycle, configuration, foregroundContexts, domMutationObservable }) => {
         getReplayStatsSpy = jasmine.createSpy()

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -79,7 +79,7 @@ function processViewUpdate(
         count: view.eventCounts.resourceCount,
       },
       time_spent: toServerDuration(view.duration),
-      in_foreground_periods: foregroundContexts.getInForegroundPeriods(view.startClocks.relative, view.duration),
+      in_foreground_periods: foregroundContexts.selectInForegroundPeriodsFor(view.startClocks.relative, view.duration),
     },
     session: {
       has_replay: replayStats ? true : undefined,

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -65,8 +65,8 @@ export function setup(): TestSetupBuilder {
   let fakeLocation: Partial<Location> = location
   let parentContexts: ParentContexts
   let foregroundContexts: ForegroundContexts = {
-    getInForeground: () => undefined,
-    getInForegroundPeriods: () => undefined,
+    isInForegroundAt: () => undefined,
+    selectInForegroundPeriodsFor: () => undefined,
     stop: noop,
   }
   const configuration: Partial<Configuration> = {


### PR DESCRIPTION
## Motivation

We have quite a log of `Reached maximum of foreground time` errors but the views do not have 500 items.

## Changes

Let's split the max in two: 
- a max of periods stored to limit memory used
- a max of periods by view to limit bandwidth

## Testing

It's unit tested