### PR TITLE
👷Minor reorg/cleanup

### DIFF
--- a/packages/rum/src/domain/record/mutationObserver.ts
+++ b/packages/rum/src/domain/record/mutationObserver.ts
@@ -1,7 +1,7 @@
 import { InitialPrivacyLevel, monitor, noop } from '@datadog/browser-core'
 import { getMutationObserverConstructor } from '@datadog/browser-rum-core'
 import { NodePrivacyLevel } from '../../constants'
-import { serializeAttribute, getNodePrivacyLevel, getTextContent } from './privacy'
+import { getNodePrivacyLevel, getTextContent } from './privacy'
 import {
   getElementInputValue,
   getSerializedNodeId,
@@ -9,7 +9,7 @@ import {
   nodeAndAncestorsHaveSerializedNode,
   NodeWithSerializedNode,
 } from './serializationUtils'
-import { serializeNodeWithId } from './serialize'
+import { serializeNodeWithId, serializeAttribute } from './serialize'
 import {
   AddedNodeMutation,
   AttributeMutation,

--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -1,14 +1,7 @@
 import { isIE } from '../../../../core/test/specHelper'
 import { NodePrivacyLevel } from '../../constants'
 import { HTML, generateLeanSerializedDoc } from '../../../test/htmlAst'
-import {
-  getNodeSelfPrivacyLevel,
-  reducePrivacyLevel,
-  getNodePrivacyLevel,
-  shouldMaskNode,
-  serializeAttribute,
-  MAX_ATTRIBUTE_VALUE_CHAR_LENGTH,
-} from './privacy'
+import { getNodeSelfPrivacyLevel, reducePrivacyLevel, getNodePrivacyLevel, shouldMaskNode } from './privacy'
 import { ElementNode, NodeType, TextNode, SerializedNodeWithId } from './types'
 
 describe('privacy helpers', () => {
@@ -394,28 +387,5 @@ describe('shouldMaskNode', () => {
       expect(shouldMaskNode(element, NodePrivacyLevel.IGNORE)).toBeTrue()
       expect(shouldMaskNode(element, NodePrivacyLevel.HIDDEN)).toBeTrue()
     })
-  })
-})
-
-describe('serializeAttribute ', () => {
-  it('truncates "data:" URIs after long string length', () => {
-    const node = document.createElement('p')
-
-    const longString = new Array(MAX_ATTRIBUTE_VALUE_CHAR_LENGTH + 1 - 5).join('a')
-    const maxAttributeValue = `data:${longString}`
-    const exceededAttributeValue = `data:${longString}1`
-    const ignoredAttributeValue = `foos:${longString}`
-
-    node.setAttribute('test-okay', maxAttributeValue)
-    node.setAttribute('test-truncate', exceededAttributeValue)
-    node.setAttribute('test-ignored', ignoredAttributeValue)
-
-    expect(serializeAttribute(node, NodePrivacyLevel.ALLOW, 'test-okay')).toBe(maxAttributeValue)
-    expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'test-okay')).toBe(maxAttributeValue)
-
-    expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'test-ignored')).toBe(ignoredAttributeValue)
-
-    expect(serializeAttribute(node, NodePrivacyLevel.ALLOW, 'test-truncate')).toBe('data:truncated')
-    expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'test-truncate')).toBe('data:truncated')
   })
 })

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -11,7 +11,6 @@ import {
   PRIVACY_CLASS_HIDDEN,
   FORM_PRIVATE_TAG_NAMES,
   CENSORED_STRING_MARK,
-  CENSORED_IMG_MARK,
   // Deprecated (now aliased) below
   PRIVACY_CLASS_INPUT_IGNORED,
   PRIVACY_CLASS_INPUT_MASKED,
@@ -21,7 +20,7 @@ import {
 
 export const MAX_ATTRIBUTE_VALUE_CHAR_LENGTH = 100_000
 
-import { makeStylesheetUrlsAbsolute, makeSrcsetUrlsAbsolute, makeUrlAbsolute } from './serializationUtils'
+import { makeStylesheetUrlsAbsolute } from './serializationUtils'
 
 import { shouldIgnoreElement } from './serialize'
 
@@ -150,66 +149,6 @@ export function shouldMaskNode(node: Node, privacyLevel: NodePrivacyLevel) {
       return isTextNode(node) ? isFormElement(node.parentNode) : isFormElement(node)
     default:
       return false
-  }
-}
-
-export function serializeAttribute(
-  element: Element,
-  nodePrivacyLevel: NodePrivacyLevel,
-  attributeName: string
-): string | number | boolean | null {
-  if (nodePrivacyLevel === NodePrivacyLevel.HIDDEN) {
-    // dup condition for direct access case
-    return null
-  }
-  const attributeValue = element.getAttribute(attributeName)
-  if (nodePrivacyLevel === NodePrivacyLevel.MASK) {
-    const tagName = element.tagName
-
-    switch (attributeName) {
-      // Mask Attribute text content
-      case 'title':
-      case 'alt':
-        return CENSORED_STRING_MARK
-    }
-    // mask image URLs
-    if (tagName === 'IMG' || tagName === 'SOURCE') {
-      if (attributeName === 'src' || attributeName === 'srcset') {
-        return CENSORED_IMG_MARK
-      }
-    }
-    // mask <a> URLs
-    if (tagName === 'A' && attributeName === 'href') {
-      return CENSORED_STRING_MARK
-    }
-    // mask data-* attributes
-    if (attributeValue && attributeName.indexOf('data-') === 0 && attributeName !== PRIVACY_ATTR_NAME) {
-      // Exception: it's safe to reveal the `${PRIVACY_ATTR_NAME}` attr
-      return CENSORED_STRING_MARK
-    }
-  }
-
-  if (!attributeValue || typeof attributeValue !== 'string') {
-    return attributeValue
-  }
-
-  // Minimum Fix for customer.
-  if (attributeValue.length > MAX_ATTRIBUTE_VALUE_CHAR_LENGTH && attributeValue.slice(0, 5) === 'data:') {
-    return 'data:truncated'
-  }
-
-  // Rebuild absolute URLs from relative (without using <base> tag)
-  const doc = element.ownerDocument
-  switch (attributeName) {
-    case 'src':
-    case 'href':
-      return makeUrlAbsolute(attributeValue, doc.location?.href)
-    case 'srcset':
-      return makeSrcsetUrlsAbsolute(attributeValue, doc.location?.href)
-    case 'style':
-      return makeStylesheetUrlsAbsolute(attributeValue, doc.location?.href)
-    default:
-      return attributeValue
   }
 }
 


### PR DESCRIPTION
## Motivation

Migrates `serializeAttribute()` from privacy.ts to serialize.ts as more appropriate position.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
