### PR TITLE
[RUMF-976] add info to monitor failing xhr fallback

### DIFF
--- a/packages/core/src/transport/batch.spec.ts
+++ b/packages/core/src/transport/batch.spec.ts
@@ -23,7 +23,7 @@ describe('batch', () => {
 
     batch.flush()
 
-    expect(transport.send).toHaveBeenCalledWith('{"message":"hello"}', jasmine.any(Number))
+    expect(transport.send).toHaveBeenCalledWith('{"message":"hello"}', jasmine.any(Number), undefined)
   })
 
   it('should empty the batch after a flush', () => {
@@ -50,7 +50,8 @@ describe('batch', () => {
     batch.add({ message: '3' })
     expect(transport.send).toHaveBeenCalledWith(
       '{"message":"1"}\n{"message":"2"}\n{"message":"3"}',
-      jasmine.any(Number)
+      jasmine.any(Number),
+      jasmine.any(String)
     )
   })
 
@@ -59,10 +60,18 @@ describe('batch', () => {
     expect(transport.send).not.toHaveBeenCalled()
 
     batch.add({ message: '60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' })
-    expect(transport.send).toHaveBeenCalledWith('{"message":"50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx"}', 50)
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"message":"50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx"}',
+      50,
+      'willReachedBytesLimitWith'
+    )
 
     batch.flush()
-    expect(transport.send).toHaveBeenCalledWith('{"message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}', 60)
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}',
+      60,
+      undefined
+    )
   })
 
   it('should consider separator size when computing the size', () => {
@@ -70,13 +79,17 @@ describe('batch', () => {
     batch.add({ message: '30 bytes - xxxxx' }) // batch: 60 sep: 1
     batch.add({ message: '39 bytes - xxxxxxxxxxxxxx' }) // batch: 99 sep: 2
 
-    expect(transport.send).toHaveBeenCalledWith('{"message":"30 bytes - xxxxx"}\n{"message":"30 bytes - xxxxx"}', 61)
+    expect(transport.send).toHaveBeenCalledWith(
+      '{"message":"30 bytes - xxxxx"}\n{"message":"30 bytes - xxxxx"}',
+      61,
+      'willReachedBytesLimitWith'
+    )
   })
 
   it('should call send one time when the size is too high and the batch is empty', () => {
     const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     batch.add({ message })
-    expect(transport.send).toHaveBeenCalledWith(`{"message":"${message}"}`, 101)
+    expect(transport.send).toHaveBeenCalledWith(`{"message":"${message}"}`, 101, 'isFull')
   })
 
   it('should flush the batch and send the message when the message is too heavy', () => {
@@ -115,7 +128,8 @@ describe('batch', () => {
 
     expect(transport.send).toHaveBeenCalledWith(
       '{"message":"2"}\n{"message":"3"}\n{"message":"4"}',
-      jasmine.any(Number)
+      jasmine.any(Number),
+      jasmine.any(String)
     )
 
     batch.upsert({ message: '5' }, 'c')
@@ -124,7 +138,8 @@ describe('batch', () => {
 
     expect(transport.send).toHaveBeenCalledWith(
       '{"message":"5"}\n{"message":"6"}\n{"message":"7"}',
-      jasmine.any(Number)
+      jasmine.any(Number),
+      jasmine.any(String)
     )
 
     batch.upsert({ message: '8' }, 'a')
@@ -133,6 +148,6 @@ describe('batch', () => {
     batch.upsert({ message: '11' }, 'b')
     batch.flush()
 
-    expect(transport.send).toHaveBeenCalledWith('{"message":"10"}\n{"message":"11"}', jasmine.any(Number))
+    expect(transport.send).toHaveBeenCalledWith('{"message":"10"}\n{"message":"11"}', jasmine.any(Number), undefined)
   })
 })

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -52,7 +52,7 @@ export class HttpRequest {
           request: {
             status: req.status,
             ready_state: req.readyState,
-            response_text: req.responseText.slice(0, 64),
+            response_text: req.responseText.slice(0, 256),
           },
         })
       }

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -53,7 +53,7 @@ export class HttpRequest {
           request: {
             status: req.status,
             ready_state: req.readyState,
-            response_text: req.responseText.slice(0, 256),
+            response_text: req.responseText.slice(0, 512),
           },
         })
       }

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -14,7 +14,7 @@ let hasReportedXhrError = false
 export class HttpRequest {
   constructor(private endpointUrl: string, private bytesLimit: number, private withBatchTime: boolean = false) {}
 
-  send(data: string | FormData, size: number) {
+  send(data: string | FormData, size: number, flushReason?: string) {
     let url = addQueryParameter(this.endpointUrl, 'dd-request-id', generateUUID())
     if (this.withBatchTime) {
       url = addQueryParameter(url, 'batch_time', new Date().getTime().toString())
@@ -44,6 +44,7 @@ export class HttpRequest {
           size,
           url,
           try_beacon: tryBeacon,
+          flush_reason: flushReason,
           event: {
             is_trusted: event.isTrusted,
             total: event.total,

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -75,7 +75,7 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(1, (calls) => {
-      expect(calls.first().args).toEqual([jasmine.any(FormData), jasmine.any(Number)])
+      expect(calls.first().args).toEqual([jasmine.any(FormData), jasmine.any(Number), 'before_unload'])
       expect(getRequestData(calls.first())).toEqual({
         'application.id': 'appId',
         creation_reason: 'init',

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -18,7 +18,8 @@ export function startRecording(
     applicationId,
     session,
     parentContexts,
-    (data, meta, rawSegmentSize) => send(configuration.sessionReplayEndpoint, data, meta, rawSegmentSize)
+    (data, meta, rawSegmentSize, flushReason) =>
+      send(configuration.sessionReplayEndpoint, data, meta, rawSegmentSize, flushReason)
   )
 
   function addRawRecord(rawRecord: RawRecord) {

--- a/packages/rum/src/domain/segmentCollection/segment.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.ts
@@ -7,6 +7,7 @@ let nextId = 0
 
 export class Segment {
   public isFlushed = false
+  public flushReason?: string
 
   private id = nextId++
   private start: number
@@ -69,9 +70,14 @@ export class Segment {
     this.worker.postMessage({ data: `,${JSON.stringify(record)}`, id: this.id, action: 'write' })
   }
 
-  flush() {
-    this.worker.postMessage({ data: `],${JSON.stringify(this.meta).slice(1)}\n`, id: this.id, action: 'flush' })
+  flush(reason?: string) {
+    this.worker.postMessage({
+      data: `],${JSON.stringify(this.meta).slice(1)}\n`,
+      id: this.id,
+      action: 'flush',
+    })
     this.isFlushed = true
+    this.flushReason = reason
   }
 
   get meta(): SegmentMeta {

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -40,7 +40,7 @@ export function startSegmentCollection(
   applicationId: string,
   session: RumSession,
   parentContexts: ParentContexts,
-  send: (data: Uint8Array, meta: SegmentMeta, rawSegmentSize: number) => void
+  send: (data: Uint8Array, meta: SegmentMeta, rawSegmentSize: number, flushReason?: string) => void
 ) {
   if (!workerSingleton) {
     workerSingleton = createDeflateWorker()
@@ -83,7 +83,7 @@ type SegmentCollectionState =
 export function doStartSegmentCollection(
   lifeCycle: LifeCycle,
   getSegmentContext: () => SegmentContext | undefined,
-  send: (data: Uint8Array, meta: SegmentMeta, rawSegmentSize: number) => void,
+  send: (data: Uint8Array, meta: SegmentMeta, rawSegmentSize: number, flushReason?: string) => void,
   worker: DeflateWorker,
   emitter: EventEmitter = window
 ) {
@@ -113,7 +113,7 @@ export function doStartSegmentCollection(
 
   function flushSegment(nextSegmentCreationReason?: CreationReason) {
     if (state.status === SegmentCollectionStatus.SegmentPending) {
-      state.segment.flush()
+      state.segment.flush(nextSegmentCreationReason || 'sdk_stopped')
       clearTimeout(state.expirationTimeoutId)
     }
 
@@ -146,7 +146,7 @@ export function doStartSegmentCollection(
         }
       },
       (data, rawSegmentSize) => {
-        send(data, segment.meta, rawSegmentSize)
+        send(data, segment.meta, rawSegmentSize, segment.flushReason)
       }
     )
 

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -3,7 +3,13 @@ import { SegmentMeta } from '../types'
 
 export const SEND_BEACON_BYTE_LENGTH_LIMIT = 60_000
 
-export function send(endpointUrl: string, data: Uint8Array, meta: SegmentMeta, rawSegmentSize: number): void {
+export function send(
+  endpointUrl: string,
+  data: Uint8Array,
+  meta: SegmentMeta,
+  rawSegmentSize: number,
+  flushReason?: string
+): void {
   const formData = new FormData()
 
   formData.set(
@@ -18,7 +24,7 @@ export function send(endpointUrl: string, data: Uint8Array, meta: SegmentMeta, r
   formData.set('raw_segment_size', rawSegmentSize.toString())
 
   const request = new HttpRequest(endpointUrl, SEND_BEACON_BYTE_LENGTH_LIMIT)
-  request.send(formData, data.byteLength)
+  request.send(formData, data.byteLength, flushReason)
 }
 
 export function toFormEntries(input: object, onEntry: (key: string, value: string) => void, prefix = '') {


### PR DESCRIPTION
## Motivation

The browser SDK uses sendBeacon() when available and the size < (16KB for rum, 60ko for replay). If not, it falls back to XMLHttpRequest. In some cases the XHR requests fail. This PR adds some information in the internal monitoring to better understand the reasons of this issue.

## Changes

- Add flush reason
- Increase response text length

## Testing

Unit, Locally
---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
