### PR TITLE
[RUM] Switch Unicode `᙮` to Ascii `x`

### DIFF
--- a/packages/rum/src/domain/record/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/mutationObserver.spec.ts
@@ -415,7 +415,7 @@ describe('startMutationCollection', () => {
             parent: expectInitialNode({ idAttribute: 'sandbox' }),
             node: expectNewNode({
               type: NodeType.Text,
-              textContent: '᙮᙮᙮ ᙮᙮᙮',
+              textContent: 'xxx xxx',
             }),
           },
         ],
@@ -474,7 +474,7 @@ describe('startMutationCollection', () => {
         texts: [
           {
             node: expectInitialNode({ text: 'foo' }),
-            value: '᙮᙮᙮ ᙮᙮᙮',
+            value: 'xxx xxx',
           },
         ],
       })

--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -320,7 +320,7 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
   describe('for privacy tag `mask-forms-only`, a DOM tree', function testMaskFormsOnlyDomTree() {
     it("doesn't mask text content", () => {
       const serializedDoc = generateLeanSerializedDoc(HTML, 'mask-forms-only')
-      expect(JSON.stringify(serializedDoc)).not.toContain('xx')
+      expect(JSON.stringify(serializedDoc)).not.toContain('᙮᙮')
     })
     it('keeps form fields private', () => {
       const serializedDoc = generateLeanSerializedDoc(HTML, 'mask-forms-only')

--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -307,7 +307,7 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
     it("doesn't have innerText alpha numeric", () => {
       const serializedDoc = generateLeanSerializedDoc(HTML, 'mask')
       expect({ text: getTextNodesFromSerialized(serializedDoc) }).not.toBe({
-        text: jasmine.stringMatching(/^[*᙮\s]+\.example {content: "anything";}[*᙮\s]+$/),
+        text: jasmine.stringMatching(/^[*x\s]+\.example {content: "anything";}[*x\s]+$/),
       })
     })
 

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -24,7 +24,7 @@ import { makeStylesheetUrlsAbsolute } from './serializationUtils'
 
 import { shouldIgnoreElement } from './serialize'
 
-const TEXT_MASKING_CHAR = '᙮'
+const TEXT_MASKING_CHAR = 'x'
 
 /**
  * Get node privacy level by iterating over its ancestors. When the direct parent privacy level is

--- a/packages/rum/test/htmlAst.ts
+++ b/packages/rum/test/htmlAst.ts
@@ -155,7 +155,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮',
+                  textContent: 'xxxxxxx xxxxx',
                 },
               ],
             },
@@ -181,7 +181,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮',
+                  textContent: 'xxxxx xxxxxxx xxxxx',
                 },
               ],
             },
@@ -196,7 +196,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮',
+                  textContent: 'xxxxxx xxxxx xxxxxxx xxxx',
                 },
               ],
             },
@@ -211,7 +211,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮',
+                  textContent: 'xxxxx xxxxxxx xxxxx',
                 },
               ],
             },
@@ -228,7 +228,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '\n      ᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮᙮\n    ',
+                  textContent: '\n      xxxxx xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n    ',
                 },
               ],
             },
@@ -342,7 +342,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '᙮᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮',
+                  textContent: 'xxxxxxxx xxxxx',
                 },
               ],
             },
@@ -377,7 +377,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '      ᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮\n    ',
+                  textContent: '      xxxxxx xxxxx xxxxxxx xxx\n    ',
                 },
               ],
             },
@@ -394,7 +394,7 @@ export const AST_MASK = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '᙮᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮',
+                  textContent: 'xxxxxxxx xxxxxxx xxx',
                 },
               ],
             },
@@ -692,7 +692,7 @@ export const AST_MASK_FORMS_ONLY = {
               childNodes: [
                 {
                   type: 3,
-                  textContent: '      ᙮᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮ ᙮᙮᙮᙮᙮᙮᙮ ᙮᙮᙮\n    ',
+                  textContent: '      xxxxxx xxxxx xxxxxxx xxx\n    ',
                 },
               ],
             },


### PR DESCRIPTION
## Motivation
Currently the privacy-by-default implementation replaces sensitive content with `᙮᙮᙮᙮᙮ ᙮᙮᙮ ᙮᙮᙮᙮᙮` like strings. These '᙮' characters are not your standard ASCII 'x' characters. In balancing the tradeoff between empirical pixel perfect sizing vs simple ASCII (font support etc), we decided to lean towards simple ASCII. Therefore we are replacing codePoint=5742 ('\u{166e}') with to codePoint=120.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
