### PR TITLE
✨ Discard long FCP and LCP

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
@@ -1,4 +1,4 @@
-import { DOM_EVENT, Duration, RelativeTime } from '@datadog/browser-core'
+import { DOM_EVENT, Duration, ONE_MINUTE, RelativeTime } from '@datadog/browser-core'
 import { createNewEvent, restorePageVisibility, setPageVisibility } from '../../../../../core/test/specHelper'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import {
@@ -136,6 +136,16 @@ describe('trackFirstContentfulPaint', () => {
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_PAINT_ENTRY)
     expect(fcpCallback).not.toHaveBeenCalled()
   })
+
+  it('should not be present if it happens after 10 minutes', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
+      ...FAKE_PAINT_ENTRY,
+      startTime: (10 * ONE_MINUTE) as RelativeTime,
+    })
+    expect(fcpCallback).not.toHaveBeenCalled()
+  })
 })
 
 describe('largestContentfulPaint', () => {
@@ -179,6 +189,16 @@ describe('largestContentfulPaint', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY)
 
+    expect(lcpCallback).not.toHaveBeenCalled()
+  })
+
+  it('should not be present if it happens after 10 minutes', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, {
+      ...FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY,
+      startTime: (10 * ONE_MINUTE) as RelativeTime,
+    })
     expect(lcpCallback).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
@@ -5,12 +5,14 @@ import {
   elapsed,
   EventEmitter,
   RelativeTime,
-  timeStampNow,
-  TimeStamp,
   ONE_MINUTE,
 } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { trackFirstHidden } from './trackFirstHidden'
+
+// Discard LCP and FCP timings above a certain delay to avoid incorrect data
+// It happens in some cases like sleep mode or some browser implementations
+export const TIMING_MAXIMUM_DELAY = 10 * ONE_MINUTE
 
 export interface Timings {
   firstContentfulPaint?: Duration
@@ -31,10 +33,10 @@ export function trackInitialViewTimings(lifeCycle: LifeCycle, callback: (timings
   }
 
   const { stop: stopNavigationTracking } = trackNavigationTimings(lifeCycle, setTimings)
-  const { stop: stopFCPTracking } = trackFirstContentfulPaint(lifeCycle, (firstContentfulPaint) =>
+  const { stop: stopFCPTracking } = trackFirstContentfulPaintTiming(lifeCycle, (firstContentfulPaint) =>
     setTimings({ firstContentfulPaint })
   )
-  const { stop: stopLCPTracking } = trackLargestContentfulPaint(lifeCycle, window, (largestContentfulPaint) => {
+  const { stop: stopLCPTracking } = trackLargestContentfulPaintTiming(lifeCycle, window, (largestContentfulPaint) => {
     setTimings({
       largestContentfulPaint,
     })
@@ -56,7 +58,7 @@ export function trackInitialViewTimings(lifeCycle: LifeCycle, callback: (timings
   }
 }
 
-export function trackNavigationTimings(lifeCycle: LifeCycle, callback: (newTimings: Partial<Timings>) => void) {
+export function trackNavigationTimings(lifeCycle: LifeCycle, callback: (timings: Partial<Timings>) => void) {
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
     if (entry.entryType === 'navigation') {
       callback({
@@ -71,14 +73,14 @@ export function trackNavigationTimings(lifeCycle: LifeCycle, callback: (newTimin
   return { stop }
 }
 
-export function trackFirstContentfulPaint(lifeCycle: LifeCycle, callback: (fcp: RelativeTime) => void) {
+export function trackFirstContentfulPaintTiming(lifeCycle: LifeCycle, callback: (fcpTiming: RelativeTime) => void) {
   const firstHidden = trackFirstHidden()
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED, (entry) => {
     if (
       entry.entryType === 'paint' &&
       entry.name === 'first-contentful-paint' &&
       entry.startTime < firstHidden.timeStamp &&
-      entry.startTime < 10 * ONE_MINUTE
+      entry.startTime < TIMING_MAXIMUM_DELAY
     ) {
       callback(entry.startTime)
     }
@@ -92,10 +94,10 @@ export function trackFirstContentfulPaint(lifeCycle: LifeCycle, callback: (fcp: 
  * Documentation: https://web.dev/lcp/
  * Reference implementation: https://github.com/GoogleChrome/web-vitals/blob/master/src/getLCP.ts
  */
-export function trackLargestContentfulPaint(
+export function trackLargestContentfulPaintTiming(
   lifeCycle: LifeCycle,
   emitter: EventEmitter,
-  callback: (value: RelativeTime) => void
+  callback: (lcpTiming: RelativeTime) => void
 ) {
   const firstHidden = trackFirstHidden()
 
@@ -112,8 +114,6 @@ export function trackLargestContentfulPaint(
     { capture: true, once: true }
   )
 
-  const lcpSizes: Array<{ timeStamp: TimeStamp; startTime: RelativeTime; size: number }> = []
-
   const { unsubscribe: unsubscribeLifeCycle } = lifeCycle.subscribe(
     LifeCycleEventType.PERFORMANCE_ENTRY_COLLECTED,
     (entry) => {
@@ -121,9 +121,8 @@ export function trackLargestContentfulPaint(
         entry.entryType === 'largest-contentful-paint' &&
         entry.startTime < firstInteractionTimestamp &&
         entry.startTime < firstHidden.timeStamp &&
-        entry.startTime < 10 * ONE_MINUTE
+        entry.startTime < TIMING_MAXIMUM_DELAY
       ) {
-        lcpSizes.push({ timeStamp: timeStampNow(), startTime: entry.startTime, size: entry.size })
         callback(entry.startTime)
       }
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
@@ -7,6 +7,7 @@ import {
   RelativeTime,
   timeStampNow,
   TimeStamp,
+  ONE_MINUTE,
 } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { trackFirstHidden } from './trackFirstHidden'
@@ -76,7 +77,8 @@ export function trackFirstContentfulPaint(lifeCycle: LifeCycle, callback: (fcp: 
     if (
       entry.entryType === 'paint' &&
       entry.name === 'first-contentful-paint' &&
-      entry.startTime < firstHidden.timeStamp
+      entry.startTime < firstHidden.timeStamp &&
+      entry.startTime < 10 * ONE_MINUTE
     ) {
       callback(entry.startTime)
     }
@@ -118,7 +120,8 @@ export function trackLargestContentfulPaint(
       if (
         entry.entryType === 'largest-contentful-paint' &&
         entry.startTime < firstInteractionTimestamp &&
-        entry.startTime < firstHidden.timeStamp
+        entry.startTime < firstHidden.timeStamp &&
+        entry.startTime < 10 * ONE_MINUTE
       ) {
         lcpSizes.push({ timeStamp: timeStampNow(), startTime: entry.startTime, size: entry.size })
         callback(entry.startTime)


### PR DESCRIPTION
## Motivation

LCP and FCP reported after 10 minutes are meaningless therefore we discard them

## Changes

Discard LCP and FCP reported after 10 min

## Testing

Unit, Locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
