### PR TITLE
👷 [ownership] add replay team on recorder code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,6 @@
 
 # Docs
 *README.md    @Datadog/rum-browser @DataDog/documentation
+
+# Replay
+packages/rum  @Datadog/rum-browser @DataDog/rum-session-replay


### PR DESCRIPTION
## Motivation

Give more visibility to replay members on recorder code changes

## Changes

add @DataDog/rum-session-replay on `packages/rum` containing specific code for the recorder

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
