### PR TITLE
✨ [RUMF-1029] remove the limit on view.loading_time 

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -4,15 +4,15 @@ import { RumEvent } from '../../../../../rum/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType, ActionType } from '../../../rawRumEvent.types'
 import { LifeCycleEventType } from '../../lifeCycle'
-import { PAGE_ACTIVITY_MAX_DURATION, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
-import { AutoAction, trackActions } from './trackActions'
+import { PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
+import { AutoAction, AUTO_ACTION_MAX_DURATION, trackActions } from './trackActions'
 
 // Used to wait some time after the creation of a action
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = PAGE_ACTIVITY_VALIDATION_DELAY * 0.8
 // Used to wait some time but it doesn't matter how much.
 const SOME_ARBITRARY_DELAY = 50
 // A long delay used to wait after any action is finished.
-const EXPIRE_DELAY = PAGE_ACTIVITY_MAX_DURATION * 10
+const EXPIRE_DELAY = AUTO_ACTION_MAX_DURATION * 10
 
 function eventsCollector<T>() {
   const events: T[] = []

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -9,6 +9,7 @@ import {
   clocksNow,
   TimeStamp,
   Configuration,
+  ONE_SECOND,
 } from '@datadog/browser-core'
 import { ActionType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
@@ -48,7 +49,7 @@ export interface AutoActionCreatedEvent {
 }
 
 // Maximum duration for automatic actions
-export const AUTO_ACTION_MAX_DURATION = 10_000
+export const AUTO_ACTION_MAX_DURATION = 10 * ONE_SECOND
 
 export function trackActions(
   lifeCycle: LifeCycle,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -4,16 +4,10 @@ import { TestSetupBuilder, setup, setupViewTest, ViewTest } from '../../../../te
 import { RumPerformanceNavigationTiming } from '../../../browser/performanceCollection'
 import { RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycle } from '../../lifeCycle'
-import {
-  PAGE_ACTIVITY_END_DELAY,
-  PAGE_ACTIVITY_MAX_DURATION,
-  PAGE_ACTIVITY_VALIDATION_DELAY,
-} from '../../trackPageActivities'
+import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
 import { THROTTLE_VIEW_UPDATE_PERIOD } from './trackViews'
 
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = (PAGE_ACTIVITY_VALIDATION_DELAY * 0.8) as Duration
-
-const AFTER_PAGE_ACTIVITY_MAX_DURATION = PAGE_ACTIVITY_MAX_DURATION * 1.1
 
 const AFTER_PAGE_ACTIVITY_END_DELAY = PAGE_ACTIVITY_END_DELAY * 1.1
 
@@ -68,7 +62,6 @@ describe('rum track view metrics', () => {
       const { getViewUpdate, getViewUpdateCount, startView } = viewTest
 
       startView()
-      clock.tick(AFTER_PAGE_ACTIVITY_MAX_DURATION)
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       expect(getViewUpdateCount()).toEqual(3)

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -1,13 +1,4 @@
-import {
-  Duration,
-  noop,
-  elapsed,
-  round,
-  timeStampNow,
-  Configuration,
-  RelativeTime,
-  ONE_SECOND,
-} from '@datadog/browser-core'
+import { Duration, noop, elapsed, round, timeStampNow, RelativeTime, ONE_SECOND } from '@datadog/browser-core'
 import { RumLayoutShiftTiming, supportPerformanceTimingEvent } from '../../../browser/performanceCollection'
 import { ViewLoadingType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
@@ -25,8 +16,7 @@ export function trackViewMetrics(
   lifeCycle: LifeCycle,
   domMutationObservable: DOMMutationObservable,
   scheduleViewUpdate: () => void,
-  loadingType: ViewLoadingType,
-  configuration: Configuration
+  loadingType: ViewLoadingType
 ) {
   const viewMetrics: ViewMetrics = {
     eventCounts: {
@@ -49,7 +39,6 @@ export function trackViewMetrics(
   const { stop: stopActivityLoadingTimeTracking } = trackActivityLoadingTime(
     lifeCycle,
     domMutationObservable,
-    configuration,
     setActivityLoadingTime
   )
 
@@ -108,22 +97,16 @@ function trackLoadingTime(loadType: ViewLoadingType, callback: (loadingTime: Dur
 function trackActivityLoadingTime(
   lifeCycle: LifeCycle,
   domMutationObservable: DOMMutationObservable,
-  configuration: Configuration,
   callback: (loadingTimeValue: Duration | undefined) => void
 ) {
   const startTime = timeStampNow()
-  const { stop: stopWaitIdlePageActivity } = waitIdlePageActivity(
-    lifeCycle,
-    domMutationObservable,
-    configuration,
-    (params) => {
-      if (params.hadActivity) {
-        callback(elapsed(startTime, params.endTime))
-      } else {
-        callback(undefined)
-      }
+  const { stop: stopWaitIdlePageActivity } = waitIdlePageActivity(lifeCycle, domMutationObservable, (params) => {
+    if (params.hadActivity) {
+      callback(elapsed(startTime, params.endTime))
+    } else {
+      callback(undefined)
     }
-  )
+  })
 
   return { stop: stopWaitIdlePageActivity }
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -11,7 +11,6 @@ import {
   timeStampNow,
   TimeStamp,
   display,
-  Configuration,
 } from '@datadog/browser-core'
 import { DOMMutationObservable } from '../../../browser/domMutationObservable'
 import { ViewLoadingType, ViewCustomTimings } from '../../../rawRumEvent.types'
@@ -59,7 +58,6 @@ export function trackViews(
   lifeCycle: LifeCycle,
   domMutationObservable: DOMMutationObservable,
   areViewsTrackedAutomatically: boolean,
-  configuration: Configuration,
   initialViewName?: string
 ) {
   const { stop: stopInitialViewTracking, initialView } = trackInitialView(initialViewName)
@@ -77,7 +75,6 @@ export function trackViews(
       location,
       ViewLoadingType.INITIAL_LOAD,
       document.referrer,
-      configuration,
       clocksOrigin(),
       name
     )
@@ -95,7 +92,6 @@ export function trackViews(
       location,
       ViewLoadingType.ROUTE_CHANGE,
       currentView.url,
-      configuration,
       startClocks,
       name
     )
@@ -176,7 +172,6 @@ function newView(
   initialLocation: Location,
   loadingType: ViewLoadingType,
   referrer: string,
-  configuration: Configuration,
   startClocks: ClocksState = clocksNow(),
   name?: string
 ) {
@@ -203,8 +198,7 @@ function newView(
     lifeCycle,
     domMutationObservable,
     scheduleViewUpdate,
-    loadingType,
-    configuration
+    loadingType
   )
 
   // Initial view update

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -29,14 +29,7 @@ export function startViewCollection(
     )
   )
 
-  return trackViews(
-    location,
-    lifeCycle,
-    domMutationObservable,
-    !configuration.trackViewsManually,
-    configuration,
-    initialViewName
-  )
+  return trackViews(location, lifeCycle, domMutationObservable, !configuration.trackViewsManually, initialViewName)
 }
 
 function processViewUpdate(

--- a/packages/rum-core/src/domain/trackPageActivities.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.ts
@@ -1,4 +1,4 @@
-import { Configuration, monitor, Observable, Subscription, TimeStamp, timeStampNow } from '@datadog/browser-core'
+import { monitor, Observable, Subscription, TimeStamp, timeStampNow } from '@datadog/browser-core'
 import { DOMMutationObservable } from '../browser/domMutationObservable'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 
@@ -18,7 +18,6 @@ export type CompletionCallbackParameters = { hadActivity: true; endTime: TimeSta
 export function waitIdlePageActivity(
   lifeCycle: LifeCycle,
   domMutationObservable: DOMMutationObservable,
-  configuration: Configuration,
   completionCallback: (params: CompletionCallbackParameters) => void
 ) {
   const { observable: pageActivitiesObservable, stop: stopPageActivitiesTracking } = trackPageActivities(
@@ -29,7 +28,6 @@ export function waitIdlePageActivity(
   const { stop: stopWaitPageActivitiesCompletion } = waitPageActivitiesCompletion(
     pageActivitiesObservable,
     stopPageActivitiesTracking,
-    configuration,
     completionCallback
   )
 
@@ -123,7 +121,6 @@ export function trackPageActivities(
 export function waitPageActivitiesCompletion(
   pageActivitiesObservable: Observable<PageActivityEvent>,
   stopPageActivitiesTracking: () => void,
-  configuration: Configuration,
   completionCallback: (params: CompletionCallbackParameters) => void
 ): { stop: () => void } {
   let idleTimeoutId: number
@@ -133,12 +130,10 @@ export function waitPageActivitiesCompletion(
     monitor(() => complete({ hadActivity: false })),
     PAGE_ACTIVITY_VALIDATION_DELAY
   )
-  const maxDurationTimeoutId =
-    !configuration.isEnabled('eternal-page-activities') &&
-    setTimeout(
-      monitor(() => complete({ hadActivity: true, endTime: timeStampNow() })),
-      PAGE_ACTIVITY_MAX_DURATION
-    )
+  const maxDurationTimeoutId = setTimeout(
+    monitor(() => complete({ hadActivity: true, endTime: timeStampNow() })),
+    PAGE_ACTIVITY_MAX_DURATION
+  )
 
   pageActivitiesObservable.subscribe(({ isBusy }) => {
     clearTimeout(validationTimeoutId)
@@ -156,9 +151,7 @@ export function waitPageActivitiesCompletion(
     hasCompleted = true
     clearTimeout(validationTimeoutId)
     clearTimeout(idleTimeoutId)
-    if (maxDurationTimeoutId) {
-      clearTimeout(maxDurationTimeoutId)
-    }
+    clearTimeout(maxDurationTimeoutId)
     stopPageActivitiesTracking()
   }
 

--- a/packages/rum-core/src/domain/trackPageActivities.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.ts
@@ -61,7 +61,7 @@ export function waitIdlePageActivity(
 //                                   v
 //                                 (End)
 //
-// Note: because maxDuration should be greater than VALIDATION_DELAY, we are sure that if the
+// Note: by assuming that maxDuration is greater than VALIDATION_DELAY, we are sure that if the
 // process is still alive after maxDuration, it has been validated.
 export function trackPageActivities(
   lifeCycle: LifeCycle,

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -217,7 +217,6 @@ export function setupViewTest(
     lifeCycle,
     domMutationObservable,
     !configuration.trackViewsManually,
-    configuration,
     initialViewName
   )
   return {


### PR DESCRIPTION
## Motivation

Remove limit on view.loading_time to avoid having a weird distribution chart in the UI

## Changes

* Revert the flag introduced by #1019 
* Remove the constant maximum duration for track page activities
* Pass the 10 seconds maximum duration for actions only

## Testing

CI, manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
