### PR TITLE
♻️ [RUMF-1015] use the url corresponding to the start of the event

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -527,6 +527,13 @@ type Combined<A, B> = A extends null ? B : B extends null ? A : Merged<A, B>
 export function combine<A, B>(a: A, b: B): Combined<A, B>
 export function combine<A, B, C>(a: A, b: B, c: C): Combined<Combined<A, B>, C>
 export function combine<A, B, C, D>(a: A, b: B, c: C, d: D): Combined<Combined<Combined<A, B>, C>, D>
+export function combine<A, B, C, D, E>(
+  a: A,
+  b: B,
+  c: C,
+  d: D,
+  e: E
+): Combined<Combined<Combined<Combined<A, B>, C>, D>, E>
 export function combine(...sources: any[]): unknown {
   let destination: any
 

--- a/packages/rum-core/src/domain/contextHistory.spec.ts
+++ b/packages/rum-core/src/domain/contextHistory.spec.ts
@@ -5,12 +5,12 @@ import { CLEAR_OLD_CONTEXTS_INTERVAL, ContextHistory } from './contextHistory'
 const EXPIRE_DELAY = 10 * ONE_MINUTE
 
 describe('contextHistory', () => {
-  let contextHistory: ContextHistory<{ value: string }, { value: string }>
+  let contextHistory: ContextHistory<{ value: string }>
   let clock: Clock
 
   beforeEach(() => {
     clock = mockClock()
-    contextHistory = new ContextHistory((raw) => ({ value: raw.value }), EXPIRE_DELAY)
+    contextHistory = new ContextHistory(EXPIRE_DELAY)
   })
 
   afterEach(() => {

--- a/packages/rum-core/src/domain/contextHistory.ts
+++ b/packages/rum-core/src/domain/contextHistory.ts
@@ -8,22 +8,22 @@ interface PreviousContext<T> {
 
 export const CLEAR_OLD_CONTEXTS_INTERVAL = ONE_MINUTE
 
-export class ContextHistory<Raw, Built> {
-  private current: Raw | undefined
+export class ContextHistory<Context> {
+  private current: Context | undefined
   private currentStart: RelativeTime | undefined
-  private previousContexts: Array<PreviousContext<Built>> = []
+  private previousContexts: Array<PreviousContext<Context>> = []
   private clearOldContextsInterval: number
 
-  constructor(private buildContext: (r: Raw) => Built, private expireDelay: number) {
+  constructor(private expireDelay: number) {
     this.clearOldContextsInterval = setInterval(() => this.clearOldContexts(), CLEAR_OLD_CONTEXTS_INTERVAL)
   }
 
   find(startTime?: RelativeTime) {
     if (startTime === undefined) {
-      return this.current ? this.buildContext(this.current) : undefined
+      return this.current ? this.current : undefined
     }
     if (this.current !== undefined && this.currentStart !== undefined && startTime >= this.currentStart) {
-      return this.buildContext(this.current)
+      return this.current
     }
     for (const previousContext of this.previousContexts) {
       if (startTime > previousContext.endTime) {
@@ -36,7 +36,7 @@ export class ContextHistory<Raw, Built> {
     return undefined
   }
 
-  setCurrent(current: Raw, startTime: RelativeTime) {
+  setCurrent(current: Context, startTime: RelativeTime) {
     this.current = current
     this.currentStart = startTime
   }
@@ -54,7 +54,7 @@ export class ContextHistory<Raw, Built> {
     if (this.current !== undefined && this.currentStart !== undefined) {
       this.previousContexts.unshift({
         endTime,
-        context: this.buildContext(this.current),
+        context: this.current,
         startTime: this.currentStart,
       })
       this.clearCurrent()

--- a/packages/rum-core/src/domain/contextHistory.ts
+++ b/packages/rum-core/src/domain/contextHistory.ts
@@ -19,10 +19,10 @@ export class ContextHistory<Context> {
   }
 
   find(startTime?: RelativeTime) {
-    if (startTime === undefined) {
-      return this.current ? this.current : undefined
-    }
-    if (this.current !== undefined && this.currentStart !== undefined && startTime >= this.currentStart) {
+    if (
+      startTime === undefined ||
+      (this.current !== undefined && this.currentStart !== undefined && startTime >= this.currentStart)
+    ) {
       return this.current
     }
     for (const previousContext of this.previousContexts) {

--- a/packages/rum-core/src/domain/parentContexts.spec.ts
+++ b/packages/rum-core/src/domain/parentContexts.spec.ts
@@ -18,10 +18,8 @@ describe('parentContexts', () => {
 
   function buildViewCreatedEvent(partialViewCreatedEvent: Partial<ViewCreatedEvent> = {}): ViewCreatedEvent {
     return {
-      location,
       startClocks,
       id: FAKE_ID,
-      referrer: 'http://foo.com',
       ...partialViewCreatedEvent,
     }
   }
@@ -111,17 +109,6 @@ describe('parentContexts', () => {
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ id: newViewId }))
 
       expect(parentContexts.findView()!.view.id).toEqual(newViewId)
-    })
-
-    it('should return the current url with the current view', () => {
-      const { lifeCycle, fakeLocation, changeLocation } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ location: fakeLocation as Location }))
-      expect(parentContexts.findView()!.view.url).toBe('http://fake-url.com/')
-
-      changeLocation('/foo')
-
-      expect(parentContexts.findView()!.view.url).toBe('http://fake-url.com/foo')
     })
 
     it('should return the view name with the view', () => {

--- a/packages/rum-core/src/domain/parentContexts.ts
+++ b/packages/rum-core/src/domain/parentContexts.ts
@@ -84,8 +84,6 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
       view: {
         id: current.id,
         name: current.name,
-        referrer: current.referrer,
-        url: current.location.href,
       },
     }
   }

--- a/packages/rum-core/src/domain/parentContexts.ts
+++ b/packages/rum-core/src/domain/parentContexts.ts
@@ -16,38 +16,20 @@ export interface ParentContexts {
 }
 
 export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): ParentContexts {
-  const viewContextHistory = new ContextHistory<ViewCreatedEvent & { sessionId?: string }, ViewContext>(
-    buildCurrentViewContext,
-    VIEW_CONTEXT_TIME_OUT_DELAY
-  )
+  const viewContextHistory = new ContextHistory<ViewContext>(VIEW_CONTEXT_TIME_OUT_DELAY)
 
-  const actionContextHistory = new ContextHistory<AutoActionCreatedEvent, ActionContext>(
-    buildCurrentActionContext,
-    ACTION_CONTEXT_TIME_OUT_DELAY
-  )
+  const actionContextHistory = new ContextHistory<ActionContext>(ACTION_CONTEXT_TIME_OUT_DELAY)
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
-    viewContextHistory.setCurrent(
-      {
-        sessionId: session.getId(),
-        ...view,
-      },
-      view.startClocks.relative
-    )
+    viewContextHistory.setCurrent(buildViewContext(view, session.getId()), view.startClocks.relative)
   })
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, (view) => {
     // A view can be updated after its end.  We have to ensure that the view being updated is the
     // most recently created.
     const current = viewContextHistory.getCurrent()
-    if (current && current.id === view.id) {
-      viewContextHistory.setCurrent(
-        {
-          sessionId: current.sessionId,
-          ...view,
-        },
-        view.startClocks.relative
-      )
+    if (current && current.view.id === view.id) {
+      viewContextHistory.setCurrent(buildViewContext(view, current.session.id), view.startClocks.relative)
     }
   })
 
@@ -56,7 +38,7 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
   })
 
   lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_CREATED, (action) => {
-    actionContextHistory.setCurrent(action, action.startClocks.relative)
+    actionContextHistory.setCurrent(buildActionContext(action), action.startClocks.relative)
   })
 
   lifeCycle.subscribe(LifeCycleEventType.AUTO_ACTION_COMPLETED, (action: AutoAction) => {
@@ -76,20 +58,20 @@ export function startParentContexts(lifeCycle: LifeCycle, session: RumSession): 
     actionContextHistory.reset()
   })
 
-  function buildCurrentViewContext(current: ViewCreatedEvent & { sessionId?: string }) {
+  function buildViewContext(view: ViewCreatedEvent, sessionId: string | undefined) {
     return {
       session: {
-        id: current.sessionId,
+        id: sessionId,
       },
       view: {
-        id: current.id,
-        name: current.name,
+        id: view.id,
+        name: view.name,
       },
     }
   }
 
-  function buildCurrentActionContext(current: AutoActionCreatedEvent) {
-    return { action: { id: current.id } }
+  function buildActionContext(action: AutoActionCreatedEvent) {
+    return { action: { id: action.id } }
   }
 
   return {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -80,9 +80,7 @@ describe('trackActions', () => {
     expect(createSpy).toHaveBeenCalled()
 
     lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
-      location,
       id: 'fake',
-      referrer: 'http://foo.com',
       startClocks: (jasmine.any(Object) as unknown) as ClocksState,
     })
     clock.tick(EXPIRE_DELAY)

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -45,44 +45,26 @@ describe('track views automatically', () => {
   })
 
   describe('location changes', () => {
-    it('should update view location on search change', () => {
-      const { changeLocation } = setupBuilder.build()
-      const { getViewCreateCount, getViewCreate, getViewUpdate, getViewUpdateCount } = viewTest
-
-      changeLocation('/foo?bar=qux')
-
-      expect(getViewCreateCount()).toBe(1)
-      expect(getViewCreate(0).location.href).toMatch(/\/foo$/)
-
-      const lastUpdate = getViewUpdate(getViewUpdateCount() - 1)
-      expect(lastUpdate.location.href).toMatch(/\/foo\?bar=qux$/)
-      expect(lastUpdate.id).toBe(getViewCreate(0).id)
-    })
-
     it('should create new view on path change', () => {
       const { changeLocation } = setupBuilder.build()
-      const { getViewCreateCount, getViewCreate } = viewTest
+      const { getViewCreateCount } = viewTest
 
       expect(getViewCreateCount()).toBe(1)
-      expect(getViewCreate(0).location.href).toMatch(/\/foo$/)
 
       changeLocation('/bar')
 
       expect(getViewCreateCount()).toBe(2)
-      expect(getViewCreate(1).location.href).toMatch(/\/bar$/)
     })
 
     it('should create new view on hash change from history', () => {
       const { changeLocation } = setupBuilder.build()
-      const { getViewCreateCount, getViewCreate } = viewTest
+      const { getViewCreateCount } = viewTest
 
       expect(getViewCreateCount()).toBe(1)
-      expect(getViewCreate(0).location.href).toMatch(/\/foo$/)
 
       changeLocation('/foo#bar')
 
       expect(getViewCreateCount()).toBe(2)
-      expect(getViewCreate(1).location.href).toMatch(/\/foo#bar$/)
     })
 
     function mockGetElementById() {
@@ -113,124 +95,6 @@ describe('track views automatically', () => {
       changeLocation('/foo#bar')
 
       expect(getViewCreateCount()).toBe(2)
-    })
-  })
-
-  describe('view referrer', () => {
-    it('should set the document referrer as referrer for the initial view', () => {
-      setupBuilder.build()
-      const { getViewCreate } = viewTest
-
-      expect(getViewCreate(0).referrer).toEqual(document.referrer)
-    })
-
-    it('should set the previous view URL as referrer when a route change occurs', () => {
-      const { changeLocation } = setupBuilder.build()
-      const { getViewCreate } = viewTest
-
-      changeLocation('/bar')
-
-      expect(getViewCreate(1).referrer).toEqual(jasmine.stringMatching(/\/foo$/))
-    })
-
-    it('should set the previous view URL as referrer when a the session is renewed', () => {
-      const { lifeCycle } = setupBuilder.build()
-      const { getViewCreate } = viewTest
-
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-
-      expect(getViewCreate(1).referrer).toEqual(jasmine.stringMatching(/\/foo$/))
-    })
-
-    it('should use the most up-to-date URL of the previous view as a referrer', () => {
-      const { changeLocation } = setupBuilder.build()
-      const { getViewCreate } = viewTest
-
-      changeLocation('/foo?a=b')
-      changeLocation('/bar')
-
-      expect(getViewCreate(1).referrer).toEqual(jasmine.stringMatching(/\/foo\?a=b$/))
-    })
-  })
-})
-
-describe('track views manually', () => {
-  let setupBuilder: TestSetupBuilder
-  let viewTest: ViewTest
-
-  beforeEach(() => {
-    setupBuilder = setup()
-      .withFakeLocation('/foo')
-      .withConfiguration({ trackViewsManually: true })
-      .beforeBuild((buildContext) => {
-        viewTest = setupViewTest(buildContext)
-        return viewTest
-      })
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
-  describe('location changes', () => {
-    it('should update view location on search change', () => {
-      const { changeLocation } = setupBuilder.build()
-      const { getViewCreateCount, getViewCreate, getViewUpdate, getViewUpdateCount } = viewTest
-
-      changeLocation('/foo?bar=qux')
-
-      expect(getViewCreateCount()).toBe(1)
-      expect(getViewCreate(0).location.href).toMatch(/\/foo$/)
-
-      const lastUpdate = getViewUpdate(getViewUpdateCount() - 1)
-      expect(lastUpdate.location.href).toMatch(/\/foo\?bar=qux$/)
-      expect(lastUpdate.id).toBe(getViewCreate(0).id)
-    })
-
-    it('should update view location on path change', () => {
-      const { changeLocation } = setupBuilder.build()
-      const { getViewCreateCount, getViewCreate, getViewUpdate, getViewUpdateCount } = viewTest
-
-      changeLocation('/bar')
-
-      expect(getViewCreateCount()).toBe(1)
-      expect(getViewCreate(0).location.href).toMatch(/\/foo$/)
-
-      const lastUpdate = getViewUpdate(getViewUpdateCount() - 1)
-      expect(lastUpdate.location.href).toMatch(/\/bar$/)
-      expect(lastUpdate.id).toBe(getViewCreate(0).id)
-    })
-  })
-
-  describe('view referrer', () => {
-    it('should set the document referrer as referrer for the initial view', () => {
-      setupBuilder.build()
-      const { getViewCreate } = viewTest
-
-      expect(getViewCreate(0).referrer).toEqual(document.referrer)
-    })
-
-    it('should set the previous view URL as referrer when starting a new view', () => {
-      const { changeLocation } = setupBuilder.build()
-      const { getViewUpdate, getViewUpdateCount, startView } = viewTest
-
-      startView()
-      changeLocation('/bar')
-
-      const lastUpdate = getViewUpdate(getViewUpdateCount() - 1)
-      expect(lastUpdate.referrer).toEqual(jasmine.stringMatching(/\/foo$/))
-      expect(lastUpdate.location.href).toEqual(jasmine.stringMatching(/\/bar$/))
-    })
-
-    it('should use the most up-to-date URL of the previous view as a referrer', () => {
-      const { changeLocation } = setupBuilder.build()
-      const { getViewCreate, startView } = viewTest
-
-      changeLocation('/foo?a=b')
-      changeLocation('/bar')
-      startView()
-
-      expect(getViewCreate(1).referrer).toEqual(jasmine.stringMatching(/\/bar$/))
     })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -26,7 +26,6 @@ const VIEW: ViewEvent = {
   loadingTime: 20 as Duration,
   loadingType: ViewLoadingType.INITIAL_LOAD,
   location: {} as Location,
-  referrer: '',
   startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
   timings: {
     domComplete: 10 as Duration,

--- a/packages/rum-core/src/domain/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/urlContexts.spec.ts
@@ -1,0 +1,136 @@
+import { relativeToClocks, RelativeTime } from '@datadog/browser-core'
+import { setup, TestSetupBuilder } from '../../test/specHelper'
+import { startUrlContexts, UrlContexts } from './urlContexts'
+import { ViewCreatedEvent, ViewEndedEvent } from './rumEventsCollection/view/trackViews'
+import { LifeCycleEventType } from './lifeCycle'
+
+describe('urlContexts', () => {
+  let setupBuilder: TestSetupBuilder
+  let urlContexts: UrlContexts
+
+  beforeEach(() => {
+    setupBuilder = setup()
+      .withFakeLocation('http://fake-url.com')
+      .withFakeClock()
+      .beforeBuild(({ lifeCycle, locationChangeObservable, location }) => {
+        urlContexts = startUrlContexts(lifeCycle, locationChangeObservable, location)
+        return urlContexts
+      })
+  })
+
+  afterEach(() => {
+    setupBuilder.cleanup()
+  })
+
+  it('should return undefined before the initial view', () => {
+    setupBuilder.build()
+
+    expect(urlContexts.findUrl()).toBeUndefined()
+  })
+
+  it('should not create url context on location change before the initial view', () => {
+    const { changeLocation } = setupBuilder.build()
+
+    changeLocation('/foo')
+
+    expect(urlContexts.findUrl()).toBeUndefined()
+  })
+
+  it('should return current url and document referrer for initial view', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(0 as RelativeTime),
+    } as ViewCreatedEvent)
+
+    const urlContext = urlContexts.findUrl()!
+    expect(urlContext.view.url).toBe('http://fake-url.com/')
+    expect(urlContext.view.referrer).toBe(document.referrer)
+  })
+
+  it('should update url context on location change', () => {
+    const { lifeCycle, changeLocation } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(0 as RelativeTime),
+    } as ViewCreatedEvent)
+    changeLocation('/foo')
+
+    const urlContext = urlContexts.findUrl()!
+    expect(urlContext.view.url).toContain('http://fake-url.com/foo')
+    expect(urlContext.view.referrer).toBe(document.referrer)
+  })
+
+  it('should update url context on new view', () => {
+    const { lifeCycle, changeLocation } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(0 as RelativeTime),
+    } as ViewCreatedEvent)
+    changeLocation('/foo')
+    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
+      endClocks: relativeToClocks(10 as RelativeTime),
+    } as ViewEndedEvent)
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(10 as RelativeTime),
+    } as ViewCreatedEvent)
+
+    const urlContext = urlContexts.findUrl()!
+    expect(urlContext.view.url).toBe('http://fake-url.com/foo')
+    expect(urlContext.view.referrer).toBe('http://fake-url.com/')
+  })
+
+  it('should return the url context corresponding to the start time', () => {
+    const { lifeCycle, changeLocation, clock } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(0 as RelativeTime),
+    } as ViewCreatedEvent)
+
+    clock.tick(10)
+    changeLocation('/foo')
+    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
+      endClocks: relativeToClocks(10 as RelativeTime),
+    } as ViewEndedEvent)
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(10 as RelativeTime),
+    } as ViewCreatedEvent)
+
+    clock.tick(10)
+    changeLocation('/foo#bar')
+
+    clock.tick(10)
+    changeLocation('/qux')
+    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
+      endClocks: relativeToClocks(30 as RelativeTime),
+    } as ViewEndedEvent)
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(30 as RelativeTime),
+    } as ViewCreatedEvent)
+
+    expect(urlContexts.findUrl(5 as RelativeTime)).toEqual({
+      view: {
+        url: 'http://fake-url.com/',
+        referrer: document.referrer,
+      },
+    })
+    expect(urlContexts.findUrl(15 as RelativeTime)).toEqual({
+      view: {
+        url: 'http://fake-url.com/foo',
+        referrer: 'http://fake-url.com/',
+      },
+    })
+    expect(urlContexts.findUrl(25 as RelativeTime)).toEqual({
+      view: {
+        url: 'http://fake-url.com/foo#bar',
+        referrer: 'http://fake-url.com/',
+      },
+    })
+    expect(urlContexts.findUrl(35 as RelativeTime)).toEqual({
+      view: {
+        url: 'http://fake-url.com/qux',
+        referrer: 'http://fake-url.com/foo',
+      },
+    })
+  })
+})

--- a/packages/rum-core/src/domain/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/urlContexts.spec.ts
@@ -133,4 +133,21 @@ describe('urlContexts', () => {
       },
     })
   })
+
+  /**
+   * It could happen if there is an event happening just between view end and view creation
+   * (which seems unlikely) and this event would anyway be rejected by lack of view id
+   */
+  it('should return undefined when no current view', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: relativeToClocks(0 as RelativeTime),
+    } as ViewCreatedEvent)
+    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
+      endClocks: relativeToClocks(10 as RelativeTime),
+    } as ViewEndedEvent)
+
+    expect(urlContexts.findUrl()).toBeUndefined()
+  })
 })

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -199,14 +199,19 @@ export interface ViewContext extends Context {
   view: {
     id: string
     name?: string
-    url: string
-    referrer: string
   }
 }
 
 export interface ActionContext extends Context {
   action: {
     id: string
+  }
+}
+
+export interface UrlContext extends Context {
+  view: {
+    url: string
+    referrer: string
   }
 }
 

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -14,8 +14,9 @@ import { LifeCycle, LifeCycleEventType, RawRumEventCollectedData } from '../src/
 import { ParentContexts } from '../src/domain/parentContexts'
 import { trackViews, ViewEvent } from '../src/domain/rumEventsCollection/view/trackViews'
 import { RumSession, RumSessionPlan } from '../src/domain/rumSession'
-import { RawRumEvent, RumContext, ViewContext } from '../src/rawRumEvent.types'
+import { RawRumEvent, RumContext, ViewContext, UrlContext } from '../src/rawRumEvent.types'
 import { LocationChange } from '../src/browser/locationChangeObservable'
+import { UrlContexts } from '../src/domain/urlContexts'
 import { validateFormat } from './formatValidation'
 import { createRumSessionMock } from './mockRumSession'
 
@@ -43,6 +44,7 @@ export interface BuildContext {
   applicationId: string
   parentContexts: ParentContexts
   foregroundContexts: ForegroundContexts
+  urlContexts: UrlContexts
 }
 
 export interface TestIO {
@@ -67,6 +69,15 @@ export function setup(): TestSetupBuilder {
   let clock: Clock
   let fakeLocation: Partial<Location> = location
   let parentContexts: ParentContexts
+  const urlContexts: UrlContexts = {
+    findUrl: () => ({
+      view: {
+        url: fakeLocation.href!,
+        referrer: document.referrer,
+      },
+    }),
+    stop: noop,
+  }
   let foregroundContexts: ForegroundContexts = {
     isInForegroundAt: () => undefined,
     selectInForegroundPeriodsFor: () => undefined,
@@ -130,6 +141,7 @@ export function setup(): TestSetupBuilder {
           domMutationObservable,
           locationChangeObservable,
           parentContexts,
+          urlContexts,
           foregroundContexts,
           session,
           applicationId: FAKE_APP_ID,
@@ -162,7 +174,7 @@ export function setup(): TestSetupBuilder {
 
 function validateRumEventFormat(rawRumEvent: RawRumEvent) {
   const fakeId = '00000000-aaaa-0000-aaaa-000000000000'
-  const fakeContext: RumContext & ViewContext = {
+  const fakeContext: RumContext & ViewContext & UrlContext = {
     _dd: {
       format_version: 2,
       drift: 0,

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -45,8 +45,6 @@ describe('startRecording', () => {
             },
             view: {
               id: viewId,
-              referrer: '',
-              url: 'http://example.org',
             },
           }
         },

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -219,7 +219,7 @@ describe('startSegmentCollection', () => {
 describe('computeSegmentContext', () => {
   const DEFAULT_VIEW_CONTEXT: ViewContext = {
     session: { id: '456' },
-    view: { id: '123', url: 'http://foo.com', referrer: 'http://bar.com' },
+    view: { id: '123' },
   }
 
   const DEFAULT_SESSION = createRumSessionMock().setId('456')


### PR DESCRIPTION
## Motivation

With the introduction of manual view tracking (#924), the creation of a view can be decoupled from URL changes.
In the case of a URL change occurring just before the end of a view, the view URL could wrongly be updated with the new location. 

**Previous behavior:**

- view events: URL updated during the lifecycle of the view
- other events: URL corresponding to the end of the event

**New behavior:**
- use the URL corresponding to the start of the event

## Changes

- Introduce `UrlContexts` to store URL states history
- Use `UrlContexts` from `assembly` to retrieve URL and referrer
- Simplify `ContextHistory` since we no more need to dynamically generate the current context

## Testing

Unit, manually

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
