### PR TITLE
🧑‍🏭 Update developer extension to support new V3 bundles

### DIFF
--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -28,7 +28,7 @@ Then, in Google Chrome:
 - Flush buffered events
 - End current session
 - Load the SDK development bundles instead of production ones
-- Switch between `datadog-rum.js` and `datadog-rum-recorder.js` bundles
+- Switch between `datadog-rum-v3.js` and `datadog-rum-slim-v3.js` bundles
 
 ## Browser compatibility
 

--- a/developer-extension/src/background/constants.ts
+++ b/developer-extension/src/background/constants.ts
@@ -1,3 +1,3 @@
 export const DEV_LOGS_URL = 'http://localhost:8080/datadog-logs.js'
-export const DEV_RUM_RECORDER_URL = 'http://localhost:8080/datadog-rum-recorder.js'
 export const DEV_RUM_URL = 'http://localhost:8080/datadog-rum.js'
+export const DEV_RUM_SLIM_URL = 'http://localhost:8080/datadog-rum-slim.js'

--- a/developer-extension/src/background/domain/replaceBundles.ts
+++ b/developer-extension/src/background/domain/replaceBundles.ts
@@ -48,6 +48,7 @@ listenAction('setStore', (newStore) => {
 function getBundleUrlPatterns(bundleName: string) {
   return [
     `https://*/datadog-${bundleName}.js`,
+    `https://*/datadog-${bundleName}-v3.js`,
     `https://*/datadog-${bundleName}-canary.js`,
     `https://*/datadog-${bundleName}-head.js`,
   ]

--- a/developer-extension/src/background/domain/replaceBundles.ts
+++ b/developer-extension/src/background/domain/replaceBundles.ts
@@ -1,5 +1,5 @@
 import { listenAction } from '../actions'
-import { DEV_LOGS_URL, DEV_RUM_RECORDER_URL, DEV_RUM_URL } from '../constants'
+import { DEV_LOGS_URL, DEV_RUM_SLIM_URL, DEV_RUM_URL } from '../constants'
 import { setStore, store } from '../store'
 
 chrome.webRequest.onBeforeRequest.addListener(
@@ -11,12 +11,12 @@ chrome.webRequest.onBeforeRequest.addListener(
       }
       if (url.pathname.includes('rum')) {
         return {
-          redirectUrl: store.useRumRecorder ? DEV_RUM_RECORDER_URL : DEV_RUM_URL,
+          redirectUrl: store.useRumSlim ? DEV_RUM_SLIM_URL : DEV_RUM_URL,
         }
       }
-    } else if (store.useRumRecorder && /\/datadog-rum(?!-recorder)/.test(info.url)) {
+    } else if (store.useRumSlim && /\/datadog-rum(?!-slim)/.test(info.url)) {
       return {
-        redirectUrl: info.url.replace(/datadog-rum/, 'datadog-rum-recorder'),
+        redirectUrl: info.url.replace(/datadog-rum/, 'datadog-rum-slim'),
       }
     }
     return
@@ -26,7 +26,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     urls: [
       ...getBundleUrlPatterns('logs'),
       ...getBundleUrlPatterns('rum'),
-      ...getBundleUrlPatterns('rum-recorder'),
+      ...getBundleUrlPatterns('rum-slim'),
       'https://localhost:8443/static/datadog-rum-hotdog.js',
     ],
   },
@@ -40,7 +40,7 @@ listenAction('getStore', () => {
 })
 
 listenAction('setStore', (newStore) => {
-  if ('useDevBundles' in newStore || 'useRumRecorder' in newStore) {
+  if ('useDevBundles' in newStore || 'useRumSlim' in newStore) {
     chrome.browsingData.removeCache({})
   }
 })

--- a/developer-extension/src/background/store.ts
+++ b/developer-extension/src/background/store.ts
@@ -5,7 +5,7 @@ export const store: Store = {
   devServerStatus: 'checking',
   logEventsFromRequests: true,
   useDevBundles: false,
-  useRumRecorder: false,
+  useRumSlim: false,
 }
 
 export function setStore(newStore: Partial<Store>) {

--- a/developer-extension/src/common/types.ts
+++ b/developer-extension/src/common/types.ts
@@ -12,6 +12,6 @@ export interface PopupActions {
 export interface Store {
   devServerStatus: 'unavailable' | 'checking' | 'available'
   useDevBundles: boolean
-  useRumRecorder: boolean
+  useRumSlim: boolean
   logEventsFromRequests: boolean
 }

--- a/developer-extension/src/popup/panel.tsx
+++ b/developer-extension/src/popup/panel.tsx
@@ -4,7 +4,7 @@ import { sendAction } from './actions'
 import { useStore } from './useStore'
 
 export function Panel() {
-  const [{ useDevBundles, useRumRecorder, logEventsFromRequests, devServerStatus }, setStore] = useStore()
+  const [{ useDevBundles, useRumSlim, logEventsFromRequests, devServerStatus }, setStore] = useStore()
   return (
     <Stack alignY="top" padding="major-2" spacing="major-2">
       <Stack orientation="horizontal" verticalBelow="0" spacing="major-2" alignX="left" alignY="center">
@@ -19,9 +19,9 @@ export function Panel() {
       </Stack>
 
       <Checkbox
-        label="Use RUM Recorder"
-        checked={useRumRecorder}
-        onChange={(e) => setStore({ useRumRecorder: isChecked(e.target) })}
+        label="Use RUM Slim"
+        checked={useRumSlim}
+        onChange={(e) => setStore({ useRumSlim: isChecked(e.target) })}
       />
 
       <Checkbox


### PR DESCRIPTION
## Motivation

The developer extension still has a 'rum-recorder' notion and doesn't intercept -v3 bundles.

## Changes

* Replace "Use RUM Recorder" with "Use RUM Slim" to force using the slim bundle
* Intercept v3 bundles

## Testing

Manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
