### PR TITLE
🔊 [RUMF-1021] add monitoring on lite plan with replay

### DIFF
--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -131,6 +131,18 @@ export function startRumAssembly(
               },
             })
           }
+          if (serverRumEvent.session.has_replay && serverRumEvent._dd.session?.plan === RumSessionPlan.LITE) {
+            addMonitoringMessage('lite session with replay', {
+              debug: {
+                eventType: serverRumEvent.type,
+                viewId: serverRumEvent.view.id,
+                sessionId: serverRumEvent.session.id,
+                replayPlan: session.hasReplayPlan(),
+                litePlan: session.hasLitePlan(),
+                docVersion: serverRumEvent._dd.document_version as number | undefined,
+              },
+            })
+          }
           lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, serverRumEvent)
         }
       }


### PR DESCRIPTION
## Motivation

Try to understand how this edge cas can happen

## Changes

add monitoring log in assembly

## Testing

Locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
