### PR TITLE
🔊 Add extra monitoring info on lite session with replay

### DIFF
--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -13,6 +13,7 @@ import {
   RawError,
   createEventRateLimiter,
   EventRateLimiter,
+  getCookie,
 } from '@datadog/browser-core'
 import { RumEventDomainContext } from '../domainContext.types'
 import {
@@ -140,9 +141,8 @@ export function startRumAssembly(
                 eventType: serverRumEvent.type,
                 viewId: serverRumEvent.view.id,
                 sessionId: serverRumEvent.session.id,
-                replayPlan: session.hasReplayPlan(),
-                litePlan: session.hasLitePlan(),
-                docVersion: serverRumEvent._dd.document_version as number | undefined,
+                event: serverRumEvent,
+                _dd_s: getCookie('_dd_s'),
               },
             })
           }


### PR DESCRIPTION
## Motivation

cf #1066 

## Changes

add full event + cookie value

## Testing

locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
