### PR TITLE
👷 implement merge into staging job

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -217,7 +217,7 @@ module.exports = {
       },
     },
     {
-      files: ['scripts/*.js'],
+      files: ['scripts/**/*.js'],
       rules: {
         'unicorn/filename-case': ['error', { case: 'kebabCase' }],
       },

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,8 @@ variables:
   CURRENT_CI_IMAGE: 25
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
+  GIT_REPOSITORY: 'git@github.com:DataDog/browser-sdk.git'
+  MAIN_BRANCH: 'main'
 
 cache:
   key: dependencies
@@ -15,6 +17,7 @@ stages:
   - ci-image
   - test
   - browserstack
+  - pre-deploy
   - pre-deploy-notify
   - deploy:canary
   - notify:canary
@@ -33,6 +36,10 @@ ci-image:
   script:
     - docker build --tag $CI_IMAGE .
     - docker push $CI_IMAGE
+
+########################################################################################################################
+# Tests
+########################################################################################################################
 
 format:
   stage: test
@@ -151,6 +158,7 @@ unit-bs:
     refs:
       - main
       - tags
+      - /^staging-[0-9]*$/
       - schedules
   resource_group: browserstack
   tags: ['runner:main', 'size:large']
@@ -168,6 +176,7 @@ e2e-bs:
     refs:
       - main
       - tags
+      - /^staging-[0-9]*$/
       - schedules
   resource_group: browserstack
   tags: ['runner:main', 'size:large']
@@ -182,10 +191,14 @@ e2e-bs:
     - yarn
     - ./scripts/ci-bs.sh test:e2e
 
-deploy-staging-head:
+########################################################################################################################
+# Deploy
+########################################################################################################################
+
+deploy-staging:
   only:
     refs:
-      - main
+      - $CURRENT_STAGING
   stage: deploy
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
@@ -244,22 +257,22 @@ notify-feature-branch-failure:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - COMMIT_URL="$CI_PROJECT_URL/commits/$CI_COMMIT_SHA"
 
-notify-staging-head-success:
+notify-staging-success:
   extends: .prepare_notification
   only:
     refs:
-      - main
+      - $CURRENT_STAGING
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :datadog_staging:."'
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"
     - postmessage "#rum-ops-stg" "$MESSAGE_TEXT"
 
-notify-staging-head-failure:
+notify-staging-failure:
   extends: .prepare_notification
   when: on_failure
   only:
     refs:
-      - main
+      - $CURRENT_STAGING
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME main pipeline for <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"
@@ -317,7 +330,7 @@ notify-prod-stable-failure:
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"
 
 ########################################################################################################################
-# Scheduled tasks
+# To staging CI
 ########################################################################################################################
 
 staging-reset-scheduled:
@@ -330,7 +343,7 @@ staging-reset-scheduled:
   before_script:
     - eval $(ssh-agent -s)
   script:
-    - node --no-warnings scripts/staging-reset.js
+    - node --no-warnings scripts/staging-ci/staging-reset.js
   artifacts:
     reports:
       dotenv: build.env
@@ -357,3 +370,18 @@ staging-reset-scheduled-failure:
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"
   dependencies:
     - staging-reset-scheduled
+
+merge-into-staging:
+  stage: pre-deploy
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  only:
+    refs:
+      - main
+  except:
+    refs:
+      - schedules
+  before_script:
+    - eval $(ssh-agent -s)
+  script:
+    - node --no-warnings scripts/staging-ci/merge-into-staging.js

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,7 +158,7 @@ unit-bs:
     refs:
       - main
       - tags
-      - /^staging-[0-9]*$/
+      - /^staging-[0-9]+$/
       - schedules
   resource_group: browserstack
   tags: ['runner:main', 'size:large']
@@ -176,7 +176,7 @@ e2e-bs:
     refs:
       - main
       - tags
-      - /^staging-[0-9]*$/
+      - /^staging-[0-9]+$/
       - schedules
   resource_group: browserstack
   tags: ['runner:main', 'size:large']

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -343,7 +343,7 @@ staging-reset-scheduled:
   before_script:
     - eval $(ssh-agent -s)
   script:
-    - node --no-warnings scripts/staging-ci/staging-reset.js
+    - node scripts/staging-ci/staging-reset.js
   artifacts:
     reports:
       dotenv: build.env
@@ -384,4 +384,4 @@ merge-into-staging:
   before_script:
     - eval $(ssh-agent -s)
   script:
-    - node --no-warnings scripts/staging-ci/merge-into-staging.js
+    - node scripts/staging-ci/merge-into-staging.js

--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const { initGitConfig, executeCommand, printLog, printError } = require('../utils')
+
+const REPOSITORY = process.env.GIT_REPOSITORY
+const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
+const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
+const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
+
+async function main() {
+  await initGitConfig(REPOSITORY)
+  await executeCommand(`git fetch --no-tags origin ${CURRENT_STAGING_BRANCH}`)
+  await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH} -f`)
+  await executeCommand(`git pull origin ${CURRENT_STAGING_BRANCH}`)
+
+  printLog(`Merging ${CI_COMMIT_REF_NAME} (${CI_COMMIT_SHA}) with ${CURRENT_STAGING_BRANCH}...`)
+  try {
+    await executeCommand(`git merge --no-ff "${CI_COMMIT_SHA}"`)
+  } catch {
+    const diff = await executeCommand(`git diff`)
+    printError(`Conflicts:\n${diff}`)
+    process.exit(1)
+  }
+
+  const commitMessage = await executeCommand(`git show -s --format=%B`)
+  const newSummary = `Gitlab merged ${CI_COMMIT_REF_NAME} (${CI_COMMIT_SHA}) with ${CURRENT_STAGING_BRANCH}`
+  const message = `${newSummary}\n\n${commitMessage}`
+
+  await executeCommand(`git commit --amend -m "${message}"`)
+  await executeCommand(`git push origin ${CURRENT_STAGING_BRANCH}`)
+
+  printLog('Merge Done.')
+}
+
+main().catch((e) => {
+  printError('\nStacktrace:\n', e)
+  process.exit(1)
+})

--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -16,10 +16,10 @@ async function main() {
   printLog(`Merging ${CI_COMMIT_REF_NAME} (${CI_COMMIT_SHA}) with ${CURRENT_STAGING_BRANCH}...`)
   try {
     await executeCommand(`git merge --no-ff "${CI_COMMIT_SHA}"`)
-  } catch {
+  } catch (e) {
     const diff = await executeCommand(`git diff`)
     printError(`Conflicts:\n${diff}`)
-    process.exit(1)
+    throw e
   }
 
   const commitMessage = await executeCommand(`git show -s --format=%B`)

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -1,13 +1,12 @@
 'use strict'
 
 const fs = require('fs')
-const { promisify } = require('util')
-const execute = promisify(require('child_process').exec)
 const replace = require('replace-in-file')
+const { initGitConfig, executeCommand, printLog, printError } = require('../helpers')
 
 const CI_FILE = '.gitlab-ci.yml'
-const REPOSITORY = 'git@github.com:DataDog/browser-sdk.git'
-const MAIN_BRANCH = 'main'
+const REPOSITORY = process.env.GIT_REPOSITORY
+const MAIN_BRANCH = process.env.MAIN_BRANCH
 
 const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
 const NEW_STAGING_NUMBER = getWeekNumber().toString().padStart(2, '0')
@@ -24,7 +23,7 @@ async function main() {
 
   const isNewBranch = CURRENT_STAGING_BRANCH !== NEW_STAGING_BRANCH
   if (isNewBranch) {
-    console.log(`Changing staging branch in ${CI_FILE}...`)
+    printLog(`Changing staging branch in ${CI_FILE}...`)
     await replace({
       files: CI_FILE,
       from: /CURRENT_STAGING: staging-.*/g,
@@ -33,57 +32,31 @@ async function main() {
     await executeCommand(`git commit ${CI_FILE} -m "👷 Bump staging to ${NEW_STAGING_BRANCH}"`)
     await executeCommand(`git push origin ${MAIN_BRANCH}`)
   } else {
-    console.log(`Staging branch already up to date in ${CI_FILE}. Skipping.`)
+    printLog(`Staging branch already up to date in ${CI_FILE}. Skipping.`)
   }
 
   const isStagingAlreadyCreated = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${NEW_STAGING_BRANCH}`)
   if (!isStagingAlreadyCreated) {
-    console.log(`Creating the new staging branch...`)
+    printLog(`Creating the new staging branch...`)
     await executeCommand(`git checkout -b ${NEW_STAGING_BRANCH}`)
     await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)
   } else {
-    console.log(`New staging branch already created. Skipping.`)
+    printLog(`New staging branch already created. Skipping.`)
   }
 
   await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH}`)
   await executeCommand(`git pull`)
 
   if (isNewBranch && fs.existsSync(CI_FILE)) {
-    console.log(`Disabling CI on the old branch...`)
+    printLog(`Disabling CI on the old branch...`)
     await executeCommand(`git rm ${CI_FILE}`)
     await executeCommand(`git commit ${CI_FILE} -m "Remove ${CI_FILE} on old branch so pushes are noop"`)
     await executeCommand(`git push origin ${CURRENT_STAGING_BRANCH}`)
   } else {
-    console.log(`CI already disabled on the old branch. Skipping.`)
+    printLog(`CI already disabled on the old branch. Skipping.`)
   }
 
-  console.log('Reset Done.')
-}
-
-async function initGitConfig() {
-  const GITHUB_DEPLOY_KEY = await getSecretKey('ci.browser-sdk.github_deploy_key')
-
-  await executeCommand(`ssh-add - <<< "${GITHUB_DEPLOY_KEY}"`)
-  await executeCommand(`mkdir -p ~/.ssh`)
-  await executeCommand(`chmod 700 ~/.ssh`)
-  await executeCommand(`ssh-keyscan -H github.com >> ~/.ssh/known_hosts`)
-  await executeCommand(`git config user.email "browser-sdk-staging-reset@datadoghq.com"`)
-  await executeCommand(`git config user.name "Gitlab staging reset job"`)
-  await executeCommand(`git remote set-url origin ${REPOSITORY}`)
-}
-
-function getSecretKey(name) {
-  const awsParameters = [
-    'ssm',
-    'get-parameter',
-    `--region=us-east-1`,
-    '--with-decryption',
-    '--query=Parameter.Value',
-    '--out=text',
-    `--name=${name}`,
-  ]
-
-  return executeCommand(`aws ${awsParameters.join(' ')}`)
+  printLog('Reset Done.')
 }
 
 function getWeekNumber() {
@@ -92,20 +65,7 @@ function getWeekNumber() {
   return Math.ceil(((today - yearStart) / 86400000 + yearStart.getUTCDay() + 1) / 7)
 }
 
-async function executeCommand(command) {
-  const commandResult = await execute(command, {
-    shell: '/bin/bash',
-  })
-  if (commandResult.error && commandResult.error.code !== 0) {
-    throw commandResult.error
-  }
-  if (commandResult.stderr) {
-    console.error(commandResult.stderr)
-  }
-  return commandResult.stdout
-}
-
 main().catch((e) => {
-  console.error('Error occurred:', e)
+  printError('\nStacktrace:\n', e)
   process.exit(1)
 })

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,60 @@
+const util = require('util')
+const execute = util.promisify(require('child_process').exec)
+
+function getSecretKey(name) {
+  const awsParameters = [
+    'ssm',
+    'get-parameter',
+    `--region=us-east-1`,
+    '--with-decryption',
+    '--query=Parameter.Value',
+    '--out=text',
+    `--name=${name}`,
+  ]
+
+  return executeCommand(`aws ${awsParameters.join(' ')}`)
+}
+
+async function initGitConfig(repository) {
+  const githubDeployKey = await getSecretKey('ci.browser-sdk.github_deploy_key')
+
+  await executeCommand(`ssh-add - <<< "${githubDeployKey}"`)
+  await executeCommand(`mkdir -p ~/.ssh`)
+  await executeCommand(`chmod 700 ~/.ssh`)
+  await executeCommand(`ssh-keyscan -H github.com >> ~/.ssh/known_hosts`)
+  await executeCommand(`git config user.email "browser-sdk-staging-reset@datadoghq.com"`)
+  await executeCommand(`git config user.name "Gitlab staging reset job"`)
+  await executeCommand(`git remote set-url origin ${repository}`)
+}
+
+async function executeCommand(command) {
+  const commandResult = await execute(command, {
+    shell: '/bin/bash',
+  })
+  if (commandResult.error && commandResult.error.code !== 0) {
+    throw commandResult.error
+  }
+  if (commandResult.stderr) {
+    console.error(commandResult.stderr)
+  }
+  return commandResult.stdout
+}
+
+const resetColor = '\x1b[0m'
+
+function printError(...params) {
+  const redColor = '\x1b[31;1m'
+  console.log(redColor, ...params, resetColor)
+}
+
+function printLog(...params) {
+  const greenColor = '\x1b[32;1m'
+  console.log(greenColor, ...params, resetColor)
+}
+
+module.exports = {
+  initGitConfig,
+  executeCommand,
+  printError,
+  printLog,
+}


### PR DESCRIPTION
## Motivation

We want to setup a staging workflow similar to web-ui: instead of deploying main on staging, a new staging-xx branch is created every week. This branch is updated on every main commits and will be deployed on staging. PRs can be merged to this branch to allow testing them early.

This PR implement the merge into staging job, which merge main into staging on each main commit.

## Changes

- Create merge into staging script
- Update gitlab-ci

## Testing

Locally, Gitlab

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
