### PR TITLE
Deprecate @datadog/browser-rum-recorder

### DIFF
--- a/packages/rum-recorder/README.md
+++ b/packages/rum-recorder/README.md
@@ -1,15 +1,6 @@
 # RUM Browser Monitoring and Session Recording
 
-## Warning
+## Warning: do not use
 
-**This package is for the private beta of our Session Replay product. If you are not enrolled in our
-Session Replay private beta, please use the [RUM package](../rum) instead.**
-
-## Overview
-
-This package is equivalent to the [RUM package](../rum), but will record the user session beside
-collecting Real User Monitoring data.
-
-## Setup
-
-See the [RUM package](../rum/README.md) documentation.
+**This package is deprecated, you should not use it anymore. Please use the [RUM package](../rum)
+instead.**

--- a/packages/rum-recorder/package.json
+++ b/packages/rum-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-recorder",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "license": "Apache-2.0",
   "main": "cjs/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Motivation

This package should not be used anymore.

## Changes

Change the README to reflect this. Bump the version so we can publish the new README on [npm](https://www.npmjs.com/package/@datadog/browser-rum-recorder).

## Release

This PR won't be merged to main. I won't do a "normal" release for `2.18.1`. 

```bash
TARGET_DATACENTER=us BUILD_MODE=release yarn build
cd packages/rum-recorder
yarn publish
npm deprecate "@datadog/browser-rum-recorder is no longer supported. Please use @datadog/browser-rum instead."
```
(there is no `yarn deprecate`)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
