### PR TITLE
👷 [RUMF-1026] Add check-staging-merge

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,6 +249,7 @@ notify-feature-branch-failure:
       - main
       - tags
       - schedules
+      - /^staging-[0-9]+$/
 
 .prepare_notification:
   extends: .slack-notifier-base
@@ -385,3 +386,18 @@ merge-into-staging:
     - eval $(ssh-agent -s)
   script:
     - node scripts/staging-ci/merge-into-staging.js
+
+check-staging-merge:
+  stage: test
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+  except:
+    refs:
+      - main
+      - tags
+      - /^staging-[0-9]+$/
+      - schedules
+  before_script:
+    - eval $(ssh-agent -s)
+  script:
+    - node scripts/staging-ci/check-staging-merge.js

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,8 +197,8 @@ e2e-bs:
 
 deploy-staging:
   only:
-    refs:
-      - $CURRENT_STAGING
+    variables:
+      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
   stage: deploy
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
@@ -261,8 +261,8 @@ notify-feature-branch-failure:
 notify-staging-success:
   extends: .prepare_notification
   only:
-    refs:
-      - $CURRENT_STAGING
+    variables:
+      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :datadog_staging:."'
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"
@@ -272,8 +272,8 @@ notify-staging-failure:
   extends: .prepare_notification
   when: on_failure
   only:
-    refs:
-      - $CURRENT_STAGING
+    variables:
+      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME main pipeline for <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#rum-deploy" "$MESSAGE_TEXT"

--- a/scripts/staging-ci/check-staging-merge.js
+++ b/scripts/staging-ci/check-staging-merge.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { initGitConfig, executeCommand, printLog, printError } = require('../utils')
+
+const REPOSITORY = process.env.GIT_REPOSITORY
+const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
+const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
+const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
+const MAIN_BRANCH = process.env.MAIN_BRANCH
+
+async function main() {
+  await initGitConfig(REPOSITORY)
+  await executeCommand(`git fetch --no-tags origin ${MAIN_BRANCH} ${CURRENT_STAGING_BRANCH}`)
+
+  printLog(`Check if the ${CI_COMMIT_REF_NAME} (${CI_COMMIT_SHA}) is up to date with ${MAIN_BRANCH}...`)
+  const lastMainCommitHash = (await executeCommand(`git rev-parse origin/${MAIN_BRANCH}`)).trim()
+
+  try {
+    await executeCommand(`git merge-base --is-ancestor ${lastMainCommitHash} ${CI_COMMIT_SHA}`)
+  } catch (e) {
+    printError(`${CI_COMMIT_REF_NAME} is out of date with the ${MAIN_BRANCH}! 
+Please merge (or rebase) ${MAIN_BRANCH} with ${CI_COMMIT_REF_NAME} and try again.`)
+    throw e
+  }
+
+  await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH} -f`)
+  await executeCommand(`git pull`)
+
+  printLog(`Checking if ${CI_COMMIT_REF_NAME} (${CI_COMMIT_SHA}) can be merged with ${CURRENT_STAGING_BRANCH}...`)
+  try {
+    await executeCommand(`git merge --no-ff "${CI_COMMIT_SHA}"`)
+  } catch {
+    const diff = await executeCommand(`git diff`)
+    printError(`Conflicts:\n${diff}`)
+    throw e
+  }
+
+  printLog('Check Done.')
+}
+
+main().catch((e) => {
+  printError('\nStacktrace:\n', e)
+  process.exit(1)
+})

--- a/scripts/staging-ci/check-staging-merge.js
+++ b/scripts/staging-ci/check-staging-merge.js
@@ -19,8 +19,11 @@ async function main() {
     await executeCommand(`git merge --no-ff "${CI_COMMIT_SHA}"`)
   } catch (e) {
     const diff = await executeCommand(`git diff`)
-    printError(`Conflicts:\n${diff}\n
-You can resolve these conflicts by running "branches-status staging fix" in your branch and resolving the merge conflicts.`)
+    printError(
+      `Conflicts:\n${diff}\n` +
+        'You can resolve these conflicts by running "branches-status staging fix" in your branch' +
+        'and resolving the merge conflicts.'
+    )
     throw e
   }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -22,8 +22,8 @@ async function initGitConfig(repository) {
   await executeCommand(`mkdir -p ~/.ssh`)
   await executeCommand(`chmod 700 ~/.ssh`)
   await executeCommand(`ssh-keyscan -H github.com >> ~/.ssh/known_hosts`)
-  await executeCommand(`git config user.email "browser-sdk-staging-reset@datadoghq.com"`)
-  await executeCommand(`git config user.name "Gitlab staging reset job"`)
+  await executeCommand(`git config user.email "ci.browser-sdk@datadoghq.com"`)
+  await executeCommand(`git config user.name "ci.browser-sdk"`)
   await executeCommand(`git remote set-url origin ${repository}`)
 }
 


### PR DESCRIPTION
## Motivation

We want to setup a staging workflow similar to web-ui: instead of deploying main on staging, a new staging-xx branch is created every week. This branch is updated on every main commits and will be deployed on staging. PRs can be merged to this branch to allow testing them early.

This PR implement the check staging merge job to check if the current branch is mergeable with the staging

## Changes

- Add check-staging-merge script
- Update gitlab-ci

## Testing

Gilab

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
