### PR TITLE
✨ [RUMF-1000] add a custom time parameter to `addTiming`

### DIFF
--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -1,4 +1,4 @@
-import { isNumber, round } from './utils'
+import { isNumber, ONE_YEAR, round } from './utils'
 
 export type Duration = number & { d: 'Duration in ms' }
 export type ServerDuration = number & { s: 'Duration in ns' }
@@ -70,6 +70,10 @@ export function getRelativeTime(timestamp: TimeStamp) {
 export function getTimeStamp(relativeTime: RelativeTime) {
   // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
   return Math.round(getNavigationStart() + relativeTime) as TimeStamp
+}
+
+export function looksLikeRelativeTime(time: RelativeTime | TimeStamp): time is RelativeTime {
+  return time < ONE_YEAR
 }
 
 /**

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -4,6 +4,7 @@ export const ONE_SECOND = 1000
 export const ONE_MINUTE = 60 * ONE_SECOND
 export const ONE_HOUR = 60 * ONE_MINUTE
 export const ONE_DAY = 24 * ONE_HOUR
+export const ONE_YEAR = 365 * ONE_DAY
 export const ONE_KILO_BYTE = 1024
 
 export const enum DOM_EVENT {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -475,6 +475,16 @@ describe('rum public api', () => {
       expect(addTimingSpy.calls.argsFor(0)[1]).toBeUndefined()
       expect(displaySpy).not.toHaveBeenCalled()
     })
+
+    it('adds custom timing with provided time', () => {
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+
+      rumPublicApi.addTiming('foo', 12)
+
+      expect(addTimingSpy.calls.argsFor(0)[0]).toEqual('foo')
+      expect(addTimingSpy.calls.argsFor(0)[1]).toBe(12 as RelativeTime)
+      expect(displaySpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('trackViews mode', () => {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -19,6 +19,8 @@ import {
   callMonitored,
   createHandlingStack,
   DefaultPrivacyLevel,
+  TimeStamp,
+  RelativeTime,
 } from '@datadog/browser-core'
 import { LifeCycle } from '../domain/lifeCycle'
 import { ParentContexts } from '../domain/parentContexts'

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -194,8 +194,8 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
       })
     },
 
-    addTiming: monitor((name: string) => {
-      addTimingStrategy(name)
+    addTiming: monitor((name: string, time?: number) => {
+      addTimingStrategy(name, time as RelativeTime | TimeStamp | undefined)
     }),
 
     setUser: monitor((newUser: User) => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -1,4 +1,4 @@
-import { Duration, RelativeTime, timeStampNow, display, relativeToClocks } from '@datadog/browser-core'
+import { Duration, RelativeTime, timeStampNow, display, relativeToClocks, relativeNow } from '@datadog/browser-core'
 import { setup, TestSetupBuilder, setupViewTest, ViewTest } from '../../../../test/specHelper'
 import {
   RumLargestContentfulPaintTiming,
@@ -447,12 +447,24 @@ describe('view custom timings', () => {
     })
   })
 
-  it('should add custom timing with a specific time', () => {
+  it('should add custom timing with a specific timestamp', () => {
     const { clock } = setupBuilder.build()
     const { getViewUpdate, addTiming } = viewTest
 
     clock.tick(1234)
     addTiming('foo', timeStampNow())
+
+    expect(getViewUpdate(1).customTimings).toEqual({
+      foo: 1234 as Duration,
+    })
+  })
+
+  it('should add custom timing with a specific relative time', () => {
+    const { clock } = setupBuilder.build()
+    const { getViewUpdate, addTiming } = viewTest
+
+    clock.tick(1234)
+    addTiming('foo', relativeNow())
 
     expect(getViewUpdate(1).customTimings).toEqual({
       foo: 1234 as Duration,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -13,6 +13,8 @@ import {
   display,
   Observable,
   Subscription,
+  RelativeTime,
+  looksLikeRelativeTime,
 } from '@datadog/browser-core'
 import { ViewLoadingType, ViewCustomTimings } from '../../../rawRumEvent.types'
 
@@ -130,7 +132,7 @@ export function trackViews(
   }
 
   return {
-    addTiming: (name: string, time = timeStampNow()) => {
+    addTiming: (name: string, time: RelativeTime | TimeStamp = timeStampNow()) => {
       currentView.addTiming(name, time)
       currentView.triggerUpdate()
     },
@@ -222,8 +224,9 @@ function newView(
         setLoadEvent(newTimings.loadEvent)
       }
     },
-    addTiming(name: string, time: TimeStamp) {
-      customTimings[sanitizeTiming(name)] = elapsed(startClocks.timeStamp, time)
+    addTiming(name: string, time: RelativeTime | TimeStamp) {
+      const relativeTime = looksLikeRelativeTime(time) ? time : elapsed(startClocks.timeStamp, time)
+      customTimings[sanitizeTiming(name)] = relativeTime
     },
   }
 }


### PR DESCRIPTION
## Motivation

Allow users to pass a custom time parameter to `addTiming`. Particularly useful in async setups, see https://github.com/DataDog/browser-sdk/issues/1005

## Changes

* support relative and absolute times in view.addTiming
* add custom timing parameter support

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
