### PR TITLE
🐛 [RUMF-1021] clear cookie cache before expanding cookie

### DIFF
--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -12,6 +12,7 @@ export interface CookieOptions {
 export interface CookieCache {
   get: () => string | undefined
   set: (value: string, expireDelay: number) => void
+  clearCache: () => void
 }
 
 export function cacheCookieAccess(name: string, options: CookieOptions): CookieCache {
@@ -40,6 +41,10 @@ export function cacheCookieAccess(name: string, options: CookieOptions): CookieC
       setCookie(name, value, expireDelay, options)
       cache = value
       cacheAccess()
+    },
+    clearCache: () => {
+      clearTimeout(timeout)
+      hasCache = false
     },
   }
 }

--- a/packages/core/src/domain/sessionManagement.ts
+++ b/packages/core/src/domain/sessionManagement.ts
@@ -37,6 +37,7 @@ export function startSessionManagement<TrackingType extends string>(
 
   const { throttled: expandOrRenewSession } = utils.throttle(
     monitor(() => {
+      sessionCookie.clearCache()
       const cookieSession = retrieveActiveSession(sessionCookie)
       const retrievedSession = { ...cookieSession }
       const { trackingType, isTracked } = computeSessionState(cookieSession[productKey])
@@ -70,6 +71,7 @@ export function startSessionManagement<TrackingType extends string>(
   )
 
   const expandSession = () => {
+    sessionCookie.clearCache()
     const session = retrieveActiveSession(sessionCookie)
     persistSession(session, sessionCookie)
   }


### PR DESCRIPTION


## Motivation

Since logs and rum share the same session cookie, we can end up with a cached value with only the first product clearing the value of the second product.

ex:
```
first product session: logs=1
second product session: logs=1&rum=1
expand first product session: logs=1
```

## Changes

Ensure that we read the up to date cookie value before overwriting it

## Testing

unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
