### PR TITLE
[RUMF-1034] allow passing `undefined` options to RUM and Logs init

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -49,39 +49,39 @@ export const DEFAULT_CONFIGURATION = {
 
 export interface InitConfiguration {
   clientToken: string
-  applicationId?: string
-  actionNameAttribute?: string
-  internalMonitoringApiKey?: string
-  allowedTracingOrigins?: Array<string | RegExp>
-  sampleRate?: number
-  replaySampleRate?: number
-  site?: string
-  enableExperimentalFeatures?: string[]
-  silentMultipleInit?: boolean
-  trackInteractions?: boolean
-  trackViewsManually?: boolean
+  applicationId?: string | undefined
+  actionNameAttribute?: string | undefined
+  internalMonitoringApiKey?: string | undefined
+  allowedTracingOrigins?: Array<string | RegExp> | undefined
+  sampleRate?: number | undefined
+  replaySampleRate?: number | undefined
+  site?: string | undefined
+  enableExperimentalFeatures?: string[] | undefined
+  silentMultipleInit?: boolean | undefined
+  trackInteractions?: boolean | undefined
+  trackViewsManually?: boolean | undefined
 
   /**
    * @deprecated Favor proxyUrl option
    */
-  proxyHost?: string
-  proxyUrl?: string
-  beforeSend?: BeforeSendCallback
-  defaultPrivacyLevel?: DefaultPrivacyLevel
+  proxyHost?: string | undefined
+  proxyUrl?: string | undefined
+  beforeSend?: BeforeSendCallback | undefined
+  defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
 
-  service?: string
-  env?: string
-  version?: string
+  service?: string | undefined
+  env?: string | undefined
+  version?: string | undefined
 
-  useAlternateIntakeDomains?: boolean
-  intakeApiVersion?: 1 | 2
+  useAlternateIntakeDomains?: boolean | undefined
+  intakeApiVersion?: 1 | 2 | undefined
 
-  useCrossSiteSessionCookie?: boolean
-  useSecureSessionCookie?: boolean
-  trackSessionAcrossSubdomains?: boolean
+  useCrossSiteSessionCookie?: boolean | undefined
+  useSecureSessionCookie?: boolean | undefined
+  trackSessionAcrossSubdomains?: boolean | undefined
 
   // only on staging build mode
-  replica?: ReplicaUserConfiguration
+  replica?: ReplicaUserConfiguration | undefined
 }
 
 export type BeforeSendCallback = (event: any, context?: any) => unknown

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -22,8 +22,8 @@ import { LogsEvent } from '../logsEvent.types'
 import { buildEnv } from './buildEnv'
 
 export interface LogsInitConfiguration extends InitConfiguration {
-  forwardErrorsToLogs?: boolean
-  beforeSend?: (event: LogsEvent) => void | boolean
+  forwardErrorsToLogs?: boolean | undefined
+  beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
 }
 
 export function startLogs(

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -33,8 +33,8 @@ import { startRum } from './startRum'
 
 export interface RumInitConfiguration extends InitConfiguration {
   applicationId: string
-  beforeSend?: (event: RumEvent, context: RumEventDomainContext) => void | boolean
-  defaultPrivacyLevel?: DefaultPrivacyLevel
+  beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => void | boolean) | undefined
+  defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
 }
 
 export type RumPublicApi = ReturnType<typeof makeRumPublicApi>

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -230,9 +230,9 @@ export interface InternalContext {
 }
 
 export interface User {
-  id?: string
-  email?: string
-  name?: string
+  id?: string | undefined
+  email?: string | undefined
+  name?: string | undefined
   [key: string]: unknown
 }
 

--- a/scripts/cli
+++ b/scripts/cli
@@ -72,8 +72,30 @@ cmd_check_typescript_compatibility () {
   yarn build
   cd test/app
   rm -rf node_modules
-  yarn
-  yarn compat:tsc || fail 'typescript 3.0 compatibility broken'
+  check_typescript_3_compatibility || fail 'typescript@3.0 compatibility broken'
+  check_typescript_latest_compatibility || fail 'typescript@latest compatibility broken'
+}
+
+check_typescript_3_compatibility () {
+  yarn compat:tsc
+}
+
+check_typescript_latest_compatibility () {
+  # Add typescript options only supported in newer versions
+  sed -i '' '3 i\
+  "exactOptionalPropertyTypes": true,
+' tsconfig.json
+
+  yarn add typescript@latest
+  local succeeded=true
+  if ! yarn compat:tsc; then
+    succeeded=false
+  fi
+
+  # Revert all changes
+  git checkout .
+
+  $succeeded
 }
 
 cmd_check_server_side_rendering_compatibility () {

--- a/test/app/app.ts
+++ b/test/app/app.ts
@@ -20,4 +20,5 @@ if (typeof window !== 'undefined') {
   // compat test
   datadogLogs.init({ clientToken: 'xxx', beforeSend: undefined })
   datadogRum.init({ clientToken: 'xxx', applicationId: 'xxx', beforeSend: undefined })
+  datadogRum.setUser({ id: undefined })
 }

--- a/test/app/app.ts
+++ b/test/app/app.ts
@@ -18,6 +18,6 @@ if (typeof window !== 'undefined') {
   }
 } else {
   // compat test
-  datadogLogs.init({ clientToken: 'xxx' })
-  datadogRum.init({ clientToken: 'xxx', applicationId: 'xxx' })
+  datadogLogs.init({ clientToken: 'xxx', beforeSend: undefined })
+  datadogRum.init({ clientToken: 'xxx', applicationId: 'xxx', beforeSend: undefined })
 }


### PR DESCRIPTION
## Motivation

TS 4.4 introduced a new option called `exactOptionalPropertyTypes`, that disallows passing `undefined` to optional properties. Example:

```ts
interface Options {
  foo?: number
}

let options: Options = {
  foo: undefined // this will raise an error with `exactOptionalPropertyTypes: true`
}
```

To ease SDK integration in projects that are using this TS option, we want to explicitly allow passing `undefined` as a value for optional properties. 

## Changes

* add a small compatibility test to check for this configuration
* explicitly allow `undefined` for all `init` configuration optional properties

## Testing

CI

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
