### PR TITLE
Base tag support: discussion of SDK side approach

### DIFF
--- a/packages/rum/src/domain/record/serializationUtils.ts
+++ b/packages/rum/src/domain/record/serializationUtils.ts
@@ -56,12 +56,27 @@ export function makeSrcsetUrlsAbsolute(attributeValue: string, baseUrl: string) 
   )
 }
 
-export function makeUrlAbsolute(url: string, baseUrl: string): string {
+export function makeUrlAbsolute(url: string, docUrl: string): string {
   try {
+    const baseUrl = getBaseHref(docUrl)
     return buildUrl(url.trim(), baseUrl).href
   } catch (_) {
     return url
   }
+}
+
+let baseTagsLiveRef: NodeListOf<HTMLBaseElement> // Live NodeList reference
+const getBaseHref = (docUrl: string) => {
+  if (!baseTagsLiveRef) {
+    // OPTIMIZATION GENERALIZATION: Reduce Search scope to within <Head/>
+    baseTagsLiveRef = document.head.querySelectorAll('base[href]')
+  }
+  const baseTag = baseTagsLiveRef[0]
+  if (!baseTag) {
+    return docUrl
+  }
+  const baseUrl = baseTag.href.trim()
+  return buildUrl(baseUrl, docUrl).href
 }
 
 /**


### PR DESCRIPTION
## Motivation

Support `<Base href={url}/>` URL resolution for relative URLs. Currently the SDK resolves relative URLs against location.href without consideration for the base tag.

We can either handle support on the record or the replay side.
- This PR discusses the record side solution.
- [This other PR discusses the replay side solution.](https://github.com/DataDog/browser-sdk/pull/1086)

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
