### PR TITLE
Base tag support: discussion of replay side approach

### DIFF
--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -20,8 +20,6 @@ import {
 
 export const MAX_ATTRIBUTE_VALUE_CHAR_LENGTH = 100_000
 
-import { makeStylesheetUrlsAbsolute } from './serializationUtils'
-
 import { shouldIgnoreElement } from './serialize'
 
 const TEXT_MASKING_CHAR = 'x'
@@ -211,7 +209,7 @@ export function getTextContent(
   } else if (shouldMaskNode(textNode, nodePrivacyLevel)) {
     if (isStyle) {
       // Style tags are `overruled` (Use `hide` to enforce privacy)
-      textContent = makeStylesheetUrlsAbsolute(textContent, location.href)
+      return textContent
     } else if (
       // Scrambling the child list breaks text nodes for DATALIST/SELECT/OPTGROUP
       parentTagName === 'DATALIST' ||

--- a/packages/rum/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum/src/domain/record/serializationUtils.spec.ts
@@ -1,14 +1,6 @@
 import { isIE } from '../../../../core/test/specHelper'
 import { NodePrivacyLevel } from '../../constants'
-import {
-  makeStylesheetUrlsAbsolute,
-  getSerializedNodeId,
-  hasSerializedNode,
-  setSerializedNodeId,
-  makeSrcsetUrlsAbsolute,
-  makeUrlAbsolute,
-  getElementInputValue,
-} from './serializationUtils'
+import { getSerializedNodeId, hasSerializedNode, setSerializedNodeId, getElementInputValue } from './serializationUtils'
 
 describe('serialized Node storage in DOM Nodes', () => {
   describe('hasSerializedNode', () => {
@@ -35,123 +27,6 @@ describe('serialized Node storage in DOM Nodes', () => {
 
       expect(getSerializedNodeId(node)).toBe(42)
     })
-  })
-})
-
-describe('absolute url to stylesheet', () => {
-  const href = 'http://localhost/css/style.css'
-
-  it('can handle relative path', () => {
-    expect(makeStylesheetUrlsAbsolute('url(a.jpg)', href)).toEqual(`url(http://localhost/css/a.jpg)`)
-  })
-
-  it('can handle same level path', () => {
-    expect(makeStylesheetUrlsAbsolute('url("./a.jpg")', href)).toEqual(`url("http://localhost/css/a.jpg")`)
-  })
-
-  it('can handle parent level path', () => {
-    expect(makeStylesheetUrlsAbsolute('url("../a.jpg")', href)).toEqual(`url("http://localhost/a.jpg")`)
-  })
-
-  it('can handle absolute path', () => {
-    expect(makeStylesheetUrlsAbsolute('url("/a.jpg")', href)).toEqual(`url("http://localhost/a.jpg")`)
-  })
-
-  it('can handle external path', () => {
-    expect(makeStylesheetUrlsAbsolute('url("http://localhost/a.jpg")', href)).toEqual(`url("http://localhost/a.jpg")`)
-  })
-
-  it('can handle single quote path', () => {
-    expect(makeStylesheetUrlsAbsolute(`url('./a.jpg')`, href)).toEqual(`url('http://localhost/css/a.jpg')`)
-  })
-
-  it('can handle no quote path', () => {
-    expect(makeStylesheetUrlsAbsolute('url(./a.jpg)', href)).toEqual(`url(http://localhost/css/a.jpg)`)
-  })
-
-  it('can handle multiple no quote paths', () => {
-    expect(
-      makeStylesheetUrlsAbsolute(
-        'background-image: url(images/b.jpg);background: #aabbcc url(images/a.jpg) 50% 50% repeat;',
-        href
-      )
-    ).toEqual(
-      `background-image: url(http://localhost/css/images/b.jpg);` +
-        `background: #aabbcc url(http://localhost/css/images/a.jpg) 50% 50% repeat;`
-    )
-  })
-
-  it('can handle data url image', () => {
-    expect(makeStylesheetUrlsAbsolute('url(data:image/gif;base64,ABC)', href)).toEqual('url(data:image/gif;base64,ABC)')
-    expect(makeStylesheetUrlsAbsolute('url(data:application/font-woff;base64,d09GMgABAAAAAAm)', href)).toEqual(
-      'url(data:application/font-woff;base64,d09GMgABAAAAAAm)'
-    )
-  })
-
-  it('preserves quotes around inline svgs with spaces', () => {
-    /* eslint-disable max-len */
-    expect(
-      makeStylesheetUrlsAbsolute(
-        "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2328a745' d='M3'/%3E%3C/svg%3E\")",
-        href
-      )
-    ).toEqual(
-      "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%2328a745' d='M3'/%3E%3C/svg%3E\")"
-    )
-    expect(
-      makeStylesheetUrlsAbsolute(
-        'url(\'data:image/svg+xml;utf8,<svg width="28" height="32" viewBox="0 0 28 32" xmlns="http://www.w3.org/2000/svg"><path d="M27 14C28" fill="white"/></svg>\')',
-        href
-      )
-    ).toEqual(
-      'url(\'data:image/svg+xml;utf8,<svg width="28" height="32" viewBox="0 0 28 32" xmlns="http://www.w3.org/2000/svg"><path d="M27 14C28" fill="white"/></svg>\')'
-    )
-    /* eslint-enable max-len */
-  })
-  it('can handle empty path', () => {
-    expect(makeStylesheetUrlsAbsolute(`url('')`, href)).toEqual(`url('')`)
-  })
-})
-
-describe('makeSrcsetUrlsAbsolute', () => {
-  it('returns an empty string if the value is empty', () => {
-    expect(makeSrcsetUrlsAbsolute('', 'https://example.org')).toBe('')
-  })
-
-  it('replaces urls in all image sources', () => {
-    expect(makeSrcsetUrlsAbsolute('elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w', 'https://example.org')).toBe(
-      'https://example.org/elva-fairy-480w.jpg 480w, https://example.org/elva-fairy-800w.jpg 800w'
-    )
-  })
-
-  it('works with image sources without a descriptor', () => {
-    expect(makeSrcsetUrlsAbsolute('elva-fairy-480w.jpg, elva-fairy-800w.jpg', 'https://example.org')).toBe(
-      'https://example.org/elva-fairy-480w.jpg, https://example.org/elva-fairy-800w.jpg'
-    )
-  })
-})
-
-describe('makeUrlAbsolute', () => {
-  beforeEach(() => {
-    if (isIE()) {
-      pending('IE not supported')
-    }
-  })
-
-  it('makes an absolute URL from a relative path', () => {
-    expect(makeUrlAbsolute('bar', 'http://example.org/foo/')).toBe('http://example.org/foo/bar')
-  })
-
-  it('makes an absolute URL from an absolute path', () => {
-    expect(makeUrlAbsolute('/bar', 'http://example.org/foo/')).toBe('http://example.org/bar')
-  })
-
-  it('does not change data URIs', () => {
-    expect(makeUrlAbsolute('data:image/gif;base64,ABC', 'http://example.org/foo/')).toBe('data:image/gif;base64,ABC')
-  })
-
-  it('returns the original value if it fails to be parsed as an URL', () => {
-    expect(makeUrlAbsolute('http://', 'http://example.org/foo/')).toBe('http://')
   })
 })
 

--- a/packages/rum/src/domain/record/serializationUtils.ts
+++ b/packages/rum/src/domain/record/serializationUtils.ts
@@ -2,6 +2,8 @@ import { buildUrl } from '@datadog/browser-core'
 import { CENSORED_STRING_MARK, NodePrivacyLevel } from '../../constants'
 import { shouldMaskNode } from './privacy'
 
+const DISABLE_ABSOLUTE = false;
+
 export type NodeWithSerializedNode = Node & { s: 'Node with serialized node' }
 
 const serializedNodeIds = new WeakMap<Node, number>()
@@ -35,6 +37,9 @@ const URL_IN_CSS_REF = /url\((?:(')([^']*)'|(")([^"]*)"|([^)]*))\)/gm
 const ABSOLUTE_URL = /^[A-Za-z]+:|^\/\//
 const DATA_URI = /^data:.*,/i
 export function makeStylesheetUrlsAbsolute(cssText: string, baseUrl: string): string {
+  if (DISABLE_ABSOLUTE) {
+    return cssText;
+  }
   return cssText.replace(
     URL_IN_CSS_REF,
     (origin: string, quote1: string, path1: string, quote2: string, path2: string, path3: string) => {
@@ -50,6 +55,9 @@ export function makeStylesheetUrlsAbsolute(cssText: string, baseUrl: string): st
 
 const SRCSET_URLS = /(^\s*|,\s*)([^\s,]+)/g
 export function makeSrcsetUrlsAbsolute(attributeValue: string, baseUrl: string) {
+  if (DISABLE_ABSOLUTE) {
+    return attributeValue;
+  }
   return attributeValue.replace(
     SRCSET_URLS,
     (_, prefix: string, url: string) => `${prefix}${makeUrlAbsolute(url, baseUrl)}`
@@ -57,6 +65,9 @@ export function makeSrcsetUrlsAbsolute(attributeValue: string, baseUrl: string) 
 }
 
 export function makeUrlAbsolute(url: string, baseUrl: string): string {
+  if (DISABLE_ABSOLUTE) {
+    return url.trim();
+  }
   try {
     return buildUrl(url.trim(), baseUrl).href
   } catch (_) {

--- a/packages/rum/src/domain/record/serializationUtils.ts
+++ b/packages/rum/src/domain/record/serializationUtils.ts
@@ -2,7 +2,7 @@ import { buildUrl } from '@datadog/browser-core'
 import { CENSORED_STRING_MARK, NodePrivacyLevel } from '../../constants'
 import { shouldMaskNode } from './privacy'
 
-const DISABLE_ABSOLUTE = false;
+const DISABLE_ABSOLUTE = false
 
 export type NodeWithSerializedNode = Node & { s: 'Node with serialized node' }
 
@@ -31,48 +31,6 @@ export function getSerializedNodeId(node: Node) {
 
 export function setSerializedNodeId(node: Node, serializeNodeId: number) {
   serializedNodeIds.set(node, serializeNodeId)
-}
-
-const URL_IN_CSS_REF = /url\((?:(')([^']*)'|(")([^"]*)"|([^)]*))\)/gm
-const ABSOLUTE_URL = /^[A-Za-z]+:|^\/\//
-const DATA_URI = /^data:.*,/i
-export function makeStylesheetUrlsAbsolute(cssText: string, baseUrl: string): string {
-  if (DISABLE_ABSOLUTE) {
-    return cssText;
-  }
-  return cssText.replace(
-    URL_IN_CSS_REF,
-    (origin: string, quote1: string, path1: string, quote2: string, path2: string, path3: string) => {
-      const filePath = path1 || path2 || path3
-      if (!filePath || ABSOLUTE_URL.test(filePath) || DATA_URI.test(filePath)) {
-        return origin
-      }
-      const maybeQuote = quote1 || quote2 || ''
-      return `url(${maybeQuote}${makeUrlAbsolute(filePath, baseUrl)}${maybeQuote})`
-    }
-  )
-}
-
-const SRCSET_URLS = /(^\s*|,\s*)([^\s,]+)/g
-export function makeSrcsetUrlsAbsolute(attributeValue: string, baseUrl: string) {
-  if (DISABLE_ABSOLUTE) {
-    return attributeValue;
-  }
-  return attributeValue.replace(
-    SRCSET_URLS,
-    (_, prefix: string, url: string) => `${prefix}${makeUrlAbsolute(url, baseUrl)}`
-  )
-}
-
-export function makeUrlAbsolute(url: string, baseUrl: string): string {
-  if (DISABLE_ABSOLUTE) {
-    return url.trim();
-  }
-  try {
-    return buildUrl(url.trim(), baseUrl).href
-  } catch (_) {
-    return url
-  }
 }
 
 /**

--- a/packages/rum/src/domain/record/serializationUtils.ts
+++ b/packages/rum/src/domain/record/serializationUtils.ts
@@ -1,8 +1,5 @@
-import { buildUrl } from '@datadog/browser-core'
 import { CENSORED_STRING_MARK, NodePrivacyLevel } from '../../constants'
 import { shouldMaskNode } from './privacy'
-
-const DISABLE_ABSOLUTE = false
 
 export type NodeWithSerializedNode = Node & { s: 'Node with serialized node' }
 

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -22,14 +22,7 @@ import {
   TextNode,
   CDataNode,
 } from './types'
-import {
-  makeStylesheetUrlsAbsolute,
-  getSerializedNodeId,
-  setSerializedNodeId,
-  getElementInputValue,
-  makeSrcsetUrlsAbsolute,
-  makeUrlAbsolute,
-} from './serializationUtils'
+import { getSerializedNodeId, setSerializedNodeId, getElementInputValue } from './serializationUtils'
 import { forEach } from './utils'
 
 // Those values are the only one that can be used when inheriting privacy levels from parent to
@@ -337,20 +330,7 @@ export function serializeAttribute(
   if (attributeValue.length > MAX_ATTRIBUTE_VALUE_CHAR_LENGTH && attributeValue.slice(0, 5) === 'data:') {
     return 'data:truncated'
   }
-
-  // Rebuild absolute URLs from relative (without using <base> tag)
-  const doc = element.ownerDocument
-  switch (attributeName) {
-    case 'src':
-    case 'href':
-      return makeUrlAbsolute(attributeValue, doc.location?.href)
-    case 'srcset':
-      return makeSrcsetUrlsAbsolute(attributeValue, doc.location?.href)
-    case 'style':
-      return makeStylesheetUrlsAbsolute(attributeValue, doc.location?.href)
-    default:
-      return attributeValue
-  }
+  return attributeValue
 }
 
 let _nextId = 1
@@ -442,7 +422,7 @@ function getAttributesForPrivacyLevel(
     if (cssText && stylesheet) {
       delete safeAttrs.rel
       delete safeAttrs.href
-      safeAttrs._cssText = makeStylesheetUrlsAbsolute(cssText, stylesheet.href!)
+      safeAttrs._cssText = cssText
     }
   }
 
@@ -455,7 +435,7 @@ function getAttributesForPrivacyLevel(
   ) {
     const cssText = getCssRulesString((element as HTMLStyleElement).sheet as CSSStyleSheet)
     if (cssText) {
-      safeAttrs._cssText = makeStylesheetUrlsAbsolute(cssText, location.href)
+      safeAttrs._cssText = cssText
     }
   }
 


### PR DESCRIPTION
## Motivation

Support `<Base href={url}/>` URL resolution for relative URLs. Currently the SDK resolves relative URLs against location.href without consideration for the base tag.

We can either handle support on the record or the replay side.
- This PR discusses the replay side solution.
- [This other PR discusses the record side solution.](https://github.com/DataDog/browser-sdk/pull/1085)

Support `<Base href={url}/>` URL resolution for relative URLs. Currently the SDK resolves relative URLs against location.href without consideration for the base tag.

**Breakdown:**
Commit # 1 shows a feature flag friendly rollout for internal testing- however the FF implementation via prop drill-down, as is, may be more error prone, so we should figure out a cleaner FF methodology going forward.

Commit # 2/3  shows the final solution without using feature flags. 
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
