### PR TITLE
♻️ Feature flag refactor: no more "prop drilldown", now just import

### DIFF
--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -35,11 +35,7 @@ const pathsWithSideEffect = new Set([
 ])
 
 // Those packages either are known to have no side effects when evaluated, or are allow listed safely
-const packagesWithoutSideEffect = new Set([
-  '@datadog/browser-core',
-  '@datadog/browser-rum-core',
-  'packages/core/src/domain/configuration/experimentalFeatures',
-])
+const packagesWithoutSideEffect = new Set(['@datadog/browser-core', '@datadog/browser-rum-core'])
 
 /**
  * Iterate over the given node and its children, and report any node that may have a side effect

--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -38,7 +38,7 @@ const pathsWithSideEffect = new Set([
 const packagesWithoutSideEffect = new Set([
   '@datadog/browser-core',
   '@datadog/browser-rum-core',
-  'packages/core/src/domain/configuration/experimentalFeatures'
+  'packages/core/src/domain/configuration/experimentalFeatures',
 ])
 
 /**

--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -34,8 +34,12 @@ const pathsWithSideEffect = new Set([
   `${packagesRoot}/rum-slim/src/index.ts`,
 ])
 
-// Those packages are known to have no side effects when evaluated
-const packagesWithoutSideEffect = new Set(['@datadog/browser-core', '@datadog/browser-rum-core'])
+// Those packages either are known to have no side effects when evaluated, or are allow listed safely
+const packagesWithoutSideEffect = new Set([
+  '@datadog/browser-core',
+  '@datadog/browser-rum-core',
+  'packages/core/src/domain/configuration/experimentalFeatures'
+])
 
 /**
  * Iterate over the given node and its children, and report any node that may have a side effect

--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -34,7 +34,7 @@ const pathsWithSideEffect = new Set([
   `${packagesRoot}/rum-slim/src/index.ts`,
 ])
 
-// Those packages either are known to have no side effects when evaluated
+// Those packages are known to have no side effects when evaluated
 const packagesWithoutSideEffect = new Set(['@datadog/browser-core', '@datadog/browser-rum-core'])
 
 /**

--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -34,7 +34,7 @@ const pathsWithSideEffect = new Set([
   `${packagesRoot}/rum-slim/src/index.ts`,
 ])
 
-// Those packages either are known to have no side effects when evaluated, or are allow listed safely
+// Those packages either are known to have no side effects when evaluated
 const packagesWithoutSideEffect = new Set(['@datadog/browser-core', '@datadog/browser-rum-core'])
 
 /**

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -49,7 +49,7 @@ export interface BuildEnv {
 }
 
 export function commonInit(initConfiguration: InitConfiguration, buildEnv: BuildEnv) {
-  updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures || [])
+  updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
   const configuration = buildConfiguration(initConfiguration, buildEnv)
   const internalMonitoring = startInternalMonitoring(configuration)
 

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -3,7 +3,7 @@ import { buildConfiguration, InitConfiguration } from '../domain/configuration'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { display } from '../tools/display'
-import { updateEnabledExperimentalFeatures } from '../domain/configuration/experimentalFeatures'
+import { updateExperimentalFeatures } from '../domain/configuration/experimentalFeatures'
 
 export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): void } {
   const publicApi = {
@@ -49,11 +49,7 @@ export interface BuildEnv {
 }
 
 export function commonInit(initConfiguration: InitConfiguration, buildEnv: BuildEnv) {
-  const enableExperimentalFeatures = Array.isArray(initConfiguration.enableExperimentalFeatures)
-    ? initConfiguration.enableExperimentalFeatures
-    : []
-  updateEnabledExperimentalFeatures(enableExperimentalFeatures)
-
+  updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures || [])
   const configuration = buildConfiguration(initConfiguration, buildEnv)
   const internalMonitoring = startInternalMonitoring(configuration)
 

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -3,6 +3,7 @@ import { buildConfiguration, InitConfiguration } from '../domain/configuration'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { display } from '../tools/display'
+import { setEnabledExperimentalFeatures } from '../domain/configuration/experimentalFeatures'
 
 export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): void } {
   const publicApi = {
@@ -50,6 +51,12 @@ export interface BuildEnv {
 export function commonInit(initConfiguration: InitConfiguration, buildEnv: BuildEnv) {
   const configuration = buildConfiguration(initConfiguration, buildEnv)
   const internalMonitoring = startInternalMonitoring(configuration)
+
+  const enableExperimentalFeatures = Array.isArray(initConfiguration.enableExperimentalFeatures)
+  ? initConfiguration.enableExperimentalFeatures
+  : []
+
+  setEnabledExperimentalFeatures(enableExperimentalFeatures)
 
   return {
     configuration,

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -49,14 +49,13 @@ export interface BuildEnv {
 }
 
 export function commonInit(initConfiguration: InitConfiguration, buildEnv: BuildEnv) {
-  const configuration = buildConfiguration(initConfiguration, buildEnv)
-  const internalMonitoring = startInternalMonitoring(configuration)
-
   const enableExperimentalFeatures = Array.isArray(initConfiguration.enableExperimentalFeatures)
     ? initConfiguration.enableExperimentalFeatures
     : []
-
   setEnabledExperimentalFeatures(enableExperimentalFeatures)
+
+  const configuration = buildConfiguration(initConfiguration, buildEnv)
+  const internalMonitoring = startInternalMonitoring(configuration)
 
   return {
     configuration,

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -53,8 +53,8 @@ export function commonInit(initConfiguration: InitConfiguration, buildEnv: Build
   const internalMonitoring = startInternalMonitoring(configuration)
 
   const enableExperimentalFeatures = Array.isArray(initConfiguration.enableExperimentalFeatures)
-  ? initConfiguration.enableExperimentalFeatures
-  : []
+    ? initConfiguration.enableExperimentalFeatures
+    : []
 
   setEnabledExperimentalFeatures(enableExperimentalFeatures)
 

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -3,7 +3,7 @@ import { buildConfiguration, InitConfiguration } from '../domain/configuration'
 import { setDebugMode, startInternalMonitoring } from '../domain/internalMonitoring'
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { display } from '../tools/display'
-import { setEnabledExperimentalFeatures } from '../domain/configuration/experimentalFeatures'
+import { updateEnabledExperimentalFeatures } from '../domain/configuration/experimentalFeatures'
 
 export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): void } {
   const publicApi = {
@@ -52,7 +52,7 @@ export function commonInit(initConfiguration: InitConfiguration, buildEnv: Build
   const enableExperimentalFeatures = Array.isArray(initConfiguration.enableExperimentalFeatures)
     ? initConfiguration.enableExperimentalFeatures
     : []
-  setEnabledExperimentalFeatures(enableExperimentalFeatures)
+  updateEnabledExperimentalFeatures(enableExperimentalFeatures)
 
   const configuration = buildConfiguration(initConfiguration, buildEnv)
   const internalMonitoring = startInternalMonitoring(configuration)

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -3,6 +3,7 @@ import { CookieOptions, getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { includes, objectHasValue, ONE_KILO_BYTE, ONE_SECOND } from '../../tools/utils'
 import { computeTransportConfiguration, TransportConfiguration } from './transportConfiguration'
+import { setEnabledExperimentalFeatures } from './experimentalFeatures'
 
 export const DefaultPrivacyLevel = {
   ALLOW: 'allow',
@@ -99,8 +100,6 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
     beforeSend?: BeforeSendCallback
 
     actionNameAttribute?: string
-
-    isEnabled: (feature: string) => boolean
   }
 
 export function buildConfiguration(initConfiguration: InitConfiguration, buildEnv: BuildEnv): Configuration {
@@ -108,12 +107,12 @@ export function buildConfiguration(initConfiguration: InitConfiguration, buildEn
     ? initConfiguration.enableExperimentalFeatures
     : []
 
-  const isEnabled = (feature: string) => includes(enableExperimentalFeatures, feature)
+  setEnabledExperimentalFeatures(enableExperimentalFeatures)
+
   const configuration: Configuration = {
     beforeSend:
       initConfiguration.beforeSend && catchUserErrors(initConfiguration.beforeSend, 'beforeSend threw an error:'),
     cookieOptions: buildCookieOptions(initConfiguration),
-    isEnabled,
     service: initConfiguration.service,
     ...computeTransportConfiguration(initConfiguration, buildEnv),
     ...DEFAULT_CONFIGURATION,

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -1,9 +1,8 @@
 import { BuildEnv } from '../../boot/init'
 import { CookieOptions, getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
-import { includes, objectHasValue, ONE_KILO_BYTE, ONE_SECOND } from '../../tools/utils'
+import { objectHasValue, ONE_KILO_BYTE, ONE_SECOND } from '../../tools/utils'
 import { computeTransportConfiguration, TransportConfiguration } from './transportConfiguration'
-import { setEnabledExperimentalFeatures } from './experimentalFeatures'
 
 export const DefaultPrivacyLevel = {
   ALLOW: 'allow',
@@ -103,11 +102,6 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
   }
 
 export function buildConfiguration(initConfiguration: InitConfiguration, buildEnv: BuildEnv): Configuration {
-  const enableExperimentalFeatures = Array.isArray(initConfiguration.enableExperimentalFeatures)
-    ? initConfiguration.enableExperimentalFeatures
-    : []
-
-  setEnabledExperimentalFeatures(enableExperimentalFeatures)
 
   const configuration: Configuration = {
     beforeSend:

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -102,7 +102,6 @@ export type Configuration = typeof DEFAULT_CONFIGURATION &
   }
 
 export function buildConfiguration(initConfiguration: InitConfiguration, buildEnv: BuildEnv): Configuration {
-
   const configuration: Configuration = {
     beforeSend:
       initConfiguration.beforeSend && catchUserErrors(initConfiguration.beforeSend, 'beforeSend threw an error:'),

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -1,0 +1,39 @@
+import {
+  updateExperimentalFeatures,
+  isExperimentalFeatureEnabled,
+  resetExperimentalFeatures,
+} from './experimentalFeatures'
+
+describe('experimentalFeatures', () => {
+  it('initial state is empty', () => {
+    resetExperimentalFeatures()
+    expect(isExperimentalFeatureEnabled(undefined as any)).toBeFalse()
+    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
+    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
+    expect(isExperimentalFeatureEnabled('')).toBeFalse()
+  })
+
+  it('updateExperimentalFeatures', () => {
+    updateExperimentalFeatures(['foo'])
+    expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
+    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
+  })
+
+  it('resetExperimentalFeatures clears state', () => {
+    resetExperimentalFeatures()
+    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
+    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
+  })
+
+  it("functions won't throw", () => {
+    resetExperimentalFeatures()
+    resetExperimentalFeatures()
+    updateExperimentalFeatures(undefined as any)
+    updateExperimentalFeatures(undefined as any)
+
+    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
+    updateExperimentalFeatures(['foo'])
+    updateExperimentalFeatures(['foo'])
+    expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
+  })
+})

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -20,15 +20,20 @@ describe('experimentalFeatures', () => {
     expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
   })
 
-  it("functions won't throw an error", () => {
-    resetExperimentalFeatures()
-    resetExperimentalFeatures()
-    updateExperimentalFeatures(undefined)
-    updateExperimentalFeatures(undefined)
-    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
-
+  it('should allow to be shared between products', () => {
     updateExperimentalFeatures(['foo'])
-    updateExperimentalFeatures([11 as any, [] as any, {} as any, null as any, undefined as any])
+    updateExperimentalFeatures(['bar'])
+
+    expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
+    expect(isExperimentalFeatureEnabled('bar')).toBeTrue()
+  })
+
+  it('should support some edge cases', () => {
+    updateExperimentalFeatures(['foo'])
+    updateExperimentalFeatures(undefined)
+    updateExperimentalFeatures([])
+    updateExperimentalFeatures([11 as any])
+
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
   })
 })

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -5,35 +5,30 @@ import {
 } from './experimentalFeatures'
 
 describe('experimentalFeatures', () => {
-  it('initial state is empty', () => {
+  afterEach(() => {
     resetExperimentalFeatures()
-    expect(isExperimentalFeatureEnabled(undefined as any)).toBeFalse()
-    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
-    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
-    expect(isExperimentalFeatureEnabled('')).toBeFalse()
   })
 
-  it('updateExperimentalFeatures', () => {
+  it('initial state is empty', () => {
+    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
+    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
+  })
+
+  it('should define enabled experimental features', () => {
     updateExperimentalFeatures(['foo'])
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
     expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
   })
 
-  it('resetExperimentalFeatures clears state', () => {
-    resetExperimentalFeatures()
-    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
-    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
-  })
-
-  it("functions won't throw", () => {
+  it("functions won't throw an error", () => {
     resetExperimentalFeatures()
     resetExperimentalFeatures()
-    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
     updateExperimentalFeatures(undefined)
     updateExperimentalFeatures(undefined)
     expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
+    
     updateExperimentalFeatures(['foo'])
-    updateExperimentalFeatures(['foo'])
+    updateExperimentalFeatures([11 as any, [] as any, {} as any, null as any, undefined as any])
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
   })
 })

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -28,9 +28,9 @@ describe('experimentalFeatures', () => {
   it("functions won't throw", () => {
     resetExperimentalFeatures()
     resetExperimentalFeatures()
-    updateExperimentalFeatures(undefined as any)
-    updateExperimentalFeatures(undefined as any)
-
+    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
+    updateExperimentalFeatures(undefined)
+    updateExperimentalFeatures(undefined)
     expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
     updateExperimentalFeatures(['foo'])
     updateExperimentalFeatures(['foo'])

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -26,7 +26,7 @@ describe('experimentalFeatures', () => {
     updateExperimentalFeatures(undefined)
     updateExperimentalFeatures(undefined)
     expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
-    
+
     updateExperimentalFeatures(['foo'])
     updateExperimentalFeatures([11 as any, [] as any, {} as any, null as any, undefined as any])
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -1,0 +1,9 @@
+let enabledExperimentalFeatures: Set<string>
+
+export function setEnabledExperimentalFeatures(enabledFeatures: string[]): void {
+  enabledExperimentalFeatures = new Set(enabledFeatures)
+}
+
+export function isEnabledExperimentalFeatures(featureName: string): boolean {
+  return enabledExperimentalFeatures.has(featureName)
+}

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -4,6 +4,6 @@ export function setEnabledExperimentalFeatures(enabledFeatures: string[]): void 
   enabledExperimentalFeatures = new Set(enabledFeatures)
 }
 
-export function isEnabledExperimentalFeatures(featureName: string): boolean {
+export function isEnabledExperimentalFeature(featureName: string): boolean {
   return enabledExperimentalFeatures.has(featureName)
 }

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -18,7 +18,7 @@ export function updateExperimentalFeatures(enabledFeatures: string[]): void {
 }
 
 export function isExperimentalFeatureEnabled(featureName: string): boolean {
-  return enabledExperimentalFeatures && enabledExperimentalFeatures.has(featureName)
+  return !!enabledExperimentalFeatures && enabledExperimentalFeatures.has(featureName)
 }
 
 export function resetExperimentalFeatures(): void {

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -1,9 +1,13 @@
 let enabledExperimentalFeatures: Set<string>
 
-export function setEnabledExperimentalFeatures(enabledFeatures: string[]): void {
-  enabledExperimentalFeatures = new Set(enabledFeatures)
+export function updateEnabledExperimentalFeatures(enabledFeatures: string[]): void {
+  if (!enabledExperimentalFeatures) {
+    enabledExperimentalFeatures = new Set(enabledFeatures)
+  } else {
+    enabledFeatures.forEach((flag) => enabledExperimentalFeatures.add(flag))
+  }
 }
 
 export function isEnabledExperimentalFeature(featureName: string): boolean {
-  return enabledExperimentalFeatures.has(featureName)
+  return enabledExperimentalFeatures && enabledExperimentalFeatures.has(featureName)
 }

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -1,6 +1,6 @@
 let enabledExperimentalFeatures: Set<string>
 
-export function updateExperimentalFeatures(enabledFeatures: string[]): void {
+export function updateExperimentalFeatures(enabledFeatures: string[] | undefined): void {
   // Safely handle external data
   if (!Array.isArray(enabledFeatures)) {
     return

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -1,13 +1,26 @@
 let enabledExperimentalFeatures: Set<string>
 
-export function updateEnabledExperimentalFeatures(enabledFeatures: string[]): void {
+export function updateExperimentalFeatures(enabledFeatures: string[]): void {
+  // Safely handle external data
+  if (!Array.isArray(enabledFeatures)) {
+    return
+  }
+
   if (!enabledExperimentalFeatures) {
     enabledExperimentalFeatures = new Set(enabledFeatures)
-  } else {
-    enabledFeatures.forEach((flag) => enabledExperimentalFeatures.add(flag))
   }
+
+  enabledFeatures
+    .filter((flag) => typeof flag === 'string')
+    .forEach((flag: string) => {
+      enabledExperimentalFeatures.add(flag)
+    })
 }
 
-export function isEnabledExperimentalFeature(featureName: string): boolean {
+export function isExperimentalFeatureEnabled(featureName: string): boolean {
   return enabledExperimentalFeatures && enabledExperimentalFeatures.has(featureName)
+}
+
+export function resetExperimentalFeatures(): void {
+  enabledExperimentalFeatures = new Set()
 }

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -1,3 +1,10 @@
+/**
+ * LIMITATION:
+ * For NPM setup, this feature flag singleton is shared between RUM and Logs product.
+ * This means that an experimental flag set on the RUM product will be set on the Logs product.
+ * So keep in mind that in certain configurations, your experimental feature flag may affect other products.
+ */
+
 let enabledExperimentalFeatures: Set<string>
 
 export function updateExperimentalFeatures(enabledFeatures: string[] | undefined): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,10 @@ export {
   BeforeSendCallback,
   DefaultPrivacyLevel,
 } from './domain/configuration'
+export {
+  isEnabledExperimentalFeature,
+  setEnabledExperimentalFeatures,
+} from './domain/configuration/experimentalFeatures'
 export { trackConsoleError } from './domain/error/trackConsoleError'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'
 export { computeStackTrace, StackTrace } from './domain/tracekit'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ export {
 } from './domain/configuration'
 export {
   isEnabledExperimentalFeature,
-  setEnabledExperimentalFeatures,
+  updateEnabledExperimentalFeatures,
 } from './domain/configuration/experimentalFeatures'
 export { trackConsoleError } from './domain/error/trackConsoleError'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,8 +7,9 @@ export {
   DefaultPrivacyLevel,
 } from './domain/configuration'
 export {
-  isEnabledExperimentalFeature,
-  updateEnabledExperimentalFeatures,
+  isExperimentalFeatureEnabled,
+  updateExperimentalFeatures,
+  resetExperimentalFeatures,
 } from './domain/configuration/experimentalFeatures'
 export { trackConsoleError } from './domain/error/trackConsoleError'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'

--- a/packages/logs/src/domain/loggerSession.spec.ts
+++ b/packages/logs/src/domain/loggerSession.spec.ts
@@ -12,7 +12,7 @@ import { LOGGER_SESSION_KEY, LoggerTrackingType, startLoggerSession } from './lo
 
 describe('logger session', () => {
   const DURATION = 123456
-  const configuration: Partial<Configuration> = { isEnabled: () => true, sampleRate: 0.5 }
+  const configuration: Partial<Configuration> = { sampleRate: 0.5 }
   let tracked = true
   let clock: Clock
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -11,9 +11,6 @@ describe('actionCollection', () => {
 
   beforeEach(() => {
     setupBuilder = setup()
-      .withConfiguration({
-        isEnabled: () => true,
-      })
       .withForegroundContexts({
         isInForegroundAt: () => true,
       })

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -10,9 +10,6 @@ describe('error collection', () => {
 
   beforeEach(() => {
     setupBuilder = setup()
-      .withConfiguration({
-        isEnabled: () => true,
-      })
       .withForegroundContexts({
         isInForegroundAt: () => true,
       })

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -18,13 +18,9 @@ describe('long task collection', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup()
-      .withConfiguration({
-        isEnabled: () => true,
-      })
-      .beforeBuild(({ lifeCycle }) => {
-        startLongTaskCollection(lifeCycle)
-      })
+    setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
+      startLongTaskCollection(lifeCycle)
+    })
   })
 
   afterEach(() => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -45,9 +45,6 @@ describe('viewCollection', () => {
 
   beforeEach(() => {
     setupBuilder = setup()
-      .withConfiguration({
-        isEnabled: () => true,
-      })
       .withForegroundContexts({
         selectInForegroundPeriodsFor: () => [{ start: 0 as ServerDuration, duration: 10 as ServerDuration }],
       })

--- a/packages/rum-core/src/domain/rumSession.spec.ts
+++ b/packages/rum-core/src/domain/rumSession.spec.ts
@@ -20,7 +20,6 @@ describe('rum session', () => {
   const DURATION = 123456
   const configuration: Partial<Configuration> = {
     ...DEFAULT_CONFIGURATION,
-    isEnabled: () => true,
     sampleRate: 50,
     replaySampleRate: 50,
   }

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -86,7 +86,6 @@ export function setup(): TestSetupBuilder {
   const configuration: Partial<Configuration> = {
     ...DEFAULT_CONFIGURATION,
     ...SPEC_ENDPOINTS,
-    isEnabled: () => true,
   }
   const FAKE_APP_ID = 'appId'
 

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -1,4 +1,4 @@
-import { Configuration, includes } from '@datadog/browser-core'
+import { Configuration } from '@datadog/browser-core'
 import {
   RecorderApi,
   ParentContexts,
@@ -32,15 +32,7 @@ describe('makeRecorderApi', () => {
       getDeflateWorkerSingletonSpy = jasmine.createSpy('getDeflateWorkerSingleton').and.returnValue({})
       recorderApi = makeRecorderApi(startRecordingSpy, getDeflateWorkerSingletonSpy)
       rumInit = (initConfiguration) => {
-        recorderApi.onRumStart(
-          lifeCycle,
-          initConfiguration,
-          {
-            isEnabled: (feature) => includes(initConfiguration.enableExperimentalFeatures || [], feature),
-          } as Configuration,
-          session,
-          {} as ParentContexts
-        )
+        recorderApi.onRumStart(lifeCycle, initConfiguration, {} as Configuration, session, {} as ParentContexts)
       }
     })
   })


### PR DESCRIPTION
## Motivation

Related to (internal) [RUMF-1004](https://datadoghq.atlassian.net/browse/RUMF-1004).

Currently prop drill-down is required to pass the configuration object around to access `configuration.isEnabled()`. This is a lot of work, and requires care to not introduce further bugs. Instead we can leverage a singleton to import `isEnabledExperimentalFeatures`.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

Moving from `configuration.isEnabled` prop drill-down  to instead `import {isEnabledExperimentalFeatures} from '@datadog/browser-core'`;
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
