### PR TITLE
🔊[RUMF-1021] add extra monitoring on session type change

### DIFF
--- a/packages/core/src/domain/sessionManagement.ts
+++ b/packages/core/src/domain/sessionManagement.ts
@@ -65,8 +65,8 @@ export function startSessionManagement<TrackingType extends string>(
             _dd_s: getCookie(SESSION_COOKIE_NAME),
           },
         })
-        inMemorySession = { ...cookieSession }
       }
+      inMemorySession = { ...cookieSession }
     }),
     COOKIE_ACCESS_DELAY
   )
@@ -85,8 +85,8 @@ export function startSessionManagement<TrackingType extends string>(
           _dd_s: getCookie(SESSION_COOKIE_NAME),
         },
       })
-      inMemorySession = { ...session }
     }
+    inMemorySession = { ...session }
   }
 
   expandOrRenewSession()
@@ -101,7 +101,6 @@ export function startSessionManagement<TrackingType extends string>(
       alternateSessionCookie.clearCache()
       if (
         inMemorySession.id === sessionCookieCheck.id &&
-        inMemorySession[productKey] !== undefined &&
         inMemorySession[productKey] !== sessionCookieCheck[productKey]
       ) {
         addMonitoringMessage('session type changed - ccc', {
@@ -113,8 +112,8 @@ export function startSessionManagement<TrackingType extends string>(
             _dd_s: getCookie(SESSION_COOKIE_NAME),
           },
         })
-        inMemorySession = { ...sessionCookieCheck }
       }
+      inMemorySession = { ...sessionCookieCheck }
     }, COOKIE_ACCESS_DELAY)
     stopCallbacks.push(() => clearInterval(cookieConsistencyCheckInterval))
   }

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -141,6 +141,7 @@ export function startRumAssembly(
                 eventType: serverRumEvent.type,
                 viewId: serverRumEvent.view.id,
                 sessionId: serverRumEvent.session.id,
+                inMemoryPlan: session.getInMemoryPlan(),
                 event: serverRumEvent,
                 _dd_s: getCookie('_dd_s'),
               },

--- a/packages/rum-core/src/domain/rumSession.ts
+++ b/packages/rum-core/src/domain/rumSession.ts
@@ -8,6 +8,7 @@ export interface RumSession {
   isTracked: () => boolean
   hasReplayPlan: () => boolean
   hasLitePlan: () => boolean
+  getInMemoryPlan: () => RumTrackingType | undefined
 }
 
 export enum RumSessionPlan {
@@ -39,6 +40,7 @@ export function startRumSession(configuration: Configuration, lifeCycle: LifeCyc
     isTracked: () => isSessionTracked(session),
     hasReplayPlan: () => isSessionTracked(session) && session.getTrackingType() === RumTrackingType.TRACKED_REPLAY,
     hasLitePlan: () => isSessionTracked(session) && session.getTrackingType() === RumTrackingType.TRACKED_LITE,
+    getInMemoryPlan: () => session.getInMemoryTrackingType(),
   }
 }
 

--- a/packages/rum-core/test/mockRumSession.ts
+++ b/packages/rum-core/test/mockRumSession.ts
@@ -25,6 +25,7 @@ export function createRumSessionMock(): RumSessionMock {
     getId() {
       return trackingType === RumTrackingType.NOT_TRACKED ? undefined : id
     },
+    getInMemoryPlan: () => trackingType,
     setId(newId) {
       id = newId
       return this


### PR DESCRIPTION
## Motivation

cf #1066, #1072, #1075, #1080

## Changes

- detect session type change on expand session
- detect session type change regularly
- add inMemory session type in lite session with replay message

## Testing

manual, staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
