### PR TITLE
🔊 [RUMF-1036] Add negative loading time internal monitoring

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -7,7 +7,6 @@ import {
   generateUUID,
   ClocksState,
   clocksNow,
-  TimeStamp,
   Configuration,
   ONE_SECOND,
   Observable,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -107,7 +107,7 @@ function startActionManagement(lifeCycle: LifeCycle, domMutationObservable: Obse
         domMutationObservable,
         (params) => {
           if (params.hadActivity) {
-            pendingAutoAction.complete(params.endTime)
+            pendingAutoAction.complete(params.endClocks)
           } else {
             pendingAutoAction.discard()
           }
@@ -138,8 +138,8 @@ class PendingAutoAction {
     this.lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_CREATED, { id: this.id, startClocks: this.startClocks })
   }
 
-  complete(endTime: TimeStamp) {
-    const actionDuration = elapsed(this.startClocks.timeStamp, endTime)
+  complete(endClocks: ClocksState) {
+    const actionDuration = elapsed(this.startClocks.timeStamp, endClocks.timeStamp)
     if (actionDuration < 0) {
       addMonitoringMessage('auto action with negative loading time', {
         debug: {
@@ -147,7 +147,7 @@ class PendingAutoAction {
           type: this.type,
           name: this.name,
           startClocks: this.startClocks,
-          endTime,
+          endClocks,
         },
       })
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -110,7 +110,7 @@ function trackActivityLoadingTime(
   const startTime = timeStampNow()
   const { stop: stopWaitIdlePageActivity } = waitIdlePageActivity(lifeCycle, domMutationObservable, (params) => {
     if (params.hadActivity) {
-      callback(elapsed(startTime, params.endTime))
+      callback(elapsed(startTime, params.endClocks.timeStamp))
     } else {
       callback(undefined)
     }

--- a/packages/rum-core/src/domain/trackPageActivities.spec.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.spec.ts
@@ -1,4 +1,4 @@
-import { ClocksState, noop, Observable, ONE_SECOND, TimeStamp, timeStampNow } from '@datadog/browser-core'
+import { noop, Observable, ONE_SECOND, TimeStamp, timeStampNow } from '@datadog/browser-core'
 import { Clock, mockClock } from '../../../core/test/specHelper'
 import { RumPerformanceNavigationTiming, RumPerformanceResourceTiming } from '../browser/performanceCollection'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'

--- a/packages/rum-core/src/domain/trackPageActivities.spec.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.spec.ts
@@ -1,4 +1,4 @@
-import { noop, Observable, ONE_SECOND, TimeStamp, timeStampNow } from '@datadog/browser-core'
+import { ClocksState, noop, Observable, ONE_SECOND, TimeStamp, timeStampNow } from '@datadog/browser-core'
 import { Clock, mockClock } from '../../../core/test/specHelper'
 import { RumPerformanceNavigationTiming, RumPerformanceResourceTiming } from '../browser/performanceCollection'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
@@ -177,8 +177,11 @@ describe('waitPageActivitiesCompletion', () => {
 
     expect(completionCallbackSpy).toHaveBeenCalledOnceWith({
       hadActivity: true,
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-      endTime: (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY) as TimeStamp,
+      endClocks: {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        timeStamp: (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY) as TimeStamp,
+        relative: BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY,
+      },
     })
   })
 
@@ -186,7 +189,6 @@ describe('waitPageActivitiesCompletion', () => {
     it('is extended while there is page activities', () => {
       const activityObservable = new Observable<PageActivityEvent>()
       const startTime = timeStampNow()
-
       // Extend the action 10 times
       const extendCount = 10
 
@@ -199,10 +201,14 @@ describe('waitPageActivitiesCompletion', () => {
 
       clock.tick(EXPIRE_DELAY)
 
+      const relative = extendCount * BEFORE_PAGE_ACTIVITY_END_DELAY
       expect(completionCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        endTime: (startTime + extendCount * BEFORE_PAGE_ACTIVITY_END_DELAY) as TimeStamp,
+        endClocks: {
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          timeStamp: (startTime + relative) as TimeStamp,
+          relative,
+        },
       })
     })
 
@@ -228,8 +234,11 @@ describe('waitPageActivitiesCompletion', () => {
 
       expect(completionCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        endTime: (startTime + MAX_DURATION) as TimeStamp,
+        endClocks: {
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          timeStamp: (startTime + MAX_DURATION) as TimeStamp,
+          relative: MAX_DURATION,
+        },
       })
     })
   })
@@ -248,10 +257,14 @@ describe('waitPageActivitiesCompletion', () => {
 
       clock.tick(EXPIRE_DELAY)
 
+      const relative = BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + PAGE_ACTIVITY_END_DELAY * 2
       expect(completionCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        endTime: (startTime + BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + PAGE_ACTIVITY_END_DELAY * 2) as TimeStamp,
+        endClocks: {
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          timeStamp: (startTime + relative) as TimeStamp,
+          relative,
+        },
       })
     })
 
@@ -267,8 +280,11 @@ describe('waitPageActivitiesCompletion', () => {
 
       expect(completionCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        endTime: (startTime + MAX_DURATION) as TimeStamp,
+        endClocks: {
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          timeStamp: (startTime + MAX_DURATION) as TimeStamp,
+          relative: MAX_DURATION,
+        },
       })
     })
   })

--- a/packages/rum-core/src/domain/trackPageActivities.ts
+++ b/packages/rum-core/src/domain/trackPageActivities.ts
@@ -1,4 +1,4 @@
-import { monitor, Observable, Subscription, TimeStamp, timeStampNow } from '@datadog/browser-core'
+import { clocksNow, ClocksState, monitor, Observable, Subscription } from '@datadog/browser-core'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 
 // Delay to wait for a page activity to validate the tracking process
@@ -10,7 +10,7 @@ export interface PageActivityEvent {
   isBusy: boolean
 }
 
-export type CompletionCallbackParameters = { hadActivity: true; endTime: TimeStamp } | { hadActivity: false }
+export type CompletionCallbackParameters = { hadActivity: true; endClocks: ClocksState } | { hadActivity: false }
 
 export function waitIdlePageActivity(
   lifeCycle: LifeCycle,
@@ -133,17 +133,17 @@ export function waitPageActivitiesCompletion(
   const maxDurationTimeoutId =
     maxDuration &&
     setTimeout(
-      monitor(() => complete({ hadActivity: true, endTime: timeStampNow() })),
+      monitor(() => complete({ hadActivity: true, endClocks: clocksNow() })),
       maxDuration
     )
 
   pageActivitiesObservable.subscribe(({ isBusy }) => {
     clearTimeout(validationTimeoutId)
     clearTimeout(idleTimeoutId)
-    const lastChangeTime = timeStampNow()
+    const lastChangeTime = clocksNow()
     if (!isBusy) {
       idleTimeoutId = setTimeout(
-        monitor(() => complete({ hadActivity: true, endTime: lastChangeTime })),
+        monitor(() => complete({ hadActivity: true, endClocks: lastChangeTime })),
         PAGE_ACTIVITY_END_DELAY
       )
     }


### PR DESCRIPTION
## Motivation

Some views and actions have a negative loading time.
Because it happens more often on actions, this PR only adds internal monitoring to them.
The first step is to identify if this behaviour comes from `waitIdlePageActivity`.

## Changes

Add internal monitoring on actions with negative loading time

## Testing

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
