### PR TITLE
🐛 [RUMF-1021] fix regression on renew session

### DIFF
--- a/packages/core/src/domain/sessionManagement.ts
+++ b/packages/core/src/domain/sessionManagement.ts
@@ -85,8 +85,8 @@ export function startSessionManagement<TrackingType extends string>(
           _dd_s: getCookie(SESSION_COOKIE_NAME),
         },
       })
+      inMemorySession = { ...session }
     }
-    inMemorySession = { ...session }
   }
 
   expandOrRenewSession()
@@ -112,8 +112,8 @@ export function startSessionManagement<TrackingType extends string>(
             _dd_s: getCookie(SESSION_COOKIE_NAME),
           },
         })
+        inMemorySession = { ...sessionCookieCheck }
       }
-      inMemorySession = { ...sessionCookieCheck }
     }, COOKIE_ACCESS_DELAY)
     stopCallbacks.push(() => clearInterval(cookieConsistencyCheckInterval))
   }


### PR DESCRIPTION
## Motivation

monitoring code introduced by #1091 can prevent session to be renewed by overwriting the in memory session id.

## Changes

Overwrite in memory session id only in `expandOrRenewSession`

## Testing

local, staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
