### PR TITLE
♻️ Use new observable pattern for page activity

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.spec.ts
@@ -4,7 +4,7 @@ import { RumEvent } from '../../../../../rum/src'
 import { setup, TestSetupBuilder } from '../../../../test/specHelper'
 import { RumEventType, ActionType } from '../../../rawRumEvent.types'
 import { LifeCycleEventType } from '../../lifeCycle'
-import { PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
+import { PAGE_ACTIVITY_VALIDATION_DELAY } from '../../pageActivityObservable'
 import { AutoAction, AUTO_ACTION_MAX_DURATION, trackActions } from './trackActions'
 
 // Used to wait some time after the creation of a action

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -4,7 +4,7 @@ import { TestSetupBuilder, setup, setupViewTest, ViewTest } from '../../../../te
 import { RumPerformanceNavigationTiming } from '../../../browser/performanceCollection'
 import { RumEventType } from '../../../rawRumEvent.types'
 import { LifeCycle } from '../../lifeCycle'
-import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../trackPageActivities'
+import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../pageActivityObservable'
 import { THROTTLE_VIEW_UPDATE_PERIOD } from './trackViews'
 
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = (PAGE_ACTIVITY_VALIDATION_DELAY * 0.8) as Duration

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -12,7 +12,7 @@ import { RumLayoutShiftTiming, supportPerformanceTimingEvent } from '../../../br
 import { ViewLoadingType } from '../../../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { EventCounts, trackEventCounts } from '../../trackEventCounts'
-import { waitIdlePageActivity } from '../../trackPageActivities'
+import { createIdlePageActivityObservable } from '../../pageActivityObservable'
 
 export interface ViewMetrics {
   eventCounts: EventCounts
@@ -108,7 +108,7 @@ function trackActivityLoadingTime(
   callback: (loadingTimeValue: Duration | undefined) => void
 ) {
   const startTime = timeStampNow()
-  const { stop: stopWaitIdlePageActivity } = waitIdlePageActivity(lifeCycle, domMutationObservable, (params) => {
+  const subscription = createIdlePageActivityObservable(lifeCycle, domMutationObservable).subscribe((params) => {
     if (params.hadActivity) {
       callback(elapsed(startTime, params.endTime))
     } else {
@@ -116,7 +116,7 @@ function trackActivityLoadingTime(
     }
   })
 
-  return { stop: stopWaitIdlePageActivity }
+  return { stop: subscription.unsubscribe }
 }
 
 /**


### PR DESCRIPTION
## Motivation

By looking at the trackPageActivity, I've seen that it could benefit from the new observable pattern.

## Changes

- trackPageActivities() => createPageActivityObservable()
- waitIdlePageActivity() => createIdlePageActivityObservable()

## Testing

Unit, Locally

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
