### PR TITLE
👷  Remove staging deploy notification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -258,16 +258,6 @@ notify-feature-branch-failure:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - COMMIT_URL="$CI_PROJECT_URL/commits/$CI_COMMIT_SHA"
 
-notify-staging-success:
-  extends: .prepare_notification
-  only:
-    variables:
-      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
-  script:
-    - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :datadog_staging:."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
-    - postmessage "#rum-ops-stg" "$MESSAGE_TEXT"
-
 notify-staging-failure:
   extends: .prepare_notification
   when: on_failure
@@ -276,7 +266,7 @@ notify-staging-failure:
       - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME main pipeline for <$BUILD_URL|$COMMIT_MESSAGE> failed."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
 
 notify-release-ready:
   extends: .prepare_notification
@@ -286,7 +276,7 @@ notify-release-ready:
       - tags
   script:
     - 'MESSAGE_TEXT=":i: $CI_PROJECT_NAME <$BUILD_URL|$COMMIT_MESSAGE> ready to be deployed to :datadog:"'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
 
 notify-prod-canary-success:
   extends: .prepare_notification
@@ -296,7 +286,7 @@ notify-prod-canary-success:
       - tags
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :datadog:."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
     - postmessage "#rum-ops" "$MESSAGE_TEXT"
 
 notify-prod-canary-failure:
@@ -308,7 +298,7 @@ notify-prod-canary-failure:
       - tags
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME release pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
 
 notify-prod-stable-success:
   extends: .prepare_notification
@@ -317,7 +307,7 @@ notify-prod-stable-success:
       - tags
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :earth_americas:."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
     - postmessage "#rum-ops" "$MESSAGE_TEXT"
 
 notify-prod-stable-failure:
@@ -328,7 +318,7 @@ notify-prod-stable-failure:
       - tags
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME release pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
 
 ########################################################################################################################
 # To staging CI
@@ -356,7 +346,7 @@ staging-reset-scheduled-success:
       - $TARGET_TASK_NAME == "staging-reset-scheduled"
   script:
     - 'MESSAGE_TEXT=":white_check_mark: [*$CI_PROJECT_NAME*] Staging has been reset from *${CURRENT_STAGING}* to *${NEW_STAGING}* on pipeline <$BUILD_URL|$COMMIT_MESSAGE>."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
   dependencies:
     - staging-reset-scheduled
 
@@ -368,7 +358,7 @@ staging-reset-scheduled-failure:
       - $TARGET_TASK_NAME == "staging-reset-scheduled"
   script:
     - 'MESSAGE_TEXT=":x: [*$CI_PROJECT_NAME*] Staging failed to reset from *${CURRENT_STAGING}* to *${NEW_STAGING}* on pipeline <$BUILD_URL|$COMMIT_MESSAGE>."'
-    - postmessage "#rum-deploy" "$MESSAGE_TEXT"
+    - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
   dependencies:
     - staging-reset-scheduled
 

--- a/scripts/staging-ci/check-staging-merge.js
+++ b/scripts/staging-ci/check-staging-merge.js
@@ -5,6 +5,7 @@ const { initGitConfig, executeCommand, printLog, printError, logAndExit } = requ
 const REPOSITORY = process.env.GIT_REPOSITORY
 const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
 const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
+const CI_COMMIT_SHORT_SHA = process.env.CI_COMMIT_SHORT_SHA
 const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
 const MAIN_BRANCH = process.env.MAIN_BRANCH
 
@@ -15,7 +16,8 @@ async function main() {
   await executeCommand(`git pull`)
 
   printLog(
-    `Checking if branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHA}) can be merged into ${CURRENT_STAGING_BRANCH}...`
+    `Checking if branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA})` +
+      ` can be merged into ${CURRENT_STAGING_BRANCH}...`
   )
   try {
     await executeCommand(`git merge --no-ff "${CI_COMMIT_SHA}"`)

--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -5,6 +5,7 @@ const { initGitConfig, executeCommand, printLog, printError, logAndExit } = requ
 const REPOSITORY = process.env.GIT_REPOSITORY
 const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
 const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
+const CI_COMMIT_SHORT_SHA = process.env.CI_COMMIT_SHORT_SHA
 const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
 
 async function main() {
@@ -13,7 +14,7 @@ async function main() {
   await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH} -f`)
   await executeCommand(`git pull origin ${CURRENT_STAGING_BRANCH}`)
 
-  printLog(`Merging branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHA}) into ${CURRENT_STAGING_BRANCH}...`)
+  printLog(`Merging branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA}) into ${CURRENT_STAGING_BRANCH}...`)
   try {
     await executeCommand(`git merge --no-ff "${CI_COMMIT_SHA}"`)
   } catch (error) {
@@ -23,7 +24,7 @@ async function main() {
   }
 
   const commitMessage = await executeCommand(`git show -s --format=%B`)
-  const newSummary = `Merge branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHA}) with ${CURRENT_STAGING_BRANCH}`
+  const newSummary = `Merge branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA}) with ${CURRENT_STAGING_BRANCH}`
   const message = `${newSummary}\n\n${commitMessage}`
 
   await executeCommand(`git commit --amend -m "${message}"`)


### PR DESCRIPTION
## Motivation

Lots of notifications are now triggered during the staging process, making noise. Our goal is to rationalize notifications to avoid spamming.

## Changes

- Remove staging deploy notification
- Rename channel #rum-deploy to #browser-sdk-deploy

## Testing

Gitlab

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
