### PR TITLE
👷 Remove gitlab jobs on release branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,36 @@ stages:
   - deploy
   - notify
 
+########################################################################################################################
+# Configuration helpers
+########################################################################################################################
+
+.base-configuration:
+  tags: ['runner:main', 'size:large']
+  image: $CI_IMAGE
+
+.feature-branch-configuration:
+  extends: .base-configuration
+  except:
+    refs:
+      - main
+      - tags
+      - /^staging-[0-9]+$/
+      - /^release\/v[0-9.]+$/
+      - schedules
+
+.test-configuration:
+  stage: test
+  extends: .base-configuration
+  except:
+    refs:
+      - /^release\/v[0-9.]+$/
+      - schedules
+
+########################################################################################################################
+# CI image
+########################################################################################################################
+
 ci-image:
   stage: ci-image
   when: manual
@@ -43,44 +73,24 @@ ci-image:
 ########################################################################################################################
 
 format:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   script:
     - yarn
     - yarn format
 
 woke:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   script:
     - yarn woke
 
 typecheck:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   script:
     - yarn
     - yarn typecheck
 
 build-and-lint:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   script:
     - yarn
     - yarn build
@@ -89,35 +99,20 @@ build-and-lint:
     - scripts/cli typecheck test/e2e
 
 build-bundle:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   script:
     - yarn
     - yarn build:bundle
 
 compatibility:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   script:
     - yarn
     - yarn test:compat:tsc
     - yarn test:compat:ssr
 
 unit:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   artifacts:
     reports:
       junit: test-report/unit/*.xml
@@ -127,12 +122,7 @@ unit:
     - ./scripts/codecov.sh
 
 e2e:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   artifacts:
     when: always
     paths:
@@ -144,26 +134,14 @@ e2e:
     - yarn test:e2e
 
 check-licenses:
-  stage: test
-  except:
-    refs:
-      - schedules
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .test-configuration
   script:
     - node --no-warnings scripts/check-licenses.js
 
 unit-bs:
   stage: browserstack
-  except:
-    refs:
-      - main
-      - tags
-      - /^staging-[0-9]+$/
-      - schedules
+  extends: .feature-branch-configuration
   resource_group: browserstack
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
   artifacts:
     reports:
       junit: test-report/unit-bs/*.xml
@@ -173,15 +151,8 @@ unit-bs:
 
 e2e-bs:
   stage: browserstack
-  except:
-    refs:
-      - main
-      - tags
-      - /^staging-[0-9]+$/
-      - schedules
+  extends: .feature-branch-configuration
   resource_group: browserstack
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
   artifacts:
     when: always
     reports:
@@ -197,40 +168,37 @@ e2e-bs:
 ########################################################################################################################
 
 deploy-staging:
+  stage: deploy
+  extends: .base-configuration
   only:
     variables:
       - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
-  stage: deploy
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
   script:
     - yarn
     - BUILD_MODE=staging yarn build:bundle
     - ./scripts/deploy.sh staging head
 
 deploy-prod-canary:
+  stage: deploy:canary
+  extends: .base-configuration
   only:
     refs:
       - tags
-  stage: deploy:canary
   when: manual
   allow_failure: false
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
   script:
     - yarn
     - BUILD_MODE=release yarn build:bundle
     - ./scripts/deploy.sh prod canary
 
 deploy-prod-stable:
+  stage: deploy
+  extends: .base-configuration
   only:
     refs:
       - tags
-  stage: deploy
   when: manual
   allow_failure: false
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
   script:
     - yarn
     - BUILD_MODE=release yarn build:bundle
@@ -244,13 +212,9 @@ deploy-prod-stable:
 include: 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
 
 notify-feature-branch-failure:
-  extends: .slack-notifier.on-failure
-  except:
-    refs:
-      - main
-      - tags
-      - schedules
-      - /^staging-[0-9]+$/
+  extends:
+    - .feature-branch-configuration
+    - .slack-notifier.on-failure
 
 .prepare_notification:
   extends: .slack-notifier-base
@@ -261,10 +225,10 @@ notify-feature-branch-failure:
 
 notify-staging-failure:
   extends: .prepare_notification
-  when: on_failure
   only:
     variables:
       - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
+  when: on_failure
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME main pipeline for <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
@@ -327,11 +291,10 @@ notify-prod-stable-failure:
 
 staging-reset-scheduled:
   stage: task
+  extends: .base-configuration
   only:
     variables:
       - $TARGET_TASK_NAME == "staging-reset-scheduled"
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
   before_script:
     - eval $(ssh-agent -s)
   script:
@@ -353,10 +316,10 @@ staging-reset-scheduled-success:
 
 staging-reset-scheduled-failure:
   extends: .prepare_notification
-  when: on_failure
   only:
     variables:
       - $TARGET_TASK_NAME == "staging-reset-scheduled"
+  when: on_failure
   script:
     - 'MESSAGE_TEXT=":x: [*$CI_PROJECT_NAME*] Staging failed to reset from *${CURRENT_STAGING}* to *${NEW_STAGING}* on pipeline <$BUILD_URL|$COMMIT_MESSAGE>."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
@@ -365,8 +328,7 @@ staging-reset-scheduled-failure:
 
 merge-into-staging:
   stage: pre-deploy
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
+  extends: .base-configuration
   only:
     refs:
       - main
@@ -380,14 +342,7 @@ merge-into-staging:
 
 check-staging-merge:
   stage: test
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
-  except:
-    refs:
-      - main
-      - tags
-      - /^staging-[0-9]+$/
-      - schedules
+  extends: .feature-branch-configuration
   before_script:
     - eval $(ssh-agent -s)
   script:
@@ -397,13 +352,6 @@ check-staging-merge:
 # staging branch, even though the pipeline is still running
 tests-passed:
   stage: after-tests
-  tags: ['runner:main', 'size:large']
-  image: $CI_IMAGE
-  except:
-    refs:
-      - main
-      - tags
-      - /^staging-[0-9]+$/
-      - schedules
+  extends: .feature-branch-configuration
   script:
     - 'true'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,13 +57,8 @@ stages:
 
 ci-image:
   stage: ci-image
+  extends: .feature-branch-configuration
   when: manual
-  except:
-    refs:
-      - tags
-      - /^staging-[0-9]+$/
-      - /^release\/v[0-9.]+$/
-      - schedules
   tags: ['runner:docker', 'size:large']
   image: $BUILD_STABLE_REGISTRY/docker:18.03.1
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,8 @@ ci-image:
   except:
     refs:
       - tags
+      - /^staging-[0-9]+$/
+      - /^release\/v[0-9.]+$/
       - schedules
   tags: ['runner:docker', 'size:large']
   image: $BUILD_STABLE_REGISTRY/docker:18.03.1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ stages:
       - main
       - tags
       - /^staging-[0-9]+$/
-      - /^release\/v[0-9.]+$/
+      - /^release\//
       - schedules
 
 .test-configuration:
@@ -48,7 +48,7 @@ stages:
   extends: .base-configuration
   except:
     refs:
-      - /^release\/v[0-9.]+$/
+      - /^release\//
       - schedules
 
 ########################################################################################################################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,16 +25,15 @@ stages:
   - deploy
   - notify
 
-########################################################################################################################
-# Configuration helpers
-########################################################################################################################
-
 .base-configuration:
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
 
-.feature-branch-configuration:
-  extends: .base-configuration
+########################################################################################################################
+# Branch selection helpers
+########################################################################################################################
+
+.feature-branches:
   except:
     refs:
       - main
@@ -43,9 +42,25 @@ stages:
       - /^release\//
       - schedules
 
-.test-configuration:
-  stage: test
-  extends: .base-configuration
+.staging:
+  only:
+    variables:
+      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
+
+.main:
+  only:
+    refs:
+      - main
+  except:
+    refs:
+      - schedules
+
+.tags:
+  only:
+    refs:
+      - tags
+
+.test-allowed-branches:
   except:
     refs:
       - /^release\//
@@ -57,7 +72,9 @@ stages:
 
 ci-image:
   stage: ci-image
-  extends: .feature-branch-configuration
+  extends:
+    - .base-configuration
+    - .feature-branches
   when: manual
   tags: ['runner:docker', 'size:large']
   image: $BUILD_STABLE_REGISTRY/docker:18.03.1
@@ -70,24 +87,32 @@ ci-image:
 ########################################################################################################################
 
 format:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   script:
     - yarn
     - yarn format
 
 woke:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   script:
     - yarn woke
 
 typecheck:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   script:
     - yarn
     - yarn typecheck
 
 build-and-lint:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   script:
     - yarn
     - yarn build
@@ -96,20 +121,26 @@ build-and-lint:
     - scripts/cli typecheck test/e2e
 
 build-bundle:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   script:
     - yarn
     - yarn build:bundle
 
 compatibility:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   script:
     - yarn
     - yarn test:compat:tsc
     - yarn test:compat:ssr
 
 unit:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   artifacts:
     reports:
       junit: test-report/unit/*.xml
@@ -119,7 +150,9 @@ unit:
     - ./scripts/codecov.sh
 
 e2e:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   artifacts:
     when: always
     paths:
@@ -131,13 +164,17 @@ e2e:
     - yarn test:e2e
 
 check-licenses:
-  extends: .test-configuration
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
   script:
     - node --no-warnings scripts/check-licenses.js
 
 unit-bs:
   stage: browserstack
-  extends: .feature-branch-configuration
+  extends:
+    - .base-configuration
+    - .feature-branches
   resource_group: browserstack
   artifacts:
     reports:
@@ -148,7 +185,9 @@ unit-bs:
 
 e2e-bs:
   stage: browserstack
-  extends: .feature-branch-configuration
+  extends:
+    - .base-configuration
+    - .feature-branches
   resource_group: browserstack
   artifacts:
     when: always
@@ -166,10 +205,9 @@ e2e-bs:
 
 deploy-staging:
   stage: deploy
-  extends: .base-configuration
-  only:
-    variables:
-      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
+  extends:
+    - .base-configuration
+    - .staging
   script:
     - yarn
     - BUILD_MODE=staging yarn build:bundle
@@ -177,10 +215,9 @@ deploy-staging:
 
 deploy-prod-canary:
   stage: deploy:canary
-  extends: .base-configuration
-  only:
-    refs:
-      - tags
+  extends:
+    - .base-configuration
+    - .tags
   when: manual
   allow_failure: false
   script:
@@ -190,10 +227,9 @@ deploy-prod-canary:
 
 deploy-prod-stable:
   stage: deploy
-  extends: .base-configuration
-  only:
-    refs:
-      - tags
+  extends:
+    - .base-configuration
+    - .tags
   when: manual
   allow_failure: false
   script:
@@ -210,8 +246,8 @@ include: 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
 
 notify-feature-branch-failure:
   extends:
-    - .feature-branch-configuration
     - .slack-notifier.on-failure
+    - .feature-branches
 
 .prepare_notification:
   extends: .slack-notifier-base
@@ -221,63 +257,57 @@ notify-feature-branch-failure:
     - COMMIT_URL="$CI_PROJECT_URL/commits/$CI_COMMIT_SHA"
 
 notify-staging-failure:
-  extends: .prepare_notification
-  only:
-    variables:
-      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
+  extends:
+    - .prepare_notification
+    - .staging
   when: on_failure
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME main pipeline for <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
 
 notify-release-ready:
-  extends: .prepare_notification
   stage: pre-deploy-notify
-  only:
-    refs:
-      - tags
+  extends:
+    - .prepare_notification
+    - .tags
   script:
     - 'MESSAGE_TEXT=":i: $CI_PROJECT_NAME <$BUILD_URL|$COMMIT_MESSAGE> ready to be deployed to :datadog:"'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
 
 notify-prod-canary-success:
-  extends: .prepare_notification
   stage: notify:canary
-  only:
-    refs:
-      - tags
+  extends:
+    - .prepare_notification
+    - .tags
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :datadog:."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
     - postmessage "#rum-ops" "$MESSAGE_TEXT"
 
 notify-prod-canary-failure:
-  extends: .prepare_notification
   stage: notify:canary
+  extends:
+    - .prepare_notification
+    - .tags
   when: on_failure
-  only:
-    refs:
-      - tags
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME release pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
 
 notify-prod-stable-success:
-  extends: .prepare_notification
-  only:
-    refs:
-      - tags
+  extends:
+    - .prepare_notification
+    - .tags
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :earth_americas:."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
     - postmessage "#rum-ops" "$MESSAGE_TEXT"
 
 notify-prod-stable-failure:
-  extends: .prepare_notification
+  extends:
+    - .prepare_notification
+    - .tags
   when: on_failure
-  only:
-    refs:
-      - tags
   script:
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME release pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
@@ -325,13 +355,9 @@ staging-reset-scheduled-failure:
 
 merge-into-staging:
   stage: pre-deploy
-  extends: .base-configuration
-  only:
-    refs:
-      - main
-  except:
-    refs:
-      - schedules
+  extends:
+    - .base-configuration
+    - .main
   before_script:
     - eval $(ssh-agent -s)
   script:
@@ -339,7 +365,9 @@ merge-into-staging:
 
 check-staging-merge:
   stage: test
-  extends: .feature-branch-configuration
+  extends:
+    - .base-configuration
+    - .feature-branches
   before_script:
     - eval $(ssh-agent -s)
   script:
@@ -349,6 +377,8 @@ check-staging-merge:
 # staging branch, even though the pipeline is still running
 tests-passed:
   stage: after-tests
-  extends: .feature-branch-configuration
+  extends:
+    - .base-configuration
+    - .feature-branches
   script:
     - 'true'


### PR DESCRIPTION
## Motivation

During our release process, the release branch and the tag run nearly the same ci jobs, making the checks twice. 
This PR removes the release branch jobs to save resources and time.

## Changes

Update gitlab-ci.yml

## Testing

Gitlab

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
