### PR TITLE
🔊[RUMF-1021] cookie check: add extra monitoring infos

### DIFF
--- a/packages/core/src/domain/sessionManagement.ts
+++ b/packages/core/src/domain/sessionManagement.ts
@@ -111,10 +111,12 @@ export function startSessionManagement<TrackingType extends string>(
           debug: {
             initTime,
             checkDelay,
-            updateDelay: Number(sessionCookieCheck.created!) - Number(inMemorySession.created!),
+            createdDelay: Number(sessionCookieCheck.created!) - Number(inMemorySession.created!),
+            expireDelay: Number(sessionCookieCheck.expire!) - Number(inMemorySession.expire!),
             productKey,
             sessionCookieCheck,
             inMemorySession,
+            _dd_s: getCookie(SESSION_COOKIE_NAME),
           },
         })
       }


### PR DESCRIPTION
## Motivation

Some cookies does not seem to be set or still have a previous value on a single tab session.
Add extra data to ease check and add real cookie value to double check the state.

## Changes

Add extra monitoring info during cookie check

## Testing

staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
