### PR TITLE
👷 Skip bs execution on tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,6 @@ stages:
   except:
     refs:
       - main
-      - tags
       - /^staging-[0-9]+$/
       - /^release\//
       - schedules

--- a/scripts/bs-wrapper.js
+++ b/scripts/bs-wrapper.js
@@ -15,13 +15,18 @@
 // to in the future.
 
 const request = require('request')
-const { spawnCommand, printLog, logAndExit } = require('./utils')
+const { spawnCommand, printLog, logAndExit, executeCommand } = require('./utils')
 
 const AVAILABILITY_CHECK_DELAY = 30_000
 // eslint-disable-next-line max-len
 const RUNNING_BUILDS_API = `https://${process.env.BS_USERNAME}:${process.env.BS_ACCESS_KEY}@api.browserstack.com/automate/builds.json?status=running`
 
 async function main() {
+  if (await executeCommand('git tag --points-at HEAD')) {
+    printLog('Skip bs execution on tags')
+    process.exit(0)
+    return
+  }
   await waitForAvailability()
   const exitCode = await runTests()
   process.exit(exitCode)


### PR DESCRIPTION
## Motivation

Avoid useless execution on release PR but keep the required github check to allow to merge release PR without admin rights

## Changes

- allow bs jobs on tags
- Skip bs command on tags

## Testing

local

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
