### PR TITLE
fix docs of log collection. `http` sends to only to Datadog.

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -605,7 +605,7 @@ window.DD_LOGS && DD_LOGS.logger.setLevel('<LEVEL>')
 
 By default, loggers created by the Datadog browser logs SDK are sending logs to Datadog. After the Datadog browser logs SDK is initialized, it is possible to configure the logger to:
 
-- send logs to the `console` and Datadog (`http`)
+- send logs to the Datadog (`http`) only
 - send logs to the `console` only
 - not send logs at all (`silent`)
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
The documentation was incorrect.
Fixed the documentation as implemented.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
The documentation follows the implementation code.
The `http` option sends only to Datadog, not to both Datadog and `console`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->
Please check that the revised document is in line with the implementation code.

### Additional Notes
#### Implementation Code
https://github.com/DataDog/browser-sdk/blob/abccf2c48b23a5daa7a7efdc841bf3adcb32eb40/packages/logs/src/domain/logger.ts#L57

#### Actual pages
- https://docs.datadoghq.com/logs/log_collection/javascript/
- https://docs.datadoghq.com/fr/logs/log_collection/javascript/
- https://docs.datadoghq.com/ja/logs/log_collection/javascript/

#### Relation PR
https://github.com/DataDog/documentation/pull/11992

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
