### PR TITLE
🔇 [RUMF-1076] remove unneeded monitoring fields

### DIFF
--- a/packages/core/src/domain/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring.spec.ts
@@ -201,10 +201,6 @@ describe('internal monitoring', () => {
         error: jasmine.anything(),
         message: 'message',
         status: 'error',
-        view: {
-          referrer: document.referrer,
-          url: window.location.href,
-        },
       })
     })
 

--- a/packages/core/src/domain/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring.ts
@@ -72,10 +72,6 @@ function startMonitoringBatch(configuration: Configuration) {
     return combine(
       {
         date: new Date().getTime(),
-        view: {
-          referrer: document.referrer,
-          url: window.location.href,
-        },
       },
       externalContextProvider !== undefined ? externalContextProvider() : {},
       message

--- a/packages/logs/src/boot/logs.entry.spec.ts
+++ b/packages/logs/src/boot/logs.entry.spec.ts
@@ -13,11 +13,7 @@ describe('logs entry', () => {
       currentContext: Context & { view: { referrer: string; url: string } }
     ) => void
   >
-  let startLogsGetGlobalContext: (() => Context) | undefined
-  const startLogs: StartLogs = (_configuration, _logger, getGlobalContext) => {
-    startLogsGetGlobalContext = getGlobalContext
-    return (sendLogsSpy as any) as ReturnType<StartLogs>
-  }
+  const startLogs: StartLogs = () => (sendLogsSpy as any) as ReturnType<StartLogs>
 
   function getLoggedMessage(index: number) {
     const [message, context] = sendLogsSpy.calls.argsFor(index)
@@ -26,7 +22,6 @@ describe('logs entry', () => {
 
   beforeEach(() => {
     sendLogsSpy = jasmine.createSpy()
-    startLogsGetGlobalContext = undefined
   })
 
   it('should define the public API with init', () => {
@@ -153,7 +148,7 @@ describe('logs entry', () => {
       expect(LOGS.getInitConfiguration()).toBeUndefined()
     })
 
-    describe('save context when submiting a log', () => {
+    describe('save context when submitting a log', () => {
       it('saves the date', () => {
         LOGS.logger.log('message')
         clock.tick(ONE_SECOND)
@@ -242,11 +237,6 @@ describe('logs entry', () => {
 
         expect(getLoggedMessage(0).context.foo).toEqual('bar')
         expect(getLoggedMessage(1).context.foo).toEqual('bar')
-      })
-
-      it('should expose global context to startLogs', () => {
-        LOGS.setLoggerGlobalContext({ foo: 'bar' })
-        expect(startLogsGetGlobalContext!()).toEqual({ foo: 'bar' })
       })
     })
 

--- a/packages/logs/src/boot/logs.entry.ts
+++ b/packages/logs/src/boot/logs.entry.ts
@@ -53,7 +53,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
         return
       }
 
-      sendLogStrategy = startLogsImpl(initConfiguration, logger, globalContextManager.get)
+      sendLogStrategy = startLogsImpl(initConfiguration, logger)
       getInitConfigurationStrategy = () => deepClone(initConfiguration)
       beforeInitSendLog.drain()
 

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -38,7 +38,6 @@ const baseConfiguration: Partial<Configuration> = {
   service: 'Service',
 }
 const internalMonitoring = { setExternalContextProvider: () => undefined }
-const getGlobalContext = () => ({})
 
 interface Rum {
   getInternalContext(startTime?: number): any | undefined
@@ -64,7 +63,7 @@ describe('logs', () => {
     configuration: configurationOverrides,
   }: { errorLogger?: Logger; configuration?: Partial<Configuration> } = {}) => {
     const configuration = { ...(baseConfiguration as Configuration), ...configurationOverrides }
-    return doStartLogs(configuration, errorObservable, internalMonitoring, session, errorLogger, getGlobalContext)
+    return doStartLogs(configuration, errorObservable, internalMonitoring, session, errorLogger)
   }
 
   beforeEach(() => {

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -27,11 +27,7 @@ export interface LogsInitConfiguration extends InitConfiguration {
   beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
 }
 
-export function startLogs(
-  initConfiguration: LogsInitConfiguration,
-  errorLogger: Logger,
-  getGlobalContext: () => Context
-) {
+export function startLogs(initConfiguration: LogsInitConfiguration, errorLogger: Logger) {
   const { configuration, internalMonitoring } = commonInit(initConfiguration, buildEnv)
   const errorObservable = new Observable<RawError>()
 
@@ -42,7 +38,7 @@ export function startLogs(
   }
 
   const session = startLoggerSession(configuration, areCookiesAuthorized(configuration.cookieOptions))
-  return doStartLogs(configuration, errorObservable, internalMonitoring, session, errorLogger, getGlobalContext)
+  return doStartLogs(configuration, errorObservable, internalMonitoring, session, errorLogger)
 }
 
 export function doStartLogs(
@@ -50,11 +46,12 @@ export function doStartLogs(
   errorObservable: Observable<RawError>,
   internalMonitoring: InternalMonitoring,
   session: LoggerSession,
-  errorLogger: Logger,
-  getGlobalContext: () => Context
+  errorLogger: Logger
 ) {
   internalMonitoring.setExternalContextProvider(() =>
-    combine({ session_id: session.getId() }, getGlobalContext(), getRUMInternalContext())
+    combine({ session_id: session.getId() }, getRUMInternalContext(), {
+      view: { name: null, url: null, referrer: null },
+    })
   )
 
   const assemble = buildAssemble(session, configuration, reportError)

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -38,7 +38,7 @@ export function startRum(
         application_id: initConfiguration.applicationId,
       },
       parentContexts.findView(),
-      getCommonContext().context
+      { view: { name: null } }
     )
   )
 


### PR DESCRIPTION
## Motivation

Avoid collecting potential sensitive data in monitoring logs

## Changes

Remove following data from monitoring logs:

- global context
- view name
- view referrer
- view url

## Testing

local

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
