### PR TITLE
🐛 [Internal monitoring] use monitoring api key for monitoring requests

### DIFF
--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -3,6 +3,7 @@ import { computeTransportConfiguration } from './transportConfiguration'
 
 describe('transportConfiguration', () => {
   const clientToken = 'some_client_token'
+  const otherClientToken = 'some_other_client_token'
   const v1IntakePath = `/v1/input/${clientToken}`
   const buildEnv: BuildEnv = {
     buildMode: BuildMode.RELEASE,
@@ -14,8 +15,11 @@ describe('transportConfiguration', () => {
       let configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.internalMonitoringEndpointBuilder).toBeUndefined()
 
-      configuration = computeTransportConfiguration({ clientToken, internalMonitoringApiKey: clientToken }, buildEnv)
-      expect(configuration.internalMonitoringEndpointBuilder?.build()).toContain(clientToken)
+      configuration = computeTransportConfiguration(
+        { clientToken, internalMonitoringApiKey: otherClientToken },
+        buildEnv
+      )
+      expect(configuration.internalMonitoringEndpointBuilder?.build()).toContain(otherClientToken)
     })
   })
 

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -38,7 +38,7 @@ export function computeTransportConfiguration(
 
   if (initConfiguration.internalMonitoringApiKey) {
     configuration.internalMonitoringEndpointBuilder = createEndpointBuilder(
-      initConfiguration,
+      { ...initConfiguration, clientToken: initConfiguration.internalMonitoringApiKey },
       buildEnv,
       'logs',
       'browser-agent-internal-monitoring'


### PR DESCRIPTION
## Motivation

Currently, monitoring requests use the `clientToken` instead of the `internalMonitoringApiKey` when sending monitoring requests.

## Changes

Use the right token.

## Testing

unit

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
