### PR TITLE
[RUMF-1046] make Tracekit stoppable

### DIFF
--- a/packages/core/src/domain/error/trackRuntimeError.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.ts
@@ -1,10 +1,10 @@
 import { ErrorSource, ErrorHandling, formatUnknownError, RawError } from '../../tools/error'
 import { Observable } from '../../tools/observable'
 import { clocksNow } from '../../tools/timeUtils'
-import { StackTrace, startUnhandledErrorCollection } from '../tracekit'
+import { startUnhandledErrorCollection } from '../tracekit'
 
 export function trackRuntimeError(errorObservable: Observable<RawError>) {
-  return startUnhandledErrorCollection((stackTrace: StackTrace, _: boolean, errorObject?: any) => {
+  return startUnhandledErrorCollection((stackTrace, errorObject) => {
     const { stack, message, type } = formatUnknownError(stackTrace, errorObject, 'Uncaught')
     errorObservable.notify({
       message,

--- a/packages/core/src/domain/error/trackRuntimeError.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.ts
@@ -1,12 +1,10 @@
 import { ErrorSource, ErrorHandling, formatUnknownError, RawError } from '../../tools/error'
 import { Observable } from '../../tools/observable'
 import { clocksNow } from '../../tools/timeUtils'
-import { StackTrace, subscribe, unsubscribe } from '../tracekit'
-
-let traceKitReportHandler: (stack: StackTrace, isWindowError: boolean, errorObject?: any) => void
+import { StackTrace, startUnhandledErrorCollection } from '../tracekit'
 
 export function trackRuntimeError(errorObservable: Observable<RawError>) {
-  traceKitReportHandler = (stackTrace: StackTrace, _: boolean, errorObject?: any) => {
+  return startUnhandledErrorCollection((stackTrace: StackTrace, _: boolean, errorObject?: any) => {
     const { stack, message, type } = formatUnknownError(stackTrace, errorObject, 'Uncaught')
     errorObservable.notify({
       message,
@@ -17,11 +15,5 @@ export function trackRuntimeError(errorObservable: Observable<RawError>) {
       originalError: errorObject,
       handling: ErrorHandling.UNHANDLED,
     })
-  }
-  subscribe(traceKitReportHandler)
-  return {
-    stop: () => {
-      unsubscribe(traceKitReportHandler)
-    },
-  }
+  })
 }

--- a/packages/core/src/domain/tracekit/index.ts
+++ b/packages/core/src/domain/tracekit/index.ts
@@ -1,3 +1,3 @@
-export { Handler, StackTrace, BrowserError } from './types'
+export { StackTrace, BrowserError } from './types'
 export { computeStackTrace } from './computeStackTrace'
-export { subscribe, unsubscribe } from './tracekit'
+export { startUnhandledErrorCollection } from './tracekit'

--- a/packages/core/src/domain/tracekit/tracekit.spec.ts
+++ b/packages/core/src/domain/tracekit/tracekit.spec.ts
@@ -1,165 +1,113 @@
 import { disableJasmineUncaughtErrorHandler } from '../../../test/specHelper'
 import { subscribe, unsubscribe, traceKitWindowOnError } from './tracekit'
-import { Handler, StackFrame } from './types'
+import { Handler } from './types'
 
 describe('traceKitWindowOnError', () => {
   const testLineNo = 1337
 
-  let subscriptionHandler: Handler | undefined
+  let subscriptionHandler: jasmine.Spy<Handler>
   let resetJasmineUncaughtErrorHandler: () => void
 
   beforeEach(() => {
     ;({ reset: resetJasmineUncaughtErrorHandler } = disableJasmineUncaughtErrorHandler())
+    subscriptionHandler = jasmine.createSpy()
+    subscribe(subscriptionHandler)
   })
 
   afterEach(() => {
+    unsubscribe(subscriptionHandler)
     resetJasmineUncaughtErrorHandler()
   })
 
   describe('with undefined arguments', () => {
-    it('should pass undefined:undefined', (done) => {
+    it('should pass undefined:undefined', () => {
       // this is probably not good behavior;  just writing this test to verify
       // that it doesn't change unintentionally
-      subscriptionHandler = (stack) => {
-        expect(stack.name).toBeUndefined()
-        expect(stack.message).toBeUndefined()
-        unsubscribe(subscriptionHandler!)
-        done()
-      }
-      subscribe(subscriptionHandler)
       traceKitWindowOnError(undefined!, undefined, testLineNo)
+      const [stack] = subscriptionHandler.calls.mostRecent().args
+      expect(stack.name).toBeUndefined()
+      expect(stack.message).toBeUndefined()
     })
   })
 
   describe('when no 5th argument (error object)', () => {
-    it('should separate name, message for default error types (e.g. ReferenceError)', (done) => {
-      subscriptionHandler = (stack) => {
-        expect(stack.name).toEqual('ReferenceError')
-        expect(stack.message).toEqual('foo is undefined')
-        unsubscribe(subscriptionHandler!)
-        done()
-      }
-      subscribe(subscriptionHandler)
+    it('should separate name, message for default error types (e.g. ReferenceError)', () => {
       traceKitWindowOnError('ReferenceError: foo is undefined', 'http://example.com', testLineNo)
+      const [stack, ,] = subscriptionHandler.calls.mostRecent().args
+      expect(stack.name).toEqual('ReferenceError')
+      expect(stack.message).toEqual('foo is undefined')
     })
 
-    it('should separate name, message for default error types (e.g. Uncaught ReferenceError)', (done) => {
-      subscriptionHandler = (stack) => {
-        expect(stack.name).toEqual('ReferenceError')
-        expect(stack.message).toEqual('foo is undefined')
-        unsubscribe(subscriptionHandler!)
-        done()
-      }
-      subscribe(subscriptionHandler)
+    it('should separate name, message for default error types (e.g. Uncaught ReferenceError)', () => {
       // should work with/without 'Uncaught'
       traceKitWindowOnError('Uncaught ReferenceError: foo is undefined', 'http://example.com', testLineNo)
+      const [stack, ,] = subscriptionHandler.calls.mostRecent().args
+      expect(stack.name).toEqual('ReferenceError')
+      expect(stack.message).toEqual('foo is undefined')
     })
 
-    it('should separate name, message for default error types on Opera Mini', (done) => {
-      subscriptionHandler = (stack) => {
-        expect(stack.name).toEqual('ReferenceError')
-        expect(stack.message).toEqual('Undefined variable: foo')
-        unsubscribe(subscriptionHandler!)
-        done()
-      }
-      subscribe(subscriptionHandler)
+    it('should separate name, message for default error types on Opera Mini', () => {
       traceKitWindowOnError(
         'Uncaught exception: ReferenceError: Undefined variable: foo',
         'http://example.com',
         testLineNo
       )
+      const [stack, ,] = subscriptionHandler.calls.mostRecent().args
+      expect(stack.name).toEqual('ReferenceError')
+      expect(stack.message).toEqual('Undefined variable: foo')
     })
 
-    it('should ignore unknown error types', (done) => {
-      // TODO: should we attempt to parse this?
-      subscriptionHandler = (stack) => {
-        expect(stack.name).toEqual(undefined)
-        expect(stack.message).toEqual('CustomError: woo scary')
-        unsubscribe(subscriptionHandler!)
-        done()
-      }
-      subscribe(subscriptionHandler)
+    it('should ignore unknown error types', () => {
       traceKitWindowOnError('CustomError: woo scary', 'http://example.com', testLineNo)
+      // TODO: should we attempt to parse this?
+      const [stack, ,] = subscriptionHandler.calls.mostRecent().args
+      expect(stack.name).toEqual(undefined)
+      expect(stack.message).toEqual('CustomError: woo scary')
     })
 
-    it('should ignore arbitrary messages passed through onerror', (done) => {
-      subscriptionHandler = (stack) => {
-        expect(stack.name).toEqual(undefined)
-        expect(stack.message).toEqual('all work and no play makes homer: something something')
-        unsubscribe(subscriptionHandler!)
-        done()
-      }
-      subscribe(subscriptionHandler)
+    it('should ignore arbitrary messages passed through onerror', () => {
       traceKitWindowOnError('all work and no play makes homer: something something', 'http://example.com', testLineNo)
+      const [stack, ,] = subscriptionHandler.calls.mostRecent().args
+      expect(stack.name).toEqual(undefined)
+      expect(stack.message).toEqual('all work and no play makes homer: something something')
     })
 
-    it('should handle object message passed through onerror', (done) => {
-      subscriptionHandler = (stack, _, error) => {
-        expect(stack.message).toBeUndefined()
-        expect(error).toEqual({ foo: 'bar' }) // consider the message as initial error
-        unsubscribe(subscriptionHandler!)
-        done()
-      }
-      subscribe(subscriptionHandler)
+    it('should handle object message passed through onerror', () => {
       traceKitWindowOnError({ foo: 'bar' } as any)
+      const [stack, , error] = subscriptionHandler.calls.mostRecent().args
+      expect(stack.message).toBeUndefined()
+      expect(error).toEqual({ foo: 'bar' }) // consider the message as initial error
     })
   })
-})
 
-describe('uncaught exception handling', () => {
-  let resetJasmineUncaughtErrorHandler: () => void
+  describe('uncaught exception handling', () => {
+    it('it should not go into an infinite loop', (done) => {
+      setTimeout(() => {
+        throw new Error('expected error')
+      })
 
-  beforeEach(() => {
-    ;({ reset: resetJasmineUncaughtErrorHandler } = disableJasmineUncaughtErrorHandler())
-  })
-
-  afterEach(() => {
-    resetJasmineUncaughtErrorHandler()
-  })
-
-  it('it should not go into an infinite loop', (done) => {
-    const stacks = []
-
-    function handler(stackInfo: StackFrame) {
-      stacks.push(stackInfo)
-    }
-
-    subscribe(handler)
-
-    setTimeout(() => {
-      throw new Error('expected error')
+      setTimeout(() => {
+        expect(subscriptionHandler).toHaveBeenCalledTimes(1)
+        done()
+      }, 1000)
     })
 
-    setTimeout(() => {
-      unsubscribe(handler)
-      expect(stacks.length).toEqual(1)
-      done()
-    }, 1000)
-  })
+    it('should get extra arguments (isWindowError and exception)', (done) => {
+      const exception = new Error('expected error')
 
-  it('should get extra arguments (isWindowError and exception)', (done) => {
-    const handler = jasmine.createSpy()
+      setTimeout(() => {
+        throw exception
+      })
 
-    const exception = new Error('expected error')
+      setTimeout(() => {
+        expect(subscriptionHandler).toHaveBeenCalledTimes(1)
 
-    subscribe(handler)
+        const [, isWindowError, reportedError] = subscriptionHandler.calls.mostRecent().args
+        expect(isWindowError).toEqual(true)
+        expect(reportedError).toEqual(exception)
 
-    setTimeout(() => {
-      throw exception
+        done()
+      }, 1000)
     })
-
-    setTimeout(() => {
-      unsubscribe(handler)
-
-      expect(handler).toHaveBeenCalledTimes(1)
-
-      const isWindowError = handler.calls.mostRecent().args[1]
-      expect(isWindowError).toEqual(true)
-
-      const e = handler.calls.mostRecent().args[2]
-      expect(e).toEqual(exception)
-
-      done()
-    }, 1000)
   })
 })

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -1,225 +1,104 @@
-import { monitor } from '../internalMonitoring'
+import { instrumentMethodAndCallOriginal } from '../../tools/instrumentMethod'
 import { computeStackTrace } from './computeStackTrace'
-import { Handler, StackTrace } from './types'
+import { Callback, StackTrace } from './types'
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Error_types
 // eslint-disable-next-line  max-len
 const ERROR_TYPES_RE = /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/
 
 /**
- * Cross-browser processing of unhandled exceptions
- *
- * Syntax:
- * ```js
- *   subscribe(function(stackInfo) { ... })
- *   unsubscribe(function(stackInfo) { ... })
- * ```
+ * Cross-browser collection of unhandled errors
  *
  * Supports:
- *   - Firefox: full stack trace with line numbers, plus column number
- *     on top frame; column number is not guaranteed
- *   - Opera: full stack trace with line and column numbers
- *   - Chrome: full stack trace with line and column numbers
- *   - Safari: line and column number for the top frame only; some frames
- *     may be missing, and column number is not guaranteed
- *   - IE: line and column number for the top frame only; some frames
- *     may be missing, and column number is not guaranteed
+ * - Firefox: full stack trace with line numbers, plus column number
+ * on top frame; column number is not guaranteed
+ * - Opera: full stack trace with line and column numbers
+ * - Chrome: full stack trace with line and column numbers
+ * - Safari: line and column number for the top frame only; some frames
+ * may be missing, and column number is not guaranteed
+ * - IE: line and column number for the top frame only; some frames
+ * may be missing, and column number is not guaranteed
  *
  * In theory, TraceKit should work on all of the following versions:
- *   - IE5.5+ (only 8.0 tested)
- *   - Firefox 0.9+ (only 3.5+ tested)
- *   - Opera 7+ (only 10.50 tested; versions 9 and earlier may require
- *     Exceptions Have Stacktrace to be enabled in opera:config)
- *   - Safari 3+ (only 4+ tested)
- *   - Chrome 1+ (only 5+ tested)
- *   - Konqueror 3.5+ (untested)
+ * - IE5.5+ (only 8.0 tested)
+ * - Firefox 0.9+ (only 3.5+ tested)
+ * - Opera 7+ (only 10.50 tested; versions 9 and earlier may require
+ * Exceptions Have Stacktrace to be enabled in opera:config)
+ * - Safari 3+ (only 4+ tested)
+ * - Chrome 1+ (only 5+ tested)
+ * - Konqueror 3.5+ (untested)
  *
- * Requires computeStackTrace.
+ * Tries to catch all unhandled errors and report them to the
+ * callback.
  *
- * Tries to catch all unhandled exceptions and report them to the
- * subscribed handlers.
- *
- * Handlers receive a StackTrace object as described in the
+ * Callbacks receive a StackTrace object as described in the
  * computeStackTrace docs.
  *
  * @memberof TraceKit
  * @namespace
  */
 
-const handlers: Handler[] = []
+export function startUnhandledErrorCollection(callback: Callback) {
+  const { stop: stopInstrumentingOnError } = instrumentOnError(callback)
+  const { stop: stopInstrumentingOnUnhandledRejection } = instrumentUnhandledRejection(callback)
 
-/**
- * Add a crash handler.
- * @param {Function} handler
- * @memberof report
- */
-export function subscribe(handler: Handler) {
-  installGlobalHandler()
-  installGlobalUnhandledRejectionHandler()
-  handlers.push(handler)
-}
-
-/**
- * Remove a crash handler.
- * @param {Function} handler
- * @memberof report
- */
-export function unsubscribe(handler: Handler) {
-  for (let i = handlers.length - 1; i >= 0; i -= 1) {
-    if (handlers[i] === handler) {
-      handlers.splice(i, 1)
-    }
+  return {
+    stop: () => {
+      stopInstrumentingOnError()
+      stopInstrumentingOnUnhandledRejection
+    },
   }
-
-  if (handlers.length === 0) {
-    uninstallGlobalHandler()
-    uninstallGlobalUnhandledRejectionHandler()
-  }
-}
-
-/**
- * Dispatch stack information to all handlers.
- * @param {StackTrace} stack
- * @param {boolean} isWindowError Is this a top-level window error?
- * @param {Error=} error The error that's being handled (if available, null otherwise)
- * @memberof report
- * @throws An exception if an error occurs while calling an handler.
- */
-function notifyHandlers(stack: StackTrace, isWindowError: boolean, error?: any) {
-  let exception
-  handlers.forEach((handler) => {
-    try {
-      handler(stack, isWindowError, error)
-    } catch (inner) {
-      exception = inner
-    }
-  })
-  if (exception) {
-    throw exception
-  }
-}
-
-let oldOnerrorHandler: OnErrorEventHandler
-let onErrorHandlerInstalled: boolean
-let oldOnunhandledrejectionHandler: Window['onunhandledrejection'] | undefined
-let onUnhandledRejectionHandlerInstalled: boolean
-
-/**
- * Ensures all global unhandled exceptions are recorded.
- * Supported by Gecko and IE.
- * @param {Event|string} message Error message.
- * @param {string=} url URL of script that generated the exception.
- * @param {(number|string)=} lineNo The line number at which the error occurred.
- * @param {(number|string)=} columnNo The column number at which the error occurred.
- * @param {Error=} errorObj The actual Error object.
- * @memberof report
- */
-export function traceKitWindowOnError(
-  this: any,
-  message: Event | string,
-  url?: string,
-  lineNo?: number,
-  columnNo?: number,
-  errorObj?: Error
-) {
-  let stack: StackTrace
-
-  if (errorObj) {
-    stack = computeStackTrace(errorObj)
-    notifyHandlers(stack, true, errorObj)
-  } else {
-    const location = {
-      url,
-      column: columnNo,
-      line: lineNo,
-    }
-
-    let name
-    let msg = message
-    if ({}.toString.call(message) === '[object String]') {
-      const groups = ERROR_TYPES_RE.exec(msg as string)
-      if (groups) {
-        name = groups[1]
-        msg = groups[2]
-      }
-    }
-
-    stack = {
-      name,
-      message: typeof msg === 'string' ? msg : undefined,
-      stack: [location],
-    }
-
-    notifyHandlers(stack, true, message)
-  }
-
-  if (oldOnerrorHandler) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return oldOnerrorHandler.apply(this, arguments as any)
-  }
-
-  return false
-}
-
-/**
- * Ensures all unhandled rejections are recorded.
- * @param {PromiseRejectionEvent} e event.
- * @memberof report
- * @see https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onunhandledrejection
- * @see https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent
- */
-function traceKitWindowOnUnhandledRejection(e: PromiseRejectionEvent) {
-  const reason = e.reason || 'Empty reason'
-  const stack = computeStackTrace(reason)
-  notifyHandlers(stack, true, reason)
 }
 
 /**
  * Install a global onerror handler
- * @memberof report
  */
-function installGlobalHandler() {
-  if (onErrorHandlerInstalled) {
-    return
-  }
+function instrumentOnError(callback: Callback) {
+  return instrumentMethodAndCallOriginal(window, 'onerror', {
+    before(this: any, message: Event | string, url?: string, lineNo?: number, columnNo?: number, errorObj?: Error) {
+      let stack: StackTrace
 
-  oldOnerrorHandler = window.onerror
-  window.onerror = monitor(traceKitWindowOnError)
-  onErrorHandlerInstalled = true
-}
+      if (errorObj) {
+        stack = computeStackTrace(errorObj)
+        callback(stack, true, errorObj)
+      } else {
+        const location = {
+          url,
+          column: columnNo,
+          line: lineNo,
+        }
 
-/**
- * Uninstall the global onerror handler
- * @memberof report
- */
-function uninstallGlobalHandler() {
-  if (onErrorHandlerInstalled) {
-    window.onerror = oldOnerrorHandler!
-    onErrorHandlerInstalled = false
-  }
+        let name
+        let msg = message
+        if ({}.toString.call(message) === '[object String]') {
+          const groups = ERROR_TYPES_RE.exec(msg as string)
+          if (groups) {
+            name = groups[1]
+            msg = groups[2]
+          }
+        }
+
+        stack = {
+          name,
+          message: typeof msg === 'string' ? msg : undefined,
+          stack: [location],
+        }
+
+        callback(stack, true, message)
+      }
+    },
+  })
 }
 
 /**
  * Install a global onunhandledrejection handler
- * @memberof report
  */
-function installGlobalUnhandledRejectionHandler() {
-  if (onUnhandledRejectionHandlerInstalled) {
-    return
-  }
-
-  oldOnunhandledrejectionHandler = window.onunhandledrejection !== null ? window.onunhandledrejection : undefined
-  window.onunhandledrejection = monitor(traceKitWindowOnUnhandledRejection)
-  onUnhandledRejectionHandlerInstalled = true
-}
-
-/**
- * Uninstall the global onunhandledrejection handler
- * @memberof report
- */
-function uninstallGlobalUnhandledRejectionHandler() {
-  if (onUnhandledRejectionHandlerInstalled) {
-    window.onunhandledrejection = oldOnunhandledrejectionHandler!
-    onUnhandledRejectionHandlerInstalled = false
-  }
+function instrumentUnhandledRejection(callback: Callback) {
+  return instrumentMethodAndCallOriginal(window, 'onunhandledrejection', {
+    before(e: PromiseRejectionEvent) {
+      const reason = e.reason || 'Empty reason'
+      const stack = computeStackTrace(reason)
+      callback(stack, true, reason)
+    },
+  })
 }

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -45,7 +45,7 @@ export function startUnhandledErrorCollection(callback: Callback) {
   return {
     stop: () => {
       stopInstrumentingOnError()
-      stopInstrumentingOnUnhandledRejection
+      stopInstrumentingOnUnhandledRejection()
     },
   }
 }

--- a/packages/core/src/domain/tracekit/types.ts
+++ b/packages/core/src/domain/tracekit/types.ts
@@ -6,7 +6,7 @@ export interface BrowserError extends Error {
   description?: string
 }
 
-export type Callback = (stack: StackTrace, isWindowError: boolean, error?: any) => any
+export type UnhandledErrorCallback = (stack: StackTrace, errorObject?: any) => any
 
 /**
  * An object representing a single stack frame.

--- a/packages/core/src/domain/tracekit/types.ts
+++ b/packages/core/src/domain/tracekit/types.ts
@@ -6,7 +6,7 @@ export interface BrowserError extends Error {
   description?: string
 }
 
-export type Handler = (stack: StackTrace, isWindowError: boolean, error?: any) => any
+export type Callback = (stack: StackTrace, isWindowError: boolean, error?: any) => any
 
 /**
  * An object representing a single stack frame.


### PR DESCRIPTION
## Motivation

In the same spirit as #1133 and #1124 , this PR allows to stop/unpatch the tracekit instrumentation.

By using the `instrumentMethod` helper, it also fixes #541 (superseds #542)

## Changes

* Simplify tracekit tests a bit to make them synchronous and factorize the subscribe/unsubscribe in before/afterEach hooks
* Make Tracekit stoppable by using `instrumentMethod`
* Add a non-regression test for #541 collocated to the similar test for `onerror`

## Testing

Unit, manual, staging

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
