### PR TITLE
🐛 [RUMF-1062] fix support for Safari 11.0

### DIFF
--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -12,7 +12,7 @@ export function send(
 ): void {
   const formData = new FormData()
 
-  formData.set(
+  formData.append(
     'segment',
     new Blob([data], {
       type: 'application/octet-stream',
@@ -20,8 +20,8 @@ export function send(
     `${meta.session.id}-${meta.start}`
   )
 
-  toFormEntries(meta, (key, value) => formData.set(key, value))
-  formData.set('raw_segment_size', rawSegmentSize.toString())
+  toFormEntries(meta, (key, value) => formData.append(key, value))
+  formData.append('raw_segment_size', rawSegmentSize.toString())
 
   const request = new HttpRequest(endpointBuilder, SEND_BEACON_BYTE_LENGTH_LIMIT)
   request.send(formData, data.byteLength, flushReason)


### PR DESCRIPTION
## Motivation

Fix Replay recorder support for Safari 11.0.

## Changes

Replace `FormData.set` (see [caniuse support](https://caniuse.com/?search=formdata.set)) usages by `FormData.append`

## Testing

Manual, staging.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
