### PR TITLE
✨ [RUMF-1074] bridge host checking

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export {
   SESSION_COOKIE_NAME,
   stopSessionManagement,
 } from './domain/sessionManagement'
-export { HttpRequest, Batch, isEventBridgePresent, getEventBridge } from './transport'
+export { HttpRequest, Batch, canUseEventBridge, getEventBridge } from './transport'
 export * from './tools/display'
 export * from './tools/urlPolyfill'
 export * from './tools/timeUtils'

--- a/packages/core/src/transport/eventBridge.spec.ts
+++ b/packages/core/src/transport/eventBridge.spec.ts
@@ -3,7 +3,7 @@ import { deleteEventBridgeStub, initEventBridgeStub } from '../../test/specHelpe
 import { getEventBridge, isEventBridgePresent } from './eventBridge'
 
 describe('isEventBridgePresent', () => {
-  const notAllowedWebViewHosts = ['foo.bar']
+  const allowedWebViewHosts = ['foo.bar']
 
   afterEach(() => {
     resetExperimentalFeatures()
@@ -25,7 +25,7 @@ describe('isEventBridgePresent', () => {
     })
 
     it('should not detect when the bridge is present and the webView host is not allowed', () => {
-      initEventBridgeStub(notAllowedWebViewHosts)
+      initEventBridgeStub(allowedWebViewHosts)
       expect(isEventBridgePresent()).toBeFalse()
     })
   })
@@ -37,7 +37,7 @@ describe('isEventBridgePresent', () => {
     })
 
     it('should not detect when the bridge is present and the webView host is not allowed', () => {
-      initEventBridgeStub(notAllowedWebViewHosts)
+      initEventBridgeStub(allowedWebViewHosts)
       expect(isEventBridgePresent()).toBeFalse()
     })
 

--- a/packages/core/src/transport/eventBridge.spec.ts
+++ b/packages/core/src/transport/eventBridge.spec.ts
@@ -62,7 +62,7 @@ describe('getEventBridge', () => {
   })
 
   it('event bridge should serialize sent events', () => {
-    const eventBridge = getEventBridge()
+    const eventBridge = getEventBridge()!
 
     eventBridge.send('view', { foo: 'bar' })
 

--- a/packages/core/src/transport/eventBridge.spec.ts
+++ b/packages/core/src/transport/eventBridge.spec.ts
@@ -3,6 +3,8 @@ import { deleteEventBridgeStub, initEventBridgeStub } from '../../test/specHelpe
 import { getEventBridge, isEventBridgePresent } from './eventBridge'
 
 describe('isEventBridgePresent', () => {
+  const notAllowedWebViewHosts = ['foo.bar']
+
   afterEach(() => {
     resetExperimentalFeatures()
     deleteEventBridgeStub()
@@ -13,7 +15,7 @@ describe('isEventBridgePresent', () => {
       updateExperimentalFeatures(['event-bridge'])
     })
 
-    it('should detect when the bridge is present', () => {
+    it('should detect when the bridge is present and the webView host is allowed', () => {
       initEventBridgeStub()
       expect(isEventBridgePresent()).toBeTrue()
     })
@@ -21,13 +23,24 @@ describe('isEventBridgePresent', () => {
     it('should not detect when the bridge is absent', () => {
       expect(isEventBridgePresent()).toBeFalse()
     })
+
+    it('should not detect when the bridge is present and the webView host is not allowed', () => {
+      initEventBridgeStub(notAllowedWebViewHosts)
+      expect(isEventBridgePresent()).toBeFalse()
+    })
   })
 
   describe('when ff disabled', () => {
-    it('should not detect when the bridge is present', () => {
+    it('should not detect when the bridge is present and the webView host is allowed', () => {
       initEventBridgeStub()
       expect(isEventBridgePresent()).toBeFalse()
     })
+
+    it('should not detect when the bridge is present and the webView host is not allowed', () => {
+      initEventBridgeStub(notAllowedWebViewHosts)
+      expect(isEventBridgePresent()).toBeFalse()
+    })
+
     it('should not detect when the bridge is absent', () => {
       expect(isEventBridgePresent()).toBeFalse()
     })

--- a/packages/core/src/transport/eventBridge.spec.ts
+++ b/packages/core/src/transport/eventBridge.spec.ts
@@ -1,8 +1,8 @@
 import { resetExperimentalFeatures, updateExperimentalFeatures } from '..'
 import { deleteEventBridgeStub, initEventBridgeStub } from '../../test/specHelper'
-import { getEventBridge, isEventBridgePresent } from './eventBridge'
+import { getEventBridge, canUseEventBridge } from './eventBridge'
 
-describe('isEventBridgePresent', () => {
+describe('canUseEventBridge', () => {
   const allowedWebViewHosts = ['foo.bar']
 
   afterEach(() => {
@@ -17,32 +17,32 @@ describe('isEventBridgePresent', () => {
 
     it('should detect when the bridge is present and the webView host is allowed', () => {
       initEventBridgeStub()
-      expect(isEventBridgePresent()).toBeTrue()
+      expect(canUseEventBridge()).toBeTrue()
     })
 
     it('should not detect when the bridge is absent', () => {
-      expect(isEventBridgePresent()).toBeFalse()
+      expect(canUseEventBridge()).toBeFalse()
     })
 
     it('should not detect when the bridge is present and the webView host is not allowed', () => {
       initEventBridgeStub(allowedWebViewHosts)
-      expect(isEventBridgePresent()).toBeFalse()
+      expect(canUseEventBridge()).toBeFalse()
     })
   })
 
   describe('when ff disabled', () => {
     it('should not detect when the bridge is present and the webView host is allowed', () => {
       initEventBridgeStub()
-      expect(isEventBridgePresent()).toBeFalse()
+      expect(canUseEventBridge()).toBeFalse()
     })
 
     it('should not detect when the bridge is present and the webView host is not allowed', () => {
       initEventBridgeStub(allowedWebViewHosts)
-      expect(isEventBridgePresent()).toBeFalse()
+      expect(canUseEventBridge()).toBeFalse()
     })
 
     it('should not detect when the bridge is absent', () => {
-      expect(isEventBridgePresent()).toBeFalse()
+      expect(canUseEventBridge()).toBeFalse()
     })
   })
 })

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -29,7 +29,7 @@ export function getEventBridge<T, E>() {
 export function isEventBridgePresent(): boolean {
   return getEventBridge()
     .getAllowedWebViewHosts()
-    .some((o) => includes(o, window.location.hostname))
+    .some((host) => includes(host, window.location.hostname))
 }
 
 function getEventBridgeGlobal() {

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -26,7 +26,7 @@ export function getEventBridge<T, E>() {
   }
 }
 
-export function isEventBridgePresent(): boolean {
+export function canUseEventBridge(): boolean {
   const bridge = getEventBridge()
   return !!bridge && includes(bridge.getAllowedWebViewHosts(), window.location.hostname)
 }

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -1,4 +1,4 @@
-import { isExperimentalFeatureEnabled } from '..'
+import { includes, isExperimentalFeatureEnabled } from '..'
 
 export interface BrowserWindow extends Window {
   DatadogEventBridge?: DatadogEventBridge
@@ -13,7 +13,7 @@ export function getEventBridge<T, E>() {
   const eventBridgeGlobal = getEventBridgeGlobal()
 
   if (!eventBridgeGlobal) {
-    return { getAllowedWebViewHosts: () => [], send: () => undefined }
+    return
   }
 
   return {
@@ -27,9 +27,8 @@ export function getEventBridge<T, E>() {
 }
 
 export function isEventBridgePresent(): boolean {
-  return getEventBridge()
-    .getAllowedWebViewHosts()
-    .some((host) => host === window.location.hostname)
+  const bridge = getEventBridge()
+  return !!bridge && includes(bridge.getAllowedWebViewHosts(), window.location.hostname)
 }
 
 function getEventBridgeGlobal() {

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -1,4 +1,4 @@
-import { includes, isExperimentalFeatureEnabled } from '..'
+import { isExperimentalFeatureEnabled } from '..'
 
 export interface BrowserWindow extends Window {
   DatadogEventBridge?: DatadogEventBridge
@@ -29,7 +29,7 @@ export function getEventBridge<T, E>() {
 export function isEventBridgePresent(): boolean {
   return getEventBridge()
     .getAllowedWebViewHosts()
-    .some((host) => includes(host, window.location.hostname))
+    .some((host) => host === window.location.hostname)
 }
 
 function getEventBridgeGlobal() {

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -1,4 +1,4 @@
-import { isExperimentalFeatureEnabled } from '..'
+import { includes, isExperimentalFeatureEnabled } from '..'
 
 export interface BrowserWindow extends Window {
   DatadogEventBridge?: DatadogEventBridge
@@ -29,7 +29,7 @@ export function getEventBridge<T, E>() {
 export function isEventBridgePresent(): boolean {
   return getEventBridge()
     .getAllowedWebViewHosts()
-    .some((o) => o.includes(window.location.hostname))
+    .some((o) => includes(o, window.location.hostname))
 }
 
 function getEventBridgeGlobal() {

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -1,3 +1,3 @@
 export { HttpRequest } from './httpRequest'
 export { Batch } from './batch'
-export { isEventBridgePresent, getEventBridge } from './eventBridge'
+export { canUseEventBridge, getEventBridge } from './eventBridge'

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -314,8 +314,11 @@ export function restoreUserAgent() {
   delete (navigator as any).userAgent
 }
 
-export function initEventBridgeStub() {
-  const eventBridgeStub = { send: () => undefined }
+export function initEventBridgeStub(allowedWebViewHosts: string[] = [window.location.host]) {
+  const eventBridgeStub = {
+    send: () => undefined,
+    getAllowedWebViewHosts: () => JSON.stringify(allowedWebViewHosts),
+  }
   ;(window as BrowserWindow).DatadogEventBridge = eventBridgeStub
   return eventBridgeStub
 }

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -314,7 +314,7 @@ export function restoreUserAgent() {
   delete (navigator as any).userAgent
 }
 
-export function initEventBridgeStub(allowedWebViewHosts: string[] = [window.location.host]) {
+export function initEventBridgeStub(allowedWebViewHosts: string[] = [window.location.hostname]) {
   const eventBridgeStub = {
     send: () => undefined,
     getAllowedWebViewHosts: () => JSON.stringify(allowedWebViewHosts),

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -19,7 +19,7 @@ import {
   DefaultPrivacyLevel,
   TimeStamp,
   RelativeTime,
-  isEventBridgePresent,
+  canUseEventBridge,
   areCookiesAuthorized,
 } from '@datadog/browser-core'
 import { LifeCycle } from '../domain/lifeCycle'
@@ -97,7 +97,7 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
   }
 
   function initRum(initConfiguration: C) {
-    if (isEventBridgePresent()) {
+    if (canUseEventBridge()) {
       initConfiguration = overrideInitConfigurationForBridge(initConfiguration)
     } else if (!canHandleSession(initConfiguration)) {
       return

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -1,4 +1,4 @@
-import { combine, Configuration, InternalMonitoring, isEventBridgePresent, Observable } from '@datadog/browser-core'
+import { combine, Configuration, InternalMonitoring, canUseEventBridge, Observable } from '@datadog/browser-core'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { startPerformanceCollection } from '../browser/performanceCollection'
 import { startRumAssembly } from '../domain/assembly'
@@ -29,7 +29,7 @@ export function startRum(
   initialViewName?: string
 ) {
   const lifeCycle = new LifeCycle()
-  const session = !isEventBridgePresent() ? startRumSession(configuration, lifeCycle) : startRumSessionStub()
+  const session = !canUseEventBridge() ? startRumSession(configuration, lifeCycle) : startRumSessionStub()
   const domMutationObservable = createDOMMutationObservable()
   const locationChangeObservable = createLocationChangeObservable(location)
 
@@ -100,7 +100,7 @@ export function startRumEventCollection(
 
   let stopBatch: () => void
 
-  if (isEventBridgePresent()) {
+  if (canUseEventBridge()) {
     startRumEventBridge(lifeCycle)
   } else {
     ;({ stop: stopBatch } = startRumBatch(configuration, lifeCycle))

--- a/packages/rum-core/src/transport/startRumEventBridge.ts
+++ b/packages/rum-core/src/transport/startRumEventBridge.ts
@@ -3,7 +3,7 @@ import { LifeCycle, LifeCycleEventType } from '../domain/lifeCycle'
 import { RumEvent } from '../rumEvent.types'
 
 export function startRumEventBridge(lifeCycle: LifeCycle) {
-  const bridge = getEventBridge<RumEvent['type'], RumEvent>()
+  const bridge = getEventBridge<RumEvent['type'], RumEvent>()!
 
   lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (serverRumEvent: RumEvent & Context) => {
     bridge.send(serverRumEvent.type, serverRumEvent)

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -1,4 +1,4 @@
-import { Configuration, isEventBridgePresent, noop, runOnReadyState } from '@datadog/browser-core'
+import { Configuration, canUseEventBridge, noop, runOnReadyState } from '@datadog/browser-core'
 import {
   LifeCycleEventType,
   RumInitConfiguration,
@@ -44,7 +44,7 @@ export function makeRecorderApi(
   startRecordingImpl: StartRecording,
   startDeflateWorkerImpl = startDeflateWorker
 ): RecorderApi {
-  if (isEventBridgePresent()) {
+  if (canUseEventBridge()) {
     return {
       start: noop,
       stop: noop,

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -150,7 +150,7 @@ function declareTest(title: string, setupOptions: SetupOptions, factory: SetupFa
     const testContext = createTestContext(servers)
     servers.intake.bindServerApp(createIntakeServerApp(testContext.serverEvents, testContext.bridgeEvents))
 
-    const setup = factory(setupOptions, servers.intake.url)
+    const setup = factory(setupOptions, servers)
     servers.base.bindServerApp(createMockServerApp(servers, setup))
     servers.crossOrigin.bindServerApp(createMockServerApp(servers, setup))
 

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -157,11 +157,13 @@ export function html(parts: readonly string[], ...vars: string[]) {
 }
 
 function setupEventBridge(servers: Servers) {
+  const baseHostname = new URL(servers.base.url).hostname
+
   return html`
     <script type="text/javascript">
       window.DatadogEventBridge = {
         getAllowedWebViewHosts() {
-          return '["${servers.base.url}"]'
+          return '["${baseHostname}"]'
         },
         send(e) {
           const { event } = JSON.parse(e)

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -1,5 +1,6 @@
 import { LogsInitConfiguration } from '@datadog/browser-logs'
 import { RumInitConfiguration } from '@datadog/browser-rum-core'
+import { Servers } from './httpServers'
 
 export interface SetupOptions {
   rum?: RumInitConfiguration
@@ -11,7 +12,7 @@ export interface SetupOptions {
   body?: string
 }
 
-export type SetupFactory = (options: SetupOptions, intakeUrl: string) => string
+export type SetupFactory = (options: SetupOptions, servers: Servers) => string
 
 const isBrowserStack =
   browser.config.services &&
@@ -25,12 +26,12 @@ export const DEFAULT_SETUPS = isBrowserStack
       { name: 'bundle', factory: bundleSetup },
     ]
 
-export function asyncSetup(options: SetupOptions, intakeUrl: string) {
+export function asyncSetup(options: SetupOptions, servers: Servers) {
   let body = options.body || ''
   let header = options.head || ''
 
   if (options.eventBridge) {
-    header += setupEventBridge(intakeUrl)
+    header += setupEventBridge(servers)
   }
 
   function formatSnippet(url: string, globalName: string) {
@@ -69,11 +70,11 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })
 }
 
-export function bundleSetup(options: SetupOptions, intakeUrl: string) {
+export function bundleSetup(options: SetupOptions, servers: Servers) {
   let header = options.head || ''
 
   if (options.eventBridge) {
-    header += setupEventBridge(intakeUrl)
+    header += setupEventBridge(servers)
   }
 
   if (options.logs) {
@@ -103,11 +104,11 @@ export function bundleSetup(options: SetupOptions, intakeUrl: string) {
   })
 }
 
-export function npmSetup(options: SetupOptions, intakeUrl: string) {
+export function npmSetup(options: SetupOptions, servers: Servers) {
   let header = options.head || ''
 
   if (options.eventBridge) {
-    header += setupEventBridge(intakeUrl)
+    header += setupEventBridge(servers)
   }
 
   if (options.logs) {
@@ -155,14 +156,17 @@ export function html(parts: readonly string[], ...vars: string[]) {
   return parts.reduce((full, part, index) => full + vars[index - 1] + part)
 }
 
-function setupEventBridge(intakeUrl: string) {
+function setupEventBridge(servers: Servers) {
   return html`
     <script type="text/javascript">
       window.DatadogEventBridge = {
+        getAllowedWebViewHosts() {
+          return '["${servers.base.url}"]'
+        },
         send(e) {
           const { event } = JSON.parse(e)
           const request = new XMLHttpRequest()
-          request.open('POST', '${intakeUrl}/v1/input/rum?bridge=1', true)
+          request.open('POST', '${servers.intake.url}/v1/input/rum?bridge=1', true)
           request.send(JSON.stringify(event))
         },
       }


### PR DESCRIPTION
## Motivation

The mobile SDKs (Android and iOS) want to track events that happen inside a webview using the browser SDK. To do so the browser SDK will send events to a bridge injected by the mobile SDK. 

Because WebView can be used to display websites not owned by the customer, we need to guarantee that if these websites also have the browser SDK, they won’t send their events to the mobile SDK. 

## Changes

Add webView host checking

## Testing

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
