### PR TITLE
🔊 [RUMF-1080] try to detect segment sent without start

### DIFF
--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -1,4 +1,11 @@
-import { HttpRequest, objectEntries, EndpointBuilder, isNumber, addMonitoringMessage } from '@datadog/browser-core'
+import {
+  HttpRequest,
+  objectEntries,
+  EndpointBuilder,
+  isNumber,
+  addMonitoringMessage,
+  Context,
+} from '@datadog/browser-core'
 import { SegmentMeta } from '../types'
 
 export const SEND_BEACON_BYTE_LENGTH_LIMIT = 60_000
@@ -15,7 +22,7 @@ export function send(
       debug: {
         start: meta.start,
         flushReason,
-        meta,
+        meta: (meta as unknown) as Context,
       },
     })
   }

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -18,7 +18,7 @@ export function send(
   flushReason?: string
 ): void {
   if (!isNumber(meta.start)) {
-    addMonitoringMessage(`invalid segment start value`, {
+    addMonitoringMessage('invalid segment start value', {
       debug: {
         start: meta.start,
         flushReason,

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, objectEntries, EndpointBuilder } from '@datadog/browser-core'
+import { HttpRequest, objectEntries, EndpointBuilder, isNumber, addMonitoringMessage } from '@datadog/browser-core'
 import { SegmentMeta } from '../types'
 
 export const SEND_BEACON_BYTE_LENGTH_LIMIT = 60_000
@@ -10,6 +10,15 @@ export function send(
   rawSegmentSize: number,
   flushReason?: string
 ): void {
+  if (!isNumber(meta.start)) {
+    addMonitoringMessage(`invalid segment start value`, {
+      debug: {
+        start: meta.start,
+        flushReason,
+        meta,
+      },
+    })
+  }
   const formData = new FormData()
 
   formData.append(

--- a/packages/rum/src/types.ts
+++ b/packages/rum/src/types.ts
@@ -12,7 +12,6 @@ export interface SegmentMeta extends SegmentContext {
   has_full_snapshot: boolean
   records_count: number
   creation_reason: CreationReason
-  [key: string]: any
 }
 
 export interface SegmentContext {

--- a/packages/rum/src/types.ts
+++ b/packages/rum/src/types.ts
@@ -12,6 +12,7 @@ export interface SegmentMeta extends SegmentContext {
   has_full_snapshot: boolean
   records_count: number
   creation_reason: CreationReason
+  [key: string]: any
 }
 
 export interface SegmentContext {


### PR DESCRIPTION
## Motivation

Start field missing during the parsing of some segments

## Changes

Add a monitoring log when segment meta start is not a number

## Testing

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
