### PR TITLE
🔊 [RUMF-1041] add initial visibilityState to lcp infos

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -27,10 +27,11 @@ export function startViewCollection(
   recorderApi: RecorderApi,
   initialViewName?: string
 ) {
+  const initialVisibilityState = document.visibilityState
   lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, (view) =>
     lifeCycle.notify(
       LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
-      processViewUpdate(view, foregroundContexts, recorderApi)
+      processViewUpdate(view, foregroundContexts, recorderApi, initialVisibilityState)
     )
   )
 
@@ -47,7 +48,8 @@ export function startViewCollection(
 function processViewUpdate(
   view: ViewEvent,
   foregroundContexts: ForegroundContexts,
-  recorderApi: RecorderApi
+  recorderApi: RecorderApi,
+  initialVisibilityState: string
 ): RawRumEventCollectedData<RawRumViewEvent> {
   const replayStats = recorderApi.getReplayStats(view.id)
   const viewEvent: RawRumViewEvent = {
@@ -108,6 +110,7 @@ function processViewUpdate(
             lcp: {
               support: supportPerformanceTimingEvent('largest-contentful-paint'),
               discard_reason: view.timings.lcpDiscardReason,
+              initial_visibility_state: initialVisibilityState,
             },
           }
         : undefined,


### PR DESCRIPTION


## Motivation

This will help confirming the assumption that LCP value is not sent by the browser when the tab is not visible. The 'discard_reason' is not enough, because it is filled only when a LCP value is emitted (and discarded), but in most cases it seems that the LCP value is not emitted at all.

## Changes

Add `document.visibilityState` in `@context.lcp.initial_visibility_state`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
