### PR TITLE
♻️ [RUMF-1083] extract session store from session management

### DIFF
--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -5,7 +5,7 @@ import {
   OLD_SESSION_COOKIE_NAME,
   tryOldCookiesMigration,
 } from './oldCookiesMigration'
-import { SESSION_COOKIE_NAME, SESSION_EXPIRATION_DELAY } from './sessionManagement'
+import { SESSION_COOKIE_NAME, SESSION_EXPIRATION_DELAY } from './sessionStore'
 
 describe('old cookies migration', () => {
   const options: CookieOptions = {}

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -1,4 +1,4 @@
-import { cacheCookieAccess, CookieOptions, getCookie, setCookie } from '../browser/cookie'
+import { cacheCookieAccess, CookieOptions, getCookie, setCookie } from '../../browser/cookie'
 import {
   OLD_LOGS_COOKIE_NAME,
   OLD_RUM_COOKIE_NAME,

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -1,4 +1,4 @@
-import { cacheCookieAccess, CookieOptions, getCookie, setCookie } from '../../browser/cookie'
+import { CookieOptions, getCookie, setCookie } from '../../browser/cookie'
 import {
   OLD_LOGS_COOKIE_NAME,
   OLD_RUM_COOKIE_NAME,
@@ -13,7 +13,7 @@ describe('old cookies migration', () => {
   it('should not touch current cookie', () => {
     setCookie(SESSION_COOKIE_NAME, 'id=abcde&rum=0&logs=1', SESSION_EXPIRATION_DELAY)
 
-    tryOldCookiesMigration(cacheCookieAccess(SESSION_COOKIE_NAME, options))
+    tryOldCookiesMigration(options)
 
     expect(getCookie(SESSION_COOKIE_NAME)).toBe('id=abcde&rum=0&logs=1')
   })
@@ -23,7 +23,7 @@ describe('old cookies migration', () => {
     setCookie(OLD_LOGS_COOKIE_NAME, '1', SESSION_EXPIRATION_DELAY)
     setCookie(OLD_RUM_COOKIE_NAME, '0', SESSION_EXPIRATION_DELAY)
 
-    tryOldCookiesMigration(cacheCookieAccess(SESSION_COOKIE_NAME, options))
+    tryOldCookiesMigration(options)
 
     expect(getCookie(SESSION_COOKIE_NAME)).toContain('id=abcde')
     expect(getCookie(SESSION_COOKIE_NAME)).toContain('rum=0')
@@ -33,7 +33,7 @@ describe('old cookies migration', () => {
   it('should create new cookie from a single old cookie', () => {
     setCookie(OLD_RUM_COOKIE_NAME, '0', SESSION_EXPIRATION_DELAY)
 
-    tryOldCookiesMigration(cacheCookieAccess(SESSION_COOKIE_NAME, options))
+    tryOldCookiesMigration(options)
 
     expect(getCookie(SESSION_COOKIE_NAME)).not.toContain('id=')
     expect(getCookie(SESSION_COOKIE_NAME)).toContain('rum=0')

--- a/packages/core/src/domain/session/oldCookiesMigration.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.ts
@@ -1,4 +1,4 @@
-import { CookieCache, getCookie } from '../browser/cookie'
+import { CookieCache, getCookie } from '../../browser/cookie'
 import { persistSession, SessionState } from './sessionManagement'
 
 export const OLD_SESSION_COOKIE_NAME = '_dd'

--- a/packages/core/src/domain/session/oldCookiesMigration.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.ts
@@ -1,5 +1,5 @@
 import { getCookie, CookieOptions, cacheCookieAccess } from '../../browser/cookie'
-import { persistSession, SessionState, SESSION_COOKIE_NAME } from './sessionManagement'
+import { persistSession, SessionState, SESSION_COOKIE_NAME } from './sessionStore'
 
 export const OLD_SESSION_COOKIE_NAME = '_dd'
 export const OLD_RUM_COOKIE_NAME = '_dd_r'

--- a/packages/core/src/domain/session/oldCookiesMigration.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.ts
@@ -1,5 +1,5 @@
-import { CookieCache, getCookie } from '../../browser/cookie'
-import { persistSession, SessionState } from './sessionManagement'
+import { getCookie, CookieOptions, cacheCookieAccess } from '../../browser/cookie'
+import { persistSession, SessionState, SESSION_COOKIE_NAME } from './sessionManagement'
 
 export const OLD_SESSION_COOKIE_NAME = '_dd'
 export const OLD_RUM_COOKIE_NAME = '_dd_r'
@@ -13,7 +13,8 @@ export const LOGS_SESSION_KEY = 'logs'
  * This migration should remain in the codebase as long as older versions are available/live
  * to allow older sdk versions to be upgraded to newer versions without compatibility issues.
  */
-export function tryOldCookiesMigration(sessionCookie: CookieCache) {
+export function tryOldCookiesMigration(options: CookieOptions) {
+  const sessionCookie = cacheCookieAccess(SESSION_COOKIE_NAME, options)
   const sessionString = sessionCookie.get()
   const oldSessionId = getCookie(OLD_SESSION_COOKIE_NAME)
   const oldRumType = getCookie(OLD_RUM_COOKIE_NAME)

--- a/packages/core/src/domain/session/sessionManagement.spec.ts
+++ b/packages/core/src/domain/session/sessionManagement.spec.ts
@@ -5,10 +5,10 @@ import {
   CookieOptions,
   getCookie,
   setCookie,
-} from '../browser/cookie'
-import { Clock, mockClock, restorePageVisibility, setPageVisibility, createNewEvent } from '../../test/specHelper'
-import { ONE_HOUR, DOM_EVENT } from '../tools/utils'
-import { isIE } from '../tools/browserDetection'
+} from '../../browser/cookie'
+import { Clock, mockClock, restorePageVisibility, setPageVisibility, createNewEvent } from '../../../test/specHelper'
+import { ONE_HOUR, DOM_EVENT } from '../../tools/utils'
+import { isIE } from '../../tools/browserDetection'
 import {
   Session,
   SESSION_COOKIE_NAME,

--- a/packages/core/src/domain/session/sessionManagement.spec.ts
+++ b/packages/core/src/domain/session/sessionManagement.spec.ts
@@ -9,15 +9,8 @@ import {
 import { Clock, mockClock, restorePageVisibility, setPageVisibility, createNewEvent } from '../../../test/specHelper'
 import { ONE_HOUR, DOM_EVENT } from '../../tools/utils'
 import { isIE } from '../../tools/browserDetection'
-import {
-  Session,
-  SESSION_COOKIE_NAME,
-  SESSION_EXPIRATION_DELAY,
-  SESSION_TIME_OUT_DELAY,
-  startSessionManagement,
-  stopSessionManagement,
-  VISIBILITY_CHECK_DELAY,
-} from './sessionManagement'
+import { Session, startSessionManagement, stopSessionManagement, VISIBILITY_CHECK_DELAY } from './sessionManagement'
+import { SESSION_COOKIE_NAME, SESSION_TIME_OUT_DELAY, SESSION_EXPIRATION_DELAY } from './sessionStore'
 
 describe('cacheCookieAccess', () => {
   const TEST_COOKIE = 'test'

--- a/packages/core/src/domain/session/sessionManagement.ts
+++ b/packages/core/src/domain/session/sessionManagement.ts
@@ -30,8 +30,8 @@ export function startSessionManagement<TrackingType extends string>(
   productKey: string,
   computeSessionState: (rawTrackingType?: string) => { trackingType: TrackingType; isTracked: boolean }
 ): Session<TrackingType> {
+  tryOldCookiesMigration(options)
   const sessionCookie = cacheCookieAccess(SESSION_COOKIE_NAME, options)
-  tryOldCookiesMigration(sessionCookie)
   const renewObservable = new Observable<void>()
   let inMemorySession = retrieveActiveSession(sessionCookie)
 

--- a/packages/core/src/domain/session/sessionManagement.ts
+++ b/packages/core/src/domain/session/sessionManagement.ts
@@ -39,7 +39,7 @@ export function stopSessionManagement() {
 
 let stopCallbacks: Array<() => void> = []
 
-export function trackActivity(expandOrRenewSession: () => void) {
+function trackActivity(expandOrRenewSession: () => void) {
   const { stop } = utils.addEventListeners(
     window,
     [utils.DOM_EVENT.CLICK, utils.DOM_EVENT.TOUCH_START, utils.DOM_EVENT.KEY_DOWN, utils.DOM_EVENT.SCROLL],

--- a/packages/core/src/domain/session/sessionManagement.ts
+++ b/packages/core/src/domain/session/sessionManagement.ts
@@ -1,12 +1,10 @@
-import { cacheCookieAccess, COOKIE_ACCESS_DELAY, CookieCache, CookieOptions } from '../../browser/cookie'
+import { CookieOptions } from '../../browser/cookie'
 import { Observable } from '../../tools/observable'
 import * as utils from '../../tools/utils'
 import { monitor } from '../internalMonitoring'
 import { tryOldCookiesMigration } from './oldCookiesMigration'
+import { startSessionStore } from './sessionStore'
 
-export const SESSION_COOKIE_NAME = '_dd_s'
-export const SESSION_EXPIRATION_DELAY = 15 * utils.ONE_MINUTE
-export const SESSION_TIME_OUT_DELAY = 4 * utils.ONE_HOUR
 export const VISIBILITY_CHECK_DELAY = utils.ONE_MINUTE
 
 export interface Session<T> {
@@ -15,125 +13,23 @@ export interface Session<T> {
   getTrackingType: () => T | undefined
 }
 
-export interface SessionState {
-  id?: string
-  created?: string
-  expire?: string
-  [key: string]: string | undefined
-}
-
-/**
- * Limit access to cookie to avoid performance issues
- */
 export function startSessionManagement<TrackingType extends string>(
   options: CookieOptions,
   productKey: string,
   computeSessionState: (rawTrackingType?: string) => { trackingType: TrackingType; isTracked: boolean }
 ): Session<TrackingType> {
   tryOldCookiesMigration(options)
-  const sessionCookie = cacheCookieAccess(SESSION_COOKIE_NAME, options)
-  const renewObservable = new Observable<void>()
-  let inMemorySession = retrieveActiveSession(sessionCookie)
+  const sessionStore = startSessionStore(options, productKey, computeSessionState)
 
-  const { throttled: expandOrRenewSession } = utils.throttle(
-    monitor(() => {
-      sessionCookie.clearCache()
-      const cookieSession = retrieveActiveSession(sessionCookie)
-      const { trackingType, isTracked } = computeSessionState(cookieSession[productKey])
-      cookieSession[productKey] = trackingType
-      if (isTracked && !cookieSession.id) {
-        cookieSession.id = utils.generateUUID()
-        cookieSession.created = String(Date.now())
-      }
-      // save changes and expand session duration
-      persistSession(cookieSession, sessionCookie)
-
-      // If the session id has changed, notify that the session has been renewed
-      if (isTracked && inMemorySession.id !== cookieSession.id) {
-        inMemorySession = { ...cookieSession }
-        renewObservable.notify()
-      }
-      inMemorySession = { ...cookieSession }
-    }),
-    COOKIE_ACCESS_DELAY
-  )
-
-  const expandSession = () => {
-    sessionCookie.clearCache()
-    const session = retrieveActiveSession(sessionCookie)
-    persistSession(session, sessionCookie)
-  }
-
-  expandOrRenewSession()
-  trackActivity(expandOrRenewSession)
-  trackVisibility(expandSession)
+  sessionStore.expandOrRenewSession()
+  trackActivity(() => sessionStore.expandOrRenewSession())
+  trackVisibility(() => sessionStore.expandSession())
 
   return {
-    getId: () => retrieveActiveSession(sessionCookie).id,
-    getTrackingType: () => retrieveActiveSession(sessionCookie)[productKey] as TrackingType | undefined,
-    renewObservable,
+    getId: () => sessionStore.retrieveSession().id,
+    getTrackingType: () => sessionStore.retrieveSession()[productKey] as TrackingType | undefined,
+    renewObservable: sessionStore.renewObservable,
   }
-}
-
-const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
-
-const SESSION_ENTRY_SEPARATOR = '&'
-
-export function isValidSessionString(sessionString: string | undefined): sessionString is string {
-  return (
-    sessionString !== undefined &&
-    (sessionString.indexOf(SESSION_ENTRY_SEPARATOR) !== -1 || SESSION_ENTRY_REGEXP.test(sessionString))
-  )
-}
-
-function retrieveActiveSession(sessionCookie: CookieCache): SessionState {
-  const session = retrieveSession(sessionCookie)
-  if (isActiveSession(session)) {
-    return session
-  }
-  clearSession(sessionCookie)
-  return {}
-}
-
-function isActiveSession(session: SessionState) {
-  // created and expire can be undefined for versions which was not storing them
-  // these checks could be removed when older versions will not be available/live anymore
-  return (
-    (session.created === undefined || Date.now() - Number(session.created) < SESSION_TIME_OUT_DELAY) &&
-    (session.expire === undefined || Date.now() < Number(session.expire))
-  )
-}
-
-function retrieveSession(sessionCookie: CookieCache): SessionState {
-  const sessionString = sessionCookie.get()
-  const session: SessionState = {}
-  if (isValidSessionString(sessionString)) {
-    sessionString.split(SESSION_ENTRY_SEPARATOR).forEach((entry) => {
-      const matches = SESSION_ENTRY_REGEXP.exec(entry)
-      if (matches !== null) {
-        const [, key, value] = matches
-        session[key] = value
-      }
-    })
-  }
-  return session
-}
-
-export function persistSession(session: SessionState, cookie: CookieCache) {
-  if (utils.isEmptyObject(session)) {
-    clearSession(cookie)
-    return
-  }
-  session.expire = String(Date.now() + SESSION_EXPIRATION_DELAY)
-  const cookieString = utils
-    .objectEntries(session)
-    .map(([key, value]) => `${key}=${value as string}`)
-    .join(SESSION_ENTRY_SEPARATOR)
-  cookie.set(cookieString, SESSION_EXPIRATION_DELAY)
-}
-
-function clearSession(cookie: CookieCache) {
-  cookie.set('', 0)
 }
 
 export function stopSessionManagement() {

--- a/packages/core/src/domain/session/sessionManagement.ts
+++ b/packages/core/src/domain/session/sessionManagement.ts
@@ -1,7 +1,7 @@
-import { cacheCookieAccess, COOKIE_ACCESS_DELAY, CookieCache, CookieOptions } from '../browser/cookie'
-import { Observable } from '../tools/observable'
-import * as utils from '../tools/utils'
-import { monitor } from './internalMonitoring'
+import { cacheCookieAccess, COOKIE_ACCESS_DELAY, CookieCache, CookieOptions } from '../../browser/cookie'
+import { Observable } from '../../tools/observable'
+import * as utils from '../../tools/utils'
+import { monitor } from '../internalMonitoring'
 import { tryOldCookiesMigration } from './oldCookiesMigration'
 
 export const SESSION_COOKIE_NAME = '_dd_s'

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -22,6 +22,9 @@ export const SESSION_COOKIE_NAME = '_dd_s'
 export const SESSION_EXPIRATION_DELAY = 15 * utils.ONE_MINUTE
 export const SESSION_TIME_OUT_DELAY = 4 * utils.ONE_HOUR
 
+const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
+const SESSION_ENTRY_SEPARATOR = '&'
+
 export function startSessionStore<TrackingType extends string>(
   options: CookieOptions,
   productKey: string,
@@ -72,11 +75,7 @@ export function startSessionStore<TrackingType extends string>(
   }
 }
 
-const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
-
-const SESSION_ENTRY_SEPARATOR = '&'
-
-export function isValidSessionString(sessionString: string | undefined): sessionString is string {
+function isValidSessionString(sessionString: string | undefined): sessionString is string {
   return (
     sessionString !== undefined &&
     (sessionString.indexOf(SESSION_ENTRY_SEPARATOR) !== -1 || SESSION_ENTRY_REGEXP.test(sessionString))

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -1,0 +1,134 @@
+import { CookieCache, CookieOptions, cacheCookieAccess, COOKIE_ACCESS_DELAY } from '../../browser/cookie'
+import { Observable } from '../../tools/observable'
+import * as utils from '../../tools/utils'
+import { monitor } from '../internalMonitoring'
+
+export interface SessionStore {
+  expandOrRenewSession: () => void
+  expandSession: () => void
+  retrieveSession: () => SessionState
+  renewObservable: Observable<void>
+}
+
+export interface SessionState {
+  id?: string
+  created?: string
+  expire?: string
+
+  [key: string]: string | undefined
+}
+
+export const SESSION_COOKIE_NAME = '_dd_s'
+export const SESSION_EXPIRATION_DELAY = 15 * utils.ONE_MINUTE
+export const SESSION_TIME_OUT_DELAY = 4 * utils.ONE_HOUR
+
+export function startSessionStore<TrackingType extends string>(
+  options: CookieOptions,
+  productKey: string,
+  computeSessionState: (rawTrackingType?: string) => { trackingType: TrackingType; isTracked: boolean }
+): SessionStore {
+  const renewObservable = new Observable<void>()
+  const sessionCookie = cacheCookieAccess(SESSION_COOKIE_NAME, options)
+  let inMemorySession = retrieveActiveSession(sessionCookie)
+
+  const { throttled: expandOrRenewSession } = utils.throttle(
+    monitor(() => {
+      sessionCookie.clearCache()
+      const cookieSession = retrieveActiveSession(sessionCookie)
+      const { trackingType, isTracked } = computeSessionState(cookieSession[productKey])
+      cookieSession[productKey] = trackingType
+      if (isTracked && !cookieSession.id) {
+        cookieSession.id = utils.generateUUID()
+        cookieSession.created = String(Date.now())
+      }
+      // save changes and expand session duration
+      persistSession(cookieSession, sessionCookie)
+
+      // If the session id has changed, notify that the session has been renewed
+      if (isTracked && inMemorySession.id !== cookieSession.id) {
+        inMemorySession = { ...cookieSession }
+        renewObservable.notify()
+      }
+      inMemorySession = { ...cookieSession }
+    }),
+    COOKIE_ACCESS_DELAY
+  )
+
+  function expandSession() {
+    sessionCookie.clearCache()
+    const session = retrieveActiveSession(sessionCookie)
+    persistSession(session, sessionCookie)
+  }
+
+  function retrieveSession() {
+    return retrieveActiveSession(sessionCookie)
+  }
+
+  return {
+    expandOrRenewSession,
+    expandSession,
+    retrieveSession,
+    renewObservable,
+  }
+}
+
+const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
+
+const SESSION_ENTRY_SEPARATOR = '&'
+
+export function isValidSessionString(sessionString: string | undefined): sessionString is string {
+  return (
+    sessionString !== undefined &&
+    (sessionString.indexOf(SESSION_ENTRY_SEPARATOR) !== -1 || SESSION_ENTRY_REGEXP.test(sessionString))
+  )
+}
+
+function retrieveActiveSession(sessionCookie: CookieCache): SessionState {
+  const session = retrieveSession(sessionCookie)
+  if (isActiveSession(session)) {
+    return session
+  }
+  clearSession(sessionCookie)
+  return {}
+}
+
+function isActiveSession(session: SessionState) {
+  // created and expire can be undefined for versions which was not storing them
+  // these checks could be removed when older versions will not be available/live anymore
+  return (
+    (session.created === undefined || Date.now() - Number(session.created) < SESSION_TIME_OUT_DELAY) &&
+    (session.expire === undefined || Date.now() < Number(session.expire))
+  )
+}
+
+function retrieveSession(sessionCookie: CookieCache): SessionState {
+  const sessionString = sessionCookie.get()
+  const session: SessionState = {}
+  if (isValidSessionString(sessionString)) {
+    sessionString.split(SESSION_ENTRY_SEPARATOR).forEach((entry) => {
+      const matches = SESSION_ENTRY_REGEXP.exec(entry)
+      if (matches !== null) {
+        const [, key, value] = matches
+        session[key] = value
+      }
+    })
+  }
+  return session
+}
+
+export function persistSession(session: SessionState, cookie: CookieCache) {
+  if (utils.isEmptyObject(session)) {
+    clearSession(cookie)
+    return
+  }
+  session.expire = String(Date.now() + SESSION_EXPIRATION_DELAY)
+  const cookieString = utils
+    .objectEntries(session)
+    .map(([key, value]) => `${key}=${value as string}`)
+    .join(SESSION_ENTRY_SEPARATOR)
+  cookie.set(cookieString, SESSION_EXPIRATION_DELAY)
+}
+
+function clearSession(cookie: CookieCache) {
+  cookie.set('', 0)
+}

--- a/packages/core/src/domain/sessionManagement.ts
+++ b/packages/core/src/domain/sessionManagement.ts
@@ -13,7 +13,6 @@ export interface Session<T> {
   renewObservable: Observable<void>
   getId: () => string | undefined
   getTrackingType: () => T | undefined
-  getInMemoryTrackingType: () => T | undefined
 }
 
 export interface SessionState {
@@ -72,7 +71,6 @@ export function startSessionManagement<TrackingType extends string>(
   return {
     getId: () => retrieveActiveSession(sessionCookie).id,
     getTrackingType: () => retrieveActiveSession(sessionCookie)[productKey] as TrackingType | undefined,
-    getInMemoryTrackingType: () => inMemorySession[productKey] as TrackingType | undefined,
     renewObservable,
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,7 +35,7 @@ export {
   // Exposed for tests
   SESSION_COOKIE_NAME,
   stopSessionManagement,
-} from './domain/sessionManagement'
+} from './domain/session/sessionManagement'
 export { HttpRequest, Batch, canUseEventBridge, getEventBridge } from './transport'
 export * from './tools/display'
 export * from './tools/urlPolyfill'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,11 +31,14 @@ export { Observable, Subscription } from './tools/observable'
 export {
   startSessionManagement,
   Session,
+  // Exposed for tests
+  stopSessionManagement,
+} from './domain/session/sessionManagement'
+export {
   SESSION_TIME_OUT_DELAY,
   // Exposed for tests
   SESSION_COOKIE_NAME,
-  stopSessionManagement,
-} from './domain/session/sessionManagement'
+} from './domain/session/sessionStore'
 export { HttpRequest, Batch, canUseEventBridge, getEventBridge } from './transport'
 export * from './tools/display'
 export * from './tools/urlPolyfill'


### PR DESCRIPTION
## Motivation

First part of session management rework

Next:

- Replace session cookie cache
- Introduce session context history

## Changes

Extract session store from session management

## Testing


- [ ] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
