### PR TITLE
👷 rename -head suffix to -staging suffix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,7 +233,7 @@ deploy-staging:
   script:
     - yarn
     - BUILD_MODE=staging yarn build:bundle
-    - ./scripts/deploy.sh staging head
+    - ./scripts/deploy.sh staging staging
 
 deploy-prod-canary:
   stage: deploy:canary

--- a/developer-extension/src/background/domain/replaceBundles.ts
+++ b/developer-extension/src/background/domain/replaceBundles.ts
@@ -50,7 +50,7 @@ function getBundleUrlPatterns(bundleName: string) {
     `https://*/datadog-${bundleName}.js`,
     `https://*/datadog-${bundleName}-v3.js`,
     `https://*/datadog-${bundleName}-canary.js`,
-    `https://*/datadog-${bundleName}-head.js`,
+    `https://*/datadog-${bundleName}-staging.js`,
   ]
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@ set -ex
 env=$1
 suffix=$2
 
-USAGE="Usage: ./deploy.sh staging|prod head|canary|vXXX"
+USAGE="Usage: ./deploy.sh staging|prod staging|canary|vXXX"
 
 case "${env}" in
 "prod")
@@ -28,7 +28,7 @@ case "${suffix}" in
 v[0-9]*)
     CACHE_CONTROL='max-age=14400, s-maxage=60'
   ;;
-"canary" | "head")
+"canary" | "staging")
     CACHE_CONTROL='max-age=900, s-maxage=60'
   ;;
 * )

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -20,7 +20,7 @@ app.use(redirectSuffixedFiles)
 app.listen(port, () => printLog(`Server listening on port ${port}.`))
 
 function redirectSuffixedFiles(req, res, next) {
-  const matches = /(.*)-(canary|head|v3)\.js/.exec(req.url)
+  const matches = /(.*)-(canary|staging|v3)\.js/.exec(req.url)
   if (matches) {
     res.redirect(`${matches[1]}.js`)
   } else {


### PR DESCRIPTION
## Motivation

Inititally, the `-head` bundle reflected the top of the `main` branch, thus the name. Since the new release workflow, this is no longer the case at is now reflects the top of the current `staging-xx` branch. 
## Changes

To remove confusion, this PR changes the `-head` suffix to `-staging`.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
