### PR TITLE
✨ [RUMF-1047] implement a Synthetics bundle

### DIFF
--- a/packages/rum-core/src/boot/buildEnv.ts
+++ b/packages/rum-core/src/boot/buildEnv.ts
@@ -1,6 +1,6 @@
 import { BuildEnv, BuildMode } from '@datadog/browser-core'
 
-interface RumBuildEnv extends BuildEnv {
+export interface RumBuildEnv extends BuildEnv {
   syntheticsBundle: boolean
 }
 

--- a/packages/rum-core/src/boot/buildEnv.ts
+++ b/packages/rum-core/src/boot/buildEnv.ts
@@ -1,6 +1,11 @@
 import { BuildEnv, BuildMode } from '@datadog/browser-core'
 
-export const buildEnv: BuildEnv = {
+interface RumBuildEnv extends BuildEnv {
+  syntheticsBundle: boolean
+}
+
+export const buildEnv: RumBuildEnv = {
   buildMode: '<<< BUILD_MODE >>>' as BuildMode,
   sdkVersion: '<<< SDK_VERSION >>>',
+  syntheticsBundle: ('<<< SYNTHETICS_BUNDLE >>>' as string) === 'true',
 }

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -98,7 +98,7 @@ export function makeRumPublicApi<C extends RumInitConfiguration>(startRumImpl: S
   }
 
   function initRum(initConfiguration: C) {
-    if (willSyntheticsInjectRum()) {
+    if (willSyntheticsInjectRum(buildEnv)) {
       return
     }
 

--- a/packages/rum-core/src/domain/syntheticsContext.spec.ts
+++ b/packages/rum-core/src/domain/syntheticsContext.spec.ts
@@ -1,4 +1,6 @@
+import { BuildMode } from '@datadog/browser-core'
 import { mockSyntheticsWorkerValues, cleanupSyntheticsWorkerValues } from '../../test/specHelper'
+import { RumBuildEnv } from '../boot/buildEnv'
 import { getSyntheticsContext, willSyntheticsInjectRum } from './syntheticsContext'
 
 describe('getSyntheticsContext', () => {
@@ -44,6 +46,12 @@ describe('getSyntheticsContext', () => {
 })
 
 describe('willSyntheticsInjectRum', () => {
+  const buildEnv: RumBuildEnv = {
+    buildMode: BuildMode.RELEASE,
+    sdkVersion: 'dev',
+    syntheticsBundle: false,
+  }
+
   afterEach(() => {
     cleanupSyntheticsWorkerValues()
   })
@@ -51,24 +59,28 @@ describe('willSyntheticsInjectRum', () => {
   it('returns false if nothing is defined', () => {
     mockSyntheticsWorkerValues({}, 'globals')
 
-    expect(willSyntheticsInjectRum()).toBeFalse()
+    expect(willSyntheticsInjectRum(buildEnv)).toBeFalse()
   })
 
   it('returns false if the INJECTS_RUM global variable is false', () => {
     mockSyntheticsWorkerValues({ injectsRum: false }, 'globals')
 
-    expect(willSyntheticsInjectRum()).toBeFalse()
+    expect(willSyntheticsInjectRum(buildEnv)).toBeFalse()
   })
 
   it('returns true if the INJECTS_RUM global variable is truthy', () => {
     mockSyntheticsWorkerValues({ injectsRum: true }, 'globals')
 
-    expect(willSyntheticsInjectRum()).toBeTrue()
+    expect(willSyntheticsInjectRum(buildEnv)).toBeTrue()
   })
 
   it('returns true if the INJECTS_RUM cookie is truthy', () => {
     mockSyntheticsWorkerValues({ injectsRum: true }, 'cookies')
 
-    expect(willSyntheticsInjectRum()).toBeTrue()
+    expect(willSyntheticsInjectRum(buildEnv)).toBeTrue()
+  })
+
+  it('returns false for the Synthetics bundle', () => {
+    expect(willSyntheticsInjectRum({ ...buildEnv, syntheticsBundle: true })).toBeFalse()
   })
 })

--- a/packages/rum-core/src/domain/syntheticsContext.ts
+++ b/packages/rum-core/src/domain/syntheticsContext.ts
@@ -1,4 +1,5 @@
 import { getCookie } from '@datadog/browser-core'
+import { RumBuildEnv } from '../boot/buildEnv'
 
 export const SYNTHETICS_TEST_ID_COOKIE_NAME = 'datadog-synthetics-public-id'
 export const SYNTHETICS_RESULT_ID_COOKIE_NAME = 'datadog-synthetics-result-id'
@@ -23,7 +24,11 @@ export function getSyntheticsContext() {
   }
 }
 
-export function willSyntheticsInjectRum() {
+export function willSyntheticsInjectRum(buildEnv: RumBuildEnv) {
+  if (buildEnv.syntheticsBundle) {
+    // We are in the synthetics bundle, so no other bundle will be injected
+    return false
+  }
   return Boolean(
     (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM || getCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
   )

--- a/packages/rum-core/src/index.ts
+++ b/packages/rum-core/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from './domainContext.types'
 export { ViewContext, CommonContext, ReplayStats } from './rawRumEvent.types'
 export { startRum } from './boot/startRum'
+export { buildEnv } from './boot/buildEnv'
 export { LifeCycle, LifeCycleEventType } from './domain/lifeCycle'
 export { ParentContexts } from './domain/parentContexts'
 export { RumSession, RumSessionPlan } from './domain/rumSession'

--- a/packages/rum/src/boot/rum.entry.ts
+++ b/packages/rum/src/boot/rum.entry.ts
@@ -1,5 +1,5 @@
 import { defineGlobal, getGlobalObject } from '@datadog/browser-core'
-import { makeRumPublicApi, RumPublicApi, startRum } from '@datadog/browser-rum-core'
+import { buildEnv, makeRumPublicApi, RumPublicApi, startRum } from '@datadog/browser-rum-core'
 
 import { startRecording } from './startRecording'
 import { makeRecorderApi } from './recorderApi'
@@ -9,5 +9,10 @@ export const datadogRum = makeRumPublicApi(startRum, recorderApi)
 
 interface BrowserWindow extends Window {
   DD_RUM?: RumPublicApi
+  DD_SYNTHETICS_INJECTED_RUM?: RumPublicApi
 }
-defineGlobal(getGlobalObject<BrowserWindow>(), 'DD_RUM', datadogRum)
+defineGlobal(
+  getGlobalObject<BrowserWindow>(),
+  buildEnv.syntheticsBundle ? 'DD_SYNTHETICS_INJECTED_RUM' : 'DD_RUM',
+  datadogRum
+)

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -14,5 +14,8 @@ module.exports = (_env, argv) => [
     mode: argv.mode,
     entry,
     filename: 'datadog-rum-synthetics.js',
+    extraBuildEnv: {
+      SYNTHETICS_BUNDLE: 'true',
+    },
   }),
 ]

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -2,9 +2,17 @@ const path = require('path')
 
 const webpackBase = require('../../webpack.base')
 
-module.exports = (_env, argv) =>
+const entry = path.resolve(__dirname, 'src/boot/rum.entry.ts')
+
+module.exports = (_env, argv) => [
   webpackBase({
     mode: argv.mode,
-    entry: path.resolve(__dirname, 'src/boot/rum.entry.ts'),
+    entry,
     filename: 'datadog-rum.js',
-  })
+  }),
+  webpackBase({
+    mode: argv.mode,
+    entry,
+    filename: 'datadog-rum-synthetics.js',
+  }),
+]

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -1,8 +1,44 @@
 const execSync = require('child_process').execSync
 const lernaJson = require('../lerna.json')
 
+/**
+ * Allows to produce slightly custom builds of bundles and packages to be used in various
+ * environment. On top of allowing some internal use cases, it also drives the SDK version being
+ * used when requesting the intake (see below).
+ */
+const BUILD_MODES = [
+  // Used while developing. This is the default if the BUILD_MODE environment variable is empty.
+  'dev',
+
+  // Used for public releases.
+  'release',
+
+  // Used by E2E tests.
+  // * Allows intake endpoints overrides when served from the E2E test framework.
+  'e2e-test',
+
+  // Used on the production Datadog web app.
+  'canary',
+
+  // Used on the staging Datadog web app.
+  // * Enables the support of the "replica" options.
+  'staging',
+]
+
+let buildMode
+if (process.env.BUILD_MODE) {
+  if (BUILD_MODES.includes(process.env.BUILD_MODE)) {
+    buildMode = process.env.BUILD_MODE
+  } else {
+    console.log(`Invalid build mode "${process.env.BUILD_MODE}". Possible build modes are: ${BUILD_MODES.join(', ')}`)
+    process.exit(1)
+  }
+} else {
+  buildMode = BUILD_MODES[0]
+}
+
 let sdkVersion
-switch (process.env.BUILD_MODE) {
+switch (buildMode) {
   case 'release':
     sdkVersion = lernaJson.version
     break
@@ -17,6 +53,6 @@ switch (process.env.BUILD_MODE) {
 }
 
 module.exports = {
-  BUILD_MODE: process.env.BUILD_MODE,
+  BUILD_MODE: buildMode,
   SDK_VERSION: sdkVersion,
 }

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -55,4 +55,8 @@ switch (buildMode) {
 module.exports = {
   BUILD_MODE: buildMode,
   SDK_VERSION: sdkVersion,
+
+  // This will be injected by webpack when building the RUM synthetics bundle. When set to 'true',
+  // the bundle will skip the check to ignore init() calls during synthetics tests.
+  SYNTHETICS_BUNDLE: '',
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -39,6 +39,7 @@ esac
 
 declare -A BUNDLES=(
   ["datadog-rum-${suffix}.js"]="packages/rum/bundle/datadog-rum.js"
+  ["datadog-rum-synthetics-${suffix}.js"]="packages/rum/bundle/datadog-rum-synthetics.js"
   ["datadog-rum-slim-${suffix}.js"]="packages/rum-slim/bundle/datadog-rum-slim.js"
   ["datadog-logs-${suffix}.js"]="packages/logs/bundle/datadog-logs.js"
 )

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -5,7 +5,7 @@ const buildEnv = require('./scripts/build-env')
 
 const tsconfigPath = path.join(__dirname, 'tsconfig.webpack.json')
 
-module.exports = ({ entry, mode, filename, types }) => ({
+module.exports = ({ entry, mode, filename, types, extraBuildEnv }) => ({
   entry,
   mode,
   output: {
@@ -20,10 +20,10 @@ module.exports = ({ entry, mode, filename, types }) => ({
         test: /\.ts$/,
         loader: 'string-replace-loader',
         options: {
-          multiple: [
-            { search: '<<< SDK_VERSION >>>', replace: buildEnv.SDK_VERSION },
-            { search: '<<< BUILD_MODE >>>', replace: buildEnv.BUILD_MODE },
-          ],
+          multiple: Object.entries({ ...buildEnv, ...extraBuildEnv }).map(([entry, value]) => ({
+            search: `<<< ${entry} >>>`,
+            replace: value,
+          })),
         },
       },
 


### PR DESCRIPTION
## Motivation

We need a bundle to be injected in Synthetics tests, that skips the [previously introduced](https://github.com/DataDog/browser-sdk/pull/1170) check to ignore `init()` calls during Synthetics tests, and expose a different global variable.

## Changes

* Document build modes. Initially I was planning to use a new build mode, so I wrote some doc, but then I chose not to use a build mode (so we can build synthetics bundles with various build modes (staging / release)). I chose to keep the documentation in the PR.

* Create and deploy the new synthetics bundle
* Skip init check for Synthetics bundle
* Rename global variable for Synthetics bundle

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
