### PR TITLE
🔊 [RUMF-1083] add monitoring message for session inconsistencies

### DIFF
--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -81,6 +81,7 @@ export function startSessionStore<TrackingType extends string>(
   function isSessionInCacheOutdated(cookieSession: SessionState) {
     if (sessionCache.id !== cookieSession.id) {
       if (cookieSession.id) {
+        // cookie id undefined could be due to cookie expiration
         addSessionInconsistenciesMessage(cookieSession, 'different id')
       }
       return true


### PR DESCRIPTION
## Motivation

Allow to monitor session inconsistencies improvements

## Changes

- consider session outdated if type change
- add monitoring message fo session inconsistencies

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
