### PR TITLE
🐛 remove self-referential xhr loop

### DIFF
--- a/packages/core/src/browser/xhrObservable.spec.ts
+++ b/packages/core/src/browser/xhrObservable.spec.ts
@@ -90,6 +90,7 @@ describe('xhr proxy', () => {
         expect(request.isAborted).toBe(false)
         expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
+        expect(request.xhr).not.toBeDefined()
         done()
       },
     })

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -94,7 +94,6 @@ function sendXhr(this: BrowserXHR<XhrStartContext>, observable: Observable<XhrCo
   startContext.startTime = relativeNow()
   startContext.startClocks = clocksNow()
   startContext.isAborted = false
-  startContext.xhr = this
 
   let hasBeenReported = false
 


### PR DESCRIPTION
The _datadog_xhr object already extends the xhr object, so putting the
xhr object on the _datadog_xhr object causes a self-referential loop,
which can cause problems for anyone using that any of that data, such
as in an error situation.

## Motivation

Removes a self-referential loop. (https://github.com/DataDog/browser-sdk/issues/1193)

## Changes

Literally just removes a self-referential loop that causes the following if the xhr or _datadog_xhr object are referenced.
<img width="486" alt="self-referential-loop-error" src="https://user-images.githubusercontent.com/7552754/145304956-d54d499a-7fb1-4330-875a-b4b4d569d55f.png">


## Testing

Added a test to verify the self-reference doesn't exist.

- [ ] Local - not sure how you want these tested, other than using the modified version in our app no longer causes the error
- [ ] Staging - not sure how you want this tested
- [x] Unit - success
- [ ] End to end - COULDN'T RUN - I've got a current version of Chrome, meanwhile the ChromeDriver will only work with an older version of Chrome:
```
[0-4] 2021-12-08T22:24:57.827Z ERROR webdriver: Request failed with status 500 due to session not created: session not created: This version of ChromeDriver only supports Chrome version 94
Current browser version is 96.0.4664.55 with binary path /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
```

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
