### PR TITLE
🔥 [RUMF-1089] Cleanup legacy intake URLs

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -73,9 +73,6 @@ export interface InitConfiguration {
   env?: string | undefined
   version?: string | undefined
 
-  useAlternateIntakeDomains?: boolean | undefined
-  intakeApiVersion?: 1 | 2 | undefined
-
   useCrossSiteSessionCookie?: boolean | undefined
   useSecureSessionCookie?: boolean | undefined
   trackSessionAcrossSubdomains?: boolean | undefined

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -1,21 +1,13 @@
 import { BuildEnv } from '../../boot/init'
 import { timeStampNow } from '../../tools/timeUtils'
-import { generateUUID, includes } from '../../tools/utils'
+import { generateUUID } from '../../tools/utils'
 import { InitConfiguration } from './configuration'
 
 export const ENDPOINTS = {
-  alternate: {
-    logs: 'logs',
-    rum: 'rum',
-    sessionReplay: 'session-replay',
-  },
-  classic: {
-    logs: 'browser',
-    rum: 'rum',
-    // session-replay has no classic endpoint
-    sessionReplay: undefined,
-  },
-}
+  logs: 'logs',
+  rum: 'rum',
+  sessionReplay: 'session-replay',
+} as const
 
 const INTAKE_TRACKS = {
   logs: 'logs',
@@ -23,17 +15,10 @@ const INTAKE_TRACKS = {
   sessionReplay: 'replay',
 }
 
-export type EndpointType = keyof typeof ENDPOINTS[IntakeType]
+type EndpointType = keyof typeof ENDPOINTS
 
 export const INTAKE_SITE_US = 'datadoghq.com'
-const INTAKE_SITE_US3 = 'us3.datadoghq.com'
-const INTAKE_SITE_GOV = 'ddog-gov.com'
-const INTAKE_SITE_EU = 'datadoghq.eu'
 
-const CLASSIC_ALLOWED_SITES = [INTAKE_SITE_US, INTAKE_SITE_EU]
-const INTAKE_V1_ALLOWED_SITES = [INTAKE_SITE_US, INTAKE_SITE_US3, INTAKE_SITE_EU, INTAKE_SITE_GOV]
-
-type IntakeType = keyof typeof ENDPOINTS
 export type EndpointBuilder = ReturnType<typeof createEndpointBuilder>
 
 export function createEndpointBuilder(
@@ -43,17 +28,7 @@ export function createEndpointBuilder(
   source?: string
 ) {
   const sdkVersion = buildEnv.sdkVersion
-  const {
-    site = INTAKE_SITE_US,
-    clientToken,
-    env,
-    proxyHost,
-    proxyUrl,
-    service,
-    version,
-    intakeApiVersion,
-    useAlternateIntakeDomains,
-  } = initConfiguration
+  const { site = INTAKE_SITE_US, clientToken, env, proxyHost, proxyUrl, service, version } = initConfiguration
 
   const host = buildHost(endpointType)
   const path = buildPath(endpointType)
@@ -75,19 +50,15 @@ export function createEndpointBuilder(
   }
 
   function buildHost(endpointType: EndpointType) {
-    if (shouldUseAlternateDomain(endpointType)) {
-      const endpoint = ENDPOINTS.alternate[endpointType]
-      const domainParts = site.split('.')
-      const extension = domainParts.pop()
-      const suffix = `${domainParts.join('-')}.${extension!}`
-      return `${endpoint}.browser-intake-${suffix}`
-    }
-    const endpoint = ENDPOINTS.classic[endpointType]!
-    return `${endpoint}-http-intake.logs.${site}`
+    const endpoint = ENDPOINTS[endpointType]
+    const domainParts = site.split('.')
+    const extension = domainParts.pop()
+    const suffix = `${domainParts.join('-')}.${extension!}`
+    return `${endpoint}.browser-intake-${suffix}`
   }
 
   function buildPath(endpointType: EndpointType) {
-    return shouldUseIntakeV2(endpointType) ? `/api/v2/${INTAKE_TRACKS[endpointType]}` : `/v1/input/${clientToken}`
+    return `/api/v2/${INTAKE_TRACKS[endpointType]}`
   }
 
   function buildQueryParameters(endpointType: EndpointType, source?: string) {
@@ -97,29 +68,19 @@ export function createEndpointBuilder(
       `${service ? `,service:${service}` : ''}` +
       `${version ? `,version:${version}` : ''}`
 
-    let parameters = `ddsource=${source || 'browser'}&ddtags=${encodeURIComponent(tags)}`
-
-    if (shouldUseIntakeV2(endpointType)) {
-      parameters +=
-        `&dd-api-key=${clientToken}` +
-        `&dd-evp-origin-version=${encodeURIComponent(sdkVersion)}` +
-        `&dd-evp-origin=browser` +
-        `&dd-request-id=${generateUUID()}`
-    }
+    let parameters =
+      `ddsource=${source || 'browser'}` +
+      `&ddtags=${encodeURIComponent(tags)}` +
+      `&dd-api-key=${clientToken}` +
+      `&dd-evp-origin-version=${encodeURIComponent(sdkVersion)}` +
+      `&dd-evp-origin=browser` +
+      `&dd-request-id=${generateUUID()}`
 
     if (endpointType === 'rum') {
       parameters += `&batch_time=${timeStampNow()}`
     }
 
     return parameters
-  }
-
-  function shouldUseIntakeV2(endpointType?: EndpointType): boolean {
-    return intakeApiVersion === 2 || !includes(INTAKE_V1_ALLOWED_SITES, site) || endpointType === 'sessionReplay'
-  }
-
-  function shouldUseAlternateDomain(endpointType?: EndpointType): boolean {
-    return useAlternateIntakeDomains || !includes(CLASSIC_ALLOWED_SITES, site) || endpointType === 'sessionReplay'
   }
 
   return {

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -56,7 +56,7 @@ describe('transportConfiguration', () => {
   })
 
   describe('query parameters', () => {
-    it('should add  intake query parameters', () => {
+    it('should add intake query parameters', () => {
       const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.rumEndpointBuilder.build()).toMatch(
         `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
@@ -139,54 +139,24 @@ describe('transportConfiguration', () => {
   })
 
   describe('isIntakeUrl', () => {
+    ;[
+      { site: 'datadoghq.eu', intakeDomain: 'browser-intake-datadoghq.eu' },
+      { site: 'datadoghq.com', intakeDomain: 'browser-intake-datadoghq.com' },
+      { site: 'us3.datadoghq.com', intakeDomain: 'browser-intake-us3-datadoghq.com' },
+      { site: 'us5.datadoghq.com', intakeDomain: 'browser-intake-us5-datadoghq.com' },
+      { site: 'ddog-gov.com', intakeDomain: 'browser-intake-ddog-gov.com' },
+    ].forEach(({ site, intakeDomain }) => {
+      it(`should detect intake request for ${site} site`, () => {
+        const configuration = computeTransportConfiguration({ clientToken, site }, buildEnv)
+        expect(configuration.isIntakeUrl(`https://rum.${intakeDomain}/api/v2/rum?xxx`)).toBe(true)
+        expect(configuration.isIntakeUrl(`https://logs.${intakeDomain}/api/v2/logs?xxx`)).toBe(true)
+        expect(configuration.isIntakeUrl(`https://session-replay.${intakeDomain}/api/v2/replay?xxx`)).toBe(true)
+      })
+    })
+
     it('should not detect non intake request', () => {
       const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.isIntakeUrl('https://www.foo.com')).toBe(false)
-    })
-
-    it('should detect intake request EU site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.eu' }, buildEnv)
-      expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.eu/api/v2/rum?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.eu/api/v2/logs?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.eu/api/v2/replay?xxx`)).toBe(
-        true
-      )
-    })
-
-    it('should detect intake request US site', () => {
-      const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
-      expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/api/v2/rum?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.com/api/v2/logs?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.com/api/v2/replay?xxx`)).toBe(
-        true
-      )
-    })
-
-    it('should detect intake request US3 site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'us3.datadoghq.com' }, buildEnv)
-      expect(configuration.isIntakeUrl('https://rum.browser-intake-us3-datadoghq.com/api/v2/rum?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://logs.browser-intake-us3-datadoghq.com/api/v2/logs?xxx')).toBe(true)
-      expect(
-        configuration.isIntakeUrl(`https://session-replay.browser-intake-us3-datadoghq.com/api/v2/replay?xxx`)
-      ).toBe(true)
-    })
-
-    it('should detect intake request US5 site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'us5.datadoghq.com' }, buildEnv)
-      expect(configuration.isIntakeUrl('https://rum.browser-intake-us5-datadoghq.com/api/v2/rum?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://logs.browser-intake-us5-datadoghq.com/api/v2/logs?xxx')).toBe(true)
-      expect(
-        configuration.isIntakeUrl(`https://session-replay.browser-intake-us5-datadoghq.com/api/v2/replay?xxx`)
-      ).toBe(true)
-    })
-
-    it('should detect intake request gov-cloud site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'ddog-gov.com' }, buildEnv)
-      expect(configuration.isIntakeUrl('https://rum.browser-intake-ddog-gov.com/api/v2/rum?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://logs.browser-intake-ddog-gov.com/api/v2/logs?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://session-replay.browser-intake-ddog-gov.com/api/v2/replay?xxx')).toBe(
-        true
-      )
     })
 
     it('should handle sites with subdomains', () => {

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -4,7 +4,6 @@ import { computeTransportConfiguration } from './transportConfiguration'
 describe('transportConfiguration', () => {
   const clientToken = 'some_client_token'
   const otherClientToken = 'some_other_client_token'
-  const v1IntakePath = `/v1/input/${clientToken}`
   const buildEnv: BuildEnv = {
     buildMode: BuildMode.RELEASE,
     sdkVersion: 'some_version',
@@ -57,8 +56,8 @@ describe('transportConfiguration', () => {
   })
 
   describe('query parameters', () => {
-    it('should add new intake query parameters when intakeApiVersion 2 is used', () => {
-      const configuration = computeTransportConfiguration({ clientToken, intakeApiVersion: 2 }, buildEnv)
+    it('should add  intake query parameters', () => {
+      const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.rumEndpointBuilder.build()).toMatch(
         `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
       )
@@ -83,29 +82,18 @@ describe('transportConfiguration', () => {
         buildEnv
       )
       expect(configuration.rumEndpointBuilder.build()).toMatch(
-        `https://proxy.io/v1/input/${clientToken}\\?ddhost=rum-http-intake.logs.datadoghq.eu&ddsource=(.*)&ddtags=(.*)`
+        `https://proxy.io/api/v2/rum\\?ddhost=rum.browser-intake-datadoghq.eu&ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
+          `&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)&batch_time=(.*)`
       )
     })
   })
 
   describe('proxyUrl', () => {
-    it(' should replace the full intake v1 endpoint by the proxyUrl and set it in the attribute ddforward', () => {
+    it('should replace the full intake endpoint by the proxyUrl and set it in the attribute ddforward', () => {
       const configuration = computeTransportConfiguration({ clientToken, proxyUrl: 'https://proxy.io/path' }, buildEnv)
       expect(configuration.rumEndpointBuilder.build()).toMatch(
         `https://proxy.io/path\\?ddforward=${encodeURIComponent(
-          `https://rum-http-intake.logs.datadoghq.com/v1/input/${clientToken}?ddsource=(.*)&ddtags=(.*)`
-        )}`
-      )
-    })
-
-    it('should replace the full intake v2 endpoint by the proxyUrl and set it in the attribute ddforward', () => {
-      const configuration = computeTransportConfiguration(
-        { clientToken, intakeApiVersion: 2, proxyUrl: 'https://proxy.io/path' },
-        buildEnv
-      )
-      expect(configuration.rumEndpointBuilder.build()).toMatch(
-        `https://proxy.io/path\\?ddforward=${encodeURIComponent(
-          `https://rum-http-intake.logs.datadoghq.com/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
+          `https://rum.browser-intake-datadoghq.com/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
             `&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)&batch_time=(.*)`
         )}`
       )
@@ -150,63 +138,55 @@ describe('transportConfiguration', () => {
     })
   })
 
-  describe('isIntakeUrl with intakeApiVersion: 1', () => {
+  describe('isIntakeUrl', () => {
     it('should not detect non intake request', () => {
       const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
       expect(configuration.isIntakeUrl('https://www.foo.com')).toBe(false)
     })
 
-    it('should detect intake request for classic EU site', () => {
+    it('should detect intake request EU site', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.eu' }, buildEnv)
-      expect(configuration.isIntakeUrl(`https://rum-http-intake.logs.datadoghq.eu${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://browser-http-intake.logs.datadoghq.eu${v1IntakePath}?xxx`)).toBe(true)
+      expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.eu/api/v2/rum?xxx')).toBe(true)
+      expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.eu/api/v2/logs?xxx')).toBe(true)
       expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.eu/api/v2/replay?xxx`)).toBe(
         true
       )
     })
 
-    it('should detect intake request for classic US site', () => {
+    it('should detect intake request US site', () => {
       const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
-
-      expect(configuration.isIntakeUrl(`https://rum-http-intake.logs.datadoghq.com${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://browser-http-intake.logs.datadoghq.com${v1IntakePath}?xxx`)).toBe(true)
+      expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/api/v2/rum?xxx')).toBe(true)
+      expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.com/api/v2/logs?xxx')).toBe(true)
       expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.com/api/v2/replay?xxx`)).toBe(
         true
       )
     })
 
-    it('should detect alternate intake domains for US site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, buildEnv)
-      expect(configuration.isIntakeUrl(`https://rum.browser-intake-datadoghq.com${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://logs.browser-intake-datadoghq.com${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.com/api/v2/replay?xxx`)).toBe(
-        true
-      )
+    it('should detect intake request US3 site', () => {
+      const configuration = computeTransportConfiguration({ clientToken, site: 'us3.datadoghq.com' }, buildEnv)
+      expect(configuration.isIntakeUrl('https://rum.browser-intake-us3-datadoghq.com/api/v2/rum?xxx')).toBe(true)
+      expect(configuration.isIntakeUrl('https://logs.browser-intake-us3-datadoghq.com/api/v2/logs?xxx')).toBe(true)
+      expect(
+        configuration.isIntakeUrl(`https://session-replay.browser-intake-us3-datadoghq.com/api/v2/replay?xxx`)
+      ).toBe(true)
     })
 
-    it('should detect alternate intake domains for EU site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, useAlternateIntakeDomains: true }, buildEnv)
-      expect(configuration.isIntakeUrl(`https://rum.browser-intake-datadoghq.com${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://logs.browser-intake-datadoghq.com${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.com/api/v2/replay?xxx`)).toBe(
-        true
-      )
+    it('should detect intake request US5 site', () => {
+      const configuration = computeTransportConfiguration({ clientToken, site: 'us5.datadoghq.com' }, buildEnv)
+      expect(configuration.isIntakeUrl('https://rum.browser-intake-us5-datadoghq.com/api/v2/rum?xxx')).toBe(true)
+      expect(configuration.isIntakeUrl('https://logs.browser-intake-us5-datadoghq.com/api/v2/logs?xxx')).toBe(true)
+      expect(
+        configuration.isIntakeUrl(`https://session-replay.browser-intake-us5-datadoghq.com/api/v2/replay?xxx`)
+      ).toBe(true)
     })
 
-    it('should force alternate intake domains for other sites', () => {
-      let configuration = computeTransportConfiguration(
-        { clientToken, site: 'us3.datadoghq.com', useAlternateIntakeDomains: false },
-        buildEnv
+    it('should detect intake request gov-cloud site', () => {
+      const configuration = computeTransportConfiguration({ clientToken, site: 'ddog-gov.com' }, buildEnv)
+      expect(configuration.isIntakeUrl('https://rum.browser-intake-ddog-gov.com/api/v2/rum?xxx')).toBe(true)
+      expect(configuration.isIntakeUrl('https://logs.browser-intake-ddog-gov.com/api/v2/logs?xxx')).toBe(true)
+      expect(configuration.isIntakeUrl('https://session-replay.browser-intake-ddog-gov.com/api/v2/replay?xxx')).toBe(
+        true
       )
-      expect(configuration.isIntakeUrl(`https://rum.browser-intake-us3-datadoghq.com${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://rum-http-intake.logs.us3.datadoghq.com${v1IntakePath}?xxx`)).toBe(false)
-
-      configuration = computeTransportConfiguration(
-        { clientToken, site: 'ddog-gov.com', useAlternateIntakeDomains: false },
-        buildEnv
-      )
-      expect(configuration.isIntakeUrl(`https://rum.browser-intake-ddog-gov.com${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://rum-http-intake.logs.ddog-gov.com${v1IntakePath}?xxx`)).toBe(false)
     })
 
     it('should handle sites with subdomains', () => {
@@ -220,14 +200,10 @@ describe('transportConfiguration', () => {
 
     it('should detect proxy intake request', () => {
       let configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, buildEnv)
-      expect(configuration.isIntakeUrl(`https://www.proxy.com${v1IntakePath}?xxx`)).toBe(true)
-      configuration = computeTransportConfiguration(
-        { clientToken, proxyHost: 'www.proxy.com', useAlternateIntakeDomains: true },
-        buildEnv
-      )
-      expect(configuration.isIntakeUrl(`https://www.proxy.com${v1IntakePath}?xxx`)).toBe(true)
+      expect(configuration.isIntakeUrl(`https://www.proxy.com/api/v2/rum?xxx`)).toBe(true)
+
       configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com/custom/path' }, buildEnv)
-      expect(configuration.isIntakeUrl(`https://www.proxy.com/custom/path${v1IntakePath}?xxx`)).toBe(true)
+      expect(configuration.isIntakeUrl(`https://www.proxy.com/custom/path/api/v2/rum?xxx`)).toBe(true)
     })
 
     it('should not detect request done on the same host as the proxy', () => {
@@ -235,109 +211,22 @@ describe('transportConfiguration', () => {
       expect(configuration.isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
     })
 
-    it('should detect replica intake request with alternate intake domains and intake v2', () => {
+    it('should detect replica intake request', () => {
       const configuration = computeTransportConfiguration(
         { clientToken, site: 'datadoghq.eu', replica: { clientToken } },
         { ...buildEnv, buildMode: BuildMode.STAGING }
       )
-      expect(configuration.isIntakeUrl(`https://rum-http-intake.logs.datadoghq.eu${v1IntakePath}?xxx`)).toBe(true)
-      expect(configuration.isIntakeUrl(`https://browser-http-intake.logs.datadoghq.eu${v1IntakePath}?xxx`)).toBe(true)
+      expect(configuration.isIntakeUrl(`https://rum.browser-intake-datadoghq.eu/api/v2/rum?xxx`)).toBe(true)
+      expect(configuration.isIntakeUrl(`https://logs.browser-intake-datadoghq.eu/api/v2/logs?xxx`)).toBe(true)
       expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.eu/api/v2/replay?xxx`)).toBe(
         true
       )
 
       expect(configuration.isIntakeUrl(`https://rum.browser-intake-datadoghq.com/api/v2/rum?xxx`)).toBe(true)
       expect(configuration.isIntakeUrl(`https://logs.browser-intake-datadoghq.com/api/v2/logs?xxx`)).toBe(true)
-    })
-
-    describe('on us5', () => {
-      it('should force alternate domains intake v2', () => {
-        const configuration = computeTransportConfiguration({ clientToken, site: 'us5.datadoghq.com' }, buildEnv)
-        expect(configuration.isIntakeUrl('https://rum.browser-intake-us5-datadoghq.com/api/v2/rum?xxx')).toBe(true)
-        expect(configuration.isIntakeUrl('https://logs.browser-intake-us5-datadoghq.com/api/v2/logs?xxx')).toBe(true)
-      })
-    })
-
-    describe('when session-replay on all env', () => {
-      it('should force alternate domains intake v2', () => {
-        let configuration = computeTransportConfiguration({ clientToken }, buildEnv)
-        expect(configuration.isIntakeUrl('https://session-replay.browser-intake-datadoghq.com/api/v2/replay?xxx')).toBe(
-          true
-        )
-
-        configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.eu' }, buildEnv)
-        expect(configuration.isIntakeUrl('https://session-replay.browser-intake-datadoghq.eu/api/v2/replay?xxx')).toBe(
-          true
-        )
-
-        configuration = computeTransportConfiguration({ clientToken, site: 'us3.datadoghq.com' }, buildEnv)
-        expect(
-          configuration.isIntakeUrl('https://session-replay.browser-intake-us3-datadoghq.com/api/v2/replay?xxx')
-        ).toBe(true)
-
-        configuration = computeTransportConfiguration({ clientToken, site: 'ddog-gov.com' }, buildEnv)
-        expect(configuration.isIntakeUrl('https://session-replay.browser-intake-ddog-gov.com/api/v2/replay?xxx')).toBe(
-          true
-        )
-
-        configuration = computeTransportConfiguration({ clientToken, site: 'us5.datadoghq.com' }, buildEnv)
-        expect(
-          configuration.isIntakeUrl('https://session-replay.browser-intake-us5-datadoghq.com/api/v2/replay?xxx')
-        ).toBe(true)
-      })
-    })
-  })
-
-  describe('isIntakeUrl with intakeApiVersion: 2', () => {
-    describe('when RUM or Logs', () => {
-      describe('on us1 and eu1', () => {
-        it('should detect classic domains intake v2', () => {
-          let configuration = computeTransportConfiguration({ clientToken, intakeApiVersion: 2 }, buildEnv)
-          expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.com/api/v2/rum?xxx')).toBe(true)
-          expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.com/api/v2/logs?xxx')).toBe(true)
-
-          configuration = computeTransportConfiguration(
-            { clientToken, site: 'datadoghq.eu', intakeApiVersion: 2 },
-            buildEnv
-          )
-          expect(configuration.isIntakeUrl('https://rum-http-intake.logs.datadoghq.eu/api/v2/rum?xxx')).toBe(true)
-          expect(configuration.isIntakeUrl('https://browser-http-intake.logs.datadoghq.eu/api/v2/logs?xxx')).toBe(true)
-        })
-
-        it('should detect alternate domains intake v2', () => {
-          let configuration = computeTransportConfiguration(
-            { clientToken, useAlternateIntakeDomains: true, intakeApiVersion: 2 },
-            buildEnv
-          )
-          expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.com/api/v2/rum?xxx')).toBe(true)
-          expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.com/api/v2/logs?xxx')).toBe(true)
-
-          configuration = computeTransportConfiguration(
-            { clientToken, site: 'datadoghq.eu', useAlternateIntakeDomains: true, intakeApiVersion: 2 },
-            buildEnv
-          )
-          expect(configuration.isIntakeUrl('https://rum.browser-intake-datadoghq.eu/api/v2/rum?xxx')).toBe(true)
-          expect(configuration.isIntakeUrl('https://logs.browser-intake-datadoghq.eu/api/v2/logs?xxx')).toBe(true)
-        })
-      })
-
-      describe('on us3 and gov', () => {
-        it('should detect alternate domains intake v2', () => {
-          let configuration = computeTransportConfiguration(
-            { clientToken, site: 'us3.datadoghq.com', intakeApiVersion: 2 },
-            buildEnv
-          )
-          expect(configuration.isIntakeUrl('https://rum.browser-intake-us3-datadoghq.com/api/v2/rum?xxx')).toBe(true)
-          expect(configuration.isIntakeUrl('https://logs.browser-intake-us3-datadoghq.com/api/v2/logs?xxx')).toBe(true)
-
-          configuration = computeTransportConfiguration(
-            { clientToken, site: 'ddog-gov.com', intakeApiVersion: 2 },
-            buildEnv
-          )
-          expect(configuration.isIntakeUrl('https://rum.browser-intake-ddog-gov.com/api/v2/rum?xxx')).toBe(true)
-          expect(configuration.isIntakeUrl('https://rum-http-intake.logs.ddog-gov.com/api/v2/logs?xxx')).toBe(false)
-        })
-      })
+      expect(configuration.isIntakeUrl(`https://session-replay.browser-intake-datadoghq.com/api/v2/replay?xxx`)).toBe(
+        false
+      )
     })
   })
 })

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -86,8 +86,6 @@ function computeReplicaConfiguration(
     site: INTAKE_SITE_US,
     applicationId: initConfiguration.replica.applicationId,
     clientToken: initConfiguration.replica.clientToken,
-    useAlternateIntakeDomains: true,
-    intakeApiVersion: 2,
   }
 
   const replicaEndpointBuilders = {

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -79,7 +79,7 @@ describe('httpRequest intake parameters', () => {
 
   beforeEach(() => {
     server = sinon.fakeServer.create()
-    endpointBuilder = createEndpointBuilder({ clientToken, intakeApiVersion: 2 }, buildEnv, 'logs')
+    endpointBuilder = createEndpointBuilder({ clientToken }, buildEnv, 'logs')
     request = new HttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 


### PR DESCRIPTION
## Motivation

To promote usages of intakes v2, we want to remove support for “classic domains” and intakes v1, to keep only “alternate domains” and intakes v2. This will greatly reduce the complexity of computing the transport configuration

## Changes

- Remove classic domain code
- Remove intake v1 code
 
## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
