### PR TITLE
♻️ [RUMF-1097] revamp configuration - logs

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -102,6 +102,11 @@ describe('validateAndBuildConfiguration', () => {
       ).toBeUndefined()
       expect(displaySpy).toHaveBeenCalledOnceWith('Sample Rate should be a number between 0 and 100')
     })
+
+    it("shouldn't display any error if the configuration is correct", () => {
+      validateAndBuildConfiguration({ clientToken: 'yes', sampleRate: 1 }, buildEnv)
+      expect(displaySpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('cookie options', () => {

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -101,6 +101,12 @@ describe('validateAndBuildConfiguration', () => {
         validateAndBuildConfiguration(({ clientToken, sampleRate: 'foo' } as unknown) as InitConfiguration, buildEnv)
       ).toBeUndefined()
       expect(displaySpy).toHaveBeenCalledOnceWith('Sample Rate should be a number between 0 and 100')
+
+      displaySpy.calls.reset()
+      expect(
+        validateAndBuildConfiguration(({ clientToken, sampleRate: 200 } as unknown) as InitConfiguration, buildEnv)
+      ).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledOnceWith('Sample Rate should be a number between 0 and 100')
     })
 
     it("shouldn't display any error if the configuration is correct", () => {

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -7,10 +7,10 @@ import {
   resetExperimentalFeatures,
 } from '@datadog/browser-core'
 import { Clock, deleteEventBridgeStub, initEventBridgeStub, mockClock } from '../../../core/test/specHelper'
+import { HybridInitConfiguration, LogsInitConfiguration } from '../domain/configuration'
 
 import { HandlerType, LogsMessage, StatusType } from '../domain/logger'
-import { HybridInitConfiguration, LogsPublicApi, makeLogsPublicApi, StartLogs } from './logsPublicApi'
-import { LogsInitConfiguration } from './startLogs'
+import { LogsPublicApi, makeLogsPublicApi, StartLogs } from './logsPublicApi'
 
 const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx' }
 

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -13,6 +13,7 @@ import { HandlerType, LogsMessage, StatusType } from '../domain/logger'
 import { LogsPublicApi, makeLogsPublicApi, StartLogs } from './logsPublicApi'
 
 const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx' }
+const INVALID_INIT_CONFIGURATION = {} as LogsInitConfiguration
 
 describe('logs entry', () => {
   let sendLogsSpy: jasmine.Spy<
@@ -21,7 +22,7 @@ describe('logs entry', () => {
       currentContext: Context & { view: { referrer: string; url: string } }
     ) => void
   >
-  const startLogs: StartLogs = () => (sendLogsSpy as any) as ReturnType<StartLogs>
+  let startLogs: jasmine.Spy<StartLogs>
 
   function getLoggedMessage(index: number) {
     const [message, context] = sendLogsSpy.calls.argsFor(index)
@@ -30,6 +31,7 @@ describe('logs entry', () => {
 
   beforeEach(() => {
     sendLogsSpy = jasmine.createSpy()
+    startLogs = jasmine.createSpy().and.callFake(() => sendLogsSpy)
   })
 
   it('should define the public API with init', () => {
@@ -47,15 +49,16 @@ describe('logs entry', () => {
       LOGS = makeLogsPublicApi(startLogs)
     })
 
-    it('init should log an error with no public api key', () => {
-      LOGS.init(undefined as any)
-      expect(displaySpy).toHaveBeenCalledTimes(1)
+    it('should start when the configuration is valid', () => {
+      LOGS.init(DEFAULT_INIT_CONFIGURATION)
+      expect(displaySpy).not.toHaveBeenCalled()
+      expect(startLogs).toHaveBeenCalled()
+    })
 
-      LOGS.init({ stillNoApiKey: true } as any)
-      expect(displaySpy).toHaveBeenCalledTimes(2)
-
-      LOGS.init({ clientToken: 'yeah' })
-      expect(displaySpy).toHaveBeenCalledTimes(2)
+    it('should not start when the configuration is invalid', () => {
+      LOGS.init(INVALID_INIT_CONFIGURATION)
+      expect(displaySpy).toHaveBeenCalled()
+      expect(startLogs).not.toHaveBeenCalled()
     })
 
     it('should add a `_setDebug` that works', () => {
@@ -76,41 +79,28 @@ describe('logs entry', () => {
       setDebug(false)
     })
 
-    it('init should log an error if sampleRate is invalid', () => {
-      LOGS.init({ clientToken: 'yes', sampleRate: 'foo' as any })
-      expect(displaySpy).toHaveBeenCalledTimes(1)
+    describe('multiple init', () => {
+      it('should log an error if init is called several times', () => {
+        LOGS.init(DEFAULT_INIT_CONFIGURATION)
+        expect(displaySpy).toHaveBeenCalledTimes(0)
 
-      LOGS.init({ clientToken: 'yes', sampleRate: 200 })
-      expect(displaySpy).toHaveBeenCalledTimes(2)
-    })
-
-    it('should log an error if init is called several times', () => {
-      LOGS.init({ clientToken: 'yes', sampleRate: 1 })
-      expect(displaySpy).toHaveBeenCalledTimes(0)
-
-      LOGS.init({ clientToken: 'yes', sampleRate: 1 })
-      expect(displaySpy).toHaveBeenCalledTimes(1)
-    })
-
-    it('should not log an error if init is called several times and silentMultipleInit is true', () => {
-      LOGS.init({
-        clientToken: 'yes',
-        sampleRate: 1,
-        silentMultipleInit: true,
+        LOGS.init(DEFAULT_INIT_CONFIGURATION)
+        expect(displaySpy).toHaveBeenCalledTimes(1)
       })
-      expect(displaySpy).toHaveBeenCalledTimes(0)
 
-      LOGS.init({
-        clientToken: 'yes',
-        sampleRate: 1,
-        silentMultipleInit: true,
+      it('should not log an error if init is called several times and silentMultipleInit is true', () => {
+        LOGS.init({
+          ...DEFAULT_INIT_CONFIGURATION,
+          silentMultipleInit: true,
+        })
+        expect(displaySpy).toHaveBeenCalledTimes(0)
+
+        LOGS.init({
+          ...DEFAULT_INIT_CONFIGURATION,
+          silentMultipleInit: true,
+        })
+        expect(displaySpy).toHaveBeenCalledTimes(0)
       })
-      expect(displaySpy).toHaveBeenCalledTimes(0)
-    })
-
-    it("shouldn't trigger any console.error if the configuration is correct", () => {
-      LOGS.init({ clientToken: 'yes', sampleRate: 1 })
-      expect(displaySpy).toHaveBeenCalledTimes(0)
     })
 
     describe('if event bridge present', () => {
@@ -129,6 +119,7 @@ describe('logs entry', () => {
         LOGS.init(hybridInitConfiguration as LogsInitConfiguration)
 
         expect(displaySpy).not.toHaveBeenCalled()
+        expect(startLogs).toHaveBeenCalled()
       })
     })
   })

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -54,7 +54,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
         return
       }
 
-      sendLogStrategy = startLogsImpl(initConfiguration, configuration, logger)
+      sendLogStrategy = startLogsImpl(configuration, logger)
       getInitConfigurationStrategy = () => deepClone(initConfiguration)
       beforeInitSendLog.drain()
 

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -10,9 +10,12 @@ import {
   deepClone,
   InitConfiguration,
   canUseEventBridge,
+  updateExperimentalFeatures,
+  buildConfiguration,
 } from '@datadog/browser-core'
 import { LogsInitConfiguration } from '../domain/configuration'
 import { HandlerType, Logger, LogsMessage, StatusType } from '../domain/logger'
+import { buildEnv } from './buildEnv'
 import { startLogs } from './startLogs'
 
 export interface LoggerConfiguration {
@@ -50,7 +53,10 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
         return
       }
 
-      sendLogStrategy = startLogsImpl(initConfiguration, logger)
+      updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
+      const configuration = buildConfiguration(initConfiguration, buildEnv)
+
+      sendLogStrategy = startLogsImpl(initConfiguration, configuration, logger)
       getInitConfigurationStrategy = () => deepClone(initConfiguration)
       beforeInitSendLog.drain()
 

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -11,16 +11,15 @@ import {
   InitConfiguration,
   canUseEventBridge,
 } from '@datadog/browser-core'
+import { LogsInitConfiguration } from '../domain/configuration'
 import { HandlerType, Logger, LogsMessage, StatusType } from '../domain/logger'
-import { startLogs, LogsInitConfiguration } from './startLogs'
+import { startLogs } from './startLogs'
 
 export interface LoggerConfiguration {
   level?: StatusType
   handler?: HandlerType | HandlerType[]
   context?: object
 }
-
-export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>
 
 export type LogsPublicApi = ReturnType<typeof makeLogsPublicApi>
 

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -180,14 +180,14 @@ describe('logs', () => {
       updateExperimentalFeatures(['event-bridge'])
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
 
-      let configuration = { ...baseConfiguration, sampleRate: 0 } as LogsInitConfiguration
-      let sendLog = originalStartLogs(configuration, new Logger(noop))
+      let configuration = { ...baseConfiguration, sampleRate: 0 } as LogsConfiguration
+      let sendLog = originalStartLogs({} as LogsInitConfiguration, configuration, new Logger(noop))
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(sendSpy).not.toHaveBeenCalled()
 
-      configuration = { ...baseConfiguration, sampleRate: 100 } as LogsInitConfiguration
-      sendLog = originalStartLogs(configuration, new Logger(noop))
+      configuration = { ...baseConfiguration, sampleRate: 100 } as LogsConfiguration
+      sendLog = originalStartLogs({} as LogsInitConfiguration, configuration, new Logger(noop))
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(sendSpy).toHaveBeenCalled()

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -20,7 +20,7 @@ import {
   mockClock,
   stubEndpointBuilder,
 } from '../../../core/test/specHelper'
-import { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
+import { LogsConfiguration } from '../domain/configuration'
 
 import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LogsSessionManager } from '../domain/logsSessionManager'
@@ -181,13 +181,13 @@ describe('logs', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
 
       let configuration = { ...baseConfiguration, sampleRate: 0 } as LogsConfiguration
-      let sendLog = originalStartLogs({} as LogsInitConfiguration, configuration, new Logger(noop))
+      let sendLog = originalStartLogs(configuration, new Logger(noop))
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(sendSpy).not.toHaveBeenCalled()
 
       configuration = { ...baseConfiguration, sampleRate: 100 } as LogsConfiguration
-      sendLog = originalStartLogs({} as LogsInitConfiguration, configuration, new Logger(noop))
+      sendLog = originalStartLogs(configuration, new Logger(noop))
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(sendSpy).toHaveBeenCalled()

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -1,5 +1,4 @@
 import {
-  Configuration,
   Context,
   DEFAULT_CONFIGURATION,
   ErrorSource,
@@ -21,7 +20,7 @@ import {
   mockClock,
   stubEndpointBuilder,
 } from '../../../core/test/specHelper'
-import { LogsInitConfiguration } from '../domain/configuration'
+import { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
 
 import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LogsSessionManager } from '../domain/logsSessionManager'
@@ -42,7 +41,7 @@ function getLoggedMessage(server: sinon.SinonFakeServer, index: number) {
 }
 const FAKE_DATE = 123456
 const SESSION_ID = 'session-id'
-const baseConfiguration: Partial<Configuration> = {
+const baseConfiguration: Partial<LogsConfiguration> = {
   ...DEFAULT_CONFIGURATION,
   logsEndpointBuilder: stubEndpointBuilder('https://localhost/v1/input/log'),
   maxBatchSize: 1,
@@ -71,8 +70,8 @@ describe('logs', () => {
   const startLogs = ({
     errorLogger = new Logger(noop),
     configuration: configurationOverrides,
-  }: { errorLogger?: Logger; configuration?: Partial<Configuration> } = {}) => {
-    const configuration = { ...(baseConfiguration as Configuration), ...configurationOverrides }
+  }: { errorLogger?: Logger; configuration?: Partial<LogsConfiguration> } = {}) => {
+    const configuration = { ...(baseConfiguration as LogsConfiguration), ...configurationOverrides }
     return doStartLogs(configuration, errorObservable, internalMonitoring, sessionManager, errorLogger)
   }
 
@@ -181,13 +180,13 @@ describe('logs', () => {
       updateExperimentalFeatures(['event-bridge'])
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
 
-      let configuration = { ...baseConfiguration, ...{ sampleRate: 0 } } as LogsInitConfiguration
+      let configuration = { ...baseConfiguration, sampleRate: 0 } as LogsInitConfiguration
       let sendLog = originalStartLogs(configuration, new Logger(noop))
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(sendSpy).not.toHaveBeenCalled()
 
-      configuration = { ...baseConfiguration, ...{ sampleRate: 100 } } as LogsInitConfiguration
+      configuration = { ...baseConfiguration, sampleRate: 100 } as LogsInitConfiguration
       sendLog = originalStartLogs(configuration, new Logger(noop))
       sendLog(DEFAULT_MESSAGE, {})
 
@@ -204,7 +203,7 @@ describe('logs', () => {
       assemble = buildAssemble(
         sessionManager,
         {
-          ...(baseConfiguration as Configuration),
+          ...(baseConfiguration as LogsConfiguration),
           beforeSend: (x: LogsEvent) => beforeSend(x),
         },
         noop

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -21,11 +21,12 @@ import {
   mockClock,
   stubEndpointBuilder,
 } from '../../../core/test/specHelper'
+import { LogsInitConfiguration } from '../domain/configuration'
 
 import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LogsSessionManager } from '../domain/logsSessionManager'
 import { LogsEvent } from '../logsEvent.types'
-import { buildAssemble, doStartLogs, LogsInitConfiguration, startLogs as originalStartLogs } from './startLogs'
+import { buildAssemble, doStartLogs, startLogs as originalStartLogs } from './startLogs'
 
 interface SentMessage extends LogsMessage {
   logger?: { name: string }

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -18,18 +18,14 @@ import { trackNetworkError } from '../domain/trackNetworkError'
 import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LogsSessionManager, startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
 import { startLoggerBatch } from '../transport/startLoggerBatch'
-import { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
+import { LogsConfiguration } from '../domain/configuration'
 
-export function startLogs(
-  initConfiguration: LogsInitConfiguration,
-  configuration: LogsConfiguration,
-  errorLogger: Logger
-) {
+export function startLogs(configuration: LogsConfiguration, errorLogger: Logger) {
   const internalMonitoring = startInternalMonitoring(configuration)
 
   const errorObservable = new Observable<RawError>()
 
-  if (initConfiguration.forwardErrorsToLogs !== false) {
+  if (configuration.forwardErrorsToLogs) {
     trackConsoleError(errorObservable)
     trackRuntimeError(errorObservable)
     trackNetworkError(configuration, errorObservable)

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -1,7 +1,6 @@
 import {
   areCookiesAuthorized,
   combine,
-  Configuration,
   Context,
   createEventRateLimiter,
   InternalMonitoring,
@@ -23,6 +22,7 @@ import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LogsSessionManager, startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
 import { LogsEvent } from '../logsEvent.types'
 import { startLoggerBatch } from '../transport/startLoggerBatch'
+import { LogsConfiguration } from '../domain/configuration'
 import { buildEnv } from './buildEnv'
 
 export interface LogsInitConfiguration extends InitConfiguration {
@@ -52,7 +52,7 @@ export function startLogs(initConfiguration: LogsInitConfiguration, errorLogger:
 }
 
 export function doStartLogs(
-  configuration: Configuration,
+  configuration: LogsConfiguration,
   errorObservable: Observable<RawError>,
   internalMonitoring: InternalMonitoring,
   sessionManager: LogsSessionManager,
@@ -111,7 +111,7 @@ export function doStartLogs(
 
 export function buildAssemble(
   sessionManager: LogsSessionManager,
-  configuration: Configuration,
+  configuration: LogsConfiguration,
   reportError: (error: RawError) => void
 ) {
   const errorRateLimiter = createEventRateLimiter(StatusType.error, configuration.maxErrorsPerMinute, reportError)

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -13,8 +13,6 @@ import {
   canUseEventBridge,
   getEventBridge,
   getRelativeTime,
-  updateExperimentalFeatures,
-  buildConfiguration,
   startInternalMonitoring,
 } from '@datadog/browser-core'
 import { trackNetworkError } from '../domain/trackNetworkError'
@@ -23,16 +21,17 @@ import { LogsSessionManager, startLogsSessionManager, startLogsSessionManagerStu
 import { LogsEvent } from '../logsEvent.types'
 import { startLoggerBatch } from '../transport/startLoggerBatch'
 import { LogsConfiguration } from '../domain/configuration'
-import { buildEnv } from './buildEnv'
 
 export interface LogsInitConfiguration extends InitConfiguration {
   forwardErrorsToLogs?: boolean | undefined
   beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
 }
 
-export function startLogs(initConfiguration: LogsInitConfiguration, errorLogger: Logger) {
-  updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
-  const configuration = buildConfiguration(initConfiguration, buildEnv)
+export function startLogs(
+  initConfiguration: LogsInitConfiguration,
+  configuration: LogsConfiguration,
+  errorLogger: Logger
+) {
   const internalMonitoring = startInternalMonitoring(configuration)
 
   const errorObservable = new Observable<RawError>()

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -7,7 +7,6 @@ import {
   Observable,
   RawError,
   RelativeTime,
-  InitConfiguration,
   trackRuntimeError,
   trackConsoleError,
   canUseEventBridge,
@@ -18,14 +17,8 @@ import {
 import { trackNetworkError } from '../domain/trackNetworkError'
 import { Logger, LogsMessage, StatusType } from '../domain/logger'
 import { LogsSessionManager, startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
-import { LogsEvent } from '../logsEvent.types'
 import { startLoggerBatch } from '../transport/startLoggerBatch'
-import { LogsConfiguration } from '../domain/configuration'
-
-export interface LogsInitConfiguration extends InitConfiguration {
-  forwardErrorsToLogs?: boolean | undefined
-  beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
-}
+import { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
 
 export function startLogs(
   initConfiguration: LogsInitConfiguration,

--- a/packages/logs/src/domain/configuration.spec.ts
+++ b/packages/logs/src/domain/configuration.spec.ts
@@ -1,0 +1,25 @@
+import { validateAndBuildLogsConfiguration } from './configuration'
+
+const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx' }
+
+describe('validateAndBuildLogsConfiguration', () => {
+  describe('forwardErrorsToLogs', () => {
+    it('defaults to false if the option is not provided', () => {
+      expect(validateAndBuildLogsConfiguration(DEFAULT_INIT_CONFIGURATION)!.forwardErrorsToLogs).toBeFalse()
+    })
+
+    it('is set to provided value', () => {
+      expect(
+        validateAndBuildLogsConfiguration({ ...DEFAULT_INIT_CONFIGURATION, forwardErrorsToLogs: true })!
+          .forwardErrorsToLogs
+      ).toBeTrue()
+    })
+
+    it('the provided value is cast to boolean', () => {
+      expect(
+        validateAndBuildLogsConfiguration({ ...DEFAULT_INIT_CONFIGURATION, forwardErrorsToLogs: 'foo' as any })!
+          .forwardErrorsToLogs
+      ).toBeTrue()
+    })
+  })
+})

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -1,4 +1,5 @@
-import { Configuration, InitConfiguration } from '@datadog/browser-core'
+import { Configuration, InitConfiguration, validateAndBuildConfiguration } from '@datadog/browser-core'
+import { buildEnv } from '../boot/buildEnv'
 import { LogsEvent } from '../logsEvent.types'
 
 export interface LogsInitConfiguration extends InitConfiguration {
@@ -9,3 +10,14 @@ export interface LogsInitConfiguration extends InitConfiguration {
 export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>
 
 export type LogsConfiguration = Configuration
+
+export function validateAndBuildLogsConfiguration(
+  initConfiguration: LogsInitConfiguration
+): LogsConfiguration | undefined {
+  const configuration = validateAndBuildConfiguration(initConfiguration, buildEnv)
+  if (!configuration) {
+    return
+  }
+
+  return configuration
+}

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -9,14 +9,27 @@ export interface LogsInitConfiguration extends InitConfiguration {
 
 export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>
 
-export type LogsConfiguration = Configuration
+const DEFAULT_LOGS_CONFIGURATION = {
+  forwardErrorsToLogs: false,
+}
+
+export type LogsConfiguration = Configuration & typeof DEFAULT_LOGS_CONFIGURATION
 
 export function validateAndBuildLogsConfiguration(
   initConfiguration: LogsInitConfiguration
 ): LogsConfiguration | undefined {
-  const configuration = validateAndBuildConfiguration(initConfiguration, buildEnv)
-  if (!configuration) {
+  const baseConfiguration = validateAndBuildConfiguration(initConfiguration, buildEnv)
+  if (!baseConfiguration) {
     return
+  }
+
+  const configuration: LogsConfiguration = {
+    ...baseConfiguration,
+    ...DEFAULT_LOGS_CONFIGURATION,
+  }
+
+  if (initConfiguration.forwardErrorsToLogs !== undefined) {
+    configuration.forwardErrorsToLogs = !!initConfiguration.forwardErrorsToLogs
   }
 
   return configuration

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -1,0 +1,9 @@
+import { InitConfiguration } from '@datadog/browser-core'
+import { LogsEvent } from '../logsEvent.types'
+
+export interface LogsInitConfiguration extends InitConfiguration {
+  forwardErrorsToLogs?: boolean | undefined
+  beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
+}
+
+export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -1,4 +1,4 @@
-import { InitConfiguration } from '@datadog/browser-core'
+import { Configuration, InitConfiguration } from '@datadog/browser-core'
 import { LogsEvent } from '../logsEvent.types'
 
 export interface LogsInitConfiguration extends InitConfiguration {
@@ -7,3 +7,5 @@ export interface LogsInitConfiguration extends InitConfiguration {
 }
 
 export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>
+
+export type LogsConfiguration = Configuration

--- a/packages/logs/src/domain/logsSessionManager.ts
+++ b/packages/logs/src/domain/logsSessionManager.ts
@@ -1,4 +1,5 @@
-import { Configuration, performDraw, startSessionManager, RelativeTime } from '@datadog/browser-core'
+import { performDraw, startSessionManager, RelativeTime } from '@datadog/browser-core'
+import { LogsConfiguration } from './configuration'
 
 export const LOGS_SESSION_KEY = 'logs'
 
@@ -15,7 +16,7 @@ export enum LoggerTrackingType {
   TRACKED = '1',
 }
 
-export function startLogsSessionManager(configuration: Configuration): LogsSessionManager {
+export function startLogsSessionManager(configuration: LogsConfiguration): LogsSessionManager {
   const sessionManager = startSessionManager(configuration.cookieOptions, LOGS_SESSION_KEY, (rawTrackingType) =>
     computeSessionState(configuration, rawTrackingType)
   )
@@ -31,7 +32,7 @@ export function startLogsSessionManager(configuration: Configuration): LogsSessi
   }
 }
 
-export function startLogsSessionManagerStub(configuration: Configuration): LogsSessionManager {
+export function startLogsSessionManagerStub(configuration: LogsConfiguration): LogsSessionManager {
   const isTracked = computeTrackingType(configuration) === LoggerTrackingType.TRACKED
   const session = isTracked ? {} : undefined
   return {
@@ -39,14 +40,14 @@ export function startLogsSessionManagerStub(configuration: Configuration): LogsS
   }
 }
 
-function computeTrackingType(configuration: Configuration) {
+function computeTrackingType(configuration: LogsConfiguration) {
   if (!performDraw(configuration.sampleRate)) {
     return LoggerTrackingType.NOT_TRACKED
   }
   return LoggerTrackingType.TRACKED
 }
 
-function computeSessionState(configuration: Configuration, rawSessionType?: string) {
+function computeSessionState(configuration: LogsConfiguration, rawSessionType?: string) {
   const trackingType = hasValidLoggerSession(rawSessionType) ? rawSessionType : computeTrackingType(configuration)
   return {
     trackingType,

--- a/packages/logs/src/domain/trackNetworkError.spec.ts
+++ b/packages/logs/src/domain/trackNetworkError.spec.ts
@@ -1,5 +1,6 @@
-import { Configuration, isIE, Observable, RawError } from '@datadog/browser-core'
+import { isIE, Observable, RawError } from '@datadog/browser-core'
 import { FetchStub, FetchStubManager, SPEC_ENDPOINTS, stubFetch } from '../../../core/test/specHelper'
+import { LogsConfiguration } from './configuration'
 
 import { trackNetworkError } from './trackNetworkError'
 
@@ -8,7 +9,7 @@ describe('network error tracker', () => {
   let fetchStub: FetchStub
   let fetchStubManager: FetchStubManager
   let stopNetworkErrorTracking: () => void
-  let configuration: Configuration
+  let configuration: LogsConfiguration
   let errorObservable: Observable<RawError>
   const FAKE_URL = 'http://fake.com/'
   const DEFAULT_REQUEST = {
@@ -29,7 +30,7 @@ describe('network error tracker', () => {
     configuration = {
       requestErrorResponseLengthLimit: 32,
       ...SPEC_ENDPOINTS,
-    } as Configuration
+    } as LogsConfiguration
 
     fetchStubManager = stubFetch()
     ;({ stop: stopNetworkErrorTracking } = trackNetworkError(configuration, errorObservable))

--- a/packages/logs/src/domain/trackNetworkError.ts
+++ b/packages/logs/src/domain/trackNetworkError.ts
@@ -1,5 +1,4 @@
 import {
-  Configuration,
   ErrorSource,
   FetchCompleteContext,
   initXhrObservable,
@@ -9,8 +8,9 @@ import {
   initFetchObservable,
   XhrCompleteContext,
 } from '@datadog/browser-core'
+import { LogsConfiguration } from './configuration'
 
-export function trackNetworkError(configuration: Configuration, errorObservable: Observable<RawError>) {
+export function trackNetworkError(configuration: LogsConfiguration, errorObservable: Observable<RawError>) {
   const xhrSubscription = initXhrObservable().subscribe((context) => {
     if (context.state === 'complete') {
       handleCompleteRequest(RequestType.XHR, context)
@@ -54,7 +54,7 @@ function isServerError(request: { status: number }) {
   return request.status >= 500
 }
 
-function truncateResponseText(responseText: string | undefined, configuration: Configuration) {
+function truncateResponseText(responseText: string | undefined, configuration: LogsConfiguration) {
   if (responseText && responseText.length > configuration.requestErrorResponseLengthLimit) {
     return `${responseText.substring(0, configuration.requestErrorResponseLengthLimit)}...`
   }

--- a/packages/logs/src/entries/main.ts
+++ b/packages/logs/src/entries/main.ts
@@ -4,7 +4,7 @@ import { startLogs } from '../boot/startLogs'
 
 export { Logger, LogsMessage, StatusType, HandlerType } from '../domain/logger'
 export { LoggerConfiguration, LogsPublicApi as LogsGlobal } from '../boot/logsPublicApi'
-export { LogsInitConfiguration } from '../boot/startLogs'
+export { LogsInitConfiguration } from '../domain/configuration'
 export { LogsEvent } from '../logsEvent.types'
 
 export const datadogLogs = makeLogsPublicApi(startLogs)

--- a/packages/logs/src/transport/startLoggerBatch.ts
+++ b/packages/logs/src/transport/startLoggerBatch.ts
@@ -1,6 +1,7 @@
-import { Batch, Configuration, Context, HttpRequest, EndpointBuilder } from '@datadog/browser-core'
+import { Batch, Context, HttpRequest, EndpointBuilder } from '@datadog/browser-core'
+import { LogsConfiguration } from '../domain/configuration'
 
-export function startLoggerBatch(configuration: Configuration) {
+export function startLoggerBatch(configuration: LogsConfiguration) {
   const primaryBatch = createLoggerBatch(configuration.logsEndpointBuilder)
 
   let replicaBatch: Batch | undefined


### PR DESCRIPTION
## Motivation

Followup of #1216 . This PR focuses on the logs part.

## Changes

* Move init configuration typings into a new `logs/src/domain/configuration` module
* Introduce a new `LogsConfiguration` to be used internally in the Logs SDK 
* Validate and build the configuration in `init()`, by using the previously introduced `validateAndBuildConfiguration` function from `core`
* Add `forwardErrorToLogs` to `LogsConfiguration`, to avoid using `InitConfiguration` outside of `init()`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
