### PR TITLE
✅ [RUMF-1090] update minimal version to 3.8.2

### DIFF
--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -1,7 +1,7 @@
 import { Context } from '../../tools/context'
 import { display } from '../../tools/display'
 import { toStackTraceString } from '../../tools/error'
-import { assign, combine, jsonStringify, Parameters, ThisParameterType } from '../../tools/utils'
+import { assign, combine, jsonStringify } from '../../tools/utils'
 import { canUseEventBridge, getEventBridge } from '../../transport'
 import { Configuration } from '../configuration'
 import { computeStackTrace } from '../tracekit'

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -549,11 +549,3 @@ export function combine(...sources: any[]): unknown {
 
   return destination as unknown
 }
-
-// Define those utilities for TS 3.0 compatibility
-// https://www.typescriptlang.org/docs/handbook/utility-types.html#thisparametertypetype
-export type ThisParameterType<T> = T extends (this: infer U, ...args: any[]) => any ? U : unknown
-// https://www.typescriptlang.org/docs/handbook/utility-types.html#parameterstype
-export type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never
-// https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys
-export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -98,7 +98,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
 
 ### TypeScript
 
-Types are compatible with TypeScript >= 3.0. For earlier versions, import JS sources and use global variables to avoid any compilation issues:
+Types are compatible with TypeScript >= 3.8.2. For earlier versions, import JS sources and use global variables to avoid any compilation issues:
 
 ```typescript
 import '@datadog/browser-logs/bundle/datadog-logs'

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -6,7 +6,6 @@ import {
   getRelativeTime,
   isNumber,
   monitor,
-  Omit,
   relativeNow,
   RelativeTime,
   runOnReadyState,

--- a/packages/rum-core/src/domainContext.types.ts
+++ b/packages/rum-core/src/domainContext.types.ts
@@ -2,7 +2,6 @@
  * Keep these types in a separate file in order to reference it from the official doc
  */
 
-import { Omit } from '@datadog/browser-core'
 import { RumEventType } from './rawRumEvent.types'
 
 export type RumEventDomainContext<T extends RumEventType = any> = T extends RumEventType.VIEW

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -110,7 +110,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ### TypeScript
 
-Types are compatible with TypeScript >= 3.0. For earlier versions, import JS sources and use global variables to avoid any compilation issues:
+Types are compatible with TypeScript >= 3.8.2. For earlier versions, import JS sources and use global variables to avoid any compilation issues:
 
 ```javascript
 import '@datadog/browser-rum/bundle/datadog-rum'

--- a/scripts/cli
+++ b/scripts/cli
@@ -72,7 +72,7 @@ cmd_check_typescript_compatibility () {
   yarn build
   cd test/app
   rm -rf node_modules
-  check_typescript_3_compatibility || fail 'typescript@3.0 compatibility broken'
+  check_typescript_3_compatibility || fail 'typescript@3.8.2 compatibility broken'
   check_typescript_latest_compatibility || fail 'typescript@latest compatibility broken'
 }
 

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "ts-loader": "6.2.1",
-    "typescript": "3.0.1",
+    "typescript": "3.8.2",
     "webpack": "5.28.0"
   }
 }

--- a/test/app/yarn.lock
+++ b/test/app/yarn.lock
@@ -681,10 +681,10 @@ tslib@^1.10.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-typescript@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
-  integrity sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==
+typescript@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
## Motivation

Allows to use newer TS features in consumed typings (ex: `import type`)

## Changes

Update minimal TS version to 3.8.2 (the first stable release of TS 3.8)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
