### PR TITLE
♻️ [RUMF-1092] use a WeakMap to store XHR context

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
   ],
   rules: {
     'arrow-body-style': 'error',
-    camelcase: ['error', { properties: 'never', allow: ['_datadog_xhr', '_dd_temp_'] }],
+    camelcase: ['error', { properties: 'never', allow: ['_dd_temp_'] }],
     eqeqeq: ['error', 'smart'],
     'guard-for-in': 'error',
     'id-denylist': [

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -28,7 +28,7 @@ export interface XhrCompleteContext extends Omit<XhrStartContext, 'state'> {
 export type XhrContext = XhrOpenContext | XhrStartContext | XhrCompleteContext
 
 let xhrObservable: Observable<XhrContext> | undefined
-const xhrContexts: WeakMap<XMLHttpRequest, XhrContext> = new WeakMap()
+const xhrContexts = new WeakMap<XMLHttpRequest, XhrContext>()
 
 export function initXhrObservable() {
   if (!xhrObservable) {


### PR DESCRIPTION
## Motivation

Don't expose internal XHR context to users. Also, it will avoid any conflict between double instrumentation when two SDKs are present.

## Changes

Use a WeakMap instead of a property to store the XHR context

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
