### PR TITLE
🐛 Fix proxy url intake detection

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -1,5 +1,6 @@
 import { BuildEnv } from '../../boot/init'
 import { timeStampNow } from '../../tools/timeUtils'
+import { normalizeUrl } from '../../tools/urlPolyfill'
 import { generateUUID, includes } from '../../tools/utils'
 import { InitConfiguration } from './configuration'
 
@@ -43,12 +44,12 @@ export function createEndpointBuilder(
   source?: string
 ) {
   const sdkVersion = buildEnv.sdkVersion
+  const proxyUrl = initConfiguration.proxyUrl && normalizeUrl(initConfiguration.proxyUrl)
   const {
     site = INTAKE_SITE_US,
     clientToken,
     env,
     proxyHost,
-    proxyUrl,
     service,
     version,
     intakeApiVersion,

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -70,6 +70,10 @@ export function createEndpointBuilder(
   }
 
   function buildIntakeUrl(): string {
+    if (proxyUrl) {
+      return `${proxyUrl}?ddforward`
+    }
+
     const endpoint = build()
     return endpoint.slice(0, endpoint.indexOf('?'))
   }

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -218,7 +218,7 @@ describe('transportConfiguration', () => {
       ).toBe(true)
     })
 
-    it('should detect proxy intake request', () => {
+    it('should detect proxy intake request with proxyHost', () => {
       let configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, buildEnv)
       expect(configuration.isIntakeUrl(`https://www.proxy.com${v1IntakePath}?xxx`)).toBe(true)
       configuration = computeTransportConfiguration(
@@ -230,8 +230,24 @@ describe('transportConfiguration', () => {
       expect(configuration.isIntakeUrl(`https://www.proxy.com/custom/path${v1IntakePath}?xxx`)).toBe(true)
     })
 
-    it('should not detect request done on the same host as the proxy', () => {
+    it('should not detect request done on the same host as the proxy with proxyHost', () => {
       const configuration = computeTransportConfiguration({ clientToken, proxyHost: 'www.proxy.com' }, buildEnv)
+      expect(configuration.isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
+    })
+
+    it('should detect proxy intake request with proxyUrl', () => {
+      let configuration = computeTransportConfiguration({ clientToken, proxyUrl: 'https://www.proxy.com' }, buildEnv)
+      expect(configuration.isIntakeUrl(`https://www.proxy.com?ddforward=xxx`)).toBe(true)
+
+      configuration = computeTransportConfiguration(
+        { clientToken, proxyUrl: 'https://www.proxy.com/custom/path' },
+        buildEnv
+      )
+      expect(configuration.isIntakeUrl(`https://www.proxy.com/custom/path?ddforward=xxx`)).toBe(true)
+    })
+
+    it('should not detect request done on the same host as the proxy with proxyUrl', () => {
+      const configuration = computeTransportConfiguration({ clientToken, proxyUrl: 'https://www.proxy.com' }, buildEnv)
       expect(configuration.isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
     })
 

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -237,7 +237,7 @@ describe('transportConfiguration', () => {
 
     it('should detect proxy intake request with proxyUrl', () => {
       let configuration = computeTransportConfiguration({ clientToken, proxyUrl: 'https://www.proxy.com' }, buildEnv)
-      expect(configuration.isIntakeUrl(`https://www.proxy.com?ddforward=xxx`)).toBe(true)
+      expect(configuration.isIntakeUrl(`https://www.proxy.com/?ddforward=xxx`)).toBe(true)
 
       configuration = computeTransportConfiguration(
         { clientToken, proxyUrl: 'https://www.proxy.com/custom/path' },


### PR DESCRIPTION
## Motivation

With the current proxyUrl implementation, if a user set the same url for his proxy and his backend, we con't collect backend requests as resources. 

Example:
```js
init({proxyUrl: 'https://www.proxy.com'...})
fetch('https://www.proxy.com/foo') // no resource collected
```

## Changes

Update buildIntakeUrl logic 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
