### PR TITLE
🐛 [RUMF-1122] fix view updates while session is expired

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -492,6 +492,19 @@ describe('rum assembly', () => {
 
       expect(rumSessionManager.findTrackedSession).toHaveBeenCalledWith(123 as RelativeTime)
     })
+
+    it('should get current session state for view event', () => {
+      const rumSessionManager = createRumSessionManagerMock()
+      spyOn(rumSessionManager, 'findTrackedSession').and.callThrough()
+
+      const { lifeCycle } = setupBuilder.withSessionManager(rumSessionManager).build()
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+        startTime: 123 as RelativeTime,
+      })
+
+      expect(rumSessionManager.findTrackedSession).toHaveBeenCalledWith(undefined)
+    })
   })
 
   describe('session context', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -81,7 +81,7 @@ export function startRumAssembly(
     ({ startTime, rawRumEvent, domainContext, savedCommonContext, customerContext }) => {
       const viewContext = parentContexts.findView(startTime)
       const urlContext = urlContexts.findUrl(startTime)
-      const session = sessionManager.findTrackedSession(startTime)
+      const session = sessionManager.findTrackedSession(rawRumEvent.type !== RumEventType.VIEW ? startTime : undefined)
       if (session && viewContext && urlContext) {
         const actionContext = parentContexts.findAction(startTime)
         const commonContext = savedCommonContext || getCommonContext()

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -81,6 +81,9 @@ export function startRumAssembly(
     ({ startTime, rawRumEvent, domainContext, savedCommonContext, customerContext }) => {
       const viewContext = parentContexts.findView(startTime)
       const urlContext = urlContexts.findUrl(startTime)
+      // allow to send events if the session was tracked when they start
+      // except for views which are continuously updated
+      // TODO: stop sending view updates when session is expired
       const session = sessionManager.findTrackedSession(rawRumEvent.type !== RumEventType.VIEW ? startTime : undefined)
       if (session && viewContext && urlContext) {
         const actionContext = parentContexts.findAction(startTime)


### PR DESCRIPTION
## Motivation

Bump in session time spent matching the deployment of #1187. 
Suspected root cause: regression allowing views to send updates while the session is expired

## Changes

For view updates, check if the session is currently tracked instead of if the session was tracked at the beginning of the view.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
