### PR TITLE
👷 [RUMF-1106] enable some ESLint import rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -158,6 +158,7 @@ module.exports = {
     'import/no-default-export': 'error',
     'import/no-extraneous-dependencies': 'error',
     'import/no-unresolved': 'error',
+    'import/no-useless-path-segments': 'error',
     'import/order': 'error',
 
     'jasmine/no-focused-tests': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'plugin:import/typescript',
     'prettier',
     'prettier/@typescript-eslint',
   ],
@@ -156,6 +157,7 @@ module.exports = {
 
     'import/no-default-export': 'error',
     'import/no-extraneous-dependencies': 'error',
+    'import/no-unresolved': 'error',
     'import/order': 'error',
 
     'jasmine/no-focused-tests': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -155,6 +155,7 @@ module.exports = {
     '@typescript-eslint/triple-slash-reference': ['error', { path: 'always', types: 'prefer-import', lib: 'always' }],
 
     'import/no-default-export': 'error',
+    'import/no-extraneous-dependencies': 'error',
     'import/order': 'error',
 
     'jasmine/no-focused-tests': 'error',
@@ -219,6 +220,13 @@ module.exports = {
       },
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+    {
+      files: ['test/e2e/**/*.ts'],
+      rules: {
+        // E2E codebase is importing @datadog/browser-* packages referenced by tsconfig.
+        'import/no-extraneous-dependencies': 'off',
       },
     },
   ],

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -66,6 +66,7 @@ dev,puppeteer,Apache-2.0,Copyright 2017 Google Inc.
 dev,replace-in-file,MIT,Copyright 2015-2019 Adam Reis
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen
 dev,string-replace-loader,MIT,Copyright 2015 Valentyn Barmashyn
+dev,terser-webpack-plugin,MIT,Copyright JS Foundation and other contributors
 dev,ts-loader,MIT,Copyright 2015 TypeStrong
 dev,ts-node,MIT,Copyright 2014 Blake Embrey
 dev,tsconfig-paths-webpack-plugin,MIT,Copyright 2016 Jonas Kello

--- a/developer-extension/package.json
+++ b/developer-extension/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "16",
     "copy-webpack-plugin": "8.1.0",
     "html-webpack-plugin": "5.3.1",
+    "webpack": "5.28.0",
     "webpack-webextension-plugin": "0.4.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "replace-in-file": "6.2.0",
     "sinon": "9.2.4",
     "string-replace-loader": "3.0.1",
+    "terser-webpack-plugin": "5.1.1",
     "ts-loader": "8.0.18",
     "ts-node": "9.1.1",
     "tsconfig-paths-webpack-plugin": "3.5.1",

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -1,4 +1,4 @@
-import { BuildEnv, BuildMode } from '@datadog/browser-core'
+import { BuildEnv, BuildMode } from '../../boot/init'
 import { computeTransportConfiguration } from './transportConfiguration'
 
 describe('transportConfiguration', () => {

--- a/packages/core/src/tools/catchUserErrors.spec.ts
+++ b/packages/core/src/tools/catchUserErrors.spec.ts
@@ -1,5 +1,5 @@
-import { display } from '@datadog/browser-core'
 import { catchUserErrors } from './catchUserErrors'
+import { display } from './display'
 
 describe('catchUserErrors', () => {
   it('returns the same result as the original function', () => {

--- a/packages/core/src/tools/observable.spec.ts
+++ b/packages/core/src/tools/observable.spec.ts
@@ -1,4 +1,4 @@
-import { Observable } from '@datadog/browser-core'
+import { Observable } from './observable'
 
 describe('observable', () => {
   let observable: Observable<void>

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import sinon from 'sinon'
-import { stubEndpointBuilder } from 'packages/core/test/specHelper'
+import { stubEndpointBuilder } from '../../test/specHelper'
 import { createEndpointBuilder, EndpointBuilder } from '../domain/configuration/endpointBuilder'
 import { BuildEnv } from '..'
 import { HttpRequest } from './httpRequest'

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -1,4 +1,4 @@
-import { clearAllCookies } from '../test/specHelper'
+import { clearAllCookies } from './specHelper'
 
 beforeEach(() => {
   ;(navigator.sendBeacon as any) = false

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -1,5 +1,7 @@
-import { buildUrl, EndpointBuilder, instrumentMethod } from '@datadog/browser-core'
+import { EndpointBuilder } from '../src/domain/configuration/endpointBuilder'
+import { instrumentMethod } from '../src/tools/instrumentMethod'
 import { resetNavigationStart } from '../src/tools/timeUtils'
+import { buildUrl } from '../src/tools/urlPolyfill'
 import { noop, objectEntries, assign } from '../src/tools/utils'
 import { BrowserWindow } from '../src/transport/eventBridge'
 

--- a/packages/rum-core/src/domain/internalContext.spec.ts
+++ b/packages/rum-core/src/domain/internalContext.spec.ts
@@ -1,5 +1,5 @@
-import { createRumSessionManagerMock } from 'packages/rum-core/test/mockRumSessionManager'
 import { RelativeTime } from '@datadog/browser-core'
+import { createRumSessionManagerMock } from '../../test/mockRumSessionManager'
 import { setup, TestSetupBuilder } from '../../test/specHelper'
 import { startInternalContext } from './internalContext'
 import { ParentContexts } from './parentContexts'

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -1,9 +1,9 @@
 import { Context, RelativeTime, Duration, relativeNow } from '@datadog/browser-core'
-import { LifeCycleEventType, RumEvent } from '@datadog/browser-rum-core'
+import { RumEvent } from '../../../rumEvent.types'
 import { TestSetupBuilder, setup, setupViewTest, ViewTest } from '../../../../test/specHelper'
 import { RumPerformanceNavigationTiming } from '../../../browser/performanceCollection'
 import { RumEventType } from '../../../rawRumEvent.types'
-import { LifeCycle } from '../../lifeCycle'
+import { LifeCycle, LifeCycleEventType } from '../../lifeCycle'
 import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitIdlePage'
 import { THROTTLE_VIEW_UPDATE_PERIOD } from './trackViews'
 

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,5 +1,4 @@
-import { isIE } from '@datadog/browser-core'
-import { DefaultPrivacyLevel } from 'packages/core/src/domain/configuration'
+import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import { Clock, createNewEvent } from '../../../../core/test/specHelper'
 import { collectAsyncCalls } from '../../../test/utils'
 import { RecordType, IncrementalSource, RawRecord, IncrementalSnapshotRecord, FocusRecord } from '../../types'

--- a/performances/src/profilers/startCpuProfiling.ts
+++ b/performances/src/profilers/startCpuProfiling.ts
@@ -1,5 +1,5 @@
 import { CDPSession } from 'puppeteer'
-import { ProfilingOptions } from 'src/types'
+import { ProfilingOptions } from '../types'
 import { isSdkBundleUrl } from './startProfiling'
 
 export async function startCPUProfiling(options: ProfilingOptions, client: CDPSession) {

--- a/performances/src/profilers/startMemoryProfiling.ts
+++ b/performances/src/profilers/startMemoryProfiling.ts
@@ -1,5 +1,5 @@
 import { CDPSession } from 'puppeteer'
-import { ProfilingOptions } from 'src/types'
+import { ProfilingOptions } from '../types'
 import { isSdkBundleUrl } from './startProfiling'
 
 export async function startMemoryProfiling(options: ProfilingOptions, client: CDPSession) {

--- a/performances/src/profilers/startNetworkProfiling.ts
+++ b/performances/src/profilers/startNetworkProfiling.ts
@@ -1,5 +1,5 @@
 import { CDPSession, Protocol } from 'puppeteer'
-import { ProfilingOptions } from 'src/types'
+import { ProfilingOptions } from '../types'
 import { isSdkBundleUrl } from './startProfiling'
 
 export async function startNetworkProfiling(options: ProfilingOptions, client: CDPSession) {

--- a/performances/src/profilers/startProfiling.ts
+++ b/performances/src/profilers/startProfiling.ts
@@ -1,5 +1,5 @@
 import { Page } from 'puppeteer'
-import { ProfilingOptions, ProfilingResults } from 'src/types'
+import { ProfilingOptions, ProfilingResults } from '../types'
 import { startNetworkProfiling } from './startNetworkProfiling'
 import { startCPUProfiling } from './startCpuProfiling'
 import { startMemoryProfiling } from './startMemoryProfiling'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8881,7 +8881,7 @@ temp-write@^4.0.0:
     temp-dir "^1.0.0"
     uuid "^3.3.2"
 
-terser-webpack-plugin@^5.1.1:
+terser-webpack-plugin@5.1.1, terser-webpack-plugin@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz#7effadee06f7ecfa093dbbd3e9ab23f5f3ed8673"
   integrity sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==


### PR DESCRIPTION
## Motivation

Enforce `import` path consistency

## Changes

* Enable the `import/no-useless-path-segments` rule to make sure import paths are the simplest possible. 

* Enable the `import/no-unresolved` rule and  extend the `plugin:import/typescript` ESLint configuration to make sure ESLint is able to resolve all files (currently there is some imports that work with TS but not with ESLint)

* Enable the` import/no-extraneous-dependencies` rule to make sure we don’t import from the same package (ex: importing from @datadog/browser-core in the core package). 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
