### PR TITLE
🏷️ [RUMF-1098] move init options into their related interfaces

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -16,7 +16,7 @@ export type DefaultPrivacyLevel = typeof DefaultPrivacyLevel[keyof typeof Defaul
 export interface InitConfiguration {
   // global options
   clientToken: string
-  beforeSend?: BeforeSendCallback | undefined
+  beforeSend?: GenericBeforeSendCallback | undefined
   sampleRate?: number | undefined
   silentMultipleInit?: boolean | undefined
 
@@ -41,7 +41,9 @@ export interface InitConfiguration {
   replica?: ReplicaUserConfiguration | undefined
 }
 
-export type BeforeSendCallback = (event: any, context?: any) => unknown
+// This type is only used to build the core configuration. Logs and RUM SDKs are using a proper type
+// for this option.
+type GenericBeforeSendCallback = (event: any, context?: any) => unknown
 
 interface ReplicaUserConfiguration {
   applicationId?: string
@@ -50,7 +52,7 @@ interface ReplicaUserConfiguration {
 
 export interface Configuration extends TransportConfiguration {
   // Built from init configuration
-  beforeSend: BeforeSendCallback | undefined
+  beforeSend: GenericBeforeSendCallback | undefined
   cookieOptions: CookieOptions
   sampleRate: number
   service: string | undefined

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -14,30 +14,29 @@ export const DefaultPrivacyLevel = {
 export type DefaultPrivacyLevel = typeof DefaultPrivacyLevel[keyof typeof DefaultPrivacyLevel]
 
 export interface InitConfiguration {
+  // global options
   clientToken: string
-  applicationId?: string | undefined
-  actionNameAttribute?: string | undefined
-  internalMonitoringApiKey?: string | undefined
-  allowedTracingOrigins?: Array<string | RegExp> | undefined
-  sampleRate?: number | undefined
-  replaySampleRate?: number | undefined
-  site?: string | undefined
-  enableExperimentalFeatures?: string[] | undefined
-  silentMultipleInit?: boolean | undefined
-  trackInteractions?: boolean | undefined
-  trackViewsManually?: boolean | undefined
-  proxyUrl?: string | undefined
   beforeSend?: BeforeSendCallback | undefined
-  defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
+  sampleRate?: number | undefined
+  silentMultipleInit?: boolean | undefined
 
+  // transport options
+  proxyUrl?: string | undefined
+  site?: string | undefined
+
+  // tag and context options
   service?: string | undefined
   env?: string | undefined
   version?: string | undefined
 
+  // cookie options
   useCrossSiteSessionCookie?: boolean | undefined
   useSecureSessionCookie?: boolean | undefined
   trackSessionAcrossSubdomains?: boolean | undefined
 
+  // internal options
+  enableExperimentalFeatures?: string[] | undefined
+  internalMonitoringApiKey?: string | undefined
   // only on staging build mode
   replica?: ReplicaUserConfiguration | undefined
 }

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -2,7 +2,6 @@ export {
   Configuration,
   InitConfiguration,
   buildCookieOptions,
-  BeforeSendCallback,
   DefaultPrivacyLevel,
   validateAndBuildConfiguration,
 } from './configuration'

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -89,7 +89,6 @@ function computeReplicaConfiguration(
   const replicaConfiguration: InitConfiguration = {
     ...initConfiguration,
     site: INTAKE_SITE_US,
-    applicationId: initConfiguration.replica.applicationId,
     clientToken: initConfiguration.replica.clientToken,
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,6 @@ export {
   InitConfiguration,
   buildCookieOptions,
   validateAndBuildConfiguration,
-  BeforeSendCallback,
   DefaultPrivacyLevel,
 } from './domain/configuration'
 export {

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -3,8 +3,8 @@ import { buildEnv } from '../boot/buildEnv'
 import { LogsEvent } from '../logsEvent.types'
 
 export interface LogsInitConfiguration extends InitConfiguration {
-  forwardErrorsToLogs?: boolean | undefined
   beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
+  forwardErrorsToLogs?: boolean | undefined
 }
 
 export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -6,7 +6,6 @@ import {
   timeStampNow,
   currentDrift,
   display,
-  BeforeSendCallback,
   RawError,
   createEventRateLimiter,
   EventRateLimiter,
@@ -134,7 +133,7 @@ export function startRumAssembly(
 
 function shouldSend(
   event: RumEvent & Context,
-  beforeSend: BeforeSendCallback | undefined,
+  beforeSend: RumConfiguration['beforeSend'],
   domainContext: RumEventDomainContext,
   eventRateLimiters: { [key in RumEventType]?: EventRateLimiter }
 ) {

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -12,9 +12,23 @@ import { RumEventDomainContext } from '../domainContext.types'
 import { RumEvent } from '../rumEvent.types'
 
 export interface RumInitConfiguration extends InitConfiguration {
+  // global options
   applicationId: string
   beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => void | boolean) | undefined
+
+  // tracing options
+  allowedTracingOrigins?: Array<string | RegExp> | undefined
+
+  // replay options
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
+  replaySampleRate?: number | undefined
+
+  // action options
+  trackInteractions?: boolean | undefined
+  actionNameAttribute?: string | undefined
+
+  // view options
+  trackViewsManually?: boolean | undefined
 }
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -17,7 +17,7 @@ export interface RumInitConfiguration extends InitConfiguration {
   beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => void | boolean) | undefined
 
   // tracing options
-  allowedTracingOrigins?: Array<string | RegExp> | undefined
+  allowedTracingOrigins?: ReadonlyArray<string | RegExp> | undefined
 
   // replay options
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined


### PR DESCRIPTION
## Motivation

Improve init configuration typings 

## Changes

* 🚚 Move some `InitConfiguration` properties to their own package.
* 🎨 Group/reorder properties

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
