### PR TITLE
✨ [RUMF-1119] Implement dual ship for other orgs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -234,7 +234,7 @@ deploy-staging:
     - .staging
   script:
     - yarn
-    - BUILD_MODE=staging yarn build:bundle
+    - BUILD_MODE=canary yarn build:bundle
     - ./scripts/deploy.sh staging staging
 
 deploy-prod-canary:

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -35,7 +35,6 @@ export function defineGlobal<Global, Name extends keyof Global>(global: Global, 
 
 export enum BuildMode {
   RELEASE = 'release',
-  STAGING = 'staging',
   CANARY = 'canary',
   E2E_TEST = 'e2e-test',
 }

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -46,7 +46,6 @@ export interface InitConfiguration {
   useSecureSessionCookie?: boolean | undefined
   trackSessionAcrossSubdomains?: boolean | undefined
 
-  // only on staging build mode
   replica?: ReplicaUserConfiguration | undefined
 }
 
@@ -55,6 +54,7 @@ export type BeforeSendCallback = (event: any, context?: any) => unknown
 interface ReplicaUserConfiguration {
   applicationId?: string
   clientToken: string
+  datacenter: string
 }
 
 export interface Configuration extends TransportConfiguration {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -26,6 +26,13 @@ const INTAKE_TRACKS = {
 
 export type EndpointType = keyof typeof ENDPOINTS[IntakeType]
 
+const INTAKE_DATACENTERS: { [site: string]: string } = {
+  'datadoghq.eu': 'eu1.prod.dog',
+  'datadoghq.com': 'us1.prod.dog',
+  'us3.datadoghq.com': 'us3.prod.dog',
+  'us5.datadoghq.com': 'us5.prod.dog',
+}
+
 export const INTAKE_SITE_US = 'datadoghq.com'
 const INTAKE_SITE_US3 = 'us3.datadoghq.com'
 const INTAKE_SITE_GOV = 'ddog-gov.com'
@@ -41,6 +48,7 @@ export function createEndpointBuilder(
   initConfiguration: InitConfiguration,
   buildEnv: BuildEnv,
   endpointType: EndpointType,
+  sourceSite?: string,
   source?: string
 ) {
   const sdkVersion = buildEnv.sdkVersion
@@ -96,11 +104,13 @@ export function createEndpointBuilder(
   }
 
   function buildQueryParameters(endpointType: EndpointType, source?: string) {
+    const datacenter = INTAKE_DATACENTERS[sourceSite ?? site]
     const tags =
       `sdk_version:${sdkVersion}` +
       `${env ? `,env:${env}` : ''}` +
       `${service ? `,service:${service}` : ''}` +
-      `${version ? `,version:${version}` : ''}`
+      `${version ? `,version:${version}` : ''}` +
+      `${datacenter ? `,datacenter:${datacenter}` : ''}`
 
     let parameters = `ddsource=${source || 'browser'}&ddtags=${encodeURIComponent(tags)}`
 

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -26,17 +26,12 @@ const INTAKE_TRACKS = {
 
 export type EndpointType = keyof typeof ENDPOINTS[IntakeType]
 
-const INTAKE_DATACENTERS: { [site: string]: string } = {
-  'datadoghq.eu': 'eu1.prod.dog',
-  'datadoghq.com': 'us1.prod.dog',
-  'us3.datadoghq.com': 'us3.prod.dog',
-  'us5.datadoghq.com': 'us5.prod.dog',
-}
-
 export const INTAKE_SITE_US = 'datadoghq.com'
 const INTAKE_SITE_US3 = 'us3.datadoghq.com'
 const INTAKE_SITE_GOV = 'ddog-gov.com'
 const INTAKE_SITE_EU = 'datadoghq.eu'
+
+const INTAKE_DATACENTER_US = 'us1.prod.dog'
 
 const CLASSIC_ALLOWED_SITES = [INTAKE_SITE_US, INTAKE_SITE_EU]
 const INTAKE_V1_ALLOWED_SITES = [INTAKE_SITE_US, INTAKE_SITE_US3, INTAKE_SITE_EU, INTAKE_SITE_GOV]
@@ -48,7 +43,7 @@ export function createEndpointBuilder(
   initConfiguration: InitConfiguration,
   buildEnv: BuildEnv,
   endpointType: EndpointType,
-  sourceSite?: string,
+  datacenter?: string,
   source?: string
 ) {
   const sdkVersion = buildEnv.sdkVersion
@@ -63,6 +58,10 @@ export function createEndpointBuilder(
     intakeApiVersion,
     useAlternateIntakeDomains,
   } = initConfiguration
+
+  if (!datacenter && site === INTAKE_SITE_US) {
+    datacenter = INTAKE_DATACENTER_US
+  }
 
   const host = buildHost(endpointType)
   const path = buildPath(endpointType)
@@ -104,7 +103,6 @@ export function createEndpointBuilder(
   }
 
   function buildQueryParameters(endpointType: EndpointType, source?: string) {
-    const datacenter = INTAKE_DATACENTERS[sourceSite ?? site]
     const tags =
       `sdk_version:${sdkVersion}` +
       `${env ? `,env:${env}` : ''}` +

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -148,18 +148,11 @@ describe('transportConfiguration', () => {
       { site: 'us3.datadoghq.com', datacenter: 'us3.prod.dog' },
       { site: 'us5.datadoghq.com', datacenter: 'us5.prod.dog' },
     ].forEach(({ site, datacenter }) => {
-      it(`should be set as tag for site ${site} in the logs and rum endpoints`, () => {
-        const configuration = computeTransportConfiguration({ clientToken, site }, buildEnv)
-        expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).toMatch(
-          `&ddtags=(.*),datacenter:${datacenter}`
-        )
-        expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).toMatch(
-          `&ddtags=(.*),datacenter:${datacenter}`
-        )
-      })
-
       it(`should be set as tag for site ${site} in the logs and rum endpoints replicas`, () => {
-        const configuration = computeTransportConfiguration({ clientToken, site, replica: { clientToken } }, buildEnv)
+        const configuration = computeTransportConfiguration(
+          { clientToken, site, replica: { clientToken, datacenter } },
+          buildEnv
+        )
 
         expect(decodeURIComponent(configuration.replica!.rumEndpointBuilder.build())).toMatch(
           `&ddtags=(.*),datacenter:${datacenter}`
@@ -168,6 +161,16 @@ describe('transportConfiguration', () => {
           `&ddtags=(.*),datacenter:${datacenter}`
         )
       })
+    })
+
+    it(`should be set as tag for US1 site in the logs and rum endpoints`, () => {
+      const configuration = computeTransportConfiguration({ clientToken }, buildEnv)
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).toMatch(
+        `&ddtags=(.*),datacenter:us1.prod.dog`
+      )
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).toMatch(
+        `&ddtags=(.*),datacenter:us1.prod.dog`
+      )
     })
 
     it('should not be set as tag for other datacenters in the logs and rum endpoints', () => {
@@ -293,7 +296,13 @@ describe('transportConfiguration', () => {
     ].forEach(({ site, intakeDomain }) => {
       it(`should detect replica intake request for site ${site} with alternate intake domains and intake v2`, () => {
         const configuration = computeTransportConfiguration(
-          { clientToken, useAlternateIntakeDomains: true, intakeApiVersion: 2, site, replica: { clientToken } },
+          {
+            clientToken,
+            useAlternateIntakeDomains: true,
+            intakeApiVersion: 2,
+            site,
+            replica: { clientToken, datacenter: '' },
+          },
           buildEnv
         )
 

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -9,7 +9,6 @@ export interface TransportConfiguration {
   sessionReplayEndpointBuilder: EndpointBuilder
   internalMonitoringEndpointBuilder?: EndpointBuilder
   isIntakeUrl: (url: string) => boolean
-  // only on staging build mode
   replica?: ReplicaConfiguration
 }
 
@@ -64,6 +63,7 @@ function computeEndpointBuilders(initConfiguration: InitConfiguration, buildEnv:
         { ...initConfiguration, clientToken: initConfiguration.internalMonitoringApiKey },
         buildEnv,
         'logs',
+        undefined,
         'browser-agent-internal-monitoring'
       ),
     }
@@ -81,23 +81,25 @@ function computeReplicaConfiguration(
     return
   }
 
+  const { applicationId, clientToken, datacenter } = initConfiguration.replica
+
   const replicaConfiguration: InitConfiguration = {
     ...initConfiguration,
     site: INTAKE_SITE_US,
-    applicationId: initConfiguration.replica.applicationId,
-    clientToken: initConfiguration.replica.clientToken,
+    applicationId,
+    clientToken,
     useAlternateIntakeDomains: true,
     intakeApiVersion: 2,
   }
 
   const replicaEndpointBuilders = {
-    logsEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'logs', initConfiguration.site),
-    rumEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'rum', initConfiguration.site),
+    logsEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'logs', datacenter),
+    rumEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'rum', datacenter),
     internalMonitoringEndpointBuilder: createEndpointBuilder(
       replicaConfiguration,
       buildEnv,
       'logs',
-      initConfiguration.site,
+      datacenter,
       'browser-agent-internal-monitoring'
     ),
   }

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -77,7 +77,7 @@ function computeReplicaConfiguration(
   buildEnv: BuildEnv,
   intakeEndpoints: string[]
 ): ReplicaConfiguration | undefined {
-  if (buildEnv.buildMode !== BuildMode.STAGING || initConfiguration.replica === undefined) {
+  if (!initConfiguration.replica) {
     return
   }
 
@@ -91,12 +91,13 @@ function computeReplicaConfiguration(
   }
 
   const replicaEndpointBuilders = {
-    logsEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'logs'),
-    rumEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'rum'),
+    logsEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'logs', initConfiguration.site),
+    rumEndpointBuilder: createEndpointBuilder(replicaConfiguration, buildEnv, 'rum', initConfiguration.site),
     internalMonitoringEndpointBuilder: createEndpointBuilder(
       replicaConfiguration,
       buildEnv,
       'logs',
+      initConfiguration.site,
       'browser-agent-internal-monitoring'
     ),
   }

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -18,12 +18,8 @@ const BUILD_MODES = [
   // * Allows intake endpoints overrides when served from the E2E test framework.
   'e2e-test',
 
-  // Used on the production Datadog web app.
+  // Used on staging and production Datadog web app.
   'canary',
-
-  // Used on the staging Datadog web app.
-  // * Enables the support of the "replica" options.
-  'staging',
 ]
 
 let buildMode
@@ -43,8 +39,7 @@ switch (buildMode) {
   case 'release':
     sdkVersion = lernaJson.version
     break
-  case 'canary':
-  case 'staging': {
+  case 'canary': {
     const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
     sdkVersion = `${lernaJson.version}+${commitSha1}`
     break


### PR DESCRIPTION
## Motivation

Other Datadog data sources are dual shipped to US1 (org 2). In order to allow correlation of this data with RUM data, we would like to dual ship browser data from other data centers (except govcloud) to US1.

The PR enable the replica configuration for other orgs

## Changes

- Add the new datacenter tag
- Remove the browser SDK staging safe guard

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
