### PR TITLE
👷 [RUMF-1107] implement the disallowProtectedDirectoryImport rule 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     'plugin:import/typescript',
     'prettier',
     'prettier/@typescript-eslint',
+    'plugin:import/typescript',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -187,6 +188,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/restrict-plus-operands': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
       },
     },
@@ -230,6 +232,13 @@ module.exports = {
       rules: {
         // E2E codebase is importing @datadog/browser-* packages referenced by tsconfig.
         'import/no-extraneous-dependencies': 'off',
+      },
+    },
+    {
+      files: ['**/*'],
+      excludedFiles: ['packages/*/test/**', '**/*.spec.ts'],
+      rules: {
+        'local-rules/disallow-protected-directory-import': 'error',
       },
     },
   ],

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -37,6 +37,7 @@ dev,cors,MIT,Copyright 2013 Troy Goode
 dev,emoji-name-map,MIT,Copyright 2016-19 Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)
 dev,eslint,MIT,Copyright JS Foundation and other contributors
 dev,eslint-config-prettier,MIT,Copyright (c) 2017, 2018, 2019, 2020 Simon Lydell and contributors
+dev,eslint-module-utils,MIT,Copyright (c) 2015 Ben Mosher
 dev,eslint-plugin-import,MIT,Copyright (c) 2015 Ben Mosher
 dev,eslint-plugin-jasmine,MIT,Copyright (c) 2021 Tom Vincent
 dev,eslint-plugin-jsdoc,BSD-3-Clause,Copyright (c) 2018, Gajus Kuizinas (http://gajus.com/)

--- a/eslint-local-rules/disallowProtectedDirectoryImport.js
+++ b/eslint-local-rules/disallowProtectedDirectoryImport.js
@@ -1,0 +1,62 @@
+const resolve = require('eslint-module-utils/resolve').default
+const moduleVisitor = require('eslint-module-utils/moduleVisitor').default
+const importType = require('eslint-plugin-import/lib/core/importType').default
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Consider directories containing an "index" file as protected, and disallow importing modules from them.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return moduleVisitor((source) => {
+      const protectedDirectory = getFirstProtectedDirectory(source.value, context)
+      if (protectedDirectory) {
+        context.report(source, `${protectedDirectory} is a protected directory, import from its index module instead`)
+      }
+    })
+  },
+}
+
+function getFirstProtectedDirectory(importedModule, context) {
+  // only consider relative and absolute paths, no package or builtin imports
+  if (!['absolute', 'sibling', 'index', 'parent'].includes(importType(importedModule, context))) {
+    return
+  }
+
+  // only consider imports that can be resolved
+  if (!resolve(importedModule, context)) {
+    return
+  }
+
+  return findProtectedDirectory(splitLast(importedModule)[0])
+
+  function findProtectedDirectory(potentialProtectedDirectory) {
+    const [parentPotentialProtectedDirectory, basename] = splitLast(potentialProtectedDirectory)
+    if (basename === '' || basename === '..' || basename === '.') {
+      return
+    }
+
+    // look for a directory higher in the hierarchy first
+    const parentProtectedDirectory = findProtectedDirectory(parentPotentialProtectedDirectory)
+    if (parentProtectedDirectory) {
+      return parentProtectedDirectory
+    }
+
+    // If we can import directly from the directory, it means that it contains an 'index' file.
+    // Consider it protected.
+    if (resolve(potentialProtectedDirectory, context)) {
+      return potentialProtectedDirectory
+    }
+  }
+}
+
+function splitLast(importSource) {
+  const lastIndex = importSource.lastIndexOf('/')
+  if (lastIndex < 0) {
+    return ['', importSource]
+  }
+  return [importSource.slice(0, lastIndex), importSource.slice(lastIndex + 1)]
+}

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -10,4 +10,5 @@ module.exports = {
   'disallow-side-effects': require('./disallowSideEffects'),
   'disallow-enum-exports': require('./disallowEnumExports'),
   'disallow-spec-import': require('./disallowSpecImport'),
+  'disallow-protected-directory-import': require('./disallowProtectedDirectoryImport'),
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "emoji-name-map": "1.2.9",
     "eslint": "7.20.0",
     "eslint-config-prettier": "7.2.0",
+    "eslint-module-utils": "2.6.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jasmine": "4.1.2",
     "eslint-plugin-jsdoc": "32.0.0",

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -6,3 +6,9 @@ export {
   DefaultPrivacyLevel,
   validateAndBuildConfiguration,
 } from './configuration'
+export { EndpointBuilder } from './endpointBuilder'
+export {
+  isExperimentalFeatureEnabled,
+  updateExperimentalFeatures,
+  resetExperimentalFeatures,
+} from './experimentalFeatures'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,12 +5,11 @@ export {
   validateAndBuildConfiguration,
   BeforeSendCallback,
   DefaultPrivacyLevel,
-} from './domain/configuration'
-export {
+  EndpointBuilder,
   isExperimentalFeatureEnabled,
   updateExperimentalFeatures,
   resetExperimentalFeatures,
-} from './domain/configuration/experimentalFeatures'
+} from './domain/configuration'
 export { trackConsoleError } from './domain/error/trackConsoleError'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'
 export { computeStackTrace, StackTrace } from './domain/tracekit'
@@ -53,7 +52,6 @@ export { Context, ContextArray, ContextValue } from './tools/context'
 export { areCookiesAuthorized, getCookie, setCookie, deleteCookie, COOKIE_ACCESS_DELAY } from './browser/cookie'
 export { initXhrObservable, XhrCompleteContext, XhrStartContext } from './browser/xhrObservable'
 export { initFetchObservable, FetchCompleteContext, FetchStartContext, FetchContext } from './browser/fetchObservable'
-export { EndpointBuilder } from './domain/configuration/endpointBuilder'
 export { BoundedBuffer } from './tools/boundedBuffer'
 export { catchUserErrors } from './tools/catchUserErrors'
 export { createContextManager } from './tools/contextManager'

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -1,4 +1,4 @@
-import { EndpointBuilder } from '../domain/configuration/endpointBuilder'
+import { EndpointBuilder } from '../domain/configuration'
 import { monitor, addMonitoringError, addMonitoringMessage } from '../domain/internalMonitoring'
 
 let hasReportedXhrError = false

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -8,7 +8,7 @@ import {
   RumConfiguration,
 } from '@datadog/browser-rum-core'
 import { getReplayStats } from '../domain/replayStats'
-import { startDeflateWorker } from '../domain/segmentCollection/startDeflateWorker'
+import { startDeflateWorker } from '../domain/segmentCollection'
 
 import { startRecording } from './startRecording'
 

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -7,8 +7,7 @@ import {
 } from '@datadog/browser-rum-core'
 
 import { record } from '../domain/record'
-import { startSegmentCollection } from '../domain/segmentCollection'
-import { DeflateWorker } from '../domain/segmentCollection/deflateWorker'
+import { startSegmentCollection, DeflateWorker } from '../domain/segmentCollection'
 import { send } from '../transport/send'
 import { RawRecord, RecordType } from '../types'
 

--- a/packages/rum/src/domain/record/index.ts
+++ b/packages/rum/src/domain/record/index.ts
@@ -1,1 +1,3 @@
 export { record } from './record'
+export { serializeNodeWithId } from './serialize'
+export * from './types'

--- a/packages/rum/src/domain/segmentCollection/index.ts
+++ b/packages/rum/src/domain/segmentCollection/index.ts
@@ -1,1 +1,3 @@
 export { startSegmentCollection } from './segmentCollection'
+export { DeflateWorker } from './deflateWorker'
+export { startDeflateWorker } from './startDeflateWorker'

--- a/packages/rum/src/entries/internal.ts
+++ b/packages/rum/src/entries/internal.ts
@@ -19,7 +19,7 @@ export {
   AddedNodeMutation,
   MousePosition,
   RemovedNodeMutation,
-} from '../domain/record/types'
+} from '../domain/record'
 
 export {
   PRIVACY_ATTR_NAME,
@@ -32,4 +32,4 @@ export {
 
 export * from '../types'
 
-export { serializeNodeWithId } from '../domain/record/serialize'
+export { serializeNodeWithId } from '../domain/record'

--- a/packages/rum/src/types.ts
+++ b/packages/rum/src/types.ts
@@ -1,6 +1,6 @@
-import { IncrementalData, SerializedNodeWithId } from './domain/record/types'
+import { IncrementalData, SerializedNodeWithId } from './domain/record'
 
-export { IncrementalSource, MutationData, ViewportResizeData, ScrollData } from './domain/record/types'
+export { IncrementalSource, MutationData, ViewportResizeData, ScrollData } from './domain/record'
 
 export interface Segment extends SegmentMeta {
   records: Record[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,7 +4127,7 @@ eslint-import-resolver-node@^0.3.4:
     debug "^2.6.9"
     resolve "^1.13.1"
 
-eslint-module-utils@^2.6.0:
+eslint-module-utils@2.6.0, eslint-module-utils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
   integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==


### PR DESCRIPTION
## Motivation

Make sure we don't import from protected modules

## Changes

Implement an ESLint rule for it, then fix issues that it yields.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
