### PR TITLE
⚡️ [RUMF-1030] Decrease BoundedBuffer limitation to 500

### DIFF
--- a/packages/core/src/tools/boundedBuffer.spec.ts
+++ b/packages/core/src/tools/boundedBuffer.spec.ts
@@ -26,4 +26,17 @@ describe('BoundedBuffer', () => {
     buffered.drain()
     expect(spy.calls.count()).toEqual(5)
   })
+
+  it('store at most 500 callbacks by default', () => {
+    const spy = jasmine.createSpy<() => void>()
+    const buffered = new BoundedBuffer()
+    const limit = 500
+
+    for (let i = 0; i < limit + 1; i += 1) {
+      buffered.add(spy)
+    }
+
+    buffered.drain()
+    expect(spy.calls.count()).toEqual(limit)
+  })
 })

--- a/packages/core/src/tools/boundedBuffer.spec.ts
+++ b/packages/core/src/tools/boundedBuffer.spec.ts
@@ -15,19 +15,7 @@ describe('BoundedBuffer', () => {
     expect(spy.calls.count()).toBe(1)
   })
 
-  it('store only the N last callbacks', () => {
-    const spy = jasmine.createSpy<() => void>()
-    const buffered = new BoundedBuffer(5)
-
-    for (let i = 0; i < 10; i += 1) {
-      buffered.add(spy)
-    }
-
-    buffered.drain()
-    expect(spy.calls.count()).toEqual(5)
-  })
-
-  it('store at most 500 callbacks by default', () => {
+  it('store at most 500 callbacks', () => {
     const spy = jasmine.createSpy<() => void>()
     const buffered = new BoundedBuffer()
     const limit = 500

--- a/packages/core/src/tools/boundedBuffer.ts
+++ b/packages/core/src/tools/boundedBuffer.ts
@@ -1,4 +1,4 @@
-const DEFAULT_LIMIT = 10_000
+const DEFAULT_LIMIT = 500
 
 export class BoundedBuffer {
   private buffer: Array<() => void> = []

--- a/packages/core/src/tools/boundedBuffer.ts
+++ b/packages/core/src/tools/boundedBuffer.ts
@@ -1,13 +1,11 @@
-const DEFAULT_LIMIT = 500
+const BUFFER_LIMIT = 500
 
 export class BoundedBuffer {
   private buffer: Array<() => void> = []
 
-  constructor(private limit: number = DEFAULT_LIMIT) {}
-
   add(callback: () => void) {
     const length = this.buffer.push(callback)
-    if (length > this.limit) {
+    if (length > BUFFER_LIMIT) {
       this.buffer.splice(0, 1)
     }
   }


### PR DESCRIPTION
## Motivation

The BoundedBuffer is used to buffer api calls before the SDK initialisation. It stores views, actions, and errors and has a limit of 10000 api calls. In case of big user defined contexts or if the init() is never called, it can have a significant impact.
This PR decrease the limit from 10000 to 500 buffered api calls to lower our memory impact.

## Changes

Decrease bounded buffer limitation to 500

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
