### PR TITLE
[REPLAY-564] ♻️ Remove FF - enable visual viewport recording

### DIFF
--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -83,7 +83,7 @@ describe('startRecording', () => {
         creation_reason: 'init',
         end: jasmine.stringMatching(/^\d{13}$/),
         has_full_snapshot: 'true',
-        records_count: '3',
+        records_count: '4',
         segment: jasmine.any(File),
         'session.id': 'session-id',
         start: jasmine.stringMatching(/^\d{13}$/),
@@ -106,7 +106,7 @@ describe('startRecording', () => {
     }
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe(String(inputCount + 3))
+      expect(getRequestData(calls.first()).records_count).toBe(String(inputCount + 4))
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -123,7 +123,7 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe('4')
+      expect(getRequestData(calls.first()).records_count).toBe('5')
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -220,7 +220,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe('4')
+        expect(getRequestData(calls.first()).records_count).toBe('5')
         expectNoExtraRequestSendCalls(done)
       })
     })
@@ -233,7 +233,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe('3')
+        expect(getRequestData(calls.first()).records_count).toBe('4')
         expectNoExtraRequestSendCalls(done)
       })
     })

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -5,7 +5,7 @@ import { createRumSessionManagerMock, RumSessionManagerMock } from '../../../rum
 import { createNewEvent } from '../../../core/test/specHelper'
 
 import { setup, TestSetupBuilder } from '../../../rum-core/test/specHelper'
-import { collectAsyncCalls, addRecordsPerFullSnapshot } from '../../test/utils'
+import { collectAsyncCalls, recordsPerFullSnapshotPlus } from '../../test/utils'
 import { setMaxSegmentSize, startDeflateWorker } from '../domain/segmentCollection'
 
 import { Segment, RecordType } from '../types'
@@ -83,7 +83,7 @@ describe('startRecording', () => {
         creation_reason: 'init',
         end: jasmine.stringMatching(/^\d{13}$/),
         has_full_snapshot: 'true',
-        records_count: addRecordsPerFullSnapshot(0).toString(),
+        records_count: recordsPerFullSnapshotPlus(0).toString(),
         segment: jasmine.any(File),
         'session.id': 'session-id',
         start: jasmine.stringMatching(/^\d{13}$/),
@@ -106,7 +106,7 @@ describe('startRecording', () => {
     }
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(inputCount).toString())
+      expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(inputCount).toString())
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -123,7 +123,7 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(1).toString())
+      expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(1).toString())
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -220,7 +220,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(1).toString())
+        expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(1).toString())
         expectNoExtraRequestSendCalls(done)
       })
     })
@@ -233,7 +233,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(0).toString())
+        expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(0).toString())
         expectNoExtraRequestSendCalls(done)
       })
     })

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -5,7 +5,7 @@ import { createRumSessionManagerMock, RumSessionManagerMock } from '../../../rum
 import { createNewEvent } from '../../../core/test/specHelper'
 
 import { setup, TestSetupBuilder } from '../../../rum-core/test/specHelper'
-import { collectAsyncCalls, recordsPerFullSnapshotPlus } from '../../test/utils'
+import { collectAsyncCalls, recordsPerFullSnapshot } from '../../test/utils'
 import { setMaxSegmentSize, startDeflateWorker } from '../domain/segmentCollection'
 
 import { Segment, RecordType } from '../types'
@@ -83,7 +83,7 @@ describe('startRecording', () => {
         creation_reason: 'init',
         end: jasmine.stringMatching(/^\d{13}$/),
         has_full_snapshot: 'true',
-        records_count: recordsPerFullSnapshotPlus(0).toString(),
+        records_count: String(recordsPerFullSnapshot()),
         segment: jasmine.any(File),
         'session.id': 'session-id',
         start: jasmine.stringMatching(/^\d{13}$/),
@@ -106,7 +106,7 @@ describe('startRecording', () => {
     }
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(inputCount).toString())
+      expect(getRequestData(calls.first()).records_count).toBe(String(inputCount + recordsPerFullSnapshot()))
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -123,7 +123,7 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(1).toString())
+      expect(getRequestData(calls.first()).records_count).toBe(String(1 + recordsPerFullSnapshot()))
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -220,7 +220,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(1).toString())
+        expect(getRequestData(calls.first()).records_count).toBe(String(1 + recordsPerFullSnapshot()))
         expectNoExtraRequestSendCalls(done)
       })
     })
@@ -233,7 +233,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe(recordsPerFullSnapshotPlus(0).toString())
+        expect(getRequestData(calls.first()).records_count).toBe(String(recordsPerFullSnapshot()))
         expectNoExtraRequestSendCalls(done)
       })
     })

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -5,7 +5,7 @@ import { createRumSessionManagerMock, RumSessionManagerMock } from '../../../rum
 import { createNewEvent } from '../../../core/test/specHelper'
 
 import { setup, TestSetupBuilder } from '../../../rum-core/test/specHelper'
-import { collectAsyncCalls } from '../../test/utils'
+import { collectAsyncCalls, addRecordsPerFullSnapshot } from '../../test/utils'
 import { setMaxSegmentSize, startDeflateWorker } from '../domain/segmentCollection'
 
 import { Segment, RecordType } from '../types'
@@ -58,7 +58,7 @@ describe('startRecording', () => {
           defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
         })
         .beforeBuild(({ lifeCycle, configuration, parentContexts, sessionManager }) => {
-          const recording = startRecording(lifeCycle, configuration, sessionManager, parentContexts, worker!)
+          const recording = startRecording(lifeCycle, configuration, sessionManager, parentContexts, worker)
           stopRecording = recording ? recording.stop : noop
           return { stop: stopRecording }
         })
@@ -83,7 +83,7 @@ describe('startRecording', () => {
         creation_reason: 'init',
         end: jasmine.stringMatching(/^\d{13}$/),
         has_full_snapshot: 'true',
-        records_count: '4',
+        records_count: addRecordsPerFullSnapshot(0).toString(),
         segment: jasmine.any(File),
         'session.id': 'session-id',
         start: jasmine.stringMatching(/^\d{13}$/),
@@ -106,7 +106,7 @@ describe('startRecording', () => {
     }
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe(String(inputCount + 4))
+      expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(inputCount).toString())
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -123,7 +123,7 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(1, (calls) => {
-      expect(getRequestData(calls.first()).records_count).toBe('5')
+      expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(1).toString())
       expectNoExtraRequestSendCalls(done)
     })
   })
@@ -220,7 +220,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe('5')
+        expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(1).toString())
         expectNoExtraRequestSendCalls(done)
       })
     })
@@ -233,7 +233,7 @@ describe('startRecording', () => {
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {
-        expect(getRequestData(calls.first()).records_count).toBe('4')
+        expect(getRequestData(calls.first()).records_count).toBe(addRecordsPerFullSnapshot(0).toString())
         expectNoExtraRequestSendCalls(done)
       })
     })

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -58,7 +58,7 @@ describe('startRecording', () => {
           defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
         })
         .beforeBuild(({ lifeCycle, configuration, parentContexts, sessionManager }) => {
-          const recording = startRecording(lifeCycle, configuration, sessionManager, parentContexts, worker)
+          const recording = startRecording(lifeCycle, configuration, sessionManager, parentContexts, worker!)
           stopRecording = recording ? recording.stop : noop
           return { stop: stopRecording }
         })

--- a/packages/rum/src/domain/record/observer.ts
+++ b/packages/rum/src/domain/record/observer.ts
@@ -7,7 +7,6 @@ import {
   addEventListener,
   includes,
   DefaultPrivacyLevel,
-  isExperimentalFeatureEnabled,
   noop,
 } from '@datadog/browser-core'
 import { NodePrivacyLevel } from '../../constants'
@@ -60,10 +59,7 @@ export function initObservers(o: ObserverParam): ListenerHandler {
   const mediaInteractionHandler = initMediaInteractionObserver(o.mediaInteractionCb, o.defaultPrivacyLevel)
   const styleSheetObserver = initStyleSheetObserver(o.styleSheetRuleCb)
   const focusHandler = initFocusObserver(o.focusCb)
-
-  const visualViewportResizeHandler = isExperimentalFeatureEnabled('visualviewport')
-    ? initVisualViewportResizeObserver(o.visualViewportResizeCb)
-    : noop
+  const visualViewportResizeHandler = initVisualViewportResizeObserver(o.visualViewportResizeCb)
 
   return () => {
     mutationHandler()
@@ -99,7 +95,7 @@ function initMoveObserver(cb: MousemoveCallBack): ListenerHandler {
           x: clientX,
           y: clientY,
         }
-        if (isExperimentalFeatureEnabled('visualviewport') && window.visualViewport) {
+        if (window.visualViewport) {
           const { visualViewportX, visualViewportY } = convertMouseEventToLayoutCoordinates(clientX, clientY)
           position.x = visualViewportX
           position.y = visualViewportY
@@ -146,7 +142,7 @@ function initMouseInteractionObserver(
       x: clientX,
       y: clientY,
     }
-    if (isExperimentalFeatureEnabled('visualviewport') && window.visualViewport) {
+    if (window.visualViewport) {
       const { visualViewportX, visualViewportY } = convertMouseEventToLayoutCoordinates(clientX, clientY)
       position.x = visualViewportX
       position.y = visualViewportY
@@ -172,7 +168,7 @@ function initScrollObserver(cb: ScrollCallback, defaultPrivacyLevel: DefaultPriv
       }
       const id = getSerializedNodeId(target)
       if (target === document) {
-        if (isExperimentalFeatureEnabled('visualviewport')) {
+        if (window.visualViewport) {
           cb({
             id,
             x: getScrollX(),

--- a/packages/rum/src/domain/record/observer.ts
+++ b/packages/rum/src/domain/record/observer.ts
@@ -168,20 +168,11 @@ function initScrollObserver(cb: ScrollCallback, defaultPrivacyLevel: DefaultPriv
       }
       const id = getSerializedNodeId(target)
       if (target === document) {
-        if (window.visualViewport) {
-          cb({
-            id,
-            x: getScrollX(),
-            y: getScrollY(),
-          })
-        } else {
-          const scrollEl = (document.scrollingElement || document.documentElement)!
-          cb({
-            id,
-            x: scrollEl.scrollLeft,
-            y: scrollEl.scrollTop,
-          })
-        }
+        cb({
+          id,
+          x: getScrollX(),
+          y: getScrollY(),
+        })
       } else {
         cb({
           id,

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -49,54 +49,56 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    waitEmitCalls(9, () => {
+    waitEmitCalls(10, () => {
       const records = getEmittedRecords()
 
       expect(records[0].type).toEqual(RecordType.Meta)
       expect(records[1].type).toEqual(RecordType.Focus)
       expect(records[2].type).toEqual(RecordType.FullSnapshot)
-      expect(records[3].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[3] as IncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { background: #000; }', index: undefined }],
-        })
-      )
+      expect(records[3].type).toEqual(RecordType.VisualViewport)
       expect(records[4].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[4] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { background: #111; }', index: undefined }],
+          adds: [{ rule: 'body { background: #000; }', index: undefined }],
         })
       )
       expect(records[5].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[5] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
-          removes: [{ index: 0 }],
+          adds: [{ rule: 'body { background: #111; }', index: undefined }],
         })
       )
       expect(records[6].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[6] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { color: #fff; }', index: undefined }],
+          removes: [{ index: 0 }],
         })
       )
       expect(records[7].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[7] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
-          removes: [{ index: 0 }],
+          adds: [{ rule: 'body { color: #fff; }', index: undefined }],
         })
       )
       expect(records[8].type).toEqual(RecordType.IncrementalSnapshot)
       expect((records[8] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
+          removes: [{ index: 0 }],
+        })
+      )
+      expect(records[9].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[9] as IncrementalSnapshotRecord).data).toEqual(
+        jasmine.objectContaining({
+          source: IncrementalSource.StyleSheetRule,
           adds: [{ rule: 'body { color: #ccc; }', index: undefined }],
         })
       )
+      expect(records[10].type).toEqual(RecordType.VisualViewport)
 
       expectNoExtraEmitCalls(done)
     })
@@ -109,17 +111,19 @@ describe('record', () => {
 
     recordApi.takeFullSnapshot()
 
-    waitEmitCalls(7, () => {
+    waitEmitCalls(9, () => {
       const records = getEmittedRecords()
 
       expect(records[0].type).toEqual(RecordType.Meta)
       expect(records[1].type).toEqual(RecordType.Focus)
       expect(records[2].type).toEqual(RecordType.FullSnapshot)
-      expect(records[3].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[3] as IncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
-      expect(records[4].type).toEqual(RecordType.Meta)
-      expect(records[5].type).toEqual(RecordType.Focus)
-      expect(records[6].type).toEqual(RecordType.FullSnapshot)
+      expect(records[3].type).toEqual(RecordType.VisualViewport)
+      expect(records[4].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[4] as IncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
+      expect(records[5].type).toEqual(RecordType.Meta)
+      expect(records[6].type).toEqual(RecordType.Focus)
+      expect(records[7].type).toEqual(RecordType.FullSnapshot)
+      expect(records[8].type).toEqual(RecordType.VisualViewport)
 
       expectNoExtraEmitCalls(done)
     })

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,6 +1,6 @@
 import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import { Clock, createNewEvent } from '../../../../core/test/specHelper'
-import { collectAsyncCalls, addRecordsPerFullSnapshot } from '../../../test/utils'
+import { collectAsyncCalls, recordsPerFullSnapshotPlus } from '../../../test/utils'
 import { RecordType, IncrementalSource, RawRecord, IncrementalSnapshotRecord, FocusRecord } from '../../types'
 import { record } from './record'
 import { RecordAPI } from './types'
@@ -49,7 +49,7 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    waitEmitCalls(addRecordsPerFullSnapshot(6), () => {
+    waitEmitCalls(recordsPerFullSnapshotPlus(6), () => {
       const records = getEmittedRecords()
       let i = 0
 
@@ -115,7 +115,7 @@ describe('record', () => {
 
     recordApi.takeFullSnapshot()
 
-    waitEmitCalls(addRecordsPerFullSnapshot(5), () => {
+    waitEmitCalls(recordsPerFullSnapshotPlus(1) + recordsPerFullSnapshotPlus(0), () => {
       const records = getEmittedRecords()
       let i = 0
 
@@ -131,10 +131,6 @@ describe('record', () => {
       expect(records[i++].type).toEqual(RecordType.Meta)
       expect(records[i++].type).toEqual(RecordType.Focus)
       expect(records[i++].type).toEqual(RecordType.FullSnapshot)
-
-      if (window.visualViewport) {
-        expect(records[i++].type).toEqual(RecordType.VisualViewport)
-      }
 
       expectNoExtraEmitCalls(done)
     })

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,6 +1,6 @@
 import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import { Clock, createNewEvent } from '../../../../core/test/specHelper'
-import { collectAsyncCalls, recordsPerFullSnapshotPlus } from '../../../test/utils'
+import { collectAsyncCalls, recordsPerFullSnapshot } from '../../../test/utils'
 import { RecordType, IncrementalSource, RawRecord, IncrementalSnapshotRecord, FocusRecord } from '../../types'
 import { record } from './record'
 import { RecordAPI } from './types'
@@ -49,7 +49,7 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    waitEmitCalls(recordsPerFullSnapshotPlus(6), () => {
+    waitEmitCalls(recordsPerFullSnapshot() + 6, () => {
       const records = getEmittedRecords()
       let i = 0
 
@@ -115,7 +115,7 @@ describe('record', () => {
 
     recordApi.takeFullSnapshot()
 
-    waitEmitCalls(recordsPerFullSnapshotPlus(1) + recordsPerFullSnapshotPlus(0), () => {
+    waitEmitCalls(1 + 2 * recordsPerFullSnapshot(), () => {
       const records = getEmittedRecords()
       let i = 0
 

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,6 +1,6 @@
 import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import { Clock, createNewEvent } from '../../../../core/test/specHelper'
-import { collectAsyncCalls } from '../../../test/utils'
+import { collectAsyncCalls, addRecordsPerFullSnapshot } from '../../../test/utils'
 import { RecordType, IncrementalSource, RawRecord, IncrementalSnapshotRecord, FocusRecord } from '../../types'
 import { record } from './record'
 import { RecordAPI } from './types'
@@ -49,56 +49,60 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    waitEmitCalls(10, () => {
+    waitEmitCalls(addRecordsPerFullSnapshot(6), () => {
       const records = getEmittedRecords()
+      let i = 0
 
-      expect(records[0].type).toEqual(RecordType.Meta)
-      expect(records[1].type).toEqual(RecordType.Focus)
-      expect(records[2].type).toEqual(RecordType.FullSnapshot)
-      expect(records[3].type).toEqual(RecordType.VisualViewport)
-      expect(records[4].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[4] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[i++].type).toEqual(RecordType.Meta)
+      expect(records[i++].type).toEqual(RecordType.Focus)
+      expect(records[i++].type).toEqual(RecordType.FullSnapshot)
+
+      if (window.visualViewport) {
+        expect(records[i++].type).toEqual(RecordType.VisualViewport)
+      }
+
+      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[i++] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
           adds: [{ rule: 'body { background: #000; }', index: undefined }],
         })
       )
-      expect(records[5].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[5] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[i++] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
           adds: [{ rule: 'body { background: #111; }', index: undefined }],
         })
       )
-      expect(records[6].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[6] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[i++] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
           removes: [{ index: 0 }],
         })
       )
-      expect(records[7].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[7] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[i++] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
           adds: [{ rule: 'body { color: #fff; }', index: undefined }],
         })
       )
-      expect(records[8].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[8] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[i++] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
           removes: [{ index: 0 }],
         })
       )
-      expect(records[9].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[9] as IncrementalSnapshotRecord).data).toEqual(
+      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[i++] as IncrementalSnapshotRecord).data).toEqual(
         jasmine.objectContaining({
           source: IncrementalSource.StyleSheetRule,
           adds: [{ rule: 'body { color: #ccc; }', index: undefined }],
         })
       )
-      expect(records[10].type).toEqual(RecordType.VisualViewport)
 
       expectNoExtraEmitCalls(done)
     })
@@ -111,19 +115,26 @@ describe('record', () => {
 
     recordApi.takeFullSnapshot()
 
-    waitEmitCalls(9, () => {
+    waitEmitCalls(addRecordsPerFullSnapshot(5), () => {
       const records = getEmittedRecords()
+      let i = 0
 
-      expect(records[0].type).toEqual(RecordType.Meta)
-      expect(records[1].type).toEqual(RecordType.Focus)
-      expect(records[2].type).toEqual(RecordType.FullSnapshot)
-      expect(records[3].type).toEqual(RecordType.VisualViewport)
-      expect(records[4].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[4] as IncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
-      expect(records[5].type).toEqual(RecordType.Meta)
-      expect(records[6].type).toEqual(RecordType.Focus)
-      expect(records[7].type).toEqual(RecordType.FullSnapshot)
-      expect(records[8].type).toEqual(RecordType.VisualViewport)
+      expect(records[i++].type).toEqual(RecordType.Meta)
+      expect(records[i++].type).toEqual(RecordType.Focus)
+      expect(records[i++].type).toEqual(RecordType.FullSnapshot)
+
+      if (window.visualViewport) {
+        expect(records[i++].type).toEqual(RecordType.VisualViewport)
+      }
+      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+      expect((records[i++] as IncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
+      expect(records[i++].type).toEqual(RecordType.Meta)
+      expect(records[i++].type).toEqual(RecordType.Focus)
+      expect(records[i++].type).toEqual(RecordType.FullSnapshot)
+
+      if (window.visualViewport) {
+        expect(records[i++].type).toEqual(RecordType.VisualViewport)
+      }
 
       expectNoExtraEmitCalls(done)
     })

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -1,4 +1,3 @@
-import { isExperimentalFeatureEnabled } from '@datadog/browser-core'
 import { RecordType } from '../../types'
 import { serializeDocument } from './serialize'
 import { initObservers } from './observer'
@@ -46,7 +45,7 @@ export function record(options: RecordOptions): RecordAPI {
       type: RecordType.FullSnapshot,
     })
 
-    if (isExperimentalFeatureEnabled('visualviewport') && window.visualViewport) {
+    if (window.visualViewport) {
       emit({
         data: getVisualViewport(),
         type: RecordType.VisualViewport,

--- a/packages/rum/src/domain/record/viewports.spec.ts
+++ b/packages/rum/src/domain/record/viewports.spec.ts
@@ -4,6 +4,10 @@ function isMobileSafari12() {
   return /iPhone OS 12.* like Mac OS.* Version\/12.* Mobile.*Safari/.test(navigator.userAgent)
 }
 
+function getChromeHeadlessCorrection() {
+  return /Macintosh.* HeadlessChrome\//.test(navigator.userAgent) ? 15 : 0
+}
+
 describe('layout viewport', () => {
   beforeEach(() => {
     document.body.style.setProperty('margin-bottom', '2000px')
@@ -18,7 +22,8 @@ describe('layout viewport', () => {
     it('normalized scroll matches native behaviour', () => {
       const initialInnerWidth = getWindowWidth()
       const initialInnerHeight = getWindowHeight()
-      expect(initialInnerWidth).toBe(window.innerWidth)
+      const correction = getChromeHeadlessCorrection()
+      expect(initialInnerWidth).toBe(window.innerWidth - correction)
       expect(initialInnerHeight).toBe(window.innerHeight)
     })
   })

--- a/packages/rum/src/domain/record/viewports.spec.ts
+++ b/packages/rum/src/domain/record/viewports.spec.ts
@@ -1,11 +1,7 @@
-import { getScrollX, getScrollY, getWindowWidth, getWindowHeight } from './viewports'
+import { getScrollX, getScrollY, getWindowHeight } from './viewports'
 
 function isMobileSafari12() {
   return /iPhone OS 12.* like Mac OS.* Version\/12.* Mobile.*Safari/.test(navigator.userAgent)
-}
-
-function getChromeHeadlessCorrection() {
-  return /Macintosh.* HeadlessChrome\//.test(navigator.userAgent) ? 15 : 0
 }
 
 describe('layout viewport', () => {
@@ -18,12 +14,9 @@ describe('layout viewport', () => {
     window.scrollTo(0, 0)
   })
 
-  describe('get window width and height', () => {
+  describe('get window height', () => {
     it('normalized scroll matches native behaviour', () => {
-      const initialInnerWidth = getWindowWidth()
       const initialInnerHeight = getWindowHeight()
-      const correction = getChromeHeadlessCorrection()
-      expect(initialInnerWidth).toBe(window.innerWidth - correction)
       expect(initialInnerHeight).toBe(window.innerHeight)
     })
   })

--- a/packages/rum/src/domain/record/viewports.spec.ts
+++ b/packages/rum/src/domain/record/viewports.spec.ts
@@ -6,10 +6,10 @@ function isMobileSafari12() {
 
 describe('layout viewport', () => {
   const addVerticalScrollBar = () => {
-    document.body.style.setProperty('margin-bottom', '2000px')
+    document.body.style.setProperty('margin-bottom', '5000px')
   }
   const addHorizontalScrollBar = () => {
-    document.body.style.setProperty('margin-bottom', '2000px')
+    document.body.style.setProperty('margin-right', '5000px')
   }
 
   afterEach(() => {

--- a/packages/rum/src/domain/record/viewports.spec.ts
+++ b/packages/rum/src/domain/record/viewports.spec.ts
@@ -4,24 +4,6 @@ function isMobileSafari12() {
   return /iPhone OS 12.* like Mac OS.* Version\/12.* Mobile.*Safari/.test(navigator.userAgent)
 }
 
-function getCurrentScrollbarWidth() {
-  const thickness = window.innerWidth - document.documentElement.clientWidth
-  // eslint-disable-next-line no-console
-  console.log('getCurrentScrollbarWidth:', thickness, window.innerWidth, document.documentElement.clientWidth)
-  expect(thickness).toBeLessThanOrEqual(20)
-  expect(thickness).toBeGreaterThanOrEqual(0)
-  return thickness
-}
-
-function getCurrentScrollbarHeight() {
-  const thickness = window.innerHeight - document.documentElement.clientHeight
-  // eslint-disable-next-line no-console
-  console.log('getCurrentScrollbarHeight:', thickness, window.innerHeight, document.documentElement.clientHeight)
-  expect(thickness).toBeLessThanOrEqual(20)
-  expect(thickness).toBeGreaterThanOrEqual(0)
-  return thickness
-}
-
 describe('layout viewport', () => {
   const addVerticalScrollBar = () => {
     document.body.style.setProperty('margin-bottom', '2000px')
@@ -37,29 +19,33 @@ describe('layout viewport', () => {
   })
 
   describe('get window width has similar native behaviour', () => {
-    // innerWidth includes the thickness of the sidebar while `visualViewport.width` excludes it
+    // innerWidth includes the thickness of the sidebar while `visualViewport.width` and clientWidth exclude it
     it('without scrollbars', () => {
-      const initialInnerWidth = getWindowWidth()
-      expect(initialInnerWidth).toBe(window.innerWidth)
+      expect(getWindowWidth()).toBe(window.innerWidth)
     })
 
     it('with scrollbars', () => {
       addHorizontalScrollBar()
-      const initialInnerWidth = getWindowWidth()
-      expect(initialInnerWidth).toBe(window.innerWidth - getCurrentScrollbarWidth())
+      expect([
+        // Some devices don't follow specification of including scrollbars
+        window.innerWidth,
+        document.documentElement.clientWidth,
+      ]).toContain(getWindowWidth())
     })
   })
 
   describe('get window height has similar native behaviour', () => {
-    // innerHeight includes the thickness of the sidebar while `visualViewport.height` excludes it
+    // innerHeight includes the thickness of the sidebar while `visualViewport.height` and clientHeight exclude it
     it('without scrollbars', () => {
-      const initialInnerHeight = getWindowHeight()
-      expect(initialInnerHeight).toBe(window.innerHeight)
+      expect(getWindowHeight()).toBe(window.innerHeight)
     })
     it('with scrollbars', () => {
       addVerticalScrollBar()
-      const initialInnerHeight = getWindowHeight()
-      expect(initialInnerHeight).toBe(window.innerHeight - getCurrentScrollbarHeight())
+      expect([
+        // Some devices don't follow specification of including scrollbars
+        window.innerHeight,
+        document.documentElement.clientHeight,
+      ]).toContain(getWindowHeight())
     })
   })
 

--- a/packages/rum/src/domain/record/viewports.spec.ts
+++ b/packages/rum/src/domain/record/viewports.spec.ts
@@ -1,28 +1,71 @@
-import { getScrollX, getScrollY, getWindowHeight } from './viewports'
+import { getScrollX, getScrollY, getWindowHeight, getWindowWidth } from './viewports'
 
 function isMobileSafari12() {
   return /iPhone OS 12.* like Mac OS.* Version\/12.* Mobile.*Safari/.test(navigator.userAgent)
 }
 
+function getCurrentScrollbarWidth() {
+  const thickness = window.innerWidth - document.documentElement.clientWidth
+  // eslint-disable-next-line no-console
+  console.log('getCurrentScrollbarWidth:', thickness, window.innerWidth, document.documentElement.clientWidth)
+  expect(thickness).toBeLessThanOrEqual(20)
+  expect(thickness).toBeGreaterThanOrEqual(0)
+  return thickness
+}
+
+function getCurrentScrollbarHeight() {
+  const thickness = window.innerHeight - document.documentElement.clientHeight
+  // eslint-disable-next-line no-console
+  console.log('getCurrentScrollbarHeight:', thickness, window.innerHeight, document.documentElement.clientHeight)
+  expect(thickness).toBeLessThanOrEqual(20)
+  expect(thickness).toBeGreaterThanOrEqual(0)
+  return thickness
+}
+
 describe('layout viewport', () => {
-  beforeEach(() => {
+  const addVerticalScrollBar = () => {
     document.body.style.setProperty('margin-bottom', '2000px')
-  })
+  }
+  const addHorizontalScrollBar = () => {
+    document.body.style.setProperty('margin-bottom', '2000px')
+  }
 
   afterEach(() => {
     document.body.style.removeProperty('margin-bottom')
+    document.body.style.removeProperty('margin-right')
     window.scrollTo(0, 0)
   })
 
-  describe('get window height', () => {
-    it('normalized scroll matches native behaviour', () => {
+  describe('get window width has similar native behaviour', () => {
+    // innerWidth includes the thickness of the sidebar while `visualViewport.width` excludes it
+    it('without scrollbars', () => {
+      const initialInnerWidth = getWindowWidth()
+      expect(initialInnerWidth).toBe(window.innerWidth)
+    })
+
+    it('with scrollbars', () => {
+      addHorizontalScrollBar()
+      const initialInnerWidth = getWindowWidth()
+      expect(initialInnerWidth).toBe(window.innerWidth - getCurrentScrollbarWidth())
+    })
+  })
+
+  describe('get window height has similar native behaviour', () => {
+    // innerHeight includes the thickness of the sidebar while `visualViewport.height` excludes it
+    it('without scrollbars', () => {
       const initialInnerHeight = getWindowHeight()
       expect(initialInnerHeight).toBe(window.innerHeight)
+    })
+    it('with scrollbars', () => {
+      addVerticalScrollBar()
+      const initialInnerHeight = getWindowHeight()
+      expect(initialInnerHeight).toBe(window.innerHeight - getCurrentScrollbarHeight())
     })
   })
 
   describe('getScrollX/Y', () => {
     it('normalized scroll matches initial behaviour', () => {
+      addVerticalScrollBar()
       expect(getScrollX()).toBe(0)
       expect(getScrollY()).toBe(0)
       expect(getScrollX()).toBe(window.scrollX || window.pageXOffset)
@@ -35,6 +78,7 @@ describe('layout viewport', () => {
         // https://coderwall.com/p/c-aqqw/scrollable-iframe-on-mobile-safari
         pending('Mobile Safari 12 not supported')
       }
+      addVerticalScrollBar()
       const SCROLL_DOWN_PX = 100
       window.scrollTo(0, SCROLL_DOWN_PX)
       expect(getScrollX()).toBe(0)

--- a/packages/rum/src/domain/record/viewports.ts
+++ b/packages/rum/src/domain/record/viewports.ts
@@ -9,7 +9,6 @@
  * viewport is being measured by the browser
  */
 
-import { isExperimentalFeatureEnabled } from '@datadog/browser-core'
 import type { VisualViewportRecord } from '../../types'
 
 // Scrollbar widths vary across properties on different devices and browsers
@@ -75,7 +74,7 @@ export const getVisualViewport = (): VisualViewportRecord['data'] => {
 // excludes the width of any rendered classic scrollbar that is fixed to the visual viewport
 export function getWindowWidth(): number {
   const visual = window.visualViewport
-  if (isExperimentalFeatureEnabled('visualviewport') && visual) {
+  if (visual) {
     return visual.width * visual.scale
   }
   return window.innerWidth || 0
@@ -84,7 +83,7 @@ export function getWindowWidth(): number {
 // excludes the height of any rendered classic scrollbar that is fixed to the visual viewport
 export function getWindowHeight(): number {
   const visual = window.visualViewport
-  if (isExperimentalFeatureEnabled('visualviewport') && visual) {
+  if (visual) {
     return visual.height * visual.scale
   }
   return window.innerHeight || 0
@@ -92,7 +91,7 @@ export function getWindowHeight(): number {
 
 export function getScrollX() {
   const visual = window.visualViewport
-  if (isExperimentalFeatureEnabled('visualviewport') && visual) {
+  if (visual) {
     return visual.pageLeft - visual.offsetLeft
   }
   if (window.scrollX !== undefined) {
@@ -103,7 +102,7 @@ export function getScrollX() {
 
 export function getScrollY() {
   const visual = window.visualViewport
-  if (isExperimentalFeatureEnabled('visualviewport') && visual) {
+  if (visual) {
     return visual.pageTop - visual.offsetTop
   }
   if (window.scrollY !== undefined) {

--- a/packages/rum/test/utils.ts
+++ b/packages/rum/test/utils.ts
@@ -212,7 +212,7 @@ export function findAllIncrementalSnapshots(segment: Segment, source: Incrementa
 
 // Returns the textContent of a ElementNode, if any.
 export function findTextContent(elem: ElementNode): string | null {
-  const text = elem.childNodes.find((child) => child.type === NodeType.Text) as TextNode
+  const text = elem.childNodes.find((child) => child.type === NodeType.Text)
   return text ? text.textContent : null
 }
 
@@ -228,14 +228,12 @@ export function findElementWithTagName(root: SerializedNodeWithId, tagName: stri
 
 // Returns the first TextNode with the given content contained in a node, if any.
 export function findTextNode(root: SerializedNodeWithId, textContent: string) {
-  return findNode(root, (node) => isTextNode(node) && node.textContent === textContent) as
-    | (TextNode & { id: number })
-    | null
+  return findNode(root, (node) => isTextNode(node) && node.textContent === textContent)
 }
 
 // Returns the first ElementNode matching the predicate
 export function findElement(root: SerializedNodeWithId, predicate: (node: ElementNode) => boolean) {
-  return findNode(root, (node) => isElementNode(node) && predicate(node)) as (ElementNode & { id: number }) | null
+  return findNode(root, (node) => isElementNode(node) && predicate(node))
 }
 
 // Returns the first SerializedNodeWithId matching the predicate
@@ -367,7 +365,7 @@ export function createMutationPayloadValidator(initialDocument: SerializedNodeWi
     return new ExpectedNode({
       ...node,
       id: maxNodeId,
-    } as any)
+    })
   }
 
   return {
@@ -468,4 +466,13 @@ export function createMutationPayloadValidatorFromSegment(segment: Segment) {
     ...mutationPayloadValidator,
     validate: (expected: ExpectedMutationsPayload) => mutationPayloadValidator.validate(mutations[0].data, expected),
   }
+}
+
+/**
+ * Simplify asserting record lengths across multiple devices when not all record types are supported
+ */
+export const addRecordsPerFullSnapshot = (otherRecordsCount: number) => {
+  // Meta, Focus, FullSnapshot, VisualViewport (support limited)
+  const recordsPerFullsnapshot = window.visualViewport ? 4 : 3
+  return recordsPerFullsnapshot + otherRecordsCount
 }

--- a/packages/rum/test/utils.ts
+++ b/packages/rum/test/utils.ts
@@ -473,8 +473,8 @@ export function createMutationPayloadValidatorFromSegment(segment: Segment) {
 /**
  * Simplify asserting record lengths across multiple devices when not all record types are supported
  */
-export const addRecordsPerFullSnapshot = (otherRecordsCount: number) => {
+export const recordsPerFullSnapshotPlus = (otherRecordsCount: number) => {
   // Meta, Focus, FullSnapshot, VisualViewport (support limited)
-  const recordsPerFullsnapshot = window.visualViewport ? 4 : 3
-  return recordsPerFullsnapshot + otherRecordsCount
+  const recordsPerFullSnapshot = window.visualViewport ? 4 : 3
+  return recordsPerFullSnapshot + otherRecordsCount
 }

--- a/packages/rum/test/utils.ts
+++ b/packages/rum/test/utils.ts
@@ -473,8 +473,6 @@ export function createMutationPayloadValidatorFromSegment(segment: Segment) {
 /**
  * Simplify asserting record lengths across multiple devices when not all record types are supported
  */
-export const recordsPerFullSnapshotPlus = (otherRecordsCount: number) => {
+export const recordsPerFullSnapshot = () =>
   // Meta, Focus, FullSnapshot, VisualViewport (support limited)
-  const recordsPerFullSnapshot = window.visualViewport ? 4 : 3
-  return recordsPerFullSnapshot + otherRecordsCount
-}
+  window.visualViewport ? 4 : 3

--- a/packages/rum/test/utils.ts
+++ b/packages/rum/test/utils.ts
@@ -212,7 +212,7 @@ export function findAllIncrementalSnapshots(segment: Segment, source: Incrementa
 
 // Returns the textContent of a ElementNode, if any.
 export function findTextContent(elem: ElementNode): string | null {
-  const text = elem.childNodes.find((child) => child.type === NodeType.Text)
+  const text = elem.childNodes.find((child) => child.type === NodeType.Text) as TextNode
   return text ? text.textContent : null
 }
 
@@ -228,12 +228,14 @@ export function findElementWithTagName(root: SerializedNodeWithId, tagName: stri
 
 // Returns the first TextNode with the given content contained in a node, if any.
 export function findTextNode(root: SerializedNodeWithId, textContent: string) {
-  return findNode(root, (node) => isTextNode(node) && node.textContent === textContent)
+  return findNode(root, (node) => isTextNode(node) && node.textContent === textContent) as
+    | (TextNode & { id: number })
+    | null
 }
 
 // Returns the first ElementNode matching the predicate
 export function findElement(root: SerializedNodeWithId, predicate: (node: ElementNode) => boolean) {
-  return findNode(root, (node) => isElementNode(node) && predicate(node))
+  return findNode(root, (node) => isElementNode(node) && predicate(node)) as (ElementNode & { id: number }) | null
 }
 
 // Returns the first SerializedNodeWithId matching the predicate
@@ -365,7 +367,7 @@ export function createMutationPayloadValidator(initialDocument: SerializedNodeWi
     return new ExpectedNode({
       ...node,
       id: maxNodeId,
-    })
+    } as any)
   }
 
   return {

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -130,8 +130,8 @@ function getLastSegment(serverEvents: EventRegistry) {
 }
 
 function initRumAndStartRecording(initConfiguration: RumInitConfiguration) {
-  window.DD_RUM.init(initConfiguration)
-  window.DD_RUM.startSessionReplayRecording()
+  window.DD_RUM!.init(initConfiguration)
+  window.DD_RUM!.startSessionReplayRecording()
 }
 
 const isGestureUnsupported = () => {

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -24,7 +24,7 @@ describe('recorder', () => {
 
   describe('layout viewport properties', () => {
     createTest('getWindowWidth/Height should not be affected by pinch zoom')
-      .withRum({ enableExperimentalFeatures: ['visualviewport'] })
+      .withRum()
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .withBody(html`${VIEWPORT_META_TAGS}`)
@@ -55,7 +55,7 @@ describe('recorder', () => {
      * We need to ensure that our measurements are not affected by pinch zoom
      */
     createTest('getScrollX/Y should not be affected by pinch scroll')
-      .withRum({ enableExperimentalFeatures: ['visualviewport'] })
+      .withRum()
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .withBody(html`${VIEWPORT_META_TAGS}`)
@@ -97,7 +97,7 @@ describe('recorder', () => {
 
   describe('visual viewport properties', () => {
     createTest('pinch zoom "scroll" event reports visual viewport position')
-      .withRum({ enableExperimentalFeatures: ['visualviewport'] })
+      .withRum()
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .withBody(html`${VIEWPORT_META_TAGS}`)
@@ -112,7 +112,7 @@ describe('recorder', () => {
       })
 
     createTest('pinch zoom "resize" event reports visual viewport scale')
-      .withRum({ enableExperimentalFeatures: ['visualviewport'] })
+      .withRum()
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .withBody(html`${VIEWPORT_META_TAGS}`)
@@ -130,8 +130,8 @@ function getLastSegment(serverEvents: EventRegistry) {
 }
 
 function initRumAndStartRecording(initConfiguration: RumInitConfiguration) {
-  window.DD_RUM!.init(initConfiguration)
-  window.DD_RUM!.startSessionReplayRecording()
+  window.DD_RUM.init(initConfiguration)
+  window.DD_RUM.startSessionReplayRecording()
 }
 
 const isGestureUnsupported = () => {

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -135,14 +135,8 @@ function initRumAndStartRecording(initConfiguration: RumInitConfiguration) {
 }
 
 const isGestureUnsupported = () => {
-  const { capabilities } = browser
-  return (
-    capabilities.browserName === 'firefox' ||
-    capabilities.browserName === 'Safari 12.0' ||
-    capabilities.browserName === 'msedge' ||
-    capabilities.platformName === 'windows' ||
-    capabilities.platformName === 'linux'
-  )
+  const { browserName, platformName } = browser.capabilities
+  return /firefox|safai|msedge/i.exec(browserName ?? '') || /windows|linux/i.exec(platformName ?? '')
 }
 
 // Flakiness: Working with viewport sizes has variations per device of a few pixels

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -138,7 +138,7 @@ const isGestureUnsupported = () => {
   const { capabilities } = browser
   return (
     capabilities.browserName === 'firefox' ||
-    capabilities.browserName === 'Safari' ||
+    capabilities.browserName === 'Safari 12.0' ||
     capabilities.browserName === 'msedge' ||
     capabilities.platformName === 'windows' ||
     capabilities.platformName === 'linux'

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -136,7 +136,7 @@ function initRumAndStartRecording(initConfiguration: RumInitConfiguration) {
 
 const isGestureUnsupported = () => {
   const { browserName, platformName } = browser.capabilities
-  return /firefox|safai|msedge/i.exec(browserName ?? '') || /windows|linux/i.exec(platformName ?? '')
+  return /firefox|safari|msedge/i.exec(browserName ?? '') || /windows|linux/i.exec(platformName ?? '')
 }
 
 // Flakiness: Working with viewport sizes has variations per device of a few pixels


### PR DESCRIPTION
## Motivation

It's been a while, time to enable visual viewport recording by default. The is a follow up from implementation https://github.com/DataDog/browser-sdk/pull/1089.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
