### PR TITLE
🐛 remove child with action-names innerText instead of replacing them

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -309,16 +309,17 @@ describe('getActionNameFromElement', () => {
       ).toBe('bar')
     })
 
-    it('replaces the programmatic action name in textual content', () => {
+    it('remove children with programmatic action name in textual content', () => {
       expect(getActionNameFromElement(element`<div>Foo <div data-dd-action-name="custom action">bar<div></div>`)).toBe(
-        'Foo custom action'
+        'Foo'
       )
     })
 
-    it('replaces the programmatic action name in textual content based on the user-configured attribute', () => {
+    // eslint-disable-next-line max-len
+    it('remove children with programmatic action name in textual content based on the user-configured attribute', () => {
       expect(
         getActionNameFromElement(element`<div>Foo <div data-test-id="custom action">bar<div></div>`, 'data-test-id')
-      ).toBe('Foo custom action')
+      ).toBe('Foo')
     })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
@@ -173,14 +173,14 @@ function getTextualContent(element: Element | HTMLElement, userProgrammaticAttri
   if ('innerText' in element) {
     let text = element.innerText
 
-    const replaceTextFromElements = (query: string, replacer: (element: Element) => string) => {
+    const removeTextFromElements = (query: string) => {
       const list = element.querySelectorAll<Element | HTMLElement>(query)
       for (let index = 0; index < list.length; index += 1) {
         const element = list[index]
         if ('innerText' in element) {
           const textToReplace = element.innerText
           if (textToReplace && textToReplace.trim().length > 0) {
-            text = text.replace(textToReplace, replacer(element))
+            text = text.replace(textToReplace, '')
           }
         }
       }
@@ -189,20 +189,14 @@ function getTextualContent(element: Element | HTMLElement, userProgrammaticAttri
     if (!supportsInnerTextScriptAndStyleRemoval()) {
       // remove the inner text of SCRIPT and STYLES from the result. This is a bit dirty, but should
       // be relatively fast and work in most cases.
-      replaceTextFromElements('script, style', () => '')
+      removeTextFromElements('script, style')
     }
 
-    // replace the text of elements with their programmatic attribute value
-    replaceTextFromElements(
-      `[${DEFAULT_PROGRAMMATIC_ATTRIBUTE}]`,
-      (element) => element.getAttribute(DEFAULT_PROGRAMMATIC_ATTRIBUTE)!
-    )
+    // remove the text of elements with programmatic attribute value
+    removeTextFromElements(`[${DEFAULT_PROGRAMMATIC_ATTRIBUTE}]`)
 
     if (userProgrammaticAttribute) {
-      replaceTextFromElements(
-        `[${userProgrammaticAttribute}]`,
-        (element) => element.getAttribute(userProgrammaticAttribute)!
-      )
+      removeTextFromElements(`[${userProgrammaticAttribute}]`)
     }
 
     return text


### PR DESCRIPTION
## Motivation

Using programmatic action names from children to format an element action name breaks some use cases where the user expects that the programmatic action only shows up when the action comes from the child element.

## Changes

Instead of using the programmatic action names from children, remove those children inner text from the action name. This will bring the same guarantees on sensitive data mentioned by the [related PR](https://github.com/DataDog/browser-sdk/pull/1200).

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
