### PR TITLE
🐛 let the backend do most of the tags sanitization

### DIFF
--- a/packages/core/src/domain/configuration/tags.spec.ts
+++ b/packages/core/src/domain/configuration/tags.spec.ts
@@ -22,20 +22,23 @@ describe('buildTag', () => {
     displaySpy = spyOn(display, 'warn')
   })
 
-  it('lowercases tags', () => {
-    expect(buildTag('env', 'BaR')).toBe('env:bar')
+  it('shows a warning when the tag contains uppercase letters', () => {
+    buildTag('env', 'BaR')
     expectWarning()
   })
 
-  it('trims large tags', () => {
-    const tag = buildTag('env', LARGE_VALUE)
-    expect(tag.length).toBe(TAG_SIZE_LIMIT)
-    expect(tag).toBe(`env:${LARGE_VALUE.slice(0, TAG_SIZE_LIMIT - 4)}`)
+  it('shows a warning when the tag is too large', () => {
+    buildTag('env', LARGE_VALUE)
     expectWarning()
   })
 
-  it('replaces forbidden characters with slashes', () => {
-    expect(buildTag('env', 'b#r')).toBe('env:b_r')
+  it('shows a warning when the tag contains forbidden characters', () => {
+    buildTag('env', 'b#r')
+    expectWarning()
+  })
+
+  it('forbids to craft multiple tags by passing a value with a comma', () => {
+    expect(buildTag('env', 'foo,bar')).toBe('env:foo_bar')
     expectWarning()
   })
 

--- a/packages/core/src/domain/configuration/tags.ts
+++ b/packages/core/src/domain/configuration/tags.ts
@@ -20,17 +20,21 @@ export function buildTags(configuration: InitConfiguration): string[] {
   return tags
 }
 
-export function buildTag(key: string, rawValue: string) {
-  // See https://docs.datadoghq.com/getting_started/tagging/#defining-tags for tags syntax.
-  const valueSizeLimit = TAG_SIZE_LIMIT - key.length - 1
-  const sanitizedValue = rawValue
-    .toLowerCase()
-    .slice(0, valueSizeLimit)
-    .replace(/[^a-z0-9_:./-]/g, '_')
+const FORBIDDEN_CHARACTERS = /[^a-z0-9_:./-]/
 
-  if (sanitizedValue !== rawValue) {
+export function buildTag(key: string, rawValue: string) {
+  // See https://docs.datadoghq.com/getting_started/tagging/#defining-tags for tags syntax. Note
+  // that the backend may not follow the exact same rules, so we only want to display an informal
+  // warning.
+  const valueSizeLimit = TAG_SIZE_LIMIT - key.length - 1
+
+  if (rawValue.length > valueSizeLimit || FORBIDDEN_CHARACTERS.test(rawValue)) {
     display.warn(`${key} value doesn't meet tag requirements and will be sanitized`)
   }
+
+  // Let the backend do most of the sanitization, but still make sure multiple tags can't be crafted
+  // by forging a value containing commas.
+  const sanitizedValue = rawValue.replace(/,/g, '_')
 
   return `${key}:${sanitizedValue}`
 }


### PR DESCRIPTION
## Motivation

The backend has sanitization rule that may differ from the actual documentation.

## Changes

 Let's keep it simple and only print a warning if we detect that something look weird, and let the backend do the actual sanitization.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
