### PR TITLE
👷 update v3 references across the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repository contains several packages:
 
 | Package          | npm                      | size                     | cdn                       | doc                                 |
 | ---------------- | ------------------------ | ------------------------ | ------------------------- | ----------------------------------- |
-| browser-logs     | [![npm version][01]][02] | [![bundle size][03]][04] | [datadog-logs-v3][05]     | [![API][1]][07] [![product][2]][08] |
-| browser-rum      | [![npm version][11]][12] | [![bundle size][13]][14] | [datadog-rum-v3][15]      | [![API][1]][17] [![product][2]][18] |
-| browser-rum-slim | [![npm version][21]][22] | [![bundle size][23]][24] | [datadog-rum-slim-v3][25] | [![API][1]][27] [![product][2]][28] |
+| browser-logs     | [![npm version][01]][02] | [![bundle size][03]][04] | [datadog-logs-v4][05]     | [![API][1]][07] [![product][2]][08] |
+| browser-rum      | [![npm version][11]][12] | [![bundle size][13]][14] | [datadog-rum-v4][15]      | [![API][1]][17] [![product][2]][18] |
+| browser-rum-slim | [![npm version][21]][22] | [![bundle size][23]][24] | [datadog-rum-slim-v4][25] | [![API][1]][27] [![product][2]][28] |
 | browser-rum-core | [![npm version][51]][52] | [![bundle size][53]][54] |                           |
 | browser-core     | [![npm version][41]][42] | [![bundle size][43]][44] |                           |
 
@@ -20,21 +20,21 @@ This repository contains several packages:
 [02]: https://badge.fury.io/js/%40datadog%2Fbrowser-logs
 [03]: https://badgen.net/bundlephobia/minzip/@datadog/browser-logs
 [04]: https://bundlephobia.com/result?p=@datadog/browser-logs
-[05]: https://www.datadoghq-browser-agent.com/datadog-logs-v3.js
+[05]: https://www.datadoghq-browser-agent.com/datadog-logs-v4.js
 [07]: ./packages/logs/README.md
 [08]: https://docs.datadoghq.com/logs/log_collection/javascript/?tab=npm
 [11]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum.svg
 [12]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum
 [13]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum
 [14]: https://bundlephobia.com/result?p=@datadog/browser-rum
-[15]: https://www.datadoghq-browser-agent.com/datadog-rum-v3.js
+[15]: https://www.datadoghq-browser-agent.com/datadog-rum-v4.js
 [17]: ./packages/rum/README.md
 [18]: https://docs.datadoghq.com/real_user_monitoring/
 [21]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-slim.svg
 [22]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-slim
 [23]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum-slim
 [24]: https://bundlephobia.com/result?p=@datadog/browser-rum-slim
-[25]: https://www.datadoghq-browser-agent.com/datadog-rum-slim-v3.js
+[25]: https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js
 [27]: ./packages/rum-slim/README.md
 [28]: https://docs.datadoghq.com/real_user_monitoring/
 [41]: https://badge.fury.io/js/%40datadog%2Fbrowser-core.svg

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -29,7 +29,7 @@ Then, in Google Chrome:
 - Flush buffered events
 - End current session
 - Load the SDK development bundles instead of production ones
-- Switch between `datadog-rum-v3.js` and `datadog-rum-slim-v3.js` bundles
+- Switch between `datadog-rum-v4.js` and `datadog-rum-slim-v4.js` bundles
 - Retrieve Logs/RUM configuration
 
 ## Browser compatibility

--- a/developer-extension/src/background/domain/replaceBundles.ts
+++ b/developer-extension/src/background/domain/replaceBundles.ts
@@ -48,7 +48,7 @@ listenAction('setStore', (newStore) => {
 function getBundleUrlPatterns(bundleName: string) {
   return [
     `https://*/datadog-${bundleName}.js`,
-    `https://*/datadog-${bundleName}-v3.js`,
+    `https://*/datadog-${bundleName}-v4.js`,
     `https://*/datadog-${bundleName}-canary.js`,
     `https://*/datadog-${bundleName}-staging.js`,
   ]

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -56,7 +56,7 @@ Load and configure the SDK in the head section of your pages.
         h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
         d=o.createElement(u);d.async=1;d.src=n
         n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-      })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-logs-v3.js','DD_LOGS')
+      })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-logs-v4.js','DD_LOGS')
       DD_LOGS.onReady(function() {
           DD_LOGS.init({
             clientToken: 'XXX',
@@ -80,7 +80,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
 <html>
   <head>
     <title>Example to send logs to Datadog</title>
-    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v3.js"></script>
+    <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
     <script>
       window.DD_LOGS &&
         DD_LOGS.init({

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -61,7 +61,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
    d=o.createElement(u);d.async=1;d.src=n
    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-})(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v3.js','DD_RUM')
+})(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM')
   DD_RUM.onReady(function() {
     DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
@@ -87,7 +87,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 Add the generated code snippet to the head tag (in front of any other script tags) of every HTML page you want to monitor in your application. Including the script tag higher and synchronized ensures Datadog RUM can collect all performance data and errors.
 
 ```html
-<script src="https://www.datadoghq-browser-agent.com/datadog-rum-v3.js" type="text/javascript"></script>
+<script src="https://www.datadoghq-browser-agent.com/datadog-rum-v4.js" type="text/javascript"></script>
 <script>
   window.DD_RUM &&
     window.DD_RUM.init({

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -30,7 +30,7 @@ Options:
   const proxy = await startProxy()
 
   const options: ProfilingOptions = {
-    bundleUrl: 'https://www.datadoghq-browser-agent.com/datadog-rum-v3.js',
+    bundleUrl: 'https://www.datadoghq-browser-agent.com/datadog-rum-v4.js',
     proxy,
     startRecording,
   }

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -20,7 +20,7 @@ app.use(redirectSuffixedFiles)
 app.listen(port, () => printLog(`Server listening on port ${port}.`))
 
 function redirectSuffixedFiles(req, res, next) {
-  const matches = /(.*)-(canary|staging|v3)\.js/.exec(req.url)
+  const matches = /(.*)-(canary|staging|v4)\.js/.exec(req.url)
   if (matches) {
     res.redirect(`${matches[1]}.js`)
   } else {


### PR DESCRIPTION
## Motivation

V4 has been released, but we still talk about v3 in the Browser SDK codebase (readme, tooling...)

## Changes

Update all v3 references to v4 in the codebase

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
