### PR TITLE
⚗ [RUMF-1079] tweak max number of lock retries

### DIFF
--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -11,7 +11,7 @@ export const SESSION_COOKIE_NAME = '_dd_s'
 
 // arbitrary values
 export const LOCK_RETRY_DELAY = 10
-export const MAX_NUMBER_OF_LOCK_RETRIES = 50
+export const MAX_NUMBER_OF_LOCK_RETRIES = 100
 
 type Operations = {
   options: CookieOptions


### PR DESCRIPTION
## Motivation

Since the initial `MAX_NUMBER_OF_LOCK_RETRIES` was arbitrarily defined, try to double the value and see the impact on the number of logs.

## Changes

Increase `MAX_NUMBER_OF_LOCK_RETRIES` from `50` to `100`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
