### PR TITLE
Revert "[Documentation] Fix typo"

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -277,7 +277,7 @@ datadogRum.init({
 });
 ```
 
-For example, to collect 50% of your sessions using the Browser RUM option and 50% of your sessions using the Session Replay RUM option:
+For example, to collect 25% of your sessions using the Browser RUM option and 25% of your sessions using the Session Replay RUM option:
 
 ```
 datadogRum.init({


### PR DESCRIPTION
As mentioned below the example:

> In the example above, 50% of all sessions are collected. The Session Replay RUM option tracks half of these sessions while the Browser RUM option tracks the remaining half of these sessions.

meaning:
- 25% of sessions are collected using the Browser RUM option
- 25% of sessions are collected using the Session Replay RUM option
- 50% of sessions are not collected

Reverts DataDog/browser-sdk#1266