### PR TITLE
👷 [RUMF-1148] Move deployment notification to dedicated channels

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -304,7 +304,7 @@ notify-prod-canary-success:
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :datadog:."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
-    - postmessage "#rum-ops" "$MESSAGE_TEXT"
+    - postmessage "#rum-browser-sdk-ops" "$MESSAGE_TEXT"
 
 notify-prod-canary-failure:
   stage: notify:canary
@@ -323,7 +323,7 @@ notify-prod-stable-success:
   script:
     - 'MESSAGE_TEXT=":rocket: $CI_PROJECT_NAME <$COMMIT_URL|$COMMIT_MESSAGE> deployed to :earth_americas:."'
     - postmessage "#browser-sdk-deploy" "$MESSAGE_TEXT"
-    - postmessage "#rum-ops" "$MESSAGE_TEXT"
+    - postmessage "#rum-browser-sdk-ops" "$MESSAGE_TEXT"
 
 notify-prod-stable-failure:
   extends:


### PR DESCRIPTION
## Motivation

Move deployment notification to dedicated browser sdk channels

## Changes

gitlab ci

## Testing

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
