### PR TITLE
🔊 [RUMF-1079] audit cookie operations at start of the session

### DIFF
--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -182,9 +182,9 @@ export class Audit {
 
   private addEntry(phase: string, operation: string, session: SessionState) {
     if (this.entries.length < MAX_AUDIT_ENTRIES) {
-      const currentDate = new Date()
+      const now = new Date()
       // hh:mm:ss.xxx in the browser timezone
-      const formattedTime = `${currentDate.toTimeString().substr(0, 8)}.${currentDate.getMilliseconds()}`
+      const formattedTime = `${now.toTimeString().substr(0, 8)}.${`00${now.getMilliseconds()}`.slice(-3)}`
       this.entries.push(`${formattedTime} - ${this.productKey} ${phase} ${operation} ${toSessionString(session)}`)
     }
   }

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -3,7 +3,6 @@ import { getCookie, setCookie } from '../../browser/cookie'
 import * as utils from '../../tools/utils'
 import { isExperimentalFeatureEnabled } from '../configuration'
 import { monitor, addMonitoringMessage } from '../internalMonitoring'
-import { timeStampNow } from '../../tools/timeUtils'
 import type { SessionState } from './sessionStore'
 import { SESSION_EXPIRATION_DELAY } from './sessionStore'
 
@@ -178,7 +177,7 @@ export class Audit {
 
   private addEntry(phase: string, operation: string, session: SessionState) {
     if (this.entries.length < MAX_AUDIT_ENTRIES) {
-      const currentDate = new Date(timeStampNow())
+      const currentDate = new Date()
       this.entries.push(
         `${currentDate.toLocaleTimeString()}.${currentDate.getMilliseconds()} - ${
           this.productKey

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -17,7 +17,7 @@ export const MAX_NUMBER_OF_LOCK_RETRIES = 100
 
 type Operations = {
   options: CookieOptions
-  audit?: Audit
+  audit?: AuditBehavior
   phase?: string
   process: (cookieSession: SessionState) => SessionState | undefined
   after?: (cookieSession: SessionState) => void
@@ -163,6 +163,11 @@ function clearSession(options: CookieOptions) {
 }
 
 const MAX_AUDIT_ENTRIES = 50
+
+export interface AuditBehavior {
+  addRead: Audit['addRead']
+  addWrite: Audit['addWrite']
+}
 
 export class Audit {
   constructor(private productKey: string, private entries: string[]) {}

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -178,11 +178,9 @@ export class Audit {
   private addEntry(phase: string, operation: string, session: SessionState) {
     if (this.entries.length < MAX_AUDIT_ENTRIES) {
       const currentDate = new Date()
-      this.entries.push(
-        `${currentDate.toLocaleTimeString()}.${currentDate.getMilliseconds()} - ${
-          this.productKey
-        } ${phase} ${operation} ${toSessionString(session)}`
-      )
+      // hh:mm:ss.xxx in the browser timezone
+      const formattedTime = `${currentDate.toTimeString().substr(0, 8)}.${currentDate.getMilliseconds()}`
+      this.entries.push(`${formattedTime} - ${this.productKey} ${phase} ${operation} ${toSessionString(session)}`)
     }
   }
 }


### PR DESCRIPTION
## Motivation

Try to understand what leads to missing value in session cookie 
Will be reverted after investigation

## Changes

- Audit read/write to session cookie
- Expose audit logs in a global variable to share the between logs/rum
- Add audit logs to session inconsistencies messages

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
