### PR TITLE
✨[RUMF-1135] expose SDK version through global variable

### DIFF
--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -1,9 +1,14 @@
 import { setDebugMode } from '../domain/internalMonitoring'
 import { catchUserErrors } from '../tools/catchUserErrors'
 
-export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): void } {
+export function makePublicApi<T>(
+  buildEnv: BuildEnv,
+  stub: T
+): T & { onReady(callback: () => void): void; version: string } {
   const publicApi = {
     ...stub,
+
+    version: buildEnv.sdkVersion,
 
     // This API method is intentionally not monitored, since the only thing executed is the
     // user-provided 'callback'.  All SDK usages executed in the callback should be monitored, and
@@ -13,7 +18,7 @@ export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): 
     },
   }
 
-  // Add an "hidden" property to set debug mode. We define it that way to hide it
+  // Add a "hidden" property to set debug mode. We define it that way to hide it
   // as much as possible but of course it's not a real protection.
   Object.defineProperty(publicApi, '_setDebug', {
     get() {

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -43,6 +43,11 @@ describe('logs entry', () => {
     expect(!!LOGS.init).toEqual(true)
   })
 
+  it('should provide sdk version', () => {
+    const LOGS = makeLogsPublicApi(startLogs)
+    expect(LOGS.version).toBe('dev')
+  })
+
   describe('configuration validation', () => {
     let LOGS: LogsPublicApi
     let displaySpy: jasmine.Spy

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -14,6 +14,7 @@ import { validateAndBuildLogsConfiguration } from '../domain/configuration'
 import type { HandlerType, LogsMessage, StatusType } from '../domain/logger'
 import { Logger } from '../domain/logger'
 import type { startLogs } from './startLogs'
+import { buildEnv } from './buildEnv'
 
 export interface LoggerConfiguration {
   level?: StatusType
@@ -38,7 +39,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
   let getInitConfigurationStrategy = (): InitConfiguration | undefined => undefined
   const logger = new Logger(sendLog)
 
-  return makePublicApi({
+  return makePublicApi(buildEnv, {
     logger,
 
     init: monitor((initConfiguration: LogsInitConfiguration) => {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -733,4 +733,9 @@ describe('rum public api', () => {
       expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].defaultPrivacyLevel).toBe(DefaultPrivacyLevel.MASK)
     })
   })
+
+  it('should provide sdk version', () => {
+    const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
+    expect(rumPublicApi.version).toBe('dev')
+  })
 })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -24,6 +24,7 @@ import { willSyntheticsInjectRum } from '../domain/syntheticsContext'
 import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
 import { validateAndBuildRumConfiguration } from '../domain/configuration'
 import type { startRum } from './startRum'
+import { buildEnv } from './buildEnv'
 
 export type RumPublicApi = ReturnType<typeof makeRumPublicApi>
 
@@ -166,7 +167,7 @@ export function makeRumPublicApi(
     )
   }
 
-  const rumPublicApi = makePublicApi({
+  const rumPublicApi = makePublicApi(buildEnv, {
     init: monitor(initRum),
 
     addRumGlobalContext: monitor(globalContextManager.add),


### PR DESCRIPTION
## Motivation

- Allow to easily check the SDK version for test/debug purposes
- Could use future integration use cases

## Changes

Expose SDK version through:

- `DD_RUM.version`
- `DD_LOGS.version`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
