### PR TITLE
⚗ [RUMF-1079] release lock asynchronously

### DIFF
--- a/packages/core/src/domain/session/sessionCookieStore.spec.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.spec.ts
@@ -74,39 +74,54 @@ describe('session cookie store', () => {
       resetExperimentalFeatures()
     })
 
-    it('should persist session when process return a value', () => {
+    it('should persist session when process return a value', (done) => {
       persistSession(initialSession, COOKIE_OPTIONS)
       processSpy.and.callFake((session) => ({ ...otherSession, lock: session.lock }))
 
-      withCookieLockAccess({ options: COOKIE_OPTIONS, process: processSpy, after: afterSpy })
-
-      expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
-      const expectedSession = { ...otherSession, expire: jasmine.any(String) }
-      expect(retrieveSession()).toEqual(expectedSession)
-      expect(afterSpy).toHaveBeenCalledWith(expectedSession)
+      withCookieLockAccess({
+        options: COOKIE_OPTIONS,
+        process: processSpy,
+        after: (afterSession) => {
+          expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
+          const expectedSession = { ...otherSession, expire: jasmine.any(String) }
+          expect(retrieveSession()).toEqual(expectedSession)
+          expect(afterSession).toEqual(expectedSession)
+          done()
+        },
+      })
     })
 
-    it('should clear session when process return an empty value', () => {
+    it('should clear session when process return an empty value', (done) => {
       persistSession(initialSession, COOKIE_OPTIONS)
       processSpy.and.returnValue({})
 
-      withCookieLockAccess({ options: COOKIE_OPTIONS, process: processSpy, after: afterSpy })
-
-      expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
-      const expectedSession = {}
-      expect(retrieveSession()).toEqual(expectedSession)
-      expect(afterSpy).toHaveBeenCalledWith(expectedSession)
+      withCookieLockAccess({
+        options: COOKIE_OPTIONS,
+        process: processSpy,
+        after: (afterSession) => {
+          expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
+          const expectedSession = {}
+          expect(retrieveSession()).toEqual(expectedSession)
+          expect(afterSession).toEqual(expectedSession)
+          done()
+        },
+      })
     })
 
-    it('should not persist session when process return undefined', () => {
+    it('should not persist session when process return undefined', (done) => {
       persistSession(initialSession, COOKIE_OPTIONS)
       processSpy.and.returnValue(undefined)
 
-      withCookieLockAccess({ options: COOKIE_OPTIONS, process: processSpy, after: afterSpy })
-
-      expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
-      expect(retrieveSession()).toEqual(initialSession)
-      expect(afterSpy).toHaveBeenCalledWith(initialSession)
+      withCookieLockAccess({
+        options: COOKIE_OPTIONS,
+        process: processSpy,
+        after: (afterSession) => {
+          expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
+          expect(retrieveSession()).toEqual(initialSession)
+          expect(afterSession).toEqual(initialSession)
+          done()
+        },
+      })
     })
 
     type OnLockCheck = () => { currentState: SessionState; retryState: SessionState }


### PR DESCRIPTION
## Motivation

Some cookie writes do not seem to be taken into account: 

```
task 1
...
set cookie value1

task 2
get cookie value1
set cookie value1+lock
get cookie value1+lock
set cookie value2+lock
get cookie value2+lock
set cookie value2

task 3
get cookie value1 // expected value2
```

## Changes

Experiment with releasing the lock asynchronously:
```
task 1
get cookie value1
set cookie value1+lock
get cookie value1+lock
set cookie value2+lock

task 2
get cookie value2+lock
set cookie value2
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
