### PR TITLE
⚗ [RUMF-1079] restrict cookie-lock to chromium browsers

### DIFF
--- a/packages/core/src/domain/session/sessionCookieStore.spec.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.spec.ts
@@ -1,4 +1,5 @@
 import { stubCookie, mockClock } from '../../../test/specHelper'
+import { isChromium } from '../../tools/browserDetection'
 import { resetExperimentalFeatures, updateExperimentalFeatures } from '../configuration'
 import { startFakeInternalMonitoring, resetInternalMonitoring } from '../internalMonitoring'
 import {
@@ -67,6 +68,7 @@ describe('session cookie store', () => {
 
   describe('with cookie-lock enabled', () => {
     beforeEach(() => {
+      !isChromium() && pending('cookie-lock only enabled on chromium browsers')
       updateExperimentalFeatures(['cookie-lock'])
     })
 

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -1,5 +1,6 @@
 import type { CookieOptions } from '../../browser/cookie'
 import { getCookie, setCookie } from '../../browser/cookie'
+import { isChromium } from '../../tools/browserDetection'
 import * as utils from '../../tools/utils'
 import { isExperimentalFeatureEnabled } from '../configuration'
 import { monitor, addMonitoringMessage } from '../internalMonitoring'
@@ -42,7 +43,7 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
   let currentLock: string
   let currentSession = retrieveSession()
   operations.audit?.addRead(`${operations.phase || ''} (1)`, currentSession)
-  if (isExperimentalFeatureEnabled('cookie-lock')) {
+  if (isCookieLockEnabled()) {
     // if someone has lock, retry later
     if (currentSession.lock) {
       retryLater(operations, numberOfRetries)
@@ -62,7 +63,7 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
     }
   }
   let processedSession = operations.process(currentSession)
-  if (isExperimentalFeatureEnabled('cookie-lock')) {
+  if (isCookieLockEnabled()) {
     // if lock corrupted after process, retry later
     currentSession = retrieveSession()
     operations.audit?.addRead(`${operations.phase || ''} (4)`, currentSession)
@@ -75,7 +76,7 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
     persistSession(processedSession, operations.options)
     operations.audit?.addWrite(`${operations.phase || ''} (5)`, processedSession)
   }
-  if (isExperimentalFeatureEnabled('cookie-lock')) {
+  if (isCookieLockEnabled()) {
     // correctly handle lock around expiration would require to handle this case properly at several levels
     // since we don't have evidence of lock issues around expiration, let's just not do the corruption check for it
     if (!(processedSession && isExpiredState(processedSession))) {
@@ -96,6 +97,10 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
   // up-to-date cookie value, the value could have been modified by another tab
   operations.after?.(processedSession || currentSession)
   next()
+}
+
+function isCookieLockEnabled() {
+  return isExperimentalFeatureEnabled('cookie-lock') && isChromium()
 }
 
 function retryLater(operations: Operations, currentNumberOfRetries: number) {

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -99,6 +99,10 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
   next()
 }
 
+/**
+ * Cookie lock strategy allows mitigating issues due to concurrent access to cookie.
+ * This issue concerns only chromium browsers and enabling this on firefox increase cookie write failures.
+ */
 function isCookieLockEnabled() {
   return isExperimentalFeatureEnabled('cookie-lock') && isChromium()
 }

--- a/packages/core/src/tools/browserDetection.ts
+++ b/packages/core/src/tools/browserDetection.ts
@@ -1,3 +1,7 @@
 export function isIE() {
   return Boolean((document as any).documentMode)
 }
+
+export function isChromium() {
+  return !!(window as any).chrome
+}


### PR DESCRIPTION
## Motivation

On firefox, the cookie lock strategy seems to increase the lost of some cookie writes:

```
task 1
...
set cookie value1

task 2
get cookie value1
set cookie value1+lock
get cookie value1+lock
set cookie value2+lock
get cookie value2+lock
set cookie value2

task 3
get cookie value1 // expected value2
```

## Changes

Enable cookie lock only on chromium browsers

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
