### PR TITLE
👷 tweak dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,11 @@ updates:
         update-types: ['version-update:semver-major']
       # update node & express types: RUMF-1158
       - dependency-name: '@types/node'
-        update-types: ['version-update:semver-major']
       - dependency-name: '@types/express'
       # update busboy: RUMF-1159
-      - dependency-name: '*busboy'
+      - dependency-name: 'connect-busboy'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@types/connect-busboy'
       # update jasmine: RUMF-1161
       - dependency-name: '*jasmine*'
       - dependency-name: '*sinon*'


### PR DESCRIPTION
## Motivation

Still issue with some minor versions

## Changes

Avoid notifications for `@types/connect-busboy` and `@types/node`

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
