### PR TITLE
✨ [RUMF-1174] forward event to bridge with rum type

### DIFF
--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -231,8 +231,10 @@ describe('internal monitoring', () => {
       })
 
       expect(server.requests.length).toEqual(0)
+
       const [msg] = sendSpy.calls.mostRecent().args
-      expect(msg).toContain('{"eventType":"internal_log","event":')
+      expect(msg).toContain('"eventType":"internal_log"')
+      expect(msg).toContain('"message":"message"')
     })
   })
 

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -232,9 +232,13 @@ describe('internal monitoring', () => {
 
       expect(server.requests.length).toEqual(0)
 
-      const [msg] = sendSpy.calls.mostRecent().args
-      expect(msg).toContain('"eventType":"internal_log"')
-      expect(msg).toContain('"message":"message"')
+      const [message] = sendSpy.calls.mostRecent().args
+      const parsedMessage = JSON.parse(message)
+
+      expect(parsedMessage).toEqual({
+        eventType: 'internal_log',
+        event: jasmine.objectContaining({ message: 'message' }),
+      })
     })
   })
 

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -231,7 +231,8 @@ describe('internal monitoring', () => {
       })
 
       expect(server.requests.length).toEqual(0)
-      expect(sendSpy).toHaveBeenCalled()
+      const [msg] = sendSpy.calls.mostRecent().args
+      expect(msg).toContain('{"eventType":"internal_log","event":')
     })
   })
 

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -37,7 +37,7 @@ export function startInternalMonitoring(configuration: Configuration): InternalM
   let externalContextProvider: () => Context
 
   if (canUseEventBridge()) {
-    const bridge = getEventBridge()!
+    const bridge = getEventBridge<'internal_log', MonitoringMessage>()!
     onInternalMonitoringMessageCollected = (message: MonitoringMessage) =>
       bridge.send('internal_log', withContext(message))
   } else if (configuration.internalMonitoringEndpointBuilder) {

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -375,7 +375,7 @@ export function restorePageVisibility() {
 
 export function initEventBridgeStub(allowedWebViewHosts: string[] = [window.location.hostname]) {
   const eventBridgeStub = {
-    send: () => undefined,
+    send: (msg: string) => undefined,
     getAllowedWebViewHosts: () => JSON.stringify(allowedWebViewHosts),
   }
   ;(window as BrowserWindowWithEventBridge).DatadogEventBridge = eventBridgeStub

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -168,10 +168,9 @@ describe('logs', () => {
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(server.requests.length).toEqual(0)
-      expect(sendSpy).toHaveBeenCalledOnceWith(
-        '{"eventType":"log",' +
-          '"event":{"service":"service","session_id":"session-id","status":"info","message":"message"}}'
-      )
+      const [msg] = sendSpy.calls.mostRecent().args
+      expect(msg).toContain('"eventType":"log"')
+      expect(msg).toContain('"message":"message"')
     })
   })
 

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -168,9 +168,12 @@ describe('logs', () => {
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(server.requests.length).toEqual(0)
-      const [msg] = sendSpy.calls.mostRecent().args
-      expect(msg).toContain('"eventType":"log"')
-      expect(msg).toContain('"message":"message"')
+      const [message] = sendSpy.calls.mostRecent().args
+      const parsedMessage = JSON.parse(message)
+      expect(parsedMessage).toEqual({
+        eventType: 'log',
+        event: jasmine.objectContaining({ message: 'message' }),
+      })
     })
   })
 

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -168,7 +168,10 @@ describe('logs', () => {
       sendLog(DEFAULT_MESSAGE, {})
 
       expect(server.requests.length).toEqual(0)
-      expect(sendSpy).toHaveBeenCalled()
+      expect(sendSpy).toHaveBeenCalledOnceWith(
+        '{"eventType":"log",' +
+          '"event":{"service":"service","session_id":"session-id","status":"info","message":"message"}}'
+      )
     })
   })
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -55,7 +55,7 @@ export function doStartLogs(
 
   let onLogEventCollected: (message: Context) => void
   if (canUseEventBridge()) {
-    const bridge = getEventBridge()!
+    const bridge = getEventBridge<'log', Context>()!
     onLogEventCollected = (message) => bridge.send('log', message)
   } else {
     const batch = startLoggerBatch(configuration)

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -300,9 +300,9 @@ describe('startRumEventCollection', () => {
   it('should send bridge event when bridge is present', () => {
     const { lifeCycle } = setupBuilder.build()
 
-    const collectedRumEvent = {} as RumEvent & Context
+    const collectedRumEvent = { type: 'action' } as RumEvent & Context
     lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, collectedRumEvent)
 
-    expect(sendSpy).toHaveBeenCalled()
+    expect(sendSpy).toHaveBeenCalledOnceWith('{"eventType":"rum","event":{"type":"action"}}')
   })
 })

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -303,6 +303,8 @@ describe('startRumEventCollection', () => {
     const collectedRumEvent = { type: 'action' } as RumEvent & Context
     lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, collectedRumEvent)
 
-    expect(sendSpy).toHaveBeenCalledOnceWith('{"eventType":"rum","event":{"type":"action"}}')
+    const [msg] = sendSpy.calls.mostRecent().args
+    expect(msg).toContain('"eventType":"rum"')
+    expect(msg).toContain('"type":"action"')
   })
 })

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -303,8 +303,12 @@ describe('startRumEventCollection', () => {
     const collectedRumEvent = { type: 'action' } as RumEvent & Context
     lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, collectedRumEvent)
 
-    const [msg] = sendSpy.calls.mostRecent().args
-    expect(msg).toContain('"eventType":"rum"')
-    expect(msg).toContain('"type":"action"')
+    const [message] = sendSpy.calls.mostRecent().args
+    const parsedMessage = JSON.parse(message)
+
+    expect(parsedMessage).toEqual({
+      eventType: 'rum',
+      event: jasmine.objectContaining({ type: 'action' }),
+    })
   })
 })

--- a/packages/rum-core/src/transport/startRumEventBridge.ts
+++ b/packages/rum-core/src/transport/startRumEventBridge.ts
@@ -5,9 +5,9 @@ import { LifeCycleEventType } from '../domain/lifeCycle'
 import type { RumEvent } from '../rumEvent.types'
 
 export function startRumEventBridge(lifeCycle: LifeCycle) {
-  const bridge = getEventBridge<RumEvent['type'], RumEvent>()!
+  const bridge = getEventBridge<'rum', RumEvent>()!
 
   lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (serverRumEvent: RumEvent & Context) => {
-    bridge.send(serverRumEvent.type, serverRumEvent)
+    bridge.send('rum', serverRumEvent)
   })
 }


### PR DESCRIPTION
## Motivation

The mobile SDKs tracks events that happen inside a webview using the browser SDK. Mobile SDK inject a JS bridge to receive event from the browser SDK.
Now, RUM event won't be deserialized on the Mobile side so we don't have to differentiate rum event types in the bridge. We can flag them as "rum".

## Changes

- update rum event bridge
- improve bridge unit tests

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
