### PR TITLE
🔇[RUMF-1079] remove session inconsistencies monitoring

### DIFF
--- a/packages/core/src/domain/session/sessionCookieStore.spec.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.spec.ts
@@ -1,7 +1,6 @@
 import { stubCookie, mockClock } from '../../../test/specHelper'
 import { isChromium } from '../../tools/browserDetection'
 import { resetExperimentalFeatures, updateExperimentalFeatures } from '../configuration'
-import { startFakeInternalMonitoring, resetInternalMonitoring } from '../internalMonitoring'
 import {
   SESSION_COOKIE_NAME,
   toSessionString,
@@ -197,7 +196,6 @@ describe('session cookie store', () => {
 
     it('should abort after a max number of retry', () => {
       const clock = mockClock()
-      const monitoringMessages = startFakeInternalMonitoring()
 
       persistSession(initialSession, COOKIE_OPTIONS)
       cookie.setSpy.calls.reset()
@@ -209,9 +207,7 @@ describe('session cookie store', () => {
       expect(processSpy).not.toHaveBeenCalled()
       expect(afterSpy).not.toHaveBeenCalled()
       expect(cookie.setSpy).not.toHaveBeenCalled()
-      expect(monitoringMessages.length).toBe(1)
 
-      resetInternalMonitoring()
       clock.cleanup()
     })
 

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -18,8 +18,6 @@ export const MAX_NUMBER_OF_LOCK_RETRIES = 100
 
 type Operations = {
   options: CookieOptions
-  audit?: AuditBehavior
-  phase?: string
   process: (cookieSession: SessionState) => SessionState | undefined
   after?: (cookieSession: SessionState) => void
 }
@@ -42,7 +40,6 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
   }
   let currentLock: string
   let currentSession = retrieveSession()
-  operations.audit?.addRead(`${operations.phase || ''} (1)`, currentSession)
   if (isCookieLockEnabled()) {
     // if someone has lock, retry later
     if (currentSession.lock) {
@@ -53,10 +50,8 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
     currentLock = utils.generateUUID()
     currentSession.lock = currentLock
     setSession(currentSession, operations.options)
-    operations.audit?.addWrite(`${operations.phase || ''} (2)`, currentSession)
     // if lock is not acquired, retry later
     currentSession = retrieveSession()
-    operations.audit?.addRead(`${operations.phase || ''} (3)`, currentSession)
     if (currentSession.lock !== currentLock) {
       retryLater(operations, numberOfRetries)
       return
@@ -66,7 +61,6 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
   if (isCookieLockEnabled()) {
     // if lock corrupted after process, retry later
     currentSession = retrieveSession()
-    operations.audit?.addRead(`${operations.phase || ''} (4)`, currentSession)
     if (currentSession.lock !== currentLock!) {
       retryLater(operations, numberOfRetries)
       return
@@ -74,7 +68,6 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
   }
   if (processedSession) {
     persistSession(processedSession, operations.options)
-    operations.audit?.addWrite(`${operations.phase || ''} (5)`, processedSession)
   }
   if (isCookieLockEnabled()) {
     // correctly handle lock around expiration would require to handle this case properly at several levels
@@ -82,14 +75,12 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
     if (!(processedSession && isExpiredState(processedSession))) {
       // if lock corrupted after persist, retry later
       currentSession = retrieveSession()
-      operations.audit?.addRead(`${operations.phase || ''} (6)`, currentSession)
       if (currentSession.lock !== currentLock!) {
         retryLater(operations, numberOfRetries)
         return
       }
       delete currentSession.lock
       setSession(currentSession, operations.options)
-      operations.audit?.addWrite(`${operations.phase || ''} (7)`, currentSession)
       processedSession = currentSession
     }
   }
@@ -172,32 +163,4 @@ function isExpiredState(session: SessionState) {
 
 function clearSession(options: CookieOptions) {
   setCookie(SESSION_COOKIE_NAME, '', 0, options)
-}
-
-const MAX_AUDIT_ENTRIES = 50
-
-export interface AuditBehavior {
-  addRead: Audit['addRead']
-  addWrite: Audit['addWrite']
-}
-
-export class Audit {
-  constructor(private productKey: string, private entries: string[]) {}
-
-  addWrite(phase: string, session: SessionState) {
-    this.addEntry(phase, 'write', session)
-  }
-
-  addRead(phase: string, session: SessionState) {
-    this.addEntry(phase, 'read', session)
-  }
-
-  private addEntry(phase: string, operation: string, session: SessionState) {
-    if (this.entries.length < MAX_AUDIT_ENTRIES) {
-      const now = new Date()
-      // hh:mm:ss.xxx in the browser timezone
-      const formattedTime = `${now.toTimeString().substr(0, 8)}.${`00${now.getMilliseconds()}`.slice(-3)}`
-      this.entries.push(`${formattedTime} - ${this.productKey} ${phase} ${operation} ${toSessionString(session)}`)
-    }
-  }
 }

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -3,7 +3,7 @@ import { getCookie, setCookie } from '../../browser/cookie'
 import { isChromium } from '../../tools/browserDetection'
 import * as utils from '../../tools/utils'
 import { isExperimentalFeatureEnabled } from '../configuration'
-import { monitor, addMonitoringMessage } from '../internalMonitoring'
+import { monitor } from '../internalMonitoring'
 import type { SessionState } from './sessionStore'
 import { SESSION_EXPIRATION_DELAY } from './sessionStore'
 
@@ -34,7 +34,6 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
     return
   }
   if (numberOfRetries >= MAX_NUMBER_OF_LOCK_RETRIES) {
-    addMonitoringMessage('Reach max lock retry')
     next()
     return
   }

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -2,8 +2,6 @@ import type { Clock } from '../../../test/specHelper'
 import { mockClock } from '../../../test/specHelper'
 import type { CookieOptions } from '../../browser/cookie'
 import { getCookie, setCookie, COOKIE_ACCESS_DELAY } from '../../browser/cookie'
-import type { MonitoringMessage } from '../internalMonitoring'
-import { startFakeInternalMonitoring, resetInternalMonitoring } from '../internalMonitoring'
 import type { SessionStore } from './sessionStore'
 import { startSessionStore, SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionStore'
 import { SESSION_COOKIE_NAME } from './sessionCookieStore'
@@ -283,16 +281,6 @@ describe('session store', () => {
   })
 
   describe('regular watch', () => {
-    let monitoringMessages: MonitoringMessage[]
-
-    beforeEach(() => {
-      monitoringMessages = startFakeInternalMonitoring()
-    })
-
-    afterEach(() => {
-      resetInternalMonitoring()
-    })
-
     it('when session not in cache and session not in store, should do nothing', () => {
       setupSessionStore()
 
@@ -300,7 +288,6 @@ describe('session store', () => {
 
       expect(sessionStore.getSession().id).toBeUndefined()
       expect(expireSpy).not.toHaveBeenCalled()
-      expect(monitoringMessages.length).toBe(0)
     })
 
     it('when session not in cache and session in store, should do nothing', () => {
@@ -311,7 +298,6 @@ describe('session store', () => {
 
       expect(sessionStore.getSession().id).toBeUndefined()
       expect(expireSpy).not.toHaveBeenCalled()
-      expect(monitoringMessages.length).toBe(0)
     })
 
     it('when session in cache and session not in store, should expire session', () => {
@@ -323,7 +309,6 @@ describe('session store', () => {
 
       expect(sessionStore.getSession().id).toBeUndefined()
       expect(expireSpy).toHaveBeenCalled()
-      expect(monitoringMessages.length).toBe(0)
     })
 
     it('when session in cache is same session than in store, should synchronize session', () => {
@@ -336,7 +321,6 @@ describe('session store', () => {
       expect(sessionStore.getSession().id).toBe(FIRST_ID)
       expect(sessionStore.getSession().expire).toBe(getStoreExpiration())
       expect(expireSpy).not.toHaveBeenCalled()
-      expect(monitoringMessages.length).toBe(0)
     })
 
     it('when session id in cache is different than session id in store, should expire session', () => {
@@ -348,7 +332,6 @@ describe('session store', () => {
 
       expect(sessionStore.getSession().id).toBeUndefined()
       expect(expireSpy).toHaveBeenCalled()
-      expect(monitoringMessages.length).toBe(1)
     })
 
     it('when session type in cache is different than session type in store, should expire session', () => {
@@ -360,7 +343,6 @@ describe('session store', () => {
 
       expect(sessionStore.getSession().id).toBeUndefined()
       expect(expireSpy).toHaveBeenCalled()
-      expect(monitoringMessages.length).toBe(1)
     })
   })
 })

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -2,11 +2,8 @@ import type { CookieOptions } from '../../browser/cookie'
 import { COOKIE_ACCESS_DELAY } from '../../browser/cookie'
 import { Observable } from '../../tools/observable'
 import * as utils from '../../tools/utils'
-import { noop } from '../../tools/utils'
 import { monitor, addMonitoringMessage } from '../internalMonitoring'
-import { isExperimentalFeatureEnabled } from '../configuration'
-import type { AuditBehavior } from './sessionCookieStore'
-import { Audit, retrieveSession, withCookieLockAccess } from './sessionCookieStore'
+import { retrieveSession, withCookieLockAccess } from './sessionCookieStore'
 
 export interface SessionStore {
   expandOrRenewSession: () => void
@@ -30,30 +27,6 @@ export const SESSION_EXPIRATION_DELAY = 15 * utils.ONE_MINUTE
 export const SESSION_TIME_OUT_DELAY = 4 * utils.ONE_HOUR
 
 /**
- * Expose audit logs to share them between rum and logs
- */
-interface BrowserWindow extends Window {
-  DD_SDK_AUDIT?: string[]
-}
-
-function initAudit(productKey: string): { audit: AuditBehavior; auditEntries: string[] } {
-  if (!isExperimentalFeatureEnabled('cookie-lock')) {
-    return {
-      audit: {
-        addRead: noop,
-        addWrite: noop,
-      },
-      auditEntries: [],
-    }
-  }
-  ;(window as BrowserWindow).DD_SDK_AUDIT = (window as BrowserWindow).DD_SDK_AUDIT || []
-  return {
-    audit: new Audit(productKey, (window as BrowserWindow).DD_SDK_AUDIT!),
-    auditEntries: (window as BrowserWindow).DD_SDK_AUDIT!,
-  }
-}
-
-/**
  * Different session concepts:
  * - tracked, the session has an id and is updated along the user navigation
  * - not tracked, the session does not have an id but it is updated along the user navigation
@@ -67,18 +40,13 @@ export function startSessionStore<TrackingType extends string>(
   const renewObservable = new Observable<void>()
   const expireObservable = new Observable<void>()
 
-  const { audit, auditEntries } = initAudit(productKey)
-
   const watchSessionTimeoutId = setInterval(monitor(watchSession), COOKIE_ACCESS_DELAY)
   let sessionCache: SessionState = retrieveActiveSession()
-  audit.addRead('start', sessionCache)
 
   function expandOrRenewSession() {
     let isTracked: boolean
     withCookieLockAccess({
       options,
-      audit,
-      phase: 'expandOrRenew',
       process: (cookieSession) => {
         const synchronizedSession = synchronizeSession(cookieSession)
         isTracked = expandOrRenewCookie(synchronizedSession)
@@ -96,8 +64,6 @@ export function startSessionStore<TrackingType extends string>(
   function expandSession() {
     withCookieLockAccess({
       options,
-      audit,
-      phase: 'expand',
       process: (cookieSession) => (hasSessionInCache() ? synchronizeSession(cookieSession) : undefined),
     })
   }
@@ -110,8 +76,6 @@ export function startSessionStore<TrackingType extends string>(
   function watchSession() {
     withCookieLockAccess({
       options,
-      audit,
-      phase: 'watch',
       process: (cookieSession) => (!isActiveSession(cookieSession) ? {} : undefined),
       after: synchronizeSession,
     })
@@ -171,7 +135,6 @@ export function startSessionStore<TrackingType extends string>(
         sessionCache,
         cookieSession,
         cause,
-        auditEntries: auditEntries.join('\n'),
       },
     })
   }

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -2,7 +2,7 @@ import type { CookieOptions } from '../../browser/cookie'
 import { COOKIE_ACCESS_DELAY } from '../../browser/cookie'
 import { Observable } from '../../tools/observable'
 import * as utils from '../../tools/utils'
-import { monitor, addMonitoringMessage } from '../internalMonitoring'
+import { monitor } from '../internalMonitoring'
 import { retrieveSession, withCookieLockAccess } from './sessionCookieStore'
 
 export interface SessionStore {
@@ -110,33 +110,7 @@ export function startSessionStore<TrackingType extends string>(
   }
 
   function isSessionInCacheOutdated(cookieSession: SessionState) {
-    if (sessionCache.id !== cookieSession.id) {
-      if (cookieSession.id && isActiveSession(sessionCache)) {
-        // cookie id undefined could be due to cookie expiration
-        // inactive session in cache could happen if renew session in another tab and cache not yet cleared
-        addSessionInconsistenciesMessage(cookieSession, 'different id')
-      }
-      return true
-    }
-    if (sessionCache[productKey] !== cookieSession[productKey]) {
-      addSessionInconsistenciesMessage(
-        cookieSession,
-        cookieSession[productKey] === undefined ? 'tracking type missing' : 'different tracking type'
-      )
-      return true
-    }
-    return false
-  }
-
-  function addSessionInconsistenciesMessage(cookieSession: SessionState, cause: string) {
-    addMonitoringMessage('Session inconsistencies detected', {
-      debug: {
-        productKey,
-        sessionCache,
-        cookieSession,
-        cause,
-      },
-    })
+    return sessionCache.id !== cookieSession.id || sessionCache[productKey] !== cookieSession[productKey]
   }
 
   function expireSession() {


### PR DESCRIPTION
## Motivation

Investigations are done, avoid to collect unneeded logs

## Changes

Remove:

- audit cookie operations
- reach max log retry
- session inconsistencies

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
