### PR TITLE
🐛 chromium detection did not work in headless mode

### DIFF
--- a/packages/core/src/tools/browserDetection.ts
+++ b/packages/core/src/tools/browserDetection.ts
@@ -3,5 +3,5 @@ export function isIE() {
 }
 
 export function isChromium() {
-  return !!(window as any).chrome
+  return !!(window as any).chrome || /HeadlessChrome/.test(window.navigator.userAgent)
 }


### PR DESCRIPTION
## Motivation

`isChromium` check does not work in unit test because `window.chrome === false` in headless mode 🤦 

## Changes

Check user agent for HeadlessChrome

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
