### PR TITLE
🐛 [RUMF-1153] fix initial view loading time computation

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -102,6 +102,7 @@ function startActionManagement(lifeCycle: LifeCycle, domMutationObservable: Obse
           }
           currentAction = undefined
         },
+        pendingAutoAction.startClocks,
         AUTO_ACTION_MAX_DURATION
       ))
     },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackActions.ts
@@ -1,5 +1,5 @@
 import type { Context, Duration, ClocksState, Observable } from '@datadog/browser-core'
-import { addEventListener, DOM_EVENT, generateUUID, clocksNow, ONE_SECOND } from '@datadog/browser-core'
+import { addEventListener, DOM_EVENT, generateUUID, clocksNow, ONE_SECOND, elapsed } from '@datadog/browser-core'
 import { ActionType } from '../../../rawRumEvent.types'
 import type { RumConfiguration } from '../../configuration'
 import type { LifeCycle } from '../../lifeCycle'
@@ -95,14 +95,18 @@ function startActionManagement(lifeCycle: LifeCycle, domMutationObservable: Obse
         lifeCycle,
         domMutationObservable,
         (event) => {
-          if (event.hadActivity && event.duration >= 0) {
-            pendingAutoAction.complete(event.duration)
+          if (event.hadActivity) {
+            const duration = elapsed(pendingAutoAction.startClocks.timeStamp, event.end)
+            if (duration >= 0) {
+              pendingAutoAction.complete(duration)
+            } else {
+              pendingAutoAction.discard()
+            }
           } else {
             pendingAutoAction.discard()
           }
           currentAction = undefined
         },
-        pendingAutoAction.startClocks,
         AUTO_ACTION_MAX_DURATION
       ))
     },

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -148,13 +148,7 @@ describe('rum track view metrics', () => {
         BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY +
         1
 
-      setupBuilder.beforeBuild((buildContext) => {
-        // need to restart the view test to introducing a clock gap before the tracking start
-        viewTest.stop()
-        buildContext.clock.tick(CLOCK_GAP)
-        viewTest = setupViewTest(buildContext)
-        return viewTest
-      })
+      setupBuilder.clock!.tick(CLOCK_GAP)
 
       const { lifeCycle, domMutationObservable, clock } = setupBuilder.build()
       const { getViewUpdate, getViewUpdateCount } = viewTest

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -1,4 +1,4 @@
-import type { Duration, RelativeTime, Observable } from '@datadog/browser-core'
+import type { Duration, RelativeTime, Observable, ClocksState } from '@datadog/browser-core'
 import { noop, round, ONE_SECOND } from '@datadog/browser-core'
 import type { RumLayoutShiftTiming } from '../../../browser/performanceCollection'
 import { supportPerformanceTimingEvent } from '../../../browser/performanceCollection'
@@ -19,7 +19,8 @@ export function trackViewMetrics(
   lifeCycle: LifeCycle,
   domMutationObservable: Observable<void>,
   scheduleViewUpdate: () => void,
-  loadingType: ViewLoadingType
+  loadingType: ViewLoadingType,
+  viewStart: ClocksState
 ) {
   const viewMetrics: ViewMetrics = {
     eventCounts: {
@@ -42,7 +43,8 @@ export function trackViewMetrics(
   const { stop: stopActivityLoadingTimeTracking } = trackActivityLoadingTime(
     lifeCycle,
     domMutationObservable,
-    setActivityLoadingTime
+    setActivityLoadingTime,
+    viewStart
   )
 
   let stopCLSTracking: () => void
@@ -100,15 +102,21 @@ function trackLoadingTime(loadType: ViewLoadingType, callback: (loadingTime: Dur
 function trackActivityLoadingTime(
   lifeCycle: LifeCycle,
   domMutationObservable: Observable<void>,
-  callback: (loadingTimeValue: Duration | undefined) => void
+  callback: (loadingTimeValue: Duration | undefined) => void,
+  viewStart: ClocksState
 ) {
-  return waitIdlePage(lifeCycle, domMutationObservable, (event) => {
-    if (event.hadActivity) {
-      callback(event.duration)
-    } else {
-      callback(undefined)
-    }
-  })
+  return waitIdlePage(
+    lifeCycle,
+    domMutationObservable,
+    (event) => {
+      if (event.hadActivity) {
+        callback(event.duration)
+      } else {
+        callback(undefined)
+      }
+    },
+    viewStart
+  )
 }
 
 /**

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -1,5 +1,5 @@
 import type { Duration, RelativeTime, Observable, ClocksState } from '@datadog/browser-core'
-import { noop, round, ONE_SECOND } from '@datadog/browser-core'
+import { noop, round, ONE_SECOND, elapsed } from '@datadog/browser-core'
 import type { RumLayoutShiftTiming } from '../../../browser/performanceCollection'
 import { supportPerformanceTimingEvent } from '../../../browser/performanceCollection'
 import { ViewLoadingType } from '../../../rawRumEvent.types'
@@ -105,18 +105,13 @@ function trackActivityLoadingTime(
   callback: (loadingTimeValue: Duration | undefined) => void,
   viewStart: ClocksState
 ) {
-  return waitIdlePage(
-    lifeCycle,
-    domMutationObservable,
-    (event) => {
-      if (event.hadActivity) {
-        callback(event.duration)
-      } else {
-        callback(undefined)
-      }
-    },
-    viewStart
-  )
+  return waitIdlePage(lifeCycle, domMutationObservable, (event) => {
+    if (event.hadActivity) {
+      callback(elapsed(viewStart.timeStamp, event.end))
+    } else {
+      callback(undefined)
+    }
+  })
 }
 
 /**

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -179,7 +179,7 @@ function newView(
     setLoadEvent,
     stop: stopViewMetricsTracking,
     viewMetrics,
-  } = trackViewMetrics(lifeCycle, domMutationObservable, scheduleViewUpdate, loadingType)
+  } = trackViewMetrics(lifeCycle, domMutationObservable, scheduleViewUpdate, loadingType, startClocks)
 
   // Initial view update
   triggerViewUpdate()

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -51,6 +51,7 @@ export interface BuildContext {
   parentContexts: ParentContexts
   foregroundContexts: ForegroundContexts
   urlContexts: UrlContexts
+  clock: Clock
 }
 
 export interface TestIO {
@@ -152,6 +153,7 @@ export function setup(): TestSetupBuilder {
           applicationId: FAKE_APP_ID,
           configuration,
           location: fakeLocation as Location,
+          clock,
         })
         if (result && result.stop) {
           cleanupTasks.push(result.stop)

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -35,6 +35,8 @@ export interface TestSetupBuilder {
   withFakeClock: () => TestSetupBuilder
   beforeBuild: (callback: BeforeBuildCallback) => TestSetupBuilder
 
+  clock?: Clock
+
   cleanup: () => void
   build: () => TestIO
 }
@@ -51,7 +53,6 @@ export interface BuildContext {
   parentContexts: ParentContexts
   foregroundContexts: ForegroundContexts
   urlContexts: UrlContexts
-  clock: Clock
 }
 
 export interface TestIO {
@@ -111,7 +112,7 @@ export function setup(): TestSetupBuilder {
     })
   }
 
-  const setupBuilder = {
+  const setupBuilder: TestSetupBuilder = {
     withFakeLocation(initialUrl: string) {
       fakeLocation = buildLocation(initialUrl)
       return setupBuilder
@@ -134,6 +135,7 @@ export function setup(): TestSetupBuilder {
     },
     withFakeClock() {
       clock = mockClock()
+      setupBuilder.clock = clock
       return setupBuilder
     },
     beforeBuild(callback: BeforeBuildCallback) {
@@ -153,7 +155,6 @@ export function setup(): TestSetupBuilder {
           applicationId: FAKE_APP_ID,
           configuration,
           location: fakeLocation as Location,
-          clock,
         })
         if (result && result.stop) {
           cleanupTasks.push(result.stop)


### PR DESCRIPTION
## Motivation

Loading time was computed from the start of the activity tracking. In the case of initial view, the loading time should be computed from the start of the view which can be quite different from the start of the tracking, especially for async setup.

## Changes

Compute the activity loading time from the start of the associated parent

## Testing

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
