### PR TITLE
🐛 [RUMF-1079] limit session inconsistencies issue on chromium browsers

### DIFF
--- a/packages/core/src/domain/session/sessionCookieStore.spec.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.spec.ts
@@ -1,6 +1,5 @@
 import { stubCookie, mockClock } from '../../../test/specHelper'
 import { isChromium } from '../../tools/browserDetection'
-import { resetExperimentalFeatures, updateExperimentalFeatures } from '../configuration'
 import {
   SESSION_COOKIE_NAME,
   toSessionString,
@@ -29,6 +28,10 @@ describe('session cookie store', () => {
   })
 
   describe('with cookie-lock disabled', () => {
+    beforeEach(() => {
+      isChromium() && pending('cookie-lock only disabled on non chromium browsers')
+    })
+
     it('should persist session when process return a value', () => {
       persistSession(initialSession, COOKIE_OPTIONS)
       processSpy.and.returnValue({ ...otherSession })
@@ -68,11 +71,6 @@ describe('session cookie store', () => {
   describe('with cookie-lock enabled', () => {
     beforeEach(() => {
       !isChromium() && pending('cookie-lock only enabled on chromium browsers')
-      updateExperimentalFeatures(['cookie-lock'])
-    })
-
-    afterEach(() => {
-      resetExperimentalFeatures()
     })
 
     it('should persist session when process return a value', () => {

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -2,7 +2,6 @@ import type { CookieOptions } from '../../browser/cookie'
 import { getCookie, setCookie } from '../../browser/cookie'
 import { isChromium } from '../../tools/browserDetection'
 import * as utils from '../../tools/utils'
-import { isExperimentalFeatureEnabled } from '../configuration'
 import { monitor } from '../internalMonitoring'
 import type { SessionState } from './sessionStore'
 import { SESSION_EXPIRATION_DELAY } from './sessionStore'
@@ -94,7 +93,7 @@ export function withCookieLockAccess(operations: Operations, numberOfRetries = 0
  * This issue concerns only chromium browsers and enabling this on firefox increase cookie write failures.
  */
 function isCookieLockEnabled() {
-  return isExperimentalFeatureEnabled('cookie-lock') && isChromium()
+  return isChromium()
 }
 
 function retryLater(operations: Operations, currentNumberOfRetries: number) {

--- a/test/e2e/lib/helpers/session.ts
+++ b/test/e2e/lib/helpers/session.ts
@@ -9,7 +9,8 @@ export async function renewSession() {
 
 export async function expireSession() {
   await deleteAllCookies()
-  expect(await findSessionCookie()).not.toBeDefined()
+  const sessionCookie = await findSessionCookie()
+  expect(sessionCookie === undefined || sessionCookie.value === '').toBeTrue()
   // Cookies are cached for 1s, wait until the cache expires
   await browser.pause(1100)
 }


### PR DESCRIPTION
## Motivation

Mitigate session inconsistencies due to concurrent access to cookies by different tabs on chromium browsers.

## Changes

Enable changes introduced by:

- #1230 
- #1283 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
