### PR TITLE
✨ [RUMF-1180] add `error.source_type` attribute

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -49,6 +49,7 @@ describe('error collection', () => {
             handling_stack: 'Error: handling foo',
             type: 'Error',
             handling: ErrorHandling.HANDLED,
+            source_type: 'browser',
           },
           type: RumEventType.ERROR,
           view: {
@@ -153,6 +154,7 @@ describe('error collection', () => {
           handling_stack: undefined,
           type: 'foo',
           handling: undefined,
+          source_type: 'browser',
         },
         view: {
           in_foreground: true,

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -88,6 +88,7 @@ function processError(
       handling_stack: error.handlingStack,
       type: error.type,
       handling: error.handling,
+      source_type: 'browser',
     },
     type: RumEventType.ERROR as const,
   }

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -62,6 +62,7 @@ export interface RawRumErrorEvent {
     source: ErrorSource
     message: string
     handling?: ErrorHandling
+    source_type: 'browser'
   }
   view?: {
     in_foreground: boolean

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -43,6 +43,7 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
             message: 'oh snap',
             source: ErrorSource.SOURCE,
             handling: ErrorHandling.HANDLED,
+            source_type: 'browser',
           },
         },
         overrides


### PR DESCRIPTION
## Motivation

Add this field to ease the error tracking processing for hybrid app

cf https://github.com/DataDog/rum-events-format/pull/46

## Changes

add `error.source_type` attribute

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
