### PR TITLE
👷 tweak dd ci configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,14 +154,14 @@ unit:
     - .base-configuration
     - .test-allowed-branches
   artifacts:
-    paths:
-      - test-report/unit/
     reports:
       junit: test-report/unit/*.xml
   script:
     - yarn
     - yarn test:unit
     - ./scripts/codecov.sh
+  after_script:
+    - node ./scripts/export-test-result.js unit
 
 e2e:
   extends:
@@ -169,13 +169,13 @@ e2e:
     - .test-allowed-branches
   artifacts:
     when: always
-    paths:
-      - test-report/e2e/
     reports:
       junit: test-report/e2e/*.xml
   script:
     - yarn
     - yarn test:e2e
+  after_script:
+    - node ./scripts/export-test-result.js e2e
 
 check-licenses:
   extends:
@@ -196,6 +196,8 @@ unit-bs:
   script:
     - yarn
     - ./scripts/ci-bs.sh test:unit
+  after_script:
+    - node ./scripts/export-test-result.js unit-bs
 
 e2e-bs:
   stage: browserstack
@@ -205,23 +207,13 @@ e2e-bs:
   resource_group: browserstack
   artifacts:
     when: always
-    paths:
-      - test-report/e2e-bs/
     reports:
       junit: test-report/e2e-bs/*.xml
-
   script:
     - yarn
     - ./scripts/ci-bs.sh test:e2e
-
-export-test-result:
-  stage: notify
-  extends:
-    - .base-configuration
-    - .test-allowed-branches
-  when: always
-  script:
-    - node ./scripts/export-test-result.js
+  after_script:
+    - node ./scripts/export-test-result.js e2e-bs
 
 ########################################################################################################################
 # Deploy

--- a/scripts/export-test-result.js
+++ b/scripts/export-test-result.js
@@ -3,17 +3,18 @@
 const { getSecretKey, executeCommand, printLog, logAndExit } = require('./utils')
 
 async function main() {
-  await exportTestResult('unit', ['test-report/unit/', 'test-report/unit-bs/'])
-  await exportTestResult('e2e', ['test-report/e2e/', 'test-report/e2e-bs/'])
+  await exportTestResult('unit', 'test-report/unit/')
+  await exportTestResult('unit-bs', 'test-report/unit-bs/')
+  await exportTestResult('e2e', 'test-report/e2e/')
+  await exportTestResult('e2e-bs', 'test-report/e2e-bs/')
 }
 
-async function exportTestResult(type, folders) {
+async function exportTestResult(type, folder) {
   const DATADOG_API_KEY = await getSecretKey('ci.browser-sdk.datadog_ci_api_key')
 
-  await executeCommand(
-    `datadog-ci junit upload --service browser-sdk --env ci --tags type:${type} ${folders.join(' ')}`,
-    { DATADOG_API_KEY }
-  )
+  await executeCommand(`datadog-ci junit upload --service browser-sdk --env ci --tags test.type:${type} ${folder}`, {
+    DATADOG_API_KEY,
+  })
 
   printLog(`Export ${type} tests done.`)
 }

--- a/scripts/export-test-result.js
+++ b/scripts/export-test-result.js
@@ -2,21 +2,26 @@
 
 const { getSecretKey, executeCommand, printLog, logAndExit } = require('./utils')
 
-async function main() {
-  await exportTestResult('unit', 'test-report/unit/')
-  await exportTestResult('unit-bs', 'test-report/unit-bs/')
-  await exportTestResult('e2e', 'test-report/e2e/')
-  await exportTestResult('e2e-bs', 'test-report/e2e-bs/')
-}
+/**
+ * Upload test result to datadog
+ * Usage:
+ * node export-test-result.js testType
+ */
 
-async function exportTestResult(type, folder) {
+const testType = process.argv[2]
+const resultFolder = `test-report/${testType}/`
+
+async function main() {
   const DATADOG_API_KEY = await getSecretKey('ci.browser-sdk.datadog_ci_api_key')
 
-  await executeCommand(`datadog-ci junit upload --service browser-sdk --env ci --tags test.type:${type} ${folder}`, {
-    DATADOG_API_KEY,
-  })
+  await executeCommand(
+    `datadog-ci junit upload --service browser-sdk --env ci --tags test.type:${testType} ${resultFolder}`,
+    {
+      DATADOG_API_KEY,
+    }
+  )
 
-  printLog(`Export ${type} tests done.`)
+  printLog(`Export ${testType} tests done.`)
 }
 
 main().catch(logAndExit)


### PR DESCRIPTION
## Motivation

Hard to investigate test failure occurrences with current setup:

- can't filter on test type
- not all jobs are reported to datadog (retry and unit failure are missing)

## Changes

- use standard `test.type` tags instead of `type`
- split `unit`, `e2e`, `unit-bs`, `e2e-bs`
- ensure to report to datadog after each execution
 
## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->


manual

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
