### PR TITLE
♻️ Simplify trackLoadingTime

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -35,16 +35,15 @@ export function trackViewMetrics(
     scheduleViewUpdate()
   })
 
-  const { setActivityLoadingTime, setLoadEvent } = trackLoadingTime(loadingType, (newLoadingTime) => {
-    viewMetrics.loadingTime = newLoadingTime
-    scheduleViewUpdate()
-  })
-
-  const { stop: stopActivityLoadingTimeTracking } = trackActivityLoadingTime(
+  const { stopWaitIdlePage, setLoadEvent } = trackLoadingTime(
     lifeCycle,
     domMutationObservable,
-    setActivityLoadingTime,
-    viewStart
+    loadingType,
+    viewStart,
+    (newLoadingTime) => {
+      viewMetrics.loadingTime = newLoadingTime
+      scheduleViewUpdate()
+    }
   )
 
   let stopCLSTracking: () => void
@@ -60,7 +59,7 @@ export function trackViewMetrics(
   return {
     stop: () => {
       stopEventCountsTracking()
-      stopActivityLoadingTimeTracking()
+      stopWaitIdlePage()
       stopCLSTracking()
     },
     setLoadEvent,
@@ -68,7 +67,13 @@ export function trackViewMetrics(
   }
 }
 
-function trackLoadingTime(loadType: ViewLoadingType, callback: (loadingTime: Duration) => void) {
+function trackLoadingTime(
+  lifeCycle: LifeCycle,
+  domMutationObservable: Observable<void>,
+  loadType: ViewLoadingType,
+  viewStart: ClocksState,
+  callback: (loadingTime: Duration) => void
+) {
   let isWaitingForLoadEvent = loadType === ViewLoadingType.INITIAL_LOAD
   let isWaitingForActivityLoadingTime = true
   const loadingTimeCandidates: Duration[] = []
@@ -79,7 +84,18 @@ function trackLoadingTime(loadType: ViewLoadingType, callback: (loadingTime: Dur
     }
   }
 
+  const { stop: stopWaitIdlePage } = waitIdlePage(lifeCycle, domMutationObservable, (event) => {
+    if (isWaitingForActivityLoadingTime) {
+      isWaitingForActivityLoadingTime = false
+      if (event.hadActivity) {
+        loadingTimeCandidates.push(elapsed(viewStart.timeStamp, event.end))
+      }
+      invokeCallbackIfAllCandidatesAreReceived()
+    }
+  })
+
   return {
+    stopWaitIdlePage,
     setLoadEvent: (loadEvent: Duration) => {
       if (isWaitingForLoadEvent) {
         isWaitingForLoadEvent = false
@@ -87,31 +103,7 @@ function trackLoadingTime(loadType: ViewLoadingType, callback: (loadingTime: Dur
         invokeCallbackIfAllCandidatesAreReceived()
       }
     },
-    setActivityLoadingTime: (activityLoadingTime: Duration | undefined) => {
-      if (isWaitingForActivityLoadingTime) {
-        isWaitingForActivityLoadingTime = false
-        if (activityLoadingTime !== undefined) {
-          loadingTimeCandidates.push(activityLoadingTime)
-        }
-        invokeCallbackIfAllCandidatesAreReceived()
-      }
-    },
   }
-}
-
-function trackActivityLoadingTime(
-  lifeCycle: LifeCycle,
-  domMutationObservable: Observable<void>,
-  callback: (loadingTimeValue: Duration | undefined) => void,
-  viewStart: ClocksState
-) {
-  return waitIdlePage(lifeCycle, domMutationObservable, (event) => {
-    if (event.hadActivity) {
-      callback(elapsed(viewStart.timeStamp, event.end))
-    } else {
-      callback(undefined)
-    }
-  })
 }
 
 /**

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -35,7 +35,7 @@ export function trackViewMetrics(
     scheduleViewUpdate()
   })
 
-  const { stopWaitIdlePage, setLoadEvent } = trackLoadingTime(
+  const { stop: stopLoadingTimeTracking, setLoadEvent } = trackLoadingTime(
     lifeCycle,
     domMutationObservable,
     loadingType,
@@ -59,7 +59,7 @@ export function trackViewMetrics(
   return {
     stop: () => {
       stopEventCountsTracking()
-      stopWaitIdlePage()
+      stopLoadingTimeTracking()
       stopCLSTracking()
     },
     setLoadEvent,
@@ -84,7 +84,7 @@ function trackLoadingTime(
     }
   }
 
-  const { stop: stopWaitIdlePage } = waitIdlePage(lifeCycle, domMutationObservable, (event) => {
+  const { stop } = waitIdlePage(lifeCycle, domMutationObservable, (event) => {
     if (isWaitingForActivityLoadingTime) {
       isWaitingForActivityLoadingTime = false
       if (event.hadActivity) {
@@ -95,7 +95,7 @@ function trackLoadingTime(
   })
 
   return {
-    stopWaitIdlePage,
+    stop,
     setLoadEvent: (loadEvent: Duration) => {
       if (isWaitingForLoadEvent) {
         isWaitingForLoadEvent = false


### PR DESCRIPTION
## Motivation

Simplify loading time tracking logic

## Changes

- remove `trackActivityLoadingTime`
- call `waitIdlePage` directly into `trackLoadingTime`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
