### PR TITLE
👷 [RUMF-1185] remove some useless entries from changelog generation

### DIFF
--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -75,12 +75,26 @@ async function getChangesList() {
 
   const changesWithEmojis = emojiNameToUnicode(commits)
 
-  const changesWithPullRequestLinks = changesWithEmojis.replace(
+  const allowedChanges = changesWithEmojis
+    .split('\n')
+    .filter(isNotVersionEntry)
+    .filter(isNotMaintenanceEntry)
+    .join('\n')
+
+  const changesWithPullRequestLinks = allowedChanges.replace(
     /\(#(\d+)\)/gm,
     (_, id) => `([#${id}](https://github.com/DataDog/browser-sdk/pull/${id}))`
   )
 
   return changesWithPullRequestLinks
+}
+
+function isNotVersionEntry(line) {
+  return !/^- v\d+\.\d+\.\d+/.test(line)
+}
+
+function isNotMaintenanceEntry(line) {
+  return !/^- 👷/.test(line)
 }
 
 function emojiNameToUnicode(changes) {


### PR DESCRIPTION
## Motivation

Avoid some manual cleanup while releasing 😅

## Changes

Remove version and maintenance entries while generating the changelog

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
