### PR TITLE
[RUMF-1136] POC: upload source maps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -228,6 +228,7 @@ deploy-staging:
     - yarn
     - BUILD_MODE=canary yarn build:bundle
     - ./scripts/deploy.sh staging staging
+    - BUILD_MODE=canary node ./scripts/upload-source-maps.js datad0g.com staging
 
 deploy-prod-canary:
   stage: deploy:canary
@@ -238,6 +239,7 @@ deploy-prod-canary:
     - yarn
     - BUILD_MODE=canary yarn build:bundle
     - ./scripts/deploy.sh prod canary
+    # - BUILD_MODE=canary node ./scripts/upload-source-maps.js datadoghq.com canary
 
 deploy-prod-stable:
   stage: deploy
@@ -251,6 +253,7 @@ deploy-prod-stable:
     - BUILD_MODE=release yarn build:bundle
     - VERSION=$(node -p -e "require('./lerna.json').version")
     - ./scripts/deploy.sh prod v${VERSION%%.*}
+    # - BUILD_MODE=release node ./scripts/upload-source-maps.js datadoghq.com v${VERSION%%.*}
 
 ########################################################################################################################
 # Notify

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -68,8 +68,7 @@ function computeEndpointBuilders(initConfiguration: InitConfiguration, buildEnv:
         { ...initConfiguration, clientToken: initConfiguration.internalMonitoringApiKey },
         buildEnv,
         'logs',
-        tags,
-        'browser-agent-internal-monitoring'
+        [`service:browser-sdk`, `version:${buildEnv.sdkVersion}`]
       ),
     }
   }

--- a/scripts/upload-source-maps.js
+++ b/scripts/upload-source-maps.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const { getSecretKey, executeCommand, printLog, logAndExit } = require('./utils')
+const { SDK_VERSION } = require('./build-env')
+
+/**
+ * Upload source maps to datadog
+ * Usage:
+ * BUILD_MODE=canary|release node upload-source-maps.js datadoghq.com staging|canary|vXXX
+ */
+
+const site = process.argv[2]
+const suffix = process.argv[3]
+
+async function uploadSourceMaps(apiKey, packageName) {
+  const bundleFolder = `packages/${packageName}/bundle`
+
+  // The datadog-ci CLI is taking a directory as an argument. It will scan every source map files in
+  // it and upload those along with the minified bundle. The file names must match the one from the
+  // CDN, thus we need to rename the bundles with the right suffix.
+  for (const ext of ['js', 'js.map']) {
+    const filePath = `${bundleFolder}/datadog-${packageName}.${ext}`
+    const suffixedFilePath = `${bundleFolder}/datadog-${packageName}-${suffix}.${ext}`
+    await executeCommand(`mv ${filePath} ${suffixedFilePath}`)
+  }
+
+  const output = await executeCommand(
+    `
+    datadog-ci sourcemaps upload ${bundleFolder} \
+      --service browser-sdk \
+      --release-version ${SDK_VERSION} \
+      --minified-path-prefix / \
+      --project-path @datadog/browser-${packageName}/ \
+  `,
+    {
+      DATADOG_API_KEY: apiKey,
+      DATADOG_SITE: site,
+    }
+  )
+  console.log(output)
+}
+
+async function main() {
+  const apiKey = await getSecretKey('ci.browser-sdk.datadog_ci_api_key')
+
+  for (const packageName of ['logs', 'rum', 'rum-slim']) {
+    await uploadSourceMaps(apiKey, packageName)
+  }
+
+  printLog(`Source map upload done.`)
+}
+
+main().catch(logAndExit)

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -13,7 +13,7 @@ module.exports = ({ entry, mode, filename, types }) => ({
     path: path.resolve('./bundle'),
   },
   target: ['web', 'es5'],
-  devtool: mode === 'development' ? 'inline-source-map' : false,
+  devtool: mode === 'development' ? 'inline-source-map' : 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
## Motivation

Understand how we could have unminified internal monitoring error log stack traces.

## Changes

* Upload source maps via the `datadog-ci` CLI
* Adjust internal monitoring logs tags so they don't reflect the customer tags anymore:
  * `service` is now `browser-sdk`
  * `version` is now the browser SDK version
* Adjust the `source` tag to `browser` (condition to have those stack traces unminified)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
