### PR TITLE
⚡️ [RUMF-1171] prefer const enums 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,13 @@ module.exports = {
     'no-extra-bind': 'error',
     'no-new-func': 'error',
     'no-new-wrappers': 'error',
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'TSEnumDeclaration:not([const=true])',
+        message: 'When possible, use `const enum` as it produces less code when transpiled.',
+      },
+    ],
     'no-return-await': 'error',
     'no-sequences': 'error',
     'no-template-curly-in-string': 'error',

--- a/eslint-local-rules/disallowEnumExports.js
+++ b/eslint-local-rules/disallowEnumExports.js
@@ -62,16 +62,27 @@ module.exports = {
         const moduleExports = checker.getExportsOfModule(moduleSymbol)
 
         for (const symbol of moduleExports) {
-          if (isEnum(symbol)) {
+          if (isEnum(symbol, checker)) {
             context.report(node, `Cannot export enum ${symbol.getName()}`)
           }
         }
       },
     }
-  },
-}
 
-function isEnum(symbol) {
-  // eslint-disable-next-line no-bitwise
-  return symbol.getFlags() & SymbolFlags.Enum
+    function isEnum(symbol) {
+      const flags = symbol.getFlags()
+
+      // eslint-disable-next-line no-bitwise
+      if (flags & SymbolFlags.Enum) {
+        return true
+      }
+
+      // eslint-disable-next-line no-bitwise
+      if (flags & SymbolFlags.Alias) {
+        return isEnum(checker.getAliasedSymbol(symbol))
+      }
+
+      return false
+    }
+  },
 }

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -7,7 +7,7 @@ import type { Configuration } from '../configuration'
 import { computeStackTrace } from '../tracekit'
 import { startMonitoringBatch } from './startMonitoringBatch'
 
-enum StatusType {
+const enum StatusType {
   info = 'info',
   error = 'error',
 }

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -10,7 +10,7 @@ import { startSessionManager, stopSessionManager, VISIBILITY_CHECK_DELAY } from 
 import { SESSION_TIME_OUT_DELAY, SESSION_EXPIRATION_DELAY } from './sessionStore'
 import { SESSION_COOKIE_NAME } from './sessionCookieStore'
 
-enum FakeTrackingType {
+const enum FakeTrackingType {
   NOT_TRACKED = 'not-tracked',
   TRACKED = 'tracked',
 }

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -6,7 +6,7 @@ import type { SessionStore } from './sessionStore'
 import { startSessionStore, SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionStore'
 import { SESSION_COOKIE_NAME } from './sessionCookieStore'
 
-enum FakeTrackingType {
+const enum FakeTrackingType {
   TRACKED = 'tracked',
   NOT_TRACKED = 'not-tracked',
 }

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -29,7 +29,7 @@ export const ErrorSource = {
   SOURCE: 'source',
 } as const
 
-export enum ErrorHandling {
+export const enum ErrorHandling {
   HANDLED = 'handled',
   UNHANDLED = 'unhandled',
 }

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -38,7 +38,7 @@ export const enum DOM_EVENT {
   PAUSE = 'pause',
 }
 
-export enum ResourceType {
+export const enum ResourceType {
   DOCUMENT = 'document',
   XHR = 'xhr',
   BEACON = 'beacon',
@@ -51,7 +51,7 @@ export enum ResourceType {
   OTHER = 'other',
 }
 
-export enum RequestType {
+export const enum RequestType {
   FETCH = ResourceType.FETCH,
   XHR = ResourceType.XHR,
 }

--- a/packages/logs/src/domain/logsSessionManager.ts
+++ b/packages/logs/src/domain/logsSessionManager.ts
@@ -12,7 +12,7 @@ export type LogsSession = {
   id?: string // session can be tracked without id
 }
 
-export enum LoggerTrackingType {
+export const enum LoggerTrackingType {
   NOT_TRACKED = '0',
   TRACKED = '1',
 }

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -34,7 +34,7 @@ import type { RumConfiguration } from './configuration'
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
 
-enum SessionType {
+const enum SessionType {
   SYNTHETICS = 'synthetics',
   USER = 'user',
   CI_TEST = 'ci_test',

--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -7,7 +7,7 @@ import type { RequestCompleteEvent, RequestStartEvent } from './requestCollectio
 import type { AutoAction, AutoActionCreatedEvent } from './rumEventsCollection/action/trackActions'
 import type { ViewEvent, ViewCreatedEvent, ViewEndedEvent } from './rumEventsCollection/view/trackViews'
 
-export enum LifeCycleEventType {
+export const enum LifeCycleEventType {
   PERFORMANCE_ENTRIES_COLLECTED,
   AUTO_ACTION_CREATED,
   AUTO_ACTION_COMPLETED,

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -16,12 +16,12 @@ export type RumSession = {
   hasLitePlan: boolean
 }
 
-export enum RumSessionPlan {
+export const enum RumSessionPlan {
   LITE = 1,
   REPLAY = 2,
 }
 
-export enum RumTrackingType {
+export const enum RumTrackingType {
   NOT_TRACKED = '0',
   // Note: the "tracking type" value (stored in the session cookie) does not match the "session
   // plan" value (sent in RUM events). This is expected, and was done to keep retrocompatibility

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -9,7 +9,7 @@ import type {
 } from '@datadog/browser-core'
 import type { RumSessionPlan } from './domain/rumSessionManager'
 
-export enum RumEventType {
+export const enum RumEventType {
   ACTION = 'action',
   ERROR = 'error',
   LONG_TASK = 'long_task',
@@ -110,7 +110,7 @@ export interface InForegroundPeriod {
   duration: ServerDuration
 }
 
-export enum ViewLoadingType {
+export const enum ViewLoadingType {
   INITIAL_LOAD = 'initial_load',
   ROUTE_CHANGE = 'route_change',
 }
@@ -157,7 +157,7 @@ export interface RawRumActionEvent {
   }
 }
 
-export enum ActionType {
+export const enum ActionType {
   CLICK = 'click',
   CUSTOM = 'custom',
 }

--- a/packages/rum/src/domain/record/types.ts
+++ b/packages/rum/src/domain/record/types.ts
@@ -2,52 +2,54 @@ import type { DefaultPrivacyLevel } from '@datadog/browser-core'
 import type { FocusRecord, RawRecord, VisualViewportRecord } from '../../types'
 import type { MutationController } from './mutationObserver'
 
-export enum IncrementalSource {
-  Mutation = 0,
-  MouseMove = 1,
-  MouseInteraction = 2,
-  Scroll = 3,
-  ViewportResize = 4,
-  Input = 5,
-  TouchMove = 6,
-  MediaInteraction = 7,
-  StyleSheetRule = 8,
-  // CanvasMutation = 9,
-  // Font = 10,
-}
+export const IncrementalSource = {
+  Mutation: 0,
+  MouseMove: 1,
+  MouseInteraction: 2,
+  Scroll: 3,
+  ViewportResize: 4,
+  Input: 5,
+  TouchMove: 6,
+  MediaInteraction: 7,
+  StyleSheetRule: 8,
+  // CanvasMutation : 9,
+  // Font : 10,
+} as const
+
+export type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource]
 
 export type MutationData = {
-  source: IncrementalSource.Mutation
+  source: typeof IncrementalSource.Mutation
 } & MutationPayload
 
 export interface MousemoveData {
-  source: IncrementalSource.MouseMove | IncrementalSource.TouchMove
+  source: typeof IncrementalSource.MouseMove | typeof IncrementalSource.TouchMove
   positions: MousePosition[]
 }
 
 export type MouseInteractionData = {
-  source: IncrementalSource.MouseInteraction
+  source: typeof IncrementalSource.MouseInteraction
 } & MouseInteractionParam
 
 export type ScrollData = {
-  source: IncrementalSource.Scroll
+  source: typeof IncrementalSource.Scroll
 } & ScrollPosition
 
 export type ViewportResizeData = {
-  source: IncrementalSource.ViewportResize
+  source: typeof IncrementalSource.ViewportResize
 } & ViewportResizeDimention
 
 export type InputData = {
-  source: IncrementalSource.Input
+  source: typeof IncrementalSource.Input
   id: number
 } & InputState
 
 export type MediaInteractionData = {
-  source: IncrementalSource.MediaInteraction
+  source: typeof IncrementalSource.MediaInteraction
 } & MediaInteractionParam
 
 export type StyleSheetRuleData = {
-  source: IncrementalSource.StyleSheetRule
+  source: typeof IncrementalSource.StyleSheetRule
 } & StyleSheetRuleParam
 
 export type IncrementalData =
@@ -158,7 +160,7 @@ export type MutationCallBack = (m: MutationPayload) => void
 
 export type MousemoveCallBack = (
   p: MousePosition[],
-  source: IncrementalSource.MouseMove | IncrementalSource.TouchMove
+  source: typeof IncrementalSource.MouseMove | typeof IncrementalSource.TouchMove
 ) => void
 
 export interface MousePosition {
@@ -248,7 +250,7 @@ export type VisualViewportResizeCallback = (data: VisualViewportRecord['data']) 
 export type ListenerHandler = () => void
 export type HookResetter = () => void
 
-export enum NodeType {
+export const enum NodeType {
   Document,
   DocumentType,
   Element,

--- a/test/e2e/lib/types/serverEvents.ts
+++ b/test/e2e/lib/types/serverEvents.ts
@@ -1,5 +1,5 @@
 import type { RumActionEvent, RumErrorEvent, RumEvent, RumResourceEvent, RumViewEvent } from '@datadog/browser-rum'
-import type { Segment } from '@datadog/browser-rum/cjs/types'
+import type { Segment } from '@datadog/browser-rum/src/types'
 
 export interface ServerInternalMonitoringMessage {
   message: string

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -1,7 +1,8 @@
-import type { CreationReason, Segment } from '@datadog/browser-rum/cjs/types'
-import { IncrementalSource, RecordType } from '@datadog/browser-rum/cjs/types'
-import type { InputData, StyleSheetRuleData } from '@datadog/browser-rum/cjs/domain/record/types'
-import { NodeType } from '@datadog/browser-rum/cjs/domain/record/types'
+import type { CreationReason, Segment } from '@datadog/browser-rum/src/types'
+import { IncrementalSource, RecordType } from '@datadog/browser-rum/src/types'
+import type { InputData, StyleSheetRuleData } from '@datadog/browser-rum/src/domain/record/types'
+import { NodeType } from '@datadog/browser-rum/src/domain/record/types'
+
 import type { RumInitConfiguration } from '@datadog/browser-rum-core'
 import { DefaultPrivacyLevel } from '@datadog/browser-rum'
 


### PR DESCRIPTION
## Motivation

Minified size in bytes:
| Package  | Before  | After | Delta |
|---- |--- | -- | -- |
| datadog-logs.js  | 33188 | 32690  | -1.5%
| datadog-rum-slim.js | 63867 | 60910  | -4.6% |
| datadog-rum.js  | 113044 | 109360 | -3.3% |


## Changes

* Enforce and change enum to const enums
* Fix the `disallowEnumExports` rule because I noticed that some enums were still exported, and convert the `IncrementalSource` enum to a plain object

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
