### PR TITLE
🔥 Clear remaining code of network error removal

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.spec.ts
@@ -43,7 +43,6 @@ describe('error collection', () => {
           error: {
             id: jasmine.any(String),
             message: 'foo',
-            resource: undefined,
             source: ErrorSource.CUSTOM,
             stack: jasmine.stringMatching('Error: foo'),
             handling_stack: 'Error: handling foo',
@@ -125,12 +124,7 @@ describe('error collection', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, {
         error: {
           message: 'hello',
-          resource: {
-            method: 'GET',
-            statusCode: 500,
-            url: 'url',
-          },
-          source: ErrorSource.NETWORK,
+          source: ErrorSource.CUSTOM,
           stack: 'bar',
           startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
           type: 'foo',
@@ -144,12 +138,7 @@ describe('error collection', () => {
         error: {
           id: jasmine.any(String),
           message: 'hello',
-          resource: {
-            method: 'GET',
-            status_code: 500,
-            url: 'url',
-          },
-          source: ErrorSource.NETWORK,
+          source: ErrorSource.CUSTOM,
           stack: 'bar',
           handling_stack: undefined,
           type: 'foo',

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -85,13 +85,6 @@ function processError(
     error: {
       id: generateUUID(),
       message: error.message,
-      resource: error.resource
-        ? {
-            method: error.resource.method,
-            status_code: error.resource.statusCode,
-            url: error.resource.url,
-          }
-        : undefined,
       source: error.source,
       stack: error.stack,
       handling_stack: error.handlingStack,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -50,11 +50,6 @@ export interface RawRumErrorEvent {
   date: TimeStamp
   type: RumEventType.ERROR
   error: {
-    resource?: {
-      url: string
-      status_code: number
-      method: string
-    }
     id: string
     type?: string
     stack?: string


### PR DESCRIPTION
## Motivation

Since there is no more network error in RUM (cf [PR](https://github.com/DataDog/browser-sdk/pull/930)) we don't have to map the resource. 

## Changes

Update errorCollection

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
