### PR TITLE
⚗️ [RUMF-1181] collect telemetry events

### DIFF
--- a/packages/core/src/domain/internalMonitoring/index.ts
+++ b/packages/core/src/domain/internalMonitoring/index.ts
@@ -11,3 +11,4 @@ export {
   setDebugMode,
   startInternalMonitoring,
 } from './internalMonitoring'
+export { TelemetryEvent } from './telemetryEvent.types'

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -1,4 +1,6 @@
+import type { Context } from '../../tools/context'
 import type { Configuration } from '../configuration'
+import { updateExperimentalFeatures, resetExperimentalFeatures } from '../configuration'
 import type { InternalMonitoring, MonitoringMessage } from './internalMonitoring'
 import {
   monitor,
@@ -7,6 +9,7 @@ import {
   startInternalMonitoring,
   callMonitored,
 } from './internalMonitoring'
+import type { TelemetryEvent } from './telemetryEvent.types'
 
 const configuration: Partial<Configuration> = {
   maxInternalMonitoringMessagesPerPage: 7,
@@ -183,6 +186,82 @@ describe('internal monitoring', () => {
         throw new Error('message')
       })
       expect(notifySpy.calls.mostRecent().args[0].foo).not.toBeDefined()
+    })
+  })
+
+  describe('new telemetry', () => {
+    let internalMonitoring: InternalMonitoring
+    let notifySpy: jasmine.Spy<(event: TelemetryEvent & Context) => void>
+
+    describe('when enabled', () => {
+      beforeEach(() => {
+        updateExperimentalFeatures(['telemetry'])
+        internalMonitoring = startInternalMonitoring(configuration as Configuration)
+        notifySpy = jasmine.createSpy('notified')
+        internalMonitoring.telemetryEventObservable.subscribe(notifySpy)
+      })
+
+      afterEach(() => {
+        resetExperimentalFeatures()
+        resetInternalMonitoring()
+      })
+
+      it('should notify observable', () => {
+        callMonitored(() => {
+          throw new Error('message')
+        })
+
+        expect(notifySpy).toHaveBeenCalled()
+        const telemetryEvent = notifySpy.calls.mostRecent().args[0]
+        expect(telemetryEvent.message).toEqual('message')
+        expect(telemetryEvent._dd.event_type).toEqual('internal_telemetry')
+      })
+
+      it('should add telemetry context', () => {
+        internalMonitoring.setTelemetryContextProvider(() => ({ foo: 'bar' }))
+
+        callMonitored(() => {
+          throw new Error('message')
+        })
+
+        expect(notifySpy).toHaveBeenCalled()
+        const telemetryEvent = notifySpy.calls.mostRecent().args[0]
+        expect(telemetryEvent.foo).toEqual('bar')
+      })
+
+      it('should still use existing system', () => {
+        internalMonitoring.setExternalContextProvider(() => ({
+          foo: 'bar',
+        }))
+        const oldNotifySpy = jasmine.createSpy<(message: MonitoringMessage) => void>('old')
+        internalMonitoring.monitoringMessageObservable.subscribe(oldNotifySpy)
+
+        callMonitored(() => {
+          throw new Error('message')
+        })
+
+        expect(oldNotifySpy.calls.mostRecent().args[0].foo).toEqual('bar')
+      })
+    })
+
+    describe('when disabled', () => {
+      beforeEach(() => {
+        internalMonitoring = startInternalMonitoring(configuration as Configuration)
+        notifySpy = jasmine.createSpy('notified')
+        internalMonitoring.telemetryEventObservable.subscribe(notifySpy)
+      })
+
+      afterEach(() => {
+        resetInternalMonitoring()
+      })
+
+      it('should not notify observable', () => {
+        callMonitored(() => {
+          throw new Error('message')
+        })
+
+        expect(notifySpy).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export {
   startFakeInternalMonitoring,
   resetInternalMonitoring,
   setDebugMode,
+  TelemetryEvent,
 } from './domain/internalMonitoring'
 export { Observable, Subscription } from './tools/observable'
 export {

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -1,4 +1,4 @@
-import type { Context, EndpointBuilder } from '@datadog/browser-core'
+import type { Context, EndpointBuilder, TelemetryEvent, Observable } from '@datadog/browser-core'
 import { Batch, combine, HttpRequest } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
@@ -6,7 +6,11 @@ import { LifeCycleEventType } from '../domain/lifeCycle'
 import { RumEventType } from '../rawRumEvent.types'
 import type { RumEvent } from '../rumEvent.types'
 
-export function startRumBatch(configuration: RumConfiguration, lifeCycle: LifeCycle) {
+export function startRumBatch(
+  configuration: RumConfiguration,
+  lifeCycle: LifeCycle,
+  telemetryEventObservable: Observable<TelemetryEvent & Context>
+) {
   const batch = makeRumBatch(configuration, lifeCycle)
 
   lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (serverRumEvent: RumEvent & Context) => {
@@ -16,6 +20,8 @@ export function startRumBatch(configuration: RumConfiguration, lifeCycle: LifeCy
       batch.add(serverRumEvent)
     }
   })
+
+  telemetryEventObservable.subscribe((event) => batch.add(event))
 }
 
 interface RumBatch {

--- a/test/e2e/lib/framework/eventsRegistry.ts
+++ b/test/e2e/lib/framework/eventsRegistry.ts
@@ -1,22 +1,30 @@
 import type { LogsEvent } from '@datadog/browser-logs'
 import type { RumEvent } from '@datadog/browser-rum'
+import type { TelemetryEvent } from '@datadog/browser-core'
 import type { SessionReplayCall, ServerInternalMonitoringMessage } from '../types/serverEvents'
 import { isRumErrorEvent, isRumResourceEvent, isRumUserActionEvent, isRumViewEvent } from '../types/serverEvents'
 
-type IntakeType = 'logs' | 'rum' | 'internalMonitoring' | 'sessionReplay'
+type IntakeType = 'logs' | 'rum' | 'internalMonitoring' | 'sessionReplay' | 'telemetry'
 
 export class EventRegistry {
   readonly rum: RumEvent[] = []
   readonly logs: LogsEvent[] = []
   readonly sessionReplay: SessionReplayCall[] = []
   readonly internalMonitoring: ServerInternalMonitoringMessage[] = []
+  readonly telemetry: TelemetryEvent[] = []
 
   push(type: IntakeType, event: any) {
     this[type].push(event)
   }
 
   get count() {
-    return this.logs.length + this.rum.length + this.internalMonitoring.length + this.sessionReplay.length
+    return (
+      this.logs.length +
+      this.rum.length +
+      this.internalMonitoring.length +
+      this.sessionReplay.length +
+      this.telemetry.length
+    )
   }
 
   get rumActions() {
@@ -38,6 +46,7 @@ export class EventRegistry {
   empty() {
     this.rum.length = 0
     this.internalMonitoring.length = 0
+    this.telemetry.length = 0
     this.logs.length = 0
   }
 }

--- a/test/e2e/lib/framework/serverApps/intake.ts
+++ b/test/e2e/lib/framework/serverApps/intake.ts
@@ -18,8 +18,19 @@ export function createIntakeServerApp(serverEvents: EventRegistry, bridgeEvents:
     const isBridge = req.query.bridge
     const events = isBridge ? bridgeEvents : serverEvents
 
-    if (endpoint === 'rum' || endpoint === 'logs' || endpoint === 'internalMonitoring') {
+    if (endpoint === 'logs' || endpoint === 'internalMonitoring') {
       ;(req.body as string).split('\n').map((rawEvent) => events.push(endpoint, JSON.parse(rawEvent)))
+    }
+
+    if (endpoint === 'rum') {
+      ;(req.body as string).split('\n').map((rawEvent) => {
+        const event = JSON.parse(rawEvent)
+        if (event._dd?.event_type === 'internal_telemetry') {
+          events.push('telemetry', event)
+        } else {
+          events.push('rum', event)
+        }
+      })
     }
 
     if (endpoint === 'sessionReplay' && req.busboy) {

--- a/test/e2e/scenario/internalMonitoring.scenario.ts
+++ b/test/e2e/scenario/internalMonitoring.scenario.ts
@@ -1,9 +1,10 @@
+import type { TelemetryErrorEvent } from '@datadog/browser-core/src/domain/internalMonitoring/telemetryEvent.types'
 import { bundleSetup, createTest } from '../lib/framework'
 import { browserExecute } from '../lib/helpers/browser'
 import { flushEvents } from '../lib/helpers/flushEvents'
 
 describe('internal monitoring', () => {
-  createTest('send errors')
+  createTest('send errors for logs')
     .withSetup(bundleSetup)
     .withLogs({
       internalMonitoringApiKey: 'xxx',
@@ -23,6 +24,80 @@ describe('internal monitoring', () => {
       const event = serverEvents.internalMonitoring[0]
       expect(event.message).toBe('bar')
       expect(event.error.kind).toBe('Error')
+      expect(event.status).toBe('error')
+      serverEvents.empty()
+    })
+
+  createTest('send errors for RUM')
+    .withSetup(bundleSetup)
+    .withRum({
+      internalMonitoringApiKey: 'xxx',
+    })
+    .run(async ({ serverEvents }) => {
+      await browserExecute(() => {
+        const context = {
+          get foo() {
+            throw new window.Error('bar')
+          },
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        window.DD_RUM!.addAction('hop', context as any)
+      })
+      await flushEvents()
+      expect(serverEvents.internalMonitoring.length).toBe(1)
+      const event = serverEvents.internalMonitoring[0]
+      expect(event.message).toBe('bar')
+      expect(event.error.kind).toBe('Error')
+      expect(event.status).toBe('error')
+      serverEvents.empty()
+    })
+})
+
+describe('telemetry', () => {
+  createTest('send errors for logs')
+    .withSetup(bundleSetup)
+    .withLogs({
+      enableExperimentalFeatures: ['telemetry'],
+    })
+    .run(async ({ serverEvents }) => {
+      await browserExecute(() => {
+        const context = {
+          get foo() {
+            throw new window.Error('bar')
+          },
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        window.DD_LOGS!.logger.log('hop', context as any)
+      })
+      await flushEvents()
+      expect(serverEvents.telemetry.length).toBe(1)
+      const event = serverEvents.telemetry[0] as TelemetryErrorEvent
+      expect(event.message).toBe('bar')
+      expect(event.error!.kind).toBe('Error')
+      expect(event.status).toBe('error')
+      serverEvents.empty()
+    })
+
+  createTest('send errors for RUM')
+    .withSetup(bundleSetup)
+    .withRum({
+      enableExperimentalFeatures: ['telemetry'],
+    })
+    .run(async ({ serverEvents }) => {
+      await browserExecute(() => {
+        const context = {
+          get foo() {
+            throw new window.Error('bar')
+          },
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        window.DD_RUM!.addAction('hop', context as any)
+      })
+      await flushEvents()
+      expect(serverEvents.telemetry.length).toBe(1)
+      const event = serverEvents.telemetry[0] as TelemetryErrorEvent
+      expect(event.message).toBe('bar')
+      expect(event.error!.kind).toBe('Error')
       expect(event.status).toBe('error')
       serverEvents.empty()
     })


### PR DESCRIPTION
## Motivation

Experiment with dual shipping telemetry events in existing and new system

Superseed https://github.com/DataDog/browser-sdk/pull/1351


## Changes

Behind telemetry feature flag:

- core: update internalMonitoring to handle new telemetry events
- RUM: send them in the batch of RUM events
- logs: send them in a new "RUM" batch

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging (FF disabled)
- [ ] Staging (FF enabled)
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
