### PR TITLE
[RUMF-576] 🐛  fix logs printed twice in console

### DIFF
--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -28,7 +28,7 @@ describe('logs entry', () => {
 
   beforeEach(() => {
     sendLogsSpy = jasmine.createSpy()
-    startLogs = jasmine.createSpy().and.callFake(() => sendLogsSpy)
+    startLogs = jasmine.createSpy().and.callFake(() => ({ sendLog: sendLogsSpy }))
   })
 
   it('should define the public API with init', () => {

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -55,8 +55,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       if (!configuration) {
         return
       }
-
-      sendLogStrategy = startLogsImpl(configuration, logger)
+      sendLogStrategy = startLogsImpl(configuration, logger).sendLog
       getInitConfigurationStrategy = () => deepClone(initConfiguration)
       beforeInitSendLog.drain()
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -185,15 +185,22 @@ export function doStartLogs(
     logWithoutConsoleHandler(logger, () => logger.log(message, messageContext, logStatus))
   }
 
-  rawErrorObservable.subscribe(reportRawError)
-  consoleObservable.subscribe(reportConsoleLog)
-  reportObservable.subscribe(logReport)
+  const rawErrorSubscription = rawErrorObservable.subscribe(reportRawError)
+  const consoleSubscription = consoleObservable.subscribe(reportConsoleLog)
+  const reportSubscription = reportObservable.subscribe(logReport)
 
-  return (message: LogsMessage, currentContext: Context) => {
-    const contextualizedMessage = assemble(message, currentContext)
-    if (contextualizedMessage) {
-      onLogEventCollected(contextualizedMessage)
-    }
+  return {
+    stop: () => {
+      rawErrorSubscription.unsubscribe()
+      consoleSubscription.unsubscribe()
+      reportSubscription.unsubscribe()
+    },
+    sendLog: (message: LogsMessage, currentContext: Context) => {
+      const contextualizedMessage = assemble(message, currentContext)
+      if (contextualizedMessage) {
+        onLogEventCollected(contextualizedMessage)
+      }
+    },
   }
 }
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -27,7 +27,7 @@ import {
 } from '@datadog/browser-core'
 import { trackNetworkError } from '../domain/trackNetworkError'
 import type { Logger, LogsMessage } from '../domain/logger'
-import { StatusType } from '../domain/logger'
+import { StatusType, logWithoutConsoleHandler } from '../domain/logger'
 import type { LogsSessionManager } from '../domain/logsSessionManager'
 import { startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
 import type { LogsConfiguration } from '../domain/configuration'
@@ -150,7 +150,7 @@ export function doStartLogs(
         url: error.resource.url,
       }
     }
-    logger.error(error.message, messageContext)
+    logWithoutConsoleHandler(logger, () => logger.error(error.message, messageContext))
   }
 
   function reportConsoleLog(log: ConsoleLog) {
@@ -163,7 +163,7 @@ export function doStartLogs(
         },
       }
     }
-    logger.log(log.message, messageContext, LogStatusForApi[log.api])
+    logWithoutConsoleHandler(logger, () => logger.log(log.message, messageContext, LogStatusForApi[log.api]))
   }
 
   function logReport(report: RawReport) {
@@ -182,7 +182,7 @@ export function doStartLogs(
       message += ` Found in ${getFileFromStackTraceString(report.stack)!}`
     }
 
-    logger.log(message, messageContext, logStatus)
+    logWithoutConsoleHandler(logger, () => logger.log(message, messageContext, logStatus))
   }
 
   rawErrorObservable.subscribe(reportRawError)

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -1,6 +1,6 @@
 import { display } from '@datadog/browser-core'
 import type { LogsMessage } from './logger'
-import { HandlerType, Logger, STATUSES, StatusType } from './logger'
+import { HandlerType, Logger, STATUSES, StatusType, logWithoutConsoleHandler } from './logger'
 
 describe('Logger', () => {
   let logger: Logger
@@ -124,5 +124,26 @@ describe('Logger', () => {
       expect(sendLogSpy).not.toHaveBeenCalled()
       expect(display.log).toHaveBeenCalled()
     })
+  })
+})
+
+describe('logWithoutConsoleHandler', () => {
+  let logger: Logger
+  let sendLogSpy: jasmine.Spy<(message: LogsMessage) => void>
+
+  beforeEach(() => {
+    sendLogSpy = jasmine.createSpy()
+    logger = new Logger(sendLogSpy)
+    spyOn(display, 'log')
+  })
+
+  it('should log without console handler', () => {
+    const handlers = [HandlerType.console, HandlerType.http]
+    logger.setHandler(handlers)
+    logWithoutConsoleHandler(logger, () => logger.log('message'))
+
+    expect(sendLogSpy).toHaveBeenCalled()
+    expect(display.log).not.toHaveBeenCalledWith()
+    expect(logger['handlerType']).toEqual(handlers)
   })
 })

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -102,3 +102,12 @@ export class Logger {
     this.level = level
   }
 }
+
+export function logWithoutConsoleHandler(logger: Logger, log: () => void) {
+  const handlers = Array.isArray(logger['handlerType']) ? logger['handlerType'] : [logger['handlerType']]
+  if (includes(handlers, 'console')) {
+    logger.setHandler(handlers.filter((t) => t !== 'console'))
+  }
+  log()
+  logger.setHandler(handlers)
+}


### PR DESCRIPTION
## Motivation

With the logs SDK installed with 'forwardErrorsToLogs' enabled and a 'console' handler, when a console api is called the message is displayed twice in the console.

We expected the message to be displayed only once.

This is a naive approach to fix it in order to unlock console calls collection in browser Logs.
It has to be improved with the next Logs refactoring (cf: RUMF-1178)

## Changes

Add logWithoutConsoleHandler 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
