### PR TITLE
Update browser config to include SDK version

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -254,7 +254,8 @@ init(configuration: {
 ```
 
 ### Browser and Session Replay sampling configuration
-Note: requires SDK version > 3.6.0
+
+**Note**: This feature requires SDK v3.6.0+.
 
 When new session is created, it can be either tracked as:
 

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -254,6 +254,7 @@ init(configuration: {
 ```
 
 ### Browser and Session Replay sampling configuration
+Note: requires SDK version > 3.6.0
 
 When new session is created, it can be either tracked as:
 


### PR DESCRIPTION
## Motivation

For people on older SDKs we need to call out to update to a newer SDK version

"hi team, my customer XXXXX has let me know they were [configuring their SDK](https://docs.datadoghq.com/real_user_monitoring/browser/#browser-and-session-replay-sampling-configuration) to remove long tasks and resources but i still see in the plan and usage page that they are technically on the session replay SKU-can someone help me confirm if they have turned off these features? thanks!" 

"- did they check their SDK version? from what I can see they are still on 2.18.0"

