### PR TITLE
👷 [RUMF-1168] remove forgotten dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,3 @@ updates:
       # update node-fetch: RUMF-1167
       - dependency-name: 'node-fetch'
         update-types: ['version-update:semver-major']
-      # typescript: RUMF-1168
-      - dependency-name: 'ts-loader'
-      - dependency-name: 'ts-node'


### PR DESCRIPTION
## Motivation

In #1368 , I forgot to remove some dependabot ignored packages

## Changes

Remove forgotten dependabot ignores

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
