### PR TITLE
🐛 fix build-env replacement in npm packages

### DIFF
--- a/scripts/replace-build-env.js
+++ b/scripts/replace-build-env.js
@@ -15,7 +15,7 @@ async function main() {
 
   const results = await replace({
     files: `${buildDirectory}/**/*.js`,
-    from: Object.keys(buildEnv).map((entry) => `__BUILD_ENV__${entry}__`),
+    from: Object.keys(buildEnv).map((entry) => new RegExp(`__BUILD_ENV__${entry}__`, 'g')),
     to: Object.values(buildEnv).map((value) => `"${value}"`),
   })
   printLog(


### PR DESCRIPTION
## Motivation

NPM packages of v4.6.0 are broken because `__BUILD_ENV__SDK_VERSION__` is not always replaced in `esm` and `cjs` files.

The `replace-in-file` package works just like JS `string.replace`: if a string is provided, a single occurrence is replaced. Sadly, we are using __BUILD_ENV__SDK_VERSION__ [two times in `endpointBuilder`](https://github.com/DataDog/browser-sdk/blob/c1eb0487c676dcf43408f4cf34804f0bbaecad45/packages/core/src/domain/configuration/endpointBuilder.ts#L45-L48,) so the second occurrence is not replaced.

This has not been found during E2E tests because the endpoint builder is overriden in this case. We'll work on improving the situation in a future PR.

## Changes

To work around this, we have to use a regex with the "global" flag.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
