### PR TITLE
👷 Bump @types/node-forge

### DIFF
--- a/performances/package.json
+++ b/performances/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@types/node": "15.0.1",
-    "@types/node-forge": "1.0.0",
+    "@types/node-forge": "1.0.1",
     "node-forge": "1.2.1",
     "puppeteer": "8.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,10 +1753,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node-forge@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.0.0.tgz#0b4e9507209485945115a4db4879f39632230593"
-  integrity sha512-h0bgwPKq5u99T9Gor4qtV1lCZ41xNkai0pie1n/a2mh2/4+jENWOlo7AJ4YKxTZAnSZ8FRurUpdIN7ohaPPuHA==
+"@types/node-forge@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.0.1.tgz#0df103639da9d5ec6a708d462020f0df70679f37"
+  integrity sha512-96ELNKv9tQJ19afdBUiM5iDw7OYEc53iUc51gAPR2aGaqRsO1DBROjqgZRjZa1tkPj7TnEOR0EnyAX6iryGkzA==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
## Motivation

The dependabot PR has unecessary changes in the yarn.lock, and breaks type checking.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
