### PR TITLE
👷 run dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+      time: '09:00'
     commit-message:
       prefix: '👷'
     ignore:


### PR DESCRIPTION
The number of updates to do daily is a bit overwhelming. Let's run dependabot once a week, at the beginning of each IH shift

