### PR TITLE
 🐛 [RUMF-1203] fix `stopSessionReplayRecording` instrumentation cleanup

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,7 @@ export * from './tools/timeUtils'
 export * from './tools/utils'
 export * from './tools/createEventRateLimiter'
 export * from './tools/browserDetection'
-export { instrumentMethod, instrumentMethodAndCallOriginal } from './tools/instrumentMethod'
+export { instrumentMethod, instrumentMethodAndCallOriginal, instrumentSetter } from './tools/instrumentMethod'
 export {
   ErrorSource,
   ErrorHandling,

--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -1,4 +1,7 @@
-import { instrumentMethod } from './instrumentMethod'
+import type { Clock } from '../../test/specHelper'
+import { mockClock } from '../../test/specHelper'
+import { instrumentMethod, instrumentSetter } from './instrumentMethod'
+import { noop } from './utils'
 
 describe('instrumentMethod', () => {
   it('replaces the original method', () => {
@@ -102,5 +105,157 @@ describe('instrumentMethod', () => {
   function thirdPartyInstrumentation(object: { method: () => number }) {
     const originalMethod = object.method
     object.method = () => originalMethod() + 2
+  }
+})
+
+describe('instrumentSetter', () => {
+  let clock: Clock
+  beforeEach(() => {
+    clock = mockClock()
+  })
+  afterEach(() => {
+    clock.cleanup()
+  })
+
+  it('replaces the original setter', () => {
+    const originalSetter = () => {
+      // do nothing particular, only used to test if this setter gets replaced
+    }
+    const object = {} as { foo: number }
+    Object.defineProperty(object, 'foo', { set: originalSetter, configurable: true })
+
+    instrumentSetter(object, 'foo', noop)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(Object.getOwnPropertyDescriptor(object, 'foo')!.set).not.toBe(originalSetter)
+  })
+
+  it('skips instrumentation if there is no original setter', () => {
+    const object = { foo: 1 }
+
+    instrumentSetter(object, 'foo', noop)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(Object.getOwnPropertyDescriptor(object, 'foo')!.set).toBeUndefined()
+  })
+
+  it('skips instrumentation if the descriptor is not configurable', () => {
+    const originalSetter = () => {
+      // do nothing particular, only used to test if this setter gets replaced
+    }
+    const object = {} as { foo: number }
+    Object.defineProperty(object, 'foo', { set: originalSetter, configurable: false })
+
+    instrumentSetter(object, 'foo', noop)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(Object.getOwnPropertyDescriptor(object, 'foo')!.set).toBe(originalSetter)
+  })
+
+  it('calls the original setter', () => {
+    const originalSetterSpy = jasmine.createSpy()
+    const object = {} as { foo: number }
+    Object.defineProperty(object, 'foo', { set: originalSetterSpy, configurable: true })
+
+    instrumentSetter(object, 'foo', noop)
+
+    object.foo = 1
+    expect(originalSetterSpy).toHaveBeenCalledOnceWith(1)
+  })
+
+  it('calls the instrumentation asynchronously', () => {
+    const instrumentationSetterSpy = jasmine.createSpy()
+    const object = {} as { foo: number }
+    Object.defineProperty(object, 'foo', { set: noop, configurable: true })
+
+    instrumentSetter(object, 'foo', instrumentationSetterSpy)
+
+    object.foo = 1
+    expect(instrumentationSetterSpy).not.toHaveBeenCalled()
+    clock.tick(0)
+    expect(instrumentationSetterSpy).toHaveBeenCalledOnceWith(object, 1)
+  })
+
+  it('allows other instrumentations from third parties', () => {
+    const object = {} as { foo: number }
+    Object.defineProperty(object, 'foo', { set: noop, configurable: true })
+    const instrumentationSetterSpy = jasmine.createSpy()
+    instrumentSetter(object, 'foo', instrumentationSetterSpy)
+
+    const thirdPartyInstrumentationSpy = thirdPartyInstrumentation(object)
+
+    object.foo = 2
+    expect(thirdPartyInstrumentationSpy).toHaveBeenCalledOnceWith(2)
+    clock.tick(0)
+    expect(instrumentationSetterSpy).toHaveBeenCalledOnceWith(object, 2)
+  })
+
+  describe('stop()', () => {
+    it('restores the original behavior', () => {
+      const object = {} as { foo: number }
+      const originalSetter = () => {
+        // do nothing particular, only used to test if this setter gets replaced
+      }
+      Object.defineProperty(object, 'foo', { set: originalSetter, configurable: true })
+      const { stop } = instrumentSetter(object, 'foo', noop)
+
+      stop()
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(Object.getOwnPropertyDescriptor(object, 'foo')!.set).toBe(originalSetter)
+    })
+
+    it('does not call the instrumentation anymore', () => {
+      const object = {} as { foo: number }
+      Object.defineProperty(object, 'foo', { set: noop, configurable: true })
+      const instrumentationSetterSpy = jasmine.createSpy()
+      const { stop } = instrumentSetter(object, 'foo', instrumentationSetterSpy)
+
+      stop()
+
+      object.foo = 2
+
+      expect(instrumentationSetterSpy).not.toHaveBeenCalled()
+    })
+
+    describe('when the method has been instrumented by a third party', () => {
+      it('should not break the third party instrumentation', () => {
+        const object = {} as { foo: number }
+        Object.defineProperty(object, 'foo', { set: noop, configurable: true })
+        const { stop } = instrumentSetter(object, 'foo', noop)
+
+        const thirdPartyInstrumentationSpy = thirdPartyInstrumentation(object)
+
+        stop()
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(Object.getOwnPropertyDescriptor(object, 'foo')!.set).toBe(thirdPartyInstrumentationSpy)
+      })
+
+      it('does not call the instrumentation', () => {
+        const object = {} as { foo: number }
+        Object.defineProperty(object, 'foo', { set: noop, configurable: true })
+        const instrumentationSetterSpy = jasmine.createSpy()
+        const { stop } = instrumentSetter(object, 'foo', noop)
+
+        thirdPartyInstrumentation(object)
+
+        stop()
+
+        object.foo = 2
+
+        expect(instrumentationSetterSpy).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  function thirdPartyInstrumentation(object: { foo: number }) {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalSetter = Object.getOwnPropertyDescriptor(object, 'foo')!.set
+    const thirdPartyInstrumentationSpy = jasmine.createSpy().and.callFake(function (this: any, value) {
+      if (originalSetter) {
+        originalSetter.call(this, value)
+      }
+    })
+    Object.defineProperty(object, 'foo', { set: thirdPartyInstrumentationSpy })
+    return thirdPartyInstrumentationSpy
   }
 })

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -35,8 +35,8 @@ export function instrumentMethodAndCallOriginal<OBJECT extends { [key: string]: 
     before,
     after,
   }: {
-    before?: (this: OBJECT, ...args: Parameters<OBJECT[METHOD]>) => ReturnType<OBJECT[METHOD]>
-    after?: (this: OBJECT, ...args: Parameters<OBJECT[METHOD]>) => ReturnType<OBJECT[METHOD]>
+    before?: (this: OBJECT, ...args: Parameters<OBJECT[METHOD]>) => void
+    after?: (this: OBJECT, ...args: Parameters<OBJECT[METHOD]>) => void
   }
 ) {
   return instrumentMethod(

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -1,4 +1,5 @@
-import { callMonitored } from '../domain/internalMonitoring'
+import { callMonitored, monitor } from '../domain/internalMonitoring'
+import { noop } from './utils'
 
 export function instrumentMethod<OBJECT extends { [key: string]: any }, METHOD extends keyof OBJECT>(
   object: OBJECT,
@@ -64,4 +65,44 @@ export function instrumentMethodAndCallOriginal<OBJECT extends { [key: string]: 
         return result
       }
   )
+}
+
+export function instrumentSetter<OBJECT extends { [key: string]: any }, PROPERTY extends keyof OBJECT>(
+  object: OBJECT,
+  property: PROPERTY,
+  after: (thisObject: OBJECT, value: OBJECT[PROPERTY]) => void
+) {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(object, property)
+  if (!originalDescriptor || !originalDescriptor.set || !originalDescriptor.configurable) {
+    return { stop: noop }
+  }
+
+  let instrumentation = (thisObject: OBJECT, value: OBJECT[PROPERTY]) => {
+    // put hooked setter into event loop to avoid of set latency
+    setTimeout(
+      monitor(() => {
+        after(thisObject, value)
+      }),
+      0
+    )
+  }
+
+  const instrumentationWrapper = function (this: OBJECT, value: OBJECT[PROPERTY]) {
+    originalDescriptor.set!.call(this, value)
+    instrumentation(this, value)
+  }
+
+  Object.defineProperty(object, property, {
+    set: instrumentationWrapper,
+  })
+
+  return {
+    stop: () => {
+      if (Object.getOwnPropertyDescriptor(object, property)?.set === instrumentationWrapper) {
+        Object.defineProperty(object, property, originalDescriptor)
+      } else {
+        instrumentation = noop
+      }
+    },
+  }
 }

--- a/packages/rum/src/domain/record/types.ts
+++ b/packages/rum/src/domain/record/types.ts
@@ -248,7 +248,6 @@ export type FocusCallback = (data: FocusRecord['data']) => void
 export type VisualViewportResizeCallback = (data: VisualViewportRecord['data']) => void
 
 export type ListenerHandler = () => void
-export type HookResetter = () => void
 
 export const enum NodeType {
   Document,

--- a/packages/rum/src/domain/record/utils.ts
+++ b/packages/rum/src/domain/record/utils.ts
@@ -1,27 +1,3 @@
-import type { HookResetter } from './types'
-
-export function hookSetter<T>(
-  target: T,
-  key: string | number | symbol,
-  d: { set(this: T, value: unknown): void }
-): HookResetter {
-  const original = Object.getOwnPropertyDescriptor(target, key)
-  Object.defineProperty(target, key, {
-    set(this: T, value) {
-      // put hooked setter into event loop to avoid of set latency
-      setTimeout(() => {
-        d.set.call(this, value)
-      }, 0)
-      if (original && original.set) {
-        original.set.call(this, value)
-      }
-    },
-  })
-  return () => {
-    Object.defineProperty(target, key, original || {})
-  }
-}
-
 export function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent {
   return Boolean((event as TouchEvent).changedTouches)
 }


### PR DESCRIPTION
## Motivation

As observed in #1397  , we badly instrument a few native methods in the recorder:
* `cssStyleSheet.insertRule()` and `cssStyleSheet.deleteRule()`
* some form input `.value` property setters

This causes unexpected behavior when calling `stopSessionReplayRecording()` after another library instrumented those.

## Changes

* Use `instrumentMethod` on `CssStyleSheet` methods
* Implement and use `instrumentSetter` on input property setters

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
