### PR TITLE
🐛   Adjust records generated during view change so their date matches the view date

### DIFF
--- a/packages/rum-core/src/index.ts
+++ b/packages/rum-core/src/index.ts
@@ -21,6 +21,7 @@ export {
 export { ViewContext, CommonContext, ReplayStats } from './rawRumEvent.types'
 export { startRum } from './boot/startRum'
 export { LifeCycle, LifeCycleEventType } from './domain/lifeCycle'
+export { ViewCreatedEvent } from './domain/rumEventsCollection/view/trackViews'
 export { ViewContexts } from './domain/viewContexts'
 export { RumSessionManager, RumSessionPlan } from './domain/rumSessionManager'
 export { getMutationObserverConstructor } from './browser/domMutationObservable'

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -177,22 +177,18 @@ describe('startRecording', () => {
 
     waitRequestSendCalls(2, (calls) => {
       readRequestSegment(calls.first(), (segment) => {
-        expect(segment.records).toEqual([
-          { type: RecordType.Meta, timestamp: timeStampNow(), data: jasmine.any(Object) },
-          { type: RecordType.Focus, timestamp: timeStampNow(), data: jasmine.any(Object) },
-          { type: RecordType.FullSnapshot, timestamp: timeStampNow(), data: jasmine.any(Object) },
-          { type: RecordType.VisualViewport, timestamp: timeStampNow(), data: jasmine.any(Object) },
-          { type: RecordType.ViewEnd, timestamp: timeStampNow() },
-        ])
+        expect(segment.records[0].timestamp).toEqual(timeStampNow())
+        expect(segment.records[1].timestamp).toEqual(timeStampNow())
+        expect(segment.records[2].timestamp).toEqual(timeStampNow())
+        expect(segment.records[3].timestamp).toEqual(timeStampNow())
+
         clock.cleanup()
 
         readRequestSegment(calls.mostRecent(), (segment) => {
-          expect(segment.records).toEqual([
-            { type: RecordType.Meta, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
-            { type: RecordType.Focus, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
-            { type: RecordType.FullSnapshot, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
-            { type: RecordType.VisualViewport, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
-          ])
+          expect(segment.records[0].timestamp).toEqual(VIEW_TIMESTAMP)
+          expect(segment.records[1].timestamp).toEqual(VIEW_TIMESTAMP)
+          expect(segment.records[2].timestamp).toEqual(VIEW_TIMESTAMP)
+
           expectNoExtraRequestSendCalls(done)
         })
       })

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,4 +1,5 @@
-import { HttpRequest, DefaultPrivacyLevel, noop, isIE } from '@datadog/browser-core'
+import type { TimeStamp } from '@datadog/browser-core'
+import { HttpRequest, DefaultPrivacyLevel, noop, isIE, timeStampNow } from '@datadog/browser-core'
 import type { LifeCycle, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import { inflate } from 'pako'
@@ -15,6 +16,8 @@ import type { Segment } from '../types'
 import { RecordType } from '../types'
 import { resetReplayStats } from '../domain/replayStats'
 import { startRecording } from './startRecording'
+
+const VIEW_TIMESTAMP = 1 as TimeStamp
 
 describe('startRecording', () => {
   let setupBuilder: TestSetupBuilder
@@ -175,20 +178,20 @@ describe('startRecording', () => {
     waitRequestSendCalls(2, (calls) => {
       readRequestSegment(calls.first(), (segment) => {
         expect(segment.records).toEqual([
-          { type: RecordType.Meta, timestamp: Date.now(), data: jasmine.any(Object) },
-          { type: RecordType.Focus, timestamp: Date.now(), data: jasmine.any(Object) },
-          { type: RecordType.FullSnapshot, timestamp: Date.now(), data: jasmine.any(Object) },
-          { type: RecordType.VisualViewport, timestamp: Date.now(), data: jasmine.any(Object) },
-          { type: RecordType.ViewEnd, timestamp: Date.now() },
+          { type: RecordType.Meta, timestamp: timeStampNow(), data: jasmine.any(Object) },
+          { type: RecordType.Focus, timestamp: timeStampNow(), data: jasmine.any(Object) },
+          { type: RecordType.FullSnapshot, timestamp: timeStampNow(), data: jasmine.any(Object) },
+          { type: RecordType.VisualViewport, timestamp: timeStampNow(), data: jasmine.any(Object) },
+          { type: RecordType.ViewEnd, timestamp: timeStampNow() },
         ])
         clock.cleanup()
 
         readRequestSegment(calls.mostRecent(), (segment) => {
           expect(segment.records).toEqual([
-            { type: RecordType.Meta, timestamp: 1, data: jasmine.any(Object) },
-            { type: RecordType.Focus, timestamp: 1, data: jasmine.any(Object) },
-            { type: RecordType.FullSnapshot, timestamp: 1, data: jasmine.any(Object) },
-            { type: RecordType.VisualViewport, timestamp: 1, data: jasmine.any(Object) },
+            { type: RecordType.Meta, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
+            { type: RecordType.Focus, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
+            { type: RecordType.FullSnapshot, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
+            { type: RecordType.VisualViewport, timestamp: VIEW_TIMESTAMP, data: jasmine.any(Object) },
           ])
           expectNoExtraRequestSendCalls(done)
         })
@@ -279,7 +282,7 @@ describe('startRecording', () => {
     lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {} as any)
     viewId = 'view-id-2'
     lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
-      startClocks: { relative: 1, timeStamp: 1 },
+      startClocks: { relative: 1, timeStamp: VIEW_TIMESTAMP },
     } as Partial<ViewCreatedEvent> as any)
   }
 })

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -1,3 +1,4 @@
+import { timeStampNow } from '@datadog/browser-core'
 import type {
   LifeCycle,
   ViewContexts,
@@ -42,7 +43,7 @@ export function startRecording(
   const { unsubscribe: unsubscribeViewEnded } = lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, () => {
     flushMutations()
     addRecord({
-      timestamp: Date.now(),
+      timestamp: timeStampNow(),
       type: RecordType.ViewEnd,
     })
   })

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -1,12 +1,16 @@
-import { assign } from '@datadog/browser-core'
-import type { LifeCycle, ViewContexts, RumConfiguration, RumSessionManager } from '@datadog/browser-rum-core'
+import type {
+  LifeCycle,
+  ViewContexts,
+  RumConfiguration,
+  RumSessionManager,
+  ViewCreatedEvent,
+} from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 
 import { record } from '../domain/record'
 import type { DeflateWorker } from '../domain/segmentCollection'
 import { startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'
-import type { RawRecord } from '../types'
 import { RecordType } from '../types'
 
 export function startRecording(
@@ -26,26 +30,28 @@ export function startRecording(
     worker
   )
 
-  function addRawRecord(rawRecord: RawRecord) {
-    addRecord(assign({ timestamp: Date.now() }, rawRecord))
-  }
-
   const {
     stop: stopRecording,
     takeFullSnapshot,
     flushMutations,
   } = record({
-    emit: addRawRecord,
+    emit: addRecord,
     defaultPrivacyLevel: configuration.defaultPrivacyLevel,
   })
 
   const { unsubscribe: unsubscribeViewEnded } = lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, () => {
     flushMutations()
-    addRawRecord({
+    addRecord({
+      timestamp: Date.now(),
       type: RecordType.ViewEnd,
     })
   })
-  const { unsubscribe: unsubscribeViewCreated } = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, takeFullSnapshot)
+  const { unsubscribe: unsubscribeViewCreated } = lifeCycle.subscribe(
+    LifeCycleEventType.VIEW_CREATED,
+    (view: ViewCreatedEvent) => {
+      takeFullSnapshot(view.startClocks.timeStamp)
+    }
+  )
 
   return {
     stop: () => {

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -2,7 +2,7 @@ import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import type { Clock } from '../../../../core/test/specHelper'
 import { createNewEvent } from '../../../../core/test/specHelper'
 import { collectAsyncCalls, recordsPerFullSnapshot } from '../../../test/utils'
-import type { RawRecord, IncrementalSnapshotRecord, FocusRecord } from '../../types'
+import type { IncrementalSnapshotRecord, FocusRecord, Record } from '../../types'
 import { RecordType, IncrementalSource } from '../../types'
 import { record } from './record'
 import type { RecordAPI } from './types'
@@ -10,7 +10,7 @@ import type { RecordAPI } from './types'
 describe('record', () => {
   let sandbox: HTMLElement
   let recordApi: RecordAPI
-  let emitSpy: jasmine.Spy<(record: RawRecord) => void>
+  let emitSpy: jasmine.Spy<(record: Record) => void>
   let waitEmitCalls: (expectedCallsCount: number, callback: () => void) => void
   let expectNoExtraEmitCalls: (done: () => void) => void
   let clock: Clock | undefined
@@ -150,6 +150,7 @@ describe('record', () => {
       startRecording()
       expect(getEmittedRecords()[1]).toEqual({
         type: RecordType.Focus,
+        timestamp: jasmine.any(Number),
         data: {
           has_focus: true,
         },

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -1,4 +1,4 @@
-import { assign } from '@datadog/browser-core'
+import { assign, timeStampNow } from '@datadog/browser-core'
 import type { IncrementalSnapshotRecord } from '../../types'
 import { RecordType } from '../../types'
 import { serializeDocument } from './serialize'
@@ -30,7 +30,7 @@ export function record(options: RecordOptions): RecordAPI {
 
   const mutationController = new MutationController()
 
-  const takeFullSnapshot = (timestamp = Date.now()) => {
+  const takeFullSnapshot = (timestamp = timeStampNow()) => {
     mutationController.flush() // process any pending mutation before taking a full snapshot
 
     emit({
@@ -92,13 +92,13 @@ export function record(options: RecordOptions): RecordAPI {
       emit({
         data,
         type: RecordType.Focus,
-        timestamp: Date.now(),
+        timestamp: timeStampNow(),
       }),
     visualViewportResizeCb: (data) => {
       emit({
         data,
         type: RecordType.VisualViewport,
-        timestamp: Date.now(),
+        timestamp: timeStampNow(),
       })
     },
   })
@@ -122,6 +122,6 @@ function assembleIncrementalSnapshot<Data extends IncrementalData>(
       data
     ) as Data,
     type: RecordType.IncrementalSnapshot,
-    timestamp: Date.now(),
+    timestamp: timeStampNow(),
   }
 }

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -30,7 +30,7 @@ export function record(options: RecordOptions): RecordAPI {
 
   const mutationController = new MutationController()
 
-  const takeFullSnapshot = () => {
+  const takeFullSnapshot = (timestamp = Date.now()) => {
     mutationController.flush() // process any pending mutation before taking a full snapshot
 
     emit({
@@ -40,6 +40,7 @@ export function record(options: RecordOptions): RecordAPI {
         width: getWindowWidth(),
       },
       type: RecordType.Meta,
+      timestamp,
     })
 
     emit({
@@ -47,6 +48,7 @@ export function record(options: RecordOptions): RecordAPI {
         has_focus: document.hasFocus(),
       },
       type: RecordType.Focus,
+      timestamp,
     })
 
     emit({
@@ -58,12 +60,14 @@ export function record(options: RecordOptions): RecordAPI {
         },
       },
       type: RecordType.FullSnapshot,
+      timestamp,
     })
 
     if (window.visualViewport) {
       emit({
         data: getVisualViewport(),
         type: RecordType.VisualViewport,
+        timestamp,
       })
     }
   }
@@ -86,13 +90,15 @@ export function record(options: RecordOptions): RecordAPI {
 
     focusCb: (data) =>
       emit({
-        type: RecordType.Focus,
         data,
+        type: RecordType.Focus,
+        timestamp: Date.now(),
       }),
     visualViewportResizeCb: (data) => {
       emit({
         data,
         type: RecordType.VisualViewport,
+        timestamp: Date.now(),
       })
     },
   })
@@ -116,5 +122,6 @@ function assembleIncrementalSnapshot<Data extends IncrementalData>(
       data
     ) as Data,
     type: RecordType.IncrementalSnapshot,
+    timestamp: Date.now(),
   }
 }

--- a/packages/rum/src/domain/record/types.ts
+++ b/packages/rum/src/domain/record/types.ts
@@ -1,4 +1,4 @@
-import type { DefaultPrivacyLevel } from '@datadog/browser-core'
+import type { DefaultPrivacyLevel, TimeStamp } from '@datadog/browser-core'
 import type { FocusRecord, VisualViewportRecord, Record } from '../../types'
 import type { MutationController } from './mutationObserver'
 
@@ -69,7 +69,7 @@ export interface RecordOptions {
 
 export interface RecordAPI {
   stop: ListenerHandler
-  takeFullSnapshot: (timestamp?: number) => void
+  takeFullSnapshot: (timestamp?: TimeStamp) => void
   flushMutations: () => void
 }
 

--- a/packages/rum/src/domain/record/types.ts
+++ b/packages/rum/src/domain/record/types.ts
@@ -1,5 +1,5 @@
 import type { DefaultPrivacyLevel } from '@datadog/browser-core'
-import type { FocusRecord, RawRecord, VisualViewportRecord } from '../../types'
+import type { FocusRecord, VisualViewportRecord, Record } from '../../types'
 import type { MutationController } from './mutationObserver'
 
 export const IncrementalSource = {
@@ -63,13 +63,13 @@ export type IncrementalData =
   | StyleSheetRuleData
 
 export interface RecordOptions {
-  emit?: (record: RawRecord) => void
+  emit?: (record: Record) => void
   defaultPrivacyLevel: DefaultPrivacyLevel
 }
 
 export interface RecordAPI {
   stop: ListenerHandler
-  takeFullSnapshot: () => void
+  takeFullSnapshot: (timestamp?: number) => void
   flushMutations: () => void
 }
 

--- a/packages/rum/src/domain/segmentCollection/segment.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.spec.ts
@@ -1,3 +1,4 @@
+import type { TimeStamp } from '@datadog/browser-core'
 import { noop, setDebugMode, display, isIE } from '@datadog/browser-core'
 import { MockWorker, parseSegment } from '../../../test/utils'
 import type { CreationReason, Record, SegmentContext } from '../../types'
@@ -6,9 +7,9 @@ import { getReplayStats, resetReplayStats } from '../replayStats'
 import { Segment } from './segment'
 
 const CONTEXT: SegmentContext = { application: { id: 'a' }, view: { id: 'b' }, session: { id: 'c' } }
-
-const RECORD: Record = { type: RecordType.ViewEnd, timestamp: 10 }
-const FULL_SNAPSHOT_RECORD: Record = { type: RecordType.FullSnapshot, timestamp: 10, data: {} as any }
+const RECORD_TIMESTAMP = 10 as TimeStamp
+const RECORD: Record = { type: RecordType.ViewEnd, timestamp: RECORD_TIMESTAMP }
+const FULL_SNAPSHOT_RECORD: Record = { type: RecordType.FullSnapshot, timestamp: RECORD_TIMESTAMP, data: {} as any }
 const ENCODED_SEGMENT_HEADER_SIZE = 12 // {"records":[
 const ENCODED_RECORD_SIZE = 25
 const ENCODED_FULL_SNAPSHOT_RECORD_SIZE = 35
@@ -53,7 +54,7 @@ describe('Segment', () => {
       has_full_snapshot: false,
       records: [
         {
-          timestamp: 10,
+          timestamp: RECORD_TIMESTAMP,
           type: RecordType.ViewEnd,
         },
       ],
@@ -123,7 +124,7 @@ describe('Segment', () => {
       let segment: Segment
       beforeEach(() => {
         segment = createSegment()
-        segment.addRecord({ type: RecordType.ViewEnd, timestamp: 15 })
+        segment.addRecord({ type: RecordType.ViewEnd, timestamp: 15 as TimeStamp })
       })
       it('increments records_count', () => {
         expect(segment.metadata.records_count).toBe(2)

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -1,3 +1,4 @@
+import type { TimeStamp } from '@datadog/browser-core'
 import { DOM_EVENT, isIE } from '@datadog/browser-core'
 import type { ViewContexts, ViewContext } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
@@ -16,12 +17,12 @@ import { SEND_BEACON_BYTE_LENGTH_LIMIT } from '../../transport/send'
 import { computeSegmentContext, doStartSegmentCollection, MAX_SEGMENT_DURATION } from './segmentCollection'
 
 const CONTEXT: SegmentContext = { application: { id: 'a' }, view: { id: 'b' }, session: { id: 'c' } }
-const RECORD: Record = { type: RecordType.ViewEnd, timestamp: 10 }
+const RECORD: Record = { type: RecordType.ViewEnd, timestamp: 10 as TimeStamp }
 
 // A record that will make the segment size reach the SEND_BEACON_BYTE_LENGTH_LIMIT limit
 const VERY_BIG_RECORD: Record = {
   type: RecordType.FullSnapshot,
-  timestamp: 10,
+  timestamp: 10 as TimeStamp,
   data: Array(SEND_BEACON_BYTE_LENGTH_LIMIT).join('a') as any,
 }
 

--- a/packages/rum/src/types.ts
+++ b/packages/rum/src/types.ts
@@ -29,18 +29,13 @@ export type CreationReason =
   | 'before_unload'
   | 'visibility_hidden'
 
-export type RawRecord =
+export type Record =
   | FullSnapshotRecord
   | IncrementalSnapshotRecord
   | MetaRecord
   | FocusRecord
   | ViewEndRecord
   | VisualViewportRecord
-
-export type Record = RawRecord & {
-  timestamp: number
-  delay?: number
-}
 
 export const RecordType = {
   FullSnapshot: 2,
@@ -55,6 +50,7 @@ export type RecordType = typeof RecordType[keyof typeof RecordType]
 
 export interface FullSnapshotRecord {
   type: typeof RecordType.FullSnapshot
+  timestamp: number
   data: {
     node: SerializedNodeWithId
     initialOffset: {
@@ -66,11 +62,13 @@ export interface FullSnapshotRecord {
 
 export interface IncrementalSnapshotRecord {
   type: typeof RecordType.IncrementalSnapshot
+  timestamp: number
   data: IncrementalData
 }
 
 export interface MetaRecord {
   type: typeof RecordType.Meta
+  timestamp: number
   data: {
     href: string
     width: number
@@ -80,6 +78,7 @@ export interface MetaRecord {
 
 export interface FocusRecord {
   type: typeof RecordType.Focus
+  timestamp: number
   data: {
     has_focus: boolean
   }
@@ -87,10 +86,12 @@ export interface FocusRecord {
 
 export interface ViewEndRecord {
   type: typeof RecordType.ViewEnd
+  timestamp: number
 }
 
 export interface VisualViewportRecord {
   type: typeof RecordType.VisualViewport
+  timestamp: number
   data: {
     scale: number
     offsetLeft: number

--- a/packages/rum/src/types.ts
+++ b/packages/rum/src/types.ts
@@ -1,3 +1,4 @@
+import type { TimeStamp } from '@datadog/browser-core'
 import type { IncrementalData, SerializedNodeWithId } from './domain/record'
 
 export { IncrementalSource, MutationData, ViewportResizeData, ScrollData } from './domain/record'
@@ -50,7 +51,7 @@ export type RecordType = typeof RecordType[keyof typeof RecordType]
 
 export interface FullSnapshotRecord {
   type: typeof RecordType.FullSnapshot
-  timestamp: number
+  timestamp: TimeStamp
   data: {
     node: SerializedNodeWithId
     initialOffset: {
@@ -62,13 +63,13 @@ export interface FullSnapshotRecord {
 
 export interface IncrementalSnapshotRecord {
   type: typeof RecordType.IncrementalSnapshot
-  timestamp: number
+  timestamp: TimeStamp
   data: IncrementalData
 }
 
 export interface MetaRecord {
   type: typeof RecordType.Meta
-  timestamp: number
+  timestamp: TimeStamp
   data: {
     href: string
     width: number
@@ -78,7 +79,7 @@ export interface MetaRecord {
 
 export interface FocusRecord {
   type: typeof RecordType.Focus
-  timestamp: number
+  timestamp: TimeStamp
   data: {
     has_focus: boolean
   }
@@ -86,12 +87,12 @@ export interface FocusRecord {
 
 export interface ViewEndRecord {
   type: typeof RecordType.ViewEnd
-  timestamp: number
+  timestamp: TimeStamp
 }
 
 export interface VisualViewportRecord {
   type: typeof RecordType.VisualViewport
-  timestamp: number
+  timestamp: TimeStamp
   data: {
     scale: number
     offsetLeft: number


### PR DESCRIPTION
## Motivation

Currently, when a new view is generated we get the current timestamp to define the view date.
Then we take a full snapshot, which consists [in 3-4 records](https://github.com/DataDog/browser-sdk/blob/c050a2006a2b0f9ed1175478abb90bc0cec7f250/packages/rum/src/domain/record/record.ts#L36-L70) every time a record is emitted, we get the current timestamp to define its date

This causes an issue during replay, when seeking: when the user clicks on a View event, the player actually shows the previous view, because the records corresponding to the new view are a few milliseconds after the view start.

This PR set the view date to the fullsnapshot emitted records when a view change

## Changes

Set the view date to the fullsnapshot emitted records when a view change

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
