### PR TITLE
✨ [RUMF-1237] The event bridge allowed hosts should also match subdomains

### DIFF
--- a/packages/core/src/transport/eventBridge.spec.ts
+++ b/packages/core/src/transport/eventBridge.spec.ts
@@ -9,16 +9,25 @@ describe('canUseEventBridge', () => {
   })
 
   it('should detect when the bridge is present and the webView host is allowed', () => {
-    initEventBridgeStub()
-    expect(canUseEventBridge()).toBeTrue()
-  })
-
-  it('should not detect when the bridge is absent', () => {
-    expect(canUseEventBridge()).toBeFalse()
+    initEventBridgeStub(allowedWebViewHosts)
+    expect(canUseEventBridge('foo.bar')).toBeTrue()
+    expect(canUseEventBridge('baz.foo.bar')).toBeTrue()
+    expect(canUseEventBridge('www.foo.bar')).toBeTrue()
   })
 
   it('should not detect when the bridge is present and the webView host is not allowed', () => {
     initEventBridgeStub(allowedWebViewHosts)
+    expect(canUseEventBridge('foo.com')).toBeFalse()
+    expect(canUseEventBridge('foo.bar.baz')).toBeFalse()
+    expect(canUseEventBridge('bazfoo.bar')).toBeFalse()
+  })
+
+  it('should not detect when the bridge on the parent domain if only the subdomain is allowed', () => {
+    initEventBridgeStub(['baz.foo.bar'])
+    expect(canUseEventBridge('foo.bar')).toBeFalse()
+  })
+
+  it('should not detect when the bridge is absent', () => {
     expect(canUseEventBridge()).toBeFalse()
   })
 })

--- a/packages/core/src/transport/eventBridge.spec.ts
+++ b/packages/core/src/transport/eventBridge.spec.ts
@@ -13,6 +13,7 @@ describe('canUseEventBridge', () => {
     expect(canUseEventBridge('foo.bar')).toBeTrue()
     expect(canUseEventBridge('baz.foo.bar')).toBeTrue()
     expect(canUseEventBridge('www.foo.bar')).toBeTrue()
+    expect(canUseEventBridge('www.qux.foo.bar')).toBeTrue()
   })
 
   it('should not detect when the bridge is present and the webView host is not allowed', () => {

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -1,4 +1,4 @@
-import { getGlobalObject, includes } from '..'
+import { getGlobalObject } from '..'
 
 export interface BrowserWindowWithEventBridge extends Window {
   DatadogEventBridge?: DatadogEventBridge
@@ -26,10 +26,16 @@ export function getEventBridge<T, E>() {
   }
 }
 
-export function canUseEventBridge(): boolean {
+export function canUseEventBridge(hostname = window.location.hostname): boolean {
   const bridge = getEventBridge()
-
-  return !!bridge && includes(bridge.getAllowedWebViewHosts(), window.location.hostname)
+  return (
+    !!bridge &&
+    bridge.getAllowedWebViewHosts().some((host) => {
+      const escapedHost = host.replace(/\./g, '\\$&')
+      const isDomainOrSubDomain = new RegExp(`(^|.+\\.)${escapedHost}$`)
+      return !!isDomainOrSubDomain.exec(hostname)
+    })
+  )
 }
 
 function getEventBridgeGlobal() {

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -33,7 +33,7 @@ export function canUseEventBridge(hostname = getGlobalObject<Window>().location?
     bridge.getAllowedWebViewHosts().some((host) => {
       const escapedHost = host.replace(/\./g, '\\.')
       const isDomainOrSubDomain = new RegExp(`^(.+\\.)*${escapedHost}$`)
-      return !!isDomainOrSubDomain.exec(hostname)
+      return isDomainOrSubDomain.test(hostname)
     })
   )
 }

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -26,7 +26,7 @@ export function getEventBridge<T, E>() {
   }
 }
 
-export function canUseEventBridge(hostname = window.location.hostname): boolean {
+export function canUseEventBridge(hostname = getGlobalObject<Window>().location?.hostname): boolean {
   const bridge = getEventBridge()
   return (
     !!bridge &&

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -31,8 +31,8 @@ export function canUseEventBridge(hostname = window.location.hostname): boolean 
   return (
     !!bridge &&
     bridge.getAllowedWebViewHosts().some((host) => {
-      const escapedHost = host.replace(/\./g, '\\$&')
-      const isDomainOrSubDomain = new RegExp(`(^|.+\\.)${escapedHost}$`)
+      const escapedHost = host.replace(/\./g, '\\.')
+      const isDomainOrSubDomain = new RegExp(`^(.+\\.)*${escapedHost}$`)
       return !!isDomainOrSubDomain.exec(hostname)
     })
   )


### PR DESCRIPTION
## Motivation

When  a bridge is injected by mobile with `AllowedWebViewHosts`
The browser SDK should send data to the bridge if on domains and subdomains that match AllowedWebViewHosts

## Changes

Update canUseEventBridge

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
