### PR TITLE
Initialization parameters minor fix

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -127,7 +127,7 @@ The following parameters are available to configure the Datadog browser logs SDK
 | `forwardErrorsToLogs` | Boolean | No       | `true`          | Set to `false` to stop forwarding console.error logs, uncaught exceptions and network errors to Datadog.                     |
 | `sampleRate`          | Number  | No       | `100`           | The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send logs.                           |
 | `silentMultipleInit`  | Boolean | No       |                 | Prevent logging errors while having multiple init.                                                                           |
-| `proxyUrl`            | Boolean | No       |                 | Optional proxy URL (ex: https://www.proxy.com/path), see the full [proxy setup guide][6] for more information.               |
+| `proxyUrl`            | String  | No       |                 | Optional proxy URL (ex: https://www.proxy.com/path), see the full [proxy setup guide][6] for more information.               |
 
 Options that must have a matching configuration when using the `RUM` SDK:
 


### PR DESCRIPTION
## Motivation

https://datadog.zendesk.com/agent/tickets/783066 Customer caught the error: proxyUrl parameter is listed as boolean.

## Changes

It should be String

## Testing
Doc changes only.

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
