### PR TITLE
✨ [RUMF-1192] forward `console.*` logs to Datadog

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -117,17 +117,18 @@ window.DD_LOGS.init({
 
 The following parameters are available to configure the Datadog browser logs SDK to send logs to Datadog:
 
-| Parameter             | Type    | Required | Default         | Description                                                                                                                  |
-| --------------------- | ------- | -------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `clientToken`         | String  | Yes      |                 | A [Datadog client token][2].                                                                                                 |
-| `site`                | String  | Yes      | `datadoghq.com` | The Datadog site of your organization. US: `datadoghq.com`, EU: `datadoghq.eu`                                               |
-| `service`             | String  | No       |                 | The service name for your application. It should follow the [tag syntax requirements][7].                                    |
-| `env`                 | String  | No       |                 | The application’s environment, for example: prod, pre-prod, staging, etc. It should follow the [tag syntax requirements][7]. |
-| `version`             | String  | No       |                 | The application’s version, for example: 1.2.3, 6c44da20, 2020.02.13, etc. It should follow the [tag syntax requirements][7]. |
-| `forwardErrorsToLogs` | Boolean | No       | `true`          | Set to `false` to stop forwarding console.error logs, uncaught exceptions and network errors to Datadog.                     |
-| `sampleRate`          | Number  | No       | `100`           | The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send logs.                           |
-| `silentMultipleInit`  | Boolean | No       |                 | Prevent logging errors while having multiple init.                                                                           |
-| `proxyUrl`            | Boolean | No       |                 | Optional proxy URL (ex: https://www.proxy.com/path), see the full [proxy setup guide][6] for more information.               |
+| Parameter             | Type                                                                 | Required | Default         | Description                                                                                                                            |
+| --------------------- | -------------------------------------------------------------------- | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `clientToken`         | String                                                               | Yes      |                 | A [Datadog client token][2].                                                                                                           |
+| `site`                | String                                                               | Yes      | `datadoghq.com` | The Datadog site of your organization. US: `datadoghq.com`, EU: `datadoghq.eu`                                                         |
+| `service`             | String                                                               | No       |                 | The service name for your application. It should follow the [tag syntax requirements][7].                                              |
+| `env`                 | String                                                               | No       |                 | The application’s environment, for example: prod, pre-prod, staging, etc. It should follow the [tag syntax requirements][7].           |
+| `version`             | String                                                               | No       |                 | The application’s version, for example: 1.2.3, 6c44da20, 2020.02.13, etc. It should follow the [tag syntax requirements][7].           |
+| `forwardErrorsToLogs` | Boolean                                                              | No       | `true`          | Set to `false` to stop forwarding console.error logs, uncaught exceptions and network errors to Datadog.                               |
+| `forwardConsoleLogs`  | `"all"` or an Array of `"log"` `"debug"` `"info"` `"warn"` `"error"` | No       | `[]`            | Forward logs from `console.*` to Datadog. Use `"all"` to forward everything or an array of console API names to forward only a subset. |
+| `sampleRate`          | Number                                                               | No       | `100`           | The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send logs.                                     |
+| `silentMultipleInit`  | Boolean                                                              | No       |                 | Prevent logging errors while having multiple init.                                                                                     |
+| `proxyUrl`            | Boolean                                                              | No       |                 | Optional proxy URL (ex: https://www.proxy.com/path), see the full [proxy setup guide][6] for more information.                         |
 
 Options that must have a matching configuration when using the `RUM` SDK:
 
@@ -185,6 +186,7 @@ The results are the same when using NPM, CDN async or CDN sync:
   "id": 123,
   "message": "Button clicked",
   "date": 1234567890000,
+  "origin": "logger",
   "http": {
     "useragent": "Mozilla/5.0 ...",
   },

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -1,12 +1,5 @@
 import type { Context } from '@datadog/browser-core'
-import {
-  monitor,
-  ONE_SECOND,
-  display,
-  ErrorSource,
-  updateExperimentalFeatures,
-  resetExperimentalFeatures,
-} from '@datadog/browser-core'
+import { monitor, ONE_SECOND, display, ErrorSource } from '@datadog/browser-core'
 import type { Clock } from '../../../core/test/specHelper'
 import { deleteEventBridgeStub, initEventBridgeStub, mockClock } from '../../../core/test/specHelper'
 import type { HybridInitConfiguration, LogsInitConfiguration } from '../domain/configuration'
@@ -216,10 +209,6 @@ describe('logs entry', () => {
       LOGS.init(DEFAULT_INIT_CONFIGURATION)
     })
 
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
     it('logs a message', () => {
       LOGS.logger.log('message')
 
@@ -234,15 +223,9 @@ describe('logs entry', () => {
         message: {
           message: 'message',
           status: StatusType.info,
+          origin: ErrorSource.LOGGER,
         },
       })
-    })
-
-    it('logs a message with "logger" origin when ff forward-logs is enabled', () => {
-      updateExperimentalFeatures(['forward-logs'])
-      LOGS.logger.log('message')
-
-      expect(getLoggedMessage(0).message.origin).toEqual(ErrorSource.LOGGER)
     })
 
     it('returns cloned initial configuration', () => {
@@ -296,6 +279,7 @@ describe('logs entry', () => {
 
         expect(sendLogsSpy).not.toHaveBeenCalled()
         expect(display.log).toHaveBeenCalledWith('error: message', {
+          origin: 'logger',
           error: { origin: 'logger' },
           logger: { name: 'foo' },
         })
@@ -310,7 +294,7 @@ describe('logs entry', () => {
         logger.debug('message')
 
         expect(sendLogsSpy).toHaveBeenCalled()
-        expect(display.log).toHaveBeenCalledWith('debug: message', { logger: { name: 'foo' } })
+        expect(display.log).toHaveBeenCalledWith('debug: message', { origin: 'logger', logger: { name: 'foo' } })
       })
 
       it('should have their name in their context', () => {

--- a/packages/logs/src/domain/assemble.spec.ts
+++ b/packages/logs/src/domain/assemble.spec.ts
@@ -181,6 +181,7 @@ describe('assemble', () => {
           message,
           status: StatusType.error,
           date: clocksNow().timeStamp,
+          origin: ErrorSource.AGENT,
           error: {
             kind: undefined,
             origin: ErrorSource.AGENT,

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -42,8 +42,7 @@ export function validateAndBuildLogsConfiguration(
   const forwardConsoleLogs = validateAndBuildForwardOption<ConsoleApiName>(
     initConfiguration.forwardConsoleLogs,
     objectValues(ConsoleApiName),
-    'Forward Console Logs',
-    'forward-logs'
+    'Forward Console Logs'
   )
 
   const forwardReports = validateAndBuildForwardOption<RawReportType>(
@@ -76,9 +75,9 @@ export function validateAndBuildForwardOption<T>(
   option: readonly T[] | 'all' | undefined,
   allowedValues: T[],
   label: string,
-  featureFlag: string
+  featureFlag?: string
 ): T[] | undefined {
-  if (!isExperimentalFeatureEnabled(featureFlag) || option === undefined) {
+  if ((featureFlag !== undefined && !isExperimentalFeatureEnabled(featureFlag)) || option === undefined) {
     return []
   }
 

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -1,4 +1,4 @@
-import { display, ErrorSource, resetExperimentalFeatures, updateExperimentalFeatures } from '@datadog/browser-core'
+import { display, ErrorSource } from '@datadog/browser-core'
 import type { LogsMessage } from './logger'
 import { HandlerType, Logger, STATUSES, StatusType } from './logger'
 import type { Sender } from './sender'
@@ -19,10 +19,6 @@ describe('Logger', () => {
     logger = new Logger(sender)
   })
 
-  afterEach(() => {
-    resetExperimentalFeatures()
-  })
-
   describe('log methods', () => {
     it("'logger.log' should have info status by default", () => {
       logger.log('message')
@@ -30,20 +26,13 @@ describe('Logger', () => {
       expect(getLoggedMessage(0).status).toEqual(StatusType.info)
     })
 
-    it("'logger.log' should set 'logger' origin when ff forward-logs enabled", () => {
-      updateExperimentalFeatures(['forward-logs'])
+    it("'logger.log' should set 'logger' origin", () => {
       logger.log('message')
 
       expect(getLoggedMessage(0).origin).toEqual(ErrorSource.LOGGER)
     })
 
-    it("'logger.log' should not set 'logger' origin when ff forward-logs disabled", () => {
-      logger.log('message')
-      expect(getLoggedMessage(0).origin).not.toBeDefined()
-    })
-
     it("'logger.log' message context can override the 'logger' origin", () => {
-      updateExperimentalFeatures(['forward-logs'])
       logger.log('message', { origin: 'foo' })
 
       expect(getLoggedMessage(0).origin).toEqual('foo')
@@ -118,6 +107,7 @@ describe('Logger', () => {
       expect(sendLogSpy).not.toHaveBeenCalled()
       expect(display.log).toHaveBeenCalledWith('error: message', {
         error: { origin: 'logger' },
+        origin: 'logger',
         foo: 'bar',
         lorem: 'ipsum',
       })

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -1,5 +1,5 @@
 import type { ContextValue, TimeStamp } from '@datadog/browser-core'
-import { combine, ErrorSource, monitored, isExperimentalFeatureEnabled } from '@datadog/browser-core'
+import { combine, ErrorSource, monitored } from '@datadog/browser-core'
 import type { Sender } from './sender'
 
 export const StatusType = {
@@ -32,13 +32,16 @@ export class Logger {
 
   @monitored
   log(message: string, messageContext?: object, status: StatusType = StatusType.info) {
-    let logOrigin
-    if (isExperimentalFeatureEnabled('forward-logs')) {
-      logOrigin = {
-        origin: ErrorSource.LOGGER,
-      }
-    }
-    this.sender.sendLog(message, combine(logOrigin, messageContext), status)
+    this.sender.sendLog(
+      message,
+      combine(
+        {
+          origin: ErrorSource.LOGGER,
+        },
+        messageContext
+      ),
+      status
+    )
   }
 
   debug(message: string, messageContext?: object) {

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
@@ -1,10 +1,4 @@
-import {
-  ErrorSource,
-  resetExperimentalFeatures,
-  updateExperimentalFeatures,
-  display,
-  noop,
-} from '@datadog/browser-core'
+import { ErrorSource, display, noop } from '@datadog/browser-core'
 import { validateAndBuildLogsConfiguration } from '../../configuration'
 import { HandlerType, StatusType } from '../../logger'
 import { createSender } from '../../sender'
@@ -24,12 +18,10 @@ describe('console collection', () => {
   })
 
   afterEach(() => {
-    resetExperimentalFeatures()
     stopConsolCollection()
   })
 
-  it('should send console logs when ff forward-logs is enabled', () => {
-    updateExperimentalFeatures(['forward-logs'])
+  it('should send console logs', () => {
     ;({ stop: stopConsolCollection } = startConsoleCollection(
       validateAndBuildLogsConfiguration({ ...initConfiguration, forwardConsoleLogs: ['log'] })!,
       createSender(sendLogSpy)
@@ -45,44 +37,6 @@ describe('console collection', () => {
     })
 
     expect(consoleLogSpy).toHaveBeenCalled()
-  })
-
-  it('should not send console logs when ff forward-logs is disabled', () => {
-    ;({ stop: stopConsolCollection } = startConsoleCollection(
-      validateAndBuildLogsConfiguration({ ...initConfiguration, forwardConsoleLogs: ['log'] })!,
-      createSender(sendLogSpy)
-    ))
-
-    /* eslint-disable-next-line no-console */
-    console.log('foo', 'bar')
-
-    expect(sendLogSpy).not.toHaveBeenCalled()
-    expect(consoleLogSpy).toHaveBeenCalled()
-  })
-
-  it('should send console errors with "console" origin when ff forward-logs is enabled', () => {
-    updateExperimentalFeatures(['forward-logs'])
-    ;({ stop: stopConsolCollection } = startConsoleCollection(
-      validateAndBuildLogsConfiguration({ ...initConfiguration, forwardErrorsToLogs: true })!,
-      createSender(sendLogSpy)
-    ))
-
-    /* eslint-disable-next-line no-console */
-    console.error('foo', 'bar')
-
-    expect(sendLogSpy.calls.mostRecent().args[0].origin).toEqual(ErrorSource.CONSOLE)
-  })
-
-  it('should not send console errors with "console" origin when ff forward-logs is disabled', () => {
-    ;({ stop: stopConsolCollection } = startConsoleCollection(
-      validateAndBuildLogsConfiguration({ ...initConfiguration, forwardErrorsToLogs: true })!,
-      createSender(sendLogSpy)
-    ))
-
-    /* eslint-disable-next-line no-console */
-    console.error('foo', 'bar')
-
-    expect(sendLogSpy.calls.mostRecent().args[0].origin).not.toBeDefined()
   })
 
   it('console error should have an error object defined', () => {
@@ -101,8 +55,6 @@ describe('console collection', () => {
   })
 
   it('should not print the log twice when console handler is enabled', () => {
-    updateExperimentalFeatures(['forward-logs'])
-
     const sender = createSender(sendLogSpy)
     const displaySpy = spyOn(display, 'log')
     ;({ stop: stopConsolCollection } = startConsoleCollection(

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
@@ -1,5 +1,5 @@
 import type { Context, ClocksState, ConsoleLog } from '@datadog/browser-core'
-import { ConsoleApiName, ErrorSource, initConsoleObservable, isExperimentalFeatureEnabled } from '@datadog/browser-core'
+import { ConsoleApiName, ErrorSource, initConsoleObservable } from '@datadog/browser-core'
 import type { LogsEvent } from '../../../logsEvent.types'
 import type { LogsConfiguration } from '../../configuration'
 import { StatusType } from '../../logger'
@@ -24,17 +24,14 @@ export function startConsoleCollection(configuration: LogsConfiguration, sender:
   const consoleSubscription = consoleObservable.subscribe(reportConsoleLog)
 
   function reportConsoleLog(log: ConsoleLog) {
-    let messageContext: Partial<LogsEvent> = {}
-    if (log.api === ConsoleApiName.error) {
-      messageContext = {
-        error: {
-          origin: ErrorSource.CONSOLE, // Todo: Remove in the next major release
-          stack: log.stack,
-        },
-      }
+    const messageContext: Partial<LogsEvent> = {
+      origin: ErrorSource.CONSOLE,
     }
-    if (isExperimentalFeatureEnabled('forward-logs')) {
-      messageContext.origin = ErrorSource.CONSOLE
+    if (log.api === ConsoleApiName.error) {
+      messageContext.error = {
+        origin: ErrorSource.CONSOLE, // Todo: Remove in the next major release
+        stack: log.stack,
+      }
     }
     sender.sendToHttp(log.message, messageContext, LogStatusForApi[log.api])
   }

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
@@ -1,4 +1,4 @@
-import { isIE, ErrorSource, updateExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
+import { isIE, ErrorSource } from '@datadog/browser-core'
 import type { FetchStub, FetchStubManager } from '@datadog/browser-core/test/specHelper'
 import { SPEC_ENDPOINTS, ResponseStub, stubFetch } from '@datadog/browser-core/test/specHelper'
 import type { LogsConfiguration } from '../../configuration'
@@ -46,18 +46,6 @@ describe('network error collection', () => {
   afterEach(() => {
     stopNetworkErrorCollection()
     fetchStubManager.reset()
-    resetExperimentalFeatures()
-  })
-
-  it('should send server errors with "network" origin when ff forward-logs is enabled', (done) => {
-    updateExperimentalFeatures(['forward-logs'])
-
-    fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
-
-    fetchStubManager.whenAllComplete(() => {
-      expect(sendLogSpy.calls.mostRecent().args[0].origin).toEqual(ErrorSource.NETWORK)
-      done()
-    })
   })
 
   it('should track server error', (done) => {
@@ -68,6 +56,7 @@ describe('network error collection', () => {
         message: 'Fetch error GET http://fake.com/',
         date: jasmine.any(Number),
         status: StatusType.error,
+        origin: ErrorSource.NETWORK,
         error: {
           origin: ErrorSource.NETWORK,
           stack: 'Server error',

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
@@ -8,7 +8,6 @@ import {
   toStackTraceString,
   monitor,
   noop,
-  isExperimentalFeatureEnabled,
 } from '@datadog/browser-core'
 import type { LogsEvent } from '../../../logsEvent.types'
 import type { LogsConfiguration } from '../../configuration'
@@ -50,9 +49,7 @@ export function startNetworkErrorCollection(configuration: LogsConfiguration, se
           status_code: request.status,
           url: request.url,
         },
-      }
-      if (isExperimentalFeatureEnabled('forward-logs')) {
-        messageContext.origin = ErrorSource.NETWORK
+        origin: ErrorSource.NETWORK,
       }
 
       sender.sendToHttp(`${format(type)} error ${request.method} ${request.url}`, messageContext, StatusType.error)

--- a/packages/logs/src/domain/logsCollection/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/runtimeError/runtimeErrorCollection.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorSource, Observable, resetExperimentalFeatures, updateExperimentalFeatures } from '@datadog/browser-core'
+import { ErrorSource, Observable } from '@datadog/browser-core'
 import type { RawError, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../../configuration'
 import { createSender } from '../../sender'
@@ -21,7 +21,6 @@ describe('runtime error collection', () => {
 
   afterEach(() => {
     stopRuntimeErrorCollection()
-    resetExperimentalFeatures()
   })
 
   it('should send runtime errors', () => {
@@ -39,21 +38,8 @@ describe('runtime error collection', () => {
         error: { origin: ErrorSource.SOURCE, kind: 'Error', stack: undefined },
         message: 'error!',
         status: StatusType.error,
+        origin: ErrorSource.SOURCE,
       },
     ])
-  })
-
-  it('should send runtime errors with "source" origin when ff forward-logs is enabled', (done) => {
-    updateExperimentalFeatures(['forward-logs'])
-
-    rawErrorObservable.notify({
-      message: 'error!',
-      source: ErrorSource.SOURCE,
-      startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
-      type: 'Error',
-    })
-
-    expect(sendLogSpy.calls.mostRecent().args[0].origin).toEqual(ErrorSource.SOURCE)
-    done()
   })
 })

--- a/packages/logs/src/domain/reportRawError.ts
+++ b/packages/logs/src/domain/reportRawError.ts
@@ -1,5 +1,4 @@
 import type { RawError } from '@datadog/browser-core'
-import { isExperimentalFeatureEnabled } from '@datadog/browser-core'
 import type { LogsEvent } from '../logsEvent.types'
 import { StatusType } from './logger'
 import type { Sender } from './sender'
@@ -12,9 +11,7 @@ export function reportRawError(error: RawError, sender: Sender) {
       origin: error.source, // Todo: Remove in the next major release
       stack: error.stack,
     },
-  }
-  if (isExperimentalFeatureEnabled('forward-logs')) {
-    messageContext.origin = error.source
+    origin: error.source,
   }
   sender.sendToHttp(error.message, messageContext, StatusType.error)
 }


### PR DESCRIPTION
## Motivation

This PR enables the `forward-logs` feature implemented in #1316 

## Changes

* Remove "forward-logs" flag usage
* Add README doc

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
