### PR TITLE
Update links to api key docs

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -666,8 +666,8 @@ window.DD_LOGS && DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
 
-[1]: /account_management/api-app-keys/#api-keys
-[2]: /account_management/api-app-keys/#client-tokens
+[1]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+[2]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [3]: https://www.npmjs.com/package/@datadog/browser-logs
 [4]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/BROWSER_SUPPORT.md
 [5]: /real_user_monitoring/guide/enrich-and-control-rum-data/

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -666,6 +666,7 @@ window.DD_LOGS && DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
 
+<!-- Note: all URLs should be absolute -->
 [1]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
 [2]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [3]: https://www.npmjs.com/package/@datadog/browser-logs

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -670,7 +670,7 @@ window.DD_LOGS && DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 [2]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [3]: https://www.npmjs.com/package/@datadog/browser-logs
 [4]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/BROWSER_SUPPORT.md
-[5]: /real_user_monitoring/guide/enrich-and-control-rum-data/
+[5]: https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/
 [6]: https://docs.datadoghq.com/real_user_monitoring/faq/proxy_rum_data/
 [7]: https://docs.datadoghq.com/getting_started/tagging/#defining-tags
 [8]: https://developer.mozilla.org/en-US/docs/Web/API/Reporting_API

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -667,6 +667,7 @@ window.DD_LOGS && DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
 
 <!-- Note: all URLs should be absolute -->
+
 [1]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
 [2]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
 [3]: https://www.npmjs.com/package/@datadog/browser-logs

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -306,6 +306,7 @@ datadogRum.init({
 {{< partial name="whats-next/whats-next.html" >}}
 
 <!-- Note: all URLs should be absolute -->
+
 [1]: https://app.datadoghq.com/rum/list
 [2]: https://docs.datadoghq.com/real_user_monitoring/data_collected/
 [3]: https://docs.datadoghq.com/real_user_monitoring/dashboards/

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -305,6 +305,7 @@ datadogRum.init({
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+<!-- Note: all URLs should be absolute -->
 [1]: https://app.datadoghq.com/rum/list
 [2]: https://docs.datadoghq.com/real_user_monitoring/data_collected/
 [3]: https://docs.datadoghq.com/real_user_monitoring/dashboards/


### PR DESCRIPTION
## Motivation

When looking for links on tokens I noticed the links on `npmjs.com` and `github.com` are broken.

## Changes

Update the links to the `docs.datadoghq.com` pages.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
