### PR TITLE
⚗️ [RUMF-1182] add telemetry sample rate

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -33,6 +33,11 @@ describe('validateAndBuildConfiguration', () => {
       expect(displaySpy).toHaveBeenCalledOnceWith('Client Token is not configured, we will not send any data.')
     })
 
+    it("shouldn't display any error if the configuration is correct", () => {
+      validateAndBuildConfiguration({ clientToken: 'yes' })
+      expect(displaySpy).not.toHaveBeenCalled()
+    })
+
     it('requires sampleRate to be a percentage', () => {
       expect(
         validateAndBuildConfiguration({ clientToken, sampleRate: 'foo' } as unknown as InitConfiguration)
@@ -44,10 +49,26 @@ describe('validateAndBuildConfiguration', () => {
         validateAndBuildConfiguration({ clientToken, sampleRate: 200 } as unknown as InitConfiguration)
       ).toBeUndefined()
       expect(displaySpy).toHaveBeenCalledOnceWith('Sample Rate should be a number between 0 and 100')
+
+      displaySpy.calls.reset()
+      validateAndBuildConfiguration({ clientToken: 'yes', sampleRate: 1 })
+      expect(displaySpy).not.toHaveBeenCalled()
     })
 
-    it("shouldn't display any error if the configuration is correct", () => {
-      validateAndBuildConfiguration({ clientToken: 'yes', sampleRate: 1 })
+    it('requires telemetrySampleRate to be a percentage', () => {
+      expect(
+        validateAndBuildConfiguration({ clientToken, telemetrySampleRate: 'foo' } as unknown as InitConfiguration)
+      ).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledOnceWith('Telemetry Sample Rate should be a number between 0 and 100')
+
+      displaySpy.calls.reset()
+      expect(
+        validateAndBuildConfiguration({ clientToken, telemetrySampleRate: 200 } as unknown as InitConfiguration)
+      ).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledOnceWith('Telemetry Sample Rate should be a number between 0 and 100')
+
+      displaySpy.calls.reset()
+      validateAndBuildConfiguration({ clientToken: 'yes', telemetrySampleRate: 1 })
       expect(displaySpy).not.toHaveBeenCalled()
     })
   })

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -19,6 +19,7 @@ export interface InitConfiguration {
   clientToken: string
   beforeSend?: GenericBeforeSendCallback | undefined
   sampleRate?: number | undefined
+  telemetrySampleRate?: number | undefined
   silentMultipleInit?: boolean | undefined
 
   // transport options
@@ -56,6 +57,7 @@ export interface Configuration extends TransportConfiguration {
   beforeSend: GenericBeforeSendCallback | undefined
   cookieOptions: CookieOptions
   sampleRate: number
+  telemetrySampleRate: number
   service: string | undefined
   silentMultipleInit: boolean
 
@@ -81,6 +83,11 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     return
   }
 
+  if (initConfiguration.telemetrySampleRate !== undefined && !isPercentage(initConfiguration.telemetrySampleRate)) {
+    display.error('Telemetry Sample Rate should be a number between 0 and 100')
+    return
+  }
+
   // Set the experimental feature flags as early as possible, so we can use them in most places
   updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
 
@@ -90,6 +97,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
         initConfiguration.beforeSend && catchUserErrors(initConfiguration.beforeSend, 'beforeSend threw an error:'),
       cookieOptions: buildCookieOptions(initConfiguration),
       sampleRate: initConfiguration.sampleRate ?? 100,
+      telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
       service: initConfiguration.service,
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
 

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -1,4 +1,5 @@
 import type { Context } from '../../tools/context'
+import { display } from '../../tools/display'
 import type { Configuration } from '../configuration'
 import { updateExperimentalFeatures, resetExperimentalFeatures } from '../configuration'
 import type { InternalMonitoring, MonitoringMessage } from './internalMonitoring'
@@ -8,6 +9,7 @@ import {
   resetInternalMonitoring,
   startInternalMonitoring,
   callMonitored,
+  setDebugMode,
 } from './internalMonitoring'
 import type { TelemetryEvent } from './telemetryEvent.types'
 
@@ -186,6 +188,39 @@ describe('internal monitoring', () => {
         throw new Error('message')
       })
       expect(notifySpy.calls.mostRecent().args[0].foo).not.toBeDefined()
+    })
+  })
+
+  describe('setDebug', () => {
+    let displaySpy: jasmine.Spy
+
+    beforeEach(() => {
+      displaySpy = spyOn(display, 'error')
+    })
+
+    afterEach(() => {
+      resetInternalMonitoring()
+    })
+
+    it('when not called, should not display error', () => {
+      startInternalMonitoring(configuration as Configuration)
+
+      callMonitored(() => {
+        throw new Error('message')
+      })
+
+      expect(displaySpy).not.toHaveBeenCalled()
+    })
+
+    it('when called, should display error', () => {
+      startInternalMonitoring(configuration as Configuration)
+      setDebugMode(true)
+
+      callMonitored(() => {
+        throw new Error('message')
+      })
+
+      expect(displaySpy).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -113,6 +113,7 @@ export function startFakeInternalMonitoring() {
 
 export function resetInternalMonitoring() {
   onInternalMonitoringMessageCollected = undefined
+  monitoringConfiguration.debugMode = undefined
 }
 
 export function monitored<T extends (...params: any[]) => unknown>(

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -1,7 +1,7 @@
 import type { Context } from '../../tools/context'
 import { display } from '../../tools/display'
 import { toStackTraceString } from '../../tools/error'
-import { assign, combine, jsonStringify } from '../../tools/utils'
+import { assign, combine, jsonStringify, performDraw } from '../../tools/utils'
 import type { Configuration } from '../configuration'
 import { computeStackTrace } from '../tracekit'
 import { Observable } from '../../tools/observable'
@@ -38,7 +38,8 @@ const monitoringConfiguration: {
   debugMode?: boolean
   maxMessagesPerPage: number
   sentMessageCount: number
-} = { maxMessagesPerPage: 0, sentMessageCount: 0 }
+  telemetryEnabled: boolean
+} = { maxMessagesPerPage: 0, sentMessageCount: 0, telemetryEnabled: false }
 
 let onInternalMonitoringMessageCollected: ((message: MonitoringMessage) => void) | undefined
 
@@ -48,9 +49,11 @@ export function startInternalMonitoring(configuration: Configuration): InternalM
   const monitoringMessageObservable = new Observable<MonitoringMessage>()
   const telemetryEventObservable = new Observable<TelemetryEvent & Context>()
 
+  monitoringConfiguration.telemetryEnabled = performDraw(configuration.telemetrySampleRate)
+
   onInternalMonitoringMessageCollected = (message: MonitoringMessage) => {
     monitoringMessageObservable.notify(withContext(message))
-    if (isExperimentalFeatureEnabled('telemetry')) {
+    if (isExperimentalFeatureEnabled('telemetry') && monitoringConfiguration.telemetryEnabled) {
       telemetryEventObservable.notify(toTelemetryEvent(message))
     }
   }

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -15,11 +15,13 @@ import { createMockServerApp } from './serverApps/mock'
 const DEFAULT_RUM_CONFIGURATION = {
   applicationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   clientToken: 'token',
+  telemetrySampleRate: 100,
   enableExperimentalFeatures: [],
 }
 
 const DEFAULT_LOGS_CONFIGURATION = {
   clientToken: 'token',
+  telemetrySampleRate: 100,
 }
 
 export function createTest(title: string) {


### PR DESCRIPTION
## Motivation

Add a sample rate to control which percentage of pages can send telemetry events.

## Changes

- New init option `telemetrySampleRate?: number`
- default value `20`, like in the volume projection, could be tweaked when starting to enable customers

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
