### PR TITLE
✨ [RUMF-1214] implement frustration signals counters

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -224,14 +224,14 @@ describe('rum track view metrics', () => {
       const { getViewUpdate, getViewUpdateCount, startView } = viewTest
 
       expect(getViewUpdateCount()).toEqual(1)
-      expect(getViewUpdate(0).eventCounts.userActionCount).toEqual(0)
+      expect(getViewUpdate(0).eventCounts.actionCount).toEqual(0)
 
       lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.ACTION } as RumEvent & Context)
       startView()
 
       expect(getViewUpdateCount()).toEqual(3)
-      expect(getViewUpdate(1).eventCounts.userActionCount).toEqual(1)
-      expect(getViewUpdate(2).eventCounts.userActionCount).toEqual(0)
+      expect(getViewUpdate(1).eventCounts.actionCount).toEqual(1)
+      expect(getViewUpdate(2).eventCounts.actionCount).toEqual(0)
     })
 
     it('should reset event count when the view changes', () => {
@@ -266,7 +266,7 @@ describe('rum track view metrics', () => {
         errorCount: 0,
         longTaskCount: 0,
         resourceCount: 0,
-        userActionCount: 0,
+        actionCount: 0,
       })
 
       lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type: RumEventType.RESOURCE } as RumEvent & Context)
@@ -280,7 +280,7 @@ describe('rum track view metrics', () => {
         errorCount: 0,
         longTaskCount: 0,
         resourceCount: 1,
-        userActionCount: 0,
+        actionCount: 0,
       })
     })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -28,6 +28,7 @@ export function trackViewMetrics(
       longTaskCount: 0,
       resourceCount: 0,
       actionCount: 0,
+      frustrationCount: 0,
     },
   }
   const { stop: stopEventCountsTracking } = trackEventCounts(lifeCycle, (newEventCounts) => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -27,7 +27,7 @@ export function trackViewMetrics(
       errorCount: 0,
       longTaskCount: 0,
       resourceCount: 0,
-      userActionCount: 0,
+      actionCount: 0,
     },
   }
   const { stop: stopEventCountsTracking } = trackEventCounts(lifeCycle, (newEventCounts) => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -20,7 +20,7 @@ const VIEW: ViewEvent = {
     errorCount: 10,
     longTaskCount: 10,
     resourceCount: 10,
-    userActionCount: 10,
+    actionCount: 10,
   },
   id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   name: undefined,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -21,6 +21,7 @@ const VIEW: ViewEvent = {
     longTaskCount: 10,
     resourceCount: 10,
     actionCount: 10,
+    frustrationCount: 10,
   },
   id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   name: undefined,
@@ -87,6 +88,9 @@ describe('viewCollection', () => {
       type: RumEventType.VIEW,
       view: {
         action: {
+          count: 10,
+        },
+        frustration: {
           count: 10,
         },
         cumulative_layout_shift: 1,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -55,6 +55,9 @@ function processViewUpdate(
       action: {
         count: view.eventCounts.actionCount,
       },
+      frustration: {
+        count: view.eventCounts.frustrationCount,
+      },
       cumulative_layout_shift: view.cumulativeLayoutShift,
       dom_complete: toServerDuration(view.timings.domComplete),
       dom_content_loaded: toServerDuration(view.timings.domContentLoaded),

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -53,7 +53,7 @@ function processViewUpdate(
     type: RumEventType.VIEW,
     view: {
       action: {
-        count: view.eventCounts.userActionCount,
+        count: view.eventCounts.actionCount,
       },
       cumulative_layout_shift: view.cumulativeLayoutShift,
       dom_complete: toServerDuration(view.timings.domComplete),

--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -1,7 +1,7 @@
 import type { Context } from '@datadog/browser-core'
 import { objectValues } from '@datadog/browser-core'
 import type { RumEvent } from '../rumEvent.types'
-import { RumEventType } from '../rawRumEvent.types'
+import { FrustrationType, RumEventType } from '../rawRumEvent.types'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
 import type { EventCounts } from './trackEventCounts'
 import { trackEventCounts } from './trackEventCounts'
@@ -13,46 +13,60 @@ describe('trackEventCounts', () => {
     lifeCycle = new LifeCycle()
   })
 
-  function notifyCollectedRawRumEvent(type: RumEventType) {
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, { type } as RumEvent & Context)
+  function notifyCollectedRawRumEvent(partialEvent: Partial<RumEvent>) {
+    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, partialEvent as RumEvent & Context)
   }
 
   it('tracks errors', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    notifyCollectedRawRumEvent(RumEventType.ERROR)
+    notifyCollectedRawRumEvent({ type: RumEventType.ERROR })
     expect(eventCounts.errorCount).toBe(1)
   })
 
   it('tracks long tasks', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    notifyCollectedRawRumEvent(RumEventType.LONG_TASK)
+    notifyCollectedRawRumEvent({ type: RumEventType.LONG_TASK })
     expect(eventCounts.longTaskCount).toBe(1)
   })
 
   it("doesn't track views", () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    notifyCollectedRawRumEvent(RumEventType.VIEW)
+    notifyCollectedRawRumEvent({ type: RumEventType.VIEW })
     expect(objectValues(eventCounts as unknown as { [key: string]: number }).every((value) => value === 0)).toBe(true)
   })
 
   it('tracks actions', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    notifyCollectedRawRumEvent(RumEventType.ACTION)
+    notifyCollectedRawRumEvent({ type: RumEventType.ACTION, action: { type: 'custom' } })
     expect(eventCounts.actionCount).toBe(1)
   })
 
   it('tracks resources', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
-    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
+  })
+
+  it('tracks frustration counts', () => {
+    const { eventCounts } = trackEventCounts(lifeCycle)
+    notifyCollectedRawRumEvent({
+      type: RumEventType.ACTION,
+      action: {
+        type: 'click',
+        frustration: {
+          type: [FrustrationType.ERROR, FrustrationType.DEAD],
+        },
+      },
+    })
+    expect(eventCounts.frustrationCount).toBe(2)
   })
 
   it('stops tracking when stop is called', () => {
     const { eventCounts, stop } = trackEventCounts(lifeCycle)
-    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
     stop()
-    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
   })
 
@@ -60,11 +74,11 @@ describe('trackEventCounts', () => {
     const spy = jasmine.createSpy<(eventCounts: EventCounts) => void>()
     trackEventCounts(lifeCycle, spy)
 
-    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(1)
 
-    notifyCollectedRawRumEvent(RumEventType.RESOURCE)
+    notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(spy).toHaveBeenCalledTimes(2)
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(2)
   })

--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -32,13 +32,13 @@ describe('trackEventCounts', () => {
   it("doesn't track views", () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
     notifyCollectedRawRumEvent(RumEventType.VIEW)
-    expect(objectValues(eventCounts).every((value) => value === 0)).toBe(true)
+    expect(objectValues(eventCounts as unknown as { [key: string]: number }).every((value) => value === 0)).toBe(true)
   })
 
   it('tracks actions', () => {
     const { eventCounts } = trackEventCounts(lifeCycle)
     notifyCollectedRawRumEvent(RumEventType.ACTION)
-    expect(eventCounts.userActionCount).toBe(1)
+    expect(eventCounts.actionCount).toBe(1)
   })
 
   it('tracks resources', () => {

--- a/packages/rum-core/src/domain/trackEventCounts.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.ts
@@ -5,17 +5,17 @@ import { LifeCycleEventType } from './lifeCycle'
 
 export interface EventCounts {
   errorCount: number
-  userActionCount: number
+  actionCount: number
   longTaskCount: number
   resourceCount: number
 }
 
 export function trackEventCounts(lifeCycle: LifeCycle, callback: (eventCounts: EventCounts) => void = noop) {
-  const eventCounts = {
+  const eventCounts: EventCounts = {
     errorCount: 0,
     longTaskCount: 0,
     resourceCount: 0,
-    userActionCount: 0,
+    actionCount: 0,
   }
 
   const subscription = lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, ({ type }): void => {
@@ -25,7 +25,7 @@ export function trackEventCounts(lifeCycle: LifeCycle, callback: (eventCounts: E
         callback(eventCounts)
         break
       case RumEventType.ACTION:
-        eventCounts.userActionCount += 1
+        eventCounts.actionCount += 1
         callback(eventCounts)
         break
       case RumEventType.LONG_TASK:

--- a/packages/rum-core/src/domain/trackEventCounts.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.ts
@@ -8,6 +8,7 @@ export interface EventCounts {
   actionCount: number
   longTaskCount: number
   resourceCount: number
+  frustrationCount: number
 }
 
 export function trackEventCounts(lifeCycle: LifeCycle, callback: (eventCounts: EventCounts) => void = noop) {
@@ -16,16 +17,20 @@ export function trackEventCounts(lifeCycle: LifeCycle, callback: (eventCounts: E
     longTaskCount: 0,
     resourceCount: 0,
     actionCount: 0,
+    frustrationCount: 0,
   }
 
-  const subscription = lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, ({ type }): void => {
-    switch (type) {
+  const subscription = lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event): void => {
+    switch (event.type) {
       case RumEventType.ERROR:
         eventCounts.errorCount += 1
         callback(eventCounts)
         break
       case RumEventType.ACTION:
         eventCounts.actionCount += 1
+        if (event.action.frustration) {
+          eventCounts.frustrationCount += event.action.frustration.type.length
+        }
         callback(eventCounts)
         break
       case RumEventType.LONG_TASK:

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -89,6 +89,7 @@ export interface RawRumViewEvent {
     action: Count
     long_task: Count
     resource: Count
+    frustration: Count
     in_foreground_periods?: InForegroundPeriod[]
   }
   session: {

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -73,6 +73,7 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
           view: {
             id: generateUUID(),
             action: { count: 0 },
+            frustration: { count: 0 },
             error: { count: 0 },
             is_active: true,
             loading_type: ViewLoadingType.INITIAL_LOAD,

--- a/test/e2e/lib/framework/eventsRegistry.ts
+++ b/test/e2e/lib/framework/eventsRegistry.ts
@@ -2,7 +2,7 @@ import type { LogsEvent } from '@datadog/browser-logs'
 import type { RumEvent } from '@datadog/browser-rum'
 import type { TelemetryEvent } from '@datadog/browser-core'
 import type { SessionReplayCall, ServerInternalMonitoringMessage } from '../types/serverEvents'
-import { isRumErrorEvent, isRumResourceEvent, isRumUserActionEvent, isRumViewEvent } from '../types/serverEvents'
+import { isRumErrorEvent, isRumResourceEvent, isRumActionEvent, isRumViewEvent } from '../types/serverEvents'
 
 export type IntakeType = 'logs' | 'rum' | 'internalMonitoring' | 'sessionReplay' | 'telemetry'
 
@@ -28,7 +28,7 @@ export class EventRegistry {
   }
 
   get rumActions() {
-    return this.rum.filter(isRumUserActionEvent)
+    return this.rum.filter(isRumActionEvent)
   }
 
   get rumErrors() {

--- a/test/e2e/lib/types/serverEvents.ts
+++ b/test/e2e/lib/types/serverEvents.ts
@@ -13,7 +13,7 @@ export function isRumResourceEvent(event: RumEvent): event is RumResourceEvent {
   return event.type === 'resource'
 }
 
-export function isRumUserActionEvent(event: RumEvent): event is RumActionEvent {
+export function isRumActionEvent(event: RumEvent): event is RumActionEvent {
   return event.type === 'action'
 }
 

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -115,6 +115,9 @@ describe('action collection', () => {
       expect(actionEvents.length).toBe(1)
       expect(actionEvents[0].action.frustration!.type).toEqual(['error'])
       expect(actionEvents[0].action.error!.count).toBe(1)
+
+      expect(serverEvents.rumViews[0].view.frustration!.count).toBe(1)
+
       await withBrowserLogs((browserLogs) => {
         expect(browserLogs.length).toEqual(1)
       })
@@ -131,6 +134,8 @@ describe('action collection', () => {
 
       expect(actionEvents.length).toBe(1)
       expect(actionEvents[0].action.frustration!.type).toEqual(['dead'])
+
+      expect(serverEvents.rumViews[0].view.frustration!.count).toBe(1)
     })
 
   createTest('collect multiple frustrations in one action')
@@ -154,6 +159,9 @@ describe('action collection', () => {
 
       expect(actionEvents.length).toBe(1)
       expect(actionEvents[0].action.frustration!.type).toEqual(jasmine.arrayWithExactContents(['error', 'dead']))
+
+      expect(serverEvents.rumViews[0].view.frustration!.count).toBe(2)
+
       await withBrowserLogs((browserLogs) => {
         expect(browserLogs.length).toEqual(1)
       })


### PR DESCRIPTION
## Motivation

Count the number of frustration occuring during a view

## Changes

* Do a bit of renaming, `userAction` are now `action`
* Implement the counter

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
