### PR TITLE
🐛 [RUMF-1240] fix attribute mutating to an empty value

### DIFF
--- a/packages/rum/src/domain/record/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/mutationObserver.spec.ts
@@ -528,6 +528,43 @@ describe('startMutationCollection', () => {
       })
     })
 
+    it('emits a mutation with an empty string when an attribute is changed to an empty string', () => {
+      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const { mutationController, getLatestMutationPayload } = startMutationCollection()
+
+      sandbox.setAttribute('foo', '')
+      mutationController.flush()
+
+      const { validate, expectInitialNode } = createMutationPayloadValidator(serializedDocument)
+      validate(getLatestMutationPayload(), {
+        attributes: [
+          {
+            node: expectInitialNode({ idAttribute: 'sandbox' }),
+            attributes: { foo: '' },
+          },
+        ],
+      })
+    })
+
+    it('emits a mutation with `null` when an attribute is removed', () => {
+      sandbox.setAttribute('foo', 'bar')
+      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const { mutationController, getLatestMutationPayload } = startMutationCollection()
+
+      sandbox.removeAttribute('foo')
+      mutationController.flush()
+
+      const { validate, expectInitialNode } = createMutationPayloadValidator(serializedDocument)
+      validate(getLatestMutationPayload(), {
+        attributes: [
+          {
+            node: expectInitialNode({ idAttribute: 'sandbox' }),
+            attributes: { foo: null },
+          },
+        ],
+      })
+    })
+
     it('does not emit a mutation when an attribute keeps the same value', () => {
       sandbox.setAttribute('foo', 'bar')
       serializeDocument(document, NodePrivacyLevel.ALLOW)

--- a/packages/rum/src/domain/record/mutationObserver.ts
+++ b/packages/rum/src/domain/record/mutationObserver.ts
@@ -311,7 +311,7 @@ function processAttributesMutations(
         continue
       }
       transformedValue = inputValue
-    } else if (attributeValue && typeof attributeValue === 'string') {
+    } else if (typeof attributeValue === 'string') {
       transformedValue = attributeValue
     } else {
       transformedValue = null


### PR DESCRIPTION
## Motivation

Fix HTML elements incorrect visual state when replay.


The SDK incorrectly sent empty attribute mutations as `null`. But `null` is also used for removed attributes, so instead setting the attribute to an empty string, the player removes the attribute, which may have an impact on the visual state of some elements.

## Changes

To fix the issue, this PR sends empty attribute mutations as an empty string instead.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
