### PR TITLE
🔇 Remove useless debug logs

### DIFF
--- a/packages/core/src/transport/batch.spec.ts
+++ b/packages/core/src/transport/batch.spec.ts
@@ -23,7 +23,7 @@ describe('batch', () => {
 
     batch.flush()
 
-    expect(transport.send).toHaveBeenCalledWith('{"message":"hello"}', jasmine.any(Number), undefined)
+    expect(transport.send).toHaveBeenCalledWith('{"message":"hello"}', jasmine.any(Number))
   })
 
   it('should empty the batch after a flush', () => {
@@ -50,8 +50,7 @@ describe('batch', () => {
     batch.add({ message: '3' })
     expect(transport.send).toHaveBeenCalledWith(
       '{"message":"1"}\n{"message":"2"}\n{"message":"3"}',
-      jasmine.any(Number),
-      jasmine.any(String)
+      jasmine.any(Number)
     )
   })
 
@@ -60,18 +59,10 @@ describe('batch', () => {
     expect(transport.send).not.toHaveBeenCalled()
 
     batch.add({ message: '60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' })
-    expect(transport.send).toHaveBeenCalledWith(
-      '{"message":"50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx"}',
-      50,
-      'willReachedBytesLimitWith'
-    )
+    expect(transport.send).toHaveBeenCalledWith('{"message":"50 bytes - xxxxxxxxxxxxxxxxxxxxxxxxx"}', 50)
 
     batch.flush()
-    expect(transport.send).toHaveBeenCalledWith(
-      '{"message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}',
-      60,
-      undefined
-    )
+    expect(transport.send).toHaveBeenCalledWith('{"message":"60 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}', 60)
   })
 
   it('should consider separator size when computing the size', () => {
@@ -79,17 +70,13 @@ describe('batch', () => {
     batch.add({ message: '30 bytes - xxxxx' }) // batch: 60 sep: 1
     batch.add({ message: '39 bytes - xxxxxxxxxxxxxx' }) // batch: 99 sep: 2
 
-    expect(transport.send).toHaveBeenCalledWith(
-      '{"message":"30 bytes - xxxxx"}\n{"message":"30 bytes - xxxxx"}',
-      61,
-      'willReachedBytesLimitWith'
-    )
+    expect(transport.send).toHaveBeenCalledWith('{"message":"30 bytes - xxxxx"}\n{"message":"30 bytes - xxxxx"}', 61)
   })
 
   it('should call send one time when the size is too high and the batch is empty', () => {
     const message = '101 bytes - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     batch.add({ message })
-    expect(transport.send).toHaveBeenCalledWith(`{"message":"${message}"}`, 101, 'isFull')
+    expect(transport.send).toHaveBeenCalledWith(`{"message":"${message}"}`, 101)
   })
 
   it('should flush the batch and send the message when the message is too heavy', () => {
@@ -128,8 +115,7 @@ describe('batch', () => {
 
     expect(transport.send).toHaveBeenCalledWith(
       '{"message":"2"}\n{"message":"3"}\n{"message":"4"}',
-      jasmine.any(Number),
-      jasmine.any(String)
+      jasmine.any(Number)
     )
 
     batch.upsert({ message: '5' }, 'c')
@@ -138,8 +124,7 @@ describe('batch', () => {
 
     expect(transport.send).toHaveBeenCalledWith(
       '{"message":"5"}\n{"message":"6"}\n{"message":"7"}',
-      jasmine.any(Number),
-      jasmine.any(String)
+      jasmine.any(Number)
     )
 
     batch.upsert({ message: '8' }, 'a')
@@ -148,6 +133,6 @@ describe('batch', () => {
     batch.upsert({ message: '11' }, 'b')
     batch.flush()
 
-    expect(transport.send).toHaveBeenCalledWith('{"message":"10"}\n{"message":"11"}', jasmine.any(Number), undefined)
+    expect(transport.send).toHaveBeenCalledWith('{"message":"10"}\n{"message":"11"}', jasmine.any(Number))
   })
 })

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -34,10 +34,10 @@ export class Batch {
     this.addOrUpdate(message, key)
   }
 
-  flush(reason?: string) {
+  flush() {
     if (this.bufferMessageCount !== 0) {
       const messages = this.pushOnlyBuffer.concat(objectValues(this.upsertBuffer))
-      this.request.send(messages.join('\n'), this.bufferBytesSize, reason)
+      this.request.send(messages.join('\n'), this.bufferBytesSize)
       this.pushOnlyBuffer = []
       this.upsertBuffer = {}
       this.bufferBytesSize = 0
@@ -68,11 +68,11 @@ export class Batch {
       this.remove(key)
     }
     if (this.willReachedBytesLimitWith(messageBytesSize)) {
-      this.flush('willReachedBytesLimitWith')
+      this.flush()
     }
     this.push(processedMessage, messageBytesSize, key)
     if (this.isFull()) {
-      this.flush('isFull')
+      this.flush()
     }
   }
 
@@ -123,7 +123,7 @@ export class Batch {
   private flushPeriodically() {
     setTimeout(
       monitor(() => {
-        this.flush('flushPeriodically')
+        this.flush()
         this.flushPeriodically()
       }),
       this.flushTimeout
@@ -149,7 +149,7 @@ export class Batch {
        */
       addEventListener(document, DOM_EVENT.VISIBILITY_CHANGE, () => {
         if (document.visibilityState === 'hidden') {
-          this.flush(DOM_EVENT.VISIBILITY_CHANGE)
+          this.flush()
         }
       })
       /**
@@ -157,7 +157,7 @@ export class Batch {
        * - a visibility change during doc unload (cf: https://bugs.webkit.org/show_bug.cgi?id=194897)
        * - a page hide transition (cf: https://bugs.webkit.org/show_bug.cgi?id=188329)
        */
-      addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => this.flush(DOM_EVENT.BEFORE_UNLOAD))
+      addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => this.flush())
     }
   }
 }

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -1,7 +1,5 @@
 import type { EndpointBuilder } from '../domain/configuration'
-import { monitor, addMonitoringError, addMonitoringMessage } from '../domain/internalMonitoring'
-
-let hasReportedXhrError = false
+import { addMonitoringError } from '../domain/internalMonitoring'
 
 /**
  * Use POST request without content type to:
@@ -14,10 +12,10 @@ let hasReportedXhrError = false
 export class HttpRequest {
   constructor(private endpointBuilder: EndpointBuilder, private bytesLimit: number) {}
 
-  send(data: string | FormData, size: number, flushReason?: string) {
+  send(data: string | FormData, size: number) {
     const url = this.endpointBuilder.build()
-    const tryBeacon = !!navigator.sendBeacon && size < this.bytesLimit
-    if (tryBeacon) {
+    const canUseBeacon = !!navigator.sendBeacon && size < this.bytesLimit
+    if (canUseBeacon) {
       try {
         const isQueued = navigator.sendBeacon(url, data)
         if (isQueued) {
@@ -28,38 +26,7 @@ export class HttpRequest {
       }
     }
 
-    const transportIntrospection = (event: ProgressEvent) => {
-      const req = event?.currentTarget as XMLHttpRequest
-      if (req.status >= 200 && req.status < 300) {
-        return
-      }
-      if (!hasReportedXhrError) {
-        hasReportedXhrError = true
-        addMonitoringMessage('XHR fallback failed', {
-          on_line: navigator.onLine,
-          size,
-          url,
-          try_beacon: tryBeacon,
-          flush_reason: flushReason,
-          event: {
-            is_trusted: event.isTrusted,
-            total: event.total,
-            loaded: event.loaded,
-          },
-          request: {
-            status: req.status,
-            ready_state: req.readyState,
-            response_text: req.responseText.slice(0, 512),
-          },
-        })
-      }
-    }
-
     const request = new XMLHttpRequest()
-    request.addEventListener(
-      'loadend',
-      monitor((event) => transportIntrospection(event))
-    )
     request.open('POST', url, true)
     request.send(data)
   }

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -84,7 +84,7 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(1, (calls) => {
-      expect(calls.first().args).toEqual([jasmine.any(FormData), jasmine.any(Number), 'before_unload'])
+      expect(calls.first().args).toEqual([jasmine.any(FormData), jasmine.any(Number)])
       expect(getRequestData(calls.first())).toEqual({
         'application.id': 'appId',
         creation_reason: 'init',

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -26,8 +26,8 @@ export function startRecording(
     configuration.applicationId,
     sessionManager,
     viewContexts,
-    (data, metadata, rawSegmentSize, flushReason) =>
-      send(configuration.sessionReplayEndpointBuilder, data, metadata, rawSegmentSize, flushReason),
+    (data, metadata, rawSegmentSize) =>
+      send(configuration.sessionReplayEndpointBuilder, data, metadata, rawSegmentSize),
     worker
   )
 

--- a/packages/rum/src/domain/segmentCollection/segment.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.ts
@@ -8,7 +8,6 @@ let nextId = 0
 
 export class Segment {
   public isFlushed = false
-  public flushReason?: string
   public readonly metadata: SegmentMetadata
 
   private id = nextId++
@@ -76,13 +75,12 @@ export class Segment {
     this.worker.postMessage({ data: `,${JSON.stringify(record)}`, id: this.id, action: 'write' })
   }
 
-  flush(reason?: string) {
+  flush() {
     this.worker.postMessage({
       data: `],${JSON.stringify(this.metadata).slice(1)}\n`,
       id: this.id,
       action: 'flush',
     })
     this.isFlushed = true
-    this.flushReason = reason
   }
 }

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -15,7 +15,7 @@ let MAX_SEGMENT_SIZE = SEND_BEACON_BYTE_LENGTH_LIMIT
 // namings). They are stored without any processing from the intake, and fetched one after the
 // other while a session is being replayed. Their encoding (deflate) are carefully crafted to allow
 // concatenating multiple segments together. Segments have a size overhead (metadata), so our goal is to
-// build segments containing as much records as possible while complying with the various flush
+// build segments containing as many records as possible while complying with the various flush
 // strategies to guarantee a good replay quality.
 //
 // When the recording starts, a segment is initially created.  The segment is flushed (finalized and
@@ -40,7 +40,7 @@ export function startSegmentCollection(
   applicationId: string,
   sessionManager: RumSessionManager,
   viewContexts: ViewContexts,
-  send: (data: Uint8Array, metadata: SegmentMetadata, rawSegmentSize: number, flushReason?: string) => void,
+  send: (data: Uint8Array, metadata: SegmentMetadata, rawSegmentSize: number) => void,
   worker: DeflateWorker
 ) {
   return doStartSegmentCollection(
@@ -73,7 +73,7 @@ type SegmentCollectionState =
 export function doStartSegmentCollection(
   lifeCycle: LifeCycle,
   getSegmentContext: () => SegmentContext | undefined,
-  send: (data: Uint8Array, metadata: SegmentMetadata, rawSegmentSize: number, flushReason?: string) => void,
+  send: (data: Uint8Array, metadata: SegmentMetadata, rawSegmentSize: number) => void,
   worker: DeflateWorker,
   emitter: EventEmitter = window
 ) {
@@ -103,7 +103,7 @@ export function doStartSegmentCollection(
 
   function flushSegment(nextSegmentCreationReason?: CreationReason) {
     if (state.status === SegmentCollectionStatus.SegmentPending) {
-      state.segment.flush(nextSegmentCreationReason || 'sdk_stopped')
+      state.segment.flush()
       clearTimeout(state.expirationTimeoutId)
     }
 
@@ -136,7 +136,7 @@ export function doStartSegmentCollection(
         }
       },
       (data, rawSegmentSize) => {
-        send(data, segment.metadata, rawSegmentSize, segment.flushReason)
+        send(data, segment.metadata, rawSegmentSize)
       }
     )
 

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -8,8 +8,7 @@ export function send(
   endpointBuilder: EndpointBuilder,
   data: Uint8Array,
   metadata: SegmentMetadata,
-  rawSegmentSize: number,
-  flushReason?: string
+  rawSegmentSize: number
 ): void {
   const formData = new FormData()
 
@@ -25,7 +24,7 @@ export function send(
   formData.append('raw_segment_size', rawSegmentSize.toString())
 
   const request = new HttpRequest(endpointBuilder, SEND_BEACON_BYTE_LENGTH_LIMIT)
-  request.send(formData, data.byteLength, flushReason)
+  request.send(formData, data.byteLength)
 }
 
 export function toFormEntries(input: object, onEntry: (key: string, value: string) => void, prefix = '') {


### PR DESCRIPTION
## Motivation

Remove XHR fallback failed logs since it is the main source of telemetry logs and we don't use them.
We could reintroduce them when needed.

## Changes

Remove code introduced by #902 and #1035

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
