### PR TITLE
🏷️ rename action.frustration_type to action.frustration.type 

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -49,7 +49,9 @@ describe('actionCollection', () => {
         },
         id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
         loading_time: (100 * 1e6) as ServerDuration,
-        frustration_type: [],
+        frustration: {
+          type: [],
+        },
         long_task: {
           count: 10,
         },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -61,7 +61,9 @@ function processAction(
         action: {
           id: action.id,
           loading_time: toServerDuration(action.duration),
-          frustration_type: action.frustrationTypes,
+          frustration: {
+            type: action.frustrationTypes,
+          },
           error: {
             count: action.counts.errorCount,
           },

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -140,7 +140,9 @@ export interface RawRumActionEvent {
     id: string
     type: ActionType
     loading_time?: ServerDuration
-    frustration_type?: FrustrationType[]
+    frustration?: {
+      type: FrustrationType[]
+    }
     error?: Count
     long_task?: Count
     resource?: Count

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -42,9 +42,15 @@ export type RumActionEvent = CommonProperties & {
       [k: string]: unknown
     }
     /**
-     * Action frustration types
+     * Action frustration properties
      */
-    readonly frustration_type?: ('rage' | 'dead' | 'error')[]
+    readonly frustration?: {
+      /**
+       * Action frustration types
+       */
+      readonly type: ('rage' | 'dead' | 'error')[]
+      [k: string]: unknown
+    }
     /**
      * Properties of the errors of the action
      */
@@ -565,6 +571,16 @@ export type RumViewEvent = CommonProperties & {
     readonly resource: {
       /**
        * Number of resources that occurred on the view
+       */
+      readonly count: number
+      [k: string]: unknown
+    }
+    /**
+     * Properties of the frustrations of the view
+     */
+    readonly frustration?: {
+      /**
+       * Number of frustrations that occurred on the view
        */
       readonly count: number
       [k: string]: unknown

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -39,7 +39,9 @@ describe('action collection', () => {
           name: 'click me',
         },
         type: 'click',
-        frustration_type: [],
+        frustration: {
+          type: [],
+        },
       })
     })
 
@@ -81,7 +83,9 @@ describe('action collection', () => {
           name: 'click me',
         },
         type: 'click',
-        frustration_type: [],
+        frustration: {
+          type: [],
+        },
       })
 
       expect(resourceEvents.length).toBe(1)
@@ -109,7 +113,7 @@ describe('action collection', () => {
       const actionEvents = serverEvents.rumActions
 
       expect(actionEvents.length).toBe(1)
-      expect(actionEvents[0].action.frustration_type).toEqual(['error'])
+      expect(actionEvents[0].action.frustration!.type).toEqual(['error'])
       expect(actionEvents[0].action.error!.count).toBe(1)
       await withBrowserLogs((browserLogs) => {
         expect(browserLogs.length).toEqual(1)
@@ -126,7 +130,7 @@ describe('action collection', () => {
       const actionEvents = serverEvents.rumActions
 
       expect(actionEvents.length).toBe(1)
-      expect(actionEvents[0].action.frustration_type).toEqual(['dead'])
+      expect(actionEvents[0].action.frustration!.type).toEqual(['dead'])
     })
 
   createTest('collect multiple frustrations in one action')
@@ -149,7 +153,7 @@ describe('action collection', () => {
       const actionEvents = serverEvents.rumActions
 
       expect(actionEvents.length).toBe(1)
-      expect(actionEvents[0].action.frustration_type).toEqual(jasmine.arrayWithExactContents(['error', 'dead']))
+      expect(actionEvents[0].action.frustration!.type).toEqual(jasmine.arrayWithExactContents(['error', 'dead']))
       await withBrowserLogs((browserLogs) => {
         expect(browserLogs.length).toEqual(1)
       })


### PR DESCRIPTION
## Motivation

We decided to rename `action.frustration_type` to `action.frustration.type` to be closer to the future `view.frustration.count` pattern.

## Changes

* Update rum-events-format
* Rename the field

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
