### PR TITLE
✨ [RUMF-1251] allow to enable telemetry by site

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -21,6 +21,9 @@ const INTAKE_TRACKS = {
 type EndpointType = keyof typeof ENDPOINTS
 
 export const INTAKE_SITE_US = 'datadoghq.com'
+export const INTAKE_SITE_US3 = 'us3.datadoghq.com'
+export const INTAKE_SITE_US5 = 'us5.datadoghq.com'
+export const INTAKE_SITE_EU = 'datadoghq.eu'
 
 export type EndpointBuilder = ReturnType<typeof createEndpointBuilder>
 

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -5,7 +5,14 @@ export {
   DefaultPrivacyLevel,
   validateAndBuildConfiguration,
 } from './configuration'
-export { createEndpointBuilder, EndpointBuilder } from './endpointBuilder'
+export {
+  createEndpointBuilder,
+  EndpointBuilder,
+  INTAKE_SITE_US5,
+  INTAKE_SITE_US,
+  INTAKE_SITE_US3,
+  INTAKE_SITE_EU,
+} from './endpointBuilder'
 export {
   isExperimentalFeatureEnabled,
   updateExperimentalFeatures,

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -23,11 +23,13 @@ describe('transportConfiguration', () => {
     it('should use US site by default', () => {
       const configuration = computeTransportConfiguration({ clientToken })
       expect(configuration.rumEndpointBuilder.build()).toContain('datadoghq.com')
+      expect(configuration.site).toBe('datadoghq.com')
     })
 
     it('should use site value when set', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'foo.com' })
       expect(configuration.rumEndpointBuilder.build()).toContain('foo.com')
+      expect(configuration.site).toBe('foo.com')
     })
   })
 

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -11,6 +11,7 @@ export interface TransportConfiguration {
   internalMonitoringEndpointBuilder?: EndpointBuilder
   isIntakeUrl: (url: string) => boolean
   replica?: ReplicaConfiguration
+  site: string
 }
 
 export interface ReplicaConfiguration {
@@ -32,6 +33,7 @@ export function computeTransportConfiguration(initConfiguration: InitConfigurati
     {
       isIntakeUrl: (url: string) => intakeEndpoints.some((intakeEndpoint) => url.indexOf(intakeEndpoint) === 0),
       replica: replicaConfiguration,
+      site: initConfiguration.site || INTAKE_SITE_US,
     },
     endpointBuilders
   )

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -1,7 +1,14 @@
 import type { Context } from '../../tools/context'
 import { display } from '../../tools/display'
 import type { Configuration } from '../configuration'
-import { updateExperimentalFeatures, resetExperimentalFeatures } from '../configuration'
+import {
+  updateExperimentalFeatures,
+  resetExperimentalFeatures,
+  INTAKE_SITE_US,
+  INTAKE_SITE_US3,
+  INTAKE_SITE_EU,
+  INTAKE_SITE_US5,
+} from '../configuration'
 import type { InternalMonitoring, MonitoringMessage } from './internalMonitoring'
 import {
   monitor,
@@ -241,6 +248,31 @@ describe('internal monitoring', () => {
   describe('new telemetry', () => {
     let internalMonitoring: InternalMonitoring
     let notifySpy: jasmine.Spy<(event: TelemetryEvent & Context) => void>
+
+    describe('rollout', () => {
+      ;[
+        { site: INTAKE_SITE_US5, enabled: false },
+        { site: INTAKE_SITE_US3, enabled: false },
+        { site: INTAKE_SITE_EU, enabled: false },
+        { site: INTAKE_SITE_US, enabled: false },
+      ].forEach(({ site, enabled }) => {
+        it('should be enabled by site', () => {
+          internalMonitoring = startInternalMonitoring({ ...configuration, site } as Configuration)
+          notifySpy = jasmine.createSpy('notified')
+          internalMonitoring.telemetryEventObservable.subscribe(notifySpy)
+
+          callMonitored(() => {
+            throw new Error('message')
+          })
+
+          if (enabled) {
+            expect(notifySpy).toHaveBeenCalled()
+          } else {
+            expect(notifySpy).not.toHaveBeenCalled()
+          }
+        })
+      })
+    })
 
     describe('when enabled', () => {
       beforeEach(() => {

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -256,7 +256,7 @@ describe('internal monitoring', () => {
         { site: INTAKE_SITE_EU, enabled: false },
         { site: INTAKE_SITE_US, enabled: false },
       ].forEach(({ site, enabled }) => {
-        it('should be enabled by site', () => {
+        it(`should be ${enabled ? 'enabled' : 'disabled'} on ${site}`, () => {
           internalMonitoring = startInternalMonitoring({ ...configuration, site } as Configuration)
           notifySpy = jasmine.createSpy('notified')
           internalMonitoring.telemetryEventObservable.subscribe(notifySpy)

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -1,7 +1,7 @@
 import type { Context } from '../../tools/context'
 import { display } from '../../tools/display'
 import { toStackTraceString } from '../../tools/error'
-import { assign, combine, jsonStringify, performDraw } from '../../tools/utils'
+import { assign, combine, jsonStringify, performDraw, includes } from '../../tools/utils'
 import type { Configuration } from '../configuration'
 import { computeStackTrace } from '../tracekit'
 import { Observable } from '../../tools/observable'
@@ -34,6 +34,13 @@ export interface MonitoringMessage extends Context {
   }
 }
 
+const TELEMETRY_ALLOWED_SITES: string[] = [
+  // INTAKE_SITE_US5,
+  // INTAKE_SITE_US3,
+  // INTAKE_SITE_EU,
+  // INTAKE_SITE_US,
+]
+
 const monitoringConfiguration: {
   debugMode?: boolean
   maxMessagesPerPage: number
@@ -53,7 +60,10 @@ export function startInternalMonitoring(configuration: Configuration): InternalM
 
   onInternalMonitoringMessageCollected = (message: MonitoringMessage) => {
     monitoringMessageObservable.notify(withContext(message))
-    if (isExperimentalFeatureEnabled('telemetry') && monitoringConfiguration.telemetryEnabled) {
+    if (
+      (isExperimentalFeatureEnabled('telemetry') || includes(TELEMETRY_ALLOWED_SITES, configuration.site)) &&
+      monitoringConfiguration.telemetryEnabled
+    ) {
       telemetryEventObservable.notify(toTelemetryEvent(message))
     }
   }


### PR DESCRIPTION
## Motivation

Prepare telemetry rollout

## Changes

- Add logic to enable telemetry by site
- allow to override with feature flag to keep sending telemetry for internal orgs

Data centers will be enabled in following PRs

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
