### PR TITLE
✨[RUMF-1257] prevent dual shipping of telemetry events

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -20,6 +20,7 @@ const INTAKE_TRACKS = {
 
 type EndpointType = keyof typeof ENDPOINTS
 
+export const INTAKE_SITE_STAGING = 'datad0g.com'
 export const INTAKE_SITE_US = 'datadoghq.com'
 export const INTAKE_SITE_US3 = 'us3.datadoghq.com'
 export const INTAKE_SITE_US5 = 'us5.datadoghq.com'

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   createEndpointBuilder,
   EndpointBuilder,
+  INTAKE_SITE_STAGING,
   INTAKE_SITE_US5,
   INTAKE_SITE_US,
   INTAKE_SITE_US3,

--- a/packages/core/src/domain/internalMonitoring/index.ts
+++ b/packages/core/src/domain/internalMonitoring/index.ts
@@ -10,5 +10,6 @@ export {
   resetInternalMonitoring,
   setDebugMode,
   startInternalMonitoring,
+  isTelemetryReplicationAllowed,
 } from './internalMonitoring'
 export { TelemetryEvent } from './telemetryEvent.types'

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -6,7 +6,7 @@ import type { Configuration } from '../configuration'
 import { computeStackTrace } from '../tracekit'
 import { Observable } from '../../tools/observable'
 import { timeStampNow } from '../../tools/timeUtils'
-import { isExperimentalFeatureEnabled } from '../configuration'
+import { isExperimentalFeatureEnabled, INTAKE_SITE_STAGING } from '../configuration'
 import type { TelemetryEvent } from './telemetryEvent.types'
 
 // replaced at build time
@@ -127,6 +127,14 @@ export function startFakeInternalMonitoring() {
 export function resetInternalMonitoring() {
   onInternalMonitoringMessageCollected = undefined
   monitoringConfiguration.debugMode = undefined
+}
+
+/**
+ * Avoid mixing telemetry events from different data centers
+ * but keep replicating staging events for reliability
+ */
+export function isTelemetryReplicationAllowed(configuration: Configuration) {
+  return configuration.site === INTAKE_SITE_STAGING
 }
 
 export function monitored<T extends (...params: any[]) => unknown>(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export {
   resetInternalMonitoring,
   setDebugMode,
   TelemetryEvent,
+  isTelemetryReplicationAllowed,
 } from './domain/internalMonitoring'
 export { Observable, Subscription } from './tools/observable'
 export {

--- a/packages/core/src/transport/startBatchWithReplica.ts
+++ b/packages/core/src/transport/startBatchWithReplica.ts
@@ -24,9 +24,9 @@ export function startBatchWithReplica<T extends Context>(
   }
 
   return {
-    add(message: T) {
+    add(message: T, replicated = true) {
       primaryBatch.add(message)
-      if (replicaBatch) {
+      if (replicaBatch && replicated) {
         replicaBatch.add(message)
       }
     },

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -89,7 +89,7 @@ function startLogsInternalMonitoring(configuration: LogsConfiguration) {
       configuration.rumEndpointBuilder,
       configuration.replica?.rumEndpointBuilder
     )
-    internalMonitoring.telemetryEventObservable.subscribe((event) => monitoringBatch.add(event))
+    internalMonitoring.telemetryEventObservable.subscribe((event) => monitoringBatch.add(event, false))
   }
   return internalMonitoring
 }

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -6,6 +6,7 @@ import {
   getEventBridge,
   startInternalMonitoring,
   startBatchWithReplica,
+  isTelemetryReplicationAllowed,
 } from '@datadog/browser-core'
 import { startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
 import type { LogsConfiguration } from '../domain/configuration'
@@ -89,7 +90,9 @@ function startLogsInternalMonitoring(configuration: LogsConfiguration) {
       configuration.rumEndpointBuilder,
       configuration.replica?.rumEndpointBuilder
     )
-    internalMonitoring.telemetryEventObservable.subscribe((event) => monitoringBatch.add(event, false))
+    internalMonitoring.telemetryEventObservable.subscribe((event) =>
+      monitoringBatch.add(event, isTelemetryReplicationAllowed(configuration))
+    )
   }
   return internalMonitoring
 }

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -21,11 +21,11 @@ export function startRumBatch(
     }
   })
 
-  telemetryEventObservable.subscribe((event) => batch.add(event))
+  telemetryEventObservable.subscribe((event) => batch.add(event, false))
 }
 
 interface RumBatch {
-  add: (message: Context) => void
+  add: (message: Context, replicated?: boolean) => void
   upsert: (message: Context, key: string) => void
 }
 
@@ -56,9 +56,9 @@ function makeRumBatch(configuration: RumConfiguration, lifeCycle: LifeCycle): Ru
   }
 
   return {
-    add: (message: Context) => {
+    add: (message: Context, replicated = true) => {
       primaryBatch.add(message)
-      if (replicaBatch) {
+      if (replicaBatch && replicated) {
         replicaBatch.add(withReplicaApplicationId(message))
       }
     },

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -1,5 +1,5 @@
 import type { Context, EndpointBuilder, TelemetryEvent, Observable } from '@datadog/browser-core'
-import { Batch, combine, HttpRequest } from '@datadog/browser-core'
+import { Batch, combine, HttpRequest, isTelemetryReplicationAllowed } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
 import { LifeCycleEventType } from '../domain/lifeCycle'
@@ -21,7 +21,7 @@ export function startRumBatch(
     }
   })
 
-  telemetryEventObservable.subscribe((event) => batch.add(event, false))
+  telemetryEventObservable.subscribe((event) => batch.add(event, isTelemetryReplicationAllowed(configuration)))
 }
 
 interface RumBatch {


### PR DESCRIPTION
## Motivation

Ensure that telemetry events of different datacenters are not mixed together.
Keep sending staging events to prod for reliability.

## Changes

Add an extra flag on `batch.add` to control replication by message.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
