### PR TITLE
⚗✨ [RUMF-1210] add a `trackFrustrations` initialization parameter

### DIFF
--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -1,4 +1,9 @@
-import { DefaultPrivacyLevel, display } from '@datadog/browser-core'
+import {
+  DefaultPrivacyLevel,
+  display,
+  resetExperimentalFeatures,
+  updateExperimentalFeatures,
+} from '@datadog/browser-core'
 import { validateAndBuildRumConfiguration } from './configuration'
 
 const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx', applicationId: 'xxx' }
@@ -88,6 +93,66 @@ describe('validateAndBuildRumConfiguration', () => {
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: 'foo' as any })!
           .trackInteractions
       ).toBeTrue()
+    })
+  })
+
+  describe('trackFrustrations', () => {
+    describe('without frustration-signals flag', () => {
+      it('defaults to false', () => {
+        expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackFrustrations).toBeFalse()
+      })
+
+      it('the initialization parameter is ignored, no matter its value', () => {
+        expect(
+          validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!
+            .trackFrustrations
+        ).toBeFalse()
+        expect(
+          validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: 'foo' as any })!
+            .trackFrustrations
+        ).toBeFalse()
+      })
+
+      it('does not impact "trackInteractions"', () => {
+        expect(
+          validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!
+            .trackInteractions
+        ).toBeFalse()
+      })
+    })
+
+    describe('with frustration-signals flag', () => {
+      beforeEach(() => {
+        updateExperimentalFeatures(['frustration-signals'])
+      })
+      afterEach(() => {
+        resetExperimentalFeatures()
+      })
+
+      it('defaults to false', () => {
+        expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackFrustrations).toBeFalse()
+      })
+
+      it('the initialization parameter is set to provided value', () => {
+        expect(
+          validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!
+            .trackFrustrations
+        ).toBeTrue()
+      })
+
+      it('the initialization parameter the provided value is cast to boolean', () => {
+        expect(
+          validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: 'foo' as any })!
+            .trackFrustrations
+        ).toBeTrue()
+      })
+
+      it('implies "trackInteractions"', () => {
+        expect(
+          validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!
+            .trackInteractions
+        ).toBeTrue()
+      })
     })
   })
 

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -86,6 +86,9 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: true })!.trackInteractions
       ).toBeTrue()
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: false })!.trackInteractions
+      ).toBeFalse()
     })
 
     it('the provided value is cast to boolean', () => {
@@ -138,6 +141,10 @@ describe('validateAndBuildRumConfiguration', () => {
           validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!
             .trackFrustrations
         ).toBeTrue()
+        expect(
+          validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: false })!
+            .trackFrustrations
+        ).toBeFalse()
       })
 
       it('the initialization parameter the provided value is cast to boolean', () => {
@@ -166,6 +173,10 @@ describe('validateAndBuildRumConfiguration', () => {
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackViewsManually: true })!
           .trackViewsManually
       ).toBeTrue()
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackViewsManually: false })!
+          .trackViewsManually
+      ).toBeFalse()
     })
 
     it('the provided value is cast to boolean', () => {

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -1,5 +1,6 @@
 import type { Configuration, InitConfiguration } from '@datadog/browser-core'
 import {
+  isExperimentalFeatureEnabled,
   assign,
   DefaultPrivacyLevel,
   display,
@@ -24,6 +25,7 @@ export interface RumInitConfiguration extends InitConfiguration {
 
   // action options
   trackInteractions?: boolean | undefined
+  trackFrustrations?: boolean | undefined
   actionNameAttribute?: string | undefined
 
   // view options
@@ -40,6 +42,7 @@ export interface RumConfiguration extends Configuration {
   defaultPrivacyLevel: DefaultPrivacyLevel
   replaySampleRate: number
   trackInteractions: boolean
+  trackFrustrations: boolean
   trackViewsManually: boolean
   version?: string
 }
@@ -73,6 +76,8 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
+  const trackFrustrations = isExperimentalFeatureEnabled('frustration-signals') && !!initConfiguration.trackFrustrations
+
   return assign(
     {
       applicationId: initConfiguration.applicationId,
@@ -80,7 +85,8 @@ export function validateAndBuildRumConfiguration(
       actionNameAttribute: initConfiguration.actionNameAttribute,
       replaySampleRate: initConfiguration.replaySampleRate ?? 100,
       allowedTracingOrigins: initConfiguration.allowedTracingOrigins ?? [],
-      trackInteractions: !!initConfiguration.trackInteractions,
+      trackInteractions: !!initConfiguration.trackInteractions || trackFrustrations,
+      trackFrustrations,
       trackViewsManually: !!initConfiguration.trackViewsManually,
       defaultPrivacyLevel: objectHasValue(DefaultPrivacyLevel, initConfiguration.defaultPrivacyLevel)
         ? initConfiguration.defaultPrivacyLevel

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -1,5 +1,5 @@
 import type { Context, ClocksState, Observable, Duration } from '@datadog/browser-core'
-import { timeStampNow, resetExperimentalFeatures, updateExperimentalFeatures, relativeNow } from '@datadog/browser-core'
+import { timeStampNow, relativeNow } from '@datadog/browser-core'
 import type { Clock } from '../../../../../core/test/specHelper'
 import { createNewEvent } from '../../../../../core/test/specHelper'
 import type { TestSetupBuilder } from '../../../../test/specHelper'
@@ -138,7 +138,7 @@ describe('trackClickActions', () => {
     expect(events[0].name).toBe('test-1')
   })
 
-  describe('without frustration-signals flag', () => {
+  describe('without tracking frustrations', () => {
     it('discards any click action with a negative duration', () => {
       const { domMutationObservable, clock } = setupBuilder.build()
       emulateClickWithActivity(domMutationObservable, clock, button, -1)
@@ -206,12 +206,9 @@ describe('trackClickActions', () => {
     })
   })
 
-  describe('with frustration-signals flag', () => {
+  describe('when tracking frustrations', () => {
     beforeEach(() => {
-      updateExperimentalFeatures(['frustration-signals'])
-    })
-    afterEach(() => {
-      resetExperimentalFeatures()
+      setupBuilder.withConfiguration({ trackFrustrations: true })
     })
 
     it('discards any click action with a negative duration', () => {

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -93,7 +93,7 @@ describe('action collection', () => {
     })
 
   createTest('collect an "error click"')
-    .withRum({ trackInteractions: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
     .withBody(
       html`
         <button>click me</button>
@@ -124,7 +124,7 @@ describe('action collection', () => {
     })
 
   createTest('collect a "dead click"')
-    .withRum({ trackInteractions: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
     .withBody(html` <button>click me</button> `)
     .run(async ({ serverEvents }) => {
       const button = await $('button')
@@ -139,7 +139,7 @@ describe('action collection', () => {
     })
 
   createTest('collect a "rage click"')
-    .withRum({ trackInteractions: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
     .withBody(
       html`
         <button>click me</button>
@@ -164,7 +164,7 @@ describe('action collection', () => {
     })
 
   createTest('collect multiple frustrations in one action')
-    .withRum({ trackInteractions: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
     .withBody(
       html`
         <button>click me</button>


### PR DESCRIPTION
## Motivation

Allow to opt-in to frustrations tracking. This change is still behind the `frustration-signals` experimental feature flag.

## Changes

Introduce the `trackFrustrations` initialization parameter, and use it in `trackClickAction`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
