### PR TITLE
⚗️✨ [RUMF-1258] stop ongoing action on view end 

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.spec.ts
@@ -1,4 +1,4 @@
-import { noop, ONE_SECOND, timeStampNow } from '@datadog/browser-core'
+import { Observable, ONE_SECOND, timeStampNow } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test/specHelper'
 import { mockClock, createNewEvent } from '@datadog/browser-core/test/specHelper'
 import { FrustrationType } from '../../../rawRumEvent.types'
@@ -185,7 +185,7 @@ describe('isRage', () => {
 })
 
 function createFakeClick(eventPartial?: Partial<MouseEvent>): Click & { clonedClick?: Click } {
-  let onStopCallback = noop
+  const stopObservable = new Observable<void>()
   let isStopped = false
   let clonedClick: Click | undefined
   const frustrations = new Set<FrustrationType>()
@@ -197,13 +197,11 @@ function createFakeClick(eventPartial?: Partial<MouseEvent>): Click & { clonedCl
       timeStamp: timeStampNow(),
       ...eventPartial,
     }),
-    onStop: (newOnStopCallback) => {
-      onStopCallback = newOnStopCallback
-    },
+    stopObservable,
     isStopped: () => isStopped,
     stop: () => {
       isStopped = true
-      onStopCallback()
+      stopObservable.notify()
     },
     clone: () => {
       clonedClick = createFakeClick(eventPartial)

--- a/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.ts
@@ -24,7 +24,7 @@ export function createRageClickChain(firstClick: Click): RageClickChain {
   appendClick(firstClick)
 
   function appendClick(click: Click) {
-    click.onStop(tryFinalize)
+    click.stopObservable.subscribe(tryFinalize)
     bufferedClicks.push(click)
     clearTimeout(maxDurationBetweenClicksTimeout)
     maxDurationBetweenClicksTimeout = setTimeout(monitor(dontAcceptMoreClick), MAX_DURATION_BETWEEN_CLICKS)

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -149,7 +149,7 @@ export function trackClickActions(
       click.stop()
     })
 
-    click.onStop(() => {
+    click.stopObservable.subscribe(() => {
       viewEndedSubscription.unsubscribe()
       stopWaitingIdlePage()
       stopSubscription.unsubscribe()
@@ -197,7 +197,7 @@ function newClick(
   const eventCountsSubscription = trackEventCounts(lifeCycle)
   let state: ClickState = { status: ClickStatus.ONGOING }
   const frustrations = new Set<FrustrationType>()
-  const onStopCallbacks: Array<() => void> = []
+  const stopObservable = new Observable<void>()
 
   function stop(endTime?: TimeStamp) {
     if (state.status !== ClickStatus.ONGOING) {
@@ -210,7 +210,7 @@ function newClick(
       historyEntry.remove()
     }
     eventCountsSubscription.stop()
-    onStopCallbacks.forEach((callback) => callback())
+    stopObservable.notify()
   }
 
   function addFrustration(frustration: FrustrationType) {
@@ -223,12 +223,9 @@ function newClick(
     event: base.event,
     addFrustration,
     stop,
+    stopObservable,
 
     getFrustrations: () => frustrations,
-
-    onStop: (onStopCallback: () => void) => {
-      onStopCallbacks.push(onStopCallback)
-    },
 
     isStopped: () => state.status === ClickStatus.STOPPED || state.status === ClickStatus.FINALIZED,
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -242,8 +242,8 @@ function newView(
     scheduleUpdate: scheduleViewUpdate,
     end(clocks = clocksNow()) {
       endClocks = clocks
-      stopViewMetricsTracking()
       lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks })
+      stopViewMetricsTracking()
     },
     triggerUpdate() {
       // cancel any pending view updates execution


### PR DESCRIPTION
## Motivation

Having actions spaning on multiple views is a bit weird.

## Changes

* Stop any ongoing action and rage click chain on view end 
* Adjust the VIEW_ENDED event so we have a chance to increase the counter when the view ends
* Add a E2E test to make sure this works

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
