### PR TITLE
👷 use only the 'bundle' setup when running E2E tests locally

### DIFF
--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -19,13 +19,18 @@ const isBrowserStack =
   browser.config.services &&
   browser.config.services.some((service) => (Array.isArray(service) ? service[0] : service) === 'browserstack')
 
-export const DEFAULT_SETUPS = isBrowserStack
-  ? [{ name: 'bundle', factory: bundleSetup }]
-  : [
-      { name: 'async', factory: asyncSetup },
-      { name: 'npm', factory: npmSetup },
-      { name: 'bundle', factory: bundleSetup },
-    ]
+const isContinuousIntegration = Boolean(process.env.CI_JOB_ID)
+
+// By default, run tests only with the 'bundle' setup outside of the CI (to run faster on the
+// developer laptop) or with Browser Stack (to limit flakiness).
+export const DEFAULT_SETUPS =
+  !isContinuousIntegration || isBrowserStack
+    ? [{ name: 'bundle', factory: bundleSetup }]
+    : [
+        { name: 'async', factory: asyncSetup },
+        { name: 'npm', factory: npmSetup },
+        { name: 'bundle', factory: bundleSetup },
+      ]
 
 export function asyncSetup(options: SetupOptions, servers: Servers) {
   let body = options.body || ''


### PR DESCRIPTION
## Motivation

Run E2E tests faster when running outside of the CI. This is something I always did manually when running E2E tests locally.

## Changes

Use only the 'bundle' setup by default when running E2E tests outside of the CI

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
