### PR TITLE
🐛 [RUMF-1259] support Zone.js < 0.8.6

### DIFF
--- a/packages/rum-core/src/browser/domMutationObservable.ts
+++ b/packages/rum-core/src/browser/domMutationObservable.ts
@@ -1,4 +1,4 @@
-import { monitor, Observable } from '@datadog/browser-core'
+import { monitor, noop, Observable } from '@datadog/browser-core'
 
 export function createDOMMutationObservable() {
   const MutationObserver = getMutationObserverConstructor()
@@ -21,10 +21,10 @@ export function createDOMMutationObservable() {
 }
 
 type MutationObserverConstructor = new (callback: MutationCallback) => MutationObserver
-interface BrowserWindow extends Window {
+export interface BrowserWindow extends Window {
   MutationObserver?: MutationObserverConstructor
   Zone?: {
-    __symbol__(name: string): string
+    __symbol__: (name: string) => string
   }
 }
 
@@ -38,14 +38,36 @@ export function getMutationObserverConstructor(): MutationObserverConstructor | 
   // component: on some occasions, the callback is being called in an infinite loop, causing the
   // page to freeze (even if the callback is completely empty).
   //
-  // To work around this issue, we are using the Zone __symbol__ API to get the original, unpatched
-  // MutationObserver constructor.
+  // To work around this issue, we try to get the original MutationObserver constructor stored by
+  // Zone.js.
   //
   // [1] https://github.com/angular/angular/issues/26948
   // [2] https://github.com/angular/angular/issues/31712
   if (browserWindow.Zone) {
-    const symbol = browserWindow.Zone.__symbol__('MutationObserver')
-    constructor = browserWindow[symbol as any] as any
+    const zoneSymbol = browserWindow.Zone.__symbol__
+
+    // Zone.js 0.8.6+ is storing original class constructors into the browser 'window' object[3].
+    //
+    // [3] https://github.com/angular/angular/blob/6375fa79875c0fe7b815efc45940a6e6f5c9c9eb/packages/zone.js/lib/common/utils.ts#L288
+    constructor = browserWindow[zoneSymbol('MutationObserver') as any] as unknown as
+      | MutationObserverConstructor
+      | undefined
+
+    if (!constructor && browserWindow.MutationObserver) {
+      // Anterior Zone.js versions (used in Angular 2) does not expose the original MutationObserver
+      // in the 'window' object. Luckily, the patched MutationObserver class is storing an original
+      // instance in its properties[4]. Let's get the original MutationObserver constructor from
+      // there.
+      //
+      // [4] https://github.com/angular/zone.js/blob/v0.8.5/lib/common/utils.ts#L412
+
+      const patchedInstance = new browserWindow.MutationObserver(noop) as any
+      const originalInstance = patchedInstance[zoneSymbol('originalInstance')] as
+        | { constructor: MutationObserverConstructor }
+        | undefined
+
+      constructor = originalInstance && originalInstance.constructor
+    }
   }
 
   if (!constructor) {


### PR DESCRIPTION

## Motivation

The workaround we are using to support Zone.js is only possible since 0.8.6 (see in [commit](https://github.com/angular/zone.js/commit/0d0ee53974601738fb16235baa3e5cca8b95be4e)). 

## Changes

This commit introduces another workaround for older Zone.js versions.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
