### PR TITLE
✨ Rename Replay plan to Premium plan

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -579,7 +579,7 @@ describe('rum assembly', () => {
         type: 'user',
       })
       expect(serverRumEvents[0]._dd.session).toEqual({
-        plan: RumSessionPlan.REPLAY,
+        plan: RumSessionPlan.PREMIUM,
       })
     })
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -105,7 +105,7 @@ export function startRumAssembly(
             format_version: 2,
             drift: currentDrift(),
             session: {
-              plan: session.hasReplayPlan ? RumSessionPlan.REPLAY : RumSessionPlan.LITE,
+              plan: session.hasPremiumPlan ? RumSessionPlan.PREMIUM : RumSessionPlan.LITE,
             },
             browser_sdk_version: canUseEventBridge() ? __BUILD_ENV__SDK_VERSION__ : undefined,
           },

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -24,26 +24,41 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('replaySampleRate', () => {
+  describe('premiumSampleRate', () => {
     it('defaults to 100 if the option is not provided', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.replaySampleRate).toBe(100)
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.premiumSampleRate).toBe(100)
     })
 
     it('is set to provided value', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 50 })!.replaySampleRate
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 50 })!.premiumSampleRate
+      ).toBe(50)
+    })
+
+    it('is set to `replaySampleRate` if not defined', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 50 })!.premiumSampleRate
+      ).toBe(50)
+      expect(
+        validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          replaySampleRate: 25,
+          premiumSampleRate: 50,
+        })!.premiumSampleRate
       ).toBe(50)
     })
 
     it('does not validate the configuration if an incorrect value is provided', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 'foo' as any })
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 'foo' as any })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Replay Sample Rate should be a number between 0 and 100')
+      expect(displaySpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
 
       displaySpy.calls.reset()
-      expect(validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 200 })).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Replay Sample Rate should be a number between 0 and 100')
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 200 })
+      ).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
     })
   })
 

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -15,12 +15,16 @@ export interface RumInitConfiguration extends InitConfiguration {
   // global options
   applicationId: string
   beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => void | boolean) | undefined
+  premiumSampleRate?: number | undefined
 
   // tracing options
   allowedTracingOrigins?: ReadonlyArray<string | RegExp> | undefined
 
   // replay options
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
+  /**
+   * @deprecated use premiumSampleRate instead
+   */
   replaySampleRate?: number | undefined
 
   // action options
@@ -40,7 +44,7 @@ export interface RumConfiguration extends Configuration {
   allowedTracingOrigins: Array<string | RegExp>
   applicationId: string
   defaultPrivacyLevel: DefaultPrivacyLevel
-  replaySampleRate: number
+  premiumSampleRate: number
   trackInteractions: boolean
   trackFrustrations: boolean
   trackViewsManually: boolean
@@ -55,8 +59,13 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  if (initConfiguration.replaySampleRate !== undefined && !isPercentage(initConfiguration.replaySampleRate)) {
-    display.error('Replay Sample Rate should be a number between 0 and 100')
+  // TODO remove me in next major
+  if (initConfiguration.replaySampleRate !== undefined && initConfiguration.premiumSampleRate === undefined) {
+    initConfiguration.premiumSampleRate = initConfiguration.replaySampleRate
+  }
+
+  if (initConfiguration.premiumSampleRate !== undefined && !isPercentage(initConfiguration.premiumSampleRate)) {
+    display.error('Premium Sample Rate should be a number between 0 and 100')
     return
   }
 
@@ -83,7 +92,7 @@ export function validateAndBuildRumConfiguration(
       applicationId: initConfiguration.applicationId,
       version: initConfiguration.version,
       actionNameAttribute: initConfiguration.actionNameAttribute,
-      replaySampleRate: initConfiguration.replaySampleRate ?? 100,
+      premiumSampleRate: initConfiguration.premiumSampleRate ?? 100,
       allowedTracingOrigins: initConfiguration.allowedTracingOrigins ?? [],
       trackInteractions: !!initConfiguration.trackInteractions || trackFrustrations,
       trackFrustrations,

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -61,12 +61,9 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  // TODO remove me in next major
-  if (initConfiguration.replaySampleRate !== undefined && initConfiguration.premiumSampleRate === undefined) {
-    initConfiguration.premiumSampleRate = initConfiguration.replaySampleRate
-  }
-
-  if (initConfiguration.premiumSampleRate !== undefined && !isPercentage(initConfiguration.premiumSampleRate)) {
+  // TODO remove fallback in next major
+  const premiumSampleRate = initConfiguration.premiumSampleRate ?? initConfiguration.replaySampleRate
+  if (premiumSampleRate !== undefined && !isPercentage(premiumSampleRate)) {
     display.error('Premium Sample Rate should be a number between 0 and 100')
     return
   }
@@ -99,7 +96,7 @@ export function validateAndBuildRumConfiguration(
       applicationId: initConfiguration.applicationId,
       version: initConfiguration.version,
       actionNameAttribute: initConfiguration.actionNameAttribute,
-      premiumSampleRate: initConfiguration.premiumSampleRate ?? 100,
+      premiumSampleRate: premiumSampleRate ?? 100,
       allowedTracingOrigins: initConfiguration.allowedTracingOrigins ?? [],
       tracingSampleRate: initConfiguration.tracingSampleRate ?? 100,
       trackInteractions: !!initConfiguration.trackInteractions || trackFrustrations,

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -45,10 +45,10 @@ describe('long task collection', () => {
     expect(rawRumEvents.length).toBe(1)
   })
 
-  it('should only collect when session has a replay plan', () => {
+  it('should only collect when session has a premium plan', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
-    sessionManager.setReplayPlan()
+    sessionManager.setPremiumPlan()
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
     expect(rawRumEvents.length).toBe(1)
 

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -26,7 +26,7 @@ describe('rum session manager', () => {
 
   function setupDraws({ tracked, trackedWithReplay }: { tracked?: boolean; trackedWithReplay?: boolean }) {
     configuration.sampleRate = tracked ? 100 : 0
-    configuration.replaySampleRate = trackedWithReplay ? 100 : 0
+    configuration.premiumSampleRate = trackedWithReplay ? 100 : 0
   }
 
   beforeEach(() => {
@@ -36,7 +36,7 @@ describe('rum session manager', () => {
     configuration = {
       ...validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: 'xxx' })!,
       sampleRate: 50,
-      replaySampleRate: 50,
+      premiumSampleRate: 50,
     }
     clock = mockClock()
     expireSessionSpy = jasmine.createSpy('expireSessionSpy')
@@ -55,14 +55,14 @@ describe('rum session manager', () => {
   })
 
   describe('cookie storage', () => {
-    it('when tracked with replay plan should store session type and id', () => {
+    it('when tracked with premium plan should store session type and id', () => {
       setupDraws({ tracked: true, trackedWithReplay: true })
 
       startRumSessionManager(configuration, lifeCycle)
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_REPLAY}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
 
@@ -95,7 +95,7 @@ describe('rum session manager', () => {
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_REPLAY}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
       expect(getCookie(SESSION_COOKIE_NAME)).toContain('id=abcdef')
     })
 
@@ -124,7 +124,7 @@ describe('rum session manager', () => {
 
       expect(expireSessionSpy).toHaveBeenCalled()
       expect(renewSessionSpy).toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_REPLAY}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
   })
@@ -159,17 +159,17 @@ describe('rum session manager', () => {
       expect(rumSessionManager.findTrackedSession(0 as RelativeTime)!.id).toBe('abcdef')
     })
 
-    it('should return session with replay plan', () => {
+    it('should return session with premium plan', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=1', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.hasReplayPlan).toBeTrue()
+      expect(rumSessionManager.findTrackedSession()!.hasPremiumPlan).toBeTrue()
       expect(rumSessionManager.findTrackedSession()!.hasLitePlan).toBeFalse()
     })
 
     it('should return session with lite plan', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=2', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.hasReplayPlan).toBeFalse()
+      expect(rumSessionManager.findTrackedSession()!.hasPremiumPlan).toBeFalse()
       expect(rumSessionManager.findTrackedSession()!.hasLitePlan).toBeTrue()
     })
   })

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -24,9 +24,9 @@ describe('rum session manager', () => {
   let renewSessionSpy: jasmine.Spy
   let clock: Clock
 
-  function setupDraws({ tracked, trackedWithReplay }: { tracked?: boolean; trackedWithReplay?: boolean }) {
+  function setupDraws({ tracked, trackedWithPremium }: { tracked?: boolean; trackedWithPremium?: boolean }) {
     configuration.sampleRate = tracked ? 100 : 0
-    configuration.premiumSampleRate = trackedWithReplay ? 100 : 0
+    configuration.premiumSampleRate = trackedWithPremium ? 100 : 0
   }
 
   beforeEach(() => {
@@ -56,7 +56,7 @@ describe('rum session manager', () => {
 
   describe('cookie storage', () => {
     it('when tracked with premium plan should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithReplay: true })
+      setupDraws({ tracked: true, trackedWithPremium: true })
 
       startRumSessionManager(configuration, lifeCycle)
 
@@ -67,7 +67,7 @@ describe('rum session manager', () => {
     })
 
     it('when tracked with lite plan should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithReplay: false })
+      setupDraws({ tracked: true, trackedWithPremium: false })
 
       startRumSessionManager(configuration, lifeCycle)
 
@@ -119,7 +119,7 @@ describe('rum session manager', () => {
       expect(renewSessionSpy).not.toHaveBeenCalled()
       clock.tick(COOKIE_ACCESS_DELAY)
 
-      setupDraws({ tracked: true, trackedWithReplay: true })
+      setupDraws({ tracked: true, trackedWithPremium: true })
       document.dispatchEvent(new CustomEvent('click'))
 
       expect(expireSessionSpy).toHaveBeenCalled()

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -12,13 +12,13 @@ export interface RumSessionManager {
 
 export type RumSession = {
   id: string
-  hasReplayPlan: boolean
+  hasPremiumPlan: boolean
   hasLitePlan: boolean
 }
 
 export const enum RumSessionPlan {
   LITE = 1,
-  REPLAY = 2,
+  PREMIUM = 2,
 }
 
 export const enum RumTrackingType {
@@ -26,7 +26,7 @@ export const enum RumTrackingType {
   // Note: the "tracking type" value (stored in the session cookie) does not match the "session
   // plan" value (sent in RUM events). This is expected, and was done to keep retrocompatibility
   // with active sessions when upgrading the SDK.
-  TRACKED_REPLAY = '1',
+  TRACKED_PREMIUM = '1',
   TRACKED_LITE = '2',
 }
 
@@ -51,7 +51,7 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
       }
       return {
         id: session.id,
-        hasReplayPlan: session.trackingType === RumTrackingType.TRACKED_REPLAY,
+        hasPremiumPlan: session.trackingType === RumTrackingType.TRACKED_PREMIUM,
         hasLitePlan: session.trackingType === RumTrackingType.TRACKED_LITE,
       }
     },
@@ -60,12 +60,12 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
 
 /**
  * Start a tracked replay session stub
- * It needs to be a replay plan in order to get long tasks
+ * It needs to be a premium plan in order to get long tasks
  */
 export function startRumSessionManagerStub(): RumSessionManager {
   const session = {
     id: '00000000-aaaa-0000-aaaa-000000000000',
-    hasReplayPlan: true,
+    hasPremiumPlan: true,
     hasLitePlan: false,
   }
   return {
@@ -79,10 +79,10 @@ function computeSessionState(configuration: RumConfiguration, rawTrackingType?: 
     trackingType = rawTrackingType
   } else if (!performDraw(configuration.sampleRate)) {
     trackingType = RumTrackingType.NOT_TRACKED
-  } else if (!performDraw(configuration.replaySampleRate)) {
+  } else if (!performDraw(configuration.premiumSampleRate)) {
     trackingType = RumTrackingType.TRACKED_LITE
   } else {
-    trackingType = RumTrackingType.TRACKED_REPLAY
+    trackingType = RumTrackingType.TRACKED_PREMIUM
   }
   return {
     trackingType,
@@ -93,11 +93,11 @@ function computeSessionState(configuration: RumConfiguration, rawTrackingType?: 
 function hasValidRumSession(trackingType?: string): trackingType is RumTrackingType {
   return (
     trackingType === RumTrackingType.NOT_TRACKED ||
-    trackingType === RumTrackingType.TRACKED_REPLAY ||
+    trackingType === RumTrackingType.TRACKED_PREMIUM ||
     trackingType === RumTrackingType.TRACKED_LITE
   )
 }
 
 function isTypeTracked(rumSessionType: RumTrackingType | undefined) {
-  return rumSessionType === RumTrackingType.TRACKED_LITE || rumSessionType === RumTrackingType.TRACKED_REPLAY
+  return rumSessionType === RumTrackingType.TRACKED_LITE || rumSessionType === RumTrackingType.TRACKED_PREMIUM
 }

--- a/packages/rum-core/test/mockRumSessionManager.ts
+++ b/packages/rum-core/test/mockRumSessionManager.ts
@@ -4,7 +4,7 @@ import { RumTrackingType } from '../src/domain/rumSessionManager'
 export interface RumSessionManagerMock extends RumSessionManager {
   setId(id: string): RumSessionManagerMock
   setNotTracked(): RumSessionManagerMock
-  setReplayPlan(): RumSessionManagerMock
+  setPremiumPlan(): RumSessionManagerMock
   setLitePlan(): RumSessionManagerMock
 }
 
@@ -12,14 +12,14 @@ const DEFAULT_ID = 'session-id'
 
 export function createRumSessionManagerMock(): RumSessionManagerMock {
   let id = DEFAULT_ID
-  let trackingType = RumTrackingType.TRACKED_REPLAY
+  let trackingType = RumTrackingType.TRACKED_PREMIUM
   return {
     findTrackedSession() {
       return trackingType !== RumTrackingType.NOT_TRACKED
         ? {
             id,
             hasLitePlan: trackingType === RumTrackingType.TRACKED_LITE,
-            hasReplayPlan: trackingType === RumTrackingType.TRACKED_REPLAY,
+            hasPremiumPlan: trackingType === RumTrackingType.TRACKED_PREMIUM,
           }
         : undefined
     },
@@ -35,8 +35,8 @@ export function createRumSessionManagerMock(): RumSessionManagerMock {
       trackingType = RumTrackingType.TRACKED_LITE
       return this
     },
-    setReplayPlan() {
-      trackingType = RumTrackingType.TRACKED_REPLAY
+    setPremiumPlan() {
+      trackingType = RumTrackingType.TRACKED_PREMIUM
       return this
     },
   }

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -198,7 +198,7 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
       format_version: 2,
       drift: 0,
       session: {
-        plan: RumSessionPlan.REPLAY,
+        plan: RumSessionPlan.PREMIUM,
       },
     },
     application: {

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -44,7 +44,7 @@ datadogRum.init({
   //  env: 'production',
   //  version: '1.0.0',
   sampleRate: 100,
-  replaySampleRate: 100, // if not included - default 100
+  replaySampleRate: 100, // RUM Premium - default 100
   trackInteractions: true,
 })
 ```
@@ -72,7 +72,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       //  env: 'production',
       //  version: '1.0.0',
       sampleRate: 100,
-      replaySampleRate: 100, // if not included - default 100
+      replaySampleRate: 100, // RUM Premium - default 100
       trackInteractions: true,
     })
   })
@@ -100,7 +100,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       //  env: 'production',
       //  version: '1.0.0',
       sampleRate: 100,
-      replaySampleRate: 100, // if not included - default 100
+      replaySampleRate: 100, // RUM Premium - default 100
       trackInteractions: true,
     })
 </script>
@@ -256,20 +256,20 @@ init(configuration: {
 })
 ```
 
-### Browser and Session Replay sampling configuration
+### Browser RUM and RUM Premium sampling configuration
 
 **Note**: This feature requires SDK v3.6.0+.
 
 When new session is created, it can be either tracked as:
 
 - [**Browser RUM**][11]: **Only** _Sessions_, _Views_, _Actions_, and _Errors_ are collected. Calls to `startSessionReplayRecording()` are ignored.
-- [**Session Replay RUM**][11]: Everything from Browser RUM plus _Resources_, _Long Tasks_, and _Replay_ recordings are collected. A call to `startSessionReplayRecording()` is needed to collect _Replay_ recordings.
+- [**RUM Premium**][11]: Everything from Browser RUM plus _Resources_, _Long Tasks_, and _Replay_ recordings are collected. A call to `startSessionReplayRecording()` is needed to collect _Replay_ recordings.
 
 Two initialization parameters are available to control how the session is tracked:
 
 - `sampleRate` controls the percentage of overall sessions being tracked. It defaults to `100%`, so every sessions will be tracked by default.
 
-- `replaySampleRate` is applied **after** the overall sample rate, and controls the percentage of sessions tracked as Session Replay RUM. It defaults to `100%`, so every sessions will be tracked as Session Replay RUM by default.
+- `replaySampleRate` is applied **after** the overall sample rate, and controls the percentage of sessions tracked as RUM Premium. It defaults to `100%`, so every sessions will be tracked as RUM Premium by default.
 
 For example, to track 100% of your sessions as Browser RUM:
 
@@ -281,7 +281,7 @@ datadogRum.init({
 });
 ```
 
-For example, to track 100% of your sessions as Session Replay RUM:
+For example, to track 100% of your sessions as RUM Premium:
 
 ```
 datadogRum.init({
@@ -291,7 +291,7 @@ datadogRum.init({
 });
 ```
 
-For example, to track only 50% of your overall sessions, with half tracked as Browser RUM and the other half tracked as Session Replay RUM, set the `sampleRate` and the `replaySampleRate` to 50:
+For example, to track only 50% of your overall sessions, with half tracked as Browser RUM and the other half tracked as RUM Premium, set the `sampleRate` and the `replaySampleRate` to 50:
 
 ```
 datadogRum.init({

--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -44,7 +44,7 @@ datadogRum.init({
   //  env: 'production',
   //  version: '1.0.0',
   sampleRate: 100,
-  replaySampleRate: 100, // RUM Premium - default 100
+  premiumSampleRate: 100, // if not included - default 100
   trackInteractions: true,
 })
 ```
@@ -72,7 +72,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       //  env: 'production',
       //  version: '1.0.0',
       sampleRate: 100,
-      replaySampleRate: 100, // RUM Premium - default 100
+      premiumSampleRate: 100, // if not included - default 100
       trackInteractions: true,
     })
   })
@@ -100,7 +100,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       //  env: 'production',
       //  version: '1.0.0',
       sampleRate: 100,
-      replaySampleRate: 100, // RUM Premium - default 100
+      premiumSampleRate: 100, // if not included - default 100
       trackInteractions: true,
     })
 </script>
@@ -190,13 +190,19 @@ Specify your own attribute to be used to [name actions][9].
 : Optional<br/>
 **Type**: Number<br/>
 **Default**: `100`<br/>
-The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send RUM events. For more details about `sampleRate`, see the [sampling configuration](#browser-and-session-replay-sampling-configuration).
+The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send RUM events. For more details about `sampleRate`, see the [sampling configuration](#browser-rum-and-rum-premium-sampling-configuration).
 
 `replaySampleRate`
+: Optional - **Deprecated**<br/>
+**Type**: Number<br/>
+**Default**: `100`<br/>
+See `premiumSampleRate`.
+
+`premiumSampleRate`
 : Optional<br/>
 **Type**: Number<br/>
 **Default**: `100`<br/>
-The percentage of tracked sessions with [Session Replay pricing][11] features: `100` for all, `0` for none. For more details about `replaySampleRate`, see the [sampling configuration](#browser-and-session-replay-sampling-configuration).
+The percentage of tracked sessions with [Premium pricing][11] features: `100` for all, `0` for none. For more details about `premiumSampleRate`, see the [sampling configuration](#browser-rum-and-rum-premium-sampling-configuration).
 
 `silentMultipleInit`
 : Optional<br/>
@@ -269,7 +275,7 @@ Two initialization parameters are available to control how the session is tracke
 
 - `sampleRate` controls the percentage of overall sessions being tracked. It defaults to `100%`, so every sessions will be tracked by default.
 
-- `replaySampleRate` is applied **after** the overall sample rate, and controls the percentage of sessions tracked as RUM Premium. It defaults to `100%`, so every sessions will be tracked as RUM Premium by default.
+- `premiumSampleRate` is applied **after** the overall sample rate, and controls the percentage of sessions tracked as RUM Premium. It defaults to `100%`, so every sessions will be tracked as RUM Premium by default.
 
 For example, to track 100% of your sessions as Browser RUM:
 
@@ -277,7 +283,7 @@ For example, to track 100% of your sessions as Browser RUM:
 datadogRum.init({
     ....
     sampleRate: 100,
-    replaySampleRate: 0
+    premiumSampleRate: 0
 });
 ```
 
@@ -287,17 +293,17 @@ For example, to track 100% of your sessions as RUM Premium:
 datadogRum.init({
     ....
     sampleRate: 100,
-    replaySampleRate: 100
+    premiumSampleRate: 100
 });
 ```
 
-For example, to track only 50% of your overall sessions, with half tracked as Browser RUM and the other half tracked as RUM Premium, set the `sampleRate` and the `replaySampleRate` to 50:
+For example, to track only 50% of your overall sessions, with half tracked as Browser RUM and the other half tracked as RUM Premium, set the `sampleRate` and the `premiumSampleRate` to 50:
 
 ```
 datadogRum.init({
     ....
     sampleRate: 50,
-    replaySampleRate: 50
+    premiumSampleRate: 50
 });
 ```
 

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -193,14 +193,14 @@ describe('makeRecorderApi', () => {
       rumInit()
     })
 
-    describe('from LITE to REPLAY', () => {
+    describe('from LITE to PREMIUM', () => {
       beforeEach(() => {
         sessionManager.setLitePlan()
       })
 
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setReplayPlan()
+        sessionManager.setPremiumPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
@@ -211,7 +211,7 @@ describe('makeRecorderApi', () => {
       it('does not starts recording if stopSessionReplayRecording was called', () => {
         recorderApi.start()
         recorderApi.stop()
-        sessionManager.setReplayPlan()
+        sessionManager.setPremiumPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -247,9 +247,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from REPLAY to LITE', () => {
+    describe('from PREMIUM to LITE', () => {
       beforeEach(() => {
-        sessionManager.setReplayPlan()
+        sessionManager.setPremiumPlan()
       })
 
       it('stops recording if startSessionReplayRecording was called', () => {
@@ -275,9 +275,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from REPLAY to untracked', () => {
+    describe('from PREMIUM to untracked', () => {
       beforeEach(() => {
-        sessionManager.setReplayPlan()
+        sessionManager.setPremiumPlan()
       })
 
       it('stops recording if startSessionReplayRecording was called', () => {
@@ -291,9 +291,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from REPLAY to REPLAY', () => {
+    describe('from PREMIUM to PREMIUM', () => {
       beforeEach(() => {
-        sessionManager.setReplayPlan()
+        sessionManager.setPremiumPlan()
       })
 
       it('keeps recording if startSessionReplayRecording was called', () => {
@@ -324,7 +324,7 @@ describe('makeRecorderApi', () => {
 
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setReplayPlan()
+        sessionManager.setPremiumPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalled()
@@ -334,7 +334,7 @@ describe('makeRecorderApi', () => {
       it('does not starts recording if stopSessionReplayRecording was called', () => {
         recorderApi.start()
         recorderApi.stop()
-        sessionManager.setReplayPlan()
+        sessionManager.setPremiumPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -90,7 +90,7 @@ export function makeRecorderApi(
 
       startStrategy = () => {
         const session = sessionManager.findTrackedSession()
-        if (!session || !session.hasReplayPlan) {
+        if (!session || !session.hasPremiumPlan) {
           state = { status: RecorderStatus.IntentToStart }
           return
         }

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -142,7 +142,7 @@ describe('startRecording', () => {
 
     document.body.dispatchEvent(createNewEvent('click'))
 
-    sessionManager.setId('new-session-id').setReplayPlan()
+    sessionManager.setId('new-session-id').setPremiumPlan()
     flushSegment(lifeCycle)
     document.body.dispatchEvent(createNewEvent('click'))
 


### PR DESCRIPTION
## Motivation

New premium plan name to reduce confusion between replay feature and replay plan.

## Changes

- introduce `premiumSampleRate` option and deprecate `replaySampleRate`
- rename `replay` plan occurrences to `premium`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
