### PR TITLE
✨ [RUMF-1191] enable telemetry on us5 site

### DIFF
--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -251,7 +251,7 @@ describe('internal monitoring', () => {
 
     describe('rollout', () => {
       ;[
-        { site: INTAKE_SITE_US5, enabled: false },
+        { site: INTAKE_SITE_US5, enabled: true },
         { site: INTAKE_SITE_US3, enabled: false },
         { site: INTAKE_SITE_EU, enabled: false },
         { site: INTAKE_SITE_US, enabled: false },

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -6,7 +6,7 @@ import type { Configuration } from '../configuration'
 import { computeStackTrace } from '../tracekit'
 import { Observable } from '../../tools/observable'
 import { timeStampNow } from '../../tools/timeUtils'
-import { isExperimentalFeatureEnabled, INTAKE_SITE_STAGING } from '../configuration'
+import { isExperimentalFeatureEnabled, INTAKE_SITE_STAGING, INTAKE_SITE_US5 } from '../configuration'
 import type { TelemetryEvent } from './telemetryEvent.types'
 
 // replaced at build time
@@ -35,7 +35,7 @@ export interface MonitoringMessage extends Context {
 }
 
 const TELEMETRY_ALLOWED_SITES: string[] = [
-  // INTAKE_SITE_US5,
+  INTAKE_SITE_US5,
   // INTAKE_SITE_US3,
   // INTAKE_SITE_EU,
   // INTAKE_SITE_US,


### PR DESCRIPTION
## Motivation

Regional rollout of telemetry, step 1/4

## Changes

Enable u5

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
