### PR TITLE
🐛 Fix dependency issue

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -2,6 +2,7 @@ import { timeStampNow } from '../../tools/timeUtils'
 import { normalizeUrl } from '../../tools/urlPolyfill'
 import { generateUUID } from '../../tools/utils'
 import type { InitConfiguration } from './configuration'
+import { INTAKE_SITE_US } from './intakeSites'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
@@ -19,12 +20,6 @@ const INTAKE_TRACKS = {
 }
 
 type EndpointType = keyof typeof ENDPOINTS
-
-export const INTAKE_SITE_STAGING = 'datad0g.com'
-export const INTAKE_SITE_US = 'datadoghq.com'
-export const INTAKE_SITE_US3 = 'us3.datadoghq.com'
-export const INTAKE_SITE_US5 = 'us5.datadoghq.com'
-export const INTAKE_SITE_EU = 'datadoghq.eu'
 
 export type EndpointBuilder = ReturnType<typeof createEndpointBuilder>
 

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -5,17 +5,10 @@ export {
   DefaultPrivacyLevel,
   validateAndBuildConfiguration,
 } from './configuration'
-export {
-  createEndpointBuilder,
-  EndpointBuilder,
-  INTAKE_SITE_STAGING,
-  INTAKE_SITE_US5,
-  INTAKE_SITE_US,
-  INTAKE_SITE_US3,
-  INTAKE_SITE_EU,
-} from './endpointBuilder'
+export { createEndpointBuilder, EndpointBuilder } from './endpointBuilder'
 export {
   isExperimentalFeatureEnabled,
   updateExperimentalFeatures,
   resetExperimentalFeatures,
 } from './experimentalFeatures'
+export * from './intakeSites'

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -1,0 +1,5 @@
+export const INTAKE_SITE_STAGING = 'datad0g.com'
+export const INTAKE_SITE_US = 'datadoghq.com'
+export const INTAKE_SITE_US3 = 'us3.datadoghq.com'
+export const INTAKE_SITE_US5 = 'us5.datadoghq.com'
+export const INTAKE_SITE_EU = 'datadoghq.eu'

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -1,8 +1,9 @@
 import { assign, objectValues } from '../../tools/utils'
 import type { InitConfiguration } from './configuration'
 import type { EndpointBuilder } from './endpointBuilder'
-import { createEndpointBuilder, INTAKE_SITE_US } from './endpointBuilder'
+import { createEndpointBuilder } from './endpointBuilder'
 import { buildTags } from './tags'
+import { INTAKE_SITE_US } from './intakeSites'
 
 export interface TransportConfiguration {
   logsEndpointBuilder: EndpointBuilder

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -4,10 +4,10 @@ import type { Configuration } from '../configuration'
 import {
   updateExperimentalFeatures,
   resetExperimentalFeatures,
-  INTAKE_SITE_US,
-  INTAKE_SITE_US3,
   INTAKE_SITE_EU,
   INTAKE_SITE_US5,
+  INTAKE_SITE_US3,
+  INTAKE_SITE_US,
 } from '../configuration'
 import type { InternalMonitoring, MonitoringMessage } from './internalMonitoring'
 import {

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -6,7 +6,7 @@ import type { Configuration } from '../configuration'
 import { computeStackTrace } from '../tracekit'
 import { Observable } from '../../tools/observable'
 import { timeStampNow } from '../../tools/timeUtils'
-import { isExperimentalFeatureEnabled, INTAKE_SITE_STAGING, INTAKE_SITE_US5, INTAKE_SITE_US3 } from '../configuration'
+import { isExperimentalFeatureEnabled, INTAKE_SITE_US5, INTAKE_SITE_US3, INTAKE_SITE_STAGING } from '../configuration'
 import type { TelemetryEvent } from './telemetryEvent.types'
 
 // replaced at build time


### PR DESCRIPTION
## Motivation

fixes https://github.com/DataDog/browser-sdk/issues/1547

## Changes

Avoid circular dependency around `internalMonitoring` and `endpointBuilder`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
