### PR TITLE
⚡️ [RUMF-1038] Lower batch size limit

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -1,8 +1,13 @@
 import type { RumEvent } from '../../../../rum-core/src'
 import { display } from '../../tools/display'
+import { ONE_KILO_BYTE } from '../../tools/utils'
 import type { InitConfiguration } from './configuration'
 import { validateAndBuildConfiguration } from './configuration'
-import { isExperimentalFeatureEnabled, updateExperimentalFeatures } from './experimentalFeatures'
+import {
+  isExperimentalFeatureEnabled,
+  resetExperimentalFeatures,
+  updateExperimentalFeatures,
+} from './experimentalFeatures'
 
 describe('validateAndBuildConfiguration', () => {
   const clientToken = 'some_client_token'
@@ -121,6 +126,23 @@ describe('validateAndBuildConfiguration', () => {
       const displaySpy = spyOn(display, 'error')
       expect(configuration.beforeSend!(null, {})).toBeUndefined()
       expect(displaySpy).toHaveBeenCalledWith('beforeSend threw an error:', myError)
+    })
+  })
+
+  describe('batchBytesLimit ', () => {
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
+
+    it('should be set to 10KB when lower-batch-size is enabled', () => {
+      updateExperimentalFeatures(['lower-batch-size'])
+      const configuration = validateAndBuildConfiguration({ clientToken })!
+      expect(configuration.batchBytesLimit).toEqual(10 * ONE_KILO_BYTE)
+    })
+
+    it('should be set to 16KB when lower-batch-size is disabled', () => {
+      const configuration = validateAndBuildConfiguration({ clientToken })!
+      expect(configuration.batchBytesLimit).toEqual(16 * ONE_KILO_BYTE)
     })
   })
 })

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -105,7 +105,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
        * beacon payload max queue size implementation is 64kb
        * ensure that we leave room for logs, rum and potential other users
        */
-      batchBytesLimit: 16 * ONE_KILO_BYTE,
+      batchBytesLimit: 10 * ONE_KILO_BYTE,
 
       eventRateLimiterThreshold: 3000,
       maxInternalMonitoringMessagesPerPage: 15,

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -3,7 +3,7 @@ import { getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { display } from '../../tools/display'
 import { assign, isPercentage, ONE_KILO_BYTE, ONE_SECOND } from '../../tools/utils'
-import { updateExperimentalFeatures } from './experimentalFeatures'
+import { isExperimentalFeatureEnabled, updateExperimentalFeatures } from './experimentalFeatures'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
 
@@ -105,7 +105,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
        * beacon payload max queue size implementation is 64kb
        * ensure that we leave room for logs, rum and potential other users
        */
-      batchBytesLimit: 10 * ONE_KILO_BYTE,
+      batchBytesLimit: isExperimentalFeatureEnabled('lower-batch-size') ? 10 * ONE_KILO_BYTE : 16 * ONE_KILO_BYTE,
 
       eventRateLimiterThreshold: 3000,
       maxInternalMonitoringMessagesPerPage: 15,

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,13 +1,5 @@
-import { ONE_KILO_BYTE, TimeStamp } from '@datadog/browser-core'
-import {
-  resetExperimentalFeatures,
-  updateExperimentalFeatures,
-  HttpRequest,
-  DefaultPrivacyLevel,
-  noop,
-  isIE,
-  timeStampNow,
-} from '@datadog/browser-core'
+import type { TimeStamp } from '@datadog/browser-core'
+import { HttpRequest, DefaultPrivacyLevel, noop, isIE, timeStampNow } from '@datadog/browser-core'
 import type { LifeCycle, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import { inflate } from 'pako'
@@ -18,7 +10,7 @@ import { createNewEvent, mockClock } from '../../../core/test/specHelper'
 import type { TestSetupBuilder } from '../../../rum-core/test/specHelper'
 import { setup } from '../../../rum-core/test/specHelper'
 import { collectAsyncCalls, recordsPerFullSnapshot } from '../../test/utils'
-import { SEGMENT_BYTES_LIMIT, setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
+import { setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
 
 import type { Segment } from '../types'
 import { RecordType } from '../types'

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,5 +1,13 @@
-import type { TimeStamp } from '@datadog/browser-core'
-import { HttpRequest, DefaultPrivacyLevel, noop, isIE, timeStampNow } from '@datadog/browser-core'
+import { ONE_KILO_BYTE, TimeStamp } from '@datadog/browser-core'
+import {
+  resetExperimentalFeatures,
+  updateExperimentalFeatures,
+  HttpRequest,
+  DefaultPrivacyLevel,
+  noop,
+  isIE,
+  timeStampNow,
+} from '@datadog/browser-core'
 import type { LifeCycle, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import { inflate } from 'pako'
@@ -10,7 +18,7 @@ import { createNewEvent, mockClock } from '../../../core/test/specHelper'
 import type { TestSetupBuilder } from '../../../rum-core/test/specHelper'
 import { setup } from '../../../rum-core/test/specHelper'
 import { collectAsyncCalls, recordsPerFullSnapshot } from '../../test/utils'
-import { setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
+import { SEGMENT_BYTES_LIMIT, setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
 
 import type { Segment } from '../types'
 import { RecordType } from '../types'

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -1,4 +1,4 @@
-import { timeStampNow } from '@datadog/browser-core'
+import { isExperimentalFeatureEnabled, ONE_KILO_BYTE, timeStampNow } from '@datadog/browser-core'
 import type {
   LifeCycle,
   ViewContexts,
@@ -10,7 +10,7 @@ import { LifeCycleEventType } from '@datadog/browser-rum-core'
 
 import { record } from '../domain/record'
 import type { DeflateWorker } from '../domain/segmentCollection'
-import { startSegmentCollection } from '../domain/segmentCollection'
+import { setSegmentBytesLimit, startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'
 import { RecordType } from '../types'
 
@@ -21,6 +21,10 @@ export function startRecording(
   viewContexts: ViewContexts,
   worker: DeflateWorker
 ) {
+  if (isExperimentalFeatureEnabled('lower-batch-size')) {
+    setSegmentBytesLimit(22 * ONE_KILO_BYTE)
+  }
+
   const { addRecord, stop: stopSegmentCollection } = startSegmentCollection(
     lifeCycle,
     configuration.applicationId,

--- a/packages/rum/src/domain/segmentCollection/index.ts
+++ b/packages/rum/src/domain/segmentCollection/index.ts
@@ -1,3 +1,4 @@
 export { startSegmentCollection, setSegmentBytesLimit } from './segmentCollection'
 export { DeflateWorker, DeflateWorkerAction, DeflateWorkerListener } from './deflateWorker'
 export { startDeflateWorker } from './startDeflateWorker'
+export { SEGMENT_BYTES_LIMIT } from './segmentCollection'

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -13,17 +13,21 @@ import { createRumSessionManagerMock } from '../../../../rum-core/test/mockRumSe
 import type { Record, SegmentContext, SegmentMetadata } from '../../types'
 import { RecordType } from '../../types'
 import { MockWorker } from '../../../test/utils'
-import { SEND_BEACON_BYTES_LIMIT } from '../../transport/send'
-import { computeSegmentContext, doStartSegmentCollection, SEGMENT_DURATION_LIMIT } from './segmentCollection'
+import {
+  computeSegmentContext,
+  doStartSegmentCollection,
+  SEGMENT_BYTES_LIMIT,
+  SEGMENT_DURATION_LIMIT,
+} from './segmentCollection'
 
 const CONTEXT: SegmentContext = { application: { id: 'a' }, view: { id: 'b' }, session: { id: 'c' } }
 const RECORD: Record = { type: RecordType.ViewEnd, timestamp: 10 as TimeStamp }
 
-// A record that will make the segment size reach the SEND_BEACON_BYTES_LIMIT
+// A record that will make the segment size reach the SEGMENT_BYTES_LIMIT
 const VERY_BIG_RECORD: Record = {
   type: RecordType.FullSnapshot,
   timestamp: 10 as TimeStamp,
-  data: Array(SEND_BEACON_BYTES_LIMIT).join('a') as any,
+  data: Array(SEGMENT_BYTES_LIMIT).join('a') as any,
 }
 
 const BEFORE_SEGMENT_DURATION_LIMIT = SEGMENT_DURATION_LIMIT * 0.9
@@ -142,7 +146,7 @@ describe('startSegmentCollection', () => {
     })
 
     describe('segment_bytes_limit flush strategy', () => {
-      it('flushes segment when the current segment deflate size reaches SEND_BEACON_BYTES_LIMIT', () => {
+      it('flushes segment when the current segment deflate size reaches SEGMENT_BYTES_LIMIT', () => {
         const { worker, addRecord, sendCurrentSegment } = startSegmentCollection(CONTEXT)
         addRecord(VERY_BIG_RECORD)
         worker.processAllMessages()

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,14 +1,17 @@
 import type { EventEmitter, TimeoutId } from '@datadog/browser-core'
-import { ONE_SECOND, addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
+import { ONE_KILO_BYTE, ONE_SECOND, addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
 import type { LifeCycle, ViewContexts, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
-import { SEND_BEACON_BYTES_LIMIT } from '../../transport/send'
 import type { CreationReason, Record, SegmentContext, SegmentMetadata } from '../../types'
 import type { DeflateWorker } from './deflateWorker'
 import { Segment } from './segment'
 
 export const SEGMENT_DURATION_LIMIT = 30 * ONE_SECOND
-let SEGMENT_BYTES_LIMIT = SEND_BEACON_BYTES_LIMIT
+/**
+ * beacon payload max queue size implementation is 64kb
+ * ensure that we leave room for logs, rum and potential other users
+ */
+export let SEGMENT_BYTES_LIMIT = 22 * ONE_KILO_BYTE
 
 // Segments are the main data structure for session replays. They contain context information used
 // for indexing or UI needs, and a list of records (RRWeb 'events', renamed to avoid confusing
@@ -197,6 +200,6 @@ export function computeSegmentContext(
   }
 }
 
-export function setSegmentBytesLimit(newSegmentBytesLimit: number = SEND_BEACON_BYTES_LIMIT) {
+export function setSegmentBytesLimit(newSegmentBytesLimit: number = SEGMENT_BYTES_LIMIT) {
   SEGMENT_BYTES_LIMIT = newSegmentBytesLimit
 }

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter, TimeoutId } from '@datadog/browser-core'
-import { ONE_KILO_BYTE, ONE_SECOND, addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
+import { ONE_SECOND, addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
 import type { LifeCycle, ViewContexts, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { CreationReason, Record, SegmentContext, SegmentMetadata } from '../../types'
@@ -11,7 +11,7 @@ export const SEGMENT_DURATION_LIMIT = 30 * ONE_SECOND
  * beacon payload max queue size implementation is 64kb
  * ensure that we leave room for logs, rum and potential other users
  */
-export let SEGMENT_BYTES_LIMIT = 22 * ONE_KILO_BYTE
+export let SEGMENT_BYTES_LIMIT = 60_000
 
 // Segments are the main data structure for session replays. They contain context information used
 // for indexing or UI needs, and a list of records (RRWeb 'events', renamed to avoid confusing
@@ -200,6 +200,6 @@ export function computeSegmentContext(
   }
 }
 
-export function setSegmentBytesLimit(newSegmentBytesLimit: number = SEGMENT_BYTES_LIMIT) {
+export function setSegmentBytesLimit(newSegmentBytesLimit = 60_000) {
   SEGMENT_BYTES_LIMIT = newSegmentBytesLimit
 }

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -1,8 +1,7 @@
 import type { EndpointBuilder } from '@datadog/browser-core'
-import { ONE_KILO_BYTE, HttpRequest, objectEntries } from '@datadog/browser-core'
+import { HttpRequest, objectEntries } from '@datadog/browser-core'
+import { SEGMENT_BYTES_LIMIT } from '../domain/segmentCollection'
 import type { SegmentMetadata } from '../types'
-
-export const SEND_BEACON_BYTES_LIMIT = 22 * ONE_KILO_BYTE
 
 export function send(
   endpointBuilder: EndpointBuilder,
@@ -24,7 +23,7 @@ export function send(
   toFormEntries(metadata, (key, value) => formData.append(key, value))
   formData.append('raw_segment_size', rawSegmentBytesCount.toString())
 
-  const request = new HttpRequest(endpointBuilder, SEND_BEACON_BYTES_LIMIT)
+  const request = new HttpRequest(endpointBuilder, SEGMENT_BYTES_LIMIT)
   request.send(formData, data.byteLength, reason)
 }
 

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -1,8 +1,8 @@
 import type { EndpointBuilder } from '@datadog/browser-core'
-import { HttpRequest, objectEntries } from '@datadog/browser-core'
+import { ONE_KILO_BYTE, HttpRequest, objectEntries } from '@datadog/browser-core'
 import type { SegmentMetadata } from '../types'
 
-export const SEND_BEACON_BYTES_LIMIT = 60_000
+export const SEND_BEACON_BYTES_LIMIT = 22 * ONE_KILO_BYTE
 
 export function send(
   endpointBuilder: EndpointBuilder,


### PR DESCRIPTION
## Motivation

Given  RUM / Logs / Replay
When  they send requests at the same time with sendBeacon
Then  collisions may happen

This PR experiment lower batch size limits to be under the sendBeacon limit when RUM / logs / replay are enabled and leave some space for third party apps.

## Changes

- Batch limit from: `60KB (replay) + 16KB (RUM) + 16KB (Logs) ` to `22KB (replay) + 10KB (RUM) + 10KB (Logs)`
- Remove SEND_BEACON_BYTES_LIMIT and only use SEGMENT_BYTES_LIMIT

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
