### PR TITLE
✨ [RUMF-1191] enable telemetry on us1 site

### DIFF
--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.spec.ts
@@ -247,7 +247,7 @@ describe('internal monitoring', () => {
         { site: INTAKE_SITE_US5, enabled: true },
         { site: INTAKE_SITE_US3, enabled: true },
         { site: INTAKE_SITE_EU, enabled: true },
-        { site: INTAKE_SITE_US, enabled: false },
+        { site: INTAKE_SITE_US, enabled: true },
       ].forEach(({ site, enabled }) => {
         it(`should be ${enabled ? 'enabled' : 'disabled'} on ${site}`, () => {
           internalMonitoring = startInternalMonitoring({ ...configuration, site } as Configuration)

--- a/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
+++ b/packages/core/src/domain/internalMonitoring/internalMonitoring.ts
@@ -13,6 +13,7 @@ import {
   INTAKE_SITE_US3,
   INTAKE_SITE_STAGING,
   INTAKE_SITE_EU,
+  INTAKE_SITE_US,
 } from '../configuration'
 import type { TelemetryEvent } from './telemetryEvent.types'
 
@@ -48,12 +49,7 @@ export interface MonitoringMessage extends Context {
   }
 }
 
-const TELEMETRY_ALLOWED_SITES: string[] = [
-  INTAKE_SITE_US5,
-  INTAKE_SITE_US3,
-  INTAKE_SITE_EU,
-  // INTAKE_SITE_US,
-]
+const TELEMETRY_ALLOWED_SITES: string[] = [INTAKE_SITE_US5, INTAKE_SITE_US3, INTAKE_SITE_EU, INTAKE_SITE_US]
 
 const monitoringConfiguration: {
   debugMode?: boolean

--- a/test/e2e/scenario/eventBridge.scenario.ts
+++ b/test/e2e/scenario/eventBridge.scenario.ts
@@ -77,7 +77,7 @@ describe('bridge present', () => {
 
       await flushEvents()
       expect(serverEvents.internalMonitoring.length).toBe(0)
-      expect(bridgeEvents.internalMonitoring.length).toBe(1)
+      expect(bridgeEvents.internalMonitoring.length).toBe(2)
     })
 
   createTest('forward logs to the bridge')


### PR DESCRIPTION
## Motivation

Regional rollout of telemetry, step 4/4

## Changes

Enable us1

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
