### PR TITLE
♻️ [RUMF-1277] rename frustration types 

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.spec.ts
@@ -120,15 +120,15 @@ describe('createRageClickChain', () => {
       const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
       createValidatedRageClickChain(clicks)
       const expectedFrustrations = new Set()
-      expectedFrustrations.add(FrustrationType.RAGE)
+      expectedFrustrations.add(FrustrationType.RAGE_CLICK)
       expect(clicks[0].clonedClick?.getFrustrations()).toEqual(expectedFrustrations)
     })
 
     it('the rage click should contains other clicks frustration', () => {
       const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
-      clicks[1].addFrustration(FrustrationType.DEAD)
+      clicks[1].addFrustration(FrustrationType.DEAD_CLICK)
       createValidatedRageClickChain(clicks)
-      expect(clicks[0].clonedClick?.getFrustrations().has(FrustrationType.RAGE)).toBe(true)
+      expect(clicks[0].clonedClick?.getFrustrations().has(FrustrationType.RAGE_CLICK)).toBe(true)
     })
 
     function createValidatedRageClickChain(clicks: Click[]) {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/rageClickChain.ts
@@ -91,7 +91,7 @@ function finalizeClicks(clicks: Click[], rageClick: Click) {
         rageClick.addFrustration(frustration)
       })
     })
-    rageClick.addFrustration(FrustrationType.RAGE)
+    rageClick.addFrustration(FrustrationType.RAGE_CLICK)
     rageClick.validate(timeStampNow())
   } else {
     rageClick.discard()

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -254,7 +254,7 @@ describe('trackClickActions', () => {
 
       clock.tick(EXPIRE_DELAY)
       expect(events.length).toBe(1)
-      expect(events[0].frustrationTypes).toEqual([FrustrationType.DEAD])
+      expect(events[0].frustrationTypes).toEqual([FrustrationType.DEAD_CLICK])
       expect(findActionId()).toEqual([])
     })
 
@@ -288,7 +288,7 @@ describe('trackClickActions', () => {
         clock.tick(EXPIRE_DELAY)
         expect(events.length).toBe(1)
         expect(events[0].startClocks.timeStamp).toBe(firstClickTimeStamp)
-        expect(events[0].frustrationTypes).toEqual([FrustrationType.RAGE])
+        expect(events[0].frustrationTypes).toEqual([FrustrationType.RAGE_CLICK])
         expect(events[0].duration).toBe((MAX_DURATION_BETWEEN_CLICKS + 2 * actionDuration) as Duration)
       })
 
@@ -310,7 +310,11 @@ describe('trackClickActions', () => {
         clock.tick(EXPIRE_DELAY)
         expect(events.length).toBe(1)
         expect(events[0].frustrationTypes).toEqual(
-          jasmine.arrayWithExactContents([FrustrationType.DEAD, FrustrationType.ERROR, FrustrationType.RAGE])
+          jasmine.arrayWithExactContents([
+            FrustrationType.DEAD_CLICK,
+            FrustrationType.ERROR_CLICK,
+            FrustrationType.RAGE_CLICK,
+          ])
         )
       })
     })
@@ -325,7 +329,7 @@ describe('trackClickActions', () => {
 
         clock.tick(EXPIRE_DELAY)
         expect(events.length).toBe(1)
-        expect(events[0].frustrationTypes).toEqual([FrustrationType.ERROR])
+        expect(events[0].frustrationTypes).toEqual([FrustrationType.ERROR_CLICK])
       })
 
       // eslint-disable-next-line max-len
@@ -338,7 +342,7 @@ describe('trackClickActions', () => {
         clock.tick(EXPIRE_DELAY)
         expect(events.length).toBe(1)
         expect(events[0].frustrationTypes).toEqual(
-          jasmine.arrayWithExactContents([FrustrationType.ERROR, FrustrationType.DEAD])
+          jasmine.arrayWithExactContents([FrustrationType.ERROR_CLICK, FrustrationType.DEAD_CLICK])
         )
       })
     })
@@ -351,7 +355,7 @@ describe('trackClickActions', () => {
 
         clock.tick(EXPIRE_DELAY)
         expect(events.length).toBe(1)
-        expect(events[0].frustrationTypes).toEqual([FrustrationType.DEAD])
+        expect(events[0].frustrationTypes).toEqual([FrustrationType.DEAD_CLICK])
       })
     })
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -124,7 +124,7 @@ export function trackClickActions(
           // If it has no activity, consider it as a dead click.
           // TODO: this will yield a lot of false positive. We'll need to refine it in the future.
           if (trackFrustrations) {
-            click.addFrustration(FrustrationType.DEAD)
+            click.addFrustration(FrustrationType.DEAD_CLICK)
             click.stop()
           } else {
             click.discard()
@@ -240,7 +240,7 @@ function newClick(
       }
 
       if (eventCountsSubscription.eventCounts.errorCount > 0) {
-        addFrustration(FrustrationType.ERROR)
+        addFrustration(FrustrationType.ERROR_CLICK)
       }
 
       const { resourceCount, errorCount, longTaskCount } = eventCountsSubscription.eventCounts

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -249,7 +249,7 @@ describe('rum track view metrics', () => {
         action: {
           type: 'click',
           frustration: {
-            type: [FrustrationType.DEAD, FrustrationType.ERROR],
+            type: [FrustrationType.DEAD_CLICK, FrustrationType.ERROR_CLICK],
           },
         },
       } as RumEvent & Context)

--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -54,7 +54,7 @@ describe('trackEventCounts', () => {
       action: {
         type: 'click',
         frustration: {
-          type: [FrustrationType.ERROR, FrustrationType.DEAD],
+          type: [FrustrationType.ERROR_CLICK, FrustrationType.DEAD_CLICK],
         },
       },
     })

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -162,9 +162,9 @@ export const enum ActionType {
 }
 
 export const enum FrustrationType {
-  RAGE = 'rage',
-  ERROR = 'error',
-  DEAD = 'dead',
+  RAGE_CLICK = 'rage_click',
+  ERROR_CLICK = 'error_click',
+  DEAD_CLICK = 'dead_click',
 }
 
 export type RawRumEvent =

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -48,7 +48,7 @@ export type RumActionEvent = CommonProperties & {
       /**
        * Action frustration types
        */
-      readonly type: ('rage' | 'dead' | 'error')[]
+      readonly type: ('rage_click' | 'dead_click' | 'error_click')[]
       [k: string]: unknown
     }
     /**


### PR DESCRIPTION
## Motivation

See related PR: https://github.com/DataDog/rum-events-format/pull/60

## Changes

Rename frustration type values

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
