### PR TITLE
🏷️  [RUMF-1256] adjust StyleSheetRule records to support index paths

### DIFF
--- a/packages/rum/src/domain/record/types.ts
+++ b/packages/rum/src/domain/record/types.ts
@@ -203,11 +203,11 @@ export type ScrollCallback = (p: ScrollPosition) => void
 
 export interface StyleSheetAddRule {
   rule: string
-  index?: number
+  index?: number | number[]
 }
 
 export interface StyleSheetDeleteRule {
-  index: number
+  index: number | number[]
 }
 
 export interface StyleSheetRuleParam {


### PR DESCRIPTION
## Motivation

This is in preparation to support nested CSS rules in Session Replay.

## Changes

Adjust StyleSheetRule records `index` properties to allow an "index path" 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
