### PR TITLE
📝 clarify supported versions for premium plan sampling

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -279,7 +279,7 @@ init(configuration: {
 
 ### Browser RUM and RUM Premium sampling configuration
 
-This feature requires the RUM Browser SDK v3.6.0+.
+This feature requires the RUM Browser SDK v3.0.0+. The `premiumSampleRate` initialization parameter has been introduced in the RUM Browser SDK v4.10.2, deprecating the former `replaySampleRate` initialization parameter.
 
 When a new session is created, it can be tracked as either:
 


### PR DESCRIPTION
## Motivation

The minimum version for premium plan sampling is 3.0.0, not 3.6.0
The initialization parameter changed in 4.10.2

This PR tries to clarify that.

## Changes

Fix the version number and add a note about the former initialization parameter.


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
