### PR TITLE
🔊 Update failSendBeacon FF

### DIFF
--- a/packages/core/src/transport/failedSendBeacon.spec.ts
+++ b/packages/core/src/transport/failedSendBeacon.spec.ts
@@ -28,9 +28,9 @@ describe('failedSendBeacon', () => {
     clock.cleanup()
   })
 
-  describe('when ff lower-batch-size enabled', () => {
+  describe('when ff failed-sendbeacon enabled', () => {
     beforeEach(() => {
-      updateExperimentalFeatures(['lower-batch-size'])
+      updateExperimentalFeatures(['failed-sendbeacon'])
     })
 
     it('should flush failed sendBeacon asynchronously', () => {
@@ -58,7 +58,7 @@ describe('failedSendBeacon', () => {
     })
   })
 
-  describe('when ff lower-batch-size disabled', () => {
+  describe('when ff failed-sendbeacon disabled', () => {
     it('should not flush failed sendBeacon asynchronously', () => {
       startFlushFailedSendBeacons()
       clock.tick(0)

--- a/packages/core/src/transport/failedSendBeacon.ts
+++ b/packages/core/src/transport/failedSendBeacon.ts
@@ -9,14 +9,14 @@ declare const __BUILD_ENV__SDK_VERSION__: string
 export const LOCAL_STORAGE_KEY = 'datadog-browser-sdk-failed-send-beacon'
 
 export function startFlushFailedSendBeacons() {
-  if (!isExperimentalFeatureEnabled('lower-batch-size')) return
+  if (!isExperimentalFeatureEnabled('failed-sendbeacon')) return
 
   // delay the computation to prevent the SDK from blocking the main thread on init
   setTimeout(monitor(flushFailedSendBeacon))
 }
 
 export function addFailedSendBeacon(endpointType: string, size: number, reason?: string) {
-  if (!isExperimentalFeatureEnabled('lower-batch-size')) return
+  if (!isExperimentalFeatureEnabled('failed-sendbeacon')) return
 
   const failSendBeaconLog = {
     reason,


### PR DESCRIPTION
## Motivation

Use a specific failed sendbeacon feature flag to monitor them even when lower-batch-size is disabled

## Changes

User `failed-sendbeacon` FF in `failedSendBeacon.ts`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
