### PR TITLE
👷 add volta config

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,9 @@
   },
   "resolutions": {
     "ansi-regex": "5.0.1"
+  },
+  "volta": {
+    "node": "16.3.0",
+    "yarn": "1.22.18"
   }
 }


### PR DESCRIPTION
## Motivation

Datadog frontend teams are migrating from nodenv to volta. Let's follow the trend

## Changes

* Add volta config to `package.json`
* Keep `.node-version` for now, to let the @DataDog/rum-browser team migrate when they have time

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
