### PR TITLE
🏷️ adjust types to allow updating the SDK in Datadog app

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -155,7 +155,7 @@ export function makeRumPublicApi(
   }
 
   const startView: {
-    (name: string): void
+    (name?: string): void
     // (options: ViewOptions): void // uncomment when removing the feature flag
   } = monitor((options?: string) => {
     const sanitizedOptions = typeof options === 'object' ? options : { name: options }

--- a/packages/rum/src/entries/internal.ts
+++ b/packages/rum/src/entries/internal.ts
@@ -5,6 +5,7 @@
  * WARNING: this module is not intended for public usages, and won't follow semver for breaking
  * changes.
  */
+export type { TimeStamp } from '@datadog/browser-core'
 export { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_HIDDEN, PRIVACY_CLASS_HIDDEN, NodePrivacyLevel } from '../constants'
 
 export * from '../types'


### PR DESCRIPTION
## Motivation

* the Datadog app is using `startView(undefined)`, but the types don't allow that anymore
* the Datadog app is mocking Records, which now have `TimeStamp` values

## Changes

* Adjust `startView` typing
* Export `TimeStamp` from `/internal`
*
## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
