### PR TITLE
✨ Feature flag sampling

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -136,8 +136,8 @@ describe('validateAndBuildConfiguration', () => {
     })
 
     it('should be set to 10KB when lower-batch-size is enabled', () => {
-      updateExperimentalFeatures(['lower-batch-size'])
       setSampledExperimentalFeatures({ 'lower-batch-size': 100 })
+      updateExperimentalFeatures(['lower-batch-size'])
 
       const configuration = validateAndBuildConfiguration({ clientToken })!
       expect(configuration.batchBytesLimit).toEqual(10 * ONE_KILO_BYTE)

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -6,7 +6,6 @@ import { validateAndBuildConfiguration } from './configuration'
 import {
   isExperimentalFeatureEnabled,
   resetExperimentalFeatures,
-  setSampledExperimentalFeatures,
   updateExperimentalFeatures,
 } from './experimentalFeatures'
 
@@ -136,7 +135,6 @@ describe('validateAndBuildConfiguration', () => {
     })
 
     it('should be set to 10KB when lower-batch-size is enabled', () => {
-      setSampledExperimentalFeatures({ 'lower-batch-size': 100 })
       updateExperimentalFeatures(['lower-batch-size'])
 
       const configuration = validateAndBuildConfiguration({ clientToken })!

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -6,7 +6,7 @@ import { validateAndBuildConfiguration } from './configuration'
 import {
   isExperimentalFeatureEnabled,
   resetExperimentalFeatures,
-  sampleExperimentalFeature,
+  setSampledExperimentalFeatures,
   updateExperimentalFeatures,
 } from './experimentalFeatures'
 
@@ -137,7 +137,7 @@ describe('validateAndBuildConfiguration', () => {
 
     it('should be set to 10KB when lower-batch-size is enabled', () => {
       updateExperimentalFeatures(['lower-batch-size'])
-      sampleExperimentalFeature('lower-batch-size', 100)
+      setSampledExperimentalFeatures({ 'lower-batch-size': 100 })
 
       const configuration = validateAndBuildConfiguration({ clientToken })!
       expect(configuration.batchBytesLimit).toEqual(10 * ONE_KILO_BYTE)

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -6,6 +6,7 @@ import { validateAndBuildConfiguration } from './configuration'
 import {
   isExperimentalFeatureEnabled,
   resetExperimentalFeatures,
+  sampleExperimentalFeature,
   updateExperimentalFeatures,
 } from './experimentalFeatures'
 
@@ -136,6 +137,8 @@ describe('validateAndBuildConfiguration', () => {
 
     it('should be set to 10KB when lower-batch-size is enabled', () => {
       updateExperimentalFeatures(['lower-batch-size'])
+      sampleExperimentalFeature('lower-batch-size', 100)
+
       const configuration = validateAndBuildConfiguration({ clientToken })!
       expect(configuration.batchBytesLimit).toEqual(10 * ONE_KILO_BYTE)
     })

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -3,11 +3,7 @@ import { getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { display } from '../../tools/display'
 import { assign, isPercentage, ONE_KILO_BYTE, ONE_SECOND } from '../../tools/utils'
-import {
-  isExperimentalFeatureEnabled,
-  sampleExperimentalFeature,
-  updateExperimentalFeatures,
-} from './experimentalFeatures'
+import { isExperimentalFeatureEnabled, updateExperimentalFeatures } from './experimentalFeatures'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
 
@@ -93,8 +89,6 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
 
   // Set the experimental feature flags as early as possible, so we can use them in most places
   updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
-
-  sampleExperimentalFeature('lower-batch-size', 50)
 
   return assign(
     {

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -3,7 +3,11 @@ import { getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { display } from '../../tools/display'
 import { assign, isPercentage, ONE_KILO_BYTE, ONE_SECOND } from '../../tools/utils'
-import { isExperimentalFeatureEnabled, updateExperimentalFeatures } from './experimentalFeatures'
+import {
+  isExperimentalFeatureEnabled,
+  sampleExperimentalFeature,
+  updateExperimentalFeatures,
+} from './experimentalFeatures'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
 
@@ -89,6 +93,8 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
 
   // Set the experimental feature flags as early as possible, so we can use them in most places
   updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
+
+  sampleExperimentalFeature('lower-batch-size', 50)
 
   return assign(
     {

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -37,7 +37,7 @@ export interface InitConfiguration {
   trackSessionAcrossSubdomains?: boolean | undefined
 
   // internal options
-  enableExperimentalFeatures?: string[] | undefined
+  enableExperimentalFeatures?: Array<string | { [name: string]: number }> | undefined
   replica?: ReplicaUserConfiguration | undefined
   datacenter?: string
 }

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -2,7 +2,6 @@ import {
   updateExperimentalFeatures,
   isExperimentalFeatureEnabled,
   resetExperimentalFeatures,
-  setSampledExperimentalFeatures,
 } from './experimentalFeatures'
 
 describe('experimentalFeatures', () => {
@@ -37,12 +36,9 @@ describe('experimentalFeatures', () => {
 
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
   })
-})
 
-describe('setSampledExperimentalFeatures', () => {
   it('should sample experimental features', () => {
-    setSampledExperimentalFeatures({ foo: 100, bar: 0 })
-    updateExperimentalFeatures(['foo', 'bar', 'baz'])
+    updateExperimentalFeatures([{ foo: 100 }, { bar: 0 }, 'baz'])
 
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
     expect(isExperimentalFeatureEnabled('bar')).toBeFalse()

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -38,10 +38,11 @@ describe('experimentalFeatures', () => {
   })
 
   it('should sample experimental features', () => {
-    updateExperimentalFeatures([{ foo: 100 }, { bar: 0 }, 'baz'])
+    updateExperimentalFeatures([{ foo: 100, bar: 100 }, 'baz', { qux: 0 }])
 
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
-    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
+    expect(isExperimentalFeatureEnabled('bar')).toBeTrue()
     expect(isExperimentalFeatureEnabled('baz')).toBeTrue()
+    expect(isExperimentalFeatureEnabled('qux')).toBeFalse()
   })
 })

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -2,7 +2,7 @@ import {
   updateExperimentalFeatures,
   isExperimentalFeatureEnabled,
   resetExperimentalFeatures,
-  sampleExperimentalFeature,
+  setSampledExperimentalFeatures,
 } from './experimentalFeatures'
 
 describe('experimentalFeatures', () => {
@@ -39,17 +39,13 @@ describe('experimentalFeatures', () => {
   })
 })
 
-describe('sampleExperimentalFeature', () => {
-  it('should sample experimental feature', () => {
-    updateExperimentalFeatures(['foo'])
-    updateExperimentalFeatures(['bar'])
-    updateExperimentalFeatures(['baz'])
+describe('setSampledExperimentalFeatures', () => {
+  it('should sample experimental features', () => {
+    setSampledExperimentalFeatures({ foo: 100, bar: 0 })
+    updateExperimentalFeatures(['foo', 'bar', 'baz'])
 
-    sampleExperimentalFeature('foo', 0)
-    sampleExperimentalFeature('bar', 100)
-
-    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
-    expect(isExperimentalFeatureEnabled('bar')).toBeTrue()
+    expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
+    expect(isExperimentalFeatureEnabled('bar')).toBeFalse()
     expect(isExperimentalFeatureEnabled('baz')).toBeTrue()
   })
 })

--- a/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.spec.ts
@@ -2,6 +2,7 @@ import {
   updateExperimentalFeatures,
   isExperimentalFeatureEnabled,
   resetExperimentalFeatures,
+  sampleExperimentalFeature,
 } from './experimentalFeatures'
 
 describe('experimentalFeatures', () => {
@@ -35,5 +36,20 @@ describe('experimentalFeatures', () => {
     updateExperimentalFeatures([11 as any])
 
     expect(isExperimentalFeatureEnabled('foo')).toBeTrue()
+  })
+})
+
+describe('sampleExperimentalFeature', () => {
+  it('should sample experimental feature', () => {
+    updateExperimentalFeatures(['foo'])
+    updateExperimentalFeatures(['bar'])
+    updateExperimentalFeatures(['baz'])
+
+    sampleExperimentalFeature('foo', 0)
+    sampleExperimentalFeature('bar', 100)
+
+    expect(isExperimentalFeatureEnabled('foo')).toBeFalse()
+    expect(isExperimentalFeatureEnabled('bar')).toBeTrue()
+    expect(isExperimentalFeatureEnabled('baz')).toBeTrue()
   })
 })

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -5,7 +5,10 @@
  * So keep in mind that in certain configurations, your experimental feature flag may affect other products.
  */
 
+import { performDraw } from '../../tools/utils'
+
 let enabledExperimentalFeatures: Set<string>
+let sampledExperimentalFeatures: Map<string, boolean>
 
 export function updateExperimentalFeatures(enabledFeatures: string[] | undefined): void {
   // Safely handle external data
@@ -25,9 +28,29 @@ export function updateExperimentalFeatures(enabledFeatures: string[] | undefined
 }
 
 export function isExperimentalFeatureEnabled(featureName: string): boolean {
-  return !!enabledExperimentalFeatures && enabledExperimentalFeatures.has(featureName)
+  return (
+    !!enabledExperimentalFeatures &&
+    enabledExperimentalFeatures.has(featureName) &&
+    isExperimentalFeatureSampled(featureName)
+  )
 }
 
 export function resetExperimentalFeatures(): void {
   enabledExperimentalFeatures = new Set()
+  sampledExperimentalFeatures = new Map()
+}
+
+export function sampleExperimentalFeature(featureName: string, sampleRate: number): void {
+  if (!sampledExperimentalFeatures) {
+    sampledExperimentalFeatures = new Map()
+  }
+  sampledExperimentalFeatures.set(featureName, performDraw(sampleRate))
+}
+
+function isExperimentalFeatureSampled(featureName: string): boolean {
+  return (
+    !sampledExperimentalFeatures ||
+    !sampledExperimentalFeatures.has(featureName) ||
+    sampledExperimentalFeatures.get(featureName)!
+  )
 }

--- a/packages/core/src/domain/configuration/experimentalFeatures.ts
+++ b/packages/core/src/domain/configuration/experimentalFeatures.ts
@@ -22,11 +22,14 @@ export function updateExperimentalFeatures(
   }
 
   for (const feature of enabledFeatures) {
-    const featureName = typeof feature === 'object' ? Object.keys(feature)[0] : feature
-    const sampleRate = typeof feature === 'object' ? feature[featureName] : undefined
-
-    if (sampleRate === undefined || performDraw(sampleRate)) {
-      enabledExperimentalFeatures.add(featureName)
+    if (typeof feature === 'string') {
+      enabledExperimentalFeatures.add(feature)
+    } else {
+      for (const featureName in feature) {
+        if (Object.prototype.hasOwnProperty.call(feature, featureName) && performDraw(feature[featureName])) {
+          enabledExperimentalFeatures.add(featureName)
+        }
+      }
     }
   }
 }

--- a/packages/core/src/transport/failedSendBeacon.ts
+++ b/packages/core/src/transport/failedSendBeacon.ts
@@ -25,6 +25,7 @@ export function addFailedSendBeacon(endpointType: string, size: number, reason?:
     connection: navigator.connection ? (navigator.connection as any).effectiveType : undefined,
     onLine: navigator.onLine,
     size,
+    hasLowerBatchSize: isExperimentalFeatureEnabled('lower-batch-size'),
   }
 
   if (reason === 'before_unload' || reason === 'visibility_hidden') {


### PR DESCRIPTION
## Motivation

While experimenting the lower batch size, I was wondering "**how to test the impact of a change in a short period of time**"
The answer is that  I created a `sampleExperimentalFeature` which enable a feature flag only for X% of users. This way I can gather data with and without the feature enabled as the same time.

## Changes

- Create `sampleExperimentalFeature`
- Sample 'lower-batch-size' ff by 50%

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
