### PR TITLE
[RUMF-1209] frustration signals: track selection change

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -37,6 +37,7 @@ export const enum DOM_EVENT {
   PLAY = 'play',
   PAUSE = 'pause',
   SECURITY_POLICY_VIOLATION = 'securitypolicyviolation',
+  SELECTION_CHANGE = 'selectionchange',
 }
 
 export const enum ResourceType {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.spec.ts
@@ -157,6 +157,7 @@ function createFakeClick(eventPartial?: Partial<MouseEvent & { target: Element }
     },
     hasError: false,
     hasActivity: true,
+    hasSelectionChanged: false,
     addFrustration: jasmine.createSpy(),
   }
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.spec.ts
@@ -2,17 +2,12 @@ import { Observable, ONE_SECOND, timeStampNow } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test/specHelper'
 import { mockClock, createNewEvent } from '@datadog/browser-core/test/specHelper'
 import { FrustrationType } from '../../../rawRumEvent.types'
-import type { RageClickChain } from './rageClickChain'
-import {
-  MAX_DISTANCE_BETWEEN_CLICKS,
-  MAX_DURATION_BETWEEN_CLICKS,
-  createRageClickChain,
-  isRage,
-} from './rageClickChain'
+import type { ClickChain } from './clickChain'
+import { MAX_DISTANCE_BETWEEN_CLICKS, MAX_DURATION_BETWEEN_CLICKS, createClickChain, isRage } from './clickChain'
 import type { Click } from './trackClickActions'
 
-describe('createRageClickChain', () => {
-  let clickChain: RageClickChain | undefined
+describe('createClickChain', () => {
+  let clickChain: ClickChain | undefined
   let clock: Clock
 
   beforeEach(() => {
@@ -25,7 +20,7 @@ describe('createRageClickChain', () => {
   })
 
   it('creates a click chain', () => {
-    clickChain = createRageClickChain(createFakeClick())
+    clickChain = createClickChain(createFakeClick())
     expect(clickChain).toEqual({
       tryAppend: jasmine.any(Function),
       stop: jasmine.any(Function),
@@ -33,14 +28,14 @@ describe('createRageClickChain', () => {
   })
 
   it('appends a click', () => {
-    clickChain = createRageClickChain(createFakeClick())
+    clickChain = createClickChain(createFakeClick())
     expect(clickChain.tryAppend(createFakeClick())).toBe(true)
   })
 
   describe('finalize', () => {
     it('finalizes if we try to append a non-similar click', () => {
       const firstClick = createFakeClick({ target: document.documentElement })
-      clickChain = createRageClickChain(firstClick)
+      clickChain = createClickChain(firstClick)
       firstClick.stop()
       clickChain.tryAppend(createFakeClick({ target: document.body }))
       expect(firstClick.validate).toHaveBeenCalled()
@@ -48,7 +43,7 @@ describe('createRageClickChain', () => {
 
     it('does not finalize until it waited long enough to ensure no other click can be appended', () => {
       const firstClick = createFakeClick()
-      clickChain = createRageClickChain(firstClick)
+      clickChain = createClickChain(firstClick)
       firstClick.stop()
       clock.tick(MAX_DURATION_BETWEEN_CLICKS - 1)
       expect(firstClick.validate).not.toHaveBeenCalled()
@@ -58,7 +53,7 @@ describe('createRageClickChain', () => {
 
     it('does not finalize until all clicks are stopped', () => {
       const firstClick = createFakeClick()
-      clickChain = createRageClickChain(firstClick)
+      clickChain = createClickChain(firstClick)
       clock.tick(MAX_DURATION_BETWEEN_CLICKS)
       expect(firstClick.validate).not.toHaveBeenCalled()
       firstClick.stop()
@@ -67,7 +62,7 @@ describe('createRageClickChain', () => {
 
     it('finalizes when stopping the click chain', () => {
       const firstClick = createFakeClick({ target: document.documentElement })
-      clickChain = createRageClickChain(firstClick)
+      clickChain = createClickChain(firstClick)
       firstClick.stop()
       clickChain.stop()
       expect(firstClick.validate).toHaveBeenCalled()
@@ -76,25 +71,25 @@ describe('createRageClickChain', () => {
 
   describe('clicks similarity', () => {
     it('does not accept a click if its timestamp is long after the previous one', () => {
-      clickChain = createRageClickChain(createFakeClick())
+      clickChain = createClickChain(createFakeClick())
       clock.tick(MAX_DURATION_BETWEEN_CLICKS)
       expect(clickChain.tryAppend(createFakeClick())).toBe(false)
     })
 
     it('does not accept a click if its target is different', () => {
-      clickChain = createRageClickChain(createFakeClick({ target: document.documentElement }))
+      clickChain = createClickChain(createFakeClick({ target: document.documentElement }))
       expect(clickChain.tryAppend(createFakeClick({ target: document.body }))).toBe(false)
     })
 
     it('does not accept a click if its location is far from the previous one', () => {
-      clickChain = createRageClickChain(createFakeClick({ clientX: 100, clientY: 100 }))
+      clickChain = createClickChain(createFakeClick({ clientX: 100, clientY: 100 }))
       expect(
         clickChain.tryAppend(createFakeClick({ clientX: 100, clientY: 100 + MAX_DISTANCE_BETWEEN_CLICKS + 1 }))
       ).toBe(false)
     })
 
     it('considers clicks relative to the previous one', () => {
-      clickChain = createRageClickChain(createFakeClick())
+      clickChain = createClickChain(createFakeClick())
       clock.tick(MAX_DURATION_BETWEEN_CLICKS - 1)
       clickChain.tryAppend(createFakeClick())
       clock.tick(MAX_DURATION_BETWEEN_CLICKS - 1)
@@ -105,20 +100,20 @@ describe('createRageClickChain', () => {
   describe('when rage is detected', () => {
     it('discards individual clicks', () => {
       const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
-      createValidatedRageClickChain(clicks)
+      createValidatedClickChain(clicks)
       clicks.forEach((click) => expect(click.discard).toHaveBeenCalled())
     })
 
     it('uses a clone of the first click to represent the rage click', () => {
       const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
-      createValidatedRageClickChain(clicks)
+      createValidatedClickChain(clicks)
       expect(clicks[0].clonedClick).toBeTruthy()
       expect(clicks[0].clonedClick?.validate).toHaveBeenCalled()
     })
 
     it('the rage click should have a "rage" frustration', () => {
       const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
-      createValidatedRageClickChain(clicks)
+      createValidatedClickChain(clicks)
       const expectedFrustrations = new Set()
       expectedFrustrations.add(FrustrationType.RAGE_CLICK)
       expect(clicks[0].clonedClick?.getFrustrations()).toEqual(expectedFrustrations)
@@ -127,12 +122,12 @@ describe('createRageClickChain', () => {
     it('the rage click should contains other clicks frustration', () => {
       const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
       clicks[1].addFrustration(FrustrationType.DEAD_CLICK)
-      createValidatedRageClickChain(clicks)
+      createValidatedClickChain(clicks)
       expect(clicks[0].clonedClick?.getFrustrations().has(FrustrationType.RAGE_CLICK)).toBe(true)
     })
 
-    function createValidatedRageClickChain(clicks: Click[]) {
-      clickChain = createRageClickChain(clicks[0])
+    function createValidatedClickChain(clicks: Click[]) {
+      clickChain = createClickChain(clicks[0])
       clicks.slice(1).forEach((click) => clickChain!.tryAppend(click))
       clicks.forEach((click) => click.stop())
       clock.tick(MAX_DURATION_BETWEEN_CLICKS)

--- a/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.ts
@@ -2,7 +2,7 @@ import { monitor, ONE_SECOND, timeStampNow } from '@datadog/browser-core'
 import { FrustrationType } from '../../../rawRumEvent.types'
 import type { Click } from './trackClickActions'
 
-export interface RageClickChain {
+export interface ClickChain {
   tryAppend: (click: Click) => boolean
   stop: () => void
 }
@@ -10,15 +10,15 @@ export interface RageClickChain {
 export const MAX_DURATION_BETWEEN_CLICKS = ONE_SECOND
 export const MAX_DISTANCE_BETWEEN_CLICKS = 100
 
-const enum RageClickChainStatus {
+const enum ClickChainStatus {
   WaitingForMoreClicks,
   WaitingForClicksToStop,
   Finalized,
 }
 
-export function createRageClickChain(firstClick: Click): RageClickChain {
+export function createClickChain(firstClick: Click): ClickChain {
   const bufferedClicks: Click[] = []
-  let status = RageClickChainStatus.WaitingForMoreClicks
+  let status = ClickChainStatus.WaitingForMoreClicks
   let maxDurationBetweenClicksTimeout: number | undefined
   const rageClick = firstClick.clone()
   appendClick(firstClick)
@@ -31,23 +31,23 @@ export function createRageClickChain(firstClick: Click): RageClickChain {
   }
 
   function tryFinalize() {
-    if (status === RageClickChainStatus.WaitingForClicksToStop && bufferedClicks.every((click) => click.isStopped())) {
-      status = RageClickChainStatus.Finalized
+    if (status === ClickChainStatus.WaitingForClicksToStop && bufferedClicks.every((click) => click.isStopped())) {
+      status = ClickChainStatus.Finalized
       finalizeClicks(bufferedClicks, rageClick)
     }
   }
 
   function dontAcceptMoreClick() {
     clearTimeout(maxDurationBetweenClicksTimeout)
-    if (status === RageClickChainStatus.WaitingForMoreClicks) {
-      status = RageClickChainStatus.WaitingForClicksToStop
+    if (status === ClickChainStatus.WaitingForMoreClicks) {
+      status = ClickChainStatus.WaitingForClicksToStop
       tryFinalize()
     }
   }
 
   return {
     tryAppend: (click) => {
-      if (status !== RageClickChainStatus.WaitingForMoreClicks) {
+      if (status !== ClickChainStatus.WaitingForMoreClicks) {
         return false
       }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -54,6 +54,13 @@ describe('computeFrustration', () => {
       expect(clicks[1].frustrationTypes).toEqual([FrustrationType.DEAD_CLICK])
     })
 
+    it('does not add a dead frustration to clicks if one of them is associated with a selection change', () => {
+      clicks[1].hasActivity = false
+      clicks[0].hasSelectionChanged = true
+      computeFrustration(clicks, rageClick)
+      expect(clicks[1].frustrationTypes).toEqual([])
+    })
+
     it('adds an error frustration to clicks that have an error', () => {
       clicks[1].hasError = true
       computeFrustration(clicks, rageClick)
@@ -75,6 +82,10 @@ describe('isRage', () => {
 
   it('considers as rage three clicks happening at the same time', () => {
     expect(isRage([createFakeClick(), createFakeClick(), createFakeClick()])).toBe(true)
+  })
+
+  it('considers as rage three clicks if one of them has selection change', () => {
+    expect(isRage([createFakeClick(), createFakeClick({ hasSelectionChanged: true }), createFakeClick()])).toBe(false)
   })
 
   it('does not consider as rage two clicks happening at the same time', () => {
@@ -116,6 +127,7 @@ function createFakeClick(partialClick: Partial<Click> = {}) {
     }),
     hasError: false,
     hasActivity: true,
+    hasSelectionChanged: false,
     addFrustration: (frustrationType: FrustrationType) => frustrationTypes.push(frustrationType),
     ...partialClick,
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -54,7 +54,7 @@ describe('computeFrustration', () => {
       expect(clicks[1].frustrationTypes).toEqual([FrustrationType.DEAD_CLICK])
     })
 
-    it('does not add a dead frustration to clicks if one of them is associated with a selection change', () => {
+    it('does not add a dead frustration when double clicking to select a word', () => {
       clicks[1].hasActivity = false
       clicks[0].hasSelectionChanged = true
       computeFrustration(clicks, rageClick)
@@ -84,7 +84,7 @@ describe('isRage', () => {
     expect(isRage([createFakeClick(), createFakeClick(), createFakeClick()])).toBe(true)
   })
 
-  it('considers as rage three clicks if one of them has selection change', () => {
+  it('does not consider as rage when triple clicking to select a paragraph', () => {
     expect(isRage([createFakeClick(), createFakeClick({ hasSelectionChanged: true }), createFakeClick()])).toBe(false)
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -1,0 +1,127 @@
+import { ONE_SECOND, timeStampNow } from '@datadog/browser-core'
+import { FrustrationType } from '../../../rawRumEvent.types'
+import type { Clock } from '../../../../../core/test/specHelper'
+import { createNewEvent, mockClock } from '../../../../../core/test/specHelper'
+import { computeFrustration, isRage } from './computeFrustration'
+import type { Click } from './trackClickActions'
+
+describe('computeFrustration', () => {
+  let clicks: Array<ReturnType<typeof createFakeClick>>
+  let clicksConsideredAsRage: Array<ReturnType<typeof createFakeClick>>
+  let rageClick: ReturnType<typeof createFakeClick>
+
+  beforeEach(() => {
+    clicks = [createFakeClick(), createFakeClick()]
+    clicksConsideredAsRage = [createFakeClick(), createFakeClick(), createFakeClick()]
+    rageClick = createFakeClick()
+  })
+
+  it('returns whether the clicks are considered as rage', () => {
+    expect(computeFrustration(clicksConsideredAsRage, rageClick).isRage).toBeTrue()
+    expect(computeFrustration(clicks, rageClick).isRage).toBeFalse()
+  })
+
+  describe('if clicks are considered as rage', () => {
+    it('adds a rage frustration to the rage click', () => {
+      computeFrustration(clicksConsideredAsRage, rageClick)
+      expect(rageClick.frustrationTypes).toEqual([FrustrationType.RAGE_CLICK])
+    })
+
+    it('adds a dead frustration to the rage click if any click does not have activity', () => {
+      clicksConsideredAsRage[1].hasActivity = false
+      computeFrustration(clicksConsideredAsRage, rageClick)
+      expect(rageClick.frustrationTypes).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.DEAD_CLICK])
+    })
+
+    it('adds an error frustration to the rage click if any click does not have activity', () => {
+      rageClick.hasError = true
+      computeFrustration(clicksConsideredAsRage, rageClick)
+      expect(rageClick.frustrationTypes).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.ERROR_CLICK])
+    })
+  })
+
+  describe('if clicks are not considered as rage', () => {
+    it('does not add any frustration by default', () => {
+      computeFrustration(clicks, rageClick)
+      for (const click of clicks) {
+        expect(click.frustrationTypes).toEqual([])
+      }
+    })
+
+    it('adds a dead frustration to clicks that do not have activity', () => {
+      clicks[1].hasActivity = false
+      computeFrustration(clicks, rageClick)
+      expect(clicks[1].frustrationTypes).toEqual([FrustrationType.DEAD_CLICK])
+    })
+
+    it('adds an error frustration to clicks that have an error', () => {
+      clicks[1].hasError = true
+      computeFrustration(clicks, rageClick)
+      expect(clicks[1].frustrationTypes).toEqual([FrustrationType.ERROR_CLICK])
+    })
+  })
+})
+
+describe('isRage', () => {
+  let clock: Clock
+
+  beforeEach(() => {
+    clock = mockClock()
+  })
+
+  afterEach(() => {
+    clock.cleanup()
+  })
+
+  it('considers as rage three clicks happening at the same time', () => {
+    expect(isRage([createFakeClick(), createFakeClick(), createFakeClick()])).toBe(true)
+  })
+
+  it('does not consider as rage two clicks happening at the same time', () => {
+    expect(isRage([createFakeClick(), createFakeClick()])).toBe(false)
+  })
+
+  it('does not consider as rage a first click long before two fast clicks', () => {
+    const clicks = [createFakeClick()]
+    clock.tick(ONE_SECOND * 2)
+    clicks.push(createFakeClick(), createFakeClick())
+
+    expect(isRage(clicks)).toBe(false)
+  })
+
+  it('considers as rage a first click long before three fast clicks', () => {
+    const clicks = [createFakeClick()]
+    clock.tick(ONE_SECOND * 2)
+    clicks.push(createFakeClick(), createFakeClick(), createFakeClick())
+
+    expect(isRage(clicks)).toBe(true)
+  })
+
+  it('considers as rage three fast clicks long before a last click', () => {
+    const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
+    clock.tick(ONE_SECOND * 2)
+    clicks.push(createFakeClick())
+
+    expect(isRage(clicks)).toBe(true)
+  })
+})
+
+function createFakeClick(partialClick: Partial<Click> = {}) {
+  const frustrationTypes: FrustrationType[] = []
+
+  const click: Partial<Click> = {
+    event: createNewEvent('click', {
+      target: document.body,
+      timeStamp: timeStampNow(),
+    }),
+    hasError: false,
+    hasActivity: true,
+    addFrustration: (frustrationType: FrustrationType) => frustrationTypes.push(frustrationType),
+    ...partialClick,
+  }
+
+  return {
+    ...(click as Click),
+    frustrationTypes,
+  }
+}

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -1,14 +1,15 @@
-import { ONE_SECOND, timeStampNow } from '@datadog/browser-core'
+import { ONE_SECOND } from '@datadog/browser-core'
 import { FrustrationType } from '../../../rawRumEvent.types'
 import type { Clock } from '../../../../../core/test/specHelper'
-import { createNewEvent, mockClock } from '../../../../../core/test/specHelper'
+import { mockClock } from '../../../../../core/test/specHelper'
+import type { FakeClick } from '../../../../test/createFakeClick'
+import { createFakeClick } from '../../../../test/createFakeClick'
 import { computeFrustration, isRage } from './computeFrustration'
-import type { Click } from './trackClickActions'
 
 describe('computeFrustration', () => {
-  let clicks: Array<ReturnType<typeof createFakeClick>>
-  let clicksConsideredAsRage: Array<ReturnType<typeof createFakeClick>>
-  let rageClick: ReturnType<typeof createFakeClick>
+  let clicks: FakeClick[]
+  let clicksConsideredAsRage: FakeClick[]
+  let rageClick: FakeClick
 
   beforeEach(() => {
     clicks = [createFakeClick(), createFakeClick()]
@@ -24,19 +25,23 @@ describe('computeFrustration', () => {
   describe('if clicks are considered as rage', () => {
     it('adds a rage frustration to the rage click', () => {
       computeFrustration(clicksConsideredAsRage, rageClick)
-      expect(rageClick.frustrationTypes).toEqual([FrustrationType.RAGE_CLICK])
+      expect(rageClick.addFrustration).toHaveBeenCalledOnceWith(FrustrationType.RAGE_CLICK)
     })
 
     it('adds a dead frustration to the rage click if any click does not have activity', () => {
       clicksConsideredAsRage[1].hasActivity = false
       computeFrustration(clicksConsideredAsRage, rageClick)
-      expect(rageClick.frustrationTypes).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.DEAD_CLICK])
+      expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
+      expect(rageClick.addFrustration.calls.argsFor(0)).toEqual([FrustrationType.RAGE_CLICK])
+      expect(rageClick.addFrustration.calls.argsFor(1)).toEqual([FrustrationType.DEAD_CLICK])
     })
 
     it('adds an error frustration to the rage click if any click does not have activity', () => {
       rageClick.hasError = true
       computeFrustration(clicksConsideredAsRage, rageClick)
-      expect(rageClick.frustrationTypes).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.ERROR_CLICK])
+      expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
+      expect(rageClick.addFrustration.calls.argsFor(0)).toEqual([FrustrationType.RAGE_CLICK])
+      expect(rageClick.addFrustration.calls.argsFor(1)).toEqual([FrustrationType.ERROR_CLICK])
     })
   })
 
@@ -44,27 +49,27 @@ describe('computeFrustration', () => {
     it('does not add any frustration by default', () => {
       computeFrustration(clicks, rageClick)
       for (const click of clicks) {
-        expect(click.frustrationTypes).toEqual([])
+        expect(click.addFrustration).not.toHaveBeenCalled()
       }
     })
 
     it('adds a dead frustration to clicks that do not have activity', () => {
       clicks[1].hasActivity = false
       computeFrustration(clicks, rageClick)
-      expect(clicks[1].frustrationTypes).toEqual([FrustrationType.DEAD_CLICK])
+      expect(clicks[1].addFrustration).toHaveBeenCalledOnceWith(FrustrationType.DEAD_CLICK)
     })
 
     it('does not add a dead frustration when double clicking to select a word', () => {
       clicks[1].hasActivity = false
       clicks[0].hasSelectionChanged = true
       computeFrustration(clicks, rageClick)
-      expect(clicks[1].frustrationTypes).toEqual([])
+      expect(clicks[1].addFrustration).not.toHaveBeenCalled()
     })
 
     it('adds an error frustration to clicks that have an error', () => {
       clicks[1].hasError = true
       computeFrustration(clicks, rageClick)
-      expect(clicks[1].frustrationTypes).toEqual([FrustrationType.ERROR_CLICK])
+      expect(clicks[1].addFrustration).toHaveBeenCalledOnceWith(FrustrationType.ERROR_CLICK)
     })
   })
 })
@@ -116,24 +121,3 @@ describe('isRage', () => {
     expect(isRage(clicks)).toBe(true)
   })
 })
-
-function createFakeClick(partialClick: Partial<Click> = {}) {
-  const frustrationTypes: FrustrationType[] = []
-
-  const click: Partial<Click> = {
-    event: createNewEvent('click', {
-      target: document.body,
-      timeStamp: timeStampNow(),
-    }),
-    hasError: false,
-    hasActivity: true,
-    hasSelectionChanged: false,
-    addFrustration: (frustrationType: FrustrationType) => frustrationTypes.push(frustrationType),
-    ...partialClick,
-  }
-
-  return {
-    ...(click as Click),
-    frustrationTypes,
-  }
-}

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -1,0 +1,41 @@
+import { ONE_SECOND } from '@datadog/browser-core'
+import { FrustrationType } from '../../../rawRumEvent.types'
+import type { Click } from './trackClickActions'
+
+const MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE = 3
+
+export function computeFrustration(clicks: Click[], rageClick: Click) {
+  if (isRage(clicks)) {
+    rageClick.addFrustration(FrustrationType.RAGE_CLICK)
+    if (clicks.some((click) => !click.hasActivity)) {
+      rageClick.addFrustration(FrustrationType.DEAD_CLICK)
+    }
+    if (rageClick.hasError) {
+      rageClick.addFrustration(FrustrationType.ERROR_CLICK)
+    }
+    return { isRage: true }
+  }
+
+  clicks.forEach((click) => {
+    if (click.hasError) {
+      click.addFrustration(FrustrationType.ERROR_CLICK)
+    }
+    if (!click.hasActivity) {
+      click.addFrustration(FrustrationType.DEAD_CLICK)
+    }
+  })
+  return { isRage: false }
+}
+
+export function isRage(clicks: Click[]) {
+  // TODO: this condition should be improved to avoid reporting 3-click selection as rage click
+  for (let i = 0; i < clicks.length - (MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE - 1); i += 1) {
+    if (
+      clicks[i + MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE - 1].event.timeStamp - clicks[i].event.timeStamp <=
+      ONE_SECOND
+    ) {
+      return true
+    }
+  }
+  return false
+}

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -16,11 +16,16 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
     return { isRage: true }
   }
 
+  const hasSelectionChanged = clicks.some((click) => click.hasSelectionChanged)
   clicks.forEach((click) => {
     if (click.hasError) {
       click.addFrustration(FrustrationType.ERROR_CLICK)
     }
-    if (!click.hasActivity) {
+    if (
+      !click.hasActivity &&
+      // Avoid considering clicks part of a double-click or triple-click selections as dead
+      !hasSelectionChanged
+    ) {
       click.addFrustration(FrustrationType.DEAD_CLICK)
     }
   })
@@ -28,7 +33,9 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
 }
 
 export function isRage(clicks: Click[]) {
-  // TODO: this condition should be improved to avoid reporting 3-click selection as rage click
+  if (clicks.some((click) => click.hasSelectionChanged)) {
+    return false
+  }
   for (let i = 0; i < clicks.length - (MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE - 1); i += 1) {
     if (
       clicks[i + MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE - 1].event.timeStamp - clicks[i].event.timeStamp <=

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -23,7 +23,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
     }
     if (
       !click.hasActivity &&
-      // Avoid considering clicks part of a double-click or triple-click selections as dead
+      // Avoid considering clicks part of a double-click or triple-click selections as dead clicks
       !hasSelectionChanged
     ) {
       click.addFrustration(FrustrationType.DEAD_CLICK)

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -35,7 +35,7 @@ describe('listenActionEvents', () => {
 
     it('click without selection impact should not report a selection change', () => {
       emulateClick()
-      expect(onClickSpy.calls.mostRecent().args[1]).toBe(false)
+      expect(hasSelectionChanged()).toBe(false)
     })
 
     it('click and drag to select text should reports a selection change', () => {
@@ -44,7 +44,7 @@ describe('listenActionEvents', () => {
           emulateNodeSelection(0, 3)
         },
       })
-      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+      expect(hasSelectionChanged()).toBe(true)
     })
 
     it('click and drag that adds a selection range should reports a selection change', () => {
@@ -55,7 +55,7 @@ describe('listenActionEvents', () => {
           emulateNodeSelection(3, 6, { clearSelection: false })
         },
       })
-      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+      expect(hasSelectionChanged()).toBe(true)
     })
 
     it('click to deselect previously selected text should report a selection change', () => {
@@ -65,7 +65,7 @@ describe('listenActionEvents', () => {
           emulateNodeSelection(0, 0)
         },
       })
-      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+      expect(hasSelectionChanged()).toBe(true)
     })
 
     // eslint-disable-next-line max-len
@@ -76,7 +76,7 @@ describe('listenActionEvents', () => {
           emulateNodeSelection(0, 7)
         },
       })
-      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+      expect(hasSelectionChanged()).toBe(true)
     })
 
     it('click that change the caret (collapsed selection) position should not report selection change', () => {
@@ -86,8 +86,12 @@ describe('listenActionEvents', () => {
           emulateNodeSelection(1, 1)
         },
       })
-      expect(onClickSpy.calls.mostRecent().args[1]).toBe(false)
+      expect(hasSelectionChanged()).toBe(false)
     })
+
+    function hasSelectionChanged() {
+      return onClickSpy.calls.mostRecent().args[1]
+    }
 
     function emulateNodeSelection(
       start: number,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -47,6 +47,17 @@ describe('listenActionEvents', () => {
       expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
     })
 
+    it('click and drag that adds a selection range should reports a selection change', () => {
+      // Example: Command-Click selection on Firefox
+      emulateNodeSelection(0, 3)
+      emulateClick({
+        beforeMouseUp() {
+          emulateNodeSelection(3, 6, { clearSelection: false })
+        },
+      })
+      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+    })
+
     it('click to deselect previously selected text should report a selection change', () => {
       emulateNodeSelection(0, 3)
       emulateClick({
@@ -78,12 +89,18 @@ describe('listenActionEvents', () => {
       expect(onClickSpy.calls.mostRecent().args[1]).toBe(false)
     })
 
-    function emulateNodeSelection(start: number, end: number) {
+    function emulateNodeSelection(
+      start: number,
+      end: number,
+      { clearSelection = true }: { clearSelection?: boolean } = {}
+    ) {
       const selection = document.getSelection()!
       const range = document.createRange()
       range.setStart(text, start)
       range.setEnd(text, end)
-      selection.removeAllRanges()
+      if (clearSelection) {
+        selection.removeAllRanges()
+      }
       selection.addRange(range)
       window.dispatchEvent(createNewEvent('selectionchange', { target: document }))
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -1,14 +1,14 @@
 import { createNewEvent } from '../../../../../core/test/specHelper'
-import type { OnClickCallback } from './listenEvents'
-import { listenEvents } from './listenEvents'
+import type { OnClickCallback } from './listenActionEvents'
+import { listenActionEvents } from './listenActionEvents'
 
-describe('listenEvents', () => {
+describe('listenActionEvents', () => {
   let onClickSpy: jasmine.Spy<OnClickCallback>
   let stopListenEvents: () => void
 
   beforeEach(() => {
     onClickSpy = jasmine.createSpy()
-    ;({ stop: stopListenEvents } = listenEvents({ onClick: onClickSpy }))
+    ;({ stop: stopListenEvents } = listenActionEvents({ onClick: onClickSpy }))
   })
 
   afterEach(() => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -2,7 +2,7 @@ import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 
 export type OnClickCallback = (clickEvent: MouseEvent & { target: Element }, hasSelectionChanged: boolean) => void
 
-export function listenEvents({ onClick }: { onClick: OnClickCallback }) {
+export function listenActionEvents({ onClick }: { onClick: OnClickCallback }) {
   let hasSelectionChanged = false
   let selectionEmptyAtMouseDown: boolean
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.spec.ts
@@ -33,12 +33,12 @@ describe('listenEvents', () => {
       document.getSelection()!.removeAllRanges()
     })
 
-    it('does not report selection change if nothing changes', () => {
+    it('click without selection impact should not report a selection change', () => {
       emulateClick()
       expect(onClickSpy.calls.mostRecent().args[1]).toBe(false)
     })
 
-    it('reports selection change if some node gets selected', () => {
+    it('click and drag to select text should reports a selection change', () => {
       emulateClick({
         beforeMouseUp() {
           emulateNodeSelection(0, 3)
@@ -47,7 +47,7 @@ describe('listenEvents', () => {
       expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
     })
 
-    it('reports selection change if some node gets deselected', () => {
+    it('click to deselect previously selected text should report a selection change', () => {
       emulateNodeSelection(0, 3)
       emulateClick({
         beforeMouseUp() {
@@ -57,7 +57,18 @@ describe('listenEvents', () => {
       expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
     })
 
-    it('does not report selection change if the selection changes but stays empty', () => {
+    // eslint-disable-next-line max-len
+    it('click to change the selection position (ex: last click of a triple-click selection) should report a selection change', () => {
+      emulateNodeSelection(3, 4)
+      emulateClick({
+        beforeMouseUp() {
+          emulateNodeSelection(0, 7)
+        },
+      })
+      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+    })
+
+    it('click that change the caret (collapsed selection) position should not report selection change', () => {
       emulateNodeSelection(0, 0)
       emulateClick({
         beforeMouseUp() {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.spec.ts
@@ -17,11 +17,70 @@ describe('listenEvents', () => {
 
   it('listen to click events', () => {
     emulateClick()
-    expect(onClickSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ type: 'click' }))
+    expect(onClickSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ type: 'click' }), false)
   })
 
-  function emulateClick() {
+  describe('selection change', () => {
+    let text: Text
+
+    beforeEach(() => {
+      text = document.createTextNode('foo bar')
+      document.body.appendChild(text)
+    })
+
+    afterEach(() => {
+      document.body.removeChild(text)
+      document.getSelection()!.removeAllRanges()
+    })
+
+    it('does not report selection change if nothing changes', () => {
+      emulateClick()
+      expect(onClickSpy.calls.mostRecent().args[1]).toBe(false)
+    })
+
+    it('reports selection change if some node gets selected', () => {
+      emulateClick({
+        beforeMouseUp() {
+          emulateNodeSelection(0, 3)
+        },
+      })
+      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+    })
+
+    it('reports selection change if some node gets deselected', () => {
+      emulateNodeSelection(0, 3)
+      emulateClick({
+        beforeMouseUp() {
+          emulateNodeSelection(0, 0)
+        },
+      })
+      expect(onClickSpy.calls.mostRecent().args[1]).toBe(true)
+    })
+
+    it('does not report selection change if the selection changes but stays empty', () => {
+      emulateNodeSelection(0, 0)
+      emulateClick({
+        beforeMouseUp() {
+          emulateNodeSelection(1, 1)
+        },
+      })
+      expect(onClickSpy.calls.mostRecent().args[1]).toBe(false)
+    })
+
+    function emulateNodeSelection(start: number, end: number) {
+      const selection = document.getSelection()!
+      const range = document.createRange()
+      range.setStart(text, start)
+      range.setEnd(text, end)
+      selection.removeAllRanges()
+      selection.addRange(range)
+      window.dispatchEvent(createNewEvent('selectionchange', { target: document }))
+    }
+  })
+
+  function emulateClick({ beforeMouseUp }: { beforeMouseUp?(): void } = {}) {
     document.body.dispatchEvent(createNewEvent('mousedown'))
+    beforeMouseUp?.()
     document.body.dispatchEvent(createNewEvent('mouseup'))
     document.body.dispatchEvent(createNewEvent('click'))
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.spec.ts
@@ -1,0 +1,28 @@
+import { createNewEvent } from '../../../../../core/test/specHelper'
+import type { OnClickCallback } from './listenEvents'
+import { listenEvents } from './listenEvents'
+
+describe('listenEvents', () => {
+  let onClickSpy: jasmine.Spy<OnClickCallback>
+  let stopListenEvents: () => void
+
+  beforeEach(() => {
+    onClickSpy = jasmine.createSpy()
+    ;({ stop: stopListenEvents } = listenEvents({ onClick: onClickSpy }))
+  })
+
+  afterEach(() => {
+    stopListenEvents()
+  })
+
+  it('listen to click events', () => {
+    emulateClick()
+    expect(onClickSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ type: 'click' }))
+  })
+
+  function emulateClick() {
+    document.body.dispatchEvent(createNewEvent('mousedown'))
+    document.body.dispatchEvent(createNewEvent('mouseup'))
+    document.body.dispatchEvent(createNewEvent('click'))
+  }
+})

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.ts
@@ -20,7 +20,7 @@ export function listenEvents({ onClick }: { onClick: OnClickCallback }) {
     window,
     DOM_EVENT.SELECTION_CHANGE,
     () => {
-      if (selectionEmptyAtMouseDown !== isSelectionEmpty()) {
+      if (!selectionEmptyAtMouseDown || !isSelectionEmpty()) {
         hasSelectionChanged = true
       }
     },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.ts
@@ -1,0 +1,22 @@
+import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
+
+export type OnClickCallback = (clickEvent: MouseEvent & { target: Element }) => void
+
+export function listenEvents({ onClick }: { onClick: OnClickCallback }) {
+  const { stop: stopClickListener } = addEventListener(
+    window,
+    DOM_EVENT.CLICK,
+    (clickEvent: MouseEvent) => {
+      if (clickEvent.target instanceof Element) {
+        onClick(clickEvent as MouseEvent & { target: Element })
+      }
+    },
+    { capture: true }
+  )
+
+  return {
+    stop: () => {
+      stopClickListener()
+    },
+  }
+}

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenEvents.ts
@@ -1,14 +1,38 @@
 import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 
-export type OnClickCallback = (clickEvent: MouseEvent & { target: Element }) => void
+export type OnClickCallback = (clickEvent: MouseEvent & { target: Element }, hasSelectionChanged: boolean) => void
 
 export function listenEvents({ onClick }: { onClick: OnClickCallback }) {
+  let hasSelectionChanged = false
+  let selectionEmptyAtMouseDown: boolean
+
+  const { stop: stopMouseDownListener } = addEventListener(
+    window,
+    DOM_EVENT.MOUSE_DOWN,
+    () => {
+      hasSelectionChanged = false
+      selectionEmptyAtMouseDown = isSelectionEmpty()
+    },
+    { capture: true }
+  )
+
+  const { stop: stopSelectionChangeListener } = addEventListener(
+    window,
+    DOM_EVENT.SELECTION_CHANGE,
+    () => {
+      if (selectionEmptyAtMouseDown !== isSelectionEmpty()) {
+        hasSelectionChanged = true
+      }
+    },
+    { capture: true }
+  )
+
   const { stop: stopClickListener } = addEventListener(
     window,
     DOM_EVENT.CLICK,
     (clickEvent: MouseEvent) => {
       if (clickEvent.target instanceof Element) {
-        onClick(clickEvent as MouseEvent & { target: Element })
+        onClick(clickEvent as MouseEvent & { target: Element }, hasSelectionChanged)
       }
     },
     { capture: true }
@@ -16,7 +40,14 @@ export function listenEvents({ onClick }: { onClick: OnClickCallback }) {
 
   return {
     stop: () => {
+      stopMouseDownListener()
+      stopSelectionChangeListener()
       stopClickListener()
     },
   }
+}
+
+function isSelectionEmpty(): boolean {
+  const selection = window.getSelection()
+  return !selection || selection.isCollapsed
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -17,7 +17,7 @@ import { PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitPageActivityEnd'
 import type { ActionContexts } from './actionCollection'
 import type { ClickAction } from './trackClickActions'
 import { CLICK_ACTION_MAX_DURATION, trackClickActions } from './trackClickActions'
-import { MAX_DURATION_BETWEEN_CLICKS } from './rageClickChain'
+import { MAX_DURATION_BETWEEN_CLICKS } from './clickChain'
 
 // Used to wait some time after the creation of an action
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = PAGE_ACTIVITY_VALIDATION_DELAY * 0.8

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -14,9 +14,10 @@ import { RumEventType, ActionType, FrustrationType } from '../../../rawRumEvent.
 import type { RumEvent } from '../../../rumEvent.types'
 import { LifeCycleEventType } from '../../lifeCycle'
 import { PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitPageActivityEnd'
+import { createFakeClick } from '../../../../test/createFakeClick'
 import type { ActionContexts } from './actionCollection'
 import type { ClickAction } from './trackClickActions'
-import { CLICK_ACTION_MAX_DURATION, trackClickActions } from './trackClickActions'
+import { finalizeClicks, CLICK_ACTION_MAX_DURATION, trackClickActions } from './trackClickActions'
 import { MAX_DURATION_BETWEEN_CLICKS } from './clickChain'
 
 // Used to wait some time after the creation of an action
@@ -420,4 +421,45 @@ describe('trackClickActions', () => {
       })
     )
   }
+})
+
+describe('finalizeClicks', () => {
+  describe('when no rage is detected', () => {
+    it('discards the rage click', () => {
+      const clicks = [createFakeClick(), createFakeClick()]
+      const rageClick = createFakeClick()
+      finalizeClicks(clicks, rageClick)
+      expect(rageClick.discard).toHaveBeenCalled()
+    })
+
+    it('validates individual clicks', () => {
+      const clicks = [createFakeClick(), createFakeClick()]
+      const rageClick = createFakeClick()
+      finalizeClicks(clicks, rageClick)
+      clicks.forEach((click) => expect(click.validate).toHaveBeenCalled())
+    })
+  })
+
+  describe('when rage is detected', () => {
+    it('discards individual clicks', () => {
+      const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
+      const rageClick = createFakeClick()
+      finalizeClicks(clicks, rageClick)
+      clicks.forEach((click) => expect(click.discard).toHaveBeenCalled())
+    })
+
+    it('validates the rage click', () => {
+      const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
+      const rageClick = createFakeClick()
+      finalizeClicks(clicks, rageClick)
+      expect(rageClick.validate).toHaveBeenCalled()
+    })
+
+    it('the rage click should have a "rage" frustration', () => {
+      const clicks = [createFakeClick(), createFakeClick(), createFakeClick()]
+      const rageClick = createFakeClick()
+      finalizeClicks(clicks, rageClick)
+      expect(rageClick.addFrustration).toHaveBeenCalledWith(FrustrationType.RAGE_CLICK)
+    })
+  })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -20,8 +20,8 @@ import type { LifeCycle } from '../../lifeCycle'
 import { LifeCycleEventType } from '../../lifeCycle'
 import { trackEventCounts } from '../../trackEventCounts'
 import { waitPageActivityEnd } from '../../waitPageActivityEnd'
-import type { RageClickChain } from './rageClickChain'
-import { createRageClickChain } from './rageClickChain'
+import type { ClickChain } from './clickChain'
+import { createClickChain } from './clickChain'
 import { getActionNameFromElement } from './getActionNameFromElement'
 import { getSelectorFromElement } from './getSelectorFromElement'
 
@@ -66,14 +66,14 @@ export function trackClickActions(
   const history: ClickActionIdHistory = new ContextHistory(ACTION_CONTEXT_TIME_OUT_DELAY)
   const stopObservable = new Observable<void>()
   const { trackFrustrations } = configuration
-  let currentRageClickChain: RageClickChain | undefined
+  let currentClickChain: ClickChain | undefined
 
   lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
     history.reset()
   })
 
-  lifeCycle.subscribe(LifeCycleEventType.BEFORE_UNLOAD, stopRageClickChain)
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, stopRageClickChain)
+  lifeCycle.subscribe(LifeCycleEventType.BEFORE_UNLOAD, stopClickChain)
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, stopClickChain)
 
   const { stop: stopListener } = listenClickEvents(processClick)
 
@@ -84,16 +84,16 @@ export function trackClickActions(
 
   return {
     stop: () => {
-      stopRageClickChain()
+      stopClickChain()
       stopObservable.notify()
       stopListener()
     },
     actionContexts,
   }
 
-  function stopRageClickChain() {
-    if (currentRageClickChain) {
-      currentRageClickChain.stop()
+  function stopClickChain() {
+    if (currentClickChain) {
+      currentClickChain.stop()
     }
   }
 
@@ -119,8 +119,8 @@ export function trackClickActions(
       startClocks,
     })
 
-    if (trackFrustrations && (!currentRageClickChain || !currentRageClickChain.tryAppend(click))) {
-      currentRageClickChain = createRageClickChain(click)
+    if (trackFrustrations && (!currentClickChain || !currentClickChain.tryAppend(click))) {
+      currentClickChain = createClickChain(click)
     }
 
     const { stop: stopWaitPageActivityEnd } = waitPageActivityEnd(

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -6,8 +6,6 @@ import {
   getRelativeTime,
   ONE_MINUTE,
   ContextHistory,
-  addEventListener,
-  DOM_EVENT,
   generateUUID,
   clocksNow,
   ONE_SECOND,
@@ -24,6 +22,7 @@ import type { ClickChain } from './clickChain'
 import { createClickChain } from './clickChain'
 import { getActionNameFromElement } from './getActionNameFromElement'
 import { getSelectorFromElement } from './getSelectorFromElement'
+import { listenEvents } from './listenEvents'
 
 interface ActionCounts {
   errorCount: number
@@ -75,7 +74,7 @@ export function trackClickActions(
   lifeCycle.subscribe(LifeCycleEventType.BEFORE_UNLOAD, stopClickChain)
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, stopClickChain)
 
-  const { stop: stopListener } = listenClickEvents(processClick)
+  const { stop: stopListener } = listenEvents({ onClick: processClick })
 
   const actionContexts: ActionContexts = {
     findActionId: (startTime?: RelativeTime) =>
@@ -164,19 +163,6 @@ export function trackClickActions(
       stopSubscription.unsubscribe()
     })
   }
-}
-
-function listenClickEvents(callback: (clickEvent: MouseEvent & { target: Element }) => void) {
-  return addEventListener(
-    window,
-    DOM_EVENT.CLICK,
-    (clickEvent: MouseEvent) => {
-      if (clickEvent.target instanceof Element) {
-        callback(clickEvent as MouseEvent & { target: Element })
-      }
-    },
-    { capture: true }
-  )
 }
 
 const enum ClickStatus {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -22,7 +22,7 @@ import type { ClickChain } from './clickChain'
 import { createClickChain } from './clickChain'
 import { getActionNameFromElement } from './getActionNameFromElement'
 import { getSelectorFromElement } from './getSelectorFromElement'
-import { listenEvents } from './listenEvents'
+import { listenActionEvents } from './listenActionEvents'
 
 interface ActionCounts {
   errorCount: number
@@ -74,7 +74,7 @@ export function trackClickActions(
   lifeCycle.subscribe(LifeCycleEventType.BEFORE_UNLOAD, stopClickChain)
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, stopClickChain)
 
-  const { stop: stopListener } = listenEvents({ onClick: processClick })
+  const { stop: stopActionEventsListener } = listenActionEvents({ onClick: processClick })
 
   const actionContexts: ActionContexts = {
     findActionId: (startTime?: RelativeTime) =>
@@ -85,7 +85,7 @@ export function trackClickActions(
     stop: () => {
       stopClickChain()
       stopObservable.notify()
-      stopListener()
+      stopActionEventsListener()
     },
     actionContexts,
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -96,7 +96,7 @@ export function trackClickActions(
     }
   }
 
-  function processClick(event: MouseEvent & { target: Element }) {
+  function processClick(event: MouseEvent & { target: Element }, hasSelectionChanged: boolean) {
     if (!trackFrustrations && history.find()) {
       // TODO: remove this in a future major version. To keep retrocompatibility, ignore any new
       // action if another one is already occurring.
@@ -112,7 +112,7 @@ export function trackClickActions(
 
     const startClocks = clocksNow()
 
-    const click = newClick(lifeCycle, history, {
+    const click = newClick(lifeCycle, history, hasSelectionChanged, {
       name,
       event,
       startClocks,
@@ -179,6 +179,7 @@ export type Click = ReturnType<typeof newClick>
 function newClick(
   lifeCycle: LifeCycle,
   history: ClickActionIdHistory,
+  hasSelectionChanged: boolean,
   base: Pick<ClickAction, 'startClocks' | 'event' | 'name'>
 ) {
   const id = generateUUID()
@@ -231,13 +232,14 @@ function newClick(
     get hasActivity() {
       return activityEndTime !== undefined
     },
+    hasSelectionChanged,
     addFrustration: (frustrationType: FrustrationType) => {
       frustrationTypes.push(frustrationType)
     },
 
     isStopped: () => status === ClickStatus.STOPPED || status === ClickStatus.FINALIZED,
 
-    clone: () => newClick(lifeCycle, history, base),
+    clone: () => newClick(lifeCycle, history, hasSelectionChanged, base),
 
     validate: () => {
       stop()

--- a/packages/rum-core/test/createFakeClick.ts
+++ b/packages/rum-core/test/createFakeClick.ts
@@ -1,0 +1,41 @@
+import { Observable, timeStampNow } from '@datadog/browser-core'
+import { createNewEvent } from '../../core/test/specHelper'
+
+export type FakeClick = ReturnType<typeof createFakeClick>
+
+export function createFakeClick(partialClick?: {
+  hasSelectionChanged?: boolean
+  event?: Partial<MouseEvent & { target: Element }>
+}) {
+  const stopObservable = new Observable<void>()
+  let isStopped = false
+
+  function clone() {
+    return createFakeClick(partialClick)
+  }
+
+  return {
+    stopObservable,
+    isStopped: () => isStopped,
+    stop: () => {
+      isStopped = true
+      stopObservable.notify()
+    },
+    discard: jasmine.createSpy(),
+    validate: jasmine.createSpy(),
+    hasError: false,
+    hasActivity: true,
+    hasSelectionChanged: false,
+    addFrustration: jasmine.createSpy(),
+    clone: jasmine.createSpy<typeof clone>().and.callFake(clone),
+
+    ...partialClick,
+    event: createNewEvent('click', {
+      clientX: 100,
+      clientY: 100,
+      timeStamp: timeStampNow(),
+      target: document.body,
+      ...partialClick?.event,
+    }),
+  }
+}


### PR DESCRIPTION
## Motivation

Do not consider clicks as dead or rage if the selection changed

## Changes

* Bit of refactoring, to compute frustrations at a single place
* Track selectionchange events, store this information in `Click` objects, and use it when computing frustrations

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
