### PR TITLE
🐛 [RUMF-1305] forbid the usage of `Date.now`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -233,6 +233,10 @@ module.exports = {
             selector: 'ArrayExpression > SpreadElement',
             message: 'Array spread is not authorized. Please use .concat instead.',
           },
+          {
+            selector: 'MemberExpression[object.name="Date"][property.name="now"]',
+            message: '`Date.now()` is not authorized. Please use `dateNow()` instead',
+          },
         ],
       },
     },

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -2,6 +2,7 @@ import type { CookieOptions } from '../../browser/cookie'
 import { getCookie, setCookie } from '../../browser/cookie'
 import { isChromium } from '../../tools/browserDetection'
 import { monitor } from '../../tools/monitor'
+import { dateNow } from '../../tools/timeUtils'
 import * as utils from '../../tools/utils'
 import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
 import type { SessionState } from './sessionStore'
@@ -118,7 +119,7 @@ export function persistSession(session: SessionState, options: CookieOptions) {
     clearSession(options)
     return
   }
-  session.expire = String(Date.now() + SESSION_EXPIRATION_DELAY)
+  session.expire = String(dateNow() + SESSION_EXPIRATION_DELAY)
   setSession(session, options)
 }
 

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -2,6 +2,7 @@ import type { CookieOptions } from '../../browser/cookie'
 import { COOKIE_ACCESS_DELAY } from '../../browser/cookie'
 import { monitor } from '../../tools/monitor'
 import { Observable } from '../../tools/observable'
+import { dateNow } from '../../tools/timeUtils'
 import * as utils from '../../tools/utils'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import { retrieveSession, withCookieLockAccess } from './sessionCookieStore'
@@ -98,7 +99,7 @@ export function startSessionStore<TrackingType extends string>(
     cookieSession[productKey] = trackingType
     if (isTracked && !cookieSession.id) {
       cookieSession.id = utils.generateUUID()
-      cookieSession.created = String(Date.now())
+      cookieSession.created = String(dateNow())
     }
     return isTracked
   }
@@ -133,8 +134,8 @@ export function startSessionStore<TrackingType extends string>(
     // created and expire can be undefined for versions which was not storing them
     // these checks could be removed when older versions will not be available/live anymore
     return (
-      (session.created === undefined || Date.now() - Number(session.created) < SESSION_TIME_OUT_DELAY) &&
-      (session.expire === undefined || Date.now() < Number(session.expire))
+      (session.created === undefined || dateNow() - Number(session.created) < SESSION_TIME_OUT_DELAY) &&
+      (session.expire === undefined || dateNow() < Number(session.expire))
     )
   }
 

--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -11,7 +11,7 @@ export function relativeToClocks(relative: RelativeTime) {
 }
 
 function getCorrectedTimeStamp(relativeTime: RelativeTime) {
-  const correctedOrigin = Date.now() - performance.now()
+  const correctedOrigin = dateNow() - performance.now()
   // apply correction only for positive drift
   if (correctedOrigin > getNavigationStart()) {
     // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
@@ -22,7 +22,7 @@ function getCorrectedTimeStamp(relativeTime: RelativeTime) {
 
 export function currentDrift() {
   // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  return Math.round(Date.now() - (getNavigationStart() + performance.now()))
+  return Math.round(dateNow() - (getNavigationStart() + performance.now()))
 }
 
 export function toServerDuration(duration: Duration): ServerDuration
@@ -34,8 +34,17 @@ export function toServerDuration(duration: Duration | undefined) {
   return round(duration * 1e6, 0) as ServerDuration
 }
 
+export function dateNow() {
+  // Do not use `Date.now` because sometimes websites are wrongly "polyfilling" it. For example, we
+  // had some users using a very old version of `datejs`, which patched `Date.now` to return a Date
+  // instance instead of a timestamp[1]. Those users are unlikely to fix this, so let's handle this
+  // case ourselves.
+  // [1]: https://github.com/datejs/Datejs/blob/97f5c7c58c5bc5accdab8aa7602b6ac56462d778/src/core-debug.js#L14-L16
+  return new Date().getTime()
+}
+
 export function timeStampNow() {
-  return Date.now() as TimeStamp
+  return dateNow() as TimeStamp
 }
 
 export function relativeNow() {

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -1,5 +1,6 @@
 import type { Duration, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import {
+  dateNow,
   assign,
   addEventListeners,
   DOM_EVENT,
@@ -209,7 +210,7 @@ function retrieveNavigationTiming(callback: (timing: RumPerformanceNavigationTim
  * https://github.com/GoogleChrome/web-vitals/blob/master/src/lib/polyfills/firstInputPolyfill.ts
  */
 function retrieveFirstInputTiming(callback: (timing: RumFirstInputTiming) => void) {
-  const startTimeStamp = Date.now()
+  const startTimeStamp = dateNow()
   let timingSent = false
 
   const { stop: removeEventListeners } = addEventListeners(
@@ -268,7 +269,7 @@ function retrieveFirstInputTiming(callback: (timing: RumFirstInputTiming) => voi
       // - https://github.com/GoogleChromeLabs/first-input-delay/issues/6
       // - https://github.com/GoogleChromeLabs/first-input-delay/issues/7
       const delay = timing.processingStart - timing.startTime
-      if (delay >= 0 && delay < Date.now() - startTimeStamp) {
+      if (delay >= 0 && delay < dateNow() - startTimeStamp) {
         callback(timing)
       }
     }

--- a/packages/rum-core/src/domain/tracing/getDocumentTraceId.ts
+++ b/packages/rum-core/src/domain/tracing/getDocumentTraceId.ts
@@ -1,5 +1,5 @@
 import type { TimeStamp } from '@datadog/browser-core'
-import { findCommaSeparatedValue, ONE_MINUTE } from '@datadog/browser-core'
+import { dateNow, findCommaSeparatedValue, ONE_MINUTE } from '@datadog/browser-core'
 
 interface DocumentTraceData {
   traceId: string
@@ -11,7 +11,7 @@ export const INITIAL_DOCUMENT_OUTDATED_TRACE_ID_THRESHOLD = 2 * ONE_MINUTE
 export function getDocumentTraceId(document: Document): string | undefined {
   const data = getDocumentTraceDataFromMeta(document) || getDocumentTraceDataFromComment(document)
 
-  if (!data || data.traceTime <= Date.now() - INITIAL_DOCUMENT_OUTDATED_TRACE_ID_THRESHOLD) {
+  if (!data || data.traceTime <= dateNow() - INITIAL_DOCUMENT_OUTDATED_TRACE_ID_THRESHOLD) {
     return undefined
   }
 


### PR DESCRIPTION
## Motivation

Do not use `Date.now` because sometimes websites are wrongly "polyfilling" it. For example, we had some users using a very old version of `datejs`, which patched `Date.now` to return [a Date instance instead of a timestamp][1]. Those users are unlikely to fix this, so let's handle this case ourselves.

[1]: https://github.com/datejs/Datejs/blob/97f5c7c58c5bc5accdab8aa7602b6ac56462d778/src/core-debug.js#L14-L16

## Changes

* Replace `Date.now` usages with a utility function
* Adjust the ESLint configuration to make sure we don't use `Date.now` in our source files

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
