### PR TITLE
✨[RUMF-1225] Enable service and version update on startView

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -156,8 +156,8 @@ export function makeRumPublicApi(
 
   const startView: {
     (name?: string): void
-    // (options: ViewOptions): void // uncomment when removing the feature flag
-  } = monitor((options?: string) => {
+    (options: ViewOptions): void
+  } = monitor((options?: string | ViewOptions) => {
     const sanitizedOptions = typeof options === 'object' ? options : { name: options }
     startViewStrategy(sanitizedOptions)
   })

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,11 +1,5 @@
 import type { RawError, RelativeTime } from '@datadog/browser-core'
-import {
-  ErrorSource,
-  ONE_MINUTE,
-  display,
-  resetExperimentalFeatures,
-  updateExperimentalFeatures,
-} from '@datadog/browser-core'
+import { ErrorSource, ONE_MINUTE, display } from '@datadog/browser-core'
 import { createRumSessionManagerMock } from '../../test/mockRumSessionManager'
 import { createRawRumEvent } from '../../test/fixtures'
 import type { TestSetupBuilder } from '../../test/specHelper'
@@ -468,46 +462,24 @@ describe('rum assembly', () => {
       extraConfigurationOptions = { service: 'default service', version: 'default version' }
     })
 
-    describe('when sub-apps ff enabled', () => {
-      beforeEach(() => {
-        updateExperimentalFeatures(['sub-apps'])
-      })
+    it('should come from the init configuration by default', () => {
+      const { lifeCycle } = setupBuilder.build()
 
-      afterEach(() => {
-        resetExperimentalFeatures()
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })
-
-      it('should come from the init configuration by default', () => {
-        const { lifeCycle } = setupBuilder.build()
-
-        notifyRawRumEvent(lifeCycle, {
-          rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-        })
-        expect(serverRumEvents[0].service).toEqual('default service')
-        expect(serverRumEvents[0].version).toEqual('default version')
-      })
-
-      it('should be overridden by the view context', () => {
-        const { lifeCycle } = setupBuilder.build()
-        findView = () => ({ service: 'new service', version: 'new version', id: '1234' })
-        notifyRawRumEvent(lifeCycle, {
-          rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-        })
-        expect(serverRumEvents[0].service).toEqual('new service')
-        expect(serverRumEvents[0].version).toEqual('new version')
-      })
+      expect(serverRumEvents[0].service).toEqual('default service')
+      expect(serverRumEvents[0].version).toEqual('default version')
     })
 
-    describe('when sub-apps ff disabled', () => {
-      it('should not be overridden by the view context', () => {
-        const { lifeCycle } = setupBuilder.build()
-        findView = () => ({ service: 'new service', version: 'new version', id: '1234' })
-        notifyRawRumEvent(lifeCycle, {
-          rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-        })
-        expect(serverRumEvents[0].service).toEqual('default service')
-        expect(serverRumEvents[0].version).not.toBeDefined()
+    it('should be overridden by the view context', () => {
+      const { lifeCycle } = setupBuilder.build()
+      findView = () => ({ service: 'new service', version: 'new version', id: '1234' })
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })
+      expect(serverRumEvents[0].service).toEqual('new service')
+      expect(serverRumEvents[0].version).toEqual('new version')
     })
   })
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -8,7 +8,6 @@ import {
   display,
   createEventRateLimiter,
   canUseEventBridge,
-  isExperimentalFeatureEnabled,
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type {
@@ -116,10 +115,8 @@ export function startRumAssembly(
             id: configuration.applicationId,
           },
           date: timeStampNow(),
-          service: isExperimentalFeatureEnabled('sub-apps')
-            ? viewContext.service || configuration.service
-            : configuration.service,
-          version: isExperimentalFeatureEnabled('sub-apps') ? viewContext.version || configuration.version : undefined,
+          service: viewContext.service || configuration.service,
+          version: viewContext.version || configuration.version,
           source: 'browser',
           session: {
             id: session.id,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -1,12 +1,5 @@
 import type { Context, Duration, RelativeTime } from '@datadog/browser-core'
-import {
-  timeStampNow,
-  display,
-  relativeToClocks,
-  relativeNow,
-  resetExperimentalFeatures,
-  updateExperimentalFeatures,
-} from '@datadog/browser-core'
+import { timeStampNow, display, relativeToClocks, relativeNow, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder, ViewTest } from '../../../../test/specHelper'
 import { setup, setupViewTest } from '../../../../test/specHelper'
 import type {
@@ -284,7 +277,6 @@ describe('renew session', () => {
   })
 
   it('should use the current view name, service and version for the new view', () => {
-    updateExperimentalFeatures(['sub-apps'])
     const { lifeCycle, changeLocation } = setupBuilder.build()
     const { getViewCreateCount, getViewCreate, startView } = viewTest
 
@@ -619,8 +611,6 @@ describe('start view', () => {
   })
 
   it('should have service and version', () => {
-    updateExperimentalFeatures(['sub-apps'])
-
     setupBuilder.build()
     const { getViewUpdate, startView } = viewTest
 


### PR DESCRIPTION
## Motivation

In the context of sub-apps, web and mobile developers want to only see RUM events happening in their area of ownership. 
For example, a developer working on the Log Management product at Datadog wants to see RUM events that happened in the Log Management only. To do so we make the service attribute first-class-citizen in RUM and allow customers to update the current `service` and `version` with the `startView` API.

## Changes

Remove the `sub-app` feature flag

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
