### PR TITLE
[RUMF-1297] frustration signals: track input changes

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -29,7 +29,7 @@ describe('computeFrustration', () => {
     })
 
     it('adds a dead frustration to the rage click if any click does not have page activity', () => {
-      clicksConsideredAsRage[1].hasPageActivity = false
+      clicksConsideredAsRage[1] = createFakeClick({ hasPageActivity: false })
       computeFrustration(clicksConsideredAsRage, rageClick)
       expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
       expect(rageClick.addFrustration.calls.argsFor(0)).toEqual([FrustrationType.RAGE_CLICK])
@@ -37,7 +37,7 @@ describe('computeFrustration', () => {
     })
 
     it('adds an error frustration to the rage click if an error occurs during the rage click lifetime', () => {
-      rageClick.hasError = true
+      rageClick = createFakeClick({ hasError: true })
       computeFrustration(clicksConsideredAsRage, rageClick)
       expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
       expect(rageClick.addFrustration.calls.argsFor(0)).toEqual([FrustrationType.RAGE_CLICK])
@@ -54,20 +54,20 @@ describe('computeFrustration', () => {
     })
 
     it('adds a dead frustration to clicks that do not have activity', () => {
-      clicks[1].hasPageActivity = false
+      clicks[1] = createFakeClick({ hasPageActivity: false })
       computeFrustration(clicks, rageClick)
       expect(clicks[1].addFrustration).toHaveBeenCalledOnceWith(FrustrationType.DEAD_CLICK)
     })
 
     it('does not add a dead frustration when double clicking to select a word', () => {
-      clicks[1].hasPageActivity = false
-      clicks[0].hasSelectionChanged = true
+      clicks[0] = createFakeClick({ userActivity: { selection: true } })
+      clicks[1] = createFakeClick({ hasPageActivity: false })
       computeFrustration(clicks, rageClick)
       expect(clicks[1].addFrustration).not.toHaveBeenCalled()
     })
 
     it('adds an error frustration to clicks that have an error', () => {
-      clicks[1].hasError = true
+      clicks[1] = createFakeClick({ hasError: true })
       computeFrustration(clicks, rageClick)
       expect(clicks[1].addFrustration).toHaveBeenCalledOnceWith(FrustrationType.ERROR_CLICK)
     })
@@ -90,7 +90,9 @@ describe('isRage', () => {
   })
 
   it('does not consider as rage when triple clicking to select a paragraph', () => {
-    expect(isRage([createFakeClick(), createFakeClick({ hasSelectionChanged: true }), createFakeClick()])).toBe(false)
+    expect(isRage([createFakeClick(), createFakeClick({ userActivity: { selection: true } }), createFakeClick()])).toBe(
+      false
+    )
   })
 
   it('does not consider as rage two clicks happening at the same time', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -28,15 +28,15 @@ describe('computeFrustration', () => {
       expect(rageClick.addFrustration).toHaveBeenCalledOnceWith(FrustrationType.RAGE_CLICK)
     })
 
-    it('adds a dead frustration to the rage click if any click does not have activity', () => {
-      clicksConsideredAsRage[1].hasActivity = false
+    it('adds a dead frustration to the rage click if any click does not have page activity', () => {
+      clicksConsideredAsRage[1].hasPageActivity = false
       computeFrustration(clicksConsideredAsRage, rageClick)
       expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
       expect(rageClick.addFrustration.calls.argsFor(0)).toEqual([FrustrationType.RAGE_CLICK])
       expect(rageClick.addFrustration.calls.argsFor(1)).toEqual([FrustrationType.DEAD_CLICK])
     })
 
-    it('adds an error frustration to the rage click if any click does not have activity', () => {
+    it('adds an error frustration to the rage click if an error occurs during the rage click lifetime', () => {
       rageClick.hasError = true
       computeFrustration(clicksConsideredAsRage, rageClick)
       expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
@@ -54,13 +54,13 @@ describe('computeFrustration', () => {
     })
 
     it('adds a dead frustration to clicks that do not have activity', () => {
-      clicks[1].hasActivity = false
+      clicks[1].hasPageActivity = false
       computeFrustration(clicks, rageClick)
       expect(clicks[1].addFrustration).toHaveBeenCalledOnceWith(FrustrationType.DEAD_CLICK)
     })
 
     it('does not add a dead frustration when double clicking to select a word', () => {
-      clicks[1].hasActivity = false
+      clicks[1].hasPageActivity = false
       clicks[0].hasSelectionChanged = true
       computeFrustration(clicks, rageClick)
       expect(clicks[1].addFrustration).not.toHaveBeenCalled()

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -4,7 +4,7 @@ import type { Clock } from '../../../../../core/test/specHelper'
 import { mockClock } from '../../../../../core/test/specHelper'
 import type { FakeClick } from '../../../../test/createFakeClick'
 import { createFakeClick } from '../../../../test/createFakeClick'
-import { computeFrustration, isRage } from './computeFrustration'
+import { computeFrustration, isRage, isDead } from './computeFrustration'
 
 describe('computeFrustration', () => {
   let clicks: FakeClick[]
@@ -32,6 +32,12 @@ describe('computeFrustration', () => {
       clicksConsideredAsRage[1] = createFakeClick({ hasPageActivity: false })
       computeFrustration(clicksConsideredAsRage, rageClick)
       expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.DEAD_CLICK])
+    })
+
+    it('do not add a dead frustration to the rage click if clicks are associated with an "input" event', () => {
+      clicksConsideredAsRage[1] = createFakeClick({ hasPageActivity: false, userActivity: { input: true } })
+      computeFrustration(clicksConsideredAsRage, rageClick)
+      expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK])
     })
 
     it('adds an error frustration to the rage click if an error occurs during the rage click lifetime', () => {
@@ -121,5 +127,19 @@ describe('isRage', () => {
     clicks.push(createFakeClick())
 
     expect(isRage(clicks)).toBe(true)
+  })
+})
+
+describe('isDead', () => {
+  it('considers as dead when the click has no page activity', () => {
+    expect(isDead(createFakeClick({ hasPageActivity: false }))).toBe(true)
+  })
+
+  it('does not consider as dead when the click has page activity', () => {
+    expect(isDead(createFakeClick({ hasPageActivity: true }))).toBe(false)
+  })
+
+  it('does not consider as dead when the click is related to an "input" event', () => {
+    expect(isDead(createFakeClick({ hasPageActivity: false, userActivity: { input: true } }))).toBe(false)
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -25,23 +25,19 @@ describe('computeFrustration', () => {
   describe('if clicks are considered as rage', () => {
     it('adds a rage frustration to the rage click', () => {
       computeFrustration(clicksConsideredAsRage, rageClick)
-      expect(rageClick.addFrustration).toHaveBeenCalledOnceWith(FrustrationType.RAGE_CLICK)
+      expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK])
     })
 
     it('adds a dead frustration to the rage click if any click does not have page activity', () => {
       clicksConsideredAsRage[1] = createFakeClick({ hasPageActivity: false })
       computeFrustration(clicksConsideredAsRage, rageClick)
-      expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
-      expect(rageClick.addFrustration.calls.argsFor(0)).toEqual([FrustrationType.RAGE_CLICK])
-      expect(rageClick.addFrustration.calls.argsFor(1)).toEqual([FrustrationType.DEAD_CLICK])
+      expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.DEAD_CLICK])
     })
 
     it('adds an error frustration to the rage click if an error occurs during the rage click lifetime', () => {
       rageClick = createFakeClick({ hasError: true })
       computeFrustration(clicksConsideredAsRage, rageClick)
-      expect(rageClick.addFrustration).toHaveBeenCalledTimes(2)
-      expect(rageClick.addFrustration.calls.argsFor(0)).toEqual([FrustrationType.RAGE_CLICK])
-      expect(rageClick.addFrustration.calls.argsFor(1)).toEqual([FrustrationType.ERROR_CLICK])
+      expect(getFrustrations(rageClick)).toEqual([FrustrationType.RAGE_CLICK, FrustrationType.ERROR_CLICK])
     })
   })
 
@@ -49,29 +45,33 @@ describe('computeFrustration', () => {
     it('does not add any frustration by default', () => {
       computeFrustration(clicks, rageClick)
       for (const click of clicks) {
-        expect(click.addFrustration).not.toHaveBeenCalled()
+        expect(getFrustrations(click)).toEqual([])
       }
     })
 
     it('adds a dead frustration to clicks that do not have activity', () => {
       clicks[1] = createFakeClick({ hasPageActivity: false })
       computeFrustration(clicks, rageClick)
-      expect(clicks[1].addFrustration).toHaveBeenCalledOnceWith(FrustrationType.DEAD_CLICK)
+      expect(getFrustrations(clicks[1])).toEqual([FrustrationType.DEAD_CLICK])
     })
 
     it('does not add a dead frustration when double clicking to select a word', () => {
       clicks[0] = createFakeClick({ userActivity: { selection: true } })
       clicks[1] = createFakeClick({ hasPageActivity: false })
       computeFrustration(clicks, rageClick)
-      expect(clicks[1].addFrustration).not.toHaveBeenCalled()
+      expect(getFrustrations(clicks[1])).toEqual([])
     })
 
     it('adds an error frustration to clicks that have an error', () => {
       clicks[1] = createFakeClick({ hasError: true })
       computeFrustration(clicks, rageClick)
-      expect(clicks[1].addFrustration).toHaveBeenCalledOnceWith(FrustrationType.ERROR_CLICK)
+      expect(getFrustrations(clicks[1])).toEqual([FrustrationType.ERROR_CLICK])
     })
   })
+
+  function getFrustrations(click: FakeClick) {
+    return click.addFrustration.calls.allArgs().map((args) => args[0])
+  }
 })
 
 describe('isRage', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -7,7 +7,7 @@ const MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE = 3
 export function computeFrustration(clicks: Click[], rageClick: Click) {
   if (isRage(clicks)) {
     rageClick.addFrustration(FrustrationType.RAGE_CLICK)
-    if (clicks.some((click) => !click.hasActivity)) {
+    if (clicks.some((click) => !click.hasPageActivity)) {
       rageClick.addFrustration(FrustrationType.DEAD_CLICK)
     }
     if (rageClick.hasError) {
@@ -22,7 +22,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
       click.addFrustration(FrustrationType.ERROR_CLICK)
     }
     if (
-      !click.hasActivity &&
+      !click.hasPageActivity &&
       // Avoid considering clicks part of a double-click or triple-click selections as dead clicks
       !hasSelectionChanged
     ) {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -16,7 +16,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
     return { isRage: true }
   }
 
-  const hasSelectionChanged = clicks.some((click) => click.hasSelectionChanged)
+  const hasSelectionChanged = clicks.some((click) => click.getUserActivity().selection)
   clicks.forEach((click) => {
     if (click.hasError) {
       click.addFrustration(FrustrationType.ERROR_CLICK)
@@ -33,7 +33,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
 }
 
 export function isRage(clicks: Click[]) {
-  if (clicks.some((click) => click.hasSelectionChanged)) {
+  if (clicks.some((click) => click.getUserActivity().selection)) {
     return false
   }
   for (let i = 0; i < clicks.length - (MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE - 1); i += 1) {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -7,7 +7,7 @@ const MIN_CLICKS_PER_SECOND_TO_CONSIDER_RAGE = 3
 export function computeFrustration(clicks: Click[], rageClick: Click) {
   if (isRage(clicks)) {
     rageClick.addFrustration(FrustrationType.RAGE_CLICK)
-    if (clicks.some((click) => !click.hasPageActivity)) {
+    if (clicks.some(isDead)) {
       rageClick.addFrustration(FrustrationType.DEAD_CLICK)
     }
     if (rageClick.hasError) {
@@ -22,7 +22,7 @@ export function computeFrustration(clicks: Click[], rageClick: Click) {
       click.addFrustration(FrustrationType.ERROR_CLICK)
     }
     if (
-      !click.hasPageActivity &&
+      isDead(click) &&
       // Avoid considering clicks part of a double-click or triple-click selections as dead clicks
       !hasSelectionChanged
     ) {
@@ -45,4 +45,8 @@ export function isRage(clicks: Click[]) {
     }
   }
   return false
+}
+
+export function isDead(click: Click) {
+  return !click.hasPageActivity && !click.getUserActivity().input
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -1,4 +1,5 @@
-import { createNewEvent } from '../../../../../core/test/specHelper'
+import type { Clock } from '../../../../../core/test/specHelper'
+import { createNewEvent, mockClock } from '../../../../../core/test/specHelper'
 import type { OnClickContext } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
 
@@ -110,6 +111,55 @@ describe('listenActionEvents', () => {
       }
       selection.addRange(range)
       window.dispatchEvent(createNewEvent('selectionchange', { target: document }))
+    }
+  })
+
+  describe('input user activity', () => {
+    let clock: Clock
+
+    beforeEach(() => {
+      clock = mockClock()
+    })
+
+    afterEach(() => {
+      clock.cleanup()
+    })
+
+    it('click that do not trigger an input input event should not report input user activity', () => {
+      emulateClick()
+      expect(hasInputUserActivity()).toBe(false)
+    })
+
+    it('click that triggers an input event during the click should report an input user activity', () => {
+      emulateClick({
+        beforeMouseUp() {
+          emulateInputEvent()
+        },
+      })
+      expect(hasInputUserActivity()).toBe(true)
+    })
+
+    it('click that triggers an input event slightly after the click should report an input user activity', () => {
+      emulateClick()
+      emulateInputEvent()
+      clock.tick(1)
+      expect(hasInputUserActivity()).toBe(true)
+    })
+
+    it('click and type should report an input user activity', () => {
+      emulateClick({
+        beforeMouseUp() {
+          emulateInputEvent()
+        },
+      })
+      expect(hasInputUserActivity()).toBe(true)
+    })
+
+    function emulateInputEvent() {
+      window.dispatchEvent(createNewEvent('input'))
+    }
+    function hasInputUserActivity() {
+      return onClickSpy.calls.mostRecent().args[0].getUserActivity().input
     }
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -1,9 +1,9 @@
 import { createNewEvent } from '../../../../../core/test/specHelper'
-import type { OnClickCallback } from './listenActionEvents'
+import type { OnClickContext } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
 
 describe('listenActionEvents', () => {
-  let onClickSpy: jasmine.Spy<OnClickCallback>
+  let onClickSpy: jasmine.Spy<(context: OnClickContext) => void>
   let stopListenEvents: () => void
 
   beforeEach(() => {
@@ -17,7 +17,10 @@ describe('listenActionEvents', () => {
 
   it('listen to click events', () => {
     emulateClick()
-    expect(onClickSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ type: 'click' }), false)
+    expect(onClickSpy).toHaveBeenCalledOnceWith({
+      event: jasmine.objectContaining({ type: 'click' }),
+      getUserActivity: jasmine.any(Function),
+    })
   })
 
   describe('selection change', () => {
@@ -90,7 +93,7 @@ describe('listenActionEvents', () => {
     })
 
     function hasSelectionChanged() {
-      return onClickSpy.calls.mostRecent().args[1]
+      return onClickSpy.calls.mostRecent().args[0].getUserActivity().selection
     }
 
     function emulateNodeSelection(

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -1,4 +1,4 @@
-import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
+import { addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
 
 export interface OnClickContext {
   event: MouseEvent & { target: Element }
@@ -43,9 +43,11 @@ export function listenActionEvents({ onClick }: { onClick(context: OnClickContex
             input: hasInputChanged,
           }
           if (!hasInputChanged) {
-            setTimeout(() => {
-              userActivity.input = hasInputChanged
-            })
+            setTimeout(
+              monitor(() => {
+                userActivity.input = hasInputChanged
+              })
+            )
           }
 
           onClick({

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -2,12 +2,13 @@ import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 
 export interface OnClickContext {
   event: MouseEvent & { target: Element }
-  getUserActivity(): { selection: boolean }
+  getUserActivity(): { selection: boolean; input: boolean }
 }
 
 export function listenActionEvents({ onClick }: { onClick(context: OnClickContext): void }) {
   let hasSelectionChanged = false
   let selectionEmptyAtMouseDown: boolean
+  let hasInputChanged = false
 
   const listeners = [
     addEventListener(
@@ -37,13 +38,30 @@ export function listenActionEvents({ onClick }: { onClick(context: OnClickContex
       (clickEvent: MouseEvent) => {
         if (clickEvent.target instanceof Element) {
           // Use a scoped variable to make sure the value is not changed by other clicks
-          const userActivity = { selection: hasSelectionChanged }
+          const userActivity = {
+            selection: hasSelectionChanged,
+            input: hasInputChanged,
+          }
+          if (!hasInputChanged) {
+            setTimeout(() => {
+              userActivity.input = hasInputChanged
+            })
+          }
 
           onClick({
             event: clickEvent as MouseEvent & { target: Element },
             getUserActivity: () => userActivity,
           })
         }
+      },
+      { capture: true }
+    ),
+
+    addEventListener(
+      window,
+      DOM_EVENT.INPUT,
+      () => {
+        hasInputChanged = true
       },
       { capture: true }
     ),

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -9,49 +9,49 @@ export function listenActionEvents({ onClick }: { onClick(context: OnClickContex
   let hasSelectionChanged = false
   let selectionEmptyAtMouseDown: boolean
 
-  const { stop: stopMouseDownListener } = addEventListener(
-    window,
-    DOM_EVENT.MOUSE_DOWN,
-    () => {
-      hasSelectionChanged = false
-      selectionEmptyAtMouseDown = isSelectionEmpty()
-    },
-    { capture: true }
-  )
+  const listeners = [
+    addEventListener(
+      window,
+      DOM_EVENT.MOUSE_DOWN,
+      () => {
+        hasSelectionChanged = false
+        selectionEmptyAtMouseDown = isSelectionEmpty()
+      },
+      { capture: true }
+    ),
 
-  const { stop: stopSelectionChangeListener } = addEventListener(
-    window,
-    DOM_EVENT.SELECTION_CHANGE,
-    () => {
-      if (!selectionEmptyAtMouseDown || !isSelectionEmpty()) {
-        hasSelectionChanged = true
-      }
-    },
-    { capture: true }
-  )
+    addEventListener(
+      window,
+      DOM_EVENT.SELECTION_CHANGE,
+      () => {
+        if (!selectionEmptyAtMouseDown || !isSelectionEmpty()) {
+          hasSelectionChanged = true
+        }
+      },
+      { capture: true }
+    ),
 
-  const { stop: stopClickListener } = addEventListener(
-    window,
-    DOM_EVENT.CLICK,
-    (clickEvent: MouseEvent) => {
-      if (clickEvent.target instanceof Element) {
-        // Use a scoped variable to make sure the value is not changed by other clicks
-        const userActivity = { selection: hasSelectionChanged }
+    addEventListener(
+      window,
+      DOM_EVENT.CLICK,
+      (clickEvent: MouseEvent) => {
+        if (clickEvent.target instanceof Element) {
+          // Use a scoped variable to make sure the value is not changed by other clicks
+          const userActivity = { selection: hasSelectionChanged }
 
-        onClick({
-          event: clickEvent as MouseEvent & { target: Element },
-          getUserActivity: () => userActivity,
-        })
-      }
-    },
-    { capture: true }
-  )
+          onClick({
+            event: clickEvent as MouseEvent & { target: Element },
+            getUserActivity: () => userActivity,
+          })
+        }
+      },
+      { capture: true }
+    ),
+  ]
 
   return {
     stop: () => {
-      stopMouseDownListener()
-      stopSelectionChangeListener()
-      stopClickListener()
+      listeners.forEach((listener) => listener.stop())
     },
   }
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -234,7 +234,7 @@ function newClick(
     get hasError() {
       return eventCountsSubscription.eventCounts.errorCount > 0
     },
-    get hasActivity() {
+    get hasPageActivity() {
       return activityEndTime !== undefined
     },
     hasSelectionChanged,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -23,6 +23,7 @@ import type { ClickChain } from './clickChain'
 import { createClickChain } from './clickChain'
 import { getActionNameFromElement } from './getActionNameFromElement'
 import { getSelectorFromElement } from './getSelectorFromElement'
+import type { OnClickContext } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
 import { computeFrustration } from './computeFrustration'
 
@@ -98,7 +99,7 @@ export function trackClickActions(
     }
   }
 
-  function processClick(event: MouseEvent & { target: Element }, hasSelectionChanged: boolean) {
+  function processClick({ event, getUserActivity }: OnClickContext) {
     if (!trackFrustrations && history.find()) {
       // TODO: remove this in a future major version. To keep retrocompatibility, ignore any new
       // action if another one is already occurring.
@@ -114,7 +115,7 @@ export function trackClickActions(
 
     const startClocks = clocksNow()
 
-    const click = newClick(lifeCycle, history, hasSelectionChanged, {
+    const click = newClick(lifeCycle, history, getUserActivity, {
       name,
       event,
       startClocks,
@@ -184,7 +185,7 @@ export type Click = ReturnType<typeof newClick>
 function newClick(
   lifeCycle: LifeCycle,
   history: ClickActionIdHistory,
-  hasSelectionChanged: boolean,
+  getUserActivity: OnClickContext['getUserActivity'],
   base: Pick<ClickAction, 'startClocks' | 'event' | 'name'>
 ) {
   const id = generateUUID()
@@ -237,14 +238,14 @@ function newClick(
     get hasPageActivity() {
       return activityEndTime !== undefined
     },
-    hasSelectionChanged,
+    getUserActivity,
     addFrustration: (frustrationType: FrustrationType) => {
       frustrationTypes.push(frustrationType)
     },
 
     isStopped: () => status === ClickStatus.STOPPED || status === ClickStatus.FINALIZED,
 
-    clone: () => newClick(lifeCycle, history, hasSelectionChanged, base),
+    clone: () => newClick(lifeCycle, history, getUserActivity, base),
 
     validate: () => {
       stop()

--- a/packages/rum-core/test/createFakeClick.ts
+++ b/packages/rum-core/test/createFakeClick.ts
@@ -1,5 +1,6 @@
 import { Observable, timeStampNow } from '@datadog/browser-core'
 import { createNewEvent } from '../../core/test/specHelper'
+import type { Click } from '../src/domain/rumEventsCollection/action/trackClickActions'
 
 export type FakeClick = Readonly<ReturnType<typeof createFakeClick>>
 
@@ -11,7 +12,7 @@ export function createFakeClick({
 }: {
   hasError?: boolean
   hasPageActivity?: boolean
-  userActivity?: { selection?: boolean }
+  userActivity?: { selection?: boolean; input?: boolean }
   event?: Partial<MouseEvent & { target: Element }>
 } = {}) {
   const stopObservable = new Observable<void>()
@@ -36,7 +37,7 @@ export function createFakeClick({
       selection: false,
       ...userActivity,
     }),
-    addFrustration: jasmine.createSpy(),
+    addFrustration: jasmine.createSpy<Click['addFrustration']>(),
     clone: jasmine.createSpy<typeof clone>().and.callFake(clone),
 
     event: createNewEvent('click', {

--- a/packages/rum-core/test/createFakeClick.ts
+++ b/packages/rum-core/test/createFakeClick.ts
@@ -24,7 +24,7 @@ export function createFakeClick(partialClick?: {
     discard: jasmine.createSpy(),
     validate: jasmine.createSpy(),
     hasError: false,
-    hasActivity: true,
+    hasPageActivity: true,
     hasSelectionChanged: false,
     addFrustration: jasmine.createSpy(),
     clone: jasmine.createSpy<typeof clone>().and.callFake(clone),

--- a/packages/rum-core/test/createFakeClick.ts
+++ b/packages/rum-core/test/createFakeClick.ts
@@ -35,6 +35,7 @@ export function createFakeClick({
     hasPageActivity,
     getUserActivity: () => ({
       selection: false,
+      input: false,
       ...userActivity,
     }),
     addFrustration: jasmine.createSpy<Click['addFrustration']>(),

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -176,6 +176,32 @@ describe('action collection', () => {
       expect(serverEvents.rumViews[0].view.frustration!.count).toBe(1)
     })
 
+  createTest('do not consider a click on a checkbox as "dead_click"')
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withBody(html` <input type="checkbox" /> `)
+    .run(async ({ serverEvents }) => {
+      const input = await $('input')
+      await input.click()
+      await flushEvents()
+      const actionEvents = serverEvents.rumActions
+
+      expect(actionEvents.length).toBe(1)
+      expect(actionEvents[0].action.frustration!.type).toEqual([])
+    })
+
+  createTest('do not consider a click to change the value of a "range" input as "dead_click"')
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withBody(html` <input type="range" /> `)
+    .run(async ({ serverEvents }) => {
+      const input = await $('input')
+      await input.click({ x: 10 })
+      await flushEvents()
+      const actionEvents = serverEvents.rumActions
+
+      expect(actionEvents.length).toBe(1)
+      expect(actionEvents[0].action.frustration!.type).toEqual([])
+    })
+
   createTest('collect a "rage click"')
     .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
     .withBody(


### PR DESCRIPTION
## Motivation

Do not consider clicks that trigger an `input` event as dead.

## Changes

* Do some light refactoring
* Track input events occurring during and after every click to adjust frustration signals assigned to them

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
