### PR TITLE
🐛  [RUMF-1294] ignore dead clicks based on the click event target

### DIFF
--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -4,6 +4,7 @@ import {
   combine,
   cssEscape,
   deepClone,
+  elementMatches,
   findCommaSeparatedValue,
   getType,
   jsonStringify,
@@ -577,5 +578,19 @@ describe('cssEscape', () => {
     expect(cssEscape('()[]{}')).toEqual('\\(\\)\\[\\]\\{\\}')
     expect(cssEscape('--a')).toEqual('--a')
     expect(cssEscape('\0')).toEqual('\ufffd')
+  })
+})
+
+describe('elementMatches', () => {
+  it('should return true if the element matches the selector', () => {
+    const element = document.createElement('div')
+    element.classList.add('foo')
+    expect(elementMatches(element, '.foo')).toEqual(true)
+  })
+
+  it('should return false if the element does not match the selector', () => {
+    const element = document.createElement('div')
+    element.classList.add('bar')
+    expect(elementMatches(element, '.foo')).toEqual(false)
   })
 })

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -416,6 +416,17 @@ export function addEventListeners<E extends Event>(
   }
 }
 
+export function elementMatches(element: Element & { msMatchesSelector?(selector: string): boolean }, selector: string) {
+  if (element.matches) {
+    return element.matches(selector)
+  }
+  // IE11 support
+  if (element.msMatchesSelector) {
+    return element.msMatchesSelector(selector)
+  }
+  return false
+}
+
 export function runOnReadyState(expectedReadyState: 'complete' | 'interactive', callback: () => void) {
   if (document.readyState === expectedReadyState || document.readyState === 'complete') {
     callback()

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -1,4 +1,4 @@
-import type { IsolatedDom } from '../../../../test/createIsolatedDom';
+import type { IsolatedDom } from '../../../../test/createIsolatedDom'
 import { createIsolatedDom } from '../../../../test/createIsolatedDom'
 import { getActionNameFromElement } from './getActionNameFromElement'
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -1,54 +1,55 @@
-import { createIsolatedDOM } from '../../../../test/createIsolatedDom'
+import type { IsolatedDom } from '../../../../test/createIsolatedDom';
+import { createIsolatedDom } from '../../../../test/createIsolatedDom'
 import { getActionNameFromElement } from './getActionNameFromElement'
 
 describe('getActionNameFromElement', () => {
-  let isolatedDOM: ReturnType<typeof createIsolatedDOM>
+  let isolatedDom: IsolatedDom
 
   beforeEach(() => {
-    isolatedDOM = createIsolatedDOM()
+    isolatedDom = createIsolatedDom()
   })
 
   afterEach(() => {
-    isolatedDOM.clear()
+    isolatedDom.clear()
   })
 
   it('extracts the textual content of an element', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<div>Foo <div>bar</div></div>`)).toBe('Foo bar')
+    expect(getActionNameFromElement(isolatedDom.element`<div>Foo <div>bar</div></div>`)).toBe('Foo bar')
   })
 
   it('extracts the text of an input button', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<input type="button" value="Click" />`)).toBe('Click')
+    expect(getActionNameFromElement(isolatedDom.element`<input type="button" value="Click" />`)).toBe('Click')
   })
 
   it('extracts the alt text of an image', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<img title="foo" alt="bar" />`)).toBe('bar')
+    expect(getActionNameFromElement(isolatedDom.element`<img title="foo" alt="bar" />`)).toBe('bar')
   })
 
   it('extracts the title text of an image', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<img title="foo" />`)).toBe('foo')
+    expect(getActionNameFromElement(isolatedDom.element`<img title="foo" />`)).toBe('foo')
   })
 
   it('extracts the text of an aria-label attribute', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<span aria-label="Foo" />`)).toBe('Foo')
+    expect(getActionNameFromElement(isolatedDom.element`<span aria-label="Foo" />`)).toBe('Foo')
   })
 
   it('gets the parent element textual content if everything else fails', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<div>Foo <img target /></div>`)).toBe('Foo')
+    expect(getActionNameFromElement(isolatedDom.element`<div>Foo <img target /></div>`)).toBe('Foo')
   })
 
   it("doesn't get the value of a text input", () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<input type="text" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(isolatedDom.element`<input type="text" value="foo" />`)).toBe('')
   })
 
   it("doesn't get the value of a password input", () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<input type="password" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(isolatedDom.element`<input type="password" value="foo" />`)).toBe('')
   })
 
   it('limits the name length to a reasonable size', () => {
     expect(
       getActionNameFromElement(
         // eslint-disable-next-line  max-len
-        isolatedDOM.element`<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>`
+        isolatedDom.element`<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>`
       )
     ).toBe(
       // eslint-disable-next-line  max-len
@@ -57,20 +58,20 @@ describe('getActionNameFromElement', () => {
   })
 
   it('normalize white spaces', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<div>foo\tbar\n\n  baz</div>`)).toBe('foo bar baz')
+    expect(getActionNameFromElement(isolatedDom.element`<div>foo\tbar\n\n  baz</div>`)).toBe('foo bar baz')
   })
 
   it('ignores the inline script textual content', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<div><script>console.log('toto')</script>b</div>`)).toBe('b')
+    expect(getActionNameFromElement(isolatedDom.element`<div><script>console.log('toto')</script>b</div>`)).toBe('b')
   })
 
   it('extracts text from SVG elements', () => {
-    expect(getActionNameFromElement(isolatedDOM.element`<svg><text>foo  bar</text></svg>`)).toBe('foo bar')
+    expect(getActionNameFromElement(isolatedDom.element`<svg><text>foo  bar</text></svg>`)).toBe('foo bar')
   })
 
   it('extracts text from an associated label', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <label for="toto">label text</label>
           <div>ignored</div>
@@ -82,7 +83,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts text from a parent label', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <label>
           foo
           <div>
@@ -96,7 +97,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts text from the first OPTION element when clicking on a SELECT', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <select>
           <option>foo</option>
           <option>bar</option>
@@ -107,7 +108,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts text from a aria-labelledby associated element', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <label id="toto">label text</label>
           <div>ignored</div>
@@ -119,7 +120,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts text from multiple aria-labelledby associated elements', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <label id="toto1">label</label>
           <div>ignored</div>
@@ -133,7 +134,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts text from a BUTTON element', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <div>ignored</div>
           <button target>foo</button>
@@ -144,7 +145,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts text from a role=button element', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <div>ignored</div>
           <div role="button" target>foo</div>
@@ -155,7 +156,7 @@ describe('getActionNameFromElement', () => {
 
   it('limits the recursion to the 10th parent', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <div>ignored</div>
           <i><i><i><i><i><i><i><i><i><i>
@@ -168,7 +169,7 @@ describe('getActionNameFromElement', () => {
 
   it('limits the recursion to the BODY element', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>ignored</div>
         <i target></i>
       `)
@@ -177,7 +178,7 @@ describe('getActionNameFromElement', () => {
 
   it('limits the recursion to a FORM element', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <div>ignored</div>
           <form>
@@ -190,7 +191,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts the name from a parent FORM element', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div>
           <div>ignored</div>
           <form title="foo">
@@ -203,7 +204,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts the whole textual content of a button', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <button>
           foo
           <i target>bar</i>
@@ -214,7 +215,7 @@ describe('getActionNameFromElement', () => {
 
   it('ignores the textual content of contenteditable elements', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div contenteditable>
           <i target>ignored</i>
           ignored
@@ -225,7 +226,7 @@ describe('getActionNameFromElement', () => {
 
   it('extracts the name from attributes of contenteditable elements', () => {
     expect(
-      getActionNameFromElement(isolatedDOM.element`
+      getActionNameFromElement(isolatedDom.element`
         <div contenteditable>
           <i aria-label="foo" target>ignored</i>
           ignored
@@ -237,14 +238,14 @@ describe('getActionNameFromElement', () => {
   describe('programmatically declared action name', () => {
     it('extracts the name from the data-dd-action-name attribute', () => {
       expect(
-        getActionNameFromElement(isolatedDOM.element`
+        getActionNameFromElement(isolatedDom.element`
           <div data-dd-action-name="foo">ignored</div>
         `)
       ).toBe('foo')
     })
 
     it('considers any parent', () => {
-      const target = isolatedDOM.element`
+      const target = isolatedDom.element`
         <form>
           <i><i><i><i><i><i><i><i><i><i><i><i>
             <span target>ignored</span>
@@ -258,7 +259,7 @@ describe('getActionNameFromElement', () => {
 
     it('normalizes the value', () => {
       expect(
-        getActionNameFromElement(isolatedDOM.element`
+        getActionNameFromElement(isolatedDom.element`
           <div data-dd-action-name="   foo  \t bar  ">ignored</div>
         `)
       ).toBe('foo bar')
@@ -266,7 +267,7 @@ describe('getActionNameFromElement', () => {
 
     it('fallback on an automatic strategy if the attribute is empty', () => {
       expect(
-        getActionNameFromElement(isolatedDOM.element`
+        getActionNameFromElement(isolatedDom.element`
           <div data-dd-action-name="ignored">
             <div data-dd-action-name="">
               <span target>foo</span>
@@ -279,7 +280,7 @@ describe('getActionNameFromElement', () => {
     it('extracts the name from a user-configured attribute', () => {
       expect(
         getActionNameFromElement(
-          isolatedDOM.element`
+          isolatedDom.element`
           <div data-test-id="foo">ignored</div>
         `,
           'data-test-id'
@@ -290,7 +291,7 @@ describe('getActionNameFromElement', () => {
     it('favors data-dd-action-name over user-configured attribute', () => {
       expect(
         getActionNameFromElement(
-          isolatedDOM.element`
+          isolatedDom.element`
           <div data-test-id="foo" data-dd-action-name="bar">ignored</div>
         `,
           'data-test-id'
@@ -300,7 +301,7 @@ describe('getActionNameFromElement', () => {
 
     it('remove children with programmatic action name in textual content', () => {
       expect(
-        getActionNameFromElement(isolatedDOM.element`<div>Foo <div data-dd-action-name="custom action">bar<div></div>`)
+        getActionNameFromElement(isolatedDom.element`<div>Foo <div data-dd-action-name="custom action">bar<div></div>`)
       ).toBe('Foo')
     })
 
@@ -308,7 +309,7 @@ describe('getActionNameFromElement', () => {
     it('remove children with programmatic action name in textual content based on the user-configured attribute', () => {
       expect(
         getActionNameFromElement(
-          isolatedDOM.element`<div>Foo <div data-test-id="custom action">bar<div></div>`,
+          isolatedDom.element`<div>Foo <div data-test-id="custom action">bar<div></div>`,
           'data-test-id'
         )
       ).toBe('Foo')

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.spec.ts
@@ -1,4 +1,4 @@
-import type { IsolatedDom } from '../../../../test/createIsolatedDom';
+import type { IsolatedDom } from '../../../../test/createIsolatedDom'
 import { createIsolatedDom } from '../../../../test/createIsolatedDom'
 import { getSelectorFromElement } from './getSelectorFromElement'
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.spec.ts
@@ -1,24 +1,25 @@
-import { createIsolatedDOM } from '../../../../test/createIsolatedDom'
+import type { IsolatedDom } from '../../../../test/createIsolatedDom';
+import { createIsolatedDom } from '../../../../test/createIsolatedDom'
 import { getSelectorFromElement } from './getSelectorFromElement'
 
 describe('getSelectorFromElement', () => {
-  let isolatedDOM: ReturnType<typeof createIsolatedDOM>
+  let isolatedDom: IsolatedDom
 
   beforeEach(() => {
-    isolatedDOM = createIsolatedDOM()
+    isolatedDom = createIsolatedDom()
   })
 
   afterEach(() => {
-    isolatedDOM.clear()
+    isolatedDom.clear()
   })
 
   describe('ID selector', () => {
     it('should use the ID selector when the element as an ID', () => {
-      expect(getSelectorFromElement(isolatedDOM.element`<div id="foo"></div>`)).toBe('#foo')
+      expect(getSelectorFromElement(isolatedDom.element`<div id="foo"></div>`)).toBe('#foo')
     })
 
     it('should not use the ID selector when the ID is not unique', () => {
-      expect(getSelectorFromElement(isolatedDOM.element`<div id="foo"></div><div id="foo"></div>`)).not.toContain(
+      expect(getSelectorFromElement(isolatedDom.element`<div id="foo"></div><div id="foo"></div>`)).not.toContain(
         '#foo'
       )
     })
@@ -26,51 +27,51 @@ describe('getSelectorFromElement', () => {
 
   describe('class selector', () => {
     it('should use the class selector when the element as classes', () => {
-      expect(getSelectorFromElement(isolatedDOM.element`<div class="foo bar"></div>`)).toBe('BODY>DIV.bar.foo')
+      expect(getSelectorFromElement(isolatedDom.element`<div class="foo bar"></div>`)).toBe('BODY>DIV.bar.foo')
     })
 
     it('should use the class selector when siblings have the same classes but different tags', () => {
-      expect(getSelectorFromElement(isolatedDOM.element`<div target class="foo"></div><span class="foo"></span>`)).toBe(
+      expect(getSelectorFromElement(isolatedDom.element`<div target class="foo"></div><span class="foo"></span>`)).toBe(
         'BODY>DIV.foo'
       )
     })
 
     it('should not use the class selector when siblings have the tag + classes', () => {
       expect(
-        getSelectorFromElement(isolatedDOM.element`<div target class="foo"></div><div class="foo"></div>`)
+        getSelectorFromElement(isolatedDom.element`<div target class="foo"></div><div class="foo"></div>`)
       ).not.toContain('DIV.foo')
       expect(
-        getSelectorFromElement(isolatedDOM.element`<div target class="foo bar"></div><div class="bar foo baz"></div>`)
+        getSelectorFromElement(isolatedDom.element`<div target class="foo bar"></div><div class="bar foo baz"></div>`)
       ).not.toContain('DIV.foo')
     })
   })
 
   describe('position selector', () => {
     it('should use nth-of-type when the element as siblings', () => {
-      const html = isolatedDOM.element`<span></span><div></div><span></span><div target></div>`
+      const html = isolatedDom.element`<span></span><div></div><span></span><div target></div>`
       expect(getSelectorFromElement(html)).toBe('BODY>DIV:nth-of-type(2)')
     })
 
     it('should not use nth-of-type when the element has no siblings', () => {
-      const html = isolatedDOM.element`<div></div>`
+      const html = isolatedDom.element`<div></div>`
       expect(getSelectorFromElement(html)).toBe('BODY>DIV')
     })
   })
 
   describe('strategies priority', () => {
     it('ID selector should take precedence over class selector', () => {
-      expect(getSelectorFromElement(isolatedDOM.element`<div id="foo" class="bar"></div>`)).toBe('#foo')
+      expect(getSelectorFromElement(isolatedDom.element`<div id="foo" class="bar"></div>`)).toBe('#foo')
     })
 
     it('class selector should take precedence over position selector', () => {
-      expect(getSelectorFromElement(isolatedDOM.element`<div class="bar"></div><div></div>`)).toBe('BODY>DIV.bar')
+      expect(getSelectorFromElement(isolatedDom.element`<div class="bar"></div><div></div>`)).toBe('BODY>DIV.bar')
     })
   })
 
   describe('should escape CSS selectors', () => {
     it('ID selector should take precedence over class selector', () => {
       expect(
-        getSelectorFromElement(isolatedDOM.element`<div id="#bar"><button target class=".foo"></button></div>`)
+        getSelectorFromElement(isolatedDom.element`<div id="#bar"><button target class=".foo"></button></div>`)
       ).toBe('#\\#bar>BUTTON.\\.foo')
     })
   })

--- a/packages/rum-core/test/createIsolatedDom.ts
+++ b/packages/rum-core/test/createIsolatedDom.ts
@@ -11,11 +11,16 @@ export function createIsolatedDom() {
   doc.write('<html><body></body></html>')
   doc.close()
 
+  function append(html: string) {
+    iframe.contentDocument!.body.innerHTML = html
+    return doc.querySelector('[target]') || doc.body.children[0]
+  }
+
   return {
     element(s: TemplateStringsArray) {
-      iframe.contentDocument!.body.innerHTML = s[0]
-      return doc.querySelector('[target]') || doc.body.children[0]
+      return append(s[0])
     },
+    append,
     clear() {
       iframe.parentNode!.removeChild(iframe)
     },

--- a/packages/rum-core/test/createIsolatedDom.ts
+++ b/packages/rum-core/test/createIsolatedDom.ts
@@ -1,4 +1,6 @@
-export function createIsolatedDOM() {
+export type IsolatedDom = ReturnType<typeof createIsolatedDom>
+
+export function createIsolatedDom() {
   // Simply using a DOMParser does not fit here, because script tags created this way are
   // considered as normal markup, so they are not ignored when getting the textual content of the
   // target via innerText

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -202,6 +202,32 @@ describe('action collection', () => {
       expect(actionEvents[0].action.frustration!.type).toEqual([])
     })
 
+  createTest('consider a click on an already checked "radio" input as "dead_click"')
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withBody(html` <input type="radio" checked /> `)
+    .run(async ({ serverEvents }) => {
+      const input = await $('input')
+      await input.click()
+      await flushEvents()
+      const actionEvents = serverEvents.rumActions
+
+      expect(actionEvents.length).toBe(1)
+      expect(actionEvents[0].action.frustration!.type).toEqual(['dead_click'])
+    })
+
+  createTest('do not consider a click on text input as "dead_click"')
+    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
+    .withBody(html` <input type="text" /> `)
+    .run(async ({ serverEvents }) => {
+      const input = await $('input')
+      await input.click()
+      await flushEvents()
+      const actionEvents = serverEvents.rumActions
+
+      expect(actionEvents.length).toBe(1)
+      expect(actionEvents[0].action.frustration!.type).toEqual([])
+    })
+
   createTest('collect a "rage click"')
     .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['frustration-signals'] })
     .withBody(


### PR DESCRIPTION
## Motivation

In some cases, we cannot track whether a click leads to a meaningful UI change. 

## Changes

This PR implements a list of elements that should never be associated with a dead click.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
