### PR TITLE
🐛 [RUMF-1273] fix BUILD_MODE scope

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -226,7 +226,7 @@ deploy-staging:
     - .base-configuration
     - .staging
   script:
-    - BUILD_MODE=canary
+    - export BUILD_MODE=canary
     - yarn
     - yarn build:bundle
     - ./scripts/deploy.sh staging staging
@@ -238,7 +238,7 @@ deploy-prod-canary:
     - .base-configuration
     - .main
   script:
-    - BUILD_MODE=canary
+    - export BUILD_MODE=canary
     - yarn
     - yarn build:bundle
     - ./scripts/deploy.sh prod canary
@@ -252,7 +252,7 @@ deploy-prod-stable:
   when: manual
   allow_failure: false
   script:
-    - BUILD_MODE=release
+    - export BUILD_MODE=release
     - VERSION=$(node -p -e "require('./lerna.json').version")
     - yarn
     - yarn build:bundle


### PR DESCRIPTION
## Motivation

Following #1614, mutualizing `BUILD_MODE` make it unavailable from scripts 🤦‍♂️ 

## Changes

promote `BUILD_MODE` as an env variable

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] ci

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
