### PR TITLE
🐛 [RUMF-1327] rum synthetics: fix logs session conflict

### DIFF
--- a/packages/core/src/domain/synthetics/syntheticsWorkerValues.spec.ts
+++ b/packages/core/src/domain/synthetics/syntheticsWorkerValues.spec.ts
@@ -1,0 +1,86 @@
+import { mockSyntheticsWorkerValues, cleanupSyntheticsWorkerValues } from '../../../test/syntheticsWorkerValues'
+import { getSyntheticsResultId, getSyntheticsTestId, willSyntheticsInjectRum } from './syntheticsWorkerValues'
+
+describe('syntheticsWorkerValues', () => {
+  afterEach(() => {
+    cleanupSyntheticsWorkerValues()
+  })
+
+  describe('willSyntheticsInjectRum', () => {
+    it('returns false if nothing is defined', () => {
+      mockSyntheticsWorkerValues({}, 'globals')
+
+      expect(willSyntheticsInjectRum()).toBeFalse()
+    })
+
+    it('returns false if the INJECTS_RUM global variable is false', () => {
+      mockSyntheticsWorkerValues({ injectsRum: false }, 'globals')
+
+      expect(willSyntheticsInjectRum()).toBeFalse()
+    })
+
+    it('returns true if the INJECTS_RUM global variable is truthy', () => {
+      mockSyntheticsWorkerValues({ injectsRum: true }, 'globals')
+
+      expect(willSyntheticsInjectRum()).toBeTrue()
+    })
+
+    it('returns true if the INJECTS_RUM cookie is truthy', () => {
+      mockSyntheticsWorkerValues({ injectsRum: true }, 'cookies')
+
+      expect(willSyntheticsInjectRum()).toBeTrue()
+    })
+  })
+
+  describe('getSyntheticsTestId', () => {
+    it('returns undefined if nothing is defined', () => {
+      mockSyntheticsWorkerValues({}, 'globals')
+
+      expect(getSyntheticsTestId()).toBeUndefined()
+    })
+
+    it('returns the test id if the PUBLIC_ID global variable is defined', () => {
+      mockSyntheticsWorkerValues({ publicId: 'toto' }, 'globals')
+
+      expect(getSyntheticsTestId()).toBe('toto')
+    })
+
+    it('returns undefined if the PUBLIC_ID global variable is not a string', () => {
+      mockSyntheticsWorkerValues({ publicId: 1 }, 'globals')
+
+      expect(getSyntheticsTestId()).toBeUndefined()
+    })
+
+    it('returns undefined if the PUBLIC_ID cookie is defined', () => {
+      mockSyntheticsWorkerValues({ publicId: 'toto' }, 'cookies')
+
+      expect(getSyntheticsTestId()).toBe('toto')
+    })
+  })
+
+  describe('getSyntheticsResultId', () => {
+    it('returns undefined if nothing is defined', () => {
+      mockSyntheticsWorkerValues({}, 'globals')
+
+      expect(getSyntheticsResultId()).toBeUndefined()
+    })
+
+    it('returns the test id if the RESULT_ID global variable is defined', () => {
+      mockSyntheticsWorkerValues({ resultId: 'toto' }, 'globals')
+
+      expect(getSyntheticsResultId()).toBe('toto')
+    })
+
+    it('returns undefined if the RESULT_ID global variable is not a string', () => {
+      mockSyntheticsWorkerValues({ resultId: 1 }, 'globals')
+
+      expect(getSyntheticsResultId()).toBeUndefined()
+    })
+
+    it('returns undefined if the RESULT_ID cookie is defined', () => {
+      mockSyntheticsWorkerValues({ resultId: 'toto' }, 'cookies')
+
+      expect(getSyntheticsResultId()).toBe('toto')
+    })
+  })
+})

--- a/packages/core/src/domain/synthetics/syntheticsWorkerValues.ts
+++ b/packages/core/src/domain/synthetics/syntheticsWorkerValues.ts
@@ -1,0 +1,27 @@
+import { getCookie } from '../../browser/cookie'
+
+export const SYNTHETICS_TEST_ID_COOKIE_NAME = 'datadog-synthetics-public-id'
+export const SYNTHETICS_RESULT_ID_COOKIE_NAME = 'datadog-synthetics-result-id'
+export const SYNTHETICS_INJECTS_RUM_COOKIE_NAME = 'datadog-synthetics-injects-rum'
+
+export interface BrowserWindow extends Window {
+  _DATADOG_SYNTHETICS_PUBLIC_ID?: unknown
+  _DATADOG_SYNTHETICS_RESULT_ID?: unknown
+  _DATADOG_SYNTHETICS_INJECTS_RUM?: unknown
+}
+
+export function willSyntheticsInjectRum(): boolean {
+  return Boolean(
+    (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM || getCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
+  )
+}
+
+export function getSyntheticsTestId(): string | undefined {
+  const value = (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID || getCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
+  return typeof value === 'string' ? value : undefined
+}
+
+export function getSyntheticsResultId(): string | undefined {
+  const value = (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID || getCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
+  return typeof value === 'string' ? value : undefined
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,3 +72,8 @@ export { createContextManager } from './tools/contextManager'
 export { limitModification } from './tools/limitModification'
 export { ContextHistory, ContextHistoryEntry, CLEAR_OLD_CONTEXTS_INTERVAL } from './tools/contextHistory'
 export { SESSION_COOKIE_NAME } from './domain/session/sessionCookieStore'
+export {
+  willSyntheticsInjectRum,
+  getSyntheticsTestId,
+  getSyntheticsResultId,
+} from './domain/synthetics/syntheticsWorkerValues'

--- a/packages/core/test/syntheticsWorkerValues.ts
+++ b/packages/core/test/syntheticsWorkerValues.ts
@@ -1,0 +1,48 @@
+import { deleteCookie, setCookie } from '../src/browser/cookie'
+import type { BrowserWindow } from '../src/domain/synthetics/syntheticsWorkerValues'
+import {
+  SYNTHETICS_INJECTS_RUM_COOKIE_NAME,
+  SYNTHETICS_RESULT_ID_COOKIE_NAME,
+  SYNTHETICS_TEST_ID_COOKIE_NAME,
+} from '../src/domain/synthetics/syntheticsWorkerValues'
+import { ONE_MINUTE } from '../src/tools/utils'
+
+// Duration to create a cookie lasting at least until the end of the test
+const COOKIE_DURATION = ONE_MINUTE
+
+export function mockSyntheticsWorkerValues(
+  { publicId, resultId, injectsRum }: { publicId?: any; resultId?: any; injectsRum?: any } = {
+    publicId: 'synthetics_public_id',
+    resultId: 'synthetics_result_id',
+    injectsRum: false,
+  },
+  method: 'globals' | 'cookies' = 'globals'
+) {
+  switch (method) {
+    case 'globals':
+      ;(window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID = publicId
+      ;(window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID = resultId
+      ;(window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM = injectsRum
+      break
+    case 'cookies':
+      if (publicId !== undefined) {
+        setCookie(SYNTHETICS_TEST_ID_COOKIE_NAME, publicId, COOKIE_DURATION)
+      }
+      if (resultId !== undefined) {
+        setCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME, resultId, COOKIE_DURATION)
+      }
+      if (injectsRum !== undefined) {
+        setCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME, injectsRum, COOKIE_DURATION)
+      }
+      break
+  }
+}
+
+export function cleanupSyntheticsWorkerValues() {
+  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID
+  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID
+  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM
+  deleteCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
+  deleteCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
+  deleteCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
+}

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -1,6 +1,6 @@
 import { ErrorSource, display, stopSessionManager, getCookie, SESSION_COOKIE_NAME } from '@datadog/browser-core'
-import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from 'packages/core/test/syntheticsWorkerValues'
 import sinon from 'sinon'
+import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../core/test/syntheticsWorkerValues'
 import { deleteEventBridgeStub, initEventBridgeStub, stubEndpointBuilder } from '../../../core/test/specHelper'
 import type { LogsConfiguration } from '../domain/configuration'
 import { validateAndBuildLogsConfiguration } from '../domain/configuration'

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -20,6 +20,7 @@ interface Rum {
 declare global {
   interface Window {
     DD_RUM?: Rum
+    DD_RUM_SYNTHETICS?: Rum
   }
 }
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -1,5 +1,5 @@
-import type { Context, TelemetryEvent } from '@datadog/browser-core'
-import {
+import type { Context, TelemetryEvent} from '@datadog/browser-core';
+import { willSyntheticsInjectRum ,
   areCookiesAuthorized,
   canUseEventBridge,
   getEventBridge,
@@ -47,7 +47,7 @@ export function startLogs(configuration: LogsConfiguration, getCommonContext: ()
   const { handleLog } = startLoggerCollection(lifeCycle)
 
   const session =
-    areCookiesAuthorized(configuration.cookieOptions) && !canUseEventBridge()
+    areCookiesAuthorized(configuration.cookieOptions) && !canUseEventBridge() && !willSyntheticsInjectRum()
       ? startLogsSessionManager(configuration)
       : startLogsSessionManagerStub(configuration)
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -1,5 +1,6 @@
-import type { Context, TelemetryEvent} from '@datadog/browser-core';
-import { willSyntheticsInjectRum ,
+import type { Context, TelemetryEvent } from '@datadog/browser-core'
+import {
+  willSyntheticsInjectRum,
   areCookiesAuthorized,
   canUseEventBridge,
   getEventBridge,

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,13 +1,9 @@
 import type { RelativeTime, TimeStamp } from '@datadog/browser-core'
 import { ONE_SECOND, getTimeStamp, display, DefaultPrivacyLevel } from '@datadog/browser-core'
+import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../core/test/syntheticsWorkerValues'
 import { initEventBridgeStub, deleteEventBridgeStub } from '../../../core/test/specHelper'
 import type { TestSetupBuilder } from '../../test/specHelper'
-import {
-  cleanupSyntheticsWorkerValues,
-  mockSyntheticsWorkerValues,
-  noopRecorderApi,
-  setup,
-} from '../../test/specHelper'
+import { noopRecorderApi, setup } from '../../test/specHelper'
 import type { HybridInitConfiguration, RumInitConfiguration } from '../domain/configuration'
 import { ActionType } from '../rawRumEvent.types'
 import type { RumPublicApi, StartRum, RecorderApi } from './rumPublicApi'

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -1,5 +1,6 @@
 import type { Context, InitConfiguration, TimeStamp, RelativeTime } from '@datadog/browser-core'
 import {
+  willSyntheticsInjectRum,
   assign,
   BoundedBuffer,
   buildCookieOptions,
@@ -20,7 +21,6 @@ import type { ViewContexts } from '../domain/contexts/viewContexts'
 import type { RumSessionManager } from '../domain/rumSessionManager'
 import type { CommonContext, User, ReplayStats } from '../rawRumEvent.types'
 import { ActionType } from '../rawRumEvent.types'
-import { willSyntheticsInjectRum } from '../domain/contexts/syntheticsContext'
 import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
 import { validateAndBuildRumConfiguration } from '../domain/configuration'
 import type { ViewOptions } from '../domain/rumEventsCollection/view/trackViews'

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -3,18 +3,13 @@ import { ErrorSource, ONE_MINUTE, display } from '@datadog/browser-core'
 import { createRumSessionManagerMock } from '../../test/mockRumSessionManager'
 import { createRawRumEvent } from '../../test/fixtures'
 import type { TestSetupBuilder } from '../../test/specHelper'
-import {
-  cleanupSyntheticsWorkerValues,
-  mockSyntheticsWorkerValues,
-  mockCiVisibilityWindowValues,
-  cleanupCiVisibilityWindowValues,
-  setup,
-} from '../../test/specHelper'
+import { mockCiVisibilityWindowValues, cleanupCiVisibilityWindowValues, setup } from '../../test/specHelper'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type { CommonContext, RawRumActionEvent, RawRumErrorEvent, RawRumEvent } from '../rawRumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
 import type { RumActionEvent, RumErrorEvent, RumEvent } from '../rumEvent.types'
 import { initEventBridgeStub, deleteEventBridgeStub } from '../../../core/test/specHelper'
+import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../core/test/syntheticsWorkerValues'
 import { startRumAssembly } from './assembly'
 import type { LifeCycle, RawRumEventCollectedData } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'

--- a/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
@@ -1,5 +1,5 @@
-import { mockSyntheticsWorkerValues, cleanupSyntheticsWorkerValues } from '../../../test/specHelper'
-import { getSyntheticsContext, willSyntheticsInjectRum } from './syntheticsContext'
+import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../../core/test/syntheticsWorkerValues'
+import { getSyntheticsContext } from './syntheticsContext'
 
 describe('getSyntheticsContext', () => {
   afterEach(() => {
@@ -48,35 +48,5 @@ describe('getSyntheticsContext', () => {
     mockSyntheticsWorkerValues({ publicId: 'foo' }, 'cookies')
 
     expect(getSyntheticsContext()).toBeUndefined()
-  })
-})
-
-describe('willSyntheticsInjectRum', () => {
-  afterEach(() => {
-    cleanupSyntheticsWorkerValues()
-  })
-
-  it('returns false if nothing is defined', () => {
-    mockSyntheticsWorkerValues({}, 'globals')
-
-    expect(willSyntheticsInjectRum()).toBeFalse()
-  })
-
-  it('returns false if the INJECTS_RUM global variable is false', () => {
-    mockSyntheticsWorkerValues({ injectsRum: false }, 'globals')
-
-    expect(willSyntheticsInjectRum()).toBeFalse()
-  })
-
-  it('returns true if the INJECTS_RUM global variable is truthy', () => {
-    mockSyntheticsWorkerValues({ injectsRum: true }, 'globals')
-
-    expect(willSyntheticsInjectRum()).toBeTrue()
-  })
-
-  it('returns true if the INJECTS_RUM cookie is truthy', () => {
-    mockSyntheticsWorkerValues({ injectsRum: true }, 'cookies')
-
-    expect(willSyntheticsInjectRum()).toBeTrue()
   })
 })

--- a/packages/rum-core/src/domain/contexts/syntheticsContext.ts
+++ b/packages/rum-core/src/domain/contexts/syntheticsContext.ts
@@ -1,31 +1,14 @@
-import { getCookie } from '@datadog/browser-core'
-
-export const SYNTHETICS_TEST_ID_COOKIE_NAME = 'datadog-synthetics-public-id'
-export const SYNTHETICS_RESULT_ID_COOKIE_NAME = 'datadog-synthetics-result-id'
-export const SYNTHETICS_INJECTS_RUM_COOKIE_NAME = 'datadog-synthetics-injects-rum'
-
-export interface BrowserWindow extends Window {
-  _DATADOG_SYNTHETICS_PUBLIC_ID?: string
-  _DATADOG_SYNTHETICS_RESULT_ID?: string
-  _DATADOG_SYNTHETICS_INJECTS_RUM?: boolean
-}
+import { getSyntheticsResultId, getSyntheticsTestId, willSyntheticsInjectRum } from '@datadog/browser-core'
 
 export function getSyntheticsContext() {
-  const testId = (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID || getCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
-  const resultId =
-    (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID || getCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
+  const testId = getSyntheticsTestId()
+  const resultId = getSyntheticsResultId()
 
-  if (typeof testId === 'string' && typeof resultId === 'string') {
+  if (testId && resultId) {
     return {
       test_id: testId,
       result_id: resultId,
       injected: willSyntheticsInjectRum(),
     }
   }
-}
-
-export function willSyntheticsInjectRum() {
-  return Boolean(
-    (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM || getCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
-  )
 }

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -1,5 +1,5 @@
 import type { Context, TimeStamp } from '@datadog/browser-core'
-import { assign, combine, Observable, noop, setCookie, deleteCookie, ONE_MINUTE } from '@datadog/browser-core'
+import { assign, combine, Observable, noop } from '@datadog/browser-core'
 import type { Clock } from '../../core/test/specHelper'
 import { SPEC_ENDPOINTS, mockClock, buildLocation } from '../../core/test/specHelper'
 import type { RecorderApi } from '../src/boot/rumPublicApi'
@@ -14,12 +14,6 @@ import { RumSessionPlan } from '../src/domain/rumSessionManager'
 import type { RawRumEvent, RumContext } from '../src/rawRumEvent.types'
 import type { LocationChange } from '../src/browser/locationChangeObservable'
 import type { UrlContexts } from '../src/domain/contexts/urlContexts'
-import type { BrowserWindow } from '../src/domain/contexts/syntheticsContext'
-import {
-  SYNTHETICS_INJECTS_RUM_COOKIE_NAME,
-  SYNTHETICS_RESULT_ID_COOKIE_NAME,
-  SYNTHETICS_TEST_ID_COOKIE_NAME,
-} from '../src/domain/contexts/syntheticsContext'
 import type { CiTestWindow } from '../src/domain/contexts/ciTestContext'
 import type { RumConfiguration } from '../src/domain/configuration'
 import { validateAndBuildRumConfiguration } from '../src/domain/configuration'
@@ -275,46 +269,6 @@ export const noopRecorderApi: RecorderApi = {
   isRecording: () => false,
   onRumStart: noop,
   getReplayStats: () => undefined,
-}
-
-// Duration to create a cookie lasting at least until the end of the test
-const COOKIE_DURATION = ONE_MINUTE
-
-export function mockSyntheticsWorkerValues(
-  { publicId, resultId, injectsRum }: { publicId?: any; resultId?: any; injectsRum?: any } = {
-    publicId: 'synthetics_public_id',
-    resultId: 'synthetics_result_id',
-    injectsRum: false,
-  },
-  method: 'globals' | 'cookies' = 'globals'
-) {
-  switch (method) {
-    case 'globals':
-      ;(window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID = publicId
-      ;(window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID = resultId
-      ;(window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM = injectsRum
-      break
-    case 'cookies':
-      if (publicId !== undefined) {
-        setCookie(SYNTHETICS_TEST_ID_COOKIE_NAME, publicId, COOKIE_DURATION)
-      }
-      if (resultId !== undefined) {
-        setCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME, resultId, COOKIE_DURATION)
-      }
-      if (injectsRum !== undefined) {
-        setCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME, injectsRum, COOKIE_DURATION)
-      }
-      break
-  }
-}
-
-export function cleanupSyntheticsWorkerValues() {
-  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID
-  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID
-  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM
-  deleteCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
-  deleteCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
-  deleteCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
 }
 
 export function mockCiVisibilityWindowValues(traceId?: unknown) {


### PR DESCRIPTION
## Motivation

We identified an issue when the RUM SDK is injected by the Synthetics Worker and the Web application is using the Logs SDK: cookie options might be different, and the session cookie accesses have unexpected behaviors.

## Changes

To avoid that, this PR makes sure that the Logs SDK does not create a cookie session when the RUM SDK will be injected by the Synthetics Worker

In this context, the Logs SDK will rely on the session created by the inject RUM SDK

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
