### PR TITLE
⬇️ [RUMF-1329] downgrade woke to a working version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get -y install procps
 
 # Woke
 RUN curl -sSfL https://git.io/getwoke | \
-  bash -s -- -b /usr/local/bin
+  bash -s -- -b /usr/local/bin v0.17.1
 
 # Codecov https://docs.codecov.com/docs/codecov-uploader
 RUN apt-get -y install gnupg coreutils


### PR DESCRIPTION


## Motivation

We can't build our CI image with the latest version of `woke` because of
https://github.com/get-woke/woke/issues/195 .

I didn't find an alternative to woke.

I tried a bit to fix the issue, but:

* I'm not fluent with go, and the fix is non-trivial

* the issue seems to be in a woke dependency (`go-git`), and woke is using a fork of a fork of this dependency, making it hazardous to fix.

## Changes

Downgrade woke

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
