### PR TITLE
🐛 frustration signals: track window open

### DIFF
--- a/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
@@ -83,6 +83,13 @@ describe('createPageActivityObservable', () => {
     expect(events).toEqual([])
   })
 
+  it('emits an activity event when `window.open` is used', () => {
+    spyOn(window, 'open')
+    setupBuilder.build()
+    window.open('toto')
+    expect(events).toEqual([{ isBusy: false }])
+  })
+
   it('stops emitting activities after calling stop()', () => {
     const { domMutationObservable } = setupBuilder.build()
     domMutationObservable.notify()

--- a/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
@@ -74,17 +74,7 @@ describe('createPageActivityObservable', () => {
     expect(events).toEqual([{ isBusy: false }])
   })
 
-  it('emits an activity event on resource collected', () => {
-    const { lifeCycle } = setupBuilder.build()
-    const performanceTiming = {
-      entryType: 'resource',
-      name: EXCLUDED_FAKE_URL,
-    } as RumPerformanceResourceTiming
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [performanceTiming])
-    expect(events).toEqual([])
-  })
-
-  it('ignores resources that should be excluded by configuration', () => {
+  it('does not emit an activity event when a navigation occurs', () => {
     const { lifeCycle } = setupBuilder.build()
     const performanceTiming = {
       entryType: 'navigation',
@@ -137,6 +127,16 @@ describe('createPageActivityObservable', () => {
     })
 
     describe('excludedActivityUrls', () => {
+      it('ignores resources that should be excluded by configuration', () => {
+        const { lifeCycle } = setupBuilder.build()
+        const performanceTiming = {
+          entryType: 'resource',
+          name: EXCLUDED_FAKE_URL,
+        } as RumPerformanceResourceTiming
+        lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [performanceTiming])
+        expect(events).toEqual([])
+      })
+
       it('ignores requests that should be excluded by configuration', () => {
         const { lifeCycle } = setupBuilder.build()
         lifeCycle.notify(LifeCycleEventType.REQUEST_STARTED, makeFakeRequestStartEvent(10, EXCLUDED_FAKE_URL))

--- a/packages/rum-core/src/domain/waitPageActivityEnd.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.ts
@@ -146,7 +146,12 @@ export function createPageActivityObservable(
       })
     )
 
-    return () => subscriptions.forEach((s) => s.unsubscribe())
+    const { stop: stopTrackingWindowOpen } = trackWindowOpen(notifyPageActivity)
+
+    return () => {
+      stopTrackingWindowOpen()
+      subscriptions.forEach((s) => s.unsubscribe())
+    }
 
     function notifyPageActivity() {
       observable.notify({ isBusy: pendingRequestsCount > 0 })
@@ -158,4 +163,8 @@ export function createPageActivityObservable(
 
 function isExcludedUrl(configuration: RumConfiguration, requestUrl: string): boolean {
   return matchList(configuration.excludedActivityUrls, requestUrl)
+}
+
+function trackWindowOpen(callback: () => void) {
+  return instrumentMethodAndCallOriginal(window, 'open', { before: callback })
 }

--- a/packages/rum-core/src/domain/waitPageActivityEnd.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.ts
@@ -1,5 +1,5 @@
 import type { Subscription, TimeoutId, TimeStamp } from '@datadog/browser-core'
-import { matchList, monitor, Observable, timeStampNow } from '@datadog/browser-core'
+import { instrumentMethodAndCallOriginal, matchList, monitor, Observable, timeStampNow } from '@datadog/browser-core'
 import type { RumConfiguration } from './configuration'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
@@ -116,10 +116,10 @@ export function createPageActivityObservable(
     let pendingRequestsCount = 0
 
     subscriptions.push(
-      domMutationObservable.subscribe(() => notifyPageActivity(pendingRequestsCount)),
+      domMutationObservable.subscribe(notifyPageActivity),
       lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, (entries) => {
         if (entries.some((entry) => entry.entryType === 'resource' && !isExcludedUrl(configuration, entry.name))) {
-          notifyPageActivity(pendingRequestsCount)
+          notifyPageActivity()
         }
       }),
       lifeCycle.subscribe(LifeCycleEventType.REQUEST_STARTED, (startEvent) => {
@@ -129,8 +129,8 @@ export function createPageActivityObservable(
         if (firstRequestIndex === undefined) {
           firstRequestIndex = startEvent.requestIndex
         }
-
-        notifyPageActivity(++pendingRequestsCount)
+        pendingRequestsCount += 1
+        notifyPageActivity()
       }),
       lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, (request) => {
         if (
@@ -141,16 +141,17 @@ export function createPageActivityObservable(
         ) {
           return
         }
-        notifyPageActivity(--pendingRequestsCount)
+        pendingRequestsCount -= 1
+        notifyPageActivity()
       })
     )
 
     return () => subscriptions.forEach((s) => s.unsubscribe())
-  })
 
-  function notifyPageActivity(pendingRequestsCount: number) {
-    observable.notify({ isBusy: pendingRequestsCount > 0 })
-  }
+    function notifyPageActivity() {
+      observable.notify({ isBusy: pendingRequestsCount > 0 })
+    }
+  })
 
   return observable
 }


### PR DESCRIPTION
## Motivation

When the user clicks and the application is using `window.open` to open an url in a new tab/window, a dead click is reported as we are not aware of it.

## Changes

Track `window.open` calls and consider them as "page activity", in the same spirit as DOM mutations.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
