### PR TITLE
[RUMF-1328] better data transfer with retry and throttling

### DIFF
--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -43,8 +43,11 @@ export class Batch {
       this.upsertBuffer = {}
       this.bufferBytesCount = 0
       this.bufferMessagesCount = 0
-
-      this.request.send(messages.join('\n'), bytesCount, reason)
+      if (reason === 'visibility_hidden' || reason === 'before_unload') {
+        this.request.send(messages.join('\n'), bytesCount, reason)
+      } else {
+        this.request.sendWithRetry(messages.join('\n'), bytesCount)
+      }
     }
   }
 

--- a/packages/core/src/transport/httpRetry.ts
+++ b/packages/core/src/transport/httpRetry.ts
@@ -1,0 +1,133 @@
+import type { TimeoutId } from '../tools/utils'
+import { ONE_SECOND } from '../tools/utils'
+import type { Observable } from '../tools/observable'
+import { monitor } from '../tools/monitor'
+
+const MIN_RETRY_INTERVAL = ONE_SECOND
+const MAX_RETRY_INTERVAL = 8 * ONE_SECOND
+
+export function httpRetry(
+  send: (data: string | FormData, bytesCount: number) => Observable<Response>,
+  configuration: {
+    bufferBytesLimit: number
+    ongoingBytesLimit: number
+    ongoingRequestsLimit: number
+  }
+) {
+  const buffer: Array<{ data: string | FormData; bytesCount: number }> = []
+
+  let isIntakeAvailable = true
+  let scheduleRetryTimeoutId: TimeoutId
+  let retryInterval = MIN_RETRY_INTERVAL
+
+  const throttling = httpThrottling(() => flush(), configuration)
+
+  /**
+   * Schedule the task to "detect" the intake availability
+   */
+  function scheduleRetry() {
+    if (scheduleRetryTimeoutId) clearTimeout(scheduleRetryTimeoutId)
+
+    scheduleRetryTimeoutId = window.setTimeout(
+      monitor(() => detectIntakeAvailability()),
+      retryInterval
+    )
+  }
+
+  /**
+   * Send a request and check the response to see if the intake is available
+   */
+  function detectIntakeAvailability() {
+    const { data, bytesCount } = buffer.shift()!
+
+    send(data, bytesCount).subscribe((response) => {
+      if (isFailedRequest(response)) {
+        buffer.unshift({ data, bytesCount })
+        if (retryInterval < MAX_RETRY_INTERVAL) {
+          retryInterval *= 2
+        }
+        scheduleRetry()
+      } else {
+        isIntakeAvailable = true
+        retryInterval = MIN_RETRY_INTERVAL
+        flush()
+      }
+    })
+  }
+
+  /**
+   * Exposed sending method for the batch.
+   * Check if the intake is available and throttling limits are okay
+   * Check the response of the request to see if the intake is still available
+   * If not schedule a retry
+   */
+  function retried(data: string | FormData, bytesCount: number): void {
+    if (!isIntakeAvailable || throttling.isLimitReached()) {
+      buffer.push({ data, bytesCount })
+      return
+    }
+
+    const observable = send(data, bytesCount)
+
+    throttling.trackRequest(observable, bytesCount)
+
+    observable.subscribe((response) => {
+      if (isFailedRequest(response)) {
+        buffer.push({ data, bytesCount })
+        scheduleRetry()
+        isIntakeAvailable = false
+      }
+    })
+  }
+
+  function flush() {
+    let request = buffer.shift()
+    while (request) {
+      retried(request.data, request.bytesCount)
+      request = buffer.shift()
+    }
+  }
+
+  return {
+    send: retried,
+  }
+}
+
+function httpThrottling(
+  onLimitReleased: () => void,
+  configuration: {
+    ongoingBytesLimit: number
+    ongoingRequestsLimit: number
+  }
+) {
+  const ongoingRequests = new Set<Observable<Response>>()
+
+  let ongoingBytesCount = 0
+  let isLimitReached = false
+
+  return {
+    isLimitReached() {
+      if (
+        ongoingRequests.size >= configuration.ongoingRequestsLimit ||
+        ongoingBytesCount > configuration.ongoingBytesLimit
+      ) {
+        isLimitReached = true
+      }
+
+      return isLimitReached
+    },
+    trackRequest(request: Observable<Response>, bytesCount: number) {
+      ongoingBytesCount += bytesCount
+      ongoingRequests.add(request)
+      request.subscribe(() => {
+        ongoingRequests.delete(request)
+        ongoingBytesCount -= bytesCount
+
+        if (isLimitReached) {
+          isLimitReached = false
+          onLimitReleased()
+        }
+      })
+    },
+  }
+}

--- a/packages/core/src/transport/httpRetry.ts
+++ b/packages/core/src/transport/httpRetry.ts
@@ -89,7 +89,7 @@ export function httpRetry(
   }
 
   return {
-    send: retried,
+    retried,
   }
 }
 


### PR DESCRIPTION
## Motivation

This is a draft PR of what the data transfer might look like with the retry and throttling strategies.
So it:
- assume httRequest.send already switch from sendbeacon to fetch keepalive and return an observable
- assume a function`isFailedRequest(response)` exists and check is the http status code tell the intake is unavailable
- does not handle buffer bytesLimit

The goal is to agree on the target design to then implementing it incrementally like so:
- Implement the switch from sendbeacon to fetch keepalive
- Implement the request throttling
- Implement the retry strategy


## Changes

- Add a httpRetry module
- Add sendWithRetry in httpRequest
- Use sendWithRetry in batch

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
