### PR TITLE
👷 configure dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+    commit-message:
+      prefix: '👷'
+
   - package-ecosystem: npm
     directory: /
     schedule:


### PR DESCRIPTION
## Motivation

Keep github actions up to date

## Changes

Configure dependabot to watch github actions

## Testing

None

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
