### PR TITLE
👷 [RUMF-1336] guard against prototype pollution

### DIFF
--- a/packages/core/src/tools/limitModification.ts
+++ b/packages/core/src/tools/limitModification.ts
@@ -54,5 +54,5 @@ function set(object: unknown, path: string, value: unknown) {
 }
 
 function isValidObjectContaining(object: unknown, field: string): object is { [key: string]: unknown } {
-  return typeof object === 'object' && object !== null && field in object
+  return typeof object === 'object' && object !== null && Object.prototype.hasOwnProperty.call(object, field)
 }


### PR DESCRIPTION
## Motivation

To please the code scanner

## Changes

In `limitModification`, ensure that modified field is owned by the object and not only exist on the object.
No risk on the current state since we are controlling which fields can be modified and that those fields are owned by the objects.
This change should not change current behavior.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
