### PR TITLE
🔒 [RUMF-1335] fix incorrect string escape

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -289,6 +289,10 @@ export function startsWith(candidate: string, search: string) {
   return candidate.slice(0, search.length) === search
 }
 
+export function endsWith(candidate: string, search: string) {
+  return candidate.slice(-search.length) === search
+}
+
 /**
  * inspired by https://mathiasbynens.be/notes/globalthis
  */

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -228,12 +228,17 @@ export function arrayFrom<T>(arrayLike: ArrayLike<T> | Set<T>): T[] {
 }
 
 export function find<T, S extends T>(
-  array: T[],
-  predicate: (item: T, index: number, array: T[]) => item is S
-): S | undefined {
+  array: ArrayLike<T>,
+  predicate: (item: T, index: number) => item is S
+): S | undefined
+export function find<T>(array: ArrayLike<T>, predicate: (item: T, index: number) => boolean): T | undefined
+export function find(
+  array: ArrayLike<unknown>,
+  predicate: (item: unknown, index: number) => boolean
+): unknown | undefined {
   for (let i = 0; i < array.length; i += 1) {
     const item = array[i]
-    if (predicate(item, i, array)) {
+    if (predicate(item, i)) {
       return item
     }
   }

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -1,4 +1,4 @@
-import { getGlobalObject } from '../tools/utils'
+import { endsWith, getGlobalObject } from '../tools/utils'
 
 export interface BrowserWindowWithEventBridge extends Window {
   DatadogEventBridge?: DatadogEventBridge
@@ -26,15 +26,13 @@ export function getEventBridge<T, E>() {
   }
 }
 
-export function canUseEventBridge(hostname = getGlobalObject<Window>().location?.hostname): boolean {
+export function canUseEventBridge(currentHost = getGlobalObject<Window>().location?.hostname): boolean {
   const bridge = getEventBridge()
   return (
     !!bridge &&
-    bridge.getAllowedWebViewHosts().some((host) => {
-      const escapedHost = host.replace(/\./g, '\\.')
-      const isDomainOrSubDomain = new RegExp(`^(.+\\.)*${escapedHost}$`)
-      return isDomainOrSubDomain.test(hostname)
-    })
+    bridge
+      .getAllowedWebViewHosts()
+      .some((allowedHost) => currentHost === allowedHost || endsWith(currentHost, `.${allowedHost}`))
   )
 }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
@@ -65,12 +65,7 @@ const priorityStrategies: NameStrategy[] = [
     } else if (element.id) {
       const label =
         element.ownerDocument &&
-        find(element.ownerDocument.querySelectorAll('label'), (label) =>
-          label.control
-            ? label === element
-            : // label.control is not defined for IE11
-              label.htmlFor === element.id
-        )
+        find(element.ownerDocument.querySelectorAll('label'), (label) => label.htmlFor === element.id)
       return label && getTextualContent(label, userProgrammaticAttribute)
     }
   },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.ts
@@ -1,4 +1,4 @@
-import { safeTruncate, isIE } from '@datadog/browser-core'
+import { safeTruncate, isIE, find } from '@datadog/browser-core'
 
 /**
  * Get the action name from the attribute 'data-dd-action-name' on the element or any of its parent.
@@ -64,7 +64,13 @@ const priorityStrategies: NameStrategy[] = [
       }
     } else if (element.id) {
       const label =
-        element.ownerDocument && element.ownerDocument.querySelector(`label[for="${element.id.replace('"', '\\"')}"]`)
+        element.ownerDocument &&
+        find(element.ownerDocument.querySelectorAll('label'), (label) =>
+          label.control
+            ? label === element
+            : // label.control is not defined for IE11
+              label.htmlFor === element.id
+        )
       return label && getTextualContent(label, userProgrammaticAttribute)
     }
   },


### PR DESCRIPTION
## Motivation

Fix hasarduous string escapes 

https://github.com/DataDog/browser-sdk/security/code-scanning/8
https://github.com/DataDog/browser-sdk/security/code-scanning/7

## Changes

Remove the need to escape strings.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
