### PR TITLE
🐛 improve `jsonStringify` implementation

### DIFF
--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -247,17 +247,22 @@ describe('utils', () => {
   })
 
   describe('jsonStringify', () => {
-    it('should jsonStringify an object with toJSON directly defined', () => {
-      const value = [{ 1: 'a' }]
+    afterEach(() => {
+      delete (Array.prototype as any).toJSON
+      delete (Object.prototype as any).toJSON
+    })
+
+    it('should jsonStringify an Object with toJSON defined on its prototype', () => {
+      const value = { 1: 'a' }
       const expectedJson = JSON.stringify(value)
 
       expect(jsonStringify(value)).toEqual(expectedJson)
-      ;(value as any).toJSON = () => '42'
+      ;(Object.prototype as any).toJSON = () => '42'
       expect(jsonStringify(value)).toEqual(expectedJson)
       expect(JSON.stringify(value)).toEqual('"42"')
     })
 
-    it('should jsonStringify an object with toJSON defined on prototype', () => {
+    it('should jsonStringify an Array with toJSON defined on its prototype', () => {
       const value = [{ 2: 'b' }]
       const expectedJson = JSON.stringify(value)
 
@@ -265,8 +270,13 @@ describe('utils', () => {
       ;(Array.prototype as any).toJSON = () => '42'
       expect(jsonStringify(value)).toEqual(expectedJson)
       expect(JSON.stringify(value)).toEqual('"42"')
+    })
 
-      delete (Array.prototype as any).toJSON
+    it('should not restore the toJSON method on the wrong prototype', () => {
+      const value = [{ 1: 'a' }]
+      ;(Object.prototype as any).toJSON = () => '42'
+      jsonStringify(value)
+      expect(Object.prototype.hasOwnProperty.call(Array.prototype, 'toJSON')).toBe(false)
     })
 
     it('should jsonStringify edge cases', () => {

--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -252,8 +252,28 @@ describe('utils', () => {
       delete (Object.prototype as any).toJSON
     })
 
-    it('should jsonStringify an Object with toJSON defined on its prototype', () => {
+    it('should jsonStringify a value with toJSON directly defined', () => {
       const value = { 1: 'a' }
+      const expectedJson = JSON.stringify(value)
+
+      expect(jsonStringify(value)).toEqual(expectedJson)
+      ;(value as any).toJSON = () => '42'
+      expect(jsonStringify(value)).toEqual(expectedJson)
+      expect(JSON.stringify(value)).toEqual('"42"')
+    })
+
+    it('should jsonStringify a value with toJSON defined on its prototype', () => {
+      const value = createSampleClassInstance()
+      const expectedJson = JSON.stringify(value)
+
+      expect(jsonStringify(value)).toEqual(expectedJson)
+      Object.getPrototypeOf(value).toJSON = () => '42'
+      expect(jsonStringify(value)).toEqual(expectedJson)
+      expect(JSON.stringify(value)).toEqual('"42"')
+    })
+
+    it('should jsonStringify a value when toJSON is defined on Object prototype', () => {
+      const value = createSampleClassInstance()
       const expectedJson = JSON.stringify(value)
 
       expect(jsonStringify(value)).toEqual(expectedJson)
@@ -262,14 +282,14 @@ describe('utils', () => {
       expect(JSON.stringify(value)).toEqual('"42"')
     })
 
-    it('should jsonStringify an Array with toJSON defined on its prototype', () => {
-      const value = [{ 2: 'b' }]
+    it('should jsonStringify a value when toJSON is defined on Array prototype', () => {
+      const value = createSampleClassInstance([1])
       const expectedJson = JSON.stringify(value)
 
       expect(jsonStringify(value)).toEqual(expectedJson)
       ;(Array.prototype as any).toJSON = () => '42'
       expect(jsonStringify(value)).toEqual(expectedJson)
-      expect(JSON.stringify(value)).toEqual('"42"')
+      expect(JSON.stringify(value)).toEqual('{"value":"42"}')
     })
 
     it('should not restore the toJSON method on the wrong prototype', () => {
@@ -292,6 +312,13 @@ describe('utils', () => {
 
       expect(jsonStringify(circularReference)).toEqual('<error: unable to serialize object>')
     })
+
+    function createSampleClassInstance(value: any = 'value') {
+      class Foo {
+        value = value
+      }
+      return new Foo()
+    }
   })
 
   describe('safeTruncate', () => {

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -149,7 +149,7 @@ export function noop() {}
 /**
  * Custom implementation of JSON.stringify that ignores some toJSON methods. We need to do that
  * because some sites badly override toJSON on certain objects. Removing all toJSON methods from
- * nested values would be too costly, so we just remove them from the root value, and native classes
+ * nested values would be too costly, so we just detach them from the root value, and native classes
  * used to build JSON values (Array and Object).
  *
  * Note: this still assumes that JSON.stringify is correct.
@@ -159,12 +159,12 @@ export function jsonStringify(
   replacer?: Array<string | number>,
   space?: string | number
 ): string | undefined {
-  // Note: The order matter here. We need to remove toJSON methods on parent classes before their
+  // Note: The order matter here. We need to detach toJSON methods on parent classes before their
   // subclasses.
-  const restoreObjectPrototypeToJson = removeToJsonMethod(Object.prototype)
-  const restoreArrayPrototypeToJson = removeToJsonMethod(Array.prototype)
-  const restoreValuePrototypeToJson = removeToJsonMethod(value && Object.getPrototypeOf(value))
-  const restoreValueToJson = removeToJsonMethod(value)
+  const restoreObjectPrototypeToJson = detachToJsonMethod(Object.prototype)
+  const restoreArrayPrototypeToJson = detachToJsonMethod(Array.prototype)
+  const restoreValuePrototypeToJson = detachToJsonMethod(value && Object.getPrototypeOf(value))
+  const restoreValueToJson = detachToJsonMethod(value)
 
   try {
     return JSON.stringify(value, replacer, space)
@@ -181,7 +181,7 @@ export function jsonStringify(
 interface ObjectWithToJsonMethod {
   toJSON: (() => object) | undefined
 }
-function removeToJsonMethod(value: unknown) {
+function detachToJsonMethod(value: unknown) {
   if (typeof value === 'object' && value !== null) {
     const object = value as ObjectWithToJsonMethod
     const objectToJson = object.toJSON

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -159,7 +159,7 @@ export function jsonStringify(
   replacer?: Array<string | number>,
   space?: string | number
 ): string | undefined {
-  if (!value || typeof value !== 'object') {
+  if (typeof value !== 'object' || value === null) {
     return JSON.stringify(value)
   }
 
@@ -177,13 +177,13 @@ export function jsonStringify(
   } finally {
     restoreObjectPrototypeToJson()
     restoreArrayPrototypeToJson()
-    restoreValueToJson()
     restoreValuePrototypeToJson()
+    restoreValueToJson()
   }
 }
 
 interface ObjectWithToJsonMethod {
-  toJSON: (() => object) | undefined
+  toJSON: unknown
 }
 function detachToJsonMethod(value: object) {
   const object = value as ObjectWithToJsonMethod


### PR DESCRIPTION


## Motivation

The previous implementation only removed toJSON on the input value and its prototype. We usually pass an Object as input, so it was focused on Object.

But websites using outdated libraries that define toJSON to Array objects (ex: prototype.js before 1.7) are still an issue with this strategy.

## Changes

This new implementation assumes that internally, the SDK won't use other objects than Array and Object (primitive types like string and number are unaffected), and those objects won't be defined with an own toJSON method. So, it focuses on removing toJSON to Array and Object prototypes, which completely solves the issue.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
