### PR TITLE
[RUMF-1333] Switch from sendbeacon to fetch keepalive

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,14 @@ export {
 export {
   SESSION_TIME_OUT_DELAY, // Exposed for tests
 } from './domain/session/sessionConstants'
-export { HttpRequest, Batch, canUseEventBridge, getEventBridge, startBatchWithReplica } from './transport'
+export {
+  createHttpRequest,
+  HttpRequest,
+  Batch,
+  canUseEventBridge,
+  getEventBridge,
+  startBatchWithReplica,
+} from './transport'
 export * from './tools/display'
 export * from './tools/urlPolyfill'
 export * from './tools/timeUtils'

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -1,100 +1,156 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import sinon from 'sinon'
 import { stubEndpointBuilder } from '../../test/specHelper'
 import type { EndpointBuilder } from '../domain/configuration'
-import { createEndpointBuilder } from '../domain/configuration'
-import { HttpRequest } from './httpRequest'
+import { resetExperimentalFeatures, updateExperimentalFeatures, createEndpointBuilder } from '../domain/configuration'
+import type { HttpRequest } from './httpRequest'
+import { createHttpRequest } from './httpRequest'
 
-describe('httpRequest', () => {
+const DATA = '{"foo":"bar1"}\n{"foo":"bar2"}'
+
+describe('createHttpRequest', () => {
   const BATCH_BYTES_LIMIT = 100
-  let server: sinon.SinonFakeServer
   let endpointBuilder: EndpointBuilder
   let request: HttpRequest
   const ENDPOINT_URL = 'http://my.website'
+  let xmlHttpRequestSpy: jasmine.Spy
 
   beforeEach(() => {
-    server = sinon.fakeServer.create()
+    xmlHttpRequestSpy = spyOn(XMLHttpRequest.prototype, 'send').and.callFake(() => undefined)
+
     endpointBuilder = stubEndpointBuilder(ENDPOINT_URL)
-    request = new HttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
+
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 
-  afterEach(() => {
-    server.restore()
-  })
-
-  it('should use xhr when sendBeacon is not defined', () => {
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-    expect(server.requests.length).toEqual(1)
-    expect(server.requests[0].url).toContain(ENDPOINT_URL)
-    expect(server.requests[0].requestBody).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
-  })
-
-  it('should use sendBeacon when the bytes count is correct', () => {
-    spyOn(navigator, 'sendBeacon').and.callFake(() => true)
-
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-    expect(navigator.sendBeacon).toHaveBeenCalled()
-  })
-
-  it('should use xhr over sendBeacon when the bytes count is too high', () => {
-    spyOn(navigator, 'sendBeacon').and.callFake(() => true)
-
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
-
-    expect(server.requests.length).toEqual(1)
-    expect(server.requests[0].url).toContain(ENDPOINT_URL)
-    expect(server.requests[0].requestBody).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
-  })
-
-  it('should fallback to xhr when sendBeacon is not queued', () => {
-    spyOn(navigator, 'sendBeacon').and.callFake(() => false)
-
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-    expect(navigator.sendBeacon).toHaveBeenCalled()
-    expect(server.requests.length).toEqual(1)
-  })
-
-  it('should fallback to xhr when sendBeacon throws', () => {
-    spyOn(navigator, 'sendBeacon').and.callFake(() => {
-      throw new TypeError()
+  describe('when ff fetch-keepalive is enabled ', () => {
+    beforeEach(() => {
+      updateExperimentalFeatures(['fetch-keepalive'])
     })
 
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
 
-    expect(navigator.sendBeacon).toHaveBeenCalled()
-    expect(server.requests.length).toEqual(1)
+    it('should use xhr when fetch with keepalive is not defined', () => {
+      spyOn(window, 'fetch').and.resolveTo({} as Response)
+      spyOn(window, 'Request').and.returnValue(undefined as unknown as Request)
+      request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
+
+      request.send(DATA, 10)
+
+      expect(xmlHttpRequestSpy).toHaveBeenCalledOnceWith(DATA)
+      expect(window.fetch).not.toHaveBeenCalled()
+    })
+
+    it('should use xhr when the bytes count is too high', () => {
+      spyOn(window, 'fetch').and.resolveTo({} as Response)
+
+      request.send(DATA, BATCH_BYTES_LIMIT + 1)
+
+      expect(xmlHttpRequestSpy).toHaveBeenCalledOnceWith(DATA)
+      expect(window.fetch).not.toHaveBeenCalled()
+    })
+
+    it('should use fetch with keepalive when the bytes count is correct', () => {
+      spyOn(window, 'fetch').and.resolveTo({} as Response)
+
+      request.send(DATA, 10)
+
+      expect(window.fetch).toHaveBeenCalledOnceWith(ENDPOINT_URL, jasmine.objectContaining({ body: DATA }))
+      expect(xmlHttpRequestSpy).not.toHaveBeenCalled()
+    })
+
+    it('should fallback to xhr when a network error happens with fetch with keepalive ', (done) => {
+      spyOn(window, 'fetch').and.rejectWith()
+
+      request.send(DATA, 10)
+
+      setTimeout(() => {
+        expect(window.fetch).toHaveBeenCalledWith(ENDPOINT_URL, jasmine.objectContaining({ body: DATA }))
+        expect(xmlHttpRequestSpy).toHaveBeenCalledOnceWith(DATA)
+
+        done()
+      })
+    })
+  })
+
+  describe('when ff fetch-keepalive is disabled ', () => {
+    let originalSendBeacon: typeof navigator.sendBeacon
+    beforeEach(() => {
+      originalSendBeacon = navigator.sendBeacon
+    })
+    afterEach(() => {
+      navigator.sendBeacon = originalSendBeacon
+    })
+
+    it('should use xhr when sendBeacon is not defined', () => {
+      ;(navigator.sendBeacon as any) = undefined
+      request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
+
+      request.send(DATA, 10)
+
+      expect(xmlHttpRequestSpy).toHaveBeenCalledOnceWith(DATA)
+    })
+
+    it('should use sendBeacon when the bytes count is correct', () => {
+      spyOn(navigator, 'sendBeacon').and.returnValue(true)
+
+      request.send(DATA, 10)
+
+      expect(navigator.sendBeacon).toHaveBeenCalledOnceWith(ENDPOINT_URL, DATA)
+      expect(xmlHttpRequestSpy).not.toHaveBeenCalled()
+    })
+
+    it('should use xhr over sendBeacon when the bytes count is too high', () => {
+      spyOn(navigator, 'sendBeacon').and.returnValue(true)
+
+      request.send(DATA, BATCH_BYTES_LIMIT)
+
+      expect(xmlHttpRequestSpy).toHaveBeenCalledOnceWith(DATA)
+      expect(navigator.sendBeacon).not.toHaveBeenCalled()
+    })
+
+    it('should fallback to xhr when sendBeacon is not queued', () => {
+      spyOn(navigator, 'sendBeacon').and.returnValue(false)
+
+      request.send(DATA, 10)
+
+      expect(navigator.sendBeacon).toHaveBeenCalledOnceWith(ENDPOINT_URL, DATA)
+      expect(xmlHttpRequestSpy).toHaveBeenCalledOnceWith(DATA)
+    })
+
+    it('should fallback to xhr when sendBeacon throws', () => {
+      spyOn(navigator, 'sendBeacon').and.throwError(new TypeError())
+
+      request.send(DATA, 10)
+      expect(navigator.sendBeacon).toHaveBeenCalledOnceWith(ENDPOINT_URL, DATA)
+      expect(xmlHttpRequestSpy).toHaveBeenCalledOnceWith(DATA)
+    })
   })
 })
 
 describe('httpRequest intake parameters', () => {
   const clientToken = 'some_client_token'
   const BATCH_BYTES_LIMIT = 100
-  let server: sinon.SinonFakeServer
   let endpointBuilder: EndpointBuilder
-  let request: HttpRequest
+  let request: ReturnType<typeof createHttpRequest>
+  let urlSpy: jasmine.Spy
 
   beforeEach(() => {
-    server = sinon.fakeServer.create()
     endpointBuilder = createEndpointBuilder({ clientToken }, 'logs', [])
-    request = new HttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
-  })
-
-  afterEach(() => {
-    server.restore()
+    urlSpy = spyOn(endpointBuilder, 'build').and.callThrough()
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 
   it('should have a unique request id', () => {
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
-    const search = /dd-request-id=([^&]*)/
-    const requestId1 = search.exec(server.requests[0].url)?.[1]
-    const requestId2 = search.exec(server.requests[1].url)?.[1]
+    expect(urlSpy).toHaveBeenCalledTimes(2)
 
+    const search = /dd-request-id=([^&]*)/
+    const requestId1 = search.exec(urlSpy.calls.first().returnValue)?.[1]
+    const requestId2 = search.exec(urlSpy.calls.mostRecent().returnValue)?.[1]
     expect(requestId1).not.toBe(requestId2)
-    expect(server.requests.length).toEqual(2)
   })
 })

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -1,4 +1,4 @@
-export { HttpRequest } from './httpRequest'
+export { createHttpRequest, HttpRequest } from './httpRequest'
 export { Batch } from './batch'
 export { canUseEventBridge, getEventBridge, BrowserWindowWithEventBridge } from './eventBridge'
 export { startBatchWithReplica } from './startBatchWithReplica'

--- a/packages/core/src/transport/startBatchWithReplica.ts
+++ b/packages/core/src/transport/startBatchWithReplica.ts
@@ -1,7 +1,7 @@
 import type { Configuration, EndpointBuilder } from '../domain/configuration'
 import type { Context } from '../tools/context'
 import { Batch } from './batch'
-import { HttpRequest } from './httpRequest'
+import { createHttpRequest } from './httpRequest'
 
 export function startBatchWithReplica<T extends Context>(
   configuration: Configuration,
@@ -16,7 +16,7 @@ export function startBatchWithReplica<T extends Context>(
 
   function createBatch(endpointBuilder: EndpointBuilder) {
     return new Batch(
-      new HttpRequest(endpointBuilder, configuration.batchBytesLimit),
+      createHttpRequest(endpointBuilder, configuration.batchBytesLimit),
       configuration.batchMessagesLimit,
       configuration.batchBytesLimit,
       configuration.messageBytesLimit,

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -3,7 +3,6 @@ import { clearAllCookies } from './specHelper'
 
 beforeEach(() => {
   ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'dev'
-  ;(navigator.sendBeacon as any) = false
   // reset globals
   ;(window as any).DD_LOGS = {}
   ;(window as any).DD_RUM = {}

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -23,9 +23,12 @@ import { startLogsBridge } from '../transport/startLogsBridge'
 import type { Logger } from '../domain/logger'
 import { startInternalContext } from '../domain/internalContext'
 
-export function startLogs(configuration: LogsConfiguration, getCommonContext: () => CommonContext, mainLogger: Logger) {
-  const lifeCycle = new LifeCycle()
-
+export function startLogs(
+  configuration: LogsConfiguration,
+  getCommonContext: () => CommonContext,
+  mainLogger: Logger,
+  lifeCycle = new LifeCycle()
+) {
   const telemetry = startLogsTelemetry(configuration)
   telemetry.setContextProvider(() => ({
     application: {

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -1,5 +1,5 @@
 import type { Context, EndpointBuilder, TelemetryEvent, Observable } from '@datadog/browser-core'
-import { Batch, combine, HttpRequest, isTelemetryReplicationAllowed } from '@datadog/browser-core'
+import { Batch, combine, createHttpRequest, isTelemetryReplicationAllowed } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
 import { LifeCycleEventType } from '../domain/lifeCycle'
@@ -42,7 +42,7 @@ function makeRumBatch(configuration: RumConfiguration, lifeCycle: LifeCycle): Ru
 
   function createRumBatch(endpointBuilder: EndpointBuilder, unloadCallback?: () => void) {
     return new Batch(
-      new HttpRequest(endpointBuilder, configuration.batchBytesLimit),
+      createHttpRequest(endpointBuilder, configuration.batchBytesLimit),
       configuration.batchMessagesLimit,
       configuration.batchBytesLimit,
       configuration.messageBytesLimit,

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,5 +1,5 @@
-import type { TimeStamp } from '@datadog/browser-core'
-import { HttpRequest, DefaultPrivacyLevel, noop, isIE, timeStampNow } from '@datadog/browser-core'
+import type { TimeStamp, HttpRequest } from '@datadog/browser-core'
+import { createHttpRequest, DefaultPrivacyLevel, noop, isIE, timeStampNow } from '@datadog/browser-core'
 import type { LifeCycle, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import { inflate } from 'pako'
@@ -10,7 +10,7 @@ import { createNewEvent, mockClock } from '../../../core/test/specHelper'
 import type { TestSetupBuilder } from '../../../rum-core/test/specHelper'
 import { setup } from '../../../rum-core/test/specHelper'
 import { collectAsyncCalls, recordsPerFullSnapshot } from '../../test/utils'
-import { setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
+import { SEGMENT_BYTES_LIMIT, setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
 
 import type { Segment } from '../types'
 import { RecordType } from '../types'
@@ -45,10 +45,6 @@ describe('startRecording', () => {
     textField = document.createElement('input')
     sandbox.appendChild(textField)
 
-    const requestSendSpy = spyOn(HttpRequest.prototype, 'send')
-    ;({ waitAsyncCalls: waitRequestSendCalls, expectNoExtraAsyncCall: expectNoExtraRequestSendCalls } =
-      collectAsyncCalls(requestSendSpy))
-
     startDeflateWorker((worker) => {
       setupBuilder = setup()
         .withViewContexts({
@@ -61,7 +57,13 @@ describe('startRecording', () => {
           defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
         })
         .beforeBuild(({ lifeCycle, configuration, viewContexts, sessionManager }) => {
-          const recording = startRecording(lifeCycle, configuration, sessionManager, viewContexts, worker!)
+          const httpRequest = createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT)
+
+          const requestSendSpy = spyOn(httpRequest, 'send')
+          ;({ waitAsyncCalls: waitRequestSendCalls, expectNoExtraAsyncCall: expectNoExtraRequestSendCalls } =
+            collectAsyncCalls(requestSendSpy))
+
+          const recording = startRecording(lifeCycle, configuration, sessionManager, viewContexts, worker!, httpRequest)
           stopRecording = recording ? recording.stop : noop
           return { stop: stopRecording }
         })

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -1,4 +1,4 @@
-import { timeStampNow } from '@datadog/browser-core'
+import { createHttpRequest, timeStampNow } from '@datadog/browser-core'
 import type {
   LifeCycle,
   ViewContexts,
@@ -10,7 +10,7 @@ import { LifeCycleEventType } from '@datadog/browser-rum-core'
 
 import { record } from '../domain/record'
 import type { DeflateWorker } from '../domain/segmentCollection'
-import { startSegmentCollection } from '../domain/segmentCollection'
+import { SEGMENT_BYTES_LIMIT, startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'
 import { RecordType } from '../types'
 
@@ -19,15 +19,15 @@ export function startRecording(
   configuration: RumConfiguration,
   sessionManager: RumSessionManager,
   viewContexts: ViewContexts,
-  worker: DeflateWorker
+  worker: DeflateWorker,
+  httpRequest = createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT)
 ) {
   const { addRecord, stop: stopSegmentCollection } = startSegmentCollection(
     lifeCycle,
     configuration.applicationId,
     sessionManager,
     viewContexts,
-    (data, metadata, rawSegmentBytesCount) =>
-      send(configuration.sessionReplayEndpointBuilder, data, metadata, rawSegmentBytesCount),
+    (data, metadata, rawSegmentBytesCount) => send(httpRequest, data, metadata, rawSegmentBytesCount),
     worker
   )
 

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -1,10 +1,9 @@
-import type { EndpointBuilder } from '@datadog/browser-core'
-import { HttpRequest, objectEntries } from '@datadog/browser-core'
-import { SEGMENT_BYTES_LIMIT } from '../domain/segmentCollection'
+import type { HttpRequest } from '@datadog/browser-core'
+import { objectEntries } from '@datadog/browser-core'
 import type { SegmentMetadata } from '../types'
 
 export function send(
-  endpointBuilder: EndpointBuilder,
+  request: HttpRequest,
   data: Uint8Array,
   metadata: SegmentMetadata,
   rawSegmentBytesCount: number
@@ -22,7 +21,6 @@ export function send(
   toFormEntries(metadata, (key, value) => formData.append(key, value))
   formData.append('raw_segment_size', rawSegmentBytesCount.toString())
 
-  const request = new HttpRequest(endpointBuilder, SEGMENT_BYTES_LIMIT)
   request.send(formData, data.byteLength)
 }
 


### PR DESCRIPTION
## Motivation

In the context of a better data transfert strategy with retry. First switch sendBeacon by fetch with keepalive.

## Changes

- Switch sendBeacon to keepalive except on visibility hidden and before_send
- Refactor httpRequest class using a function 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
