### PR TITLE
🐛 [RUMF-1274] track request to undefined/null URL

### DIFF
--- a/packages/core/src/browser/xhrObservable.spec.ts
+++ b/packages/core/src/browser/xhrObservable.spec.ts
@@ -1,4 +1,5 @@
 import { stubXhr, withXhr } from '../../test/specHelper'
+import { isIE } from '../tools/browserDetection'
 import type { Subscription } from '../tools/observable'
 import type { XhrCompleteContext, XhrContext } from './xhrObservable'
 import { initXhrObservable } from './xhrObservable'
@@ -326,6 +327,9 @@ describe('xhr observable', () => {
   })
 
   it('should track request to URL object', (done) => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
     withXhr({
       setup(xhr) {
         xhr.open('GET', new URL('http://example.com/path'))

--- a/packages/core/src/browser/xhrObservable.spec.ts
+++ b/packages/core/src/browser/xhrObservable.spec.ts
@@ -3,7 +3,7 @@ import type { Subscription } from '../tools/observable'
 import type { XhrCompleteContext, XhrContext } from './xhrObservable'
 import { initXhrObservable } from './xhrObservable'
 
-describe('xhr proxy', () => {
+describe('xhr observable', () => {
   let requestsTrackingSubscription: Subscription
   let contextEditionSubscription: Subscription | undefined
   let requests: XhrCompleteContext[]
@@ -286,6 +286,56 @@ describe('xhr proxy', () => {
         expect(xhr.onreadystatechange).toHaveBeenCalledTimes(2)
         expect(listeners.load.length).toBe(0)
         expect(listeners.loadend.length).toBe(0)
+        done()
+      },
+    })
+  })
+
+  it('should track request to undefined url', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', undefined)
+        xhr.send()
+        xhr.complete(404, 'NOT FOUND')
+      },
+      onComplete() {
+        const request = requests[0]
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/undefined')
+        expect(request.status).toBe(404)
+        done()
+      },
+    })
+  })
+
+  it('should track request to null url', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', null)
+        xhr.send()
+        xhr.complete(404, 'NOT FOUND')
+      },
+      onComplete() {
+        const request = requests[0]
+        expect(request.method).toBe('GET')
+        expect(request.url).toContain('/null')
+        expect(request.status).toBe(404)
+        done()
+      },
+    })
+  })
+
+  it('should track request to URL object', (done) => {
+    withXhr({
+      setup(xhr) {
+        xhr.open('GET', new URL('http://example.com/path'))
+        xhr.send()
+        xhr.complete(200, 'ok')
+      },
+      onComplete() {
+        const request = requests[0]
+        expect(request.method).toBe('GET')
+        expect(request.url).toBe('http://example.com/path')
         done()
       },
     })

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -63,11 +63,11 @@ function createXhrObservable() {
   return observable
 }
 
-function openXhr(this: XMLHttpRequest, method: string, url: string | URL) {
+function openXhr(this: XMLHttpRequest, method: string, url: string | URL | undefined | null) {
   xhrContexts.set(this, {
     state: 'open',
     method,
-    url: normalizeUrl(url.toString()),
+    url: normalizeUrl(url ? url.toString() : String(url)),
   })
 }
 

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -67,7 +67,7 @@ function openXhr(this: XMLHttpRequest, method: string, url: string | URL | undef
   xhrContexts.set(this, {
     state: 'open',
     method,
-    url: normalizeUrl(url ? url.toString() : String(url)),
+    url: normalizeUrl(String(url)),
   })
 }
 

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -271,7 +271,7 @@ class StubXhr extends StubEventEmitter {
   private hasEnded = false
 
   /* eslint-disable @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars */
-  open(method: string, url: string) {
+  open(method: string, url: string | URL | undefined | null) {
     this.hasEnded = false
   }
 


### PR DESCRIPTION
## Motivation

Avoid telemetry spam on this specific error

## Changes

Handle correctly requests to `undefined` or `null`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
