### PR TITLE
Remove `prefer-object-spread` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,6 @@ module.exports = {
     'object-shorthand': 'error',
     'one-var': ['error', 'never'],
     'prefer-rest-params': 'off',
-    'prefer-object-spread': 'error',
     'prefer-template': 'error',
     quotes: ['error', 'single', { avoidEscape: true }],
     radix: 'error',


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
We have 2 ESLint rules that are fighting each other:
```
'prefer-object-spread': 'error',
```
and
``` 
'no-restricted-syntax': [
  'error',
  {
    selector: 'ObjectExpression > SpreadElement',
    message: 'Object spread is not authorized. Please use "assign" from the core package utils instead.',
  },
  {
    selector: 'ArrayExpression > SpreadElement',
    message: 'Array spread is not authorized. Please use .concat instead.',
  },
],
```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
Drop `'prefer-object-spread': 'error',`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
