### PR TITLE
Remove eslint rules against spreading

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -225,14 +225,6 @@ module.exports = {
         'no-restricted-syntax': [
           'error',
           {
-            selector: 'ObjectExpression > SpreadElement',
-            message: 'Object spread is not authorized. Please use "assign" from the core package utils instead.',
-          },
-          {
-            selector: 'ArrayExpression > SpreadElement',
-            message: 'Array spread is not authorized. Please use .concat instead.',
-          },
-          {
             selector: 'MemberExpression[object.name="Date"][property.name="now"]',
             message: '`Date.now()` is not authorized. Please use `dateNow()` instead',
           },


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
We have conflicting ESLint rules on spread operators vs Object.assign. We have decided to support spread.

I thought I already removed this conflict in a [previous PR](https://github.com/DataDog/browser-sdk/pull/1671), but it appears that I am missing some edge cases

## Changes

Remove edge cases

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
