### PR TITLE
Remove rum-events-format from linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ dist
 test/app/dist
 sandbox
 coverage
+rum-events-format


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
We do not want to apply linting rules to the subdirectory rum-events-format

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
add `rum-events-format` to `.eslintignore`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
