### PR TITLE
⚡ [RUMF-1344] Access scroll attributes only on initial full snapshot

### DIFF
--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -8,7 +8,7 @@ import type {
 } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 
-import { record } from '../domain/record'
+import { record, SerializationContext } from '../domain/record'
 import type { DeflateWorker } from '../domain/segmentCollection'
 import { startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'
@@ -51,7 +51,7 @@ export function startRecording(
   const { unsubscribe: unsubscribeViewCreated } = lifeCycle.subscribe(
     LifeCycleEventType.VIEW_CREATED,
     (view: ViewCreatedEvent) => {
-      takeFullSnapshot(view.startClocks.timeStamp)
+      takeFullSnapshot(view.startClocks.timeStamp, SerializationContext.SUBSEQUENT_FULL_SNAPSHOT)
     }
   )
 

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -8,7 +8,7 @@ import type {
 } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 
-import { record, SerializationContext } from '../domain/record'
+import { record } from '../domain/record'
 import type { DeflateWorker } from '../domain/segmentCollection'
 import { startSegmentCollection } from '../domain/segmentCollection'
 import { send } from '../transport/send'

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -33,7 +33,7 @@ export function startRecording(
 
   const {
     stop: stopRecording,
-    takeFullSnapshot,
+    takeSubsequentFullSnapshot,
     flushMutations,
   } = record({
     emit: addRecord,
@@ -51,7 +51,7 @@ export function startRecording(
   const { unsubscribe: unsubscribeViewCreated } = lifeCycle.subscribe(
     LifeCycleEventType.VIEW_CREATED,
     (view: ViewCreatedEvent) => {
-      takeFullSnapshot(view.startClocks.timeStamp, SerializationContext.SUBSEQUENT_FULL_SNAPSHOT)
+      takeSubsequentFullSnapshot(view.startClocks.timeStamp)
     }
   )
 

--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -1,0 +1,23 @@
+import { addTelemetryDebug } from '@datadog/browser-core'
+
+export type ElementsScrollPositions = ReturnType<typeof createElementsScrollPositions>
+export type ScrollPositions = { scrollLeft: number; scrollTop: number }
+
+export function createElementsScrollPositions() {
+  const scrollPositionsByElement = new WeakMap<Element, ScrollPositions>()
+  const documentScrollingElement = document.scrollingElement!
+  if (!documentScrollingElement) {
+    addTelemetryDebug('document without scrollingElement')
+  }
+  return {
+    set(element: Element | Document, scrollPositions: ScrollPositions) {
+      scrollPositionsByElement.set(
+        element === document ? documentScrollingElement : (element as Element),
+        scrollPositions
+      )
+    },
+    get(element: Element) {
+      return scrollPositionsByElement.get(element)
+    },
+  }
+}

--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -19,5 +19,8 @@ export function createElementsScrollPositions() {
     get(element: Element) {
       return scrollPositionsByElement.get(element)
     },
+    has(element: Element) {
+      return scrollPositionsByElement.has(element)
+    },
   }
 }

--- a/packages/rum/src/domain/record/index.ts
+++ b/packages/rum/src/domain/record/index.ts
@@ -1,2 +1,3 @@
 export { record } from './record'
-export { serializeNodeWithId, serializeDocument, SerializationContext } from './serialize'
+export { serializeNodeWithId, serializeDocument, SerializationContextStatus } from './serialize'
+export { createElementsScrollPositions } from './elementsScrollPositions'

--- a/packages/rum/src/domain/record/index.ts
+++ b/packages/rum/src/domain/record/index.ts
@@ -1,2 +1,2 @@
 export { record } from './record'
-export { serializeNodeWithId, serializeDocument } from './serialize'
+export { serializeNodeWithId, serializeDocument, SerializationContext } from './serialize'

--- a/packages/rum/src/domain/record/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/mutationObserver.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../constants'
 import type { AttributeMutation, Attributes } from '../../types'
 import { NodeType } from '../../types'
-import { serializeDocument, SerializationContext } from './serialize'
+import { serializeDocument, SerializationContextStatus } from './serialize'
 import { sortAddedAndMovedNodes, startMutationObserver, MutationController } from './mutationObserver'
 import type { MutationCallBack } from './observers'
 import { createElementsScrollPositions } from './elementsScrollPositions'
@@ -36,12 +36,10 @@ describe('startMutationCollection', () => {
   }
 
   function serializeDocumentWithDefaults() {
-    return serializeDocument(
-      document,
-      NodePrivacyLevel.ALLOW,
-      SerializationContext.INITIAL_FULL_SNAPSHOT,
-      createElementsScrollPositions()
-    )
+    return serializeDocument(document, NodePrivacyLevel.ALLOW, {
+      status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
+      elementsScrollPositions: createElementsScrollPositions(),
+    })
   }
 
   beforeEach(() => {

--- a/packages/rum/src/domain/record/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/mutationObserver.spec.ts
@@ -12,6 +12,7 @@ import { NodeType } from '../../types'
 import { serializeDocument, SerializationContext } from './serialize'
 import { sortAddedAndMovedNodes, startMutationObserver, MutationController } from './mutationObserver'
 import type { MutationCallBack } from './observers'
+import { createElementsScrollPositions } from './elementsScrollPositions'
 
 describe('startMutationCollection', () => {
   let sandbox: HTMLElement
@@ -35,7 +36,12 @@ describe('startMutationCollection', () => {
   }
 
   function serializeDocumentWithDefaults() {
-    return serializeDocument(document, NodePrivacyLevel.ALLOW, SerializationContext.INITIAL_FULL_SNAPSHOT)
+    return serializeDocument(
+      document,
+      NodePrivacyLevel.ALLOW,
+      SerializationContext.INITIAL_FULL_SNAPSHOT,
+      createElementsScrollPositions()
+    )
   }
 
   beforeEach(() => {

--- a/packages/rum/src/domain/record/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/mutationObserver.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../constants'
 import type { AttributeMutation, Attributes } from '../../types'
 import { NodeType } from '../../types'
-import { serializeDocument } from './serialize'
+import { serializeDocument, SerializationContext } from './serialize'
 import { sortAddedAndMovedNodes, startMutationObserver, MutationController } from './mutationObserver'
 import type { MutationCallBack } from './observers'
 
@@ -34,6 +34,10 @@ describe('startMutationCollection', () => {
     }
   }
 
+  function serializeDocumentWithDefaults() {
+    return serializeDocument(document, NodePrivacyLevel.ALLOW, SerializationContext.INITIAL_FULL_SNAPSHOT)
+  }
+
   beforeEach(() => {
     if (isIE()) {
       pending('IE not supported')
@@ -51,7 +55,7 @@ describe('startMutationCollection', () => {
 
   describe('childList mutation records', () => {
     it('emits a mutation when a node is appended to a known node', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
 
       sandbox.appendChild(document.createElement('div'))
@@ -71,7 +75,7 @@ describe('startMutationCollection', () => {
     })
 
     it('processes mutations asynchronously', (done) => {
-      serializeDocument(document, NodePrivacyLevel.ALLOW)
+      serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()
       const { waitAsyncCalls: waitMutationCallbackCalls, expectNoExtraAsyncCall: expectNoExtraMutationCallbackCalls } =
         collectAsyncCalls(mutationCallbackSpy)
@@ -96,7 +100,7 @@ describe('startMutationCollection', () => {
     })
 
     it('emits buffered mutation records on flush', () => {
-      serializeDocument(document, NodePrivacyLevel.ALLOW)
+      serializeDocumentWithDefaults()
       const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
       sandbox.appendChild(document.createElement('div'))
@@ -112,7 +116,7 @@ describe('startMutationCollection', () => {
       it('attribute mutations', () => {
         const element = document.createElement('div')
         sandbox.appendChild(element)
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -126,7 +130,7 @@ describe('startMutationCollection', () => {
       it('text mutations', () => {
         const textNode = document.createTextNode('foo')
         sandbox.appendChild(textNode)
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -138,7 +142,7 @@ describe('startMutationCollection', () => {
       })
 
       it('add mutations', () => {
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -152,7 +156,7 @@ describe('startMutationCollection', () => {
       it('remove mutations', () => {
         const element = document.createElement('div')
         sandbox.appendChild(element)
-        const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+        const serializedDocument = serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -181,7 +185,7 @@ describe('startMutationCollection', () => {
       it('attribute mutations', () => {
         const element = document.createElement('div')
         sandbox.appendChild(element)
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -197,7 +201,7 @@ describe('startMutationCollection', () => {
       it('text mutations', () => {
         const textNode = document.createTextNode('foo')
         sandbox.appendChild(textNode)
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -215,7 +219,7 @@ describe('startMutationCollection', () => {
         const child = document.createElement('b')
         sandbox.appendChild(parent)
         parent.appendChild(child)
-        const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+        const serializedDocument = serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -252,7 +256,7 @@ describe('startMutationCollection', () => {
       })
 
       it('remove mutations', () => {
-        const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+        const serializedDocument = serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -278,7 +282,7 @@ describe('startMutationCollection', () => {
 
     it('emits only an "add" mutation when adding, removing then re-adding a child', () => {
       const element = document.createElement('a')
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
 
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -304,7 +308,7 @@ describe('startMutationCollection', () => {
       const elementB = document.createElement('b')
       sandbox.appendChild(elementA)
       sandbox.appendChild(elementB)
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
 
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -337,7 +341,7 @@ describe('startMutationCollection', () => {
       sandbox.appendChild(element)
       sandbox.appendChild(container1)
       sandbox.appendChild(container2)
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
 
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -364,7 +368,7 @@ describe('startMutationCollection', () => {
     })
 
     it('keep nodes order when adding multiple sibling nodes', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
 
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -399,7 +403,7 @@ describe('startMutationCollection', () => {
     })
 
     it('respects the default privacy level setting', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, getLatestMutationPayload } = startMutationCollection(DefaultPrivacyLevel.MASK)
 
       sandbox.innerText = 'foo bar'
@@ -429,7 +433,7 @@ describe('startMutationCollection', () => {
     })
 
     it('emits a mutation when a text node is changed', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
 
       textNode.data = 'bar'
@@ -449,7 +453,7 @@ describe('startMutationCollection', () => {
     })
 
     it('does not emit a mutation when a text node keeps the same value', () => {
-      serializeDocument(document, NodePrivacyLevel.ALLOW)
+      serializeDocumentWithDefaults()
       const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
       textNode.data = 'bar'
@@ -460,7 +464,7 @@ describe('startMutationCollection', () => {
     })
 
     it('respects the default privacy level setting', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, getLatestMutationPayload } = startMutationCollection(DefaultPrivacyLevel.MASK)
 
       textNode.data = 'foo bar'
@@ -486,7 +490,7 @@ describe('startMutationCollection', () => {
       div.innerText = 'foo 81'
       wrapper.appendChild(div)
 
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.MASK)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection(
         DefaultPrivacyLevel.MASK
       )
@@ -510,7 +514,7 @@ describe('startMutationCollection', () => {
 
   describe('attributes mutations', () => {
     it('emits a mutation when an attribute is changed', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
 
       sandbox.setAttribute('foo', 'bar')
@@ -530,7 +534,7 @@ describe('startMutationCollection', () => {
     })
 
     it('emits a mutation with an empty string when an attribute is changed to an empty string', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
       sandbox.setAttribute('foo', '')
@@ -549,7 +553,7 @@ describe('startMutationCollection', () => {
 
     it('emits a mutation with `null` when an attribute is removed', () => {
       sandbox.setAttribute('foo', 'bar')
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
       sandbox.removeAttribute('foo')
@@ -568,7 +572,7 @@ describe('startMutationCollection', () => {
 
     it('does not emit a mutation when an attribute keeps the same value', () => {
       sandbox.setAttribute('foo', 'bar')
-      serializeDocument(document, NodePrivacyLevel.ALLOW)
+      serializeDocumentWithDefaults()
       const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
       sandbox.setAttribute('foo', 'biz')
@@ -579,7 +583,7 @@ describe('startMutationCollection', () => {
     })
 
     it('reuse the same mutation when multiple attributes are changed', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
       sandbox.setAttribute('foo1', 'biz')
@@ -598,7 +602,7 @@ describe('startMutationCollection', () => {
     })
 
     it('respects the default privacy level setting', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
       const { mutationController, getLatestMutationPayload } = startMutationCollection(DefaultPrivacyLevel.MASK)
 
       sandbox.setAttribute('data-foo', 'biz')
@@ -625,7 +629,7 @@ describe('startMutationCollection', () => {
     })
 
     it('skips ignored nodes when looking for the next id', () => {
-      const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+      const serializedDocument = serializeDocumentWithDefaults()
 
       const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -647,7 +651,7 @@ describe('startMutationCollection', () => {
     describe('does not emit mutations occurring in ignored node', () => {
       it('when adding an ignored node', () => {
         ignoredElement.remove()
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
@@ -659,7 +663,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when changing the attributes of an ignored node', () => {
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
@@ -671,7 +675,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when adding a new child node', () => {
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
@@ -685,7 +689,7 @@ describe('startMutationCollection', () => {
       it('when mutating a known child node', () => {
         const textNode = document.createTextNode('function foo() {}')
         sandbox.appendChild(textNode)
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
         ignoredElement.appendChild(textNode)
 
         const { mutationController, mutationCallbackSpy } = startMutationCollection()
@@ -700,7 +704,7 @@ describe('startMutationCollection', () => {
       it('when adding a known child node', () => {
         const textNode = document.createTextNode('function foo() {}')
         sandbox.appendChild(textNode)
-        const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+        const serializedDocument = serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -727,7 +731,7 @@ describe('startMutationCollection', () => {
         sandbox.appendChild(a)
         sandbox.appendChild(script)
         sandbox.appendChild(b)
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
@@ -748,7 +752,7 @@ describe('startMutationCollection', () => {
     })
 
     it('does not emit attribute mutations on hidden nodes', () => {
-      serializeDocument(document, NodePrivacyLevel.ALLOW)
+      serializeDocumentWithDefaults()
 
       const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
@@ -761,7 +765,7 @@ describe('startMutationCollection', () => {
 
     describe('does not emit mutations occurring in hidden node', () => {
       it('when adding a new node', () => {
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
 
         const { mutationController, mutationCallbackSpy } = startMutationCollection()
 
@@ -775,7 +779,7 @@ describe('startMutationCollection', () => {
       it('when mutating a known child node', () => {
         const textNode = document.createTextNode('function foo() {}')
         sandbox.appendChild(textNode)
-        serializeDocument(document, NodePrivacyLevel.ALLOW)
+        serializeDocumentWithDefaults()
         hiddenElement.appendChild(textNode)
 
         const { mutationController, mutationCallbackSpy } = startMutationCollection()
@@ -790,7 +794,7 @@ describe('startMutationCollection', () => {
       it('when moving a known node into an hidden node', () => {
         const textNode = document.createTextNode('function foo() {}')
         sandbox.appendChild(textNode)
-        const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+        const serializedDocument = serializeDocumentWithDefaults()
 
         const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -880,7 +884,7 @@ describe('startMutationCollection', () => {
           } else {
             sandbox.setAttribute(PRIVACY_ATTR_NAME, privacyAttributeValue)
           }
-          const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+          const serializedDocument = serializeDocumentWithDefaults()
 
           const { mutationController, getLatestMutationPayload } = startMutationCollection()
 
@@ -911,7 +915,7 @@ describe('startMutationCollection', () => {
             sandbox.setAttribute(PRIVACY_ATTR_NAME, privacyAttributeValue)
           }
           sandbox.appendChild(input)
-          const serializedDocument = serializeDocument(document, NodePrivacyLevel.ALLOW)
+          const serializedDocument = serializeDocumentWithDefaults()
 
           const { mutationController, getLatestMutationPayload, mutationCallbackSpy } = startMutationCollection()
 

--- a/packages/rum/src/domain/record/mutationObserver.ts
+++ b/packages/rum/src/domain/record/mutationObserver.ts
@@ -11,7 +11,7 @@ import {
   hasSerializedNode,
   nodeAndAncestorsHaveSerializedNode,
 } from './serializationUtils'
-import { serializeNodeWithId, serializeAttribute, SerializationContext } from './serialize'
+import { serializeNodeWithId, serializeAttribute, SerializationContextStatus } from './serialize'
 import { forEach } from './utils'
 import { createMutationBatch } from './mutationBatch'
 import type { MutationCallBack } from './observers'
@@ -211,7 +211,7 @@ function processChildListMutations(
       document,
       serializedNodeIds,
       parentNodePrivacyLevel,
-      serializationContext: SerializationContext.MUTATION,
+      serializationContext: { status: SerializationContextStatus.MUTATION },
     })
     if (!serializedNode) {
       continue

--- a/packages/rum/src/domain/record/mutationObserver.ts
+++ b/packages/rum/src/domain/record/mutationObserver.ts
@@ -11,7 +11,7 @@ import {
   hasSerializedNode,
   nodeAndAncestorsHaveSerializedNode,
 } from './serializationUtils'
-import { serializeNodeWithId, serializeAttribute } from './serialize'
+import { serializeNodeWithId, serializeAttribute, SerializationContext } from './serialize'
 import { forEach } from './utils'
 import { createMutationBatch } from './mutationBatch'
 import type { MutationCallBack } from './observers'
@@ -211,7 +211,7 @@ function processChildListMutations(
       document,
       serializedNodeIds,
       parentNodePrivacyLevel,
-      serializationContext: 'mutation',
+      serializationContext: SerializationContext.MUTATION,
     })
     if (!serializedNode) {
       continue

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -7,7 +7,7 @@ import { NodePrivacyLevel, PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT
 import { RecordType } from '../../types'
 import type { FrustrationCallback, InputCallback } from './observers'
 import { initFrustrationObserver, initInputObserver } from './observers'
-import { serializeDocument, SerializationContext } from './serialize'
+import { serializeDocument, SerializationContextStatus } from './serialize'
 import { createElementsScrollPositions } from './elementsScrollPositions'
 
 describe('initInputObserver', () => {
@@ -27,12 +27,10 @@ describe('initInputObserver', () => {
     sandbox.appendChild(input)
     document.body.appendChild(sandbox)
 
-    serializeDocument(
-      document,
-      NodePrivacyLevel.ALLOW,
-      SerializationContext.INITIAL_FULL_SNAPSHOT,
-      createElementsScrollPositions()
-    )
+    serializeDocument(document, NodePrivacyLevel.ALLOW, {
+      status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
+      elementsScrollPositions: createElementsScrollPositions(),
+    })
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -7,7 +7,7 @@ import { NodePrivacyLevel, PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT
 import { RecordType } from '../../types'
 import type { FrustrationCallback, InputCallback } from './observers'
 import { initFrustrationObserver, initInputObserver } from './observers'
-import { serializeDocument } from './serialize'
+import { serializeDocument, SerializationContext } from './serialize'
 
 describe('initInputObserver', () => {
   let stopInputObserver: () => void
@@ -26,7 +26,7 @@ describe('initInputObserver', () => {
     sandbox.appendChild(input)
     document.body.appendChild(sandbox)
 
-    serializeDocument(document, NodePrivacyLevel.ALLOW)
+    serializeDocument(document, NodePrivacyLevel.ALLOW, SerializationContext.INITIAL_FULL_SNAPSHOT)
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -8,6 +8,7 @@ import { RecordType } from '../../types'
 import type { FrustrationCallback, InputCallback } from './observers'
 import { initFrustrationObserver, initInputObserver } from './observers'
 import { serializeDocument, SerializationContext } from './serialize'
+import { createElementsScrollPositions } from './elementsScrollPositions'
 
 describe('initInputObserver', () => {
   let stopInputObserver: () => void
@@ -26,7 +27,12 @@ describe('initInputObserver', () => {
     sandbox.appendChild(input)
     document.body.appendChild(sandbox)
 
-    serializeDocument(document, NodePrivacyLevel.ALLOW, SerializationContext.INITIAL_FULL_SNAPSHOT)
+    serializeDocument(
+      document,
+      NodePrivacyLevel.ALLOW,
+      SerializationContext.INITIAL_FULL_SNAPSHOT,
+      createElementsScrollPositions()
+    )
   })
 
   afterEach(() => {

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -116,7 +116,7 @@ describe('record', () => {
 
     sandbox.appendChild(document.createElement('div'))
 
-    recordApi.takeFullSnapshot()
+    recordApi.takeSubsequentFullSnapshot()
 
     waitEmitCalls(1 + 2 * recordsPerFullSnapshot(), () => {
       const records = getEmittedRecords()
@@ -178,7 +178,7 @@ describe('record', () => {
       startRecording()
       emitSpy.calls.reset()
 
-      recordApi.takeFullSnapshot()
+      recordApi.takeSubsequentFullSnapshot()
       expect(getEmittedRecords()[1].type).toBe(RecordType.Focus)
     })
 

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -13,7 +13,7 @@ import type {
   ViewportResizeData,
 } from '../../types'
 import { RecordType, IncrementalSource } from '../../types'
-import { serializeDocument, SerializationContext } from './serialize'
+import { serializeDocument, SerializationContextStatus } from './serialize'
 import { initObservers } from './observers'
 
 import { MutationController } from './mutationObserver'
@@ -45,7 +45,7 @@ export function record(options: RecordOptions): RecordAPI {
 
   const takeFullSnapshot = (
     timestamp = timeStampNow(),
-    serializationContext = SerializationContext.INITIAL_FULL_SNAPSHOT
+    serializationContext = { status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT, elementsScrollPositions }
   ) => {
     mutationController.flush() // process any pending mutation before taking a full snapshot
     const { width, height } = getViewportDimension()
@@ -69,7 +69,7 @@ export function record(options: RecordOptions): RecordAPI {
 
     emit({
       data: {
-        node: serializeDocument(document, options.defaultPrivacyLevel, serializationContext, elementsScrollPositions),
+        node: serializeDocument(document, options.defaultPrivacyLevel, serializationContext),
         initialOffset: {
           left: getScrollX(),
           top: getScrollY(),
@@ -124,7 +124,10 @@ export function record(options: RecordOptions): RecordAPI {
   return {
     stop: stopObservers,
     takeSubsequentFullSnapshot: (timestamp) =>
-      takeFullSnapshot(timestamp, SerializationContext.SUBSEQUENT_FULL_SNAPSHOT),
+      takeFullSnapshot(timestamp, {
+        status: SerializationContextStatus.SUBSEQUENT_FULL_SNAPSHOT,
+        elementsScrollPositions,
+      }),
     flushMutations: () => mutationController.flush(),
   }
 }

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -19,6 +19,7 @@ import { initObservers } from './observers'
 import { MutationController } from './mutationObserver'
 import { getVisualViewport, getScrollX, getScrollY } from './viewports'
 import { assembleIncrementalSnapshot } from './utils'
+import { createElementsScrollPositions } from './elementsScrollPositions'
 
 export interface RecordOptions {
   emit?: (record: BrowserRecord) => void
@@ -40,6 +41,7 @@ export function record(options: RecordOptions): RecordAPI {
   }
 
   const mutationController = new MutationController()
+  const elementsScrollPositions = createElementsScrollPositions()
 
   const takeFullSnapshot = (
     timestamp = timeStampNow(),
@@ -67,7 +69,7 @@ export function record(options: RecordOptions): RecordAPI {
 
     emit({
       data: {
-        node: serializeDocument(document, options.defaultPrivacyLevel, serializationContext),
+        node: serializeDocument(document, options.defaultPrivacyLevel, serializationContext, elementsScrollPositions),
         initialOffset: {
           left: getScrollX(),
           top: getScrollY(),
@@ -91,6 +93,7 @@ export function record(options: RecordOptions): RecordAPI {
   const stopObservers = initObservers({
     lifeCycle: options.lifeCycle,
     mutationController,
+    elementsScrollPositions,
     defaultPrivacyLevel: options.defaultPrivacyLevel,
     inputCb: (v) => emit(assembleIncrementalSnapshot<InputData>(IncrementalSource.Input, v)),
     mediaInteractionCb: (p) =>

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -1,5 +1,5 @@
-import { timeStampNow } from '@datadog/browser-core'
 import type { DefaultPrivacyLevel, TimeStamp } from '@datadog/browser-core'
+import { timeStampNow } from '@datadog/browser-core'
 import type { LifeCycle } from '@datadog/browser-rum-core'
 import { getViewportDimension } from '@datadog/browser-rum-core'
 import type {
@@ -29,7 +29,7 @@ export interface RecordOptions {
 
 export interface RecordAPI {
   stop: () => void
-  takeFullSnapshot: (timestamp?: TimeStamp, serializationContext?: SerializationContext) => void
+  takeSubsequentFullSnapshot: (timestamp?: TimeStamp) => void
   flushMutations: () => void
 }
 
@@ -123,7 +123,8 @@ export function record(options: RecordOptions): RecordAPI {
 
   return {
     stop: stopObservers,
-    takeFullSnapshot,
+    takeSubsequentFullSnapshot: (timestamp) =>
+      takeFullSnapshot(timestamp, SerializationContext.SUBSEQUENT_FULL_SNAPSHOT),
     flushMutations: () => mutationController.flush(),
   }
 }

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -13,7 +13,7 @@ import type {
   ViewportResizeData,
 } from '../../types'
 import { RecordType, IncrementalSource } from '../../types'
-import { serializeDocument } from './serialize'
+import { serializeDocument, SerializationContext } from './serialize'
 import { initObservers } from './observers'
 
 import { MutationController } from './mutationObserver'
@@ -28,7 +28,7 @@ export interface RecordOptions {
 
 export interface RecordAPI {
   stop: () => void
-  takeFullSnapshot: (timestamp?: TimeStamp) => void
+  takeFullSnapshot: (timestamp?: TimeStamp, serializationContext?: SerializationContext) => void
   flushMutations: () => void
 }
 
@@ -41,7 +41,10 @@ export function record(options: RecordOptions): RecordAPI {
 
   const mutationController = new MutationController()
 
-  const takeFullSnapshot = (timestamp = timeStampNow()) => {
+  const takeFullSnapshot = (
+    timestamp = timeStampNow(),
+    serializationContext = SerializationContext.INITIAL_FULL_SNAPSHOT
+  ) => {
     mutationController.flush() // process any pending mutation before taking a full snapshot
     const { width, height } = getViewportDimension()
     emit({
@@ -64,7 +67,7 @@ export function record(options: RecordOptions): RecordAPI {
 
     emit({
       data: {
-        node: serializeDocument(document, options.defaultPrivacyLevel),
+        node: serializeDocument(document, options.defaultPrivacyLevel, serializationContext),
         initialOffset: {
           left: getScrollX(),
           top: getScrollY(),

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -32,7 +32,7 @@ import { MAX_ATTRIBUTE_VALUE_CHAR_LENGTH } from './privacy'
 const DEFAULT_OPTIONS: SerializeOptions = {
   document,
   parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
-  serializationContext: SerializationContext.FULL_SNAPSHOT,
+  serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
 }
 
 describe('serializeNodeWithId', () => {
@@ -54,7 +54,7 @@ describe('serializeNodeWithId', () => {
   describe('document serialization', () => {
     it('serializes a document', () => {
       const document = new DOMParser().parseFromString('<!doctype html><html>foo</html>', 'text/html')
-      expect(serializeDocument(document, NodePrivacyLevel.ALLOW)).toEqual({
+      expect(serializeDocument(document, NodePrivacyLevel.ALLOW, SerializationContext.INITIAL_FULL_SNAPSHOT)).toEqual({
         type: NodeType.Document,
         childNodes: [
           jasmine.objectContaining({ type: NodeType.DocumentType, name: 'html', publicId: '', systemId: '' }),
@@ -118,8 +118,13 @@ describe('serializeNodeWithId', () => {
     })
     ;[
       {
-        description: 'serializes scroll position during full snapshot',
-        serializationContext: SerializationContext.FULL_SNAPSHOT,
+        description: 'serializes scroll position during initial full snapshot',
+        serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
+        shouldSerializeScroll: true,
+      },
+      {
+        description: 'serializes scroll position during subsequent full snapshot',
+        serializationContext: SerializationContext.SUBSEQUENT_FULL_SNAPSHOT,
         shouldSerializeScroll: true,
       },
       {
@@ -515,7 +520,7 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
     const serializeOptionsMask: SerializeOptions = {
       document,
       parentNodePrivacyLevel: NodePrivacyLevel.MASK,
-      serializationContext: SerializationContext.FULL_SNAPSHOT,
+      serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
     }
     expect(serializeDocumentNode(document, serializeOptionsMask)).toEqual({
       type: NodeType.Document,

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -28,11 +28,14 @@ import {
   SerializationContext,
 } from './serialize'
 import { MAX_ATTRIBUTE_VALUE_CHAR_LENGTH } from './privacy'
+import type { ElementsScrollPositions } from './elementsScrollPositions'
+import { createElementsScrollPositions } from './elementsScrollPositions'
 
 const DEFAULT_OPTIONS: SerializeOptions = {
   document,
   parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
   serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
+  elementsScrollPositions: createElementsScrollPositions(),
 }
 
 describe('serializeNodeWithId', () => {
@@ -54,7 +57,14 @@ describe('serializeNodeWithId', () => {
   describe('document serialization', () => {
     it('serializes a document', () => {
       const document = new DOMParser().parseFromString('<!doctype html><html>foo</html>', 'text/html')
-      expect(serializeDocument(document, NodePrivacyLevel.ALLOW, SerializationContext.INITIAL_FULL_SNAPSHOT)).toEqual({
+      expect(
+        serializeDocument(
+          document,
+          NodePrivacyLevel.ALLOW,
+          SerializationContext.INITIAL_FULL_SNAPSHOT,
+          createElementsScrollPositions()
+        )
+      ).toEqual({
         type: NodeType.Document,
         childNodes: [
           jasmine.objectContaining({ type: NodeType.DocumentType, name: 'html', publicId: '', systemId: '' }),
@@ -116,25 +126,13 @@ describe('serializeNodeWithId', () => {
         style: 'width: 10px;',
       })
     })
-    ;[
-      {
-        description: 'serializes scroll position during initial full snapshot',
-        serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
-        shouldSerializeScroll: true,
-      },
-      {
-        description: 'serializes scroll position during subsequent full snapshot',
-        serializationContext: SerializationContext.SUBSEQUENT_FULL_SNAPSHOT,
-        shouldSerializeScroll: true,
-      },
-      {
-        description: 'does not serialize scroll position during mutation',
-        serializationContext: SerializationContext.MUTATION,
-        shouldSerializeScroll: false,
-      },
-    ].forEach(({ description, serializationContext, shouldSerializeScroll }) => {
-      it(description, () => {
-        const element = document.createElement('div')
+
+    describe('rr scroll attributes', () => {
+      let element: HTMLDivElement
+      let elementsScrollPositions: ElementsScrollPositions
+
+      beforeEach(() => {
+        element = document.createElement('div')
         Object.assign(element.style, { width: '100px', height: '100px', overflow: 'scroll' })
         const inner = document.createElement('div')
         Object.assign(inner.style, { width: '200px', height: '200px' })
@@ -142,19 +140,81 @@ describe('serializeNodeWithId', () => {
         sandbox.appendChild(element)
         element.scrollBy(10, 20)
 
-        const serializedAttributes = (
-          serializeNodeWithId(element, { ...DEFAULT_OPTIONS, serializationContext })! as ElementNode
-        ).attributes
-        const attributesWithScrollPositions = jasmine.objectContaining({
-          rr_scrollTop: 20,
-          rr_scrollLeft: 10,
-        })
+        elementsScrollPositions = createElementsScrollPositions()
+      })
 
-        if (shouldSerializeScroll) {
-          expect(serializedAttributes).toEqual(attributesWithScrollPositions)
-        } else {
-          expect(serializedAttributes).not.toEqual(attributesWithScrollPositions)
-        }
+      it('should be retrieved from attributes during initial full snapshot', () => {
+        const serializedAttributes = (
+          serializeNodeWithId(element, {
+            ...DEFAULT_OPTIONS,
+            elementsScrollPositions,
+            serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
+          }) as ElementNode
+        ).attributes
+
+        expect(serializedAttributes).toEqual(
+          jasmine.objectContaining({
+            rr_scrollLeft: 10,
+            rr_scrollTop: 20,
+          })
+        )
+        expect(elementsScrollPositions.get(element)).toEqual({ scrollLeft: 10, scrollTop: 20 })
+      })
+
+      it('should not be retrieved from attributes during subsequent full snapshot', () => {
+        const serializedAttributes = (
+          serializeNodeWithId(element, {
+            ...DEFAULT_OPTIONS,
+            elementsScrollPositions,
+            serializationContext: SerializationContext.SUBSEQUENT_FULL_SNAPSHOT,
+          }) as ElementNode
+        ).attributes
+
+        expect(serializedAttributes).not.toEqual(
+          jasmine.objectContaining({
+            rr_scrollLeft: 10,
+            rr_scrollTop: 20,
+          })
+        )
+        expect(elementsScrollPositions.get(element)).toBeUndefined()
+      })
+
+      it('should be retrieved from elementsScrollPositions during subsequent full snapshot', () => {
+        elementsScrollPositions.set(element, { scrollLeft: 10, scrollTop: 20 })
+
+        const serializedAttributes = (
+          serializeNodeWithId(element, {
+            ...DEFAULT_OPTIONS,
+            elementsScrollPositions,
+            serializationContext: SerializationContext.SUBSEQUENT_FULL_SNAPSHOT,
+          }) as ElementNode
+        ).attributes
+
+        expect(serializedAttributes).toEqual(
+          jasmine.objectContaining({
+            rr_scrollLeft: 10,
+            rr_scrollTop: 20,
+          })
+        )
+      })
+
+      it('should not be retrieved during mutation', () => {
+        elementsScrollPositions.set(element, { scrollLeft: 10, scrollTop: 20 })
+
+        const serializedAttributes = (
+          serializeNodeWithId(element, {
+            ...DEFAULT_OPTIONS,
+            elementsScrollPositions,
+            serializationContext: SerializationContext.MUTATION,
+          }) as ElementNode
+        ).attributes
+
+        expect(serializedAttributes).not.toEqual(
+          jasmine.objectContaining({
+            rr_scrollLeft: 10,
+            rr_scrollTop: 20,
+          })
+        )
       })
     })
 
@@ -521,6 +581,7 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
       document,
       parentNodePrivacyLevel: NodePrivacyLevel.MASK,
       serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
+      elementsScrollPositions: createElementsScrollPositions(),
     }
     expect(serializeDocumentNode(document, serializeOptionsMask)).toEqual({
       type: NodeType.Document,

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -18,20 +18,21 @@ import {
 import type { ElementNode, SerializedNodeWithId, TextNode } from '../../types'
 import { NodeType } from '../../types'
 import { hasSerializedNode } from './serializationUtils'
-import type { SerializeOptions, SerializationContext } from './serialize'
+import type { SerializeOptions } from './serialize'
 import {
   serializeDocument,
   serializeNodeWithId,
   serializeDocumentNode,
   serializeChildNodes,
   serializeAttribute,
+  SerializationContext,
 } from './serialize'
 import { MAX_ATTRIBUTE_VALUE_CHAR_LENGTH } from './privacy'
 
 const DEFAULT_OPTIONS: SerializeOptions = {
   document,
   parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
-  serializationContext: 'full-snapshot',
+  serializationContext: SerializationContext.FULL_SNAPSHOT,
 }
 
 describe('serializeNodeWithId', () => {
@@ -118,12 +119,12 @@ describe('serializeNodeWithId', () => {
     ;[
       {
         description: 'serializes scroll position during full snapshot',
-        serializationContext: 'full-snapshot' as SerializationContext,
+        serializationContext: SerializationContext.FULL_SNAPSHOT,
         shouldSerializeScroll: true,
       },
       {
         description: 'does not serialize scroll position during mutation',
-        serializationContext: 'mutation' as SerializationContext,
+        serializationContext: SerializationContext.MUTATION,
         shouldSerializeScroll: false,
       },
     ].forEach(({ description, serializationContext, shouldSerializeScroll }) => {
@@ -514,7 +515,7 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
     const serializeOptionsMask: SerializeOptions = {
       document,
       parentNodePrivacyLevel: NodePrivacyLevel.MASK,
-      serializationContext: 'full-snapshot',
+      serializationContext: SerializationContext.FULL_SNAPSHOT,
     }
     expect(serializeDocumentNode(document, serializeOptionsMask)).toEqual({
       type: NodeType.Document,

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -25,7 +25,7 @@ import {
   serializeDocumentNode,
   serializeChildNodes,
   serializeAttribute,
-  SerializationContext,
+  SerializationContextStatus,
 } from './serialize'
 import { MAX_ATTRIBUTE_VALUE_CHAR_LENGTH } from './privacy'
 import type { ElementsScrollPositions } from './elementsScrollPositions'
@@ -34,8 +34,10 @@ import { createElementsScrollPositions } from './elementsScrollPositions'
 const DEFAULT_OPTIONS: SerializeOptions = {
   document,
   parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
-  serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
-  elementsScrollPositions: createElementsScrollPositions(),
+  serializationContext: {
+    status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
+    elementsScrollPositions: createElementsScrollPositions(),
+  },
 }
 
 describe('serializeNodeWithId', () => {
@@ -57,14 +59,7 @@ describe('serializeNodeWithId', () => {
   describe('document serialization', () => {
     it('serializes a document', () => {
       const document = new DOMParser().parseFromString('<!doctype html><html>foo</html>', 'text/html')
-      expect(
-        serializeDocument(
-          document,
-          NodePrivacyLevel.ALLOW,
-          SerializationContext.INITIAL_FULL_SNAPSHOT,
-          createElementsScrollPositions()
-        )
-      ).toEqual({
+      expect(serializeDocument(document, NodePrivacyLevel.ALLOW, DEFAULT_OPTIONS.serializationContext)).toEqual({
         type: NodeType.Document,
         childNodes: [
           jasmine.objectContaining({ type: NodeType.DocumentType, name: 'html', publicId: '', systemId: '' }),
@@ -147,8 +142,7 @@ describe('serializeNodeWithId', () => {
         const serializedAttributes = (
           serializeNodeWithId(element, {
             ...DEFAULT_OPTIONS,
-            elementsScrollPositions,
-            serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
+            serializationContext: { status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT, elementsScrollPositions },
           }) as ElementNode
         ).attributes
 
@@ -165,8 +159,10 @@ describe('serializeNodeWithId', () => {
         const serializedAttributes = (
           serializeNodeWithId(element, {
             ...DEFAULT_OPTIONS,
-            elementsScrollPositions,
-            serializationContext: SerializationContext.SUBSEQUENT_FULL_SNAPSHOT,
+            serializationContext: {
+              status: SerializationContextStatus.SUBSEQUENT_FULL_SNAPSHOT,
+              elementsScrollPositions,
+            },
           }) as ElementNode
         ).attributes
 
@@ -181,8 +177,10 @@ describe('serializeNodeWithId', () => {
         const serializedAttributes = (
           serializeNodeWithId(element, {
             ...DEFAULT_OPTIONS,
-            elementsScrollPositions,
-            serializationContext: SerializationContext.SUBSEQUENT_FULL_SNAPSHOT,
+            serializationContext: {
+              status: SerializationContextStatus.SUBSEQUENT_FULL_SNAPSHOT,
+              elementsScrollPositions,
+            },
           }) as ElementNode
         ).attributes
 
@@ -200,8 +198,7 @@ describe('serializeNodeWithId', () => {
         const serializedAttributes = (
           serializeNodeWithId(element, {
             ...DEFAULT_OPTIONS,
-            elementsScrollPositions,
-            serializationContext: SerializationContext.MUTATION,
+            serializationContext: { status: SerializationContextStatus.MUTATION },
           }) as ElementNode
         ).attributes
 
@@ -572,8 +569,7 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
     const serializeOptionsMask: SerializeOptions = {
       document,
       parentNodePrivacyLevel: NodePrivacyLevel.MASK,
-      serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
-      elementsScrollPositions: createElementsScrollPositions(),
+      serializationContext: DEFAULT_OPTIONS.serializationContext,
     }
     expect(serializeDocumentNode(document, serializeOptionsMask)).toEqual({
       type: NodeType.Document,

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -170,12 +170,8 @@ describe('serializeNodeWithId', () => {
           }) as ElementNode
         ).attributes
 
-        expect(serializedAttributes).not.toEqual(
-          jasmine.objectContaining({
-            rr_scrollLeft: 10,
-            rr_scrollTop: 20,
-          })
-        )
+        expect(serializedAttributes.rr_scrollLeft).toBeUndefined()
+        expect(serializedAttributes.rr_scrollTop).toBeUndefined()
         expect(elementsScrollPositions.get(element)).toBeUndefined()
       })
 
@@ -209,12 +205,8 @@ describe('serializeNodeWithId', () => {
           }) as ElementNode
         ).attributes
 
-        expect(serializedAttributes).not.toEqual(
-          jasmine.objectContaining({
-            rr_scrollLeft: 10,
-            rr_scrollTop: 20,
-          })
-        )
+        expect(serializedAttributes.rr_scrollLeft).toBeUndefined()
+        expect(serializedAttributes.rr_scrollTop).toBeUndefined()
       })
     })
 

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -416,26 +416,27 @@ function getAttributesForPrivacyLevel(
   /**
    * Serialize the scroll state for each element only for full snapshot
    */
-  let scrollPositions
+  let scrollTop: number | undefined
+  let scrollLeft: number | undefined
   switch (serializationContext) {
     case SerializationContext.INITIAL_FULL_SNAPSHOT:
-      scrollPositions = {
-        scrollTop: Math.round(element.scrollTop),
-        scrollLeft: Math.round(element.scrollLeft),
-      }
-      if (scrollPositions.scrollTop || scrollPositions.scrollLeft) {
-        elementsScrollPositions?.set(element, scrollPositions)
+      scrollTop = Math.round(element.scrollTop)
+      scrollLeft = Math.round(element.scrollLeft)
+      if (scrollTop || scrollLeft) {
+        elementsScrollPositions?.set(element, { scrollTop, scrollLeft })
       }
       break
     case SerializationContext.SUBSEQUENT_FULL_SNAPSHOT:
-      scrollPositions = elementsScrollPositions?.get(element)
+      if (elementsScrollPositions?.has(element)) {
+        ;({ scrollTop, scrollLeft } = elementsScrollPositions.get(element)!)
+      }
       break
   }
-  if (scrollPositions?.scrollLeft) {
-    safeAttrs.rr_scrollLeft = scrollPositions.scrollLeft
+  if (scrollLeft) {
+    safeAttrs.rr_scrollLeft = scrollLeft
   }
-  if (scrollPositions?.scrollTop) {
-    safeAttrs.rr_scrollTop = scrollPositions.scrollTop
+  if (scrollTop) {
+    safeAttrs.rr_scrollTop = scrollTop
   }
 
   return safeAttrs

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -420,8 +420,8 @@ function getAttributesForPrivacyLevel(
   switch (serializationContext) {
     case SerializationContext.INITIAL_FULL_SNAPSHOT:
       scrollPositions = {
-        scrollTop: element.scrollTop && Math.round(element.scrollTop),
-        scrollLeft: element.scrollLeft && Math.round(element.scrollLeft),
+        scrollTop: Math.round(element.scrollTop),
+        scrollLeft: Math.round(element.scrollLeft),
       }
       if (scrollPositions.scrollTop || scrollPositions.scrollLeft) {
         elementsScrollPositions?.set(element, scrollPositions)

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -35,7 +35,8 @@ type ParentNodePrivacyLevel =
   | typeof NodePrivacyLevel.MASK_USER_INPUT
 
 export enum SerializationContext {
-  FULL_SNAPSHOT,
+  INITIAL_FULL_SNAPSHOT,
+  SUBSEQUENT_FULL_SNAPSHOT,
   MUTATION,
 }
 
@@ -49,13 +50,14 @@ export interface SerializeOptions {
 
 export function serializeDocument(
   document: Document,
-  defaultPrivacyLevel: ParentNodePrivacyLevel
+  defaultPrivacyLevel: ParentNodePrivacyLevel,
+  serializationContext: SerializationContext
 ): SerializedNodeWithId {
   // We are sure that Documents are never ignored, so this function never returns null
   return serializeNodeWithId(document, {
     document,
     parentNodePrivacyLevel: defaultPrivacyLevel,
-    serializationContext: SerializationContext.FULL_SNAPSHOT,
+    serializationContext,
   })!
 }
 
@@ -404,13 +406,16 @@ function getAttributesForPrivacyLevel(
   /**
    * Serialize the scroll state for each element only for full snapshot
    */
-  if (serializationContext === SerializationContext.FULL_SNAPSHOT) {
-    if (element.scrollLeft) {
-      safeAttrs.rr_scrollLeft = Math.round(element.scrollLeft)
-    }
-    if (element.scrollTop) {
-      safeAttrs.rr_scrollTop = Math.round(element.scrollTop)
-    }
+  switch (serializationContext) {
+    case SerializationContext.INITIAL_FULL_SNAPSHOT:
+    case SerializationContext.SUBSEQUENT_FULL_SNAPSHOT:
+      if (element.scrollLeft) {
+        safeAttrs.rr_scrollLeft = Math.round(element.scrollLeft)
+      }
+      if (element.scrollTop) {
+        safeAttrs.rr_scrollTop = Math.round(element.scrollTop)
+      }
+      break
   }
 
   return safeAttrs

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -34,7 +34,10 @@ type ParentNodePrivacyLevel =
   | typeof NodePrivacyLevel.MASK
   | typeof NodePrivacyLevel.MASK_USER_INPUT
 
-export type SerializationContext = 'full-snapshot' | 'mutation'
+export enum SerializationContext {
+  FULL_SNAPSHOT,
+  MUTATION,
+}
 
 export interface SerializeOptions {
   document: Document
@@ -52,7 +55,7 @@ export function serializeDocument(
   return serializeNodeWithId(document, {
     document,
     parentNodePrivacyLevel: defaultPrivacyLevel,
-    serializationContext: 'full-snapshot',
+    serializationContext: SerializationContext.FULL_SNAPSHOT,
   })!
 }
 
@@ -401,7 +404,7 @@ function getAttributesForPrivacyLevel(
   /**
    * Serialize the scroll state for each element only for full snapshot
    */
-  if (serializationContext === 'full-snapshot') {
+  if (serializationContext === SerializationContext.FULL_SNAPSHOT) {
     if (element.scrollLeft) {
       safeAttrs.rr_scrollLeft = Math.round(element.scrollLeft)
     }

--- a/packages/rum/test/htmlAst.ts
+++ b/packages/rum/test/htmlAst.ts
@@ -1,6 +1,6 @@
 import { objectValues } from '../../core/src'
 import type { SerializedNodeWithId } from '../src/types'
-import { serializeNodeWithId, SerializationContext } from '../src/domain/record'
+import { serializeNodeWithId, SerializationContextStatus, createElementsScrollPositions } from '../src/domain/record'
 import { NodePrivacyLevel, PRIVACY_ATTR_NAME } from '../src/constants'
 
 export const makeHtmlDoc = (htmlContent: string, privacyTag: string) => {
@@ -32,7 +32,10 @@ export const generateLeanSerializedDoc = (htmlContent: string, privacyTag: strin
     serializeNodeWithId(newDoc, {
       document: newDoc,
       parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
-      serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
+      serializationContext: {
+        status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
+        elementsScrollPositions: createElementsScrollPositions(),
+      },
     })! as unknown as Record<string, unknown>
   ) as unknown as SerializedNodeWithId
   return serializedDoc

--- a/packages/rum/test/htmlAst.ts
+++ b/packages/rum/test/htmlAst.ts
@@ -32,7 +32,7 @@ export const generateLeanSerializedDoc = (htmlContent: string, privacyTag: strin
     serializeNodeWithId(newDoc, {
       document: newDoc,
       parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
-      serializationContext: SerializationContext.FULL_SNAPSHOT,
+      serializationContext: SerializationContext.INITIAL_FULL_SNAPSHOT,
     })! as unknown as Record<string, unknown>
   ) as unknown as SerializedNodeWithId
   return serializedDoc

--- a/packages/rum/test/htmlAst.ts
+++ b/packages/rum/test/htmlAst.ts
@@ -1,6 +1,6 @@
 import { objectValues } from '../../core/src'
 import type { SerializedNodeWithId } from '../src/types'
-import { serializeNodeWithId } from '../src/domain/record'
+import { serializeNodeWithId, SerializationContext } from '../src/domain/record'
 import { NodePrivacyLevel, PRIVACY_ATTR_NAME } from '../src/constants'
 
 export const makeHtmlDoc = (htmlContent: string, privacyTag: string) => {
@@ -32,7 +32,7 @@ export const generateLeanSerializedDoc = (htmlContent: string, privacyTag: strin
     serializeNodeWithId(newDoc, {
       document: newDoc,
       parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
-      serializationContext: 'full-snapshot',
+      serializationContext: SerializationContext.FULL_SNAPSHOT,
     })! as unknown as Record<string, unknown>
   ) as unknown as SerializedNodeWithId
   return serializedDoc


### PR DESCRIPTION
## Motivation

Accessing scroll positions of DOM elements during serialization is costly so let's avoid to do it when we can.

## Changes

Following #1670, remove more scroll attributes accesses by:

- keeping in memory scroll positions during initial full snapshot and scroll events
- retrieve from memory scroll positions during subsequent full snapshot

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
