### PR TITLE
⚗️ [RUMF-1333] Experiment with fetch keepalive

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,14 @@ export {
 export {
   SESSION_TIME_OUT_DELAY, // Exposed for tests
 } from './domain/session/sessionConstants'
-export { HttpRequest, Batch, canUseEventBridge, getEventBridge, startBatchWithReplica } from './transport'
+export {
+  HttpRequest,
+  createHttpRequest,
+  Batch,
+  canUseEventBridge,
+  getEventBridge,
+  startBatchWithReplica,
+} from './transport'
 export * from './tools/display'
 export * from './tools/urlPolyfill'
 export * from './tools/timeUtils'

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -22,7 +22,7 @@ export class Batch {
     private flushTimeout: number,
     private beforeUnloadCallback: () => void = noop
   ) {
-    this.flushOnVisibilityHidden()
+    this.setupFlushOnExit()
     this.flushPeriodically()
   }
 
@@ -48,8 +48,8 @@ export class Batch {
     }
   }
 
-  beaconFlush() {
-    this.flush(this.request.sendBeacon)
+  flushOnExit() {
+    this.flush(this.request.sendOnExit)
   }
 
   computeBytesCount(candidate: string) {
@@ -140,7 +140,7 @@ export class Batch {
     )
   }
 
-  private flushOnVisibilityHidden() {
+  private setupFlushOnExit() {
     /**
      * With sendBeacon, requests are guaranteed to be successfully sent during document unload
      */
@@ -159,7 +159,7 @@ export class Batch {
        */
       addEventListener(document, DOM_EVENT.VISIBILITY_CHANGE, () => {
         if (document.visibilityState === 'hidden') {
-          this.beaconFlush()
+          this.flushOnExit()
         }
       })
       /**
@@ -167,7 +167,7 @@ export class Batch {
        * - a visibility change during doc unload (cf: https://bugs.webkit.org/show_bug.cgi?id=194897)
        * - a page hide transition (cf: https://bugs.webkit.org/show_bug.cgi?id=188329)
        */
-      addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => this.beaconFlush())
+      addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => this.flushOnExit())
     }
   }
 }

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -34,7 +34,7 @@ export class Batch {
     this.addOrUpdate(message, key)
   }
 
-  flush() {
+  flush(sendFn = this.request.send) {
     if (this.bufferMessagesCount !== 0) {
       const messages = this.pushOnlyBuffer.concat(objectValues(this.upsertBuffer))
       const bytesCount = this.bufferBytesCount
@@ -44,8 +44,12 @@ export class Batch {
       this.bufferBytesCount = 0
       this.bufferMessagesCount = 0
 
-      this.request.send(messages.join('\n'), bytesCount)
+      sendFn(messages.join('\n'), bytesCount)
     }
+  }
+
+  beaconFlush() {
+    this.flush(this.request.sendBeacon)
   }
 
   computeBytesCount(candidate: string) {
@@ -155,7 +159,7 @@ export class Batch {
        */
       addEventListener(document, DOM_EVENT.VISIBILITY_CHANGE, () => {
         if (document.visibilityState === 'hidden') {
-          this.flush()
+          this.beaconFlush()
         }
       })
       /**
@@ -163,7 +167,7 @@ export class Batch {
        * - a visibility change during doc unload (cf: https://bugs.webkit.org/show_bug.cgi?id=194897)
        * - a page hide transition (cf: https://bugs.webkit.org/show_bug.cgi?id=188329)
        */
-      addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => this.flush())
+      addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => this.beaconFlush())
     }
   }
 }

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -25,7 +25,7 @@ describe('httpRequest', () => {
     interceptor.restore()
   })
 
-  describe('send (without fetch-keepalive FF)', () => {
+  describe('send (without fetch_keepalive FF)', () => {
     it('should use xhr when sendBeacon is not defined', () => {
       interceptor.withSendBeacon(false)
 
@@ -84,9 +84,9 @@ describe('httpRequest', () => {
     })
   })
 
-  describe('send (with fetch-keepalive FF)', () => {
+  describe('send (with fetch_keepalive FF)', () => {
     beforeEach(() => {
-      updateExperimentalFeatures(['fetch-keepalive'])
+      updateExperimentalFeatures(['fetch_keepalive'])
     })
 
     afterEach(() => {

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -142,11 +142,11 @@ describe('httpRequest', () => {
     })
   })
 
-  describe('sendBeacon', () => {
+  describe('sendOnExit', () => {
     it('should use xhr when sendBeacon is not defined', () => {
       interceptor.withSendBeacon(false)
 
-      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -159,14 +159,14 @@ describe('httpRequest', () => {
         pending('no sendBeacon support')
       }
 
-      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('sendBeacon')
     })
 
     it('should use xhr over sendBeacon when the bytes count is too high', () => {
-      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
+      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -178,7 +178,7 @@ describe('httpRequest', () => {
       }
       interceptor.withSendBeacon(() => false)
 
-      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -194,7 +194,7 @@ describe('httpRequest', () => {
         throw new TypeError()
       })
 
-      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
       expect(sendBeaconCalled).toBe(true)
       expect(requests.length).toEqual(1)

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -8,21 +8,26 @@ import type { HttpRequest } from './httpRequest'
 
 describe('httpRequest', () => {
   const BATCH_BYTES_LIMIT = 100
+  let interceptor: ReturnType<typeof interceptRequests>
   let requests: Request[]
   let endpointBuilder: EndpointBuilder
   let request: HttpRequest
   const ENDPOINT_URL = 'http://my.website'
 
   beforeEach(() => {
-    requests = interceptRequests()
+    interceptor = interceptRequests()
+    requests = interceptor.requests
     endpointBuilder = stubEndpointBuilder(ENDPOINT_URL)
     request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 
+  afterEach(() => {
+    interceptor.restore()
+  })
+
   describe('send (without fetch-keepalive FF)', () => {
     it('should use xhr when sendBeacon is not defined', () => {
-      const originalSendBeacon = navigator.sendBeacon && navigator.sendBeacon.bind(navigator)
-      ;(navigator.sendBeacon as any) = false
+      interceptor.withSendBeacon(false)
 
       request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
@@ -30,11 +35,10 @@ describe('httpRequest', () => {
       expect(requests[0].type).toBe('xhr')
       expect(requests[0].url).toContain(ENDPOINT_URL)
       expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
-      navigator.sendBeacon = originalSendBeacon
     })
 
     it('should use sendBeacon when the bytes count is correct', () => {
-      if (!navigator.sendBeacon) {
+      if (!interceptor.isSendBeaconSupported()) {
         pending('no sendBeacon support')
       }
 
@@ -52,10 +56,10 @@ describe('httpRequest', () => {
     })
 
     it('should fallback to xhr when sendBeacon is not queued', () => {
-      if (!navigator.sendBeacon) {
+      if (!interceptor.isSendBeaconSupported()) {
         pending('no sendBeacon support')
       }
-      spyOn(navigator, 'sendBeacon').and.callFake(() => false)
+      interceptor.withSendBeacon(() => false)
 
       request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
@@ -64,16 +68,17 @@ describe('httpRequest', () => {
     })
 
     it('should fallback to xhr when sendBeacon throws', () => {
-      if (!navigator.sendBeacon) {
+      if (!interceptor.isSendBeaconSupported()) {
         pending('no sendBeacon support')
       }
-      spyOn(navigator, 'sendBeacon').and.callFake(() => {
+      let sendBeaconCalled = false
+      interceptor.withSendBeacon(() => {
+        sendBeaconCalled = true
         throw new TypeError()
       })
 
       request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-      expect(navigator.sendBeacon).toHaveBeenCalled()
+      expect(sendBeaconCalled).toBe(true)
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
     })
@@ -89,8 +94,7 @@ describe('httpRequest', () => {
     })
 
     it('should use xhr when fetch keepalive is not available', () => {
-      const originalRequest = window.Request
-      ;(window.Request as any) = false
+      interceptor.withRequest(false)
 
       request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
@@ -98,11 +102,10 @@ describe('httpRequest', () => {
       expect(requests[0].type).toBe('xhr')
       expect(requests[0].url).toContain(ENDPOINT_URL)
       expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
-      window.Request = originalRequest
     })
 
     it('should use fetch keepalive when the bytes count is correct', () => {
-      if (!('fetch' in window) || !('keepalive' in new window.Request(''))) {
+      if (!interceptor.isFetchKeepAliveSupported()) {
         pending('no fetch keepalive support')
       }
 
@@ -120,12 +123,11 @@ describe('httpRequest', () => {
     })
 
     it('should fallback to xhr when fetch keepalive is not queued', (done) => {
-      if (!('fetch' in window) || !('keepalive' in new window.Request(''))) {
+      if (!interceptor.isFetchKeepAliveSupported()) {
         pending('no fetch keepalive support')
       }
-
       let notQueuedFetch: Promise<never>
-      spyOn(window, 'fetch').and.callFake(() => {
+      interceptor.withFetch(() => {
         notQueuedFetch = Promise.reject()
         return notQueuedFetch
       })
@@ -142,8 +144,7 @@ describe('httpRequest', () => {
 
   describe('sendBeacon', () => {
     it('should use xhr when sendBeacon is not defined', () => {
-      const originalSendBeacon = navigator.sendBeacon && navigator.sendBeacon.bind(navigator)
-      ;(navigator.sendBeacon as any) = false
+      interceptor.withSendBeacon(false)
 
       request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
@@ -151,11 +152,10 @@ describe('httpRequest', () => {
       expect(requests[0].type).toBe('xhr')
       expect(requests[0].url).toContain(ENDPOINT_URL)
       expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
-      navigator.sendBeacon = originalSendBeacon
     })
 
     it('should use sendBeacon when the bytes count is correct', () => {
-      if (!navigator.sendBeacon) {
+      if (!interceptor.isSendBeaconSupported()) {
         pending('no sendBeacon support')
       }
 
@@ -173,10 +173,10 @@ describe('httpRequest', () => {
     })
 
     it('should fallback to xhr when sendBeacon is not queued', () => {
-      if (!navigator.sendBeacon) {
+      if (!interceptor.isSendBeaconSupported()) {
         pending('no sendBeacon support')
       }
-      spyOn(navigator, 'sendBeacon').and.callFake(() => false)
+      interceptor.withSendBeacon(() => false)
 
       request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
@@ -185,16 +185,18 @@ describe('httpRequest', () => {
     })
 
     it('should fallback to xhr when sendBeacon throws', () => {
-      if (!navigator.sendBeacon) {
+      if (!interceptor.isSendBeaconSupported()) {
         pending('no sendBeacon support')
       }
-      spyOn(navigator, 'sendBeacon').and.callFake(() => {
+      let sendBeaconCalled = false
+      interceptor.withSendBeacon(() => {
+        sendBeaconCalled = true
         throw new TypeError()
       })
 
       request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
-      expect(navigator.sendBeacon).toHaveBeenCalled()
+      expect(sendBeaconCalled).toBe(true)
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
     })
@@ -204,14 +206,20 @@ describe('httpRequest', () => {
 describe('httpRequest intake parameters', () => {
   const clientToken = 'some_client_token'
   const BATCH_BYTES_LIMIT = 100
+  let interceptor: ReturnType<typeof interceptRequests>
   let requests: Request[]
   let endpointBuilder: EndpointBuilder
   let request: HttpRequest
 
   beforeEach(() => {
-    requests = interceptRequests()
+    interceptor = interceptRequests()
+    requests = interceptor.requests
     endpointBuilder = createEndpointBuilder({ clientToken }, 'logs', [])
     request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
+  })
+
+  afterEach(() => {
+    interceptor.restore()
   })
 
   it('should have a unique request id', () => {

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import sinon from 'sinon'
-import { stubEndpointBuilder } from '../../test/specHelper'
+import { stubEndpointBuilder, interceptRequests } from '../../test/specHelper'
+import type { Request } from '../../test/specHelper'
 import type { EndpointBuilder } from '../domain/configuration'
 import { createEndpointBuilder } from '../domain/configuration'
 import { createHttpRequest } from './httpRequest'
@@ -8,57 +8,64 @@ import type { HttpRequest } from './httpRequest'
 
 describe('httpRequest', () => {
   const BATCH_BYTES_LIMIT = 100
-  let server: sinon.SinonFakeServer
+  let requests: Request[]
   let endpointBuilder: EndpointBuilder
   let request: HttpRequest
   const ENDPOINT_URL = 'http://my.website'
 
   beforeEach(() => {
-    server = sinon.fakeServer.create()
+    requests = interceptRequests()
     endpointBuilder = stubEndpointBuilder(ENDPOINT_URL)
     request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 
-  afterEach(() => {
-    server.restore()
-  })
-
   it('should use xhr when sendBeacon is not defined', () => {
+    const originalSendBeacon = navigator.sendBeacon.bind(navigator)
+    ;(navigator.sendBeacon as any) = false
+
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
-    expect(server.requests.length).toEqual(1)
-    expect(server.requests[0].url).toContain(ENDPOINT_URL)
-    expect(server.requests[0].requestBody).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
+    expect(requests.length).toEqual(1)
+    expect(requests[0].type).toBe('xhr')
+    expect(requests[0].url).toContain(ENDPOINT_URL)
+    expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
+    navigator.sendBeacon = originalSendBeacon
   })
 
   it('should use sendBeacon when the bytes count is correct', () => {
-    spyOn(navigator, 'sendBeacon').and.callFake(() => true)
+    if (!navigator.sendBeacon) {
+      pending('no sendBeacon support')
+    }
 
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
-    expect(navigator.sendBeacon).toHaveBeenCalled()
+    expect(requests.length).toEqual(1)
+    expect(requests[0].type).toBe('sendBeacon')
   })
 
   it('should use xhr over sendBeacon when the bytes count is too high', () => {
-    spyOn(navigator, 'sendBeacon').and.callFake(() => true)
-
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
 
-    expect(server.requests.length).toEqual(1)
-    expect(server.requests[0].url).toContain(ENDPOINT_URL)
-    expect(server.requests[0].requestBody).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
+    expect(requests.length).toEqual(1)
+    expect(requests[0].type).toBe('xhr')
   })
 
   it('should fallback to xhr when sendBeacon is not queued', () => {
+    if (!navigator.sendBeacon) {
+      pending('no sendBeacon support')
+    }
     spyOn(navigator, 'sendBeacon').and.callFake(() => false)
 
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
-    expect(navigator.sendBeacon).toHaveBeenCalled()
-    expect(server.requests.length).toEqual(1)
+    expect(requests.length).toEqual(1)
+    expect(requests[0].type).toBe('xhr')
   })
 
   it('should fallback to xhr when sendBeacon throws', () => {
+    if (!navigator.sendBeacon) {
+      pending('no sendBeacon support')
+    }
     spyOn(navigator, 'sendBeacon').and.callFake(() => {
       throw new TypeError()
     })
@@ -66,25 +73,22 @@ describe('httpRequest', () => {
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
     expect(navigator.sendBeacon).toHaveBeenCalled()
-    expect(server.requests.length).toEqual(1)
+    expect(requests.length).toEqual(1)
+    expect(requests[0].type).toBe('xhr')
   })
 })
 
 describe('httpRequest intake parameters', () => {
   const clientToken = 'some_client_token'
   const BATCH_BYTES_LIMIT = 100
-  let server: sinon.SinonFakeServer
+  let requests: Request[]
   let endpointBuilder: EndpointBuilder
   let request: HttpRequest
 
   beforeEach(() => {
-    server = sinon.fakeServer.create()
+    requests = interceptRequests()
     endpointBuilder = createEndpointBuilder({ clientToken }, 'logs', [])
     request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
-  })
-
-  afterEach(() => {
-    server.restore()
   })
 
   it('should have a unique request id', () => {
@@ -92,10 +96,10 @@ describe('httpRequest intake parameters', () => {
     request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
     const search = /dd-request-id=([^&]*)/
-    const requestId1 = search.exec(server.requests[0].url)?.[1]
-    const requestId2 = search.exec(server.requests[1].url)?.[1]
+    const requestId1 = search.exec(requests[0].url)?.[1]
+    const requestId2 = search.exec(requests[1].url)?.[1]
 
     expect(requestId1).not.toBe(requestId2)
-    expect(server.requests.length).toEqual(2)
+    expect(requests.length).toEqual(2)
   })
 })

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -2,7 +2,7 @@
 import { stubEndpointBuilder, interceptRequests } from '../../test/specHelper'
 import type { Request } from '../../test/specHelper'
 import type { EndpointBuilder } from '../domain/configuration'
-import { createEndpointBuilder } from '../domain/configuration'
+import { createEndpointBuilder, updateExperimentalFeatures, resetExperimentalFeatures } from '../domain/configuration'
 import { createHttpRequest } from './httpRequest'
 import type { HttpRequest } from './httpRequest'
 
@@ -19,62 +19,185 @@ describe('httpRequest', () => {
     request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 
-  it('should use xhr when sendBeacon is not defined', () => {
-    const originalSendBeacon = navigator.sendBeacon.bind(navigator)
-    ;(navigator.sendBeacon as any) = false
+  describe('send (without fetch-keepalive FF)', () => {
+    it('should use xhr when sendBeacon is not defined', () => {
+      const originalSendBeacon = navigator.sendBeacon && navigator.sendBeacon.bind(navigator)
+      ;(navigator.sendBeacon as any) = false
 
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
 
-    expect(requests.length).toEqual(1)
-    expect(requests[0].type).toBe('xhr')
-    expect(requests[0].url).toContain(ENDPOINT_URL)
-    expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
-    navigator.sendBeacon = originalSendBeacon
-  })
-
-  it('should use sendBeacon when the bytes count is correct', () => {
-    if (!navigator.sendBeacon) {
-      pending('no sendBeacon support')
-    }
-
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-    expect(requests.length).toEqual(1)
-    expect(requests[0].type).toBe('sendBeacon')
-  })
-
-  it('should use xhr over sendBeacon when the bytes count is too high', () => {
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
-
-    expect(requests.length).toEqual(1)
-    expect(requests[0].type).toBe('xhr')
-  })
-
-  it('should fallback to xhr when sendBeacon is not queued', () => {
-    if (!navigator.sendBeacon) {
-      pending('no sendBeacon support')
-    }
-    spyOn(navigator, 'sendBeacon').and.callFake(() => false)
-
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-    expect(requests.length).toEqual(1)
-    expect(requests[0].type).toBe('xhr')
-  })
-
-  it('should fallback to xhr when sendBeacon throws', () => {
-    if (!navigator.sendBeacon) {
-      pending('no sendBeacon support')
-    }
-    spyOn(navigator, 'sendBeacon').and.callFake(() => {
-      throw new TypeError()
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+      expect(requests[0].url).toContain(ENDPOINT_URL)
+      expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
+      navigator.sendBeacon = originalSendBeacon
     })
 
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+    it('should use sendBeacon when the bytes count is correct', () => {
+      if (!navigator.sendBeacon) {
+        pending('no sendBeacon support')
+      }
 
-    expect(navigator.sendBeacon).toHaveBeenCalled()
-    expect(requests.length).toEqual(1)
-    expect(requests[0].type).toBe('xhr')
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('sendBeacon')
+    })
+
+    it('should use xhr over sendBeacon when the bytes count is too high', () => {
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+    })
+
+    it('should fallback to xhr when sendBeacon is not queued', () => {
+      if (!navigator.sendBeacon) {
+        pending('no sendBeacon support')
+      }
+      spyOn(navigator, 'sendBeacon').and.callFake(() => false)
+
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+    })
+
+    it('should fallback to xhr when sendBeacon throws', () => {
+      if (!navigator.sendBeacon) {
+        pending('no sendBeacon support')
+      }
+      spyOn(navigator, 'sendBeacon').and.callFake(() => {
+        throw new TypeError()
+      })
+
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(navigator.sendBeacon).toHaveBeenCalled()
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+    })
+  })
+
+  describe('send (with fetch-keepalive FF)', () => {
+    beforeEach(() => {
+      updateExperimentalFeatures(['fetch-keepalive'])
+    })
+
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
+
+    it('should use xhr when fetch keepalive is not available', () => {
+      const originalRequest = window.Request
+      ;(window.Request as any) = false
+
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+      expect(requests[0].url).toContain(ENDPOINT_URL)
+      expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
+      window.Request = originalRequest
+    })
+
+    it('should use fetch keepalive when the bytes count is correct', () => {
+      if (!('fetch' in window) || !('keepalive' in new window.Request(''))) {
+        pending('no fetch keepalive support')
+      }
+
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('fetch')
+    })
+
+    it('should use xhr over fetch keepalive when the bytes count is too high', () => {
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+    })
+
+    it('should fallback to xhr when fetch keepalive is not queued', (done) => {
+      if (!('fetch' in window) || !('keepalive' in new window.Request(''))) {
+        pending('no fetch keepalive support')
+      }
+
+      let notQueuedFetch: Promise<never>
+      spyOn(window, 'fetch').and.callFake(() => {
+        notQueuedFetch = Promise.reject()
+        return notQueuedFetch
+      })
+
+      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      notQueuedFetch!.catch(() => {
+        expect(requests.length).toEqual(1)
+        expect(requests[0].type).toBe('xhr')
+        done()
+      })
+    })
+  })
+
+  describe('sendBeacon', () => {
+    it('should use xhr when sendBeacon is not defined', () => {
+      const originalSendBeacon = navigator.sendBeacon && navigator.sendBeacon.bind(navigator)
+      ;(navigator.sendBeacon as any) = false
+
+      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+      expect(requests[0].url).toContain(ENDPOINT_URL)
+      expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
+      navigator.sendBeacon = originalSendBeacon
+    })
+
+    it('should use sendBeacon when the bytes count is correct', () => {
+      if (!navigator.sendBeacon) {
+        pending('no sendBeacon support')
+      }
+
+      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('sendBeacon')
+    })
+
+    it('should use xhr over sendBeacon when the bytes count is too high', () => {
+      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+    })
+
+    it('should fallback to xhr when sendBeacon is not queued', () => {
+      if (!navigator.sendBeacon) {
+        pending('no sendBeacon support')
+      }
+      spyOn(navigator, 'sendBeacon').and.callFake(() => false)
+
+      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+    })
+
+    it('should fallback to xhr when sendBeacon throws', () => {
+      if (!navigator.sendBeacon) {
+        pending('no sendBeacon support')
+      }
+      spyOn(navigator, 'sendBeacon').and.callFake(() => {
+        throw new TypeError()
+      })
+
+      request.sendBeacon('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+
+      expect(navigator.sendBeacon).toHaveBeenCalled()
+      expect(requests.length).toEqual(1)
+      expect(requests[0].type).toBe('xhr')
+    })
   })
 })
 

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -3,7 +3,8 @@ import sinon from 'sinon'
 import { stubEndpointBuilder } from '../../test/specHelper'
 import type { EndpointBuilder } from '../domain/configuration'
 import { createEndpointBuilder } from '../domain/configuration'
-import { HttpRequest } from './httpRequest'
+import { createHttpRequest } from './httpRequest'
+import type { HttpRequest } from './httpRequest'
 
 describe('httpRequest', () => {
   const BATCH_BYTES_LIMIT = 100
@@ -15,7 +16,7 @@ describe('httpRequest', () => {
   beforeEach(() => {
     server = sinon.fakeServer.create()
     endpointBuilder = stubEndpointBuilder(ENDPOINT_URL)
-    request = new HttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 
   afterEach(() => {
@@ -79,7 +80,7 @@ describe('httpRequest intake parameters', () => {
   beforeEach(() => {
     server = sinon.fakeServer.create()
     endpointBuilder = createEndpointBuilder({ clientToken }, 'logs', [])
-    request = new HttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT)
   })
 
   afterEach(() => {

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -56,7 +56,7 @@ export function createHttpRequest(endpointBuilder: EndpointBuilder, bytesLimit: 
 
   return {
     send: (data: string | FormData, bytesCount: number) => {
-      if (!isExperimentalFeatureEnabled('fetch-keepalive')) {
+      if (!isExperimentalFeatureEnabled('fetch_keepalive')) {
         sendBeaconStrategy(data, bytesCount)
       } else {
         fetchKeepAliveStrategy(data, bytesCount)

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -56,7 +56,6 @@ export function createHttpRequest(endpointBuilder: EndpointBuilder, bytesLimit: 
 
   return {
     send: (data: string | FormData, bytesCount: number) => {
-      // TODO check tests without flag
       if (!isExperimentalFeatureEnabled('fetch-keepalive')) {
         sendBeacon(data, bytesCount)
       } else {

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -1,4 +1,4 @@
-export { HttpRequest } from './httpRequest'
+export { HttpRequest, createHttpRequest } from './httpRequest'
 export { Batch } from './batch'
 export { canUseEventBridge, getEventBridge, BrowserWindowWithEventBridge } from './eventBridge'
 export { startBatchWithReplica } from './startBatchWithReplica'

--- a/packages/core/src/transport/startBatchWithReplica.ts
+++ b/packages/core/src/transport/startBatchWithReplica.ts
@@ -1,7 +1,7 @@
 import type { Configuration, EndpointBuilder } from '../domain/configuration'
 import type { Context } from '../tools/context'
 import { Batch } from './batch'
-import { HttpRequest } from './httpRequest'
+import { createHttpRequest } from './httpRequest'
 
 export function startBatchWithReplica<T extends Context>(
   configuration: Configuration,
@@ -16,7 +16,7 @@ export function startBatchWithReplica<T extends Context>(
 
   function createBatch(endpointBuilder: EndpointBuilder) {
     return new Batch(
-      new HttpRequest(endpointBuilder, configuration.batchBytesLimit),
+      createHttpRequest(endpointBuilder, configuration.batchBytesLimit),
       configuration.batchMessagesLimit,
       configuration.batchBytesLimit,
       configuration.messageBytesLimit,

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -3,7 +3,6 @@ import { clearAllCookies } from './specHelper'
 
 beforeEach(() => {
   ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'dev'
-  jasmine.getEnv().allowRespy(true)
   // reset globals
   ;(window as any).DD_LOGS = {}
   ;(window as any).DD_RUM = {}

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -3,7 +3,7 @@ import { clearAllCookies } from './specHelper'
 
 beforeEach(() => {
   ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'dev'
-  ;(navigator.sendBeacon as any) = false
+  jasmine.getEnv().allowRespy(true)
   // reset globals
   ;(window as any).DD_LOGS = {}
   ;(window as any).DD_RUM = {}

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -422,21 +422,53 @@ export interface Request {
 
 export function interceptRequests() {
   const requests: Request[] = []
+  const originalSendBeacon = isSendBeaconSupported() && navigator.sendBeacon.bind(navigator)
+  const originalRequest = window.Request
+  const originalFetch = window.fetch
 
   spyOn(XMLHttpRequest.prototype, 'open').and.callFake((_, url) => requests.push({ type: 'xhr', url } as Request))
   spyOn(XMLHttpRequest.prototype, 'send').and.callFake((body) => (requests[requests.length - 1].body = body as string))
-  if ((navigator as any).sendBeacon) {
+  if (isSendBeaconSupported()) {
     spyOn(navigator, 'sendBeacon').and.callFake((url, body) => {
       requests.push({ type: 'sendBeacon', url: url as string, body: body as string })
       return true
     })
   }
-  if ((window as any).fetch) {
+  if (isFetchKeepAliveSupported()) {
     spyOn(window, 'fetch').and.callFake((url, config) => {
       requests.push({ type: 'fetch', url: url as string, body: config!.body as string })
       return new Promise<Response>(() => undefined)
     })
   }
 
-  return requests
+  function isSendBeaconSupported() {
+    return !!navigator.sendBeacon
+  }
+
+  function isFetchKeepAliveSupported() {
+    return 'fetch' in window && 'keepalive' in new window.Request('')
+  }
+
+  return {
+    requests,
+    isSendBeaconSupported,
+    isFetchKeepAliveSupported,
+    withSendBeacon(newSendBeacon: any) {
+      navigator.sendBeacon = newSendBeacon
+    },
+    withRequest(newRequest: any) {
+      window.Request = newRequest
+    },
+    withFetch(newFetch: any) {
+      window.fetch = newFetch
+    },
+    restore() {
+      if (originalSendBeacon) {
+        navigator.sendBeacon = originalSendBeacon
+      }
+      if (originalRequest) {
+        window.Request = originalRequest
+      }
+    },
+  }
 }

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -415,7 +415,7 @@ export function stubCookie() {
 }
 
 export interface Request {
-  type: 'xhr' | 'sendBeacon'
+  type: 'xhr' | 'sendBeacon' | 'fetch'
   url: string
   body: string
 }
@@ -429,6 +429,12 @@ export function interceptRequests() {
     spyOn(navigator, 'sendBeacon').and.callFake((url, body) => {
       requests.push({ type: 'sendBeacon', url: url as string, body: body as string })
       return true
+    })
+  }
+  if ((window as any).fetch) {
+    spyOn(window, 'fetch').and.callFake((url, config) => {
+      requests.push({ type: 'fetch', url: url as string, body: config!.body as string })
+      return new Promise<Response>(() => undefined)
     })
   }
 

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -413,3 +413,24 @@ export function stubCookie() {
     },
   }
 }
+
+export interface Request {
+  type: 'xhr' | 'sendBeacon'
+  url: string
+  body: string
+}
+
+export function interceptRequests() {
+  const requests: Request[] = []
+
+  spyOn(XMLHttpRequest.prototype, 'open').and.callFake((_, url) => requests.push({ type: 'xhr', url } as Request))
+  spyOn(XMLHttpRequest.prototype, 'send').and.callFake((body) => (requests[requests.length - 1].body = body as string))
+  if ((navigator as any).sendBeacon) {
+    spyOn(navigator, 'sendBeacon').and.callFake((url, body) => {
+      requests.push({ type: 'sendBeacon', url: url as string, body: body as string })
+      return true
+    })
+  }
+
+  return requests
+}

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -1,7 +1,12 @@
 import { ErrorSource, display, stopSessionManager, getCookie, SESSION_COOKIE_NAME } from '@datadog/browser-core'
-import sinon from 'sinon'
 import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../core/test/syntheticsWorkerValues'
-import { deleteEventBridgeStub, initEventBridgeStub, stubEndpointBuilder } from '../../../core/test/specHelper'
+import {
+  deleteEventBridgeStub,
+  initEventBridgeStub,
+  stubEndpointBuilder,
+  interceptRequests,
+} from '../../../core/test/specHelper'
+import type { Request } from '../../../core/test/specHelper'
 import type { LogsConfiguration } from '../domain/configuration'
 import { validateAndBuildLogsConfiguration } from '../domain/configuration'
 
@@ -10,8 +15,8 @@ import type { startLoggerCollection } from '../domain/logsCollection/logger/logg
 import type { LogsEvent } from '../logsEvent.types'
 import { startLogs } from './startLogs'
 
-function getLoggedMessage(server: sinon.SinonFakeServer, index: number) {
-  return JSON.parse(server.requests[index].requestBody) as LogsEvent
+function getLoggedMessage(requests: Request[], index: number) {
+  return JSON.parse(requests[index].body) as LogsEvent
 }
 
 interface Rum {
@@ -33,7 +38,7 @@ const COMMON_CONTEXT = {
 describe('logs', () => {
   const initConfiguration = { clientToken: 'xxx', service: 'service' }
   let baseConfiguration: LogsConfiguration
-  let server: sinon.SinonFakeServer
+  let requests: Request[]
   let handleLog: ReturnType<typeof startLoggerCollection>['handleLog']
   let logger: Logger
   let consoleLogSpy: jasmine.Spy
@@ -46,13 +51,12 @@ describe('logs', () => {
       batchMessagesLimit: 1,
     }
     logger = new Logger((...params) => handleLog(...params))
-    server = sinon.fakeServer.create()
+    requests = interceptRequests()
     consoleLogSpy = spyOn(console, 'log')
     displayLogSpy = spyOn(display, 'log')
   })
 
   afterEach(() => {
-    server.restore()
     delete window.DD_RUM
     deleteEventBridgeStub()
     stopSessionManager()
@@ -64,9 +68,9 @@ describe('logs', () => {
 
       handleLog({ message: 'message', status: StatusType.warn, context: { foo: 'bar' } }, logger, COMMON_CONTEXT)
 
-      expect(server.requests.length).toEqual(1)
-      expect(server.requests[0].url).toContain(baseConfiguration.logsEndpointBuilder.build())
-      expect(getLoggedMessage(server, 0)).toEqual({
+      expect(requests.length).toEqual(1)
+      expect(requests[0].url).toContain(baseConfiguration.logsEndpointBuilder.build())
+      expect(getLoggedMessage(requests, 0)).toEqual({
         date: jasmine.any(Number),
         foo: 'bar',
         message: 'message',
@@ -88,7 +92,7 @@ describe('logs', () => {
       handleLog(DEFAULT_MESSAGE, logger)
       handleLog(DEFAULT_MESSAGE, logger)
 
-      expect(server.requests.length).toEqual(1)
+      expect(requests.length).toEqual(1)
     })
 
     it('should send bridge event when bridge is present', () => {
@@ -97,7 +101,7 @@ describe('logs', () => {
 
       handleLog(DEFAULT_MESSAGE, logger)
 
-      expect(server.requests.length).toEqual(0)
+      expect(requests.length).toEqual(0)
       const [message] = sendSpy.calls.mostRecent().args
       const parsedMessage = JSON.parse(message)
       expect(parsedMessage).toEqual({

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -38,6 +38,7 @@ const COMMON_CONTEXT = {
 describe('logs', () => {
   const initConfiguration = { clientToken: 'xxx', service: 'service' }
   let baseConfiguration: LogsConfiguration
+  let interceptor: ReturnType<typeof interceptRequests>
   let requests: Request[]
   let handleLog: ReturnType<typeof startLoggerCollection>['handleLog']
   let logger: Logger
@@ -51,7 +52,8 @@ describe('logs', () => {
       batchMessagesLimit: 1,
     }
     logger = new Logger((...params) => handleLog(...params))
-    requests = interceptRequests()
+    interceptor = interceptRequests()
+    requests = interceptor.requests
     consoleLogSpy = spyOn(console, 'log')
     displayLogSpy = spyOn(display, 'log')
   })
@@ -60,6 +62,7 @@ describe('logs', () => {
     delete window.DD_RUM
     deleteEventBridgeStub()
     stopSessionManager()
+    interceptor.restore()
   })
 
   describe('request', () => {

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -1,5 +1,5 @@
 import type { Context, EndpointBuilder, TelemetryEvent, Observable } from '@datadog/browser-core'
-import { Batch, combine, HttpRequest, isTelemetryReplicationAllowed } from '@datadog/browser-core'
+import { Batch, combine, createHttpRequest, isTelemetryReplicationAllowed } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
 import { LifeCycleEventType } from '../domain/lifeCycle'
@@ -42,7 +42,7 @@ function makeRumBatch(configuration: RumConfiguration, lifeCycle: LifeCycle): Ru
 
   function createRumBatch(endpointBuilder: EndpointBuilder, unloadCallback?: () => void) {
     return new Batch(
-      new HttpRequest(endpointBuilder, configuration.batchBytesLimit),
+      createHttpRequest(endpointBuilder, configuration.batchBytesLimit),
       configuration.batchMessagesLimit,
       configuration.batchBytesLimit,
       configuration.messageBytesLimit,

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -1,4 +1,4 @@
-import { timeStampNow } from '@datadog/browser-core'
+import { timeStampNow, createHttpRequest } from '@datadog/browser-core'
 import type {
   LifeCycle,
   ViewContexts,
@@ -10,7 +10,7 @@ import { LifeCycleEventType } from '@datadog/browser-rum-core'
 
 import { record } from '../domain/record'
 import type { DeflateWorker } from '../domain/segmentCollection'
-import { startSegmentCollection } from '../domain/segmentCollection'
+import { startSegmentCollection, SEGMENT_BYTES_LIMIT } from '../domain/segmentCollection'
 import { send } from '../transport/send'
 import { RecordType } from '../types'
 
@@ -19,15 +19,15 @@ export function startRecording(
   configuration: RumConfiguration,
   sessionManager: RumSessionManager,
   viewContexts: ViewContexts,
-  worker: DeflateWorker
+  worker: DeflateWorker,
+  httpRequest = createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT)
 ) {
   const { addRecord, stop: stopSegmentCollection } = startSegmentCollection(
     lifeCycle,
     configuration.applicationId,
     sessionManager,
     viewContexts,
-    (data, metadata, rawSegmentBytesCount) =>
-      send(configuration.sessionReplayEndpointBuilder, data, metadata, rawSegmentBytesCount),
+    (data, metadata, rawSegmentBytesCount) => send(httpRequest, data, metadata, rawSegmentBytesCount),
     worker
   )
 

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -1,10 +1,9 @@
-import type { EndpointBuilder } from '@datadog/browser-core'
-import { HttpRequest, objectEntries } from '@datadog/browser-core'
-import { SEGMENT_BYTES_LIMIT } from '../domain/segmentCollection'
+import type { HttpRequest } from '@datadog/browser-core'
+import { objectEntries } from '@datadog/browser-core'
 import type { BrowserSegmentMetadata } from '../types'
 
 export function send(
-  endpointBuilder: EndpointBuilder,
+  httpRequest: HttpRequest,
   data: Uint8Array,
   metadata: BrowserSegmentMetadata,
   rawSegmentBytesCount: number
@@ -22,8 +21,7 @@ export function send(
   toFormEntries(metadata, (key, value) => formData.append(key, value))
   formData.append('raw_segment_size', rawSegmentBytesCount.toString())
 
-  const request = new HttpRequest(endpointBuilder, SEGMENT_BYTES_LIMIT)
-  request.send(formData, data.byteLength)
+  httpRequest.send(formData, data.byteLength)
 }
 
 export function toFormEntries(input: object, onEntry: (key: string, value: string) => void, prefix = '') {


### PR DESCRIPTION
## Motivation

In order to improve our data transfer, experiment with fetch keepalive in order to later be able to access to intake response.

## Changes

Behind `fetch-keepalive` flag, use fetch keepalive except on visibility hidden and before unload

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
