### PR TITLE
🐛 fix compatibility check

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -72,6 +72,7 @@ cmd_check_typescript_compatibility () {
   yarn build
   cd test/app
   rm -rf node_modules
+  yarn
   check_typescript_3_compatibility || fail 'typescript@3.8.2 compatibility broken'
   check_typescript_latest_compatibility || fail 'typescript@latest compatibility broken'
 }

--- a/scripts/cli
+++ b/scripts/cli
@@ -83,11 +83,9 @@ check_typescript_3_compatibility () {
 
 check_typescript_latest_compatibility () {
   # Add typescript options only supported in newer versions
-  sed -i '' '3 i\
-  "exactOptionalPropertyTypes": true,
-' tsconfig.json
+  perl -i -l -p -e 'print "\"exactOptionalPropertyTypes\": true," if $. == 3' tsconfig.json
 
-  yarn add typescript@latest
+  yarn add --dev typescript@latest
   local succeeded=true
   if ! yarn compat:tsc; then
     succeeded=false


### PR DESCRIPTION
## Motivation


* We previously removed node_modules without reinstalling, so the parent TS version was used instead of the test/app one. By installing test/app dependencies, we make sure the correct version of TS is installed. Note: compatibility errors were caught by our ssr compatibility check

* A sed command worked on Mac but not on Linux, so we didn't test for `exactOptionalPropertyTypes` compatibility on CI



## Changes

* Install test/app dependencies before checking compatibility
* Replace sed by perl

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
