### PR TITLE
🐛[RUMF-1344] handle document scroll when document has no scrolling element

### DIFF
--- a/packages/rum/src/domain/record/elementsScrollPositions.spec.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.spec.ts
@@ -1,0 +1,45 @@
+import { createElementsScrollPositions } from './elementsScrollPositions'
+
+describe('elementsScrollPositions', () => {
+  beforeEach(() => {
+    document.body.style.setProperty('height', '5000px')
+    document.body.style.setProperty('width', '5000px')
+    window.scroll(10, 20)
+  })
+
+  afterEach(() => {
+    window.scroll(0, 0)
+    document.body.style.removeProperty('height')
+    document.body.style.removeProperty('width')
+  })
+
+  it('should attach document scroll positions to document scrolling element', () => {
+    const elementsScrollPositions = createElementsScrollPositions()
+
+    elementsScrollPositions.set(document, { scrollLeft: 10, scrollTop: 20 })
+
+    expect(elementsScrollPositions.get(document.scrollingElement!)).toEqual({ scrollLeft: 10, scrollTop: 20 })
+  })
+
+  it('should attach document scroll positions to unavailable document scrolling element', () => {
+    const documentScrollingElement = document.scrollingElement!
+    Object.defineProperty(document, 'scrollingElement', { value: null, configurable: true })
+    const elementsScrollPositions = createElementsScrollPositions()
+    elementsScrollPositions.set(document, { scrollLeft: 10, scrollTop: 20 })
+
+    expect(elementsScrollPositions.get(documentScrollingElement)).toEqual({ scrollLeft: 10, scrollTop: 20 })
+    Object.defineProperty(document, 'scrollingElement', { value: documentScrollingElement, configurable: true })
+  })
+
+  it('should not attach document scroll positions if no scrolling element find', () => {
+    window.scroll(30, 40)
+    const documentScrollingElement = document.scrollingElement!
+    Object.defineProperty(document, 'scrollingElement', { value: null, configurable: true })
+    const elementsScrollPositions = createElementsScrollPositions()
+
+    elementsScrollPositions.set(document, { scrollLeft: 10, scrollTop: 20 })
+
+    expect(elementsScrollPositions.get(documentScrollingElement)).toBeUndefined()
+    Object.defineProperty(document, 'scrollingElement', { value: documentScrollingElement, configurable: true })
+  })
+})

--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -1,19 +1,24 @@
 import { addTelemetryDebug } from '@datadog/browser-core'
+import { forEach } from './utils'
 
 export type ElementsScrollPositions = ReturnType<typeof createElementsScrollPositions>
 export type ScrollPositions = { scrollLeft: number; scrollTop: number }
 
 export function createElementsScrollPositions() {
   const scrollPositionsByElement = new WeakMap<Element, ScrollPositions>()
-  const documentScrollingElement = document.scrollingElement!
-  if (!documentScrollingElement) {
-    addTelemetryDebug('document without scrollingElement')
-  }
+  let documentScrollingElement = document.scrollingElement
   return {
     set(element: Element | Document, scrollPositions: ScrollPositions) {
+      if (element === document && !documentScrollingElement) {
+        documentScrollingElement = findDocumentScrollingElement(document.childNodes, scrollPositions)
+        if (!documentScrollingElement) {
+          addTelemetryDebug('unable to find document scrolling element')
+          return
+        }
+      }
       try {
         scrollPositionsByElement.set(
-          element === document ? documentScrollingElement : (element as Element),
+          element === document ? documentScrollingElement! : (element as Element),
           scrollPositions
         )
       } catch (e) {
@@ -27,4 +32,22 @@ export function createElementsScrollPositions() {
       return scrollPositionsByElement.has(element)
     },
   }
+}
+
+function findDocumentScrollingElement(childNodes: NodeList, scrollPositions: ScrollPositions) {
+  let scrollingElement: Element | null = null
+  forEach(childNodes, (node) => {
+    if (!scrollingElement && node.nodeType === node.ELEMENT_NODE) {
+      const element = node as Element
+      if (
+        Math.round(element.scrollTop) === scrollPositions.scrollTop &&
+        Math.round(element.scrollLeft) === scrollPositions.scrollLeft
+      ) {
+        scrollingElement = element
+      } else {
+        findDocumentScrollingElement(element.childNodes, scrollPositions)
+      }
+    }
+  })
+  return scrollingElement
 }

--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -11,10 +11,14 @@ export function createElementsScrollPositions() {
   }
   return {
     set(element: Element | Document, scrollPositions: ScrollPositions) {
-      scrollPositionsByElement.set(
-        element === document ? documentScrollingElement : (element as Element),
-        scrollPositions
-      )
+      try {
+        scrollPositionsByElement.set(
+          element === document ? documentScrollingElement : (element as Element),
+          scrollPositions
+        )
+      } catch (e) {
+        addTelemetryDebug(`invalid element: ${String(element)}`)
+      }
     },
     get(element: Element) {
       return scrollPositionsByElement.get(element)


### PR DESCRIPTION
## Motivation

Following #1680, some telemetry events show that some documents seems to lack scrolling element:

- specific debug log: 'unable to find document scrolling element'
- error on setting null as a weak map key

I have not been able to reproduce the behavior while going on available customer pages.

## Changes

- when document scrolling element is not available, try to find it after a document scroll
- catch weak map set error to see if we face other cases

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
