### PR TITLE
🐛 [RUMF-1344] try to improve document scrolling element handling

### DIFF
--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -36,6 +36,7 @@ function tryToFindScrollingElement(scrollPositions: ScrollPositions) {
   if (document.scrollingElement) {
     return document.scrollingElement
   }
+  addTelemetryDebug('null document scrolling element')
   if (scrollPositions.scrollLeft === 0 && scrollPositions.scrollTop === 0) {
     addTelemetryDebug('Unable to find scrolling element for scroll (0,0)')
     return null

--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -5,15 +5,18 @@ export type ScrollPositions = { scrollLeft: number; scrollTop: number }
 
 export function createElementsScrollPositions() {
   const scrollPositionsByElement = new WeakMap<Element, ScrollPositions>()
-  const documentScrollingElement = document.scrollingElement!
-  if (!documentScrollingElement) {
-    addTelemetryDebug('document without scrollingElement')
-  }
+  let documentScrollingElement: Element | null
   return {
     set(element: Element | Document, scrollPositions: ScrollPositions) {
+      if (element === document && !documentScrollingElement) {
+        documentScrollingElement = tryToFindScrollingElement(scrollPositions)
+        if (!documentScrollingElement) {
+          return
+        }
+      }
       try {
         scrollPositionsByElement.set(
-          element === document ? documentScrollingElement : (element as Element),
+          element === document ? documentScrollingElement! : (element as Element),
           scrollPositions
         )
       } catch (e) {
@@ -27,4 +30,22 @@ export function createElementsScrollPositions() {
       return scrollPositionsByElement.has(element)
     },
   }
+}
+
+function tryToFindScrollingElement(scrollPositions: ScrollPositions) {
+  if (document.scrollingElement) {
+    return document.scrollingElement
+  }
+  if (scrollPositions.scrollLeft === 0 && scrollPositions.scrollTop === 0) {
+    addTelemetryDebug('Unable to find scrolling element for scroll (0,0)')
+    return null
+  }
+  if (
+    Math.round(document.documentElement.scrollLeft) === scrollPositions.scrollLeft &&
+    Math.round(document.documentElement.scrollTop) === scrollPositions.scrollTop
+  ) {
+    return document.documentElement
+  }
+  addTelemetryDebug('Unable to find scrolling element')
+  return null
 }

--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -11,10 +11,14 @@ export function createElementsScrollPositions() {
   }
   return {
     set(element: Element | Document, scrollPositions: ScrollPositions) {
-      scrollPositionsByElement.set(
-        element === document ? documentScrollingElement : (element as Element),
-        scrollPositions
-      )
+      try {
+        scrollPositionsByElement.set(
+          element === document ? documentScrollingElement : (element as Element),
+          scrollPositions
+        )
+      } catch (e) {
+        addTelemetryDebug(`invalid element: ${String(element)}`)
+      }
     },
     get(element: Element) {
       return scrollPositionsByElement.get(element)


### PR DESCRIPTION
## Motivation

Following #1680, some telemetry events show that some documents seems to lack scrolling element:

- specific debug log: 'unable to find document scrolling element'
- error on setting null as a weak map key

I have not been able to reproduce the behavior while going on available customer pages.

## Changes

- access document.scrollingElement only on document scroll
- try to fallback on document.documentElement
- improve logging

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
