### PR TITLE
[RUMF-1356] selectors using stable attributes and no class names

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.spec.ts
@@ -120,4 +120,14 @@ describe('getSelectorFromElement', () => {
       return getSelectorsFromElement(isolatedDom.append(html), actionNameAttribute).selector_with_stable_attributes
     }
   })
+
+  describe('selector without classes', () => {
+    it('does not rely on classes', () => {
+      expect(getSelectorWithoutClasses('<div class="foo"></div>')).toBe('BODY>DIV')
+    })
+
+    function getSelectorWithoutClasses(html: string, actionNameAttribute?: string): string {
+      return getSelectorsFromElement(isolatedDom.append(html), actionNameAttribute).selector_without_classes
+    }
+  })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.ts
@@ -35,6 +35,11 @@ export function getSelectorsFromElement(element: Element, actionNameAttribute: s
       attributeSelectors.concat(getIDSelector),
       attributeSelectors.concat(getClassSelector)
     ),
+    selector_without_classes: getSelectorFromElement(
+      element,
+      attributeSelectors.concat(getIDSelector),
+      attributeSelectors
+    ),
   }
 }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -123,7 +123,13 @@ describe('trackClickActions', () => {
       clock.tick(EXPIRE_DELAY)
       expect(events[0]).toEqual(
         jasmine.objectContaining({
-          target: { selector: '#button', selector_with_stable_attributes: '#button', width: 100, height: 100 },
+          target: {
+            selector: '#button',
+            selector_with_stable_attributes: '#button',
+            selector_without_classes: '#button',
+            width: 100,
+            height: 100,
+          },
           position: { x: 50, y: 50 },
         })
       )


### PR DESCRIPTION
## Motivation

Explore various selector strategies for heatmaps. Don't use class names in CSS selector, as they might be unreliable in some cases.

## Changes

Implement a new selector without class names.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
