### PR TITLE
🐛 [RUMF-1344] remove fallback for null scrollingElement

### DIFF
--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -1,27 +1,19 @@
-import { addTelemetryDebug } from '@datadog/browser-core'
-
 export type ElementsScrollPositions = ReturnType<typeof createElementsScrollPositions>
 export type ScrollPositions = { scrollLeft: number; scrollTop: number }
 
 export function createElementsScrollPositions() {
   const scrollPositionsByElement = new WeakMap<Element, ScrollPositions>()
-  let documentScrollingElement: Element | null
   return {
     set(element: Element | Document, scrollPositions: ScrollPositions) {
-      if (element === document && !documentScrollingElement) {
-        documentScrollingElement = tryToFindScrollingElement(scrollPositions)
-        if (!documentScrollingElement) {
-          return
-        }
+      if (element === document && !document.scrollingElement) {
+        // cf https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement,
+        // in some cases scrolling elements can not be defined, we don't support those for now
+        return
       }
-      try {
-        scrollPositionsByElement.set(
-          element === document ? documentScrollingElement! : (element as Element),
-          scrollPositions
-        )
-      } catch (e) {
-        addTelemetryDebug(`invalid element: ${String(element)}`)
-      }
+      scrollPositionsByElement.set(
+        element === document ? document.scrollingElement! : (element as Element),
+        scrollPositions
+      )
     },
     get(element: Element) {
       return scrollPositionsByElement.get(element)
@@ -30,23 +22,4 @@ export function createElementsScrollPositions() {
       return scrollPositionsByElement.has(element)
     },
   }
-}
-
-function tryToFindScrollingElement(scrollPositions: ScrollPositions) {
-  if (document.scrollingElement) {
-    return document.scrollingElement
-  }
-  addTelemetryDebug('null document scrolling element')
-  if (scrollPositions.scrollLeft === 0 && scrollPositions.scrollTop === 0) {
-    addTelemetryDebug('Unable to find scrolling element for scroll (0,0)')
-    return null
-  }
-  if (
-    Math.round(document.documentElement.scrollLeft) === scrollPositions.scrollLeft &&
-    Math.round(document.documentElement.scrollTop) === scrollPositions.scrollTop
-  ) {
-    return document.documentElement
-  }
-  addTelemetryDebug('Unable to find scrolling element')
-  return null
 }


### PR DESCRIPTION
## Motivation

Following #1688, current fallback does not improve much the situation.

## Changes

- Remove fallback when scrolling element is null and don't handle document scroll in this case.
- Remove try/catch around weakmap as it should not happen anymore

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
