### PR TITLE
Update logger Global Context APIs

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -532,19 +532,19 @@ DD_LOGS.onReady(function () {
 })
 
 DD_LOGS.onReady(function () {
-  datadogLogs.removeGlobalContextProperty('referrer')
+  DD_LOGS.removeGlobalContextProperty('referrer')
 })
 
 DD_LOGS.onReady(function () {
-  datadogLogs.getGlobalContext() // => {env: 'staging'}
+  DD_LOGS.getGlobalContext() // => {env: 'staging'}
 })
 
 DD_LOGS.onReady(function () {
-  datadogLogs.clearGlobalContext()
+  DD_LOGS.clearGlobalContext()
 })
 
 DD_LOGS.onReady(function () {
-  datadogLogs.getGlobalContext() // => {}
+  DD_LOGS.getGlobalContext() // => {}
 })
 ```
 

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -484,10 +484,11 @@ After the Datadog browser logs SDK is initialized, it is possible to:
 - Get the entire global context with `getGlobalContext ()` API.
 
 > The Log Browser SDK v4.17.0 has updated the names of several APIs:
-> -  `getGlobalContext` instead of `getLoggerGlobalContext`
-> -  `setGlobalContext` instead of `setLoggerGlobalContext`
-> -  `setGlobalContextProperty` instead of `addLoggerGlobalContext`
-> -  `removeGlobalContextProperty` instead of `removeLoggerGlobalContext`
+>
+> - `getGlobalContext` instead of `getLoggerGlobalContext`
+> - `setGlobalContext` instead of `setLoggerGlobalContext`
+> - `setGlobalContextProperty` instead of `addLoggerGlobalContext`
+> - `removeGlobalContextProperty` instead of `removeLoggerGlobalContext`
 
 ##### NPM
 

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -479,9 +479,15 @@ if (window.DD_LOGS) {
 
 After the Datadog browser logs SDK is initialized, it is possible to:
 
-- Set the entire context for all your loggers with the `setLoggerGlobalContext (context: Context)` API.
-- Add a context to all your loggers with `addLoggerGlobalContext (key: string, value: any)` API.
-- Get the entire global context with `getLoggerGlobalContext ()` API.
+- Set the entire context for all your loggers with the `setGlobalContext (context: Context)` API.
+- Add a context to all your loggers with `setGlobalContextProperty (key: string, value: any)` API.
+- Get the entire global context with `getGlobalContext ()` API.
+
+> The Log Browser SDK v4.17.0 has updated the names of several APIs:
+> -  `getGlobalContext` instead of `getLoggerGlobalContext`
+> -  `setGlobalContext` instead of `setLoggerGlobalContext`
+> -  `setGlobalContextProperty` instead of `addLoggerGlobalContext`
+> -  `removeGlobalContextProperty` instead of `removeLoggerGlobalContext`
 
 ##### NPM
 
@@ -490,11 +496,19 @@ For NPM, use:
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs'
 
-datadogLogs.setLoggerGlobalContext({ env: 'staging' })
+datadogLogs.setGlobalContext({ env: 'staging' })
 
-datadogLogs.addLoggerGlobalContext('referrer', document.referrer)
+datadogLogs.setGlobalContextProperty('referrer', document.referrer)
 
-const context = datadogLogs.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
+datadogLogs.getGlobalContext() // => {env: 'staging', referrer: ...}
+
+datadogLogs.removeGlobalContextProperty('referrer')
+
+datadogLogs.getGlobalContext() // => {env: 'staging'}
+
+datadogLogs.clearGlobalContext()
+
+datadogLogs.getGlobalContext() // => {}
 ```
 
 #### CDN async
@@ -503,15 +517,31 @@ For CDN async, use:
 
 ```javascript
 DD_LOGS.onReady(function () {
-  DD_LOGS.setLoggerGlobalContext({ env: 'staging' })
+  DD_LOGS.setGlobalContext({ env: 'staging' })
 })
 
 DD_LOGS.onReady(function () {
-  DD_LOGS.addLoggerGlobalContext('referrer', document.referrer)
+  DD_LOGS.setGlobalContextProperty('referrer', document.referrer)
 })
 
 DD_LOGS.onReady(function () {
-  var context = DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
+  DD_LOGS.getGlobalContext() // => {env: 'staging', referrer: ...}
+})
+
+DD_LOGS.onReady(function () {
+  datadogLogs.removeGlobalContextProperty('referrer')
+})
+
+DD_LOGS.onReady(function () {
+  datadogLogs.getGlobalContext() // => {env: 'staging'}
+})
+
+DD_LOGS.onReady(function () {
+  datadogLogs.clearGlobalContext()
+})
+
+DD_LOGS.onReady(function () {
+  datadogLogs.getGlobalContext() // => {}
 })
 ```
 
@@ -522,11 +552,19 @@ DD_LOGS.onReady(function () {
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setLoggerGlobalContext({ env: 'staging' })
+window.DD_LOGS && DD_LOGS.setGlobalContext({ env: 'staging' })
 
-window.DD_LOGS && DD_LOGS.addLoggerGlobalContext('referrer', document.referrer)
+window.DD_LOGS && DD_LOGS.setGlobalContextProperty('referrer', document.referrer)
 
-var context = window.DD_LOGS && DD_LOGS.getLoggerGlobalContext() // => {env: 'staging', referrer: ...}
+window.DD_LOGS && DD_LOGS.getGlobalContext() // => {env: 'staging', referrer: ...}
+
+window.DD_LOGS && DD_LOGS.removeGlobalContextProperty('referrer')
+
+window.DD_LOGS && DD_LOGS.getGlobalContext() // => {env: 'staging'}
+
+window.DD_LOGS && DD_LOGS.clearGlobalContext()
+
+window.DD_LOGS && DD_LOGS.getGlobalContext() // => {}
 ```
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -479,7 +479,7 @@ if (window.DD_LOGS) {
 
 After the Datadog browser logs SDK is initialized, it is possible to:
 
-- Set the entire context for all your loggers with the `setGlobalContext (context: Context)` API.
+- Set the entire context for all your loggers with the `setGlobalContext (context: object)` API.
 - Add a context to all your loggers with the `setGlobalContextProperty (key: string, value: any)` API.
 - Get the entire global context with the `getGlobalContext ()` API.
 - Remove context property with the `removeGlobalContextProperty (key: string)` API.
@@ -576,7 +576,7 @@ window.DD_LOGS && DD_LOGS.getGlobalContext() // => {}
 
 After a logger is created, it is possible to:
 
-- Set the entire context for your logger with the `setContext (context: Context)` API.
+- Set the entire context for your logger with the `setContext (context: object)` API.
 - Add a context to your logger with `addContext (key: string, value: any)` API:
 
 ##### NPM

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -480,7 +480,7 @@ if (window.DD_LOGS) {
 After the Datadog browser logs SDK is initialized, it is possible to:
 
 - Set the entire context for all your loggers with the `setGlobalContext (context: Context)` API.
-- Add a context to all your loggers with `setGlobalContextProperty (key: string, value: any)` API.
+- Add a context to all your loggers with the `setGlobalContextProperty (key: string, value: any)` API.
 - Get the entire global context with `getGlobalContext ()` API.
 
 > The Log Browser SDK v4.17.0 has updated the names of several APIs:

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -482,6 +482,8 @@ After the Datadog browser logs SDK is initialized, it is possible to:
 - Set the entire context for all your loggers with the `setGlobalContext (context: Context)` API.
 - Add a context to all your loggers with the `setGlobalContextProperty (key: string, value: any)` API.
 - Get the entire global context with the `getGlobalContext ()` API.
+- Remove context property with the `removeGlobalContextProperty (key: string)` API.
+- Clear all existing context properties with the `clearGlobalContext ()` API.
 
 > The Log Browser SDK v4.17.0 has updated the names of several APIs:
 >

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -481,7 +481,7 @@ After the Datadog browser logs SDK is initialized, it is possible to:
 
 - Set the entire context for all your loggers with the `setGlobalContext (context: Context)` API.
 - Add a context to all your loggers with the `setGlobalContextProperty (key: string, value: any)` API.
-- Get the entire global context with `getGlobalContext ()` API.
+- Get the entire global context with the `getGlobalContext ()` API.
 
 > The Log Browser SDK v4.17.0 has updated the names of several APIs:
 >


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Update the Doc to reflect the updated Logger Global Context APIs. Relates to changes make in RUM Global Context https://github.com/DataDog/documentation/pull/15013

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
- Change the API names
-  Add `removeGlobalContextProperty` and `clearGlobalContext` examples

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
