### PR TITLE
🐛 Fix instrumention of null function with 3rd party wrapper (#1570)

### DIFF
--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -54,6 +54,17 @@ describe('instrumentMethod', () => {
     expect(instrumentationSpy).toHaveBeenCalled()
   })
 
+  it('handles undefined methods with third party wrappers after stop', () => {
+    const object: { method?: () => number } = {}
+    const instrumentationStub = () => 2
+    const { stop } = instrumentMethod(object, 'method', () => instrumentationStub)
+
+    thirdPartyInstrumentation(object)
+
+    stop()
+    expect(object.method).not.toThrow()
+  })
+
   describe('stop()', () => {
     it('restores the original behavior', () => {
       const object = { method: () => 1 }
@@ -102,9 +113,11 @@ describe('instrumentMethod', () => {
     })
   })
 
-  function thirdPartyInstrumentation(object: { method: () => number }) {
+  function thirdPartyInstrumentation(object: { method?: () => number }) {
     const originalMethod = object.method
-    object.method = () => originalMethod() + 2
+    if (typeof originalMethod === 'function') {
+      object.method = () => originalMethod() + 2
+    }
   }
 })
 

--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -54,17 +54,6 @@ describe('instrumentMethod', () => {
     expect(instrumentationSpy).toHaveBeenCalled()
   })
 
-  it('handles undefined methods with third party wrappers after stop', () => {
-    const object: { method?: () => number } = {}
-    const instrumentationStub = () => 2
-    const { stop } = instrumentMethod(object, 'method', () => instrumentationStub)
-
-    thirdPartyInstrumentation(object)
-
-    stop()
-    expect(object.method).not.toThrow()
-  })
-
   describe('stop()', () => {
     it('restores the original behavior', () => {
       const object = { method: () => 1 }
@@ -109,6 +98,18 @@ describe('instrumentMethod', () => {
         stop()
 
         expect(instrumentationSpy).not.toHaveBeenCalled()
+      })
+
+      it('should not throw errors if original method was undefined', () => {
+        const object: { method?: () => number } = {}
+        const instrumentationStub = () => 2
+        const { stop } = instrumentMethod(object, 'method', () => instrumentationStub)
+
+        thirdPartyInstrumentation(object)
+
+        stop()
+
+        expect(object.method).not.toThrow()
       })
     })
   })

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -13,8 +13,10 @@ export function instrumentMethod<OBJECT extends { [key: string]: any }, METHOD e
   let instrumentation = instrumentationFactory(original)
 
   const instrumentationWrapper = function (this: OBJECT): ReturnType<OBJECT[METHOD]> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return instrumentation.apply(this, arguments as unknown as Parameters<OBJECT[METHOD]>)
+    if (typeof instrumentation === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return instrumentation.apply(this, arguments as unknown as Parameters<OBJECT[METHOD]>)
+    }
   }
   object[method] = instrumentationWrapper as OBJECT[METHOD]
 

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -12,12 +12,12 @@ export function instrumentMethod<OBJECT extends { [key: string]: any }, METHOD e
 
   let instrumentation = instrumentationFactory(original)
 
-  const instrumentationWrapper = function (this: OBJECT): ReturnType<OBJECT[METHOD]> | null {
-      if (typeof instrumentation === 'function') {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          return instrumentation.apply(this, arguments as unknown as Parameters<OBJECT[METHOD]>)
-      }
-      return null
+  const instrumentationWrapper = function (this: OBJECT): ReturnType<OBJECT[METHOD]> | undefined {
+    if (typeof instrumentation !== 'function') {
+      return undefined
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return instrumentation.apply(this, arguments as unknown as Parameters<OBJECT[METHOD]>)
   }
   object[method] = instrumentationWrapper as OBJECT[METHOD]
 

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -12,11 +12,12 @@ export function instrumentMethod<OBJECT extends { [key: string]: any }, METHOD e
 
   let instrumentation = instrumentationFactory(original)
 
-  const instrumentationWrapper = function (this: OBJECT): ReturnType<OBJECT[METHOD]> {
-    if (typeof instrumentation === 'function') {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return instrumentation.apply(this, arguments as unknown as Parameters<OBJECT[METHOD]>)
-    }
+  const instrumentationWrapper = function (this: OBJECT): ReturnType<OBJECT[METHOD]> | null {
+      if (typeof instrumentation === 'function') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return instrumentation.apply(this, arguments as unknown as Parameters<OBJECT[METHOD]>)
+      }
+      return null
   }
   object[method] = instrumentationWrapper as OBJECT[METHOD]
 


### PR DESCRIPTION
## Motivation

Issue #1570 is causing noisy errors when wrapping a null/undefined method that also has third party wrappers.

## Changes

Adds a condition when executing a wrapped function to protect against the case when we "unwrap" the function ourselves and set it to null (its previous value).

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
