### PR TITLE
RUMF-1309: Implement nested CSS support

### DIFF
--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -194,7 +194,7 @@ describe('initStyleSheetObserver', () => {
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.removes).toBeUndefined()
         expect(styleSheetRule.adds?.length).toEqual(1)
-        expect(styleSheetRule.adds?.pop()?.index).toEqual(undefined)
+        expect(styleSheetRule.adds?.[0]?.index).toEqual(undefined)
       })
 
       it('should capture CSSStyleRule insertion when index is provided', () => {
@@ -208,7 +208,7 @@ describe('initStyleSheetObserver', () => {
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.removes).toBeUndefined()
         expect(styleSheetRule.adds?.length).toEqual(1)
-        expect(styleSheetRule.adds?.pop()?.index).toEqual(index)
+        expect(styleSheetRule.adds?.[0]?.index).toEqual(index)
       })
     })
 
@@ -225,7 +225,7 @@ describe('initStyleSheetObserver', () => {
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.adds).toBeUndefined()
         expect(styleSheetRule.removes?.length).toEqual(1)
-        expect(styleSheetRule.removes?.pop()).toEqual({ index })
+        expect(styleSheetRule.removes?.[0]).toEqual({ index })
       })
     })
   })
@@ -245,7 +245,7 @@ describe('initStyleSheetObserver', () => {
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.removes).toBeUndefined()
         expect(styleSheetRule.adds?.length).toEqual(1)
-        expect(styleSheetRule.adds?.pop()?.index).toEqual([1, 0, 1])
+        expect(styleSheetRule.adds?.[0]?.index).toEqual([1, 0, 1])
       })
 
       it('should not create record when inserting into a detached CSSGroupingRule', () => {
@@ -280,7 +280,7 @@ describe('initStyleSheetObserver', () => {
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.adds).toBeUndefined()
         expect(styleSheetRule.removes?.length).toEqual(1)
-        expect(styleSheetRule.removes?.pop()?.index).toEqual([1, 0, 0])
+        expect(styleSheetRule.removes?.[0]?.index).toEqual([1, 0, 0])
       })
 
       it('should not create record when removing from a detached CSSGroupingRule', () => {

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -154,3 +154,131 @@ describe('initFrustrationObserver', () => {
     expect(frustrationsCallbackSpy).not.toHaveBeenCalled()
   })
 })
+
+// const rule = '.selector-1 { color: #fff }'
+
+// describe('initStyleSheetObserver', () => {
+//   let stopStyleSheetObserver: () => void
+//   let styleSheetCallbackSpy: jasmine.Spy<StyleSheetRuleCallback>
+//   let styleElement: HTMLStyleElement
+//   let styleSheet: CSSStyleSheet
+
+//   beforeEach(() => {
+//     if (isIE()) {
+//       pending('IE not supported')
+//     }
+//     styleSheetCallbackSpy = jasmine.createSpy()
+
+//     styleElement = document.createElement('style');
+//     document.head.appendChild(styleElement);
+
+//     styleSheet = <CSSStyleSheet>styleElement.sheet
+//   })
+
+//   afterEach(() => {
+//     stopStyleSheetObserver()
+//     styleElement.remove()
+//   })
+
+//   describe('observing high level css stylesheet', () => {
+//     describe('when inserting rules into stylesheet', () => {
+//       it('should capture CSSStyleRule insertion when no index is provided', () => {
+//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+//         // When
+//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+//         styleSheet.insertRule(rule)
+//         // Then
+//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+//         expect(styleSheetRule.id).toBeDefined()
+//         expect(styleSheetRule.removes).toBeUndefined()
+//         expect(styleSheetRule.adds?.length).toEqual(1)
+//         expect(styleSheetRule.adds?.pop()?.index).toEqual(undefined)
+//       })
+//       it('should capture CSSStyleRule insertion when index is provided', () => {
+//         // Given
+//         const index = 0
+//         // When
+//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+//         styleSheet.insertRule(rule, index)
+//         // Then
+//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+//         expect(styleSheetRule.id).toBeDefined()
+//         expect(styleSheetRule.removes).toBeUndefined()
+//         expect(styleSheetRule.adds?.length).toEqual(1)
+//         expect(styleSheetRule.adds?.pop()?.index).toEqual(index)
+//       })
+//     })
+
+//     describe('when removing rules from stylesheet', () => {
+//       it('should capture CSSStyleRule removal with the correct index', () => {
+//         styleSheet.insertRule(rule)
+//         // Given
+//         const index = 0
+//         // When
+//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+//         styleSheet.deleteRule(index)
+//         // Then
+//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+//         expect(styleSheetRule.id).toBeDefined()
+//         expect(styleSheetRule.adds).toBeUndefined()
+//         expect(styleSheetRule.removes?.length).toEqual(1)
+//         expect(styleSheetRule.removes?.pop()).toEqual({ index })
+//       })
+//     })
+//   })
+
+//   describe('observing CSSGroupingRules inside a CSSStyleSheet', () => {
+//     describe('when inserting CSSRules inside a CSSGroupingRule', () => {
+//       it('should capture CSSRule with the correct path when no index is provided', () => {
+//         styleSheet.insertRule(
+//           '.main {opacity: 0}; @media cond-1 {.nest-1 { color: #ccc }; @media cond-2 { .nest-2 {display: none } }};'
+//         )
+//         // Given
+//         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[1] as CSSGroupingRule
+//         // When
+//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+//         groupingRule.insertRule(rule)
+//         // Then
+//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+//         expect(styleSheetRule.id).toBeDefined()
+//         expect(styleSheetRule.removes).toBeUndefined()
+//         expect(styleSheetRule.adds?.length).toEqual(1)
+//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1,1,0])
+//       })
+//       it('should capture CSSRule with the correct path when index is provided', () => {
+//         styleSheet.insertRule(
+//           '.main { opacity: 0 } @media cond-1 { .nest-1 { color: #ccc } @media cond-2 { .nest-2 {display: none } } }'
+//         )
+//         // Given
+//         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[1] as CSSGroupingRule
+//         // When
+//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+//         groupingRule.insertRule(rule, 1)
+//         // Then
+//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+//         expect(styleSheetRule.id).toBeDefined()
+//         expect(styleSheetRule.removes).toBeUndefined()
+//         expect(styleSheetRule.adds?.length).toEqual(1)
+//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1,1,1])
+//       })
+//     })
+//     describe('when removing CSSRules from a CSSGroupingRule', () => {
+//       it('should capture CSSRule removal with the correct path', () => {
+//         styleSheet.insertRule(
+//           '.main { opacity: 0 } @media cond-1 { .nest-1 { color: #ccc } @media cond-2 { .nest-2 {display: none } } }'
+//         )
+//         // Given
+//         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[1] as CSSGroupingRule
+//         // When
+//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+//         groupingRule.deleteRule(0)
+//         // Then
+//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+//         expect(styleSheetRule.id).toBeDefined()
+//         expect(styleSheetRule.adds).toBeUndefined()
+//         expect(styleSheetRule.removes?.length).toEqual(1)
+//         expect(styleSheetRule.removes?.pop()?.index).toEqual([1,1,0])
+//       })
+//     })
+//   })
+// })

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -170,7 +170,7 @@ describe('initStyleSheetObserver', () => {
     styleSheetCallbackSpy = jasmine.createSpy()
     styleElement = document.createElement('style')
     document.head.appendChild(styleElement)
-    styleSheet = <CSSStyleSheet>styleElement.sheet
+    styleSheet = styleElement.sheet!
 
     serializeDocument(document, NodePrivacyLevel.ALLOW, {
       status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
@@ -262,7 +262,7 @@ describe('initStyleSheetObserver', () => {
         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         groupingRule.insertRule(styleRule, 0)
         // Then
-        expect(styleSheetCallbackSpy.calls.all().length).toEqual(0)
+        expect(styleSheetCallbackSpy).not.toHaveBeenCalled()
       })
     })
 
@@ -297,7 +297,7 @@ describe('initStyleSheetObserver', () => {
         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         groupingRule.deleteRule(0)
         // Then
-        expect(styleSheetCallbackSpy.calls.all().length).toEqual(0)
+        expect(styleSheetCallbackSpy).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -162,24 +162,19 @@ describe('initFrustrationObserver', () => {
 //   let styleSheetCallbackSpy: jasmine.Spy<StyleSheetRuleCallback>
 //   let styleElement: HTMLStyleElement
 //   let styleSheet: CSSStyleSheet
-
 //   beforeEach(() => {
 //     if (isIE()) {
 //       pending('IE not supported')
 //     }
 //     styleSheetCallbackSpy = jasmine.createSpy()
-
-//     styleElement = document.createElement('style');
-//     document.head.appendChild(styleElement);
-
+//     styleElement = document.createElement('style')
+//     document.head.appendChild(styleElement)
 //     styleSheet = <CSSStyleSheet>styleElement.sheet
 //   })
-
 //   afterEach(() => {
 //     stopStyleSheetObserver()
 //     styleElement.remove()
 //   })
-
 //   describe('observing high level css stylesheet', () => {
 //     describe('when inserting rules into stylesheet', () => {
 //       it('should capture CSSStyleRule insertion when no index is provided', () => {
@@ -199,7 +194,9 @@ describe('initFrustrationObserver', () => {
 //         const index = 0
 //         // When
 //         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         styleSheet.insertRule(rule, index)
+//         styleSheet.insertRule('@media cond { .class {opacity: 0}}', index)
+//         const b = styleSheet.cssRules[0] as CSSGroupingRule
+//         b.insertRule(rule, 0)
 //         // Then
 //         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
 //         expect(styleSheetRule.id).toBeDefined()
@@ -208,7 +205,6 @@ describe('initFrustrationObserver', () => {
 //         expect(styleSheetRule.adds?.pop()?.index).toEqual(index)
 //       })
 //     })
-
 //     describe('when removing rules from stylesheet', () => {
 //       it('should capture CSSStyleRule removal with the correct index', () => {
 //         styleSheet.insertRule(rule)
@@ -226,7 +222,6 @@ describe('initFrustrationObserver', () => {
 //       })
 //     })
 //   })
-
 //   describe('observing CSSGroupingRules inside a CSSStyleSheet', () => {
 //     describe('when inserting CSSRules inside a CSSGroupingRule', () => {
 //       it('should capture CSSRule with the correct path when no index is provided', () => {
@@ -243,7 +238,7 @@ describe('initFrustrationObserver', () => {
 //         expect(styleSheetRule.id).toBeDefined()
 //         expect(styleSheetRule.removes).toBeUndefined()
 //         expect(styleSheetRule.adds?.length).toEqual(1)
-//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1,1,0])
+//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1, 1, 0])
 //       })
 //       it('should capture CSSRule with the correct path when index is provided', () => {
 //         styleSheet.insertRule(
@@ -259,8 +254,9 @@ describe('initFrustrationObserver', () => {
 //         expect(styleSheetRule.id).toBeDefined()
 //         expect(styleSheetRule.removes).toBeUndefined()
 //         expect(styleSheetRule.adds?.length).toEqual(1)
-//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1,1,1])
+//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1, 1, 1])
 //       })
+//       it('should not create record when inserting into a detached CSSGroupingRule', () => {})
 //     })
 //     describe('when removing CSSRules from a CSSGroupingRule', () => {
 //       it('should capture CSSRule removal with the correct path', () => {
@@ -277,8 +273,9 @@ describe('initFrustrationObserver', () => {
 //         expect(styleSheetRule.id).toBeDefined()
 //         expect(styleSheetRule.adds).toBeUndefined()
 //         expect(styleSheetRule.removes?.length).toEqual(1)
-//         expect(styleSheetRule.removes?.pop()?.index).toEqual([1,1,0])
+//         expect(styleSheetRule.removes?.pop()?.index).toEqual([1, 1, 0])
 //       })
+//       it('should not create record when removing from a detached CSSGroupingRule', () => {})
 //     })
 //   })
 // })

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -5,8 +5,8 @@ import type { RawRumEventCollectedData } from 'packages/rum-core/src/domain/life
 import { createNewEvent, isFirefox } from '../../../../core/test/specHelper'
 import { NodePrivacyLevel, PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '../../constants'
 import { RecordType } from '../../types'
-import type { FrustrationCallback, InputCallback, CSSRuleCallback } from './observers'
-import { initCSSObservers, initFrustrationObserver, initInputObserver } from './observers'
+import type { FrustrationCallback, InputCallback, StyleSheetCallback } from './observers'
+import { initStyleSheetObserver, initFrustrationObserver, initInputObserver } from './observers'
 import { serializeDocument, SerializationContextStatus } from './serialize'
 import { createElementsScrollPositions } from './elementsScrollPositions'
 
@@ -155,9 +155,9 @@ describe('initFrustrationObserver', () => {
   })
 })
 
-describe('initCSSObservers', () => {
-  let stopCSSObservers: () => void
-  let cssRulesCallbackSpy: jasmine.Spy<CSSRuleCallback>
+describe('initStyleSheetObserver', () => {
+  let stopStyleSheetObserver: () => void
+  let styleSheetCallbackSpy: jasmine.Spy<StyleSheetCallback>
   let styleElement: HTMLStyleElement
   let styleSheet: CSSStyleSheet
   const styleRule = '.selector-1 { color: #fff }'
@@ -166,7 +166,7 @@ describe('initCSSObservers', () => {
     if (isIE()) {
       pending('IE not supported')
     }
-    cssRulesCallbackSpy = jasmine.createSpy()
+    styleSheetCallbackSpy = jasmine.createSpy()
     styleElement = document.createElement('style')
     document.head.appendChild(styleElement)
     styleSheet = styleElement.sheet!
@@ -178,17 +178,17 @@ describe('initCSSObservers', () => {
   })
 
   afterEach(() => {
-    stopCSSObservers()
+    stopStyleSheetObserver()
     styleElement.remove()
   })
 
   describe('observing high level css stylesheet', () => {
     describe('when inserting rules into stylesheet', () => {
       it('should capture CSSStyleRule insertion when no index is provided', () => {
-        stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         styleSheet.insertRule(styleRule)
 
-        const styleSheetRule = cssRulesCallbackSpy.calls.first().args[0]
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.removes).toBeUndefined()
         expect(styleSheetRule.adds?.length).toEqual(1)
@@ -198,10 +198,10 @@ describe('initCSSObservers', () => {
       it('should capture CSSStyleRule insertion when index is provided', () => {
         const index = 0
 
-        stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         styleSheet.insertRule(styleRule, index)
 
-        const styleSheetRule = cssRulesCallbackSpy.calls.first().args[0]
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.removes).toBeUndefined()
         expect(styleSheetRule.adds?.length).toEqual(1)
@@ -214,10 +214,10 @@ describe('initCSSObservers', () => {
         styleSheet.insertRule(styleRule)
         const index = 0
 
-        stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         styleSheet.deleteRule(index)
 
-        const styleSheetRule = cssRulesCallbackSpy.calls.first().args[0]
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.adds).toBeUndefined()
         expect(styleSheetRule.removes?.length).toEqual(1)
@@ -233,10 +233,10 @@ describe('initCSSObservers', () => {
         styleSheet.insertRule('.main {opacity: 0}')
         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[0] as CSSGroupingRule
 
-        stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         groupingRule.insertRule(styleRule, 1)
 
-        const styleSheetRule = cssRulesCallbackSpy.calls.first().args[0]
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.removes).toBeUndefined()
         expect(styleSheetRule.adds?.length).toEqual(1)
@@ -254,10 +254,10 @@ describe('initCSSObservers', () => {
         const groupingRule = parentRule.cssRules[0] as CSSGroupingRule
         parentRule.deleteRule(0)
 
-        stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         groupingRule.insertRule(styleRule, 0)
 
-        expect(cssRulesCallbackSpy).not.toHaveBeenCalled()
+        expect(styleSheetCallbackSpy).not.toHaveBeenCalled()
       })
     })
 
@@ -267,10 +267,10 @@ describe('initCSSObservers', () => {
         styleSheet.insertRule('.main {opacity: 0}')
         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[0] as CSSGroupingRule
 
-        stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         groupingRule.deleteRule(0)
 
-        const styleSheetRule = cssRulesCallbackSpy.calls.first().args[0]
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
         expect(styleSheetRule.id).toBeDefined()
         expect(styleSheetRule.adds).toBeUndefined()
         expect(styleSheetRule.removes?.length).toEqual(1)
@@ -288,10 +288,10 @@ describe('initCSSObservers', () => {
         const groupingRule = parentRule.cssRules[0] as CSSGroupingRule
         parentRule.deleteRule(0)
 
-        stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
         groupingRule.deleteRule(0)
 
-        expect(cssRulesCallbackSpy).not.toHaveBeenCalled()
+        expect(styleSheetCallbackSpy).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -5,11 +5,10 @@ import type { RawRumEventCollectedData } from 'packages/rum-core/src/domain/life
 import { createNewEvent, isFirefox } from '../../../../core/test/specHelper'
 import { NodePrivacyLevel, PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '../../constants'
 import { RecordType } from '../../types'
-import type { FrustrationCallback, InputCallback, StyleSheetRuleCallback } from './observers'
+import type { FrustrationCallback, InputCallback, CSSRuleCallback } from './observers'
 import { initCSSObservers, initFrustrationObserver, initInputObserver } from './observers'
 import { serializeDocument, SerializationContextStatus } from './serialize'
 import { createElementsScrollPositions } from './elementsScrollPositions'
-import type { GroupingCSSRule } from './utils'
 
 describe('initInputObserver', () => {
   let stopInputObserver: () => void
@@ -158,7 +157,7 @@ describe('initFrustrationObserver', () => {
 
 describe('initCSSObservers', () => {
   let stopCSSObservers: () => void
-  let cssRulesCallbackSpy: jasmine.Spy<StyleSheetRuleCallback>
+  let cssRulesCallbackSpy: jasmine.Spy<CSSRuleCallback>
   let styleElement: HTMLStyleElement
   let styleSheet: CSSStyleSheet
   const styleRule = '.selector-1 { color: #fff }'
@@ -232,7 +231,7 @@ describe('initCSSObservers', () => {
       it('should capture CSSRule with the correct path when no index is provided', () => {
         styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
         styleSheet.insertRule('.main {opacity: 0}')
-        const groupingRule = (styleSheet.cssRules[1] as GroupingCSSRule).cssRules[0] as GroupingCSSRule
+        const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[0] as CSSGroupingRule
 
         stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
         groupingRule.insertRule(styleRule, 1)
@@ -251,8 +250,8 @@ describe('initCSSObservers', () => {
 
         styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
 
-        const parentRule = styleSheet.cssRules[0] as GroupingCSSRule
-        const groupingRule = parentRule.cssRules[0] as GroupingCSSRule
+        const parentRule = styleSheet.cssRules[0] as CSSGroupingRule
+        const groupingRule = parentRule.cssRules[0] as CSSGroupingRule
         parentRule.deleteRule(0)
 
         stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
@@ -266,7 +265,7 @@ describe('initCSSObservers', () => {
       it('should capture CSSRule removal with the correct path', () => {
         styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
         styleSheet.insertRule('.main {opacity: 0}')
-        const groupingRule = (styleSheet.cssRules[1] as GroupingCSSRule).cssRules[0] as GroupingCSSRule
+        const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[0] as CSSGroupingRule
 
         stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)
         groupingRule.deleteRule(0)
@@ -285,8 +284,8 @@ describe('initCSSObservers', () => {
 
         styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
 
-        const parentRule = styleSheet.cssRules[0] as GroupingCSSRule
-        const groupingRule = parentRule.cssRules[0] as GroupingCSSRule
+        const parentRule = styleSheet.cssRules[0] as CSSGroupingRule
+        const groupingRule = parentRule.cssRules[0] as CSSGroupingRule
         parentRule.deleteRule(0)
 
         stopCSSObservers = initCSSObservers(cssRulesCallbackSpy)

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -5,8 +5,8 @@ import type { RawRumEventCollectedData } from 'packages/rum-core/src/domain/life
 import { createNewEvent } from '../../../../core/test/specHelper'
 import { NodePrivacyLevel, PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '../../constants'
 import { RecordType } from '../../types'
-import type { FrustrationCallback, InputCallback } from './observers'
-import { initFrustrationObserver, initInputObserver } from './observers'
+import type { FrustrationCallback, InputCallback, StyleSheetRuleCallback } from './observers'
+import { initStyleSheetObserver, initFrustrationObserver, initInputObserver } from './observers'
 import { serializeDocument, SerializationContextStatus } from './serialize'
 import { createElementsScrollPositions } from './elementsScrollPositions'
 
@@ -155,127 +155,141 @@ describe('initFrustrationObserver', () => {
   })
 })
 
-// const rule = '.selector-1 { color: #fff }'
+describe('initStyleSheetObserver', () => {
+  let stopStyleSheetObserver: () => void
+  let styleSheetCallbackSpy: jasmine.Spy<StyleSheetRuleCallback>
+  let styleElement: HTMLStyleElement
+  let styleSheet: CSSStyleSheet
+  const styleRule = '.selector-1 { color: #fff }'
 
-// describe('initStyleSheetObserver', () => {
-//   let stopStyleSheetObserver: () => void
-//   let styleSheetCallbackSpy: jasmine.Spy<StyleSheetRuleCallback>
-//   let styleElement: HTMLStyleElement
-//   let styleSheet: CSSStyleSheet
-//   beforeEach(() => {
-//     if (isIE()) {
-//       pending('IE not supported')
-//     }
-//     styleSheetCallbackSpy = jasmine.createSpy()
-//     styleElement = document.createElement('style')
-//     document.head.appendChild(styleElement)
-//     styleSheet = <CSSStyleSheet>styleElement.sheet
-//   })
-//   afterEach(() => {
-//     stopStyleSheetObserver()
-//     styleElement.remove()
-//   })
-//   describe('observing high level css stylesheet', () => {
-//     describe('when inserting rules into stylesheet', () => {
-//       it('should capture CSSStyleRule insertion when no index is provided', () => {
-//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         // When
-//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         styleSheet.insertRule(rule)
-//         // Then
-//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
-//         expect(styleSheetRule.id).toBeDefined()
-//         expect(styleSheetRule.removes).toBeUndefined()
-//         expect(styleSheetRule.adds?.length).toEqual(1)
-//         expect(styleSheetRule.adds?.pop()?.index).toEqual(undefined)
-//       })
-//       it('should capture CSSStyleRule insertion when index is provided', () => {
-//         // Given
-//         const index = 0
-//         // When
-//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         styleSheet.insertRule('@media cond { .class {opacity: 0}}', index)
-//         const b = styleSheet.cssRules[0] as CSSGroupingRule
-//         b.insertRule(rule, 0)
-//         // Then
-//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
-//         expect(styleSheetRule.id).toBeDefined()
-//         expect(styleSheetRule.removes).toBeUndefined()
-//         expect(styleSheetRule.adds?.length).toEqual(1)
-//         expect(styleSheetRule.adds?.pop()?.index).toEqual(index)
-//       })
-//     })
-//     describe('when removing rules from stylesheet', () => {
-//       it('should capture CSSStyleRule removal with the correct index', () => {
-//         styleSheet.insertRule(rule)
-//         // Given
-//         const index = 0
-//         // When
-//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         styleSheet.deleteRule(index)
-//         // Then
-//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
-//         expect(styleSheetRule.id).toBeDefined()
-//         expect(styleSheetRule.adds).toBeUndefined()
-//         expect(styleSheetRule.removes?.length).toEqual(1)
-//         expect(styleSheetRule.removes?.pop()).toEqual({ index })
-//       })
-//     })
-//   })
-//   describe('observing CSSGroupingRules inside a CSSStyleSheet', () => {
-//     describe('when inserting CSSRules inside a CSSGroupingRule', () => {
-//       it('should capture CSSRule with the correct path when no index is provided', () => {
-//         styleSheet.insertRule(
-//           '.main {opacity: 0}; @media cond-1 {.nest-1 { color: #ccc }; @media cond-2 { .nest-2 {display: none } }};'
-//         )
-//         // Given
-//         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[1] as CSSGroupingRule
-//         // When
-//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         groupingRule.insertRule(rule)
-//         // Then
-//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
-//         expect(styleSheetRule.id).toBeDefined()
-//         expect(styleSheetRule.removes).toBeUndefined()
-//         expect(styleSheetRule.adds?.length).toEqual(1)
-//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1, 1, 0])
-//       })
-//       it('should capture CSSRule with the correct path when index is provided', () => {
-//         styleSheet.insertRule(
-//           '.main { opacity: 0 } @media cond-1 { .nest-1 { color: #ccc } @media cond-2 { .nest-2 {display: none } } }'
-//         )
-//         // Given
-//         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[1] as CSSGroupingRule
-//         // When
-//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         groupingRule.insertRule(rule, 1)
-//         // Then
-//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
-//         expect(styleSheetRule.id).toBeDefined()
-//         expect(styleSheetRule.removes).toBeUndefined()
-//         expect(styleSheetRule.adds?.length).toEqual(1)
-//         expect(styleSheetRule.adds?.pop()?.index).toEqual([1, 1, 1])
-//       })
-//       it('should not create record when inserting into a detached CSSGroupingRule', () => {})
-//     })
-//     describe('when removing CSSRules from a CSSGroupingRule', () => {
-//       it('should capture CSSRule removal with the correct path', () => {
-//         styleSheet.insertRule(
-//           '.main { opacity: 0 } @media cond-1 { .nest-1 { color: #ccc } @media cond-2 { .nest-2 {display: none } } }'
-//         )
-//         // Given
-//         const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[1] as CSSGroupingRule
-//         // When
-//         stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
-//         groupingRule.deleteRule(0)
-//         // Then
-//         const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
-//         expect(styleSheetRule.id).toBeDefined()
-//         expect(styleSheetRule.adds).toBeUndefined()
-//         expect(styleSheetRule.removes?.length).toEqual(1)
-//         expect(styleSheetRule.removes?.pop()?.index).toEqual([1, 1, 0])
-//       })
-//       it('should not create record when removing from a detached CSSGroupingRule', () => {})
-//     })
-//   })
-// })
+  beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+    styleSheetCallbackSpy = jasmine.createSpy()
+    styleElement = document.createElement('style')
+    document.head.appendChild(styleElement)
+    styleSheet = <CSSStyleSheet>styleElement.sheet
+
+    serializeDocument(document, NodePrivacyLevel.ALLOW, {
+      status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
+      elementsScrollPositions: createElementsScrollPositions(),
+    })
+  })
+
+  afterEach(() => {
+    stopStyleSheetObserver()
+    styleElement.remove()
+  })
+
+  describe('observing high level css stylesheet', () => {
+    describe('when inserting rules into stylesheet', () => {
+      it('should capture CSSStyleRule insertion when no index is provided', () => {
+        // When
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+        styleSheet.insertRule(styleRule)
+        // Then
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+        expect(styleSheetRule.id).toBeDefined()
+        expect(styleSheetRule.removes).toBeUndefined()
+        expect(styleSheetRule.adds?.length).toEqual(1)
+        expect(styleSheetRule.adds?.pop()?.index).toEqual(undefined)
+      })
+
+      it('should capture CSSStyleRule insertion when index is provided', () => {
+        // Given
+        const index = 0
+        // When
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+        styleSheet.insertRule(styleRule, index)
+        // Then
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+        expect(styleSheetRule.id).toBeDefined()
+        expect(styleSheetRule.removes).toBeUndefined()
+        expect(styleSheetRule.adds?.length).toEqual(1)
+        expect(styleSheetRule.adds?.pop()?.index).toEqual(index)
+      })
+    })
+
+    describe('when removing rules from stylesheet', () => {
+      it('should capture CSSStyleRule removal with the correct index', () => {
+        styleSheet.insertRule(styleRule)
+        // Given
+        const index = 0
+        // When
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+        styleSheet.deleteRule(index)
+        // Then
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+        expect(styleSheetRule.id).toBeDefined()
+        expect(styleSheetRule.adds).toBeUndefined()
+        expect(styleSheetRule.removes?.length).toEqual(1)
+        expect(styleSheetRule.removes?.pop()).toEqual({ index })
+      })
+    })
+  })
+
+  describe('observing CSSGroupingRules inside a CSSStyleSheet', () => {
+    describe('when inserting CSSRules inside a CSSGroupingRule', () => {
+      it('should capture CSSRule with the correct path when no index is provided', () => {
+        styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
+        styleSheet.insertRule('.main {opacity: 0}')
+        // Given
+        const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[0] as CSSGroupingRule
+        // When
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+        groupingRule.insertRule(styleRule, 1)
+        // Then
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+        expect(styleSheetRule.id).toBeDefined()
+        expect(styleSheetRule.removes).toBeUndefined()
+        expect(styleSheetRule.adds?.length).toEqual(1)
+        expect(styleSheetRule.adds?.pop()?.index).toEqual([1, 0, 1])
+      })
+
+      it('should not create record when inserting into a detached CSSGroupingRule', () => {
+        styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
+        // Given
+        const parentRule = styleSheet.cssRules[0] as CSSGroupingRule
+        const groupingRule = parentRule.cssRules[0] as CSSGroupingRule
+        parentRule.deleteRule(0)
+        // When
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+        groupingRule.insertRule(styleRule, 0)
+        // Then
+        expect(styleSheetCallbackSpy.calls.all().length).toEqual(0)
+      })
+    })
+
+    describe('when removing CSSRules from a CSSGroupingRule', () => {
+      it('should capture CSSRule removal with the correct path', () => {
+        styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
+        styleSheet.insertRule('.main {opacity: 0}')
+        // Given
+        const groupingRule = (styleSheet.cssRules[1] as CSSGroupingRule).cssRules[0] as CSSGroupingRule
+        // When
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+        groupingRule.deleteRule(0)
+        // Then
+        const styleSheetRule = styleSheetCallbackSpy.calls.first().args[0]
+        expect(styleSheetRule.id).toBeDefined()
+        expect(styleSheetRule.adds).toBeUndefined()
+        expect(styleSheetRule.removes?.length).toEqual(1)
+        expect(styleSheetRule.removes?.pop()?.index).toEqual([1, 0, 0])
+      })
+
+      it('should not create record when removing from a detached CSSGroupingRule', () => {
+        styleSheet.insertRule('@media cond-2 { @media cond-1 { .nest-1 { color: #ccc } } }')
+        // Given
+        const parentRule = styleSheet.cssRules[0] as CSSGroupingRule
+        const groupingRule = parentRule.cssRules[0] as CSSGroupingRule
+        parentRule.deleteRule(0)
+        // When
+        stopStyleSheetObserver = initStyleSheetObserver(styleSheetCallbackSpy)
+        groupingRule.deleteRule(0)
+        // Then
+        expect(styleSheetCallbackSpy.calls.all().length).toEqual(0)
+      })
+    })
+  })
+})

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -93,7 +93,7 @@ interface ObserverParam {
   visualViewportResizeCb: VisualViewportResizeCallback
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
-  styleSheetRuleCb: StyleSheetRuleCallback
+  cssRulesCb: StyleSheetRuleCallback
   focusCb: FocusCallback
   frustrationCb: FrustrationCallback
 }
@@ -106,7 +106,7 @@ export function initObservers(o: ObserverParam): ListenerHandler {
   const viewportResizeHandler = initViewportResizeObserver(o.viewportResizeCb)
   const inputHandler = initInputObserver(o.inputCb, o.defaultPrivacyLevel)
   const mediaInteractionHandler = initMediaInteractionObserver(o.mediaInteractionCb, o.defaultPrivacyLevel)
-  const styleSheetObserver = initStyleSheetObserver(o.styleSheetRuleCb)
+  const CSSObservers = initCSSObservers(o.cssRulesCb)
   const focusHandler = initFocusObserver(o.focusCb)
   const visualViewportResizeHandler = initVisualViewportResizeObserver(o.visualViewportResizeCb)
   const frustrationHandler = initFrustrationObserver(o.lifeCycle, o.frustrationCb)
@@ -119,7 +119,7 @@ export function initObservers(o: ObserverParam): ListenerHandler {
     viewportResizeHandler()
     inputHandler()
     mediaInteractionHandler()
-    styleSheetObserver()
+    CSSObservers()
     focusHandler()
     visualViewportResizeHandler()
     frustrationHandler()
@@ -350,7 +350,7 @@ export function initInputObserver(cb: InputCallback, defaultPrivacyLevel: Defaul
   }
 }
 
-export function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHandler {
+export function initCSSObservers(cb: StyleSheetRuleCallback): ListenerHandler {
   function checkStyleSheetAndCallback(styleSheet: CSSStyleSheet | null, callback: (id: number) => void): void {
     if (styleSheet && hasSerializedNode(styleSheet.ownerNode!)) {
       callback(getSerializedNodeId(styleSheet.ownerNode))

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -66,7 +66,7 @@ type MouseInteractionCallBack = (record: BrowserIncrementalSnapshotRecord) => vo
 
 type ScrollCallback = (p: ScrollPosition) => void
 
-export type StyleSheetRuleCallback = (s: StyleSheetRule) => void
+export type CSSRuleCallback = (s: StyleSheetRule) => void
 
 type ViewportResizeCallback = (d: ViewportResizeDimension) => void
 
@@ -93,7 +93,7 @@ interface ObserverParam {
   visualViewportResizeCb: VisualViewportResizeCallback
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
-  cssRulesCb: StyleSheetRuleCallback
+  cssRulesCb: CSSRuleCallback
   focusCb: FocusCallback
   frustrationCb: FrustrationCallback
 }
@@ -350,7 +350,7 @@ export function initInputObserver(cb: InputCallback, defaultPrivacyLevel: Defaul
   }
 }
 
-export function initCSSObservers(cb: StyleSheetRuleCallback): ListenerHandler {
+export function initCSSObservers(cb: CSSRuleCallback): ListenerHandler {
   function checkStyleSheetAndCallback(styleSheet: CSSStyleSheet | null, callback: (id: number) => void): void {
     if (styleSheet && hasSerializedNode(styleSheet.ownerNode!)) {
       callback(getSerializedNodeId(styleSheet.ownerNode))

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -372,7 +372,8 @@ export function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHand
       checkStyleSheetAndCallback(this.parentStyleSheet, (id) => {
         const path = getPathToNestedCSSRule(this)
         if (path) {
-          cb({ id, adds: [{ rule, index: path.push(index ?? 0) }] })
+          path.push(index ?? 0)
+          cb({ id, adds: [{ rule, index: path }] })
         }
       })
     },
@@ -382,7 +383,8 @@ export function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHand
       checkStyleSheetAndCallback(this.parentStyleSheet, (id) => {
         const path = getPathToNestedCSSRule(this)
         if (path) {
-          cb({ id, removes: [{ index: path.push(index) }] })
+          path.push(index)
+          cb({ id, removes: [{ index: path }] })
         }
       })
     },

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -33,6 +33,7 @@ import { getNodePrivacyLevel, shouldMaskNode } from './privacy'
 import { getElementInputValue, getSerializedNodeId, hasSerializedNode } from './serializationUtils'
 import type { GroupingCSSRuleTypes } from './utils'
 import {
+  isNestedRulesSupported,
   assembleIncrementalSnapshot,
   forEach,
   getPathToNestedCSSRule,
@@ -368,6 +369,13 @@ export function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHand
       checkStyleSheetAndCallback(this, (id) => cb({ id, removes: [{ index }] }))
     },
   })
+
+  if (!isNestedRulesSupported()) {
+    return () => {
+      restoreInsertRule()
+      restoreDeleteRule()
+    }
+  }
 
   const originalInsertRestorers = getSupportedCSSRuleTypes().map((ruleType) => {
     const { stop: restoreInsertNestedRule } = instrumentMethodAndCallOriginal(ruleType.prototype, 'insertRule', {

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -33,7 +33,7 @@ import { getNodePrivacyLevel, shouldMaskNode } from './privacy'
 import { getElementInputValue, getSerializedNodeId, hasSerializedNode } from './serializationUtils'
 import type { GroupingCSSRuleTypes } from './utils'
 import {
-  isNestedRulesSupported,
+  browserSupportsGroupingRules,
   assembleIncrementalSnapshot,
   forEach,
   getPathToNestedCSSRule,
@@ -370,7 +370,7 @@ export function initStyleSheetObserver(cb: StyleSheetRuleCallback): ListenerHand
     },
   })
 
-  if (!isNestedRulesSupported()) {
+  if (!browserSupportsGroupingRules()) {
     return () => {
       restoreInsertRule()
       restoreDeleteRule()

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -66,7 +66,7 @@ type MouseInteractionCallBack = (record: BrowserIncrementalSnapshotRecord) => vo
 
 type ScrollCallback = (p: ScrollPosition) => void
 
-export type CSSRuleCallback = (s: StyleSheetRule) => void
+export type StyleSheetCallback = (s: StyleSheetRule) => void
 
 type ViewportResizeCallback = (d: ViewportResizeDimension) => void
 
@@ -93,7 +93,7 @@ interface ObserverParam {
   visualViewportResizeCb: VisualViewportResizeCallback
   inputCb: InputCallback
   mediaInteractionCb: MediaInteractionCallback
-  cssRulesCb: CSSRuleCallback
+  styleSheetCb: StyleSheetCallback
   focusCb: FocusCallback
   frustrationCb: FrustrationCallback
 }
@@ -106,7 +106,7 @@ export function initObservers(o: ObserverParam): ListenerHandler {
   const viewportResizeHandler = initViewportResizeObserver(o.viewportResizeCb)
   const inputHandler = initInputObserver(o.inputCb, o.defaultPrivacyLevel)
   const mediaInteractionHandler = initMediaInteractionObserver(o.mediaInteractionCb, o.defaultPrivacyLevel)
-  const CSSObservers = initCSSObservers(o.cssRulesCb)
+  const styleSheetObserver = initStyleSheetObserver(o.styleSheetCb)
   const focusHandler = initFocusObserver(o.focusCb)
   const visualViewportResizeHandler = initVisualViewportResizeObserver(o.visualViewportResizeCb)
   const frustrationHandler = initFrustrationObserver(o.lifeCycle, o.frustrationCb)
@@ -119,7 +119,7 @@ export function initObservers(o: ObserverParam): ListenerHandler {
     viewportResizeHandler()
     inputHandler()
     mediaInteractionHandler()
-    CSSObservers()
+    styleSheetObserver()
     focusHandler()
     visualViewportResizeHandler()
     frustrationHandler()
@@ -350,7 +350,7 @@ export function initInputObserver(cb: InputCallback, defaultPrivacyLevel: Defaul
   }
 }
 
-export function initCSSObservers(cb: CSSRuleCallback): ListenerHandler {
+export function initStyleSheetObserver(cb: StyleSheetCallback): ListenerHandler {
   function checkStyleSheetAndCallback(styleSheet: CSSStyleSheet | null, callback: (id: number) => void): void {
     if (styleSheet && hasSerializedNode(styleSheet.ownerNode!)) {
       callback(getSerializedNodeId(styleSheet.ownerNode))

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -102,7 +102,7 @@ export function record(options: RecordOptions): RecordAPI {
     mousemoveCb: (positions, source) => emit(assembleIncrementalSnapshot<MousemoveData>(source, { positions })),
     mutationCb: (m) => emit(assembleIncrementalSnapshot<BrowserMutationData>(IncrementalSource.Mutation, m)),
     scrollCb: (p) => emit(assembleIncrementalSnapshot<ScrollData>(IncrementalSource.Scroll, p)),
-    styleSheetRuleCb: (r) => emit(assembleIncrementalSnapshot<StyleSheetRuleData>(IncrementalSource.StyleSheetRule, r)),
+    cssRulesCb: (r) => emit(assembleIncrementalSnapshot<StyleSheetRuleData>(IncrementalSource.StyleSheetRule, r)),
     viewportResizeCb: (d) => emit(assembleIncrementalSnapshot<ViewportResizeData>(IncrementalSource.ViewportResize, d)),
 
     frustrationCb: (frustrationRecord) => emit(frustrationRecord),

--- a/packages/rum/src/domain/record/record.ts
+++ b/packages/rum/src/domain/record/record.ts
@@ -102,7 +102,7 @@ export function record(options: RecordOptions): RecordAPI {
     mousemoveCb: (positions, source) => emit(assembleIncrementalSnapshot<MousemoveData>(source, { positions })),
     mutationCb: (m) => emit(assembleIncrementalSnapshot<BrowserMutationData>(IncrementalSource.Mutation, m)),
     scrollCb: (p) => emit(assembleIncrementalSnapshot<ScrollData>(IncrementalSource.Scroll, p)),
-    cssRulesCb: (r) => emit(assembleIncrementalSnapshot<StyleSheetRuleData>(IncrementalSource.StyleSheetRule, r)),
+    styleSheetCb: (r) => emit(assembleIncrementalSnapshot<StyleSheetRuleData>(IncrementalSource.StyleSheetRule, r)),
     viewportResizeCb: (d) => emit(assembleIncrementalSnapshot<ViewportResizeData>(IncrementalSource.ViewportResize, d)),
 
     frustrationCb: (frustrationRecord) => emit(frustrationRecord),

--- a/packages/rum/src/domain/record/utils.spec.ts
+++ b/packages/rum/src/domain/record/utils.spec.ts
@@ -3,7 +3,7 @@ import { getPathToNestedCSSRule } from './utils'
 
 const firstStyleRule = '.selector-1 { color: #aaa }'
 const secondStyleRule = '.selector-2 { color: #bbb }'
-const firstsecondMediaRule = `
+const firstMediaRule = `
     @media cond-1 {
         .selector-3-1 { color: #ccc }
         .selector-3-2 { color: #ddd }
@@ -27,7 +27,7 @@ describe('getPathToNestedCSSRule', () => {
     styleSheet = styleElement.sheet!
 
     styleSheet.insertRule(secondMediaRule)
-    styleSheet.insertRule(firstsecondMediaRule)
+    styleSheet.insertRule(firstMediaRule)
     styleSheet.insertRule(secondStyleRule)
     styleSheet.insertRule(firstStyleRule)
   })
@@ -37,13 +37,13 @@ describe('getPathToNestedCSSRule', () => {
   })
 
   it('should return undefined if the rule is not attached to a parent StyleSheet', () => {
-    const grouppingRule = styleSheet.cssRules[3]
-    expect(grouppingRule.parentStyleSheet).toBeDefined()
+    const groupingRule = styleSheet.cssRules[3]
+    expect(groupingRule.parentStyleSheet).toBeDefined()
     // Removing rule from CSSStyleSheet
     styleSheet.deleteRule(3)
 
-    expect(grouppingRule.parentStyleSheet).toEqual(null)
-    expect(getPathToNestedCSSRule(grouppingRule)).toBeUndefined()
+    expect(groupingRule.parentStyleSheet).toEqual(null)
+    expect(getPathToNestedCSSRule(groupingRule)).toBeUndefined()
   })
 
   it('should return path to high level CSSStyleRule', () => {

--- a/packages/rum/src/domain/record/utils.spec.ts
+++ b/packages/rum/src/domain/record/utils.spec.ts
@@ -1,0 +1,48 @@
+import { getPathToNestedCSSRule } from './utils'
+
+const firstStyleRule = '.selector-1 { color: #aaa }'
+const secondStyleRule = '.selector-2 { color: #bbb }'
+const firstsecondMediaRule = `
+    @media cond-1 {
+        .selector-3-1 { color: #ccc }
+        .selector-3-2 { color: #ddd }
+        .selector-3-3 { color: #eee }
+    }`
+const secondMediaRule = `
+    @media cond-2 {
+        @media cond-2-1 {.selector-2-1-1 { display: none }}
+        @media cond-2-2 {.selector-2-2-1 { display: clock }}
+    }`
+
+describe('getPathToNestedCSSRule', () => {
+  let styleSheet: CSSStyleSheet
+  beforeAll(() => {
+    styleSheet = new CSSStyleSheet()
+    styleSheet.insertRule(secondMediaRule)
+    styleSheet.insertRule(firstsecondMediaRule)
+    styleSheet.insertRule(secondStyleRule)
+    styleSheet.insertRule(firstStyleRule)
+  })
+  it('should return path to high level CSSStyleRule', () => {
+    expect(getPathToNestedCSSRule(styleSheet.cssRules[1])).toEqual([1])
+  })
+
+  it('should return path to high level CSSGroupingRule', () => {
+    expect(getPathToNestedCSSRule(styleSheet.cssRules[3])).toEqual([3])
+  })
+
+  it('should return path to nested CSSStyleRule', () => {
+    const rule = (styleSheet.cssRules[2] as CSSGroupingRule).cssRules[1]
+    expect(getPathToNestedCSSRule(rule)).toEqual([2, 1])
+  })
+
+  it('should return path to nested CSSGroupingRule', () => {
+    const rule = (styleSheet.cssRules[3] as CSSGroupingRule).cssRules[0]
+    expect(getPathToNestedCSSRule(rule)).toEqual([3, 0])
+  })
+
+  it('should return path to leaf CSSRule', () => {
+    const rule = ((styleSheet.cssRules[3] as CSSGroupingRule).cssRules[1] as CSSGroupingRule).cssRules[0]
+    expect(getPathToNestedCSSRule(rule)).toEqual([3, 1, 0])
+  })
+})

--- a/packages/rum/src/domain/record/utils.spec.ts
+++ b/packages/rum/src/domain/record/utils.spec.ts
@@ -30,8 +30,8 @@ describe('getPathToNestedCSSRule', () => {
     // Removing rule from CSSStyleSheet
     styleSheet.deleteRule(3)
 
-    expect(grouppingRule.parentStyleSheet).toBeUndefined()
-    expect(getPathToNestedCSSRule(styleSheet.cssRules[3])).toBeUndefined()
+    expect(grouppingRule.parentStyleSheet).toEqual(null)
+    expect(getPathToNestedCSSRule(grouppingRule)).toBeUndefined()
   })
 
   it('should return path to high level CSSStyleRule', () => {

--- a/packages/rum/src/domain/record/utils.spec.ts
+++ b/packages/rum/src/domain/record/utils.spec.ts
@@ -16,12 +16,20 @@ const secondMediaRule = `
 
 describe('getPathToNestedCSSRule', () => {
   let styleSheet: CSSStyleSheet
+  let styleElement: HTMLStyleElement
   beforeEach(() => {
-    styleSheet = new CSSStyleSheet()
+    styleElement = document.createElement('style')
+    document.head.appendChild(styleElement)
+    styleSheet = <CSSStyleSheet>styleElement.sheet
+
     styleSheet.insertRule(secondMediaRule)
     styleSheet.insertRule(firstsecondMediaRule)
     styleSheet.insertRule(secondStyleRule)
     styleSheet.insertRule(firstStyleRule)
+  })
+
+  afterEach(() => {
+    styleElement.remove()
   })
 
   it('should return undefined if the rule is not attached to a parent StyleSheet', () => {

--- a/packages/rum/src/domain/record/utils.spec.ts
+++ b/packages/rum/src/domain/record/utils.spec.ts
@@ -24,7 +24,7 @@ describe('getPathToNestedCSSRule', () => {
     }
     styleElement = document.createElement('style')
     document.head.appendChild(styleElement)
-    styleSheet = <CSSStyleSheet>styleElement.sheet
+    styleSheet = styleElement.sheet!
 
     styleSheet.insertRule(secondMediaRule)
     styleSheet.insertRule(firstsecondMediaRule)

--- a/packages/rum/src/domain/record/utils.spec.ts
+++ b/packages/rum/src/domain/record/utils.spec.ts
@@ -16,13 +16,24 @@ const secondMediaRule = `
 
 describe('getPathToNestedCSSRule', () => {
   let styleSheet: CSSStyleSheet
-  beforeAll(() => {
+  beforeEach(() => {
     styleSheet = new CSSStyleSheet()
     styleSheet.insertRule(secondMediaRule)
     styleSheet.insertRule(firstsecondMediaRule)
     styleSheet.insertRule(secondStyleRule)
     styleSheet.insertRule(firstStyleRule)
   })
+
+  it('should return undefined if the rule is not attached to a parent StyleSheet', () => {
+    const grouppingRule = styleSheet.cssRules[3]
+    expect(grouppingRule.parentStyleSheet).toBeDefined()
+    // Removing rule from CSSStyleSheet
+    styleSheet.deleteRule(3)
+
+    expect(grouppingRule.parentStyleSheet).toBeUndefined()
+    expect(getPathToNestedCSSRule(styleSheet.cssRules[3])).toBeUndefined()
+  })
+
   it('should return path to high level CSSStyleRule', () => {
     expect(getPathToNestedCSSRule(styleSheet.cssRules[1])).toEqual([1])
   })

--- a/packages/rum/src/domain/record/utils.spec.ts
+++ b/packages/rum/src/domain/record/utils.spec.ts
@@ -1,3 +1,4 @@
+import { isIE } from '@datadog/browser-core'
 import { getPathToNestedCSSRule } from './utils'
 
 const firstStyleRule = '.selector-1 { color: #aaa }'
@@ -18,6 +19,9 @@ describe('getPathToNestedCSSRule', () => {
   let styleSheet: CSSStyleSheet
   let styleElement: HTMLStyleElement
   beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
     styleElement = document.createElement('style')
     document.head.appendChild(styleElement)
     styleSheet = <CSSStyleSheet>styleElement.sheet

--- a/packages/rum/src/domain/record/utils.ts
+++ b/packages/rum/src/domain/record/utils.ts
@@ -29,13 +29,11 @@ export function assembleIncrementalSnapshot<Data extends BrowserIncrementalData>
   }
 }
 
-export type GroupingCSSRule = CSSGroupingRule | CSSSupportsRule | CSSMediaRule
-
 export function getPathToNestedCSSRule(rule: CSSRule): number[] | undefined {
   const path: number[] = []
   let currentRule = rule
   while (currentRule.parentRule) {
-    const rules = Array.from((currentRule.parentRule as GroupingCSSRule).cssRules)
+    const rules = Array.from((currentRule.parentRule as CSSGroupingRule).cssRules)
     const index = rules.indexOf(currentRule)
     path.unshift(index)
     currentRule = currentRule.parentRule

--- a/packages/rum/src/domain/record/utils.ts
+++ b/packages/rum/src/domain/record/utils.ts
@@ -1,7 +1,6 @@
 import { assign, timeStampNow } from '@datadog/browser-core'
 import type { BrowserIncrementalData, BrowserIncrementalSnapshotRecord } from '../../types'
 import { RecordType } from '../../types'
-import { getSerializedNodeId, hasSerializedNode } from './serializationUtils'
 
 export function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent {
   return Boolean((event as TouchEvent).changedTouches)
@@ -30,45 +29,7 @@ export function assembleIncrementalSnapshot<Data extends BrowserIncrementalData>
   }
 }
 
-export function checkStyleSheetAndCallback(styleSheet: CSSStyleSheet | null, callback: (id: number) => void): void {
-  if (styleSheet && hasSerializedNode(styleSheet.ownerNode!)) {
-    callback(getSerializedNodeId(styleSheet.ownerNode))
-  }
-}
-
-/*
- * We can ignore CSSCondition rule in this workaround
- * (see https://caniuse.com/?search=cssconditionrule & https://caniuse.com/?search=cssgroupingrule)
- * if CSSGroupingRule is defined, there is no need to handle each sub interface separatly (CSSMediaRule,
- * CSSSupprtsRule, CSSConditionRule). If CSSGroupingRule is not defined, CSSConditionRule is not defined
- * neither and we fall back to supported rules only.
- */
-
-export type GroupingCSSRuleTypes = typeof CSSGroupingRule | typeof CSSMediaRule | typeof CSSSupportsRule
 export type GroupingCSSRule = CSSGroupingRule | CSSSupportsRule | CSSMediaRule
-
-export const isCSSGroupingRuleSupported = typeof CSSGroupingRule !== 'undefined'
-export const isCSSMediaRuleSupported = typeof CSSMediaRule !== 'undefined'
-export const isCSSSupportsRuleSupported = typeof CSSSupportsRule !== 'undefined'
-
-export function browserSupportsGroupingRules(): boolean {
-  return isCSSGroupingRuleSupported || isCSSMediaRuleSupported || isCSSSupportsRuleSupported
-}
-
-export function getSupportedCSSRuleTypes(): GroupingCSSRuleTypes[] {
-  if (isCSSGroupingRuleSupported) {
-    return [CSSGroupingRule]
-  }
-  const supported = []
-  if (isCSSSupportsRuleSupported) {
-    supported.push(CSSSupportsRule)
-  }
-  if (isCSSMediaRuleSupported) {
-    supported.push(CSSMediaRule)
-  }
-
-  return supported
-}
 
 export function getPathToNestedCSSRule(rule: CSSRule): number[] | undefined {
   const path: number[] = []

--- a/packages/rum/src/domain/record/utils.ts
+++ b/packages/rum/src/domain/record/utils.ts
@@ -36,11 +36,45 @@ export function checkStyleSheetAndCallback(styleSheet: CSSStyleSheet | null, cal
   }
 }
 
+/*
+ * We can ignore CSSCondition rule in this work around
+ * (see https://caniuse.com/?search=cssconditionrule & https://caniuse.com/?search=cssgroupingrule)
+ * if CSSGroupingRule is defined, there is no need to each sub interface (CSSMediaRule, CSSSupprtsRule,
+ * CSSConditionRule). if CSSGroupingRule is not defined, CSSConditionRule is not defined neither and we
+ * fall back to supported rules only
+ */
+
+export type GroupingCSSRuleTypes = typeof CSSGroupingRule | typeof CSSMediaRule | typeof CSSSupportsRule
+export type GroupingCSSRule = CSSGroupingRule | CSSSupportsRule | CSSMediaRule
+
+export const isCSSGroupingRuleSupported = typeof CSSGroupingRule !== 'undefined'
+export const isCSSMediaRuleSupported = typeof CSSMediaRule !== 'undefined'
+export const isCSSSupportsRuleSupported = typeof CSSSupportsRule !== 'undefined'
+
+export function isNestedRulesSupported() {
+  return isCSSGroupingRuleSupported || isCSSMediaRuleSupported || isCSSSupportsRuleSupported
+}
+
+export function getSupportedCSSRuleTypes() {
+  if (isCSSGroupingRuleSupported) {
+    return [CSSGroupingRule]
+  }
+  const supported = []
+  if (isCSSSupportsRuleSupported) {
+    supported.push(CSSSupportsRule)
+  }
+  if (isCSSMediaRuleSupported) {
+    supported.push(CSSMediaRule)
+  }
+
+  return supported
+}
+
 export function getPathToNestedCSSRule(rule: CSSRule): number[] | undefined {
   const path: number[] = []
   let currentRule = rule
   while (currentRule.parentRule) {
-    const rules = Array.from((currentRule.parentRule as CSSGroupingRule).cssRules)
+    const rules = Array.from((currentRule.parentRule as GroupingCSSRule).cssRules)
     const index = rules.indexOf(currentRule)
     path.unshift(index)
     currentRule = currentRule.parentRule

--- a/packages/rum/src/domain/record/utils.ts
+++ b/packages/rum/src/domain/record/utils.ts
@@ -28,3 +28,19 @@ export function assembleIncrementalSnapshot<Data extends BrowserIncrementalData>
     timestamp: timeStampNow(),
   }
 }
+
+export function getPathToNestedCSSRule(rule: CSSRule): number[] {
+  const path: number[] = []
+  let currentRule = rule
+  while (currentRule.parentRule instanceof CSSGroupingRule) {
+    const rules = Array.from(currentRule.parentRule.cssRules)
+    const index = rules.indexOf(currentRule)
+    path.unshift(index)
+    currentRule = currentRule.parentRule
+  }
+  const rules = Array.from(currentRule.parentStyleSheet!.cssRules)
+  const index = rules.indexOf(currentRule)
+  path.unshift(index)
+
+  return path
+}

--- a/packages/rum/src/domain/record/utils.ts
+++ b/packages/rum/src/domain/record/utils.ts
@@ -37,11 +37,11 @@ export function checkStyleSheetAndCallback(styleSheet: CSSStyleSheet | null, cal
 }
 
 /*
- * We can ignore CSSCondition rule in this work around
+ * We can ignore CSSCondition rule in this workaround
  * (see https://caniuse.com/?search=cssconditionrule & https://caniuse.com/?search=cssgroupingrule)
- * if CSSGroupingRule is defined, there is no need to each sub interface (CSSMediaRule, CSSSupprtsRule,
- * CSSConditionRule). if CSSGroupingRule is not defined, CSSConditionRule is not defined neither and we
- * fall back to supported rules only
+ * if CSSGroupingRule is defined, there is no need to handle each sub interface separatly (CSSMediaRule,
+ * CSSSupprtsRule, CSSConditionRule). If CSSGroupingRule is not defined, CSSConditionRule is not defined
+ * neither and we fall back to supported rules only.
  */
 
 export type GroupingCSSRuleTypes = typeof CSSGroupingRule | typeof CSSMediaRule | typeof CSSSupportsRule
@@ -51,11 +51,11 @@ export const isCSSGroupingRuleSupported = typeof CSSGroupingRule !== 'undefined'
 export const isCSSMediaRuleSupported = typeof CSSMediaRule !== 'undefined'
 export const isCSSSupportsRuleSupported = typeof CSSSupportsRule !== 'undefined'
 
-export function isNestedRulesSupported() {
+export function browserSupportsGroupingRules(): boolean {
   return isCSSGroupingRuleSupported || isCSSMediaRuleSupported || isCSSSupportsRuleSupported
 }
 
-export function getSupportedCSSRuleTypes() {
+export function getSupportedCSSRuleTypes(): GroupingCSSRuleTypes[] {
   if (isCSSGroupingRuleSupported) {
     return [CSSGroupingRule]
   }

--- a/packages/rum/src/domain/record/utils.ts
+++ b/packages/rum/src/domain/record/utils.ts
@@ -1,6 +1,7 @@
 import { assign, timeStampNow } from '@datadog/browser-core'
 import type { BrowserIncrementalData, BrowserIncrementalSnapshotRecord } from '../../types'
 import { RecordType } from '../../types'
+import { getSerializedNodeId, hasSerializedNode } from './serializationUtils'
 
 export function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent {
   return Boolean((event as TouchEvent).changedTouches)
@@ -29,16 +30,27 @@ export function assembleIncrementalSnapshot<Data extends BrowserIncrementalData>
   }
 }
 
-export function getPathToNestedCSSRule(rule: CSSRule): number[] {
+export function checkStyleSheetAndCallback(styleSheet: CSSStyleSheet | null, callback: (id: number) => void): void {
+  if (styleSheet && hasSerializedNode(styleSheet.ownerNode!)) {
+    callback(getSerializedNodeId(styleSheet.ownerNode))
+  }
+}
+
+export function getPathToNestedCSSRule(rule: CSSRule): number[] | undefined {
   const path: number[] = []
   let currentRule = rule
-  while (currentRule.parentRule instanceof CSSGroupingRule) {
-    const rules = Array.from(currentRule.parentRule.cssRules)
+  while (currentRule.parentRule) {
+    const rules = Array.from((currentRule.parentRule as CSSGroupingRule).cssRules)
     const index = rules.indexOf(currentRule)
     path.unshift(index)
     currentRule = currentRule.parentRule
   }
-  const rules = Array.from(currentRule.parentStyleSheet!.cssRules)
+  // A rule may not be attached to a stylesheet
+  if (!currentRule.parentStyleSheet) {
+    return
+  }
+
+  const rules = Array.from(currentRule.parentStyleSheet.cssRules)
   const index = rules.indexOf(currentRule)
   path.unshift(index)
 

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -694,49 +694,6 @@ describe('recorder', () => {
         expect(styleSheetRules[1].data.adds).toEqual([{ rule: '.added {}', index: [0, 1] }])
         expect(styleSheetRules[2].data.removes).toEqual([{ index: [1, 1] }])
       })
-
-    createTest('ignore changes applied on detached rules')
-      .withRum()
-      .withRumInit(initRumAndStartRecording)
-      .withSetup(bundleSetup)
-      .withBody(
-        html`
-          <style>
-            @media condition-1 {
-              .foo {
-              }
-            }
-            @media condition-2 {
-              .bar {
-              }
-              .baz {
-              }
-            }
-          </style>
-        `
-      )
-      .run(async ({ serverEvents }) => {
-        await browserExecute(() => {
-          const groupingRule = document.styleSheets[0].cssRules[0] as CSSGroupingRule
-          document.styleSheets[0].deleteRule(0)
-
-          groupingRule.deleteRule(0)
-          groupingRule.insertRule('.inserted {}', 0)
-          groupingRule.insertRule('.added {}', 1)
-        })
-
-        await flushEvents()
-
-        expect(serverEvents.sessionReplay.length).toBe(1)
-
-        const segment = getFirstSegment(serverEvents)
-
-        const styleSheetRules = findAllIncrementalSnapshots(segment, IncrementalSource.StyleSheetRule) as Array<{
-          data: StyleSheetRuleData
-        }>
-
-        expect(styleSheetRules.length).toBe(1)
-      })
   })
 
   describe('session renewal', () => {

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -657,11 +657,11 @@ describe('recorder', () => {
       .withBody(
         html`
           <style>
-            @media condition-1 {
+            @supports (display: grid) {
               .foo {
               }
             }
-            @media condition-2 {
+            @media condition {
               .bar {
               }
               .baz {
@@ -672,12 +672,12 @@ describe('recorder', () => {
       )
       .run(async ({ serverEvents }) => {
         await browserExecute(() => {
-          const firstGroupingRule = document.styleSheets[0].cssRules[0] as CSSMediaRule
-          const secondGroupingRule = document.styleSheets[0].cssRules[1] as GroupingCSSRule
+          const supportsRule = document.styleSheets[0].cssRules[0] as GroupingCSSRule
+          const mediaRule = document.styleSheets[0].cssRules[1] as GroupingCSSRule
 
-          firstGroupingRule.insertRule('.inserted {}', 0)
-          firstGroupingRule.insertRule('.added {}', 1)
-          secondGroupingRule.deleteRule(1)
+          supportsRule.insertRule('.inserted {}', 0)
+          supportsRule.insertRule('.added {}', 1)
+          mediaRule.deleteRule(1)
         })
 
         await flushEvents()

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -24,6 +24,7 @@ import {
   findMouseInteractionRecords,
   findElementWithTagName,
 } from '@datadog/browser-rum/test/utils'
+import type { GroupingCSSRule } from '@datadog/browser-rum/src/domain/record/utils'
 import { renewSession } from '../../lib/helpers/session'
 import type { EventRegistry } from '../../lib/framework'
 import { flushEvents, createTest, bundleSetup, html } from '../../lib/framework'
@@ -672,7 +673,7 @@ describe('recorder', () => {
       .run(async ({ serverEvents }) => {
         await browserExecute(() => {
           const firstGroupingRule = document.styleSheets[0].cssRules[0] as CSSMediaRule
-          const secondGroupingRule = document.styleSheets[0].cssRules[1] as CSSGroupingRule
+          const secondGroupingRule = document.styleSheets[0].cssRules[1] as GroupingCSSRule
 
           firstGroupingRule.insertRule('.inserted {}', 0)
           firstGroupingRule.insertRule('.added {}', 1)

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -24,7 +24,6 @@ import {
   findMouseInteractionRecords,
   findElementWithTagName,
 } from '@datadog/browser-rum/test/utils'
-import type { GroupingCSSRule } from '@datadog/browser-rum/src/domain/record/utils'
 import { renewSession } from '../../lib/helpers/session'
 import type { EventRegistry } from '../../lib/framework'
 import { flushEvents, createTest, bundleSetup, html } from '../../lib/framework'
@@ -672,8 +671,8 @@ describe('recorder', () => {
       )
       .run(async ({ serverEvents }) => {
         await browserExecute(() => {
-          const supportsRule = document.styleSheets[0].cssRules[0] as GroupingCSSRule
-          const mediaRule = document.styleSheets[0].cssRules[1] as GroupingCSSRule
+          const supportsRule = document.styleSheets[0].cssRules[0] as CSSGroupingRule
+          const mediaRule = document.styleSheets[0].cssRules[1] as CSSGroupingRule
 
           supportsRule.insertRule('.inserted {}', 0)
           supportsRule.insertRule('.added {}', 1)


### PR DESCRIPTION
## Motivation

Some customers use CSS-in-JS libraries to style their applications. One of those libraries [(Stitches)](https://stitches.dev/) insert CSS rules inside CSSMedialRule `@media`, which is not tracked nowadays. The replay of those sessions seems to be broken and non-styled. 

## Changes

Not all browsers support `CSSGroupingRule` (see [CSSGroupingRule](https://caniuse.com/?search=cssgroupingrule), [CSSConditionRule](https://caniuse.com/?search=cssconditionrule), [CSSMediaRule](https://caniuse.com/?search=cssmediarule) & [CSSSupportsRule](https://caniuse.com/?search=csssupportsrule)

- New observers are added to watch over `insertRule` and `deleteRule` of `CSSGroupingRule` prototype if supported by the browser. If not supported, we fall back to `CSSMediaRule` (which is supported by all browsers) and `CSSSupportsRule` (which is not supported only by early version of browsers) and report the rule that was inserted or deleted, and how to access it from the parent `CSSStyleSheet`.
- If we assume that the `sdk` is run on a browser that support `CSSMediaRule` and doesn't support `CSSSupportsRule`, this later will be ignored.

## Testing

- [ ] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
