### PR TITLE
⚗️[RUMF-1351] experiment request retry strategy

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -2,7 +2,7 @@ import type { CookieOptions } from '../../browser/cookie'
 import { getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { display } from '../../tools/display'
-import { assign, isPercentage, ONE_KILO_BYTE, ONE_SECOND } from '../../tools/utils'
+import { assign, isPercentage, ONE_KIBI_BYTE, ONE_SECOND } from '../../tools/utils'
 import { updateExperimentalFeatures } from './experimentalFeatures'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
@@ -104,7 +104,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
        * beacon payload max queue size implementation is 64kb
        * ensure that we leave room for logs, rum and potential other users
        */
-      batchBytesLimit: 16 * ONE_KILO_BYTE,
+      batchBytesLimit: 16 * ONE_KIBI_BYTE,
 
       eventRateLimiterThreshold: 3000,
       maxTelemetryEventsPerPage: 15,
@@ -119,7 +119,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
        * Logs intake limit
        */
       batchMessagesLimit: 50,
-      messageBytesLimit: 256 * ONE_KILO_BYTE,
+      messageBytesLimit: 256 * ONE_KIBI_BYTE,
     },
     computeTransportConfiguration(initConfiguration)
   )

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -6,6 +6,7 @@ export const ONE_HOUR = 60 * ONE_MINUTE
 export const ONE_DAY = 24 * ONE_HOUR
 export const ONE_YEAR = 365 * ONE_DAY
 export const ONE_KILO_BYTE = 1024
+export const ONE_MEGA_BYTE = 1024 * ONE_KILO_BYTE
 
 export const enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -5,8 +5,8 @@ export const ONE_MINUTE = 60 * ONE_SECOND
 export const ONE_HOUR = 60 * ONE_MINUTE
 export const ONE_DAY = 24 * ONE_HOUR
 export const ONE_YEAR = 365 * ONE_DAY
-export const ONE_KILO_BYTE = 1024
-export const ONE_MEGA_BYTE = 1024 * ONE_KILO_BYTE
+export const ONE_KIBI_BYTE = 1024
+export const ONE_MEBI_BYTE = 1024 * ONE_KIBI_BYTE
 
 export const enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -44,7 +44,7 @@ export class Batch {
       this.bufferBytesCount = 0
       this.bufferMessagesCount = 0
 
-      sendFn(messages.join('\n'), bytesCount)
+      sendFn({ data: messages.join('\n'), bytesCount })
     }
   }
 

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -29,7 +29,7 @@ describe('httpRequest', () => {
     it('should use xhr when fetch keepalive is not available', () => {
       interceptor.withRequest(false)
 
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -42,14 +42,14 @@ describe('httpRequest', () => {
         pending('no fetch keepalive support')
       }
 
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('fetch')
     })
 
     it('should use xhr over fetch keepalive when the bytes count is too high', () => {
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
+      request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: BATCH_BYTES_LIMIT })
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -65,7 +65,7 @@ describe('httpRequest', () => {
         return notQueuedFetch
       })
 
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
       notQueuedFetch!.catch(() => {
         expect(requests.length).toEqual(1)
@@ -79,7 +79,7 @@ describe('httpRequest', () => {
     it('should use xhr when sendBeacon is not defined', () => {
       interceptor.withSendBeacon(false)
 
-      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -92,14 +92,14 @@ describe('httpRequest', () => {
         pending('no sendBeacon support')
       }
 
-      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('sendBeacon')
     })
 
     it('should use xhr over sendBeacon when the bytes count is too high', () => {
-      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
+      request.sendOnExit({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: BATCH_BYTES_LIMIT })
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -111,7 +111,7 @@ describe('httpRequest', () => {
       }
       interceptor.withSendBeacon(() => false)
 
-      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
       expect(requests.length).toEqual(1)
       expect(requests[0].type).toBe('xhr')
@@ -127,7 +127,7 @@ describe('httpRequest', () => {
         throw new TypeError()
       })
 
-      request.sendOnExit('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+      request.sendOnExit({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
       expect(sendBeaconCalled).toBe(true)
       expect(requests.length).toEqual(1)
@@ -156,8 +156,8 @@ describe('httpRequest intake parameters', () => {
   })
 
   it('should have a unique request id', () => {
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-    request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
+    request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
+    request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
     const search = /dd-request-id=([^&]*)/
     const requestId1 = search.exec(requests[0].url)?.[1]

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -1,0 +1,212 @@
+import { mockClock } from '../../test/specHelper'
+import type { Clock } from '../../test/specHelper'
+import { ONE_SECOND } from '../tools/utils'
+import type { RetryState } from './sendWithRetryStrategy'
+import {
+  newRetryState,
+  sendWithRetryStrategy,
+  MAX_ONGOING_BYTES_COUNT,
+  MAX_ONGOING_REQUESTS,
+  MAX_QUEUE_BYTES_COUNT,
+} from './sendWithRetryStrategy'
+import type { Payload, HttpResponse } from './httpRequest'
+
+describe('sendWithRetryStrategy', () => {
+  let sendStub: ReturnType<typeof newSendStub>
+  let state: RetryState
+  let sendRequest: (payload?: Partial<Payload>) => void
+  let clock: Clock
+
+  function newSendStub() {
+    const requests: Array<(r: HttpResponse) => void> = []
+    return {
+      sendStrategy: (_: Payload, onResponse: (r: HttpResponse) => void) => {
+        requests.push(onResponse)
+      },
+      respondWith: (index: number, r: HttpResponse) => {
+        requests[index](r)
+        requests[index] = () => {
+          throw new Error('response already handled')
+        }
+      },
+    }
+  }
+
+  beforeEach(() => {
+    sendStub = newSendStub()
+    state = newRetryState()
+    clock = mockClock()
+    sendRequest = (payload) => {
+      const effectivePayload = {
+        data: payload?.data ?? 'a',
+        bytesCount: payload?.bytesCount ?? 1,
+      }
+      sendWithRetryStrategy(effectivePayload, state, sendStub.sendStrategy)
+    }
+  })
+
+  afterEach(() => {
+    clock.cleanup()
+  })
+
+  describe('nominal cases:', () => {
+    it('should send request when no bandwidth limit reached', () => {
+      sendRequest()
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(0)
+
+      sendStub.respondWith(0, { status: 200 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(0)
+      expect(state.queuedPayloads.size()).toBe(0)
+    })
+
+    it('should allow to send request payload greater than bandwidth limit', () => {
+      sendRequest({ bytesCount: MAX_ONGOING_BYTES_COUNT + 10 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(0)
+    })
+
+    it('should send concurrent requests ', () => {
+      sendRequest()
+      sendRequest()
+      sendRequest()
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(3)
+      expect(state.queuedPayloads.size()).toBe(0)
+
+      sendStub.respondWith(0, { status: 200 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(2)
+
+      sendStub.respondWith(1, { status: 200 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+
+      sendStub.respondWith(2, { status: 200 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(0)
+    })
+  })
+
+  describe('bandwidth limitation:', () => {
+    it('should queue request when its payload would overflow bytes limit', () => {
+      sendRequest({ bytesCount: MAX_ONGOING_BYTES_COUNT - 10 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(0)
+
+      sendRequest({ bytesCount: 11 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(1)
+    })
+
+    it('should queue request when too much ongoing requests', () => {
+      for (let i = 1; i <= MAX_ONGOING_REQUESTS; i++) {
+        sendRequest()
+      }
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(MAX_ONGOING_REQUESTS)
+      expect(state.queuedPayloads.size()).toBe(0)
+
+      sendRequest()
+      expect(state.queuedPayloads.size()).toBe(1)
+    })
+
+    it('should not queue payload bigger than queue limit', () => {
+      sendRequest()
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(0)
+
+      sendRequest({ bytesCount: MAX_QUEUE_BYTES_COUNT + 1 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(0)
+    })
+  })
+
+  describe('dequeue:', () => {
+    it('should send as much queued request as possible after a successful request', () => {
+      sendRequest({ bytesCount: MAX_ONGOING_BYTES_COUNT })
+      for (let i = 1; i <= MAX_ONGOING_REQUESTS; i++) {
+        sendRequest()
+      }
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(MAX_ONGOING_REQUESTS)
+
+      sendStub.respondWith(0, { status: 200 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(MAX_ONGOING_REQUESTS)
+      expect(state.queuedPayloads.size()).toBe(0)
+    })
+
+    it('should remove the oldest payloads when a new payload would overflow queue bytes limit', () => {
+      sendRequest({ bytesCount: MAX_ONGOING_BYTES_COUNT })
+      sendRequest({ bytesCount: MAX_QUEUE_BYTES_COUNT - 10 })
+      sendRequest({ bytesCount: 10 })
+      expect(state.queuedPayloads.size()).toBe(2)
+      expect(state.queuedPayloads.bytesCount).toBe(MAX_QUEUE_BYTES_COUNT)
+
+      sendRequest({ bytesCount: 1 })
+      expect(state.queuedPayloads.size()).toBe(2)
+      expect(state.queuedPayloads.bytesCount).toBe(11)
+    })
+  })
+
+  describe('when a request fails:', () => {
+    it('should start queueing following requests', () => {
+      sendRequest()
+      sendStub.respondWith(0, { status: 500 })
+      expect(state.queuedPayloads.size()).toBe(1)
+
+      sendRequest()
+      expect(state.queuedPayloads.size()).toBe(2)
+      sendRequest()
+      expect(state.queuedPayloads.size()).toBe(3)
+    })
+
+    it('should send queued requests if another ongoing request succeed', () => {
+      sendRequest()
+      sendRequest()
+      sendStub.respondWith(0, { status: 500 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(1)
+
+      sendRequest()
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      expect(state.queuedPayloads.size()).toBe(2)
+
+      sendStub.respondWith(1, { status: 200 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(2)
+      expect(state.queuedPayloads.size()).toBe(0)
+    })
+  })
+
+  describe('when intake offline:', () => {
+    it('should regularly try to send first queued request', () => {
+      sendRequest()
+      sendStub.respondWith(0, { status: 500 })
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(0)
+
+      clock.tick(ONE_SECOND)
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      sendStub.respondWith(1, { status: 500 })
+
+      clock.tick(2 * ONE_SECOND)
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      sendStub.respondWith(2, { status: 500 })
+
+      clock.tick(4 * ONE_SECOND)
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      sendStub.respondWith(3, { status: 500 })
+    })
+
+    it('should send queued requests after first successful request', () => {
+      sendRequest()
+      sendStub.respondWith(0, { status: 500 })
+      sendRequest()
+      sendRequest()
+      sendRequest()
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(0)
+      expect(state.queuedPayloads.size()).toBe(4)
+
+      clock.tick(ONE_SECOND)
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+      sendStub.respondWith(1, { status: 200 })
+
+      expect(state.bandwidthMonitor.ongoingRequestCount).toBe(3)
+      expect(state.queuedPayloads.size()).toBe(0)
+    })
+  })
+})

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -1,6 +1,5 @@
 import { mockClock } from '../../test/specHelper'
 import type { Clock } from '../../test/specHelper'
-import { ONE_SECOND } from '../tools/utils'
 import type { RetryState } from './sendWithRetryStrategy'
 import {
   newRetryState,
@@ -8,6 +7,7 @@ import {
   MAX_ONGOING_BYTES_COUNT,
   MAX_ONGOING_REQUESTS,
   MAX_QUEUE_BYTES_COUNT,
+  INITIAL_BACKOFF_TIME,
 } from './sendWithRetryStrategy'
 import type { Payload, HttpResponse } from './httpRequest'
 
@@ -179,15 +179,15 @@ describe('sendWithRetryStrategy', () => {
       sendStub.respondWith(0, { status: 500 })
       expect(state.bandwidthMonitor.ongoingRequestCount).toBe(0)
 
-      clock.tick(ONE_SECOND)
+      clock.tick(INITIAL_BACKOFF_TIME)
       expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
       sendStub.respondWith(1, { status: 500 })
 
-      clock.tick(2 * ONE_SECOND)
+      clock.tick(2 * INITIAL_BACKOFF_TIME)
       expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
       sendStub.respondWith(2, { status: 500 })
 
-      clock.tick(4 * ONE_SECOND)
+      clock.tick(4 * INITIAL_BACKOFF_TIME)
       expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
       sendStub.respondWith(3, { status: 500 })
     })
@@ -201,7 +201,7 @@ describe('sendWithRetryStrategy', () => {
       expect(state.bandwidthMonitor.ongoingRequestCount).toBe(0)
       expect(state.queuedPayloads.size()).toBe(4)
 
-      clock.tick(ONE_SECOND)
+      clock.tick(INITIAL_BACKOFF_TIME)
       expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
       sendStub.respondWith(1, { status: 200 })
 

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -199,7 +199,6 @@ describe('sendWithRetryStrategy', () => {
 
       clock.tick(4 * INITIAL_BACKOFF_TIME)
       expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
-      sendStub.respondWith(3, { status: 500 })
     })
 
     it('should send queued requests after first successful request', () => {

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -9,7 +9,7 @@ export const MAX_QUEUE_BYTES_COUNT = 3 * ONE_MEBI_BYTE
 export const MAX_BACKOFF_TIME = 256 * ONE_SECOND
 export const INITIAL_BACKOFF_TIME = ONE_SECOND
 
-enum TransportStatus {
+const enum TransportStatus {
   UP,
   FAILURE_DETECTED,
   DOWN,

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -98,6 +98,9 @@ function send(
 
 function retryQueuedPayloads(state: RetryState, sendStrategy: SendStrategy) {
   const previousQueue = state.queuedPayloads
+  if (previousQueue.isFull()) {
+    addTelemetryDebug('retry queue full')
+  }
   state.queuedPayloads = newPayloadQueue()
   while (previousQueue.size() > 0) {
     sendWithRetryStrategy(previousQueue.dequeue()!, state, sendStrategy)
@@ -123,7 +126,7 @@ function newPayloadQueue() {
   return {
     bytesCount: 0,
     enqueue(payload: Payload) {
-      if (this.bytesCount >= MAX_QUEUE_BYTES_COUNT) {
+      if (this.isFull()) {
         return
       }
       queue.push(payload)
@@ -141,6 +144,9 @@ function newPayloadQueue() {
     },
     size() {
       return queue.length
+    },
+    isFull() {
+      return this.bytesCount >= MAX_QUEUE_BYTES_COUNT
     },
   }
 }

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -1,11 +1,11 @@
 import { addTelemetryDebug } from '../domain/telemetry'
 import { monitor } from '../tools/monitor'
-import { ONE_KILO_BYTE, ONE_MEGA_BYTE, ONE_SECOND } from '../tools/utils'
+import { ONE_KIBI_BYTE, ONE_MEBI_BYTE, ONE_SECOND } from '../tools/utils'
 import type { Payload, HttpResponse } from './httpRequest'
 
-export const MAX_ONGOING_BYTES_COUNT = 80 * ONE_KILO_BYTE
+export const MAX_ONGOING_BYTES_COUNT = 80 * ONE_KIBI_BYTE
 export const MAX_ONGOING_REQUESTS = 32
-export const MAX_QUEUE_BYTES_COUNT = 3 * ONE_MEGA_BYTE
+export const MAX_QUEUE_BYTES_COUNT = 3 * ONE_MEBI_BYTE
 export const MAX_BACKOFF_TIME = 256 * ONE_SECOND
 export const INITIAL_BACKOFF_TIME = ONE_SECOND
 

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -7,6 +7,7 @@ export const MAX_ONGOING_BYTES_COUNT = 80 * ONE_KILO_BYTE
 export const MAX_ONGOING_REQUESTS = 32
 export const MAX_QUEUE_BYTES_COUNT = 3 * ONE_MEGA_BYTE
 export const MAX_BACKOFF_TIME = 256 * ONE_SECOND
+export const INITIAL_BACKOFF_TIME = ONE_SECOND
 
 export interface RetryState {
   isIntakeAvailable: boolean
@@ -48,7 +49,7 @@ function scheduleRetry(state: RetryState, sendStrategy: SendStrategy) {
             queuedPayloadCount: state.queuedPayloads.size(),
             queuedPayloadBytesCount: state.queuedPayloads.bytesCount,
           })
-          state.currentBackoffTime = ONE_SECOND
+          state.currentBackoffTime = INITIAL_BACKOFF_TIME
           sendNextPayload(state, sendStrategy)
         },
         onFailure: () => {
@@ -94,7 +95,7 @@ function wasRequestSuccessful(response: HttpResponse) {
 export function newRetryState(): RetryState {
   return {
     isIntakeAvailable: true,
-    currentBackoffTime: ONE_SECOND,
+    currentBackoffTime: INITIAL_BACKOFF_TIME,
     bandwidthMonitor: newBandwidthMonitor(),
     queuedPayloads: newPayloadQueue(),
   }

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -97,11 +97,11 @@ function send(
 }
 
 function retryQueuedPayloads(state: RetryState, sendStrategy: SendStrategy) {
-  const pendingPayloads = []
-  while (state.queuedPayloads.size() > 0) {
-    pendingPayloads.push(state.queuedPayloads.dequeue()!)
+  const previousQueue = state.queuedPayloads
+  state.queuedPayloads = newPayloadQueue()
+  while (previousQueue.size() > 0) {
+    sendWithRetryStrategy(previousQueue.dequeue()!, state, sendStrategy)
   }
-  pendingPayloads.map((payload) => sendWithRetryStrategy(payload, state, sendStrategy))
 }
 
 function wasRequestSuccessful(response: HttpResponse) {

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -1,0 +1,147 @@
+import { monitor } from '../tools/monitor'
+import { ONE_KILO_BYTE, ONE_MEGA_BYTE, ONE_SECOND } from '../tools/utils'
+import type { Payload, HttpResponse } from './httpRequest'
+
+export const MAX_ONGOING_BYTES_COUNT = 80 * ONE_KILO_BYTE
+export const MAX_ONGOING_REQUESTS = 32
+export const MAX_QUEUE_BYTES_COUNT = 3 * ONE_MEGA_BYTE
+export const MAX_BACKOFF_TIME = 256 * ONE_SECOND
+
+export interface RetryState {
+  isIntakeAvailable: boolean
+  currentBackoffTime: number
+  bandwidthMonitor: ReturnType<typeof newBandwidthMonitor>
+  queuedPayloads: ReturnType<typeof newPayloadQueue>
+}
+
+type SendStrategy = (payload: Payload, onResponse: (r: HttpResponse) => void) => void
+
+export function sendWithRetryStrategy(payload: Payload, state: RetryState, sendStrategy: SendStrategy) {
+  if (state.isIntakeAvailable && state.bandwidthMonitor.canHandle(payload)) {
+    send(payload, state, sendStrategy, {
+      onSuccess: () => sendNextPayload(state, sendStrategy),
+      onFailure: () => {
+        state.queuedPayloads.enqueue(payload)
+        scheduleRetry(state, sendStrategy)
+      },
+    })
+    sendNextPayload(state, sendStrategy)
+  } else {
+    state.queuedPayloads.enqueue(payload)
+  }
+}
+
+function scheduleRetry(state: RetryState, sendStrategy: SendStrategy) {
+  if (state.bandwidthMonitor.ongoingRequestCount !== 0) {
+    // avoid to enter a retry phase if another ongoing request can succeed
+    return
+  }
+  setTimeout(
+    monitor(() => {
+      const payload = state.queuedPayloads.first()
+      send(payload, state, sendStrategy, {
+        onSuccess: () => {
+          state.queuedPayloads.dequeue()
+          state.currentBackoffTime = ONE_SECOND
+          sendNextPayload(state, sendStrategy)
+        },
+        onFailure: () => {
+          state.currentBackoffTime = Math.min(MAX_BACKOFF_TIME, state.currentBackoffTime * 2)
+          scheduleRetry(state, sendStrategy)
+        },
+      })
+    }),
+    state.currentBackoffTime
+  )
+}
+
+function sendNextPayload(state: RetryState, sendStrategy: SendStrategy) {
+  const nextPayload = state.queuedPayloads.dequeue()
+  if (nextPayload) {
+    sendWithRetryStrategy(nextPayload, state, sendStrategy)
+  }
+}
+
+function send(
+  payload: Payload,
+  state: RetryState,
+  sendStrategy: SendStrategy,
+  { onSuccess, onFailure }: { onSuccess: () => void; onFailure: () => void }
+) {
+  state.bandwidthMonitor.add(payload)
+  sendStrategy(payload, (response) => {
+    state.bandwidthMonitor.remove(payload)
+    if (wasRequestSuccessful(response)) {
+      state.isIntakeAvailable = true
+      onSuccess()
+    } else {
+      state.isIntakeAvailable = false
+      onFailure()
+    }
+  })
+}
+
+function wasRequestSuccessful(response: HttpResponse) {
+  return response.status < 500
+}
+
+export function newRetryState(): RetryState {
+  return {
+    isIntakeAvailable: true,
+    currentBackoffTime: ONE_SECOND,
+    bandwidthMonitor: newBandwidthMonitor(),
+    queuedPayloads: newPayloadQueue(),
+  }
+}
+
+function newPayloadQueue() {
+  const queue: Payload[] = []
+  return {
+    bytesCount: 0,
+    enqueue(payload: Payload) {
+      if (payload.bytesCount > MAX_QUEUE_BYTES_COUNT) {
+        return
+      }
+      while (payload.bytesCount + this.bytesCount > MAX_QUEUE_BYTES_COUNT) {
+        this.dequeue()
+      }
+      queue.push(payload)
+      this.bytesCount += payload.bytesCount
+    },
+    first() {
+      return queue[0]
+    },
+    dequeue() {
+      const payload = queue.shift()
+      if (payload) {
+        this.bytesCount -= payload.bytesCount
+      }
+      return payload
+    },
+    size() {
+      return queue.length
+    },
+  }
+}
+
+function newBandwidthMonitor() {
+  return {
+    ongoingRequestCount: 0,
+    ongoingByteCount: 0,
+    canHandle(payload: Payload) {
+      return (
+        this.ongoingRequestCount === 0 ||
+        (this.ongoingByteCount + payload.bytesCount <= MAX_ONGOING_BYTES_COUNT &&
+          this.ongoingRequestCount < MAX_ONGOING_REQUESTS)
+      )
+    },
+    add(payload: Payload) {
+      this.ongoingRequestCount += 1
+      this.ongoingByteCount += payload.bytesCount
+    },
+    remove(payload: Payload) {
+      this.ongoingRequestCount -= 1
+      this.ongoingByteCount -= payload.bytesCount
+    },
+  }
+}

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -1,3 +1,4 @@
+import { addTelemetryDebug } from '../domain/telemetry'
 import { monitor } from '../tools/monitor'
 import { ONE_KILO_BYTE, ONE_MEGA_BYTE, ONE_SECOND } from '../tools/utils'
 import type { Payload, HttpResponse } from './httpRequest'
@@ -42,6 +43,11 @@ function scheduleRetry(state: RetryState, sendStrategy: SendStrategy) {
       send(payload, state, sendStrategy, {
         onSuccess: () => {
           state.queuedPayloads.dequeue()
+          addTelemetryDebug('resuming after intake failure', {
+            currentBackoffTime: state.currentBackoffTime,
+            queuedPayloadCount: state.queuedPayloads.size(),
+            queuedPayloadBytesCount: state.queuedPayloads.bytesCount,
+          })
           state.currentBackoffTime = ONE_SECOND
           sendNextPayload(state, sendStrategy)
         },

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -1,7 +1,7 @@
 import type { Configuration, InitConfiguration } from '@datadog/browser-core'
 import {
   assign,
-  ONE_KILO_BYTE,
+  ONE_KIBI_BYTE,
   validateAndBuildConfiguration,
   display,
   removeDuplicates,
@@ -31,7 +31,7 @@ export interface LogsConfiguration extends Configuration {
 /**
  * arbitrary value, byte precision not needed
  */
-export const DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT = 32 * ONE_KILO_BYTE
+export const DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT = 32 * ONE_KIBI_BYTE
 
 export function validateAndBuildLogsConfiguration(
   initConfiguration: LogsInitConfiguration

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -82,7 +82,7 @@ describe('startRecording', () => {
     flushSegment(lifeCycle)
 
     waitRequestSendCalls(1, (calls) => {
-      expect(calls.first().args).toEqual([jasmine.any(FormData), jasmine.any(Number)])
+      expect(calls.first().args[0]).toEqual({ data: jasmine.any(FormData), bytesCount: jasmine.any(Number) })
       expect(getRequestData(calls.first())).toEqual({
         'application.id': 'appId',
         creation_reason: 'init',
@@ -309,9 +309,9 @@ function readRequestSegment(
 }
 
 function getRequestFormData(call: jasmine.CallInfo<HttpRequest['sendOnExit']>) {
-  const data = call.args[0]
-  expect(data).toEqual(jasmine.any(FormData))
-  return data as FormData
+  const payload = call.args[0]
+  expect(payload.data).toEqual(jasmine.any(FormData))
+  return payload.data as FormData
 }
 
 function createRandomString(minLength: number) {

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -21,7 +21,7 @@ export function send(
   toFormEntries(metadata, (key, value) => formData.append(key, value))
   formData.append('raw_segment_size', rawSegmentBytesCount.toString())
 
-  httpRequest.sendOnExit(formData, data.byteLength)
+  httpRequest.sendOnExit({ data: formData, bytesCount: data.byteLength })
 }
 
 export function toFormEntries(input: object, onEntry: (key: string, value: string) => void, prefix = '') {


### PR DESCRIPTION
## Motivation

We want to improve our data transfer to:

- limit our impact on end user bandwidth
- not loose data in case of short intake unavailability

## Changes

Introduce new request strategy allowing us to:
- limit the number of concurrent requests to the intake -> max 32 by product
- limit the total ongoing bytes of requests to the intake -> max 80kb by product
- retry requests if the intake is momentarily unavailable -> exponential backoff strategy 1s to 256s
- limit the size of queued requests due to throttling or failure -> max 3Mb by product

Behind `retry` flag, use this new strategy for logs/rum for non exit requests.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
