### PR TITLE
✨ [RUMF-1333] Send request with fetch keepalive + fallback

### DIFF
--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -2,7 +2,7 @@
 import { stubEndpointBuilder, interceptRequests } from '../../test/specHelper'
 import type { Request } from '../../test/specHelper'
 import type { EndpointBuilder } from '../domain/configuration'
-import { createEndpointBuilder, updateExperimentalFeatures, resetExperimentalFeatures } from '../domain/configuration'
+import { createEndpointBuilder } from '../domain/configuration'
 import { createHttpRequest } from './httpRequest'
 import type { HttpRequest } from './httpRequest'
 
@@ -25,74 +25,7 @@ describe('httpRequest', () => {
     interceptor.restore()
   })
 
-  describe('send (without fetch_keepalive FF)', () => {
-    it('should use xhr when sendBeacon is not defined', () => {
-      interceptor.withSendBeacon(false)
-
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-      expect(requests.length).toEqual(1)
-      expect(requests[0].type).toBe('xhr')
-      expect(requests[0].url).toContain(ENDPOINT_URL)
-      expect(requests[0].body).toEqual('{"foo":"bar1"}\n{"foo":"bar2"}')
-    })
-
-    it('should use sendBeacon when the bytes count is correct', () => {
-      if (!interceptor.isSendBeaconSupported()) {
-        pending('no sendBeacon support')
-      }
-
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-      expect(requests.length).toEqual(1)
-      expect(requests[0].type).toBe('sendBeacon')
-    })
-
-    it('should use xhr over sendBeacon when the bytes count is too high', () => {
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', BATCH_BYTES_LIMIT)
-
-      expect(requests.length).toEqual(1)
-      expect(requests[0].type).toBe('xhr')
-    })
-
-    it('should fallback to xhr when sendBeacon is not queued', () => {
-      if (!interceptor.isSendBeaconSupported()) {
-        pending('no sendBeacon support')
-      }
-      interceptor.withSendBeacon(() => false)
-
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-
-      expect(requests.length).toEqual(1)
-      expect(requests[0].type).toBe('xhr')
-    })
-
-    it('should fallback to xhr when sendBeacon throws', () => {
-      if (!interceptor.isSendBeaconSupported()) {
-        pending('no sendBeacon support')
-      }
-      let sendBeaconCalled = false
-      interceptor.withSendBeacon(() => {
-        sendBeaconCalled = true
-        throw new TypeError()
-      })
-
-      request.send('{"foo":"bar1"}\n{"foo":"bar2"}', 10)
-      expect(sendBeaconCalled).toBe(true)
-      expect(requests.length).toEqual(1)
-      expect(requests[0].type).toBe('xhr')
-    })
-  })
-
-  describe('send (with fetch_keepalive FF)', () => {
-    beforeEach(() => {
-      updateExperimentalFeatures(['fetch_keepalive'])
-    })
-
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
+  describe('send', () => {
     it('should use xhr when fetch keepalive is not available', () => {
       interceptor.withRequest(false)
 

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -1,5 +1,4 @@
 import type { EndpointBuilder } from '../domain/configuration'
-import { isExperimentalFeatureEnabled } from '../domain/configuration'
 import { addTelemetryError } from '../domain/telemetry'
 import { monitor } from '../tools/monitor'
 
@@ -56,11 +55,7 @@ export function createHttpRequest(endpointBuilder: EndpointBuilder, bytesLimit: 
 
   return {
     send: (data: string | FormData, bytesCount: number) => {
-      if (!isExperimentalFeatureEnabled('fetch_keepalive')) {
-        sendBeaconStrategy(data, bytesCount)
-      } else {
-        fetchKeepAliveStrategy(data, bytesCount)
-      }
+      fetchKeepAliveStrategy(data, bytesCount)
     },
     /**
      * Since fetch keepalive behaves like regular fetch on Firefox,

--- a/packages/rum/src/transport/send.ts
+++ b/packages/rum/src/transport/send.ts
@@ -21,7 +21,7 @@ export function send(
   toFormEntries(metadata, (key, value) => formData.append(key, value))
   formData.append('raw_segment_size', rawSegmentBytesCount.toString())
 
-  httpRequest.send(formData, data.byteLength)
+  httpRequest.sendOnExit(formData, data.byteLength)
 }
 
 export function toFormEntries(input: object, onEntry: (key: string, value: string) => void, prefix = '') {


### PR DESCRIPTION
## Motivation

In order to improve our data transfer, send request with fetch keepalive and fallback in order to later be able to access to intake response.
Follow up of #1682 

## Changes

Remove `fetch-keepalive` flag

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
