### PR TITLE
👷 e2e tests: report only failed specs

### DIFF
--- a/test/e2e/wdio.base.conf.js
+++ b/test/e2e/wdio.base.conf.js
@@ -2,7 +2,7 @@ const path = require('path')
 const { unlinkSync, mkdirSync } = require('fs')
 const getTestReportDirectory = require('../getTestReportDirectory')
 
-const reporters = ['spec']
+const reporters = [['spec', { onlyFailures: true }]]
 let logsPath
 
 const testReportDirectory = getTestReportDirectory()


### PR DESCRIPTION
## Motivation

e2e browserstack logs are a bit hard to navigate to pin point which tests failed 

## Changes

Configure wdio spec reporter to only print failed spec results

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
