### PR TITLE
👷 e2e: improve logging capabilities

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,6 +169,7 @@ e2e:
     - .test-allowed-branches
   artifacts:
     when: always
+    paths: ['test-report/e2e/specs.log']
     reports:
       junit: test-report/e2e/*.xml
   script:
@@ -208,6 +209,7 @@ e2e-bs:
   resource_group: browserstack
   artifacts:
     when: always
+    paths: ['test-report/e2e-bs/specs.log']
     reports:
       junit: test-report/e2e-bs/*.xml
   script:

--- a/test/e2e/lib/framework/httpServers.ts
+++ b/test/e2e/lib/framework/httpServers.ts
@@ -58,9 +58,13 @@ async function createServer<App extends ServerApp>(): Promise<Server<App>> {
   })
 
   server.on('request', (req: http.IncomingMessage, res: http.ServerResponse) => {
+    let body = ''
+    req.on('data', (chunk) => {
+      body += chunk
+    })
     res.on('close', () => {
       const requestUrl = `${req.headers.host!}${req.url!}`
-      log(`${req.method!} ${requestUrl} ${res.statusCode}`)
+      log(`${req.method!} ${requestUrl} ${res.statusCode}${body ? `\n${body}` : ''}`)
     })
   })
 


### PR DESCRIPTION
## Motivation

During e2e tests, requests to local intakes are logged. Having those logs for gitlab jobs could be heplfull to debug flaky tests.

## Changes

- save `specs.logs` as gitlab artifact
- log intake request payload

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
