### PR TITLE
👷 fix ESLint rule on non-const enum

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,13 +57,6 @@ module.exports = {
     'no-extra-bind': 'error',
     'no-new-func': 'error',
     'no-new-wrappers': 'error',
-    'no-restricted-syntax': [
-      'error',
-      {
-        selector: 'TSEnumDeclaration:not([const=true])',
-        message: 'When possible, use `const enum` as it produces less code when transpiled.',
-      },
-    ],
     'no-return-await': 'error',
     'no-sequences': 'error',
     'no-template-curly-in-string': 'error',
@@ -235,6 +228,10 @@ module.exports = {
           {
             selector: 'MemberExpression[object.name="Date"][property.name="now"]',
             message: '`Date.now()` is not authorized. Please use `dateNow()` instead',
+          },
+          {
+            selector: 'TSEnumDeclaration:not([const=true])',
+            message: 'When possible, use `const enum` as it produces less code when transpiled.',
           },
         ],
       },


### PR DESCRIPTION


## Motivation

The `no-restricted-syntax` related to enums introduced in #1364 is overridden by other restricted syntaxes on transpiled files introduced by #1347, so it's not actually applied to source files.

## Changes

Because the enum limitation is also about transpilation optimization, simply move it to the special casing.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
