### PR TITLE
🐛 [RUMF-1333] fix keepalive support check

### DIFF
--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -34,7 +34,7 @@ export function createHttpRequest(endpointBuilder: EndpointBuilder, bytesLimit: 
 
   function fetchKeepAliveStrategy(data: string | FormData, bytesCount: number) {
     const url = endpointBuilder.build()
-    const canUseKeepAlive = window.Request && 'keepalive' in new Request('') && bytesCount < bytesLimit
+    const canUseKeepAlive = isKeepAliveSupported(url) && bytesCount < bytesLimit
     if (canUseKeepAlive) {
       fetch(url, { method: 'POST', body: data, keepalive: true }).catch(
         monitor(() => {
@@ -44,6 +44,18 @@ export function createHttpRequest(endpointBuilder: EndpointBuilder, bytesLimit: 
       )
     } else {
       sendXHR(url, data)
+    }
+  }
+
+  /**
+   * Request can throw
+   * cf https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#errors
+   */
+  function isKeepAliveSupported(url: string) {
+    try {
+      return window.Request && 'keepalive' in new Request(url)
+    } catch {
+      return false
     }
   }
 

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -34,7 +34,7 @@ export function createHttpRequest(endpointBuilder: EndpointBuilder, bytesLimit: 
 
   function fetchKeepAliveStrategy(data: string | FormData, bytesCount: number) {
     const url = endpointBuilder.build()
-    const canUseKeepAlive = isKeepAliveSupported(url) && bytesCount < bytesLimit
+    const canUseKeepAlive = isKeepAliveSupported() && bytesCount < bytesLimit
     if (canUseKeepAlive) {
       fetch(url, { method: 'POST', body: data, keepalive: true }).catch(
         monitor(() => {
@@ -47,13 +47,10 @@ export function createHttpRequest(endpointBuilder: EndpointBuilder, bytesLimit: 
     }
   }
 
-  /**
-   * Request can throw
-   * cf https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#errors
-   */
-  function isKeepAliveSupported(url: string) {
+  function isKeepAliveSupported() {
+    // Request can throw, cf https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#errors
     try {
-      return window.Request && 'keepalive' in new Request(url)
+      return window.Request && 'keepalive' in new Request('http://a')
     } catch {
       return false
     }


### PR DESCRIPTION
## Motivation

Request can throw if the URL contains credentials

## Changes

- use endpoint url instead of current url
- wrap Request check in try/catch

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
