### PR TITLE
✨ [RUMF-1371] Collect view time to first byte

### DIFF
--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -181,6 +181,7 @@ describe('rum session keep alive', () => {
 
 describe('rum events url', () => {
   const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
+    responseStart: 123 as RelativeTime,
     domComplete: 456 as RelativeTime,
     domContentLoadedEventEnd: 345 as RelativeTime,
     domInteractive: 234 as RelativeTime,

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -59,6 +59,7 @@ export interface RumPerformanceNavigationTiming {
   domContentLoadedEventEnd: RelativeTime
   domInteractive: RelativeTime
   loadEventEnd: RelativeTime
+  responseStart: RelativeTime
 }
 
 export interface RumLargestContentfulPaintTiming {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
@@ -28,6 +28,7 @@ const FAKE_PAINT_ENTRY: RumPerformancePaintTiming = {
 }
 
 const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
+  responseStart: 123 as RelativeTime,
   domComplete: 456 as RelativeTime,
   domContentLoadedEventEnd: 345 as RelativeTime,
   domInteractive: 234 as RelativeTime,
@@ -71,6 +72,7 @@ describe('trackTimings', () => {
 
     expect(timingsCallback).toHaveBeenCalledTimes(3)
     expect(timingsCallback.calls.mostRecent().args[0]).toEqual({
+      firstByte: 123 as Duration,
       domComplete: 456 as Duration,
       domContentLoaded: 345 as Duration,
       domInteractive: 234 as Duration,
@@ -102,6 +104,7 @@ describe('trackNavigationTimings', () => {
 
     expect(navigationTimingsCallback).toHaveBeenCalledTimes(1)
     expect(navigationTimingsCallback).toHaveBeenCalledWith({
+      firstByte: 123 as Duration,
       domComplete: 456 as Duration,
       domContentLoaded: 345 as Duration,
       domInteractive: 234 as Duration,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
@@ -16,6 +16,7 @@ export const TIMING_MAXIMUM_DELAY = 10 * ONE_MINUTE
 
 export interface Timings {
   firstContentfulPaint?: Duration
+  firstByte?: Duration
   domInteractive?: Duration
   domContentLoaded?: Duration
   domComplete?: Duration
@@ -67,6 +68,7 @@ export function trackNavigationTimings(lifeCycle: LifeCycle, callback: (timings:
           domContentLoaded: entry.domContentLoadedEventEnd,
           domInteractive: entry.domInteractive,
           loadEvent: entry.loadEventEnd,
+          firstByte: entry.responseStart,
         })
       }
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -15,6 +15,7 @@ const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = (PAGE_ACTIVITY_VALIDATION_DELAY * 
 const AFTER_PAGE_ACTIVITY_END_DELAY = PAGE_ACTIVITY_END_DELAY * 1.1
 
 const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
+  responseStart: 123 as RelativeTime,
   domComplete: 456 as RelativeTime,
   domContentLoadedEventEnd: 345 as RelativeTime,
   domInteractive: 234 as RelativeTime,
@@ -23,6 +24,7 @@ const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
 }
 
 const FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_BEFORE_ACTIVITY_TIMING: RumPerformanceNavigationTiming = {
+  responseStart: 1 as RelativeTime,
   domComplete: 2 as RelativeTime,
   domContentLoadedEventEnd: 1 as RelativeTime,
   domInteractive: 1 as RelativeTime,
@@ -31,6 +33,7 @@ const FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_BEFORE_ACTIVITY_TIMING: RumPerformanc
 }
 
 const FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING: RumPerformanceNavigationTiming = {
+  responseStart: 1 as RelativeTime,
   domComplete: 2 as RelativeTime,
   domContentLoadedEventEnd: 1 as RelativeTime,
   domInteractive: 1 as RelativeTime,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -24,6 +24,7 @@ const FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY: RumLargestContentfulPaintTiming = {
   size: 10,
 }
 const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
+  responseStart: 123 as RelativeTime,
   domComplete: 456 as RelativeTime,
   domContentLoadedEventEnd: 345 as RelativeTime,
   domInteractive: 234 as RelativeTime,
@@ -142,6 +143,7 @@ describe('initial view', () => {
 
       expect(getViewUpdateCount()).toEqual(2)
       expect(getViewUpdate(1).timings).toEqual({
+        firstByte: 123 as Duration,
         domComplete: 456 as Duration,
         domContentLoaded: 345 as Duration,
         domInteractive: 234 as Duration,
@@ -167,6 +169,7 @@ describe('initial view', () => {
 
       expect(getViewUpdateCount()).toEqual(3)
       expect(getViewUpdate(1).timings).toEqual({
+        firstByte: 123 as Duration,
         domComplete: 456 as Duration,
         domContentLoaded: 345 as Duration,
         domInteractive: 234 as Duration,
@@ -223,6 +226,7 @@ describe('initial view', () => {
 
       it('should set timings only on the initial view', () => {
         expect(initialView.last.timings).toEqual({
+          firstByte: 123 as Duration,
           domComplete: 456 as Duration,
           domContentLoaded: 345 as Duration,
           domInteractive: 234 as Duration,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -31,6 +31,7 @@ const VIEW: ViewEvent = {
   location: {} as Location,
   startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
   timings: {
+    firstByte: 10 as Duration,
     domComplete: 10 as Duration,
     domContentLoaded: 10 as Duration,
     domInteractive: 10 as Duration,
@@ -98,6 +99,7 @@ describe('viewCollection', () => {
           bar: (20 * 1e6) as ServerDuration,
           foo: (10 * 1e6) as ServerDuration,
         },
+        first_byte: (10 * 1e6) as ServerDuration,
         dom_complete: (10 * 1e6) as ServerDuration,
         dom_content_loaded: (10 * 1e6) as ServerDuration,
         dom_interactive: (10 * 1e6) as ServerDuration,

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -60,6 +60,7 @@ function processViewUpdate(
         count: view.eventCounts.frustrationCount,
       },
       cumulative_layout_shift: view.cumulativeLayoutShift,
+      first_byte: toServerDuration(view.timings.firstByte),
       dom_complete: toServerDuration(view.timings.domComplete),
       dom_content_loaded: toServerDuration(view.timings.domContentLoaded),
       dom_interactive: toServerDuration(view.timings.domInteractive),

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -70,6 +70,7 @@ export interface RawRumViewEvent {
   type: RumEventType.VIEW
   view: {
     loading_type: ViewLoadingType
+    first_byte?: ServerDuration
     first_contentful_paint?: ServerDuration
     first_input_delay?: ServerDuration
     first_input_time?: ServerDuration

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -530,7 +530,7 @@ export type RumViewEvent = CommonProperties & {
      */
     readonly first_input_time?: number
     /**
-     * Total layout shift score that occured on the view
+     * Total layout shift score that occurred on the view
      */
     readonly cumulative_layout_shift?: number
     /**
@@ -549,6 +549,10 @@ export type RumViewEvent = CommonProperties & {
      * Duration in ns to the end of the load event handler execution
      */
     readonly load_event?: number
+    /**
+     * Duration in ns to the response start of the document request
+     */
+    readonly first_byte?: number
     /**
      * User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
      */

--- a/test/e2e/scenario/rum/views.scenario.ts
+++ b/test/e2e/scenario/rum/views.scenario.ts
@@ -9,6 +9,7 @@ describe('rum views', () => {
       await flushEvents()
       const viewEvent = serverEvents.rumViews[0]
       expect(viewEvent).toBeDefined()
+      expect(viewEvent.view.first_byte).toBeGreaterThan(0)
       expect(viewEvent.view.dom_complete).toBeGreaterThan(0)
       expect(viewEvent.view.dom_content_loaded).toBeGreaterThan(0)
       expect(viewEvent.view.dom_interactive).toBeGreaterThan(0)


### PR DESCRIPTION
## Motivation

Allow to track the [time to first byte](https://developer.mozilla.org/en-US/docs/Glossary/time_to_first_byte) of the resource corresponding to the document loading at the view level.

## Changes

Add `view.first_byte` from response start [navigation timing](https://www.w3.org/TR/navigation-timing/#processing-model).

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
