### PR TITLE
Disable ESLint `max-len`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,6 @@ module.exports = {
       'undefined',
     ],
     'id-match': 'error',
-    'max-len': ['error', { code: 120, ignoreUrls: true }],
     'no-bitwise': 'error',
     'no-caller': 'error',
     'no-else-return': 'error',

--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -154,7 +154,6 @@ function isAllowedImport(basePath, source) {
   return packagesWithoutSideEffect.has(source)
 }
 
-/* eslint-disable max-len */
 /**
  * Authorize some call expressions. Feel free to add more exceptions here. Good candidates would
  * be functions that are known to be ECMAScript functions without side effects, that are likely to
@@ -166,7 +165,6 @@ function isAllowedImport(basePath, source) {
  * Webpack is not as smart as Rollup, and it usually treat all call expressions as impure, but it
  * could be fine to allow it nonetheless at it pulls very little code.
  */
-/* eslint-enable max-len */
 function isAllowedCallExpression({ callee }) {
   // Allow "Object.keys()"
   if (callee.type === 'MemberExpression' && callee.object.name === 'Object' && callee.property.name === 'keys') {
@@ -181,7 +179,6 @@ function isAllowedCallExpression({ callee }) {
   return false
 }
 
-/* eslint-disable max-len */
 /**
  * Authorize some 'new' expressions. Feel free to add more exceptions here. Good candidates would
  * be functions that are known to be ECMAScript functions without side effects, that are likely to
@@ -193,7 +190,6 @@ function isAllowedCallExpression({ callee }) {
  * Webpack is not as smart as Rollup, and it usually treat all 'new' expressions as impure, but it
  * could be fine to allow it nonetheless at it pulls very little code.
  */
-/* eslint-enable max-len */
 function isAllowedNewExpression({ callee }) {
   switch (callee.name) {
     case 'WeakMap': // Allow "new WeakMap()"

--- a/eslint-local-rules/disallowSpecImport.js
+++ b/eslint-local-rules/disallowSpecImport.js
@@ -1,9 +1,7 @@
 module.exports = {
   meta: {
     docs: {
-      description:
-        // eslint-disable-next-line max-len
-        'Disallow importing spec file code to avoid to execute the tests from the imported spec file twice',
+      description: 'Disallow importing spec file code to avoid to execute the tests from the imported spec file twice',
       recommended: false,
     },
     schema: [],

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -921,9 +921,7 @@ Error: foo
       column: 41,
       func: 'this',
       line: 74,
-      url:
-        // eslint-disable-next-line  max-len
-        '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js',
+      url: '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js',
     })
   })
 

--- a/packages/core/src/domain/tracekit/computeStackTrace.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.ts
@@ -99,7 +99,6 @@ function parseWinLine(line: string): StackFrame | undefined {
 }
 
 const GECKO_LINE_RE =
-  // eslint-disable-next-line max-len
   /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|capacitor|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i
 const GECKO_EVAL_RE = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i
 

--- a/packages/core/src/tools/createEventRateLimiter.spec.ts
+++ b/packages/core/src/tools/createEventRateLimiter.spec.ts
@@ -55,7 +55,6 @@ describe('createEventRateLimiter', () => {
     })
   })
 
-  // eslint-disable-next-line max-len
   it('returns false when called from the "onLimitReached" callback to bypass the limit for the "limit reached" error', () => {
     eventLimiter = createEventRateLimiter('error', limit, () => {
       expect(eventLimiter!.isLimitReached()).toBe(false)
@@ -88,7 +87,6 @@ describe('createEventRateLimiter', () => {
     expect(eventLimiter.isLimitReached()).toBe(true)
   })
 
-  // eslint-disable-next-line max-len
   it('returns true when the limit is reached and the "onLimitReached" callback does not call "isLimitReached" (ex: excluded by beforeSend)', () => {
     eventLimiter = createEventRateLimiter('error', limit, () => {
       // do not call isLimitReached

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -30,7 +30,6 @@ export const enum ErrorHandling {
   UNHANDLED = 'unhandled',
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type ErrorSource = typeof ErrorSource[keyof typeof ErrorSource]
 
 export function formatUnknownError(

--- a/packages/core/src/transport/batch.spec.ts
+++ b/packages/core/src/transport/batch.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import sinon from 'sinon'
 import { noop } from '../tools/utils'
 import { Batch } from './batch'

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { stubEndpointBuilder, interceptRequests } from '../../test/specHelper'
 import type { Request } from '../../test/specHelper'
 import type { EndpointBuilder } from '../domain/configuration'

--- a/packages/core/test/capturedExceptions.ts
+++ b/packages/core/test/capturedExceptions.ts
@@ -238,7 +238,6 @@ export const PHANTOMJS_1_19 = {
     at http://path/to/file.js:4287`,
 }
 
-/* eslint-disable max-len */
 export const ANDROID_REACT_NATIVE = {
   message: 'Error: test',
   name: 'Error',
@@ -252,7 +251,6 @@ export const ANDROID_REACT_NATIVE = {
   at children(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactMultiChild.js:264:10)
   at this(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js:74:41)\n`,
 }
-/* eslint-enable max-len */
 
 export const ANDROID_REACT_NATIVE_PROD = {
   message: 'Error: test',

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -271,7 +271,7 @@ class StubXhr extends StubEventEmitter {
 
   private hasEnded = false
 
-  /* eslint-disable @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars */
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   open(method: string, url: string | URL | undefined | null) {
     this.hasEnded = false
   }

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -286,7 +286,6 @@ function computeRelativePerformanceTiming() {
   for (const key in timing) {
     if (isNumber(timing[key as keyof PerformanceTiming])) {
       const numberKey = key as keyof RelativePerformanceTiming
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const timingElement = timing[numberKey] as TimeStamp
       result[numberKey] = timingElement === 0 ? (0 as RelativeTime) : getRelativeTime(timingElement)
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -50,7 +50,6 @@ export function isRage(clicks: Click[]) {
 const DEAD_CLICK_EXCLUDE_SELECTOR =
   // inputs that don't trigger a meaningful event like "input" when clicked, including textual
   // inputs (using a negative selector is shorter here)
-  // eslint-disable-next-line max-len
   'input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="range"]),' +
   'textarea,' +
   'select,' +

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getActionNameFromElement.spec.ts
@@ -48,13 +48,9 @@ describe('getActionNameFromElement', () => {
   it('limits the name length to a reasonable size', () => {
     expect(
       getActionNameFromElement(
-        // eslint-disable-next-line  max-len
         isolatedDom.element`<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>`
       )
-    ).toBe(
-      // eslint-disable-next-line  max-len
-      'Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]'
-    )
+    ).toBe('Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]')
   })
 
   it('normalize white spaces', () => {
@@ -305,7 +301,6 @@ describe('getActionNameFromElement', () => {
       ).toBe('Foo')
     })
 
-    // eslint-disable-next-line max-len
     it('remove children with programmatic action name in textual content based on the user-configured attribute', () => {
       expect(
         getActionNameFromElement(

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.spec.ts
@@ -88,7 +88,6 @@ describe('getSelectorFromElement', () => {
         )
       })
 
-      // eslint-disable-next-line max-len
       it('attribute selector with the custom action name attribute takes precedence over other stable attribute selectors', () => {
         expect(getStableAttributeSelector('<div action-name="foo" data-testid="bar"></div>', 'action-name')).toBe(
           'DIV[action-name="foo"]'

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -72,7 +72,6 @@ describe('listenActionEvents', () => {
       expect(hasSelectionChanged()).toBe(true)
     })
 
-    // eslint-disable-next-line max-len
     it('click to change the selection position (ex: last click of a triple-click selection) should report a selection change', () => {
       emulateNodeSelection(3, 4)
       emulateClick({

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -375,7 +375,6 @@ describe('trackClickActions', () => {
     })
 
     describe('error clicks', () => {
-      // eslint-disable-next-line max-len
       it('considers a "click with activity" followed by an error as a click action with "error" frustration type', () => {
         const { lifeCycle, domMutationObservable, clock } = setupBuilder.build()
 
@@ -387,7 +386,6 @@ describe('trackClickActions', () => {
         expect(events[0].frustrationTypes).toEqual([FrustrationType.ERROR_CLICK])
       })
 
-      // eslint-disable-next-line max-len
       it('considers a "click without activity" followed by an error as a click action with "error" (and "dead") frustration type', () => {
         const { lifeCycle, clock } = setupBuilder.build()
 

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceUtils.ts
@@ -20,7 +20,6 @@ export interface PerformanceResourceDetails {
   dns?: PerformanceResourceDetailsElement
   connect?: PerformanceResourceDetailsElement
   ssl?: PerformanceResourceDetailsElement
-  // eslint-disable-next-line camelcase
   first_byte: PerformanceResourceDetailsElement
   download: PerformanceResourceDetailsElement
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -120,7 +120,6 @@ describe('rum track view metrics', () => {
       )
     })
 
-    // eslint-disable-next-line max-len
     it('should use computed loading time for initial view when load event is smaller than computed loading time', () => {
       const { lifeCycle, domMutationObservable, clock } = setupBuilder.build()
       const { getViewUpdate, getViewUpdateCount } = viewTest

--- a/packages/rum-core/src/domain/tracing/getDocumentTraceId.ts
+++ b/packages/rum-core/src/domain/tracing/getDocumentTraceId.ts
@@ -54,7 +54,6 @@ export function findTraceComment(document: Document): string | undefined {
   // 1. Try to find the comment as a direct child of the document
   // Note: TSLint advises to use a 'for of', but TS doesn't allow to use 'for of' if the iterated
   // value is not an array or string (here, a NodeList).
-  // eslint-disable-next-line @typescript-eslint/prefer-for-of
   for (let i = 0; i < document.childNodes.length; i += 1) {
     const comment = getTraceCommentFromNode(document.childNodes[i])
     if (comment) {

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -229,7 +229,6 @@ describe('startRecording', () => {
     })
   })
 
-  // eslint-disable-next-line max-len
   it('does not split Meta, Focus and FullSnapshot records between multiple segments when taking a full snapshot', (done) => {
     setSegmentBytesLimit(0)
     setupBuilder.build()

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -523,7 +523,6 @@ describe('serializeNodeWithId', () => {
         const privateWordMatchCount = innerText.match(/private/g)?.length
         expect(privateWordMatchCount).toBe(10)
         expect(innerText).toBe(
-          // eslint-disable-next-line max-len
           '  \n      .example {content: "anything";}\n       private title \n \n     hello private world \n     Loreum ipsum private text \n     hello private world \n     \n      Click https://private.com/path/nested?query=param#hash\n     \n      \n     \n       private option A \n       private option B \n       private option C \n     \n      \n      \n      \n     inputFoo label \n\n      \n\n           Loreum Ipsum private ...\n     \n\n     editable private div \n'
         )
       })

--- a/packages/rum/test/htmlAst.ts
+++ b/packages/rum/test/htmlAst.ts
@@ -10,7 +10,6 @@ export const makeHtmlDoc = (htmlContent: string, privacyTag: string) => {
     newDoc.documentElement.setAttribute(PRIVACY_ATTR_NAME, privacyTag)
     return newDoc
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.error('Failed to set innerHTML of new doc:', e)
     return document
   }

--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -13,7 +13,6 @@ export async function browserExecuteAsync<R, A, B>(
 export async function browserExecuteAsync<R, A>(fn: (a: A, done: (result: R) => void) => any, arg: A): Promise<R>
 export async function browserExecuteAsync<R>(fn: (done: (result: R) => void) => any): Promise<R>
 export async function browserExecuteAsync<A extends any[]>(fn: (...params: A) => any, ...args: A) {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return browser.executeAsync(fn as any, ...args)
 }
 

--- a/test/e2e/scenario/eventBridge.scenario.ts
+++ b/test/e2e/scenario/eventBridge.scenario.ts
@@ -70,7 +70,6 @@ describe('bridge present', () => {
             throw new window.Error('bar')
           },
         }
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         window.DD_LOGS!.logger.log('hop', context as any)
       })
 
@@ -84,7 +83,6 @@ describe('bridge present', () => {
     .withEventBridge()
     .run(async ({ serverEvents, bridgeEvents }) => {
       await browserExecute(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         window.DD_LOGS!.logger.log('hello')
       })
       await flushEvents()

--- a/test/e2e/scenario/logs.scenario.ts
+++ b/test/e2e/scenario/logs.scenario.ts
@@ -8,7 +8,6 @@ describe('logs', () => {
     .withLogs()
     .run(async ({ serverEvents }) => {
       await browserExecute(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         window.DD_LOGS!.logger.log('hello')
       })
       await flushEvents()
@@ -165,7 +164,6 @@ describe('logs', () => {
     .withLogs()
     .run(async ({ serverEvents }) => {
       await browserExecute(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         window.DD_LOGS!.logger.log('hello')
       })
       await flushEvents()
@@ -182,7 +180,6 @@ describe('logs', () => {
     })
     .run(async ({ serverEvents }) => {
       await browserExecute(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         window.DD_LOGS!.logger.log('hello', {})
       })
       await flushEvents()

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -13,7 +13,6 @@ describe('telemetry', () => {
             throw new window.Error('bar')
           },
         }
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         window.DD_LOGS!.logger.log('hop', context as any)
       })
       await flushEvents()
@@ -35,7 +34,6 @@ describe('telemetry', () => {
             throw new window.Error('bar')
           },
         }
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         window.DD_RUM!.addAction('hop', context as any)
       })
       await flushEvents()


### PR DESCRIPTION
## Motivation

Prettier already does its best to keep lines below the limit, so max-len is more annoying than anything else. Also, sometimes this rule conflicts with Prettier, and vjeux himself (prettier author) [advises to disable the rule when using Prettier](https://github.com/prettier/prettier/issues/1954#issuecomment-310457491)

## Changes

Disable the ESLint rule
Remove unneeded `eslint-disable` comments (using [`reportUnusedDisableDirectives`](https://eslint.org/docs/latest/user-guide/configuring/rules#report-unused-eslint-disable-comments))

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
