### PR TITLE
⚗️ [RUMF-1351] tweak retry strategy

### DIFF
--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -191,6 +191,7 @@ describe('sendWithRetryStrategy', () => {
   })
   ;[
     { description: 'when the intake returns error:', status: 500 },
+    { description: 'when the intake returns too many request:', status: 429 },
     { description: 'when network is down:', status: 0 },
   ].forEach(({ description, status }) => {
     describe(description, () => {

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -3,14 +3,14 @@ import type { EndpointType } from '../domain/configuration'
 import { monitor } from '../tools/monitor'
 import type { RawError } from '../tools/error'
 import { clocksNow } from '../tools/timeUtils'
-import { ONE_KIBI_BYTE, ONE_MEBI_BYTE, ONE_SECOND } from '../tools/utils'
+import { ONE_KIBI_BYTE, ONE_MEBI_BYTE, ONE_SECOND, ONE_MINUTE } from '../tools/utils'
 import { ErrorSource } from '../tools/error'
 import type { Payload, HttpResponse } from './httpRequest'
 
 export const MAX_ONGOING_BYTES_COUNT = 80 * ONE_KIBI_BYTE
 export const MAX_ONGOING_REQUESTS = 32
 export const MAX_QUEUE_BYTES_COUNT = 3 * ONE_MEBI_BYTE
-export const MAX_BACKOFF_TIME = 256 * ONE_SECOND
+export const MAX_BACKOFF_TIME = ONE_MINUTE
 export const INITIAL_BACKOFF_TIME = ONE_SECOND
 
 const enum TransportStatus {

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -137,7 +137,7 @@ function retryQueuedPayloads(
 }
 
 function wasRequestSuccessful(response: HttpResponse) {
-  return response.status !== 0 && response.status < 500
+  return response.status !== 0 && response.status !== 429 && response.status < 500
 }
 
 export function newRetryState(): RetryState {


### PR DESCRIPTION
## Motivation

Following #1700, try to improve the strategy

## Changes

- consider transport down on status code `429` (too many request)
- reduce retry max time to `1min` to be more likely to send the data on transport up

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
