### PR TITLE
✨⚗️ [RUMF-1378] use stable attributes when computing heatmap selector

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.spec.ts
@@ -71,40 +71,34 @@ describe('getSelectorFromElement', () => {
       })
     })
 
-    function getDefaultSelector(html: string): string {
-      return getSelectorsFromElement(isolatedDom.append(html), undefined).selector
-    }
-  })
-
-  describe('selector with stable attributes', () => {
     describe('attribute selector', () => {
       it('uses a stable attribute if the element has one', () => {
-        expect(getStableAttributeSelector('<div data-testid="foo"></div>')).toBe('DIV[data-testid="foo"]')
+        expect(getDefaultSelector('<div data-testid="foo"></div>')).toBe('DIV[data-testid="foo"]')
       })
 
       it('escapes the attribute value', () => {
-        expect(getStableAttributeSelector('<div data-testid="&quot;foo bar&quot;"></div>')).toBe(
+        expect(getDefaultSelector('<div data-testid="&quot;foo bar&quot;"></div>')).toBe(
           'DIV[data-testid="\\"foo\\ bar\\""]'
         )
       })
 
       it('attribute selector with the custom action name attribute takes precedence over other stable attribute selectors', () => {
-        expect(getStableAttributeSelector('<div action-name="foo" data-testid="bar"></div>', 'action-name')).toBe(
+        expect(getDefaultSelector('<div action-name="foo" data-testid="bar"></div>', 'action-name')).toBe(
           'DIV[action-name="foo"]'
         )
       })
 
       it('stable attribute selector should take precedence over class selector', () => {
-        expect(getStableAttributeSelector('<div class="foo" data-testid="foo"></div>')).toBe('DIV[data-testid="foo"]')
+        expect(getDefaultSelector('<div class="foo" data-testid="foo"></div>')).toBe('DIV[data-testid="foo"]')
       })
 
       it('stable attribute selector should take precedence over ID selector', () => {
-        expect(getStableAttributeSelector('<div id="foo" data-testid="foo"></div>')).toBe('DIV[data-testid="foo"]')
+        expect(getDefaultSelector('<div id="foo" data-testid="foo"></div>')).toBe('DIV[data-testid="foo"]')
       })
 
       it("uses a stable attribute selector and continue recursing if it's not unique globally", () => {
         expect(
-          getStableAttributeSelector(`
+          getDefaultSelector(`
             <button target data-testid="foo"></button>
 
             <div>
@@ -115,8 +109,8 @@ describe('getSelectorFromElement', () => {
       })
     })
 
-    function getStableAttributeSelector(html: string, actionNameAttribute?: string): string {
-      return getSelectorsFromElement(isolatedDom.append(html), actionNameAttribute).selector_with_stable_attributes
+    function getDefaultSelector(html: string, actionNameAttribute?: string): string {
+      return getSelectorsFromElement(isolatedDom.append(html), actionNameAttribute).selector
     }
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.ts
@@ -29,8 +29,7 @@ export function getSelectorsFromElement(element: Element, actionNameAttribute: s
     )
   }
   return {
-    selector: getSelectorFromElement(element, [getIDSelector], [getClassSelector]),
-    selector_with_stable_attributes: getSelectorFromElement(
+    selector: getSelectorFromElement(
       element,
       attributeSelectors.concat(getIDSelector),
       attributeSelectors.concat(getClassSelector)

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -125,7 +125,6 @@ describe('trackClickActions', () => {
         jasmine.objectContaining({
           target: {
             selector: '#button',
-            selector_with_stable_attributes: '#button',
             selector_without_classes: '#button',
             width: 100,
             height: 100,


### PR DESCRIPTION


## Motivation

We've seen that when fixing #1721 , this strategy yields slightly but strictly better results than the default strategy.

## Changes

Use the "stable attributes" experimental selector strategy by default.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
