### PR TITLE
🐛 [RUMF-1369] Exclude error message from stacktrace parsing

### DIFF
--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -502,7 +502,7 @@ Error: foo
   it('should not include error message into stacktrace ', () => {
     const stackFrames = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
 
-    expect(stackFrames.stack[0].url).not.toBe('http://path/to/file.js')
+    expect(stackFrames.stack[0]?.url).not.toBe('http://path/to/file.js')
   })
 
   it('should parse Chrome anonymous function errors', () => {

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -499,6 +499,38 @@ Error: foo
     })
   })
 
+  it('should ignore custom error message', () => {
+    const stack = `HttpError: 400 Bad Request, see context.apiResponse for more details
+    at s (spa.min.js:3:5)
+    at b (spa.min.js:6:8)
+    at spa.min.js:2:1`
+
+    const stackFrames = computeStackTrace({ stack } as Error)
+
+    expect(stackFrames.stack.length).toEqual(3)
+    expect(stackFrames.stack[0]).toEqual({
+      args: [],
+      column: 5,
+      func: 's',
+      line: 3,
+      url: 'spa.min.js',
+    })
+    expect(stackFrames.stack[1]).toEqual({
+      args: [],
+      column: 8,
+      func: 'b',
+      line: 6,
+      url: 'spa.min.js',
+    })
+    expect(stackFrames.stack[2]).toEqual({
+      args: [],
+      column: 1,
+      func: '?',
+      line: 2,
+      url: 'spa.min.js',
+    })
+  })
+
   it('should parse Chrome anonymous function errors', () => {
     const stack = `Error: RTE Simulation
     at https://datadoghq.com/somefile.js:8489:191

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -499,7 +499,7 @@ Error: foo
     })
   })
 
-  it('should ignore custom error messages on chrome ', () => {
+  it('should ignore custom error messages ', () => {
     const stackFrames = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
 
     expect(stackFrames.stack[0].url).not.toBe('http://path/to/file.js')

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -502,13 +502,7 @@ Error: foo
   it('should ignore custom error messages on chrome ', () => {
     const stackFrames = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
 
-    expect(stackFrames.stack[0]).not.toEqual({
-      args: [],
-      column: 1,
-      func: 'Error: bar',
-      line: 1,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[0].url).not.toBe('http://path/to/file.js')
   })
 
   it('should ignore messages that come from the `toString` of the error on chrome ', () => {

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -499,13 +499,28 @@ Error: foo
     })
   })
 
-  it('should ignore custom error message', () => {
+  it('should ignore custom error messages on chrome ', () => {
+    const stackFrames = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
+
+    expect(stackFrames.stack[0]).not.toEqual({
+      args: [],
+      column: 1,
+      func: 'Error: bar',
+      line: 1,
+      url: 'http://path/to/file.js',
+    })
+  })
+
+  it('should ignore messages that come from the `toString` of the error on chrome ', () => {
     const stack = `HttpError: 400 Bad Request, see context.apiResponse for more details
     at s (spa.min.js:3:5)
     at b (spa.min.js:6:8)
     at spa.min.js:2:1`
 
-    const stackFrames = computeStackTrace({ stack } as Error)
+    const stackFrames = computeStackTrace({
+      stack,
+      toString: () => 'HttpError: 400 Bad Request, see context.apiResponse for more details',
+    } as Error)
 
     expect(stackFrames.stack.length).toEqual(3)
     expect(stackFrames.stack[0]).toEqual({

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -500,12 +500,9 @@ Error: foo
   })
 
   it('should ignore custom error messages ', () => {
-    const stackFrames = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
+    const stackFramesNewError = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
 
-    expect(stackFrames.stack[0].url).not.toBe('http://path/to/file.js')
-  })
-
-  it('should ignore messages that come from the `toString` of the error on chrome ', () => {
+    expect(stackFramesNewError.stack[0].url).not.toBe('http://path/to/file.js')
     const stack = `HttpError: 400 Bad Request, see context.apiResponse for more details
     at s (spa.min.js:3:5)
     at b (spa.min.js:6:8)

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -499,7 +499,7 @@ Error: foo
     })
   })
 
-  it('should ignore custom error messages ', () => {
+  it('should not include error message into stacktrace ', () => {
     const stackFrames = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
 
     expect(stackFrames.stack[0].url).not.toBe('http://path/to/file.js')

--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -500,41 +500,9 @@ Error: foo
   })
 
   it('should ignore custom error messages ', () => {
-    const stackFramesNewError = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
+    const stackFrames = computeStackTrace(new Error('bar@http://path/to/file.js:1:1'))
 
-    expect(stackFramesNewError.stack[0].url).not.toBe('http://path/to/file.js')
-    const stack = `HttpError: 400 Bad Request, see context.apiResponse for more details
-    at s (spa.min.js:3:5)
-    at b (spa.min.js:6:8)
-    at spa.min.js:2:1`
-
-    const stackFrames = computeStackTrace({
-      stack,
-      toString: () => 'HttpError: 400 Bad Request, see context.apiResponse for more details',
-    } as Error)
-
-    expect(stackFrames.stack.length).toEqual(3)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 5,
-      func: 's',
-      line: 3,
-      url: 'spa.min.js',
-    })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 8,
-      func: 'b',
-      line: 6,
-      url: 'spa.min.js',
-    })
-    expect(stackFrames.stack[2]).toEqual({
-      args: [],
-      column: 1,
-      func: '?',
-      line: 2,
-      url: 'spa.min.js',
-    })
+    expect(stackFrames.stack[0].url).not.toBe('http://path/to/file.js')
   })
 
   it('should parse Chrome anonymous function errors', () => {

--- a/packages/core/src/domain/tracekit/computeStackTrace.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.ts
@@ -1,4 +1,4 @@
-import { startsWith } from '@datadog/browser-core'
+import { startsWith } from '../../tools/utils'
 import type { StackTrace, StackFrame } from './types'
 
 const UNKNOWN_FUNCTION = '?'

--- a/packages/core/src/domain/tracekit/computeStackTrace.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.ts
@@ -104,9 +104,8 @@ const GECKO_EVAL_RE = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i
 
 function parseGeckoLine(line: string): StackFrame | undefined {
   const parts = GECKO_LINE_RE.exec(line)
-  if (!parts) {
-    return
-  }
+  if (!parts) return
+  if (parts[3] === line && line !== '[native code]') return // overly greedy regex likely means this is a custom error message (exception native code)
 
   const isEval = parts[3] && parts[3].indexOf(' > eval') > -1
   const submatch = GECKO_EVAL_RE.exec(parts[3])


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

We accidentally parse error messages that looked similar to stackTrace:

Example:
```
HttpError: 400 Bad Request, see context.apiResponse for more details
    at s (spa.min.js:2:2418592)
```
would output
```
    [{
      args: [],
      column: undefined,
      func: '?',
      line: undefined,
      url: 'HttpError: 400 Bad Request, see context.apiResponse for more details',
    }, {
      args: [],
      column: 5,
      func: 's',
      line: 3,
      url: 'spa.min.js',
    }]
```

`'HttpError: 400 Bad Request, see context.apiResponse for more details'` is not a valid URL

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Get the `toString` of the error (casting error as a `String`) and remove it from the beginning of the stack trace if present

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
