### PR TITLE
⚗️ [RUMF-1351] retry request on timeout

### DIFF
--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -192,6 +192,7 @@ describe('sendWithRetryStrategy', () => {
   ;[
     { description: 'when the intake returns error:', status: 500 },
     { description: 'when the intake returns too many request:', status: 429 },
+    { description: 'when the intake returns request timeout:', status: 408 },
     { description: 'when network is down:', status: 0 },
   ].forEach(({ description, status }) => {
     describe(description, () => {

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -101,7 +101,7 @@ function send(
   state.bandwidthMonitor.add(payload)
   sendStrategy(payload, (response) => {
     state.bandwidthMonitor.remove(payload)
-    if (wasRequestSuccessful(response)) {
+    if (!shouldRetryRequest(response)) {
       state.transportStatus = TransportStatus.UP
       onSuccess()
     } else {
@@ -136,8 +136,8 @@ function retryQueuedPayloads(
   }
 }
 
-function wasRequestSuccessful(response: HttpResponse) {
-  return response.status !== 0 && response.status !== 429 && response.status < 500
+function shouldRetryRequest(response: HttpResponse) {
+  return response.status === 0 || response.status === 408 || response.status === 429 || response.status >= 500
 }
 
 export function newRetryState(): RetryState {


### PR DESCRIPTION
## Motivation

Following #1700, improve the strategy

## Changes

consider transport down on status code 408 (request timeout)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
