### PR TITLE
🐛 [RUMF-1384] Filter abnormal TTFB values

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
@@ -1,5 +1,14 @@
 import type { Duration, EventEmitter, RelativeTime } from '@datadog/browser-core'
-import { assign, addEventListeners, DOM_EVENT, elapsed, ONE_MINUTE, find, findLast } from '@datadog/browser-core'
+import {
+  assign,
+  addEventListeners,
+  DOM_EVENT,
+  elapsed,
+  ONE_MINUTE,
+  find,
+  findLast,
+  relativeNow,
+} from '@datadog/browser-core'
 
 import type { LifeCycle } from '../../lifeCycle'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -68,7 +77,11 @@ export function trackNavigationTimings(lifeCycle: LifeCycle, callback: (timings:
           domContentLoaded: entry.domContentLoadedEventEnd,
           domInteractive: entry.domInteractive,
           loadEvent: entry.loadEventEnd,
-          firstByte: entry.responseStart,
+          // In some cases the value reported is negative or is larger
+          // than the current page time. Ignore these cases:
+          // https://github.com/GoogleChrome/web-vitals/issues/137
+          // https://github.com/GoogleChrome/web-vitals/issues/162
+          firstByte: entry.responseStart >= 0 && entry.responseStart <= relativeNow() ? entry.responseStart : undefined,
         })
       }
     }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -135,6 +135,7 @@ describe('initial view', () => {
       expect(getViewUpdateCount()).toEqual(1)
       expect(getViewUpdate(0).timings).toEqual({})
 
+      clock.tick(FAKE_NAVIGATION_ENTRY.responseStart) // ensure now > responseStart
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_NAVIGATION_ENTRY])
 
       expect(getViewUpdateCount()).toEqual(1)


### PR DESCRIPTION
## Motivation

Negative and high TTFB values has been observed. 

## Changes

Similar to [google implementation](https://github.com/GoogleChrome/web-vitals/blob/main/src/onTTFB.ts), filter out:

- negative values
- values bigger than current time

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
