### PR TITLE
♻️ [RUMF-1368] use the PointerDown event target for click actions

### DIFF
--- a/packages/core/src/tools/contextHistory.spec.ts
+++ b/packages/core/src/tools/contextHistory.spec.ts
@@ -1,6 +1,7 @@
 import type { Clock } from '../../test/specHelper'
 import { mockClock } from '../../test/specHelper'
-import type { RelativeTime } from './timeUtils'
+import type { Duration, RelativeTime } from './timeUtils'
+import { addDuration } from './timeUtils'
 import { ONE_MINUTE } from './utils'
 import { CLEAR_OLD_CONTEXTS_INTERVAL, ContextHistory } from './contextHistory'
 
@@ -115,8 +116,7 @@ describe('contextHistory', () => {
 
   it('should clear old contexts', () => {
     const originalTime = performance.now() as RelativeTime
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-    contextHistory.add('foo', originalTime).close((originalTime + 10) as RelativeTime)
+    contextHistory.add('foo', originalTime).close(addDuration(originalTime, 10 as Duration))
     clock.tick(10)
 
     expect(contextHistory.find(originalTime)).toBeDefined()

--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -65,6 +65,13 @@ export function elapsed(start: number, end: number) {
   return (end - start) as Duration
 }
 
+export function addDuration(a: TimeStamp, b: Duration): TimeStamp
+export function addDuration(a: RelativeTime, b: Duration): RelativeTime
+export function addDuration(a: Duration, b: Duration): Duration
+export function addDuration(a: number, b: number) {
+  return a + b
+}
+
 /**
  * Get the time since the navigation was started.
  *

--- a/packages/core/src/tools/timeUtils.ts
+++ b/packages/core/src/tools/timeUtils.ts
@@ -11,18 +11,16 @@ export function relativeToClocks(relative: RelativeTime) {
 }
 
 function getCorrectedTimeStamp(relativeTime: RelativeTime) {
-  const correctedOrigin = dateNow() - performance.now()
+  const correctedOrigin = (dateNow() - performance.now()) as TimeStamp
   // apply correction only for positive drift
   if (correctedOrigin > getNavigationStart()) {
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-    return Math.round(correctedOrigin + relativeTime) as TimeStamp
+    return Math.round(addDuration(correctedOrigin, relativeTime)) as TimeStamp
   }
   return getTimeStamp(relativeTime)
 }
 
 export function currentDrift() {
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  return Math.round(dateNow() - (getNavigationStart() + performance.now()))
+  return Math.round(dateNow() - addDuration(getNavigationStart(), performance.now() as Duration))
 }
 
 export function toServerDuration(duration: Duration): ServerDuration
@@ -84,8 +82,7 @@ export function getRelativeTime(timestamp: TimeStamp) {
 }
 
 export function getTimeStamp(relativeTime: RelativeTime) {
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  return Math.round(getNavigationStart() + relativeTime) as TimeStamp
+  return Math.round(addDuration(getNavigationStart(), relativeTime)) as TimeStamp
 }
 
 export function looksLikeRelativeTime(time: RelativeTime | TimeStamp): time is RelativeTime {

--- a/packages/rum-core/src/domain/contexts/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/contexts/foregroundContexts.ts
@@ -1,5 +1,5 @@
 import type { RelativeTime, Duration } from '@datadog/browser-core'
-import { addEventListener, DOM_EVENT, elapsed, relativeNow, toServerDuration } from '@datadog/browser-core'
+import { addDuration, addEventListener, DOM_EVENT, elapsed, relativeNow, toServerDuration } from '@datadog/browser-core'
 import type { InForegroundPeriod } from '../../rawRumEvent.types'
 
 // Arbitrary value to cap number of element mostly for backend & to save bandwidth
@@ -99,8 +99,7 @@ function isInForegroundAt(startTime: RelativeTime): boolean {
 }
 
 function selectInForegroundPeriodsFor(eventStartTime: RelativeTime, duration: Duration): InForegroundPeriod[] {
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  const eventEndTime = (eventStartTime + duration) as RelativeTime
+  const eventEndTime = addDuration(eventStartTime, duration)
   const filteredForegroundPeriods: InForegroundPeriod[] = []
 
   const earliestIndex = Math.max(0, foregroundPeriods.length - MAX_NUMBER_OF_SELECTABLE_FOREGROUND_PERIODS)

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -1,10 +1,10 @@
 import type { Clock } from '../../../../../core/test/specHelper'
 import { createNewEvent, mockClock } from '../../../../../core/test/specHelper'
-import type { OnClickContext } from './listenActionEvents'
+import type { OnClickCallback } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
 
 describe('listenActionEvents', () => {
-  let onClickSpy: jasmine.Spy<(context: OnClickContext) => void>
+  let onClickSpy: jasmine.Spy<OnClickCallback>
   let stopListenEvents: () => void
 
   beforeEach(() => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -54,6 +54,15 @@ describe('listenActionEvents', () => {
     expect(actionEventsHooks.onClick.calls.mostRecent().args[0]).toBe(context)
   })
 
+  it('ignore "click" events if no "pointerdown" event happened since the previous "click" event', () => {
+    emulateClick()
+    actionEventsHooks.onClick.calls.reset()
+
+    window.dispatchEvent(createNewEvent('click', { target: document.body }))
+
+    expect(actionEventsHooks.onClick).not.toHaveBeenCalled()
+  })
+
   describe('selection change', () => {
     let text: Text
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -22,7 +22,7 @@ describe('listenActionEvents', () => {
     stopListenEvents()
   })
 
-  it('listen to mousedown events', () => {
+  it('listen to pointerdown events', () => {
     emulateClick()
     expect(actionEventsHooks.onPointerDown).toHaveBeenCalledOnceWith(jasmine.objectContaining({ type: 'pointerdown' }))
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -1,11 +1,14 @@
 import { addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
 
+export type MouseEventOnElement = MouseEvent & { target: Element }
+
+export type OnClickCallback = (context: OnClickContext) => void
 export interface OnClickContext {
-  event: MouseEvent & { target: Element }
+  event: MouseEventOnElement
   getUserActivity(): { selection: boolean; input: boolean }
 }
 
-export function listenActionEvents({ onClick }: { onClick(context: OnClickContext): void }) {
+export function listenActionEvents({ onClick }: { onClick: OnClickCallback }) {
   let hasSelectionChanged = false
   let selectionEmptyAtMouseDown: boolean
   let hasInputChanged = false
@@ -36,7 +39,7 @@ export function listenActionEvents({ onClick }: { onClick(context: OnClickContex
       window,
       DOM_EVENT.CLICK,
       (clickEvent: MouseEvent) => {
-        if (clickEvent.target instanceof Element) {
+        if (isMouseEventOnElement(clickEvent)) {
           // Use a scoped variable to make sure the value is not changed by other clicks
           const userActivity = {
             selection: hasSelectionChanged,
@@ -51,7 +54,7 @@ export function listenActionEvents({ onClick }: { onClick(context: OnClickContex
           }
 
           onClick({
-            event: clickEvent as MouseEvent & { target: Element },
+            event: clickEvent,
             getUserActivity: () => userActivity,
           })
         }
@@ -79,4 +82,8 @@ export function listenActionEvents({ onClick }: { onClick(context: OnClickContex
 function isSelectionEmpty(): boolean {
   const selection = window.getSelection()
   return !selection || selection.isCollapsed
+}
+
+function isMouseEventOnElement(event: Event): event is MouseEventOnElement {
+  return event.target instanceof Element
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -1,5 +1,6 @@
 import type { Context, Observable, Duration } from '@datadog/browser-core'
 import {
+  addDuration,
   updateExperimentalFeatures,
   resetExperimentalFeatures,
   clocksNow,
@@ -24,6 +25,8 @@ import { MAX_DURATION_BETWEEN_CLICKS } from './clickChain'
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = PAGE_ACTIVITY_VALIDATION_DELAY * 0.8
 // A long delay used to wait after any action is finished.
 const EXPIRE_DELAY = CLICK_ACTION_MAX_DURATION * 10
+// Arbitrary duration between pointerdown and pointerup for emulated clicks
+const EMULATED_CLICK_DURATION = 80 as Duration
 
 function eventsCollector<T>() {
   const events: T[] = []
@@ -83,6 +86,7 @@ describe('trackClickActions', () => {
 
   it('starts a click action when clicking on an element', () => {
     const { domMutationObservable, clock } = setupBuilder.build()
+    const pointerDownClocks = clocksNow()
     emulateClickWithActivity(domMutationObservable, clock)
     expect(findActionId()).not.toBeUndefined()
     clock.tick(EXPIRE_DELAY)
@@ -97,7 +101,10 @@ describe('trackClickActions', () => {
         duration: BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY as Duration,
         id: jasmine.any(String),
         name: 'Click me',
-        startClocks: jasmine.any(Object),
+        startClocks: {
+          relative: addDuration(pointerDownClocks.relative, EMULATED_CLICK_DURATION),
+          timeStamp: addDuration(pointerDownClocks.timeStamp, EMULATED_CLICK_DURATION),
+        },
         type: ActionType.CLICK,
         event: domEvent,
         frustrationTypes: [],
@@ -141,11 +148,11 @@ describe('trackClickActions', () => {
 
   it('should keep track of previously validated click actions', () => {
     const { domMutationObservable, clock } = setupBuilder.build()
-    const clickActionStartTime = relativeNow()
+    const pointerDownStart = relativeNow()
     emulateClickWithActivity(domMutationObservable, clock)
     clock.tick(EXPIRE_DELAY)
 
-    expect(findActionId(clickActionStartTime)).not.toBeUndefined()
+    expect(findActionId(addDuration(pointerDownStart, EMULATED_CLICK_DURATION))).not.toBeUndefined()
   })
 
   it('counts errors occurring during the click action', () => {
@@ -211,18 +218,18 @@ describe('trackClickActions', () => {
     it('ignores any starting click action while another one is ongoing', () => {
       const { domMutationObservable, clock } = setupBuilder.build()
 
-      const firstClickTimeStamp = timeStampNow()
+      const firstPointerDownTimeStamp = timeStampNow()
       emulateClickWithActivity(domMutationObservable, clock)
       emulateClickWithActivity(domMutationObservable, clock)
 
       clock.tick(EXPIRE_DELAY)
       expect(events.length).toBe(1)
-      expect(events[0].startClocks.timeStamp).toBe(firstClickTimeStamp)
+      expect(events[0].startClocks.timeStamp).toBe(addDuration(firstPointerDownTimeStamp, EMULATED_CLICK_DURATION))
     })
 
     it('discards a click action when nothing happens after a click', () => {
       const { clock } = setupBuilder.build()
-      emulateClickWithoutActivity()
+      emulateClickWithoutActivity(clock)
 
       clock.tick(EXPIRE_DELAY)
       expect(events).toEqual([])
@@ -282,20 +289,20 @@ describe('trackClickActions', () => {
     it('collect click actions even if another one is ongoing', () => {
       const { domMutationObservable, clock } = setupBuilder.build()
 
-      const firstClickTimeStamp = timeStampNow()
+      const firstPointerDownTimeStamp = timeStampNow()
       emulateClickWithActivity(domMutationObservable, clock)
-      const secondClickTimeStamp = timeStampNow()
+      const secondPointerDownTimeStamp = timeStampNow()
       emulateClickWithActivity(domMutationObservable, clock)
 
       clock.tick(EXPIRE_DELAY)
       expect(events.length).toBe(2)
-      expect(events[0].startClocks.timeStamp).toBe(firstClickTimeStamp)
-      expect(events[1].startClocks.timeStamp).toBe(secondClickTimeStamp)
+      expect(events[0].startClocks.timeStamp).toBe(addDuration(firstPointerDownTimeStamp, EMULATED_CLICK_DURATION))
+      expect(events[1].startClocks.timeStamp).toBe(addDuration(secondPointerDownTimeStamp, EMULATED_CLICK_DURATION))
     })
 
     it('collect click actions even if nothing happens after a click (dead click)', () => {
       const { clock } = setupBuilder.build()
-      emulateClickWithoutActivity()
+      emulateClickWithoutActivity(clock)
 
       clock.tick(EXPIRE_DELAY)
       expect(events.length).toBe(1)
@@ -305,7 +312,7 @@ describe('trackClickActions', () => {
 
     it('does not set a duration for dead clicks', () => {
       const { clock } = setupBuilder.build()
-      emulateClickWithoutActivity()
+      emulateClickWithoutActivity(clock)
 
       clock.tick(EXPIRE_DELAY)
       expect(events.length).toBe(1)
@@ -324,7 +331,7 @@ describe('trackClickActions', () => {
     describe('rage clicks', () => {
       it('considers a chain of three clicks or more as a single action with "rage" frustration type', () => {
         const { domMutationObservable, clock } = setupBuilder.build()
-        const firstClickTimeStamp = timeStampNow()
+        const firstPointerDownTimeStamp = timeStampNow()
         const actionDuration = 5
         emulateClickWithActivity(domMutationObservable, clock, undefined, actionDuration)
         emulateClickWithActivity(domMutationObservable, clock, undefined, actionDuration)
@@ -332,9 +339,11 @@ describe('trackClickActions', () => {
 
         clock.tick(EXPIRE_DELAY)
         expect(events.length).toBe(1)
-        expect(events[0].startClocks.timeStamp).toBe(firstClickTimeStamp)
+        expect(events[0].startClocks.timeStamp).toBe(addDuration(firstPointerDownTimeStamp, EMULATED_CLICK_DURATION))
         expect(events[0].frustrationTypes).toEqual([FrustrationType.RAGE_CLICK])
-        expect(events[0].duration).toBe((MAX_DURATION_BETWEEN_CLICKS + 2 * actionDuration) as Duration)
+        expect(events[0].duration).toBe(
+          (MAX_DURATION_BETWEEN_CLICKS + 2 * actionDuration + 2 * EMULATED_CLICK_DURATION) as Duration
+        )
       })
 
       it('should contain original events from of rage sequence', () => {
@@ -354,7 +363,7 @@ describe('trackClickActions', () => {
         const { lifeCycle, domMutationObservable, clock } = setupBuilder.build()
 
         // Dead
-        emulateClickWithoutActivity()
+        emulateClickWithoutActivity(clock)
         clock.tick(PAGE_ACTIVITY_VALIDATION_DELAY)
 
         // Error
@@ -392,7 +401,7 @@ describe('trackClickActions', () => {
       it('considers a "click without activity" followed by an error as a click action with "error" (and "dead") frustration type', () => {
         const { lifeCycle, clock } = setupBuilder.build()
 
-        emulateClickWithoutActivity()
+        emulateClickWithoutActivity(clock)
         lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, RAW_ERROR_EVENT)
 
         clock.tick(EXPIRE_DELAY)
@@ -407,7 +416,7 @@ describe('trackClickActions', () => {
       it('considers a "click without activity" as a dead click', () => {
         const { clock } = setupBuilder.build()
 
-        emulateClickWithoutActivity()
+        emulateClickWithoutActivity(clock)
 
         clock.tick(EXPIRE_DELAY)
         expect(events.length).toBe(1)
@@ -422,26 +431,28 @@ describe('trackClickActions', () => {
     target: HTMLElement = button,
     clickActionDuration: number = BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY
   ) {
-    emulateClickWithoutActivity(target)
+    emulateClickWithoutActivity(clock, target)
     clock.tick(clickActionDuration)
     // Since we don't collect dom mutations for this test, manually dispatch one
     domMutationObservable.notify()
   }
 
-  function emulateClickWithoutActivity(target: HTMLElement = button) {
+  function emulateClickWithoutActivity(clock: Clock, target: HTMLElement = button) {
     const targetPosition = target.getBoundingClientRect()
     const offsetX = targetPosition.width / 2
     const offsetY = targetPosition.height / 2
-    target.dispatchEvent(
-      createNewEvent('click', {
-        target,
-        clientX: targetPosition.left + offsetX,
-        clientY: targetPosition.top + offsetY,
-        offsetX,
-        offsetY,
-        timeStamp: timeStampNow(),
-      })
-    )
+    const eventProperties = {
+      target,
+      clientX: targetPosition.left + offsetX,
+      clientY: targetPosition.top + offsetY,
+      offsetX,
+      offsetY,
+      timeStamp: timeStampNow(),
+    }
+    target.dispatchEvent(createNewEvent('pointerdown', eventProperties))
+    clock.tick(EMULATED_CLICK_DURATION)
+    target.dispatchEvent(createNewEvent('pointerup', eventProperties))
+    target.dispatchEvent(createNewEvent('click', eventProperties))
   }
 })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -79,9 +79,9 @@ export function trackClickActions(
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, stopClickChain)
 
   const { stop: stopActionEventsListener } = listenActionEvents<ClickActionBase>({
-    onPointerDown: (pointerDownEvent) => onPointerDown(configuration, history, pointerDownEvent),
+    onPointerDown: (pointerDownEvent) => processPointerDown(configuration, history, pointerDownEvent),
     onClick: (clickActionBase, clickEvent, getUserActivity) =>
-      onClick(
+      processClick(
         configuration,
         lifeCycle,
         domMutationObservable,
@@ -124,7 +124,7 @@ export function trackClickActions(
   }
 }
 
-function onPointerDown(
+function processPointerDown(
   configuration: RumConfiguration,
   history: ClickActionIdHistory,
   pointerDownEvent: MouseEventOnElement
@@ -145,7 +145,7 @@ function onPointerDown(
   return clickActionBase
 }
 
-function onClick(
+function processClick(
   configuration: RumConfiguration,
   lifeCycle: LifeCycle,
   domMutationObservable: Observable<void>,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -23,7 +23,7 @@ import type { ClickChain } from './clickChain'
 import { createClickChain } from './clickChain'
 import { getActionNameFromElement } from './getActionNameFromElement'
 import { getSelectorsFromElement } from './getSelectorsFromElement'
-import type { OnClickContext } from './listenActionEvents'
+import type { MouseEventOnElement, OnClickContext } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
 import { computeFrustration } from './computeFrustration'
 
@@ -47,7 +47,7 @@ export interface ClickAction {
   startClocks: ClocksState
   duration?: Duration
   counts: ActionCounts
-  event: MouseEvent & { target: Element }
+  event: MouseEventOnElement
   frustrationTypes: FrustrationType[]
   events: Event[]
 }
@@ -191,7 +191,7 @@ function processClick(
   })
 }
 
-function computeClickActionBase(event: MouseEvent & { target: Element }, actionNameAttribute?: string) {
+function computeClickActionBase(event: MouseEventOnElement, actionNameAttribute?: string) {
   let target: ClickAction['target']
   let position: ClickAction['position']
 

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
@@ -1,4 +1,5 @@
 import type { Duration, RelativeTime } from '@datadog/browser-core'
+import { addDuration } from '@datadog/browser-core'
 import type { RumPerformanceResourceTiming } from '../../../browser/performanceCollection'
 import type { RequestCompleteEvent } from '../../requestCollection'
 import { toValidEntry } from './resourceUtils'
@@ -59,12 +60,10 @@ function firstCanBeOptionRequest(correspondingEntries: RumPerformanceResourceTim
 }
 
 function endTime(timing: Timing) {
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  return (timing.startTime + timing.duration) as RelativeTime
+  return addDuration(timing.startTime, timing.duration)
 }
 
 function isBetween(timing: Timing, start: RelativeTime, end: RelativeTime) {
-  const errorMargin = 1
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  return timing.startTime >= start - errorMargin && endTime(timing) <= end + errorMargin
+  const errorMargin = 1 as Duration
+  return timing.startTime >= start - errorMargin && endTime(timing) <= addDuration(end, errorMargin)
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.spec.ts
@@ -1,5 +1,5 @@
 import type { Context, RelativeTime, Duration } from '@datadog/browser-core'
-import { relativeNow } from '@datadog/browser-core'
+import { addDuration, relativeNow } from '@datadog/browser-core'
 import type { RumEvent } from '../../../rumEvent.types'
 import type { TestSetupBuilder, ViewTest } from '../../../../test/specHelper'
 import { setup, setupViewTest } from '../../../../test/specHelper'
@@ -145,10 +145,9 @@ describe('rum track view metrics', () => {
       // introduce a gap between time origin and tracking start
       // ensure that `load event > activity delay` and `load event < activity delay + clock gap`
       // to make the test fail if the clock gap is not correctly taken into account
-      const CLOCK_GAP =
-        FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING.loadEventEnd -
+      const CLOCK_GAP = (FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING.loadEventEnd -
         BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY +
-        1
+        1) as Duration
 
       setupBuilder.clock!.tick(CLOCK_GAP)
 
@@ -169,8 +168,7 @@ describe('rum track view metrics', () => {
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       expect(getViewUpdateCount()).toEqual(2)
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-      expect(getViewUpdate(1).loadingTime).toEqual((BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + CLOCK_GAP) as Duration)
+      expect(getViewUpdate(1).loadingTime).toEqual(addDuration(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY, CLOCK_GAP))
     })
   })
 

--- a/packages/rum-core/test/createFakeClick.ts
+++ b/packages/rum-core/test/createFakeClick.ts
@@ -1,4 +1,4 @@
-import { Observable, timeStampNow } from '@datadog/browser-core'
+import { clocksNow, Observable, timeStampNow } from '@datadog/browser-core'
 import { createNewEvent } from '../../core/test/specHelper'
 import type { Click } from '../src/domain/rumEventsCollection/action/trackClickActions'
 
@@ -31,6 +31,7 @@ export function createFakeClick({
     },
     discard: jasmine.createSpy(),
     validate: jasmine.createSpy(),
+    startClocks: clocksNow(),
     hasError,
     hasPageActivity,
     getUserActivity: () => ({

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -87,10 +87,10 @@ describe('action collection', () => {
       expect(actionEvents[0]._dd.action?.target?.selector).toBe('BODY>BUTTON')
     })
 
-  // When the target element changes between mousedown and mousedown, Firefox does not dispatch a
+  // When the target element changes between mousedown and mouseup, Firefox does not dispatch a
   // click event. Skip this test.
   if (getBrowserName() !== 'firefox') {
-    createTest('does not report a click on the body when the target element changes between mouseup and mousedown')
+    createTest('does not report a click on the body when the target element changes between mousedown and mouseup')
       .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['clickmap'] })
       .withBody(
         html`

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -1,4 +1,4 @@
-import { withBrowserLogs } from '../../lib/helpers/browser'
+import { getBrowserName, withBrowserLogs } from '../../lib/helpers/browser'
 import { createTest, flushEvents, html, waitForServersIdle } from '../../lib/framework'
 
 describe('action collection', () => {
@@ -69,10 +69,7 @@ describe('action collection', () => {
         <script>
           const button = document.querySelector('button')
           button.addEventListener('pointerdown', () => {
-            // Move the button to the right, so the mouseup/pointerup event target is different
-            // than the <button> element and click event target gets set to <body>
-            button.style.left = '1000px'
-
+            button.textContent = 'Clicked'
             button.classList.add('active')
           })
         </script>
@@ -88,6 +85,35 @@ describe('action collection', () => {
       expect(actionEvents[0].action?.target?.name).toBe('click me')
       expect(actionEvents[0]._dd.action?.target?.selector).toBe('BODY>BUTTON')
     })
+
+  // When the target element changes between mousedown and mousedown, Firefox does not dispatch a
+  // click event. Skip this test.
+  if (getBrowserName() !== 'firefox') {
+    createTest('does not report a click on the body when the target element changes between mouseup and mousedown')
+      .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['clickmap'] })
+      .withBody(
+        html`
+          <button style="position: relative">click me</button>
+          <script>
+            const button = document.querySelector('button')
+            button.addEventListener('pointerdown', () => {
+              // Move the button to the right, so the mouseup/pointerup event target is different
+              // than the <button> element and click event target gets set to <body>
+              button.style.left = '1000px'
+            })
+          </script>
+        `
+      )
+      .run(async ({ serverEvents }) => {
+        const button = await $('button')
+        await button.click()
+        await flushEvents()
+        const actionEvents = serverEvents.rumActions
+
+        expect(actionEvents.length).toBe(1)
+        expect(actionEvents[0].action?.target?.name).toBe('click me')
+      })
+  }
 
   createTest('associate a request to its action')
     .withRum({ trackInteractions: true })

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -69,7 +69,8 @@ describe('action collection', () => {
         <script>
           const button = document.querySelector('button')
           button.addEventListener('pointerdown', () => {
-            button.textContent = 'Clicked'
+            // Using .textContent or .innerText prevents the click event to be dispatched in Safari
+            button.childNodes[0].data = 'Clicked'
             button.classList.add('active')
           })
         </script>


### PR DESCRIPTION
## Motivation

### Click target inaccuracy

When the click starts (mouse/pointer down) on an element and ends (mouse/pointer up) on another element, the `click` event target is set to the `BODY` element by the browser. This is problematic, because we report  clicks occuring on the `BODY` even if the user uses a whole other element. This impacts the RUM click action target name (`@action.target.name`), as well as the experimental heatmaps CSS selector generation.

Using the `pointerdown` event target instead improves the situation: the element used to compute the action target name and CSS selector is the element the user intended to click.

### Heatmap CSS selector improvement

Some application add a temporary class name when an element is being clicked (similarly to the [`:active`](https://developer.mozilla.org/en-US/docs/Web/CSS/:active) CSS pseudo-class) or focused. Those temporary class names blocks us from finding again the element when rendering the Heatmap again.

Generating the CSS selector before the application UI reacts to it should improve the situation a bit (`pointerdown` is the first event triggered when a click occurs).

### Frustration signal follow-up

This change is also a first step in fixing one of the most common dead click false positive cases: currently, we are only watching for page activity during or following a `click` event. But in some cases the application updates the UI earlier (ex: on `mousedown`, `focus`...). Those kind of clicks we are incorrectly considered a click as "dead".

In a future follow-up, we'll fix this by watching page activity during or following the `pointerdown` event as well, to avoid marking those clicks as "dead".

## Changes

Beside a bit of refactoring, the main change was to update the `listenActionEvents` to call a callback on `pointerdown`. This callback can return a `onClick` closure that will be called during the next `click` event. This allows to build the target-related properties earlier and still build the `Click` during the `click` event.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end


## Notes

This PR does not fix the issue in the recorder part:  clicks event will still be reported on the `body` element when the element target changes between mousedown and mouseup. This should not matter too much, as the click position is also collected.

To keep backward compatibility, the `event` send as context in the `beforeSend` callback is still the `click` event.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
