### PR TITLE
💥[RUMF-1391] introduce new RUM plans and remove old ones

### DIFF
--- a/developer-extension/src/panel/components/infosTab.tsx
+++ b/developer-extension/src/panel/components/infosTab.tsx
@@ -23,8 +23,8 @@ export function InfosTab() {
               value={formatSessionType(
                 infos.cookie.rum,
                 'Not tracked',
-                'Tracked as Browser Premium',
-                'Tracked as Browser'
+                'Tracked as Browser Replay',
+                'Tracked as Browser Pro'
               )}
             />
             <Entry name="Created" value={formatDate(Number(infos.cookie.created))} />

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -56,7 +56,7 @@ function startRum(
     noopRecorderApi
   )
 
-  startLongTaskCollection(lifeCycle, sessionManager)
+  startLongTaskCollection(lifeCycle)
   return {
     stop: () => {
       rumEventCollectionStop()

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -73,7 +73,7 @@ export function startRum(
     reportError
   )
 
-  startLongTaskCollection(lifeCycle, session)
+  startLongTaskCollection(lifeCycle)
   startResourceCollection(lifeCycle, configuration)
   const { addTiming, startView } = startViewCollection(
     lifeCycle,

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -548,7 +548,7 @@ describe('rum assembly', () => {
         type: 'user',
       })
       expect(serverRumEvents[0]._dd.session).toEqual({
-        plan: RumSessionPlan.PREMIUM,
+        plan: RumSessionPlan.REPLAY,
       })
     })
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -104,7 +104,7 @@ export function startRumAssembly(
             format_version: 2,
             drift: currentDrift(),
             session: {
-              plan: session.hasPremiumPlan ? RumSessionPlan.PREMIUM : RumSessionPlan.LITE,
+              plan: session.hasReplayPlan ? RumSessionPlan.REPLAY : RumSessionPlan.PRO,
             },
             browser_sdk_version: canUseEventBridge() ? __BUILD_ENV__SDK_VERSION__ : undefined,
           },

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -19,41 +19,26 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('premiumSampleRate', () => {
-    it('defaults to 100 if the option is not provided', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.premiumSampleRate).toBe(100)
+  describe('replaySampleRate', () => {
+    it('defaults to 0 if the option is not provided', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.replaySampleRate).toBe(0)
     })
 
     it('is set to provided value', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 50 })!.premiumSampleRate
-      ).toBe(50)
-    })
-
-    it('is set to `replaySampleRate` if not defined', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 50 })!.premiumSampleRate
-      ).toBe(50)
-      expect(
-        validateAndBuildRumConfiguration({
-          ...DEFAULT_INIT_CONFIGURATION,
-          replaySampleRate: 25,
-          premiumSampleRate: 50,
-        })!.premiumSampleRate
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 50 })!.replaySampleRate
       ).toBe(50)
     })
 
     it('does not validate the configuration if an incorrect value is provided', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 'foo' as any })
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 'foo' as any })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
+      expect(displaySpy).toHaveBeenCalledOnceWith('Replay Sample Rate should be a number between 0 and 100')
 
       displaySpy.calls.reset()
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 200 })
-      ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
+      expect(validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 200 })).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledOnceWith('Replay Sample Rate should be a number between 0 and 100')
     })
   })
 

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -14,7 +14,6 @@ export interface RumInitConfiguration extends InitConfiguration {
   // global options
   applicationId: string
   beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => void | boolean) | undefined
-  premiumSampleRate?: number | undefined
   excludedActivityUrls?: ReadonlyArray<string | RegExp> | undefined
 
   // tracing options
@@ -23,9 +22,6 @@ export interface RumInitConfiguration extends InitConfiguration {
 
   // replay options
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
-  /**
-   * @deprecated use premiumSampleRate instead
-   */
   replaySampleRate?: number | undefined
 
   // action options
@@ -47,7 +43,7 @@ export interface RumConfiguration extends Configuration {
   excludedActivityUrls: Array<string | RegExp>
   applicationId: string
   defaultPrivacyLevel: DefaultPrivacyLevel
-  premiumSampleRate: number
+  replaySampleRate: number
   trackInteractions: boolean
   trackFrustrations: boolean
   trackViewsManually: boolean
@@ -62,10 +58,8 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  // TODO remove fallback in next major
-  const premiumSampleRate = initConfiguration.premiumSampleRate ?? initConfiguration.replaySampleRate
-  if (premiumSampleRate !== undefined && !isPercentage(premiumSampleRate)) {
-    display.error('Premium Sample Rate should be a number between 0 and 100')
+  if (initConfiguration.replaySampleRate !== undefined && !isPercentage(initConfiguration.replaySampleRate)) {
+    display.error('Replay Sample Rate should be a number between 0 and 100')
     return
   }
 
@@ -102,7 +96,7 @@ export function validateAndBuildRumConfiguration(
       applicationId: initConfiguration.applicationId,
       version: initConfiguration.version,
       actionNameAttribute: initConfiguration.actionNameAttribute,
-      premiumSampleRate: premiumSampleRate ?? 100,
+      replaySampleRate: initConfiguration.replaySampleRate ?? 0,
       allowedTracingOrigins: initConfiguration.allowedTracingOrigins ?? [],
       tracingSampleRate: initConfiguration.tracingSampleRate,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -24,8 +24,8 @@ describe('long task collection', () => {
     sessionManager = createRumSessionManagerMock()
     setupBuilder = setup()
       .withSessionManager(sessionManager)
-      .beforeBuild(({ lifeCycle, sessionManager }) => {
-        startLongTaskCollection(lifeCycle, sessionManager)
+      .beforeBuild(({ lifeCycle }) => {
+        startLongTaskCollection(lifeCycle)
       })
   })
 
@@ -42,18 +42,6 @@ describe('long task collection', () => {
       { duration: 100 as Duration, entryType: 'paint', startTime: 1234 },
     ] as RumPerformanceEntry[])
 
-    expect(rawRumEvents.length).toBe(1)
-  })
-
-  it('should only collect when session has a premium plan', () => {
-    const { lifeCycle, rawRumEvents } = setupBuilder.build()
-
-    sessionManager.setPremiumPlan()
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
-    expect(rawRumEvents.length).toBe(1)
-
-    sessionManager.setLitePlan()
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
     expect(rawRumEvents.length).toBe(1)
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
@@ -3,16 +3,11 @@ import type { RawRumLongTaskEvent } from '../../../rawRumEvent.types'
 import { RumEventType } from '../../../rawRumEvent.types'
 import type { LifeCycle } from '../../lifeCycle'
 import { LifeCycleEventType } from '../../lifeCycle'
-import type { RumSessionManager } from '../../rumSessionManager'
 
-export function startLongTaskCollection(lifeCycle: LifeCycle, sessionManager: RumSessionManager) {
+export function startLongTaskCollection(lifeCycle: LifeCycle) {
   lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, (entries) => {
     for (const entry of entries) {
       if (entry.entryType !== 'longtask') {
-        break
-      }
-      const session = sessionManager.findTrackedSession(entry.startTime)
-      if (!session || session.hasLitePlan) {
         break
       }
       const startClocks = relativeToClocks(entry.startTime)

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -24,9 +24,9 @@ describe('rum session manager', () => {
   let renewSessionSpy: jasmine.Spy
   let clock: Clock
 
-  function setupDraws({ tracked, trackedWithPremium }: { tracked?: boolean; trackedWithPremium?: boolean }) {
+  function setupDraws({ tracked, trackedWithReplay }: { tracked?: boolean; trackedWithReplay?: boolean }) {
     configuration.sampleRate = tracked ? 100 : 0
-    configuration.premiumSampleRate = trackedWithPremium ? 100 : 0
+    configuration.replaySampleRate = trackedWithReplay ? 100 : 0
   }
 
   beforeEach(() => {
@@ -36,7 +36,7 @@ describe('rum session manager', () => {
     configuration = {
       ...validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: 'xxx' })!,
       sampleRate: 50,
-      premiumSampleRate: 50,
+      replaySampleRate: 50,
     }
     clock = mockClock()
     expireSessionSpy = jasmine.createSpy('expireSessionSpy')
@@ -55,25 +55,25 @@ describe('rum session manager', () => {
   })
 
   describe('cookie storage', () => {
-    it('when tracked with premium plan should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithPremium: true })
+    it('when tracked with replay plan should store session type and id', () => {
+      setupDraws({ tracked: true, trackedWithReplay: true })
 
       startRumSessionManager(configuration, lifeCycle)
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_REPLAY}`)
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
 
-    it('when tracked with lite plan should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithPremium: false })
+    it('when tracked with pro plan should store session type and id', () => {
+      setupDraws({ tracked: true, trackedWithReplay: false })
 
       startRumSessionManager(configuration, lifeCycle)
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_LITE}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PRO}`)
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
 
@@ -95,7 +95,7 @@ describe('rum session manager', () => {
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_REPLAY}`)
       expect(getCookie(SESSION_COOKIE_NAME)).toContain('id=abcdef')
     })
 
@@ -119,12 +119,12 @@ describe('rum session manager', () => {
       expect(renewSessionSpy).not.toHaveBeenCalled()
       clock.tick(COOKIE_ACCESS_DELAY)
 
-      setupDraws({ tracked: true, trackedWithPremium: true })
+      setupDraws({ tracked: true, trackedWithReplay: true })
       document.dispatchEvent(new CustomEvent('click'))
 
       expect(expireSessionSpy).toHaveBeenCalled()
       expect(renewSessionSpy).toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_REPLAY}`)
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
   })
@@ -159,18 +159,16 @@ describe('rum session manager', () => {
       expect(rumSessionManager.findTrackedSession(0 as RelativeTime)!.id).toBe('abcdef')
     })
 
-    it('should return session with premium plan', () => {
+    it('should return session with replay plan', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=1', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.hasPremiumPlan).toBeTrue()
-      expect(rumSessionManager.findTrackedSession()!.hasLitePlan).toBeFalse()
+      expect(rumSessionManager.findTrackedSession()!.hasReplayPlan).toBeTrue()
     })
 
-    it('should return session with lite plan', () => {
+    it('should return session with pro plan', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=2', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.hasPremiumPlan).toBeFalse()
-      expect(rumSessionManager.findTrackedSession()!.hasLitePlan).toBeTrue()
+      expect(rumSessionManager.findTrackedSession()!.hasReplayPlan).toBeFalse()
     })
   })
 })

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -921,9 +921,9 @@ export interface CommonProperties {
      */
     session?: {
       /**
-       * Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+       * Session plan: 1 is the 'lite' plan, 2 is the 'premium' plan, 3 is the 'pro' plan, 4 is the 'replay' plan
        */
-      plan: 1 | 2
+      plan: 1 | 2 | 3 | 4
       [k: string]: unknown
     }
     /**

--- a/packages/rum-core/test/mockRumSessionManager.ts
+++ b/packages/rum-core/test/mockRumSessionManager.ts
@@ -4,22 +4,21 @@ import { RumTrackingType } from '../src/domain/rumSessionManager'
 export interface RumSessionManagerMock extends RumSessionManager {
   setId(id: string): RumSessionManagerMock
   setNotTracked(): RumSessionManagerMock
-  setPremiumPlan(): RumSessionManagerMock
-  setLitePlan(): RumSessionManagerMock
+  setReplayPlan(): RumSessionManagerMock
+  setProPlan(): RumSessionManagerMock
 }
 
 const DEFAULT_ID = 'session-id'
 
 export function createRumSessionManagerMock(): RumSessionManagerMock {
   let id = DEFAULT_ID
-  let trackingType = RumTrackingType.TRACKED_PREMIUM
+  let trackingType = RumTrackingType.TRACKED_REPLAY
   return {
     findTrackedSession() {
       return trackingType !== RumTrackingType.NOT_TRACKED
         ? {
             id,
-            hasLitePlan: trackingType === RumTrackingType.TRACKED_LITE,
-            hasPremiumPlan: trackingType === RumTrackingType.TRACKED_PREMIUM,
+            hasReplayPlan: trackingType === RumTrackingType.TRACKED_REPLAY,
           }
         : undefined
     },
@@ -31,12 +30,12 @@ export function createRumSessionManagerMock(): RumSessionManagerMock {
       trackingType = RumTrackingType.NOT_TRACKED
       return this
     },
-    setLitePlan() {
-      trackingType = RumTrackingType.TRACKED_LITE
+    setProPlan() {
+      trackingType = RumTrackingType.TRACKED_PRO
       return this
     },
-    setPremiumPlan() {
-      trackingType = RumTrackingType.TRACKED_PREMIUM
+    setReplayPlan() {
+      trackingType = RumTrackingType.TRACKED_REPLAY
       return this
     },
   }

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -190,7 +190,7 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
       format_version: 2,
       drift: 0,
       session: {
-        plan: RumSessionPlan.PREMIUM,
+        plan: RumSessionPlan.REPLAY,
       },
     },
     application: {

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -111,7 +111,7 @@ describe('makeRecorderApi', () => {
     })
 
     it('ignores calls if the session plan is LITE', () => {
-      setupBuilder.withSessionManager(createRumSessionManagerMock().setLitePlan()).build()
+      setupBuilder.withSessionManager(createRumSessionManagerMock().setProPlan()).build()
       rumInit()
       recorderApi.start()
       expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -216,14 +216,14 @@ describe('makeRecorderApi', () => {
       rumInit()
     })
 
-    describe('from LITE to PREMIUM', () => {
+    describe('from PRO to REPLAY', () => {
       beforeEach(() => {
-        sessionManager.setLitePlan()
+        sessionManager.setProPlan()
       })
 
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setPremiumPlan()
+        sessionManager.setReplayPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
@@ -234,7 +234,7 @@ describe('makeRecorderApi', () => {
       it('does not starts recording if stopSessionReplayRecording was called', () => {
         recorderApi.start()
         recorderApi.stop()
-        sessionManager.setPremiumPlan()
+        sessionManager.setReplayPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -243,7 +243,7 @@ describe('makeRecorderApi', () => {
 
     describe('from LITE to untracked', () => {
       beforeEach(() => {
-        sessionManager.setLitePlan()
+        sessionManager.setProPlan()
       })
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
@@ -258,7 +258,7 @@ describe('makeRecorderApi', () => {
 
     describe('from LITE to LITE', () => {
       beforeEach(() => {
-        sessionManager.setLitePlan()
+        sessionManager.setProPlan()
       })
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
@@ -270,15 +270,15 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from PREMIUM to LITE', () => {
+    describe('from REPLAY to PRO', () => {
       beforeEach(() => {
-        sessionManager.setPremiumPlan()
+        sessionManager.setReplayPlan()
       })
 
       it('stops recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         expect(startRecordingSpy).toHaveBeenCalledTimes(1)
-        sessionManager.setLitePlan()
+        sessionManager.setProPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         expect(stopRecordingSpy).toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
@@ -290,7 +290,7 @@ describe('makeRecorderApi', () => {
         const { triggerOnDomLoaded } = mockDocumentReadyState()
         rumInit()
         recorderApi.start()
-        sessionManager.setLitePlan()
+        sessionManager.setProPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         triggerOnDomLoaded()
@@ -298,9 +298,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from PREMIUM to untracked', () => {
+    describe('from REPLAY to untracked', () => {
       beforeEach(() => {
-        sessionManager.setPremiumPlan()
+        sessionManager.setReplayPlan()
       })
 
       it('stops recording if startSessionReplayRecording was called', () => {
@@ -314,9 +314,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from PREMIUM to PREMIUM', () => {
+    describe('from REPLAY to REPLAY', () => {
       beforeEach(() => {
-        sessionManager.setPremiumPlan()
+        sessionManager.setReplayPlan()
       })
 
       it('keeps recording if startSessionReplayRecording was called', () => {
@@ -347,7 +347,7 @@ describe('makeRecorderApi', () => {
 
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setPremiumPlan()
+        sessionManager.setReplayPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalled()
@@ -357,7 +357,7 @@ describe('makeRecorderApi', () => {
       it('does not starts recording if stopSessionReplayRecording was called', () => {
         recorderApi.start()
         recorderApi.stop()
-        sessionManager.setPremiumPlan()
+        sessionManager.setReplayPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -372,7 +372,7 @@ describe('makeRecorderApi', () => {
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setLitePlan()
+        sessionManager.setProPlan()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -90,7 +90,7 @@ export function makeRecorderApi(
 
       startStrategy = () => {
         const session = sessionManager.findTrackedSession()
-        if (!session || !session.hasPremiumPlan) {
+        if (!session || !session.hasReplayPlan) {
           state = { status: RecorderStatus.IntentToStart }
           return
         }

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -141,7 +141,7 @@ describe('startRecording', () => {
 
     document.body.dispatchEvent(createNewEvent('click'))
 
-    sessionManager.setId('new-session-id').setPremiumPlan()
+    sessionManager.setId('new-session-id').setReplayPlan()
     flushSegment(lifeCycle)
     document.body.dispatchEvent(createNewEvent('click'))
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -9,6 +9,7 @@
       DD_RUM.init({
         clientToken: 'xxx',
         applicationId: 'xxx',
+        replaySampleRate: 100,
         telemetrySampleRate: 100,
       })
       DD_LOGS.init({

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -16,6 +16,7 @@ const DEFAULT_RUM_CONFIGURATION = {
   applicationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   clientToken: 'token',
   telemetrySampleRate: 100,
+  replaySampleRate: 100,
   enableExperimentalFeatures: [],
 }
 


### PR DESCRIPTION
## Motivation

Introduction of new RUM pricing plans.

## Changes

- Remove `Browser Lite` and `Browser Premium` plans
- Introduce:
  - `Browser Pro`: collect all RUM events but don't allow replay
  - `Browser Replay`: collect all RUM events and allow replay
- Use `replaySampleRate` to control repartition between Pro and Replay, default value: `0`


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
