### PR TITLE
💥[RUMF-1390] Remove deprecated `RumActionEventDomainContext.event`

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -91,7 +91,6 @@ describe('actionCollection', () => {
       },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
-      event,
       events: [event],
     })
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -105,7 +105,7 @@ function processAction(
     customerContext,
     rawRumEvent: actionEvent,
     startTime: action.startClocks.relative,
-    domainContext: isAutoAction(action) ? { event: action.event, events: action.events } : {},
+    domainContext: isAutoAction(action) ? { events: action.events } : {},
   }
 }
 

--- a/packages/rum-core/src/domainContext.types.ts
+++ b/packages/rum-core/src/domainContext.types.ts
@@ -21,10 +21,6 @@ export interface RumViewEventDomainContext {
 }
 
 export interface RumActionEventDomainContext {
-  /**
-   * @deprecated use events array instead
-   */
-  event?: Event
   events?: Event[]
 }
 

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -112,7 +112,7 @@ describe('initFrustrationObserver', () => {
           },
         },
       },
-      domainContext: { event: mouseEvent, events: [mouseEvent] },
+      domainContext: { events: [mouseEvent] },
     }
   })
 


### PR DESCRIPTION
## Motivation

Cleanup

## Changes

Remove `RumActionEventDomainContext.event` in favor of `RumActionEventDomainContext.events`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
