### PR TITLE
⚗✨ [RUMF-1379] use experimented CSS selectors strategies by default

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorsFromElement.ts
@@ -1,4 +1,4 @@
-import { arrayFrom, cssEscape, elementMatches } from '@datadog/browser-core'
+import { cssEscape, elementMatches } from '@datadog/browser-core'
 
 /**
  * Stable attributes are attributes that are commonly used to identify parts of a UI (ex:
@@ -31,35 +31,8 @@ export function getSelectorsFromElement(element: Element, actionNameAttribute: s
   return {
     selector: getSelectorFromElement(
       element,
-      attributeSelectors.concat(createIDSelector({})),
-      attributeSelectors.concat(createClassSelector({}))
-    ),
-    selector_without_classes: getSelectorFromElement(
-      element,
-      attributeSelectors.concat(createIDSelector({})),
-      attributeSelectors
-    ),
-    selector_without_body_classes: getSelectorFromElement(
-      element,
-      attributeSelectors.concat(createIDSelector({})),
-      attributeSelectors.concat(createClassSelector({ ignoreBody: true }))
-    ),
-    selector_without_generated_id_and_classes: getSelectorFromElement(
-      element,
-      attributeSelectors.concat(createIDSelector({ ignoreGeneratedValue: true })),
-      attributeSelectors.concat(createClassSelector({ ignoreGeneratedValue: true }))
-    ),
-    selector_with_only_first_class: getSelectorFromElement(
-      element,
-      attributeSelectors.concat(createIDSelector({})),
-      attributeSelectors.concat(createClassSelector({ keepOnlyFirst: true }))
-    ),
-    selector_all_together: getSelectorFromElement(
-      element,
-      attributeSelectors.concat(createIDSelector({ ignoreGeneratedValue: true })),
-      attributeSelectors.concat(
-        createClassSelector({ ignoreGeneratedValue: true, ignoreBody: true, keepOnlyFirst: true })
-      )
+      attributeSelectors.concat(getIDSelector),
+      attributeSelectors.concat(getClassSelector)
     ),
   }
 }
@@ -110,39 +83,24 @@ function getSelectorFromElement(
   return targetElementSelector.join('>')
 }
 
-function createIDSelector({ ignoreGeneratedValue }: { ignoreGeneratedValue?: boolean }) {
-  return (element: Element): string | undefined => {
-    if (element.id && (!ignoreGeneratedValue || !isGeneratedValue(element.id))) {
-      return `#${cssEscape(element.id)}`
-    }
+function getIDSelector(element: Element): string | undefined {
+  if (element.id && !isGeneratedValue(element.id)) {
+    return `#${cssEscape(element.id)}`
   }
 }
 
-function createClassSelector({
-  ignoreBody,
-  ignoreGeneratedValue,
-  keepOnlyFirst,
-}: {
-  ignoreBody?: boolean
-  ignoreGeneratedValue?: boolean
-  keepOnlyFirst?: boolean
-}) {
-  return (element: Element): string | undefined => {
-    if (ignoreBody && element.tagName === 'BODY') {
-      return
-    }
-    if (element.classList.length > 0) {
-      let classList = arrayFrom(element.classList)
-      if (ignoreGeneratedValue) {
-        classList = classList.filter((value) => !isGeneratedValue(value))
+function getClassSelector(element: Element): string | undefined {
+  if (element.tagName === 'BODY') {
+    return
+  }
+  if (element.classList.length > 0) {
+    for (let i = 0; i < element.classList.length; i += 1) {
+      const className = element.classList[i]
+      if (isGeneratedValue(className)) {
+        continue
       }
-      if (keepOnlyFirst) {
-        classList = classList.slice(0, 1)
-      }
-      return `${element.tagName}${classList
-        .sort()
-        .map((className) => `.${cssEscape(className)}`)
-        .join('')}`
+
+      return `${element.tagName}.${cssEscape(className)}`
     }
   }
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -132,11 +132,6 @@ describe('trackClickActions', () => {
         jasmine.objectContaining({
           target: {
             selector: '#button',
-            selector_without_classes: '#button',
-            selector_without_body_classes: '#button',
-            selector_without_generated_id_and_classes: '#button',
-            selector_with_only_first_class: '#button',
-            selector_all_together: '#button',
             width: 100,
             height: 100,
           },


### PR DESCRIPTION
## Motivation

All experiments introduced in #1726 proved to be benefical.

## Changes

Use all experimental strategies by default

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
