### PR TITLE
✨ [RUMF-1391] Introduce trackResources, trackLongTasks and sessionReplaySampleRate

### DIFF
--- a/developer-extension/src/panel/components/infosTab.tsx
+++ b/developer-extension/src/panel/components/infosTab.tsx
@@ -23,8 +23,8 @@ export function InfosTab() {
               value={formatSessionType(
                 infos.cookie.rum,
                 'Not tracked',
-                'Tracked as Browser Premium',
-                'Tracked as Browser'
+                'Tracked with Session Replay',
+                'Tracked without Session Replay'
               )}
             />
             <Entry name="Created" value={formatDate(Number(infos.cookie.created))} />

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -74,7 +74,7 @@ export function startRum(
   )
 
   startLongTaskCollection(lifeCycle, session)
-  startResourceCollection(lifeCycle, configuration)
+  startResourceCollection(lifeCycle, configuration, session)
   const { addTiming, startView } = startViewCollection(
     lifeCycle,
     configuration,

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -548,7 +548,7 @@ describe('rum assembly', () => {
         type: 'user',
       })
       expect(serverRumEvents[0]._dd.session).toEqual({
-        plan: RumSessionPlan.PREMIUM,
+        plan: RumSessionPlan.WITH_SESSION_REPLAY,
       })
     })
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -27,7 +27,6 @@ import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
 import type { ViewContexts } from './contexts/viewContexts'
 import type { RumSessionManager } from './rumSessionManager'
-import { RumSessionPlan } from './rumSessionManager'
 import type { UrlContexts } from './contexts/urlContexts'
 import type { RumConfiguration } from './configuration'
 import type { ActionContexts } from './rumEventsCollection/action/actionCollection'
@@ -104,7 +103,7 @@ export function startRumAssembly(
             format_version: 2,
             drift: currentDrift(),
             session: {
-              plan: session.hasPremiumPlan ? RumSessionPlan.PREMIUM : RumSessionPlan.LITE,
+              plan: session.plan,
             },
             browser_sdk_version: canUseEventBridge() ? __BUILD_ENV__SDK_VERSION__ : undefined,
           },

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -4,10 +4,12 @@ import { validateAndBuildRumConfiguration } from './configuration'
 const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx', applicationId: 'xxx' }
 
 describe('validateAndBuildRumConfiguration', () => {
-  let displaySpy: jasmine.Spy<typeof display.error>
+  let displayErrorSpy: jasmine.Spy<typeof display.error>
+  let displayWarnSpy: jasmine.Spy<typeof display.warn>
 
   beforeEach(() => {
-    displaySpy = spyOn(display, 'error')
+    displayErrorSpy = spyOn(display, 'error')
+    displayWarnSpy = spyOn(display, 'warn')
   })
 
   describe('applicationId', () => {
@@ -15,45 +17,126 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, applicationId: undefined as any })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Application ID is not configured, no RUM data will be collected.')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith(
+        'Application ID is not configured, no RUM data will be collected.'
+      )
     })
   })
 
-  describe('premiumSampleRate', () => {
+  describe('sessionReplaySampleRate', () => {
     it('defaults to 100 if the option is not provided', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.premiumSampleRate).toBe(100)
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.sessionReplaySampleRate).toBe(100)
     })
 
-    it('is set to provided value', () => {
+    it('is set to `sessionReplaySampleRate` provided value', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 50 })!.premiumSampleRate
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 50 })!
+          .sessionReplaySampleRate
       ).toBe(50)
     })
 
-    it('is set to `replaySampleRate` if not defined', () => {
+    it('is set to `premiumSampleRate` provided value', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 50 })!.premiumSampleRate
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 50 })!
+          .sessionReplaySampleRate
       ).toBe(50)
+    })
+
+    it('is set to `replaySampleRate` provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 50 })!
+          .sessionReplaySampleRate
+      ).toBe(50)
+    })
+
+    it('is set with precedence `sessionReplaySampleRate` > `premiumSampleRate` > `replaySampleRate`', () => {
       expect(
         validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
           replaySampleRate: 25,
           premiumSampleRate: 50,
-        })!.premiumSampleRate
+          sessionReplaySampleRate: 75,
+        })!.sessionReplaySampleRate
+      ).toBe(75)
+      expect(
+        validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          replaySampleRate: 25,
+          premiumSampleRate: 50,
+        })!.sessionReplaySampleRate
       ).toBe(50)
     })
 
     it('does not validate the configuration if an incorrect value is provided', () => {
       expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 'foo' as any })
+      ).toBeUndefined()
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith(
+        'Session Replay Sample Rate should be a number between 0 and 100'
+      )
+
+      displayErrorSpy.calls.reset()
+
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 200 })
+      ).toBeUndefined()
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith(
+        'Session Replay Sample Rate should be a number between 0 and 100'
+      )
+
+      displayErrorSpy.calls.reset()
+
+      expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 'foo' as any })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
 
-      displaySpy.calls.reset()
+      displayErrorSpy.calls.reset()
+
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 200 })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
+
+      displayErrorSpy.calls.reset()
+
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 'foo' as any })
+      ).toBeUndefined()
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
+
+      displayErrorSpy.calls.reset()
+
+      expect(validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 200 })).toBeUndefined()
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
+
+      displayErrorSpy.calls.reset()
+    })
+
+    it('should validate and display a warn if both `sessionReplaySampleRate` and `premiumSampleRate` are set', () => {
+      expect(
+        validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          sessionReplaySampleRate: 100,
+          premiumSampleRate: 100,
+        })
+      ).toBeDefined()
+      expect(displayWarnSpy).toHaveBeenCalledOnceWith(
+        'Ignoring Premium Sample Rate because Session Replay Sample Rate is set'
+      )
+    })
+  })
+
+  describe('oldPlansBehavior', () => {
+    it('should be true by default', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.oldPlansBehavior).toBeTrue()
+    })
+
+    it('should be false if `sessionReplaySampleRate` is set', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 100 })!
+          .oldPlansBehavior
+      ).toBeFalse()
     })
   })
 
@@ -72,13 +155,13 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 'foo' as any })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Tracing Sample Rate should be a number between 0 and 100')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Tracing Sample Rate should be a number between 0 and 100')
 
-      displaySpy.calls.reset()
+      displayErrorSpy.calls.reset()
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 200 })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Tracing Sample Rate should be a number between 0 and 100')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Tracing Sample Rate should be a number between 0 and 100')
     })
   })
 
@@ -101,14 +184,14 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, allowedTracingOrigins: ['foo'] })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Service need to be configured when tracing is enabled')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Service need to be configured when tracing is enabled')
     })
 
     it('does not validate the configuration if an incorrect value is provided', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, allowedTracingOrigins: 'foo' as any })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Allowed Tracing Origins should be an array')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Allowed Tracing Origins should be an array')
     })
   })
 
@@ -131,7 +214,7 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, excludedActivityUrls: 'foo' as any })
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Excluded Activity Urls should be an array')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Excluded Activity Urls should be an array')
     })
   })
 
@@ -243,6 +326,36 @@ describe('validateAndBuildRumConfiguration', () => {
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, defaultPrivacyLevel: 'foo' as any })!
           .defaultPrivacyLevel
       ).toBe(DefaultPrivacyLevel.MASK_USER_INPUT)
+    })
+  })
+
+  describe('trackResources', () => {
+    it('defaults to undefined', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackResources).toBeUndefined()
+    })
+
+    it('is set to provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResources: true })!.trackResources
+      ).toBeTrue()
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResources: false })!.trackResources
+      ).toBeFalse()
+    })
+  })
+
+  describe('trackLongTasks', () => {
+    it('defaults to undefined', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackLongTasks).toBeUndefined()
+    })
+
+    it('is set to provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackLongTasks: true })!.trackLongTasks
+      ).toBeTrue()
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackLongTasks: false })!.trackLongTasks
+      ).toBeFalse()
     })
   })
 })

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -14,6 +14,9 @@ export interface RumInitConfiguration extends InitConfiguration {
   // global options
   applicationId: string
   beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => void | boolean) | undefined
+  /**
+   * @deprecated use sessionReplaySampleRate instead
+   */
   premiumSampleRate?: number | undefined
   excludedActivityUrls?: ReadonlyArray<string | RegExp> | undefined
 
@@ -24,9 +27,10 @@ export interface RumInitConfiguration extends InitConfiguration {
   // replay options
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
   /**
-   * @deprecated use premiumSampleRate instead
+   * @deprecated use sessionReplaySampleRate instead
    */
   replaySampleRate?: number | undefined
+  sessionReplaySampleRate?: number | undefined
 
   // action options
   trackInteractions?: boolean | undefined
@@ -35,6 +39,9 @@ export interface RumInitConfiguration extends InitConfiguration {
 
   // view options
   trackViewsManually?: boolean | undefined
+
+  trackResources?: boolean | undefined
+  trackLongTasks?: boolean | undefined
 }
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>
@@ -47,10 +54,13 @@ export interface RumConfiguration extends Configuration {
   excludedActivityUrls: Array<string | RegExp>
   applicationId: string
   defaultPrivacyLevel: DefaultPrivacyLevel
-  premiumSampleRate: number
+  oldPlansBehavior: boolean
+  sessionReplaySampleRate: number
   trackInteractions: boolean
   trackFrustrations: boolean
   trackViewsManually: boolean
+  trackResources: boolean | undefined
+  trackLongTasks: boolean | undefined
   version?: string
 }
 
@@ -62,8 +72,21 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
+  if (
+    initConfiguration.sessionReplaySampleRate !== undefined &&
+    !isPercentage(initConfiguration.sessionReplaySampleRate)
+  ) {
+    display.error('Session Replay Sample Rate should be a number between 0 and 100')
+    return
+  }
+
   // TODO remove fallback in next major
-  const premiumSampleRate = initConfiguration.premiumSampleRate ?? initConfiguration.replaySampleRate
+  let premiumSampleRate = initConfiguration.premiumSampleRate ?? initConfiguration.replaySampleRate
+  if (premiumSampleRate !== undefined && initConfiguration.sessionReplaySampleRate !== undefined) {
+    display.warn('Ignoring Premium Sample Rate because Session Replay Sample Rate is set')
+    premiumSampleRate = undefined
+  }
+
   if (premiumSampleRate !== undefined && !isPercentage(premiumSampleRate)) {
     display.error('Premium Sample Rate should be a number between 0 and 100')
     return
@@ -102,13 +125,16 @@ export function validateAndBuildRumConfiguration(
       applicationId: initConfiguration.applicationId,
       version: initConfiguration.version,
       actionNameAttribute: initConfiguration.actionNameAttribute,
-      premiumSampleRate: premiumSampleRate ?? 100,
+      sessionReplaySampleRate: initConfiguration.sessionReplaySampleRate ?? premiumSampleRate ?? 100,
+      oldPlansBehavior: initConfiguration.sessionReplaySampleRate === undefined,
       allowedTracingOrigins: initConfiguration.allowedTracingOrigins ?? [],
       tracingSampleRate: initConfiguration.tracingSampleRate,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],
       trackInteractions: !!initConfiguration.trackInteractions || trackFrustrations,
       trackFrustrations,
       trackViewsManually: !!initConfiguration.trackViewsManually,
+      trackResources: initConfiguration.trackResources,
+      trackLongTasks: initConfiguration.trackLongTasks,
       defaultPrivacyLevel: objectHasValue(DefaultPrivacyLevel, initConfiguration.defaultPrivacyLevel)
         ? initConfiguration.defaultPrivacyLevel
         : DefaultPrivacyLevel.MASK_USER_INPUT,

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -69,6 +69,9 @@ describe('long task collection', () => {
         duration: (100 * 1e6) as ServerDuration,
       },
       type: RumEventType.LONG_TASK,
+      _dd: {
+        discarded: false,
+      },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
       performanceEntry: { name: 'self', duration: 100, entryType: 'longtask', startTime: 1234 },

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -45,14 +45,14 @@ describe('long task collection', () => {
     expect(rawRumEvents.length).toBe(1)
   })
 
-  it('should only collect when session has a premium plan', () => {
+  it('should only collect when session allows long tasks', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
-    sessionManager.setPremiumPlan()
+    sessionManager.setLongTaskAllowed(true)
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
     expect(rawRumEvents.length).toBe(1)
 
-    sessionManager.setLitePlan()
+    sessionManager.setLongTaskAllowed(false)
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
     expect(rawRumEvents.length).toBe(1)
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
@@ -23,6 +23,9 @@ export function startLongTaskCollection(lifeCycle: LifeCycle, sessionManager: Ru
           duration: toServerDuration(entry.duration),
         },
         type: RumEventType.LONG_TASK,
+        _dd: {
+          discarded: false,
+        },
       }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
         rawRumEvent,

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
@@ -12,7 +12,7 @@ export function startLongTaskCollection(lifeCycle: LifeCycle, sessionManager: Ru
         break
       }
       const session = sessionManager.findTrackedSession(entry.startTime)
-      if (!session || session.hasLitePlan) {
+      if (!session || !session.longTaskAllowed) {
         break
       }
       const startClocks = relativeToClocks(entry.startTime)

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -9,16 +9,18 @@ import { LifeCycleEventType } from '../../lifeCycle'
 import type { RequestCompleteEvent } from '../../requestCollection'
 import { TraceIdentifier } from '../../tracing/tracer'
 import { validateAndBuildRumConfiguration } from '../../configuration'
+import { createRumSessionManagerMock } from '../../../../test/mockRumSessionManager'
 import { startResourceCollection } from './resourceCollection'
 
 describe('resourceCollection', () => {
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
-    setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
+    setupBuilder = setup().beforeBuild(({ lifeCycle, sessionManager }) => {
       startResourceCollection(
         lifeCycle,
-        validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: 'xxx' })!
+        validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: 'xxx' })!,
+        sessionManager
       )
     })
   })
@@ -47,6 +49,9 @@ describe('resourceCollection', () => {
         url: 'https://resource.com/valid',
       },
       type: RumEventType.RESOURCE,
+      _dd: {
+        discarded: false,
+      },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
       performanceEntry,
@@ -81,6 +86,9 @@ describe('resourceCollection', () => {
         url: 'https://resource.com/valid',
       },
       type: RumEventType.RESOURCE,
+      _dd: {
+        discarded: false,
+      },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
       xhr,
@@ -125,6 +133,9 @@ describe('resourceCollection', () => {
         url: 'https://resource.com/valid',
       },
       type: RumEventType.RESOURCE,
+      _dd: {
+        discarded: false,
+      },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
       performanceEntry: undefined,
@@ -156,9 +167,9 @@ describe('resourceCollection', () => {
           traceId: '1234',
         }),
       ])
-      const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
-      expect(traceInfo).toBeDefined()
-      expect(traceInfo.trace_id).toBe('1234')
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      expect(privateFields).toBeDefined()
+      expect(privateFields.trace_id).toBe('1234')
     })
 
     it('should be processed from sampled completed request', () => {
@@ -171,10 +182,9 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
-      expect(traceInfo).toBeDefined()
-      expect(traceInfo.trace_id).toBeDefined()
-      expect(traceInfo.span_id).toBeDefined()
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      expect(privateFields.trace_id).toBeDefined()
+      expect(privateFields.span_id).toBeDefined()
     })
 
     it('should not be processed from not sampled completed request', () => {
@@ -187,19 +197,21 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
-      expect(traceInfo).not.toBeDefined()
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      expect(privateFields.trace_id).not.toBeDefined()
+      expect(privateFields.span_id).not.toBeDefined()
     })
 
     it('should pull tracingSampleRate from config if present', () => {
-      setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
+      setupBuilder = setup().beforeBuild(({ lifeCycle, sessionManager }) => {
         startResourceCollection(
           lifeCycle,
           validateAndBuildRumConfiguration({
             clientToken: 'xxx',
             applicationId: 'xxx',
             tracingSampleRate: 60,
-          })!
+          })!,
+          sessionManager
         )
       })
 
@@ -212,18 +224,19 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
-      expect(traceInfo.rule_psr).toEqual(0.6)
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      expect(privateFields.rule_psr).toEqual(0.6)
     })
 
     it('should not define rule_psr if tracingSampleRate is undefined', () => {
-      setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
+      setupBuilder = setup().beforeBuild(({ lifeCycle, sessionManager }) => {
         startResourceCollection(
           lifeCycle,
           validateAndBuildRumConfiguration({
             clientToken: 'xxx',
             applicationId: 'xxx',
-          })!
+          })!,
+          sessionManager
         )
       })
 
@@ -236,19 +249,20 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
-      expect(traceInfo.rule_psr).toBeUndefined()
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      expect(privateFields.rule_psr).toBeUndefined()
     })
 
     it('should define rule_psr to 0 if tracingSampleRate is set to 0', () => {
-      setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
+      setupBuilder = setup().beforeBuild(({ lifeCycle, sessionManager }) => {
         startResourceCollection(
           lifeCycle,
           validateAndBuildRumConfiguration({
             clientToken: 'xxx',
             applicationId: 'xxx',
             tracingSampleRate: 0,
-          })!
+          })!,
+          sessionManager
         )
       })
 
@@ -261,8 +275,37 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const traceInfo = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
-      expect(traceInfo.rule_psr).toEqual(0)
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      expect(privateFields.rule_psr).toEqual(0)
+    })
+  })
+
+  describe('indexing info', () => {
+    it('should not be set if session is not tracked', () => {
+      setupBuilder.withSessionManager(createRumSessionManagerMock().setNotTracked())
+      const { lifeCycle, rawRumEvents } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
+
+      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd).not.toBeDefined()
+    })
+
+    it('should be discarded=true if session does not allow resources', () => {
+      setupBuilder.withSessionManager(createRumSessionManagerMock().setResourceAllowed(false))
+      const { lifeCycle, rawRumEvents } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
+
+      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!.discarded).toBeTrue()
+    })
+
+    it('should be discarded=false if session allows resources', () => {
+      setupBuilder.withSessionManager(createRumSessionManagerMock().setResourceAllowed(true))
+      const { lifeCycle, rawRumEvents } = setupBuilder.build()
+
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
+
+      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!.discarded).toBeFalse()
     })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -167,7 +167,7 @@ describe('resourceCollection', () => {
           traceId: '1234',
         }),
       ])
-      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields).toBeDefined()
       expect(privateFields.trace_id).toBe('1234')
     })
@@ -182,7 +182,7 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields.trace_id).toBeDefined()
       expect(privateFields.span_id).toBeDefined()
     })
@@ -197,7 +197,7 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields.trace_id).not.toBeDefined()
       expect(privateFields.span_id).not.toBeDefined()
     })
@@ -224,7 +224,7 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields.rule_psr).toEqual(0.6)
     })
 
@@ -249,7 +249,7 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields.rule_psr).toBeUndefined()
     })
 
@@ -275,19 +275,19 @@ describe('resourceCollection', () => {
           traceId: new TraceIdentifier(),
         })
       )
-      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!
+      const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields.rule_psr).toEqual(0)
     })
   })
 
   describe('indexing info', () => {
-    it('should not be set if session is not tracked', () => {
+    it('should be discarded=true if session is not tracked', () => {
       setupBuilder.withSessionManager(createRumSessionManagerMock().setNotTracked())
       const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
 
-      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd).not.toBeDefined()
+      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd.discarded).toBeTrue()
     })
 
     it('should be discarded=true if session does not allow resources', () => {
@@ -296,7 +296,7 @@ describe('resourceCollection', () => {
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
 
-      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!.discarded).toBeTrue()
+      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd.discarded).toBeTrue()
     })
 
     it('should be discarded=false if session allows resources', () => {
@@ -305,7 +305,7 @@ describe('resourceCollection', () => {
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
 
-      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd!.discarded).toBeFalse()
+      expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd.discarded).toBeFalse()
     })
   })
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -188,11 +188,9 @@ function getRulePsr(configuration: RumConfiguration) {
 
 function computeIndexingInfo(sessionManager: RumSessionManager, resourceStart: ClocksState) {
   const session = sessionManager.findTrackedSession(resourceStart.relative)
-  return session
-    ? {
-        _dd: {
-          discarded: !session.resourceAllowed,
-        },
-      }
-    : undefined
+  return {
+    _dd: {
+      discarded: !session || !session.resourceAllowed,
+    },
+  }
 }

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -24,9 +24,15 @@ describe('rum session manager', () => {
   let renewSessionSpy: jasmine.Spy
   let clock: Clock
 
-  function setupDraws({ tracked, trackedWithPremium }: { tracked?: boolean; trackedWithPremium?: boolean }) {
+  function setupDraws({
+    tracked,
+    trackedWithSessionReplay,
+  }: {
+    tracked?: boolean
+    trackedWithSessionReplay?: boolean
+  }) {
     configuration.sampleRate = tracked ? 100 : 0
-    configuration.premiumSampleRate = trackedWithPremium ? 100 : 0
+    configuration.premiumSampleRate = trackedWithSessionReplay ? 100 : 0
   }
 
   beforeEach(() => {
@@ -55,25 +61,29 @@ describe('rum session manager', () => {
   })
 
   describe('cookie storage', () => {
-    it('when tracked with premium plan should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithPremium: true })
+    it('when tracked with session replay should store session type and id', () => {
+      setupDraws({ tracked: true, trackedWithSessionReplay: true })
 
       startRumSessionManager(configuration, lifeCycle)
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(
+        `${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_WITH_SESSION_REPLAY}`
+      )
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
 
-    it('when tracked with lite plan should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithPremium: false })
+    it('when tracked without session replay should store session type and id', () => {
+      setupDraws({ tracked: true, trackedWithSessionReplay: false })
 
       startRumSessionManager(configuration, lifeCycle)
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_LITE}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(
+        `${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_WITHOUT_SESSION_REPLAY}`
+      )
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
 
@@ -95,7 +105,9 @@ describe('rum session manager', () => {
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(
+        `${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_WITH_SESSION_REPLAY}`
+      )
       expect(getCookie(SESSION_COOKIE_NAME)).toContain('id=abcdef')
     })
 
@@ -119,12 +131,14 @@ describe('rum session manager', () => {
       expect(renewSessionSpy).not.toHaveBeenCalled()
       clock.tick(COOKIE_ACCESS_DELAY)
 
-      setupDraws({ tracked: true, trackedWithPremium: true })
+      setupDraws({ tracked: true, trackedWithSessionReplay: true })
       document.dispatchEvent(new CustomEvent('click'))
 
       expect(expireSessionSpy).toHaveBeenCalled()
       expect(renewSessionSpy).toHaveBeenCalled()
-      expect(getCookie(SESSION_COOKIE_NAME)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_PREMIUM}`)
+      expect(getCookie(SESSION_COOKIE_NAME)).toContain(
+        `${RUM_SESSION_KEY}=${RumTrackingType.TRACKED_WITH_SESSION_REPLAY}`
+      )
       expect(getCookie(SESSION_COOKIE_NAME)).toMatch(/id=[a-f0-9-]/)
     })
   })
@@ -159,19 +173,19 @@ describe('rum session manager', () => {
       expect(rumSessionManager.findTrackedSession(0 as RelativeTime)!.id).toBe('abcdef')
     })
 
-    it('should return session with premium plan', () => {
+    it('should return session with plan WITH_SESSION_REPLAY', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=1', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.plan).toBe(RumSessionPlan.PREMIUM)
+      expect(rumSessionManager.findTrackedSession()!.plan).toBe(RumSessionPlan.WITH_SESSION_REPLAY)
       expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBeTrue()
       expect(rumSessionManager.findTrackedSession()!.longTaskAllowed).toBeTrue()
       expect(rumSessionManager.findTrackedSession()!.resourceAllowed).toBeTrue()
     })
 
-    it('should return session with lite plan', () => {
+    it('should return session with plan WITHOUT_SESSION_REPLAY', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=2', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.plan).toBe(RumSessionPlan.LITE)
+      expect(rumSessionManager.findTrackedSession()!.plan).toBe(RumSessionPlan.WITHOUT_SESSION_REPLAY)
       expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBeFalse()
       expect(rumSessionManager.findTrackedSession()!.longTaskAllowed).toBeFalse()
       expect(rumSessionManager.findTrackedSession()!.resourceAllowed).toBeFalse()

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -14,7 +14,7 @@ import type { RumConfiguration } from './configuration'
 import { validateAndBuildRumConfiguration } from './configuration'
 
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
-import { RUM_SESSION_KEY, RumTrackingType, startRumSessionManager } from './rumSessionManager'
+import { RUM_SESSION_KEY, RumTrackingType, startRumSessionManager, RumSessionPlan } from './rumSessionManager'
 
 describe('rum session manager', () => {
   const DURATION = 123456
@@ -162,15 +162,19 @@ describe('rum session manager', () => {
     it('should return session with premium plan', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=1', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.hasPremiumPlan).toBeTrue()
-      expect(rumSessionManager.findTrackedSession()!.hasLitePlan).toBeFalse()
+      expect(rumSessionManager.findTrackedSession()!.plan).toBe(RumSessionPlan.PREMIUM)
+      expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBeTrue()
+      expect(rumSessionManager.findTrackedSession()!.longTaskAllowed).toBeTrue()
+      expect(rumSessionManager.findTrackedSession()!.resourceAllowed).toBeTrue()
     })
 
     it('should return session with lite plan', () => {
       setCookie(SESSION_COOKIE_NAME, 'id=abcdef&rum=2', DURATION)
       const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
-      expect(rumSessionManager.findTrackedSession()!.hasPremiumPlan).toBeFalse()
-      expect(rumSessionManager.findTrackedSession()!.hasLitePlan).toBeTrue()
+      expect(rumSessionManager.findTrackedSession()!.plan).toBe(RumSessionPlan.LITE)
+      expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBeFalse()
+      expect(rumSessionManager.findTrackedSession()!.longTaskAllowed).toBeFalse()
+      expect(rumSessionManager.findTrackedSession()!.resourceAllowed).toBeFalse()
     })
   })
 })

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -59,8 +59,14 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
         id: session.id,
         plan,
         sessionReplayAllowed: plan === RumSessionPlan.WITH_SESSION_REPLAY,
-        longTaskAllowed: plan === RumSessionPlan.WITH_SESSION_REPLAY,
-        resourceAllowed: plan === RumSessionPlan.WITH_SESSION_REPLAY,
+        longTaskAllowed:
+          configuration.trackLongTasks !== undefined
+            ? configuration.trackLongTasks
+            : configuration.oldPlansBehavior && plan === RumSessionPlan.WITH_SESSION_REPLAY,
+        resourceAllowed:
+          configuration.trackResources !== undefined
+            ? configuration.trackResources
+            : configuration.oldPlansBehavior && plan === RumSessionPlan.WITH_SESSION_REPLAY,
       }
     },
   }
@@ -72,7 +78,7 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
 export function startRumSessionManagerStub(): RumSessionManager {
   const session: RumSession = {
     id: '00000000-aaaa-0000-aaaa-000000000000',
-    plan: RumSessionPlan.WITH_SESSION_REPLAY, // plan value should not be taken into account for mobile
+    plan: RumSessionPlan.WITHOUT_SESSION_REPLAY, // plan value should not be taken into account for mobile
     sessionReplayAllowed: false,
     longTaskAllowed: true,
     resourceAllowed: true,
@@ -88,7 +94,7 @@ function computeSessionState(configuration: RumConfiguration, rawTrackingType?: 
     trackingType = rawTrackingType
   } else if (!performDraw(configuration.sampleRate)) {
     trackingType = RumTrackingType.NOT_TRACKED
-  } else if (!performDraw(configuration.premiumSampleRate)) {
+  } else if (!performDraw(configuration.sessionReplaySampleRate)) {
     trackingType = RumTrackingType.TRACKED_WITHOUT_SESSION_REPLAY
   } else {
     trackingType = RumTrackingType.TRACKED_WITH_SESSION_REPLAY

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -12,8 +12,10 @@ export interface RumSessionManager {
 
 export type RumSession = {
   id: string
-  hasPremiumPlan: boolean
-  hasLitePlan: boolean
+  plan: RumSessionPlan
+  sessionReplayAllowed: boolean
+  longTaskAllowed: boolean
+  resourceAllowed: boolean
 }
 
 export const enum RumSessionPlan {
@@ -49,10 +51,14 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
       if (!session || !isTypeTracked(session.trackingType)) {
         return
       }
+      const plan =
+        session.trackingType === RumTrackingType.TRACKED_PREMIUM ? RumSessionPlan.PREMIUM : RumSessionPlan.LITE
       return {
         id: session.id,
-        hasPremiumPlan: session.trackingType === RumTrackingType.TRACKED_PREMIUM,
-        hasLitePlan: session.trackingType === RumTrackingType.TRACKED_LITE,
+        plan,
+        sessionReplayAllowed: plan === RumSessionPlan.PREMIUM,
+        longTaskAllowed: plan === RumSessionPlan.PREMIUM,
+        resourceAllowed: plan === RumSessionPlan.PREMIUM,
       }
     },
   }
@@ -60,13 +66,14 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
 
 /**
  * Start a tracked replay session stub
- * It needs to be a premium plan in order to get long tasks
  */
 export function startRumSessionManagerStub(): RumSessionManager {
-  const session = {
+  const session: RumSession = {
     id: '00000000-aaaa-0000-aaaa-000000000000',
-    hasPremiumPlan: true,
-    hasLitePlan: false,
+    plan: RumSessionPlan.PREMIUM, // plan value should not be taken into account for mobile
+    sessionReplayAllowed: false,
+    longTaskAllowed: true,
+    resourceAllowed: true,
   }
   return {
     findTrackedSession: () => session,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -39,6 +39,7 @@ export interface RawRumResourceEvent {
     trace_id?: string
     span_id?: string // not available for initial document tracing
     rule_psr?: number
+    discarded?: boolean
   }
 }
 

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -35,11 +35,11 @@ export interface RawRumResourceEvent {
     first_byte?: PerformanceResourceDetailsElement
     download?: PerformanceResourceDetailsElement
   }
-  _dd?: {
+  _dd: {
     trace_id?: string
     span_id?: string // not available for initial document tracing
     rule_psr?: number
-    discarded?: boolean
+    discarded: boolean
   }
 }
 

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -135,6 +135,9 @@ export interface RawRumLongTaskEvent {
     id: string
     duration: ServerDuration
   }
+  _dd: {
+    discarded: boolean
+  }
 }
 
 export interface RawRumActionEvent {

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -311,6 +311,16 @@ export type RumLongTaskEvent = CommonProperties &
       readonly is_frozen_frame?: boolean
       [k: string]: unknown
     }
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+      /**
+       * Whether the long task should be discarded or indexed
+       */
+      readonly discarded?: boolean
+      [k: string]: unknown
+    }
     [k: string]: unknown
   }
 /**

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -219,7 +219,7 @@ export type RumErrorEvent = CommonProperties &
       /**
        * Source type of the error (the language or platform impacting the error stacktrace format)
        */
-      readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter'
+      readonly source_type?: 'android' | 'browser' | 'ios' | 'react-native' | 'flutter' | 'roku'
       /**
        * Resource properties of the error
        */
@@ -499,6 +499,10 @@ export type RumResourceEvent = CommonProperties &
        * tracing sample rate in decimal format
        */
       readonly rule_psr?: number
+      /**
+       * Whether the resource should be discarded or indexed
+       */
+      readonly discarded?: boolean
       [k: string]: unknown
     }
     [k: string]: unknown
@@ -955,9 +959,9 @@ export interface CommonProperties {
      */
     session?: {
       /**
-       * Session plan: 1 is the 'lite' plan, 2 is the 'premium' plan, 3 is the 'pro' plan, 4 is the 'replay' plan
+       * Session plan: 1 is the plan without replay, 2 is the plan with replay
        */
-      plan: 1 | 2 | 3 | 4
+      plan: 1 | 2
       [k: string]: unknown
     }
     /**

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -30,6 +30,9 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
             id: generateUUID(),
             duration: 0 as ServerDuration,
           },
+          _dd: {
+            discarded: false,
+          },
         },
         overrides
       )

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -62,6 +62,9 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
             type: ResourceType.OTHER,
             url: 'http://foo.bar',
           },
+          _dd: {
+            discarded: false,
+          },
         },
         overrides
       )

--- a/packages/rum-core/test/mockRumSessionManager.ts
+++ b/packages/rum-core/test/mockRumSessionManager.ts
@@ -1,11 +1,11 @@
 import type { RumSessionManager } from '../src/domain/rumSessionManager'
-import { RumTrackingType, RumSessionPlan } from '../src/domain/rumSessionManager'
+import { RumSessionPlan } from '../src/domain/rumSessionManager'
 
 export interface RumSessionManagerMock extends RumSessionManager {
   setId(id: string): RumSessionManagerMock
   setNotTracked(): RumSessionManagerMock
-  setPremiumPlan(): RumSessionManagerMock
-  setLitePlan(): RumSessionManagerMock
+  setPlanWithoutSessionReplay(): RumSessionManagerMock
+  setPlanWithSessionReplay(): RumSessionManagerMock
   setLongTaskAllowed(longTaskAllowed: boolean): RumSessionManagerMock
   setResourceAllowed(resourceAllowed: boolean): RumSessionManagerMock
 }
@@ -14,19 +14,21 @@ const DEFAULT_ID = 'session-id'
 
 export function createRumSessionManagerMock(): RumSessionManagerMock {
   let id = DEFAULT_ID
-  let trackingType = RumTrackingType.TRACKED_PREMIUM
+  let tracked = true
+  let sessionReplayAllowed = true
+  let resourceAllowed = true
+  let longTaskAllowed = true
   return {
     findTrackedSession() {
-      if (trackingType === RumTrackingType.NOT_TRACKED) {
+      if (!tracked) {
         return undefined
       }
-      const plan = trackingType === RumTrackingType.TRACKED_PREMIUM ? RumSessionPlan.PREMIUM : RumSessionPlan.LITE
       return {
         id,
-        plan,
-        sessionReplayAllowed: plan === RumSessionPlan.PREMIUM,
-        longTaskAllowed: plan === RumSessionPlan.PREMIUM,
-        resourceAllowed: plan === RumSessionPlan.PREMIUM,
+        plan: sessionReplayAllowed ? RumSessionPlan.WITH_SESSION_REPLAY : RumSessionPlan.WITHOUT_SESSION_REPLAY,
+        sessionReplayAllowed,
+        longTaskAllowed,
+        resourceAllowed,
       }
     },
     setId(newId) {
@@ -34,23 +36,25 @@ export function createRumSessionManagerMock(): RumSessionManagerMock {
       return this
     },
     setNotTracked() {
-      trackingType = RumTrackingType.NOT_TRACKED
+      tracked = false
       return this
     },
-    setLitePlan() {
-      trackingType = RumTrackingType.TRACKED_LITE
+    setPlanWithoutSessionReplay() {
+      tracked = true
+      sessionReplayAllowed = false
       return this
     },
-    setPremiumPlan() {
-      trackingType = RumTrackingType.TRACKED_PREMIUM
+    setPlanWithSessionReplay() {
+      tracked = true
+      sessionReplayAllowed = true
       return this
     },
-    setLongTaskAllowed(longTaskAllowed: boolean) {
-      trackingType = longTaskAllowed ? RumTrackingType.TRACKED_PREMIUM : RumTrackingType.TRACKED_LITE
+    setLongTaskAllowed(isAllowed: boolean) {
+      longTaskAllowed = isAllowed
       return this
     },
-    setResourceAllowed(resourceAllowed: boolean) {
-      trackingType = resourceAllowed ? RumTrackingType.TRACKED_PREMIUM : RumTrackingType.TRACKED_LITE
+    setResourceAllowed(isAllowed: boolean) {
+      resourceAllowed = isAllowed
       return this
     },
   }

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -190,7 +190,7 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
       format_version: 2,
       drift: 0,
       session: {
-        plan: RumSessionPlan.PREMIUM,
+        plan: RumSessionPlan.WITH_SESSION_REPLAY,
       },
     },
     application: {

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -110,8 +110,8 @@ describe('makeRecorderApi', () => {
       expect(startRecordingSpy).not.toHaveBeenCalled()
     })
 
-    it('ignores calls if the session plan is LITE', () => {
-      setupBuilder.withSessionManager(createRumSessionManagerMock().setLitePlan()).build()
+    it('ignores calls if the session plan is WITHOUT_REPLAY', () => {
+      setupBuilder.withSessionManager(createRumSessionManagerMock().setPlanWithoutSessionReplay()).build()
       rumInit()
       recorderApi.start()
       expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -216,14 +216,14 @@ describe('makeRecorderApi', () => {
       rumInit()
     })
 
-    describe('from LITE to PREMIUM', () => {
+    describe('from WITHOUT_REPLAY to WITH_REPLAY', () => {
       beforeEach(() => {
-        sessionManager.setLitePlan()
+        sessionManager.setPlanWithoutSessionReplay()
       })
 
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setPremiumPlan()
+        sessionManager.setPlanWithSessionReplay()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
@@ -234,16 +234,16 @@ describe('makeRecorderApi', () => {
       it('does not starts recording if stopSessionReplayRecording was called', () => {
         recorderApi.start()
         recorderApi.stop()
-        sessionManager.setPremiumPlan()
+        sessionManager.setPlanWithSessionReplay()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
       })
     })
 
-    describe('from LITE to untracked', () => {
+    describe('from WITHOUT_REPLAY to untracked', () => {
       beforeEach(() => {
-        sessionManager.setLitePlan()
+        sessionManager.setPlanWithoutSessionReplay()
       })
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
@@ -256,9 +256,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from LITE to LITE', () => {
+    describe('from WITHOUT_REPLAY to WITHOUT_REPLAY', () => {
       beforeEach(() => {
-        sessionManager.setLitePlan()
+        sessionManager.setPlanWithoutSessionReplay()
       })
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
@@ -270,15 +270,15 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from PREMIUM to LITE', () => {
+    describe('from WITH_REPLAY to WITHOUT_REPLAY', () => {
       beforeEach(() => {
-        sessionManager.setPremiumPlan()
+        sessionManager.setPlanWithSessionReplay()
       })
 
       it('stops recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
         expect(startRecordingSpy).toHaveBeenCalledTimes(1)
-        sessionManager.setLitePlan()
+        sessionManager.setPlanWithoutSessionReplay()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         expect(stopRecordingSpy).toHaveBeenCalled()
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
@@ -290,7 +290,7 @@ describe('makeRecorderApi', () => {
         const { triggerOnDomLoaded } = mockDocumentReadyState()
         rumInit()
         recorderApi.start()
-        sessionManager.setLitePlan()
+        sessionManager.setPlanWithoutSessionReplay()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         triggerOnDomLoaded()
@@ -298,9 +298,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from PREMIUM to untracked', () => {
+    describe('from WITH_REPLAY to untracked', () => {
       beforeEach(() => {
-        sessionManager.setPremiumPlan()
+        sessionManager.setPlanWithSessionReplay()
       })
 
       it('stops recording if startSessionReplayRecording was called', () => {
@@ -314,9 +314,9 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from PREMIUM to PREMIUM', () => {
+    describe('from WITH_REPLAY to WITH_REPLAY', () => {
       beforeEach(() => {
-        sessionManager.setPremiumPlan()
+        sessionManager.setPlanWithSessionReplay()
       })
 
       it('keeps recording if startSessionReplayRecording was called', () => {
@@ -347,7 +347,7 @@ describe('makeRecorderApi', () => {
 
       it('starts recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setPremiumPlan()
+        sessionManager.setPlanWithSessionReplay()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).toHaveBeenCalled()
@@ -357,7 +357,7 @@ describe('makeRecorderApi', () => {
       it('does not starts recording if stopSessionReplayRecording was called', () => {
         recorderApi.start()
         recorderApi.stop()
-        sessionManager.setPremiumPlan()
+        sessionManager.setPlanWithSessionReplay()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -365,14 +365,14 @@ describe('makeRecorderApi', () => {
       })
     })
 
-    describe('from untracked to LITE', () => {
+    describe('from untracked to WITHOUT_REPLAY', () => {
       beforeEach(() => {
         sessionManager.setNotTracked()
       })
 
       it('keeps not recording if startSessionReplayRecording was called', () => {
         recorderApi.start()
-        sessionManager.setLitePlan()
+        sessionManager.setPlanWithoutSessionReplay()
         lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
         lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
         expect(startRecordingSpy).not.toHaveBeenCalled()

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -90,7 +90,7 @@ export function makeRecorderApi(
 
       startStrategy = () => {
         const session = sessionManager.findTrackedSession()
-        if (!session || !session.hasPremiumPlan) {
+        if (!session || !session.sessionReplayAllowed) {
           state = { status: RecorderStatus.IntentToStart }
           return
         }

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -141,7 +141,7 @@ describe('startRecording', () => {
 
     document.body.dispatchEvent(createNewEvent('click'))
 
-    sessionManager.setId('new-session-id').setPremiumPlan()
+    sessionManager.setId('new-session-id').setPlanWithSessionReplay()
     flushSegment(lifeCycle)
     document.body.dispatchEvent(createNewEvent('click'))
 

--- a/packages/rum/src/types/sessionReplay.ts
+++ b/packages/rum/src/types/sessionReplay.ts
@@ -333,7 +333,7 @@ export interface CommonSegmentMetadataSchema {
   /**
    * The index of this Segment in the segments list that was recorded for this view ID. Starts from 0.
    */
-  index_in_view: number
+  index_in_view?: number
   /**
    * Whether this Segment contains a full snapshot record or not.
    */

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -9,11 +9,17 @@
       DD_RUM.init({
         clientToken: 'xxx',
         applicationId: 'xxx',
+        sessionReplaySampleRate: 100,
+        trackResources: true,
+        trackLongTasks: true,
         telemetrySampleRate: 100,
+        enableExperimentalFeatures: [],
       })
+      DD_RUM.startSessionReplayRecording()
       DD_LOGS.init({
         clientToken: 'xxx',
         telemetrySampleRate: 100,
+        enableExperimentalFeatures: [],
       })
     </script>
   </head>

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -15,6 +15,9 @@ import { createMockServerApp } from './serverApps/mock'
 const DEFAULT_RUM_CONFIGURATION = {
   applicationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   clientToken: 'token',
+  sessionReplaySampleRate: 100,
+  trackResources: true,
+  trackLongTasks: true,
   telemetrySampleRate: 100,
   enableExperimentalFeatures: [],
 }


### PR DESCRIPTION
## Motivation

Reflect modification of pricing plans content and behavior while keeping current behavior for existing customers.

## Changes

New configuration parameters:

- `trackResources`: allow to collect resource events
- `trackLongTasks`: allow to collect long task events
- `sessionReplaySampleRate`: replace `premiumSampleRate` but only control the percentage of sessions that have session replay (and are billed for it).

```
premiumSampleRate | sessionReplaySampleRate | trackResources/LongTasks || do track resources/long tasks
========================================================================================================
 used             | undefined               | undefined                || true if session replay, false otherwise
 used             | undefined               | false                    || false
 used             | undefined               | true                     || true
 undefined        | used                    | undefined                || false
 undefined        | used                    | false                    || false
 undefined        | used                    | true                     || true

```




**Nb:** Documentation changes will come in a following PR.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
