### PR TITLE
📝 [RUMF-1391] Document new pricing plans default setup and init parameters

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -51,6 +51,29 @@ datadogRum.init({
   //  env: 'production',
   //  version: '1.0.0',
   sampleRate: 100,
+  sessionReplaySampleRate: 100, // if not included, the default is 100
+  trackResources: true,
+  trackLongTasks: true,
+  trackInteractions: true,
+})
+```
+
+</details>
+
+<details>
+  <summary>before <code>v4.20.0</code></summary>
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum'
+
+datadogRum.init({
+  applicationId: '<DATADOG_APPLICATION_ID>',
+  clientToken: '<DATADOG_CLIENT_TOKEN>',
+  site: '<DATADOG_SITE>',
+  //  service: 'my-web-application',
+  //  env: 'production',
+  //  version: '1.0.0',
+  sampleRate: 100,
   premiumSampleRate: 100, // if not included, the default is 100
   trackInteractions: true,
 })
@@ -87,6 +110,37 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 
 <details open>
   <summary>Latest version</summary>
+
+<!-- prettier-ignore -->
+```html
+<script>
+  (function(h,o,u,n,d) {
+     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+     d=o.createElement(u);d.async=1;d.src=n
+     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM')
+  DD_RUM.onReady(function() {
+    DD_RUM.init({
+      clientToken: '<CLIENT_TOKEN>',
+      applicationId: '<APPLICATION_ID>',
+      site: '<DATADOG_SITE>',
+      //  service: 'my-web-application',
+      //  env: 'production',
+      //  version: '1.0.0',
+      sampleRate: 100,
+      sessionReplaySampleRate: 100, // if not included, the default is 100
+      trackResources: true,
+      trackLongTasks: true,
+      trackInteractions: true,
+    })
+  })
+</script>
+```
+
+</details>
+
+<details>
+  <summary>before<code>v4.20.0</code></summary>
 
 <!-- prettier-ignore -->
 ```html
@@ -166,6 +220,31 @@ Add the generated code snippet to the head tag (in front of any other script tag
       //  env: 'production',
       //  version: '1.0.0',
       sampleRate: 100,
+      sessionReplaySampleRate: 100, // if not included, the default is 100
+      trackResources: true,
+      trackLongTasks: true,
+      trackInteractions: true,
+    })
+</script>
+```
+
+</details>
+
+<details>
+  <summary>before<code>v4.20.0</code></summary>
+
+```html
+<script src="https://www.datadoghq-browser-agent.com/datadog-rum-v4.js" type="text/javascript"></script>
+<script>
+  window.DD_RUM &&
+    window.DD_RUM.init({
+      clientToken: '<CLIENT_TOKEN>',
+      applicationId: '<APPLICATION_ID>',
+      site: '<DATADOG_SITE>',
+      //  service: 'my-web-application',
+      //  env: 'production',
+      //  version: '1.0.0',
+      sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
     })
@@ -213,7 +292,9 @@ window.DD_RUM.init({
   clientToken: 'XXX',
   site: 'datadoghq.com',
   sampleRate: 100,
-  premiumSampleRate: 100,
+  sessionReplaySampleRate: 100, // if not included, the default is 100
+  trackResources: true,
+  trackLongTasks: true,
 })
 ```
 
@@ -221,7 +302,7 @@ window.DD_RUM.init({
 
 ### Initialization parameters
 
-The following parameters are available:
+Call the initialization command to start tracking, the following parameters are available:
 
 `applicationId`
 : Required<br/>
@@ -272,6 +353,18 @@ Enables [automatic collection of users actions][6].
 **Default**: `false` <br/>
 Enables [automatic collection of user frustrations][20]. Implies `trackInteractions: true`.
 
+`trackResources`
+: Optional<br/>
+**Type**: Boolean<br/>
+**Default**: `false` <br/>
+Enables collection of resource events.
+
+`trackLongTasks`
+: Optional<br/>
+**Type**: Boolean<br/>
+**Default**: `false` <br/>
+Enables collection of long task events.
+
 `defaultPrivacyLevel`
 : Optional<br/>
 **Type**: String<br/>
@@ -287,19 +380,25 @@ Specify your own attribute to be used to [name actions][9].
 : Optional<br/>
 **Type**: Number<br/>
 **Default**: `100`<br/>
-The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send RUM events. For more details about `sampleRate`, see the [sampling configuration](#browser-and-browser-premium-sampling-configuration).
+The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send RUM events. For more details about `sampleRate`, see the [sampling configuration][21].
 
 `replaySampleRate`
 : Optional - **Deprecated**<br/>
 **Type**: Number<br/>
 **Default**: `100`<br/>
-See `premiumSampleRate`.
+See `sessionReplaySampleRate`.
 
 `premiumSampleRate`
-: Optional<br/>
+: Optional - **Deprecated**<br/>
 **Type**: Number<br/>
 **Default**: `100`<br/>
-The percentage of tracked sessions with [Browser Premium pricing][11] features: `100` for all, `0` for none. For more details about `premiumSampleRate`, see the [sampling configuration](#browser-and-browser-premium-sampling-configuration).
+See `sessionReplaySampleRate`.
+
+`sessionReplaySampleRate`
+: Optional - **Deprecated**<br/>
+**Type**: Number<br/>
+**Default**: `100`<br/>
+The percentage of tracked sessions with [Browser RUM & Session Replay pricing][11] features: `100` for all, `0` for none. For more details about `sessionReplaySampleRate`, see the [sampling configuration][21].
 
 `silentMultipleInit`
 : Optional<br/>
@@ -353,26 +452,6 @@ Use a secure session cookie. This disables RUM events sent on insecure (non-HTTP
 **Type**: Boolean<br/>
 **Default**:`false`<br/>
 Use a secure cross-site session cookie. This allows the RUM Browser SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`.
-
-Call the initialization command to start tracking:
-
-```
-init(configuration: {
-    applicationId: string,
-    clientToken: string,
-    site?: string,
-    sampleRate?: number,
-    silentMultipleInit?: boolean,
-    trackInteractions?: boolean,
-    service?: string,
-    env?: string,
-    version?: string,
-    allowedTracingOrigins?: Array<String|Regexp>,
-    trackSessionAcrossSubdomains?: boolean,
-    useSecureSessionCookie?: boolean,
-    useCrossSiteSessionCookie?: boolean,
-})
-```
 
 ### Tagging
 


### PR DESCRIPTION
## Motivation

Following new pricing plans, document new config parameters / setup instructions.

## Changes

- Update latest setup instructions to use new config parameters
- Add previous setup instructions (Before 4.20.0)
- Document new init parameters
- Fix broken references
- Remove outdated init command description

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
