### PR TITLE
👷‍ Setup publish to npm from ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,6 +261,16 @@ deploy-prod-stable:
     - ./scripts/deploy.sh prod v${VERSION%%.*}
     - node ./scripts/upload-source-maps.js datadoghq.com,datadoghq.eu,us3.datadoghq.com,us5.datadoghq.com v${VERSION%%.*}
 
+publish-npm:
+  stage: deploy
+  extends:
+    - .base-configuration
+    - .tags
+  when: manual
+  allow_failure: false
+  script:
+    - ./scripts/publish-npm.sh
+
 ########################################################################################################################
 # Notify
 ########################################################################################################################

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "dev": "node scripts/dev-server.js",
     "release": "scripts/cli release",
     "version": "scripts/cli version",
-    "publish:npm": "BUILD_MODE=release yarn build && lerna publish from-package",
     "test": "yarn test:unit:watch",
     "test:unit": "karma start ./test/unit/karma.local.conf.js",
     "test:unit:watch": "yarn test:unit --no-single-run",

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+export NPM_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.browser-sdk.npm_token --with-decryption --query "Parameter.Value" --out text)
+BUILD_MODE=release yarn build
+lerna publish from-package


### PR DESCRIPTION
## Motivation

Avoid to publish to npm from developer laptop

## Changes

- new script to publish to npm using a npm automation token
- add extra manual step on the deploy tag stage

## Testing

only a `npm whoami` to test the token setup
we will see how it goes with the next release

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
