### PR TITLE
🐛[RUMF-1276] handle performance entry without `toJSON`

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -102,11 +102,6 @@ export function supportPerformanceTimingEvent(entryType: string) {
   )
 }
 
-export function supportPerformanceEntry() {
-  // Safari 10 doesn't support PerformanceEntry
-  return typeof PerformanceEntry === 'function'
-}
-
 export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: RumConfiguration) {
   retrieveInitialDocumentResourceTiming((timing) => {
     handleRumPerformanceEntries(lifeCycle, configuration, [timing])

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -173,10 +173,9 @@ function computeEntryTracingInfo(entry: RumPerformanceResourceTiming, configurat
 }
 
 function toPerformanceEntryRepresentation(entry: RumPerformanceEntry): PerformanceEntryRepresentation {
-  if (supportPerformanceEntry() && entry instanceof PerformanceEntry) {
-    entry.toJSON()
-  }
-  return entry as PerformanceEntryRepresentation
+  return (
+    supportPerformanceEntry() && entry instanceof PerformanceEntry && 'toJSON' in entry ? entry.toJSON() : entry
+  ) as PerformanceEntryRepresentation
 }
 
 /**

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -11,7 +11,6 @@ import {
 import type { ClocksState } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
 import type { RumPerformanceEntry, RumPerformanceResourceTiming } from '../../../browser/performanceCollection'
-import { supportPerformanceEntry } from '../../../browser/performanceCollection'
 import type {
   PerformanceEntryRepresentation,
   RumXhrResourceEventDomainContext,
@@ -172,10 +171,9 @@ function computeEntryTracingInfo(entry: RumPerformanceResourceTiming, configurat
   }
 }
 
+// TODO next major: use directly PerformanceEntry type in domain context
 function toPerformanceEntryRepresentation(entry: RumPerformanceEntry): PerformanceEntryRepresentation {
-  return (
-    supportPerformanceEntry() && entry instanceof PerformanceEntry && 'toJSON' in entry ? entry.toJSON() : entry
-  ) as PerformanceEntryRepresentation
+  return entry as PerformanceEntryRepresentation
 }
 
 /**


### PR DESCRIPTION
## Motivation

fix issue raised by telemetry

## Changes

remove useless toJSON call and checks

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
