### PR TITLE
⚗️[RUMF-1405] add mechanism to simulate intake issue

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -4,6 +4,7 @@ import { catchUserErrors } from '../../tools/catchUserErrors'
 import { display } from '../../tools/display'
 import { assign, isPercentage, ONE_KIBI_BYTE, ONE_SECOND } from '../../tools/utils'
 import { updateExperimentalFeatures } from './experimentalFeatures'
+import { initSimulation } from './simulation'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
 
@@ -40,6 +41,11 @@ export interface InitConfiguration {
   enableExperimentalFeatures?: string[] | undefined
   replica?: ReplicaUserConfiguration | undefined
   datacenter?: string
+
+  // simulation options
+  simulationStart?: string | undefined
+  simulationEnd?: string | undefined
+  simulationLabel?: string | undefined
 }
 
 // This type is only used to build the core configuration. Logs and RUM SDKs are using a proper type
@@ -89,6 +95,8 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
 
   // Set the experimental feature flags as early as possible, so we can use them in most places
   updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
+
+  initSimulation(initConfiguration.simulationStart, initConfiguration.simulationEnd, initConfiguration.simulationLabel)
 
   return assign(
     {

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -13,3 +13,4 @@ export {
   getExperimentalFeatures,
 } from './experimentalFeatures'
 export * from './intakeSites'
+export { isSimulationActive, getSimulationLabel } from './simulation'

--- a/packages/core/src/domain/configuration/simulation.ts
+++ b/packages/core/src/domain/configuration/simulation.ts
@@ -1,0 +1,29 @@
+import { dateNow } from '../../tools/timeUtils'
+import type { TimeStamp } from '../../tools/timeUtils'
+
+interface Simulation {
+  start: TimeStamp
+  end: TimeStamp
+  label: string
+}
+
+let simulation: Simulation | undefined
+
+export function initSimulation(simulationStart?: string, simulationEnd?: string, simulationLabel?: string) {
+  if (simulationStart && simulationEnd && simulationLabel) {
+    simulation = {
+      start: new Date(simulationStart).getTime() as TimeStamp,
+      end: new Date(simulationEnd).getTime() as TimeStamp,
+      label: simulationLabel,
+    }
+  }
+}
+
+export function isSimulationActive() {
+  const now = dateNow()
+  return simulation !== undefined && now >= simulation.start && now <= simulation.end
+}
+
+export function getSimulationLabel() {
+  return simulation?.label
+}

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -89,7 +89,7 @@ export function startTelemetry(configuration: Configuration): Telemetry {
         experimental_features: arrayFrom(getExperimentalFeatures()),
       },
       contextProvider !== undefined ? contextProvider() : {},
-      isSimulationActive() ? { simulation_label: getSimulationLabel() } : {}
+      isSimulationActive() ? { telemetry: { simulation_label: getSimulationLabel() } } : {}
     )
   }
 

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -3,7 +3,13 @@ import { ConsoleApiName } from '../../tools/display'
 import { toStackTraceString } from '../../tools/error'
 import { assign, combine, jsonStringify, performDraw, includes, startsWith, arrayFrom } from '../../tools/utils'
 import type { Configuration } from '../configuration'
-import { getExperimentalFeatures, INTAKE_SITE_STAGING, INTAKE_SITE_US1_FED } from '../configuration'
+import {
+  getExperimentalFeatures,
+  getSimulationLabel,
+  INTAKE_SITE_STAGING,
+  INTAKE_SITE_US1_FED,
+  isSimulationActive,
+} from '../configuration'
 import type { StackTrace } from '../tracekit'
 import { computeStackTrace } from '../tracekit'
 import { Observable } from '../../tools/observable'
@@ -82,7 +88,8 @@ export function startTelemetry(configuration: Configuration): Telemetry {
         telemetry: event as any, // https://github.com/microsoft/TypeScript/issues/48457
         experimental_features: arrayFrom(getExperimentalFeatures()),
       },
-      contextProvider !== undefined ? contextProvider() : {}
+      contextProvider !== undefined ? contextProvider() : {},
+      isSimulationActive() ? { simulation_label: getSimulationLabel() } : {}
     )
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,8 @@ export {
   isExperimentalFeatureEnabled,
   updateExperimentalFeatures,
   resetExperimentalFeatures,
+  isSimulationActive,
+  getSimulationLabel,
 } from './domain/configuration'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'
 export { computeStackTrace, StackTrace } from './domain/tracekit'

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -18,7 +18,7 @@ describe('httpRequest', () => {
     interceptor = interceptRequests()
     requests = interceptor.requests
     endpointBuilder = stubEndpointBuilder(ENDPOINT_URL)
-    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT, noop)
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT, noop, true)
   })
 
   afterEach(() => {
@@ -209,7 +209,7 @@ describe('httpRequest intake parameters', () => {
     interceptor = interceptRequests()
     requests = interceptor.requests
     endpointBuilder = createEndpointBuilder({ clientToken }, 'logs', [])
-    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT, noop)
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT, noop, true)
   })
 
   afterEach(() => {

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -1,7 +1,7 @@
 import type { EndpointBuilder } from '../domain/configuration'
 import { addTelemetryError } from '../domain/telemetry'
 import { monitor } from '../tools/monitor'
-import { isExperimentalFeatureEnabled } from '../domain/configuration'
+import { isExperimentalFeatureEnabled, isSimulationActive } from '../domain/configuration'
 import type { RawError } from '../tools/error'
 import { newRetryState, sendWithRetryStrategy } from './sendWithRetryStrategy'
 
@@ -15,6 +15,7 @@ import { newRetryState, sendWithRetryStrategy } from './sendWithRetryStrategy'
  */
 
 export type HttpRequest = ReturnType<typeof createHttpRequest>
+
 export interface HttpResponse {
   status: number
 }
@@ -27,7 +28,8 @@ export interface Payload {
 export function createHttpRequest(
   endpointBuilder: EndpointBuilder,
   bytesLimit: number,
-  reportError: (error: RawError) => void
+  reportError: (error: RawError) => void,
+  toPrimaryEndpoint: boolean
 ) {
   const retryState = newRetryState()
   const sendStrategyForRetry = (payload: Payload, onResponse: (r: HttpResponse) => void) =>
@@ -38,7 +40,14 @@ export function createHttpRequest(
       if (!isExperimentalFeatureEnabled('retry')) {
         fetchKeepAliveStrategy(endpointBuilder, bytesLimit, payload)
       } else {
-        sendWithRetryStrategy(payload, retryState, sendStrategyForRetry, endpointBuilder.endpointType, reportError)
+        sendWithRetryStrategy(
+          payload,
+          retryState,
+          sendStrategyForRetry,
+          endpointBuilder.endpointType,
+          toPrimaryEndpoint,
+          reportError
+        )
       }
     },
     /**
@@ -46,6 +55,14 @@ export function createHttpRequest(
      * keep using sendBeaconStrategy on exit
      */
     sendOnExit: (payload: Payload) => {
+      if (
+        isExperimentalFeatureEnabled('retry') &&
+        endpointBuilder.endpointType !== 'sessionReplay' &&
+        toPrimaryEndpoint &&
+        isSimulationActive()
+      ) {
+        return
+      }
       sendBeaconStrategy(endpointBuilder, bytesLimit, payload)
     },
   }

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -45,7 +45,7 @@ describe('sendWithRetryStrategy', () => {
         data: payload?.data ?? 'a',
         bytesCount: payload?.bytesCount ?? 1,
       }
-      sendWithRetryStrategy(effectivePayload, state, sendStub.sendStrategy, ENDPOINT_TYPE, reportErrorSpy)
+      sendWithRetryStrategy(effectivePayload, state, sendStub.sendStrategy, ENDPOINT_TYPE, true, reportErrorSpy)
     }
   })
 

--- a/packages/core/src/transport/startBatchWithReplica.ts
+++ b/packages/core/src/transport/startBatchWithReplica.ts
@@ -10,15 +10,15 @@ export function startBatchWithReplica<T extends Context>(
   reportError: (error: RawError) => void,
   replicaEndpoint?: EndpointBuilder
 ) {
-  const primaryBatch = createBatch(endpoint)
+  const primaryBatch = createBatch(endpoint, true)
   let replicaBatch: Batch | undefined
   if (replicaEndpoint) {
-    replicaBatch = createBatch(replicaEndpoint)
+    replicaBatch = createBatch(replicaEndpoint, false)
   }
 
-  function createBatch(endpointBuilder: EndpointBuilder) {
+  function createBatch(endpointBuilder: EndpointBuilder, toPrimaryEndpoint: boolean) {
     return new Batch(
-      createHttpRequest(endpointBuilder, configuration.batchBytesLimit, reportError),
+      createHttpRequest(endpointBuilder, configuration.batchBytesLimit, reportError, toPrimaryEndpoint),
       configuration.batchMessagesLimit,
       configuration.batchBytesLimit,
       configuration.messageBytesLimit,

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -8,6 +8,8 @@ import {
   combine,
   createEventRateLimiter,
   getRelativeTime,
+  isSimulationActive,
+  getSimulationLabel,
 } from '@datadog/browser-core'
 import type { CommonContext } from '../rawLogsEvent.types'
 import type { LogsConfiguration } from './configuration'
@@ -51,6 +53,10 @@ export function startLogsAssembly(
         logger.getContext(),
         messageContext
       )
+
+      if (isSimulationActive()) {
+        log.simulation_label = getSimulationLabel()
+      }
 
       if (
         // Todo: [RUMF-1230] Move this check to the logger collection in the next major release

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -8,6 +8,8 @@ import {
   display,
   createEventRateLimiter,
   canUseEventBridge,
+  isSimulationActive,
+  getSimulationLabel,
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type {
@@ -132,6 +134,10 @@ export function startRumAssembly(
 
         const serverRumEvent = combine(rumContext as RumContext & Context, rawRumEvent) as RumEvent & Context
         serverRumEvent.context = combine(commonContext.context, customerContext)
+
+        if (isSimulationActive()) {
+          serverRumEvent.context.simulation_label = getSimulationLabel()
+        }
 
         if (!('has_replay' in serverRumEvent.session)) {
           ;(serverRumEvent.session as Mutable<RumEvent['session']>).has_replay = commonContext.hasReplay

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -35,19 +35,19 @@ function makeRumBatch(
   lifeCycle: LifeCycle,
   reportError: (error: RawError) => void
 ): RumBatch {
-  const primaryBatch = createRumBatch(configuration.rumEndpointBuilder, () =>
+  const primaryBatch = createRumBatch(configuration.rumEndpointBuilder, true, () =>
     lifeCycle.notify(LifeCycleEventType.BEFORE_UNLOAD)
   )
 
   let replicaBatch: Batch | undefined
   const replica = configuration.replica
   if (replica !== undefined) {
-    replicaBatch = createRumBatch(replica.rumEndpointBuilder)
+    replicaBatch = createRumBatch(replica.rumEndpointBuilder, false)
   }
 
-  function createRumBatch(endpointBuilder: EndpointBuilder, unloadCallback?: () => void) {
+  function createRumBatch(endpointBuilder: EndpointBuilder, toPrimaryEndpoint: boolean, unloadCallback?: () => void) {
     return new Batch(
-      createHttpRequest(endpointBuilder, configuration.batchBytesLimit, reportError),
+      createHttpRequest(endpointBuilder, configuration.batchBytesLimit, reportError, toPrimaryEndpoint),
       configuration.batchMessagesLimit,
       configuration.batchBytesLimit,
       configuration.messageBytesLimit,

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -57,7 +57,12 @@ describe('startRecording', () => {
           defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
         })
         .beforeBuild(({ lifeCycle, configuration, viewContexts, sessionManager }) => {
-          const httpRequest = createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT, noop)
+          const httpRequest = createHttpRequest(
+            configuration.sessionReplayEndpointBuilder,
+            SEGMENT_BYTES_LIMIT,
+            noop,
+            true
+          )
 
           const requestSendSpy = spyOn(httpRequest, 'sendOnExit')
           ;({ waitAsyncCalls: waitRequestSendCalls, expectNoExtraAsyncCall: expectNoExtraRequestSendCalls } =

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -28,7 +28,7 @@ export function startRecording(
   }
 
   const replayRequest =
-    httpRequest || createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT, reportError)
+    httpRequest || createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT, reportError, true)
 
   const { addRecord, stop: stopSegmentCollection } = startSegmentCollection(
     lifeCycle,


### PR DESCRIPTION
## Motivation

Analyze behavior of retry strategy during intake issue

## Changes

- Introduce simulation parameters:

```
simulationStart?: string | undefined
simulationEnd?: string | undefined
simulationLabel?: string | undefined
```

- consider request to primary as failed during simulation
- add simulation label to events during simulation

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
