### PR TITLE
🔊 Collect configuration telemetry event

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -3,7 +3,7 @@ import { getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { display } from '../../tools/display'
 import { assign, isPercentage, ONE_KIBI_BYTE, ONE_SECOND } from '../../tools/utils'
-import type { RawConfigurationTelemetryEvent } from '../telemetry'
+import type { RawTelemetryConfiguration } from '../telemetry'
 import { updateExperimentalFeatures } from './experimentalFeatures'
 import { initSimulation } from './simulation'
 import type { TransportConfiguration } from './transportConfiguration'
@@ -153,9 +153,7 @@ function mustUseSecureCookie(initConfiguration: InitConfiguration) {
   return !!initConfiguration.useSecureSessionCookie || !!initConfiguration.useCrossSiteSessionCookie
 }
 
-export function serializeConfiguration(
-  configuration: InitConfiguration
-): Partial<RawConfigurationTelemetryEvent['configuration']> {
+export function serializeConfiguration(configuration: InitConfiguration): Partial<RawTelemetryConfiguration> {
   return {
     session_sample_rate: configuration.sampleRate,
     telemetry_sample_rate: configuration.telemetrySampleRate,

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -149,3 +149,16 @@ export function buildCookieOptions(initConfiguration: InitConfiguration) {
 function mustUseSecureCookie(initConfiguration: InitConfiguration) {
   return !!initConfiguration.useSecureSessionCookie || !!initConfiguration.useCrossSiteSessionCookie
 }
+
+export function serializeConfiguration(configuration: InitConfiguration) {
+  return {
+    session_sample_rate: configuration.sampleRate,
+    telemetry_sample_rate: configuration.telemetrySampleRate,
+    use_before_send: !!configuration.beforeSend,
+    use_cross_site_session_cookie: configuration.useCrossSiteSessionCookie,
+    use_secure_session_cookie: configuration.useSecureSessionCookie,
+    use_proxy: configuration.proxyUrl !== undefined ? !!configuration.proxyUrl : undefined,
+    silent_multiple_init: configuration.silentMultipleInit,
+    track_session_across_subdomains: configuration.trackSessionAcrossSubdomains,
+  }
+}

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -63,6 +63,7 @@ export interface Configuration extends TransportConfiguration {
   cookieOptions: CookieOptions
   sampleRate: number
   telemetrySampleRate: number
+  telemetryConfigurationSampleRate: number
   service: string | undefined
   silentMultipleInit: boolean
 
@@ -105,6 +106,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       cookieOptions: buildCookieOptions(initConfiguration),
       sampleRate: initConfiguration.sampleRate ?? 100,
       telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
+      telemetryConfigurationSampleRate: 20,
       service: initConfiguration.service,
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -42,6 +42,7 @@ export interface InitConfiguration {
   enableExperimentalFeatures?: string[] | undefined
   replica?: ReplicaUserConfiguration | undefined
   datacenter?: string
+  telemetryConfigurationSampleRate?: number
 
   // simulation options
   simulationStart?: string | undefined
@@ -95,6 +96,14 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     return
   }
 
+  if (
+    initConfiguration.telemetryConfigurationSampleRate !== undefined &&
+    !isPercentage(initConfiguration.telemetryConfigurationSampleRate)
+  ) {
+    display.error('Telemetry Configuration Sample Rate should be a number between 0 and 100')
+    return
+  }
+
   // Set the experimental feature flags as early as possible, so we can use them in most places
   updateExperimentalFeatures(initConfiguration.enableExperimentalFeatures)
 
@@ -107,7 +116,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       cookieOptions: buildCookieOptions(initConfiguration),
       sampleRate: initConfiguration.sampleRate ?? 100,
       telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
-      telemetryConfigurationSampleRate: 5,
+      telemetryConfigurationSampleRate: initConfiguration.telemetryConfigurationSampleRate ?? 5,
       service: initConfiguration.service,
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
 
@@ -157,6 +166,7 @@ export function serializeConfiguration(configuration: InitConfiguration): Partia
   return {
     session_sample_rate: configuration.sampleRate,
     telemetry_sample_rate: configuration.telemetrySampleRate,
+    telemetry_configuration_sample_rate: configuration.telemetryConfigurationSampleRate,
     use_before_send: !!configuration.beforeSend,
     use_cross_site_session_cookie: configuration.useCrossSiteSessionCookie,
     use_secure_session_cookie: configuration.useSecureSessionCookie,

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -3,6 +3,7 @@ import { getCurrentSite } from '../../browser/cookie'
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { display } from '../../tools/display'
 import { assign, isPercentage, ONE_KIBI_BYTE, ONE_SECOND } from '../../tools/utils'
+import type { RawConfigurationTelemetryEvent } from '../telemetry'
 import { updateExperimentalFeatures } from './experimentalFeatures'
 import { initSimulation } from './simulation'
 import type { TransportConfiguration } from './transportConfiguration'
@@ -106,7 +107,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       cookieOptions: buildCookieOptions(initConfiguration),
       sampleRate: initConfiguration.sampleRate ?? 100,
       telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
-      telemetryConfigurationSampleRate: 20,
+      telemetryConfigurationSampleRate: 5,
       service: initConfiguration.service,
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
 
@@ -152,7 +153,9 @@ function mustUseSecureCookie(initConfiguration: InitConfiguration) {
   return !!initConfiguration.useSecureSessionCookie || !!initConfiguration.useCrossSiteSessionCookie
 }
 
-export function serializeConfiguration(configuration: InitConfiguration) {
+export function serializeConfiguration(
+  configuration: InitConfiguration
+): Partial<RawConfigurationTelemetryEvent['configuration']> {
   return {
     session_sample_rate: configuration.sampleRate,
     telemetry_sample_rate: configuration.telemetrySampleRate,

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -4,6 +4,7 @@ export {
   buildCookieOptions,
   DefaultPrivacyLevel,
   validateAndBuildConfiguration,
+  serializeConfiguration,
 } from './configuration'
 export { createEndpointBuilder, EndpointBuilder, EndpointType } from './endpointBuilder'
 export {

--- a/packages/core/src/domain/telemetry/index.ts
+++ b/packages/core/src/domain/telemetry/index.ts
@@ -1,11 +1,13 @@
 export {
   Telemetry,
-  RawTelemetryEvent,
   addTelemetryDebug,
   addTelemetryError,
   startFakeTelemetry,
   resetTelemetry,
   startTelemetry,
   isTelemetryReplicationAllowed,
+  addTelemetryConfiguration,
 } from './telemetry'
+
+export * from './rawTelemetryEvent.types'
 export * from './telemetryEvent.types'

--- a/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
@@ -1,9 +1,9 @@
 import type { TelemetryEvent, TelemetryConfigurationEvent } from './telemetryEvent.types'
 
-export const enum TelemetryType {
-  log = 'log',
-  configuration = 'configuration',
-}
+export const TelemetryType = {
+  log: 'log',
+  configuration: 'configuration',
+} as const
 
 export const enum StatusType {
   debug = 'debug',
@@ -11,4 +11,4 @@ export const enum StatusType {
 }
 
 export type RawTelemetryEvent = TelemetryEvent['telemetry']
-export type RawConfigurationTelemetryEvent = TelemetryConfigurationEvent['telemetry']['configuration']
+export type RawTelemetryConfiguration = TelemetryConfigurationEvent['telemetry']['configuration']

--- a/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
@@ -1,4 +1,4 @@
-import type { Context } from '../../tools/context'
+import type { TelemetryEvent, TelemetryConfigurationEvent } from './telemetryEvent.types'
 
 export const enum TelemetryType {
   log = 'log',
@@ -10,25 +10,5 @@ export const enum StatusType {
   error = 'error',
 }
 
-export type RawTelemetryEvent = RawDebugTelemetryEvent | RawErrorTelemetryEvent | RawConfigurationTelemetryEvent
-
-export interface RawDebugTelemetryEvent extends Context {
-  message: string
-  status: StatusType.debug
-  type: TelemetryType.log
-  error?: {
-    kind?: string
-    stack: string
-  }
-}
-
-export interface RawErrorTelemetryEvent extends Context {
-  message: string
-  status: StatusType.error
-  type: TelemetryType.log
-}
-
-export interface RawConfigurationTelemetryEvent {
-  type: TelemetryType.configuration
-  configuration: any
-}
+export type RawTelemetryEvent = TelemetryEvent['telemetry']
+export type RawConfigurationTelemetryEvent = TelemetryConfigurationEvent['telemetry']['configuration']

--- a/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
@@ -1,0 +1,34 @@
+import type { Context } from '../../tools/context'
+
+export const enum TelemetryType {
+  log = 'log',
+  configuration = 'configuration',
+}
+
+export const enum StatusType {
+  debug = 'debug',
+  error = 'error',
+}
+
+export type RawTelemetryEvent = RawDebugTelemetryEvent | RawErrorTelemetryEvent | RawConfigurationTelemetryEvent
+
+export interface RawDebugTelemetryEvent extends Context {
+  message: string
+  status: StatusType.debug
+  type: TelemetryType.log
+  error?: {
+    kind?: string
+    stack: string
+  }
+}
+
+export interface RawErrorTelemetryEvent extends Context {
+  message: string
+  status: StatusType.error
+  type: TelemetryType.log
+}
+
+export interface RawConfigurationTelemetryEvent {
+  type: TelemetryType.configuration
+  configuration: any
+}

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -47,7 +47,7 @@ describe('telemetry', () => {
       resetExperimentalFeatures()
     })
 
-    it('should notify configuration when sampled and ff is enabled', () => {
+    it('should collects configuration when sampled and ff is enabled', () => {
       updateExperimentalFeatures(['telemetry_configuration'])
 
       const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryConfigurationSampleRate: 100 })
@@ -68,6 +68,15 @@ describe('telemetry', () => {
     it('should not notify configuration when not sampled and ff is enabled', () => {
       updateExperimentalFeatures(['telemetry_configuration'])
       const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryConfigurationSampleRate: 0 })
+
+      addTelemetryConfiguration({})
+
+      expect(notifySpy).not.toHaveBeenCalled()
+    })
+
+    it('should not notify configuration when telemetrySampleRate is 0 and ff is enabled', () => {
+      updateExperimentalFeatures(['telemetry_configuration'])
+      const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 0, telemetryConfigurationSampleRate: 100 })
 
       addTelemetryConfiguration({})
 

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -1,8 +1,19 @@
 import type { StackTrace } from '@datadog/browser-core'
 import { callMonitored } from '../../tools/monitor'
 import type { Configuration } from '../configuration'
-import { updateExperimentalFeatures, INTAKE_SITE_US1, INTAKE_SITE_US1_FED } from '../configuration'
-import { resetTelemetry, startTelemetry, scrubCustomerFrames, formatError } from './telemetry'
+import {
+  resetExperimentalFeatures,
+  updateExperimentalFeatures,
+  INTAKE_SITE_US1,
+  INTAKE_SITE_US1_FED,
+} from '../configuration'
+import {
+  resetTelemetry,
+  startTelemetry,
+  scrubCustomerFrames,
+  formatError,
+  addTelemetryConfiguration,
+} from './telemetry'
 
 function startAndSpyTelemetry(configuration?: Partial<Configuration>) {
   const telemetry = startTelemetry({
@@ -29,6 +40,39 @@ describe('telemetry', () => {
       throw new Error('message')
     })
     expect(notifySpy).toHaveBeenCalledTimes(1)
+  })
+
+  describe('addTelemetryConfiguration', () => {
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
+
+    it('should notify configuration when sampled and ff is enabled', () => {
+      updateExperimentalFeatures(['telemetry_configuration'])
+
+      const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryConfigurationSampleRate: 100 })
+
+      addTelemetryConfiguration({})
+
+      expect(notifySpy).toHaveBeenCalled()
+    })
+
+    it('should not notify configuration when sampled and ff is disabled', () => {
+      const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryConfigurationSampleRate: 100 })
+
+      addTelemetryConfiguration({})
+
+      expect(notifySpy).not.toHaveBeenCalled()
+    })
+
+    it('should not notify configuration when not sampled and ff is enabled', () => {
+      updateExperimentalFeatures(['telemetry_configuration'])
+      const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryConfigurationSampleRate: 0 })
+
+      addTelemetryConfiguration({})
+
+      expect(notifySpy).not.toHaveBeenCalled()
+    })
   })
 
   it('should contains feature flags', () => {

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -17,7 +17,7 @@ import { Observable } from '../../tools/observable'
 import { timeStampNow } from '../../tools/timeUtils'
 import { displayIfDebugEnabled, startMonitorErrorCollection } from '../../tools/monitor'
 import type { TelemetryEvent } from './telemetryEvent.types'
-import type { RawConfigurationTelemetryEvent, RawTelemetryEvent } from './rawTelemetryEvent.types'
+import type { RawTelemetryConfiguration, RawTelemetryEvent } from './rawTelemetryEvent.types'
 import { StatusType, TelemetryType } from './rawTelemetryEvent.types'
 
 // replaced at build time
@@ -124,7 +124,7 @@ export function addTelemetryDebug(message: string, context?: Context) {
   addTelemetry(
     assign(
       {
-        type: TelemetryType.log as const,
+        type: TelemetryType.log,
         message,
         status: StatusType.debug,
       },
@@ -137,7 +137,7 @@ export function addTelemetryError(e: unknown) {
   addTelemetry(
     assign(
       {
-        type: TelemetryType.log as const,
+        type: TelemetryType.log,
         status: StatusType.error,
       },
       formatError(e)
@@ -145,10 +145,10 @@ export function addTelemetryError(e: unknown) {
   )
 }
 
-export function addTelemetryConfiguration(configuration: RawConfigurationTelemetryEvent) {
+export function addTelemetryConfiguration(configuration: RawTelemetryConfiguration) {
   if (isExperimentalFeatureEnabled('telemetry_configuration') && telemetryConfiguration.telemetryConfigurationEnabled) {
     addTelemetry({
-      type: TelemetryType.configuration as const,
+      type: TelemetryType.configuration,
       configuration,
     })
   }

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -145,7 +145,7 @@ export function addTelemetryError(e: unknown) {
   )
 }
 
-export function addTelemetryConfiguration(configuration: RawConfigurationTelemetryEvent['configuration']) {
+export function addTelemetryConfiguration(configuration: RawConfigurationTelemetryEvent) {
   if (isExperimentalFeatureEnabled('telemetry_configuration') && telemetryConfiguration.telemetryConfigurationEnabled) {
     addTelemetry({
       type: TelemetryType.configuration as const,

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -94,6 +94,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       telemetry_sample_rate?: number
       /**
+       * The percentage of telemetry configuration events sent after being sampled by telemetry_sample_rate
+       */
+      telemetry_configuration_sample_rate?: number
+      /**
        * The percentage of requests traced
        */
       trace_sample_rate?: number

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -6,15 +6,19 @@
 /**
  * Schema of all properties of a telemetry event
  */
-export type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent
+export type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent
 /**
  * Schema of all properties of a telemetry error event
  */
 export type TelemetryErrorEvent = CommonTelemetryProperties & {
   /**
-   * The telemetry information
+   * The telemetry log information
    */
   telemetry: {
+    /**
+     * Telemetry type
+     */
+    type?: 'log'
     /**
      * Level/severity of the log
      */
@@ -46,9 +50,13 @@ export type TelemetryErrorEvent = CommonTelemetryProperties & {
  */
 export type TelemetryDebugEvent = CommonTelemetryProperties & {
   /**
-   * The telemetry information
+   * The telemetry log information
    */
   telemetry: {
+    /**
+     * Telemetry type
+     */
+    type?: 'log'
     /**
      * Level/severity of the log
      */
@@ -61,7 +69,140 @@ export type TelemetryDebugEvent = CommonTelemetryProperties & {
   }
   [k: string]: unknown
 }
-
+/**
+ * Schema of all properties of a telemetry configuration event
+ */
+export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
+  /**
+   * The telemetry configuration information
+   */
+  telemetry: {
+    /**
+     * Telemetry type
+     */
+    type: 'configuration'
+    /**
+     * Configuration properties
+     */
+    configuration: {
+      /**
+       * The percentage of sessions tracked
+       */
+      session_sample_rate?: number
+      /**
+       * The percentage of telemetry events sent
+       */
+      telemetry_sample_rate?: number
+      /**
+       * The percentage of requests traced
+       */
+      trace_sample_rate?: number
+      /**
+       * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
+       */
+      premium_sample_rate?: number
+      /**
+       * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
+       */
+      replay_sample_rate?: number
+      /**
+       * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+       */
+      session_replay_sample_rate?: number
+      /**
+       * Whether a proxy configured is used
+       */
+      use_proxy?: boolean
+      /**
+       * Whether beforeSend callback function is used
+       */
+      use_before_send?: boolean
+      /**
+       * Whether initialization fails silently if the SDK is already initialized
+       */
+      silent_multiple_init?: boolean
+      /**
+       * Whether sessions across subdomains for the same site are tracked
+       */
+      track_session_across_subdomains?: boolean
+      /**
+       * Whether a secure cross-site session cookie is used
+       */
+      use_cross_site_session_cookie?: boolean
+      /**
+       * Whether a secure session cookie is used
+       */
+      use_secure_session_cookie?: boolean
+      /**
+       * Attribute to be used to name actions
+       */
+      action_name_attribute?: string
+      /**
+       * Whether the allowed tracing origins list is used
+       */
+      use_allowed_tracing_origins?: boolean
+      /**
+       * Session replay default privacy level
+       */
+      default_privacy_level?: string
+      /**
+       * Whether the request origins list to ignore when computing the page activity is used
+       */
+      use_excluded_activity_urls?: boolean
+      /**
+       * Whether user frustrations are tracked
+       */
+      track_frustrations?: boolean
+      /**
+       * Whether the RUM views creation is handled manually
+       */
+      track_views_manually?: boolean
+      /**
+       * Whether user actions are tracked
+       */
+      track_interactions?: boolean
+      /**
+       * Whether console.error logs, uncaught exceptions and network errors are tracked
+       */
+      forward_errors_to_logs?: boolean
+      /**
+       * The console.* tracked
+       */
+      forward_console_logs?: string[] | 'all'
+      /**
+       * The reports from the Reporting API tracked
+       */
+      forward_reports?: string[] | 'all'
+      /**
+       * Whether local encryption is used
+       */
+      use_local_encryption?: boolean
+      /**
+       * View tracking strategy
+       */
+      view_tracking_strategy?:
+        | 'ActivityViewTrackingStrategy'
+        | 'FragmentViewTrackingStrategy'
+        | 'MixedViewTrackingStrategy'
+        | 'NavigationViewTrackingStrategy'
+      /**
+       * Whether RUM events are tracked when the application is in Background
+       */
+      track_background_events?: boolean
+      /**
+       * The period between each Mobile Vital sample (in milliseconds)
+       */
+      mobile_vitals_update_period?: number
+      /**
+       * Whether native crashes are tracked
+       */
+      track_native_crashes?: boolean
+      [k: string]: unknown
+    }
+    [k: string]: unknown
+  }
+  [k: string]: unknown
+}
 /**
  * Schema of common properties of Telemetry events
  */

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -203,6 +203,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
   }
   [k: string]: unknown
 }
+
 /**
  * Schema of common properties of Telemetry events
  */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export {
   TelemetryEvent,
   TelemetryErrorEvent,
   TelemetryDebugEvent,
+  TelemetryConfigurationEvent,
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
 } from './domain/telemetry'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   resetExperimentalFeatures,
   isSimulationActive,
   getSimulationLabel,
+  serializeConfiguration,
 } from './domain/configuration'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'
 export { computeStackTrace, StackTrace } from './domain/tracekit'
@@ -27,6 +28,7 @@ export {
   TelemetryErrorEvent,
   TelemetryDebugEvent,
   isTelemetryReplicationAllowed,
+  addTelemetryConfiguration,
 } from './domain/telemetry'
 export { monitored, monitor, callMonitored, setDebugMode } from './tools/monitor'
 export { Observable, Subscription } from './tools/observable'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   startTelemetry,
   Telemetry,
   RawTelemetryEvent,
+  RawConfigurationTelemetryEvent,
   addTelemetryDebug,
   addTelemetryError,
   startFakeTelemetry,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export {
   startTelemetry,
   Telemetry,
   RawTelemetryEvent,
-  RawConfigurationTelemetryEvent,
+  RawTelemetryConfiguration,
   addTelemetryDebug,
   addTelemetryError,
   startFakeTelemetry,

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -140,7 +140,7 @@ describe('logs entry', () => {
     it('should have the current date, view and global context', () => {
       LOGS.addLoggerGlobalContext('foo', 'bar')
 
-      const getCommonContext = startLogs.calls.mostRecent().args[1]
+      const getCommonContext = startLogs.calls.mostRecent().args[2]
       expect(getCommonContext()).toEqual({
         view: {
           referrer: document.referrer,

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -78,6 +78,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       }
 
       ;({ handleLog: handleLogStrategy, getInternalContext: getInternalContextStrategy } = startLogsImpl(
+        initConfiguration,
         configuration,
         getCommonContext,
         mainLogger

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -67,7 +67,7 @@ describe('logs', () => {
 
   describe('request', () => {
     it('should send the needed data', () => {
-      ;({ handleLog: handleLog } = startLogs(baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog: handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
 
       handleLog({ message: 'message', status: StatusType.warn, context: { foo: 'bar' } }, logger, COMMON_CONTEXT)
 
@@ -89,7 +89,12 @@ describe('logs', () => {
     })
 
     it('should all use the same batch', () => {
-      ;({ handleLog } = startLogs({ ...baseConfiguration, batchMessagesLimit: 3 }, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(
+        initConfiguration,
+        { ...baseConfiguration, batchMessagesLimit: 3 },
+        () => COMMON_CONTEXT,
+        logger
+      ))
 
       handleLog(DEFAULT_MESSAGE, logger)
       handleLog(DEFAULT_MESSAGE, logger)
@@ -100,7 +105,7 @@ describe('logs', () => {
 
     it('should send bridge event when bridge is present', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
-      ;({ handleLog: handleLog } = startLogs(baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog: handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
 
       handleLog(DEFAULT_MESSAGE, logger)
 
@@ -119,13 +124,13 @@ describe('logs', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
 
       let configuration = { ...baseConfiguration, sampleRate: 0 }
-      ;({ handleLog } = startLogs(configuration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT, logger))
       handleLog(DEFAULT_MESSAGE, logger)
 
       expect(sendSpy).not.toHaveBeenCalled()
 
       configuration = { ...baseConfiguration, sampleRate: 100 }
-      ;({ handleLog } = startLogs(configuration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT, logger))
       handleLog(DEFAULT_MESSAGE, logger)
 
       expect(sendSpy).toHaveBeenCalled()
@@ -134,7 +139,12 @@ describe('logs', () => {
 
   it('should not print the log twice when console handler is enabled', () => {
     logger.setHandler([HandlerType.console])
-    ;({ handleLog } = startLogs({ ...baseConfiguration, forwardConsoleLogs: ['log'] }, () => COMMON_CONTEXT, logger))
+    ;({ handleLog } = startLogs(
+      initConfiguration,
+      { ...baseConfiguration, forwardConsoleLogs: ['log'] },
+      () => COMMON_CONTEXT,
+      logger
+    ))
 
     /* eslint-disable-next-line no-console */
     console.log('foo', 'bar')
@@ -149,21 +159,21 @@ describe('logs', () => {
     })
 
     it('creates a session on normal conditions', () => {
-      ;({ handleLog } = startLogs(baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
 
       expect(getCookie(SESSION_COOKIE_NAME)).not.toBeUndefined()
     })
 
     it('does not create a session if event bridge is present', () => {
       initEventBridgeStub()
-      ;({ handleLog } = startLogs(baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
 
       expect(getCookie(SESSION_COOKIE_NAME)).toBeUndefined()
     })
 
     it('does not create a session if synthetics worker will inject RUM', () => {
       mockSyntheticsWorkerValues({ injectsRum: true })
-      ;({ handleLog } = startLogs(baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
 
       expect(getCookie(SESSION_COOKIE_NAME)).toBeUndefined()
     })

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -36,7 +36,7 @@ const COMMON_CONTEXT = {
 }
 
 describe('logs', () => {
-  const initConfiguration = { clientToken: 'xxx', service: 'service' }
+  const initConfiguration = { clientToken: 'xxx', service: 'service', telemetrySampleRate: 0 }
   let baseConfiguration: LogsConfiguration
   let interceptor: ReturnType<typeof interceptRequests>
   let requests: Request[]

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -8,9 +8,11 @@ import {
   startBatchWithReplica,
   isTelemetryReplicationAllowed,
   ErrorSource,
+  addTelemetryConfiguration,
 } from '@datadog/browser-core'
 import { startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
-import type { LogsConfiguration } from '../domain/configuration'
+import type { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
+import { serializeLogsConfiguration } from '../domain/configuration'
 import { startLogsAssembly, getRUMInternalContext } from '../domain/assembly'
 import { startConsoleCollection } from '../domain/logsCollection/console/consoleCollection'
 import { startReportCollection } from '../domain/logsCollection/report/reportCollection'
@@ -25,7 +27,12 @@ import type { Logger } from '../domain/logger'
 import { StatusType } from '../domain/logger'
 import { startInternalContext } from '../domain/internalContext'
 
-export function startLogs(configuration: LogsConfiguration, getCommonContext: () => CommonContext, mainLogger: Logger) {
+export function startLogs(
+  initConfiguration: LogsInitConfiguration,
+  configuration: LogsConfiguration,
+  getCommonContext: () => CommonContext,
+  mainLogger: Logger
+) {
   const lifeCycle = new LifeCycle()
 
   const reportError = (error: RawError) =>
@@ -75,6 +82,7 @@ export function startLogs(configuration: LogsConfiguration, getCommonContext: ()
     startLogsBridge(lifeCycle)
   }
 
+  addTelemetryConfiguration(serializeLogsConfiguration(initConfiguration))
   const internalContext = startInternalContext(session)
 
   return {

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -490,6 +490,7 @@ describe('getRUMInternalContext', () => {
           telemetry: {
             message: 'Logs sent before RUM is injected by the synthetics worker',
             status: 'debug',
+            type: 'log',
             testId: 'test-id',
             resultId: 'result-id',
           },

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -1,4 +1,4 @@
-import type { Configuration, InitConfiguration, RawConfigurationTelemetryEvent } from '@datadog/browser-core'
+import type { Configuration, InitConfiguration, RawTelemetryConfiguration } from '@datadog/browser-core'
 import {
   serializeConfiguration,
   assign,
@@ -87,7 +87,7 @@ export function validateAndBuildForwardOption<T>(
   return option === 'all' ? allowedValues : removeDuplicates<T>(option)
 }
 
-export function serializeLogsConfiguration(configuration: LogsInitConfiguration): RawConfigurationTelemetryEvent {
+export function serializeLogsConfiguration(configuration: LogsInitConfiguration): RawTelemetryConfiguration {
   const baseSerializedInitConfiguration = serializeConfiguration(configuration)
 
   return assign(

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -1,5 +1,6 @@
 import type { Configuration, InitConfiguration } from '@datadog/browser-core'
 import {
+  serializeConfiguration,
   assign,
   ONE_KIBI_BYTE,
   validateAndBuildConfiguration,
@@ -84,4 +85,17 @@ export function validateAndBuildForwardOption<T>(
   }
 
   return option === 'all' ? allowedValues : removeDuplicates<T>(option)
+}
+
+export function serializeLogsConfiguration(configuration: LogsInitConfiguration) {
+  const baseSerializedInitConfiguration = serializeConfiguration(configuration)
+
+  return assign(
+    {
+      forward_errors_to_logs: configuration.forwardErrorsToLogs,
+      forward_console_logs: configuration.forwardConsoleLogs,
+      forward_reports: configuration.forwardReports,
+    },
+    baseSerializedInitConfiguration
+  )
 }

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -1,4 +1,4 @@
-import type { Configuration, InitConfiguration } from '@datadog/browser-core'
+import type { Configuration, InitConfiguration, RawConfigurationTelemetryEvent } from '@datadog/browser-core'
 import {
   serializeConfiguration,
   assign,
@@ -16,8 +16,8 @@ import type { LogsEvent } from '../logsEvent.types'
 export interface LogsInitConfiguration extends InitConfiguration {
   beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
   forwardErrorsToLogs?: boolean | undefined
-  forwardConsoleLogs?: readonly ConsoleApiName[] | 'all' | undefined
-  forwardReports?: readonly RawReportType[] | 'all' | undefined
+  forwardConsoleLogs?: ConsoleApiName[] | 'all' | undefined
+  forwardReports?: RawReportType[] | 'all' | undefined
 }
 
 export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>
@@ -87,7 +87,7 @@ export function validateAndBuildForwardOption<T>(
   return option === 'all' ? allowedValues : removeDuplicates<T>(option)
 }
 
-export function serializeLogsConfiguration(configuration: LogsInitConfiguration) {
+export function serializeLogsConfiguration(configuration: LogsInitConfiguration): RawConfigurationTelemetryEvent {
   const baseSerializedInitConfiguration = serializeConfiguration(configuration)
 
   return assign(

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -686,7 +686,7 @@ describe('rum public api', () => {
 
         rumPublicApi.init(MANUAL_CONFIGURATION)
         expect(startRumSpy).toHaveBeenCalled()
-        expect(startRumSpy.calls.argsFor(0)[3]).toEqual({ name: 'foo' })
+        expect(startRumSpy.calls.argsFor(0)[4]).toEqual({ name: 'foo' })
         expect(recorderApiOnRumStartSpy).toHaveBeenCalled()
         expect(startViewSpy).not.toHaveBeenCalled()
       })
@@ -698,7 +698,7 @@ describe('rum public api', () => {
 
         rumPublicApi.startView('foo')
         expect(startRumSpy).toHaveBeenCalled()
-        expect(startRumSpy.calls.argsFor(0)[3]).toEqual({ name: 'foo' })
+        expect(startRumSpy.calls.argsFor(0)[4]).toEqual({ name: 'foo' })
         expect(recorderApiOnRumStartSpy).toHaveBeenCalled()
         expect(startViewSpy).not.toHaveBeenCalled()
       })
@@ -709,7 +709,7 @@ describe('rum public api', () => {
         rumPublicApi.startView('bar')
 
         expect(startRumSpy).toHaveBeenCalled()
-        expect(startRumSpy.calls.argsFor(0)[3]).toEqual({ name: 'foo' })
+        expect(startRumSpy.calls.argsFor(0)[4]).toEqual({ name: 'foo' })
         expect(recorderApiOnRumStartSpy).toHaveBeenCalled()
         expect(startViewSpy).toHaveBeenCalled()
         expect(startViewSpy.calls.argsFor(0)[0]).toEqual({ name: 'bar' })
@@ -754,7 +754,7 @@ describe('rum public api', () => {
     let startRumSpy: jasmine.Spy<StartRum>
 
     function getCommonContext() {
-      return startRumSpy.calls.argsFor(0)[1]()
+      return startRumSpy.calls.argsFor(0)[2]()
     }
 
     beforeEach(() => {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -112,7 +112,7 @@ export function makeRumPublicApi(
     }
 
     if (!configuration.trackViewsManually) {
-      doStartRum(configuration)
+      doStartRum(initConfiguration, configuration)
     } else {
       // drain beforeInitCalls by buffering them until we start RUM
       // if we get a startView, drain re-buffered calls before continuing to drain beforeInitCalls
@@ -121,7 +121,7 @@ export function makeRumPublicApi(
       bufferApiCalls = new BoundedBuffer()
 
       startViewStrategy = (options) => {
-        doStartRum(configuration, options)
+        doStartRum(initConfiguration, configuration, options)
       }
       beforeInitCalls.drain()
     }
@@ -130,8 +130,13 @@ export function makeRumPublicApi(
     isAlreadyInitialized = true
   }
 
-  function doStartRum(configuration: RumConfiguration, initialViewOptions?: ViewOptions) {
+  function doStartRum(
+    initConfiguration: RumInitConfiguration,
+    configuration: RumConfiguration,
+    initialViewOptions?: ViewOptions
+  ) {
     const startRumResults = startRumImpl(
+      initConfiguration,
       configuration,
       () => ({
         user: userContextManager.getContext(),

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -1,5 +1,5 @@
 import type { Observable, TelemetryEvent, RawError } from '@datadog/browser-core'
-import { startTelemetry, canUseEventBridge, getEventBridge } from '@datadog/browser-core'
+import { addTelemetryConfiguration, startTelemetry, canUseEventBridge, getEventBridge } from '@datadog/browser-core'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { startPerformanceCollection } from '../browser/performanceCollection'
 import { startRumAssembly } from '../domain/assembly'
@@ -21,11 +21,13 @@ import { startRumEventBridge } from '../transport/startRumEventBridge'
 import { startUrlContexts } from '../domain/contexts/urlContexts'
 import type { LocationChange } from '../browser/locationChangeObservable'
 import { createLocationChangeObservable } from '../browser/locationChangeObservable'
-import type { RumConfiguration } from '../domain/configuration'
+import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
+import { serializeRumConfiguration } from '../domain/configuration'
 import type { ViewOptions } from '../domain/rumEventsCollection/view/trackViews'
 import type { RecorderApi } from './rumPublicApi'
 
 export function startRum(
+  initConfiguration: RumInitConfiguration,
   configuration: RumConfiguration,
   getCommonContext: () => CommonContext,
   recorderApi: RecorderApi,
@@ -72,6 +74,7 @@ export function startRum(
     getCommonContext,
     reportError
   )
+  addTelemetryConfiguration(serializeRumConfiguration(initConfiguration))
 
   startLongTaskCollection(lifeCycle, session)
   startResourceCollection(lifeCycle, configuration, session)

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -1,4 +1,4 @@
-import type { Configuration, InitConfiguration } from '@datadog/browser-core'
+import type { Configuration, InitConfiguration, RawConfigurationTelemetryEvent } from '@datadog/browser-core'
 import {
   serializeConfiguration,
   assign,
@@ -144,7 +144,7 @@ export function validateAndBuildRumConfiguration(
   )
 }
 
-export function serializeRumConfiguration(configuration: RumInitConfiguration) {
+export function serializeRumConfiguration(configuration: RumInitConfiguration): RawConfigurationTelemetryEvent {
   const baseSerializedConfiguration = serializeConfiguration(configuration)
 
   return assign(
@@ -154,10 +154,10 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
       session_replay_sample_rate: configuration.sessionReplaySampleRate,
       action_name_attribute: configuration.actionNameAttribute,
       use_allowed_tracing_origins:
-        configuration.allowedTracingOrigins !== undefined ? !!configuration.allowedTracingOrigins : undefined,
+        Array.isArray(configuration.allowedTracingOrigins) && configuration.allowedTracingOrigins.length > 0,
       default_privacy_level: configuration.defaultPrivacyLevel,
       use_excluded_activity_urls:
-        configuration.excludedActivityUrls !== undefined ? !!configuration.excludedActivityUrls : undefined,
+        Array.isArray(configuration.allowedTracingOrigins) && configuration.allowedTracingOrigins.length > 0,
       track_frustrations: configuration.trackFrustrations,
       track_views_manually: configuration.trackViewsManually,
       track_interactions: configuration.trackInteractions,

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -1,4 +1,4 @@
-import type { Configuration, InitConfiguration, RawConfigurationTelemetryEvent } from '@datadog/browser-core'
+import type { Configuration, InitConfiguration, RawTelemetryConfiguration } from '@datadog/browser-core'
 import {
   serializeConfiguration,
   assign,
@@ -144,7 +144,7 @@ export function validateAndBuildRumConfiguration(
   )
 }
 
-export function serializeRumConfiguration(configuration: RumInitConfiguration): RawConfigurationTelemetryEvent {
+export function serializeRumConfiguration(configuration: RumInitConfiguration): RawTelemetryConfiguration {
   const baseSerializedConfiguration = serializeConfiguration(configuration)
 
   return assign(

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -1,5 +1,6 @@
 import type { Configuration, InitConfiguration } from '@datadog/browser-core'
 import {
+  serializeConfiguration,
   assign,
   DefaultPrivacyLevel,
   display,
@@ -140,5 +141,27 @@ export function validateAndBuildRumConfiguration(
         : DefaultPrivacyLevel.MASK_USER_INPUT,
     },
     baseConfiguration
+  )
+}
+
+export function serializeRumConfiguration(configuration: RumInitConfiguration) {
+  const baseSerializedConfiguration = serializeConfiguration(configuration)
+
+  return assign(
+    {
+      premium_sample_rate: configuration.premiumSampleRate,
+      replay_sample_rate: configuration.replaySampleRate,
+      session_replay_sample_rate: configuration.sessionReplaySampleRate,
+      action_name_attribute: configuration.actionNameAttribute,
+      use_allowed_tracing_origins:
+        configuration.allowedTracingOrigins !== undefined ? !!configuration.allowedTracingOrigins : undefined,
+      default_privacy_level: configuration.defaultPrivacyLevel,
+      use_excluded_activity_urls:
+        configuration.excludedActivityUrls !== undefined ? !!configuration.excludedActivityUrls : undefined,
+      track_frustrations: configuration.trackFrustrations,
+      track_views_manually: configuration.trackViewsManually,
+      track_interactions: configuration.trackInteractions,
+    },
+    baseSerializedConfiguration
   )
 }

--- a/packages/rum/src/domain/segmentCollection/startDeflateWorker.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/startDeflateWorker.spec.ts
@@ -166,8 +166,8 @@ describe('startDeflateWorker', () => {
       deflateWorker.dispatchErrorMessage('boom')
       expect(telemetryEvents).toEqual([
         {
-          type: 'log' as any,
-          status: 'error' as any,
+          type: 'log',
+          status: 'error',
           message: 'Uncaught "boom"',
           error: { stack: jasmine.any(String) },
         },

--- a/packages/rum/src/domain/segmentCollection/startDeflateWorker.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/startDeflateWorker.spec.ts
@@ -142,7 +142,12 @@ describe('startDeflateWorker', () => {
         throw UNKNOWN_ERROR
       })
       expect(telemetryEvents).toEqual([
-        { status: 'error' as any, message: 'boom', error: { kind: 'Error', stack: jasmine.any(String) } },
+        {
+          type: 'log' as any,
+          status: 'error' as any,
+          message: 'boom',
+          error: { kind: 'Error', stack: jasmine.any(String) },
+        },
       ])
     })
 
@@ -160,7 +165,12 @@ describe('startDeflateWorker', () => {
 
       deflateWorker.dispatchErrorMessage('boom')
       expect(telemetryEvents).toEqual([
-        { status: 'error' as any, message: 'Uncaught "boom"', error: { stack: jasmine.any(String) } },
+        {
+          type: 'log' as any,
+          status: 'error' as any,
+          message: 'Uncaught "boom"',
+          error: { stack: jasmine.any(String) },
+        },
       ])
     })
   })

--- a/packages/rum/src/domain/segmentCollection/startDeflateWorker.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/startDeflateWorker.spec.ts
@@ -143,8 +143,8 @@ describe('startDeflateWorker', () => {
       })
       expect(telemetryEvents).toEqual([
         {
-          type: 'log' as any,
-          status: 'error' as any,
+          type: 'log',
+          status: 'error',
           message: 'boom',
           error: { kind: 'Error', stack: jasmine.any(String) },
         },

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -6,6 +6,13 @@
     <script src="http://localhost:8080/datadog-rum.js"></script>
     <script src="http://localhost:8080/datadog-logs.js"></script>
     <script>
+      let context2 = {
+        get foo() {
+          throw new window.Error('bar')
+        },
+      }
+      window.DD_RUM.addAction('hop', context2)
+
       DD_RUM.init({
         clientToken: 'xxx',
         applicationId: 'xxx',
@@ -13,14 +20,16 @@
         trackResources: true,
         trackLongTasks: true,
         telemetrySampleRate: 100,
-        enableExperimentalFeatures: [],
+        telemetryConfigurationSampleRate: 100,
+        enableExperimentalFeatures: ['telemetry_configuration'],
       })
+
       DD_RUM.startSessionReplayRecording()
-      DD_LOGS.init({
-        clientToken: 'xxx',
-        telemetrySampleRate: 100,
-        enableExperimentalFeatures: [],
-      })
+      // DD_LOGS.init({
+      //   clientToken: 'xxx',
+      //   telemetrySampleRate: 100,
+      //   enableExperimentalFeatures: [],
+      // })
     </script>
   </head>
   <body></body>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -6,13 +6,6 @@
     <script src="http://localhost:8080/datadog-rum.js"></script>
     <script src="http://localhost:8080/datadog-logs.js"></script>
     <script>
-      let context2 = {
-        get foo() {
-          throw new window.Error('bar')
-        },
-      }
-      window.DD_RUM.addAction('hop', context2)
-
       DD_RUM.init({
         clientToken: 'xxx',
         applicationId: 'xxx',
@@ -20,16 +13,14 @@
         trackResources: true,
         trackLongTasks: true,
         telemetrySampleRate: 100,
-        telemetryConfigurationSampleRate: 100,
-        enableExperimentalFeatures: ['telemetry_configuration'],
+        enableExperimentalFeatures: [],
       })
-
       DD_RUM.startSessionReplayRecording()
-      // DD_LOGS.init({
-      //   clientToken: 'xxx',
-      //   telemetrySampleRate: 100,
-      //   enableExperimentalFeatures: [],
-      // })
+      DD_LOGS.init({
+        clientToken: 'xxx',
+        telemetrySampleRate: 100,
+        enableExperimentalFeatures: [],
+      })
     </script>
   </head>
   <body></body>

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -19,12 +19,14 @@ const DEFAULT_RUM_CONFIGURATION = {
   trackResources: true,
   trackLongTasks: true,
   telemetrySampleRate: 100,
+  telemetryConfigurationSampleRate: 100,
   enableExperimentalFeatures: [],
 }
 
 const DEFAULT_LOGS_CONFIGURATION = {
   clientToken: 'token',
   telemetrySampleRate: 100,
+  telemetryConfigurationSampleRate: 100,
 }
 
 export function createTest(title: string) {

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -192,7 +192,7 @@ async function setUpTest({ baseUrl }: TestContext) {
 
 async function tearDownTest({ serverEvents, bridgeEvents }: TestContext) {
   await flushEvents()
-  expect(serverEvents.telemetry).toEqual([])
+  expect(serverEvents.telemetryErrors).toEqual([])
   validateRumFormat(serverEvents.rum)
   validateRumFormat(bridgeEvents.rum)
   await withBrowserLogs((logs) => {

--- a/test/e2e/lib/framework/eventsRegistry.ts
+++ b/test/e2e/lib/framework/eventsRegistry.ts
@@ -3,6 +3,7 @@ import type { RumEvent } from '@datadog/browser-rum'
 import type { TelemetryEvent } from '@datadog/browser-core'
 import type { SessionReplayCall } from '../types/serverEvents'
 import {
+  isTelemetryConfigurationEvent,
   isRumErrorEvent,
   isRumResourceEvent,
   isRumActionEvent,
@@ -46,6 +47,9 @@ export class EventRegistry {
     return this.telemetry.filter(isTelemetryErrorEvent)
   }
 
+  get telemetryConfigurations() {
+    return this.telemetry.filter(isTelemetryConfigurationEvent)
+  }
   empty() {
     this.rum.length = 0
     this.telemetry.length = 0

--- a/test/e2e/lib/framework/eventsRegistry.ts
+++ b/test/e2e/lib/framework/eventsRegistry.ts
@@ -2,7 +2,13 @@ import type { LogsEvent } from '@datadog/browser-logs'
 import type { RumEvent } from '@datadog/browser-rum'
 import type { TelemetryEvent } from '@datadog/browser-core'
 import type { SessionReplayCall } from '../types/serverEvents'
-import { isRumErrorEvent, isRumResourceEvent, isRumActionEvent, isRumViewEvent } from '../types/serverEvents'
+import {
+  isRumErrorEvent,
+  isRumResourceEvent,
+  isRumActionEvent,
+  isRumViewEvent,
+  isTelemetryErrorEvent,
+} from '../types/serverEvents'
 
 export type IntakeType = 'logs' | 'rum' | 'sessionReplay' | 'telemetry'
 
@@ -34,6 +40,10 @@ export class EventRegistry {
 
   get rumViews() {
     return this.rum.filter(isRumViewEvent)
+  }
+
+  get telemetryErrors() {
+    return this.telemetry.filter(isTelemetryErrorEvent)
   }
 
   empty() {

--- a/test/e2e/lib/types/serverEvents.ts
+++ b/test/e2e/lib/types/serverEvents.ts
@@ -1,3 +1,4 @@
+import type { TelemetryErrorEvent, TelemetryEvent } from '@datadog/browser-core'
 import type { RumActionEvent, RumErrorEvent, RumEvent, RumResourceEvent, RumViewEvent } from '@datadog/browser-rum'
 import type { BrowserSegment } from '@datadog/browser-rum/src/types'
 
@@ -15,6 +16,10 @@ export function isRumViewEvent(event: RumEvent): event is RumViewEvent {
 
 export function isRumErrorEvent(event: RumEvent): event is RumErrorEvent {
   return event.type === 'error'
+}
+
+export function isTelemetryErrorEvent(event: TelemetryEvent): event is TelemetryErrorEvent {
+  return event.type === 'telemetry' && event.telemetry.status === 'error'
 }
 
 export interface SegmentFile {

--- a/test/e2e/lib/types/serverEvents.ts
+++ b/test/e2e/lib/types/serverEvents.ts
@@ -1,4 +1,4 @@
-import type { TelemetryErrorEvent, TelemetryEvent } from '@datadog/browser-core'
+import type { TelemetryErrorEvent, TelemetryEvent, TelemetryConfigurationEvent } from '@datadog/browser-core'
 import type { RumActionEvent, RumErrorEvent, RumEvent, RumResourceEvent, RumViewEvent } from '@datadog/browser-rum'
 import type { BrowserSegment } from '@datadog/browser-rum/src/types'
 
@@ -20,6 +20,10 @@ export function isRumErrorEvent(event: RumEvent): event is RumErrorEvent {
 
 export function isTelemetryErrorEvent(event: TelemetryEvent): event is TelemetryErrorEvent {
   return event.type === 'telemetry' && event.telemetry.status === 'error'
+}
+
+export function isTelemetryConfigurationEvent(event: TelemetryEvent): event is TelemetryConfigurationEvent {
+  return event.type === 'telemetry' && event.telemetry.type === 'configuration'
 }
 
 export interface SegmentFile {

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -54,9 +54,7 @@ describe('telemetry', () => {
       await flushEvents()
       expect(serverEvents.telemetryConfigurations.length).toBe(1)
       const event = serverEvents.telemetryConfigurations[0]
-      expect(event.telemetry.type).toBe('configuration')
       expect(event.telemetry.configuration.forward_errors_to_logs).toEqual(true)
-      serverEvents.empty()
     })
 
   createTest('send init configuration for RUM')
@@ -69,8 +67,6 @@ describe('telemetry', () => {
       await flushEvents()
       expect(serverEvents.telemetryConfigurations.length).toBe(1)
       const event = serverEvents.telemetryConfigurations[0]
-      expect(event.telemetry.type).toBe('configuration')
       expect(event.telemetry.configuration.track_interactions).toEqual(true)
-      serverEvents.empty()
     })
 })

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -43,4 +43,34 @@ describe('telemetry', () => {
       expect(event.telemetry.status).toBe('error')
       serverEvents.empty()
     })
+
+  createTest('send init configuration for logs')
+    .withSetup(bundleSetup)
+    .withLogs({
+      enableExperimentalFeatures: ['telemetry_configuration'],
+      forwardErrorsToLogs: true,
+    })
+    .run(async ({ serverEvents }) => {
+      await flushEvents()
+      expect(serverEvents.telemetryConfigurations.length).toBe(1)
+      const event = serverEvents.telemetryConfigurations[0]
+      expect(event.telemetry.type).toBe('configuration')
+      expect(event.telemetry.configuration.forward_errors_to_logs).toEqual(true)
+      serverEvents.empty()
+    })
+
+  createTest('send init configuration for RUM')
+    .withSetup(bundleSetup)
+    .withRum({
+      enableExperimentalFeatures: ['telemetry_configuration'],
+      trackInteractions: true,
+    })
+    .run(async ({ serverEvents }) => {
+      await flushEvents()
+      expect(serverEvents.telemetryConfigurations.length).toBe(1)
+      const event = serverEvents.telemetryConfigurations[0]
+      expect(event.telemetry.type).toBe('configuration')
+      expect(event.telemetry.configuration.track_interactions).toEqual(true)
+      serverEvents.empty()
+    })
 })

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -16,8 +16,9 @@ describe('telemetry', () => {
         window.DD_LOGS!.logger.log('hop', context as any)
       })
       await flushEvents()
-      expect(serverEvents.telemetry.length).toBe(1)
-      const event = serverEvents.telemetry[0] as TelemetryErrorEvent
+
+      // get the last telemetry event because telemetry configuration may have been collected first
+      const event = serverEvents.telemetry[serverEvents.telemetry.length - 1] as TelemetryErrorEvent
       expect(event.telemetry.message).toBe('bar')
       expect(event.telemetry.error!.kind).toBe('Error')
       expect(event.telemetry.status).toBe('error')
@@ -37,8 +38,9 @@ describe('telemetry', () => {
         window.DD_RUM!.addAction('hop', context as any)
       })
       await flushEvents()
-      expect(serverEvents.telemetry.length).toBe(1)
-      const event = serverEvents.telemetry[0] as TelemetryErrorEvent
+
+      // get the last telemetry event because telemetry configuration may have been collected first
+      const event = serverEvents.telemetry[serverEvents.telemetry.length - 1] as TelemetryErrorEvent
       expect(event.telemetry.message).toBe('bar')
       expect(event.telemetry.error!.kind).toBe('Error')
       expect(event.telemetry.status).toBe('error')

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -1,4 +1,3 @@
-import type { TelemetryErrorEvent } from '@datadog/browser-core'
 import { bundleSetup, createTest, flushEvents } from '../lib/framework'
 import { browserExecute } from '../lib/helpers/browser'
 
@@ -16,9 +15,8 @@ describe('telemetry', () => {
         window.DD_LOGS!.logger.log('hop', context as any)
       })
       await flushEvents()
-
-      // get the last telemetry event because telemetry configuration may have been collected first
-      const event = serverEvents.telemetry[serverEvents.telemetry.length - 1] as TelemetryErrorEvent
+      expect(serverEvents.telemetryErrors.length).toBe(1)
+      const event = serverEvents.telemetryErrors[0]
       expect(event.telemetry.message).toBe('bar')
       expect(event.telemetry.error!.kind).toBe('Error')
       expect(event.telemetry.status).toBe('error')
@@ -38,9 +36,8 @@ describe('telemetry', () => {
         window.DD_RUM!.addAction('hop', context as any)
       })
       await flushEvents()
-
-      // get the last telemetry event because telemetry configuration may have been collected first
-      const event = serverEvents.telemetry[serverEvents.telemetry.length - 1] as TelemetryErrorEvent
+      expect(serverEvents.telemetryErrors.length).toBe(1)
+      const event = serverEvents.telemetryErrors[0]
       expect(event.telemetry.message).toBe('bar')
       expect(event.telemetry.error!.kind).toBe('Error')
       expect(event.telemetry.status).toBe('error')


### PR DESCRIPTION
## Motivation

Engineering and product would like to easily analyze how customers configure the SDKs in order to:

- Ease troubleshooting, ex: traffic spike/drop due to sampleRate change or to customer traffic
- Track feature usage, ex: what percentage of orgs use a proxy 

This PR collect customer configuration through telemetry events.

## Changes

Add `addTelemetryConfiguration`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
