### PR TITLE
📝 Clarify log SDK usage in the readme

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -1,8 +1,8 @@
 # Browser Log Collection
 
-Send logs to Datadog from browser web pages with the browser logs SDK.
+Send logs to Datadog from web browser pages with the browser logs SDK.
 
-With the browser logs SDK, you can send logs directly to Datadog from browser web pages and leverage the following features:
+With the browser logs SDK, you can send logs directly to Datadog from web browser pages and leverage the following features:
 
 - Use the SDK as a logger. Everything is forwarded to Datadog as JSON documents.
 - Add `context` and extra custom attributes to each log sent.

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -1,8 +1,8 @@
 # Browser Log Collection
 
-Send logs to Datadog from web browsers with the browser logs SDK.
+Send logs to Datadog from browser web pages with the browser logs SDK.
 
-With the browser logs SDK, you can send logs directly to Datadog from JS clients and leverage the following features:
+With the browser logs SDK, you can send logs directly to Datadog from browser web pages and leverage the following features:
 
 - Use the SDK as a logger. Everything is forwarded to Datadog as JSON documents.
 - Add `context` and extra custom attributes to each log sent.

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -1,6 +1,6 @@
 # Browser Log Collection
 
-Send logs to Datadog from web browsers or other Javascript clients with the browser logs SDK.
+Send logs to Datadog from web browsers with the browser logs SDK.
 
 With the browser logs SDK, you can send logs directly to Datadog from JS clients and leverage the following features:
 


### PR DESCRIPTION
## Motivation

Follow up of the issue #1764. 
Clarify log SDK usage in the readme

## Changes

Remove the mention of `other Javascript clients` in the readme
## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
