### PR TITLE
✨[RUMF-1377] Enable new request strategy

### DIFF
--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -5,6 +5,7 @@ import { createEndpointBuilder } from '../domain/configuration'
 import { noop } from '../tools/utils'
 import { createHttpRequest, fetchKeepAliveStrategy } from './httpRequest'
 import type { HttpRequest } from './httpRequest'
+import { INITIAL_BACKOFF_TIME } from './sendWithRetryStrategy'
 
 describe('httpRequest', () => {
   const BATCH_BYTES_LIMIT = 100
@@ -72,6 +73,26 @@ describe('httpRequest', () => {
         expect(requests[0].type).toBe('xhr')
         done()
       })
+    })
+
+    it('should use retry strategy', (done) => {
+      let calls = 0
+      interceptor.withFetch(() => {
+        calls++
+        if (calls === 1) {
+          return Promise.resolve({ status: 408 })
+        }
+        if (calls === 2) {
+          return Promise.resolve({ status: 200 })
+        }
+      })
+
+      request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
+
+      setTimeout(() => {
+        expect(calls).toEqual(2)
+        done()
+      }, INITIAL_BACKOFF_TIME + 1)
     })
   })
 

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -76,6 +76,9 @@ describe('httpRequest', () => {
     })
 
     it('should use retry strategy', (done) => {
+      if (!interceptor.isFetchKeepAliveSupported()) {
+        pending('no fetch keepalive support')
+      }
       let calls = 0
       interceptor.withFetch(() => {
         calls++

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -1,7 +1,6 @@
 import type { EndpointBuilder } from '../domain/configuration'
 import { addTelemetryError } from '../domain/telemetry'
 import { monitor } from '../tools/monitor'
-import { isExperimentalFeatureEnabled } from '../domain/configuration'
 import type { RawError } from '../tools/error'
 import { newRetryState, sendWithRetryStrategy } from './sendWithRetryStrategy'
 
@@ -15,6 +14,7 @@ import { newRetryState, sendWithRetryStrategy } from './sendWithRetryStrategy'
  */
 
 export type HttpRequest = ReturnType<typeof createHttpRequest>
+
 export interface HttpResponse {
   status: number
 }
@@ -35,11 +35,7 @@ export function createHttpRequest(
 
   return {
     send: (payload: Payload) => {
-      if (!isExperimentalFeatureEnabled('retry')) {
-        fetchKeepAliveStrategy(endpointBuilder, bytesLimit, payload)
-      } else {
-        sendWithRetryStrategy(payload, retryState, sendStrategyForRetry, endpointBuilder.endpointType, reportError)
-      }
+      sendWithRetryStrategy(payload, retryState, sendStrategyForRetry, endpointBuilder.endpointType, reportError)
     },
     /**
      * Since fetch keepalive behaves like regular fetch on Firefox,


### PR DESCRIPTION
## Motivation

We want to improve our data transfer to:

- limit our impact on end user bandwidth
- not loose data in case of short intake unavailability

## Changes

Enable new request strategy for logs/rum for non exit requests allowing us to:

- limit the number of concurrent requests to the intake -> max 32 by product
- limit the total ongoing bytes of requests to the intake -> max 80kb by product
- retry requests if the intake is momentarily unavailable -> exponential backoff strategy 1s to 60s
- limit the size of queued requests due to throttling or failure -> max 3Mb by product

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
