### PR TITLE
[RUMF-1337] Instrument fetch response

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  CURRENT_STAGING: staging-41
+  CURRENT_STAGING: staging-42
   APP: 'browser-sdk'
   CURRENT_CI_IMAGE: 35
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'

--- a/packages/core/src/browser/fetchObservable.spec.ts
+++ b/packages/core/src/browser/fetchObservable.spec.ts
@@ -89,8 +89,8 @@ describe('fetch proxy', () => {
     clock.cleanup()
   })
 
-  it('should track server error', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+  it('should track server error', async (done) => {
+    await fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
       const request = requests[0]
@@ -130,9 +130,9 @@ describe('fetch proxy', () => {
     })
   })
 
-  it('should track opaque fetch', (done) => {
+  it('should track opaque fetch', async (done) => {
     // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
-    fetchStub(FAKE_URL).resolveWith({ status: 0, type: 'opaque' })
+    await fetchStub(FAKE_URL).resolveWith({ status: 0, type: 'opaque' })
 
     fetchStubManager.whenAllComplete(() => {
       const request = requests[0]
@@ -144,8 +144,8 @@ describe('fetch proxy', () => {
     })
   })
 
-  it('should track client error', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 400, responseText: 'Not found' })
+  it('should track client error', async (done) => {
+    await fetchStub(FAKE_URL).resolveWith({ status: 400, responseText: 'Not found' })
 
     fetchStubManager.whenAllComplete(() => {
       const request = requests[0]
@@ -157,13 +157,13 @@ describe('fetch proxy', () => {
     })
   })
 
-  it('should get method from input', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL)).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL, { method: 'PUT' })).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL, { method: 'PUT' }), { method: 'POST' }).resolveWith({ status: 500 })
-    fetchStub(new Request(FAKE_URL), { method: 'POST' }).resolveWith({ status: 500 })
-    fetchStub(FAKE_URL, { method: 'POST' }).resolveWith({ status: 500 })
+  it('should get method from input', async (done) => {
+    await fetchStub(FAKE_URL).resolveWith({ status: 500 })
+    await fetchStub(new Request(FAKE_URL)).resolveWith({ status: 500 })
+    await fetchStub(new Request(FAKE_URL, { method: 'PUT' })).resolveWith({ status: 500 })
+    await fetchStub(new Request(FAKE_URL, { method: 'PUT' }), { method: 'POST' }).resolveWith({ status: 500 })
+    await fetchStub(new Request(FAKE_URL), { method: 'POST' }).resolveWith({ status: 500 })
+    await fetchStub(FAKE_URL, { method: 'POST' }).resolveWith({ status: 500 })
 
     fetchStubManager.whenAllComplete(() => {
       expect(requests[0].method).toEqual('GET')
@@ -187,13 +187,13 @@ describe('fetch proxy', () => {
     })
   })
 
-  it('should keep promise resolved behavior', (done) => {
+  it('should keep promise resolved behavior', async (done) => {
     const fetchStubPromise = fetchStub(FAKE_URL)
     const spy = jasmine.createSpy()
     fetchStubPromise.then(spy).catch(() => {
       fail('Should not have thrown an error!')
     })
-    fetchStubPromise.resolveWith({ status: 500 })
+    await fetchStubPromise.resolveWith({ status: 500 })
 
     setTimeout(() => {
       expect(spy).toHaveBeenCalled()
@@ -213,7 +213,7 @@ describe('fetch proxy', () => {
     })
   })
 
-  it('should allow to enhance the context', (done) => {
+  it('should allow to enhance the context', async (done) => {
     type CustomContext = FetchContext & { foo: string }
     contextEditionSubscription = initFetchObservable().subscribe((rawContext) => {
       const context = rawContext as CustomContext
@@ -221,7 +221,7 @@ describe('fetch proxy', () => {
         context.foo = 'bar'
       }
     })
-    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+    await fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
       expect((requests[0] as CustomContext).foo).toBe('bar')
@@ -230,10 +230,10 @@ describe('fetch proxy', () => {
   })
 
   describe('when unsubscribing', () => {
-    it('should stop tracking requests', (done) => {
+    it('should stop tracking requests', async (done) => {
       requestsTrackingSubscription.unsubscribe()
 
-      fetchStub(FAKE_URL).resolveWith({ status: 200, responseText: 'ok' })
+      await fetchStub(FAKE_URL).resolveWith({ status: 200, responseText: 'ok' })
 
       fetchStubManager.whenAllComplete(() => {
         expect(requests).toEqual([])

--- a/packages/core/src/browser/fetchObservable.spec.ts
+++ b/packages/core/src/browser/fetchObservable.spec.ts
@@ -161,7 +161,9 @@ describe('fetch proxy', () => {
     await fetchStub(FAKE_URL).resolveWith({ status: 500 })
     await fetchStub(new Request(FAKE_URL)).resolveWith({ status: 500 })
     await fetchStub(new Request(FAKE_URL, { method: 'PUT' })).resolveWith({ status: 500 })
-    await fetchStub(new Request(FAKE_URL, { method: 'PUT' }), { method: 'POST' }).resolveWith({ status: 500 })
+    await fetchStub(new Request(FAKE_URL, { method: 'PUT' }), { method: 'POST' }).resolveWith({
+      status: 500,
+    })
     await fetchStub(new Request(FAKE_URL), { method: 'POST' }).resolveWith({ status: 500 })
     await fetchStub(FAKE_URL, { method: 'POST' }).resolveWith({ status: 500 })
 

--- a/packages/core/src/browser/fetchObservable.ts
+++ b/packages/core/src/browser/fetchObservable.ts
@@ -170,7 +170,7 @@ function afterSend(
   }
 
   responsePromise.then(
-    monitor((response) => (!response.ok ? reportFetch(response) : reportFetchResolve(response))),
+    monitor((response) => (response.ok ? reportFetchResolve(response) : reportFetch(response))),
     monitor(reportFetch)
   )
 }

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -141,6 +141,7 @@ export function stubFetch(): FetchStubManager {
 }
 
 export interface ResponseStubOptions {
+  ok?: boolean
   status?: number
   method?: string
   type?: ResponseType
@@ -158,6 +159,7 @@ function notYetImplemented(): never {
 }
 
 export class ResponseStub implements Response {
+  public ok = true
   private _body: ReadableStream<Uint8Array> | undefined
 
   constructor(private options: Readonly<ResponseStubOptions>) {
@@ -177,6 +179,8 @@ export class ResponseStub implements Response {
         },
       })
     }
+
+    this.ok = this.options.status === 200
 
     if (this.options.json) this.json = this.options.json
     if (this.options.arrayBuffer) this.arrayBuffer = this.options.arrayBuffer
@@ -228,9 +232,6 @@ export class ResponseStub implements Response {
     return Promise.resolve(new FormData())
   }
 
-  get ok() {
-    return notYetImplemented()
-  }
   get headers() {
     return notYetImplemented()
   }

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
@@ -61,9 +61,9 @@ describe('network error collection', () => {
     fetchStubManager.reset()
   })
 
-  it('should track server error', (done) => {
+  it('should track server error', async (done) => {
     startCollection()
-    fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
+    await fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents[0].rawLogsEvent).toEqual({
@@ -85,9 +85,9 @@ describe('network error collection', () => {
     })
   })
 
-  it('should not track network error when forwardErrorsToLogs is false', (done) => {
+  it('should not track network error when forwardErrorsToLogs is false', async (done) => {
     startCollection(false)
-    fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
+    await fetchStub(FAKE_URL).resolveWith(DEFAULT_REQUEST)
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(0)
@@ -95,9 +95,9 @@ describe('network error collection', () => {
     })
   })
 
-  it('should not track intake error', (done) => {
+  it('should not track intake error', async (done) => {
     startCollection()
-    fetchStub('https://logs-intake.com/v1/input/send?foo=bar').resolveWith(DEFAULT_REQUEST)
+    await fetchStub('https://logs-intake.com/v1/input/send?foo=bar').resolveWith(DEFAULT_REQUEST)
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(0)
@@ -115,9 +115,9 @@ describe('network error collection', () => {
     })
   })
 
-  it('should track refused request', (done) => {
+  it('should track refused request', async (done) => {
     startCollection()
-    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 0 })
+    await fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 0 })
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(1)
@@ -125,9 +125,9 @@ describe('network error collection', () => {
     })
   })
 
-  it('should not track client error', (done) => {
+  it('should not track client error', async (done) => {
     startCollection()
-    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 400 })
+    await fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 400 })
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(0)
@@ -135,9 +135,9 @@ describe('network error collection', () => {
     })
   })
 
-  it('should not track successful request', (done) => {
+  it('should not track successful request', async (done) => {
     startCollection()
-    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 200 })
+    await fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, status: 200 })
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(0)
@@ -145,9 +145,9 @@ describe('network error collection', () => {
     })
   })
 
-  it('uses a fallback when the response text is empty', (done) => {
+  it('uses a fallback when the response text is empty', async (done) => {
     startCollection()
-    fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, responseText: '' })
+    await fetchStub(FAKE_URL).resolveWith({ ...DEFAULT_REQUEST, responseText: '' })
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(1)

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -55,8 +55,8 @@ describe('collect fetch', () => {
     window.onunhandledrejection = null
   })
 
-  it('should notify on request start', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+  it('should notify on request start', async (done) => {
+    await fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
       expect(startSpy).toHaveBeenCalledWith({ requestIndex: jasmine.any(Number) as unknown as number, url: FAKE_URL })
@@ -64,8 +64,8 @@ describe('collect fetch', () => {
     })
   })
 
-  it('should notify on request complete', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+  it('should notify on request complete', async (done) => {
+    await fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
       const request = completeSpy.calls.argsFor(0)[0]
@@ -78,8 +78,8 @@ describe('collect fetch', () => {
     })
   })
 
-  it('should assign a request id', (done) => {
-    fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
+  it('should assign a request id', async (done) => {
+    await fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 
     fetchStubManager.whenAllComplete(() => {
       const startRequestIndex = startSpy.calls.argsFor(0)[0].requestIndex
@@ -90,8 +90,8 @@ describe('collect fetch', () => {
     })
   })
 
-  it('should ignore intake requests', (done) => {
-    fetchStub(SPEC_ENDPOINTS.rumEndpointBuilder.build()).resolveWith({ status: 200, responseText: 'foo' })
+  it('should ignore intake requests', async (done) => {
+    await fetchStub(SPEC_ENDPOINTS.rumEndpointBuilder.build()).resolveWith({ status: 200, responseText: 'foo' })
 
     fetchStubManager.whenAllComplete(() => {
       expect(startSpy).not.toHaveBeenCalled()
@@ -101,9 +101,9 @@ describe('collect fetch', () => {
   })
 
   describe('tracing', () => {
-    it('should trace requests by default', () => {
+    it('should trace requests by default', async () => {
       jasmine.clock().install()
-      fetchStub(FAKE_URL).resolveWith({ status: 200, responseText: 'ok' })
+      await fetchStub(FAKE_URL).resolveWith({ status: 200, responseText: 'ok' })
 
       jasmine.clock().tick(10000) // a hack used to trigger resource collections
 
@@ -127,8 +127,8 @@ describe('collect fetch', () => {
       })
     })
 
-    it('should not trace requests ending with status 0', (done) => {
-      fetchStub(FAKE_URL).resolveWith({ status: 0, responseText: 'fetch cancelled' })
+    it('should not trace requests ending with status 0', async (done) => {
+      await fetchStub(FAKE_URL).resolveWith({ status: 0, responseText: 'fetch cancelled' })
 
       fetchStubManager.whenAllComplete(() => {
         const request = completeSpy.calls.argsFor(0)[0]

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -101,15 +101,19 @@ describe('collect fetch', () => {
   })
 
   describe('tracing', () => {
-    it('should trace requests by default', (done) => {
+    it('should trace requests by default', () => {
+      jasmine.clock().install()
       fetchStub(FAKE_URL).resolveWith({ status: 200, responseText: 'ok' })
+
+      jasmine.clock().tick(10000) // a hack used to trigger resource collections
 
       fetchStubManager.whenAllComplete(() => {
         const request = completeSpy.calls.argsFor(0)[0]
 
         expect(request.traceId).toBeDefined()
-        done()
       })
+
+      jasmine.clock().uninstall()
     })
 
     it('should trace aborted requests', (done) => {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
Most browsers do not add resource entries to the performance object until after the payload has been downloaded.
This means that when we call `performance.getEntriesByName(request.url, 'resource')` after receiving a response from `Fetch`, we rarely find a corresponding entry.

To overcome this, we should create the resource when the response payload has been downloaded by instrumenting the methods used to trigger the download.


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

- create a new method `reportFetchResolve` inside `afterSend` of the `fetchObservable.ts` file
- `reportFetchResolve` attaches a callback if the response payload downloading methods are used
- if the payload is not downloaded in a certain number of milliseconds (defined by `REPORT_FETCH_TIMER`), we trigger the resource entry

## Next steps
- unit testing
- e2e testing
- determining best value for `REPORT_FETCH_TIMER`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
