### PR TITLE
🐛 [RUMF-1337] report fetch on payload callback

### DIFF
--- a/packages/core/src/browser/fetchObservable.ts
+++ b/packages/core/src/browser/fetchObservable.ts
@@ -118,7 +118,7 @@ function afterSend(
   const reportFetchOnPayloadComplete = (response: Response) => {
     const cloneResponse = response.clone()
     if (cloneResponse.body) {
-      readLimitedAmountOfBytes(cloneResponse.body, Number.MAX_SAFE_INTEGER, () => reportFetch(response), false)
+      readLimitedAmountOfBytes(cloneResponse.body, Number.POSITIVE_INFINITY, () => reportFetch(response), false)
     } else {
       reportFetch(response)
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,3 +85,4 @@ export {
   getSyntheticsTestId,
   getSyntheticsResultId,
 } from './domain/synthetics/syntheticsWorkerValues'
+export { readLimitedAmountOfBytes } from './tools/stream'

--- a/packages/core/src/tools/stream.spec.ts
+++ b/packages/core/src/tools/stream.spec.ts
@@ -1,11 +1,10 @@
 import { isIE } from './browserDetection'
 import { readLimitedAmountOfBytes } from './stream'
 
-const stringChunk = 'helloWord'
-const limit = 3
-
 describe('stream', () => {
   it('call callback once limit is reached', (done) => {
+    const stringChunk = 'helloWord'
+    const limit = 3
     if (isIE()) {
       pending('IE not supported')
     }
@@ -28,6 +27,7 @@ describe('stream', () => {
   })
 
   it('call callback with error', (done) => {
+    const limit = 3
     if (isIE()) {
       pending('IE not supported')
     }
@@ -48,6 +48,8 @@ describe('stream', () => {
   })
 
   it('call callback with empty buffer if shouldStoreChunks false', (done) => {
+    const stringChunk = 'helloWord'
+    const limit = 3
     if (isIE()) {
       pending('IE not supported')
     }

--- a/packages/core/src/tools/stream.spec.ts
+++ b/packages/core/src/tools/stream.spec.ts
@@ -1,0 +1,60 @@
+import { readLimitedAmountOfBytes } from './stream'
+
+const stringChunk = 'helloWord'
+const limit = 3
+
+describe('stream', () => {
+  it('call callback once limit is reached', (done) => {
+    const stream = new ReadableStream({
+      start(controller) {
+        setTimeout(() => {
+          controller.enqueue(stringChunk)
+          controller.close()
+        }, 0)
+      },
+    })
+
+    const spy = jasmine.createSpy()
+    readLimitedAmountOfBytes(stream, limit, spy)
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledWith(undefined, stringChunk.substring(0, limit), jasmine.any(Boolean))
+      done()
+    })
+  })
+
+  it('call callback with error', (done) => {
+    const fakeError = 'fakeError'
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.error(fakeError)
+      },
+    })
+
+    const spy = jasmine.createSpy()
+    readLimitedAmountOfBytes(stream, limit, spy)
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledWith(fakeError)
+      done()
+    })
+  })
+
+  it('call callback with empty buffer if shouldStoreChunks false', (done) => {
+    const stream = new ReadableStream({
+      start(controller) {
+        setTimeout(() => {
+          controller.enqueue(stringChunk)
+          controller.close()
+        }, 0)
+      },
+    })
+
+    const spy = jasmine.createSpy()
+    readLimitedAmountOfBytes(stream, limit, spy, false)
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      done()
+    })
+  })
+})

--- a/packages/core/src/tools/stream.spec.ts
+++ b/packages/core/src/tools/stream.spec.ts
@@ -1,3 +1,4 @@
+import { isIE } from './browserDetection'
 import { readLimitedAmountOfBytes } from './stream'
 
 const stringChunk = 'helloWord'
@@ -5,6 +6,9 @@ const limit = 3
 
 describe('stream', () => {
   it('call callback once limit is reached', (done) => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
     const stream = new ReadableStream({
       start(controller) {
         setTimeout(() => {
@@ -24,6 +28,9 @@ describe('stream', () => {
   })
 
   it('call callback with error', (done) => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
     const fakeError = 'fakeError'
     const stream = new ReadableStream({
       start(controller) {
@@ -41,6 +48,9 @@ describe('stream', () => {
   })
 
   it('call callback with empty buffer if shouldStoreChunks false', (done) => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
     const stream = new ReadableStream({
       start(controller) {
         setTimeout(() => {

--- a/packages/core/src/tools/stream.ts
+++ b/packages/core/src/tools/stream.ts
@@ -20,6 +20,7 @@ export function readLimitedAmountOfBytes(
 
   function readMore() {
     reader.read().then(
+      // @ts-ignore: https://github.com/microsoft/TypeScript/issues/42970
       monitor((result: ReadableStreamDefaultReadResult<Uint8Array>) => {
         if (result.done) {
           onDone()
@@ -35,7 +36,9 @@ export function readLimitedAmountOfBytes(
           readMore()
         }
       }),
-      monitor((error) => callback(error))
+      monitor((error) => {
+        callback(error)
+      })
     )
   }
 
@@ -45,6 +48,10 @@ export function readLimitedAmountOfBytes(
       // as an unhandled rejection
       noop
     )
+    if (!shouldStoreChunks) {
+      callback()
+      return
+    }
 
     let completeBuffer: Uint8Array
     if (chunks.length === 1) {

--- a/packages/core/src/tools/stream.ts
+++ b/packages/core/src/tools/stream.ts
@@ -1,0 +1,66 @@
+import { monitor } from './monitor'
+import { noop } from './utils'
+
+/**
+ * Read bytes from a ReadableStream until at least `limit` bytes have been read (or until the end of
+ * the stream). The callback is invoked with the at most `limit` bytes, and indicates that the limit
+ * has been exceeded if more bytes were available.
+ */
+export function readLimitedAmountOfBytes(
+  stream: ReadableStream<Uint8Array>,
+  limit: number,
+  callback: (error?: Error, bytes?: Uint8Array, limitExceeded?: boolean) => void,
+  shouldStoreChunks = true
+) {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let readBytesCount = 0
+
+  readMore()
+
+  function readMore() {
+    reader.read().then(
+      monitor((result: ReadableStreamDefaultReadResult<Uint8Array>) => {
+        if (result.done) {
+          onDone()
+          return
+        }
+
+        shouldStoreChunks && chunks.push(result.value)
+        readBytesCount += result.value.length
+
+        if (readBytesCount > limit) {
+          onDone()
+        } else {
+          readMore()
+        }
+      }),
+      monitor((error) => callback(error))
+    )
+  }
+
+  function onDone() {
+    reader.cancel().catch(
+      // we don't care if cancel fails, but we still need to catch the error to avoid reporting it
+      // as an unhandled rejection
+      noop
+    )
+
+    let completeBuffer: Uint8Array
+    if (chunks.length === 1) {
+      // optim: if the response is small enough to fit in a single buffer (provided by the browser), just
+      // use it directly.
+      completeBuffer = chunks[0]
+    } else {
+      // else, we need to copy buffers into a larger buffer to concatenate them.
+      completeBuffer = new Uint8Array(readBytesCount)
+      let offset = 0
+      chunks.forEach((chunk) => {
+        completeBuffer.set(chunk, offset)
+        offset += chunk.length
+      })
+    }
+
+    callback(undefined, completeBuffer.slice(0, limit), completeBuffer.length > limit)
+  }
+}

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
@@ -8,6 +8,7 @@ import {
   toStackTraceString,
   monitor,
   noop,
+  readLimitedAmountOfBytes,
 } from '@datadog/browser-core'
 import type { RawNetworkLogsEvent } from '../../../rawLogsEvent.types'
 import type { LogsConfiguration } from '../../configuration'
@@ -191,67 +192,4 @@ function truncateResponseStream(
       callback(undefined, responseText)
     }
   })
-}
-
-/**
- * Read bytes from a ReadableStream until at least `limit` bytes have been read (or until the end of
- * the stream). The callback is invoked with the at most `limit` bytes, and indicates that the limit
- * has been exceeded if more bytes were available.
- */
-function readLimitedAmountOfBytes(
-  stream: ReadableStream<Uint8Array>,
-  limit: number,
-  callback: (error?: Error, bytes?: Uint8Array, limitExceeded?: boolean) => void
-) {
-  const reader = stream.getReader()
-  const chunks: Uint8Array[] = []
-  let readBytesCount = 0
-
-  readMore()
-
-  function readMore() {
-    reader.read().then(
-      monitor((result: ReadableStreamDefaultReadResult<Uint8Array>) => {
-        if (result.done) {
-          onDone()
-          return
-        }
-
-        chunks.push(result.value)
-        readBytesCount += result.value.length
-
-        if (readBytesCount > limit) {
-          onDone()
-        } else {
-          readMore()
-        }
-      }),
-      monitor((error) => callback(error))
-    )
-  }
-
-  function onDone() {
-    reader.cancel().catch(
-      // we don't care if cancel fails, but we still need to catch the error to avoid reporting it
-      // as an unhandled rejection
-      noop
-    )
-
-    let completeBuffer: Uint8Array
-    if (chunks.length === 1) {
-      // optim: if the response is small enough to fit in a single buffer (provided by the browser), just
-      // use it directly.
-      completeBuffer = chunks[0]
-    } else {
-      // else, we need to copy buffers into a larger buffer to concatenate them.
-      completeBuffer = new Uint8Array(readBytesCount)
-      let offset = 0
-      chunks.forEach((chunk) => {
-        completeBuffer.set(chunk, offset)
-        offset += chunk.length
-      })
-    }
-
-    callback(undefined, completeBuffer.slice(0, limit), completeBuffer.length > limit)
-  }
 }

--- a/test/e2e/scenario/logs.scenario.ts
+++ b/test/e2e/scenario/logs.scenario.ts
@@ -83,6 +83,7 @@ describe('logs', () => {
             // The body stream needs to be cancelled, else the browser will still download the whole
             // response even if it is unused.
             response
+              .clone()
               .body!.getReader()
               .cancel()
               .catch((error) => console.log(error))
@@ -104,7 +105,7 @@ describe('logs', () => {
         // When reading the request, chunks length are probably not aligning perfectly with the
         // response length limit, so it sends few more bytes than necessary. Add a margin of error
         // to verify that it's still close to the expected limit.
-        DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT * 2
+        DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT * 4
       )
       expect(servers.base.app.getLargeResponseWroteSize()).toBeGreaterThanOrEqual(
         DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -161,6 +161,7 @@ describe('action collection', () => {
 
       expect(resourceEvents.length).toBe(1)
       expect(resourceEvents[0].action!.id).toBe(actionEvents[0].action.id!)
+      expect(resourceEvents[0].resource.first_byte).toBeDefined()
     })
 
   createTest('increment the view.action.count of the view active when the action started')


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
Most browsers do not add resource entries to the performance object until after the payload has been downloaded.
This means that when we call `performance.getEntriesByName(request.url, 'resource')` after receiving a response from `Fetch`, we rarely find a corresponding entry.

To overcome this, we listen to `reponse.body` ReadableStream and only trigger the resource creation on done.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

- lift `readLimitedAmountOfBytes` into its own function in core
- create a new method `reportFetchOnPayloadComplete` inside `afterSend` of the `fetchObservable.ts` file
- use `readLimitedAmountOfBytes` to listen to the stream
- attach `reportFetchOnPayloadComplete` on the `fetch` `then` resolve function

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
