### PR TITLE
🐛 [RUMF-1410] Allow serialization of objects with cyclic references

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@ bundle
 cjs
 esm
 coverage
+dist
 rum-events-format

--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -73,5 +73,5 @@ function formatConsoleParameters(param: unknown) {
   if (param instanceof Error) {
     return formatErrorMessage(computeStackTrace(param))
   }
-  return jsonStringify(param, undefined, 2)
+  return jsonStringify(param, 2)
 }

--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -308,11 +308,26 @@ describe('utils', () => {
       expect(jsonStringify(true)).toEqual('true')
     })
 
-    it('should not crash on serialization error', () => {
-      const circularReference: any = { otherData: 123 }
-      circularReference.myself = circularReference
+    it('should serialize objects with cyclic references', () => {
+      const nested: any = { data: 345 }
+      const circularReference: any = { otherData: 123, nested }
+      nested.parent = circularReference
 
-      expect(jsonStringify(circularReference)).toEqual('<error: unable to serialize object>')
+      expect(jsonStringify(circularReference)).toEqual(
+        '{"otherData":123,"nested":{"data":345,"parent":"<warning: cyclic reference not serialized>"}}'
+      )
+    })
+
+    it('should not crash on serialization error', () => {
+      // custom toJSON is only ignored on root object.
+      const sub = {
+        toJSON: () => {
+          throw new Error('')
+        },
+      }
+      const root = { sub }
+
+      expect(jsonStringify(root)).toEqual('<error: unable to serialize object>')
     })
 
     function createSampleClassInstance(value: any = 'value') {

--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -318,6 +318,13 @@ describe('utils', () => {
       )
     })
 
+    it('should serialize arrays with cyclic references', () => {
+      const baseArray: any[] = [1]
+      baseArray.push(baseArray)
+
+      expect(jsonStringify(baseArray)).toEqual('[1,"<warning: cyclic reference not serialized>"]')
+    })
+
     it('should not crash on serialization error', () => {
       // custom toJSON is only ignored on root object.
       const sub = {

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -173,14 +173,14 @@ export function jsonStringify(value: unknown, space?: string | number): string |
   const getCyclicReplacer = <T>() => {
     // Using a weakmap instead of a weakset to support IE11
     const visited = new WeakMap<object, boolean>()
-    return (_k: string, v: T) => {
-      if (isValidObject(v)) {
-        if (visited.has(v)) {
+    return (_key: string, value: T) => {
+      if (isValidObject(value)) {
+        if (visited.has(value)) {
           return '<warning: cyclic reference not serialized>'
         }
-        visited.set(v, true)
+        visited.set(value, true)
       }
-      return v
+      return value
     }
   }
 


### PR DESCRIPTION
## Motivation

Fix for https://github.com/DataDog/browser-sdk/issues/807

## Changes

Added a replacer within the jsonStringify function that removes cyclic references while serializing.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
