### PR TITLE
🔉[RUMF-1423] Add debug log for retry issue

### DIFF
--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -26,7 +26,6 @@ const enum RetryReason {
 
 export interface RetryState {
   transportStatus: TransportStatus
-  lastFailureStatus: number
   currentBackoffTime: number
   bandwidthMonitor: ReturnType<typeof newBandwidthMonitor>
   queuedPayloads: ReturnType<typeof newPayloadQueue>
@@ -86,11 +85,6 @@ function scheduleRetry(
       send(payload, state, sendStrategy, {
         onSuccess: () => {
           state.queuedPayloads.dequeue()
-          if (state.lastFailureStatus !== 0) {
-            addTelemetryDebug('resuming after transport down', {
-              failureStatus: state.lastFailureStatus,
-            })
-          }
           state.currentBackoffTime = INITIAL_BACKOFF_TIME
           retryQueuedPayloads(RetryReason.AFTER_RESUME, state, sendStrategy, endpointType, reportError)
         },
@@ -120,7 +114,6 @@ function send(
       // do not consider transport down if another ongoing request could succeed
       state.transportStatus =
         state.bandwidthMonitor.ongoingRequestCount > 0 ? TransportStatus.FAILURE_DETECTED : TransportStatus.DOWN
-      state.lastFailureStatus = response.status
       onFailure()
     }
   })
@@ -155,7 +148,6 @@ function shouldRetryRequest(response: HttpResponse) {
 export function newRetryState(): RetryState {
   return {
     transportStatus: TransportStatus.UP,
-    lastFailureStatus: 0,
     currentBackoffTime: INITIAL_BACKOFF_TIME,
     bandwidthMonitor: newBandwidthMonitor(),
     queuedPayloads: newPayloadQueue(),

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -71,6 +71,18 @@ function scheduleRetry(
   setTimeout(
     monitor(() => {
       const payload = state.queuedPayloads.first()
+      if (!payload) {
+        addTelemetryDebug('no payload to retry', {
+          debug: {
+            queue: {
+              size: state.queuedPayloads.size(),
+              is_full: state.queuedPayloads.isFull(),
+              bytes_count: state.queuedPayloads.bytesCount,
+            },
+            transport_status: state.transportStatus,
+          },
+        })
+      }
       send(payload, state, sendStrategy, {
         onSuccess: () => {
           state.queuedPayloads.dequeue()


### PR DESCRIPTION
## Motivation

A couple of orgs generated some telemetry errors where payload is undefined in:
https://github.com/DataDog/browser-sdk/blob/34223e32f59b94e1a0eca2abd9b9ab6d2b145fa5/packages/core/src/transport/sendWithRetryStrategy.ts#L73-L74

## Changes

- add some debug info when the first payload of the queue is not defined
- remove unnecessary `resume after transport down` debug log

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
