### PR TITLE
REPLAY-1075: Resolve relative URLS to absolute in stylesheets

### DIFF
--- a/packages/rum/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum/src/domain/record/serializationUtils.spec.ts
@@ -109,15 +109,11 @@ describe('switchToAbsoluteUrl', () => {
   describe('convert relative url to absolute', () => {
     it('should replace url when wrapped in single quote', () => {
       const cssText = "{ font-family: FontAwesome; src: url('./fonts/fontawesome-webfont.eot'); }"
-      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
-        `{ font-family: FontAwesome; src: url('${resolvedUrl}'); }`
-      )
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url('${resolvedUrl}'); }`)
     })
     it('should replace url when wrapped in double quote', () => {
       const cssText = '{ font-family: FontAwesome; src: url("./fonts/fontawesome-webfont.eot"); }'
-      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
-        `{ font-family: FontAwesome; src: url("${resolvedUrl}"); }`
-      )
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url("${resolvedUrl}"); }`)
     })
     it('should replace url when not in any quote', () => {
       const cssText = '{ font-family: FontAwesome; src: url(./fonts/fontawesome-webfont.eot); }'

--- a/packages/rum/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum/src/domain/record/serializationUtils.spec.ts
@@ -149,9 +149,15 @@ describe('replace relative urls by absolute ones', () => {
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(cssText)
     })
     it('should not replace url if data uri', () => {
-      const cssText = '{ font-family: FontAwesome; src: url(data://static/assets/fonts/fontawesome-webfont.eot); }'
+      const cssText =
+        '{ font-family: FontAwesome; src: url(data:image/png;base64,iVBORNSUhEUgAAVR42mP8z/C/HgwJ/lK3Q6wAkJggg==); }'
 
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(cssText)
+    })
+    it('should not replace url if error is thrown when building absolute url', () => {
+      const cssText =
+        '{ font-family: FontAwesome; src: url(https://site.web/app-name/static/assets/fonts/fontawesome-webfont.eot); }'
+      expect(switchToAbsoluteUrl(cssText, 'hello-world')).toEqual(cssText)
     })
   })
 })

--- a/packages/rum/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum/src/domain/record/serializationUtils.spec.ts
@@ -102,34 +102,34 @@ describe('getElementInputValue', () => {
   })
 })
 
-describe('Build stylesheet absolute url', () => {
+describe('switchToAbsoluteUrl', () => {
   const cssHref = 'https://site.web/app-name/static/assets/resource.min.css'
-  const resolvedPath = 'https://site.web/app-name/static/assets/fonts/fontawesome-webfont.eot'
+  const resolvedUrl = 'https://site.web/app-name/static/assets/fonts/fontawesome-webfont.eot'
 
-  describe('convert relative path to absolute', () => {
+  describe('convert relative url to absolute', () => {
     it('should replace url when wrapped in single quote', () => {
       const cssText = "{ font-family: FontAwesome; src: url('./fonts/fontawesome-webfont.eot'); }"
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
-        `{ font-family: FontAwesome; src: url('${resolvedPath}'); }`
+        `{ font-family: FontAwesome; src: url('${resolvedUrl}'); }`
       )
     })
     it('should replace url when wrapped in double quote', () => {
       const cssText = '{ font-family: FontAwesome; src: url("./fonts/fontawesome-webfont.eot"); }'
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
-        `{ font-family: FontAwesome; src: url("${resolvedPath}"); }`
+        `{ font-family: FontAwesome; src: url("${resolvedUrl}"); }`
       )
     })
     it('should replace url when not in any quote', () => {
       const cssText = '{ font-family: FontAwesome; src: url(./fonts/fontawesome-webfont.eot); }'
 
-      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url(${resolvedPath}); }`)
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url(${resolvedUrl}); }`)
     })
-    it('should replace url when path is relative', () => {
+    it('should replace url when url is relative', () => {
       const cssText = '{ font-family: FontAwesome; src: url(fonts/fontawesome-webfont.eot); }'
 
-      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url(${resolvedPath}); }`)
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url(${resolvedUrl}); }`)
     })
-    it('should replace url when path is at parent level', () => {
+    it('should replace url when url is at parent level', () => {
       const cssText = "{ font-family: FontAwesome; src: url('../fonts/fontawesome-webfont.eot'); }"
 
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(

--- a/packages/rum/src/domain/record/serializationUtils.spec.ts
+++ b/packages/rum/src/domain/record/serializationUtils.spec.ts
@@ -102,42 +102,56 @@ describe('getElementInputValue', () => {
   })
 })
 
-describe('replace relative urls by absolute ones', () => {
+describe('Build stylesheet absolute url', () => {
   const cssHref = 'https://site.web/app-name/static/assets/resource.min.css'
   const resolvedPath = 'https://site.web/app-name/static/assets/fonts/fontawesome-webfont.eot'
 
-  describe('replace relative url by absolute one', () => {
-    it('should replace url when wrapped with signle quote', () => {
+  describe('convert relative path to absolute', () => {
+    it('should replace url when wrapped in single quote', () => {
       const cssText = "{ font-family: FontAwesome; src: url('./fonts/fontawesome-webfont.eot'); }"
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
         `{ font-family: FontAwesome; src: url('${resolvedPath}'); }`
       )
     })
-    it('should replace url when wrapped with double quote', () => {
+    it('should replace url when wrapped in double quote', () => {
       const cssText = '{ font-family: FontAwesome; src: url("./fonts/fontawesome-webfont.eot"); }'
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
         `{ font-family: FontAwesome; src: url("${resolvedPath}"); }`
       )
     })
-    it('should replace url when not wrapped by a double quote', () => {
+    it('should replace url when not in any quote', () => {
       const cssText = '{ font-family: FontAwesome; src: url(./fonts/fontawesome-webfont.eot); }'
 
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url(${resolvedPath}); }`)
     })
-
-    it('should replace url when not wrapped by a double quote', () => {
+    it('should replace url when path is relative', () => {
       const cssText = '{ font-family: FontAwesome; src: url(fonts/fontawesome-webfont.eot); }'
 
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(`{ font-family: FontAwesome; src: url(${resolvedPath}); }`)
     })
+    it('should replace url when path is at parent level', () => {
+      const cssText = "{ font-family: FontAwesome; src: url('../fonts/fontawesome-webfont.eot'); }"
+
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
+        "{ font-family: FontAwesome; src: url('https://site.web/app-name/static/fonts/fontawesome-webfont.eot'); }"
+      )
+    })
+    it('should replace multiple urls at the same time', () => {
+      const cssText =
+        '{ background-image: url(../images/pic.png); src: url("fonts/fantasticfont.woff"); content: url("./icons/icon.jpg");}'
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(
+        '{ background-image: url(https://site.web/app-name/static/images/pic.png); src: url("https://site.web/app-name/static/assets/fonts/fantasticfont.woff"); content: url("https://site.web/app-name/static/assets/icons/icon.jpg");}'
+      )
+    })
   })
-  describe('do not replace url in css text', () => {
+
+  describe('keep urls in css text unchanged', () => {
     it('should not replace url if baseUrl is null', () => {
       const cssText = '{ font-family: FontAwesome; src: url(./fonts/fontawesome-webfont.eot); }'
 
       expect(switchToAbsoluteUrl(cssText, null)).toEqual(cssText)
     })
-    it('should not replace url if path is empty', () => {
+    it('should not replace url if it is empty', () => {
       const cssText = '{ font-family: FontAwesome; src: url(); }'
 
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(cssText)
@@ -148,9 +162,21 @@ describe('replace relative urls by absolute ones', () => {
 
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(cssText)
     })
-    it('should not replace url if data uri', () => {
+    it('should not replace url if it starts with //', () => {
+      const cssText =
+        '{ font-family: FontAwesome; src: url(//site.web/app-name/static/assets/fonts/fontawesome-webfont.eot); }'
+
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(cssText)
+    })
+    it('should not replace url if data uri: lower case', () => {
       const cssText =
         '{ font-family: FontAwesome; src: url(data:image/png;base64,iVBORNSUhEUgAAVR42mP8z/C/HgwJ/lK3Q6wAkJggg==); }'
+
+      expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(cssText)
+    })
+    it('should not replace url if data uri: not lower case', () => {
+      const cssText =
+        '{ font-family: FontAwesome; src: url(DaTa:image/png;base64,iVBORNSUhEUgAAVR42mP8z/C/HgwJ/lK3Q6wAkJggg==); }'
 
       expect(switchToAbsoluteUrl(cssText, cssHref)).toEqual(cssText)
     })

--- a/packages/rum/src/domain/record/serializationUtils.ts
+++ b/packages/rum/src/domain/record/serializationUtils.ts
@@ -79,28 +79,28 @@ export function switchToAbsoluteUrl(cssText: string, cssHref: string | null): st
   return cssText.replace(
     URL_IN_CSS_REF,
     (
-      matched: string,
+      matchingSubstring: string,
       singleQuote: string | undefined,
-      firstPathMatched: string | undefined,
+      urlWrappedInSingleQuotes: string | undefined,
       doubleQuote: string | undefined,
-      secondPathMatched: string | undefined,
-      thirdPathMatched: string | undefined
+      urlWrappedInDoubleQuotes: string | undefined,
+      urlNotWrappedInQuotes: string | undefined
     ) => {
-      const path = firstPathMatched || secondPathMatched || thirdPathMatched
+      const url = urlWrappedInSingleQuotes || urlWrappedInDoubleQuotes || urlNotWrappedInQuotes
 
-      if (!cssHref || !path || ABSOLUTE_URL.test(path) || DATA_URI.test(path)) {
-        return matched
+      if (!cssHref || !url || ABSOLUTE_URL.test(url) || DATA_URI.test(url)) {
+        return matchingSubstring
       }
 
       const quote = singleQuote || doubleQuote || ''
-      return `url(${quote}${makeUrlAbsolute(path, cssHref)}${quote})`
+      return `url(${quote}${makeUrlAbsolute(url, cssHref)}${quote})`
     }
   )
 }
 
 export function makeUrlAbsolute(url: string, baseUrl: string): string {
   try {
-    return buildUrl(url.trim(), baseUrl).href
+    return buildUrl(url, baseUrl).href
   } catch (_) {
     return url
   }

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -25,7 +25,12 @@ import {
   getNodeSelfPrivacyLevel,
   MAX_ATTRIBUTE_VALUE_CHAR_LENGTH,
 } from './privacy'
-import { getSerializedNodeId, setSerializedNodeId, getElementInputValue } from './serializationUtils'
+import {
+  getSerializedNodeId,
+  setSerializedNodeId,
+  getElementInputValue,
+  switchToAbsoluteUrl,
+} from './serializationUtils'
 import { forEach } from './utils'
 import type { ElementsScrollPositions } from './elementsScrollPositions'
 
@@ -316,7 +321,7 @@ function getValidTagName(tagName: string): string {
 function getCssRulesString(s: CSSStyleSheet): string | null {
   try {
     const rules = s.rules || s.cssRules
-    return rules ? Array.from(rules).map(getCssRuleString).join('') : null
+    return rules ? switchToAbsoluteUrl(Array.from(rules, getCssRuleString).join(''), s.href) : null
   } catch (error) {
     return null
   }

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -321,7 +321,12 @@ function getValidTagName(tagName: string): string {
 function getCssRulesString(s: CSSStyleSheet): string | null {
   try {
     const rules = s.rules || s.cssRules
-    return rules ? switchToAbsoluteUrl(Array.from(rules, getCssRuleString).join(''), s.href) : null
+    if (rules) {
+      const styleSheetCssText = Array.from(rules, getCssRuleString).join('')
+      return switchToAbsoluteUrl(styleSheetCssText, s.href)
+    }
+
+    return null
   } catch (error) {
     return null
   }


### PR DESCRIPTION
## Motivation

Resolve relative urls to absolute in CSS Style Sheets in order to properly fetch resource by the player 

## Changes

Extracting cssRules from a style sheet and converting them to text, switch absolute urls to relative ones based on the attribute href of the style sheet.

## Testing

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
