### PR TITLE
🔉[RUMF-1423] Investigation for retry issue - part 2

### DIFF
--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -112,7 +112,7 @@ describe('httpRequest', () => {
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 },
         (response) => {
-          expect(response).toEqual({ status: 429 })
+          expect(response).toEqual({ status: 429, api: 'fetch' })
           done()
         }
       )
@@ -135,7 +135,7 @@ describe('httpRequest', () => {
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 },
         (response) => {
-          expect(response).toEqual({ status: 429 })
+          expect(response).toEqual({ status: 429, api: 'xhr' })
           done()
         }
       )
@@ -153,7 +153,7 @@ describe('httpRequest', () => {
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: BATCH_BYTES_LIMIT },
         (response) => {
-          expect(response).toEqual({ status: 429 })
+          expect(response).toEqual({ status: 429, api: 'xhr' })
           done()
         }
       )


### PR DESCRIPTION
## Motivation

Following #1790, investigate some telemetry errors related to retry strategy.

## Changes

From added debug logs, before starting a retry the queue is empty and the transport is up.
Hypothesis: we somehow received multiple responses from a single send, one down followed by one up could lead to the observed issue.

Added some debug logs to validate / invalidate the hypothesis

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
