### PR TITLE
🐛[RUMF-1423] prevent unexpected behavior when our xhr are reused

### DIFF
--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -112,7 +112,7 @@ describe('httpRequest', () => {
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 },
         (response) => {
-          expect(response).toEqual({ status: 429, api: 'fetch' })
+          expect(response).toEqual({ status: 429 })
           done()
         }
       )
@@ -135,7 +135,7 @@ describe('httpRequest', () => {
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 },
         (response) => {
-          expect(response).toEqual({ status: 429, api: 'xhr' })
+          expect(response).toEqual({ status: 429 })
           done()
         }
       )
@@ -153,7 +153,7 @@ describe('httpRequest', () => {
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: BATCH_BYTES_LIMIT },
         (response) => {
-          expect(response).toEqual({ status: 429, api: 'xhr' })
+          expect(response).toEqual({ status: 429 })
           done()
         }
       )

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -3,7 +3,7 @@ import type { Request } from '../../test/specHelper'
 import type { EndpointBuilder } from '../domain/configuration'
 import { createEndpointBuilder } from '../domain/configuration'
 import { noop } from '../tools/utils'
-import { createHttpRequest, fetchKeepAliveStrategy } from './httpRequest'
+import { createHttpRequest, fetchKeepAliveStrategy, sendXHR } from './httpRequest'
 import type { HttpRequest } from './httpRequest'
 import { INITIAL_BACKOFF_TIME } from './sendWithRetryStrategy'
 
@@ -157,6 +157,35 @@ describe('httpRequest', () => {
           done()
         }
       )
+    })
+  })
+
+  describe('sendXhr', () => {
+    it('should prevent third party to trigger callback multiple times', (done) => {
+      const onResponseSpy = jasmine.createSpy('xhrOnResponse')
+      let count = 0
+
+      interceptor.withStubXhr((xhr) => {
+        count++
+        setTimeout(() => {
+          xhr.complete(count === 1 ? 200 : 202)
+          if (count === 1) {
+            // reuse the xhr instance to send another request
+            xhr.open('POST', 'foo')
+            xhr.send()
+          }
+        })
+      })
+
+      sendXHR('foo', '', onResponseSpy)
+
+      setTimeout(() => {
+        expect(onResponseSpy).toHaveBeenCalledTimes(1)
+        expect(onResponseSpy).toHaveBeenCalledWith({
+          status: 200,
+        })
+        done()
+      }, 100)
     })
   })
 

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -105,14 +105,15 @@ function isKeepAliveSupported() {
   }
 }
 
-function sendXHR(url: string, data: Payload['data'], onResponse?: (r: HttpResponse) => void) {
+export function sendXHR(url: string, data: Payload['data'], onResponse?: (r: HttpResponse) => void) {
   const request = new XMLHttpRequest()
+  const onLoadEnd = monitor(() => {
+    // prevent multiple onResponse callbacks
+    // if the xhr instance is reused by a third party
+    request.removeEventListener('loadend', onLoadEnd)
+    onResponse?.({ status: request.status })
+  })
   request.open('POST', url, true)
+  request.addEventListener('loadend', onLoadEnd)
   request.send(data)
-  request.addEventListener(
-    'loadend',
-    monitor(() => {
-      onResponse?.({ status: request.status })
-    })
-  )
 }

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -18,7 +18,6 @@ export type HttpRequest = ReturnType<typeof createHttpRequest>
 
 export interface HttpResponse extends Context {
   status: number
-  api?: string
 }
 
 export interface Payload {
@@ -86,7 +85,7 @@ export function fetchKeepAliveStrategy(
   const canUseKeepAlive = isKeepAliveSupported() && bytesCount < bytesLimit
   if (canUseKeepAlive) {
     fetch(url, { method: 'POST', body: data, keepalive: true }).then(
-      monitor((response: Response) => onResponse?.({ status: response.status, api: 'fetch' })),
+      monitor((response: Response) => onResponse?.({ status: response.status })),
       monitor(() => {
         // failed to queue the request
         sendXHR(url, data, onResponse)
@@ -113,7 +112,7 @@ function sendXHR(url: string, data: Payload['data'], onResponse?: (r: HttpRespon
   request.addEventListener(
     'loadend',
     monitor(() => {
-      onResponse?.({ status: request.status, api: 'xhr' })
+      onResponse?.({ status: request.status })
     })
   )
 }


### PR DESCRIPTION
## Motivation

Following #1790, #1793, our new request strategy can be disturb if our xhr instances are reused to send other requests.

## Changes

Prevent our xhr instances callback to be called multiple times.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
