### PR TITLE
✅ fix flaky test caused by an async scroll event

### DIFF
--- a/packages/rum/src/domain/record/viewports.spec.ts
+++ b/packages/rum/src/domain/record/viewports.spec.ts
@@ -1,4 +1,4 @@
-import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
+import { addEventListener, DOM_EVENT, isIE } from '@datadog/browser-core'
 import { getScrollX, getScrollY } from './viewports'
 
 function isMobileSafari12() {
@@ -13,6 +13,10 @@ describe('layout viewport', () => {
   }
 
   beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+
     shouldWaitForWindowScrollEvent = false
   })
 

--- a/packages/rum/src/domain/record/viewports.spec.ts
+++ b/packages/rum/src/domain/record/viewports.spec.ts
@@ -1,3 +1,4 @@
+import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 import { getScrollX, getScrollY } from './viewports'
 
 function isMobileSafari12() {
@@ -5,14 +6,27 @@ function isMobileSafari12() {
 }
 
 describe('layout viewport', () => {
+  let shouldWaitForWindowScrollEvent: boolean
+
   const addVerticalScrollBar = () => {
     document.body.style.setProperty('margin-bottom', '5000px')
   }
 
-  afterEach(() => {
+  beforeEach(() => {
+    shouldWaitForWindowScrollEvent = false
+  })
+
+  afterEach((done) => {
     document.body.style.removeProperty('margin-bottom')
-    document.body.style.removeProperty('margin-right')
     window.scrollTo(0, 0)
+
+    // Those tests are triggering asynchronous scroll events that might impact tests run after them.
+    // To avoid that, we wait for the next scroll event before continuing to the next one.
+    if (shouldWaitForWindowScrollEvent) {
+      addEventListener(window, DOM_EVENT.SCROLL, done, { passive: true, once: true, capture: true })
+    } else {
+      done()
+    }
   })
 
   describe('getScrollX/Y', () => {
@@ -23,6 +37,7 @@ describe('layout viewport', () => {
       expect(getScrollX()).toBe(window.scrollX || window.pageXOffset)
       expect(getScrollY()).toBe(window.scrollY || window.pageYOffset)
     })
+
     it('normalized scroll updates when scrolled', () => {
       if (isMobileSafari12()) {
         // Mobile Safari 12 doesn't support scrollTo() within an iframe
@@ -32,7 +47,10 @@ describe('layout viewport', () => {
       }
       addVerticalScrollBar()
       const SCROLL_DOWN_PX = 100
+
       window.scrollTo(0, SCROLL_DOWN_PX)
+      shouldWaitForWindowScrollEvent = true
+
       expect(getScrollX()).toBe(0)
       expect(getScrollY()).toBe(100)
       expect(getScrollX()).toBe(window.scrollX || window.pageXOffset)


### PR DESCRIPTION
## Motivation

When the [viewports.spec tests](https://github.com/DataDog/browser-sdk/blob/62b88f934a5cd5c949435c6b5d2df51b79e864cf/packages/rum/src/domain/record/viewports.spec.ts#L8) are run, a "scroll" event is dispatched *after* they finish to run. This scroll event can impact test cases that are run directly after them, for example the [record.spec tests](https://github.com/DataDog/browser-sdk/blob/62b88f934a5cd5c949435c6b5d2df51b79e864cf/packages/rum/src/domain/record/record.spec.ts) which are doing many assertions on generated records.

This is reproductible with Jasmine seed 67707.

Note: I also observed a similar issue with the `visualViewport` resize event, but couldn't reproduce it anymore.

## Changes

Conditionnally wait for the scroll event to happen before ending the test.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
