### PR TITLE
✨ [RUMF-1409] Provide setUser and related functions for logs SDK

### DIFF
--- a/packages/core/src/domain/user/index.ts
+++ b/packages/core/src/domain/user/index.ts
@@ -1,0 +1,2 @@
+export * from './user.types'
+export * from './user'

--- a/packages/core/src/domain/user/user.spec.ts
+++ b/packages/core/src/domain/user/user.spec.ts
@@ -1,11 +1,12 @@
+import type { Context } from '../../tools/context'
 import { sanitizeUser } from './user'
 
 describe('user functions', () => {
   it('should sanitize a user object', () => {
-    const obj = { id: 42, name: 'test', email: null }
+    const obj = { id: 42, name: true, email: null }
     const user = sanitizeUser(obj)
 
-    expect(user).toEqual({ id: '42', name: 'test', email: 'null' })
+    expect(user).toEqual({ id: '42', name: 'true', email: 'null' })
   })
 
   it('should not mutate the original data', () => {
@@ -14,5 +15,13 @@ describe('user functions', () => {
 
     expect(user.id).toEqual('42')
     expect(obj.id).toEqual(42)
+  })
+
+  it('should keep a full copy of the user data ', () => {
+    const obj = { id: 42, name: 'test', email: null, custom: { deep: true } }
+    const user = sanitizeUser(obj)
+    obj.custom.deep = false
+
+    expect((user.custom as Context).deep).toEqual(true)
   })
 })

--- a/packages/core/src/domain/user/user.spec.ts
+++ b/packages/core/src/domain/user/user.spec.ts
@@ -1,0 +1,18 @@
+import { sanitizeUser } from './user'
+
+describe('user functions', () => {
+  it('should sanitize a user object', () => {
+    const obj = { id: 42, name: 'test', email: null }
+    const user = sanitizeUser(obj)
+
+    expect(user).toEqual({ id: '42', name: 'test', email: 'null' })
+  })
+
+  it('should not mutate the original data', () => {
+    const obj = { id: 42, name: 'test', email: null }
+    const user = sanitizeUser(obj)
+
+    expect(user.id).toEqual('42')
+    expect(obj.id).toEqual(42)
+  })
+})

--- a/packages/core/src/domain/user/user.spec.ts
+++ b/packages/core/src/domain/user/user.spec.ts
@@ -1,7 +1,8 @@
 import type { Context } from '../../tools/context'
-import { sanitizeUser } from './user'
+import { checkUser, sanitizeUser } from './user'
+import type { User } from './user.types'
 
-describe('user functions', () => {
+describe('sanitize user function', () => {
   it('should sanitize a user object', () => {
     const obj = { id: 42, name: true, email: null }
     const user = sanitizeUser(obj)
@@ -23,5 +24,21 @@ describe('user functions', () => {
     obj.custom.deep = false
 
     expect((user.custom as Context).deep).toEqual(true)
+  })
+})
+
+describe('check user function', () => {
+  it('should only accept valid user objects', () => {
+    const obj: any = { id: 42, name: true, email: null } // Valid, even though not sanitized
+    const user: User = { id: '42', name: 'John', email: 'john@doe.com' }
+    const undefUser: any = undefined
+    const nullUser: any = null
+    const invalidUser: any = 42
+
+    expect(checkUser(obj)).toBe(true)
+    expect(checkUser(user)).toBe(true)
+    expect(checkUser(undefUser)).toBe(false)
+    expect(checkUser(nullUser)).toBe(false)
+    expect(checkUser(invalidUser)).toBe(false)
   })
 })

--- a/packages/core/src/domain/user/user.spec.ts
+++ b/packages/core/src/domain/user/user.spec.ts
@@ -1,4 +1,3 @@
-import type { Context } from '../../tools/context'
 import { checkUser, sanitizeUser } from './user'
 import type { User } from './user.types'
 
@@ -16,14 +15,6 @@ describe('sanitize user function', () => {
 
     expect(user.id).toEqual('42')
     expect(obj.id).toEqual(42)
-  })
-
-  it('should keep a full copy of the user data ', () => {
-    const obj = { id: 42, name: 'test', email: null, custom: { deep: true } }
-    const user = sanitizeUser(obj)
-    obj.custom.deep = false
-
-    expect((user.custom as Context).deep).toEqual(true)
   })
 })
 

--- a/packages/core/src/domain/user/user.ts
+++ b/packages/core/src/domain/user/user.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../../tools/context'
 import { display } from '../../tools/display'
-import { deepClone, getType } from '../../tools/utils'
+import { assign, getType } from '../../tools/utils'
 import type { User } from './user.types'
 
 /**
@@ -9,7 +9,8 @@ import type { User } from './user.types'
  * https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
  */
 export function sanitizeUser(newUser: Context): Context {
-  const user = deepClone(newUser)
+  // We shallow clone only to prevent mutation of user data.
+  const user = assign({}, newUser)
   const keys = ['id', 'name', 'email']
   keys.forEach((key) => {
     if (key in user) {

--- a/packages/core/src/domain/user/user.ts
+++ b/packages/core/src/domain/user/user.ts
@@ -1,21 +1,18 @@
 import type { Context } from '../../tools/context'
-import { assign } from '../../tools/utils'
+import { deepClone } from '../../tools/utils'
 
 /**
  * Clone input data and ensure known user properties (id, name, email)
  * are strings, as defined here:
  * https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
  */
-export function sanitizeUser(newUser: Context) {
-  const shallowClonedUser = assign({}, newUser)
-  if ('id' in shallowClonedUser) {
-    shallowClonedUser.id = String(shallowClonedUser.id)
-  }
-  if ('name' in shallowClonedUser) {
-    shallowClonedUser.name = String(shallowClonedUser.name)
-  }
-  if ('email' in shallowClonedUser) {
-    shallowClonedUser.email = String(shallowClonedUser.email)
-  }
-  return shallowClonedUser
+export function sanitizeUser(newUser: Context): Context {
+  const user = deepClone(newUser)
+  const keys = ['id', 'name', 'email']
+  keys.forEach((key) => {
+    if (key in user) {
+      user[key] = String(user[key])
+    }
+  })
+  return user
 }

--- a/packages/core/src/domain/user/user.ts
+++ b/packages/core/src/domain/user/user.ts
@@ -1,5 +1,7 @@
 import type { Context } from '../../tools/context'
-import { deepClone } from '../../tools/utils'
+import { display } from '../../tools/display'
+import { deepClone, getType } from '../../tools/utils'
+import type { User } from './user.types'
 
 /**
  * Clone input data and ensure known user properties (id, name, email)
@@ -15,4 +17,15 @@ export function sanitizeUser(newUser: Context): Context {
     }
   })
   return user
+}
+
+/**
+ * Simple check to ensure user is valid
+ */
+export function checkUser(newUser: User): boolean {
+  const isValid = getType(newUser) === 'object'
+  if (!isValid) {
+    display.error('Unsupported user:', newUser)
+  }
+  return isValid
 }

--- a/packages/core/src/domain/user/user.ts
+++ b/packages/core/src/domain/user/user.ts
@@ -1,0 +1,21 @@
+import type { Context } from '../../tools/context'
+import { assign } from '../../tools/utils'
+
+/**
+ * Clone input data and ensure known user properties (id, name, email)
+ * are strings, as defined here:
+ * https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
+ */
+export function sanitizeUser(newUser: Context) {
+  const shallowClonedUser = assign({}, newUser)
+  if ('id' in shallowClonedUser) {
+    shallowClonedUser.id = String(shallowClonedUser.id)
+  }
+  if ('name' in shallowClonedUser) {
+    shallowClonedUser.name = String(shallowClonedUser.name)
+  }
+  if ('email' in shallowClonedUser) {
+    shallowClonedUser.email = String(shallowClonedUser.email)
+  }
+  return shallowClonedUser
+}

--- a/packages/core/src/domain/user/user.types.ts
+++ b/packages/core/src/domain/user/user.types.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id?: string
+  email?: string
+  name?: string
+  [key: string]: unknown
+}

--- a/packages/core/src/domain/user/user.types.ts
+++ b/packages/core/src/domain/user/user.types.ts
@@ -1,6 +1,6 @@
 export interface User {
-  id?: string
-  email?: string
-  name?: string
+  id?: string | undefined
+  email?: string | undefined
+  name?: string | undefined
   [key: string]: unknown
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,3 +85,4 @@ export {
   getSyntheticsTestId,
   getSyntheticsResultId,
 } from './domain/synthetics/syntheticsWorkerValues'
+export { User, sanitizeUser } from './domain/user'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,4 +85,4 @@ export {
   getSyntheticsTestId,
   getSyntheticsResultId,
 } from './domain/synthetics/syntheticsWorkerValues'
-export { User, sanitizeUser } from './domain/user'
+export { User, checkUser, sanitizeUser } from './domain/user'

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -572,6 +572,94 @@ window.DD_LOGS && DD_LOGS.getGlobalContext() // => {}
 
 **Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
 
+#### User context
+
+The Datadog logs SDK provides convenient functions to associate a `User` with generated logs.
+
+- Set the user for all your loggers with the `setUser (newUser: User)` API.
+- Add or modify a user property to all your loggers with the `setUserProperty (key: string, value: any)` API.
+- Get the currently stored user with the `getUser ()` API.
+- Remove a user property with the `removeUserProperty (key: string)` API.
+- Clear all existing user properties with the `clearUser ()` API.
+
+**Note**: The user context is applied before the global context. Hence, every user property included in the global context will override the user context when generating logs.
+
+##### NPM
+
+For NPM, use:
+
+```javascript
+import { datadogLogs } from '@datadog/browser-logs'
+
+datadogLogs.setUser({ id: '1234', name: 'John Doe', email: 'john@doe.com' })
+datadogLogs.setUserProperty('type', 'customer')
+datadogLogs.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com', type: 'customer'}
+
+datadogLogs.removeUserProperty('type')
+datadogLogs.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com'}
+
+datadogLogs.clearUser()
+datadogLogs.getUser() // => {}
+```
+
+#### CDN async
+
+For CDN async, use:
+
+```javascript
+DD_LOGS.onReady(function () {
+  DD_LOGS.setUser({ id: '1234', name: 'John Doe', email: 'john@doe.com' })
+})
+
+DD_LOGS.onReady(function () {
+  DD_LOGS.setUserProperty('type', 'customer')
+})
+
+DD_LOGS.onReady(function () {
+  DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com', type: 'customer'}
+})
+
+DD_LOGS.onReady(function () {
+  DD_LOGS.removeUserProperty('type')
+})
+
+DD_LOGS.onReady(function () {
+  DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com'}
+})
+
+DD_LOGS.onReady(function () {
+  DD_LOGS.clearUser()
+})
+
+DD_LOGS.onReady(function () {
+  DD_LOGS.getUser() // => {}
+})
+```
+
+**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+
+##### CDN sync
+
+For CDN sync, use:
+
+```javascript
+window.DD_LOGS && DD_LOGS.setUser({ id: '1234', name: 'John Doe', email: 'john@doe.com' })
+
+window.DD_LOGS && DD_LOGS.setUserProperty('type', 'customer')
+
+window.DD_LOGS && DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com', type: 'customer'}
+
+window.DD_LOGS && DD_LOGS.removeUserProperty('type')
+
+window.DD_LOGS && DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com'}
+
+window.DD_LOGS && DD_LOGS.clearUser()
+
+window.DD_LOGS && DD_LOGS.getUser() // => {}
+```
+
+**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+
 #### Logger context
 
 After a logger is created, it is possible to:

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -94,7 +94,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
 </html>
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 ### TypeScript
 
@@ -174,7 +174,7 @@ DD_LOGS.onReady(function () {
 window.DD_LOGS && DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id: 123 })
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 #### Results
 
@@ -471,7 +471,7 @@ if (window.DD_LOGS) {
 }
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 ### Overwrite context
 
@@ -570,7 +570,7 @@ window.DD_LOGS && DD_LOGS.clearGlobalContext()
 window.DD_LOGS && DD_LOGS.getGlobalContext() // => {}
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 #### User context
 
@@ -658,7 +658,7 @@ window.DD_LOGS && DD_LOGS.clearUser()
 window.DD_LOGS && DD_LOGS.getUser() // => {}
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 #### Logger context
 
@@ -705,7 +705,7 @@ window.DD_LOGS && DD_LOGS.setContext("{'env': 'staging'}")
 window.DD_LOGS && DD_LOGS.addContext('referrer', document.referrer)
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 ### Filter by status
 
@@ -747,7 +747,7 @@ For CDN sync, use:
 window.DD_LOGS && DD_LOGS.logger.setLevel('<LEVEL>')
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 ### Change the destination
 
@@ -794,7 +794,7 @@ window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
 window.DD_LOGS && DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 ```
 
-**Note**: The `window.DD_LOGS` check is used to prevent issues if a loading failure occurs with the SDK.
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
 
 ### Access internal context
 

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -1,4 +1,4 @@
-import type { InitConfiguration } from '@datadog/browser-core'
+import type { Context, InitConfiguration, User } from '@datadog/browser-core'
 import {
   assign,
   BoundedBuffer,
@@ -9,6 +9,7 @@ import {
   deepClone,
   canUseEventBridge,
   timeStampNow,
+  sanitizeUser,
 } from '@datadog/browser-core'
 import type { LogsInitConfiguration } from '../domain/configuration'
 import { validateAndBuildLogsConfiguration } from '../domain/configuration'
@@ -33,6 +34,8 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
   let isAlreadyInitialized = false
 
   const globalContextManager = createContextManager()
+  const userContextManager = createContextManager()
+
   const customLoggers: { [name: string]: Logger | undefined } = {}
   let getInternalContextStrategy: StartLogsResult['getInternalContext'] = () => undefined
 
@@ -56,7 +59,8 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
         referrer: document.referrer,
         url: window.location.href,
       },
-      context: globalContextManager.get(),
+      context: globalContextManager.getContext(),
+      user: userContextManager.getContext(),
     }
   }
 
@@ -125,6 +129,25 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
     getInitConfiguration: monitor(() => getInitConfigurationStrategy()),
 
     getInternalContext: monitor((startTime?: number | undefined) => getInternalContextStrategy(startTime)),
+
+    setUser: monitor((newUser: User) => {
+      if (typeof newUser !== 'object' || !newUser) {
+        display.error('Unsupported user:', newUser)
+      } else {
+        userContextManager.setContext(sanitizeUser(newUser as Context))
+      }
+    }),
+
+    getUser: monitor(userContextManager.getContext),
+
+    setUserProperty: monitor((key, property) => {
+      const sanitizedProperty = sanitizeUser({ [key]: property })[key]
+      userContextManager.setContextProperty(key, sanitizedProperty)
+    }),
+
+    removeUserProperty: monitor(userContextManager.removeContextProperty),
+
+    clearUser: monitor(userContextManager.clearContext),
   })
 
   function overrideInitConfigurationForBridge<C extends InitConfiguration>(initConfiguration: C): C {

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -9,6 +9,7 @@ import {
   deepClone,
   canUseEventBridge,
   timeStampNow,
+  checkUser,
   sanitizeUser,
 } from '@datadog/browser-core'
 import type { LogsInitConfiguration } from '../domain/configuration'
@@ -131,9 +132,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
     getInternalContext: monitor((startTime?: number | undefined) => getInternalContextStrategy(startTime)),
 
     setUser: monitor((newUser: User) => {
-      if (typeof newUser !== 'object' || !newUser) {
-        display.error('Unsupported user:', newUser)
-      } else {
+      if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
       }
     }),

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -33,6 +33,7 @@ const DEFAULT_MESSAGE = { status: StatusType.info, message: 'message' }
 const COMMON_CONTEXT = {
   view: { referrer: 'common_referrer', url: 'common_url' },
   context: {},
+  user: {},
 }
 
 describe('logs', () => {

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -25,6 +25,12 @@ const COMMON_CONTEXT: CommonContext = {
     url: 'url_from_common_context',
   },
   context: { common_context_key: 'common_context_value' },
+  user: {},
+}
+
+const COMMON_CONTEXT_WITH_USER: CommonContext = {
+  ...COMMON_CONTEXT,
+  user: { id: 'id', name: 'name', email: 'test@test.com' },
 }
 
 describe('startLogsAssembly', () => {
@@ -126,6 +132,7 @@ describe('startLogsAssembly', () => {
           url: 'url_from_saved_common_context',
         },
         context: { foo: 'bar' },
+        user: { email: 'test@test.com' },
       }
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE, savedCommonContext })
 
@@ -266,6 +273,52 @@ describe('startLogsAssembly', () => {
       })
 
       expect(serverLogs[0].foo).toBe('bar')
+    })
+  })
+})
+
+describe('user management', () => {
+  const sessionManager: LogsSessionManager = {
+    findTrackedSession: () => (sessionIsTracked ? { id: SESSION_ID } : undefined),
+  }
+
+  let sessionIsTracked: boolean
+  let lifeCycle: LifeCycle
+  let serverLogs: Array<LogsEvent & Context> = []
+
+  const beforeSend: (event: LogsEvent) => void | boolean = noop
+  const mainLogger = new Logger(() => noop)
+  const configuration = {
+    ...validateAndBuildLogsConfiguration(initConfiguration)!,
+    beforeSend: (x: LogsEvent) => beforeSend(x),
+  }
+
+  beforeEach(() => {
+    sessionIsTracked = true
+    lifeCycle = new LifeCycle()
+    lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (serverRumEvent) => serverLogs.push(serverRumEvent))
+  })
+
+  afterEach(() => {
+    delete window.DD_RUM
+    serverLogs = []
+  })
+
+  it('should not output usr key if user is not set', () => {
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, mainLogger, noop)
+
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
+    expect(serverLogs[0].usr).toBeUndefined()
+  })
+
+  it('should include user data when user has been set', () => {
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT_WITH_USER, mainLogger, noop)
+
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
+    expect(serverLogs[0].usr).toEqual({
+      id: 'id',
+      name: 'name',
+      email: 'test@test.com',
     })
   })
 })

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -321,6 +321,27 @@ describe('user management', () => {
       email: 'test@test.com',
     })
   })
+
+  it('should prioritize global context over user context', () => {
+    const globalContextWithUser = {
+      ...COMMON_CONTEXT_WITH_USER,
+      context: {
+        ...COMMON_CONTEXT.context,
+        usr: {
+          id: 4242,
+          name: 'solution',
+        },
+      },
+    }
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => globalContextWithUser, mainLogger, noop)
+
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
+    expect(serverLogs[0].usr).toEqual({
+      id: 4242,
+      name: 'solution',
+      email: 'test@test.com',
+    })
+  })
 })
 
 describe('logs limitation', () => {

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -9,7 +9,6 @@ import {
   createEventRateLimiter,
   getRelativeTime,
   isEmptyObject,
-  shallowClone,
 } from '@datadog/browser-core'
 import type { CommonContext } from '../rawLogsEvent.types'
 import type { LogsConfiguration } from './configuration'
@@ -46,6 +45,7 @@ export function startLogsAssembly(
 
       const commonContext = savedCommonContext || getCommonContext()
       const log = combine(
+        !isEmptyObject(commonContext.user) ? { usr: commonContext.user } : {}, // Insert user first, global context has priority
         { service: configuration.service, session_id: session.id, view: commonContext.view },
         commonContext.context,
         getRUMInternalContext(startTime),
@@ -53,10 +53,6 @@ export function startLogsAssembly(
         logger.getContext(),
         messageContext
       )
-
-      if (!isEmptyObject(commonContext.user)) {
-        log.usr = shallowClone(commonContext.user)
-      }
 
       if (
         // Todo: [RUMF-1230] Move this check to the logger collection in the next major release

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -8,6 +8,8 @@ import {
   combine,
   createEventRateLimiter,
   getRelativeTime,
+  isEmptyObject,
+  shallowClone,
 } from '@datadog/browser-core'
 import type { CommonContext } from '../rawLogsEvent.types'
 import type { LogsConfiguration } from './configuration'
@@ -51,6 +53,10 @@ export function startLogsAssembly(
         logger.getContext(),
         messageContext
       )
+
+      if (!isEmptyObject(commonContext.user)) {
+        log.usr = shallowClone(commonContext.user)
+      }
 
       if (
         // Todo: [RUMF-1230] Move this check to the logger collection in the next major release

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -45,8 +45,13 @@ export function startLogsAssembly(
 
       const commonContext = savedCommonContext || getCommonContext()
       const log = combine(
-        !isEmptyObject(commonContext.user) ? { usr: commonContext.user } : {}, // Insert user first, global context has priority
-        { service: configuration.service, session_id: session.id, view: commonContext.view },
+        {
+          service: configuration.service,
+          session_id: session.id,
+          // Insert user first to allow overrides from global context
+          usr: !isEmptyObject(commonContext.user) ? commonContext.user : undefined,
+          view: commonContext.view,
+        },
         commonContext.context,
         getRUMInternalContext(startTime),
         rawLogsEvent,

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -1,4 +1,4 @@
-import type { Context, ErrorSource, TimeStamp } from '@datadog/browser-core'
+import type { Context, ErrorSource, TimeStamp, User } from '@datadog/browser-core'
 import type { StatusType } from './domain/logger'
 
 export type RawLogsEvent =
@@ -65,4 +65,5 @@ export interface CommonContext {
     url: string
   }
   context: Context
+  user: User
 }

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -1,4 +1,4 @@
-import type { Context, InitConfiguration, TimeStamp, RelativeTime } from '@datadog/browser-core'
+import type { Context, InitConfiguration, TimeStamp, RelativeTime, User } from '@datadog/browser-core'
 import {
   willSyntheticsInjectRum,
   assign,
@@ -15,11 +15,12 @@ import {
   createHandlingStack,
   canUseEventBridge,
   areCookiesAuthorized,
+  sanitizeUser,
 } from '@datadog/browser-core'
 import type { LifeCycle } from '../domain/lifeCycle'
 import type { ViewContexts } from '../domain/contexts/viewContexts'
 import type { RumSessionManager } from '../domain/rumSessionManager'
-import type { User, ReplayStats } from '../rawRumEvent.types'
+import type { ReplayStats } from '../rawRumEvent.types'
 import { ActionType } from '../rawRumEvent.types'
 import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
 import { validateAndBuildRumConfiguration } from '../domain/configuration'
@@ -248,20 +249,6 @@ export function makeRumPublicApi(
     stopSessionReplayRecording: monitor(recorderApi.stop),
   })
   return rumPublicApi
-
-  function sanitizeUser(newUser: Context) {
-    const shallowClonedUser = assign({}, newUser)
-    if ('id' in shallowClonedUser) {
-      shallowClonedUser.id = String(shallowClonedUser.id)
-    }
-    if ('name' in shallowClonedUser) {
-      shallowClonedUser.name = String(shallowClonedUser.name)
-    }
-    if ('email' in shallowClonedUser) {
-      shallowClonedUser.email = String(shallowClonedUser.email)
-    }
-    return shallowClonedUser
-  }
 
   function canHandleSession(initConfiguration: RumInitConfiguration): boolean {
     if (!areCookiesAuthorized(buildCookieOptions(initConfiguration))) {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -15,6 +15,7 @@ import {
   createHandlingStack,
   canUseEventBridge,
   areCookiesAuthorized,
+  checkUser,
   sanitizeUser,
 } from '@datadog/browser-core'
 import type { LifeCycle } from '../domain/lifeCycle'
@@ -223,9 +224,7 @@ export function makeRumPublicApi(
     }),
 
     setUser: monitor((newUser: User) => {
-      if (typeof newUser !== 'object' || !newUser) {
-        display.error('Unsupported user:', newUser)
-      } else {
+      if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
       }
     }),

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -250,7 +250,7 @@ export function makeRumPublicApi(
   return rumPublicApi
 
   function sanitizeUser(newUser: Context) {
-    const shallowClonedUser = assign(newUser, {})
+    const shallowClonedUser = assign({}, newUser)
     if ('id' in shallowClonedUser) {
       shallowClonedUser.id = String(shallowClonedUser.id)
     }

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -1,4 +1,4 @@
-import type { Context, RawError, EventRateLimiter } from '@datadog/browser-core'
+import type { Context, RawError, EventRateLimiter, User } from '@datadog/browser-core'
 import {
   combine,
   isEmptyObject,
@@ -17,7 +17,6 @@ import type {
   RawRumLongTaskEvent,
   RawRumResourceEvent,
   RumContext,
-  User,
 } from '../rawRumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
 import type { RumEvent } from '../rumEvent.types'

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -7,6 +7,7 @@ import type {
   ServerDuration,
   TimeStamp,
   RawErrorCause,
+  User,
 } from '@datadog/browser-core'
 import type { RumSessionPlan } from './domain/rumSessionManager'
 
@@ -238,13 +239,6 @@ export interface RumContext {
     }
     browser_sdk_version?: string
   }
-}
-
-export interface User {
-  id?: string | undefined
-  email?: string | undefined
-  name?: string | undefined
-  [key: string]: unknown
 }
 
 export interface CommonContext {


### PR DESCRIPTION
## Motivation

Issue raised here: https://github.com/DataDog/browser-sdk/issues/1675
The RUM SDK provides convenient user-related functions. This change brings the same functions to the LOGS SDK.

## Changes

Added the following functions to the logs public API: 
setUser, 
setUserProperty, 
getUser,
removeUserProperty,
clearUser

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
