### PR TITLE
⚗️ ✨ [RUMF-1425] use the retry/throttle transport strategy to send segments

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
 } from './domain/session/sessionConstants'
 export {
   HttpRequest,
+  Payload,
   createHttpRequest,
   Batch,
   canUseEventBridge,

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -1,4 +1,4 @@
-export { HttpRequest, createHttpRequest } from './httpRequest'
+export { HttpRequest, createHttpRequest, Payload } from './httpRequest'
 export { Batch } from './batch'
 export { canUseEventBridge, getEventBridge, BrowserWindowWithEventBridge } from './eventBridge'
 export { startBatchWithReplica } from './startBatchWithReplica'

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,5 +1,5 @@
 import type { TimeStamp, HttpRequest } from '@datadog/browser-core'
-import { PageExitReason, DefaultPrivacyLevel, noop, isIE, timeStampNow, createHttpRequest } from '@datadog/browser-core'
+import { PageExitReason, DefaultPrivacyLevel, noop, isIE, timeStampNow } from '@datadog/browser-core'
 import type { LifeCycle, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import { inflate } from 'pako'
@@ -10,7 +10,7 @@ import { createNewEvent, mockClock } from '../../../core/test/specHelper'
 import type { TestSetupBuilder } from '../../../rum-core/test/specHelper'
 import { setup } from '../../../rum-core/test/specHelper'
 import { collectAsyncCalls, recordsPerFullSnapshot } from '../../test/utils'
-import { setSegmentBytesLimit, startDeflateWorker, SEGMENT_BYTES_LIMIT } from '../domain/segmentCollection'
+import { setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
 
 import type { BrowserSegment } from '../types'
 import { RecordType } from '../types'
@@ -57,9 +57,12 @@ describe('startRecording', () => {
           defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
         })
         .beforeBuild(({ lifeCycle, configuration, viewContexts, sessionManager }) => {
-          const httpRequest = createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT, noop)
+          const requestSendSpy = jasmine.createSpy()
+          const httpRequest: HttpRequest = {
+            send: requestSendSpy,
+            sendOnExit: requestSendSpy,
+          }
 
-          const requestSendSpy = spyOn(httpRequest, 'sendOnExit')
           ;({ waitAsyncCalls: waitRequestSendCalls, expectNoExtraAsyncCall: expectNoExtraRequestSendCalls } =
             collectAsyncCalls(requestSendSpy))
 

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -12,7 +12,6 @@ import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import { record } from '../domain/record'
 import type { DeflateWorker } from '../domain/segmentCollection'
 import { startSegmentCollection, SEGMENT_BYTES_LIMIT } from '../domain/segmentCollection'
-import { send } from '../transport/send'
 import { RecordType } from '../types'
 
 export function startRecording(
@@ -35,7 +34,7 @@ export function startRecording(
     configuration.applicationId,
     sessionManager,
     viewContexts,
-    (data, metadata, rawSegmentBytesCount) => send(replayRequest, data, metadata, rawSegmentBytesCount),
+    replayRequest,
     worker
   )
 

--- a/packages/rum/src/domain/segmentCollection/buildReplayPayload.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/buildReplayPayload.spec.ts
@@ -1,4 +1,4 @@
-import { toFormEntries } from './send'
+import { toFormEntries } from './buildReplayPayload'
 
 describe('toFormEntries', () => {
   let callbackSpy: jasmine.Spy<(key: string, value: string) => void>

--- a/packages/rum/src/domain/segmentCollection/buildReplayPayload.ts
+++ b/packages/rum/src/domain/segmentCollection/buildReplayPayload.ts
@@ -1,13 +1,12 @@
-import type { HttpRequest } from '@datadog/browser-core'
+import type { Payload } from '@datadog/browser-core'
 import { objectEntries } from '@datadog/browser-core'
-import type { BrowserSegmentMetadata } from '../types'
+import type { BrowserSegmentMetadata } from '../../types'
 
-export function send(
-  httpRequest: HttpRequest,
+export function buildReplayPayload(
   data: Uint8Array,
   metadata: BrowserSegmentMetadata,
   rawSegmentBytesCount: number
-): void {
+): Payload {
   const formData = new FormData()
 
   formData.append(
@@ -21,7 +20,7 @@ export function send(
   toFormEntries(metadata, (key, value) => formData.append(key, value))
   formData.append('raw_segment_size', rawSegmentBytesCount.toString())
 
-  httpRequest.sendOnExit({ data: formData, bytesCount: data.byteLength })
+  return { data: formData, bytesCount: data.byteLength }
 }
 
 export function toFormEntries(input: object, onEntry: (key: string, value: string) => void, prefix = '') {

--- a/packages/rum/src/domain/segmentCollection/segment.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.ts
@@ -6,8 +6,10 @@ import type { DeflateWorker, DeflateWorkerListener } from './deflateWorker'
 
 let nextId = 0
 
+export type FlushReason = Exclude<CreationReason, 'init'> | 'stop'
+
 export class Segment {
-  public isFlushed = false
+  public flushReason: FlushReason | undefined
 
   public readonly metadata: BrowserSegmentMetadata
 
@@ -78,12 +80,12 @@ export class Segment {
     this.worker.postMessage({ data: `,${JSON.stringify(record)}`, id: this.id, action: 'write' })
   }
 
-  flush() {
+  flush(reason: FlushReason) {
     this.worker.postMessage({
       data: `],${JSON.stringify(this.metadata).slice(1)}\n`,
       id: this.id,
       action: 'flush',
     })
-    this.isFlushed = true
+    this.flushReason = reason
   }
 }

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,5 +1,5 @@
 import type { HttpRequest, TimeoutId } from '@datadog/browser-core'
-import { ONE_SECOND, monitor } from '@datadog/browser-core'
+import { isExperimentalFeatureEnabled, ONE_SECOND, monitor } from '@datadog/browser-core'
 import type { LifeCycle, ViewContexts, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { BrowserRecord, CreationReason, SegmentContext } from '../../types'
@@ -133,7 +133,15 @@ export function doStartSegmentCollection(
       },
       (data, rawSegmentBytesCount) => {
         const payload = buildReplayPayload(data, segment.metadata, rawSegmentBytesCount)
-        httpRequest.sendOnExit(payload)
+        if (
+          !isExperimentalFeatureEnabled('retry_replay') ||
+          segment.flushReason === 'visibility_hidden' ||
+          segment.flushReason === 'before_unload'
+        ) {
+          httpRequest.sendOnExit(payload)
+        } else {
+          httpRequest.send(payload)
+        }
       }
     )
 

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,9 +1,10 @@
-import type { TimeoutId } from '@datadog/browser-core'
+import type { HttpRequest, TimeoutId } from '@datadog/browser-core'
 import { ONE_SECOND, monitor } from '@datadog/browser-core'
 import type { LifeCycle, ViewContexts, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
-import type { BrowserRecord, BrowserSegmentMetadata, CreationReason, SegmentContext } from '../../types'
+import type { BrowserRecord, CreationReason, SegmentContext } from '../../types'
 import type { DeflateWorker } from './deflateWorker'
+import { buildReplayPayload } from './buildReplayPayload'
 import { Segment } from './segment'
 
 export const SEGMENT_DURATION_LIMIT = 30 * ONE_SECOND
@@ -43,13 +44,13 @@ export function startSegmentCollection(
   applicationId: string,
   sessionManager: RumSessionManager,
   viewContexts: ViewContexts,
-  send: (data: Uint8Array, metadata: BrowserSegmentMetadata, rawSegmentBytesCount: number) => void,
+  httpRequest: HttpRequest,
   worker: DeflateWorker
 ) {
   return doStartSegmentCollection(
     lifeCycle,
     () => computeSegmentContext(applicationId, sessionManager, viewContexts),
-    send,
+    httpRequest,
     worker
   )
 }
@@ -76,7 +77,7 @@ type SegmentCollectionState =
 export function doStartSegmentCollection(
   lifeCycle: LifeCycle,
   getSegmentContext: () => SegmentContext | undefined,
-  send: (data: Uint8Array, metadata: BrowserSegmentMetadata, rawSegmentBytesCount: number) => void,
+  httpRequest: HttpRequest,
   worker: DeflateWorker
 ) {
   let state: SegmentCollectionState = {
@@ -130,7 +131,8 @@ export function doStartSegmentCollection(
         }
       },
       (data, rawSegmentBytesCount) => {
-        send(data, segment.metadata, rawSegmentBytesCount)
+        const payload = buildReplayPayload(data, segment.metadata, rawSegmentBytesCount)
+        httpRequest.sendOnExit(payload)
       }
     )
 


### PR DESCRIPTION
## Motivation

With this PR, Session Replay Segments will benefit from the same features introduced for RUM/Logs data in https://github.com/DataDog/browser-sdk/pull/1770

## Changes

* Replace the `send` module with a `buildReplayPayload` and use `HttpRequest` directly in Segment Collection
* Store the flush reason in flushed segments
* Use the right `HttpRequest` strategy to send segment data

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
