### PR TITLE
🗑️ [RUMF-1433] Remove Preflight request Performance Entry check

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.spec.ts
@@ -48,16 +48,6 @@ describe('matchRequestTiming', () => {
     expect(timing).toEqual(undefined)
   })
 
-  it('should match two following timings nested in the request ', () => {
-    const optionsTiming = createResourceEntry({ startTime: 150 as RelativeTime, duration: 50 as Duration })
-    const actualTiming = createResourceEntry({ startTime: 200 as RelativeTime, duration: 100 as Duration })
-    entries.push(optionsTiming, actualTiming)
-
-    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
-
-    expect(timing).toEqual(actualTiming)
-  })
-
   it('should not match two not following timings nested in the request ', () => {
     const match1 = createResourceEntry({ startTime: 150 as RelativeTime, duration: 100 as Duration })
     const match2 = createResourceEntry({ startTime: 200 as RelativeTime, duration: 100 as Duration })

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
@@ -48,15 +48,7 @@ export function matchRequestTiming(request: RequestCompleteEvent) {
     return candidates[0]
   }
 
-  if (candidates.length === 2 && firstCanBeOptionRequest(candidates)) {
-    return candidates[1]
-  }
-
   return
-}
-
-function firstCanBeOptionRequest(correspondingEntries: RumPerformanceResourceTiming[]) {
-  return endTime(correspondingEntries[0]) <= correspondingEntries[1].startTime
 }
 
 function endTime(timing: Timing) {

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/matchRequestTiming.ts
@@ -15,12 +15,10 @@ interface Timing {
  * Observations:
  * - Timing (start, end) are nested inside the request (start, end)
  * - Some timing can be not exactly nested, being off by < 1 ms
- * - Browsers generate a timing entry for OPTIONS request
  *
  * Strategy:
  * - from valid nested entries (with 1 ms error margin)
  * - if a single timing match, return the timing
- * - if two following timings match (OPTIONS request), return the timing for the actual request
  * - otherwise we can't decide, return undefined
  */
 export function matchRequestTiming(request: RequestCompleteEvent) {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
If we match 2 performance entries on a request, we try and check if one of them is a [preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) option request. 

This behaviour is no longer present on modern browsers.

## Changes

- remove check
- delete adjacent test
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
