### PR TITLE
✨[RUMF-1435] Add some retry info on events

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -1,0 +1,55 @@
+import type { BuildEnvWindow } from '../../../test/specHelper'
+import type { InitConfiguration } from './configuration'
+import { createEndpointBuilder } from './endpointBuilder'
+
+describe('endpointBuilder', () => {
+  const clientToken = 'some_client_token'
+  let initConfiguration: InitConfiguration
+
+  beforeEach(() => {
+    initConfiguration = { clientToken }
+    ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'some_version'
+  })
+
+  describe('query parameters', () => {
+    it('should add intake query parameters', () => {
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build()).toMatch(
+        `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
+      )
+    })
+
+    it('should add batch_time for rum endpoint', () => {
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build()).toContain('&batch_time=')
+    })
+
+    it('should not add batch_time for logs and replay endpoints', () => {
+      expect(createEndpointBuilder(initConfiguration, 'logs', []).build()).not.toContain('&batch_time=')
+      expect(createEndpointBuilder(initConfiguration, 'sessionReplay', []).build()).not.toContain('&batch_time=')
+    })
+  })
+
+  describe('proxyUrl', () => {
+    it('should replace the full intake endpoint by the proxyUrl and set it in the attribute ddforward', () => {
+      expect(
+        createEndpointBuilder({ ...initConfiguration, proxyUrl: 'https://proxy.io/path' }, 'rum', []).build()
+      ).toMatch(
+        `https://proxy.io/path\\?ddforward=${encodeURIComponent(
+          `https://rum.browser-intake-datadoghq.com/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
+            '&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)&batch_time=(.*)'
+        )}`
+      )
+    })
+  })
+
+  describe('tags', () => {
+    it('should contain sdk version', () => {
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build()).toContain('ddtags=sdk_version%3Asome_version')
+    })
+
+    it('should be encoded', () => {
+      expect(
+        createEndpointBuilder(initConfiguration, 'rum', ['service:bar:foo', 'datacenter:us1.prod.dog']).build()
+      ).toContain('service%3Abar%3Afoo%2Cdatacenter%3Aus1.prod.dog')
+    })
+  })
+})

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -51,5 +51,11 @@ describe('endpointBuilder', () => {
         createEndpointBuilder(initConfiguration, 'rum', ['service:bar:foo', 'datacenter:us1.prod.dog']).build()
       ).toContain('service%3Abar%3Afoo%2Cdatacenter%3Aus1.prod.dog')
     })
+
+    it('should contain retry infos', () => {
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build({ count: 5, lastFailureStatus: 408 })).toContain(
+        'retry_count%3A5%2Cretry_after%3A408'
+      )
+    })
   })
 })

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -1,12 +1,7 @@
-import type { BuildEnvWindow } from '../../../test/specHelper'
 import { computeTransportConfiguration } from './transportConfiguration'
 
 describe('transportConfiguration', () => {
   const clientToken = 'some_client_token'
-
-  beforeEach(() => {
-    ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'some_version'
-  })
 
   describe('site', () => {
     it('should use US site by default', () => {
@@ -22,43 +17,9 @@ describe('transportConfiguration', () => {
     })
   })
 
-  describe('query parameters', () => {
-    it('should add intake query parameters', () => {
-      const configuration = computeTransportConfiguration({ clientToken })
-      expect(configuration.rumEndpointBuilder.build()).toMatch(
-        `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
-      )
-    })
-
-    it('should add batch_time for rum endpoint', () => {
-      const configuration = computeTransportConfiguration({ clientToken })
-      expect(configuration.rumEndpointBuilder.build()).toContain('&batch_time=')
-    })
-
-    it('should not add batch_time for logs and replay endpoints', () => {
-      const configuration = computeTransportConfiguration({ clientToken })
-      expect(configuration.logsEndpointBuilder.build()).not.toContain('&batch_time=')
-      expect(configuration.sessionReplayEndpointBuilder.build()).not.toContain('&batch_time=')
-    })
-  })
-
-  describe('proxyUrl', () => {
-    it('should replace the full intake endpoint by the proxyUrl and set it in the attribute ddforward', () => {
-      const configuration = computeTransportConfiguration({ clientToken, proxyUrl: 'https://proxy.io/path' })
-      expect(configuration.rumEndpointBuilder.build()).toMatch(
-        `https://proxy.io/path\\?ddforward=${encodeURIComponent(
-          `https://rum.browser-intake-datadoghq.com/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
-            '&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)&batch_time=(.*)'
-        )}`
-      )
-    })
-  })
-
   describe('sdk_version, env, version and service', () => {
     it('should not modify the logs and rum endpoints tags when not defined', () => {
       const configuration = computeTransportConfiguration({ clientToken })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).toContain('&ddtags=sdk_version:some_version')
-
       expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).not.toContain(',env:')
       expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).not.toContain(',service:')
       expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).not.toContain(',version:')
@@ -72,25 +33,8 @@ describe('transportConfiguration', () => {
 
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = computeTransportConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).toContain(
-        '&ddtags=sdk_version:some_version,env:foo,service:bar,version:baz'
-      )
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).toContain(
-        '&ddtags=sdk_version:some_version,env:foo,service:bar,version:baz'
-      )
-    })
-  })
-
-  describe('tags', () => {
-    it('should be encoded', () => {
-      const configuration = computeTransportConfiguration({
-        clientToken,
-        service: 'bar:foo',
-        datacenter: 'us1.prod.dog',
-      })
-      expect(configuration.rumEndpointBuilder.build()).toContain(
-        'ddtags=sdk_version%3Asome_version%2Cservice%3Abar%3Afoo%2Cdatacenter%3Aus1.prod.dog'
-      )
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).toContain('env:foo,service:bar,version:baz')
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).toContain('env:foo,service:bar,version:baz')
     })
   })
 

--- a/packages/core/src/domain/user/user.spec.ts
+++ b/packages/core/src/domain/user/user.spec.ts
@@ -1,3 +1,4 @@
+import { display } from '../../tools/display'
 import { checkUser, sanitizeUser } from './user'
 import type { User } from './user.types'
 
@@ -20,6 +21,8 @@ describe('sanitize user function', () => {
 
 describe('check user function', () => {
   it('should only accept valid user objects', () => {
+    spyOn(display, 'error')
+
     const obj: any = { id: 42, name: true, email: null } // Valid, even though not sanitized
     const user: User = { id: '42', name: 'John', email: 'john@doe.com' }
     const undefUser: any = undefined
@@ -31,5 +34,6 @@ describe('check user function', () => {
     expect(checkUser(undefUser)).toBe(false)
     expect(checkUser(nullUser)).toBe(false)
     expect(checkUser(invalidUser)).toBe(false)
+    expect(display.error).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -23,6 +23,12 @@ export interface HttpResponse extends Context {
 export interface Payload {
   data: string | FormData
   bytesCount: number
+  retry?: RetryInfo
+}
+
+export interface RetryInfo {
+  count: number
+  lastFailureStatus: number
 }
 
 export function createHttpRequest(
@@ -78,10 +84,10 @@ function reportBeaconError(e: unknown) {
 export function fetchKeepAliveStrategy(
   endpointBuilder: EndpointBuilder,
   bytesLimit: number,
-  { data, bytesCount }: Payload,
+  { data, bytesCount, retry }: Payload,
   onResponse?: (r: HttpResponse) => void
 ) {
-  const url = endpointBuilder.build()
+  const url = endpointBuilder.build(retry)
   const canUseKeepAlive = isKeepAliveSupported() && bytesCount < bytesLimit
   if (canUseKeepAlive) {
     fetch(url, { method: 'POST', body: data, keepalive: true }).then(

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -1,4 +1,4 @@
-export { HttpRequest, createHttpRequest, Payload } from './httpRequest'
+export { HttpRequest, createHttpRequest, Payload, RetryInfo } from './httpRequest'
 export { Batch } from './batch'
 export { canUseEventBridge, getEventBridge, BrowserWindowWithEventBridge } from './eventBridge'
 export { startBatchWithReplica } from './startBatchWithReplica'

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -222,6 +222,18 @@ describe('sendWithRetryStrategy', () => {
         expect(state.bandwidthMonitor.ongoingRequestCount).toBe(2)
         expect(state.queuedPayloads.size()).toBe(0)
       })
+
+      it('should add retry info to payloads', () => {
+        sendRequest()
+
+        sendStub.respondWith(0, { status })
+        expect(state.queuedPayloads.first().retry).toEqual({ count: 1, lastFailureStatus: status })
+
+        clock.tick(INITIAL_BACKOFF_TIME)
+
+        sendStub.respondWith(1, { status })
+        expect(state.queuedPayloads.first().retry).toEqual({ count: 2, lastFailureStatus: status })
+      })
     })
   })
 

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -101,6 +101,10 @@ function send(
       // do not consider transport down if another ongoing request could succeed
       state.transportStatus =
         state.bandwidthMonitor.ongoingRequestCount > 0 ? TransportStatus.FAILURE_DETECTED : TransportStatus.DOWN
+      payload.retry = {
+        count: payload.retry ? (payload.retry.count += 1) : 1,
+        lastFailureStatus: response.status,
+      }
       onFailure()
     }
   })

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -102,7 +102,7 @@ function send(
       state.transportStatus =
         state.bandwidthMonitor.ongoingRequestCount > 0 ? TransportStatus.FAILURE_DETECTED : TransportStatus.DOWN
       payload.retry = {
-        count: payload.retry ? (payload.retry.count += 1) : 1,
+        count: payload.retry ? payload.retry.count + 1 : 1,
         lastFailureStatus: response.status,
       }
       onFailure()


### PR DESCRIPTION
## Motivation

Flag data that has been ingested after a retry to ease investigations

## Changes

On retried requests, add the following tags:

- `retry_count`: number of times this payload has been retried
- `retry_after`: last failure status

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
