### PR TITLE
✨ [RUMF-1425] enable request retry/throttle for replay intake

### DIFF
--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,5 +1,5 @@
 import type { HttpRequest, TimeoutId } from '@datadog/browser-core'
-import { isExperimentalFeatureEnabled, ONE_SECOND, monitor } from '@datadog/browser-core'
+import { ONE_SECOND, monitor } from '@datadog/browser-core'
 import type { LifeCycle, ViewContexts, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { BrowserRecord, CreationReason, SegmentContext } from '../../types'
@@ -133,11 +133,7 @@ export function doStartSegmentCollection(
       },
       (data, rawSegmentBytesCount) => {
         const payload = buildReplayPayload(data, segment.metadata, rawSegmentBytesCount)
-        if (
-          !isExperimentalFeatureEnabled('retry_replay') ||
-          segment.flushReason === 'visibility_hidden' ||
-          segment.flushReason === 'before_unload'
-        ) {
+        if (segment.flushReason === 'visibility_hidden' || segment.flushReason === 'before_unload') {
           httpRequest.sendOnExit(payload)
         } else {
           httpRequest.send(payload)


### PR DESCRIPTION
## Motivation

Make retry/throttle strategy used by default for requests sent to the replay intake

## Changes

Enable change introduced in https://github.com/DataDog/browser-sdk/pull/1807 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
