### PR TITLE
⏪ Revert "🐛 [RUMF-1410] Allow serialization of objects with cyclic re…

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,4 @@ bundle
 cjs
 esm
 coverage
-dist
 rum-events-format

--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -73,5 +73,5 @@ function formatConsoleParameters(param: unknown) {
   if (param instanceof Error) {
     return formatErrorMessage(computeStackTrace(param))
   }
-  return jsonStringify(param, 2)
+  return jsonStringify(param, undefined, 2)
 }

--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -308,33 +308,11 @@ describe('utils', () => {
       expect(jsonStringify(true)).toEqual('true')
     })
 
-    it('should serialize objects with cyclic references', () => {
-      const nested: any = { data: 345 }
-      const circularReference: any = { otherData: 123, nested }
-      nested.parent = circularReference
-
-      expect(jsonStringify(circularReference)).toEqual(
-        '{"otherData":123,"nested":{"data":345,"parent":"<warning: cyclic reference not serialized>"}}'
-      )
-    })
-
-    it('should serialize arrays with cyclic references', () => {
-      const baseArray: any[] = [1]
-      baseArray.push(baseArray)
-
-      expect(jsonStringify(baseArray)).toEqual('[1,"<warning: cyclic reference not serialized>"]')
-    })
-
     it('should not crash on serialization error', () => {
-      // custom toJSON is only ignored on root object.
-      const sub = {
-        toJSON: () => {
-          throw new Error('')
-        },
-      }
-      const root = { sub }
+      const circularReference: any = { otherData: 123 }
+      circularReference.myself = circularReference
 
-      expect(jsonStringify(root)).toEqual('<error: unable to serialize object>')
+      expect(jsonStringify(circularReference)).toEqual('<error: unable to serialize object>')
     })
 
     function createSampleClassInstance(value: any = 'value') {


### PR DESCRIPTION
## Motivation
Removing cyclic reference can lead JSON.stringify to serialize huge objects. When serializing a DOM node, instrumented by a framework such as React, this can lead to a browser crash.

## Changes

Reverting the change introduced by PR https://github.com/DataDog/browser-sdk/pull/1783

## Testing

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
