### PR TITLE
✨ [RUMF-1236] Add support for OTel headers

### DIFF
--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -1,5 +1,5 @@
 import { display } from '../tools/display'
-import { findCommaSeparatedValue, generateUUID, ONE_SECOND } from '../tools/utils'
+import { findCommaSeparatedValue, generateUUID, ONE_MINUTE, ONE_SECOND } from '../tools/utils'
 
 export const COOKIE_ACCESS_DELAY = ONE_SECOND
 
@@ -36,7 +36,7 @@ export function areCookiesAuthorized(options: CookieOptions): boolean {
     // the test cookie lifetime
     const testCookieName = `dd_cookie_test_${generateUUID()}`
     const testCookieValue = 'test'
-    setCookie(testCookieName, testCookieValue, ONE_SECOND, options)
+    setCookie(testCookieName, testCookieValue, ONE_MINUTE, options)
     const isCookieCorrectlySet = getCookie(testCookieName) === testCookieValue
     deleteCookie(testCookieName, options)
     return isCookieCorrectlySet

--- a/packages/core/src/tools/utils.spec.ts
+++ b/packages/core/src/tools/utils.spec.ts
@@ -673,6 +673,11 @@ describe('matchList', () => {
     expect(matchList(list, 'qux')).toBe(false)
   })
 
+  it('should compare strings using startsWith when enabling the option', () => {
+    const list = ['http://my.domain.com']
+    expect(matchList(list, 'http://my.domain.com/action', true)).toBe(true)
+  })
+
   it('should catch error from provided function', () => {
     spyOn(display, 'error')
     const list = [

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -666,20 +666,25 @@ export function isMatchOption(item: unknown): item is MatchOption {
   const itemType = getType(item)
   return itemType === 'string' || itemType === 'function' || item instanceof RegExp
 }
-export function matchList(list: MatchOption[], value: string): boolean {
+/**
+ * Returns true if value can be matched by at least one of the provided MatchOptions.
+ * When comparing strings, setting useStartsWith to true will compare the value with the start of
+ * the option, instead of requiring an exact match.
+ */
+export function matchList(list: MatchOption[], value: string, useStartsWith = false): boolean {
   return list.some((item) => {
-    if (typeof item === 'function') {
-      try {
+    try {
+      if (typeof item === 'function') {
         return item(value)
-      } catch (e) {
-        display.error(e)
-        return false
+      } else if (item instanceof RegExp) {
+        return item.test(value)
+      } else if (typeof item === 'string') {
+        return useStartsWith ? startsWith(value, item) : item === value
       }
+    } catch (e) {
+      display.error(e)
     }
-    if (item instanceof RegExp) {
-      return item.test(value)
-    }
-    return item === value
+    return false
   })
 }
 

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -662,6 +662,10 @@ export function removeDuplicates<T>(array: T[]) {
 }
 
 export type MatchOption = string | RegExp | ((value: string) => boolean)
+export function isMatchOption(item: unknown): item is MatchOption {
+  const itemType = getType(item)
+  return itemType === 'string' || itemType === 'function' || item instanceof RegExp
+}
 export function matchList(list: MatchOption[], value: string): boolean {
   return list.some((item) => {
     if (typeof item === 'function') {

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -174,7 +174,7 @@ describe('validateAndBuildRumConfiguration', () => {
           allowedTracingOrigins: ['foo'],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: 'foo', headersTypes: ['dd'] }])
+      ).toEqual([{ match: 'foo', propagatorTypes: ['datadog'] }])
     })
 
     it('accepts functions', () => {
@@ -219,7 +219,7 @@ describe('validateAndBuildRumConfiguration', () => {
           allowedTracingUrls: ['foo'],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: 'foo', headersTypes: ['dd'] }])
+      ).toEqual([{ match: 'foo', propagatorTypes: ['datadog'] }])
     })
 
     it('accepts functions', () => {
@@ -231,7 +231,7 @@ describe('validateAndBuildRumConfiguration', () => {
           allowedTracingUrls: [customOriginFunction],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: customOriginFunction, headersTypes: ['dd'] }])
+      ).toEqual([{ match: customOriginFunction, propagatorTypes: ['datadog'] }])
     })
 
     it('accepts RegExp', () => {
@@ -241,17 +241,17 @@ describe('validateAndBuildRumConfiguration', () => {
           allowedTracingUrls: [/az/i],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: /az/i, headersTypes: ['dd'] }])
+      ).toEqual([{ match: /az/i, propagatorTypes: ['datadog'] }])
     })
 
     it('keeps headers', () => {
       expect(
         validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          allowedTracingUrls: [{ match: 'simple', headersTypes: ['b3m', 'w3c'] }],
+          allowedTracingUrls: [{ match: 'simple', propagatorTypes: ['b3multi', 'tracecontext'] }],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: 'simple', headersTypes: ['b3m', 'w3c'] }])
+      ).toEqual([{ match: 'simple', propagatorTypes: ['b3multi', 'tracecontext'] }])
     })
 
     it('should filter out unexpected parameter types', () => {
@@ -259,7 +259,12 @@ describe('validateAndBuildRumConfiguration', () => {
         validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
           service: 'bar',
-          allowedTracingUrls: [42 as any, undefined, { match: 42 as any, headersTypes: ['dd'] }, { match: 'toto' }],
+          allowedTracingUrls: [
+            42 as any,
+            undefined,
+            { match: 42 as any, propagatorTypes: ['datadog'] },
+            { match: 'toto' },
+          ],
         })!.allowedTracingUrls
       ).toEqual([])
 
@@ -458,32 +463,32 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('serializeRumConfiguration', () => {
-    describe('selected tracing headers serialization', () => {
-      it('should not return any header type', () => {
-        expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).selected_tracing_headers).toEqual([])
+    describe('selected tracing propagators serialization', () => {
+      it('should not return any propagator type', () => {
+        expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).selected_tracing_propagators).toEqual([])
       })
 
-      it('should return Datadog header type', () => {
+      it('should return Datadog propagator type', () => {
         const simpleTracingConfig: RumInitConfiguration = {
           ...DEFAULT_INIT_CONFIGURATION,
           allowedTracingUrls: ['foo'],
         }
-        expect(serializeRumConfiguration(simpleTracingConfig).selected_tracing_headers).toEqual(['dd'])
+        expect(serializeRumConfiguration(simpleTracingConfig).selected_tracing_propagators).toEqual(['datadog'])
       })
 
-      it('should return all header types', () => {
+      it('should return all propagator types', () => {
         const complexTracingConfig: RumInitConfiguration = {
           ...DEFAULT_INIT_CONFIGURATION,
           allowedTracingUrls: [
             'foo',
-            { match: 'first', headersTypes: ['dd'] },
-            { match: 'test', headersTypes: ['w3c'] },
-            { match: 'other', headersTypes: ['b3'] },
-            { match: 'final', headersTypes: ['b3m'] },
+            { match: 'first', propagatorTypes: ['datadog'] },
+            { match: 'test', propagatorTypes: ['tracecontext'] },
+            { match: 'other', propagatorTypes: ['b3'] },
+            { match: 'final', propagatorTypes: ['b3multi'] },
           ],
         }
-        expect(serializeRumConfiguration(complexTracingConfig).selected_tracing_headers).toEqual(
-          jasmine.arrayWithExactContents(['dd', 'b3', 'b3m', 'w3c'])
+        expect(serializeRumConfiguration(complexTracingConfig).selected_tracing_propagators).toEqual(
+          jasmine.arrayWithExactContents(['datadog', 'b3', 'b3multi', 'tracecontext'])
         )
       })
     })

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -23,7 +23,7 @@ describe('tracer', () => {
     clientToken: 'xxx',
     applicationId: 'xxx',
     service: 'service',
-    allowedTracingUrls: [{ match: window.location.origin, headersTypes: ['dd'] }],
+    allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['datadog'] }],
   }
 
   beforeEach(() => {
@@ -112,7 +112,7 @@ describe('tracer', () => {
       const configurationWithAllOtelHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
         tracingSampleRate: 50,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: ['b3', 'w3c', 'b3m'] }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext', 'b3multi'] }],
       })!
 
       const tracer = startTracer(configurationWithAllOtelHeaders, sessionManager)
@@ -157,13 +157,13 @@ describe('tracer', () => {
       expect(context.spanId).toBeDefined()
     })
 
-    it('should add only B3 Multiple headers', () => {
-      const configurationWithB3Multi = validateAndBuildRumConfiguration({
+    it('should add headers only for B3 Multiple propagator', () => {
+      const configurationWithb3multi = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: ['b3m'] }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3multi'] }],
       })!
 
-      const tracer = startTracer(configurationWithB3Multi, sessionManager)
+      const tracer = startTracer(configurationWithb3multi, sessionManager)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhrStub as unknown as XMLHttpRequest)
 
@@ -181,13 +181,13 @@ describe('tracer', () => {
       expect(xhrStub.headers['x-datadog-sampling-priority']).toBeUndefined()
     })
 
-    it('should add B3 (single) and W3C headers', () => {
-      const configurationWithB3andW3C = validateAndBuildRumConfiguration({
+    it('should add headers for B3 (single) and tracecontext propagators', () => {
+      const configurationWithB3andTracecontext = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: ['b3', 'w3c'] }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext'] }],
       })!
 
-      const tracer = startTracer(configurationWithB3andW3C, sessionManager)
+      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhrStub as unknown as XMLHttpRequest)
 
@@ -202,7 +202,7 @@ describe('tracer', () => {
     it('should not add any headers', () => {
       const configurationWithoutHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: [] }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: [] }],
       })!
 
       const tracer = startTracer(configurationWithoutHeaders, sessionManager)
@@ -215,10 +215,10 @@ describe('tracer', () => {
       expect(xhrStub.headers['X-B3-TraceId']).toBeUndefined()
     })
 
-    it('should ignore wrong header types', () => {
+    it('should ignore wrong propagator types', () => {
       const configurationWithBadParams = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: ['foo', 32, () => true] as any }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['foo', 32, () => true] as any }],
       })!
 
       const tracer = startTracer(configurationWithBadParams, sessionManager)
@@ -469,13 +469,13 @@ describe('tracer', () => {
       expect(dynamicDomainContext.spanId).toBeDefined()
     })
 
-    it('should add only B3 Multiple headers', () => {
-      const configurationWithB3Multi = validateAndBuildRumConfiguration({
+    it('should add headers only for B3 Multiple propagator', () => {
+      const configurationWithb3multi = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: ['b3m'] }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3multi'] }],
       })!
 
-      const tracer = startTracer(configurationWithB3Multi, sessionManager)
+      const tracer = startTracer(configurationWithb3multi, sessionManager)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -497,13 +497,13 @@ describe('tracer', () => {
       expect(context.init!.headers).not.toContain(jasmine.arrayContaining(['x-datadog-sampling-priority']))
     })
 
-    it('should add B3 (single) and W3C headers', () => {
-      const configurationWithB3andW3C = validateAndBuildRumConfiguration({
+    it('should add headers for b3 (single) and tracecontext propagators', () => {
+      const configurationWithB3andTracecontext = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: ['b3', 'w3c'] }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext'] }],
       })!
 
-      const tracer = startTracer(configurationWithB3andW3C, sessionManager)
+      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -518,7 +518,7 @@ describe('tracer', () => {
     it('should not add any headers', () => {
       const configurationWithoutHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        allowedTracingUrls: [{ match: window.location.origin, headersTypes: [] }],
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: [] }],
       })!
 
       const tracer = startTracer(configurationWithoutHeaders, sessionManager)

--- a/packages/rum-core/src/domain/tracing/tracer.types.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.types.ts
@@ -1,10 +1,10 @@
 import type { MatchOption } from '@datadog/browser-core'
 
 /**
- * dd: Datadog (x-datadog-*)
- * w3c: Trace Context (traceparent)
+ * datadog: Datadog (x-datadog-*)
+ * tracecontext: W3C Trace Context (traceparent)
  * b3: B3 Single Header (b3)
- * b3m: B3 Multi Headers (X-B3-*)
+ * b3multi: B3 Multiple Headers (X-B3-*)
  */
-export type TracingHeadersType = 'dd' | 'b3' | 'b3m' | 'w3c'
-export type TracingOption = { match: MatchOption; headersTypes: TracingHeadersType[] }
+export type PropagatorType = 'datadog' | 'b3' | 'b3multi' | 'tracecontext'
+export type TracingOption = { match: MatchOption; propagatorTypes: PropagatorType[] }

--- a/packages/rum-core/src/domain/tracing/tracer.types.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.types.ts
@@ -1,0 +1,11 @@
+import type { MatchOption } from '@datadog/browser-core'
+
+/**
+ * dd: Datadog (x-datadog-*)
+ * w3c: Trace Context (traceparent)
+ * b3: B3 Single Header (b3)
+ * b3m: B3 Multi Headers (X-B3-*)
+ */
+export const availableTracingHeaders = ['dd', 'b3', 'b3m', 'w3c'] as const
+export type TracingHeadersType = typeof availableTracingHeaders[number]
+export type ConfigureTracingOption = { match: MatchOption; headerTypes: TracingHeadersType[] }

--- a/packages/rum-core/src/domain/tracing/tracer.types.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.types.ts
@@ -6,6 +6,5 @@ import type { MatchOption } from '@datadog/browser-core'
  * b3: B3 Single Header (b3)
  * b3m: B3 Multi Headers (X-B3-*)
  */
-export const availableTracingHeaders = ['dd', 'b3', 'b3m', 'w3c'] as const
-export type TracingHeadersType = typeof availableTracingHeaders[number]
-export type ConfigureTracingOption = { match: MatchOption; headerTypes: TracingHeadersType[] }
+export type TracingHeadersType = 'dd' | 'b3' | 'b3m' | 'w3c'
+export type TracingOption = { match: MatchOption; headersTypes: TracingHeadersType[] }


### PR DESCRIPTION
## Motivation

Users would like to use RUM alongside backends that are instrumented with OpenTelemetry, and benefit from the correlation of traces in APM. 

## Changes

Added a new RUM configuration property: 
allowedTracingUrls: { match: MatchOption,  propagatorTypes: ("datadog" | "tracecontext" | "b3" | "b3multi")[] }
 * datadog: Datadog (x-datadog-*)
 * tracecontext: Trace Context (traceparent)
 * b3: B3 Single Header (b3)
 * b3multi: B3 Multi Headers (X-B3-*)

This allows to select which propagator types to use when creating the request headers.  It also gives more flexibility by providing the full URL to the match function (instead of origin).

## Testing

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
