### PR TITLE
👷🔥 remove reference to tslint

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,12 +13,6 @@
     "types": [],
     "lib": ["ES2016", "DOM"],
 
-    "plugins": [
-      {
-        "name": "typescript-tslint-plugin"
-      }
-    ],
-
     "paths": {
       "@datadog/browser-core": ["./packages/core/src"],
       "@datadog/browser-rum-core": ["./packages/rum-core/src"]


### PR DESCRIPTION
## Motivation

We don't use tslint since #681, but we still have a tslint reference in the tsconfig.json, and `tsserver` log a warning because it can't find the package.

## Changes

Remove useless tslint reference. 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
