### PR TITLE
🐛 [RUMF-1421] improve counters by filtering child events

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -256,7 +256,6 @@ function newClick(
   const eventCountsSubscription = trackEventCounts({
     lifeCycle,
     predicate: (event) =>
-      event.type !== 'view' &&
       event.action !== undefined &&
       (Array.isArray(event.action.id) ? includes(event.action.id, id) : event.action.id === id),
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -1,5 +1,6 @@
 import type { Duration, ClocksState, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import {
+  includes,
   timeStampNow,
   isExperimentalFeatureEnabled,
   Observable,
@@ -252,7 +253,13 @@ function newClick(
   const id = generateUUID()
   const startClocks = clocksNow()
   const historyEntry = history.add(id, startClocks.relative)
-  const eventCountsSubscription = trackEventCounts(lifeCycle)
+  const eventCountsSubscription = trackEventCounts({
+    lifeCycle,
+    predicate: (event) =>
+      event.type !== 'view' &&
+      event.action !== undefined &&
+      (Array.isArray(event.action.id) ? includes(event.action.id, id) : event.action.id === id),
+  })
   let status = ClickStatus.ONGOING
   let activityEndTime: undefined | TimeStamp
   const frustrationTypes: FrustrationType[] = []

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -255,7 +255,7 @@ function newClick(
   const historyEntry = history.add(id, startClocks.relative)
   const eventCountsSubscription = trackEventCounts({
     lifeCycle,
-    predicate: (event) =>
+    isChildEvent: (event) =>
       event.action !== undefined &&
       (Array.isArray(event.action.id) ? includes(event.action.id, id) : event.action.id === id),
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -36,7 +36,7 @@ export function trackViewMetrics(
   }
   const { stop: stopEventCountsTracking } = trackEventCounts({
     lifeCycle,
-    predicate: (event) => event.view.id === viewId,
+    isChildEvent: (event) => event.view.id === viewId,
     callback: (newEventCounts) => {
       viewMetrics.eventCounts = newEventCounts
       scheduleViewUpdate()

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -21,6 +21,7 @@ export function trackViewMetrics(
   domMutationObservable: Observable<void>,
   configuration: RumConfiguration,
   scheduleViewUpdate: () => void,
+  viewId: string,
   loadingType: ViewLoadingType,
   viewStart: ClocksState
 ) {
@@ -33,9 +34,13 @@ export function trackViewMetrics(
       frustrationCount: 0,
     },
   }
-  const { stop: stopEventCountsTracking } = trackEventCounts(lifeCycle, (newEventCounts) => {
-    viewMetrics.eventCounts = newEventCounts
-    scheduleViewUpdate()
+  const { stop: stopEventCountsTracking } = trackEventCounts({
+    lifeCycle,
+    predicate: (event) => event.view.id === viewId,
+    callback: (newEventCounts) => {
+      viewMetrics.eventCounts = newEventCounts
+      scheduleViewUpdate()
+    },
   })
 
   const { stop: stopLoadingTimeTracking, setLoadEvent } = trackLoadingTime(

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -736,10 +736,6 @@ describe('start view', () => {
 describe('view metrics', () => {
   let setupBuilder: TestSetupBuilder
   let viewTest: ViewTest
-  const FAKE_ACTION_EVENT = {
-    type: RumEventType.ACTION,
-    action: {},
-  } as RumEvent & Context
 
   beforeEach(() => {
     setupBuilder = setup()
@@ -758,7 +754,7 @@ describe('view metrics', () => {
     const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
     const { getViewUpdate, getViewUpdateCount } = viewTest
 
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, FAKE_ACTION_EVENT)
+    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, createFakeActionEvent())
 
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
@@ -770,11 +766,19 @@ describe('view metrics', () => {
     const { getViewUpdate, getViewUpdateCount } = viewTest
 
     lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, () => {
-      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, FAKE_ACTION_EVENT)
+      lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, createFakeActionEvent())
     })
 
     lifeCycle.notify(LifeCycleEventType.PAGE_EXITED, { reason: PageExitReason.UNLOADING })
 
     expect(getViewUpdate(getViewUpdateCount() - 1).eventCounts.actionCount).toBe(1)
   })
+
+  function createFakeActionEvent() {
+    return {
+      type: RumEventType.ACTION,
+      action: {},
+      view: viewTest.getLatestViewContext(),
+    } as RumEvent & Context
+  }
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -244,7 +244,15 @@ function newView(
     setLoadEvent,
     stop: stopViewMetricsTracking,
     viewMetrics,
-  } = trackViewMetrics(lifeCycle, domMutationObservable, configuration, scheduleViewUpdate, loadingType, startClocks)
+  } = trackViewMetrics(
+    lifeCycle,
+    domMutationObservable,
+    configuration,
+    scheduleViewUpdate,
+    id,
+    loadingType,
+    startClocks
+  )
 
   // Initial view update
   triggerViewUpdate()

--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -18,37 +18,37 @@ describe('trackEventCounts', () => {
   }
 
   it('tracks errors', () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.ERROR })
     expect(eventCounts.errorCount).toBe(1)
   })
 
   it('tracks long tasks', () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.LONG_TASK })
     expect(eventCounts.longTaskCount).toBe(1)
   })
 
   it("doesn't track views", () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.VIEW })
     expect(objectValues(eventCounts as unknown as { [key: string]: number }).every((value) => value === 0)).toBe(true)
   })
 
   it('tracks actions', () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.ACTION, action: { type: 'custom' } })
     expect(eventCounts.actionCount).toBe(1)
   })
 
   it('tracks resources', () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
   })
 
   it('tracks frustration counts', () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({
       type: RumEventType.ACTION,
       action: {
@@ -62,7 +62,7 @@ describe('trackEventCounts', () => {
   })
 
   it('stops tracking when stop is called', () => {
-    const { eventCounts, stop } = trackEventCounts({ lifeCycle, predicate: () => true })
+    const { eventCounts, stop } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
     stop()
@@ -72,7 +72,7 @@ describe('trackEventCounts', () => {
 
   it('invokes a potential callback when a count is increased', () => {
     const spy = jasmine.createSpy<(eventCounts: EventCounts) => void>()
-    trackEventCounts({ lifeCycle, predicate: () => true, callback: spy })
+    trackEventCounts({ lifeCycle, isChildEvent: () => true, callback: spy })
 
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(spy).toHaveBeenCalledTimes(1)
@@ -83,8 +83,8 @@ describe('trackEventCounts', () => {
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(2)
   })
 
-  it('does not take into account events rejected by the predicate', () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => false })
+  it('does not take into account events that are not child events', () => {
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => false })
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(0)
   })

--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -18,37 +18,37 @@ describe('trackEventCounts', () => {
   }
 
   it('tracks errors', () => {
-    const { eventCounts } = trackEventCounts(lifeCycle)
+    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.ERROR })
     expect(eventCounts.errorCount).toBe(1)
   })
 
   it('tracks long tasks', () => {
-    const { eventCounts } = trackEventCounts(lifeCycle)
+    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.LONG_TASK })
     expect(eventCounts.longTaskCount).toBe(1)
   })
 
   it("doesn't track views", () => {
-    const { eventCounts } = trackEventCounts(lifeCycle)
+    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.VIEW })
     expect(objectValues(eventCounts as unknown as { [key: string]: number }).every((value) => value === 0)).toBe(true)
   })
 
   it('tracks actions', () => {
-    const { eventCounts } = trackEventCounts(lifeCycle)
+    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.ACTION, action: { type: 'custom' } })
     expect(eventCounts.actionCount).toBe(1)
   })
 
   it('tracks resources', () => {
-    const { eventCounts } = trackEventCounts(lifeCycle)
+    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
   })
 
   it('tracks frustration counts', () => {
-    const { eventCounts } = trackEventCounts(lifeCycle)
+    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => true })
     notifyCollectedRawRumEvent({
       type: RumEventType.ACTION,
       action: {
@@ -62,7 +62,7 @@ describe('trackEventCounts', () => {
   })
 
   it('stops tracking when stop is called', () => {
-    const { eventCounts, stop } = trackEventCounts(lifeCycle)
+    const { eventCounts, stop } = trackEventCounts({ lifeCycle, predicate: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
     stop()
@@ -72,7 +72,7 @@ describe('trackEventCounts', () => {
 
   it('invokes a potential callback when a count is increased', () => {
     const spy = jasmine.createSpy<(eventCounts: EventCounts) => void>()
-    trackEventCounts(lifeCycle, spy)
+    trackEventCounts({ lifeCycle, predicate: () => true, callback: spy })
 
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(spy).toHaveBeenCalledTimes(1)
@@ -81,5 +81,11 @@ describe('trackEventCounts', () => {
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(spy).toHaveBeenCalledTimes(2)
     expect(spy.calls.mostRecent().args[0].resourceCount).toBe(2)
+  })
+
+  it('does not take into account events rejected by the predicate', () => {
+    const { eventCounts } = trackEventCounts({ lifeCycle, predicate: () => false })
+    notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
+    expect(eventCounts.resourceCount).toBe(0)
   })
 })

--- a/packages/rum-core/src/domain/trackEventCounts.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.ts
@@ -14,11 +14,11 @@ export interface EventCounts {
 
 export function trackEventCounts({
   lifeCycle,
-  predicate,
+  isChildEvent,
   callback = noop,
 }: {
   lifeCycle: LifeCycle
-  predicate: (event: RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent) => boolean
+  isChildEvent: (event: RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent) => boolean
   callback?: (eventCounts: EventCounts) => void
 }) {
   const eventCounts: EventCounts = {
@@ -30,7 +30,7 @@ export function trackEventCounts({
   }
 
   const subscription = lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event): void => {
-    if (event.type === 'view' || !predicate(event)) {
+    if (event.type === 'view' || !isChildEvent(event)) {
       return
     }
     switch (event.type) {

--- a/packages/rum-core/src/domain/trackEventCounts.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.ts
@@ -1,6 +1,6 @@
 import { noop } from '@datadog/browser-core'
 import { RumEventType } from '../rawRumEvent.types'
-import type { RumEvent } from '../rumEvent.types'
+import type { RumActionEvent, RumErrorEvent, RumLongTaskEvent, RumResourceEvent } from '../rumEvent.types'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
 
@@ -18,7 +18,7 @@ export function trackEventCounts({
   callback = noop,
 }: {
   lifeCycle: LifeCycle
-  predicate: (event: RumEvent) => boolean
+  predicate: (event: RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent) => boolean
   callback?: (eventCounts: EventCounts) => void
 }) {
   const eventCounts: EventCounts = {
@@ -30,7 +30,7 @@ export function trackEventCounts({
   }
 
   const subscription = lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event): void => {
-    if (!predicate(event)) {
+    if (event.type === 'view' || !predicate(event)) {
       return
     }
     switch (event.type) {

--- a/packages/rum-core/test/specHelper.ts
+++ b/packages/rum-core/test/specHelper.ts
@@ -247,6 +247,9 @@ export function setupViewTest(
     getViewUpdateCount,
     getViewCreate,
     getViewCreateCount,
+    getLatestViewContext: () => ({
+      id: getViewCreate(getViewCreateCount() - 1).id,
+    }),
   }
 }
 


### PR DESCRIPTION


## Motivation

We noticed that child event counters were often inaccurate. This first PR goal is to imporve the situation by only taking child events related to the current parent event into account.

## Changes

When computing child event counters, only take events related to the current parent event into account.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
