### PR TITLE
✨[RUMF-1435] Add transport api on events

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -13,25 +13,25 @@ describe('endpointBuilder', () => {
 
   describe('query parameters', () => {
     it('should add intake query parameters', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build()).toMatch(
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toMatch(
         `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
       )
     })
 
     it('should add batch_time for rum endpoint', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build()).toContain('&batch_time=')
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toContain('&batch_time=')
     })
 
     it('should not add batch_time for logs and replay endpoints', () => {
-      expect(createEndpointBuilder(initConfiguration, 'logs', []).build()).not.toContain('&batch_time=')
-      expect(createEndpointBuilder(initConfiguration, 'sessionReplay', []).build()).not.toContain('&batch_time=')
+      expect(createEndpointBuilder(initConfiguration, 'logs', []).build('xhr')).not.toContain('&batch_time=')
+      expect(createEndpointBuilder(initConfiguration, 'sessionReplay', []).build('xhr')).not.toContain('&batch_time=')
     })
   })
 
   describe('proxyUrl', () => {
     it('should replace the full intake endpoint by the proxyUrl and set it in the attribute ddforward', () => {
       expect(
-        createEndpointBuilder({ ...initConfiguration, proxyUrl: 'https://proxy.io/path' }, 'rum', []).build()
+        createEndpointBuilder({ ...initConfiguration, proxyUrl: 'https://proxy.io/path' }, 'rum', []).build('xhr')
       ).toMatch(
         `https://proxy.io/path\\?ddforward=${encodeURIComponent(
           `https://rum.browser-intake-datadoghq.com/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
@@ -43,19 +43,23 @@ describe('endpointBuilder', () => {
 
   describe('tags', () => {
     it('should contain sdk version', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build()).toContain('ddtags=sdk_version%3Asome_version')
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toContain('sdk_version%3Asome_version')
+    })
+
+    it('should contain api', () => {
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toContain('api%3Axhr')
     })
 
     it('should be encoded', () => {
       expect(
-        createEndpointBuilder(initConfiguration, 'rum', ['service:bar:foo', 'datacenter:us1.prod.dog']).build()
+        createEndpointBuilder(initConfiguration, 'rum', ['service:bar:foo', 'datacenter:us1.prod.dog']).build('xhr')
       ).toContain('service%3Abar%3Afoo%2Cdatacenter%3Aus1.prod.dog')
     })
 
     it('should contain retry infos', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build({ count: 5, lastFailureStatus: 408 })).toContain(
-        'retry_count%3A5%2Cretry_after%3A408'
-      )
+      expect(
+        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', { count: 5, lastFailureStatus: 408 })
+      ).toContain('retry_count%3A5%2Cretry_after%3A408')
     })
   })
 })

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -38,8 +38,8 @@ export function createEndpointBuilder(
   const proxyUrl = initConfiguration.proxyUrl && normalizeUrl(initConfiguration.proxyUrl)
 
   return {
-    build(retry?: RetryInfo) {
-      const tags = [`sdk_version:${__BUILD_ENV__SDK_VERSION__}`].concat(configurationTags)
+    build(api: 'xhr' | 'fetch' | 'beacon', retry?: RetryInfo) {
+      const tags = [`sdk_version:${__BUILD_ENV__SDK_VERSION__}`, `api:${api}`].concat(configurationTags)
       if (retry) {
         tags.push(`retry_count:${retry.count}`, `retry_after:${retry.lastFailureStatus}`)
       }

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -6,13 +6,13 @@ describe('transportConfiguration', () => {
   describe('site', () => {
     it('should use US site by default', () => {
       const configuration = computeTransportConfiguration({ clientToken })
-      expect(configuration.rumEndpointBuilder.build()).toContain('datadoghq.com')
+      expect(configuration.rumEndpointBuilder.build('xhr')).toContain('datadoghq.com')
       expect(configuration.site).toBe('datadoghq.com')
     })
 
     it('should use site value when set', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'foo.com' })
-      expect(configuration.rumEndpointBuilder.build()).toContain('foo.com')
+      expect(configuration.rumEndpointBuilder.build('xhr')).toContain('foo.com')
       expect(configuration.site).toBe('foo.com')
     })
   })
@@ -20,21 +20,25 @@ describe('transportConfiguration', () => {
   describe('sdk_version, env, version and service', () => {
     it('should not modify the logs and rum endpoints tags when not defined', () => {
       const configuration = computeTransportConfiguration({ clientToken })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).not.toContain(',env:')
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).not.toContain(',service:')
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).not.toContain(',version:')
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).not.toContain(',datacenter:')
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',env:')
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',service:')
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',version:')
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',datacenter:')
 
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).not.toContain(',env:')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).not.toContain(',service:')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).not.toContain(',version:')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).not.toContain(',datacenter:')
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',env:')
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',service:')
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',version:')
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',datacenter:')
     })
 
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = computeTransportConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build())).toContain('env:foo,service:bar,version:baz')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build())).toContain('env:foo,service:bar,version:baz')
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).toContain(
+        'env:foo,service:bar,version:baz'
+      )
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).toContain(
+        'env:foo,service:bar,version:baz'
+      )
     })
   })
 

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -55,11 +55,10 @@ export function createHttpRequest(
 }
 
 function sendBeaconStrategy(endpointBuilder: EndpointBuilder, bytesLimit: number, { data, bytesCount }: Payload) {
-  const beaconUrl = endpointBuilder.build('beacon')
-  const xhrUrl = endpointBuilder.build('xhr')
   const canUseBeacon = !!navigator.sendBeacon && bytesCount < bytesLimit
   if (canUseBeacon) {
     try {
+      const beaconUrl = endpointBuilder.build('beacon')
       const isQueued = navigator.sendBeacon(beaconUrl, data)
 
       if (isQueued) {
@@ -70,6 +69,7 @@ function sendBeaconStrategy(endpointBuilder: EndpointBuilder, bytesLimit: number
     }
   }
 
+  const xhrUrl = endpointBuilder.build('xhr')
   sendXHR(xhrUrl, data)
 }
 
@@ -89,17 +89,18 @@ export function fetchKeepAliveStrategy(
   onResponse?: (r: HttpResponse) => void
 ) {
   const canUseKeepAlive = isKeepAliveSupported() && bytesCount < bytesLimit
-  const fetchUrl = endpointBuilder.build('fetch', retry)
-  const xhrUrl = endpointBuilder.build('xhr', retry)
   if (canUseKeepAlive) {
+    const fetchUrl = endpointBuilder.build('fetch', retry)
     fetch(fetchUrl, { method: 'POST', body: data, keepalive: true }).then(
       monitor((response: Response) => onResponse?.({ status: response.status })),
       monitor(() => {
+        const xhrUrl = endpointBuilder.build('xhr', retry)
         // failed to queue the request
         sendXHR(xhrUrl, data, onResponse)
       })
     )
   } else {
+    const xhrUrl = endpointBuilder.build('xhr', retry)
     sendXHR(xhrUrl, data, onResponse)
   }
 }

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -11,7 +11,7 @@ export interface BuildEnvWindow {
 }
 
 export function stubEndpointBuilder(url: string) {
-  return { build: () => url } as EndpointBuilder
+  return { build: (_: any) => url } as EndpointBuilder
 }
 
 export const SPEC_ENDPOINTS = {

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -73,7 +73,7 @@ describe('logs', () => {
       handleLog({ message: 'message', status: StatusType.warn, context: { foo: 'bar' } }, logger, COMMON_CONTEXT)
 
       expect(requests.length).toEqual(1)
-      expect(requests[0].url).toContain(baseConfiguration.logsEndpointBuilder.build())
+      expect(requests[0].url).toContain(baseConfiguration.logsEndpointBuilder.build('xhr'))
       expect(getLoggedMessage(requests, 0)).toEqual({
         date: jasmine.any(Number),
         foo: 'bar',

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -91,7 +91,7 @@ describe('collect fetch', () => {
   })
 
   it('should ignore intake requests', (done) => {
-    fetchStub(SPEC_ENDPOINTS.rumEndpointBuilder.build()).resolveWith({ status: 200, responseText: 'foo' })
+    fetchStub(SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr')).resolveWith({ status: 200, responseText: 'foo' })
 
     fetchStubManager.whenAllComplete(() => {
       expect(startSpy).not.toHaveBeenCalled()
@@ -230,7 +230,7 @@ describe('collect xhr', () => {
   it('should ignore intake requests', (done) => {
     withXhr({
       setup(xhr) {
-        xhr.open('GET', SPEC_ENDPOINTS.rumEndpointBuilder.build())
+        xhr.open('GET', SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr'))
         xhr.send()
         xhr.complete(200)
       },


### PR DESCRIPTION
## Motivation

Flag events with the api used for transport to help investigation.

## Changes

Add `api: 'xhr' | 'fetch' | 'beacon'`  tag on events

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
