### PR TITLE
[RUMF-1446] Report `cache_status` for resources

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -37,6 +37,8 @@ export interface RumPerformanceResourceTiming {
   redirectStart: RelativeTime
   redirectEnd: RelativeTime
   decodedBodySize: number
+  cache_status?: 'cached' | 'fetched'
+  transferSize?: number
   traceId?: string
 }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -47,6 +47,7 @@ describe('resourceCollection', () => {
         size: undefined,
         type: ResourceType.OTHER,
         url: 'https://resource.com/valid',
+        cache_status: 'fetched',
       },
       type: RumEventType.RESOURCE,
       _dd: {

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -16,7 +16,7 @@ import type {
   RumXhrResourceEventDomainContext,
   RumFetchResourceEventDomainContext,
 } from '../../../domainContext.types'
-import type { RawRumResourceEvent } from '../../../rawRumEvent.types'
+import type { RawRumResourceEvent, CacheStatus } from '../../../rawRumEvent.types'
 import { RumEventType } from '../../../rawRumEvent.types'
 import type { LifeCycle, RawRumEventCollectedData } from '../../lifeCycle'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -28,6 +28,7 @@ import {
   computePerformanceResourceDuration,
   computeResourceKind,
   computeSize,
+  computeCacheStatus,
   isRequestKind,
 } from './resourceUtils'
 
@@ -138,6 +139,7 @@ function computePerformanceEntryMetrics(timing: RumPerformanceResourceTiming) {
       {
         duration: computePerformanceResourceDuration(timing),
         size: computeSize(timing),
+        cache_status: computeCacheStatus(timing) as CacheStatus,
       },
       computePerformanceResourceDetails(timing)
     ),

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceUtils.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceUtils.spec.ts
@@ -8,6 +8,7 @@ import {
   computePerformanceResourceDuration,
   computeResourceKind,
   isAllowedRequestUrl,
+  computeCacheStatus,
 } from './resourceUtils'
 
 function generateResourceWith(overrides: Partial<RumPerformanceResourceTiming>) {
@@ -288,6 +289,21 @@ describe('computePerformanceResourceDuration', () => {
     expect(computePerformanceResourceDuration(generateResourceWith({ duration: 0 as Duration }))).toBe(
       50e6 as ServerDuration
     )
+  })
+})
+
+describe('computeCacheStatus', () => {
+  it('should return undefined', () => {
+    const cacheStatus = computeCacheStatus(generateResourceWith({ transferSize: 0, decodedBodySize: 0 }))
+    expect(cacheStatus).toBeUndefined()
+  })
+  it('should return cached', () => {
+    const cacheStatus = computeCacheStatus(generateResourceWith({ transferSize: 0, decodedBodySize: 100 }))
+    expect(cacheStatus).toBe('cached')
+  })
+  it('should return fetched', () => {
+    const cacheStatus = computeCacheStatus(generateResourceWith({ transferSize: 100, decodedBodySize: 100 }))
+    expect(cacheStatus).toBe('fetched')
   })
 })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceUtils.ts
@@ -201,6 +201,11 @@ export function computeSize(entry: RumPerformanceResourceTiming) {
   return undefined
 }
 
+export function computeCacheStatus(entry: RumPerformanceResourceTiming) {
+  if (entry.decodedBodySize === 0) return
+  return entry.transferSize === 0 ? 'cached' : 'fetched'
+}
+
 export function isAllowedRequestUrl(configuration: RumConfiguration, url: string) {
   return url && !configuration.isIntakeUrl(url)
 }

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -36,6 +36,7 @@ export interface RawRumResourceEvent {
     ssl?: PerformanceResourceDetailsElement
     first_byte?: PerformanceResourceDetailsElement
     download?: PerformanceResourceDetailsElement
+    cache_status?: CacheStatus
   }
   _dd: {
     trace_id?: string
@@ -44,6 +45,8 @@ export interface RawRumResourceEvent {
     discarded: boolean
   }
 }
+
+export type CacheStatus = 'cached' | 'fetched'
 
 export interface PerformanceResourceDetailsElement {
   duration: ServerDuration


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
When we find a matching performance entry for a resource, we can easily calculate if that resource comes from the `cache` as mentioned [here](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize#value).

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
- create `computeCacheStatus` to return `cached`, `fetched` or `undefined`
- add `cache_status` field to `computePerformanceEntryMetrics`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
