### PR TITLE
✨ send data from the SDK to the extension

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -205,7 +205,7 @@ module.exports = {
       },
     },
     {
-      files: ['packages/*/src/**/*.ts'],
+      files: ['packages/*/src/**/*.ts', 'developer-extension/src/**/*.{tsx,ts}'],
       rules: {
         'no-console': 'error',
       },

--- a/developer-extension/manifest.json
+++ b/developer-extension/manifest.json
@@ -10,5 +10,12 @@
     "service_worker": "background.js",
     "type": "module"
   },
-  "devtools_page": "devtools.html"
+  "devtools_page": "devtools.html",
+  "content_scripts": [
+    {
+      "run_at": "document_start",
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"]
+    }
+  ]
 }

--- a/developer-extension/manifest.json
+++ b/developer-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Datadog Browser SDK developer extension",
-  "permissions": ["webRequest", "storage", "browsingData", "declarativeNetRequest", "webNavigation"],
+  "permissions": ["webRequest", "storage", "browsingData", "declarativeNetRequest", "webNavigation", "scripting"],
   "host_permissions": ["<all_urls>"],
   "icons": {
     "256": "icon.png"
@@ -10,12 +10,5 @@
     "service_worker": "background.js",
     "type": "module"
   },
-  "devtools_page": "devtools.html",
-  "content_scripts": [
-    {
-      "run_at": "document_start",
-      "matches": ["<all_urls>"],
-      "js": ["content-script.js"]
-    }
-  ]
+  "devtools_page": "devtools.html"
 }

--- a/developer-extension/src/background/actions.ts
+++ b/developer-extension/src/background/actions.ts
@@ -1,5 +1,15 @@
+import { createLogger } from '../common/logger'
 import { createListenAction, createSendAction } from '../common/actions'
 import type { BackgroundActions, PopupActions } from '../common/types'
 
+const logger = createLogger('action')
+
 export const listenAction = createListenAction<BackgroundActions>()
-export const sendAction = createSendAction<PopupActions>().sendAction
+export const sendAction = createSendAction<PopupActions>((error) => {
+  if (
+    error.message !== 'Could not establish connection. Receiving end does not exist.' &&
+    error.message !== 'The message port closed before a response was received.'
+  ) {
+    logger.error(`sendAction error: ${error.message}`)
+  }
+})

--- a/developer-extension/src/background/domain/messageRelay.ts
+++ b/developer-extension/src/background/domain/messageRelay.ts
@@ -1,0 +1,52 @@
+// This file implements a way to relay messages from the web page to the devtools script. Basically,
+// the devtools panel cannot simply listen for messages on the inspected page. Instead:
+//
+// * When the devtools panel opens, a messaging connection is created with the background script.
+//   This connection is associated with the inspected tab id in the background script memory.
+//
+// * When the page is loaded, a content-script is executed which listen to Browser SDK messages and
+//   send them to the background script.
+//
+// * The background script listens for messages from the content-script and send them to the
+//   devtools panel if a connection exists
+//
+// This is the solution advised in the documentation provided by Google Chrome:
+// https://developer.chrome.com/docs/extensions/mv3/devtools/#content-script-to-devtools
+
+const devtoolsConnections = new Map<number, chrome.runtime.Port>()
+
+// Listen for connection from the devtools-panel
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name !== 'devtools-panel') {
+    return
+  }
+
+  port.onMessage.addListener((message) => {
+    if (message.name === 'init') {
+      devtoolsConnections.set(message.tabId, port)
+    }
+  })
+
+  port.onDisconnect.addListener(() => {
+    for (const [tabId, otherPort] of Array.from(devtoolsConnections)) {
+      if (port === otherPort) {
+        devtoolsConnections.delete(tabId)
+      }
+    }
+  })
+})
+
+// Listen for messages coming from the content-script
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (!sender.tab || !sender.tab.id) {
+    return
+  }
+
+  const port = devtoolsConnections.get(sender.tab.id)
+  if (!port) {
+    // Extension not yet opened
+    return
+  }
+
+  port.postMessage(message)
+})

--- a/developer-extension/src/background/domain/messageRelay.ts
+++ b/developer-extension/src/background/domain/messageRelay.ts
@@ -1,16 +1,16 @@
 // This file implements a way to relay messages from the web page to the devtools script. Basically,
-// the devtools panel cannot simply listen for messages on the inspected page. Instead:
+// the devtools panel cannot simply listen for messages on the inspected page. Instead, messages
+// from the web page are relayed through a list of scripts:
 //
-// * When the devtools panel opens, a messaging connection is created with the background script.
-//   This connection is associated with the inspected tab id in the background script memory.
+// 1. web-page calls a global callback defined by a "main" content script
+// 2. the "main" content script relays the message to an "isolated" content script via a custom
+//    event
+// 3. the "isolated" content script relays the message to the background script via the
+//    chrome.runtime.sendMessage API
+// 4. the background script relays the message to the devtools panel via a persistent connection
+//    (chrome.runtime.Port)
 //
-// * When the page is loaded, a content-script is executed which listen to Browser SDK messages and
-//   send them to the background script.
-//
-// * The background script listens for messages from the content-script and send them to the
-//   devtools panel if a connection exists
-//
-// This is the solution advised in the documentation provided by Google Chrome:
+// Steps 2, 3 and 4 are a solution advised in the documentation provided by Google Chrome:
 // https://developer.chrome.com/docs/extensions/mv3/devtools/#content-script-to-devtools
 
 import { createLogger } from '../../common/logger'
@@ -33,13 +33,23 @@ chrome.runtime.onConnect.addListener((port) => {
   logger.log(`New devtools connection for tab ${tabId}`)
   devtoolsConnections.set(tabId, port)
 
+  if (devtoolsConnections.size === 1) {
+    // Register content scripts when a first devtools panel is open
+    registerContentScripts(tabId).catch((error) => logger.error('Error while registering content scripts:', error))
+  }
+
   port.onDisconnect.addListener(() => {
     logger.log(`Remove devtools connection for tab ${tabId}`)
     devtoolsConnections.delete(tabId)
+    if (devtoolsConnections.size === 0) {
+      // Unregister content scripts when the last devtools panel is open
+      unregisterContentScripts().catch((error) => logger.error('Error while unregistering content scripts:', error))
+    }
   })
 })
 
-// Listen for messages coming from the content-script
+// Listen for messages coming from the "isolated" content-script and relay them to a potential
+// devtools panel connection.
 chrome.runtime.onMessage.addListener((message, sender) => {
   if (!sender.tab || !sender.tab.id) {
     return
@@ -53,3 +63,61 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 
   port.postMessage(message)
 })
+
+const CONTENT_SCRIPTS: Array<{
+  id: string
+  file: string
+  world: chrome.scripting.ExecutionWorld
+}> = [
+  {
+    id: 'browser-sdk-content-script-main',
+    world: 'MAIN',
+    file: './content-script-main.js',
+  },
+  {
+    id: 'browser-sdk-content-script-isolated',
+    world: 'ISOLATED',
+    file: './content-script-isolated.js',
+  },
+]
+
+async function unregisterContentScripts() {
+  logger.log('Unregistering content scripts')
+  try {
+    await chrome.scripting.unregisterContentScripts({ ids: CONTENT_SCRIPTS.map((script) => script.id) })
+  } catch {
+    // This will throw an error when scripts are not registered. Just ignore it.
+  }
+}
+
+async function registerContentScripts(tabId: number) {
+  // We always refresh the content scripts, just in case they changed.
+  await unregisterContentScripts()
+
+  logger.log('Registering content scripts')
+  await chrome.scripting.registerContentScripts(
+    CONTENT_SCRIPTS.map((script) => ({
+      id: script.id,
+      allFrames: true,
+      js: [script.file],
+      matches: ['<all_urls>'],
+      world: script.world,
+      runAt: 'document_start',
+    }))
+  )
+
+  // Execute scripts in the tab where the devtools panel was first open, so we don't need to refresh
+  // the page to see events flowing.
+  await Promise.all(
+    CONTENT_SCRIPTS.map((script) =>
+      chrome.scripting.executeScript({
+        files: [script.file],
+        world: script.world,
+        target: {
+          tabId,
+          allFrames: true,
+        },
+      })
+    )
+  )
+}

--- a/developer-extension/src/background/domain/refreshDevServerStatus.ts
+++ b/developer-extension/src/background/domain/refreshDevServerStatus.ts
@@ -1,11 +1,12 @@
+import { createLogger } from '../../common/logger'
 import { listenAction } from '../actions'
 import { DEV_LOGS_URL } from '../constants'
 import { setStore } from '../store'
 
+const logger = createLogger('refreshDevServerStatus')
+
 listenAction('getStore', () => {
-  refreshDevServerStatus().catch((error) =>
-    console.error('refreshDevServerStatus: Unexpected error while refreshing dev server status:', error)
-  )
+  refreshDevServerStatus().catch((error) => logger.error('Unexpected error while refreshing dev server status:', error))
 })
 
 async function refreshDevServerStatus() {

--- a/developer-extension/src/background/domain/syncRules.ts
+++ b/developer-extension/src/background/domain/syncRules.ts
@@ -1,6 +1,9 @@
+import { createLogger } from '../../common/logger'
 import { listenAction } from '../actions'
 import { DEV_LOGS_URL, DEV_RUM_SLIM_URL, DEV_RUM_URL, INTAKE_DOMAINS } from '../constants'
 import { store } from '../store'
+
+const logger = createLogger('syncRules')
 
 listenAction('setStore', (newStore) => {
   if ('useDevBundles' in newStore || 'useRumSlim' in newStore || 'blockIntakeRequests' in newStore) {
@@ -10,7 +13,7 @@ listenAction('setStore', (newStore) => {
 })
 
 function syncRules() {
-  console.log('syncRules: Syncing rules')
+  logger.log('Syncing rules')
   chrome.declarativeNetRequest
     .getSessionRules()
     .then((existingRules) =>
@@ -19,7 +22,7 @@ function syncRules() {
         addRules: getRules(),
       })
     )
-    .catch((error) => console.error('syncRules: Error while syncing rules:', error))
+    .catch((error) => logger.error('Error while syncing rules:', error))
 }
 
 function getRules() {
@@ -28,7 +31,7 @@ function getRules() {
 
   if (store.useDevBundles) {
     const devRumUrl = store.useRumSlim ? DEV_RUM_SLIM_URL : DEV_RUM_URL
-    console.log('syncRules: add redirect to dev bundles rules')
+    logger.log('add redirect to dev bundles rules')
     rules.push(
       createRedirectRule(id++, /^https:\/\/.*\/datadog-rum(-v\d|canary|staging)?\.js$/, { url: devRumUrl }),
       createRedirectRule(id++, /^https:\/\/.*\/datadog-rum-slim(-v\d|canary|staging)?\.js$/, { url: DEV_RUM_SLIM_URL }),
@@ -36,12 +39,12 @@ function getRules() {
       createRedirectRule(id++, 'https://localhost:8443/static/datadog-rum-hotdog.js', { url: devRumUrl })
     )
   } else if (store.useRumSlim) {
-    console.log('syncRules: add redirect to rum slim rule')
+    logger.log('add redirect to rum slim rule')
     rules.push(createRedirectRule(id++, /^(https:\/\/.*\/datadog-rum)(-slim)?/, { regexSubstitution: '\\1-slim' }))
   }
 
   if (store.blockIntakeRequests) {
-    console.log('syncRules: add block intake rules')
+    logger.log('add block intake rules')
     for (const intakeDomain of INTAKE_DOMAINS) {
       rules.push({
         id: id++,

--- a/developer-extension/src/background/domain/syncRules.ts
+++ b/developer-extension/src/background/domain/syncRules.ts
@@ -33,9 +33,11 @@ function getRules() {
     const devRumUrl = store.useRumSlim ? DEV_RUM_SLIM_URL : DEV_RUM_URL
     logger.log('add redirect to dev bundles rules')
     rules.push(
-      createRedirectRule(id++, /^https:\/\/.*\/datadog-rum(-v\d|canary|staging)?\.js$/, { url: devRumUrl }),
-      createRedirectRule(id++, /^https:\/\/.*\/datadog-rum-slim(-v\d|canary|staging)?\.js$/, { url: DEV_RUM_SLIM_URL }),
-      createRedirectRule(id++, /^https:\/\/.*\/datadog-logs(-v\d|canary|staging)?\.js$/, { url: DEV_LOGS_URL }),
+      createRedirectRule(id++, /^https:\/\/.*\/datadog-rum(-v\d|-canary|-staging)?\.js$/, { url: devRumUrl }),
+      createRedirectRule(id++, /^https:\/\/.*\/datadog-rum-slim(-v\d|-canary|-staging)?\.js$/, {
+        url: DEV_RUM_SLIM_URL,
+      }),
+      createRedirectRule(id++, /^https:\/\/.*\/datadog-logs(-v\d|-canary|-staging)?\.js$/, { url: DEV_LOGS_URL }),
       createRedirectRule(id++, 'https://localhost:8443/static/datadog-rum-hotdog.js', { url: devRumUrl })
     )
   } else if (store.useRumSlim) {

--- a/developer-extension/src/background/index.ts
+++ b/developer-extension/src/background/index.ts
@@ -1,2 +1,3 @@
+import './domain/messageRelay'
 import './domain/refreshDevServerStatus'
 import './domain/syncRules'

--- a/developer-extension/src/common/actions.ts
+++ b/developer-extension/src/common/actions.ts
@@ -1,7 +1,3 @@
-import { createLogger } from './logger'
-
-const logger = createLogger('action')
-
 type ValueOf<T> = T[keyof T]
 
 type Message<Actions extends { [key: string]: any }> = ValueOf<{
@@ -30,34 +26,13 @@ export function createListenAction<Actions extends { [key: string]: any }>() {
   return listenAction
 }
 
-export function createSendAction<Actions>() {
-  let onDisconnect: (() => void) | undefined
-
+export function createSendAction<Actions>(onError: (error: { message: string }) => void) {
   function sendAction<K extends keyof Actions>(action: K, payload: Actions[K]) {
     try {
-      chrome.runtime.sendMessage({ action, payload }).catch(handleError)
+      chrome.runtime.sendMessage({ action, payload }).catch(onError)
     } catch (error) {
-      handleError(error)
+      onError(error as { message: string })
     }
   }
-
-  function handleError(error: any) {
-    const message = typeof error === 'object' && error !== null ? String(error.message) : '(no message)'
-
-    if (onDisconnect && message === 'Extension context invalidated.') {
-      onDisconnect()
-    } else if (
-      message !== 'Could not establish connection. Receiving end does not exist.' &&
-      message !== 'The message port closed before a response was received.'
-    ) {
-      logger.error(`sendAction error: ${message}`)
-    }
-  }
-
-  return {
-    sendAction,
-    setOnDisconnect: (newOnDisconnect: () => void) => {
-      onDisconnect = newOnDisconnect
-    },
-  }
+  return sendAction
 }

--- a/developer-extension/src/common/actions.ts
+++ b/developer-extension/src/common/actions.ts
@@ -1,3 +1,7 @@
+import { createLogger } from './logger'
+
+const logger = createLogger('action')
+
 type ValueOf<T> = T[keyof T]
 
 type Message<Actions extends { [key: string]: any }> = ValueOf<{
@@ -46,7 +50,7 @@ export function createSendAction<Actions>() {
       message !== 'Could not establish connection. Receiving end does not exist.' &&
       message !== 'The message port closed before a response was received.'
     ) {
-      console.error(`sendAction error: ${message}`)
+      logger.error(`sendAction error: ${message}`)
     }
   }
 

--- a/developer-extension/src/common/isDisconnectError.ts
+++ b/developer-extension/src/common/isDisconnectError.ts
@@ -1,0 +1,5 @@
+export function isDisconnectError(error: unknown) {
+  return (
+    typeof error === 'object' && error && (error as { message?: string }).message === 'Extension context invalidated.'
+  )
+}

--- a/developer-extension/src/common/logger.ts
+++ b/developer-extension/src/common/logger.ts
@@ -1,0 +1,14 @@
+const DEVELOPER_EXTENSION_PREFIX = 'Datadog Browser SDK extension:'
+
+export function createLogger(module: string) {
+  return {
+    log(...args: any[]) {
+      // eslint-disable-next-line no-console
+      console.log(DEVELOPER_EXTENSION_PREFIX, `[${module}]`, ...args)
+    },
+    error(...args: any[]) {
+      // eslint-disable-next-line no-console
+      console.error(DEVELOPER_EXTENSION_PREFIX, `[${module}]`, ...args)
+    },
+  }
+}

--- a/developer-extension/src/content-script/index.ts
+++ b/developer-extension/src/content-script/index.ts
@@ -1,0 +1,17 @@
+import { isDisconnectError } from '../common/isDisconnectError'
+import { createLogger } from '../common/logger'
+
+const logger = createLogger('content-script')
+
+window.addEventListener('__ddBrowserSdkMessage', (event) => {
+  const detail = (event as CustomEvent).detail
+  try {
+    chrome.runtime.sendMessage(detail).catch((error) => logger.error('Failed to send message:', error))
+  } catch (error) {
+    // Ignore errors when the background script is unloaded, as this is expected to happen sometimes and we
+    // don't want to spam the console in this case.
+    if (!isDisconnectError(error)) {
+      logger.error('Failed to send message:', error)
+    }
+  }
+})

--- a/developer-extension/src/content-scripts/isolated.ts
+++ b/developer-extension/src/content-scripts/isolated.ts
@@ -1,8 +1,12 @@
+// This content script is executed in the "isolated" execution world. Thus, it has not access to
+// the webpage global variables, but can use webextension APIs.
 import { isDisconnectError } from '../common/isDisconnectError'
 import { createLogger } from '../common/logger'
 
-const logger = createLogger('content-script')
+const logger = createLogger('content-script-isolated')
 
+// Listen to events from the "main" content script and relays them to the background script via the
+// webextension API.
 window.addEventListener('__ddBrowserSdkMessage', (event) => {
   const detail = (event as CustomEvent).detail
   try {

--- a/developer-extension/src/content-scripts/main.ts
+++ b/developer-extension/src/content-scripts/main.ts
@@ -1,0 +1,11 @@
+// This script is executed in the "main" execution world, the same world as the webpage. Thus, it
+// can define a global callback variable to listen to SDK events.
+
+;(window as any).__ddBrowserSdkExtensionCallback = (message: unknown) => {
+  // Relays any message to the "isolated" content-script via a custom event.
+  window.dispatchEvent(
+    new CustomEvent('__ddBrowserSdkMessage', {
+      detail: message,
+    })
+  )
+}

--- a/developer-extension/src/panel/actions.ts
+++ b/developer-extension/src/panel/actions.ts
@@ -1,6 +1,16 @@
+import { createLogger } from '../common/logger'
 import { createListenAction, createSendAction } from '../common/actions'
 import type { BackgroundActions, PopupActions } from '../common/types'
+import { isDisconnectError } from '../common/isDisconnectError'
+import { notifyDisconnectEvent } from './disconnectEvent'
 
-const { sendAction, setOnDisconnect } = createSendAction<BackgroundActions>()
-export { sendAction, setOnDisconnect }
+const logger = createLogger('action')
+
+export const sendAction = createSendAction<BackgroundActions>((error) => {
+  if (isDisconnectError(error)) {
+    notifyDisconnectEvent()
+  } else {
+    logger.error('sendAction error:', error.message)
+  }
+})
 export const listenAction = createListenAction<PopupActions>()

--- a/developer-extension/src/panel/app.tsx
+++ b/developer-extension/src/panel/app.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, Center, Group, MantineProvider } from '@mantine/core'
 import { useColorScheme } from '@mantine/hooks'
 import React, { Suspense, useState } from 'react'
-import { setOnDisconnect } from './actions'
+import { listenDisconnectEvent } from './disconnectEvent'
 
 import { Panel } from './panel'
 
@@ -9,7 +9,7 @@ export function App() {
   const colorScheme = useColorScheme()
   const [isDisconnected, setIsDisconnected] = useState(false)
 
-  setOnDisconnect(() => setIsDisconnected(true))
+  listenDisconnectEvent(() => setIsDisconnected(true))
 
   return (
     <MantineProvider

--- a/developer-extension/src/panel/backgroundScriptConnection.ts
+++ b/developer-extension/src/panel/backgroundScriptConnection.ts
@@ -1,0 +1,72 @@
+import { isDisconnectError } from '../common/isDisconnectError'
+import type { TelemetryEvent } from '../../../packages/core/src/domain/telemetry'
+import type { LogsEvent } from '../../../packages/logs/src/logsEvent.types'
+import type { RumEvent } from '../../../packages/rum-core/src/rumEvent.types'
+import type { BrowserRecord, BrowserSegmentMetadata } from '../../../packages/rum/src/types'
+import { createLogger } from '../common/logger'
+import { notifyDisconnectEvent } from './disconnectEvent'
+
+const logger = createLogger('backgroundScriptConnection')
+
+type SdkMessage =
+  | {
+      type: 'logs'
+      payload: LogsEvent
+    }
+  | {
+      type: 'rum'
+      payload: RumEvent
+    }
+  | {
+      type: 'telemetry'
+      payload: TelemetryEvent
+    }
+  | {
+      type: 'record'
+      payload: {
+        record: BrowserRecord
+        segment: BrowserSegmentMetadata
+      }
+    }
+
+let backgroundScriptConnection: chrome.runtime.Port | undefined
+
+export function listenSdkMessages(callback: (message: SdkMessage) => void) {
+  if (!backgroundScriptConnection) {
+    backgroundScriptConnection = createBackgroundScriptConnection()
+    if (!backgroundScriptConnection) {
+      return () => {
+        // nothing to cleanup in this case
+      }
+    }
+  }
+
+  backgroundScriptConnection.onMessage.addListener(callback)
+  return () => backgroundScriptConnection!.onMessage.removeListener(callback)
+}
+
+function createBackgroundScriptConnection() {
+  try {
+    const backgroundScriptConnection = chrome.runtime.connect({
+      name: 'devtools-panel',
+    })
+
+    backgroundScriptConnection.onDisconnect.addListener(() => {
+      logger.error('disconnected', chrome.runtime.lastError)
+      notifyDisconnectEvent()
+    })
+
+    backgroundScriptConnection.postMessage({
+      name: 'init',
+      tabId: chrome.devtools.inspectedWindow.tabId,
+    })
+
+    return backgroundScriptConnection
+  } catch (error) {
+    if (isDisconnectError(error)) {
+      notifyDisconnectEvent()
+    } else {
+      logger.error('While creating connection:', error)
+    }
+  }
+}

--- a/developer-extension/src/panel/backgroundScriptConnection.ts
+++ b/developer-extension/src/panel/backgroundScriptConnection.ts
@@ -48,17 +48,12 @@ export function listenSdkMessages(callback: (message: SdkMessage) => void) {
 function createBackgroundScriptConnection() {
   try {
     const backgroundScriptConnection = chrome.runtime.connect({
-      name: 'devtools-panel',
+      name: `devtools-panel-for-tab-${chrome.devtools.inspectedWindow.tabId}`,
     })
 
     backgroundScriptConnection.onDisconnect.addListener(() => {
       logger.error('disconnected', chrome.runtime.lastError)
       notifyDisconnectEvent()
-    })
-
-    backgroundScriptConnection.postMessage({
-      name: 'init',
-      tabId: chrome.devtools.inspectedWindow.tabId,
     })
 
     return backgroundScriptConnection

--- a/developer-extension/src/panel/components/settingsTab.tsx
+++ b/developer-extension/src/panel/components/settingsTab.tsx
@@ -123,7 +123,7 @@ export function SettingsTab({
                 {eventSource === 'sdk' && (
                   <>
                     Collect events by listening to messages sent from the SDK: events are available as soon as they
-                    happen. Only development versions of the SDK are supported.
+                    happen. Only newer versions of the SDK are supported.
                   </>
                 )}
               </>

--- a/developer-extension/src/panel/components/settingsTab.tsx
+++ b/developer-extension/src/panel/components/settingsTab.tsx
@@ -1,7 +1,8 @@
-import { Badge, Box, Button, Checkbox, Code, Group, Space, Text } from '@mantine/core'
+import { Badge, Box, Button, Checkbox, Code, Group, Select, Space, Text } from '@mantine/core'
 import React from 'react'
 import { createLogger } from '../../common/logger'
 import { evalInWindow } from '../evalInWindow'
+import type { EventSource } from '../types'
 import { Columns } from './columns'
 import { TabBase } from './tabBase'
 
@@ -13,10 +14,11 @@ export interface Settings {
   blockIntakeRequests: boolean
   autoFlush: boolean
   preserveEvents: boolean
+  eventSource: EventSource
 }
 
 export function SettingsTab({
-  settings: { useDevBundles, useRumSlim, blockIntakeRequests, preserveEvents, autoFlush },
+  settings: { useDevBundles, useRumSlim, blockIntakeRequests, preserveEvents, autoFlush, eventSource },
   setSettings,
   devServerStatus,
 }: {
@@ -92,6 +94,40 @@ export function SettingsTab({
               />
             }
             description={<>Don't clear events when reloading the page or navigating away.</>}
+          />
+
+          <SettingItem
+            input={
+              <Group>
+                <Text size="sm">Events source:</Text>
+                <Select
+                  data={[
+                    { label: 'Requests', value: 'requests' },
+                    { label: 'SDK', value: 'sdk' },
+                  ]}
+                  value={eventSource}
+                  onChange={(value) => setSettings({ eventSource: value as EventSource })}
+                  color="violet"
+                  sx={{ flex: 1 }}
+                />
+              </Group>
+            }
+            description={
+              <>
+                {eventSource === 'requests' && (
+                  <>
+                    Collect events by listening to intake HTTP requests: events need to be flushed to be collected. Any
+                    SDK setup is supported.
+                  </>
+                )}
+                {eventSource === 'sdk' && (
+                  <>
+                    Collect events by listening to messages sent from the SDK: events are available as soon as they
+                    happen. Only development versions of the SDK are supported.
+                  </>
+                )}
+              </>
+            }
           />
 
           <SettingItem

--- a/developer-extension/src/panel/components/settingsTab.tsx
+++ b/developer-extension/src/panel/components/settingsTab.tsx
@@ -1,8 +1,11 @@
 import { Badge, Box, Button, Checkbox, Code, Group, Space, Text } from '@mantine/core'
 import React from 'react'
+import { createLogger } from '../../common/logger'
 import { evalInWindow } from '../evalInWindow'
 import { Columns } from './columns'
 import { TabBase } from './tabBase'
+
+const logger = createLogger('settingsTab')
 
 export interface Settings {
   useDevBundles: boolean
@@ -137,5 +140,5 @@ function endSession() {
     `
       document.cookie = '_dd_s=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
     `
-  ).catch((error) => console.error('Error while ending session:', error))
+  ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/developer-extension/src/panel/disconnectEvent.ts
+++ b/developer-extension/src/panel/disconnectEvent.ts
@@ -1,0 +1,9 @@
+let listener: (() => void) | undefined
+
+export function listenDisconnectEvent(newListener: () => void) {
+  listener = newListener
+}
+
+export function notifyDisconnectEvent() {
+  if (listener) listener()
+}

--- a/developer-extension/src/panel/flushEvents.ts
+++ b/developer-extension/src/panel/flushEvents.ts
@@ -1,4 +1,7 @@
+import { createLogger } from '../common/logger'
 import { evalInWindow } from './evalInWindow'
+
+const logger = createLogger('flushEvents')
 
 export function flushEvents() {
   evalInWindow(
@@ -9,5 +12,5 @@ export function flushEvents() {
       Object.defineProperty(Document.prototype, 'visibilityState', descriptor)
       document.dispatchEvent(new Event('visibilitychange', { bubbles: true }))
     `
-  ).catch((error) => console.error('Error while flushing events:', error))
+  ).catch((error) => logger.error('Error while flushing events:', error))
 }

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react'
+import { createLogger } from '../../common/logger'
 import { evalInWindow } from '../evalInWindow'
+
+const logger = createLogger('useSdkInfos')
 
 const REFRESH_INFOS_INTERVAL = 2000
 
@@ -69,7 +72,7 @@ async function getInfos(): Promise<SdkInfos> {
       `
     )) as SdkInfos
   } catch (error) {
-    console.error('Error while getting SDK infos:', error)
+    logger.error('Error while getting SDK infos:', error)
   }
   return {}
 }

--- a/developer-extension/src/panel/panel.tsx
+++ b/developer-extension/src/panel/panel.tsx
@@ -17,15 +17,19 @@ const enum PanelTabs {
 
 export function Panel() {
   const [{ devServerStatus, ...settingsFromStore }, setStore] = useStore()
-  const [settingsFromMemory, setSettingsFromMemory] = useState<Pick<Settings, 'autoFlush' | 'preserveEvents'>>({
+  const [settingsFromMemory, setSettingsFromMemory] = useState<
+    Pick<Settings, 'autoFlush' | 'preserveEvents' | 'eventSource'>
+  >({
     preserveEvents: false,
     autoFlush: true,
+    eventSource: 'requests',
   })
 
   useAutoFlushEvents(settingsFromMemory.autoFlush)
-  const { events, filters, setFilters, clear } = useEvents(settingsFromMemory.preserveEvents)
 
   const settings: Settings = { ...settingsFromStore, ...settingsFromMemory }
+
+  const { events, filters, setFilters, clear } = useEvents(settings)
 
   return (
     <Tabs

--- a/developer-extension/src/panel/types.ts
+++ b/developer-extension/src/panel/types.ts
@@ -1,0 +1,1 @@
+export type EventSource = 'sdk' | 'requests'

--- a/developer-extension/tsconfig.json
+++ b/developer-extension/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "module": "ES6",
+    "target": "esnext",
     "jsx": "react",
     "lib": ["ES2019", "DOM"],
     "types": ["chrome", "react", "react-dom"]

--- a/developer-extension/webpack.config.js
+++ b/developer-extension/webpack.config.js
@@ -36,9 +36,15 @@ module.exports = (_env, argv) => {
       ],
     }),
     baseConfig({
-      entry: './src/content-script',
+      entry: './src/content-scripts/main.ts',
       output: {
-        filename: 'content-script.js',
+        filename: 'content-script-main.js',
+      },
+    }),
+    baseConfig({
+      entry: './src/content-scripts/isolated.ts',
+      output: {
+        filename: 'content-script-isolated.js',
       },
     }),
     baseConfig({

--- a/developer-extension/webpack.config.js
+++ b/developer-extension/webpack.config.js
@@ -36,6 +36,12 @@ module.exports = (_env, argv) => {
       ],
     }),
     baseConfig({
+      entry: './src/content-script',
+      output: {
+        filename: 'content-script.js',
+      },
+    }),
+    baseConfig({
       entry: './src/devtools',
       output: {
         filename: 'devtools.js',

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -9,6 +9,7 @@ import { computeStackTrace } from '../tracekit'
 import { Observable } from '../../tools/observable'
 import { timeStampNow } from '../../tools/timeUtils'
 import { displayIfDebugEnabled, startMonitorErrorCollection } from '../../tools/monitor'
+import { sendToExtension } from '../../tools/sendToExtension'
 import type { TelemetryEvent } from './telemetryEvent.types'
 import type { RawTelemetryConfiguration, RawTelemetryEvent } from './rawTelemetryEvent.types'
 import { StatusType, TelemetryType } from './rawTelemetryEvent.types'
@@ -52,9 +53,11 @@ export function startTelemetry(telemetryService: TelemetryService, configuration
   telemetryConfiguration.telemetryConfigurationEnabled =
     telemetryConfiguration.telemetryEnabled && performDraw(configuration.telemetryConfigurationSampleRate)
 
-  onRawTelemetryEventCollected = (event: RawTelemetryEvent) => {
+  onRawTelemetryEventCollected = (rawEvent: RawTelemetryEvent) => {
     if (!includes(TELEMETRY_EXCLUDED_SITES, configuration.site) && telemetryConfiguration.telemetryEnabled) {
-      observable.notify(toTelemetryEvent(telemetryService, event))
+      const event = toTelemetryEvent(telemetryService, rawEvent)
+      observable.notify(event)
+      sendToExtension('telemetry', event)
     }
   }
   startMonitorErrorCollection(addTelemetryError)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export * from './tools/timeUtils'
 export * from './tools/utils'
 export * from './tools/createEventRateLimiter'
 export * from './tools/browserDetection'
+export { sendToExtension } from './tools/sendToExtension'
 export { instrumentMethod, instrumentMethodAndCallOriginal, instrumentSetter } from './tools/instrumentMethod'
 export {
   ErrorSource,

--- a/packages/core/src/tools/sendToExtension.ts
+++ b/packages/core/src/tools/sendToExtension.ts
@@ -1,14 +1,12 @@
-declare const __BUILD_ENV__SDK_VERSION__: string
+interface BrowserWindow {
+  __ddBrowserSdkExtensionCallback?: (message: unknown) => void
+}
 
 type ExtensionMessageType = 'logs' | 'record' | 'rum' | 'telemetry'
 
 export function sendToExtension(type: ExtensionMessageType, payload: unknown) {
-  // Only allow this for dev bundles for now, as it might impact performances?
-  if (__BUILD_ENV__SDK_VERSION__ === 'dev') {
-    window.dispatchEvent(
-      new CustomEvent('__ddBrowserSdkMessage', {
-        detail: { type, payload },
-      })
-    )
+  const callback = (window as BrowserWindow).__ddBrowserSdkExtensionCallback
+  if (callback) {
+    callback({ type, payload })
   }
 }

--- a/packages/core/src/tools/sendToExtension.ts
+++ b/packages/core/src/tools/sendToExtension.ts
@@ -1,0 +1,14 @@
+declare const __BUILD_ENV__SDK_VERSION__: string
+
+type ExtensionMessageType = 'logs' | 'record' | 'rum' | 'telemetry'
+
+export function sendToExtension(type: ExtensionMessageType, payload: unknown) {
+  // Only allow this for dev bundles for now, as it might impact performances?
+  if (__BUILD_ENV__SDK_VERSION__ === 'dev') {
+    window.dispatchEvent(
+      new CustomEvent('__ddBrowserSdkMessage', {
+        detail: { type, payload },
+      })
+    )
+  }
+}

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -2,7 +2,7 @@ import type { BuildEnvWindow } from './specHelper'
 import { clearAllCookies } from './specHelper'
 
 beforeEach(() => {
-  ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'dev'
+  ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'test'
   // reset globals
   ;(window as any).DD_LOGS = {}
   ;(window as any).DD_RUM = {}

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -44,7 +44,7 @@ describe('logs entry', () => {
 
   it('should provide sdk version', () => {
     const LOGS = makeLogsPublicApi(startLogs)
-    expect(LOGS.version).toBe('dev')
+    expect(LOGS.version).toBe('test')
   })
 
   describe('configuration validation', () => {

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -1,5 +1,6 @@
 import type { Context, TelemetryEvent, RawError, Observable, PageExitEvent } from '@datadog/browser-core'
 import {
+  sendToExtension,
   createPageExitObservable,
   TelemetryService,
   willSyntheticsInjectRum,
@@ -36,6 +37,8 @@ export function startLogs(
   mainLogger: Logger
 ) {
   const lifeCycle = new LifeCycle()
+
+  lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (log) => sendToExtension('logs', log))
 
   const reportError = (error: RawError) =>
     lifeCycle.notify<RawAgentLogsEvent>(LifeCycleEventType.RAW_LOG_COLLECTED, {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -874,6 +874,6 @@ describe('rum public api', () => {
 
   it('should provide sdk version', () => {
     const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-    expect(rumPublicApi.version).toBe('dev')
+    expect(rumPublicApi.version).toBe('test')
   })
 })

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -1,5 +1,6 @@
 import type { Observable, TelemetryEvent, RawError } from '@datadog/browser-core'
 import {
+  sendToExtension,
   createPageExitObservable,
   TelemetryService,
   addTelemetryConfiguration,
@@ -41,6 +42,8 @@ export function startRum(
   initialViewOptions?: ViewOptions
 ) {
   const lifeCycle = new LifeCycle()
+
+  lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event) => sendToExtension('rum', event))
 
   const telemetry = startRumTelemetry(configuration)
   telemetry.setContextProvider(() => ({

--- a/packages/rum/src/domain/segmentCollection/segment.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.ts
@@ -1,4 +1,4 @@
-import { addTelemetryDebug, assign, monitor } from '@datadog/browser-core'
+import { addTelemetryDebug, assign, monitor, sendToExtension } from '@datadog/browser-core'
 import type { BrowserRecord, BrowserSegmentMetadata, CreationReason, SegmentContext } from '../../types'
 import { RecordType } from '../../types'
 import * as replayStats from '../replayStats'
@@ -68,6 +68,7 @@ export class Segment {
       }
     })
     worker.addEventListener('message', listener)
+    sendToExtension('record', { record: initialRecord, segment: this.metadata })
     this.worker.postMessage({ data: `{"records":[${JSON.stringify(initialRecord)}`, id: this.id, action: 'write' })
   }
 
@@ -77,6 +78,7 @@ export class Segment {
     this.metadata.records_count += 1
     replayStats.addRecord(this.metadata.view.id)
     this.metadata.has_full_snapshot ||= record.type === RecordType.FullSnapshot
+    sendToExtension('record', { record, segment: this.metadata })
     this.worker.postMessage({ data: `,${JSON.stringify(record)}`, id: this.id, action: 'write' })
   }
 


### PR DESCRIPTION
## Motivation

Make the SDK send its data to the extension as soon as it happens. This will allow the extension to list events as soon as they happen, and integrate with sessior replay data.

## Changes

* The SDK now notify the extension every time some data is collected. To make sure it does not have any impact in production, this is only done in dev bundles. We could change that in the future.
* Improve logging and communication error handling in the extension
* Forward messages from the SDK up to the devtools panel
* Finally, implement the setting to display events directly from the SDK

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
