### PR TITLE
👷Fix staging reset

### DIFF
--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -31,15 +31,14 @@ async function main() {
   }
 
   const doesStagingExist = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${NEW_STAGING_BRANCH}`)
-  if (!doesStagingExist) {
-    printLog('Creating the new staging branch...')
-    await executeCommand(`git checkout -b ${NEW_STAGING_BRANCH}`)
-    await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)
-  } else {
-    printLog('New staging branch already exists, updating...')
-    await executeCommand(`git branch -f ${NEW_STAGING_BRANCH}`)
-    await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)
+  if (doesStagingExist) {
+    printLog('New staging branch already exists, deleting...')
+    await executeCommand(`git branch -d ${NEW_STAGING_BRANCH}`)
+    await executeCommand(`git push origin --delete ${NEW_STAGING_BRANCH}`)
   }
+  printLog('Creating the new staging branch...')
+  await executeCommand(`git checkout -b ${NEW_STAGING_BRANCH}`)
+  await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)
 
   await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH}`)
   await executeCommand('git pull')

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -30,8 +30,8 @@ async function main() {
     printLog(`Staging branch already up to date in ${CI_FILE}. Skipping.`)
   }
 
-  const isStagingAlreadyExists = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${NEW_STAGING_BRANCH}`)
-  if (!isStagingAlreadyExists) {
+  const doesStagingExist = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${NEW_STAGING_BRANCH}`)
+  if (!doesStagingExist) {
     printLog('Creating the new staging branch...')
     await executeCommand(`git checkout -b ${NEW_STAGING_BRANCH}`)
     await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -30,13 +30,15 @@ async function main() {
     printLog(`Staging branch already up to date in ${CI_FILE}. Skipping.`)
   }
 
-  const isStagingAlreadyCreated = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${NEW_STAGING_BRANCH}`)
-  if (!isStagingAlreadyCreated) {
+  const isStagingAlreadyExists = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${NEW_STAGING_BRANCH}`)
+  if (!isStagingAlreadyExists) {
     printLog('Creating the new staging branch...')
     await executeCommand(`git checkout -b ${NEW_STAGING_BRANCH}`)
     await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)
   } else {
-    printLog('New staging branch already created. Skipping.')
+    printLog('New staging branch already exists, updating...')
+    await executeCommand(`git branch -f ${NEW_STAGING_BRANCH}`)
+    await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)
   }
 
   await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH}`)


### PR DESCRIPTION
## Motivation

During staging reset, if the staging branch already exists, it is not updated and all subsequent `merge-into-staging` checks are failing. 

## Changes

Delete staging branch if it already exists and create a fresh one.

## Testing

None, we'll see how it will go next week.

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
