### PR TITLE
👷 fix publish-npm job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,6 +269,7 @@ publish-npm:
   when: manual
   allow_failure: false
   script:
+    - yarn
     - ./scripts/publish-npm.sh
 
 ########################################################################################################################


### PR DESCRIPTION

## Motivation

The publish-npm job is only using the cache and does not install yarn dependencies itself. Because the cache is shared among all other job, it can be updated with other dependency versions in the meantime, and causing the publish-npm job to use the wrong versions.



## Changes


This commit fixes the issue by running `yarn`, ensuring the right dependencies are installed before running the publish-npm script.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
