### PR TITLE
🔊 Collect computed and perf entry durations

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -1,5 +1,12 @@
 import type { Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
-import { relativeToClocks, isIE, RequestType, ResourceType } from '@datadog/browser-core'
+import {
+  relativeToClocks,
+  resetExperimentalFeatures,
+  updateExperimentalFeatures,
+  isIE,
+  RequestType,
+  ResourceType,
+} from '@datadog/browser-core'
 import { createResourceEntry } from '../../../../test/fixtures'
 import type { TestSetupBuilder } from '../../../../test/specHelper'
 import { setup } from '../../../../test/specHelper'
@@ -26,6 +33,7 @@ describe('resourceCollection', () => {
   })
 
   afterEach(() => {
+    resetExperimentalFeatures()
     setupBuilder.cleanup()
   })
 
@@ -75,7 +83,7 @@ describe('resourceCollection', () => {
     )
 
     expect(rawRumEvents[0].startTime).toBe(1234 as RelativeTime)
-    expect(rawRumEvents[0].rawRumEvent as any).toEqual({
+    expect(rawRumEvents[0].rawRumEvent).toEqual({
       date: jasmine.any(Number),
       resource: {
         id: jasmine.any(String),
@@ -91,8 +99,6 @@ describe('resourceCollection', () => {
         resolveDuration: undefined,
         durationDiff: undefined,
         durationPercentageDiff: undefined,
-        computed_duration: 100000000,
-        performance_entry_duration: undefined,
       },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
@@ -106,6 +112,8 @@ describe('resourceCollection', () => {
   })
 
   it('should collect computed duration and performance entry duration when resource_durations ff is enabled', () => {
+    updateExperimentalFeatures(['resource_durations'])
+
     const match = createResourceEntry({ startTime: 200 as RelativeTime, duration: 300 as Duration })
     spyOn(performance, 'getEntriesByName').and.returnValues([match] as unknown as PerformanceResourceTiming[])
 
@@ -155,8 +163,7 @@ describe('resourceCollection', () => {
     )
 
     expect(rawRumEvents[0].startTime).toBe(1234 as RelativeTime)
-
-    expect(rawRumEvents[0].rawRumEvent as any).toEqual({
+    expect(rawRumEvents[0].rawRumEvent).toEqual({
       date: jasmine.any(Number),
       resource: {
         id: jasmine.any(String),
@@ -172,8 +179,6 @@ describe('resourceCollection', () => {
         resolveDuration: (50 * 1e6) as ServerDuration,
         durationDiff: (50 * 1e6) as ServerDuration,
         durationPercentageDiff: 50,
-        computed_duration: 100000000,
-        performance_entry_duration: undefined,
       },
     })
     expect(rawRumEvents[0].domainContext).toEqual({

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -68,13 +68,15 @@ function processRequest(
 
   const responseDurationInfo = computeResponseDurationInfo(request)
 
+  const duration = toServerDuration(request.duration)
+
   const resourceEvent = combine(
     {
       date: startClocks.timeStamp,
       resource: {
         id: generateUUID(),
         type,
-        duration: toServerDuration(request.duration),
+        duration,
         method: request.method,
         status_code: request.status,
         url: request.url,
@@ -84,7 +86,15 @@ function processRequest(
     tracingInfo,
     correspondingTimingOverrides,
     indexingInfo,
-    responseDurationInfo
+    responseDurationInfo,
+    {
+      _dd: {
+        computed_duration: duration,
+        performance_entry_duration: correspondingTimingOverrides
+          ? correspondingTimingOverrides.resource.duration
+          : undefined,
+      },
+    }
   )
   return {
     startTime: startClocks.relative,

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -70,6 +70,16 @@ function processRequest(
   const responseDurationInfo = computeResponseDurationInfo(request)
 
   const duration = toServerDuration(request.duration)
+  const computedAndEntryDurations = isExperimentalFeatureEnabled('resource_durations')
+    ? {
+        _dd: {
+          computed_duration: duration,
+          performance_entry_duration: correspondingTimingOverrides
+            ? correspondingTimingOverrides.resource.duration
+            : undefined,
+        },
+      }
+    : undefined
 
   const resourceEvent = combine(
     {
@@ -88,16 +98,7 @@ function processRequest(
     correspondingTimingOverrides,
     indexingInfo,
     responseDurationInfo,
-    isExperimentalFeatureEnabled('resource_durations')
-      ? {
-          _dd: {
-            computed_duration: duration,
-            performance_entry_duration: correspondingTimingOverrides
-              ? correspondingTimingOverrides.resource.duration
-              : undefined,
-          },
-        }
-      : undefined
+    computedAndEntryDurations
   )
   return {
     startTime: startClocks.relative,

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -7,6 +7,7 @@ import {
   relativeToClocks,
   assign,
   isNumber,
+  isExperimentalFeatureEnabled,
 } from '@datadog/browser-core'
 import type { ClocksState, Duration } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
@@ -87,14 +88,16 @@ function processRequest(
     correspondingTimingOverrides,
     indexingInfo,
     responseDurationInfo,
-    {
-      _dd: {
-        computed_duration: duration,
-        performance_entry_duration: correspondingTimingOverrides
-          ? correspondingTimingOverrides.resource.duration
-          : undefined,
-      },
-    }
+    isExperimentalFeatureEnabled('resource_durations')
+      ? {
+          _dd: {
+            computed_duration: duration,
+            performance_entry_duration: correspondingTimingOverrides
+              ? correspondingTimingOverrides.resource.duration
+              : undefined,
+          },
+        }
+      : undefined
   )
   return {
     startTime: startClocks.relative,


### PR DESCRIPTION
## Motivation

In the context of the investigation of resources with  long durations, I want to assess the performance entry durations correctness.
To do it, I want to colllect xhr and fetch computed durations and corresponding performance entry durations to identify:

- happens when we got a the duration from performance entry, computed duration or both
- compare entry duration with computed duration that could highlight an issue from the browser

## Changes

Adds `resource._dd.computed_duration` and `resource._dd.entry_performance_duration`
Under feature flag resource_durations

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
