### PR TITLE
✨Allow internal analytics intake

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -43,6 +43,8 @@ export interface InitConfiguration {
   enableExperimentalFeatures?: string[] | undefined
   replica?: ReplicaUserConfiguration | undefined
   datacenter?: string
+  internalAnalyticsSubdomain?: string
+
   telemetryConfigurationSampleRate?: number
 }
 

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -29,11 +29,9 @@ export function createEndpointBuilder(
   endpointType: EndpointType,
   configurationTags: string[]
 ) {
-  const { site = INTAKE_SITE_US1, clientToken } = initConfiguration
+  const { clientToken } = initConfiguration
 
-  const domainParts = site.split('.')
-  const extension = domainParts.pop()
-  const host = `${ENDPOINTS[endpointType]}.browser-intake-${domainParts.join('-')}.${extension!}`
+  const host = buildEndpointHost(initConfiguration, endpointType)
   const baseUrl = `https://${host}/api/v2/${INTAKE_TRACKS[endpointType]}`
   const proxyUrl = initConfiguration.proxyUrl && normalizeUrl(initConfiguration.proxyUrl)
 
@@ -63,4 +61,16 @@ export function createEndpointBuilder(
     },
     endpointType,
   }
+}
+
+function buildEndpointHost(initConfiguration: InitConfiguration, endpointType: EndpointType) {
+  const { site = INTAKE_SITE_US1, internalAnalyticsSubdomain } = initConfiguration
+
+  if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {
+    return `${internalAnalyticsSubdomain}.${INTAKE_SITE_US1}`
+  }
+
+  const domainParts = site.split('.')
+  const extension = domainParts.pop()
+  return `${ENDPOINTS[endpointType]}.browser-intake-${domainParts.join('-')}.${extension!}`
 }


### PR DESCRIPTION
## Motivation

To mitigate ad blockers for internal analytics monitored sites, we can now configure a specific subdomain.

## Changes

Add new init config option `internalAnalyticsSubdomain`
Only allow internal analytics intake for traffic going to `datadoghq.com` (including replica)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
