### PR TITLE
🐛 [RUMF-1449] fix Zone support when __symbol__ is missing

### DIFF
--- a/packages/core/src/tools/getZoneJsOriginalValue.spec.ts
+++ b/packages/core/src/tools/getZoneJsOriginalValue.spec.ts
@@ -1,5 +1,6 @@
 import { stubZoneJs } from '../../test/stubZoneJs'
 
+import type { BrowserWindowWithZoneJs } from './getZoneJsOriginalValue'
 import { getZoneJsOriginalValue } from './getZoneJsOriginalValue'
 import { noop } from './utils'
 
@@ -22,8 +23,14 @@ describe('getZoneJsOriginalValue', () => {
     expect(getZoneJsOriginalValue(object, 'name')).toBe(originalValue)
   })
 
-  it("returns undefined if Zone is defined but didn't patch that method", () => {
+  it("returns the original value if Zone is defined but didn't patch that method", () => {
     zoneJsStub = stubZoneJs()
+    expect(getZoneJsOriginalValue(object, 'name')).toBe(originalValue)
+  })
+
+  it('returns the original value if Zone is defined but does not define the __symbol__ function', () => {
+    zoneJsStub = stubZoneJs()
+    delete (window as BrowserWindowWithZoneJs).Zone!.__symbol__
     expect(getZoneJsOriginalValue(object, 'name')).toBe(originalValue)
   })
 

--- a/packages/core/src/tools/getZoneJsOriginalValue.ts
+++ b/packages/core/src/tools/getZoneJsOriginalValue.ts
@@ -1,6 +1,9 @@
 export interface BrowserWindowWithZoneJs extends Window {
   Zone?: {
-    __symbol__: (name: string) => string
+    // All Zone.js versions expose the __symbol__ method, but we observed that some website have a
+    // 'Zone' global variable unrelated to Zone.js, so let's consider this method optional
+    // nonetheless.
+    __symbol__?: (name: string) => string
   }
 }
 
@@ -23,7 +26,7 @@ export function getZoneJsOriginalValue<Target, Name extends keyof Target & strin
 ): Target[Name] {
   const browserWindow = window as BrowserWindowWithZoneJs
   let original: Target[Name] | undefined
-  if (browserWindow.Zone) {
+  if (browserWindow.Zone && typeof browserWindow.Zone.__symbol__ === 'function') {
     original = (target as any)[browserWindow.Zone.__symbol__(name)]
   }
   if (!original) {


### PR DESCRIPTION
## Motivation

We observed that some website define a `Zone` global variable unrelated to Zone.js, and this variable doesn't have a `__symbol__` method, so it crashes the SDK.

Related: https://github.com/angular/zone.js/issues/434

## Changes

Check for the `__symbol__` method before using it.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
