### PR TITLE
🐛[RUMF-1435] don't retry opaque response

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -40,6 +40,7 @@ export function createEndpointBuilder(
       const tags = [`sdk_version:${__BUILD_ENV__SDK_VERSION__}`, `api:${api}`].concat(configurationTags)
       if (retry) {
         tags.push(`retry_count:${retry.count}`, `retry_after:${retry.lastFailureStatus}`)
+        retry.lastFailureType && tags.push(`retry_after_type:${retry.lastFailureType}`)
       }
       let parameters =
         'ddsource=browser' +

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -105,14 +105,14 @@ describe('httpRequest', () => {
         pending('no fetch keepalive support')
       }
 
-      interceptor.withFetch(() => Promise.resolve({ status: 429 }))
+      interceptor.withFetch(() => Promise.resolve({ status: 429, type: 'cors' }))
 
       fetchKeepAliveStrategy(
         endpointBuilder,
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 },
         (response) => {
-          expect(response).toEqual({ status: 429 })
+          expect(response).toEqual({ status: 429, type: 'cors' })
           done()
         }
       )

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -30,6 +30,7 @@ export interface Payload {
 export interface RetryInfo {
   count: number
   lastFailureStatus: number
+  lastFailureType?: ResponseType
 }
 
 export function createHttpRequest(

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -18,6 +18,7 @@ export type HttpRequest = ReturnType<typeof createHttpRequest>
 
 export interface HttpResponse extends Context {
   status: number
+  type?: ResponseType
 }
 
 export interface Payload {
@@ -92,7 +93,7 @@ export function fetchKeepAliveStrategy(
   if (canUseKeepAlive) {
     const fetchUrl = endpointBuilder.build('fetch', retry)
     fetch(fetchUrl, { method: 'POST', body: data, keepalive: true, mode: 'cors' }).then(
-      monitor((response: Response) => onResponse?.({ status: response.status })),
+      monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })),
       monitor(() => {
         const xhrUrl = endpointBuilder.build('xhr', retry)
         // failed to queue the request

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -91,7 +91,7 @@ export function fetchKeepAliveStrategy(
   const canUseKeepAlive = isKeepAliveSupported() && bytesCount < bytesLimit
   if (canUseKeepAlive) {
     const fetchUrl = endpointBuilder.build('fetch', retry)
-    fetch(fetchUrl, { method: 'POST', body: data, keepalive: true }).then(
+    fetch(fetchUrl, { method: 'POST', body: data, keepalive: true, mode: 'cors' }).then(
       monitor((response: Response) => onResponse?.({ status: response.status })),
       monitor(() => {
         const xhrUrl = endpointBuilder.build('xhr', retry)

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -190,50 +190,59 @@ describe('sendWithRetryStrategy', () => {
     })
   })
   ;[
-    { description: 'when the intake returns error:', status: 500 },
-    { description: 'when the intake returns too many request:', status: 429 },
-    { description: 'when the intake returns request timeout:', status: 408 },
-    { description: 'when network is down:', status: 0 },
-  ].forEach(({ description, status }) => {
+    { expectRetry: true, description: 'when the intake returns error:', status: 500 },
+    { expectRetry: true, description: 'when the intake returns too many request:', status: 429 },
+    { expectRetry: true, description: 'when the intake returns request timeout:', status: 408 },
+    { expectRetry: true, description: 'when network error:', status: 0, type: undefined },
+    { expectRetry: false, description: 'when the intake returns opaque response:', status: 0, type: 'opaque' as const },
+  ].forEach(({ expectRetry, description, status, type }) => {
     describe(description, () => {
-      it('should start queueing following requests', () => {
-        sendRequest()
-        sendStub.respondWith(0, { status })
-        expect(state.queuedPayloads.size()).toBe(1)
+      if (expectRetry) {
+        it('should start queueing following requests', () => {
+          sendRequest()
+          sendStub.respondWith(0, { status, type })
+          expect(state.queuedPayloads.size()).toBe(1)
 
-        sendRequest()
-        expect(state.queuedPayloads.size()).toBe(2)
-        sendRequest()
-        expect(state.queuedPayloads.size()).toBe(3)
-      })
+          sendRequest()
+          expect(state.queuedPayloads.size()).toBe(2)
+          sendRequest()
+          expect(state.queuedPayloads.size()).toBe(3)
+        })
 
-      it('should send queued requests if another ongoing request succeed', () => {
-        sendRequest()
-        sendRequest()
-        sendStub.respondWith(0, { status })
-        expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
-        expect(state.queuedPayloads.size()).toBe(1)
+        it('should send queued requests if another ongoing request succeed', () => {
+          sendRequest()
+          sendRequest()
+          sendStub.respondWith(0, { status, type })
+          expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+          expect(state.queuedPayloads.size()).toBe(1)
 
-        sendRequest()
-        expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
-        expect(state.queuedPayloads.size()).toBe(2)
+          sendRequest()
+          expect(state.bandwidthMonitor.ongoingRequestCount).toBe(1)
+          expect(state.queuedPayloads.size()).toBe(2)
 
-        sendStub.respondWith(1, { status: 200 })
-        expect(state.bandwidthMonitor.ongoingRequestCount).toBe(2)
-        expect(state.queuedPayloads.size()).toBe(0)
-      })
+          sendStub.respondWith(1, { status: 200 })
+          expect(state.bandwidthMonitor.ongoingRequestCount).toBe(2)
+          expect(state.queuedPayloads.size()).toBe(0)
+        })
 
-      it('should add retry info to payloads', () => {
-        sendRequest()
+        it('should add retry info to payloads', () => {
+          sendRequest()
 
-        sendStub.respondWith(0, { status })
-        expect(state.queuedPayloads.first().retry).toEqual({ count: 1, lastFailureStatus: status })
+          sendStub.respondWith(0, { status, type })
+          expect(state.queuedPayloads.first().retry).toEqual({ count: 1, lastFailureStatus: status })
 
-        clock.tick(INITIAL_BACKOFF_TIME)
+          clock.tick(INITIAL_BACKOFF_TIME)
 
-        sendStub.respondWith(1, { status })
-        expect(state.queuedPayloads.first().retry).toEqual({ count: 2, lastFailureStatus: status })
-      })
+          sendStub.respondWith(1, { status, type })
+          expect(state.queuedPayloads.first().retry).toEqual({ count: 2, lastFailureStatus: status })
+        })
+      } else {
+        it('should not queue the payload for retry', () => {
+          sendRequest()
+          sendStub.respondWith(0, { status, type })
+          expect(state.queuedPayloads.size()).toBe(0)
+        })
+      }
     })
   })
 

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -194,6 +194,7 @@ describe('sendWithRetryStrategy', () => {
     { expectRetry: true, description: 'when the intake returns too many request:', status: 429 },
     { expectRetry: true, description: 'when the intake returns request timeout:', status: 408 },
     { expectRetry: true, description: 'when network error:', status: 0, type: undefined },
+    { expectRetry: true, description: 'when network error with response type:', status: 0, type: 'cors' as const },
     { expectRetry: false, description: 'when the intake returns opaque response:', status: 0, type: 'opaque' as const },
   ].forEach(({ expectRetry, description, status, type }) => {
     describe(description, () => {
@@ -229,12 +230,20 @@ describe('sendWithRetryStrategy', () => {
           sendRequest()
 
           sendStub.respondWith(0, { status, type })
-          expect(state.queuedPayloads.first().retry).toEqual({ count: 1, lastFailureStatus: status })
+          expect(state.queuedPayloads.first().retry).toEqual({
+            count: 1,
+            lastFailureStatus: status,
+            lastFailureType: type,
+          })
 
           clock.tick(INITIAL_BACKOFF_TIME)
 
           sendStub.respondWith(1, { status, type })
-          expect(state.queuedPayloads.first().retry).toEqual({ count: 2, lastFailureStatus: status })
+          expect(state.queuedPayloads.first().retry).toEqual({
+            count: 2,
+            lastFailureStatus: status,
+            lastFailureType: type,
+          })
         })
       } else {
         it('should not queue the payload for retry', () => {

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -135,7 +135,7 @@ function retryQueuedPayloads(
 
 function shouldRetryRequest(response: HttpResponse) {
   return (
-    response?.type !== 'opaque' &&
+    response.type !== 'opaque' &&
     (response.status === 0 || response.status === 408 || response.status === 429 || response.status >= 500)
   )
 }

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -104,6 +104,7 @@ function send(
       payload.retry = {
         count: payload.retry ? payload.retry.count + 1 : 1,
         lastFailureStatus: response.status,
+        lastFailureType: response.type,
       }
       onFailure()
     }

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -133,7 +133,10 @@ function retryQueuedPayloads(
 }
 
 function shouldRetryRequest(response: HttpResponse) {
-  return response.status === 0 || response.status === 408 || response.status === 429 || response.status >= 500
+  return (
+    response?.type !== 'opaque' &&
+    (response.status === 0 || response.status === 408 || response.status === 429 || response.status >= 500)
+  )
 }
 
 export function newRetryState(): RetryState {


### PR DESCRIPTION
## Motivation

If the browser somehow consider the intake response as [opaque](https://fetch.spec.whatwg.org/#concept-filtered-response-opaque), we won't be able to access its true status and may wrongly retry it.

## Changes

- do not retry opaque response
- force [request mode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) 'cors'
- add extra debug tag with response type

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
