### PR TITLE
⚗️ [RUMF-1345] log first 3 untrusted events

### DIFF
--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -79,14 +79,10 @@ export function addEventListeners<E extends Event>(
   { once, capture, passive }: AddEventListenerOptions = {}
 ) {
   const wrappedListener = monitor(
-    listenerWithTelemetry(
-      once
-        ? (event: Event) => {
-            stop()
-            listener(event as E)
-          }
-        : (listener as (event: Event) => void)
-    )
+    listenerWithTelemetry((event: Event) => {
+      if (once) stop()
+      listener(event as E)
+    })
   )
 
   const options = passive ? { capture, passive } : capture

--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -1,5 +1,6 @@
 import { monitor } from '../tools/monitor'
 import { getZoneJsOriginalValue } from '../tools/getZoneJsOriginalValue'
+import { listenerWithTelemetry } from '../tools/listenerWithTelemetry'
 
 export const enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
@@ -78,12 +79,14 @@ export function addEventListeners<E extends Event>(
   { once, capture, passive }: AddEventListenerOptions = {}
 ) {
   const wrappedListener = monitor(
-    once
-      ? (event: Event) => {
-          stop()
-          listener(event as E)
-        }
-      : (listener as (event: Event) => void)
+    listenerWithTelemetry(
+      once
+        ? (event: Event) => {
+            stop()
+            listener(event as E)
+          }
+        : (listener as (event: Event) => void)
+    )
   )
 
   const options = passive ? { capture, passive } : capture

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export * from './tools/utils'
 export * from './tools/createEventRateLimiter'
 export * from './tools/browserDetection'
 export { sendToExtension } from './tools/sendToExtension'
+export { runOnReadyState } from './tools/runOnReadyState'
 export { getZoneJsOriginalValue } from './tools/getZoneJsOriginalValue'
 export { instrumentMethod, instrumentMethodAndCallOriginal, instrumentSetter } from './tools/instrumentMethod'
 export {

--- a/packages/core/src/tools/listenerWithTelemetry.spec.ts
+++ b/packages/core/src/tools/listenerWithTelemetry.spec.ts
@@ -1,0 +1,69 @@
+import { updateExperimentalFeatures, resetExperimentalFeatures } from '../domain/configuration'
+import { listenerWithTelemetry } from './listenerWithTelemetry'
+import type { Context } from './context'
+import { noop } from './utils'
+
+describe('listenerWithTelemetry', () => {
+  let stubEvent
+  let fooSpy: jasmine.Spy
+  let telemetryCallbackSpy: jasmine.Spy
+  let func: {
+    foo: () => void
+    telemetryCallback: (message: string, context?: Context | undefined) => void
+  }
+
+  beforeEach(() => {
+    updateExperimentalFeatures(['log_untrusted_events'])
+    func = {
+      foo: noop,
+      telemetryCallback: (_message: string, _context?: Context | undefined) => {
+        // do nothing
+      },
+    }
+    fooSpy = spyOn(func, 'foo')
+    telemetryCallbackSpy = spyOn(func, 'telemetryCallback')
+  })
+
+  afterEach(() => {
+    resetExperimentalFeatures()
+    fooSpy.calls.reset()
+    telemetryCallbackSpy.calls.reset()
+  })
+
+  it('should normally call callback if untrusted event', () => {
+    stubEvent = { isTrusted: false } as Event
+    listenerWithTelemetry(func.foo, 0)(stubEvent)
+    expect(func.foo).toHaveBeenCalled()
+  })
+
+  it('should normally call callback if trusted event', () => {
+    stubEvent = { isTrusted: true } as Event
+    listenerWithTelemetry(func.foo, 0)(stubEvent)
+    expect(func.foo).toHaveBeenCalled()
+  })
+
+  it('should only send telemetry if event is not trusted', () => {
+    stubEvent = { type: 'someType', isTrusted: false } as Event
+    listenerWithTelemetry(func.foo, 0, func.telemetryCallback)(stubEvent)
+    expect(func.telemetryCallback).toHaveBeenCalledWith('Untrusted event', {
+      eventType: stubEvent.type,
+    })
+  })
+
+  it('should only send telemetry if counter less than 3', () => {
+    stubEvent = { type: 'someType', isTrusted: false } as Event
+    listenerWithTelemetry(func.foo, 3, func.telemetryCallback)(stubEvent)
+    expect(func.telemetryCallback).not.toHaveBeenCalled()
+    listenerWithTelemetry(func.foo, 2, func.telemetryCallback)(stubEvent)
+    expect(func.telemetryCallback).toHaveBeenCalledWith('Untrusted event', {
+      eventType: stubEvent.type,
+    })
+  })
+
+  it('should only send telemetry if flag enabled', () => {
+    resetExperimentalFeatures()
+    stubEvent = { type: 'someType', isTrusted: false } as Event
+    listenerWithTelemetry(func.foo, 0, func.telemetryCallback)(stubEvent)
+    expect(func.telemetryCallback).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/tools/listenerWithTelemetry.ts
+++ b/packages/core/src/tools/listenerWithTelemetry.ts
@@ -1,0 +1,15 @@
+import { addTelemetryDebug } from '../domain/telemetry'
+import { isExperimentalFeatureEnabled } from '../domain/configuration'
+
+let untrustedEventsCounter = 0
+export const listenerWithTelemetry =
+  (fn: (e: Event) => void, counter = untrustedEventsCounter, telemetryCallback = addTelemetryDebug) =>
+  (e: Event) => {
+    if (isExperimentalFeatureEnabled('log_untrusted_events') && counter < 3 && !e.isTrusted) {
+      telemetryCallback('Untrusted event', {
+        eventType: e.type,
+      })
+      untrustedEventsCounter++
+    }
+    fn(e)
+  }

--- a/packages/core/src/tools/listenerWithTelemetry.ts
+++ b/packages/core/src/tools/listenerWithTelemetry.ts
@@ -5,7 +5,12 @@ let untrustedEventsCounter = 0
 export const listenerWithTelemetry =
   (fn: (e: Event) => void, counter = untrustedEventsCounter, telemetryCallback = addTelemetryDebug) =>
   (e: Event) => {
-    if (isExperimentalFeatureEnabled('log_untrusted_events') && counter < 3 && !e.isTrusted) {
+    if (
+      isExperimentalFeatureEnabled('log_untrusted_events') &&
+      !isLegitimateUseCase(event) &&
+      counter < 3 &&
+      !e.isTrusted
+    ) {
       telemetryCallback('Untrusted event', {
         eventType: e.type,
       })
@@ -13,3 +18,22 @@ export const listenerWithTelemetry =
     }
     fn(e)
   }
+
+interface BrowserWindow {
+  DD_ENV?: string
+  jasmine?: any
+}
+
+// TODO: ignore "pointerdown" events from on mobile-SDK
+// https://github.com/DataDog/dd-sdk-android/blob/6c6af82decf319fb812071be25c0dd776b4c234b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt#L107
+const isLegitimateUseCase = (event?: Event) => {
+  const browserWindow = window as BrowserWindow
+  if (
+    (event && event.type === 'beforeunload') || // we recommend to use 'beforeunload' to flush events
+    browserWindow?.DD_ENV === 'test' || // running e2e test
+    (browserWindow && !browserWindow?.jasmine) // running unit test
+  ) {
+    return true
+  }
+  return false
+}

--- a/packages/core/src/tools/runOnReadyState.ts
+++ b/packages/core/src/tools/runOnReadyState.ts
@@ -1,0 +1,10 @@
+import { DOM_EVENT, addEventListener } from '../browser/addEventListener'
+
+export function runOnReadyState(expectedReadyState: 'complete' | 'interactive', callback: () => void) {
+  if (document.readyState === expectedReadyState || document.readyState === 'complete') {
+    callback()
+  } else {
+    const eventName = expectedReadyState === 'complete' ? DOM_EVENT.LOAD : DOM_EVENT.DOM_CONTENT_LOADED
+    addEventListener(window, eventName, callback, { once: true })
+  }
+}

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -1,4 +1,3 @@
-import { DOM_EVENT, addEventListener } from '../browser/addEventListener'
 import { display } from './display'
 import { monitor } from './monitor'
 
@@ -334,15 +333,6 @@ export function elementMatches(element: Element & { msMatchesSelector?(selector:
     return element.msMatchesSelector(selector)
   }
   return false
-}
-
-export function runOnReadyState(expectedReadyState: 'complete' | 'interactive', callback: () => void) {
-  if (document.readyState === expectedReadyState || document.readyState === 'complete') {
-    callback()
-  } else {
-    const eventName = expectedReadyState === 'complete' ? DOM_EVENT.LOAD : DOM_EVENT.DOM_CONTENT_LOADED
-    addEventListener(window, eventName, callback, { once: true })
-  }
 }
 
 /**

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -77,6 +77,10 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
     `
   }
 
+  body += html`<script>
+    window.DD_ENV = 'test'
+  </script>`
+
   return basePage({
     body,
     header,


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
We want to better understand what type of [untrusted events](https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted) are being recorded.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
- create `listenerWithTelemetry` to wrap listener function
- only log telemetry when `log_untrusted_events` flag enabled
- only log first 3 instances of `isTrusted` events
- lift `runOnReadyState` out of utils to avoid circular dependency

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
