### PR TITLE
👷 [RUMF-1287] don't update rum-events-format on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "performances"
   ],
   "scripts": {
-    "postinstall": "scripts/cli update_submodule",
+    "postinstall": "scripts/cli init_submodule",
     "build": "lerna run build --stream",
     "build:bundle": "lerna run build:bundle --stream",
     "format": "prettier --check .",

--- a/scripts/cli
+++ b/scripts/cli
@@ -31,6 +31,10 @@ cmd_lint () {
   eslint "$project_path"
 }
 
+cmd_init_submodule () {
+  git submodule update --init
+}
+
 cmd_update_submodule () {
   git submodule update --init
   git submodule update --remote


### PR DESCRIPTION


## Motivation

This is problematic because rum-events-format can change at any time independently of the Browser SDK repository, and it can make the CI fail when running various unit and e2e tests jobs or when publishing to NPM.

## Changes

Don't update the submodule, just initialize it during `postinstall`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
