### PR TITLE
👷  add a CI job to do some checks before the release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,6 +186,14 @@ check-licenses:
     - yarn
     - node --no-warnings scripts/check-licenses.js
 
+check-release:
+  extends:
+    - .base-configuration
+    - .tags
+  script:
+    - yarn
+    - node scripts/check-release.js
+
 unit-bs:
   stage: browserstack
   extends:

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -3,12 +3,12 @@
 const fs = require('fs')
 const path = require('path')
 const readline = require('readline')
-const { findPackages, printLog, printError, logAndExit } = require('./utils')
+const { printLog, printError, logAndExit, generateMetadataForAllNodePackages } = require('./utils')
 
 const LICENSE_FILE = 'LICENSE-3rdparty.csv'
 
 async function main() {
-  const packages = await findPackages()
+  const packages = await generateMetadataForAllNodePackages()
 
   printLog(
     'Looking for dependencies in:\n',

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -3,15 +3,19 @@
 const fs = require('fs')
 const path = require('path')
 const readline = require('readline')
-const { executeCommand, printLog, printError, logAndExit } = require('./utils')
+const { findPackages, printLog, printError, logAndExit } = require('./utils')
 
 const LICENSE_FILE = 'LICENSE-3rdparty.csv'
 
 async function main() {
-  const packageJsonPaths = await findPackageJsonPaths()
+  const packages = await findPackages()
 
-  printLog('Looking for dependencies in:\n', packageJsonPaths, '\n')
-  const declaredDependencies = withoutDuplicates(packageJsonPaths.flatMap(retrievePackageJsonDependencies)).sort()
+  printLog(
+    'Looking for dependencies in:\n',
+    packages.map((pkg) => pkg.relativePath),
+    '\n'
+  )
+  const declaredDependencies = withoutDuplicates(packages.flatMap(retrievePackageDependencies)).sort()
 
   const declaredLicenses = (await retrieveLicenses()).sort()
 
@@ -30,16 +34,9 @@ async function main() {
   printLog('Dependencies check done.')
 }
 
-async function findPackageJsonPaths() {
-  const paths = await executeCommand('find . -path "*/node_modules/*" -prune -o -name "package.json" -print')
-  return paths.trim().split('\n')
-}
-
-function retrievePackageJsonDependencies(packageJsonPath) {
-  const packageJson = require(path.join(__dirname, '..', packageJsonPath))
-
-  return Object.keys(packageJson.dependencies || {})
-    .concat(Object.keys(packageJson.devDependencies || {}))
+function retrievePackageDependencies(pkg) {
+  return Object.keys(pkg.manifest.dependencies || {})
+    .concat(Object.keys(pkg.manifest.devDependencies || {}))
     .filter((dependency) => !dependency.includes('@datadog'))
 }
 

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -3,19 +3,19 @@
 const fs = require('fs')
 const path = require('path')
 const readline = require('readline')
-const { printLog, printError, logAndExit, generateMetadataForAllNodePackages } = require('./utils')
+const { printLog, printError, logAndExit, findBrowserSdkPackageJsonFiles } = require('./utils')
 
 const LICENSE_FILE = 'LICENSE-3rdparty.csv'
 
 async function main() {
-  const packages = await generateMetadataForAllNodePackages()
+  const packageJsonFiles = await findBrowserSdkPackageJsonFiles()
 
   printLog(
     'Looking for dependencies in:\n',
-    packages.map((pkg) => pkg.relativePath),
+    packageJsonFiles.map((packageJsonFile) => packageJsonFile.relativePath),
     '\n'
   )
-  const declaredDependencies = withoutDuplicates(packages.flatMap(retrievePackageDependencies)).sort()
+  const declaredDependencies = withoutDuplicates(packageJsonFiles.flatMap(retrievePackageDependencies)).sort()
 
   const declaredLicenses = (await retrieveLicenses()).sort()
 
@@ -34,9 +34,9 @@ async function main() {
   printLog('Dependencies check done.')
 }
 
-function retrievePackageDependencies(pkg) {
-  return Object.keys(pkg.manifest.dependencies || {})
-    .concat(Object.keys(pkg.manifest.devDependencies || {}))
+function retrievePackageDependencies(packageJsonFile) {
+  return Object.keys(packageJsonFile.content.dependencies || {})
+    .concat(Object.keys(packageJsonFile.content.devDependencies || {}))
     .filter((dependency) => !dependency.includes('@datadog'))
 }
 

--- a/scripts/check-release.js
+++ b/scripts/check-release.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { version: releaseVersion } = require('../lerna.json')
+const { findPackages, printLog, logAndExit, executeCommand } = require('./utils')
+
+async function main() {
+  await checkGitTag()
+  await checkPackages()
+
+  printLog('Release check done.')
+}
+
+async function checkGitTag() {
+  printLog('Checking git tag')
+  const headRef = await executeCommand('git rev-parse HEAD')
+  let tagRef
+  try {
+    tagRef = await executeCommand(`git rev-list -n 1 v${releaseVersion} --`)
+  } catch (error) {
+    throw new Error(`Failed to find git tag reference: ${error}`)
+  }
+  if (tagRef !== headRef) {
+    throw new Error('Git tag not on HEAD')
+  }
+}
+
+async function checkPackages() {
+  const packages = await findPackages()
+
+  printLog(
+    `Checking packages:
+   - ${packages.map((pkg) => pkg.relativePath).join('\n   - ')}
+`
+  )
+
+  for (const pkg of packages) {
+    checkPackage(pkg)
+  }
+}
+
+function checkPackage(pkg) {
+  if (isBrowserSdkPackageName(pkg.manifest.name) && pkg.manifest.version !== releaseVersion) {
+    throw new Error(`Invalid version for ${pkg.relativePath}: expected ${releaseVersion}, got ${pkg.manifest.version}`)
+  }
+  checkPackageDependencyVersions(pkg)
+  checkPackageEntryPoints(pkg)
+}
+
+function checkPackageDependencyVersions(pkg) {
+  for (const dependencies of [pkg.manifest.dependencies, pkg.manifest.devDependencies, pkg.manifest.peerDependencies]) {
+    if (!dependencies) {
+      continue
+    }
+
+    for (const [dependencyName, dependencyVersion] of Object.entries(dependencies)) {
+      if (
+        isBrowserSdkPackageName(dependencyName) &&
+        !dependencyVersion.startsWith('file:') &&
+        dependencyVersion !== releaseVersion
+      ) {
+        throw new Error(
+          `Invalid dependency version for ${dependencyName} in ${pkg.relativePath}: expected ${releaseVersion}, got ${dependencyVersion}`
+        )
+      }
+    }
+  }
+}
+
+function checkPackageEntryPoints(pkg) {
+  for (const entryPointPath of [pkg.manifest.main, pkg.manifest.module, pkg.manifest.types]) {
+    if (!entryPointPath) {
+      continue
+    }
+
+    const absoluteEntryPointPath = path.resolve(pkg.path, entryPointPath)
+    if (!fs.existsSync(absoluteEntryPointPath)) {
+      throw new Error(
+        `Invalid entry point ${entryPointPath} in ${pkg.relativePath}: ${absoluteEntryPointPath} not found`
+      )
+    }
+  }
+}
+
+function isBrowserSdkPackageName(name) {
+  return name?.startsWith('@datadog/')
+}
+
+main().catch(logAndExit)

--- a/scripts/check-release.js
+++ b/scripts/check-release.js
@@ -36,11 +36,13 @@ async function checkBrowserSdkPackageJsonFiles() {
   )
 
   for (const packageJsonFile of packageJsonFiles) {
-    checkPackageJsonFile(packageJsonFile)
+    checkPackageJsonVersion(packageJsonFile)
+    checkPackageDependencyVersions(packageJsonFile)
+    checkPackageJsonEntryPoints(packageJsonFile)
   }
 }
 
-function checkPackageJsonFile(packageJsonFile) {
+function checkPackageJsonVersion(packageJsonFile) {
   if (
     isBrowserSdkPublicPackageName(packageJsonFile.content.name) &&
     packageJsonFile.content.version !== releaseVersion
@@ -49,8 +51,6 @@ function checkPackageJsonFile(packageJsonFile) {
       `Invalid version for ${packageJsonFile.relativePath}: expected ${releaseVersion}, got ${packageJsonFile.content.version}`
     )
   }
-  checkPackageDependencyVersions(packageJsonFile)
-  checkPackageJsonEntryPoints(packageJsonFile)
 }
 
 function checkPackageDependencyVersions(packageJsonFile) {

--- a/scripts/check-release.js
+++ b/scripts/check-release.js
@@ -6,7 +6,7 @@ const { version: releaseVersion } = require('../lerna.json')
 const { findBrowserSdkPackageJsonFiles, printLog, logAndExit, executeCommand } = require('./utils')
 
 async function main() {
-  // await checkGitTag()
+  await checkGitTag()
   await checkBrowserSdkPackageJsonFiles()
 
   printLog('Release check done.')

--- a/scripts/check-release.js
+++ b/scripts/check-release.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const { version: releaseVersion } = require('../lerna.json')
-const { findPackages, printLog, logAndExit, executeCommand } = require('./utils')
+const { generateMetadataForAllNodePackages, printLog, logAndExit, executeCommand } = require('./utils')
 
 async function main() {
   await checkGitTag()
@@ -27,7 +27,7 @@ async function checkGitTag() {
 }
 
 async function checkPackages() {
-  const packages = await findPackages()
+  const packages = await generateMetadataForAllNodePackages()
 
   printLog(
     `Checking packages:

--- a/scripts/check-release.js
+++ b/scripts/check-release.js
@@ -13,7 +13,7 @@ async function main() {
 }
 
 async function checkGitTag() {
-  printLog('Checking git tag')
+  printLog('Checking release version tag is on HEAD')
   const headRef = await executeCommand('git rev-parse HEAD')
   let tagRef
   try {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -104,7 +104,7 @@ async function fetchWrapper(url, options) {
   return response.text()
 }
 
-async function findPackages() {
+async function generateMetadataForAllNodePackages() {
   const manifestPaths = await executeCommand('git ls-files --recurse-submodules -- "package.json" "*/package.json"')
   return manifestPaths
     .trim()
@@ -131,5 +131,5 @@ module.exports = {
   replaceCiVariable,
   fetch: fetchWrapper,
   modifyFile,
-  findPackages,
+  generateMetadataForAllNodePackages,
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -105,7 +105,7 @@ async function fetchWrapper(url, options) {
 }
 
 async function findBrowserSdkPackageJsonFiles() {
-  const manifestPaths = await executeCommand('git ls-files --recurse-submodules -- "package.json" "*/package.json"')
+  const manifestPaths = await executeCommand('git ls-files -- "package.json" "*/package.json"')
   return manifestPaths
     .trim()
     .split('\n')

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,4 +1,5 @@
 const util = require('util')
+const path = require('path')
 const fs = require('fs/promises')
 const execute = util.promisify(require('child_process').exec)
 const spawn = require('child_process').spawn
@@ -103,6 +104,21 @@ async function fetchWrapper(url, options) {
   return response.text()
 }
 
+async function findPackages() {
+  const manifestPaths = await executeCommand('git ls-files --recurse-submodules -- "package.json" "*/package.json"')
+  return manifestPaths
+    .trim()
+    .split('\n')
+    .map((manifestPath) => {
+      const absoluteManifestPath = path.join(__dirname, '..', manifestPath)
+      return {
+        relativePath: path.dirname(manifestPath),
+        path: path.dirname(absoluteManifestPath),
+        manifest: require(absoluteManifestPath),
+      }
+    })
+}
+
 module.exports = {
   CI_FILE,
   getSecretKey,
@@ -115,4 +131,5 @@ module.exports = {
   replaceCiVariable,
   fetch: fetchWrapper,
   modifyFile,
+  findPackages,
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -104,7 +104,7 @@ async function fetchWrapper(url, options) {
   return response.text()
 }
 
-async function generateMetadataForAllNodePackages() {
+async function findBrowserSdkPackageJsonFiles() {
   const manifestPaths = await executeCommand('git ls-files --recurse-submodules -- "package.json" "*/package.json"')
   return manifestPaths
     .trim()
@@ -112,9 +112,9 @@ async function generateMetadataForAllNodePackages() {
     .map((manifestPath) => {
       const absoluteManifestPath = path.join(__dirname, '..', manifestPath)
       return {
-        relativePath: path.dirname(manifestPath),
-        path: path.dirname(absoluteManifestPath),
-        manifest: require(absoluteManifestPath),
+        relativePath: manifestPath,
+        path: absoluteManifestPath,
+        content: require(absoluteManifestPath),
       }
     })
 }
@@ -131,5 +131,5 @@ module.exports = {
   replaceCiVariable,
   fetch: fetchWrapper,
   modifyFile,
-  generateMetadataForAllNodePackages,
+  findBrowserSdkPackageJsonFiles,
 }


### PR DESCRIPTION
## Motivation

Prevents https://github.com/DataDog/browser-sdk/issues/1881
## Changes

Add a CI job to do some checks before doing a release. It checks that:
* the version tag matches the lerna version
* the git HEAD and the version tag are pointing to the same commit
* package.json files have the correct version in their `version` field and their prod/dev/peer dependencies
* packages entry points are pointing to existing files

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
