### PR TITLE
🐛 [RUMF-1435] do not retry status 0 request while online

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -40,7 +40,6 @@ export function createEndpointBuilder(
       const tags = [`sdk_version:${__BUILD_ENV__SDK_VERSION__}`, `api:${api}`].concat(configurationTags)
       if (retry) {
         tags.push(`retry_count:${retry.count}`, `retry_after:${retry.lastFailureStatus}`)
-        retry.lastFailureType && tags.push(`retry_after_type:${retry.lastFailureType}`)
       }
       let parameters =
         'ddsource=browser' +

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -30,7 +30,6 @@ export interface Payload {
 export interface RetryInfo {
   count: number
   lastFailureStatus: number
-  lastFailureType?: ResponseType
 }
 
 export function createHttpRequest(

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -230,20 +230,12 @@ describe('sendWithRetryStrategy', () => {
           sendRequest()
 
           sendStub.respondWith(0, { status, type })
-          expect(state.queuedPayloads.first().retry).toEqual({
-            count: 1,
-            lastFailureStatus: status,
-            lastFailureType: type,
-          })
+          expect(state.queuedPayloads.first().retry).toEqual({ count: 1, lastFailureStatus: status })
 
           clock.tick(INITIAL_BACKOFF_TIME)
 
           sendStub.respondWith(1, { status, type })
-          expect(state.queuedPayloads.first().retry).toEqual({
-            count: 2,
-            lastFailureStatus: status,
-            lastFailureType: type,
-          })
+          expect(state.queuedPayloads.first().retry).toEqual({ count: 2, lastFailureStatus: status })
         })
       } else {
         it('should not queue the payload for retry', () => {

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -1,4 +1,4 @@
-import { mockClock } from '../../test/specHelper'
+import { mockClock, restoreNavigatorOnLine, setNavigatorOnLine } from '../../test/specHelper'
 import type { Clock } from '../../test/specHelper'
 import { ErrorSource } from '../tools/error'
 import type { RetryState } from './sendWithRetryStrategy'
@@ -193,11 +193,19 @@ describe('sendWithRetryStrategy', () => {
     { expectRetry: true, description: 'when the intake returns error:', status: 500 },
     { expectRetry: true, description: 'when the intake returns too many request:', status: 429 },
     { expectRetry: true, description: 'when the intake returns request timeout:', status: 408 },
-    { expectRetry: true, description: 'when network error:', status: 0, type: undefined },
-    { expectRetry: true, description: 'when network error with response type:', status: 0, type: 'cors' as const },
+    { expectRetry: true, description: 'when network error while offline:', status: 0, offLine: true },
+    { expectRetry: false, description: 'when network error while online:', status: 0 },
     { expectRetry: false, description: 'when the intake returns opaque response:', status: 0, type: 'opaque' as const },
-  ].forEach(({ expectRetry, description, status, type }) => {
+  ].forEach(({ expectRetry, description, status, type, offLine }) => {
     describe(description, () => {
+      beforeEach(() => {
+        setNavigatorOnLine(!offLine)
+      })
+
+      afterEach(() => {
+        restoreNavigatorOnLine()
+      })
+
       if (expectRetry) {
         it('should start queueing following requests', () => {
           sendRequest()

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -104,7 +104,6 @@ function send(
       payload.retry = {
         count: payload.retry ? payload.retry.count + 1 : 1,
         lastFailureStatus: response.status,
-        lastFailureType: response.type,
       }
       onFailure()
     }

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -135,7 +135,10 @@ function retryQueuedPayloads(
 function shouldRetryRequest(response: HttpResponse) {
   return (
     response.type !== 'opaque' &&
-    (response.status === 0 || response.status === 408 || response.status === 429 || response.status >= 500)
+    ((response.status === 0 && !navigator.onLine) ||
+      response.status === 408 ||
+      response.status === 429 ||
+      response.status >= 500)
   )
 }
 

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -378,6 +378,19 @@ export function restorePageVisibility() {
   delete (document as any).visibilityState
 }
 
+export function setNavigatorOnLine(onLine: boolean) {
+  Object.defineProperty(navigator, 'onLine', {
+    get() {
+      return onLine
+    },
+    configurable: true,
+  })
+}
+
+export function restoreNavigatorOnLine() {
+  delete (navigator as any).onLine
+}
+
 export function initEventBridgeStub(allowedWebViewHosts: string[] = [window.location.hostname]) {
   const eventBridgeStub = {
     send: (msg: string) => undefined,


### PR DESCRIPTION
## Motivation

Some intake requests are retried due to response status 0 while the data still reach datadog. 

## Changes

- Retry request when status is 0 only when offline
- Remove `retry_after_type` debug tag

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
