### PR TITLE
🔊 add view document_count in non-view events

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -28,6 +28,7 @@ describe('rum assembly', () => {
     findView = () => ({
       id: '7890',
       name: 'view name',
+      documentVersion: 42,
     })
     reportErrorSpy = jasmine.createSpy('reportError')
     commonContext = {
@@ -453,6 +454,20 @@ describe('rum assembly', () => {
         })
       )
     })
+
+    it('should include the view document version in non-view events', () => {
+      const { lifeCycle } = setupBuilder.build()
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
+      })
+      expect(serverRumEvents[0]._dd).toEqual(
+        jasmine.objectContaining({
+          view: {
+            document_version: 42,
+          },
+        })
+      )
+    })
   })
 
   describe('service and version', () => {
@@ -472,7 +487,7 @@ describe('rum assembly', () => {
 
     it('should be overridden by the view context', () => {
       const { lifeCycle } = setupBuilder.build()
-      findView = () => ({ service: 'new service', version: 'new version', id: '1234' })
+      findView = () => ({ service: 'new service', version: 'new version', id: '1234', documentVersion: 0 })
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,5 +1,11 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import { ErrorSource, ONE_MINUTE, display } from '@datadog/browser-core'
+import {
+  updateExperimentalFeatures,
+  resetExperimentalFeatures,
+  ErrorSource,
+  ONE_MINUTE,
+  display,
+} from '@datadog/browser-core'
 import { createRumSessionManagerMock } from '../../test/mockRumSessionManager'
 import { createRawRumEvent } from '../../test/fixtures'
 import type { TestSetupBuilder } from '../../test/specHelper'
@@ -442,6 +448,10 @@ describe('rum assembly', () => {
   })
 
   describe('view context', () => {
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
+
     it('should be merged with event attributes', () => {
       const { lifeCycle } = setupBuilder.build()
       notifyRawRumEvent(lifeCycle, {
@@ -455,15 +465,18 @@ describe('rum assembly', () => {
       )
     })
 
-    it('should include the view document version in non-view events', () => {
+    it('should include the view document version in global context', () => {
+      updateExperimentalFeatures(['report_view_document_version'])
       const { lifeCycle } = setupBuilder.build()
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
       })
-      expect(serverRumEvents[0]._dd).toEqual(
+      expect(serverRumEvents[0].context).toEqual(
         jasmine.objectContaining({
-          view: {
-            document_version: 42,
+          _dd: {
+            view: {
+              document_version: 42,
+            },
           },
         })
       )

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -104,6 +104,12 @@ export function startRumAssembly(
             session: {
               plan: session.plan,
             },
+            view:
+              rawRumEvent.type === RumEventType.VIEW
+                ? undefined
+                : {
+                    document_version: viewContext.documentVersion,
+                  },
             browser_sdk_version: canUseEventBridge() ? __BUILD_ENV__SDK_VERSION__ : undefined,
           },
           application: {

--- a/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
@@ -3,7 +3,7 @@ import { relativeToClocks, CLEAR_OLD_CONTEXTS_INTERVAL } from '@datadog/browser-
 import type { TestSetupBuilder } from '../../../test/specHelper'
 import { setup } from '../../../test/specHelper'
 import { LifeCycleEventType } from '../lifeCycle'
-import type { ViewCreatedEvent } from '../rumEventsCollection/view/trackViews'
+import type { ViewCreatedEvent, ViewEvent } from '../rumEventsCollection/view/trackViews'
 import type { ViewContexts } from './viewContexts'
 import { startViewContexts, VIEW_CONTEXT_TIME_OUT_DELAY } from './viewContexts'
 
@@ -108,6 +108,23 @@ describe('viewContexts', () => {
 
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ name: 'Fake name' }))
       expect(viewContexts.findView()!.name).toBe('Fake name')
+    })
+
+    it('should update the document version on update', () => {
+      const { lifeCycle } = setupBuilder.build()
+
+      const startClocks = relativeToClocks(0 as RelativeTime)
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startClocks }))
+
+      expect(viewContexts.findView()!.documentVersion).toBe(0)
+
+      lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, {
+        startClocks,
+        documentVersion: 1,
+      } as ViewEvent)
+
+      expect(viewContexts.findView()!.documentVersion).toBe(1)
     })
   })
 

--- a/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
@@ -15,6 +15,7 @@ describe('viewContexts', () => {
     return {
       startClocks,
       id: FAKE_ID,
+      documentVersion: 0,
       ...partialViewCreatedEvent,
     }
   }

--- a/packages/rum-core/src/domain/contexts/viewContexts.ts
+++ b/packages/rum-core/src/domain/contexts/viewContexts.ts
@@ -47,7 +47,7 @@ export function startViewContexts(lifeCycle: LifeCycle): ViewContexts {
       version: view.version,
       id: view.id,
       name: view.name,
-      documentVersion: 0,
+      documentVersion: view.documentVersion,
     }
   }
 

--- a/packages/rum-core/src/domain/contexts/viewContexts.ts
+++ b/packages/rum-core/src/domain/contexts/viewContexts.ts
@@ -10,6 +10,7 @@ export interface ViewContext {
   service?: string
   version?: string
   id: string
+  documentVersion: number
   name?: string
 }
 
@@ -23,6 +24,13 @@ export function startViewContexts(lifeCycle: LifeCycle): ViewContexts {
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
     viewContextHistory.add(buildViewContext(view), view.startClocks.relative)
+  })
+
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, ({ startClocks, documentVersion }) => {
+    const viewContext = viewContextHistory.find(startClocks.relative)
+    if (viewContext) {
+      viewContext.documentVersion = documentVersion
+    }
   })
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, ({ endClocks }) => {
@@ -39,6 +47,7 @@ export function startViewContexts(lifeCycle: LifeCycle): ViewContexts {
       version: view.version,
       id: view.id,
       name: view.name,
+      documentVersion: 0,
     }
   }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -52,6 +52,7 @@ export interface ViewCreatedEvent {
   service?: string
   version?: string
   startClocks: ClocksState
+  documentVersion: number
 }
 
 export interface ViewEndedEvent {
@@ -212,6 +213,7 @@ function newView(
     startClocks,
     service,
     version,
+    documentVersion,
   })
 
   // Update the view every time the measures are changing

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -240,6 +240,9 @@ export interface RumContext {
     session: {
       plan: RumSessionPlan
     }
+    view?: {
+      document_version: number
+    }
     browser_sdk_version?: string
   }
 }

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -49,7 +49,7 @@ describe('startRecording', () => {
       setupBuilder = setup()
         .withViewContexts({
           findView() {
-            return { id: viewId }
+            return { id: viewId, documentVersion: 0 }
           },
         })
         .withSessionManager(sessionManager)

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -265,7 +265,7 @@ describe('startSegmentCollection', () => {
 })
 
 describe('computeSegmentContext', () => {
-  const DEFAULT_VIEW_CONTEXT: ViewContext = { id: '123' }
+  const DEFAULT_VIEW_CONTEXT: ViewContext = { id: '123', documentVersion: 0 }
   const DEFAULT_SESSION = createRumSessionManagerMock().setId('456')
 
   it('returns a segment context', () => {


### PR DESCRIPTION

## Motivation

Help investigate why view event counts are often incorrect.

## Changes

Add `_dd.view.document_count` reflecting the current view document count at the moment when the event is collected. In theory, the final `_dd.document_count` on View events will alway be greater than child events `_dd.view.document_count`, because any child event collected will trigger a scheduled view update. Let's verify that.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
