### PR TITLE
Fix `getInitConfiguration()` behaviour

### DIFF
--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -68,6 +68,11 @@ describe('logs entry', () => {
       expect(startLogs).not.toHaveBeenCalled()
     })
 
+    it("should return init configuration even if it's invalid", () => {
+      LOGS.init(INVALID_INIT_CONFIGURATION)
+      expect(LOGS.getInitConfiguration()).toEqual(INVALID_INIT_CONFIGURATION)
+    })
+
     it('should add a `_setDebug` that works', () => {
       const setDebug: (debug: boolean) => void = (LOGS as any)._setDebug
       expect(!!setDebug).toEqual(true)

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -69,6 +69,9 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
     logger: mainLogger,
 
     init: monitor((initConfiguration: LogsInitConfiguration) => {
+      // This function should be available, regardless of initialization success.
+      getInitConfigurationStrategy = () => deepClone(initConfiguration)
+
       if (canUseEventBridge()) {
         initConfiguration = overrideInitConfigurationForBridge(initConfiguration)
       }
@@ -89,7 +92,6 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
         mainLogger
       ))
 
-      getInitConfigurationStrategy = () => deepClone(initConfiguration)
       beforeInitLoggerLog.drain()
 
       isAlreadyInitialized = true

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -178,9 +178,14 @@ describe('rum public api', () => {
 
   describe('getInitConfiguration', () => {
     let rumPublicApi: RumPublicApi
+    let initConfiguration: RumInitConfiguration
 
     beforeEach(() => {
       rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
+      initConfiguration = { ...DEFAULT_INIT_CONFIGURATION, service: 'my-service', version: '1.4.2', env: 'dev' }
+    })
+    afterEach(() => {
+      cleanupSyntheticsWorkerValues()
     })
 
     it('returns undefined before init', () => {
@@ -188,7 +193,18 @@ describe('rum public api', () => {
     })
 
     it('returns the user configuration after init', () => {
-      const initConfiguration = { ...DEFAULT_INIT_CONFIGURATION, service: 'my-service', version: '1.4.2', env: 'dev' }
+      rumPublicApi.init(initConfiguration)
+
+      expect(rumPublicApi.getInitConfiguration()).toEqual(initConfiguration)
+      expect(rumPublicApi.getInitConfiguration()).not.toBe(initConfiguration)
+    })
+
+    it('returns the user configuration even if skipInitIfSyntheticsWillInjectRum is true', () => {
+      mockSyntheticsWorkerValues({ injectsRum: true })
+
+      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi, {
+        ignoreInitIfSyntheticsWillInjectRum: true,
+      })
       rumPublicApi.init(initConfiguration)
 
       expect(rumPublicApi.getInitConfiguration()).toEqual(initConfiguration)

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -95,6 +95,9 @@ export function makeRumPublicApi(
   }
 
   function initRum(initConfiguration: RumInitConfiguration) {
+    // This function should be available, regardless of initialization success.
+    getInitConfigurationStrategy = () => deepClone<InitConfiguration>(initConfiguration)
+
     // If we are in a Synthetics test configured to automatically inject a RUM instance, we want to
     // completely discard the customer application RUM instance by ignoring their init() call.  But,
     // we should not ignore the init() call from the Synthetics-injected RUM instance, so the
@@ -138,7 +141,6 @@ export function makeRumPublicApi(
       }
       beforeInitCalls.drain()
     }
-    getInitConfigurationStrategy = () => deepClone<InitConfiguration>(initConfiguration)
 
     isAlreadyInitialized = true
   }


### PR DESCRIPTION
## Motivation
Context: Synthetics Profiler doesn't tag profiles with correct service tag

I need `DD_RUM.getInitConfiguration()` to return init configuration even if it's inside synthetic test. Currently, when I call `DD_RUM.getInitConfiguration()` inside synthetic test, it returns undefined, because `initRum()` function is interrupted by:
```typescript
    if (ignoreInitIfSyntheticsWillInjectRum && willSyntheticsInjectRum()) {
      return
    }
```
which prevents from this code to be executed:
```typescript
    getInitConfigurationStrategy = () => deepClone<InitConfiguration>(initConfiguration)
```

This breaks profile tagging, as we can't infer service name (and because of that, we can't resolve source maps)

I think that `getInitConfiguration()` should return init configuration even if init process was not successful (as this function is not called `getValidInitConfiguration()` or `getInitConfigurationIfInitWasSuccessful()`)

## Changes
Update RUM and Logs API - `getInitConfiguration()` will return init configuration regardless of init process outcome.

## Testing
- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
