### PR TITLE
👷 Avoid renovate PRs to be listed in change log

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "group:allNonMajor"
   ],
   "labels": ["dependencies"],
+  "commitMessagePrefix": "\uD83D\uDC77 ",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
   "schedule": ["every weekend"]


### PR DESCRIPTION
## Motivation

Avoid renovate PRs to be listed in change log

## Changes

Add 👷 prefix to renovate PRs

## Testing

generate an update PR after merge

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
