### PR TITLE
👷 Renovate: exclude same deps as dependabot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,15 @@
   "commitMessagePrefix": "\uD83D\uDC77 ",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
-  "schedule": ["every weekend"]
+  "schedule": ["every weekend"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["puppeteer", "@types/node", "@types/express", "ajv", "ansi-regex"],
+      "enabled": false
+    },
+    {
+      "matchPackagePatterns": ["jasmine", "sinon", "webpack"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Motivation

Try to ease https://github.com/DataDog/browser-sdk/pull/1901

## Changes

Exclude same dependencies that were listed in dependabot.yml and would require more effort to update.

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
