### PR TITLE
👷 renovate: remove group:allNonMajor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,7 @@
     ":ignoreModulesAndTests",
     ":autodetectPinVersions",
     "group:monorepos",
-    "group:recommended",
-    "group:allNonMajor"
+    "group:recommended"
   ],
   "labels": ["dependencies"],
   "commitMessagePrefix": "\uD83D\uDC77 ",


### PR DESCRIPTION
## Motivation

Single PR for all non major is a bit complicated for now, let's see if we can move more progressively with the backlog and re-enable it when we will be on a better state.

## Changes

remove group:allNonMajor option

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
