### PR TITLE
🔊 [RUMF-1345] add telemetry logs on untrusted events

### DIFF
--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -192,8 +192,12 @@ function isAllowedCallExpression({ callee }) {
  */
 function isAllowedNewExpression({ callee }) {
   switch (callee.name) {
-    case 'WeakMap': // Allow "new WeakMap()"
-    case 'RegExp': // Allow "new RegExp()"
+    // Allow some native constructors
+    case 'RegExp':
+    case 'WeakMap':
+    case 'WeakSet':
+    case 'Set':
+    case 'Map':
       return true
 
     default:

--- a/packages/core/src/browser/addEventListener.spec.ts
+++ b/packages/core/src/browser/addEventListener.spec.ts
@@ -1,9 +1,57 @@
+import { createNewEvent } from '../../test/specHelper'
 import { stubZoneJs } from '../../test/stubZoneJs'
+import type { RawTelemetryEvent } from '../domain/telemetry'
+import { resetTelemetry, startFakeTelemetry } from '../domain/telemetry'
 import { noop } from '../tools/utils'
 
-import { addEventListener, DOM_EVENT } from './addEventListener'
+import { addEventListener, DOM_EVENT, resetUntrustedEventsCount } from './addEventListener'
 
 describe('addEventListener', () => {
+  describe('untrusted events reporting', () => {
+    let originalJasmine: typeof jasmine
+    let telemetryEvents: RawTelemetryEvent[]
+    let eventTarget: EventTarget
+
+    beforeEach(() => {
+      eventTarget = document.createElement('div')
+      originalJasmine = window.jasmine
+      delete (window as any).jasmine
+      telemetryEvents = startFakeTelemetry()
+    })
+
+    afterEach(() => {
+      window.jasmine = originalJasmine
+      resetTelemetry()
+      resetUntrustedEventsCount()
+    })
+
+    it('sends a telemetry debug log when an untrusted event is dispatched', () => {
+      addEventListener(eventTarget, DOM_EVENT.CLICK, noop)
+      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+
+      expect(telemetryEvents).toEqual([
+        {
+          message: 'Untrusted event',
+          status: 'debug',
+          type: 'log',
+          event_type: 'click',
+        },
+      ])
+    })
+
+    it('only reports the first untrusted event of each type', () => {
+      addEventListener(eventTarget, DOM_EVENT.CLICK, noop)
+      addEventListener(eventTarget, DOM_EVENT.MOUSE_UP, noop)
+
+      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+
+      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.MOUSE_UP))
+
+      expect(telemetryEvents.length).toBe(2)
+    })
+  })
+
   describe('Zone.js support', () => {
     let zoneJsStub: ReturnType<typeof stubZoneJs>
 

--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -99,27 +99,19 @@ export function addEventListeners<E extends Event>(
   }
 }
 
-let untrustedEventsReported: Set<string> | undefined
+const reportedUntrustedEventTypes = new Set<string>()
 
 function reportUntrustedEvent(event: Event) {
-  if (event.isTrusted || (window as any).jasmine) {
-    return
-  }
-
-  if (!untrustedEventsReported) {
-    untrustedEventsReported = new Set()
-  }
-
   const eventType = event.type
 
-  if (untrustedEventsReported.has(eventType)) {
+  if (event.isTrusted || (window as any).jasmine || reportedUntrustedEventTypes.has(eventType)) {
     return
   }
 
-  untrustedEventsReported.add(eventType)
+  reportedUntrustedEventTypes.add(eventType)
   addTelemetryDebug('Untrusted event', { event_type: eventType })
 }
 
 export function resetUntrustedEventsCount() {
-  untrustedEventsReported = undefined
+  reportedUntrustedEventTypes.clear()
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export * from './tools/utils'
 export * from './tools/createEventRateLimiter'
 export * from './tools/browserDetection'
 export { sendToExtension } from './tools/sendToExtension'
+export { runOnReadyState } from './tools/runOnReadyState'
 export { getZoneJsOriginalValue } from './tools/getZoneJsOriginalValue'
 export { instrumentMethod, instrumentMethodAndCallOriginal, instrumentSetter } from './tools/instrumentMethod'
 export {

--- a/packages/core/src/tools/runOnReadyState.ts
+++ b/packages/core/src/tools/runOnReadyState.ts
@@ -1,0 +1,10 @@
+import { DOM_EVENT, addEventListener } from '../browser/addEventListener'
+
+export function runOnReadyState(expectedReadyState: 'complete' | 'interactive', callback: () => void) {
+  if (document.readyState === expectedReadyState || document.readyState === 'complete') {
+    callback()
+  } else {
+    const eventName = expectedReadyState === 'complete' ? DOM_EVENT.LOAD : DOM_EVENT.DOM_CONTENT_LOADED
+    addEventListener(window, eventName, callback, { once: true })
+  }
+}

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -1,4 +1,3 @@
-import { DOM_EVENT, addEventListener } from '../browser/addEventListener'
 import { display } from './display'
 import { monitor } from './monitor'
 
@@ -334,15 +333,6 @@ export function elementMatches(element: Element & { msMatchesSelector?(selector:
     return element.msMatchesSelector(selector)
   }
   return false
-}
-
-export function runOnReadyState(expectedReadyState: 'complete' | 'interactive', callback: () => void) {
-  if (document.readyState === expectedReadyState || document.readyState === 'complete') {
-    callback()
-  } else {
-    const eventName = expectedReadyState === 'complete' ? DOM_EVENT.LOAD : DOM_EVENT.DOM_CONTENT_LOADED
-    addEventListener(window, eventName, callback, { once: true })
-  }
 }
 
 /**


### PR DESCRIPTION
## Motivation

We want to better understand what type of [untrusted events](https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted) are being recorded.

Superseds https://github.com/DataDog/browser-sdk/pull/1878

## Changes

Add a telemetry debug log when an untrusted event is dispatched and caught by our SDK. We limit the number of reported events to one per event type to avoid sending too many logs.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
