### PR TITLE
🐛 extension: handle internal analytics domain

### DIFF
--- a/developer-extension/src/background/domain/refreshDevServerStatus.ts
+++ b/developer-extension/src/background/domain/refreshDevServerStatus.ts
@@ -1,6 +1,6 @@
+import { DEV_LOGS_URL } from '../../common/constants'
 import { createLogger } from '../../common/logger'
 import { listenAction } from '../actions'
-import { DEV_LOGS_URL } from '../constants'
 import { setStore } from '../store'
 
 const logger = createLogger('refreshDevServerStatus')

--- a/developer-extension/src/background/domain/syncRules.ts
+++ b/developer-extension/src/background/domain/syncRules.ts
@@ -1,6 +1,6 @@
+import { DEV_LOGS_URL, DEV_RUM_SLIM_URL, DEV_RUM_URL, INTAKE_DOMAINS } from '../../common/constants'
 import { createLogger } from '../../common/logger'
 import { listenAction } from '../actions'
-import { DEV_LOGS_URL, DEV_RUM_SLIM_URL, DEV_RUM_URL, INTAKE_DOMAINS } from '../constants'
 import { store } from '../store'
 
 const logger = createLogger('syncRules')

--- a/developer-extension/src/common/constants.ts
+++ b/developer-extension/src/common/constants.ts
@@ -3,6 +3,7 @@ export const DEV_RUM_URL = 'http://localhost:8080/datadog-rum.js'
 export const DEV_RUM_SLIM_URL = 'http://localhost:8080/datadog-rum-slim.js'
 
 export const INTAKE_DOMAINS = [
+  'iam-rum-intake.datadoghq.com',
   'browser-intake-datadoghq.com',
   'browser-intake-datadoghq.eu',
   'browser-intake-ddog-gov.com',

--- a/developer-extension/src/common/constants.ts
+++ b/developer-extension/src/common/constants.ts
@@ -4,6 +4,7 @@ export const DEV_RUM_SLIM_URL = 'http://localhost:8080/datadog-rum-slim.js'
 
 export const INTAKE_DOMAINS = [
   'iam-rum-intake.datadoghq.com',
+  'browser-intake-datad0g.com',
   'browser-intake-datadoghq.com',
   'browser-intake-datadoghq.eu',
   'browser-intake-ddog-gov.com',


### PR DESCRIPTION
## Motivation

Some extension features were not supported on applications using internal analytics domain:

-  Event source `Requests``
- Block intake requests

## Changes

- Move `constants.ts` to `common`
- Use intake domain constants for both `listenEventsFromRequests` and `blockIntakeRequests`
- Add `iam-rum-intake.datadoghq.com` intake domain

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local on app.datadoghq.com and docs.datadoghq.com
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
