### PR TITLE
👷 fix check-release job by building packages before doing the check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,6 +192,7 @@ check-release:
     - .tags
   script:
     - yarn
+    - BUILD_MODE=release yarn build
     - node scripts/check-release.js
 
 unit-bs:


### PR DESCRIPTION
## Motivation

The check-release job is failing because it looks for files that are generated when building the packages.

## Changes

Build the packages before running the check-release script

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
