### PR TITLE
Bump typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ts-loader": "9.2.8",
     "ts-node": "10.7.0",
     "tsconfig-paths-webpack-plugin": "3.5.1",
-    "typescript": "4.6.3",
+    "typescript": "4.8.4",
     "webdriverio": "7.19.3",
     "webpack": "5.28.0",
     "webpack-cli": "4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10036,12 +10036,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
-"typescript@^3 || ^4":
+typescript@4.8.4, "typescript@^3 || ^4":
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION
## Motivation

Missing the support of the `document.adjustedStylesheet` in the current version

## Changes

Bump typescript version to 4.8.4

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
