### PR TITLE
✨[RUMF-1397] init parameter standardisation

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -38,20 +38,37 @@ describe('validateAndBuildConfiguration', () => {
       expect(displaySpy).not.toHaveBeenCalled()
     })
 
-    it('requires sampleRate to be a percentage', () => {
+    it('requires deprecated sampleRate to be a percentage', () => {
       expect(
         validateAndBuildConfiguration({ clientToken, sampleRate: 'foo' } as unknown as InitConfiguration)
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Sample Rate should be a number between 0 and 100')
+      expect(displaySpy).toHaveBeenCalledOnceWith('Session Sample Rate should be a number between 0 and 100')
 
       displaySpy.calls.reset()
       expect(
         validateAndBuildConfiguration({ clientToken, sampleRate: 200 } as unknown as InitConfiguration)
       ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Sample Rate should be a number between 0 and 100')
+      expect(displaySpy).toHaveBeenCalledOnceWith('Session Sample Rate should be a number between 0 and 100')
 
       displaySpy.calls.reset()
       validateAndBuildConfiguration({ clientToken: 'yes', sampleRate: 1 })
+      expect(displaySpy).not.toHaveBeenCalled()
+    })
+
+    it('requires sessionSampleRate to be a percentage', () => {
+      expect(
+        validateAndBuildConfiguration({ clientToken, sessionSampleRate: 'foo' } as unknown as InitConfiguration)
+      ).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledOnceWith('Session Sample Rate should be a number between 0 and 100')
+
+      displaySpy.calls.reset()
+      expect(
+        validateAndBuildConfiguration({ clientToken, sessionSampleRate: 200 } as unknown as InitConfiguration)
+      ).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledOnceWith('Session Sample Rate should be a number between 0 and 100')
+
+      displaySpy.calls.reset()
+      validateAndBuildConfiguration({ clientToken: 'yes', sessionSampleRate: 1 })
       expect(displaySpy).not.toHaveBeenCalled()
     })
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -19,7 +19,11 @@ export interface InitConfiguration {
   // global options
   clientToken: string
   beforeSend?: GenericBeforeSendCallback | undefined
+  /**
+   * @deprecated use sessionSampleRate instead
+   */
   sampleRate?: number | undefined
+  sessionSampleRate?: number | undefined
   telemetrySampleRate?: number | undefined
   silentMultipleInit?: boolean | undefined
   trackResources?: boolean | undefined
@@ -61,7 +65,7 @@ export interface Configuration extends TransportConfiguration {
   // Built from init configuration
   beforeSend: GenericBeforeSendCallback | undefined
   cookieOptions: CookieOptions
-  sampleRate: number
+  sessionSampleRate: number
   telemetrySampleRate: number
   telemetryConfigurationSampleRate: number
   service: string | undefined
@@ -84,8 +88,9 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     return
   }
 
-  if (initConfiguration.sampleRate !== undefined && !isPercentage(initConfiguration.sampleRate)) {
-    display.error('Sample Rate should be a number between 0 and 100')
+  const sessionSampleRate = initConfiguration.sessionSampleRate ?? initConfiguration.sampleRate
+  if (sessionSampleRate !== undefined && !isPercentage(sessionSampleRate)) {
+    display.error('Session Sample Rate should be a number between 0 and 100')
     return
   }
 
@@ -110,7 +115,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       beforeSend:
         initConfiguration.beforeSend && catchUserErrors(initConfiguration.beforeSend, 'beforeSend threw an error:'),
       cookieOptions: buildCookieOptions(initConfiguration),
-      sampleRate: initConfiguration.sampleRate ?? 100,
+      sessionSampleRate: sessionSampleRate ?? 100,
       telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
       telemetryConfigurationSampleRate: initConfiguration.telemetryConfigurationSampleRate ?? 5,
       service: initConfiguration.service,
@@ -160,7 +165,7 @@ function mustUseSecureCookie(initConfiguration: InitConfiguration) {
 
 export function serializeConfiguration(configuration: InitConfiguration): Partial<RawTelemetryConfiguration> {
   return {
-    session_sample_rate: configuration.sampleRate,
+    session_sample_rate: configuration.sessionSampleRate ?? configuration.sampleRate,
     telemetry_sample_rate: configuration.telemetrySampleRate,
     telemetry_configuration_sample_rate: configuration.telemetryConfigurationSampleRate,
     use_before_send: !!configuration.beforeSend,

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -150,9 +150,17 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       action_name_attribute?: string
       /**
-       * Whether the allowed tracing origins list is used
+       * Whether the allowed tracing origins list is used (deprecated in favor of use_allowed_tracing_urls)
        */
       use_allowed_tracing_origins?: boolean
+      /**
+       * Whether the allowed tracing urls list is used
+       */
+      use_allowed_tracing_urls?: boolean
+      /**
+       * A list of selected tracing propagators
+       */
+      selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[]
       /**
        * Session replay default privacy level
        */
@@ -170,9 +178,13 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       track_views_manually?: boolean
       /**
-       * Whether user actions are tracked
+       * Whether user actions are tracked (deprecated in favor of track_user_interactions)
        */
       track_interactions?: boolean
+      /**
+       * Whether user actions are tracked
+       */
+      track_user_interactions?: boolean
       /**
        * Whether console.error logs, uncaught exceptions and network errors are tracked
        */

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -124,13 +124,13 @@ describe('logs', () => {
     it('should be applied when event bridge is present', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
 
-      let configuration = { ...baseConfiguration, sampleRate: 0 }
+      let configuration = { ...baseConfiguration, sessionSampleRate: 0 }
       ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT, logger))
       handleLog(DEFAULT_MESSAGE, logger)
 
       expect(sendSpy).not.toHaveBeenCalled()
 
-      configuration = { ...baseConfiguration, sampleRate: 100 }
+      configuration = { ...baseConfiguration, sessionSampleRate: 100 }
       ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT, logger))
       handleLog(DEFAULT_MESSAGE, logger)
 

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -20,7 +20,7 @@ import {
 
 describe('logs session manager', () => {
   const DURATION = 123456
-  const configuration: Partial<LogsConfiguration> = { sampleRate: 0.5 }
+  const configuration: Partial<LogsConfiguration> = { sessionSampleRate: 0.5 }
   let clock: Clock
   let tracked: boolean
 
@@ -121,11 +121,11 @@ describe('logs session manager', () => {
 
 describe('logger session stub', () => {
   it('isTracked is computed at each init and getId is always undefined', () => {
-    const firstLogsSessionManager = startLogsSessionManagerStub({ sampleRate: 100 } as LogsConfiguration)
+    const firstLogsSessionManager = startLogsSessionManagerStub({ sessionSampleRate: 100 } as LogsConfiguration)
     expect(firstLogsSessionManager.findTrackedSession()).toBeDefined()
     expect(firstLogsSessionManager.findTrackedSession()!.id).toBeUndefined()
 
-    const secondLogsSessionManager = startLogsSessionManagerStub({ sampleRate: 0 } as LogsConfiguration)
+    const secondLogsSessionManager = startLogsSessionManagerStub({ sessionSampleRate: 0 } as LogsConfiguration)
     expect(secondLogsSessionManager.findTrackedSession()).toBeUndefined()
   })
 })

--- a/packages/logs/src/domain/logsSessionManager.ts
+++ b/packages/logs/src/domain/logsSessionManager.ts
@@ -42,7 +42,7 @@ export function startLogsSessionManagerStub(configuration: LogsConfiguration): L
 }
 
 function computeTrackingType(configuration: LogsConfiguration) {
-  if (!performDraw(configuration.sampleRate)) {
+  if (!performDraw(configuration.sessionSampleRate)) {
     return LoggerTrackingType.NOT_TRACKED
   }
   return LoggerTrackingType.TRACKED

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -93,10 +93,10 @@ describe('rum public api', () => {
         expect(display.error).not.toHaveBeenCalled()
       })
 
-      it('init should force sample rate to 100', () => {
-        const invalidConfiguration: HybridInitConfiguration = { sampleRate: 50 }
+      it('init should force session sample rate to 100', () => {
+        const invalidConfiguration: HybridInitConfiguration = { sessionSampleRate: 50 }
         rumPublicApi.init(invalidConfiguration as RumInitConfiguration)
-        expect(rumPublicApi.getInitConfiguration()?.sampleRate).toEqual(100)
+        expect(rumPublicApi.getInitConfiguration()?.sessionSampleRate).toEqual(100)
       })
     })
   })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -289,7 +289,7 @@ export function makeRumPublicApi(
     return assign({}, initConfiguration, {
       applicationId: '00000000-aaaa-0000-aaaa-000000000000',
       clientToken: 'empty',
-      sampleRate: 100,
+      sessionSampleRate: 100,
     })
   }
 

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -141,14 +141,14 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('tracingSampleRate', () => {
+  describe('deprecated tracingSampleRate', () => {
     it('defaults to undefined if the option is not provided', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.tracingSampleRate).toBeUndefined()
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.traceSampleRate).toBeUndefined()
     })
 
     it('is set to provided value', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 50 })!.tracingSampleRate
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 50 })!.traceSampleRate
       ).toBe(50)
     })
 
@@ -156,13 +156,36 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 'foo' as any })
       ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Tracing Sample Rate should be a number between 0 and 100')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Trace Sample Rate should be a number between 0 and 100')
 
       displayErrorSpy.calls.reset()
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 200 })
       ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Tracing Sample Rate should be a number between 0 and 100')
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Trace Sample Rate should be a number between 0 and 100')
+    })
+  })
+
+  describe('traceSampleRate', () => {
+    it('defaults to undefined if the option is not provided', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.traceSampleRate).toBeUndefined()
+    })
+
+    it('is set to provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceSampleRate: 50 })!.traceSampleRate
+      ).toBe(50)
+    })
+
+    it('does not validate the configuration if an incorrect value is provided', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceSampleRate: 'foo' as any })
+      ).toBeUndefined()
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Trace Sample Rate should be a number between 0 and 100')
+
+      displayErrorSpy.calls.reset()
+      expect(validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceSampleRate: 200 })).toBeUndefined()
+      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Trace Sample Rate should be a number between 0 and 100')
     })
   })
 

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -344,24 +344,50 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('trackInteractions', () => {
+  describe('deprecated trackInteractions', () => {
     it('defaults to false', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackInteractions).toBeFalse()
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackUserInteractions).toBeFalse()
     })
 
     it('is set to provided value', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: true })!.trackInteractions
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: true })!
+          .trackUserInteractions
       ).toBeTrue()
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: false })!.trackInteractions
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: false })!
+          .trackUserInteractions
       ).toBeFalse()
     })
 
     it('the provided value is cast to boolean', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: 'foo' as any })!
-          .trackInteractions
+          .trackUserInteractions
+      ).toBeTrue()
+    })
+  })
+
+  describe('trackUserInteractions', () => {
+    it('defaults to false', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackUserInteractions).toBeFalse()
+    })
+
+    it('is set to provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackUserInteractions: true })!
+          .trackUserInteractions
+      ).toBeTrue()
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackUserInteractions: false })!
+          .trackUserInteractions
+      ).toBeFalse()
+    })
+
+    it('the provided value is cast to boolean', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackUserInteractions: 'foo' as any })!
+          .trackUserInteractions
       ).toBeTrue()
     })
   })
@@ -387,9 +413,10 @@ describe('validateAndBuildRumConfiguration', () => {
       ).toBeTrue()
     })
 
-    it('implies "trackInteractions"', () => {
+    it('implies "trackUserInteractions"', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!.trackInteractions
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!
+          .trackUserInteractions
       ).toBeTrue()
     })
   })

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -47,7 +47,11 @@ export interface RumInitConfiguration extends InitConfiguration {
   sessionReplaySampleRate?: number | undefined
 
   // action options
+  /**
+   * @deprecated use trackUserInteractions instead
+   */
   trackInteractions?: boolean | undefined
+  trackUserInteractions?: boolean | undefined
   trackFrustrations?: boolean | undefined
   actionNameAttribute?: string | undefined
 
@@ -70,7 +74,7 @@ export interface RumConfiguration extends Configuration {
   defaultPrivacyLevel: DefaultPrivacyLevel
   oldPlansBehavior: boolean
   sessionReplaySampleRate: number
-  trackInteractions: boolean
+  trackUserInteractions: boolean
   trackFrustrations: boolean
   trackViewsManually: boolean
   trackResources: boolean | undefined
@@ -127,6 +131,7 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
+  const trackUserInteractions = !!(initConfiguration.trackUserInteractions ?? initConfiguration.trackInteractions)
   const trackFrustrations = !!initConfiguration.trackFrustrations
 
   return assign(
@@ -139,7 +144,7 @@ export function validateAndBuildRumConfiguration(
       traceSampleRate,
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],
-      trackInteractions: !!initConfiguration.trackInteractions || trackFrustrations,
+      trackUserInteractions: trackUserInteractions || trackFrustrations,
       trackFrustrations,
       trackViewsManually: !!initConfiguration.trackViewsManually,
       trackResources: initConfiguration.trackResources,
@@ -280,7 +285,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration): 
         Array.isArray(configuration.allowedTracingOrigins) && configuration.allowedTracingOrigins.length > 0,
       track_frustrations: configuration.trackFrustrations,
       track_views_manually: configuration.trackViewsManually,
-      track_interactions: configuration.trackInteractions,
+      track_user_interactions: configuration.trackUserInteractions ?? configuration.trackInteractions,
     },
     baseSerializedConfiguration
   )

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -32,7 +32,11 @@ export interface RumInitConfiguration extends InitConfiguration {
    */
   allowedTracingOrigins?: MatchOption[] | undefined
   allowedTracingUrls?: Array<MatchOption | TracingOption> | undefined
+  /**
+   * @deprecated use traceSampleRate instead
+   */
   tracingSampleRate?: number | undefined
+  traceSampleRate?: number | undefined
 
   // replay options
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
@@ -59,7 +63,7 @@ export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId'
 export interface RumConfiguration extends Configuration {
   // Built from init configuration
   actionNameAttribute: string | undefined
-  tracingSampleRate: number | undefined
+  traceSampleRate: number | undefined
   allowedTracingUrls: TracingOption[]
   excludedActivityUrls: MatchOption[]
   applicationId: string
@@ -102,8 +106,9 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  if (initConfiguration.tracingSampleRate !== undefined && !isPercentage(initConfiguration.tracingSampleRate)) {
-    display.error('Tracing Sample Rate should be a number between 0 and 100')
+  const traceSampleRate = initConfiguration.traceSampleRate ?? initConfiguration.tracingSampleRate
+  if (traceSampleRate !== undefined && !isPercentage(traceSampleRate)) {
+    display.error('Trace Sample Rate should be a number between 0 and 100')
     return
   }
 
@@ -131,7 +136,7 @@ export function validateAndBuildRumConfiguration(
       actionNameAttribute: initConfiguration.actionNameAttribute,
       sessionReplaySampleRate: initConfiguration.sessionReplaySampleRate ?? premiumSampleRate ?? 100,
       oldPlansBehavior: initConfiguration.sessionReplaySampleRate === undefined,
-      tracingSampleRate: initConfiguration.tracingSampleRate,
+      traceSampleRate,
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],
       trackInteractions: !!initConfiguration.trackInteractions || trackFrustrations,
@@ -263,7 +268,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration): 
       premium_sample_rate: configuration.premiumSampleRate,
       replay_sample_rate: configuration.replaySampleRate,
       session_replay_sample_rate: configuration.sessionReplaySampleRate,
-      trace_sample_rate: configuration.tracingSampleRate,
+      trace_sample_rate: configuration.traceSampleRate ?? configuration.tracingSampleRate,
       action_name_attribute: configuration.actionNameAttribute,
       use_allowed_tracing_origins:
         Array.isArray(configuration.allowedTracingOrigins) && configuration.allowedTracingOrigins.length > 0,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -32,7 +32,7 @@ export function startActionCollection(
   )
 
   let actionContexts: ActionContexts = { findActionId: noop as () => undefined }
-  if (configuration.trackInteractions) {
+  if (configuration.trackUserInteractions) {
     actionContexts = trackClickActions(lifeCycle, domMutationObservable, configuration).actionContexts
   }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -238,14 +238,14 @@ describe('resourceCollection', () => {
       expect(privateFields.span_id).not.toBeDefined()
     })
 
-    it('should pull tracingSampleRate from config if present', () => {
+    it('should pull traceSampleRate from config if present', () => {
       setupBuilder = setup().beforeBuild(({ lifeCycle, sessionManager }) => {
         startResourceCollection(
           lifeCycle,
           validateAndBuildRumConfiguration({
             clientToken: 'xxx',
             applicationId: 'xxx',
-            tracingSampleRate: 60,
+            traceSampleRate: 60,
           })!,
           sessionManager
         )
@@ -264,7 +264,7 @@ describe('resourceCollection', () => {
       expect(privateFields.rule_psr).toEqual(0.6)
     })
 
-    it('should not define rule_psr if tracingSampleRate is undefined', () => {
+    it('should not define rule_psr if traceSampleRate is undefined', () => {
       setupBuilder = setup().beforeBuild(({ lifeCycle, sessionManager }) => {
         startResourceCollection(
           lifeCycle,
@@ -289,14 +289,14 @@ describe('resourceCollection', () => {
       expect(privateFields.rule_psr).toBeUndefined()
     })
 
-    it('should define rule_psr to 0 if tracingSampleRate is set to 0', () => {
+    it('should define rule_psr to 0 if traceSampleRate is set to 0', () => {
       setupBuilder = setup().beforeBuild(({ lifeCycle, sessionManager }) => {
         startResourceCollection(
           lifeCycle,
           validateAndBuildRumConfiguration({
             clientToken: 'xxx',
             applicationId: 'xxx',
-            tracingSampleRate: 0,
+            traceSampleRate: 0,
           })!,
           sessionManager
         )

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -199,10 +199,10 @@ function toPerformanceEntryRepresentation(entry: RumPerformanceEntry): Performan
 }
 
 /**
- * @returns number between 0 and 1 which represents tracing sample rate
+ * @returns number between 0 and 1 which represents trace sample rate
  */
 function getRulePsr(configuration: RumConfiguration) {
-  return isNumber(configuration.tracingSampleRate) ? configuration.tracingSampleRate / 100 : undefined
+  return isNumber(configuration.traceSampleRate) ? configuration.traceSampleRate / 100 : undefined
 }
 
 function computeIndexingInfo(sessionManager: RumSessionManager, resourceStart: ClocksState) {

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -31,7 +31,7 @@ describe('rum session manager', () => {
     tracked?: boolean
     trackedWithSessionReplay?: boolean
   }) {
-    configuration.sampleRate = tracked ? 100 : 0
+    configuration.sessionSampleRate = tracked ? 100 : 0
     configuration.sessionReplaySampleRate = trackedWithSessionReplay ? 100 : 0
   }
 
@@ -41,7 +41,7 @@ describe('rum session manager', () => {
     }
     configuration = {
       ...validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: 'xxx' })!,
-      sampleRate: 50,
+      sessionSampleRate: 50,
       sessionReplaySampleRate: 50,
       trackResources: true,
       trackLongTasks: true,

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -92,7 +92,7 @@ function computeSessionState(configuration: RumConfiguration, rawTrackingType?: 
   let trackingType: RumTrackingType
   if (hasValidRumSession(rawTrackingType)) {
     trackingType = rawTrackingType
-  } else if (!performDraw(configuration.sampleRate)) {
+  } else if (!performDraw(configuration.sessionSampleRate)) {
     trackingType = RumTrackingType.NOT_TRACKED
   } else if (!performDraw(configuration.sessionReplaySampleRate)) {
     trackingType = RumTrackingType.TRACKED_WITHOUT_SESSION_REPLAY

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -84,7 +84,7 @@ describe('tracer', () => {
 
     it("should trace request with priority '1' when sampled", () => {
       spyOn(Math, 'random').and.callFake(() => 0)
-      const tracer = startTracer({ ...configuration, tracingSampleRate: 50 }, sessionManager)
+      const tracer = startTracer({ ...configuration, traceSampleRate: 50 }, sessionManager)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhrStub as unknown as XMLHttpRequest)
 
@@ -96,7 +96,7 @@ describe('tracer', () => {
 
     it("should trace request with priority '0' when not sampled", () => {
       spyOn(Math, 'random').and.callFake(() => 1)
-      const tracer = startTracer({ ...configuration, tracingSampleRate: 50 }, sessionManager)
+      const tracer = startTracer({ ...configuration, traceSampleRate: 50 }, sessionManager)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhrStub as unknown as XMLHttpRequest)
 
@@ -111,7 +111,7 @@ describe('tracer', () => {
 
       const configurationWithAllOtelHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
-        tracingSampleRate: 50,
+        traceSampleRate: 50,
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext', 'b3multi'] }],
       })!
 
@@ -421,7 +421,7 @@ describe('tracer', () => {
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
 
       spyOn(Math, 'random').and.callFake(() => 0)
-      const tracer = startTracer({ ...configuration, tracingSampleRate: 50 }, sessionManager)
+      const tracer = startTracer({ ...configuration, traceSampleRate: 50 }, sessionManager)
       tracer.traceFetch(context)
 
       expect(context.traceSampled).toBe(true)
@@ -434,7 +434,7 @@ describe('tracer', () => {
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
 
       spyOn(Math, 'random').and.callFake(() => 1)
-      const tracer = startTracer({ ...configuration, tracingSampleRate: 50 }, sessionManager)
+      const tracer = startTracer({ ...configuration, traceSampleRate: 50 }, sessionManager)
       tracer.traceFetch(context)
 
       expect(context.traceSampled).toBe(false)

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -120,7 +120,7 @@ function injectHeadersIfTracingAllowed(
 
   context.traceId = new TraceIdentifier()
   context.spanId = new TraceIdentifier()
-  context.traceSampled = !isNumber(configuration.tracingSampleRate) || performDraw(configuration.tracingSampleRate)
+  context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
   inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
 }
 

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -512,7 +512,7 @@ export type RumResourceEvent = CommonProperties &
        */
       readonly trace_id?: string
       /**
-       * tracing sample rate in decimal format
+       * trace sample rate in decimal format
        */
       readonly rule_psr?: number
       /**

--- a/packages/rum/src/types/sessionReplay.ts
+++ b/packages/rum/src/types/sessionReplay.ts
@@ -385,7 +385,28 @@ export interface DocumentNode {
    * The type of this Node.
    */
   readonly type: 0
+  /**
+   * Stylesheet added dynamically
+   */
+  readonly adoptedStyleSheets?: StyleSheet[]
   childNodes: SerializedNodeWithId[]
+}
+/**
+ * Browser-specific. Schema of a StyleSheet
+ */
+export interface StyleSheet {
+  /**
+   * CSS rules applied (rule.cssText)
+   */
+  cssRules: string[]
+  /**
+   * MediaList of the stylesheet
+   */
+  media?: string[]
+  /**
+   * Is the stylesheet disabled
+   */
+  disabled?: boolean
 }
 /**
  * Schema of a Document FragmentNode.
@@ -395,6 +416,10 @@ export interface DocumentFragmentNode {
    * The type of this Node.
    */
   readonly type: 11
+  /**
+   * Stylesheet added dynamically
+   */
+  readonly adoptedStyleSheets?: StyleSheet[]
   /**
    * Is this node a shadow root or not
    */

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -13,12 +13,14 @@
         trackResources: true,
         trackLongTasks: true,
         telemetrySampleRate: 100,
+        telemetryConfigurationSampleRate: 100,
         enableExperimentalFeatures: [],
       })
       DD_RUM.startSessionReplayRecording()
       DD_LOGS.init({
         clientToken: 'xxx',
         telemetrySampleRate: 100,
+        telemetryConfigurationSampleRate: 100,
         enableExperimentalFeatures: [],
       })
     </script>

--- a/test/e2e/scenario/eventBridge.scenario.ts
+++ b/test/e2e/scenario/eventBridge.scenario.ts
@@ -3,7 +3,7 @@ import { createTest, flushEvents, html } from '../lib/framework'
 
 describe('bridge present', () => {
   createTest('send action')
-    .withRum({ trackInteractions: true })
+    .withRum({ trackUserInteractions: true })
     .withEventBridge()
     .withBody(
       html`

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -3,7 +3,7 @@ import { createTest, flushEvents, html, waitForServersIdle } from '../../lib/fra
 
 describe('action collection', () => {
   createTest('track a click action')
-    .withRum({ trackInteractions: true, enableExperimentalFeatures: ['clickmap'] })
+    .withRum({ trackUserInteractions: true, enableExperimentalFeatures: ['clickmap'] })
     .withBody(
       html`
         <button>click me</button>
@@ -117,7 +117,7 @@ describe('action collection', () => {
   }
 
   createTest('associate a request to its action')
-    .withRum({ trackInteractions: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button>click me</button>

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -62,13 +62,13 @@ describe('telemetry', () => {
   createTest('send init configuration for RUM')
     .withSetup(bundleSetup)
     .withRum({
-      trackInteractions: true,
+      trackUserInteractions: true,
     })
     .run(async ({ serverEvents }) => {
       await flushEvents()
       expect(serverEvents.telemetryConfigurations.length).toBe(1)
       const event = serverEvents.telemetryConfigurations[0]
       expect(event.service).toEqual('browser-rum-sdk')
-      expect(event.telemetry.configuration.track_interactions).toEqual(true)
+      expect(event.telemetry.configuration.track_user_interactions).toEqual(true)
     })
 })


### PR DESCRIPTION
## Motivation

Uniformise init config parameters names across SDKs

## Changes

- Introduce `sessionSampleRate` and deprecate `sampleRate`
- Introduce `traceSampleRate` and deprecate `tracingSampleRate`
- Introduce `trackUserInteractions` and deprecate `trackInteractions`

**Note:** documentation will be updated after the release of those new parameters

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
