### PR TITLE
👷 [RUMF-1464] Tweak query parameters for internal analytics

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -26,6 +26,14 @@ describe('endpointBuilder', () => {
       expect(createEndpointBuilder(initConfiguration, 'logs', []).build('xhr')).not.toContain('&batch_time=')
       expect(createEndpointBuilder(initConfiguration, 'sessionReplay', []).build('xhr')).not.toContain('&batch_time=')
     })
+
+    it('should not start with ddsource for internal analytics mode', () => {
+      const url = createEndpointBuilder({ ...initConfiguration, internalAnalyticsSubdomain: 'foo' }, 'rum', []).build(
+        'xhr'
+      )
+      expect(url).not.toContain('/rum?ddsource')
+      expect(url).toContain('ddsource=browser')
+    })
   })
 
   describe('proxyUrl', () => {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -41,18 +41,22 @@ export function createEndpointBuilder(
       if (retry) {
         tags.push(`retry_count:${retry.count}`, `retry_after:${retry.lastFailureStatus}`)
       }
-      let parameters =
-        'ddsource=browser' +
-        `&ddtags=${encodeURIComponent(tags.join(','))}` +
-        `&dd-api-key=${clientToken}` +
-        `&dd-evp-origin-version=${encodeURIComponent(__BUILD_ENV__SDK_VERSION__)}` +
-        '&dd-evp-origin=browser' +
-        `&dd-request-id=${generateUUID()}`
+      const parameters = [
+        'ddsource=browser',
+        `ddtags=${encodeURIComponent(tags.join(','))}`,
+        `dd-api-key=${clientToken}`,
+        `dd-evp-origin-version=${encodeURIComponent(__BUILD_ENV__SDK_VERSION__)}`,
+        'dd-evp-origin=browser',
+        `dd-request-id=${generateUUID()}`,
+      ]
 
       if (endpointType === 'rum') {
-        parameters += `&batch_time=${timeStampNow()}`
+        parameters.push(`batch_time=${timeStampNow()}`)
       }
-      const endpointUrl = `${baseUrl}?${parameters}`
+      if (initConfiguration.internalAnalyticsSubdomain) {
+        parameters.reverse()
+      }
+      const endpointUrl = `${baseUrl}?${parameters.join('&')}`
 
       return proxyUrl ? `${proxyUrl}?ddforward=${encodeURIComponent(endpointUrl)}` : endpointUrl
     },


### PR DESCRIPTION
## Motivation

Avoid to have `ddsource` query parameter in first position for internal analytics mode

## Changes

Reverse query parameters order when `internalAnalyticsSubdomain` is used

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
