### PR TITLE
👷 change scripts main error handler strategy

### DIFF
--- a/scripts/bs-wrapper.js
+++ b/scripts/bs-wrapper.js
@@ -14,23 +14,22 @@
 // after killing it. There might be a better way of prematurely aborting the test command if we need
 // to in the future.
 
-const { spawnCommand, printLog, logAndExit, executeCommand, fetch } = require('./utils')
+const { spawnCommand, printLog, runMain, executeCommand, fetch } = require('./utils')
 
 const AVAILABILITY_CHECK_DELAY = 30_000
 const BS_USERNAME = process.env.BS_USERNAME
 const BS_ACCESS_KEY = process.env.BS_ACCESS_KEY
 const BS_BUILD_URL = 'https://api.browserstack.com/automate/builds.json?status=running'
 
-async function main() {
+runMain(async () => {
   if (await executeCommand('git tag --points-at HEAD')) {
     printLog('Skip bs execution on tags')
-    process.exit(0)
     return
   }
   await waitForAvailability()
   const exitCode = await runTests()
   process.exit(exitCode)
-}
+})
 
 async function waitForAvailability() {
   while (await hasRunningBuild()) {
@@ -55,5 +54,3 @@ function runTests() {
 function timeout(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
-
-main().catch(logAndExit)

--- a/scripts/bump-chrome-driver-version.js
+++ b/scripts/bump-chrome-driver-version.js
@@ -3,7 +3,7 @@
 const {
   printLog,
   printError,
-  logAndExit,
+  runMain,
   executeCommand,
   replaceCiFileVariable,
   initGitConfig,
@@ -20,7 +20,7 @@ const CURRENT_PACKAGE_VERSION = process.env.CHROME_PACKAGE_VERSION
 const CHROME_PACKAGE_URL = 'https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable'
 const CHROME_DRIVER_URL = 'https://chromedriver.storage.googleapis.com/?delimiter=/&prefix='
 
-async function main() {
+runMain(async () => {
   await initGitConfig(REPOSITORY)
   await executeCommand(`git fetch --no-tags origin ${MAIN_BRANCH}`)
   await executeCommand(`git checkout ${MAIN_BRANCH} -f`)
@@ -31,14 +31,14 @@ async function main() {
 
   if (majorPackageVersion <= getMajor(CURRENT_PACKAGE_VERSION)) {
     printLog('Chrome driver is up to date.')
-    process.exit()
+    return
   }
 
   const driverVersion = await getDriverVersion(majorPackageVersion)
 
   if (majorPackageVersion !== getMajor(driverVersion)) {
     printError(`No driver available for chrome ${packageVersion}.`)
-    process.exit()
+    return
   }
 
   const chromeVersionBranch = `bump-chrome-version-to-${driverVersion}`
@@ -47,7 +47,7 @@ async function main() {
   const isBranchAlreadyCreated = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${chromeVersionBranch}`)
   if (isBranchAlreadyCreated) {
     printLog('Bump chrome branch already created.')
-    process.exit()
+    return
   }
 
   await executeCommand(`git checkout -b ${chromeVersionBranch}`)
@@ -68,7 +68,7 @@ async function main() {
 
   // used to share the pull request url to the notification jobs
   await executeCommand(`echo "BUMP_CHROME_PULL_REQUEST_URL=${pullRequestUrl}" >> build.env`)
-}
+})
 
 async function getPackageVersion() {
   const packagePage = await fetch(CHROME_PACKAGE_URL)
@@ -98,5 +98,3 @@ async function createPullRequest() {
   const pullRequestUrl = await executeCommand(`gh pr create --fill --base ${MAIN_BRANCH}`)
   return pullRequestUrl.trim()
 }
-
-main().catch(logAndExit)

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -3,11 +3,11 @@
 const fs = require('fs')
 const path = require('path')
 const readline = require('readline')
-const { printLog, printError, logAndExit, findBrowserSdkPackageJsonFiles } = require('./utils')
+const { printLog, printError, runMain, findBrowserSdkPackageJsonFiles } = require('./utils')
 
 const LICENSE_FILE = 'LICENSE-3rdparty.csv'
 
-async function main() {
+runMain(async () => {
   const packageJsonFiles = await findBrowserSdkPackageJsonFiles()
 
   printLog(
@@ -32,7 +32,7 @@ async function main() {
     throw new Error('Dependencies mismatch')
   }
   printLog('Dependencies check done.')
-}
+})
 
 function retrievePackageDependencies(packageJsonFile) {
   return Object.keys(packageJsonFile.content.dependencies || {})
@@ -58,5 +58,3 @@ async function retrieveLicenses() {
   }
   return licenses
 }
-
-main().catch(logAndExit)

--- a/scripts/check-release.js
+++ b/scripts/check-release.js
@@ -3,14 +3,14 @@
 const fs = require('fs')
 const path = require('path')
 const { version: releaseVersion } = require('../lerna.json')
-const { findBrowserSdkPackageJsonFiles, printLog, logAndExit, executeCommand } = require('./utils')
+const { findBrowserSdkPackageJsonFiles, printLog, runMain, executeCommand } = require('./utils')
 
-async function main() {
+runMain(async () => {
   await checkGitTag()
   await checkBrowserSdkPackageJsonFiles()
 
   printLog('Release check done.')
-}
+})
 
 async function checkGitTag() {
   printLog('Checking release version tag is on HEAD')
@@ -99,5 +99,3 @@ function checkPackageJsonEntryPoints(packageJsonFile) {
 function isBrowserSdkPublicPackageName(name) {
   return name?.startsWith('@datadog/')
 }
-
-main().catch(logAndExit)

--- a/scripts/export-test-result.js
+++ b/scripts/export-test-result.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { getSecretKey, executeCommand, printLog, logAndExit } = require('./utils')
+const { getSecretKey, executeCommand, printLog, runMain } = require('./utils')
 
 /**
  * Upload test result to datadog
@@ -11,7 +11,7 @@ const { getSecretKey, executeCommand, printLog, logAndExit } = require('./utils'
 const testType = process.argv[2]
 const resultFolder = `test-report/${testType}/`
 
-async function main() {
+runMain(async () => {
   const DATADOG_API_KEY = await getSecretKey('ci.browser-sdk.datadog_ci_api_key')
 
   await executeCommand(
@@ -22,6 +22,4 @@ async function main() {
   )
 
   printLog(`Export ${testType} tests done.`)
-}
-
-main().catch(logAndExit)
+})

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -6,12 +6,12 @@ const readFile = util.promisify(require('fs').readFile)
 const emojiNameMap = require('emoji-name-map')
 
 const lernaConfig = require('../lerna.json')
-const { executeCommand, spawnCommand, printError, logAndExit, modifyFile } = require('./utils')
+const { executeCommand, spawnCommand, printError, runMain, modifyFile } = require('./utils')
 
 const CHANGELOG_FILE = 'CHANGELOG.md'
 const CONTRIBUTING_FILE = 'CONTRIBUTING.md'
 
-async function main() {
+runMain(async () => {
   if (!process.env.EDITOR) {
     printError('Please configure your environment variable EDITOR')
     process.exit(1)
@@ -40,7 +40,7 @@ ${content.slice(content.indexOf('\n##'))}`
   await spawnCommand('yarn', ['run', 'prettier', '--write', CHANGELOG_FILE])
 
   await executeCommand(`git add ${CHANGELOG_FILE}`)
-}
+})
 
 async function getEmojisLegend() {
   const contributing = await readFile(CONTRIBUTING_FILE, { encoding: 'utf-8' })
@@ -98,5 +98,3 @@ function emojiNameToUnicode(changes) {
   const emojiNameRegex = new RegExp(/:[^:\s]*(?:::[^:\s]*)*:/, 'gm')
   return changes.replace(emojiNameRegex, (emoji) => emojiNameMap.get(emoji) || emoji)
 }
-
-main().catch(logAndExit)

--- a/scripts/generate-schema-types.js
+++ b/scripts/generate-schema-types.js
@@ -2,12 +2,12 @@ const fs = require('fs')
 const path = require('path')
 const { compileFromFile } = require('json-schema-to-typescript')
 const prettier = require('prettier')
-const { printLog, logAndExit } = require('./utils')
+const { printLog, runMain } = require('./utils')
 
 const schemasDirectoryPath = path.join(__dirname, '../rum-events-format/schemas')
 const prettierConfigPath = path.join(__dirname, '../.prettierrc.yml')
 
-async function main() {
+runMain(async () => {
   await generateTypesFromSchema(
     path.join(__dirname, '../packages/rum-core/src/rumEvent.types.ts'),
     'rum-events-schema.json'
@@ -21,7 +21,7 @@ async function main() {
     'session-replay-browser-schema.json',
     { options: { additionalProperties: false } }
   )
-}
+})
 
 async function generateTypesFromSchema(typesPath, schema, { options = {} } = {}) {
   const schemaPath = path.join(schemasDirectoryPath, schema)
@@ -38,5 +38,3 @@ async function generateTypesFromSchema(typesPath, schema, { options = {} } = {})
   fs.writeFileSync(typesPath, compiledTypes)
   printLog('Generation done.')
 }
-
-main().catch(logAndExit)

--- a/scripts/replace-build-env.js
+++ b/scripts/replace-build-env.js
@@ -1,6 +1,6 @@
 const glob = require('glob')
 const buildEnv = require('./build-env')
-const { printLog, logAndExit, modifyFile } = require('./utils')
+const { printLog, runMain, modifyFile } = require('./utils')
 
 /**
  * Replace BuildEnv in build files
@@ -8,7 +8,7 @@ const { printLog, logAndExit, modifyFile } = require('./utils')
  * BUILD_MODE=zzz node replace-build-env.js /path/to/build/directory
  */
 
-async function main() {
+runMain(async () => {
   const buildDirectory = process.argv[2]
 
   printLog(`Replacing BuildEnv in '${buildDirectory}' with:`, JSON.stringify(buildEnv, null, 2))
@@ -18,9 +18,7 @@ async function main() {
       printLog(`Replaced BuildEnv in ${path}`)
     }
   }
-
-  process.exit(0)
-}
+})
 
 function replaceBuildEnv(content) {
   return Object.keys(buildEnv).reduce(
@@ -28,5 +26,3 @@ function replaceBuildEnv(content) {
     content
   )
 }
-
-main().catch(logAndExit)

--- a/scripts/staging-ci/check-squash-into-staging.js
+++ b/scripts/staging-ci/check-squash-into-staging.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { initGitConfig, executeCommand, printLog, printError, logAndExit } = require('../utils')
+const { initGitConfig, executeCommand, printLog, printError, runMain } = require('../utils')
 
 const REPOSITORY = process.env.GIT_REPOSITORY
 const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
@@ -8,7 +8,7 @@ const CI_COMMIT_SHORT_SHA = process.env.CI_COMMIT_SHORT_SHA
 const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
 const MAIN_BRANCH = process.env.MAIN_BRANCH
 
-async function main() {
+runMain(async () => {
   await initGitConfig(REPOSITORY)
   await executeCommand(`git fetch --no-tags origin ${MAIN_BRANCH}`)
   const ciConfigurationFromMain = await executeCommand(`git show origin/${MAIN_BRANCH}:.gitlab-ci.yml`)
@@ -48,6 +48,4 @@ async function main() {
   }
 
   printLog('Check done.')
-}
-
-main().catch(logAndExit)
+})

--- a/scripts/staging-ci/check-staging-merge.js
+++ b/scripts/staging-ci/check-staging-merge.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { initGitConfig, executeCommand, printLog, printError, logAndExit } = require('../utils')
+const { initGitConfig, executeCommand, printLog, printError, runMain } = require('../utils')
 
 const REPOSITORY = process.env.GIT_REPOSITORY
 const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
@@ -8,7 +8,7 @@ const CI_COMMIT_SHORT_SHA = process.env.CI_COMMIT_SHORT_SHA
 const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
 const MAIN_BRANCH = process.env.MAIN_BRANCH
 
-async function main() {
+runMain(async () => {
   await initGitConfig(REPOSITORY)
   await executeCommand(`git fetch --no-tags origin ${MAIN_BRANCH}`)
   const ciConfigurationFromMain = await executeCommand(`git show origin/${MAIN_BRANCH}:.gitlab-ci.yml`)
@@ -33,6 +33,4 @@ async function main() {
   }
 
   printLog('Check done.')
-}
-
-main().catch(logAndExit)
+})

--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { initGitConfig, executeCommand, printLog, printError, logAndExit } = require('../utils')
+const { initGitConfig, executeCommand, printLog, printError, runMain } = require('../utils')
 
 const REPOSITORY = process.env.GIT_REPOSITORY
 const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
@@ -8,7 +8,7 @@ const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
 const CI_COMMIT_SHORT_SHA = process.env.CI_COMMIT_SHORT_SHA
 const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
 
-async function main() {
+runMain(async () => {
   await initGitConfig(REPOSITORY)
   await executeCommand(`git fetch --no-tags origin ${CURRENT_STAGING_BRANCH}`)
   await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH} -f`)
@@ -38,7 +38,7 @@ async function main() {
   await executeCommand(`git push origin ${CURRENT_STAGING_BRANCH}`)
 
   printLog('Merge done.')
-}
+})
 
 async function isCommitAlreadyMerged() {
   try {
@@ -48,5 +48,3 @@ async function isCommitAlreadyMerged() {
     return false
   }
 }
-
-main().catch(logAndExit)

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -6,7 +6,7 @@ const {
   initGitConfig,
   executeCommand,
   printLog,
-  logAndExit,
+  runMain,
   replaceCiFileVariable,
   readCiFileVariable,
 } = require('../utils')
@@ -18,7 +18,7 @@ const CURRENT_STAGING_BRANCH = readCiFileVariable('CURRENT_STAGING')
 const NEW_STAGING_NUMBER = getWeekNumber().toString().padStart(2, '0')
 const NEW_STAGING_BRANCH = `staging-${NEW_STAGING_NUMBER}`
 
-async function main() {
+runMain(async () => {
   // used to share the new staging name to the notification jobs
   await executeCommand(`echo "NEW_STAGING=${NEW_STAGING_BRANCH}" >> build.env`)
 
@@ -62,12 +62,10 @@ async function main() {
   }
 
   printLog('Reset done.')
-}
+})
 
 function getWeekNumber() {
   const today = new Date()
   const yearStart = new Date(Date.UTC(today.getUTCFullYear(), 0, 1))
   return Math.ceil(((today - yearStart) / 86400000 + yearStart.getUTCDay() + 1) / 7)
 }
-
-main().catch(logAndExit)

--- a/scripts/update-peer-dependency-versions.js
+++ b/scripts/update-peer-dependency-versions.js
@@ -1,5 +1,5 @@
 const lernaConfig = require('../lerna.json')
-const { logAndExit, modifyFile } = require('./utils')
+const { runMain, modifyFile } = require('./utils')
 
 // This script updates the peer dependency versions between rum and logs packages to match the new
 // version during a release.
@@ -10,7 +10,7 @@ const { logAndExit, modifyFile } = require('./utils')
 //
 // [1]: https://github.com/lerna/lerna/commit/bdbfc62966e5351abfeac77830f9d47b6d69f1b1
 // [2]: https://github.com/lerna/lerna/issues/1575
-async function main() {
+runMain(async () => {
   for (const packageName of ['rum', 'rum-slim', 'logs']) {
     await modifyFile(`./packages/${packageName}/package.json`, (content) => {
       const json = JSON.parse(content)
@@ -20,6 +20,4 @@ async function main() {
       return `${JSON.stringify(json, null, 2)}\n`
     })
   }
-}
-
-main().catch(logAndExit)
+})

--- a/scripts/upload-source-maps.js
+++ b/scripts/upload-source-maps.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { getSecretKey, executeCommand, printLog, logAndExit } = require('./utils')
+const { getSecretKey, executeCommand, printLog, runMain } = require('./utils')
 const { SDK_VERSION } = require('./build-env')
 
 /**
@@ -48,7 +48,7 @@ async function uploadSourceMaps(site, apiKey, packageName, service, bundleFolder
   console.log(output)
 }
 
-async function main() {
+runMain(async () => {
   for (const { name, service } of packages) {
     const bundleFolder = `packages/${name}/bundle`
     await renameFiles(bundleFolder, name)
@@ -60,6 +60,4 @@ async function main() {
     }
   }
   printLog('Source maps upload done.')
-}
-
-main().catch(logAndExit)
+})

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -85,9 +85,16 @@ async function spawnCommand(command, args) {
   })
 }
 
-function logAndExit(error) {
-  printError('\nStacktrace:\n', error)
-  process.exit(1)
+function runMain(mainFunction) {
+  Promise.resolve()
+    // The main function can be either synchronous or asynchronous, so let's wrap it in an async
+    // callback that will catch both thrown errors and rejected promises
+    .then(() => mainFunction())
+    .catch((error) => {
+      printError('\nScript exited with error:')
+      printError(error)
+      process.exit(1)
+    })
 }
 
 const resetColor = '\x1b[0m'
@@ -134,7 +141,7 @@ module.exports = {
   spawnCommand,
   printError,
   printLog,
-  logAndExit,
+  runMain,
   readCiFileVariable,
   replaceCiFileVariable,
   fetch: fetchWrapper,


### PR DESCRIPTION


## Motivation

For [RUMF-1330] I will improve how nodejs scripts are executing commands, and I want to make those command execution synchronous. Thus, some scripts will be entirely synchronous. Our current `logAndExit` helper works better with asynchronous scripts, so the goal of this PR is to support future synchronous script execution.

## Changes

This commit replaces the `logAndExit` function with a `runMain` function which is similar but reduces a bit the scripts boilerplate and supports synchronous main function.

Before:

```
async function main() {}
main().catch(logAndExit)
```

After:

```
runMain(async () => {})
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.


[RUMF-1330]: https://datadoghq.atlassian.net/browse/RUMF-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ