### PR TITLE
[RUMF-1263] ⚡ Ignore link tags with rel=modulepreload|prefetch

### DIFF
--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -203,6 +203,26 @@ describe('getNodeSelfPrivacyLevel', () => {
       html: '<script class="dd-privacy-allow">',
       expected: NodePrivacyLevel.ALLOW,
     },
+    {
+      msg: 'is a link with rel=preload and as=script',
+      html: '<link rel="preload" crossorigins as="script">',
+      expected: NodePrivacyLevel.IGNORE,
+    },
+    {
+      msg: 'is a link with rel=modulepreload and as=script',
+      html: '<link rel="modulepreload" as="script">',
+      expected: NodePrivacyLevel.IGNORE,
+    },
+    {
+      msg: 'is a link with rel=prefetch and as=script',
+      html: '<link rel="prefetch" as="script">',
+      expected: NodePrivacyLevel.IGNORE,
+    },
+    {
+      msg: 'is a link with rel=stylesheet and a not expected as=script',
+      html: '<link rel="stylesheet" as="script">',
+      expected: undefined,
+    },
 
     // Precedence
     {

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -220,8 +220,8 @@ export function shouldIgnoreElement(element: Element): boolean {
   if (element.nodeName === 'LINK') {
     const relAttribute = getLowerCaseAttribute('rel')
     return (
-      // Scripts
-      (relAttribute === 'preload' && getLowerCaseAttribute('as') === 'script') ||
+      // Link as script - Ignore only when rel=preload, modulepreload or prefetch
+      (/preload|prefetch/i.test(relAttribute) && getLowerCaseAttribute('as') === 'script') ||
       // Favicons
       relAttribute === 'shortcut icon' ||
       relAttribute === 'icon'


### PR DESCRIPTION
## Motivation

Ignore elements of type:
```
<link rel="preload" as="script">
<link rel="modulepreload" as="script">
<link rel="prefetch" as="script">
```
to decrease payload, as they are ignored as well by replay.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
