### PR TITLE
👷 attempt to fix staging-reset

### DIFF
--- a/scripts/bump-chrome-driver-version.js
+++ b/scripts/bump-chrome-driver-version.js
@@ -5,7 +5,7 @@ const {
   printError,
   logAndExit,
   executeCommand,
-  replaceCiVariable,
+  replaceCiFileVariable,
   initGitConfig,
   getSecretKey,
   fetch,
@@ -53,9 +53,9 @@ async function main() {
   await executeCommand(`git checkout -b ${chromeVersionBranch}`)
 
   printLog('Update versions...')
-  await replaceCiVariable('CHROME_DRIVER_VERSION', driverVersion)
-  await replaceCiVariable('CHROME_PACKAGE_VERSION', packageVersion)
-  await replaceCiVariable('CURRENT_CI_IMAGE', Number(CURRENT_CI_IMAGE) + 1)
+  await replaceCiFileVariable('CHROME_DRIVER_VERSION', driverVersion)
+  await replaceCiFileVariable('CHROME_PACKAGE_VERSION', packageVersion)
+  await replaceCiFileVariable('CURRENT_CI_IMAGE', Number(CURRENT_CI_IMAGE) + 1)
 
   await executeCommand(`git add ${CI_FILE}`)
   await executeCommand(`git commit -m "${commitMessage}"`)

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -1,12 +1,20 @@
 'use strict'
 
 const fs = require('fs')
-const { CI_FILE, initGitConfig, executeCommand, printLog, logAndExit, replaceCiVariable } = require('../utils')
+const {
+  CI_FILE,
+  initGitConfig,
+  executeCommand,
+  printLog,
+  logAndExit,
+  replaceCiVariable,
+  readCiVariable,
+} = require('../utils')
 
 const REPOSITORY = process.env.GIT_REPOSITORY
 const MAIN_BRANCH = process.env.MAIN_BRANCH
 
-const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
+const CURRENT_STAGING_BRANCH = readCiVariable('CURRENT_STAGING')
 const NEW_STAGING_NUMBER = getWeekNumber().toString().padStart(2, '0')
 const NEW_STAGING_BRANCH = `staging-${NEW_STAGING_NUMBER}`
 

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -38,16 +38,11 @@ async function main() {
     printLog(`Staging branch already up to date in ${CI_FILE}. Skipping.`)
   }
 
-  let doesStagingExistLocally
   try {
-    await executeCommand(`git show-ref --heads ${NEW_STAGING_BRANCH}`)
-    doesStagingExistLocally = true
-  } catch {
-    doesStagingExistLocally = false
-  }
-  if (doesStagingExistLocally) {
-    printLog('New staging branch already exists locally, deleting...')
+    printLog('Deleting existing staging local branch if it exists...')
     await executeCommand(`git branch -D ${NEW_STAGING_BRANCH}`)
+  } catch {
+    // The local branch did not exist yet, let's continue
   }
 
   printLog('Creating the new staging branch...')

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -30,15 +30,21 @@ async function main() {
     printLog(`Staging branch already up to date in ${CI_FILE}. Skipping.`)
   }
 
-  const doesStagingExist = await executeCommand(`git ls-remote --heads ${REPOSITORY} ${NEW_STAGING_BRANCH}`)
-  if (doesStagingExist) {
-    printLog('New staging branch already exists, deleting...')
-    await executeCommand(`git branch -d ${NEW_STAGING_BRANCH}`)
-    await executeCommand(`git push origin --delete ${NEW_STAGING_BRANCH}`)
+  let doesStagingExistLocally
+  try {
+    await executeCommand(`git show-ref --heads ${NEW_STAGING_BRANCH}`)
+    doesStagingExistLocally = true
+  } catch {
+    doesStagingExistLocally = false
   }
+  if (doesStagingExistLocally) {
+    printLog('New staging branch already exists locally, deleting...')
+    await executeCommand(`git branch -D ${NEW_STAGING_BRANCH}`)
+  }
+
   printLog('Creating the new staging branch...')
   await executeCommand(`git checkout -b ${NEW_STAGING_BRANCH}`)
-  await executeCommand(`git push origin ${NEW_STAGING_BRANCH}`)
+  await executeCommand(`git push origin -f ${NEW_STAGING_BRANCH}`)
 
   await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH}`)
   await executeCommand('git pull')

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -7,14 +7,14 @@ const {
   executeCommand,
   printLog,
   logAndExit,
-  replaceCiVariable,
-  readCiVariable,
+  replaceCiFileVariable,
+  readCiFileVariable,
 } = require('../utils')
 
 const REPOSITORY = process.env.GIT_REPOSITORY
 const MAIN_BRANCH = process.env.MAIN_BRANCH
 
-const CURRENT_STAGING_BRANCH = readCiVariable('CURRENT_STAGING')
+const CURRENT_STAGING_BRANCH = readCiFileVariable('CURRENT_STAGING')
 const NEW_STAGING_NUMBER = getWeekNumber().toString().padStart(2, '0')
 const NEW_STAGING_BRANCH = `staging-${NEW_STAGING_NUMBER}`
 
@@ -31,7 +31,7 @@ async function main() {
   if (isNewBranch) {
     printLog(`Changing staging branch in ${CI_FILE}...`)
 
-    await replaceCiVariable('CURRENT_STAGING', NEW_STAGING_BRANCH)
+    await replaceCiFileVariable('CURRENT_STAGING', NEW_STAGING_BRANCH)
     await executeCommand(`git commit ${CI_FILE} -m "👷 Bump staging to ${NEW_STAGING_BRANCH}"`)
     await executeCommand(`git push origin ${MAIN_BRANCH}`)
   } else {

--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -57,7 +57,7 @@ async function main() {
 
 function getWeekNumber() {
   const today = new Date()
-  const yearStart = new Date(today.getUTCFullYear(), 0, 1)
+  const yearStart = new Date(Date.UTC(today.getUTCFullYear(), 0, 1))
   return Math.ceil(((today - yearStart) / 86400000 + yearStart.getUTCDay() + 1) / 7)
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -36,13 +36,13 @@ async function initGitConfig(repository) {
   await executeCommand(`git remote set-url origin ${repository}`)
 }
 
-function readCiVariable(variableName) {
+function readCiFileVariable(variableName) {
   const regexp = new RegExp(`${variableName}: (.*)`)
   const ciFileContent = fs.readFileSync(CI_FILE, { encoding: 'utf-8' })
   return regexp.exec(ciFileContent)?.[1]
 }
 
-async function replaceCiVariable(variableName, value) {
+async function replaceCiFileVariable(variableName, value) {
   await modifyFile(CI_FILE, (content) =>
     content.replace(new RegExp(`${variableName}: .*`), `${variableName}: ${value}`)
   )
@@ -135,8 +135,8 @@ module.exports = {
   printError,
   printLog,
   logAndExit,
-  readCiVariable,
-  replaceCiVariable,
+  readCiFileVariable,
+  replaceCiFileVariable,
   fetch: fetchWrapper,
   modifyFile,
   findBrowserSdkPackageJsonFiles,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,6 +1,7 @@
 const util = require('util')
 const path = require('path')
-const fs = require('fs/promises')
+const fsPromises = require('fs/promises')
+const fs = require('fs')
 const execute = util.promisify(require('child_process').exec)
 const spawn = require('child_process').spawn
 // node-fetch v3.x only support ESM syntax.
@@ -35,6 +36,12 @@ async function initGitConfig(repository) {
   await executeCommand(`git remote set-url origin ${repository}`)
 }
 
+function readCiVariable(variableName) {
+  const regexp = new RegExp(`${variableName}: (.*)`)
+  const ciFileContent = fs.readFileSync(CI_FILE, { encoding: 'utf-8' })
+  return regexp.exec(ciFileContent)?.[1]
+}
+
 async function replaceCiVariable(variableName, value) {
   await modifyFile(CI_FILE, (content) =>
     content.replace(new RegExp(`${variableName}: .*`), `${variableName}: ${value}`)
@@ -46,10 +53,10 @@ async function replaceCiVariable(variableName, value) {
  * @param modifier {(content: string) => string}
  */
 async function modifyFile(filePath, modifier) {
-  const content = await fs.readFile(filePath, { encoding: 'utf-8' })
+  const content = await fsPromises.readFile(filePath, { encoding: 'utf-8' })
   const modifiedContent = modifier(content)
   if (content !== modifiedContent) {
-    await fs.writeFile(filePath, modifiedContent)
+    await fsPromises.writeFile(filePath, modifiedContent)
     return true
   }
   return false
@@ -128,6 +135,7 @@ module.exports = {
   printError,
   printLog,
   logAndExit,
+  readCiVariable,
   replaceCiVariable,
   fetch: fetchWrapper,
   modifyFile,


### PR DESCRIPTION
## Motivation

Staging reset failed this morning. It appears to be multiple issues:
* It checks wether the branch exists on the remote, but it failed to delete the existing branch locally.
* When retried, the job failed again because it did not had any change when editing `.gitlab-ci.yml`. The retry was done on the same initial commit, so the CURRENT_BRANCH environment variable was still `staging-01`, but a commit to updathe this environment variable to `staging-02` was already pushed on  `main` branch.
* While investigating, I figured that week number computation was timezone dependent, which is a bit confusing when running parts of the script locally

## Changes

* Don't check whether the branch exists remotely. Instead, only check if it exists locally, and force push (that's what the dogweb script does)
* Read the CURRENT_BRANCH value directly from the CI file instead of the environment variable
* Make week number computation timezone independent

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
