### PR TITLE
👷 fix staging reset last step

### DIFF
--- a/scripts/staging-ci/staging-reset.js
+++ b/scripts/staging-ci/staging-reset.js
@@ -50,7 +50,7 @@ async function main() {
   await executeCommand(`git push origin -f ${NEW_STAGING_BRANCH}`)
 
   await executeCommand(`git checkout ${CURRENT_STAGING_BRANCH}`)
-  await executeCommand('git pull')
+  await executeCommand(`git pull origin ${CURRENT_STAGING_BRANCH}`)
 
   if (isNewBranch && fs.existsSync(CI_FILE)) {
     printLog('Disabling CI on the old branch...')


### PR DESCRIPTION

## Motivation

It appears that staging branch don't necessarily have an upstream set up, especially when the branch was just created.



## Changes


Be explicit on what we are trying to pull so git doesn't fail.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
