### PR TITLE
📝 Added allowedTracingUrls configuration parameter

### DIFF
--- a/packages/rum/README.md
+++ b/packages/rum/README.md
@@ -412,9 +412,14 @@ Initialization fails silently if the RUM Browser SDK is already initialized on t
 Optional proxy URL, for example: https://www.proxy.com/path. For more information, see the full [proxy setup guide][7].
 
 `allowedTracingOrigins`
-: Optional<br/>
+: Optional - **Deprecated**<br/>
 **Type**: List<br/>
 A list of request origins used to inject tracing headers. For more information, see [Connect RUM and Traces][12].
+
+`allowedTracingUrls`
+: Optional<br/>
+**Type**: List<br/>
+A list of request URLs used to inject tracing headers. For more information, see [Connect RUM and Traces][12].
 
 `tracingSampleRate`
 : Optional<br/>


### PR DESCRIPTION
## Motivation

Adding documentation for newly introduced allowedTracingUrls.
NOTE: [Connect RUM and Traces](https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces) needs to be updated first.


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
