### PR TITLE
Revert "🔊 [RUMF-1345] log first untrusted events of each type"

### DIFF
--- a/packages/core/src/browser/addEventListener.spec.ts
+++ b/packages/core/src/browser/addEventListener.spec.ts
@@ -1,57 +1,9 @@
-import { createNewEvent } from '../../test/specHelper'
 import { stubZoneJs } from '../../test/stubZoneJs'
-import type { RawTelemetryEvent } from '../domain/telemetry'
-import { resetTelemetry, startFakeTelemetry } from '../domain/telemetry'
 import { noop } from '../tools/utils'
 
-import { addEventListener, DOM_EVENT, resetUntrustedEventsCount } from './addEventListener'
+import { addEventListener, DOM_EVENT } from './addEventListener'
 
 describe('addEventListener', () => {
-  describe('untrusted events reporting', () => {
-    let originalJasmine: typeof jasmine
-    let telemetryEvents: RawTelemetryEvent[]
-    let eventTarget: EventTarget
-
-    beforeEach(() => {
-      eventTarget = document.createElement('div')
-      originalJasmine = window.jasmine
-      delete (window as any).jasmine
-      telemetryEvents = startFakeTelemetry()
-    })
-
-    afterEach(() => {
-      window.jasmine = originalJasmine
-      resetTelemetry()
-      resetUntrustedEventsCount()
-    })
-
-    it('sends a telemetry debug log when an untrusted event is dispatched', () => {
-      addEventListener(eventTarget, DOM_EVENT.CLICK, noop)
-      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
-
-      expect(telemetryEvents).toEqual([
-        {
-          message: 'Untrusted event',
-          status: 'debug',
-          type: 'log',
-          event_type: 'click',
-        },
-      ])
-    })
-
-    it('only reports the first untrusted event of each type', () => {
-      addEventListener(eventTarget, DOM_EVENT.CLICK, noop)
-      addEventListener(eventTarget, DOM_EVENT.MOUSE_UP, noop)
-
-      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
-      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
-
-      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.MOUSE_UP))
-
-      expect(telemetryEvents.length).toBe(2)
-    })
-  })
-
   describe('Zone.js support', () => {
     let zoneJsStub: ReturnType<typeof stubZoneJs>
 

--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -1,6 +1,5 @@
 import { monitor } from '../tools/monitor'
 import { getZoneJsOriginalValue } from '../tools/getZoneJsOriginalValue'
-import { addTelemetryDebug } from '../domain/telemetry'
 
 export const enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
@@ -81,13 +80,14 @@ export function addEventListeners<E extends Event>(
   listener: (event: E) => void,
   { once, capture, passive }: AddEventListenerOptions = {}
 ) {
-  const wrappedListener = monitor((event: Event) => {
-    if (once) {
-      stop()
-    }
-    reportUntrustedEvent(event)
-    listener(event as E)
-  })
+  const wrappedListener = monitor(
+    once
+      ? (event: Event) => {
+          stop()
+          listener(event as E)
+        }
+      : (listener as (event: Event) => void)
+  )
 
   const options = passive ? { capture, passive } : capture
 
@@ -102,21 +102,4 @@ export function addEventListeners<E extends Event>(
   return {
     stop,
   }
-}
-
-const reportedUntrustedEventTypes = new Set<string>()
-
-function reportUntrustedEvent(event: Event) {
-  const eventType = event.type
-
-  if (event.isTrusted || (window as any).jasmine || reportedUntrustedEventTypes.has(eventType)) {
-    return
-  }
-
-  reportedUntrustedEventTypes.add(eventType)
-  addTelemetryDebug('Untrusted event', { event_type: eventType })
-}
-
-export function resetUntrustedEventsCount() {
-  reportedUntrustedEventTypes.clear()
 }


### PR DESCRIPTION


## Motivation

We collected enough data around untrusted events.

## Changes

This reverts commit 3a3b9c8d07c5befa628fe952b96f2adc6e478353. It does not revert other changes from the PR https://github.com/DataDog/browser-sdk/pull/1910 (keep the `runOnReadyState` module, keep allowing a few constructiors in the side-effect eslint rule), as it could be valuable in the future.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
