### PR TITLE
👷remove scheduled dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,37 +2,10 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: '09:00'
     commit-message:
       prefix: '👷'
 
   - package-ecosystem: npm
     directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: '09:00'
     commit-message:
       prefix: '👷'
-    ignore:
-      # update puppeteer: RUMF-1157
-      - dependency-name: 'puppeteer'
-        update-types: ['version-update:semver-major']
-      # update node & express types: RUMF-1158
-      - dependency-name: '@types/node'
-      - dependency-name: '@types/express'
-      # update jasmine: RUMF-1161
-      - dependency-name: '*jasmine*'
-      - dependency-name: '*sinon*'
-      # update ajv: RUMF-1164
-      - dependency-name: 'ajv'
-        update-types: ['version-update:semver-major']
-      # update ansi-regex: RUMF-1165
-      - dependency-name: 'ansi-regex'
-      # update webpack: RUMF-1166
-      - dependency-name: '*webpack*'
-      - dependency-name: '*'
-        update-types: ['version-update:semver-minor', 'version-update:semver-patch']


### PR DESCRIPTION
## Motivation

Avoid to be notified for updates by both dependabot and renovate

## Changes

- remove dependabot update schedules
- remove dependabot ignored packages

Still keep dependabot.yml for commit message configuration for dependabot security updates.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
