### PR TITLE
👷properly disable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,16 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 0
     commit-message:
       prefix: '👷'
 
   - package-ecosystem: npm
     directory: /
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 0
     commit-message:
       prefix: '👷'


### PR DESCRIPTION
## Motivation

Following #1954, `schedule` property is actually required in the yml schema 🤦‍♂️ 

## Changes

Follow [documented workaround](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) and set open PR limit to 0.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
