### PR TITLE
Revert "🔊 add view document_count in non-view events (#1892)"

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,11 +1,5 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import {
-  updateExperimentalFeatures,
-  resetExperimentalFeatures,
-  ErrorSource,
-  ONE_MINUTE,
-  display,
-} from '@datadog/browser-core'
+import { ErrorSource, ONE_MINUTE, display } from '@datadog/browser-core'
 import { createRumSessionManagerMock } from '../../test/mockRumSessionManager'
 import { createRawRumEvent } from '../../test/fixtures'
 import type { TestSetupBuilder } from '../../test/specHelper'
@@ -34,7 +28,6 @@ describe('rum assembly', () => {
     findView = () => ({
       id: '7890',
       name: 'view name',
-      documentVersion: 42,
     })
     reportErrorSpy = jasmine.createSpy('reportError')
     commonContext = {
@@ -448,10 +441,6 @@ describe('rum assembly', () => {
   })
 
   describe('view context', () => {
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
     it('should be merged with event attributes', () => {
       const { lifeCycle } = setupBuilder.build()
       notifyRawRumEvent(lifeCycle, {
@@ -461,23 +450,6 @@ describe('rum assembly', () => {
         jasmine.objectContaining({
           id: '7890',
           name: 'view name',
-        })
-      )
-    })
-
-    it('should include the view document version in global context', () => {
-      updateExperimentalFeatures(['report_view_document_version'])
-      const { lifeCycle } = setupBuilder.build()
-      notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
-      })
-      expect(serverRumEvents[0].context).toEqual(
-        jasmine.objectContaining({
-          _dd: {
-            view: {
-              document_version: 42,
-            },
-          },
         })
       )
     })
@@ -500,7 +472,7 @@ describe('rum assembly', () => {
 
     it('should be overridden by the view context', () => {
       const { lifeCycle } = setupBuilder.build()
-      findView = () => ({ service: 'new service', version: 'new version', id: '1234', documentVersion: 0 })
+      findView = () => ({ service: 'new service', version: 'new version', id: '1234' })
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -1,6 +1,5 @@
 import type { Context, RawError, EventRateLimiter, User } from '@datadog/browser-core'
 import {
-  isExperimentalFeatureEnabled,
   combine,
   isEmptyObject,
   limitModification,
@@ -139,14 +138,6 @@ export function startRumAssembly(
 
         if (!isEmptyObject(commonContext.user)) {
           ;(serverRumEvent.usr as Mutable<RumEvent['usr']>) = commonContext.user as User & Context
-        }
-
-        if (isExperimentalFeatureEnabled('report_view_document_version')) {
-          serverRumEvent.context._dd = {
-            view: {
-              document_version: viewContext.documentVersion,
-            },
-          }
         }
 
         if (shouldSend(serverRumEvent, configuration.beforeSend, domainContext, eventRateLimiters)) {

--- a/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
@@ -3,7 +3,7 @@ import { relativeToClocks, CLEAR_OLD_CONTEXTS_INTERVAL } from '@datadog/browser-
 import type { TestSetupBuilder } from '../../../test/specHelper'
 import { setup } from '../../../test/specHelper'
 import { LifeCycleEventType } from '../lifeCycle'
-import type { ViewCreatedEvent, ViewEvent } from '../rumEventsCollection/view/trackViews'
+import type { ViewCreatedEvent } from '../rumEventsCollection/view/trackViews'
 import type { ViewContexts } from './viewContexts'
 import { startViewContexts, VIEW_CONTEXT_TIME_OUT_DELAY } from './viewContexts'
 
@@ -15,7 +15,6 @@ describe('viewContexts', () => {
     return {
       startClocks,
       id: FAKE_ID,
-      documentVersion: 0,
       ...partialViewCreatedEvent,
     }
   }
@@ -109,23 +108,6 @@ describe('viewContexts', () => {
 
       lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ name: 'Fake name' }))
       expect(viewContexts.findView()!.name).toBe('Fake name')
-    })
-
-    it('should update the document version on update', () => {
-      const { lifeCycle } = setupBuilder.build()
-
-      const startClocks = relativeToClocks(0 as RelativeTime)
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, buildViewCreatedEvent({ startClocks }))
-
-      expect(viewContexts.findView()!.documentVersion).toBe(0)
-
-      lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, {
-        startClocks,
-        documentVersion: 1,
-      } as ViewEvent)
-
-      expect(viewContexts.findView()!.documentVersion).toBe(1)
     })
   })
 

--- a/packages/rum-core/src/domain/contexts/viewContexts.ts
+++ b/packages/rum-core/src/domain/contexts/viewContexts.ts
@@ -10,7 +10,6 @@ export interface ViewContext {
   service?: string
   version?: string
   id: string
-  documentVersion: number
   name?: string
 }
 
@@ -24,13 +23,6 @@ export function startViewContexts(lifeCycle: LifeCycle): ViewContexts {
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
     viewContextHistory.add(buildViewContext(view), view.startClocks.relative)
-  })
-
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, ({ startClocks, documentVersion }) => {
-    const viewContext = viewContextHistory.find(startClocks.relative)
-    if (viewContext) {
-      viewContext.documentVersion = documentVersion
-    }
   })
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, ({ endClocks }) => {
@@ -47,7 +39,6 @@ export function startViewContexts(lifeCycle: LifeCycle): ViewContexts {
       version: view.version,
       id: view.id,
       name: view.name,
-      documentVersion: view.documentVersion,
     }
   }
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -52,7 +52,6 @@ export interface ViewCreatedEvent {
   service?: string
   version?: string
   startClocks: ClocksState
-  documentVersion: number
 }
 
 export interface ViewEndedEvent {
@@ -213,7 +212,6 @@ function newView(
     startClocks,
     service,
     version,
-    documentVersion,
   })
 
   // Update the view every time the measures are changing

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -242,9 +242,6 @@ export interface RumContext {
     session: {
       plan: RumSessionPlan
     }
-    view?: {
-      document_version: number
-    }
     browser_sdk_version?: string
   }
 }

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -49,7 +49,7 @@ describe('startRecording', () => {
       setupBuilder = setup()
         .withViewContexts({
           findView() {
-            return { id: viewId, documentVersion: 0 }
+            return { id: viewId }
           },
         })
         .withSessionManager(sessionManager)

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -265,7 +265,7 @@ describe('startSegmentCollection', () => {
 })
 
 describe('computeSegmentContext', () => {
-  const DEFAULT_VIEW_CONTEXT: ViewContext = { id: '123', documentVersion: 0 }
+  const DEFAULT_VIEW_CONTEXT: ViewContext = { id: '123' }
   const DEFAULT_SESSION = createRumSessionManagerMock().setId('456')
 
   it('returns a segment context', () => {


### PR DESCRIPTION


## Motivation

We collected enough data to confirm that most invalid counters are caused by missing view updates.

## Changes

This reverts commit 1dcc3a961a58023b52ed87ea021c41845b069f51.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
