### PR TITLE
[REPLAY] Keep Href from link even when importing CSS

### DIFF
--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -506,3 +506,12 @@ export function interceptRequests() {
 export function isAdoptedStyleSheetsSupported() {
   return Boolean((document as any).adoptedStyleSheets)
 }
+
+export function isCSSStyleSheetConstructorSupported() {
+  try {
+    new CSSStyleSheet()
+  } catch (err) {
+    return false
+  }
+  return true
+}

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -506,12 +506,3 @@ export function interceptRequests() {
 export function isAdoptedStyleSheetsSupported() {
   return Boolean((document as any).adoptedStyleSheets)
 }
-
-export function isCSSStyleSheetConstructorSupported() {
-  try {
-    new CSSStyleSheet()
-  } catch (err) {
-    return false
-  }
-  return true
-}

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -98,6 +98,16 @@ describe('serializeNodeWithId', () => {
   })
 
   describe('elements serialization', () => {
+    let isolatedDom: IsolatedDom
+
+    beforeEach(() => {
+      isolatedDom = createIsolatedDom()
+    })
+
+    afterEach(() => {
+      isolatedDom.clear()
+    })
+
     it('serializes a div', () => {
       expect(serializeNodeWithId(document.createElement('div'), DEFAULT_OPTIONS)).toEqual({
         type: NodeType.Element,
@@ -518,6 +528,60 @@ describe('serializeNodeWithId', () => {
         id: jasmine.any(Number) as unknown as number,
       })
       expect(addShadowRootSpy).not.toHaveBeenCalled()
+    })
+
+    it('serializes style node with local CSS', () => {
+      const styleNode = document.createElement('style')
+      isolatedDom.document.head.appendChild(styleNode)
+      const styleSheet = styleNode.sheet
+      styleSheet?.insertRule('body { width: 100%; }')
+      expect(serializeNodeWithId(styleNode, DEFAULT_OPTIONS)).toEqual({
+        type: NodeType.Element,
+        tagName: 'style',
+        id: jasmine.any(Number) as unknown as number,
+        isSVG: undefined,
+        attributes: { _cssText: 'body { width: 100%; }' },
+        childNodes: [],
+      })
+    })
+
+    it('serializes style node with dynamic CSS that cannot be fetched', () => {
+      const linkNode = document.createElement('link')
+      linkNode.setAttribute('rel', 'stylesheet')
+      linkNode.setAttribute('href', 'https://datadoghq.com/some/style.css')
+      isolatedDom.document.head.appendChild(linkNode)
+      expect(serializeNodeWithId(linkNode, DEFAULT_OPTIONS)).toEqual({
+        type: NodeType.Element,
+        tagName: 'link',
+        id: jasmine.any(Number) as unknown as number,
+        isSVG: undefined,
+        attributes: { rel: 'stylesheet', href: 'https://datadoghq.com/some/style.css' },
+        childNodes: [],
+      })
+    })
+
+    it('serializes style node with dynamic CSS that can be fetched', () => {
+      const linkNode = document.createElement('link')
+      linkNode.setAttribute('rel', 'stylesheet')
+      linkNode.setAttribute('href', 'https://datadoghq.com/some/style.css')
+      isolatedDom.document.head.appendChild(linkNode)
+      const styleSheet = new CSSStyleSheet()
+      styleSheet.insertRule('body { width: 100%; }')
+      spyOnProperty(styleSheet, 'href', 'get').and.returnValue('https://datadoghq.com/some/style.css')
+      spyOnProperty(isolatedDom.document, 'styleSheets', 'get').and.returnValue([styleSheet])
+
+      expect(serializeNodeWithId(linkNode, DEFAULT_OPTIONS)).toEqual({
+        type: NodeType.Element,
+        tagName: 'link',
+        id: jasmine.any(Number) as unknown as number,
+        isSVG: undefined,
+        attributes: {
+          _cssText: 'body { width: 100%; }',
+          rel: 'stylesheet',
+          href: 'https://datadoghq.com/some/style.css',
+        },
+        childNodes: [],
+      })
     })
   })
 

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -10,7 +10,7 @@ import {
   PRIVACY_ATTR_VALUE_MASK,
   PRIVACY_ATTR_VALUE_MASK_USER_INPUT,
 } from '../../constants'
-import { isAdoptedStyleSheetsSupported, isCSSStyleSheetConstructorSupported } from '../../../../core/test/specHelper'
+import { isAdoptedStyleSheetsSupported } from '../../../../core/test/specHelper'
 import {
   HTML,
   AST_ALLOW,
@@ -561,17 +561,18 @@ describe('serializeNodeWithId', () => {
     })
 
     it('serializes style node with dynamic CSS that can be fetched', () => {
-      if (!isCSSStyleSheetConstructorSupported()) {
-        pending('no CSSStyleSheet constructor')
-      }
       const linkNode = document.createElement('link')
       linkNode.setAttribute('rel', 'stylesheet')
       linkNode.setAttribute('href', 'https://datadoghq.com/some/style.css')
       isolatedDom.document.head.appendChild(linkNode)
-      const styleSheet = new CSSStyleSheet()
-      styleSheet.insertRule('body { width: 100%; }')
-      spyOnProperty(styleSheet, 'href', 'get').and.returnValue('https://datadoghq.com/some/style.css')
-      spyOnProperty(isolatedDom.document, 'styleSheets', 'get').and.returnValue([styleSheet])
+      Object.defineProperty(isolatedDom.document, 'styleSheets', {
+        value: [
+          {
+            href: 'https://datadoghq.com/some/style.css',
+            cssRules: [{ cssText: 'body { width: 100%; }' }],
+          },
+        ],
+      })
 
       expect(serializeNodeWithId(linkNode, DEFAULT_OPTIONS)).toEqual({
         type: NodeType.Element,

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -10,7 +10,7 @@ import {
   PRIVACY_ATTR_VALUE_MASK,
   PRIVACY_ATTR_VALUE_MASK_USER_INPUT,
 } from '../../constants'
-import { isAdoptedStyleSheetsSupported } from '../../../../core/test/specHelper'
+import { isAdoptedStyleSheetsSupported, isCSSStyleSheetConstructorSupported } from '../../../../core/test/specHelper'
 import {
   HTML,
   AST_ALLOW,
@@ -561,6 +561,9 @@ describe('serializeNodeWithId', () => {
     })
 
     it('serializes style node with dynamic CSS that can be fetched', () => {
+      if (!isCSSStyleSheetConstructorSupported()) {
+        pending('no CSSStyleSheet constructor')
+      }
       const linkNode = document.createElement('link')
       linkNode.setAttribute('rel', 'stylesheet')
       linkNode.setAttribute('href', 'https://datadoghq.com/some/style.css')

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -431,8 +431,6 @@ function getAttributesForPrivacyLevel(
     const stylesheet = Array.from(doc.styleSheets).find((s) => s.href === (element as HTMLLinkElement).href)
     const cssText = getCssRulesString(stylesheet as CSSStyleSheet)
     if (cssText && stylesheet) {
-      delete safeAttrs.rel
-      delete safeAttrs.href
       safeAttrs._cssText = cssText
     }
   }


### PR DESCRIPTION
## Motivation

The goal is to leave to the player the opportunity to either use inline CSS or rely on external resource

## Changes

- Keep Href from link even when importing CSS
- Add missing tests on the style serialization

## Testing

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

We now capture both `href` & `_cssText`

<img width="652" alt="image" src="https://user-images.githubusercontent.com/44997281/214268104-f44f66eb-83ba-4dd4-b732-7849d92e7df3.png">


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
