### PR TITLE
🐛 Fix jasmine spy type issue

### DIFF
--- a/packages/core/src/transport/batch.spec.ts
+++ b/packages/core/src/transport/batch.spec.ts
@@ -3,7 +3,6 @@ import type { PageExitEvent } from '../browser/pageExitObservable'
 import { PageExitReason } from '../browser/pageExitObservable'
 import { Observable } from '../tools/observable'
 import { noop } from '../tools/utils'
-import type { BatchFlushEvent } from './batch'
 import { Batch } from './batch'
 import type { HttpRequest } from './httpRequest'
 
@@ -16,7 +15,7 @@ describe('batch', () => {
   let transport: HttpRequest
   let sendSpy: jasmine.Spy<HttpRequest['send']>
   let pageExitObservable: Observable<PageExitEvent>
-  let flushNotifySpy: jasmine.Spy<() => BatchFlushEvent>
+  let flushNotifySpy: jasmine.Spy
 
   beforeEach(() => {
     transport = { send: noop } as unknown as HttpRequest


### PR DESCRIPTION
## Motivation

With the upgrade of jasmine the typecheck is more strict and fails if the jasmine spy def does not match with the test assertion

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
