### PR TITLE
🐛 reset input state at the beginning of each click

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -180,8 +180,15 @@ describe('listenActionEvents', () => {
     it('click that triggers an input event slightly after the click should report an input user activity', () => {
       emulateClick()
       emulateInputEvent()
-      clock.tick(1)
+      clock.tick(1) // run immediate timeouts
       expect(hasInputUserActivity()).toBe(true)
+    })
+
+    it('input events that precede clicks should not be taken into account', () => {
+      emulateInputEvent()
+      emulateClick()
+      clock.tick(1) // run immediate timeouts
+      expect(hasInputUserActivity()).toBe(false)
     })
 
     it('click and type should report an input user activity', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -1,3 +1,4 @@
+import { resetExperimentalFeatures, updateExperimentalFeatures } from '@datadog/browser-core'
 import type { Clock } from '../../../../../core/test/specHelper'
 import { createNewEvent, mockClock } from '../../../../../core/test/specHelper'
 import type { ActionEventsHooks } from './listenActionEvents'
@@ -184,11 +185,24 @@ describe('listenActionEvents', () => {
       expect(hasInputUserActivity()).toBe(true)
     })
 
-    it('input events that precede clicks should not be taken into account', () => {
-      emulateInputEvent()
-      emulateClick()
-      clock.tick(1) // run immediate timeouts
-      expect(hasInputUserActivity()).toBe(false)
+    describe('with fix_dead_clicks_after_input flag', () => {
+      beforeEach(() => {
+        stopListenEvents()
+
+        updateExperimentalFeatures(['fix_dead_clicks_after_input'])
+        ;({ stop: stopListenEvents } = listenActionEvents(actionEventsHooks))
+      })
+
+      afterEach(() => {
+        resetExperimentalFeatures()
+      })
+
+      it('input events that precede clicks should not be taken into account', () => {
+        emulateInputEvent()
+        emulateClick()
+        clock.tick(1) // run immediate timeouts
+        expect(hasInputUserActivity()).toBe(false)
+      })
     })
 
     it('click and type should report an input user activity', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -21,6 +21,7 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onClick }: Act
       (event) => {
         hasSelectionChanged = false
         selectionEmptyAtPointerDown = isSelectionEmpty()
+        hasInputChanged = false
         if (isMouseEventOnElement(event)) {
           clickContext = onPointerDown(event)
         }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -1,4 +1,4 @@
-import { addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
+import { addEventListener, DOM_EVENT, isExperimentalFeatureEnabled, monitor } from '@datadog/browser-core'
 
 export type MouseEventOnElement = MouseEvent & { target: Element }
 
@@ -21,7 +21,9 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onClick }: Act
       (event) => {
         hasSelectionChanged = false
         selectionEmptyAtPointerDown = isSelectionEmpty()
-        hasInputChanged = false
+        if (isExperimentalFeatureEnabled('fix_dead_clicks_after_input')) {
+          hasInputChanged = false
+        }
         if (isMouseEventOnElement(event)) {
           clickContext = onPointerDown(event)
         }


### PR DESCRIPTION

## Motivation

This issue was causing a lot of false negative dead clicks. Once an "input" event was triggered on the page, all subsequent clicks were considered to have changed an input, so no dead clicks were produced anymore.

<img src="https://media.tenor.com/YctxttUmGMYAAAAC/forehead-slap-slapping-forehead.gif" />

## Changes

Reset the `hasInputChanged` state whenever a new click happens.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
