### PR TITLE
[REPLAY] Remove exp flag for shadow dom

### DIFF
--- a/packages/rum/src/domain/record/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/mutationObserver.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPrivacyLevel, isIE, noop, updateExperimentalFeatures } from '@datadog/browser-core'
+import { DefaultPrivacyLevel, isIE, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { collectAsyncCalls, createMutationPayloadValidator } from '../../../test/utils'
 import {
@@ -455,8 +455,6 @@ describe('startMutationCollection', () => {
 
     describe('for shadow DOM', () => {
       it('should call addShadowRoot when host is added', () => {
-        updateExperimentalFeatures(['record_shadow_dom'])
-
         const serializedDocument = serializeDocumentWithDefaults()
         const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
         const host = document.createElement('div')
@@ -486,7 +484,6 @@ describe('startMutationCollection', () => {
       })
 
       it('should call removeShadowRoot when host is removed', () => {
-        updateExperimentalFeatures(['record_shadow_dom'])
         const host = document.createElement('div')
         host.id = 'host'
         const shadowRoot = host.attachShadow({ mode: 'open' })
@@ -512,7 +509,6 @@ describe('startMutationCollection', () => {
       })
 
       it('should call removeShadowRoot when parent of host is removed', () => {
-        updateExperimentalFeatures(['record_shadow_dom'])
         const parent = document.createElement('div')
         parent.id = 'parent'
         const host = document.createElement('div')

--- a/packages/rum/src/domain/record/mutationObserver.ts
+++ b/packages/rum/src/domain/record/mutationObserver.ts
@@ -1,4 +1,4 @@
-import { isExperimentalFeatureEnabled, monitor, noop } from '@datadog/browser-core'
+import { monitor, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import {
   getChildNodes,
@@ -382,9 +382,6 @@ export function sortAddedAndMovedNodes(nodes: Node[]) {
   })
 }
 function traverseRemovedShadowDom(removedNode: Node, shadowDomRemovedCallback: ShadowRootCallBack) {
-  if (!isExperimentalFeatureEnabled('record_shadow_dom')) {
-    return
-  }
   if (isNodeShadowHost(removedNode)) {
     shadowDomRemovedCallback(removedNode.shadowRoot)
   }

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -1,11 +1,4 @@
-import {
-  DefaultPrivacyLevel,
-  isIE,
-  noop,
-  relativeNow,
-  timeStampNow,
-  updateExperimentalFeatures,
-} from '@datadog/browser-core'
+import { DefaultPrivacyLevel, isIE, noop, relativeNow, timeStampNow } from '@datadog/browser-core'
 import type { RawRumActionEvent, RumConfiguration } from '@datadog/browser-rum-core'
 import { ActionType, LifeCycle, LifeCycleEventType, RumEventType, FrustrationType } from '@datadog/browser-rum-core'
 import type { RawRumEventCollectedData } from 'packages/rum-core/src/domain/lifeCycle'
@@ -68,7 +61,6 @@ describe('initInputObserver', () => {
 
   // cannot trigger a event in a Shadow DOM because event with `isTrusted:false` do not cross the root
   it('collects input values when an "input" event is composed', () => {
-    updateExperimentalFeatures(['record_shadow_dom'])
     stopInputObserver = initInputObserver(inputCallbackSpy, DefaultPrivacyLevel.ALLOW)
     dispatchInputEventWithInShadowDom('foo')
 

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -9,7 +9,6 @@ import {
   addEventListeners,
   addEventListener,
   noop,
-  isExperimentalFeatureEnabled,
 } from '@datadog/browser-core'
 import type { LifeCycle, RumConfiguration } from '@datadog/browser-rum-core'
 import {
@@ -512,11 +511,7 @@ export function initFrustrationObserver(lifeCycle: LifeCycle, frustrationCb: Fru
 }
 
 function getEventTarget(event: Event): Node {
-  if (
-    event.composed === true &&
-    isNodeShadowHost(event.target as Node) &&
-    isExperimentalFeatureEnabled('record_shadow_dom')
-  ) {
+  if (event.composed === true && isNodeShadowHost(event.target as Node)) {
     return event.composedPath()[0] as Node
   }
   return event.target as Node

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,10 +1,4 @@
-import {
-  DefaultPrivacyLevel,
-  findLast,
-  isIE,
-  resetExperimentalFeatures,
-  updateExperimentalFeatures,
-} from '@datadog/browser-core'
+import { DefaultPrivacyLevel, findLast, isIE, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycle } from '@datadog/browser-rum-core'
 import type { Clock } from '../../../../core/test/specHelper'
@@ -224,7 +218,6 @@ describe('record', () => {
     })
 
     it('should record a simple mutation inside a shadow root', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const div = document.createElement('div')
       div.className = 'toto'
       createShadow([div])
@@ -243,7 +236,6 @@ describe('record', () => {
     })
 
     it('should record a direct removal inside a shadow root', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const span = document.createElement('span')
       createShadow([span])
       startRecording()
@@ -268,7 +260,6 @@ describe('record', () => {
     })
 
     it('should record a direct addition inside a shadow root', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const span = document.createElement('span')
       const shadowRoot = createShadow([span])
       startRecording()
@@ -296,7 +287,6 @@ describe('record', () => {
     })
 
     it('should record mutation inside a shadow root added after the FS', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
@@ -329,7 +319,6 @@ describe('record', () => {
     })
 
     it('should record the change event inside a shadow root', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const radio = document.createElement('input')
       radio.setAttribute('type', 'radio')
       createShadow([radio])
@@ -349,7 +338,6 @@ describe('record', () => {
     })
 
     it('should clean the state once the shadow dom is removed to avoid memory leak', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const div = document.createElement('div')
       div.className = 'toto'
       const shadowRoot = createShadow([div])
@@ -370,7 +358,6 @@ describe('record', () => {
     })
 
     it('should clean the state when both the parent and the shadow host is removed to avoid memory leak', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const grandParent = document.createElement('div')
       const parent = document.createElement('div')
       grandParent.appendChild(parent)

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPrivacyLevel, findLast, isIE, resetExperimentalFeatures } from '@datadog/browser-core'
+import { DefaultPrivacyLevel, findLast, isIE } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycle } from '@datadog/browser-rum-core'
 import type { Clock } from '../../../../core/test/specHelper'
@@ -214,7 +214,6 @@ describe('record', () => {
 
     afterEach(() => {
       sandbox.remove()
-      resetExperimentalFeatures()
     })
 
     it('should record a simple mutation inside a shadow root', () => {

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -1,4 +1,4 @@
-import { isIE, noop, resetExperimentalFeatures, updateExperimentalFeatures } from '@datadog/browser-core'
+import { isIE, noop, resetExperimentalFeatures } from '@datadog/browser-core'
 
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { STABLE_ATTRIBUTES, DEFAULT_PROGRAMMATIC_ACTION_NAME_ATTRIBUTE } from '@datadog/browser-rum-core'
@@ -439,7 +439,6 @@ describe('serializeNodeWithId', () => {
     })
 
     it('serializes a shadow host', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const div = document.createElement('div')
       div.attachShadow({ mode: 'open' })
       expect(serializeNodeWithId(div, DEFAULT_OPTIONS)).toEqual({
@@ -461,7 +460,6 @@ describe('serializeNodeWithId', () => {
     })
 
     it('serializes a shadow host with children', () => {
-      updateExperimentalFeatures(['record_shadow_dom'])
       const div = document.createElement('div')
       div.attachShadow({ mode: 'open' })
       div.shadowRoot!.appendChild(document.createElement('hr'))
@@ -502,32 +500,6 @@ describe('serializeNodeWithId', () => {
         id: jasmine.any(Number) as unknown as number,
       })
       expect(addShadowRootSpy).toHaveBeenCalledWith(div.shadowRoot!)
-    })
-
-    it('does not serialize shadow host children when the experimental flag is missing', () => {
-      const div = document.createElement('div')
-      div.attachShadow({ mode: 'open' })
-      div.shadowRoot!.appendChild(document.createElement('hr'))
-
-      const options: SerializeOptions = {
-        ...DEFAULT_OPTIONS,
-        serializationContext: {
-          ...DEFAULT_SERIALIZATION_CONTEXT,
-          shadowRootsController: {
-            ...DEFAULT_SHADOW_ROOT_CONTROLLER,
-            addShadowRoot: addShadowRootSpy,
-          },
-        },
-      }
-      expect(serializeNodeWithId(div, options)).toEqual({
-        type: NodeType.Element,
-        tagName: 'div',
-        attributes: {},
-        isSVG: undefined,
-        childNodes: [],
-        id: jasmine.any(Number) as unknown as number,
-      })
-      expect(addShadowRootSpy).not.toHaveBeenCalled()
     })
 
     it('serializes style node with local CSS', () => {

--- a/packages/rum/src/domain/record/serialize.spec.ts
+++ b/packages/rum/src/domain/record/serialize.spec.ts
@@ -1,4 +1,4 @@
-import { isIE, noop, resetExperimentalFeatures } from '@datadog/browser-core'
+import { isIE, noop } from '@datadog/browser-core'
 
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { STABLE_ATTRIBUTES, DEFAULT_PROGRAMMATIC_ACTION_NAME_ATTRIBUTE } from '@datadog/browser-rum-core'
@@ -78,7 +78,6 @@ describe('serializeNodeWithId', () => {
   })
 
   afterEach(() => {
-    resetExperimentalFeatures()
     sandbox.remove()
   })
 

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -1,4 +1,4 @@
-import { assign, isExperimentalFeatureEnabled, startsWith } from '@datadog/browser-core'
+import { assign, startsWith } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { isNodeShadowHost, isNodeShadowRoot, STABLE_ATTRIBUTES } from '@datadog/browser-rum-core'
 import {
@@ -228,7 +228,7 @@ export function serializeElementNode(element: Element, options: SerializeOptions
     childNodes = serializeChildNodes(element, childNodesSerializationOptions)
   }
 
-  if (isNodeShadowHost(element) && isExperimentalFeatureEnabled('record_shadow_dom')) {
+  if (isNodeShadowHost(element)) {
     const shadowRoot = serializeNodeWithId(element.shadowRoot, options)
     if (shadowRoot !== null) {
       childNodes.push(shadowRoot)

--- a/test/e2e/scenario/recorder/shadowDom.scenario.ts
+++ b/test/e2e/scenario/recorder/shadowDom.scenario.ts
@@ -113,7 +113,7 @@ class DivWithStyle extends HTMLElement {
 
 describe('recorder with shadow DOM', () => {
   createTest('can record fullsnapshot with the detail inside the shadow root')
-    .withRum({ defaultPrivacyLevel: 'allow', enableExperimentalFeatures: ['record_shadow_dom'] })
+    .withRum({ defaultPrivacyLevel: 'allow' })
     .withRumInit(initRumAndStartRecording)
     .withSetup(bundleSetup)
     .withBody(
@@ -136,7 +136,7 @@ describe('recorder with shadow DOM', () => {
     })
 
   createTest('can record fullsnapshot with adoptedStylesheet')
-    .withRum({ enableExperimentalFeatures: ['record_shadow_dom'] })
+    .withRum()
     .withRumInit(initRumAndStartRecording)
     .withSetup(bundleSetup)
     .withBody(
@@ -164,7 +164,7 @@ describe('recorder with shadow DOM', () => {
     })
 
   createTest('can apply privacy level set from outside or inside the shadow DOM')
-    .withRum({ defaultPrivacyLevel: 'allow', enableExperimentalFeatures: ['record_shadow_dom'] })
+    .withRum({ defaultPrivacyLevel: 'allow' })
     .withRumInit(initRumAndStartRecording)
     .withSetup(bundleSetup)
     .withBody(
@@ -202,7 +202,7 @@ describe('recorder with shadow DOM', () => {
     })
 
   createTest('can record click with target from inside the shadow root')
-    .withRum({ enableExperimentalFeatures: ['record_shadow_dom'] })
+    .withRum()
     .withRumInit(initRumAndStartRecording)
     .withSetup(bundleSetup)
     .withBody(
@@ -228,7 +228,7 @@ describe('recorder with shadow DOM', () => {
     })
 
   createTest('can record mutation from inside the shadow root')
-    .withRum({ defaultPrivacyLevel: 'allow', enableExperimentalFeatures: ['record_shadow_dom'] })
+    .withRum({ defaultPrivacyLevel: 'allow' })
     .withRumInit(initRumAndStartRecording)
     .withSetup(bundleSetup)
     .withBody(


### PR DESCRIPTION
## Motivation

 Remove experimental flag for shadow dom

## Changes

Remove exp flag `record_shadow_dom`

## Testing

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
