### PR TITLE
[REPLAY] Fix shadow dom check

### DIFF
--- a/packages/rum-core/src/browser/htmlDomUtils.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.ts
@@ -11,7 +11,7 @@ export function isElementNode(node: Node): node is Element {
 }
 
 export function isNodeShadowHost(node: Node): node is Element & { shadowRoot: ShadowRoot } {
-  return isElementNode(node) && node.shadowRoot !== null
+  return isElementNode(node) && !!node.shadowRoot && node.shadowRoot.nodeType === Node.DOCUMENT_FRAGMENT_NODE
 }
 
 export function isNodeShadowRoot(node: Node): node is ShadowRoot {

--- a/packages/rum/src/domain/record/shadowRootsController.ts
+++ b/packages/rum/src/domain/record/shadowRootsController.ts
@@ -54,7 +54,10 @@ export const initShadowRootsController = (
     removeShadowRoot: (shadowRoot: ShadowRoot) => {
       const entry = controllerByShadowRoot.get(shadowRoot)
       if (!entry) {
-        addTelemetryDebug('no shadow root in map')
+        addTelemetryDebug('no shadow root in map', {
+          shadowRoot: shadowRoot ? shadowRoot.nodeName : 'no node name',
+          childrenLength: shadowRoot ? shadowRoot.childElementCount : '-1',
+        })
         return
       }
       entry.stop()


### PR DESCRIPTION
## Motivation

Fix shadow dom debug log: `no shadow root in map`

If `element.shadowRoot` returns `undefined`, it will be considered as shadow root

## Changes

- stricter check

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
