### PR TITLE
✅ fix Jasmine deprecation warning in unit tests/IE

### DIFF
--- a/packages/rum-core/src/browser/htmlDomUtils.spec.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.spec.ts
@@ -57,48 +57,45 @@ describe('isElementNode', () => {
   })
 })
 
-describe('isShadowRoot', () => {
-  if (isIE()) {
-    return
-  }
+if (!isIE()) {
+  describe('isShadowRoot', () => {
+    const parent = document.createElement('div')
+    parent.attachShadow({ mode: 'open' })
+    const parameters: Array<[Node, boolean]> = [
+      [parent.shadowRoot!, true],
+      [parent, false],
+      [document.body, false],
+      [document.createTextNode('hello'), false],
+      [document.createComment('hello'), false],
+    ]
 
-  const parent = document.createElement('div')
-  parent.attachShadow({ mode: 'open' })
-  const parameters: Array<[Node, boolean]> = [
-    [parent.shadowRoot!, true],
-    [parent, false],
-    [document.body, false],
-    [document.createTextNode('hello'), false],
-    [document.createComment('hello'), false],
-  ]
-
-  parameters.forEach(([element, result]) => {
-    it(`should return ${String(result)} for "${String(element)}"`, () => {
-      expect(isNodeShadowRoot(element)).toBe(result)
+    parameters.forEach(([element, result]) => {
+      it(`should return ${String(result)} for "${String(element)}"`, () => {
+        expect(isNodeShadowRoot(element)).toBe(result)
+      })
     })
   })
-})
+}
 
-describe('isShadowHost', () => {
-  if (isIE()) {
-    return
-  }
-  const host = document.createElement('div')
-  host.attachShadow({ mode: 'open' })
-  const parameters: Array<[Node, boolean]> = [
-    [host, true],
-    [host.shadowRoot!, false],
-    [document.body, false],
-    [document.createTextNode('hello'), false],
-    [document.createComment('hello'), false],
-  ]
+if (!isIE()) {
+  describe('isShadowHost', () => {
+    const host = document.createElement('div')
+    host.attachShadow({ mode: 'open' })
+    const parameters: Array<[Node, boolean]> = [
+      [host, true],
+      [host.shadowRoot!, false],
+      [document.body, false],
+      [document.createTextNode('hello'), false],
+      [document.createComment('hello'), false],
+    ]
 
-  parameters.forEach(([element, result]) => {
-    it(`should return ${String(result)} for "${String(element)}"`, () => {
-      expect(isNodeShadowHost(element)).toBe(result)
+    parameters.forEach(([element, result]) => {
+      it(`should return ${String(result)} for "${String(element)}"`, () => {
+        expect(isNodeShadowHost(element)).toBe(result)
+      })
     })
   })
-})
+}
 
 describe('getChildNodes', () => {
   it('should return the direct children for a normal node', () => {
@@ -140,27 +137,25 @@ describe('getChildNodes', () => {
   })
 })
 
-describe('getParentNode', () => {
-  if (isIE()) {
-    return
-  }
+if (!isIE()) {
+  describe('getParentNode', () => {
+    const orphanDiv = document.createElement('div')
+    const parentWithShadowRoot = document.createElement('div')
+    const shadowRoot = parentWithShadowRoot.attachShadow({ mode: 'open' })
 
-  const orphanDiv = document.createElement('div')
-  const parentWithShadowRoot = document.createElement('div')
-  const shadowRoot = parentWithShadowRoot.attachShadow({ mode: 'open' })
+    const parentWithoutShadowRoot = document.createElement('div')
+    const child = document.createElement('span')
+    parentWithoutShadowRoot.appendChild(child)
 
-  const parentWithoutShadowRoot = document.createElement('div')
-  const child = document.createElement('span')
-  parentWithoutShadowRoot.appendChild(child)
-
-  const parameters: Array<[string, Node, Node | null]> = [
-    ['return null if without parent', orphanDiv, null],
-    ['return the host for a shadow root', shadowRoot, parentWithShadowRoot],
-    ['return the parent for normal child', child, parentWithoutShadowRoot],
-  ]
-  parameters.forEach(([label, element, result]) => {
-    it(`should ${label}`, () => {
-      expect(getParentNode(element)).toBe(result)
+    const parameters: Array<[string, Node, Node | null]> = [
+      ['return null if without parent', orphanDiv, null],
+      ['return the host for a shadow root', shadowRoot, parentWithShadowRoot],
+      ['return the parent for normal child', child, parentWithoutShadowRoot],
+    ]
+    parameters.forEach(([label, element, result]) => {
+      it(`should ${label}`, () => {
+        expect(getParentNode(element)).toBe(result)
+      })
     })
   })
-})
+}


### PR DESCRIPTION


## Motivation

"DEPRECATION: describe with no children (describe() or it()) is deprecated and will be removed in a future version of Jasmine."

## Changes

Wrapping the `describe` in a `if` statement is not really pretty. Ideally we would use "shadow dom" APIs inside `beforeEach` or `it` blocks instead of `describe`, but this prevents us from using a list to generate test cases.

I think it's acceptable until we eventually drop IE support.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
