### PR TITLE
🐛[RUMF-1465] collect data for disturbed response

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -610,3 +610,12 @@ export function computeBytesCount(candidate: string): number {
 
   return new Blob([candidate]).size
 }
+
+export function tryToClone(response: Response): Response | undefined {
+  try {
+    return response.clone()
+  } catch (e) {
+    // clone can throw if the response has already been used by another instrumentation or is disturbed
+    return
+  }
+}

--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -147,6 +147,7 @@ export interface ResponseStubOptions {
   responseTextError?: Error
   body?: ReadableStream<Uint8Array>
   bodyUsed?: boolean
+  bodyDisturbed?: boolean
 }
 function notYetImplemented(): never {
   throw new Error('not yet implemented')
@@ -158,6 +159,8 @@ export class ResponseStub implements Response {
   constructor(private options: Readonly<ResponseStubOptions>) {
     if (this.options.bodyUsed) {
       this._body = { locked: true } as any
+    } else if (this.options.bodyDisturbed) {
+      this._body = { disturbed: true } as any
     } else if (this.options.body) {
       this._body = this.options.body
     } else if (this.options.responseTextError !== undefined) {
@@ -192,6 +195,10 @@ export class ResponseStub implements Response {
     return this._body ? this._body.locked : false
   }
 
+  get bodyDisturbed() {
+    return this._body ? !!(this._body as any).disturbed : false
+  }
+
   get body() {
     return this._body || null
   }
@@ -199,6 +206,9 @@ export class ResponseStub implements Response {
   clone() {
     if (this.bodyUsed) {
       throw new TypeError("Failed to execute 'clone' on 'Response': Response body is already used")
+    }
+    if (this.bodyDisturbed) {
+      throw new TypeError('Cannot clone a disturbed Response')
     }
     return new ResponseStub(this.options)
   }

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
@@ -234,6 +234,14 @@ describe('computeFetchResponseText', () => {
     })
   })
 
+  it('should return undefined if body is disturbed', (done) => {
+    const response = new ResponseStub({ bodyDisturbed: true })
+    computeFetchResponseText(response, CONFIGURATION, (responseText) => {
+      expect(responseText).toBeUndefined()
+      done()
+    })
+  })
+
   it('does not consume the response body', (done) => {
     const response = new ResponseStub({ responseText: 'foo' })
     computeFetchResponseText(response, CONFIGURATION, () => {

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
@@ -9,6 +9,7 @@ import {
   monitor,
   noop,
   readBytesFromStream,
+  tryToClone,
 } from '@datadog/browser-core'
 import type { RawNetworkLogsEvent } from '../../../rawLogsEvent.types'
 import type { LogsConfiguration } from '../../configuration'
@@ -102,12 +103,7 @@ export function computeFetchResponseText(
   configuration: LogsConfiguration,
   callback: (responseText?: string) => void
 ) {
-  let clonedResponse: Response | undefined
-  try {
-    clonedResponse = response.clone()
-  } catch (e) {
-    // clone can throw if the response has already been used by another instrumentation or is disturbed
-  }
+  const clonedResponse = tryToClone(response)
   if (!clonedResponse || !clonedResponse.body) {
     // if the clone failed or if the body is null, let's not try to read it.
     callback()

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -92,6 +92,20 @@ describe('collect fetch', () => {
     })
   })
 
+  it('should notify on request with body disturbed', (done) => {
+    fetchStub(FAKE_URL).resolveWith({ status: 200, bodyDisturbed: true })
+
+    fetchStubManager.whenAllComplete(() => {
+      const request = completeSpy.calls.argsFor(0)[0]
+
+      expect(request.type).toEqual(RequestType.FETCH)
+      expect(request.method).toEqual('GET')
+      expect(request.url).toEqual(FAKE_URL)
+      expect(request.status).toEqual(200)
+      done()
+    })
+  })
+
   it('should notify on request complete', (done) => {
     fetchStub(FAKE_URL).resolveWith({ status: 500, responseText: 'fetch error' })
 

--- a/packages/rum-core/src/domain/requestCollection.ts
+++ b/packages/rum-core/src/domain/requestCollection.ts
@@ -13,6 +13,7 @@ import {
   readBytesFromStream,
   elapsed,
   timeStampNow,
+  tryToClone,
 } from '@datadog/browser-core'
 import type { RumSessionManager } from '..'
 import type { RumConfiguration } from './configuration'
@@ -157,12 +158,7 @@ function getNextRequestIndex() {
 }
 
 function waitForResponseToComplete(context: RumFetchResolveContext, callback: (duration: Duration) => void) {
-  let clonedResponse: Response | undefined
-  try {
-    clonedResponse = context.response && context.response.clone()
-  } catch (e) {
-    // clone can throw if the response has already been used by another instrumentation or is disturbed
-  }
+  const clonedResponse = context.response && tryToClone(context.response)
   if (!clonedResponse || !clonedResponse.body) {
     // do not try to wait for the response if the clone failed, fetch error or null body
     callback(elapsed(context.startClocks.timeStamp, timeStampNow()))


### PR DESCRIPTION
## Motivation

Following #1942, we still had some telemetry errors related to `response.clone()` in the case of [disturbed](https://streams.spec.whatwg.org/#is-readable-stream-disturbed) response.

## Changes

Add `try/catch` around `response.clone()` to prevent any thrown error to disturb our data collection.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
