### PR TITLE
[REPLAY] Add telemetry for shadow dom

### DIFF
--- a/packages/rum/src/domain/record/shadowRootsController.ts
+++ b/packages/rum/src/domain/record/shadowRootsController.ts
@@ -1,4 +1,4 @@
-import { addTelemetryDebug, DOM_EVENT } from '@datadog/browser-core'
+import { addTelemetryDebug, DOM_EVENT, isExperimentalFeatureEnabled } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { startMutationObserver } from './mutationObserver'
 import { initInputObserver } from './observers'
@@ -57,6 +57,8 @@ export const initShadowRootsController = (
         addTelemetryDebug('no shadow root in map', {
           shadowRoot: shadowRoot ? shadowRoot.nodeName : 'no node name',
           childrenLength: shadowRoot ? shadowRoot.childElementCount : '-1',
+          controllerByShadowRootSize: controllerByShadowRoot.size,
+          html: shadowRoot && isExperimentalFeatureEnabled('shadow_dom_debug') ? shadowRoot.innerHTML : undefined,
         })
         return
       }

--- a/packages/rum/src/domain/record/shadowRootsController.ts
+++ b/packages/rum/src/domain/record/shadowRootsController.ts
@@ -58,7 +58,10 @@ export const initShadowRootsController = (
           shadowRoot: shadowRoot ? shadowRoot.nodeName : 'no node name',
           childrenLength: shadowRoot ? shadowRoot.childElementCount : '-1',
           controllerByShadowRootSize: controllerByShadowRoot.size,
-          html: shadowRoot && isExperimentalFeatureEnabled('shadow_dom_debug') ? shadowRoot.innerHTML : undefined,
+          html:
+            shadowRoot && isExperimentalFeatureEnabled('shadow_dom_debug')
+              ? shadowRoot.innerHTML.substring(0, 2000)
+              : undefined,
         })
         return
       }


### PR DESCRIPTION
## Motivation

[REPLAY] Add telemetry for shadow dom #1978

## Changes

- add shadow dom content if FF is present (only to be activated on org2 for privacy concerned)

## Testing


- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
