### PR TITLE
✅ fix flaky test

### DIFF
--- a/packages/core/test/collectAsyncCalls.ts
+++ b/packages/core/test/collectAsyncCalls.ts
@@ -1,0 +1,23 @@
+export function collectAsyncCalls<F extends jasmine.Func>(spy: jasmine.Spy<F>) {
+  return {
+    waitAsyncCalls: (expectedCallsCount: number, callback: (calls: jasmine.Calls<F>) => void) => {
+      if (spy.calls.count() === expectedCallsCount) {
+        callback(spy.calls)
+      } else if (spy.calls.count() > expectedCallsCount) {
+        fail('Unexpected extra call')
+      } else {
+        spy.and.callFake((() => {
+          if (spy.calls.count() === expectedCallsCount) {
+            callback(spy.calls)
+          }
+        }) as F)
+      }
+    },
+    expectNoExtraAsyncCall: (done: () => void) => {
+      spy.and.callFake((() => {
+        fail('Unexpected extra call')
+      }) as F)
+      setTimeout(done, 300)
+    },
+  }
+}

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -9,12 +9,13 @@ import { createNewEvent, mockClock } from '../../../core/test/specHelper'
 
 import type { TestSetupBuilder } from '../../../rum-core/test/specHelper'
 import { setup } from '../../../rum-core/test/specHelper'
-import { collectAsyncCalls, recordsPerFullSnapshot } from '../../test/utils'
+import { recordsPerFullSnapshot } from '../../test/utils'
 import { setSegmentBytesLimit, startDeflateWorker } from '../domain/segmentCollection'
 
 import type { BrowserSegment } from '../types'
 import { RecordType } from '../types'
 import { resetReplayStats } from '../domain/replayStats'
+import { collectAsyncCalls } from '../../../core/test/collectAsyncCalls'
 import { startRecording } from './startRecording'
 
 const VIEW_TIMESTAMP = 1 as TimeStamp

--- a/packages/rum/src/domain/record/mutationBatch.spec.ts
+++ b/packages/rum/src/domain/record/mutationBatch.spec.ts
@@ -1,4 +1,4 @@
-import { collectAsyncCalls } from '../../../test/utils'
+import { collectAsyncCalls } from '../../../../core/test/collectAsyncCalls'
 import { createMutationBatch } from './mutationBatch'
 import type { RumMutationRecord } from './mutationObserver'
 

--- a/packages/rum/src/domain/record/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/mutationObserver.spec.ts
@@ -1,6 +1,6 @@
 import { DefaultPrivacyLevel, isIE, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
-import { collectAsyncCalls, createMutationPayloadValidator } from '../../../test/utils'
+import { createMutationPayloadValidator } from '../../../test/utils'
 import {
   NodePrivacyLevel,
   PRIVACY_ATTR_NAME,
@@ -10,6 +10,7 @@ import {
 } from '../../constants'
 import type { AttributeMutation, Attributes } from '../../types'
 import { NodeType } from '../../types'
+import { collectAsyncCalls } from '../../../../core/test/collectAsyncCalls'
 import { serializeDocument, SerializationContextStatus } from './serialize'
 import { sortAddedAndMovedNodes, startMutationObserver } from './mutationObserver'
 import type { MutationCallBack } from './observers'

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,9 +1,10 @@
 import { DefaultPrivacyLevel, findLast, isIE } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycle } from '@datadog/browser-rum-core'
+import { collectAsyncCalls } from '../../../../core/test/collectAsyncCalls'
 import type { Clock } from '../../../../core/test/specHelper'
 import { createNewEvent } from '../../../../core/test/specHelper'
-import { collectAsyncCalls, findFullSnapshot, findNode, recordsPerFullSnapshot } from '../../../test/utils'
+import { findFullSnapshot, findNode, recordsPerFullSnapshot } from '../../../test/utils'
 import type {
   BrowserIncrementalSnapshotRecord,
   BrowserMutationData,

--- a/packages/rum/test/utils.ts
+++ b/packages/rum/test/utils.ts
@@ -157,30 +157,6 @@ export function parseSegment(bytes: Uint8Array) {
   return JSON.parse(new TextDecoder().decode(bytes)) as BrowserSegment
 }
 
-export function collectAsyncCalls<F extends jasmine.Func>(spy: jasmine.Spy<F>) {
-  return {
-    waitAsyncCalls: (expectedCallsCount: number, callback: (calls: jasmine.Calls<F>) => void) => {
-      if (spy.calls.count() === expectedCallsCount) {
-        callback(spy.calls)
-      } else if (spy.calls.count() > expectedCallsCount) {
-        fail('Unexpected extra call')
-      } else {
-        spy.and.callFake((() => {
-          if (spy.calls.count() === expectedCallsCount) {
-            callback(spy.calls)
-          }
-        }) as F)
-      }
-    },
-    expectNoExtraAsyncCall: (done: () => void) => {
-      spy.and.callFake((() => {
-        fail('Unexpected extra call')
-      }) as F)
-      setTimeout(done, 300)
-    },
-  }
-}
-
 // Returns the first MetaRecord in a Segment, if any.
 export function findMeta(segment: BrowserSegment): MetaRecord | null {
   return segment.records.find((record) => record.type === RecordType.Meta) as MetaRecord


### PR DESCRIPTION


## Motivation

This particular test is quite flaky.

FMU, it was assuming that `Promise.resolve` took less than 1ms. But this was often not the case, and the `setTimeout` callback was called too often.

## Changes

By using `collectAsyncCalls`, we remove this race condition.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
