### PR TITLE
🐛 [RUMF-1476] Fix removednodes.foreach is not a function

### DIFF
--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -164,6 +164,6 @@ function isBrowserSupported() {
     // Array.from is a bit less supported by browsers than CSSSupportsRule, but has higher chances
     // to be polyfilled. Test for both to be more confident. We could add more things if we find out
     // this test is not sufficient.
-    typeof Array.from === 'function' && typeof CSSSupportsRule === 'function'
+    typeof Array.from === 'function' && typeof CSSSupportsRule === 'function' && 'forEach' in NodeList.prototype
   )
 }

--- a/packages/rum/src/domain/record/mutationObserver.ts
+++ b/packages/rum/src/domain/record/mutationObserver.ts
@@ -17,7 +17,6 @@ import {
   nodeAndAncestorsHaveSerializedNode,
 } from './serializationUtils'
 import { serializeNodeWithId, serializeAttribute, SerializationContextStatus } from './serialize'
-import { forEach } from './utils'
 import { createMutationBatch } from './mutationBatch'
 import type { MutationCallBack } from './observers'
 import type { ShadowRootCallBack, ShadowRootsController } from './shadowRootsController'
@@ -106,7 +105,7 @@ function processMutations(
   mutations
     .filter((mutation): mutation is RumChildListMutationRecord => mutation.type === 'childList')
     .forEach((mutation) => {
-      forEach(mutation.removedNodes, (removedNode) => {
+      mutation.removedNodes.forEach((removedNode) => {
         traverseRemovedShadowDom(removedNode, shadowRootsController.removeShadowRoot)
       })
     })
@@ -177,10 +176,10 @@ function processChildListMutations(
   const addedAndMovedNodes = new Set<Node>()
   const removedNodes = new Map<Node, NodeWithSerializedNode>()
   for (const mutation of mutations) {
-    forEach(mutation.addedNodes, (node) => {
+    mutation.addedNodes.forEach((node) => {
       addedAndMovedNodes.add(node)
     })
-    forEach(mutation.removedNodes, (node) => {
+    mutation.removedNodes.forEach((node) => {
       if (!addedAndMovedNodes.has(node)) {
         removedNodes.set(node, mutation.target)
       }

--- a/packages/rum/src/domain/record/mutationObserver.ts
+++ b/packages/rum/src/domain/record/mutationObserver.ts
@@ -106,7 +106,7 @@ function processMutations(
   mutations
     .filter((mutation): mutation is RumChildListMutationRecord => mutation.type === 'childList')
     .forEach((mutation) => {
-      mutation.removedNodes.forEach((removedNode) => {
+      forEach(mutation.removedNodes, (removedNode) => {
         traverseRemovedShadowDom(removedNode, shadowRootsController.removeShadowRoot)
       })
     })

--- a/packages/rum/src/domain/record/serialize.ts
+++ b/packages/rum/src/domain/record/serialize.ts
@@ -33,7 +33,6 @@ import {
   switchToAbsoluteUrl,
   serializeStyleSheets,
 } from './serializationUtils'
-import { forEach } from './utils'
 import type { ElementsScrollPositions } from './elementsScrollPositions'
 import type { ShadowRootsController } from './shadowRootsController'
 import type { WithAdoptedStyleSheets } from './browser.types'
@@ -273,7 +272,7 @@ function serializeCDataNode(): CDataNode {
 
 export function serializeChildNodes(node: Node, options: SerializeOptions): SerializedNodeWithId[] {
   const result: SerializedNodeWithId[] = []
-  forEach(node.childNodes, (childNode) => {
+  node.childNodes.forEach((childNode) => {
     const serializedChildNode = serializeNodeWithId(childNode, options)
     if (serializedChildNode) {
       result.push(serializedChildNode)


### PR DESCRIPTION
## Motivation

Old browsers do not implement [NodeList.prototype.forEach()](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach). Add a check to isBrowserSupported

## Changes

Add NodeList.prototype.forEach check  to isBrowserSupported

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
