### PR TITLE
⚗️🐛 ignore contenteditable elements for dead clicks

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -1,4 +1,4 @@
-import { ONE_SECOND } from '@datadog/browser-core'
+import { ONE_SECOND, resetExperimentalFeatures, updateExperimentalFeatures } from '@datadog/browser-core'
 import { FrustrationType } from '../../../rawRumEvent.types'
 import type { Clock } from '../../../../../core/test/specHelper'
 import { mockClock } from '../../../../../core/test/specHelper'
@@ -137,10 +137,12 @@ describe('isDead', () => {
 
   beforeEach(() => {
     isolatedDom = createIsolatedDom()
+    updateExperimentalFeatures(['dead_click_fixes'])
   })
 
   afterEach(() => {
     isolatedDom.clear()
+    resetExperimentalFeatures()
   })
 
   it('considers as dead when the click has no page activity', () => {
@@ -164,6 +166,8 @@ describe('isDead', () => {
     { element: '<a id="foo">Foo</a>', expected: true },
     { element: '<a href="foo">Foo</a>', expected: false },
     { element: '<a href="foo">Foo<span target>bar</span></a>', expected: false },
+    { element: '<div contenteditable>Foo bar</div>', expected: false },
+    { element: '<div contenteditable>Foo<span target>bar</span></div>', expected: false },
   ]) {
     it(`does not consider as dead when the click target is ${element}`, () => {
       expect(

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -1,4 +1,4 @@
-import { elementMatches, ONE_SECOND } from '@datadog/browser-core'
+import { elementMatches, isExperimentalFeatureEnabled, ONE_SECOND } from '@datadog/browser-core'
 import { FrustrationType } from '../../../rawRumEvent.types'
 import type { Click } from './trackClickActions'
 
@@ -64,5 +64,11 @@ export function isDead(click: Click) {
   if (click.hasPageActivity || click.getUserActivity().input) {
     return false
   }
-  return !elementMatches(click.event.target, DEAD_CLICK_EXCLUDE_SELECTOR)
+  return !elementMatches(
+    click.event.target,
+    isExperimentalFeatureEnabled('dead_click_fixes')
+      ? // contenteditable and their descendants don't always trigger meaningful changes when manipulated
+        `${DEAD_CLICK_EXCLUDE_SELECTOR},[contenteditable],[contenteditable] *`
+      : DEAD_CLICK_EXCLUDE_SELECTOR
+  )
 }


### PR DESCRIPTION
This ticket is part of an effort to improve dead clicks. 

* https://github.com/DataDog/browser-sdk/pull/1968
* https://github.com/DataDog/browser-sdk/pull/1958
* https://github.com/DataDog/browser-sdk/pull/1979
* https://github.com/DataDog/browser-sdk/pull/1986 (this issue)

All fixes are behind the `dead_click_fixes` and will be released together after some dogfooding.

## Motivation

When users are manipulating contenteditable elements, we often report dead clicks incorrectly

## Changes

Ignore contenteditable elements for dead clicks.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
