### PR TITLE
👷 Fix generate changelog fetch tags

### DIFF
--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -64,7 +64,7 @@ async function getEmojisLegend() {
 }
 
 function getChangesList() {
-  command`git fetch --tags -q`.run()
+  command`git fetch --tags -f -q`.run()
   const lastTagHash = command`git rev-list --tags --max-count=1`.run().trim()
   const lastTagName = command`git describe --tags ${lastTagHash}`.run()
 


### PR DESCRIPTION
## Motivation

While releasing a new version, the generate-changelog script failed when[ fetching tags ](https://github.com/DataDog/browser-sdk/blob/6aec1d3657507bd002d57618db79d4ecfbec8d6e/scripts/generate-changelog.js#L67) because it `would clobber existing tag`

## Changes

Force to fetch tags in generate-changelog script

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
