### PR TITLE
[REPLAY] Discard mouse/touch event without x/y position

### DIFF
--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -125,11 +125,11 @@ describe('startRecording', () => {
   it('stops sending new segment when the session is expired', (done) => {
     const { lifeCycle } = setupBuilder.build()
 
-    document.body.dispatchEvent(createNewEvent('click'))
+    document.body.dispatchEvent(createNewEvent('click', { clientX: 1, clientY: 2 }))
 
     sessionManager.setNotTracked()
     flushSegment(lifeCycle)
-    document.body.dispatchEvent(createNewEvent('click'))
+    document.body.dispatchEvent(createNewEvent('click', { clientX: 1, clientY: 2 }))
 
     flushSegment(lifeCycle)
 
@@ -143,11 +143,11 @@ describe('startRecording', () => {
     sessionManager.setNotTracked()
     const { lifeCycle } = setupBuilder.build()
 
-    document.body.dispatchEvent(createNewEvent('click'))
+    document.body.dispatchEvent(createNewEvent('click', { clientX: 1, clientY: 2 }))
 
     sessionManager.setId('new-session-id').setPlanWithSessionReplay()
     flushSegment(lifeCycle)
-    document.body.dispatchEvent(createNewEvent('click'))
+    document.body.dispatchEvent(createNewEvent('click', { clientX: 1, clientY: 2 }))
 
     flushSegment(lifeCycle)
 
@@ -251,9 +251,9 @@ describe('startRecording', () => {
     it('stops collecting records', (done) => {
       const { lifeCycle } = setupBuilder.build()
 
-      document.body.dispatchEvent(createNewEvent('click'))
+      document.body.dispatchEvent(createNewEvent('click', { clientX: 1, clientY: 2 }))
       stopRecording()
-      document.body.dispatchEvent(createNewEvent('click'))
+      document.body.dispatchEvent(createNewEvent('click', { clientX: 1, clientY: 2 }))
       flushSegment(lifeCycle)
 
       waitRequestSendCalls(1, (calls) => {

--- a/packages/rum/src/domain/record/observers.spec.ts
+++ b/packages/rum/src/domain/record/observers.spec.ts
@@ -451,20 +451,11 @@ describe('initMouseInteractionObserver', () => {
 describe('initMoveObserver', () => {
   let mouseMoveCallbackSpy: jasmine.Spy<MousemoveCallBack>
   let stopObserver: () => void
-  let sandbox: HTMLDivElement
-  let a: HTMLAnchorElement
 
   beforeEach(() => {
     if (isIE()) {
       pending('IE not supported')
     }
-
-    sandbox = document.createElement('div')
-    a = document.createElement('a')
-    a.setAttribute('tabindex', '0') // make the element focusable
-    sandbox.appendChild(a)
-    document.body.appendChild(sandbox)
-    a.focus()
 
     serializeDocument(document, DEFAULT_CONFIGURATION, {
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
@@ -477,13 +468,12 @@ describe('initMoveObserver', () => {
   })
 
   afterEach(() => {
-    sandbox.remove()
     stopObserver()
   })
 
   it('should generate mouse move record', () => {
     const event = createNewEvent('mousemove', { clientX: 1, clientY: 2 })
-    a.dispatchEvent(event)
+    document.body.dispatchEvent(event)
 
     expect(mouseMoveCallbackSpy).toHaveBeenCalledWith(
       [
@@ -500,7 +490,7 @@ describe('initMoveObserver', () => {
 
   it('should generate touch move record', () => {
     const event = createNewEvent('touchmove', { changedTouches: [{ clientX: 1, clientY: 2 }] })
-    a.dispatchEvent(event)
+    document.body.dispatchEvent(event)
 
     expect(mouseMoveCallbackSpy).toHaveBeenCalledWith(
       [
@@ -517,7 +507,7 @@ describe('initMoveObserver', () => {
 
   it('should not generate mouse move record if x/y are missing', () => {
     const mouseMove = createNewEvent('mousemove')
-    a.dispatchEvent(mouseMove)
+    document.body.dispatchEvent(mouseMove)
 
     expect(mouseMoveCallbackSpy).not.toHaveBeenCalled()
   })

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -157,7 +157,7 @@ export function initMoveObserver(cb: MousemoveCallBack): ListenerHandler {
     monitor((event: MouseEvent | TouchEvent) => {
       const target = getEventTarget(event)
       if (hasSerializedNode(target)) {
-        const coordinates = tryComputeCoordinates(event)
+        const coordinates = tryToComputeCoordinates(event)
         if (!coordinates) {
           return
         }
@@ -208,7 +208,7 @@ export function initMouseInteractionObserver(
 
     let interaction: MouseInteraction
     if (type !== MouseInteractionType.Blur && type !== MouseInteractionType.Focus) {
-      const coordinates = tryComputeCoordinates(event)
+      const coordinates = tryToComputeCoordinates(event)
       if (!coordinates) {
         return
       }
@@ -229,7 +229,7 @@ export function initMouseInteractionObserver(
   }).stop
 }
 
-function tryComputeCoordinates(event: MouseEvent | TouchEvent) {
+function tryToComputeCoordinates(event: MouseEvent | TouchEvent) {
   let { clientX: x, clientY: y } = isTouchEvent(event) ? event.changedTouches[0] : event
   if (window.visualViewport) {
     const { visualViewportX, visualViewportY } = convertMouseEventToLayoutCoordinates(x, y)

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -159,9 +159,9 @@ export function initMoveObserver(cb: MousemoveCallBack): ListenerHandler {
       if (hasSerializedNode(target)) {
         const coordinates = tryComputeCoordinates(event)
         if (!coordinates) {
-          addTelemetryDebug('mouse/touch event without x/y', {
-            isTrusted: event.isTrusted,
-          })
+          if (event.isTrusted) {
+            addTelemetryDebug('mouse/touch event without x/y')
+          }
           return
         }
         const position: MousePosition = {
@@ -213,9 +213,9 @@ export function initMouseInteractionObserver(
     if (type !== MouseInteractionType.Blur && type !== MouseInteractionType.Focus) {
       const coordinates = tryComputeCoordinates(event)
       if (!coordinates) {
-        addTelemetryDebug('mouse/touch event without x/y', {
-          isTrusted: event.isTrusted,
-        })
+        if (event.isTrusted) {
+          addTelemetryDebug('mouse/touch event without x/y')
+        }
         return
       }
       interaction = { id, type, x: coordinates.x, y: coordinates.y }

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -159,9 +159,6 @@ export function initMoveObserver(cb: MousemoveCallBack): ListenerHandler {
       if (hasSerializedNode(target)) {
         const coordinates = tryComputeCoordinates(event)
         if (!coordinates) {
-          if (event.isTrusted) {
-            addTelemetryDebug('mouse/touch event without x/y')
-          }
           return
         }
         const position: MousePosition = {
@@ -213,9 +210,6 @@ export function initMouseInteractionObserver(
     if (type !== MouseInteractionType.Blur && type !== MouseInteractionType.Focus) {
       const coordinates = tryComputeCoordinates(event)
       if (!coordinates) {
-        if (event.isTrusted) {
-          addTelemetryDebug('mouse/touch event without x/y')
-        }
         return
       }
       interaction = { id, type, x: coordinates.x, y: coordinates.y }
@@ -243,6 +237,9 @@ function tryComputeCoordinates(event: MouseEvent | TouchEvent) {
     y = visualViewportY
   }
   if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    if (event.isTrusted) {
+      addTelemetryDebug('mouse/touch event without x/y')
+    }
     return undefined
   }
   return { x, y }


### PR DESCRIPTION
## Motivation

We have a bunch of error in the player where we have mouse record without x/y with numeric value. 

The hypothesis is that the event are not generated by the browser but by JS using `dispatchEvent` 

## Changes

- Discard mouse/touch event without x/y position
- Add telemetry with `isTrusted` to validate/invalidate the theory

## Testing

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
