### PR TITLE
✨[RUMF-1481] Remove product subdomain for ap1 intake requests

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -3,7 +3,7 @@ import { timeStampNow } from '../../tools/timeUtils'
 import { normalizeUrl } from '../../tools/urlPolyfill'
 import { generateUUID } from '../../tools/utils'
 import type { InitConfiguration } from './configuration'
-import { INTAKE_SITE_US1 } from './intakeSites'
+import { INTAKE_SITE_AP1, INTAKE_SITE_US1 } from './intakeSites'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
@@ -76,5 +76,6 @@ function buildEndpointHost(initConfiguration: InitConfiguration, endpointType: E
 
   const domainParts = site.split('.')
   const extension = domainParts.pop()
-  return `${ENDPOINTS[endpointType]}.browser-intake-${domainParts.join('-')}.${extension!}`
+  const subdomain = site !== INTAKE_SITE_AP1 ? `${ENDPOINTS[endpointType]}.` : ''
+  return `${subdomain}browser-intake-${domainParts.join('-')}.${extension!}`
 }

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -1,3 +1,4 @@
 export const INTAKE_SITE_STAGING = 'datad0g.com'
 export const INTAKE_SITE_US1 = 'datadoghq.com'
+export const INTAKE_SITE_AP1 = 'ap1.datadoghq.com'
 export const INTAKE_SITE_US1_FED = 'ddog-gov.com'


### PR DESCRIPTION
## Motivation

Avoid to setup specific subdomain for each product.

## Changes

Remove product subdomain for ap1 intake requests.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
