### PR TITLE
🐛 [RUMF-1296][RUMF-1293] fix dead click computation

### DIFF
--- a/packages/core/test/specHelper.ts
+++ b/packages/core/test/specHelper.ts
@@ -329,6 +329,10 @@ class StubXhr extends StubEventEmitter {
 }
 
 export function createNewEvent<P extends Record<string, unknown>>(eventName: 'click', properties?: P): MouseEvent & P
+export function createNewEvent<P extends Record<string, unknown>>(
+  eventName: 'pointerup',
+  properties?: P
+): PointerEvent & P
 export function createNewEvent(eventName: string, properties?: { [name: string]: unknown }): Event
 export function createNewEvent(eventName: string, properties: { [name: string]: unknown } = {}) {
   let event: Event

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -87,7 +87,6 @@ describe('actionCollection', () => {
             x: 1,
             y: 2,
           },
-          pointer_up_delay: undefined,
         },
       },
     })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -26,7 +26,7 @@ describe('actionCollection', () => {
   it('should create action from auto action', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
-    const event = createNewEvent('click', { target: document.createElement('button') })
+    const event = createNewEvent('pointerup', { target: document.createElement('button') })
     lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, {
       counts: {
         errorCount: 10,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -79,7 +79,6 @@ function processAction(
           action: {
             target: action.target,
             position: action.position,
-            pointer_up_delay: action.pointerUpDelay,
           },
         },
       }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.spec.ts
@@ -1,4 +1,4 @@
-import { ONE_SECOND, resetExperimentalFeatures, updateExperimentalFeatures } from '@datadog/browser-core'
+import { ONE_SECOND } from '@datadog/browser-core'
 import { FrustrationType } from '../../../rawRumEvent.types'
 import type { Clock } from '../../../../../core/test/specHelper'
 import { mockClock } from '../../../../../core/test/specHelper'
@@ -137,12 +137,10 @@ describe('isDead', () => {
 
   beforeEach(() => {
     isolatedDom = createIsolatedDom()
-    updateExperimentalFeatures(['dead_click_fixes'])
   })
 
   afterEach(() => {
     isolatedDom.clear()
-    resetExperimentalFeatures()
   })
 
   it('considers as dead when the click has no page activity', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/computeFrustration.ts
@@ -1,4 +1,4 @@
-import { elementMatches, isExperimentalFeatureEnabled, ONE_SECOND } from '@datadog/browser-core'
+import { elementMatches, ONE_SECOND } from '@datadog/browser-core'
 import { FrustrationType } from '../../../rawRumEvent.types'
 import type { Click } from './trackClickActions'
 
@@ -53,6 +53,9 @@ const DEAD_CLICK_EXCLUDE_SELECTOR =
   'input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="range"]),' +
   'textarea,' +
   'select,' +
+  // contenteditable and their descendants don't always trigger meaningful changes when manipulated
+  '[contenteditable],' +
+  '[contenteditable] *,' +
   // canvas, as there is no good way to detect activity occurring on them
   'canvas,' +
   // links that are interactive (have an href attribute) or any of their descendants, as they can
@@ -64,11 +67,5 @@ export function isDead(click: Click) {
   if (click.hasPageActivity || click.getUserActivity().input) {
     return false
   }
-  return !elementMatches(
-    click.event.target,
-    isExperimentalFeatureEnabled('dead_click_fixes')
-      ? // contenteditable and their descendants don't always trigger meaningful changes when manipulated
-        `${DEAD_CLICK_EXCLUDE_SELECTOR},[contenteditable],[contenteditable] *`
-      : DEAD_CLICK_EXCLUDE_SELECTOR
-  )
+  return !elementMatches(click.event.target, DEAD_CLICK_EXCLUDE_SELECTOR)
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -4,14 +4,14 @@ import { listenActionEvents } from './listenActionEvents'
 
 describe('listenActionEvents', () => {
   let actionEventsHooks: {
-    onStartEvent: jasmine.Spy<ActionEventsHooks<object>['onStartEvent']>
+    onPointerUp: jasmine.Spy<ActionEventsHooks<object>['onPointerUp']>
     onPointerDown: jasmine.Spy<ActionEventsHooks<object>['onPointerDown']>
   }
   let stopListenEvents: () => void
 
   beforeEach(() => {
     actionEventsHooks = {
-      onStartEvent: jasmine.createSpy(),
+      onPointerUp: jasmine.createSpy(),
       onPointerDown: jasmine.createSpy().and.returnValue({}),
     }
     ;({ stop: stopListenEvents } = listenActionEvents(actionEventsHooks))
@@ -37,7 +37,7 @@ describe('listenActionEvents', () => {
 
   it('listen to pointerup events', () => {
     emulateClick()
-    expect(actionEventsHooks.onStartEvent).toHaveBeenCalledOnceWith(
+    expect(actionEventsHooks.onPointerUp).toHaveBeenCalledOnceWith(
       {},
       jasmine.objectContaining({ type: 'pointerup' }),
       jasmine.any(Function)
@@ -52,23 +52,23 @@ describe('listenActionEvents', () => {
   it('can abort click lifecycle by returning undefined from the onPointerDown callback', () => {
     actionEventsHooks.onPointerDown.and.returnValue(undefined)
     emulateClick()
-    expect(actionEventsHooks.onStartEvent).not.toHaveBeenCalled()
+    expect(actionEventsHooks.onPointerUp).not.toHaveBeenCalled()
   })
 
-  it('passes the context created in onPointerDown to onStartEvent', () => {
+  it('passes the context created in onPointerDown to onPointerUp', () => {
     const context = {}
     actionEventsHooks.onPointerDown.and.returnValue(context)
     emulateClick()
-    expect(actionEventsHooks.onStartEvent.calls.mostRecent().args[0]).toBe(context)
+    expect(actionEventsHooks.onPointerUp.calls.mostRecent().args[0]).toBe(context)
   })
 
   it('ignore "click" events if no "pointerdown" event happened since the previous "click" event', () => {
     emulateClick()
-    actionEventsHooks.onStartEvent.calls.reset()
+    actionEventsHooks.onPointerUp.calls.reset()
 
     window.dispatchEvent(createNewEvent('click', { target: document.body }))
 
-    expect(actionEventsHooks.onStartEvent).not.toHaveBeenCalled()
+    expect(actionEventsHooks.onPointerUp).not.toHaveBeenCalled()
   })
 
   describe('selection change', () => {
@@ -140,7 +140,7 @@ describe('listenActionEvents', () => {
     })
 
     function hasSelectionChanged() {
-      return actionEventsHooks.onStartEvent.calls.mostRecent().args[2]().selection
+      return actionEventsHooks.onPointerUp.calls.mostRecent().args[2]().selection
     }
 
     function emulateNodeSelection(
@@ -200,7 +200,7 @@ describe('listenActionEvents', () => {
       window.dispatchEvent(createNewEvent('input'))
     }
     function hasInputUserActivity() {
-      return actionEventsHooks.onStartEvent.calls.mostRecent().args[2]().input
+      return actionEventsHooks.onPointerUp.calls.mostRecent().args[2]().input
     }
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -41,7 +41,6 @@ describe('listenActionEvents', () => {
     expect(actionEventsHooks.onStartEvent).toHaveBeenCalledOnceWith(
       {},
       jasmine.objectContaining({ type: 'pointerup' }),
-      jasmine.any(Function),
       jasmine.any(Function)
     )
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -1,4 +1,3 @@
-import { resetExperimentalFeatures, updateExperimentalFeatures } from '@datadog/browser-core'
 import type { Clock } from '../../../../../core/test/specHelper'
 import { createNewEvent, mockClock } from '../../../../../core/test/specHelper'
 import type { ActionEventsHooks } from './listenActionEvents'
@@ -37,22 +36,11 @@ describe('listenActionEvents', () => {
     expect(actionEventsHooks.onPointerDown).toHaveBeenCalledTimes(1)
   })
 
-  it('listen to click events', () => {
+  it('listen to pointerup events', () => {
     emulateClick()
     expect(actionEventsHooks.onStartEvent).toHaveBeenCalledOnceWith(
       {},
-      jasmine.objectContaining({ type: 'click' }),
-      jasmine.any(Function),
-      jasmine.any(Function)
-    )
-  })
-
-  it('listen to non-primary click events', () => {
-    // This emulates a Chrome behavior where all click events are non-primary
-    emulateClick({ clickEventIsPrimary: false })
-    expect(actionEventsHooks.onStartEvent).toHaveBeenCalledOnceWith(
-      {},
-      jasmine.objectContaining({ type: 'click' }),
+      jasmine.objectContaining({ type: 'pointerup' }),
       jasmine.any(Function),
       jasmine.any(Function)
     )
@@ -83,29 +71,6 @@ describe('listenActionEvents', () => {
     window.dispatchEvent(createNewEvent('click', { target: document.body }))
 
     expect(actionEventsHooks.onStartEvent).not.toHaveBeenCalled()
-  })
-
-  describe('dead_click_fixes experimental feature', () => {
-    beforeEach(() => {
-      stopListenEvents()
-
-      updateExperimentalFeatures(['dead_click_fixes'])
-      ;({ stop: stopListenEvents } = listenActionEvents(actionEventsHooks))
-    })
-
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('listen to pointerup events', () => {
-      emulateClick()
-      expect(actionEventsHooks.onStartEvent).toHaveBeenCalledOnceWith(
-        {},
-        jasmine.objectContaining({ type: 'pointerup' }),
-        jasmine.any(Function),
-        jasmine.any(Function)
-      )
-    })
   })
 
   describe('selection change', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -1,5 +1,4 @@
-import type { Clock } from '../../../../../core/test/specHelper'
-import { createNewEvent, mockClock } from '../../../../../core/test/specHelper'
+import { createNewEvent } from '../../../../../core/test/specHelper'
 import type { ActionEventsHooks } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
 
@@ -162,16 +161,6 @@ describe('listenActionEvents', () => {
   })
 
   describe('input user activity', () => {
-    let clock: Clock
-
-    beforeEach(() => {
-      clock = mockClock()
-    })
-
-    afterEach(() => {
-      clock.cleanup()
-    })
-
     it('click that do not trigger an input input event should not report input user activity', () => {
       emulateClick()
       expect(hasInputUserActivity()).toBe(false)
@@ -189,14 +178,12 @@ describe('listenActionEvents', () => {
     it('click that triggers an input event slightly after the click should report an input user activity', () => {
       emulateClick()
       emulateInputEvent()
-      clock.tick(1) // run immediate timeouts
       expect(hasInputUserActivity()).toBe(true)
     })
 
     it('input events that precede clicks should not be taken into account', () => {
       emulateInputEvent()
       emulateClick()
-      clock.tick(1) // run immediate timeouts
       expect(hasInputUserActivity()).toBe(false)
     })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.spec.ts
@@ -229,31 +229,11 @@ describe('listenActionEvents', () => {
       expect(hasInputUserActivity()).toBe(true)
     })
 
-    describe('with dead_click_fixes flag', () => {
-      beforeEach(() => {
-        stopListenEvents()
-
-        updateExperimentalFeatures(['dead_click_fixes'])
-        ;({ stop: stopListenEvents } = listenActionEvents(actionEventsHooks))
-      })
-
-      afterEach(() => {
-        resetExperimentalFeatures()
-      })
-
-      it('input events that precede clicks should not be taken into account', () => {
-        emulateInputEvent()
-        emulateClick()
-        clock.tick(1) // run immediate timeouts
-        expect(hasInputUserActivity()).toBe(false)
-      })
-    })
-
-    it('without dead_click_fixes, input events that precede clicks should still be taken into account', () => {
+    it('input events that precede clicks should not be taken into account', () => {
       emulateInputEvent()
       emulateClick()
       clock.tick(1) // run immediate timeouts
-      expect(hasInputUserActivity()).toBe(true)
+      expect(hasInputUserActivity()).toBe(false)
     })
 
     it('click and type should report an input user activity', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -1,5 +1,4 @@
-import type { TimeStamp } from '@datadog/browser-core'
-import { addEventListener, DOM_EVENT, isExperimentalFeatureEnabled, timeStampNow } from '@datadog/browser-core'
+import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 
 export type MouseEventOnElement = PointerEvent & { target: Element }
 
@@ -9,12 +8,7 @@ export interface UserActivity {
 }
 export interface ActionEventsHooks<ClickContext> {
   onPointerDown: (event: MouseEventOnElement) => ClickContext | undefined
-  onStartEvent: (
-    context: ClickContext,
-    event: MouseEventOnElement,
-    getUserActivity: () => UserActivity,
-    getClickEventTimeStamp: () => TimeStamp | undefined
-  ) => void
+  onStartEvent: (context: ClickContext, event: MouseEventOnElement, getUserActivity: () => UserActivity) => void
 }
 
 export function listenActionEvents<ClickContext>({ onPointerDown, onStartEvent }: ActionEventsHooks<ClickContext>) {
@@ -60,24 +54,8 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onStartEvent }
         if (isValidPointerEvent(startEvent) && clickContext) {
           // Use a scoped variable to make sure the value is not changed by other clicks
           const localUserActivity = userActivity
-          let clickEventTimeStamp: TimeStamp | undefined
-          onStartEvent(
-            clickContext,
-            startEvent,
-            () => localUserActivity,
-            () => clickEventTimeStamp
-          )
+          onStartEvent(clickContext, startEvent, () => localUserActivity)
           clickContext = undefined
-          if (isExperimentalFeatureEnabled('dead_click_fixes')) {
-            addEventListener(
-              window,
-              DOM_EVENT.CLICK,
-              () => {
-                clickEventTimeStamp = timeStampNow()
-              },
-              { capture: true, once: true }
-            )
-          }
         }
       },
       { capture: true }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -34,11 +34,7 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onStartEvent }
           selectionEmptyAtPointerDown = isSelectionEmpty()
           userActivity = {
             selection: false,
-            input: isExperimentalFeatureEnabled('dead_click_fixes')
-              ? false
-              : // Mimics the issue that was fixed in https://github.com/DataDog/browser-sdk/pull/1968
-                // The goal is to release all dead click fixes at the same time
-                userActivity.input,
+            input: false,
           }
           clickContext = onPointerDown(event)
         }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -50,11 +50,11 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onPointerUp }:
     addEventListener(
       window,
       DOM_EVENT.POINTER_UP,
-      (startEvent: PointerEvent) => {
-        if (isValidPointerEvent(startEvent) && clickContext) {
+      (event: PointerEvent) => {
+        if (isValidPointerEvent(event) && clickContext) {
           // Use a scoped variable to make sure the value is not changed by other clicks
           const localUserActivity = userActivity
-          onPointerUp(clickContext, startEvent, () => localUserActivity)
+          onPointerUp(clickContext, event, () => localUserActivity)
           clickContext = undefined
         }
       },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -8,10 +8,10 @@ export interface UserActivity {
 }
 export interface ActionEventsHooks<ClickContext> {
   onPointerDown: (event: MouseEventOnElement) => ClickContext | undefined
-  onStartEvent: (context: ClickContext, event: MouseEventOnElement, getUserActivity: () => UserActivity) => void
+  onPointerUp: (context: ClickContext, event: MouseEventOnElement, getUserActivity: () => UserActivity) => void
 }
 
-export function listenActionEvents<ClickContext>({ onPointerDown, onStartEvent }: ActionEventsHooks<ClickContext>) {
+export function listenActionEvents<ClickContext>({ onPointerDown, onPointerUp }: ActionEventsHooks<ClickContext>) {
   let selectionEmptyAtPointerDown: boolean
   let userActivity: UserActivity = {
     selection: false,
@@ -54,7 +54,7 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onStartEvent }
         if (isValidPointerEvent(startEvent) && clickContext) {
           // Use a scoped variable to make sure the value is not changed by other clicks
           const localUserActivity = userActivity
-          onStartEvent(clickContext, startEvent, () => localUserActivity)
+          onPointerUp(clickContext, startEvent, () => localUserActivity)
           clickContext = undefined
         }
       },

--- a/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/listenActionEvents.ts
@@ -1,7 +1,7 @@
 import type { TimeStamp } from '@datadog/browser-core'
 import { addEventListener, DOM_EVENT, isExperimentalFeatureEnabled, timeStampNow } from '@datadog/browser-core'
 
-export type MouseEventOnElement = MouseEvent & { target: Element }
+export type MouseEventOnElement = PointerEvent & { target: Element }
 
 export interface UserActivity {
   selection: boolean
@@ -30,7 +30,7 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onStartEvent }
       window,
       DOM_EVENT.POINTER_DOWN,
       (event: PointerEvent) => {
-        if (isValidMouseEvent(event)) {
+        if (isValidPointerEvent(event)) {
           selectionEmptyAtPointerDown = isSelectionEmpty()
           userActivity = {
             selection: false,
@@ -55,9 +55,9 @@ export function listenActionEvents<ClickContext>({ onPointerDown, onStartEvent }
 
     addEventListener(
       window,
-      isExperimentalFeatureEnabled('dead_click_fixes') ? DOM_EVENT.POINTER_UP : DOM_EVENT.CLICK,
-      (startEvent: MouseEvent) => {
-        if (isValidMouseEvent(startEvent) && clickContext) {
+      DOM_EVENT.POINTER_UP,
+      (startEvent: PointerEvent) => {
+        if (isValidPointerEvent(startEvent) && clickContext) {
           // Use a scoped variable to make sure the value is not changed by other clicks
           const localUserActivity = userActivity
           let clickEventTimeStamp: TimeStamp | undefined
@@ -105,14 +105,11 @@ function isSelectionEmpty(): boolean {
   return !selection || selection.isCollapsed
 }
 
-function isValidMouseEvent(event: MouseEvent): event is MouseEventOnElement {
+function isValidPointerEvent(event: PointerEvent): event is MouseEventOnElement {
   return (
     event.target instanceof Element &&
     // Only consider 'primary' pointer events for now. Multi-touch support could be implemented in
     // the future.
-    // On Chrome, click events are PointerEvent with `isPrimary = false`, but we should still
-    // consider them valid. This could be removed when we enable the `click-action-on-pointerup`
-    // flag, since we won't rely on click events anymore.
-    (event.type === 'click' || (event as PointerEvent).isPrimary !== false)
+    event.isPrimary !== false
   )
 }

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -108,7 +108,6 @@ describe('trackClickActions', () => {
         target: undefined,
         position: undefined,
         events: [domEvent],
-        pointerUpDelay: undefined,
       },
     ])
   })
@@ -458,17 +457,6 @@ describe('trackClickActions', () => {
           clock.tick(EXPIRE_DELAY)
           expect(events.length).toBe(1)
           expect(events[0].duration).toBe(0 as Duration)
-        })
-
-        it('reports the delay between pointerup and click event', () => {
-          const { clock } = setupBuilder.build()
-
-          const pointerUpActivityDelay = 5 as Duration
-          emulateClick({ activity: { on: 'pointerup', delay: pointerUpActivityDelay } })
-
-          clock.tick(EXPIRE_DELAY)
-          expect(events.length).toBe(1)
-          expect(events[0].pointerUpDelay).toBe(pointerUpActivityDelay)
         })
       })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -430,34 +430,24 @@ describe('trackClickActions', () => {
         expect(events[0].frustrationTypes).toEqual([FrustrationType.DEAD_CLICK])
       })
 
-      describe('dead_click_fixes experimental feature', () => {
-        beforeEach(() => {
-          updateExperimentalFeatures(['dead_click_fixes'])
-        })
+      it('does not consider a click with activity happening on pointerdown as a dead click', () => {
+        const { clock } = setupBuilder.build()
 
-        afterEach(() => {
-          resetExperimentalFeatures()
-        })
+        emulateClick({ activity: { on: 'pointerdown' } })
 
-        it('does not consider a click with activity happening on pointerdown as a dead click', () => {
-          const { clock } = setupBuilder.build()
+        clock.tick(EXPIRE_DELAY)
+        expect(events.length).toBe(1)
+        expect(events[0].frustrationTypes).toEqual([])
+      })
 
-          emulateClick({ activity: { on: 'pointerdown' } })
+      it('activity happening on pointerdown is not taken into account for the action duration', () => {
+        const { clock } = setupBuilder.build()
 
-          clock.tick(EXPIRE_DELAY)
-          expect(events.length).toBe(1)
-          expect(events[0].frustrationTypes).toEqual([])
-        })
+        emulateClick({ activity: { on: 'pointerdown' } })
 
-        it('activity happening on pointerdown is not taken into account for the action duration', () => {
-          const { clock } = setupBuilder.build()
-
-          emulateClick({ activity: { on: 'pointerdown' } })
-
-          clock.tick(EXPIRE_DELAY)
-          expect(events.length).toBe(1)
-          expect(events[0].duration).toBe(0 as Duration)
-        })
+        clock.tick(EXPIRE_DELAY)
+        expect(events.length).toBe(1)
+        expect(events[0].duration).toBe(0 as Duration)
       })
 
       it('does not consider a click with activity happening on pointerup as a dead click', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -87,7 +87,7 @@ describe('trackClickActions', () => {
     emulateClick({ activity: {} })
     expect(findActionId()).not.toBeUndefined()
     clock.tick(EXPIRE_DELAY)
-    const domEvent = createNewEvent('click', { target: document.createElement('button') })
+    const domEvent = createNewEvent('pointerup', { target: document.createElement('button') })
     expect(events).toEqual([
       {
         counts: {
@@ -460,16 +460,6 @@ describe('trackClickActions', () => {
           expect(events[0].duration).toBe(0 as Duration)
         })
 
-        it('does not consider a click with activity happening on pointerup as a dead click', () => {
-          const { clock } = setupBuilder.build()
-
-          emulateClick({ activity: { on: 'pointerup' } })
-
-          clock.tick(EXPIRE_DELAY)
-          expect(events.length).toBe(1)
-          expect(events[0].frustrationTypes).toEqual([])
-        })
-
         it('reports the delay between pointerup and click event', () => {
           const { clock } = setupBuilder.build()
 
@@ -480,6 +470,16 @@ describe('trackClickActions', () => {
           expect(events.length).toBe(1)
           expect(events[0].pointerUpDelay).toBe(pointerUpActivityDelay)
         })
+      })
+
+      it('does not consider a click with activity happening on pointerup as a dead click', () => {
+        const { clock } = setupBuilder.build()
+
+        emulateClick({ activity: { on: 'pointerup' } })
+
+        clock.tick(EXPIRE_DELAY)
+        expect(events.length).toBe(1)
+        expect(events[0].frustrationTypes).toEqual([])
       })
     })
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -84,7 +84,7 @@ export function trackClickActions(
   }>({
     onPointerDown: (pointerDownEvent) =>
       processPointerDown(configuration, lifeCycle, domMutationObservable, history, pointerDownEvent),
-    onStartEvent: ({ clickActionBase, hadActivityOnPointerDown }, startEvent, getUserActivity) =>
+    onPointerUp: ({ clickActionBase, hadActivityOnPointerDown }, startEvent, getUserActivity) =>
       startClickAction(
         configuration,
         lifeCycle,

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -151,19 +151,17 @@ function processPointerDown(
 
   let hadActivityOnPointerDown = false
 
-  if (isExperimentalFeatureEnabled('dead_click_fixes')) {
-    waitPageActivityEnd(
-      lifeCycle,
-      domMutationObservable,
-      configuration,
-      (pageActivityEndEvent) => {
-        hadActivityOnPointerDown = pageActivityEndEvent.hadActivity
-      },
-      // We don't care about the activity duration, we just want to know whether an activity did happen
-      // within the "validation delay" or not. Limit the duration so the callback is called sooner.
-      PAGE_ACTIVITY_VALIDATION_DELAY
-    )
-  }
+  waitPageActivityEnd(
+    lifeCycle,
+    domMutationObservable,
+    configuration,
+    (pageActivityEndEvent) => {
+      hadActivityOnPointerDown = pageActivityEndEvent.hadActivity
+    },
+    // We don't care about the activity duration, we just want to know whether an activity did happen
+    // within the "validation delay" or not. Limit the duration so the callback is called sooner.
+    PAGE_ACTIVITY_VALIDATION_DELAY
+  )
 
   return { clickActionBase, hadActivityOnPointerDown: () => hadActivityOnPointerDown }
 }

--- a/packages/rum-core/test/createFakeClick.ts
+++ b/packages/rum-core/test/createFakeClick.ts
@@ -13,7 +13,7 @@ export function createFakeClick({
   hasError?: boolean
   hasPageActivity?: boolean
   userActivity?: { selection?: boolean; input?: boolean }
-  event?: Partial<MouseEvent & { target: Element }>
+  event?: Partial<PointerEvent & { target: Element }>
 } = {}) {
   const stopObservable = new Observable<void>()
   let isStopped = false
@@ -42,7 +42,7 @@ export function createFakeClick({
     addFrustration: jasmine.createSpy<Click['addFrustration']>(),
     clone: jasmine.createSpy<typeof clone>().and.callFake(clone),
 
-    event: createNewEvent('click', {
+    event: createNewEvent('pointerup', {
       clientX: 100,
       clientY: 100,
       timeStamp: timeStampNow(),

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -719,7 +719,7 @@ describe('recorder', () => {
 
   describe('frustration records', () => {
     createTest('should detect a dead click and match it to mouse interaction record')
-      .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['dead_click_fixes'] })
+      .withRum({ trackFrustrations: true })
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .run(async ({ serverEvents }) => {
@@ -743,7 +743,7 @@ describe('recorder', () => {
       })
 
     createTest('should detect a rage click and match it to mouse interaction records')
-      .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['dead_click_fixes'] })
+      .withRum({ trackFrustrations: true })
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .withBody(


### PR DESCRIPTION
## Motivation

This PR enables various fixes related to dead click computation:

* https://github.com/DataDog/browser-sdk/pull/1968 will fix an issue where a lot of dead clicks were completely ignored
* https://github.com/DataDog/browser-sdk/pull/1958 will discard dead clicks when something happens during the 'pointerup' event (previously only things happening during the 'click' event were taken into account)
* https://github.com/DataDog/browser-sdk/pull/1979 will discard dead clicks when something happens during the 'pointerdown' event
* https://github.com/DataDog/browser-sdk/pull/1986 will discard dead clicks triggered by manipulating content of `contenteditable` elements


## Changes

* Remove experimental flags
* Adjust tests

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
