### PR TITLE
🐛 fix Shadow DOM support on old Microsoft Edge versions

### DIFF
--- a/packages/rum-core/src/browser/htmlDomUtils.spec.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.spec.ts
@@ -81,12 +81,18 @@ if (!isIE()) {
   describe('isShadowHost', () => {
     const host = document.createElement('div')
     host.attachShadow({ mode: 'open' })
+
+    // Edge 18 and before doesn't support shadow dom, so `Element#shadowRoot` is undefined.
+    const oldEdgeElement = document.createElement('div')
+    Object.defineProperty(oldEdgeElement, 'shadowRoot', { value: undefined })
+
     const parameters: Array<[Node, boolean]> = [
       [host, true],
       [host.shadowRoot!, false],
       [document.body, false],
       [document.createTextNode('hello'), false],
       [document.createComment('hello'), false],
+      [oldEdgeElement, false],
     ]
 
     parameters.forEach(([element, result]) => {

--- a/packages/rum-core/src/browser/htmlDomUtils.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.ts
@@ -11,7 +11,7 @@ export function isElementNode(node: Node): node is Element {
 }
 
 export function isNodeShadowHost(node: Node): node is Element & { shadowRoot: ShadowRoot } {
-  return isElementNode(node) && node.shadowRoot !== null
+  return isElementNode(node) && Boolean(node.shadowRoot)
 }
 
 export function isNodeShadowRoot(node: Node): node is ShadowRoot {


### PR DESCRIPTION
## Motivation

Shadow DOM support is broken in Microsoft Edge 18. It's not quite clear whether Session Replay should support old versions of Edge, but since it works fine currently let's fix this small issue.

## Changes

Don't assume `element.shadowRoot` is `null | Node`, as it can also be `undefined` in Edge

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
