### PR TITLE
👷 Remove dependency on example.com

### DIFF
--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -300,7 +300,7 @@ describe('action collection', () => {
         <script>
           const button = document.querySelector('button')
           button.addEventListener('click', () => {
-            window.open('https://example.com')
+            window.open(window.location.href)
           })
         </script>
       `


### PR DESCRIPTION
## Motivation

One of our scenario started to fail due to a new error on example.com:
```
https://example.com/favicon.ico - Failed to load resource: the server responded with a status of 404
```

## Changes

During the test, open a new window on the current url instead of example.com.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
