### PR TITLE
[RUMF-1484] ⚗️ use pagehide as unload event

### DIFF
--- a/packages/core/src/browser/pageExitObservable.ts
+++ b/packages/core/src/browser/pageExitObservable.ts
@@ -1,10 +1,12 @@
+import { isExperimentalFeatureEnabled } from '../domain/configuration'
 import { Observable } from '../tools/observable'
-import { includes, objectValues } from '../tools/utils'
-import { addEventListener, addEventListeners, DOM_EVENT } from './addEventListener'
+import { includes, noop, objectValues } from '../tools/utils'
+import { addEventListeners, addEventListener, DOM_EVENT } from './addEventListener'
 
 export const PageExitReason = {
   HIDDEN: 'visibility_hidden',
   UNLOADING: 'before_unload',
+  PAGEHIDE: 'pagehide',
   FROZEN: 'page_frozen',
 } as const
 
@@ -16,11 +18,17 @@ export interface PageExitEvent {
 
 export function createPageExitObservable(): Observable<PageExitEvent> {
   const observable = new Observable<PageExitEvent>(() => {
+    const pagehideEnabled = isExperimentalFeatureEnabled('pagehide')
     const { stop: stopListeners } = addEventListeners(
       window,
-      [DOM_EVENT.VISIBILITY_CHANGE, DOM_EVENT.FREEZE],
+      [DOM_EVENT.VISIBILITY_CHANGE, DOM_EVENT.FREEZE, DOM_EVENT.PAGE_HIDE],
       (event) => {
-        if (event.type === DOM_EVENT.VISIBILITY_CHANGE && document.visibilityState === 'hidden') {
+        if (event.type === DOM_EVENT.PAGE_HIDE && pagehideEnabled) {
+          /**
+           * Only event that detect page unload events while being compatible with the back/forward cache (bfcache)
+           */
+          observable.notify({ reason: PageExitReason.PAGEHIDE })
+        } else if (event.type === DOM_EVENT.VISIBILITY_CHANGE && document.visibilityState === 'hidden') {
           /**
            * Only event that guarantee to fire on mobile devices when the page transitions to background state
            * (e.g. when user switches to a different application, goes to homescreen, etc), or is being unloaded.
@@ -37,14 +45,12 @@ export function createPageExitObservable(): Observable<PageExitEvent> {
       { capture: true }
     )
 
-    /**
-     * Safari does not support yet to send a request during:
-     * - a visibility change during doc unload (cf: https://bugs.webkit.org/show_bug.cgi?id=194897)
-     * - a page hide transition (cf: https://bugs.webkit.org/show_bug.cgi?id=188329)
-     */
-    const { stop: stopBeforeUnloadListener } = addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => {
-      observable.notify({ reason: PageExitReason.UNLOADING })
-    })
+    let stopBeforeUnloadListener = noop
+    if (!pagehideEnabled) {
+      stopBeforeUnloadListener = addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => {
+        observable.notify({ reason: PageExitReason.UNLOADING })
+      }).stop
+    }
 
     return () => {
       stopListeners()

--- a/packages/core/src/browser/pageExitObservable.ts
+++ b/packages/core/src/browser/pageExitObservable.ts
@@ -6,7 +6,7 @@ import { addEventListeners, addEventListener, DOM_EVENT } from './addEventListen
 export const PageExitReason = {
   HIDDEN: 'visibility_hidden',
   UNLOADING: 'before_unload',
-  PAGEHIDE: 'pagehide',
+  PAGEHIDE: 'page_hide',
   FROZEN: 'page_frozen',
 } as const
 

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -15,7 +15,7 @@ export type FlushReason =
   | 'batch_duration_limit'
   | 'batch_bytes_limit'
   | 'before_unload'
-  | 'pagehide'
+  | 'page_hide'
   | 'visibility_hidden'
   | 'page_frozen'
 

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -4,6 +4,7 @@ import type { Context } from '../tools/context'
 import { monitor } from '../tools/monitor'
 import type { RawError } from '../tools/error'
 import { newRetryState, sendWithRetryStrategy } from './sendWithRetryStrategy'
+import type { FlushReason } from './batch'
 
 /**
  * Use POST request without content type to:
@@ -25,6 +26,7 @@ export interface Payload {
   data: string | FormData
   bytesCount: number
   retry?: RetryInfo
+  flushReason?: FlushReason
 }
 
 export interface RetryInfo {
@@ -55,11 +57,15 @@ export function createHttpRequest(
   }
 }
 
-function sendBeaconStrategy(endpointBuilder: EndpointBuilder, bytesLimit: number, { data, bytesCount }: Payload) {
+function sendBeaconStrategy(
+  endpointBuilder: EndpointBuilder,
+  bytesLimit: number,
+  { data, bytesCount, flushReason }: Payload
+) {
   const canUseBeacon = !!navigator.sendBeacon && bytesCount < bytesLimit
   if (canUseBeacon) {
     try {
-      const beaconUrl = endpointBuilder.build('beacon')
+      const beaconUrl = endpointBuilder.build('beacon', flushReason)
       const isQueued = navigator.sendBeacon(beaconUrl, data)
 
       if (isQueued) {
@@ -86,22 +92,22 @@ function reportBeaconError(e: unknown) {
 export function fetchKeepAliveStrategy(
   endpointBuilder: EndpointBuilder,
   bytesLimit: number,
-  { data, bytesCount, retry }: Payload,
+  { data, bytesCount, flushReason, retry }: Payload,
   onResponse?: (r: HttpResponse) => void
 ) {
   const canUseKeepAlive = isKeepAliveSupported() && bytesCount < bytesLimit
   if (canUseKeepAlive) {
-    const fetchUrl = endpointBuilder.build('fetch', retry)
+    const fetchUrl = endpointBuilder.build('fetch', flushReason, retry)
     fetch(fetchUrl, { method: 'POST', body: data, keepalive: true, mode: 'cors' }).then(
       monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })),
       monitor(() => {
-        const xhrUrl = endpointBuilder.build('xhr', retry)
+        const xhrUrl = endpointBuilder.build('xhr', flushReason, retry)
         // failed to queue the request
         sendXHR(xhrUrl, data, onResponse)
       })
     )
   } else {
-    const xhrUrl = endpointBuilder.build('xhr', retry)
+    const xhrUrl = endpointBuilder.build('xhr', flushReason, retry)
     sendXHR(xhrUrl, data, onResponse)
   }
 }

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -76,7 +76,7 @@ function sendBeaconStrategy(
     }
   }
 
-  const xhrUrl = endpointBuilder.build('xhr')
+  const xhrUrl = endpointBuilder.build('xhr', flushReason)
   sendXHR(xhrUrl, data)
 }
 

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -1,4 +1,4 @@
 export { HttpRequest, createHttpRequest, Payload, RetryInfo } from './httpRequest'
-export { Batch, BatchFlushEvent } from './batch'
+export { Batch, BatchFlushEvent, FlushReason } from './batch'
 export { canUseEventBridge, getEventBridge, BrowserWindowWithEventBridge } from './eventBridge'
 export { startBatchWithReplica } from './startBatchWithReplica'

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -129,7 +129,7 @@ export function trackViews(
 
     // End the current view on page unload
     lifeCycle.subscribe(LifeCycleEventType.PAGE_EXITED, (pageExitEvent) => {
-      if (pageExitEvent.reason === PageExitReason.UNLOADING) {
+      if (pageExitEvent.reason === PageExitReason.UNLOADING || pageExitEvent.reason === PageExitReason.PAGEHIDE) {
         currentView.end()
         currentView.triggerUpdate()
       }

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -93,7 +93,7 @@ export function doStartSegmentCollection(
   const { unsubscribe: unsubscribePageExited } = lifeCycle.subscribe(
     LifeCycleEventType.PAGE_EXITED,
     (pageExitEvent) => {
-      flushSegment(pageExitEvent.reason)
+      flushSegment(pageExitEvent.reason as FlushReason)
     }
   )
 

--- a/packages/rum/src/types/sessionReplay.ts
+++ b/packages/rum/src/types/sessionReplay.ts
@@ -34,6 +34,7 @@ export type CreationReason =
   | 'before_unload'
   | 'visibility_hidden'
   | 'page_frozen'
+  | 'pagehide'
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */

--- a/packages/rum/src/types/sessionReplay.ts
+++ b/packages/rum/src/types/sessionReplay.ts
@@ -34,7 +34,6 @@ export type CreationReason =
   | 'before_unload'
   | 'visibility_hidden'
   | 'page_frozen'
-  | 'page_hide'
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */

--- a/packages/rum/src/types/sessionReplay.ts
+++ b/packages/rum/src/types/sessionReplay.ts
@@ -34,7 +34,7 @@ export type CreationReason =
   | 'before_unload'
   | 'visibility_hidden'
   | 'page_frozen'
-  | 'pagehide'
+  | 'page_hide'
 /**
  * Browser-specific. Schema of a Session Replay Record.
  */


### PR DESCRIPTION
## Motivation

Use `pagehide` instead of `beforeunlaod` to:

- Prevent from not being bfcache in firefox
- Collect events / DOM mutations happening between `beforeunload` and `pagehide`
- Prevent from being wrongly notified if the unload is canceled by the user. The view won’t be wrongly ended. 

## Assess impact

To assess the impact:

- Enable `collect_flush_reason` ff to collect it for RUM events and replay segments
- Enable `pagehide`  ff for 50% of users and compare both data sets

## Changes

- pageExitObservablt use pagehide instead beforeunload (under `pagehide` ff)
- collect flush reason as a tag (under `collect_flush_reason` ff)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
