### PR TITLE
✅ improve unit test stability by increasing timeouts

### DIFF
--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -63,4 +63,10 @@ module.exports = {
     logLevel: 'warn',
   },
   plugins: ['karma-*', jasmineSeedReporterPlugin],
+
+  // Running tests on low performance environments (ex: BrowserStack) can block JS execution for a
+  // few seconds. We need to increase those two timeout values to make sure Karma (and underlying
+  // Socket.io) does not consider that the browser crashed.
+  pingTimeout: 60_000,
+  browserNoActivityTimeout: 60_000,
 }


### PR DESCRIPTION


## Motivation

Default timeouts are quite short, and some unit tests are taking a bit more time. Even evaluating all spec bundles can take more than a few seconds and exceeds the default Socket.io timeout.

This should improve unit tests flakiness especially on BrowserStack where things are a bit slower.

## Changes

Increase some karma and socket.io timeouts.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
