### PR TITLE
RUMF-1497 Allow logger APIs to pass an Error parameter

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export {
   ErrorWithCause,
   toStackTraceString,
   getFileFromStackTraceString,
+  NO_ERROR_STACK_PRESENT_MESSAGE,
+  PROVIDED_ERROR_MESSAGE_PREFIX,
 } from './tools/error'
 export { Context, ContextArray, ContextValue } from './tools/context'
 export { areCookiesAuthorized, getCookie, setCookie, deleteCookie, COOKIE_ACCESS_DELAY } from './browser/cookie'

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -4,6 +4,9 @@ import { callMonitored } from './monitor'
 import type { ClocksState } from './timeUtils'
 import { jsonStringify, noop } from './utils'
 
+export const NO_ERROR_STACK_PRESENT_MESSAGE = 'No stack, consider using an instance of Error'
+export const PROVIDED_ERROR_MESSAGE_PREFIX = 'Provided:'
+
 export interface ErrorWithCause extends Error {
   cause?: Error
 }
@@ -71,7 +74,7 @@ export function computeRawError({
       handling,
       originalError,
       message: `${nonErrorPrefix} ${jsonStringify(originalError)!}`,
-      stack: 'No stack, consider using an instance of Error',
+      stack: NO_ERROR_STACK_PRESENT_MESSAGE,
       handlingStack,
       type: stackTrace && stackTrace.name,
     }

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -5,7 +5,7 @@ import type { ClocksState } from './timeUtils'
 import { jsonStringify, noop } from './utils'
 
 export const NO_ERROR_STACK_PRESENT_MESSAGE = 'No stack, consider using an instance of Error'
-export const PROVIDED_ERROR_MESSAGE_PREFIX = 'Provided:'
+export const PROVIDED_ERROR_MESSAGE_PREFIX = 'Provided'
 
 export interface ErrorWithCause extends Error {
   cause?: Error

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -70,6 +70,7 @@ describe('Logger', () => {
         context: {
           error: {
             origin: 'logger',
+            kind: undefined,
             message: 'Provided "My Error"',
             stack: NO_ERROR_STACK_PRESENT_MESSAGE,
           },

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -1,5 +1,5 @@
 import type { LogsMessage } from './logger'
-import { HandlerType, Logger, STATUSES, StatusType } from './logger'
+import { NO_ERROR_STACK_PRESENT_MESSAGE, HandlerType, Logger, STATUSES, StatusType } from './logger'
 
 describe('Logger', () => {
   let logger: Logger
@@ -30,6 +30,19 @@ describe('Logger', () => {
         logger[status]('message')
         expect(getLoggedMessage(0).status).toEqual(status)
       })
+
+      it(`'logger.${status}' should populate an error context when an Error object is provided`, () => {
+        logger[status]('message', {}, SyntaxError('My Error'))
+
+        expect(getLoggedMessage(0).context).toEqual({
+          error: {
+            origin: 'logger',
+            kind: 'SyntaxError',
+            message: 'My Error',
+            stack: jasmine.stringMatching(/^SyntaxError: My Error/),
+          },
+        })
+      })
     })
 
     it("'logger.log' should send the log message", () => {
@@ -46,6 +59,36 @@ describe('Logger', () => {
       logger.log('message')
 
       expect(getMessageLogger(0)).toBe(logger)
+    })
+
+    it("'logger.log' should serialize error parameter value when type is not Error", () => {
+      logger.log('message', {}, StatusType.error, 'My Error' as any)
+
+      expect(getLoggedMessage(0)).toEqual({
+        message: 'message',
+        context: {
+          error: {
+            origin: 'logger',
+            message: 'Provided: "My Error"',
+            stack: NO_ERROR_STACK_PRESENT_MESSAGE,
+          },
+        },
+        status: 'error',
+      })
+    })
+
+    it("'logger.error' should populate an error context with origin even if no Error object is provided", () => {
+      logger.error('message')
+
+      expect(getLoggedMessage(0)).toEqual({
+        message: 'message',
+        context: {
+          error: {
+            origin: 'logger',
+          },
+        },
+        status: 'error',
+      })
     })
   })
 

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -70,7 +70,7 @@ describe('Logger', () => {
         context: {
           error: {
             origin: 'logger',
-            message: 'Provided: "My Error"',
+            message: 'Provided "My Error"',
             stack: NO_ERROR_STACK_PRESENT_MESSAGE,
           },
         },

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -1,5 +1,6 @@
+import { NO_ERROR_STACK_PRESENT_MESSAGE } from '@datadog/browser-core'
 import type { LogsMessage } from './logger'
-import { NO_ERROR_STACK_PRESENT_MESSAGE, HandlerType, Logger, STATUSES, StatusType } from './logger'
+import { HandlerType, Logger, STATUSES, StatusType } from './logger'
 
 describe('Logger', () => {
   let logger: Logger

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -72,9 +72,7 @@ export class Logger {
 
         errorContext.stack = rawError.stack
         errorContext.message = rawError.message
-        if (rawError.type) {
-          errorContext.kind = rawError.type
-        }
+        errorContext.kind = rawError.type
       }
 
       context = combine({ error: errorContext }, messageContext) as Context

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -1,5 +1,6 @@
 import type { Context, RawError, ClocksState } from '@datadog/browser-core'
 import {
+  PROVIDED_ERROR_MESSAGE_PREFIX,
   isEmptyObject,
   assign,
   ErrorSource,
@@ -72,7 +73,7 @@ export function doStartErrorCollection(
         originalError: error,
         handlingStack,
         startClocks,
-        nonErrorPrefix: 'Provided',
+        nonErrorPrefix: PROVIDED_ERROR_MESSAGE_PREFIX,
         source: ErrorSource.CUSTOM,
         handling: ErrorHandling.HANDLED,
       })


### PR DESCRIPTION
## Motivation

The goal of this PR is to align capabilities for error monitoring between RUM and LOGS SDKs.

## Changes

Added an optional error parameter: 
`logger.[level](message: string, messageContext?: object, error?: Error)`
which will be serialized as part of an error context, with defined fields (message, kind, stack)


- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
