### PR TITLE
🐛 [RUMF-1443] fix Zone.js/Angular crash when recording the session

### DIFF
--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -1,3 +1,4 @@
+import { getZoneJsOriginalValue } from './getZoneJsOriginalValue'
 import { callMonitored, monitor } from './monitor'
 import { noop } from './utils'
 
@@ -80,6 +81,9 @@ export function instrumentSetter<OBJECT extends { [key: string]: any }, PROPERTY
     return { stop: noop }
   }
 
+  // Using the patched `setTimeout` from Zone.js triggers a rendering loop in some Angular
+  // component, see issue RUMF-1443
+  const setTimeout = getZoneJsOriginalValue(window, 'setTimeout')
   let instrumentation = (thisObject: OBJECT, value: OBJECT[PROPERTY]) => {
     // put hooked setter into event loop to avoid of set latency
     setTimeout(


### PR DESCRIPTION
Issue reported to the Kendo-UI project here: https://github.com/telerik/kendo-angular/issues/3930

## Motivation

The issue is related to Zone.js/Angular + using the Kendo UI Grid component

1. open the official Kendo UI grid example: https://www.telerik.com/kendo-angular-ui/components/grid/examples/filter-all-columns/?theme=default-ocean-blue&themeVersion=6.1.0

2. execute the following code in the console (this is similar to what the SDK is doing):
```js
Object.defineProperty(HTMLInputElement.prototype, 'checked', { set() { setTimeout(() => { }) } })
```
3. click on the first checkbox

4. the CPU usage increases to 100%

## Diagnostic

* Angular is using Zone.js to track asynchronous executions (like `setTimeout`), and apparently in some cases triggers a component re-render when a `setTimeout` executes its callback.

* The grid component is likely using something like `input.checked = true` when being rendered.

* The Browser SDK instrumentation of `input.checked` uses `setTimeout` every time this property is set.

Thus, we have an infinite render loop consuming the CPU.



## Changes

Use the original `setTimeout` function when instrumenting property setters

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
