### PR TITLE
🚨 [RUMF-1505] ESLint rule to forbid usage of Zone.js problematic values

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -217,6 +217,7 @@ module.exports = {
       excludedFiles: '*.spec.ts',
       rules: {
         'local-rules/disallow-side-effects': 'error',
+        'local-rules/disallow-zone-js-patched-values': 'error',
         'no-restricted-syntax': [
           'error',
           {

--- a/eslint-local-rules/disallowZoneJsPatchedValues.js
+++ b/eslint-local-rules/disallowZoneJsPatchedValues.js
@@ -1,0 +1,69 @@
+const PROBLEMATIC_IDENTIFIERS = {
+  // Using the patched `MutationObserver` from Zone.js triggers an infinite callback loop on some
+  // occasion, see PRs #376 #866 #1530
+  MutationObserver: 'Use `getMutationObserverConstructor` from @datadog/browser-rum-core instead',
+
+  // TODO: disallow setTimeout, clearTimeout, addEventListener, removeEventListener
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow problematic ZoneJs patched values.',
+      recommended: false,
+    },
+    schema: [],
+  },
+  create(context) {
+    const parserServices = context.parserServices
+    const checker = parserServices.program.getTypeChecker()
+
+    return {
+      Identifier(node) {
+        if (
+          Object.hasOwn(PROBLEMATIC_IDENTIFIERS, node.name) &&
+          // Using those identifiers inside type definition is not problematic
+          !isInTypeDefinition(node)
+        ) {
+          const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node)
+          const symbol = checker.getSymbolAtLocation(originalNode)
+          if (symbol && isDeclaredInTsDomLib(symbol.declarations[0])) {
+            context.report(node, `This value might be patched by Zone.js. ${PROBLEMATIC_IDENTIFIERS[node.name]}`)
+          }
+        }
+      },
+    }
+  },
+}
+
+/**
+ * Wether the declaration is inside the TypeScript DOM declaration file (i.e. lib.dom.d.ts),
+ * indicating that it's a "native" browser API and not a function that we declare ourselves.
+ */
+function isDeclaredInTsDomLib(declaration) {
+  if (declaration.parent) {
+    return isDeclaredInTsDomLib(declaration.parent)
+  }
+  return declaration.isDeclarationFile && declaration.path.endsWith('/lib.dom.d.ts')
+}
+
+/**
+ * Whether the symbol is a concrete value and not a type
+ */
+
+function isInTypeDefinition(node) {
+  let types = new Set()
+  while (node) {
+    types.add(node.type)
+    if (isTypeDefinition(node)) {
+      return true
+    }
+    node = node.parent
+  }
+  return false
+}
+
+const typeDefinitionNodeTypes = new Set(['TSAsExpression', 'TSTypeAliasDeclaration', 'TSInterfaceDeclaration'])
+function isTypeDefinition(node) {
+  return typeDefinitionNodeTypes.has(node.type)
+}

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -11,5 +11,6 @@ module.exports = {
   'disallow-enum-exports': require('./disallowEnumExports'),
   'disallow-spec-import': require('./disallowSpecImport'),
   'disallow-protected-directory-import': require('./disallowProtectedDirectoryImport'),
+  'disallow-zone-js-patched-values': require('./disallowZoneJsPatchedValues'),
   'secure-command-execution': require('./secureCommandExecution'),
 }


### PR DESCRIPTION
## Motivation

As we've seen in the past, integrating the SDK on an app that uses Angular/Zone.js causes critical issues in various ways. See related PRs:

* #376
* #866
* #1530
* #1860
* #2030

## Changes

This PR adds an ESLint rule to forbid usage of some values that are known to cause trouble when they are patched by Zone.js. This PR focuses on introducing the rule and disallow `MutationObserver`. Future PRs will disallow more things.

![Screenshot 2023-02-23 at 16 00 53](https://user-images.githubusercontent.com/61787/220944400-fab7a2f7-f905-46a4-a8d6-e947cac44ed9.png)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
