### PR TITLE
♻️ [RUMF-1505] introduce and use a safe `setTimeout` helper function

### DIFF
--- a/eslint-local-rules/disallowZoneJsPatchedValues.js
+++ b/eslint-local-rules/disallowZoneJsPatchedValues.js
@@ -3,7 +3,12 @@ const PROBLEMATIC_IDENTIFIERS = {
   // occasion, see PRs #376 #866 #1530
   MutationObserver: 'Use `getMutationObserverConstructor` from @datadog/browser-rum-core instead',
 
-  // TODO: disallow setTimeout, clearTimeout, addEventListener, removeEventListener
+  // Using the patched `setTimeout` from Zone.js triggers a rendering loop in some Angular
+  // component, see issue PR #2030
+  setTimeout: 'Use `setTimeout` from @datadog/browser-core instead',
+  clearTimeout: 'Use `clearTimeout` from @datadog/browser-core instead',
+
+  // TODO: disallow addEventListener, removeEventListener
 }
 
 module.exports = {

--- a/packages/core/src/browser/timer.spec.ts
+++ b/packages/core/src/browser/timer.spec.ts
@@ -1,0 +1,68 @@
+import { stubZoneJs } from '../../test/stubZoneJs'
+import type { Clock } from '../../test/specHelper'
+import { mockClock } from '../../test/specHelper'
+import { noop } from '../tools/utils'
+import { resetMonitor, startMonitorErrorCollection } from '../tools/monitor'
+import { setTimeout, clearTimeout } from './timer'
+
+describe('setTimeout', () => {
+  let clock: Clock
+  let zoneJsStub: ReturnType<typeof stubZoneJs>
+
+  beforeEach(() => {
+    clock = mockClock()
+    zoneJsStub = stubZoneJs()
+  })
+
+  afterEach(() => {
+    zoneJsStub.restore()
+    clock.cleanup()
+    resetMonitor()
+  })
+
+  it('executes the callback asynchronously', () => {
+    const spy = jasmine.createSpy()
+    setTimeout(spy)
+    expect(spy).not.toHaveBeenCalled()
+    clock.tick(0)
+    expect(spy).toHaveBeenCalledOnceWith()
+  })
+
+  it('schedules an timeout task', () => {
+    const spy = jasmine.createSpy()
+    setTimeout(spy)
+    expect(spy).not.toHaveBeenCalled()
+    clock.tick(0)
+    expect(spy).toHaveBeenCalledOnceWith()
+  })
+
+  it('does not use the Zone.js setTimeout function', () => {
+    const zoneJsSetTimeoutSpy = jasmine.createSpy()
+    zoneJsStub.replaceProperty(window, 'setTimeout', zoneJsSetTimeoutSpy)
+
+    setTimeout(noop)
+    clock.tick(0)
+
+    expect(zoneJsSetTimeoutSpy).not.toHaveBeenCalled()
+  })
+
+  it('monitors the callback', () => {
+    const onMonitorErrorCollectedSpy = jasmine.createSpy()
+    startMonitorErrorCollection(onMonitorErrorCollectedSpy)
+
+    setTimeout(() => {
+      throw new Error('foo')
+    })
+    clock.tick(0)
+
+    expect(onMonitorErrorCollectedSpy).toHaveBeenCalledOnceWith(new Error('foo'))
+  })
+
+  it('can be canceled by using `clearTimeout`', () => {
+    const spy = jasmine.createSpy()
+    const timeoutId = setTimeout(spy)
+    clearTimeout(timeoutId)
+    clock.tick(0)
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/browser/timer.ts
+++ b/packages/core/src/browser/timer.ts
@@ -1,0 +1,12 @@
+import { getZoneJsOriginalValue } from '../tools/getZoneJsOriginalValue'
+import { monitor } from '../tools/monitor'
+
+export type TimeoutId = ReturnType<typeof window.setTimeout>
+
+export function setTimeout(callback: () => void, delay?: number): TimeoutId {
+  return getZoneJsOriginalValue(window, 'setTimeout')(monitor(callback), delay)
+}
+
+export function clearTimeout(timeoutId: TimeoutId | undefined) {
+  getZoneJsOriginalValue(window, 'clearTimeout')(timeoutId)
+}

--- a/packages/core/src/domain/session/sessionCookieStore.ts
+++ b/packages/core/src/domain/session/sessionCookieStore.ts
@@ -1,7 +1,7 @@
 import type { CookieOptions } from '../../browser/cookie'
 import { getCookie, setCookie } from '../../browser/cookie'
+import { setTimeout } from '../../browser/timer'
 import { isChromium } from '../../tools/browserDetection'
-import { monitor } from '../../tools/monitor'
 import { dateNow } from '../../tools/timeUtils'
 import * as utils from '../../tools/utils'
 import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
@@ -98,12 +98,9 @@ function isCookieLockEnabled() {
 }
 
 function retryLater(operations: Operations, currentNumberOfRetries: number) {
-  setTimeout(
-    monitor(() => {
-      withCookieLockAccess(operations, currentNumberOfRetries + 1)
-    }),
-    LOCK_RETRY_DELAY
-  )
+  setTimeout(() => {
+    withCookieLockAccess(operations, currentNumberOfRetries + 1)
+  }, LOCK_RETRY_DELAY)
 }
 
 function next() {

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -140,7 +140,7 @@ export function startSessionStore<TrackingType extends string>(
   }
 
   return {
-    expandOrRenewSession: utils.throttle(monitor(expandOrRenewSession), COOKIE_ACCESS_DELAY).throttled,
+    expandOrRenewSession: utils.throttle(expandOrRenewSession, COOKIE_ACCESS_DELAY).throttled,
     expandSession,
     getSession: () => sessionCache,
     renewObservable,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,7 @@ export { initXhrObservable, XhrCompleteContext, XhrStartContext } from './browse
 export { initFetchObservable, FetchResolveContext, FetchStartContext, FetchContext } from './browser/fetchObservable'
 export { createPageExitObservable, PageExitEvent, PageExitReason, isPageExitReason } from './browser/pageExitObservable'
 export * from './browser/addEventListener'
+export * from './browser/timer'
 export { initConsoleObservable, ConsoleLog } from './domain/console/consoleObservable'
 export { BoundedBuffer } from './tools/boundedBuffer'
 export { catchUserErrors } from './tools/catchUserErrors'

--- a/packages/core/src/tools/contextHistory.ts
+++ b/packages/core/src/tools/contextHistory.ts
@@ -1,6 +1,6 @@
+import type { TimeoutId } from '../browser/timer'
 import type { RelativeTime } from './timeUtils'
 import { relativeNow } from './timeUtils'
-import type { TimeoutId } from './utils'
 import { ONE_MINUTE } from './utils'
 
 const END_OF_TIMES = Infinity as RelativeTime

--- a/packages/core/src/tools/createEventRateLimiter.ts
+++ b/packages/core/src/tools/createEventRateLimiter.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from '../browser/timer'
 import type { RawError } from './error'
 import { ErrorSource } from './error'
 import { clocksNow } from './timeUtils'

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -1,5 +1,5 @@
-import { getZoneJsOriginalValue } from './getZoneJsOriginalValue'
-import { callMonitored, monitor } from './monitor'
+import { setTimeout } from '../browser/timer'
+import { callMonitored } from './monitor'
 import { noop } from './utils'
 
 export function instrumentMethod<OBJECT extends { [key: string]: any }, METHOD extends keyof OBJECT>(
@@ -81,17 +81,11 @@ export function instrumentSetter<OBJECT extends { [key: string]: any }, PROPERTY
     return { stop: noop }
   }
 
-  // Using the patched `setTimeout` from Zone.js triggers a rendering loop in some Angular
-  // component, see issue RUMF-1443
-  const setTimeout = getZoneJsOriginalValue(window, 'setTimeout')
   let instrumentation = (thisObject: OBJECT, value: OBJECT[PROPERTY]) => {
     // put hooked setter into event loop to avoid of set latency
-    setTimeout(
-      monitor(() => {
-        after(thisObject, value)
-      }),
-      0
-    )
+    setTimeout(() => {
+      after(thisObject, value)
+    }, 0)
   }
 
   const instrumentationWrapper = function (this: OBJECT, value: OBJECT[PROPERTY]) {

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -1,4 +1,5 @@
 import type { TimeoutId } from '../browser/timer'
+import { setTimeout, clearTimeout } from '../browser/timer'
 import { display } from './display'
 import { monitor } from './monitor'
 

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -1,3 +1,4 @@
+import type { TimeoutId } from '../browser/timer'
 import { display } from './display'
 import { monitor } from './monitor'
 
@@ -524,8 +525,6 @@ export function combine(...sources: any[]): unknown {
 
   return destination as unknown
 }
-
-export type TimeoutId = ReturnType<typeof setTimeout>
 
 export function requestIdleCallback(callback: () => void, opts?: { timeout?: number }) {
   // Use 'requestIdleCallback' when available: it will throttle the mutation processing if the

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -1,8 +1,8 @@
 import { display } from '../tools/display'
 import type { Context } from '../tools/context'
 import { computeBytesCount, jsonStringify, objectValues } from '../tools/utils'
-import { monitor } from '../tools/monitor'
 import { Observable } from '../tools/observable'
+import { setTimeout } from '../browser/timer'
 import type { PageExitEvent } from '../browser/pageExitObservable'
 import type { HttpRequest } from './httpRequest'
 
@@ -132,12 +132,9 @@ export class Batch {
   }
 
   private flushPeriodically() {
-    setTimeout(
-      monitor(() => {
-        this.flush('batch_duration_limit')
-        this.flushPeriodically()
-      }),
-      this.flushTimeout
-    )
+    setTimeout(() => {
+      this.flush('batch_duration_limit')
+      this.flushPeriodically()
+    }, this.flushTimeout)
   }
 }

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -7,6 +7,7 @@ import {
   getRelativeTime,
   isNumber,
   monitor,
+  setTimeout,
   relativeNow,
   runOnReadyState,
 } from '@datadog/browser-core'
@@ -111,7 +112,7 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: 
     const performanceEntries = performance.getEntries()
     // Because the performance entry list can be quite large
     // delay the computation to prevent the SDK from blocking the main thread on init
-    setTimeout(monitor(() => handleRumPerformanceEntries(lifeCycle, configuration, performanceEntries)))
+    setTimeout(() => handleRumPerformanceEntries(lifeCycle, configuration, performanceEntries))
   }
 
   if (window.PerformanceObserver) {
@@ -197,7 +198,7 @@ function retrieveNavigationTiming(callback: (timing: RumPerformanceNavigationTim
 
   runOnReadyState('complete', () => {
     // Send it a bit after the actual load event, so the "loadEventEnd" timing is accurate
-    setTimeout(monitor(sendFakeTiming))
+    setTimeout(sendFakeTiming)
   })
 }
 

--- a/packages/rum-core/src/browser/viewportObservable.ts
+++ b/packages/rum-core/src/browser/viewportObservable.ts
@@ -1,4 +1,4 @@
-import { monitor, Observable, throttle, addEventListener, DOM_EVENT } from '@datadog/browser-core'
+import { Observable, throttle, addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
 
 export interface ViewportDimension {
   height: number

--- a/packages/rum-core/src/browser/viewportObservable.ts
+++ b/packages/rum-core/src/browser/viewportObservable.ts
@@ -1,4 +1,4 @@
-import { Observable, throttle, addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
+import { Observable, throttle, addEventListener, DOM_EVENT } from '@datadog/browser-core'
 
 export interface ViewportDimension {
   height: number
@@ -16,12 +16,9 @@ export function initViewportObservable() {
 
 export function createViewportObservable() {
   const observable = new Observable<ViewportDimension>(() => {
-    const { throttled: updateDimension } = throttle(
-      monitor(() => {
-        observable.notify(getViewportDimension())
-      }),
-      200
-    )
+    const { throttled: updateDimension } = throttle(() => {
+      observable.notify(getViewportDimension())
+    }, 200)
 
     return addEventListener(window, DOM_EVENT.RESIZE, updateDimension, { capture: true, passive: true }).stop
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/clickChain.ts
@@ -1,4 +1,4 @@
-import { monitor, ONE_SECOND } from '@datadog/browser-core'
+import { ONE_SECOND, clearTimeout, setTimeout } from '@datadog/browser-core'
 import type { Click } from './trackClickActions'
 
 export interface ClickChain {
@@ -25,7 +25,7 @@ export function createClickChain(firstClick: Click, onFinalize: (clicks: Click[]
     click.stopObservable.subscribe(tryFinalize)
     bufferedClicks.push(click)
     clearTimeout(maxDurationBetweenClicksTimeout)
-    maxDurationBetweenClicksTimeout = setTimeout(monitor(dontAcceptMoreClick), MAX_DURATION_BETWEEN_CLICKS)
+    maxDurationBetweenClicksTimeout = setTimeout(dontAcceptMoreClick, MAX_DURATION_BETWEEN_CLICKS)
   }
 
   function tryFinalize() {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewEventCounts.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewEventCounts.ts
@@ -1,4 +1,4 @@
-import { monitor, ONE_MINUTE } from '@datadog/browser-core'
+import { ONE_MINUTE, setTimeout } from '@datadog/browser-core'
 import type { LifeCycle } from '../../lifeCycle'
 import { trackEventCounts } from '../../trackEventCounts'
 
@@ -28,7 +28,7 @@ export function trackViewEventCounts(lifeCycle: LifeCycle, viewId: string, onCha
 
   return {
     scheduleStop: () => {
-      setTimeout(monitor(stop), KEEP_TRACKING_EVENT_COUNTS_AFTER_VIEW_DELAY)
+      setTimeout(stop, KEEP_TRACKING_EVENT_COUNTS_AFTER_VIEW_DELAY)
     },
     eventCounts,
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -216,7 +216,7 @@ function newView(
 
   // Update the view every time the measures are changing
   const { throttled: scheduleViewUpdate, cancel: cancelScheduleViewUpdate } = throttle(
-    monitor(triggerViewUpdate),
+    triggerViewUpdate,
     THROTTLE_VIEW_UPDATE_PERIOD,
     {
       leading: false,

--- a/packages/rum-core/src/domain/waitPageActivityEnd.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.ts
@@ -1,5 +1,13 @@
 import type { Subscription, TimeoutId, TimeStamp } from '@datadog/browser-core'
-import { instrumentMethodAndCallOriginal, matchList, monitor, Observable, timeStampNow } from '@datadog/browser-core'
+import {
+  instrumentMethodAndCallOriginal,
+  matchList,
+  monitor,
+  Observable,
+  timeStampNow,
+  setTimeout,
+  clearTimeout,
+} from '@datadog/browser-core'
 import type { RumConfiguration } from './configuration'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -1,6 +1,5 @@
 import type { DefaultPrivacyLevel } from '@datadog/browser-core'
 import {
-  monitor,
   instrumentSetter,
   instrumentMethodAndCallOriginal,
   assign,
@@ -154,7 +153,7 @@ export function initMutationObserver(
 
 export function initMoveObserver(cb: MousemoveCallBack): ListenerHandler {
   const { throttled: updatePosition } = throttle(
-    monitor((event: MouseEvent | TouchEvent) => {
+    (event: MouseEvent | TouchEvent) => {
       const target = getEventTarget(event)
       if (hasSerializedNode(target)) {
         const coordinates = tryToComputeCoordinates(event)
@@ -170,7 +169,7 @@ export function initMoveObserver(cb: MousemoveCallBack): ListenerHandler {
 
         cb([position], isTouchEvent(event) ? IncrementalSource.TouchMove : IncrementalSource.MouseMove)
       }
-    }),
+    },
     MOUSE_MOVE_OBSERVER_THRESHOLD,
     {
       trailing: false,
@@ -259,36 +258,33 @@ function initScrollObserver(
   defaultPrivacyLevel: DefaultPrivacyLevel,
   elementsScrollPositions: ElementsScrollPositions
 ): ListenerHandler {
-  const { throttled: updatePosition } = throttle(
-    monitor((event: UIEvent) => {
-      const target = getEventTarget(event) as HTMLElement | Document
-      if (
-        !target ||
-        getNodePrivacyLevel(target, defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN ||
-        !hasSerializedNode(target)
-      ) {
-        return
-      }
-      const id = getSerializedNodeId(target)
-      const scrollPositions =
-        target === document
-          ? {
-              scrollTop: getScrollY(),
-              scrollLeft: getScrollX(),
-            }
-          : {
-              scrollTop: Math.round((target as HTMLElement).scrollTop),
-              scrollLeft: Math.round((target as HTMLElement).scrollLeft),
-            }
-      elementsScrollPositions.set(target, scrollPositions)
-      cb({
-        id,
-        x: scrollPositions.scrollLeft,
-        y: scrollPositions.scrollTop,
-      })
-    }),
-    SCROLL_OBSERVER_THRESHOLD
-  )
+  const { throttled: updatePosition } = throttle((event: UIEvent) => {
+    const target = getEventTarget(event) as HTMLElement | Document
+    if (
+      !target ||
+      getNodePrivacyLevel(target, defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN ||
+      !hasSerializedNode(target)
+    ) {
+      return
+    }
+    const id = getSerializedNodeId(target)
+    const scrollPositions =
+      target === document
+        ? {
+            scrollTop: getScrollY(),
+            scrollLeft: getScrollX(),
+          }
+        : {
+            scrollTop: Math.round((target as HTMLElement).scrollTop),
+            scrollLeft: Math.round((target as HTMLElement).scrollLeft),
+          }
+    elementsScrollPositions.set(target, scrollPositions)
+    cb({
+      id,
+      x: scrollPositions.scrollLeft,
+      y: scrollPositions.scrollTop,
+    })
+  }, SCROLL_OBSERVER_THRESHOLD)
   return addEventListener(document, DOM_EVENT.SCROLL, updatePosition, { capture: true, passive: true }).stop
 }
 
@@ -491,9 +487,9 @@ function initVisualViewportResizeObserver(cb: VisualViewportResizeCallback): Lis
     return noop
   }
   const { throttled: updateDimension, cancel: cancelThrottle } = throttle(
-    monitor(() => {
+    () => {
       cb(getVisualViewport())
-    }),
+    },
     VISUAL_VIEWPORT_OBSERVER_THRESHOLD,
     {
       trailing: false,

--- a/packages/rum/src/domain/record/observers.ts
+++ b/packages/rum/src/domain/record/observers.ts
@@ -1,9 +1,9 @@
 import type { DefaultPrivacyLevel } from '@datadog/browser-core'
 import {
+  monitor,
   instrumentSetter,
   instrumentMethodAndCallOriginal,
   assign,
-  monitor,
   throttle,
   DOM_EVENT,
   addEventListeners,

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,5 +1,5 @@
 import type { HttpRequest, TimeoutId } from '@datadog/browser-core'
-import { isPageExitReason, ONE_SECOND, monitor } from '@datadog/browser-core'
+import { isPageExitReason, ONE_SECOND, clearTimeout, setTimeout } from '@datadog/browser-core'
 import type { LifeCycle, ViewContexts, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { BrowserRecord, CreationReason, SegmentContext } from '../../types'
@@ -145,12 +145,9 @@ export function doStartSegmentCollection(
     state = {
       status: SegmentCollectionStatus.SegmentPending,
       segment,
-      expirationTimeoutId: setTimeout(
-        monitor(() => {
-          flushSegment('segment_duration_limit')
-        }),
-        SEGMENT_DURATION_LIMIT
-      ),
+      expirationTimeoutId: setTimeout(() => {
+        flushSegment('segment_duration_limit')
+      }, SEGMENT_DURATION_LIMIT),
     }
   }
 


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/browser-sdk/pull/2031, we want to disallow native `setTimeout` usages across the codebase.

## Changes

Introduce a safe `setTimeout` helper function and use it in packages.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
