### PR TITLE
🔇 remove some errors during Worker creation from telemetry

### DIFF
--- a/packages/rum/src/domain/segmentCollection/startDeflateWorker.ts
+++ b/packages/rum/src/domain/segmentCollection/startDeflateWorker.ts
@@ -97,7 +97,7 @@ function onInitialized(worker: DeflateWorker) {
 function onError(error: unknown) {
   if (state.status === DeflateWorkerStatus.Loading) {
     display.error('Session Replay recording failed to start: an error occurred while creating the Worker:', error)
-    if (error instanceof Event || (error instanceof Error && includes(error.message, 'Content Security Policy'))) {
+    if (error instanceof Event || (error instanceof Error && isMessageCspRelated(error.message))) {
       display.error(
         'Please make sure CSP is correctly configured ' +
           'https://docs.datadoghq.com/real_user_monitoring/faq/content_security_policy'
@@ -110,4 +110,12 @@ function onError(error: unknown) {
   } else {
     addTelemetryError(error)
   }
+}
+
+function isMessageCspRelated(message: string) {
+  return (
+    includes(message, 'Content Security Policy') ||
+    // Related to `require-trusted-types-for` CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for
+    includes(message, "requires 'TrustedScriptURL'")
+  )
 }


### PR DESCRIPTION


## Motivation

When failing to create the Worker, we try to detect whether the error is related to CSP to guide the user.

When using the `require-trusted-types-for` CSP, the error does not mention "Content Security Policy". Thus, we report it as a telemetry error.


## Changes


This commit adjusts this and consider it as a CSP error.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
