### PR TITLE
♻️ [RUMF-1505] introduce a safe `setInterval` helper function

### DIFF
--- a/eslint-local-rules/disallowZoneJsPatchedValues.js
+++ b/eslint-local-rules/disallowZoneJsPatchedValues.js
@@ -8,6 +8,11 @@ const PROBLEMATIC_IDENTIFIERS = {
   setTimeout: 'Use `setTimeout` from @datadog/browser-core instead',
   clearTimeout: 'Use `clearTimeout` from @datadog/browser-core instead',
 
+  // We didn't stumble on cases where using the patched `setInterval` from Zone.js is problematic
+  // yet, but still consider it problematic in prevention and to unify its usages with `setTimeout`.
+  setInterval: 'Use `setInterval` from @datadog/browser-core instead',
+  clearInterval: 'Use `clearInterval` from @datadog/browser-core instead',
+
   // TODO: disallow addEventListener, removeEventListener
 }
 

--- a/packages/core/src/browser/timer.ts
+++ b/packages/core/src/browser/timer.ts
@@ -10,3 +10,11 @@ export function setTimeout(callback: () => void, delay?: number): TimeoutId {
 export function clearTimeout(timeoutId: TimeoutId | undefined) {
   getZoneJsOriginalValue(window, 'clearTimeout')(timeoutId)
 }
+
+export function setInterval(callback: () => void, delay?: number): TimeoutId {
+  return getZoneJsOriginalValue(window, 'setInterval')(monitor(callback), delay)
+}
+
+export function clearInterval(timeoutId: TimeoutId | undefined) {
+  getZoneJsOriginalValue(window, 'clearInterval')(timeoutId)
+}

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -5,8 +5,8 @@ import type { Context } from '../../tools/context'
 import { ContextHistory } from '../../tools/contextHistory'
 import type { RelativeTime } from '../../tools/timeUtils'
 import { relativeNow, clocksOrigin } from '../../tools/timeUtils'
-import { monitor } from '../../tools/monitor'
 import { DOM_EVENT, addEventListener, addEventListeners } from '../../browser/addEventListener'
+import { clearInterval, setInterval } from '../../browser/timer'
 import { tryOldCookiesMigration } from './oldCookiesMigration'
 import { startSessionStore } from './sessionStore'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
@@ -81,11 +81,11 @@ function trackActivity(expandOrRenewSession: () => void) {
 }
 
 function trackVisibility(expandSession: () => void) {
-  const expandSessionWhenVisible = monitor(() => {
+  const expandSessionWhenVisible = () => {
     if (document.visibilityState === 'visible') {
       expandSession()
     }
-  })
+  }
 
   const { stop } = addEventListener(document, DOM_EVENT.VISIBILITY_CHANGE, expandSessionWhenVisible)
   stopCallbacks.push(stop)

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -1,6 +1,6 @@
 import type { CookieOptions } from '../../browser/cookie'
 import { COOKIE_ACCESS_DELAY } from '../../browser/cookie'
-import { monitor } from '../../tools/monitor'
+import { clearInterval, setInterval } from '../../browser/timer'
 import { Observable } from '../../tools/observable'
 import { dateNow } from '../../tools/timeUtils'
 import * as utils from '../../tools/utils'
@@ -39,7 +39,7 @@ export function startSessionStore<TrackingType extends string>(
   const renewObservable = new Observable<void>()
   const expireObservable = new Observable<void>()
 
-  const watchSessionTimeoutId = setInterval(monitor(watchSession), COOKIE_ACCESS_DELAY)
+  const watchSessionTimeoutId = setInterval(watchSession, COOKIE_ACCESS_DELAY)
   let sessionCache: SessionState = retrieveActiveSession()
 
   function expandOrRenewSession() {

--- a/packages/core/src/tools/contextHistory.ts
+++ b/packages/core/src/tools/contextHistory.ts
@@ -1,3 +1,4 @@
+import { setInterval, clearInterval } from '../browser/timer'
 import type { TimeoutId } from '../browser/timer'
 import type { RelativeTime } from './timeUtils'
 import { relativeNow } from './timeUtils'

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -5,7 +5,6 @@ import {
   assign,
   elapsed,
   generateUUID,
-  monitor,
   ONE_MINUTE,
   throttle,
   clocksNow,
@@ -13,6 +12,8 @@ import {
   timeStampNow,
   display,
   looksLikeRelativeTime,
+  setInterval,
+  clearInterval,
 } from '@datadog/browser-core'
 
 import type { ViewCustomTimings } from '../../../rawRumEvent.types'
@@ -136,12 +137,9 @@ export function trackViews(
     })
 
     // Session keep alive
-    const keepAliveInterval = window.setInterval(
-      monitor(() => {
-        currentView.triggerUpdate()
-      }),
-      SESSION_KEEP_ALIVE_INTERVAL
-    )
+    const keepAliveInterval = setInterval(() => {
+      currentView.triggerUpdate()
+    }, SESSION_KEEP_ALIVE_INTERVAL)
 
     return {
       stop: () => {

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
@@ -1,5 +1,5 @@
 import type { BatchFlushEvent, Context, ContextManager, Observable, Telemetry } from '@datadog/browser-core'
-import { isEmptyObject, includes, performDraw, ONE_SECOND, addTelemetryDebug, monitor } from '@datadog/browser-core'
+import { isEmptyObject, includes, performDraw, ONE_SECOND, addTelemetryDebug, setInterval } from '@datadog/browser-core'
 import { RumEventType } from '../rawRumEvent.types'
 import type { RumEvent } from '../rumEvent.types'
 import type { RumConfiguration } from './configuration'
@@ -91,7 +91,7 @@ export function startCustomerDataTelemetry(
     initCurrentBatchMeasures()
   })
 
-  setInterval(monitor(sendCurrentPeriodMeasures), MEASURES_PERIOD_DURATION)
+  setInterval(sendCurrentPeriodMeasures, MEASURES_PERIOD_DURATION)
 }
 
 function sendCurrentPeriodMeasures() {


### PR DESCRIPTION
## Motivation

See related PRs:
* https://github.com/DataDog/browser-sdk/pull/2032
* https://github.com/DataDog/browser-sdk/pull/2031

Even though we didn't found any problem when using `setInterval` on Angular websites, let's consider it problematic in prevention and to unify its usages with `setTimeout`

## Changes

Introduce a safe `setTimeout` helper function and use it in packages.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
