### PR TITLE
🐛 Handle undefined cancel idle callback

### DIFF
--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -527,13 +527,16 @@ export function combine(...sources: any[]): unknown {
   return destination as unknown
 }
 
+/**
+ * Use 'requestIdleCallback' when available: it will throttle the mutation processing if the
+ * browser is busy rendering frames (ex: when frames are below 60fps). When not available, the
+ * fallback on 'requestAnimationFrame' will still ensure the mutations are processed after any
+ * browser rendering process (Layout, Recalculate Style, etc.), so we can serialize DOM nodes efficiently.
+ *
+ * Note: check both 'requestIdleCallback' and 'cancelIdleCallback' existence because some polyfills only implement 'requestIdleCallback'.
+ */
 export function requestIdleCallback(callback: () => void, opts?: { timeout?: number }) {
-  // Use 'requestIdleCallback' when available: it will throttle the mutation processing if the
-  // browser is busy rendering frames (ex: when frames are below 60fps). When not available, the
-  // fallback on 'requestAnimationFrame' will still ensure the mutations are processed after any
-  // browser rendering process (Layout, Recalculate Style, etc.), so we can serialize DOM nodes
-  // efficiently.
-  if (window.requestIdleCallback) {
+  if (window.requestIdleCallback && window.cancelIdleCallback) {
     const id = window.requestIdleCallback(monitor(callback), opts)
     return () => window.cancelIdleCallback(id)
   }


### PR DESCRIPTION
## Motivation

`requestIdleCallback` is not supported on Safari and some customer use polyfills that only polyfills `requestIdleCallback` but not `cancelIdleCallback`.

## Changes

checks both requestIdleCallback and cancelIdleCallback existence

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
