### PR TITLE
👷 Update dependency prettier to v2.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "minimatch": "5.1.6",
     "node-fetch": "3.3.0",
     "npm-run-all": "4.1.5",
-    "prettier": "2.6.2",
+    "prettier": "2.8.4",
     "sinon": "9.2.4",
     "terser-webpack-plugin": "5.1.1",
     "ts-loader": "9.4.2",

--- a/packages/core/src/browser/pageExitObservable.ts
+++ b/packages/core/src/browser/pageExitObservable.ts
@@ -10,7 +10,7 @@ export const PageExitReason = {
   FROZEN: 'page_frozen',
 } as const
 
-type PageExitReason = typeof PageExitReason[keyof typeof PageExitReason]
+type PageExitReason = (typeof PageExitReason)[keyof typeof PageExitReason]
 
 export interface PageExitEvent {
   reason: PageExitReason

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -13,7 +13,7 @@ export const DefaultPrivacyLevel = {
   MASK: 'mask',
   MASK_USER_INPUT: 'mask-user-input',
 } as const
-export type DefaultPrivacyLevel = typeof DefaultPrivacyLevel[keyof typeof DefaultPrivacyLevel]
+export type DefaultPrivacyLevel = (typeof DefaultPrivacyLevel)[keyof typeof DefaultPrivacyLevel]
 
 export interface InitConfiguration {
   // global options

--- a/packages/core/src/domain/report/reportObservable.ts
+++ b/packages/core/src/domain/report/reportObservable.ts
@@ -11,7 +11,7 @@ export const RawReportType = {
   cspViolation: 'csp_violation',
 } as const
 
-export type RawReportType = typeof RawReportType[keyof typeof RawReportType]
+export type RawReportType = (typeof RawReportType)[keyof typeof RawReportType]
 
 export interface RawReport {
   type: RawReportType

--- a/packages/core/src/tools/display.ts
+++ b/packages/core/src/tools/display.ts
@@ -15,7 +15,7 @@ export const ConsoleApiName = {
   error: 'error',
 } as const
 
-export type ConsoleApiName = typeof ConsoleApiName[keyof typeof ConsoleApiName]
+export type ConsoleApiName = (typeof ConsoleApiName)[keyof typeof ConsoleApiName]
 
 interface Display {
   (api: ConsoleApiName, ...args: any[]): void

--- a/packages/core/src/tools/error.ts
+++ b/packages/core/src/tools/error.ts
@@ -42,7 +42,7 @@ export const enum ErrorHandling {
   UNHANDLED = 'unhandled',
 }
 
-export type ErrorSource = typeof ErrorSource[keyof typeof ErrorSource]
+export type ErrorSource = (typeof ErrorSource)[keyof typeof ErrorSource]
 
 type RawErrorParams = {
   stackTrace?: StackTrace

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -14,7 +14,7 @@ export const StatusType = {
   warn: 'warn',
 } as const
 
-export type StatusType = typeof StatusType[keyof typeof StatusType]
+export type StatusType = (typeof StatusType)[keyof typeof StatusType]
 
 export const HandlerType = {
   console: 'console',
@@ -22,7 +22,7 @@ export const HandlerType = {
   silent: 'silent',
 } as const
 
-export type HandlerType = typeof HandlerType[keyof typeof HandlerType]
+export type HandlerType = (typeof HandlerType)[keyof typeof HandlerType]
 export const STATUSES = Object.keys(StatusType) as StatusType[]
 
 export class Logger {

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -156,7 +156,7 @@ describe('makeRecorderApi', () => {
     })
 
     describe('if browser is not supported', () => {
-      let originalArrayFrom: typeof Array['from']
+      let originalArrayFrom: (typeof Array)['from']
 
       beforeEach(() => {
         originalArrayFrom = Array.from

--- a/packages/rum/src/constants.ts
+++ b/packages/rum/src/constants.ts
@@ -7,7 +7,7 @@ export const NodePrivacyLevel = {
   MASK: DefaultPrivacyLevel.MASK,
   MASK_USER_INPUT: DefaultPrivacyLevel.MASK_USER_INPUT,
 } as const
-export type NodePrivacyLevel = typeof NodePrivacyLevel[keyof typeof NodePrivacyLevel]
+export type NodePrivacyLevel = (typeof NodePrivacyLevel)[keyof typeof NodePrivacyLevel]
 
 export const PRIVACY_ATTR_NAME = 'data-dd-privacy'
 

--- a/packages/rum/src/types/sessionReplayConstants.ts
+++ b/packages/rum/src/types/sessionReplayConstants.ts
@@ -18,7 +18,7 @@ export const RecordType: {
   FrustrationRecord: 9,
 } as const
 
-export type RecordType = typeof RecordType[keyof typeof RecordType]
+export type RecordType = (typeof RecordType)[keyof typeof RecordType]
 
 export const NodeType: {
   Document: SessionReplay.DocumentNode['type']
@@ -36,7 +36,7 @@ export const NodeType: {
   DocumentFragment: 11,
 } as const
 
-export type NodeType = typeof NodeType[keyof typeof NodeType]
+export type NodeType = (typeof NodeType)[keyof typeof NodeType]
 
 export const IncrementalSource: {
   Mutation: SessionReplay.BrowserMutationData['source']
@@ -62,7 +62,7 @@ export const IncrementalSource: {
   // Font : 10,
 } as const
 
-export type IncrementalSource = typeof IncrementalSource[keyof typeof IncrementalSource]
+export type IncrementalSource = (typeof IncrementalSource)[keyof typeof IncrementalSource]
 
 export const MouseInteractionType = {
   MouseUp: 0,
@@ -76,11 +76,11 @@ export const MouseInteractionType = {
   TouchEnd: 9,
 } as const
 
-export type MouseInteractionType = typeof MouseInteractionType[keyof typeof MouseInteractionType]
+export type MouseInteractionType = (typeof MouseInteractionType)[keyof typeof MouseInteractionType]
 
 export const MediaInteractionType = {
   Play: 0,
   Pause: 1,
 } as const
 
-export type MediaInteractionType = typeof MediaInteractionType[keyof typeof MediaInteractionType]
+export type MediaInteractionType = (typeof MediaInteractionType)[keyof typeof MediaInteractionType]

--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -20,7 +20,7 @@ export async function browserExecuteAsync<A extends any[]>(fn: (...params: A) =>
 const validPlatformNames = ['windows', 'macos', 'linux', 'ios', 'android'] as const
 const validBrowserNames = ['edge', 'safari', 'chrome', 'firefox', 'ie'] as const
 
-export function getBrowserName(): typeof validBrowserNames[number] {
+export function getBrowserName(): (typeof validBrowserNames)[number] {
   const capabilities = browser.capabilities
 
   // Look for the browser name in capabilities. It should always be there as long as we don't change
@@ -39,7 +39,7 @@ export function getBrowserName(): typeof validBrowserNames[number] {
   return browserName
 }
 
-export function getPlatformName(): typeof validPlatformNames[number] {
+export function getPlatformName(): (typeof validPlatformNames)[number] {
   const capabilities = browser.capabilities
 
   let platformName: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -8791,10 +8791,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
 prettier@^2.6.2:
   version "2.7.1"


### PR DESCRIPTION
## Motivation

Upgrading to Prettier 2.8.4 introduces some improvements for readability with impact to the code base:
[Add parentheses for TSTypeQuery to improve readability](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#add-parentheses-for-tstypequery-to-improve-readability-14042-by-onishi-kohei)

Renovate does not apply the format change so CI fails.

## Changes

Updated dependencies and run `prettier --write .`

## Testing

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
