### PR TITLE
👷 renovate: group minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
   "schedule": ["every weekend"],
   "packageRules": [
     {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "excludePackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
       "matchPackageNames": ["puppeteer", "@types/node", "@types/express", "ajv", "ansi-regex"],
       "enabled": false
     },


### PR DESCRIPTION
## Motivation

Try to group easy updates together to limit the number of updates PR

## Changes

Add the grouping rule and exclude typescript package from this grouping since there is an ongoing failing PR about it.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
