### PR TITLE
⚗ Expose feature flag evaluations API

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,12 +1,5 @@
 import type { RelativeTime, TimeStamp, Context } from '@datadog/browser-core'
-import {
-  updateExperimentalFeatures,
-  resetExperimentalFeatures,
-  ONE_SECOND,
-  getTimeStamp,
-  display,
-  DefaultPrivacyLevel,
-} from '@datadog/browser-core'
+import { ONE_SECOND, getTimeStamp, display, DefaultPrivacyLevel } from '@datadog/browser-core'
 import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../core/test/syntheticsWorkerValues'
 import { initEventBridgeStub, deleteEventBridgeStub } from '../../../core/test/specHelper'
 import type { TestSetupBuilder } from '../../test/specHelper'
@@ -649,34 +642,12 @@ describe('rum public api', () => {
       setupBuilder.cleanup()
     })
 
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should add feature flag evaluation when ff feature_flags enable', () => {
-      updateExperimentalFeatures(['feature_flags'])
-
+    it('should add feature flag evaluation when ff feature_flags enabled', () => {
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).addFeatureFlagEvaluation('feature', 'foo')
+      rumPublicApi.addFeatureFlagEvaluation('feature', 'foo')
 
       expect(addFeatureFlagEvaluationSpy.calls.argsFor(0)).toEqual(['feature', 'foo'])
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('API should not be available when ff feature_flags disabled', () => {
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(Object.keys(rumPublicApi)).not.toContain('addFeatureFlagEvaluation')
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('API should not be available before init when ff feature_flags enabled', () => {
-      updateExperimentalFeatures(['feature_flags'])
-
-      expect(Object.keys(rumPublicApi)).not.toContain('addFeatureFlagEvaluation')
-
       expect(displaySpy).not.toHaveBeenCalled()
     })
   })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -1,6 +1,5 @@
 import type { Context, InitConfiguration, TimeStamp, RelativeTime, User } from '@datadog/browser-core'
 import {
-  isExperimentalFeatureEnabled,
   willSyntheticsInjectRum,
   assign,
   BoundedBuffer,
@@ -114,12 +113,6 @@ export function makeRumPublicApi(
     const configuration = validateAndBuildRumConfiguration(initConfiguration)
     if (!configuration) {
       return
-    }
-
-    if (isExperimentalFeatureEnabled('feature_flags')) {
-      ;(rumPublicApi as any).addFeatureFlagEvaluation = monitor((key: string, value: any) => {
-        addFeatureFlagEvaluationStrategy(key, value)
-      })
     }
 
     if (!configuration.trackViewsManually) {
@@ -252,6 +245,13 @@ export function makeRumPublicApi(
 
     startSessionReplayRecording: monitor(recorderApi.start),
     stopSessionReplayRecording: monitor(recorderApi.stop),
+
+    /**
+     * This feature is currently in beta. For more information see the full [feature flag tracking guide](https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/).
+     */
+    addFeatureFlagEvaluation: monitor((key: string, value: any) => {
+      addFeatureFlagEvaluationStrategy(key, value)
+    }),
   })
 
   return rumPublicApi


### PR DESCRIPTION
## Motivation

Expose `addFeatureFlagEvalution` API.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
