### PR TITLE
✨[RUMF-1500] Remove some references to legacy bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
 # Datadog Browser SDK
 
-The browser SDK is used to collect logs and RUM data from the browser.
+Collect and send browser data to Datadog.
 
-## Packages
+## Getting Started
+
+### Log Collection
+
+See the dedicated [Datadog Browser Log Collection documentation][08] to learn how to forward logs from your Browser application to Datadog.
+
+### Real User Monitoring
+
+See the dedicated [Datadog Browser RUM Collection documentation][18] to learn how to send RUM data from your Browser application to Datadog.
+
+## npm packages
 
 This repository contains several packages:
 
-| Package          | npm                      | size                     | cdn                       | doc                                 |
-| ---------------- | ------------------------ | ------------------------ | ------------------------- | ----------------------------------- |
-| browser-logs     | [![npm version][01]][02] | [![bundle size][03]][04] | [datadog-logs-v4][05]     | [![API][1]][07] [![product][2]][08] |
-| browser-rum      | [![npm version][11]][12] | [![bundle size][13]][14] | [datadog-rum-v4][15]      | [![API][1]][17] [![product][2]][18] |
-| browser-rum-slim | [![npm version][21]][22] | [![bundle size][23]][24] | [datadog-rum-slim-v4][25] | [![API][1]][27] [![product][2]][28] |
-| browser-rum-core | [![npm version][51]][52] | [![bundle size][53]][54] |                           |
-| browser-core     | [![npm version][41]][42] | [![bundle size][43]][44] |                           |
+| Package          | npm                      | size                     |
+| ---------------- | ------------------------ | ------------------------ |
+| browser-logs     | [![npm version][01]][02] | [![bundle size][03]][04] |
+| browser-rum      | [![npm version][11]][12] | [![bundle size][13]][14] |
+| browser-rum-slim | [![npm version][21]][22] | [![bundle size][23]][24] |
+| browser-rum-core | [![npm version][51]][52] | [![bundle size][53]][54] |
+| browser-core     | [![npm version][41]][42] | [![bundle size][43]][44] |
+
+## CDN bundles
+
+We provide one CDN bundle by [Datadog site][60]:
+
+| Site    | logs                                                           | rum                                                           | rum-slim                                                           |
+| ------- | -------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| US1     | https://www.datadoghq-browser-agent.com/us1/v4/datadog-logs.js | https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js | https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum-slim.js |
+| US3     | https://www.datadoghq-browser-agent.com/us3/v4/datadog-logs.js | https://www.datadoghq-browser-agent.com/us3/v4/datadog-rum.js | https://www.datadoghq-browser-agent.com/us3/v4/datadog-rum-slim.js |
+| US5     | https://www.datadoghq-browser-agent.com/us5/v4/datadog-logs.js | https://www.datadoghq-browser-agent.com/us5/v4/datadog-rum.js | https://www.datadoghq-browser-agent.com/us5/v4/datadog-rum-slim.js |
+| EU1     | https://www.datadoghq-browser-agent.com/eu1/v4/datadog-logs.js | https://www.datadoghq-browser-agent.com/eu1/v4/datadog-rum.js | https://www.datadoghq-browser-agent.com/eu1/v4/datadog-rum-slim.js |
+| US1-FED | https://www.datadoghq-browser-agent.com/datadog-logs-v4.js     | https://www.datadoghq-browser-agent.com/datadog-rum-v4.js     | https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js     |
 
 [1]: https://github.githubassets.com/favicons/favicon.png
 [2]: https://imgix.datadoghq.com/img/favicons/favicon-32x32.png
@@ -20,23 +42,16 @@ This repository contains several packages:
 [02]: https://badge.fury.io/js/%40datadog%2Fbrowser-logs
 [03]: https://badgen.net/bundlephobia/minzip/@datadog/browser-logs
 [04]: https://bundlephobia.com/result?p=@datadog/browser-logs
-[05]: https://www.datadoghq-browser-agent.com/datadog-logs-v4.js
-[07]: ./packages/logs/README.md
-[08]: https://docs.datadoghq.com/logs/log_collection/javascript/?tab=npm
+[08]: https://docs.datadoghq.com/logs/log_collection/javascript
 [11]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum.svg
 [12]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum
 [13]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum
 [14]: https://bundlephobia.com/result?p=@datadog/browser-rum
-[15]: https://www.datadoghq-browser-agent.com/datadog-rum-v4.js
-[17]: ./packages/rum/README.md
-[18]: https://docs.datadoghq.com/real_user_monitoring/
+[18]: https://docs.datadoghq.com/real_user_monitoring/browser/
 [21]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-slim.svg
 [22]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-slim
 [23]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum-slim
 [24]: https://bundlephobia.com/result?p=@datadog/browser-rum-slim
-[25]: https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js
-[27]: ./packages/rum-slim/README.md
-[28]: https://docs.datadoghq.com/real_user_monitoring/
 [41]: https://badge.fury.io/js/%40datadog%2Fbrowser-core.svg
 [42]: https://badge.fury.io/js/%40datadog%2Fbrowser-core
 [43]: https://badgen.net/bundlephobia/minzip/@datadog/browser-core
@@ -45,3 +60,4 @@ This repository contains several packages:
 [52]: https://badge.fury.io/js/%40datadog%2Fbrowser-rum-core
 [53]: https://badgen.net/bundlephobia/minzip/@datadog/browser-rum-core
 [54]: https://bundlephobia.com/result?p=@datadog/browser-rum-core
+[60]: https://docs.datadoghq.com/getting_started/site/

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -29,7 +29,7 @@ Then, in Google Chrome:
 - Flush buffered events
 - End current session
 - Load the SDK development bundles instead of production ones
-- Switch between `datadog-rum-v4.js` and `datadog-rum-slim-v4.js` bundles
+- Switch between `rum` and `rum-slim` bundles
 - Retrieve Logs/RUM configuration
 
 ## Browser compatibility


### PR DESCRIPTION
## Motivation

Promote new CDN files

## Changes

- extension readme: remove reference to v4 
- main readme: rework to add CDN bundles by datacenter

## Testing

N/A

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
