### PR TITLE
RUMF-1497 Update logger API documentation

### DIFF
--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -219,9 +219,9 @@ The Datadog backend adds more fields, like:
 - `http.useragent`
 - `network.client.ip`
 
-### Status parameter
+### Generic logger function
 
-After the Datadog browser logs SDK is initialized, send a custom log entry to Datadog with the API using the status as a parameter:
+The Datadog browser logs SDK adds shorthand functions (.debug, .info, .warn, .error) to the loggers for convenience. A generic logger function is also available, exposing the `status` parameter:
 
 ```
 log (message: string, messageContext?: Context, status? = 'debug' | 'info' | 'warn' | 'error', error?: Error)
@@ -234,7 +234,7 @@ For NPM, use:
 ```javascript
 import { datadogLogs } from '@datadog/browser-logs';
 
-datadogLogs.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>);
+datadogLogs.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
 ```
 
 #### CDN async
@@ -243,7 +243,7 @@ For CDN async, use:
 
 ```javascript
 DD_LOGS.onReady(function() {
-  DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>);
+  DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
 })
 ```
 
@@ -254,7 +254,7 @@ DD_LOGS.onReady(function() {
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>);
+window.DD_LOGS && DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
 ```
 
 #### Placeholders
@@ -266,6 +266,7 @@ The placeholders in the examples above are described below:
 | `<MESSAGE>`         | The message of your log that is fully indexed by Datadog.                               |
 | `<JSON_ATTRIBUTES>` | A valid JSON object, which includes all attributes attached to the `<MESSAGE>`.         |
 | `<STATUS>`          | The status of your log; accepted status values are `debug`, `info`, `warn`, or `error`. |
+| `<ERROR>`           | An instance of a [JavaScript Error][10] object.                                         |
 
 ## Advanced usage
 
@@ -846,3 +847,4 @@ window.DD_LOGS && window.DD_LOGS.getInternalContext() // { session_id: "xxxx-xxx
 [7]: https://docs.datadoghq.com/getting_started/tagging/#defining-tags
 [8]: https://developer.mozilla.org/en-US/docs/Web/API/Reporting_API
 [9]: https://docs.datadoghq.com/getting_started/site/
+[10]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -219,6 +219,78 @@ The Datadog backend adds more fields, like:
 - `http.useragent`
 - `network.client.ip`
 
+### Error tracking
+
+The Datadog browser logs SDK allows for manual error tracking by using the optional `error` parameter. When an instance of a [JavaScript Error][10] is provided, the SDK will extract relevant information (kind, message, stack trace) from the error.
+
+```
+logger.debug | info | warn | error (message: string, messageContext?: Context, error?: Error)
+```
+
+#### NPM
+
+```javascript
+import { datadogLogs } from '@datadog/browser-logs'
+
+try {
+  ...
+  throw new Error('Wrong behavior')
+  ...
+} catch (ex) {
+  datadogLogs.logger.error('Error occurred', {}, ex)
+}
+```
+
+#### CDN async
+
+```javascript
+try {
+  ...
+  throw new Error('Wrong behavior')
+  ...
+} catch (ex) {
+  DD_LOGS.onReady(function () {
+    DD_LOGS.logger.error('Error occurred', {}, ex)
+  })
+}
+```
+
+**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+
+#### CDN sync
+
+```javascript
+try {
+  ...
+  throw new Error('Wrong behavior')
+  ...
+} catch (ex) {
+    window.DD_LOGS && DD_LOGS.logger.error('Error occurred', {}, ex)
+}
+```
+
+**Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
+
+#### Results
+
+The results are the same when using NPM, CDN async or CDN sync:
+
+```json
+{
+  "status": "error",
+  "session_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "message": "Error occurred",
+  "date": 1234567890000,
+  "origin": "logger",
+  "error" : {
+    "message": "Wrong behavior",
+    "kind" : "Error",
+    "stack" : "Error: Wrong behavior at <anonymous> @ <anonymous>:1:1"
+  },
+  ...
+}
+```
+
 ### Generic logger function
 
 The Datadog browser logs SDK adds shorthand functions (.debug, .info, .warn, .error) to the loggers for convenience. A generic logger function is also available, exposing the `status` parameter:

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -23,7 +23,7 @@ With the browser logs SDK, you can send logs directly to Datadog from web browse
 
 | Installation method        | Use case                                                                                                                                                                                                                                                                                                                                                                   |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| npm (node package manager) | This method is recommended for modern web applications. The browser logs SDK gets packaged with the rest of your front-end javascript code. It has no impact on page load performance. However, the SDK might miss errors, resources and user actions triggered before the SDK is initialized. **Note:** it is recommended to use a matching version with RUM SDK if used. |
+| npm (node package manager) | This method is recommended for modern web applications. The browser logs SDK gets packaged with the rest of your front-end javascript code. It has no impact on page load performance. However, the SDK might miss errors, resources and user actions triggered before the SDK is initialized. **Note**: it is recommended to use a matching version with RUM SDK if used. |
 | CDN async                  | This method is recommended for web applications with performance targets. The browser logs SDK is loaded from our CDN asynchronously: this method ensures the SDK download does not impact page load performance. However, the SDK might miss errors, resources and user actions triggered before the SDK is initialized.                                                  |
 | CDN sync                   | This method is recommended for collecting all RUM events. The browser logs SDK is loaded from our CDN synchronously: this method ensures the SDK is loaded first and collects all errors, resources and user actions. This method might impact page load performance.                                                                                                      |
 
@@ -70,7 +70,7 @@ Load and configure the SDK in the head section of your pages.
 </html>
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ### CDN sync
 
@@ -167,7 +167,7 @@ DD_LOGS.onReady(function () {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 #### CDN sync
 
@@ -179,7 +179,7 @@ window.DD_LOGS && DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id
 
 #### Results
 
-The results are the same when using NPM, CDN async or CDN sync:
+The results are the same when using NPM, CDN async, or CDN sync:
 
 ```json
 {
@@ -221,7 +221,7 @@ The Datadog backend adds more fields, like:
 
 ### Error tracking
 
-The Datadog browser logs SDK allows for manual error tracking by using the optional `error` parameter. When an instance of a [JavaScript Error][10] is provided, the SDK will extract relevant information (kind, message, stack trace) from the error.
+The Datadog browser logs SDK allows for manual error tracking by using the optional `error` parameter (Available in SDK v4.36.0+). When an instance of a [JavaScript Error][10] is provided, the SDK extracts relevant information (kind, message, stack trace) from the error.
 
 ```
 logger.debug | info | warn | error (message: string, messageContext?: Context, error?: Error)
@@ -255,7 +255,7 @@ try {
 }
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 #### CDN sync
 
@@ -273,7 +273,7 @@ try {
 
 #### Results
 
-The results are the same when using NPM, CDN async or CDN sync:
+The results are the same when using NPM, CDN async, or CDN sync:
 
 ```json
 {
@@ -293,7 +293,7 @@ The results are the same when using NPM, CDN async or CDN sync:
 
 ### Generic logger function
 
-The Datadog browser logs SDK adds shorthand functions (.debug, .info, .warn, .error) to the loggers for convenience. A generic logger function is also available, exposing the `status` parameter:
+The Datadog browser logs SDK adds shorthand functions (`.debug`, `.info`, `.warn`, `.error`) to the loggers for convenience. A generic logger function is also available, exposing the `status` parameter:
 
 ```
 log (message: string, messageContext?: Context, status? = 'debug' | 'info' | 'warn' | 'error', error?: Error)
@@ -319,7 +319,7 @@ DD_LOGS.onReady(function() {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 #### CDN sync
 
@@ -524,7 +524,7 @@ DD_LOGS.onReady(function () {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
@@ -622,7 +622,7 @@ DD_LOGS.onReady(function () {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
@@ -710,7 +710,7 @@ DD_LOGS.onReady(function () {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
@@ -767,7 +767,7 @@ DD_LOGS.onReady(function () {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
@@ -811,7 +811,7 @@ DD_LOGS.onReady(function () {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
@@ -857,7 +857,7 @@ DD_LOGS.onReady(function () {
 })
 ```
 
-**Note:** Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 

--- a/packages/logs/README.md
+++ b/packages/logs/README.md
@@ -148,7 +148,7 @@ Options that must have a matching configuration when using the `RUM` SDK:
 After the Datadog browser logs SDK is initialized, send a custom log entry directly to Datadog with the API:
 
 ```
-logger.debug | info | warn | error (message: string, messageContext = Context)
+logger.debug | info | warn | error (message: string, messageContext?: Context, error?: Error)
 ```
 
 #### NPM
@@ -224,7 +224,7 @@ The Datadog backend adds more fields, like:
 After the Datadog browser logs SDK is initialized, send a custom log entry to Datadog with the API using the status as a parameter:
 
 ```
-log (message: string, messageContext: Context, status? = 'debug' | 'info' | 'warn' | 'error')
+log (message: string, messageContext?: Context, status? = 'debug' | 'info' | 'warn' | 'error', error?: Error)
 ```
 
 #### NPM


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/DataDog/browser-sdk/pull/2029
Update documentation about new `error` parameter.

## Changes

- Updated the signature of the logger functions 
- Updated the `generic` logger function section to include errors
- Added a new section showcasing the error parameter usage

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.