### PR TITLE
✅ improve async calls collection

### DIFF
--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -89,13 +89,12 @@ describe('httpRequest', () => {
           return Promise.resolve({ status: 200 })
         }
       })
-      const { waitAsyncCalls, expectNoExtraAsyncCall } = collectAsyncCalls(fetchSpy)
 
       interceptor.withFetch(fetchSpy)
 
       request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
-      waitAsyncCalls(2, () => expectNoExtraAsyncCall(done))
+      collectAsyncCalls(fetchSpy, 2, () => done())
     })
   })
 

--- a/packages/core/test/collectAsyncCalls.ts
+++ b/packages/core/test/collectAsyncCalls.ts
@@ -1,23 +1,30 @@
-export function collectAsyncCalls<F extends jasmine.Func>(spy: jasmine.Spy<F>) {
-  return {
-    waitAsyncCalls: (expectedCallsCount: number, callback: (calls: jasmine.Calls<F>) => void) => {
+import { getCurrentJasmineSpec } from './getCurrentJasmineSpec'
+
+export function collectAsyncCalls<F extends jasmine.Func>(
+  spy: jasmine.Spy<F>,
+  expectedCallsCount: number,
+  callback: (calls: jasmine.Calls<F>) => void
+) {
+  const currentSpec = getCurrentJasmineSpec()
+  if (!currentSpec) {
+    throw new Error('collectAsyncCalls should be called within jasmine code')
+  }
+
+  if (spy.calls.count() === expectedCallsCount) {
+    spy.and.callFake(extraCallDetected as F)
+    callback(spy.calls)
+  } else if (spy.calls.count() > expectedCallsCount) {
+    extraCallDetected()
+  } else {
+    spy.and.callFake((() => {
       if (spy.calls.count() === expectedCallsCount) {
+        spy.and.callFake(extraCallDetected as F)
         callback(spy.calls)
-      } else if (spy.calls.count() > expectedCallsCount) {
-        fail('Unexpected extra call')
-      } else {
-        spy.and.callFake((() => {
-          if (spy.calls.count() === expectedCallsCount) {
-            callback(spy.calls)
-          }
-        }) as F)
       }
-    },
-    expectNoExtraAsyncCall: (done: () => void) => {
-      spy.and.callFake((() => {
-        fail('Unexpected extra call')
-      }) as F)
-      setTimeout(done, 300)
-    },
+    }) as F)
+  }
+
+  function extraCallDetected() {
+    fail(`Unexpected extra call for spec '${currentSpec!.fullName}'`)
   }
 }

--- a/packages/core/test/getCurrentJasmineSpec.ts
+++ b/packages/core/test/getCurrentJasmineSpec.ts
@@ -1,0 +1,14 @@
+let currentSpec: jasmine.SpecResult | null = null
+
+export function getCurrentJasmineSpec() {
+  return currentSpec
+}
+
+jasmine.getEnv().addReporter({
+  specStarted(specResult) {
+    currentSpec = specResult
+  },
+  specDone() {
+    currentSpec = null
+  },
+})

--- a/packages/rum/src/domain/record/mutationBatch.spec.ts
+++ b/packages/rum/src/domain/record/mutationBatch.spec.ts
@@ -19,14 +19,9 @@ describe('createMutationBatch', () => {
     const mutation = { type: 'childList' } as RumMutationRecord
     mutationBatch.addMutations([mutation])
 
-    const {
-      waitAsyncCalls: waitProcessMutationBatchCalls,
-      expectNoExtraAsyncCall: expectNoExtraProcessMutationBatchCall,
-    } = collectAsyncCalls(processMutationBatchSpy)
-
-    waitProcessMutationBatchCalls(1, (calls) => {
+    collectAsyncCalls(processMutationBatchSpy, 1, (calls) => {
       expect(calls.mostRecent().args[0]).toEqual([mutation])
-      expectNoExtraProcessMutationBatchCall(done)
+      done()
     })
   })
 

--- a/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
@@ -102,16 +102,12 @@ describe('startMutationCollection', () => {
     it('processes mutations asynchronously', (done) => {
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()
-      const { waitAsyncCalls: waitMutationCallbackCalls, expectNoExtraAsyncCall: expectNoExtraMutationCallbackCalls } =
-        collectAsyncCalls(mutationCallbackSpy)
 
       sandbox.appendChild(document.createElement('div'))
 
       expect(mutationCallbackSpy).not.toHaveBeenCalled()
 
-      waitMutationCallbackCalls(1, () => {
-        expectNoExtraMutationCallbackCalls(done)
-      })
+      collectAsyncCalls(mutationCallbackSpy, 1, () => done())
     })
 
     it('does not emit a mutation when a node is appended to a unknown node', () => {

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -20,8 +20,6 @@ describe('record', () => {
   let sandbox: HTMLElement
   let recordApi: RecordAPI
   let emitSpy: jasmine.Spy<(record: BrowserRecord) => void>
-  let waitEmitCalls: (expectedCallsCount: number, callback: () => void) => void
-  let expectNoExtraEmitCalls: (done: () => void) => void
   let clock: Clock | undefined
 
   beforeEach(() => {
@@ -30,7 +28,6 @@ describe('record', () => {
     }
 
     emitSpy = jasmine.createSpy()
-    ;({ waitAsyncCalls: waitEmitCalls, expectNoExtraAsyncCall: expectNoExtraEmitCalls } = collectAsyncCalls(emitSpy))
     sandbox = createDOMSandbox()
   })
 
@@ -60,7 +57,7 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    waitEmitCalls(recordsPerFullSnapshot() + 6, () => {
+    collectAsyncCalls(emitSpy, recordsPerFullSnapshot() + 6, () => {
       const records = getEmittedRecords()
       let i = 0
 
@@ -115,7 +112,7 @@ describe('record', () => {
         })
       )
 
-      expectNoExtraEmitCalls(done)
+      done()
     })
   })
 
@@ -126,7 +123,7 @@ describe('record', () => {
 
     recordApi.takeSubsequentFullSnapshot()
 
-    waitEmitCalls(1 + 2 * recordsPerFullSnapshot(), () => {
+    collectAsyncCalls(emitSpy, 1 + 2 * recordsPerFullSnapshot(), () => {
       const records = getEmittedRecords()
       let i = 0
 
@@ -143,7 +140,7 @@ describe('record', () => {
       expect(records[i++].type).toEqual(RecordType.Focus)
       expect(records[i++].type).toEqual(RecordType.FullSnapshot)
 
-      expectNoExtraEmitCalls(done)
+      done()
     })
   })
 


### PR DESCRIPTION
## Motivation

The asynchronous call collection utility is a bit complex and suboptimal
as we wait 300ms for each test to check whether some calls are done
after the end of assertions.

## Changes

* Do not wait for 300ms to check for extra calls

* Simplify usage by asserting no extra calls are done automatically

* Help debugging by printing the spec name when an asynchronous call is
  done after the spec finished.

This change reduces tests execution time by 5 seconds on my machine.

Before:

```
Chrome Headless 111.0.5563.146 (Mac OS 10.15.7): Executed 1779 of 1782 (skipped 3) SUCCESS (16.335 secs / 15.842 secs)
```

After:

```
Chrome Headless 111.0.5563.146 (Mac OS 10.15.7): Executed 1779 of 1782 (skipped 3) SUCCESS (11.037 secs / 10.619 secs)
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
