### PR TITLE
🐛[RUMF-1517] Remove specHelper export in src code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,6 +168,7 @@ module.exports = {
     'jsdoc/check-alignment': 'error',
     'jsdoc/check-indentation': 'error',
 
+    'local-rules/disallow-test-import-export-from-src': 'error',
     'local-rules/disallow-protected-directory-import': [
       'error',
       {

--- a/eslint-local-rules/disallowTestImportExportFromSrc.js
+++ b/eslint-local-rules/disallowTestImportExportFromSrc.js
@@ -1,0 +1,36 @@
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Disallow importing or exporting test code in src code to avoid bloating customer package with test code',
+      recommended: false,
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        checkTestImportExportFromSrc(context, node)
+      },
+      ExportNamedDeclaration(node) {
+        checkTestImportExportFromSrc(context, node)
+      },
+      ExportAllDeclaration(node) {
+        checkTestImportExportFromSrc(context, node)
+      },
+    }
+  },
+}
+
+function checkTestImportExportFromSrc(context, node) {
+  if (!isTestCode(context.getFilename()) && node.source && isTestCode(node.source.value)) {
+    context.report({
+      node: node.source,
+      message: 'Test code import or export is not allowed in src code',
+    })
+  }
+}
+
+function isTestCode(filename) {
+  return /(\/test|\.specHelper|\.spec)/.test(filename)
+}

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -11,6 +11,7 @@ module.exports = {
   'disallow-enum-exports': require('./disallowEnumExports'),
   'disallow-spec-import': require('./disallowSpecImport'),
   'disallow-protected-directory-import': require('./disallowProtectedDirectoryImport'),
+  'disallow-test-import-export-from-src': require('./disallowTestImportExportFromSrc'),
   'disallow-zone-js-patched-values': require('./disallowZoneJsPatchedValues'),
   'secure-command-execution': require('./secureCommandExecution'),
 }

--- a/packages/rum/src/domain/record/observers/index.ts
+++ b/packages/rum/src/domain/record/observers/index.ts
@@ -1,5 +1,3 @@
 export { initObservers } from './observers'
 export { InputCallback, initInputObserver } from './inputObserver'
 export { initMutationObserver, MutationCallBack, RumMutationRecord } from './mutationObserver'
-export { DEFAULT_CONFIGURATION } from './observers.specHelper'
-export { DEFAULT_SHADOW_ROOT_CONTROLLER } from './observers.specHelper'


### PR DESCRIPTION
## Motivation

Avoid to bloat customer packages with test code

## Changes

- remove useless observers.specHelper exports
- add eslint rule to avoid this kind of issue

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
