### PR TITLE
🏷️ improve addEventListener typings

### DIFF
--- a/packages/core/src/domain/report/reportObservable.ts
+++ b/packages/core/src/domain/report/reportObservable.ts
@@ -63,11 +63,9 @@ function createReportObservable(reportTypes: ReportType[]) {
 
 function createCspViolationReportObservable() {
   const observable = new Observable<RawReport>(() => {
-    const handleCspViolation = monitor((event: SecurityPolicyViolationEvent) => {
+    const { stop } = addEventListener(document, DOM_EVENT.SECURITY_POLICY_VIOLATION, (event) => {
       observable.notify(buildRawReportFromCspViolation(event))
     })
-
-    const { stop } = addEventListener(document, DOM_EVENT.SECURITY_POLICY_VIOLATION, handleCspViolation)
 
     return stop
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackFirstHidden.spec.ts
@@ -17,7 +17,7 @@ describe('trackFirstHidden', () => {
 
     it('should ignore events', () => {
       setPageVisibility('hidden')
-      const eventTarget = document.createElement('div')
+      const eventTarget = createWindowEventTarget()
       const firstHidden = trackFirstHidden(eventTarget)
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.PAGE_HIDE, { timeStamp: 100 }))
@@ -33,7 +33,7 @@ describe('trackFirstHidden', () => {
     })
 
     it('should return the timestamp of the first pagehide event', () => {
-      const eventTarget = document.createElement('div')
+      const eventTarget = createWindowEventTarget()
       const firstHidden = trackFirstHidden(eventTarget)
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.PAGE_HIDE, { timeStamp: 100 }))
@@ -42,7 +42,7 @@ describe('trackFirstHidden', () => {
     })
 
     it('should return the timestamp of the first visibilitychange event if the page is hidden', () => {
-      const eventTarget = document.createElement('div')
+      const eventTarget = createWindowEventTarget()
       const firstHidden = trackFirstHidden(eventTarget)
 
       setPageVisibility('hidden')
@@ -52,7 +52,7 @@ describe('trackFirstHidden', () => {
     })
 
     it('should ignore visibilitychange event if the page is visible', () => {
-      const eventTarget = document.createElement('div')
+      const eventTarget = createWindowEventTarget()
       const firstHidden = trackFirstHidden(eventTarget)
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.VISIBILITY_CHANGE, { timeStamp: 100 }))
@@ -61,7 +61,7 @@ describe('trackFirstHidden', () => {
     })
 
     it('should ignore subsequent events', () => {
-      const eventTarget = document.createElement('div')
+      const eventTarget = createWindowEventTarget()
       const firstHidden = trackFirstHidden(eventTarget)
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.PAGE_HIDE, { timeStamp: 100 }))
@@ -74,4 +74,8 @@ describe('trackFirstHidden', () => {
       expect(firstHidden.timeStamp).toBe(100 as RelativeTime)
     })
   })
+
+  function createWindowEventTarget() {
+    return document.createElement('div') as unknown as Window
+  }
 })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackFirstHidden.ts
@@ -4,7 +4,7 @@ import { addEventListeners, DOM_EVENT } from '@datadog/browser-core'
 let trackFirstHiddenSingleton: { timeStamp: RelativeTime } | undefined
 let stopListeners: (() => void) | undefined
 
-export function trackFirstHidden(eventTarget: EventTarget = window) {
+export function trackFirstHidden(eventTarget: Window = window) {
   if (!trackFirstHiddenSingleton) {
     if (document.visibilityState === 'hidden') {
       trackFirstHiddenSingleton = {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
@@ -161,11 +161,11 @@ describe('trackFirstContentfulPaintTiming', () => {
 describe('largestContentfulPaintTiming', () => {
   let setupBuilder: TestSetupBuilder
   let lcpCallback: jasmine.Spy<(value: RelativeTime) => void>
-  let eventTarget: Element
+  let eventTarget: Window
 
   beforeEach(() => {
     lcpCallback = jasmine.createSpy()
-    eventTarget = document.createElement('div')
+    eventTarget = document.createElement('div') as unknown as Window
     setupBuilder = setup().beforeBuild(({ lifeCycle }) =>
       trackLargestContentfulPaintTiming(lifeCycle, eventTarget, lcpCallback)
     )

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.ts
@@ -116,7 +116,7 @@ export function trackFirstContentfulPaintTiming(lifeCycle: LifeCycle, callback: 
  */
 export function trackLargestContentfulPaintTiming(
   lifeCycle: LifeCycle,
-  eventTarget: EventTarget,
+  eventTarget: Window,
   callback: (lcpTiming: RelativeTime) => void
 ) {
   const firstHidden = trackFirstHidden()

--- a/packages/rum/src/domain/record/observers/inputObserver.ts
+++ b/packages/rum/src/domain/record/observers/inputObserver.ts
@@ -8,7 +8,7 @@ import { getElementInputValue, getSerializedNodeId, hasSerializedNode } from '..
 
 type InputObserverOptions = {
   domEvents?: Array<DOM_EVENT.INPUT | DOM_EVENT.CHANGE>
-  target?: Node
+  target?: Document | ShadowRoot
 }
 export type InputCallback = (v: InputState & { id: number }) => void
 

--- a/packages/rum/src/domain/record/observers/mouseInteractionObserver.ts
+++ b/packages/rum/src/domain/record/observers/mouseInteractionObserver.ts
@@ -38,7 +38,7 @@ export function initMouseInteractionObserver(
   defaultPrivacyLevel: DefaultPrivacyLevel,
   recordIds: RecordIds
 ): ListenerHandler {
-  const handler = (event: MouseEvent | TouchEvent) => {
+  const handler = (event: MouseEvent | TouchEvent | FocusEvent) => {
     const target = getEventTarget(event)
     if (getNodePrivacyLevel(target, defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN || !hasSerializedNode(target)) {
       return
@@ -48,7 +48,7 @@ export function initMouseInteractionObserver(
 
     let interaction: MouseInteraction
     if (type !== MouseInteractionType.Blur && type !== MouseInteractionType.Focus) {
-      const coordinates = tryToComputeCoordinates(event)
+      const coordinates = tryToComputeCoordinates(event as MouseEvent | TouchEvent)
       if (!coordinates) {
         return
       }
@@ -63,8 +63,13 @@ export function initMouseInteractionObserver(
     )
     cb(record)
   }
-  return addEventListeners(document, Object.keys(eventTypeToMouseInteraction) as DOM_EVENT[], handler, {
-    capture: true,
-    passive: true,
-  }).stop
+  return addEventListeners(
+    document,
+    Object.keys(eventTypeToMouseInteraction) as Array<keyof typeof eventTypeToMouseInteraction>,
+    handler,
+    {
+      capture: true,
+      passive: true,
+    }
+  ).stop
 }

--- a/packages/rum/src/domain/record/observers/scrollObserver.ts
+++ b/packages/rum/src/domain/record/observers/scrollObserver.ts
@@ -17,7 +17,7 @@ export function initScrollObserver(
   defaultPrivacyLevel: DefaultPrivacyLevel,
   elementsScrollPositions: ElementsScrollPositions
 ): ListenerHandler {
-  const { throttled: updatePosition } = throttle((event: UIEvent) => {
+  const { throttled: updatePosition } = throttle((event: Event) => {
     const target = getEventTarget(event) as HTMLElement | Document
     if (
       !target ||


### PR DESCRIPTION
## Motivation

improve addEventListener typings

## Changes

Use TS "event map" to enforce stricter types and better type inference to `addEventListener` and `addEventListeners` functions

![Screenshot 2023-03-31 at 16 47 09](https://user-images.githubusercontent.com/61787/229154022-b92dc38c-c5db-46a3-b4bd-97cf11295682.png)
![Screenshot 2023-03-31 at 16 47 57](https://user-images.githubusercontent.com/61787/229154027-87697ae6-35f1-4aad-ac4d-06454719c3dd.png)
![Screenshot 2023-03-31 at 16 48 44](https://user-images.githubusercontent.com/61787/229154028-e7a493db-c1e0-4421-94f7-b6404140e253.png)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
