### PR TITLE
♻️ [RUMF-1505] make sure we don't use Zone.js addEventListener

### DIFF
--- a/eslint-local-rules/disallowZoneJsPatchedValues.js
+++ b/eslint-local-rules/disallowZoneJsPatchedValues.js
@@ -13,7 +13,10 @@ const PROBLEMATIC_IDENTIFIERS = {
   setInterval: 'Use `setInterval` from @datadog/browser-core instead',
   clearInterval: 'Use `clearInterval` from @datadog/browser-core instead',
 
-  // TODO: disallow addEventListener, removeEventListener
+  // Using the patched `addEventListener` from Zone.js might trigger a memory leak in Firefox, see
+  // PR #1860
+  addEventListener: 'Use `addEventListener` from @datadog/browser-core instead',
+  removeEventListener: 'Use `addEventListener` from @datadog/browser-core instead',
 }
 
 module.exports = {

--- a/eslint-local-rules/disallowZoneJsPatchedValues.js
+++ b/eslint-local-rules/disallowZoneJsPatchedValues.js
@@ -16,7 +16,7 @@ const PROBLEMATIC_IDENTIFIERS = {
   // Using the patched `addEventListener` from Zone.js might trigger a memory leak in Firefox, see
   // PR #1860
   addEventListener: 'Use `addEventListener` from @datadog/browser-core instead',
-  removeEventListener: 'Use `addEventListener` from @datadog/browser-core instead',
+  removeEventListener: 'Use `addEventListener().stop` from @datadog/browser-core instead',
 }
 
 module.exports = {

--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -67,6 +67,8 @@ type EventMapFor<T> = T extends Window
   ? XMLHttpRequestEventMap
   : T extends Performance
   ? PerformanceEventMap
+  : T extends Worker
+  ? WorkerEventMap
   : Record<never, never>
 
 /**

--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -65,6 +65,8 @@ type EventMapFor<T> = T extends Window
     GlobalEventHandlersEventMap
   : T extends XMLHttpRequest
   ? XMLHttpRequestEventMap
+  : T extends Performance
+  ? PerformanceEventMap
   : Record<never, never>
 
 /**

--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -63,6 +63,8 @@ type EventMapFor<T> = T extends Window
     // GlobalEventHandlersEventMap which is more than enough as we only need to listen for events bubbling
     // through the ShadowRoot like "change" or "input"
     GlobalEventHandlersEventMap
+  : T extends XMLHttpRequest
+  ? XMLHttpRequestEventMap
   : Record<never, never>
 
 /**

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -10,6 +10,7 @@ import {
   setTimeout,
   relativeNow,
   runOnReadyState,
+  addEventListener,
 } from '@datadog/browser-core'
 
 import type { RumConfiguration } from '../domain/configuration'
@@ -141,7 +142,7 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: 
 
     if (supportPerformanceObject() && 'addEventListener' in performance) {
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1559377
-      performance.addEventListener('resourcetimingbufferfull', () => {
+      addEventListener(performance, 'resourcetimingbufferfull', () => {
         performance.clearResourceTimings()
       })
     }

--- a/packages/rum/src/domain/segmentCollection/deflateWorker.d.ts
+++ b/packages/rum/src/domain/segmentCollection/deflateWorker.d.ts
@@ -1,13 +1,7 @@
 export function createDeflateWorker(): DeflateWorker
 
-export interface DeflateWorker {
-  addEventListener(name: 'message', listener: DeflateWorkerListener): void
-  addEventListener(name: 'error', listener: (error: ErrorEvent) => void): void
-  removeEventListener(name: 'message', listener: DeflateWorkerListener): void
-  removeEventListener(name: 'error', listener: (error: ErrorEvent) => void): void
-
+export interface DeflateWorker extends Worker {
   postMessage(message: DeflateWorkerAction): void
-  terminate(): void
 }
 
 export type DeflateWorkerListener = (event: { data: DeflateWorkerResponse }) => void

--- a/packages/rum/test/mockWorker.ts
+++ b/packages/rum/test/mockWorker.ts
@@ -1,6 +1,10 @@
 import type { DeflateWorker, DeflateWorkerAction, DeflateWorkerListener } from '../src/domain/segmentCollection'
 
 export class MockWorker implements DeflateWorker {
+  public onmessage = null
+  public onmessageerror = null
+  public onerror = null
+
   readonly pendingMessages: DeflateWorkerAction[] = []
   private rawBytesCount = 0
   private deflatedData: Uint8Array[] = []
@@ -9,8 +13,6 @@ export class MockWorker implements DeflateWorker {
     error: Array<(error: unknown) => void>
   } = { message: [], error: [] }
 
-  addEventListener(eventName: 'message', listener: DeflateWorkerListener): void
-  addEventListener(eventName: 'error', listener: (error: ErrorEvent) => void): void
   addEventListener(eventName: 'message' | 'error', listener: any): void {
     const index = this.listeners[eventName].indexOf(listener)
     if (index < 0) {
@@ -18,13 +20,16 @@ export class MockWorker implements DeflateWorker {
     }
   }
 
-  removeEventListener(eventName: 'message', listener: DeflateWorkerListener): void
-  removeEventListener(eventName: 'error', listener: (error: ErrorEvent) => void): void
   removeEventListener(eventName: 'message' | 'error', listener: any): void {
     const index = this.listeners[eventName].indexOf(listener)
     if (index >= 0) {
       this.listeners[eventName].splice(index, 1)
     }
+  }
+
+  dispatchEvent(): boolean {
+    // Partial implementation, feel free to implement
+    throw new Error('not yet implemented')
   }
 
   postMessage(message: DeflateWorkerAction): void {


### PR DESCRIPTION
## Motivation

Follow-up of related PRs:
* #2044
* #2032
* #2031

We observed that using some `addEventListener` caused some critical issues when this function is patched by Zone.js. To work around that, the ESLint rule `disallow-zone-js-patched-values` is used to make sure we don't use `addEventListener` directly but instead use the "safe" `addEventListener` helper from `@datadog/browser-core`.

## Changes

* Forbid direct `addEventListener` usages
* Use the `addEventListener` utility functions everywhere we used
  `addEventListener` native methods.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
