### PR TITLE
🚨 add require-await rule and remove useless async

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,7 @@ module.exports = {
     'prefer-template': 'error',
     quotes: ['error', 'single', { avoidEscape: true }],
     radix: 'error',
+    'require-await': 'error',
     'spaced-comment': [
       'error',
       'always',

--- a/performances/src/trackNetwork.ts
+++ b/performances/src/trackNetwork.ts
@@ -21,7 +21,7 @@ export function trackNetwork(page: Page) {
   })
 
   return {
-    waitForNetworkIdle: async () =>
+    waitForNetworkIdle: () =>
       new Promise<void>((resolve) => {
         let timeoutId: NodeJS.Timeout
         const periodicalWakeIntervalId = setInterval(wake, REQUEST_TIMEOUT)

--- a/scripts/lib/execution-utils.js
+++ b/scripts/lib/execution-utils.js
@@ -10,7 +10,7 @@ const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fet
  *
  * [0]: https://matklad.github.io/2021/07/30/shell-injection.html
  */
-async function spawnCommand(command, args) {
+function spawnCommand(command, args) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { stdio: 'inherit', shell: true })
     child.on('error', reject)

--- a/test/e2e/lib/framework/httpServers.ts
+++ b/test/e2e/lib/framework/httpServers.ts
@@ -100,7 +100,7 @@ async function instantiateServer(): Promise<http.Server> {
   throw new Error(`Failed to create a server after ${MAX_SERVER_CREATION_RETRY} retries`)
 }
 
-async function instantiateServerOnPort(port: number): Promise<http.Server> {
+function instantiateServerOnPort(port: number): Promise<http.Server> {
   return new Promise((resolve, reject) => {
     const server = http.createServer()
     server.on('error', reject)
@@ -117,7 +117,7 @@ function createServerIdleWaiter(server: http.Server) {
     idleWaiter.pushActivity(new Promise((resolve) => res.on('close', resolve)))
   })
 
-  return async () => idleWaiter.idlePromise
+  return () => idleWaiter.idlePromise
 }
 
 const IDLE_WAIT_DURATION = 500

--- a/test/e2e/lib/framework/serverApps/intake.ts
+++ b/test/e2e/lib/framework/serverApps/intake.ts
@@ -91,7 +91,7 @@ function forwardEventsToIntake(req: express.Request): Promise<any> {
   })
 }
 
-async function storeReplayData(req: express.Request, events: EventRegistry): Promise<any> {
+function storeReplayData(req: express.Request, events: EventRegistry): Promise<any> {
   return new Promise((resolve, reject) => {
     const metadata: {
       [field: string]: string
@@ -125,7 +125,7 @@ async function storeReplayData(req: express.Request, events: EventRegistry): Pro
   })
 }
 
-async function forwardReplayToIntake(req: express.Request): Promise<any> {
+function forwardReplayToIntake(req: express.Request): Promise<any> {
   return new Promise((resolve, reject) => {
     const intakeRequest = prepareIntakeRequest(req)
     req.pipe(intakeRequest)
@@ -150,7 +150,7 @@ function prepareIntakeRequest(req: express.Request) {
   return https.request(new URL(ddforward, 'https://browser-intake-datadoghq.com'), options)
 }
 
-async function readStream(stream: NodeJS.ReadableStream): Promise<Buffer> {
+function readStream(stream: NodeJS.ReadableStream): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const buffers: Buffer[] = []
     stream.on('data', (data: Buffer) => {

--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -1,18 +1,14 @@
 import * as os from 'os'
 
 // typing issue for execute https://github.com/webdriverio/webdriverio/issues/3796
-export async function browserExecute(fn: any) {
+export function browserExecute(fn: any) {
   return browser.execute(fn)
 }
 
-export async function browserExecuteAsync<R, A, B>(
-  fn: (a: A, b: B, done: (result: R) => void) => any,
-  a: A,
-  b: B
-): Promise<R>
-export async function browserExecuteAsync<R, A>(fn: (a: A, done: (result: R) => void) => any, arg: A): Promise<R>
-export async function browserExecuteAsync<R>(fn: (done: (result: R) => void) => any): Promise<R>
-export async function browserExecuteAsync<A extends any[]>(fn: (...params: A) => any, ...args: A) {
+export function browserExecuteAsync<R, A, B>(fn: (a: A, b: B, done: (result: R) => void) => any, a: A, b: B): Promise<R>
+export function browserExecuteAsync<R, A>(fn: (a: A, done: (result: R) => void) => any, arg: A): Promise<R>
+export function browserExecuteAsync<R>(fn: (done: (result: R) => void) => any): Promise<R>
+export function browserExecuteAsync<A extends any[]>(fn: (...params: A) => any, ...args: A) {
   return browser.executeAsync(fn as any, ...args)
 }
 
@@ -94,7 +90,7 @@ export async function flushBrowserLogs() {
 }
 
 // wdio method does not work for some browsers
-export async function deleteAllCookies() {
+export function deleteAllCookies() {
   return browserExecute(() => {
     const cookies = document.cookie.split(';')
     for (const cookie of cookies) {

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -779,7 +779,7 @@ describe('recorder', () => {
         `
       )
       .run(async ({ serverEvents }) => {
-        async function scroll({ windowY, containerX }: { windowY: number; containerX: number }) {
+        function scroll({ windowY, containerX }: { windowY: number; containerX: number }) {
           return browserExecuteAsync(
             (windowY, containerX, done) => {
               let scrollCount = 0


### PR DESCRIPTION
## Motivation

Enforce consistent usage of `async` keywords. Proposed by @bcaudan [here](https://github.com/DataDog/browser-sdk/pull/2125#discussion_r1154381378).

## Changes

* Enable `require-await`
* Make sure we don't use `async function` when we don't use `await`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
