### PR TITLE
♻️[RUMF-1517] rename performance utils

### DIFF
--- a/performances/src/profilers/profilingUtils.ts
+++ b/performances/src/profilers/profilingUtils.ts
@@ -1,4 +1,4 @@
-import type { ProfilingOptions } from './types'
+import type { ProfilingOptions } from '../types'
 
 export function isSdkBundleUrl(options: ProfilingOptions, url: string) {
   return url === options.bundleUrl

--- a/performances/src/profilers/startCpuProfiling.ts
+++ b/performances/src/profilers/startCpuProfiling.ts
@@ -1,6 +1,6 @@
 import type { CDPSession } from 'puppeteer'
 import type { ProfilingOptions } from '../types'
-import { isSdkBundleUrl } from '../utils'
+import { isSdkBundleUrl } from './profilingUtils'
 
 export async function startCPUProfiling(options: ProfilingOptions, client: CDPSession) {
   await client.send('Profiler.enable')

--- a/performances/src/profilers/startMemoryProfiling.ts
+++ b/performances/src/profilers/startMemoryProfiling.ts
@@ -1,6 +1,6 @@
 import type { CDPSession } from 'puppeteer'
-import { isSdkBundleUrl } from '../utils'
 import type { ProfilingOptions } from '../types'
+import { isSdkBundleUrl } from './profilingUtils'
 
 export async function startMemoryProfiling(options: ProfilingOptions, client: CDPSession) {
   await client.send('HeapProfiler.enable')

--- a/performances/src/profilers/startNetworkProfiling.ts
+++ b/performances/src/profilers/startNetworkProfiling.ts
@@ -1,6 +1,6 @@
 import type { CDPSession, Protocol } from 'puppeteer'
 import type { ProfilingOptions } from '../types'
-import { isSdkBundleUrl } from '../utils'
+import { isSdkBundleUrl } from './profilingUtils'
 
 export async function startNetworkProfiling(options: ProfilingOptions, client: CDPSession) {
   await client.send('Network.enable')


### PR DESCRIPTION
## Motivation

Avoid single utils files

## Changes

rename `performances/src/utils.ts` to `performances/src/profilers/profilingUtils.ts`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
