### PR TITLE
✨ [RUMF-1533] flush pending data when calling `RUM.stopSession`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export {
   canUseEventBridge,
   getEventBridge,
   startBatchWithReplica,
+  createFlushController,
 } from './transport'
 export * from './tools/display'
 export * from './tools/urlPolyfill'

--- a/packages/core/src/transport/flushController.ts
+++ b/packages/core/src/transport/flushController.ts
@@ -1,0 +1,50 @@
+import type { PageExitEvent } from '../browser/pageExitObservable'
+import { Observable } from '../tools/observable'
+import { setTimeout } from '../tools/timer'
+
+export type FlushReason =
+  | 'batch_duration_limit'
+  | 'batch_bytes_limit'
+  | 'before_unload'
+  | 'page_hide'
+  | 'visibility_hidden'
+  | 'page_frozen'
+
+export type FlushController = ReturnType<typeof createFlushController>
+
+interface FlushControllerOptions {
+  batchMessagesLimit: number
+  batchBytesLimit: number
+  flushTimeout: number
+  pageExitObservable: Observable<PageExitEvent>
+}
+
+export function createFlushController({
+  batchMessagesLimit,
+  batchBytesLimit,
+  flushTimeout,
+  pageExitObservable,
+}: FlushControllerOptions) {
+  const flushObservable = new Observable<FlushReason>()
+
+  flushPeriodically(flushObservable, flushTimeout)
+
+  pageExitObservable.subscribe((event) => flushObservable.notify(event.reason))
+
+  return {
+    flushIfFull(messagesCount: number, bytesCount: number) {
+      if (messagesCount === batchMessagesLimit || bytesCount >= batchBytesLimit) {
+        flushObservable.notify('batch_bytes_limit')
+      }
+    },
+
+    flushObservable,
+  }
+}
+
+function flushPeriodically(flushObservable: Observable<FlushReason>, flushTimeout: number) {
+  setTimeout(() => {
+    flushObservable.notify('batch_duration_limit')
+    flushPeriodically(flushObservable, flushTimeout)
+  }, flushTimeout)
+}

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -2,3 +2,4 @@ export { HttpRequest, createHttpRequest, Payload, RetryInfo } from './httpReques
 export { Batch, BatchFlushEvent, FlushReason } from './batch'
 export { canUseEventBridge, getEventBridge, BrowserWindowWithEventBridge } from './eventBridge'
 export { startBatchWithReplica } from './startBatchWithReplica'
+export { createFlushController } from './flushController'

--- a/packages/core/src/transport/startBatchWithReplica.ts
+++ b/packages/core/src/transport/startBatchWithReplica.ts
@@ -5,6 +5,7 @@ import type { Observable } from '../tools/observable'
 import type { PageExitEvent } from '../browser/pageExitObservable'
 import { Batch } from './batch'
 import { createHttpRequest } from './httpRequest'
+import { createFlushController } from './flushController'
 
 export function startBatchWithReplica<T extends Context>(
   configuration: Configuration,
@@ -22,11 +23,13 @@ export function startBatchWithReplica<T extends Context>(
   function createBatch(endpointBuilder: EndpointBuilder) {
     return new Batch(
       createHttpRequest(endpointBuilder, configuration.batchBytesLimit, reportError),
-      configuration.batchMessagesLimit,
-      configuration.batchBytesLimit,
-      configuration.messageBytesLimit,
-      configuration.flushTimeout,
-      pageExitObservable
+      createFlushController({
+        batchMessagesLimit: configuration.batchMessagesLimit,
+        batchBytesLimit: configuration.batchBytesLimit,
+        flushTimeout: configuration.flushTimeout,
+        pageExitObservable,
+      }),
+      configuration.messageBytesLimit
     )
   }
 

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -7,7 +7,13 @@ import type {
   PageExitEvent,
   BatchFlushEvent,
 } from '@datadog/browser-core'
-import { Batch, combine, createHttpRequest, isTelemetryReplicationAllowed } from '@datadog/browser-core'
+import {
+  createFlushController,
+  Batch,
+  combine,
+  createHttpRequest,
+  isTelemetryReplicationAllowed,
+} from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
 import { LifeCycleEventType } from '../domain/lifeCycle'
@@ -57,11 +63,13 @@ function makeRumBatch(
   function createRumBatch(endpointBuilder: EndpointBuilder) {
     return new Batch(
       createHttpRequest(endpointBuilder, configuration.batchBytesLimit, reportError),
-      configuration.batchMessagesLimit,
-      configuration.batchBytesLimit,
-      configuration.messageBytesLimit,
-      configuration.flushTimeout,
-      pageExitObservable
+      createFlushController({
+        batchMessagesLimit: configuration.batchMessagesLimit,
+        batchBytesLimit: configuration.batchBytesLimit,
+        flushTimeout: configuration.flushTimeout,
+        pageExitObservable,
+      }),
+      configuration.messageBytesLimit
     )
   }
 


### PR DESCRIPTION
## Motivation

When the session is stopped, there is high chances that no further data will be produced for this session. To improve reliability, flush early.

This will also help when we want to flush pending data in controlled contexts like for CI integration purposes.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
