### PR TITLE
🐛[RUMF-1544] Fix badly polyfilled URL 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -219,6 +219,7 @@ module.exports = {
       rules: {
         'local-rules/disallow-side-effects': 'error',
         'local-rules/disallow-zone-js-patched-values': 'error',
+        'local-rules/disallow-url-constructor-patched-values': 'error',
         'no-restricted-syntax': [
           'error',
           {

--- a/eslint-local-rules/disallowUrlConstructorPatchValues.js
+++ b/eslint-local-rules/disallowUrlConstructorPatchValues.js
@@ -1,0 +1,29 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow problematic URL constructor patched values.',
+      recommended: false,
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      'Program:exit'(node) {
+        const globalScope = context.getScope(node)
+        const variable = globalScope.set.get('URL')
+
+        if (variable && variable.defs.length === 0) {
+          variable.references.forEach((ref) => {
+            const idNode = ref.identifier
+            const parent = idNode.parent
+
+            if (parent && parent.type === 'NewExpression' && parent.callee === idNode) {
+              context.report(idNode, 'This value might be patched. Use `buildUrl` from @datadog/browser-core instead')
+            }
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -13,6 +13,7 @@ module.exports = {
   'disallow-protected-directory-import': require('./disallowProtectedDirectoryImport'),
   'disallow-test-import-export-from-src': require('./disallowTestImportExportFromSrc'),
   'disallow-zone-js-patched-values': require('./disallowZoneJsPatchedValues'),
+  'disallow-url-constructor-patched-values': require('./disallowUrlConstructorPatchValues.js'),
   'disallow-generic-utils': require('./disallowGenericUtils'),
   'secure-command-execution': require('./secureCommandExecution'),
 }

--- a/packages/core/src/tools/utils/urlPolyfill.spec.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.spec.ts
@@ -30,6 +30,12 @@ describe('isValidUrl', () => {
     expect(isValidUrl('/plop')).toBe(false)
     expect(isValidUrl('')).toBe(false)
   })
+
+  it('should return the same result if the URL as been wrongfully overridden between calls', () => {
+    expect(isValidUrl('http://www.datadoghq.com')).toBe(true)
+    spyOn(window, 'URL').and.throwError('wrong URL override')
+    expect(isValidUrl('http://www.datadoghq.com')).toBe(true)
+  })
 })
 
 describe('getOrigin', () => {

--- a/packages/core/src/tools/utils/urlPolyfill.spec.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.spec.ts
@@ -31,7 +31,7 @@ describe('isValidUrl', () => {
     expect(isValidUrl('')).toBe(false)
   })
 
-  it('should return the same result if the URL as been wrongfully overridden between calls', () => {
+  it('should return the same result if the URL has been wrongfully overridden between calls', () => {
     expect(isValidUrl('http://www.datadoghq.com')).toBe(true)
     spyOn(window, 'URL').and.throwError('wrong URL override')
     expect(isValidUrl('http://www.datadoghq.com')).toBe(true)

--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -39,9 +39,7 @@ export function buildUrl(url: string, base?: string) {
     try {
       return base !== undefined ? new supportedURL(url, base) : new supportedURL(url)
     } catch (error) {
-      throw new Error(
-        `Failed to construct URL. ${jsonStringify({ url, base, error: error instanceof Error ? error.message : '' })!}`
-      )
+      throw new Error(`Failed to construct URL: ${String(error)} ${jsonStringify({ url, base })!}`)
     }
   }
   if (base === undefined && !/:/.test(url)) {

--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -63,14 +63,13 @@ export function buildUrl(url: string, base?: string) {
 const originalURL = URL
 let isURLSupported: boolean | undefined
 function getSupportedUrl(): typeof URL | undefined {
-  if (isURLSupported !== undefined) {
-    return originalURL
-  }
-  try {
-    const url = new originalURL('http://test/path')
-    isURLSupported = url.href === 'http://test/path'
-  } catch {
-    isURLSupported = false
+  if (isURLSupported === undefined) {
+    try {
+      const url = new originalURL('http://test/path')
+      isURLSupported = url.href === 'http://test/path'
+    } catch {
+      isURLSupported = false
+    }
   }
   return isURLSupported ? originalURL : undefined
 }

--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -34,9 +34,10 @@ export function getHash(url: string) {
 }
 
 export function buildUrl(url: string, base?: string) {
-  if (checkURLSupported()) {
+  const supportedURL = getSupportedUrl()
+  if (supportedURL) {
     try {
-      return base !== undefined ? new URL(url, base) : new URL(url)
+      return base !== undefined ? new supportedURL(url, base) : new supportedURL(url)
     } catch (error) {
       throw new Error(`Failed to construct URL. ${jsonStringify({ url, base })!}`)
     }
@@ -57,19 +58,19 @@ export function buildUrl(url: string, base?: string) {
   return anchorElement
 }
 
+const originalURL = URL
 let isURLSupported: boolean | undefined
-function checkURLSupported() {
+function getSupportedUrl(): typeof URL | undefined {
   if (isURLSupported !== undefined) {
-    return isURLSupported
+    return originalURL
   }
   try {
-    const url = new URL('http://test/path')
+    const url = new originalURL('http://test/path')
     isURLSupported = url.href === 'http://test/path'
-    return isURLSupported
   } catch {
     isURLSupported = false
   }
-  return isURLSupported
+  return isURLSupported ? originalURL : undefined
 }
 
 export function getLocationOrigin() {

--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -39,7 +39,9 @@ export function buildUrl(url: string, base?: string) {
     try {
       return base !== undefined ? new supportedURL(url, base) : new supportedURL(url)
     } catch (error) {
-      throw new Error(`Failed to construct URL. ${jsonStringify({ url, base })!}`)
+      throw new Error(
+        `Failed to construct URL. ${jsonStringify({ url, base, error: error instanceof Error ? error.message : '' })!}`
+      )
     }
   }
   if (base === undefined && !/:/.test(url)) {

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -164,6 +164,9 @@ function isBrowserSupported() {
     // Array.from is a bit less supported by browsers than CSSSupportsRule, but has higher chances
     // to be polyfilled. Test for both to be more confident. We could add more things if we find out
     // this test is not sufficient.
-    typeof Array.from === 'function' && typeof CSSSupportsRule === 'function' && 'forEach' in NodeList.prototype
+    typeof Array.from === 'function' &&
+    typeof CSSSupportsRule === 'function' &&
+    typeof URL.createObjectURL === 'function' &&
+    'forEach' in NodeList.prototype
   )
 }


### PR DESCRIPTION
## Motivation

It has been observed that on some customer website, URL is badly polyfilled. It might not be a constructor, and might not provide a URL.createObjectURL function.


## Changes

- Replace `checkURLSupported` by `getSupportedURL` to keep the original URL ref to avoid the `URL is not a constructor` error in the `buildUrl`.
- Check if `URL.createObjectURL` is supported for the recorder to avoid `URL.createObjectURL is not a function` error in the worker 
- Add an ESLint rule to force using `buildURL` instead of `new URL`. Inspired by [no-new-symbol rule](https://github.com/eslint/eslint/blob/main/lib/rules/no-new-symbol.js) 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
