### PR TITLE
👷 remove @type/node, jasmine from renovate exclusions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,8 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "excludePackageNames": ["typescript", "puppeteer", "@types/node", "@types/express", "ajv", "ansi-regex"],
-      "excludePackagePatterns": ["jasmine", "webpack"],
+      "excludePackageNames": ["typescript", "puppeteer", "@types/express", "ajv", "ansi-regex"],
+      "excludePackagePatterns": ["webpack"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ]


### PR DESCRIPTION
## Motivation

Possible updates have been merged, new updates could be grouped in `all non-major dependencies` updates. 

## Changes

Remove exclusion:

- `@types/node`
- `*jasmine*`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
