### PR TITLE
✨ [RUMF-1534] send a view update when session is expiring

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -265,6 +265,18 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        * The upload frequency of batches (in milliseconds)
        */
       batch_upload_frequency?: number
+      /**
+       * The version of React used in a ReactNative application
+       */
+      react_version?: string
+      /**
+       * The version of ReactNative used in a ReactNative application
+       */
+      react_native_version?: string
+      /**
+       * The version of Dart used in a Flutter application
+       */
+      dart_version?: string
       [k: string]: unknown
     }
     [k: string]: unknown

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -544,6 +544,7 @@ describe('rum assembly', () => {
       })
       expect(serverRumEvents[0].session).toEqual({
         has_replay: undefined,
+        is_active: undefined,
         id: '1234',
         type: 'user',
       })

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -315,13 +315,15 @@ describe('view lifecycle', () => {
 
     it('should send a final view update', () => {
       const { lifeCycle } = setupBuilder.build()
-      const { getViewUpdateCount } = viewTest
+      const { getViewUpdateCount, getViewUpdate } = viewTest
 
       expect(getViewUpdateCount()).toBe(1)
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
 
       expect(getViewUpdateCount()).toBe(2)
+      expect(getViewUpdate(0).sessionIsActive).toBe(true)
+      expect(getViewUpdate(1).sessionIsActive).toBe(false)
     })
 
     it('should not start a new view if the session expired', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -43,6 +43,7 @@ export interface ViewEvent {
   startClocks: ClocksState
   duration: Duration
   isActive: boolean
+  sessionIsActive: boolean
   loadingTime?: Duration
   loadingType: ViewLoadingType
   cumulativeLayoutShift?: number
@@ -223,6 +224,7 @@ function newView(
           timings,
           duration: elapsed(startClocks.timeStamp, currentEnd),
           isActive: endClocks === undefined,
+          sessionIsActive: true, // TODO set this to false when session is inactive
           eventCounts,
         },
         viewMetrics

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -41,6 +41,7 @@ const VIEW: ViewEvent = {
     largestContentfulPaint: 10 as Duration,
     loadEvent: 10 as Duration,
   },
+  sessionIsActive: true,
 }
 
 describe('viewCollection', () => {
@@ -134,9 +135,16 @@ describe('viewCollection', () => {
       },
       session: {
         has_replay: undefined,
+        is_active: undefined,
       },
       feature_flags: undefined,
     })
+  })
+
+  it('should set session.is_active to false if the session is inactive', () => {
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+    lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, { ...VIEW, sessionIsActive: false })
+    expect((rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent).session.is_active).toBe(false)
   })
 
   it('should include replay information if available', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -93,6 +93,7 @@ function processViewUpdate(
     feature_flags: featureFlagContext && !isEmptyObject(featureFlagContext) ? featureFlagContext : undefined,
     session: {
       has_replay: replayStats ? true : undefined,
+      is_active: view.sessionIsActive ? undefined : false,
     },
   }
   if (!isEmptyObject(view.customTimings)) {

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -103,6 +103,7 @@ export interface RawRumViewEvent {
   }
   session: {
     has_replay: true | undefined
+    is_active: false | undefined
   }
   feature_flags?: Context
   _dd: {

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -732,6 +732,25 @@ export type RumViewEvent = CommonProperties & {
     [k: string]: unknown
   }
   /**
+   * Session properties
+   */
+  readonly session?: {
+    /**
+     * The precondition that led to the creation of the session
+     */
+    readonly start_precondition?:
+      | 'app_launch'
+      | 'inactivity_timeout'
+      | 'max_duration'
+      | 'explicit_stop'
+      | 'background_event'
+    /**
+     * Whether this session is currently active. Set to false to manually stop a session
+     */
+    readonly is_active?: boolean
+    [k: string]: unknown
+  }
+  /**
    * Feature flags properties
    */
   readonly feature_flags?: {

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -90,6 +90,7 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
           },
           session: {
             has_replay: undefined,
+            is_active: undefined,
           },
         },
         overrides

--- a/test/e2e/scenario/rum/sessions.scenario.ts
+++ b/test/e2e/scenario/rum/sessions.scenario.ts
@@ -112,6 +112,7 @@ describe('rum sessions', () => {
         await waitForRequests()
 
         expect(serverEvents.rumViews.length).toBe(1)
+        expect(serverEvents.rumViews[0].session.is_active).toBe(false)
         expect(serverEvents.logs.length).toBe(1)
         expect(serverEvents.sessionReplay.length).toBe(1)
       })


### PR DESCRIPTION
## Motivation

Tell the backend to end the session early when we detect that the session expired, especially useful when using `stopSession()` manually.

## Changes

With this PR, the SDK will send a view update with `@session.is_active:false` every time it detects that the session expires.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
