### PR TITLE
✨ [RUMF-1534] allow (some) view updates after session expiration

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -534,19 +534,6 @@ describe('rum assembly', () => {
 
       expect(rumSessionManager.findTrackedSession).toHaveBeenCalledWith(123 as RelativeTime)
     })
-
-    it('should get current session state for view event', () => {
-      const rumSessionManager = createRumSessionManagerMock()
-      spyOn(rumSessionManager, 'findTrackedSession').and.callThrough()
-
-      const { lifeCycle } = setupBuilder.withSessionManager(rumSessionManager).build()
-      notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-        startTime: 123 as RelativeTime,
-      })
-
-      expect(rumSessionManager.findTrackedSession).toHaveBeenCalledWith(undefined)
-    })
   })
 
   describe('session context', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -89,10 +89,7 @@ export function startRumAssembly(
     ({ startTime, rawRumEvent, domainContext, savedCommonContext, customerContext }) => {
       const viewContext = viewContexts.findView(startTime)
       const urlContext = urlContexts.findUrl(startTime)
-      // allow to send events if the session was tracked when they start
-      // except for views which are continuously updated
-      // TODO: stop sending view updates when session is expired
-      const session = sessionManager.findTrackedSession(rawRumEvent.type !== RumEventType.VIEW ? startTime : undefined)
+      const session = sessionManager.findTrackedSession(startTime)
       if (session && viewContext && urlContext) {
         const commonContext = savedCommonContext || buildCommonContext()
         const actionId = actionContexts.findActionId(startTime)

--- a/packages/rum-core/src/domain/rumEventsCollection/view/setupViewTest.specHelper.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/setupViewTest.specHelper.ts
@@ -15,12 +15,17 @@ export function setupViewTest(
     getHandledCount: getViewUpdateCount,
   } = spyOnViews('view update')
   lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, viewUpdateHandler)
+
   const {
     handler: viewCreateHandler,
     getViewEvent: getViewCreate,
     getHandledCount: getViewCreateCount,
   } = spyOnViews('view create')
   lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, viewCreateHandler)
+
+  const { handler: viewEndHandler, getViewEvent: getViewEnd, getHandledCount: getViewEndCount } = spyOnViews('view end')
+  lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, viewEndHandler)
+
   const { stop, startView, addTiming } = trackViews(
     location,
     lifeCycle,
@@ -38,6 +43,8 @@ export function setupViewTest(
     getViewUpdateCount,
     getViewCreate,
     getViewCreateCount,
+    getViewEnd,
+    getViewEndCount,
     getLatestViewContext: () => ({
       id: getViewCreate(getViewCreateCount() - 1).id,
     }),

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
@@ -49,15 +49,17 @@ const FAKE_FIRST_INPUT_ENTRY: RumFirstInputTiming = {
   startTime: 1000 as RelativeTime,
 }
 
-describe('trackTimings', () => {
+describe('trackInitialViewTimings', () => {
   let setupBuilder: TestSetupBuilder
-  let timingsCallback: jasmine.Spy<(value: Partial<Timings>) => void>
+  let scheduleViewUpdateSpy: jasmine.Spy<() => void>
   let trackInitialViewTimingsResult: ReturnType<typeof trackInitialViewTimings>
+  let setLoadEventSpy: jasmine.Spy<(loadEvent: Duration) => void>
 
   beforeEach(() => {
-    timingsCallback = jasmine.createSpy()
+    scheduleViewUpdateSpy = jasmine.createSpy()
+    setLoadEventSpy = jasmine.createSpy()
     setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
-      trackInitialViewTimingsResult = trackInitialViewTimings(lifeCycle, timingsCallback)
+      trackInitialViewTimingsResult = trackInitialViewTimings(lifeCycle, setLoadEventSpy, scheduleViewUpdateSpy)
       return trackInitialViewTimingsResult
     })
   })
@@ -75,8 +77,8 @@ describe('trackTimings', () => {
       FAKE_FIRST_INPUT_ENTRY,
     ])
 
-    expect(timingsCallback).toHaveBeenCalledTimes(3)
-    expect(timingsCallback.calls.mostRecent().args[0]).toEqual({
+    expect(scheduleViewUpdateSpy).toHaveBeenCalledTimes(3)
+    expect(trackInitialViewTimingsResult.timings).toEqual({
       firstByte: 123 as Duration,
       domComplete: 456 as Duration,
       domContentLoaded: 345 as Duration,
@@ -94,13 +96,25 @@ describe('trackTimings', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_NAVIGATION_ENTRY])
 
-    expect(timingsCallback).toHaveBeenCalledTimes(1)
+    expect(scheduleViewUpdateSpy).toHaveBeenCalledTimes(1)
 
     clock.tick(KEEP_TRACKING_TIMINGS_AFTER_VIEW_DELAY)
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_PAINT_ENTRY])
 
-    expect(timingsCallback).toHaveBeenCalledTimes(1)
+    expect(scheduleViewUpdateSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls the `setLoadEvent` callback when the loadEvent timing is known', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+      FAKE_NAVIGATION_ENTRY,
+      FAKE_PAINT_ENTRY,
+      FAKE_FIRST_INPUT_ENTRY,
+    ])
+
+    expect(setLoadEventSpy).toHaveBeenCalledOnceWith(567 as Duration)
   })
 })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackInitialViewTimings.spec.ts
@@ -13,6 +13,7 @@ import { LifeCycleEventType } from '../../lifeCycle'
 import { resetFirstHidden } from './trackFirstHidden'
 import type { Timings } from './trackInitialViewTimings'
 import {
+  KEEP_TRACKING_TIMINGS_AFTER_VIEW_DELAY,
   trackFirstContentfulPaintTiming,
   trackFirstInputTimings,
   trackLargestContentfulPaintTiming,
@@ -51,10 +52,14 @@ const FAKE_FIRST_INPUT_ENTRY: RumFirstInputTiming = {
 describe('trackTimings', () => {
   let setupBuilder: TestSetupBuilder
   let timingsCallback: jasmine.Spy<(value: Partial<Timings>) => void>
+  let trackInitialViewTimingsResult: ReturnType<typeof trackInitialViewTimings>
 
   beforeEach(() => {
     timingsCallback = jasmine.createSpy()
-    setupBuilder = setup().beforeBuild(({ lifeCycle }) => trackInitialViewTimings(lifeCycle, timingsCallback))
+    setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
+      trackInitialViewTimingsResult = trackInitialViewTimings(lifeCycle, timingsCallback)
+      return trackInitialViewTimingsResult
+    })
   })
 
   afterEach(() => {
@@ -81,6 +86,21 @@ describe('trackTimings', () => {
       firstInputTime: 1000 as Duration,
       loadEvent: 567 as Duration,
     })
+  })
+
+  it('allows delaying the stop logic', () => {
+    const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+    trackInitialViewTimingsResult.scheduleStop()
+
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_NAVIGATION_ENTRY])
+
+    expect(timingsCallback).toHaveBeenCalledTimes(1)
+
+    clock.tick(KEEP_TRACKING_TIMINGS_AFTER_VIEW_DELAY)
+
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_PAINT_ENTRY])
+
+    expect(timingsCallback).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -324,7 +324,7 @@ describe('view lifecycle', () => {
       expect(getViewUpdateCount()).toBe(2)
     })
 
-    it('should not start a new view the session expires', () => {
+    it('should not start a new view if the session expired', () => {
       const { lifeCycle } = setupBuilder.build()
       const { getViewCreateCount } = viewTest
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -688,6 +688,21 @@ describe('view custom timings', () => {
     })
     expect(displaySpy).toHaveBeenCalled()
   })
+
+  it('should not add custom timing when the session has expired', () => {
+    const { clock, lifeCycle } = setupBuilder.build()
+    const { getViewUpdateCount, addTiming } = viewTest
+
+    lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+
+    expect(getViewUpdateCount()).toBe(2)
+
+    addTiming('foo', relativeNow())
+
+    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+    expect(getViewUpdateCount()).toBe(2)
+  })
 })
 
 describe('start view', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -428,6 +428,19 @@ describe('view lifecycle', () => {
 
       expect(getViewUpdateCount()).toEqual(2)
     })
+
+    it('should not send periodical updates after the session has expired', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+      const { getViewUpdateCount } = viewTest
+
+      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+
+      expect(getViewUpdateCount()).toBe(1)
+
+      clock.tick(SESSION_KEEP_ALIVE_INTERVAL)
+
+      expect(getViewUpdateCount()).toBe(1)
+    })
   })
 
   describe('page exit', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -279,16 +279,52 @@ describe('view lifecycle', () => {
     setupBuilder.cleanup()
   })
 
+  describe('expire session', () => {
+    it('should end the view when the session expires', () => {
+      const { lifeCycle } = setupBuilder.build()
+      const { getViewEndCount } = viewTest
+
+      expect(getViewEndCount()).toBe(0)
+
+      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+
+      expect(getViewEndCount()).toBe(1)
+    })
+
+    it('should not start a new view the session expires', () => {
+      const { lifeCycle } = setupBuilder.build()
+      const { getViewCreateCount } = viewTest
+
+      expect(getViewCreateCount()).toBe(1)
+
+      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+
+      expect(getViewCreateCount()).toBe(1)
+    })
+
+    it('should not end the view if the view already ended', () => {
+      const { lifeCycle } = setupBuilder.build()
+      const { getViewEndCount } = viewTest
+
+      lifeCycle.notify(LifeCycleEventType.PAGE_EXITED, { reason: PageExitReason.UNLOADING })
+
+      expect(getViewEndCount()).toBe(1)
+
+      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+
+      expect(getViewEndCount()).toBe(1)
+    })
+  })
+
   describe('renew session', () => {
     it('should create new view on renew session', () => {
       const { lifeCycle } = setupBuilder.build()
-      const { getViewCreateCount, getViewEndCount } = viewTest
+      const { getViewCreateCount } = viewTest
 
       expect(getViewCreateCount()).toBe(1)
 
       lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
-      expect(getViewEndCount()).toBe(1)
       expect(getViewCreateCount()).toBe(2)
     })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -190,6 +190,22 @@ describe('initial view', () => {
       expect(getViewUpdate(2).timings).toEqual({})
     })
 
+    it('should not update timings after session expires', () => {
+      const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
+      const { getViewUpdateCount } = viewTest
+
+      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+
+      expect(getViewUpdateCount()).toEqual(2)
+
+      clock.tick(FAKE_NAVIGATION_ENTRY.responseStart) // ensure now > responseStart
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_NAVIGATION_ENTRY])
+
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+      expect(getViewUpdateCount()).toEqual(2)
+    })
+
     describe('load event happening after initial view end', () => {
       let initialView: { init: ViewEvent; end: ViewEvent; last: ViewEvent }
       let secondView: { init: ViewEvent; last: ViewEvent }

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.spec.ts
@@ -291,6 +291,17 @@ describe('view lifecycle', () => {
       expect(getViewEndCount()).toBe(1)
     })
 
+    it('should send a final view update', () => {
+      const { lifeCycle } = setupBuilder.build()
+      const { getViewUpdateCount } = viewTest
+
+      expect(getViewUpdateCount()).toBe(1)
+
+      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+
+      expect(getViewUpdateCount()).toBe(2)
+    })
+
     it('should not start a new view the session expires', () => {
       const { lifeCycle } = setupBuilder.build()
       const { getViewCreateCount } = viewTest
@@ -304,15 +315,17 @@ describe('view lifecycle', () => {
 
     it('should not end the view if the view already ended', () => {
       const { lifeCycle } = setupBuilder.build()
-      const { getViewEndCount } = viewTest
+      const { getViewEndCount, getViewUpdateCount } = viewTest
 
       lifeCycle.notify(LifeCycleEventType.PAGE_EXITED, { reason: PageExitReason.UNLOADING })
 
       expect(getViewEndCount()).toBe(1)
+      expect(getViewUpdateCount()).toBe(2)
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
 
       expect(getViewEndCount()).toBe(1)
+      expect(getViewUpdateCount()).toBe(2)
     })
   })
 
@@ -402,18 +415,6 @@ describe('view lifecycle', () => {
       )
       resetExperimentalFeatures()
     })
-
-    it('should not update the current view when the session is renewed', () => {
-      const { lifeCycle } = setupBuilder.build()
-      const { getViewUpdateCount, getViewUpdate } = viewTest
-
-      expect(getViewUpdateCount()).toEqual(1)
-
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-
-      expect(getViewUpdateCount()).toEqual(2)
-      expect(getViewUpdate(0).id).not.toBe(getViewUpdate(1).id)
-    })
   })
 
   describe('session keep alive', () => {
@@ -435,11 +436,11 @@ describe('view lifecycle', () => {
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
 
-      expect(getViewUpdateCount()).toBe(1)
+      expect(getViewUpdateCount()).toBe(2)
 
       clock.tick(SESSION_KEEP_ALIVE_INTERVAL)
 
-      expect(getViewUpdateCount()).toBe(1)
+      expect(getViewUpdateCount()).toBe(2)
     })
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -118,14 +118,16 @@ export function trackViews(
 
   function startViewLifeCycle() {
     lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-      // do not trigger view update to avoid wrong data
-      currentView.end()
       // Renew view on session renewal
       currentView = trackViewChange(undefined, {
         name: currentView.name,
         service: currentView.service,
         version: currentView.version,
       })
+    })
+
+    lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
+      currentView.end()
     })
 
     // End the current view on page unload
@@ -267,6 +269,10 @@ function newView(
     version,
     scheduleUpdate: scheduleViewUpdate,
     end(clocks = clocksNow()) {
+      if (endClocks) {
+        // view already ended
+        return
+      }
       endClocks = clocks
       lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks })
       stopViewMetricsTracking()

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -277,6 +277,9 @@ function newView(
       scheduleViewUpdate()
     },
     addTiming(name: string, time: RelativeTime | TimeStamp) {
+      if (endClocks) {
+        return
+      }
       const relativeTime = looksLikeRelativeTime(time) ? time : elapsed(startClocks.timeStamp, time)
       customTimings[sanitizeTiming(name)] = relativeTime
       scheduleViewUpdate()

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -126,6 +126,8 @@ export function trackViews(
     })
 
     lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
+      // Make sure initial view is not updated after session expiration
+      stopInitialViewTracking()
       currentView.end()
     })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViews.ts
@@ -154,7 +154,6 @@ export function trackViews(
         currentView.end()
         currentView.triggerUpdate()
         currentView = trackViewChange()
-        return
       }
     })
   }


### PR DESCRIPTION
## Motivation

This PR is a preliminary step for notifying the backend that a session has expired via a View update. In other words, the goal is [to tackle this TODO](https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/domain/assembly.ts#L92-L95). To do so, we need to send a view update after the session has expired, which is not possible right now.

## Changes

This PR makes sure we don't send too many view updates when the session is expired. In particular, when the session expires, we now:

* end the current view which stops updates from metrics
* stops the session keep alive interval
* prevent any initial view updates
* do not accept new timings

A view can still be updated after the session expires:
* child events that started before session expiration are still collected, we need to update the view counter
* just when the session has expired, we send a last view update

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
