### PR TITLE
🐛 Fix exception when using wrong tracing parameters

### DIFF
--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -541,6 +541,14 @@ describe('validateAndBuildRumConfiguration', () => {
           jasmine.arrayWithExactContents(['datadog', 'b3', 'b3multi', 'tracecontext'])
         )
       })
+
+      it('should survive a configuration with wrong parameters', () => {
+        const wrongTracingConfig: RumInitConfiguration = {
+          ...DEFAULT_INIT_CONFIGURATION,
+          allowedTracingUrls: [42 as any, { match: 'test', propagatorTypes: 42 }, undefined, null, {}],
+        }
+        expect(serializeRumConfiguration(wrongTracingConfig).selected_tracing_propagators).toEqual([])
+      })
     })
   })
 })

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -1,5 +1,6 @@
 import type { Configuration, InitConfiguration, MatchOption, RawTelemetryConfiguration } from '@datadog/browser-core'
 import {
+  getType,
   arrayFrom,
   getOrigin,
   isMatchOption,
@@ -254,7 +255,8 @@ function getSelectedTracingPropagators(configuration: RumInitConfiguration): Pro
     configuration.allowedTracingUrls.forEach((option) => {
       if (isMatchOption(option)) {
         usedTracingPropagators.add('datadog')
-      } else {
+      } else if (getType(option) === 'object' && Array.isArray(option.propagatorTypes)) {
+        // Ensure we have an array, as we cannot rely on types yet (configuration is provided by users)
         option.propagatorTypes.forEach((propagatorType) => usedTracingPropagators.add(propagatorType))
       }
     })


### PR DESCRIPTION
## Motivation

When using wrong parameter types in `allowedTracingUrls`, such as:
`allowedTracingUrls: [42]`
The SDK properly warns that this parameter is invalid and will be ignored. However, it fails later when serializing parameters for telemetry, and stops initializing with no warning. 

## Changes

Add a check to ensure the parameter can be parsed for telemetry.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
