### PR TITLE
✨ [RUMF-1479] enable heatmaps collection

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -14,7 +14,6 @@ export enum ExperimentalFeature {
   PAGEHIDE = 'pagehide',
   FEATURE_FLAGS = 'feature_flags',
   RESOURCE_PAGE_STATES = 'resource_page_states',
-  CLICKMAP = 'clickmap',
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
   SANITIZE_INPUTS = 'sanitize_inputs',
   REPLAY_JSON_PAYLOAD = 'replay_json_payload',

--- a/packages/rum-core/src/domain/contexts/displayContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/displayContext.spec.ts
@@ -1,24 +1,16 @@
-import { ExperimentalFeature, resetExperimentalFeatures, addExperimentalFeatures } from '@datadog/browser-core'
 import { getDisplayContext, resetDisplayContext } from './displayContext'
 
 describe('displayContext', () => {
   afterEach(() => {
-    resetExperimentalFeatures()
     resetDisplayContext()
   })
 
-  it('should return current display context when ff enabled', () => {
-    addExperimentalFeatures([ExperimentalFeature.CLICKMAP])
-
+  it('should return current display context', () => {
     expect(getDisplayContext()).toEqual({
       viewport: {
         width: jasmine.any(Number),
         height: jasmine.any(Number),
       },
     })
-  })
-
-  it('should not return current display context when ff disabled', () => {
-    expect(getDisplayContext()).not.toBeDefined()
   })
 })

--- a/packages/rum-core/src/domain/contexts/displayContext.ts
+++ b/packages/rum-core/src/domain/contexts/displayContext.ts
@@ -1,14 +1,9 @@
-import { ExperimentalFeature, isExperimentalFeatureEnabled } from '@datadog/browser-core'
 import { getViewportDimension, initViewportObservable } from '../../browser/viewportObservable'
 
 let viewport: { width: number; height: number } | undefined
 let stopListeners: (() => void) | undefined
 
 export function getDisplayContext() {
-  if (!isExperimentalFeatureEnabled(ExperimentalFeature.CLICKMAP)) {
-    return
-  }
-
   if (!viewport) {
     viewport = getViewportDimension()
     stopListeners = initViewportObservable().subscribe((viewportDimension) => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.spec.ts
@@ -1,13 +1,5 @@
 import type { Context, Duration } from '@datadog/browser-core'
-import {
-  addDuration,
-  addExperimentalFeatures,
-  resetExperimentalFeatures,
-  clocksNow,
-  timeStampNow,
-  relativeNow,
-  ExperimentalFeature,
-} from '@datadog/browser-core'
+import { addDuration, clocksNow, timeStampNow, relativeNow } from '@datadog/browser-core'
 import { createNewEvent } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../../../test'
 import { setup, createFakeClick } from '../../../../test'
@@ -105,37 +97,15 @@ describe('trackClickActions', () => {
         type: ActionType.CLICK,
         event: domEvent,
         frustrationTypes: [],
-        target: undefined,
-        position: undefined,
+        target: {
+          selector: '#button',
+          width: 100,
+          height: 100,
+        },
+        position: { x: 50, y: 50 },
         events: [domEvent],
       },
     ])
-  })
-
-  describe('when clickmap ff is enabled', () => {
-    beforeEach(() => {
-      addExperimentalFeatures([ExperimentalFeature.CLICKMAP])
-    })
-
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should set click position and target', () => {
-      const { clock } = setupBuilder.build()
-      emulateClick({ activity: {} })
-      clock.tick(EXPIRE_DELAY)
-      expect(events[0]).toEqual(
-        jasmine.objectContaining({
-          target: {
-            selector: '#button',
-            width: 100,
-            height: 100,
-          },
-          position: { x: 50, y: 50 },
-        })
-      )
-    })
   })
 
   it('should keep track of previously validated click actions', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/trackClickActions.ts
@@ -2,7 +2,6 @@ import type { Duration, ClocksState, RelativeTime, TimeStamp } from '@datadog/br
 import {
   includes,
   timeStampNow,
-  isExperimentalFeatureEnabled,
   Observable,
   assign,
   getRelativeTime,
@@ -12,7 +11,6 @@ import {
   clocksNow,
   ONE_SECOND,
   elapsed,
-  ExperimentalFeature,
 } from '@datadog/browser-core'
 import type { FrustrationType } from '../../../rawRumEvent.types'
 import { ActionType } from '../../../rawRumEvent.types'
@@ -240,27 +238,19 @@ function startClickAction(
 type ClickActionBase = Pick<ClickAction, 'type' | 'name' | 'target' | 'position'>
 
 function computeClickActionBase(event: MouseEventOnElement, actionNameAttribute?: string): ClickActionBase {
-  let target: ClickAction['target']
-  let position: ClickAction['position']
-
-  if (isExperimentalFeatureEnabled(ExperimentalFeature.CLICKMAP)) {
-    const rect = event.target.getBoundingClientRect()
-    target = {
+  const rect = event.target.getBoundingClientRect()
+  return {
+    type: ActionType.CLICK,
+    target: {
       width: Math.round(rect.width),
       height: Math.round(rect.height),
       selector: getSelectorFromElement(event.target, actionNameAttribute),
-    }
-    position = {
+    },
+    position: {
       // Use clientX and Y because for SVG element offsetX and Y are relatives to the <svg> element
       x: Math.round(event.clientX - rect.left),
       y: Math.round(event.clientY - rect.top),
-    }
-  }
-
-  return {
-    type: ActionType.CLICK,
-    target,
-    position,
+    },
     name: getActionNameFromElement(event.target, actionNameAttribute),
   }
 }

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -3,7 +3,7 @@ import { createTest, flushEvents, html, waitForServersIdle } from '../../lib/fra
 
 describe('action collection', () => {
   createTest('track a click action')
-    .withRum({ trackUserInteractions: true, enableExperimentalFeatures: ['clickmap'] })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button>click me</button>
@@ -62,7 +62,7 @@ describe('action collection', () => {
     })
 
   createTest('compute action target information before the UI changes')
-    .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['clickmap'] })
+    .withRum({ trackFrustrations: true })
     .withBody(
       html`
         <button style="position: relative">click me</button>
@@ -91,7 +91,7 @@ describe('action collection', () => {
   // click event. Skip this test.
   if (getBrowserName() !== 'firefox') {
     createTest('does not report a click on the body when the target element changes between mousedown and mouseup')
-      .withRum({ trackFrustrations: true, enableExperimentalFeatures: ['clickmap'] })
+      .withRum({ trackFrustrations: true })
       .withBody(
         html`
           <button style="position: relative">click me</button>


### PR DESCRIPTION
## Motivation

Display click heatmaps within Datadog.

## Changes

Remove the `clickmap` experimental feature flag.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
