### PR TITLE
♻️ [RUMF-1508] reorganise error handling

### DIFF
--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -36,7 +36,7 @@ export function computeRawError({
     : !isErrorInstance
     ? `${nonErrorPrefix} ${jsonStringify(sanitize(originalError))!}`
     : 'Empty message'
-  const stack = isValidStackTrace(isErrorInstance, stackTrace)
+  const stack = hasUsableStack(isErrorInstance, stackTrace)
     ? toStackTraceString(stackTrace)
     : NO_ERROR_STACK_PRESENT_MESSAGE
   const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
@@ -55,7 +55,7 @@ export function computeRawError({
   }
 }
 
-function isValidStackTrace(isErrorInstance: boolean, stackTrace?: StackTrace): stackTrace is StackTrace {
+function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stackTrace is StackTrace {
   if (stackTrace === undefined) {
     return false
   }

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -30,33 +30,41 @@ export function computeRawError({
   source,
   handling,
 }: RawErrorParams): RawError {
-  if (!stackTrace || (stackTrace.message === undefined && !(originalError instanceof Error))) {
-    const sanitizedError = isExperimentalFeatureEnabled(ExperimentalFeature.SANITIZE_INPUTS)
-      ? sanitize(originalError)
-      : originalError
-    return {
-      startClocks,
-      source,
-      handling,
-      originalError: sanitizedError,
-      message: `${nonErrorPrefix} ${jsonStringify(sanitizedError)!}`,
-      stack: NO_ERROR_STACK_PRESENT_MESSAGE,
-      handlingStack,
-      type: stackTrace && stackTrace.name,
-    }
-  }
+  const isErrorInstance = originalError instanceof Error
+  const sanitizedError = isExperimentalFeatureEnabled(ExperimentalFeature.SANITIZE_INPUTS)
+    ? sanitize(originalError)
+    : originalError
+
+  const message = stackTrace?.message
+    ? stackTrace.message
+    : !isErrorInstance
+    ? `${nonErrorPrefix} ${jsonStringify(sanitizedError)!}`
+    : 'Empty message'
+  const stack = isValidStackTrace(isErrorInstance, stackTrace)
+    ? toStackTraceString(stackTrace)
+    : NO_ERROR_STACK_PRESENT_MESSAGE
+  const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
+  const type = stackTrace && stackTrace.name
 
   return {
     startClocks,
     source,
     handling,
-    originalError,
-    message: stackTrace.message || 'Empty message',
-    stack: toStackTraceString(stackTrace),
     handlingStack,
-    type: stackTrace.name,
-    causes: flattenErrorCauses(originalError as ErrorWithCause, source),
+    originalError,
+    type,
+    message,
+    stack,
+    causes,
   }
+}
+
+function isValidStackTrace(isErrorInstance: boolean, stackTrace?: StackTrace): stackTrace is StackTrace {
+  return (
+    stackTrace !== undefined &&
+    (isErrorInstance ||
+      (stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)))
+  )
 }
 
 export function toStackTraceString(stack: StackTrace) {

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -60,11 +60,13 @@ export function computeRawError({
 }
 
 function isValidStackTrace(isErrorInstance: boolean, stackTrace?: StackTrace): stackTrace is StackTrace {
-  return (
-    stackTrace !== undefined &&
-    (isErrorInstance ||
-      (stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)))
-  )
+  if (stackTrace === undefined) {
+    return false
+  }
+  if (isErrorInstance) {
+    return true
+  }
+  return stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)
 }
 
 export function toStackTraceString(stack: StackTrace) {

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -44,7 +44,7 @@ export function computeRawError({
     ? toStackTraceString(stackTrace)
     : NO_ERROR_STACK_PRESENT_MESSAGE
   const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
-  const type = stackTrace && stackTrace.name
+  const type = stackTrace?.name
 
   return {
     startClocks,

--- a/packages/core/src/domain/error/trackRuntimeError.spec.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.spec.ts
@@ -3,7 +3,7 @@ import { NO_ERROR_STACK_PRESENT_MESSAGE } from './error'
 import { trackRuntimeError } from './trackRuntimeError'
 import type { RawError } from './error.types'
 
-describe('runtime error tracker', () => {
+describe('trackRuntimeError', () => {
   const ERROR_MESSAGE = 'foo'
 
   let originalOnErrorHandler: OnErrorEventHandler
@@ -14,6 +14,14 @@ describe('runtime error tracker', () => {
 
   let notifyError: jasmine.Spy
   let stopRuntimeErrorTracking: () => void
+
+  function afterOnErrorInstrumentation(callback: () => void) {
+    const instrumentedOnError = window.onerror!
+    window.onerror = function () {
+      instrumentedOnError.apply(window, arguments as any)
+      callback()
+    }
+  }
 
   beforeEach(() => {
     originalOnErrorHandler = window.onerror
@@ -39,12 +47,11 @@ describe('runtime error tracker', () => {
   it('should call original error handler', (done) => {
     setTimeout(() => {
       throw new Error(ERROR_MESSAGE)
-    }, 10)
-
-    setTimeout(() => {
+    })
+    afterOnErrorInstrumentation(() => {
       expect(onErrorSpy.calls.mostRecent().args[0]).toMatch(ERROR_MESSAGE)
       done()
-    }, 100)
+    })
   })
 
   it('should call original unhandled rejection handler', () => {
@@ -55,27 +62,53 @@ describe('runtime error tracker', () => {
     expect(onUnhandledrejectionSpy.calls.mostRecent().args[0].reason).toMatch(ERROR_MESSAGE)
   })
 
-  it('should notify error', (done) => {
+  it('should notify unhandled error instance', (done) => {
     setTimeout(() => {
       throw new Error(ERROR_MESSAGE)
-    }, 10)
-
-    setTimeout(() => {
-      expect((notifyError.calls.mostRecent().args[0] as RawError).message).toEqual(ERROR_MESSAGE)
+    })
+    afterOnErrorInstrumentation(() => {
+      const collectedError = notifyError.calls.mostRecent().args[0] as RawError
+      expect(collectedError.message).toEqual(ERROR_MESSAGE)
+      expect(collectedError.stack).not.toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
       done()
-    }, 100)
+    })
+  })
+
+  it('should notify unhandled string', (done) => {
+    setTimeout(() => {
+      // eslint-disable-next-line no-throw-literal
+      throw 'foo'
+    })
+    afterOnErrorInstrumentation(() => {
+      const collectedError = notifyError.calls.mostRecent().args[0] as RawError
+      expect(collectedError.message).toEqual('Uncaught "foo"')
+      expect(collectedError.stack).toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
+      done()
+    })
+  })
+
+  it('should notify unhandled object', (done) => {
+    setTimeout(() => {
+      // eslint-disable-next-line no-throw-literal
+      throw { a: 'foo' }
+    })
+    afterOnErrorInstrumentation(() => {
+      const collectedError = notifyError.calls.mostRecent().args[0] as RawError
+      expect(collectedError.message).toEqual('Uncaught {"a":"foo"}')
+      expect(collectedError.stack).toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
+      done()
+    })
   })
 
   it('should handle direct onerror calls with objects', (done) => {
     setTimeout(() => {
       window.onerror!({ foo: 'bar' } as any)
-    }, 10)
-
-    setTimeout(() => {
+    })
+    afterOnErrorInstrumentation(() => {
       const collectedError = notifyError.calls.mostRecent().args[0] as RawError
       expect(collectedError.message).toEqual('Uncaught {"foo":"bar"}')
       expect(collectedError.stack).toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
       done()
-    }, 100)
+    })
   })
 })

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -76,11 +76,7 @@ function tryToParseMessage(messageObj: unknown) {
   let name
   let message
   if ({}.toString.call(messageObj) === '[object String]') {
-    const groups = ERROR_TYPES_RE.exec(messageObj as string)
-    if (groups) {
-      name = groups[1]
-      message = groups[2]
-    }
+    ;[, name, message] = ERROR_TYPES_RE.exec(messageObj as string)!
   }
   return { name, message }
 }


### PR DESCRIPTION
## Motivation

Prepare handling of error without stacktrace

## Changes

- add more tests
- reorganise instrumentOnError
- reorganise computeRawError

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
