### PR TITLE
✨[RUMF-1508] Provide stack trace for all uncaught exceptions

### DIFF
--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -31,11 +31,12 @@ export function computeRawError({
 }: RawErrorParams): RawError {
   const isErrorInstance = originalError instanceof Error
 
-  const message = stackTrace?.message
-    ? stackTrace.message
-    : !isErrorInstance
-    ? `${nonErrorPrefix} ${jsonStringify(sanitize(originalError))!}`
-    : 'Empty message'
+  const message =
+    stackTrace?.message && stackTrace?.name
+      ? stackTrace.message
+      : !isErrorInstance
+      ? `${nonErrorPrefix} ${jsonStringify(sanitize(originalError))!}`
+      : 'Empty message'
   const stack = hasUsableStack(isErrorInstance, stackTrace)
     ? toStackTraceString(stackTrace)
     : NO_ERROR_STACK_PRESENT_MESSAGE

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -31,12 +31,7 @@ export function computeRawError({
 }: RawErrorParams): RawError {
   const isErrorInstance = originalError instanceof Error
 
-  const message =
-    stackTrace?.message && stackTrace?.name
-      ? stackTrace.message
-      : !isErrorInstance
-      ? `${nonErrorPrefix} ${jsonStringify(sanitize(originalError))!}`
-      : 'Empty message'
+  const message = computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError)
   const stack = hasUsableStack(isErrorInstance, stackTrace)
     ? toStackTraceString(stackTrace)
     : NO_ERROR_STACK_PRESENT_MESSAGE
@@ -56,6 +51,21 @@ export function computeRawError({
   }
 }
 
+function computeMessage(
+  stackTrace: StackTrace | undefined,
+  isErrorInstance: boolean,
+  nonErrorPrefix: NonErrorPrefix,
+  originalError: unknown
+) {
+  // Favor stackTrace message only if tracekit has really been able to extract something meaningful (message + name)
+  // TODO rework tracekit integration to avoid scattering error building logic
+  return stackTrace?.message && stackTrace?.name
+    ? stackTrace.message
+    : !isErrorInstance
+    ? `${nonErrorPrefix} ${jsonStringify(sanitize(originalError))!}`
+    : 'Empty message'
+}
+
 function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stackTrace is StackTrace {
   if (stackTrace === undefined) {
     return false
@@ -63,6 +73,8 @@ function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stac
   if (isErrorInstance) {
     return true
   }
+  // handle cases where tracekit return stack = [] or stack = [{url: undefined, line: undefined, column: undefined}]
+  // TODO rework tracekit integration to avoid generating those unusable stack
   return stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)
 }
 

--- a/packages/core/src/domain/error/trackRuntimeError.spec.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.spec.ts
@@ -75,7 +75,7 @@ describe('trackRuntimeError', () => {
     collectAsyncCalls(onErrorSpy, 1, () => {
       const collectedError = notifyError.calls.mostRecent().args[0] as RawError
       expect(collectedError.message).toEqual('Uncaught "foo"')
-      expect(collectedError.stack).toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
+      expect(collectedError.stack).not.toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
       done()
     })
   })
@@ -88,7 +88,7 @@ describe('trackRuntimeError', () => {
     collectAsyncCalls(onErrorSpy, 1, () => {
       const collectedError = notifyError.calls.mostRecent().args[0] as RawError
       expect(collectedError.message).toEqual('Uncaught {"a":"foo"}')
-      expect(collectedError.stack).toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
+      expect(collectedError.stack).not.toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
       done()
     })
   })

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -56,7 +56,7 @@ export function startUnhandledErrorCollection(callback: UnhandledErrorCallback) 
 function instrumentOnError(callback: UnhandledErrorCallback) {
   return instrumentMethodAndCallOriginal(window, 'onerror', {
     before(this: any, messageObj: unknown, url?: string, line?: number, column?: number, errorObj?: unknown) {
-      if (errorObj) {
+      if (errorObj instanceof Error) {
         callback(computeStackTrace(errorObj), errorObj)
         return
       }
@@ -67,7 +67,7 @@ function instrumentOnError(callback: UnhandledErrorCallback) {
         message,
         stack,
       }
-      callback(stackTrace, messageObj)
+      callback(stackTrace, errorObj ?? messageObj)
     },
   })
 }


### PR DESCRIPTION
## Motivation

Errors require a stack trace to be automatically grouped by error tracking.
When an uncaught exception is not an error instance, we don't provide a stack trace. 
However, in some cases some info can be retrieved from the [window.onerror handler arguments](https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event#arguments).

## Changes

- Better handle non error instance:
  - Avoid to compute stack trace but build one from from handler arguments
  - Pass to the caller the thrown object instead of the message
- Used computed stack trace message only when it brings extra value (error instance or successfully parsed error message) 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
