### PR TITLE
✅ Remove remaining feature flag test warning noise

### DIFF
--- a/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
@@ -33,6 +33,7 @@ describe('featureFlagContexts', () => {
   })
 
   afterEach(() => {
+    featureFlagContexts.stop()
     resetExperimentalFeatures()
     setupBuilder.cleanup()
   })

--- a/packages/rum-core/test/testSetupBuilder.ts
+++ b/packages/rum-core/test/testSetupBuilder.ts
@@ -88,6 +88,7 @@ export function setup(): TestSetupBuilder {
   let featureFlagContexts: FeatureFlagContexts = {
     findFeatureFlagEvaluations: () => undefined,
     addFeatureFlagEvaluation: noop,
+    stop: noop,
     getFeatureFlagBytesCount: () => 0,
   }
   let actionContexts: ActionContexts = {


### PR DESCRIPTION
## Motivation

Still some `The feature flag evaluation data is over 3KiB ...` warning in test output from time to time.

## Changes

**Root cause**: Since the byte count computation is throttled, a throttled computation could unexpectedly be executed while the `fakeByteCount` is set at `3073` from the warning behaviour test.

**Change**:  Cancel throttled computation after each test.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
