### PR TITLE
📝 Update FCP browser support

### DIFF
--- a/packages/rum/BROWSER_SUPPORT.md
+++ b/packages/rum/BROWSER_SUPPORT.md
@@ -19,7 +19,7 @@
 | resource timing   | ✅     | ✅      | ⚠️(2)  | ✅   | ✅             | ⚠️(2)      | ⚠️(3) | ❌     | ✅    |
 | navigation timing | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ✅    | ❌     | ✅    |
 | web vitals        | ✅     | ⚠️(1)   | ⚠️(1)  | ✅   | ✅             | ⚠️(1)      | ❌    | ❌     | ✅    |
-| FCP               | ✅     | ❌      | ❌     | ✅   | ✅             | ❌         | ❌    | ❌     | ✅    |
+| FCP               | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ❌    | ❌     | ✅    |
 
 1. FID only
 2. size information not available


### PR DESCRIPTION
## Motivation

Safari and Firefox now support [FCP timing](https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming).
Linked to https://github.com/DataDog/browser-sdk/issues/2174

## Changes

Update BROWSER_SUPPORT.md

## Testing

Tested on Safari laptop / mobile and Firefox via BrowserStack 

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
