### PR TITLE
✨ [RUMF-1573] Allow to provide custom fingerprint to RUM errors

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.spec.ts
+++ b/packages/core/src/domain/console/consoleObservable.spec.ts
@@ -110,4 +110,29 @@ describe('console error observable', () => {
       expect(stack).toContain('TypeError: foo')
     }
   })
+
+  it('should retrieve fingerprint from error', () => {
+    interface DatadogError extends Error {
+      dd_fingerprint?: string
+    }
+    const error = new Error('foo')
+    ;(error as DatadogError).dd_fingerprint = 'my-fingerprint'
+
+    // eslint-disable-next-line no-console
+    console.error(error)
+
+    const consoleLog = notifyLog.calls.mostRecent().args[0]
+    expect(consoleLog.fingerprint).toBe('my-fingerprint')
+  })
+
+  it('should sanitize error fingerprint', () => {
+    const error = new Error('foo')
+    ;(error as any).dd_fingerprint = 2
+
+    // eslint-disable-next-line no-console
+    console.error(error)
+
+    const consoleLog = notifyLog.calls.mostRecent().args[0]
+    expect(consoleLog.fingerprint).toBe('2')
+  })
 })

--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -1,5 +1,5 @@
 import { computeStackTrace } from '../tracekit'
-import { createHandlingStack, formatErrorMessage, toStackTraceString, isErrorWithFingerprint } from '../error/error'
+import { createHandlingStack, formatErrorMessage, toStackTraceString, tryToGetFingerprint } from '../error/error'
 import { mergeObservables, Observable } from '../../tools/observable'
 import { ConsoleApiName } from '../../tools/display'
 import { callMonitored } from '../../tools/monitor'
@@ -63,7 +63,7 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
   if (api === ConsoleApiName.error) {
     const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
     stack = firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined
-    fingerprint = isErrorWithFingerprint(firstErrorParam) ? String(firstErrorParam.dd_fingerprint) : undefined
+    fingerprint = tryToGetFingerprint(firstErrorParam)
     message = `console error: ${message}`
   }
 

--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -1,5 +1,5 @@
 import { computeStackTrace } from '../tracekit'
-import { createHandlingStack, formatErrorMessage, toStackTraceString } from '../error/error'
+import { createHandlingStack, formatErrorMessage, toStackTraceString, isErrorWithFingerprint } from '../error/error'
 import { mergeObservables, Observable } from '../../tools/observable'
 import { ConsoleApiName } from '../../tools/display'
 import { callMonitored } from '../../tools/monitor'
@@ -12,9 +12,10 @@ export interface ConsoleLog {
   api: ConsoleApiName
   stack?: string
   handlingStack?: string
+  fingerprint?: string
 }
 
-const consoleObservablesByApi: { [k in ConsoleApiName]?: Observable<ConsoleLog> } = {}
+let consoleObservablesByApi: { [k in ConsoleApiName]?: Observable<ConsoleLog> } = {}
 
 export function initConsoleObservable(apis: ConsoleApiName[]) {
   const consoleObservables = apis.map((api) => {
@@ -25,6 +26,10 @@ export function initConsoleObservable(apis: ConsoleApiName[]) {
   })
 
   return mergeObservables<ConsoleLog>(...consoleObservables)
+}
+
+export function resetConsoleObservable() {
+  consoleObservablesByApi = {}
 }
 
 /* eslint-disable no-console */
@@ -53,10 +58,12 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
   // Todo: remove console error prefix in the next major version
   let message = params.map((param) => formatConsoleParameters(param)).join(' ')
   let stack
+  let fingerprint
 
   if (api === ConsoleApiName.error) {
     const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
     stack = firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined
+    fingerprint = isErrorWithFingerprint(firstErrorParam) ? String(firstErrorParam.dd_fingerprint) : undefined
     message = `console error: ${message}`
   }
 
@@ -65,6 +72,7 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
     message,
     stack,
     handlingStack,
+    fingerprint,
   }
 }
 

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -67,7 +67,7 @@ function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stac
   return stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)
 }
 
-function isErrorWithFingerprint(error: unknown): error is { dd_fingerprint: unknown } {
+export function isErrorWithFingerprint(error: unknown): error is { dd_fingerprint: unknown } {
   return error instanceof Error && 'dd_fingerprint' in error
 }
 

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -41,6 +41,7 @@ export function computeRawError({
     : NO_ERROR_STACK_PRESENT_MESSAGE
   const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
   const type = stackTrace?.name
+  const fingerprint = isErrorWithFingerprint(originalError) ? String(originalError.dd_fingerprint) : undefined
 
   return {
     startClocks,
@@ -52,6 +53,7 @@ export function computeRawError({
     message,
     stack,
     causes,
+    fingerprint,
   }
 }
 
@@ -63,6 +65,10 @@ function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stac
     return true
   }
   return stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)
+}
+
+function isErrorWithFingerprint(error: unknown): error is { dd_fingerprint: unknown } {
+  return error instanceof Error && 'dd_fingerprint' in error
 }
 
 export function toStackTraceString(stack: StackTrace) {

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -41,7 +41,7 @@ export function computeRawError({
     : NO_ERROR_STACK_PRESENT_MESSAGE
   const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
   const type = stackTrace?.name
-  const fingerprint = isErrorWithFingerprint(originalError) ? String(originalError.dd_fingerprint) : undefined
+  const fingerprint = tryToGetFingerprint(originalError)
 
   return {
     startClocks,
@@ -67,8 +67,10 @@ function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stac
   return stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)
 }
 
-export function isErrorWithFingerprint(error: unknown): error is { dd_fingerprint: unknown } {
-  return error instanceof Error && 'dd_fingerprint' in error
+export function tryToGetFingerprint(originalError: unknown) {
+  return originalError instanceof Error && 'dd_fingerprint' in originalError
+    ? String(originalError.dd_fingerprint)
+    : undefined
 }
 
 export function toStackTraceString(stack: StackTrace) {

--- a/packages/core/src/domain/error/error.types.ts
+++ b/packages/core/src/domain/error/error.types.ts
@@ -21,6 +21,7 @@ export interface RawError {
   handling?: ErrorHandling
   handlingStack?: string
   causes?: RawErrorCause[]
+  fingerprint?: string
 }
 
 export const ErrorSource = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,7 +91,7 @@ export { initFetchObservable, FetchResolveContext, FetchStartContext, FetchConte
 export { createPageExitObservable, PageExitEvent, PageExitReason, isPageExitReason } from './browser/pageExitObservable'
 export * from './browser/addEventListener'
 export * from './tools/timer'
-export { initConsoleObservable, ConsoleLog } from './domain/console/consoleObservable'
+export { initConsoleObservable, resetConsoleObservable, ConsoleLog } from './domain/console/consoleObservable'
 export { BoundedBuffer } from './tools/boundedBuffer'
 export { catchUserErrors } from './tools/catchUserErrors'
 export { createContextManager, ContextManager } from './tools/serialisation/contextManager'

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
@@ -60,6 +60,28 @@ describe('console collection', () => {
     expect(rawLogsEvents[0].rawLogsEvent.error).toEqual({
       origin: ErrorSource.CONSOLE,
       stack: undefined,
+      fingerprint: undefined,
+    })
+  })
+
+  it('should retrieve fingerprint from console error', () => {
+    ;({ stop: stopConsoleCollection } = startConsoleCollection(
+      validateAndBuildLogsConfiguration({ ...initConfiguration, forwardErrorsToLogs: true })!,
+      lifeCycle
+    ))
+    interface DatadogError extends Error {
+      dd_fingerprint?: string
+    }
+    const error = new Error('foo')
+    ;(error as DatadogError).dd_fingerprint = 'my-fingerprint'
+
+    // eslint-disable-next-line no-console
+    console.error(error)
+
+    expect(rawLogsEvents[0].rawLogsEvent.error).toEqual({
+      origin: ErrorSource.CONSOLE,
+      stack: jasmine.any(String),
+      fingerprint: 'my-fingerprint',
     })
   })
 })

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
@@ -31,6 +31,7 @@ export function startConsoleCollection(configuration: LogsConfiguration, lifeCyc
             ? {
                 origin: ErrorSource.CONSOLE, // Todo: Remove in the next major release
                 stack: log.stack,
+                fingerprint: log.fingerprint,
               }
             : undefined,
         status: LogStatusForApi[log.api],

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -13,6 +13,7 @@ type Error = {
   kind?: string
   origin: ErrorSource // Todo: Remove in the next major release
   stack?: string
+  fingerprint?: string
   [k: string]: unknown
 }
 

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -227,7 +227,23 @@ describe('rum assembly', () => {
         })
       })
 
-      it('should reject modification on non sensitive and non context field', () => {
+      describe('allowed customer provided field', () => {
+        it('should allow modification of the error fingerprint', () => {
+          const { lifeCycle } = setupBuilder
+            .withConfiguration({
+              beforeSend: (event) => (event.error.fingerprint = 'my_fingerprint'),
+            })
+            .build()
+
+          notifyRawRumEvent(lifeCycle, {
+            rawRumEvent: createRawRumEvent(RumEventType.ERROR),
+          })
+
+          expect((serverRumEvents[0] as RumErrorEvent).error.fingerprint).toBe('my_fingerprint')
+        })
+      })
+
+      it('should reject modification of field not sensitive, context or customer provided', () => {
         const { lifeCycle } = setupBuilder
           .withConfiguration({
             beforeSend: (event: RumEvent) => ((event.view as any).id = 'modified'),

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -72,6 +72,7 @@ export function startRumAssembly(
         'error.message': 'string',
         'error.stack': 'string',
         'error.resource.url': 'string',
+        'error.fingerprint': 'string',
       },
       USER_CUSTOMIZABLE_FIELD_PATHS,
       VIEW_MODIFIABLE_FIELD_PATHS

--- a/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/errorCollection.ts
@@ -104,6 +104,7 @@ function processError(
       handling: error.handling,
       causes: error.causes,
       source_type: 'browser',
+      fingerprint: error.fingerprint,
     },
     type: RumEventType.ERROR as const,
   }

--- a/packages/rum-core/src/domain/rumEventsCollection/error/trackConsoleError.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/error/trackConsoleError.ts
@@ -7,6 +7,7 @@ export function trackConsoleError(errorObservable: Observable<RawError>) {
       startClocks: clocksNow(),
       message: consoleError.message,
       stack: consoleError.stack,
+      fingerprint: consoleError.fingerprint,
       source: ErrorSource.CONSOLE,
       handling: ErrorHandling.HANDLED,
       handlingStack: consoleError.handlingStack,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -59,6 +59,7 @@ export interface RawRumErrorEvent {
     type?: string
     stack?: string
     handling_stack?: string
+    fingerprint?: string
     source: ErrorSource
     message: string
     handling?: ErrorHandling

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -205,6 +205,10 @@ export type RumErrorEvent = CommonProperties &
        */
       readonly is_crash?: boolean
       /**
+       * Fingerprint used for Error Tracking custom grouping
+       */
+      fingerprint?: string
+      /**
        * The type of the error
        */
       readonly type?: string


### PR DESCRIPTION
## Motivation

Support [Error Tracking custom grouping](https://docs.datadoghq.com/logs/error_tracking/custom_grouping/#overview) for RUM errors.

## Changes

In order to use `my-custom-grouping-material` to group RUM errors into a single issue in Error Tracking, from the APIs:

```javascript
const error = new Error('oh snap')
error.dd_fingerprint = 'my-custom-grouping-material'

DD_RUM.addError(error)
// or
console.error(error) 
```

Or from beforeSend callback:

```javascript
DD_RUM.init({
  ...
  beforeSend: () => {
    if (event.type === 'error') {
      event.error.fingerprint = 'my-custom-grouping-material'
    }
  },
})
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
