### PR TITLE
👷 avoid running bs jobs in mergequeue staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ stages:
   except:
     refs:
       - main
+      - /^mq-working-branch-staging-[0-9]+-[0-9]+$/
       - /^staging-[0-9]+$/
       - /^release\//
       - schedules


### PR DESCRIPTION
## Motivation

Avoid to run browserstack job when `to-staging` is performed from mergequeue

## Changes

Exclude mergequeue staging branches from `bs-allowed-branches`.
Branch name example: `mq-working-branch-staging-17-1911075`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
