### PR TITLE
🐛 Revert Errors serialization behavior

### DIFF
--- a/packages/core/src/tools/serialisation/sanitize.spec.ts
+++ b/packages/core/src/tools/serialisation/sanitize.spec.ts
@@ -85,6 +85,23 @@ describe('sanitize', () => {
       })
     })
 
+    it('should serialize errors as JSON.stringify does', () => {
+      // Explicitely keep the previous behavior to avoid breaking changes in 4.x
+      // Browsers have different behaviors:
+      // IE11 adds a description field
+      // Safari IOS12 adds parts of the stack
+      const error = new Error('My Error')
+      expect(JSON.stringify(sanitize(error))).toEqual(JSON.stringify(error))
+    })
+
+    it('should serialize additional properties from errors', () => {
+      // JSON.stringify does not serialize message/name/stack from an Error, but
+      // will serialize all other additional properties
+      const error = new Error('My Error')
+      ;(error as any).additionalProperty = { inner: 'test' }
+      expect(JSON.stringify(sanitize(error))).toEqual(JSON.stringify(error))
+    })
+
     it('should serialize objects like maps as a string', () => {
       const map = new Map([
         ['a', 13],

--- a/packages/core/src/tools/serialisation/sanitize.spec.ts
+++ b/packages/core/src/tools/serialisation/sanitize.spec.ts
@@ -91,15 +91,15 @@ describe('sanitize', () => {
       // IE11 adds a description field
       // Safari IOS12 adds parts of the stack
       const error = new Error('My Error')
-      expect(JSON.stringify(sanitize(error))).toEqual(JSON.stringify(error))
+      expect(sanitize(error)).toEqual({ ...error })
     })
 
-    it('should serialize additional properties from errors', () => {
+    it('should keep additional properties from errors', () => {
       // JSON.stringify does not serialize message/name/stack from an Error, but
       // will serialize all other additional properties
       const error = new Error('My Error')
       ;(error as any).additionalProperty = { inner: 'test' }
-      expect(JSON.stringify(sanitize(error))).toEqual(JSON.stringify(error))
+      expect(sanitize(error)).toEqual({ ...error })
     })
 
     it('should serialize objects like maps as a string', () => {

--- a/packages/core/src/tools/serialisation/sanitize.ts
+++ b/packages/core/src/tools/serialisation/sanitize.ts
@@ -150,7 +150,7 @@ function sanitizeProcessor(
   }
 
   const sanitizedSource = sanitizeObjects(sourceToSanitize)
-  if (sanitizedSource !== '[Object]' && sanitizedSource !== '[Array]') {
+  if (sanitizedSource !== '[Object]' && sanitizedSource !== '[Array]' && sanitizedSource !== '[Error]') {
     return sanitizedSource
   }
 


### PR DESCRIPTION
## Motivation

Change of behavior when serializing errors:
https://github.com/DataDog/browser-sdk/issues/2195

Previously, an errror was serialized as an empty object `{}`. However, additional properties (added manually or from a custom error) were serialized:
```
const err = new Error('test')
err.myProp = 42

JSON.stringify(err)
=> { myProp : 42 }
```

Errors fall in the catch-all within the sanitize process, resulting in :
```
sanitize(err)
=> '[Error]'
```

## Changes

Specific handler for `instanceof` Error 
Serialize additional properties from errors
=> [Error] reverts back to `{}` (empty object) for errors without additional properties.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
