### PR TITLE
👷 fix mergequeue staging still executing bs jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ stages:
   except:
     refs:
       - main
-      - /^mq-working-branch-staging-[0-9]+-[0-9]+$/
+      - /^mq-working-branch-staging-[0-9]+-[a-z0-9]+$/
       - /^staging-[0-9]+$/
       - /^release\//
       - schedules


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/browser-sdk/pull/2192, mergequeue branch names can actually have letters, cf `mq-working-branch-staging-18-3d98637` 🤦‍♂️

## Changes

Tweak mergequeue staging regex

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
