### PR TITLE
👷 fix check release script

### DIFF
--- a/scripts/release/check-release.js
+++ b/scripts/release/check-release.js
@@ -68,7 +68,7 @@ function checkPackageDependencyVersions(packageJsonFile) {
     for (const [dependencyName, dependencyVersion] of Object.entries(dependencies)) {
       if (
         isBrowserSdkPublicPackageName(dependencyName) &&
-        !dependencyVersion.startsWith('file:') &&
+        !dependencyVersion.startsWith('portal:') &&
         dependencyVersion !== releaseVersion
       ) {
         throw new Error(


### PR DESCRIPTION
## Motivation

Following yarn 3 update, check release script is failing on test app dependencies 

## Changes

Change dependency check exclusion from `file:` to `portal:`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
