### PR TITLE
🐛 [RUMF-1576] fix support for tools that removes console.* references

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -1,7 +1,7 @@
 import { computeStackTrace } from '../tracekit'
 import { createHandlingStack, formatErrorMessage, toStackTraceString, tryToGetFingerprint } from '../error/error'
 import { mergeObservables, Observable } from '../../tools/observable'
-import { ConsoleApiName } from '../../tools/display'
+import { ConsoleApiName, globalConsole } from '../../tools/display'
 import { callMonitored } from '../../tools/monitor'
 import { sanitize } from '../../tools/serialisation/sanitize'
 import { find } from '../../tools/utils/polyfills'
@@ -32,12 +32,11 @@ export function resetConsoleObservable() {
   consoleObservablesByApi = {}
 }
 
-/* eslint-disable no-console */
 function createConsoleObservable(api: ConsoleApiName) {
   const observable = new Observable<ConsoleLog>(() => {
-    const originalConsoleApi = console[api]
+    const originalConsoleApi = globalConsole[api]
 
-    console[api] = (...params: unknown[]) => {
+    globalConsole[api] = (...params: unknown[]) => {
       originalConsoleApi.apply(console, params)
       const handlingStack = createHandlingStack()
 
@@ -47,7 +46,7 @@ function createConsoleObservable(api: ConsoleApiName) {
     }
 
     return () => {
-      console[api] = originalConsoleApi
+      globalConsole[api] = originalConsoleApi
     }
   })
 

--- a/packages/core/src/tools/display.ts
+++ b/packages/core/src/tools/display.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, local-rules/disallow-side-effects */
+/* eslint-disable local-rules/disallow-side-effects */
 /**
  * Keep references on console methods to avoid triggering patched behaviors
  *
@@ -33,8 +33,19 @@ export const display: Display = (api, ...args) => {
   display[api](...args)
 }
 
-display.debug = console.debug.bind(console)
-display.log = console.log.bind(console)
-display.info = console.info.bind(console)
-display.warn = console.warn.bind(console)
-display.error = console.error.bind(console)
+/**
+ * When building JS bundles, some users might use a plugin[1] or configuration[2] to remove
+ * "console.*" references. This causes some issue as we expect `console.*` to be defined.
+ * As a workaround, let's use a variable alias, so those expressions won't be taken into account by
+ * simple static analysis.
+ *
+ * [1]: https://babeljs.io/docs/babel-plugin-transform-remove-console/
+ * [2]: https://github.com/terser/terser#compress-options (look for drop_console)
+ */
+export const globalConsole = console
+
+display.debug = globalConsole.debug.bind(globalConsole)
+display.log = globalConsole.log.bind(globalConsole)
+display.info = globalConsole.info.bind(globalConsole)
+display.warn = globalConsole.warn.bind(globalConsole)
+display.error = globalConsole.error.bind(globalConsole)


### PR DESCRIPTION
## Motivation

When building JS bundles, some users might use a [plugin][1] or [configuration][2] to remove "console.*" references. This causes some issue as we expect `console.*` to be defined. As a workaround, let's use a variable alias, so those expressions won't be taken into account by simple static analysis.

[1]: https://babeljs.io/docs/babel-plugin-transform-remove-console/
[2]: https://github.com/terser/terser#compress-options
 
## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
