### PR TITLE
🐛 [Extension] Fix TypeError when document.cookie is empty

### DIFF
--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -50,7 +50,7 @@ async function getInfos(): Promise<SdkInfos> {
       `
         const cookieRawValue = document.cookie
           .split(';')
-          .map(cookie => cookie.match(/(\\S*?)=(.*)/).slice(1))
+          .map(cookie => cookie.match(/(\\S*?)=(.*)/)?.slice(1) || [])
           .find(([name, _]) => name === '_dd_s')
           ?.[1]
 


### PR DESCRIPTION
## Motivation

Navigating to a site with no cookies and opening the developer panel leads to the extension erroring: 

`Datadog Browser SDK extension: [useSdkInfos] Error while getting SDK infos: Error: Failed to evaluate code: TypeError: Cannot read properties of null (reading 'slice')`

## Changes

Handle the case where `document.cookie === ''` and perhaps other parsing issues.

## Testing

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
