### PR TITLE
📦👷 include upgraded dependencies in minor/patch deps upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,7 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "excludePackageNames": ["typescript", "puppeteer", "@types/express", "ajv", "ansi-regex"],
-      "excludePackagePatterns": ["webpack"],
+      "excludePackageNames": ["puppeteer", "ajv", "ansi-regex"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ]


### PR DESCRIPTION
## Motivation

* `@types/express` have been upgraded in https://github.com/DataDog/browser-sdk/pull/2170
* `webpack` related dependencies have been upgraded in https://github.com/DataDog/browser-sdk/pull/2212
* `typescript` have been upgraded in https://github.com/DataDog/browser-sdk/pull/2202

We can include them in the global minor/patch dependency PRs from renovate.

## Changes

Tweak renovate configuration

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
