### PR TITLE
👷 install dependencies in `bump-chrome-version` job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -489,6 +489,7 @@ bump-chrome-version-scheduled:
   before_script:
     - eval $(ssh-agent -s)
   script:
+    - yarn
     - node scripts/test/bump-chrome-driver-version.js
   artifacts:
     reports:


### PR DESCRIPTION

## Motivation

Since the Yarn upgrade, `node_modules` is not in the cache anymore, we actually need to install dependencies.


## Changes

Install dependencies in the gitlab job

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
