### PR TITLE
⚡ remove spec files from npm packages

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -2,3 +2,5 @@
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*
+/src/**/*.spec.ts
+/src/**/*.specHelper.ts

--- a/packages/logs/.npmignore
+++ b/packages/logs/.npmignore
@@ -3,3 +3,5 @@
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*
+/src/**/*.spec.ts
+/src/**/*.specHelper.ts

--- a/packages/rum-core/.npmignore
+++ b/packages/rum-core/.npmignore
@@ -2,3 +2,5 @@
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*
+/src/**/*.spec.ts
+/src/**/*.specHelper.ts

--- a/packages/rum-slim/.npmignore
+++ b/packages/rum-slim/.npmignore
@@ -3,3 +3,5 @@
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*
+/src/**/*.spec.ts
+/src/**/*.specHelper.ts

--- a/packages/rum/.npmignore
+++ b/packages/rum/.npmignore
@@ -3,5 +3,7 @@
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*
+/src/**/*.spec.ts
+/src/**/*.specHelper.ts
 !/internal/*
 !/internal-synthetics/*


### PR DESCRIPTION
## Motivation

Unnecessary bloat npm packages size.
cf https://github.com/DataDog/browser-sdk/issues/2221

## Changes

Exclude `spec` and `specHelper` files

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
