### PR TITLE
use a separate job to deploy US1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -286,25 +286,25 @@ deploy-prod-canary:
     - node ./scripts/deploy/deploy.js prod v${VERSION%%.*} $UPLOAD_PATH
     - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*} $UPLOAD_PATH
 
-deploy-prod-minor-dcs:
+step-1_deploy-prod-minor-dcs:
   extends:
     - .deploy-prod
   variables:
     UPLOAD_PATH: eu1,us3,us5,ap1
 
-deploy-prod-us1:
+step-2_deploy-prod-us1:
   extends:
     - .deploy-prod
   variables:
     UPLOAD_PATH: us1
 
-deploy-prod-root:
+step-3_deploy-prod-root:
   extends:
     - .deploy-prod
   variables:
     UPLOAD_PATH: root
 
-publish-npm:
+step-4_publish-npm:
   stage: deploy
   extends:
     - .base-configuration

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -271,7 +271,7 @@ deploy-prod-canary:
     - node ./scripts/deploy/deploy.js prod canary root
     - node ./scripts/deploy/upload-source-maps.js canary root
 
-deploy-prod-all-dcs:
+.deploy-prod:
   stage: deploy
   extends:
     - .base-configuration
@@ -283,23 +283,26 @@ deploy-prod-all-dcs:
     - VERSION=$(node -p -e "require('./lerna.json').version")
     - yarn
     - yarn build:bundle
-    - node ./scripts/deploy/deploy.js prod v${VERSION%%.*} us1,eu1,us3,us5,ap1
-    - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*} us1,eu1,us3,us5,ap1
+    - node ./scripts/deploy/deploy.js prod v${VERSION%%.*} $UPLOAD_PATH
+    - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*} $UPLOAD_PATH
+
+deploy-prod-minor-dcs:
+  extends:
+    - .deploy-prod
+  variables:
+    UPLOAD_PATH: eu1,us3,us5,ap1
+
+deploy-prod-us1:
+  extends:
+    - .deploy-prod
+  variables:
+    UPLOAD_PATH: us1
 
 deploy-prod-root:
-  stage: deploy
   extends:
-    - .base-configuration
-    - .tags
-  when: manual
-  allow_failure: false
-  script:
-    - export BUILD_MODE=release
-    - VERSION=$(node -p -e "require('./lerna.json').version")
-    - yarn
-    - yarn build:bundle
-    - node ./scripts/deploy/deploy.js prod v${VERSION%%.*} root
-    - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*} root
+    - .deploy-prod
+  variables:
+    UPLOAD_PATH: root
 
 publish-npm:
   stage: deploy


### PR DESCRIPTION
## Motivation

We reached more than 100 orgs using the new CDN URL on US1. When doing a release, deploy US1 separately to limit the scope.

## Changes

Split `deploy-prod-all-dcs` into `deploy-prod-minor-dcs` and `deploy-prod-us1`. I used gitlab `extend` to avoid repeating ourselves too much.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
