### PR TITLE
🔊 [RUMF-1577] Collect page lifecycle states

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -14,6 +14,7 @@ export enum ExperimentalFeature {
   PAGEHIDE = 'pagehide',
   FEATURE_FLAGS = 'feature_flags',
   RESOURCE_PAGE_STATES = 'resource_page_states',
+  PAGE_STATES = 'page_states',
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
 }
 

--- a/packages/core/src/tools/valueHistory.spec.ts
+++ b/packages/core/src/tools/valueHistory.spec.ts
@@ -5,6 +5,7 @@ import { addDuration, ONE_MINUTE } from './utils/timeUtils'
 import { CLEAR_OLD_VALUES_INTERVAL, ValueHistory } from './valueHistory'
 
 const EXPIRE_DELAY = 10 * ONE_MINUTE
+const MAX_ENTRIES = 5
 
 describe('valueHistory', () => {
   let valueHistory: ValueHistory<string>
@@ -12,7 +13,7 @@ describe('valueHistory', () => {
 
   beforeEach(() => {
     clock = mockClock()
-    valueHistory = new ValueHistory(EXPIRE_DELAY)
+    valueHistory = new ValueHistory(EXPIRE_DELAY, MAX_ENTRIES)
   })
 
   afterEach(() => {
@@ -134,5 +135,14 @@ describe('valueHistory', () => {
     clock.tick(EXPIRE_DELAY + CLEAR_OLD_VALUES_INTERVAL)
 
     expect(valueHistory.find(originalTime)).toBeUndefined()
+  })
+
+  it('should limit the number of entries', () => {
+    for (let i = 0; i < MAX_ENTRIES + 1; i++) {
+      valueHistory.add(`${i}`, 0 as RelativeTime)
+    }
+    const values = valueHistory.findAll()
+    expect(values.length).toEqual(5)
+    expect(values).toEqual(['5', '4', '3', '2', '1'])
   })
 })

--- a/packages/core/src/tools/valueHistory.spec.ts
+++ b/packages/core/src/tools/valueHistory.spec.ts
@@ -86,6 +86,17 @@ describe('valueHistory', () => {
 
       expect(valueHistory.findAll(15 as RelativeTime)).toEqual([])
     })
+
+    it('should return all context overlapping with the duration', () => {
+      valueHistory.add('foo', 0 as RelativeTime)
+      valueHistory.add('bar', 5 as RelativeTime).close(10 as RelativeTime)
+      valueHistory.add('baz', 10 as RelativeTime).close(15 as RelativeTime)
+      valueHistory.add('qux', 15 as RelativeTime)
+
+      expect(valueHistory.findAll(0 as RelativeTime, 20 as Duration)).toEqual(['qux', 'baz', 'bar', 'foo'])
+      expect(valueHistory.findAll(6 as RelativeTime, 5 as Duration)).toEqual(['baz', 'bar', 'foo'])
+      expect(valueHistory.findAll(11 as RelativeTime, 5 as Duration)).toEqual(['qux', 'baz', 'foo'])
+    })
   })
 
   describe('removing entries', () => {

--- a/packages/core/src/tools/valueHistory.ts
+++ b/packages/core/src/tools/valueHistory.ts
@@ -23,7 +23,7 @@ export class ValueHistory<Value> {
   private entries: Array<ValueHistoryEntry<Value>> = []
   private clearOldValuesInterval: TimeoutId
 
-  constructor(private expireDelay: number) {
+  constructor(private expireDelay: number, private maxEntries?: number) {
     this.clearOldValuesInterval = setInterval(() => this.clearOldValues(), CLEAR_OLD_VALUES_INTERVAL)
   }
 
@@ -46,7 +46,13 @@ export class ValueHistory<Value> {
         entry.endTime = endTime
       },
     }
+
+    if (this.maxEntries && this.entries.length >= this.maxEntries) {
+      this.entries.pop()
+    }
+
     this.entries.unshift(entry)
+
     return entry
   }
 

--- a/packages/core/src/tools/valueHistory.ts
+++ b/packages/core/src/tools/valueHistory.ts
@@ -1,7 +1,7 @@
 import { setInterval, clearInterval } from './timer'
 import type { TimeoutId } from './timer'
-import type { RelativeTime } from './utils/timeUtils'
-import { relativeNow, ONE_MINUTE } from './utils/timeUtils'
+import type { Duration, RelativeTime } from './utils/timeUtils'
+import { addDuration, relativeNow, ONE_MINUTE } from './utils/timeUtils'
 
 const END_OF_TIMES = Infinity as RelativeTime
 
@@ -77,12 +77,14 @@ export class ValueHistory<Value> {
   }
 
   /**
-   * Return all values that were active during `startTime`, or all currently active values if no
-   * `startTime` is provided.
+   * Return all values with an active period overlapping with the duration,
+   * or all values that were active during `startTime` if no duration is provided,
+   * or all currently active values if no `startTime` is provided.
    */
-  findAll(startTime: RelativeTime = END_OF_TIMES): Value[] {
+  findAll(startTime: RelativeTime = END_OF_TIMES, duration = 0 as Duration): Value[] {
+    const endTime = addDuration(startTime, duration)
     return this.entries
-      .filter((entry) => entry.startTime <= startTime && startTime <= entry.endTime)
+      .filter((entry) => entry.startTime <= endTime && startTime <= entry.endTime)
       .map((entry) => entry.value)
   }
 

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -25,6 +25,7 @@ import type { RumSessionManager } from '..'
 import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
 import { RumEventType } from '../rawRumEvent.types'
 import { startFeatureFlagContexts } from '../domain/contexts/featureFlagContext'
+import type { PageStateHistory } from '../domain/contexts/pageStateHistory'
 import { startRum, startRumEventCollection } from './startRum'
 
 function collectServerEvents(lifeCycle: LifeCycle) {
@@ -42,6 +43,7 @@ function startRumStub(
   location: Location,
   domMutationObservable: Observable<void>,
   locationChangeObservable: Observable<LocationChange>,
+  pageStateHistory: PageStateHistory,
   reportError: (error: RawError) => void
 ) {
   const { stop: rumEventCollectionStop, foregroundContexts } = startRumEventCollection(
@@ -66,6 +68,7 @@ function startRumStub(
     locationChangeObservable,
     foregroundContexts,
     startFeatureFlagContexts(lifeCycle),
+    pageStateHistory,
     noopRecorderApi
   )
 
@@ -88,7 +91,15 @@ describe('rum session', () => {
     }
 
     setupBuilder = setup().beforeBuild(
-      ({ location, lifeCycle, configuration, sessionManager, domMutationObservable, locationChangeObservable }) => {
+      ({
+        location,
+        lifeCycle,
+        configuration,
+        sessionManager,
+        domMutationObservable,
+        locationChangeObservable,
+        pageStateHistory,
+      }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
         return startRumStub(
           lifeCycle,
@@ -97,6 +108,7 @@ describe('rum session', () => {
           location,
           domMutationObservable,
           locationChangeObservable,
+          pageStateHistory,
           noop
         )
       }
@@ -141,7 +153,15 @@ describe('rum session keep alive', () => {
       .withFakeClock()
       .withSessionManager(sessionManager)
       .beforeBuild(
-        ({ location, lifeCycle, configuration, sessionManager, domMutationObservable, locationChangeObservable }) => {
+        ({
+          location,
+          lifeCycle,
+          configuration,
+          sessionManager,
+          domMutationObservable,
+          locationChangeObservable,
+          pageStateHistory,
+        }) => {
           serverRumEvents = collectServerEvents(lifeCycle)
           return startRumStub(
             lifeCycle,
@@ -150,6 +170,7 @@ describe('rum session keep alive', () => {
             location,
             domMutationObservable,
             locationChangeObservable,
+            pageStateHistory,
             noop
           )
         }
@@ -212,7 +233,15 @@ describe('rum events url', () => {
 
   beforeEach(() => {
     setupBuilder = setup().beforeBuild(
-      ({ location, lifeCycle, configuration, sessionManager, domMutationObservable, locationChangeObservable }) => {
+      ({
+        location,
+        lifeCycle,
+        configuration,
+        sessionManager,
+        domMutationObservable,
+        locationChangeObservable,
+        pageStateHistory,
+      }) => {
         serverRumEvents = collectServerEvents(lifeCycle)
         return startRumStub(
           lifeCycle,
@@ -221,6 +250,7 @@ describe('rum events url', () => {
           location,
           domMutationObservable,
           locationChangeObservable,
+          pageStateHistory,
           noop
         )
       }

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -102,21 +102,21 @@ export function startRum(
   const domMutationObservable = createDOMMutationObservable()
   const locationChangeObservable = createLocationChangeObservable(location)
 
-  const { viewContexts, foregroundContexts, urlContexts, actionContexts, addAction } = startRumEventCollection(
-    lifeCycle,
-    configuration,
-    location,
-    session,
-    locationChangeObservable,
-    domMutationObservable,
-    () => buildCommonContext(globalContextManager, userContextManager, recorderApi),
-    reportError
-  )
+  const { viewContexts, foregroundContexts, pageStateHistory, urlContexts, actionContexts, addAction } =
+    startRumEventCollection(
+      lifeCycle,
+      configuration,
+      location,
+      session,
+      locationChangeObservable,
+      domMutationObservable,
+      () => buildCommonContext(globalContextManager, userContextManager, recorderApi),
+      reportError
+    )
 
   addTelemetryConfiguration(serializeRumConfiguration(initConfiguration))
 
   startLongTaskCollection(lifeCycle, session)
-  const pageStateHistory = startPageStateHistory()
   startResourceCollection(lifeCycle, configuration, session, pageStateHistory)
   const { addTiming, startView } = startViewCollection(
     lifeCycle,
@@ -126,6 +126,7 @@ export function startRum(
     locationChangeObservable,
     foregroundContexts,
     featureFlagContexts,
+    pageStateHistory,
     recorderApi,
     initialViewOptions
   )
@@ -179,6 +180,8 @@ export function startRumEventCollection(
   const urlContexts = startUrlContexts(lifeCycle, locationChangeObservable, location)
 
   const foregroundContexts = startForegroundContexts()
+  const pageStateHistory = startPageStateHistory()
+
   const { addAction, actionContexts } = startActionCollection(
     lifeCycle,
     domMutationObservable,
@@ -200,6 +203,7 @@ export function startRumEventCollection(
   return {
     viewContexts,
     foregroundContexts,
+    pageStateHistory,
     urlContexts,
     addAction,
     actionContexts,

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
@@ -40,10 +40,18 @@ describe('pageStateHistory', () => {
     clock.tick(10)
     pageStateHistory.addPageState(PageState.TERMINATED)
 
-    expect(pageStateHistory.findAll(15 as RelativeTime, 20 as RelativeTime)).toEqual([
+    /*
+    page state time    0     10    20    30    40
+    event time                  15<-------->35
+    */
+    const event = {
+      startTime: 15 as RelativeTime,
+      duration: 20 as RelativeTime,
+    }
+    expect(pageStateHistory.findAll(event.startTime, event.duration)).toEqual([
       {
         state: PageState.PASSIVE,
-        start: 0 as ServerDuration,
+        start: -5000000 as ServerDuration,
       },
       {
         state: PageState.HIDDEN,

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
@@ -1,9 +1,9 @@
-import type { RelativeTime } from '@datadog/browser-core'
+import type { RelativeTime, ServerDuration } from '@datadog/browser-core'
 import { resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../test'
 import { setup } from '../../../test'
 import type { PageStateHistory } from './pageStateHistory'
-import { resetPageStates, startPageStateHistory, addPageState, PageState } from './pageStateHistory'
+import { startPageStateHistory, PageState } from './pageStateHistory'
 
 describe('pageStateHistory', () => {
   let pageStateHistory: PageStateHistory
@@ -20,7 +20,7 @@ describe('pageStateHistory', () => {
 
   afterEach(() => {
     setupBuilder.cleanup()
-    resetPageStates()
+    pageStateHistory.stop()
     resetExperimentalFeatures()
   })
 
@@ -36,56 +36,33 @@ describe('pageStateHistory', () => {
 
   it('should return the correct page states for the given time period', () => {
     const { clock } = setupBuilder.build()
-    resetPageStates()
 
-    addPageState(PageState.ACTIVE)
-
-    clock.tick(10)
-    addPageState(PageState.PASSIVE)
+    pageStateHistory.addPageState(PageState.ACTIVE)
 
     clock.tick(10)
-    addPageState(PageState.HIDDEN)
+    pageStateHistory.addPageState(PageState.PASSIVE)
 
     clock.tick(10)
-    addPageState(PageState.FROZEN)
+    pageStateHistory.addPageState(PageState.HIDDEN)
 
     clock.tick(10)
-    addPageState(PageState.TERMINATED)
+    pageStateHistory.addPageState(PageState.FROZEN)
+
+    clock.tick(10)
+    pageStateHistory.addPageState(PageState.TERMINATED)
 
     expect(pageStateHistory.findAll(15 as RelativeTime, 20 as RelativeTime)).toEqual([
       {
         state: PageState.PASSIVE,
-        startTime: 10 as RelativeTime,
+        start: 0 as ServerDuration,
       },
       {
         state: PageState.HIDDEN,
-        startTime: 20 as RelativeTime,
+        start: 5000000 as ServerDuration,
       },
       {
         state: PageState.FROZEN,
-        startTime: 30 as RelativeTime,
-      },
-    ])
-  })
-
-  it('should limit the history entry number', () => {
-    const limit = 1
-    const { clock } = setupBuilder.build()
-    resetPageStates()
-
-    clock.tick(10)
-    addPageState(PageState.ACTIVE, limit)
-
-    clock.tick(10)
-    addPageState(PageState.PASSIVE, limit)
-
-    clock.tick(10)
-    addPageState(PageState.HIDDEN, limit)
-
-    expect(pageStateHistory.findAll(0 as RelativeTime, 40 as RelativeTime)).toEqual([
-      {
-        state: PageState.HIDDEN,
-        startTime: 30 as RelativeTime,
+        start: 15000000 as ServerDuration,
       },
     ])
   })

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.ts
@@ -85,14 +85,12 @@ export function startPageStateHistory(
 
       for (let index = pageStateEntries.length - 1; index >= limit; index--) {
         const pageState = pageStateEntries[index]
-        // correct the start time to allays be higher or equal to the event start time
-        const correctedStartTime = eventStartTime > pageState.startTime ? eventStartTime : pageState.startTime
-        // recenter the start time to be relative to the event start time (ex: to be relative to the view start time)
-        const recenteredStartTime = elapsed(eventStartTime, correctedStartTime)
+        // compute the start time relative to the event start time (ex: to be relative to the view start time)
+        const relativeStartTime = elapsed(eventStartTime, pageState.startTime)
 
         pageStateServerEntries.push({
           state: pageState.state,
-          start: toServerDuration(recenteredStartTime),
+          start: toServerDuration(relativeStartTime),
         })
       }
 

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.ts
@@ -81,8 +81,10 @@ export function startPageStateHistory(
       }
 
       const pageStateServerEntries = []
+      // limit the number of entries to return
       const limit = Math.max(0, pageStateEntries.length - maxPageStateEntriesSelectable)
 
+      // loop page state entries backward to return the selected ones in desc order
       for (let index = pageStateEntries.length - 1; index >= limit; index--) {
         const pageState = pageStateEntries[index]
         // compute the start time relative to the event start time (ex: to be relative to the view start time)

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -8,7 +8,7 @@ import type {
   TimeStamp,
   RawErrorCause,
 } from '@datadog/browser-core'
-import type { PageStateEntry } from './domain/contexts/pageStateHistory'
+import type { PageState } from './domain/contexts/pageStateHistory'
 import type { RumSessionPlan } from './domain/rumSessionManager'
 
 export const enum RumEventType {
@@ -42,7 +42,7 @@ export interface RawRumResourceEvent {
     span_id?: string // not available for initial document tracing
     rule_psr?: number
     discarded: boolean
-    page_states?: PageStateEntry[]
+    page_states?: PageStateServerEntry[]
   }
 }
 
@@ -110,6 +110,7 @@ export interface RawRumViewEvent {
   _dd: {
     document_version: number
     replay_stats?: ReplayStats
+    page_states?: PageStateServerEntry[]
   }
 }
 
@@ -117,6 +118,8 @@ export interface InForegroundPeriod {
   start: ServerDuration
   duration: ServerDuration
 }
+
+export type PageStateServerEntry = { state: PageState; start: ServerDuration }
 
 export const enum ViewLoadingType {
   INITIAL_LOAD = 'initial_load',

--- a/packages/rum-core/test/testSetupBuilder.ts
+++ b/packages/rum-core/test/testSetupBuilder.ts
@@ -1,4 +1,4 @@
-import type { Context, ContextManager, TimeStamp } from '@datadog/browser-core'
+import type { Context, ContextManager, ServerDuration, TimeStamp } from '@datadog/browser-core'
 import { CustomerDataType, assign, combine, createContextManager, noop, Observable } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, buildLocation, SPEC_ENDPOINTS } from '@datadog/browser-core/test'
@@ -8,6 +8,7 @@ import { validateAndBuildRumConfiguration } from '../src/domain/configuration'
 import type { FeatureFlagContexts } from '../src/domain/contexts/featureFlagContext'
 import type { ForegroundContexts } from '../src/domain/contexts/foregroundContexts'
 import type { PageStateHistory } from '../src/domain/contexts/pageStateHistory'
+import { PageState } from '../src/domain/contexts/pageStateHistory'
 import type { UrlContexts } from '../src/domain/contexts/urlContexts'
 import type { ViewContexts } from '../src/domain/contexts/viewContexts'
 import type { RawRumEventCollectedData } from '../src/domain/lifeCycle'
@@ -102,7 +103,8 @@ export function setup(): TestSetupBuilder {
   const globalContextManager = createContextManager(CustomerDataType.GlobalContext)
   const userContextManager = createContextManager(CustomerDataType.User)
   const pageStateHistory: PageStateHistory = {
-    findAll: () => undefined,
+    findAll: () => [{ start: 0 as ServerDuration, state: PageState.ACTIVE }],
+    addPageState: noop,
     stop: noop,
   }
   const FAKE_APP_ID = 'appId'


### PR DESCRIPTION
## Motivation

Modern browsers today will sometimes suspend pages or discard them entirely when system resources are constrained, which can lead to unexpected behaviors. The [Page Lifecycle API](https://developer.chrome.com/blog/page-lifecycle-api/), provides lifecycle hooks so we can detect and handle these browser interventions.

This PR, collect page lifecycle state changes during a view to help Browser SDK issue investigations.

## Changes

- Value history findAll accepts a duration
- Add maxEntries limit to valueHistory
- Use valueHistory in pageSateHistory
- Collect page states changes during views
- Limit the number of page states collected per view

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
