### PR TITLE
💥 Promote track frustration as default action behaviour

### DIFF
--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -392,35 +392,6 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('trackFrustrations', () => {
-    it('defaults to false', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackFrustrations).toBeFalse()
-    })
-
-    it('the initialization parameter is set to provided value', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!.trackFrustrations
-      ).toBeTrue()
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: false })!.trackFrustrations
-      ).toBeFalse()
-    })
-
-    it('the initialization parameter the provided value is cast to boolean', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: 'foo' as any })!
-          .trackFrustrations
-      ).toBeTrue()
-    })
-
-    it('implies "trackUserInteractions"', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackFrustrations: true })!
-          .trackUserInteractions
-      ).toBeTrue()
-    })
-  })
-
   describe('trackViewsManually', () => {
     it('defaults to false', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackViewsManually).toBeFalse()

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -54,7 +54,6 @@ export interface RumInitConfiguration extends InitConfiguration {
    */
   trackInteractions?: boolean | undefined
   trackUserInteractions?: boolean | undefined
-  trackFrustrations?: boolean | undefined
   actionNameAttribute?: string | undefined
 
   // view options
@@ -77,7 +76,6 @@ export interface RumConfiguration extends Configuration {
   oldPlansBehavior: boolean
   sessionReplaySampleRate: number
   trackUserInteractions: boolean
-  trackFrustrations: boolean
   trackViewsManually: boolean
   trackResources: boolean | undefined
   trackLongTasks: boolean | undefined
@@ -136,7 +134,6 @@ export function validateAndBuildRumConfiguration(
   }
 
   const trackUserInteractions = !!(initConfiguration.trackUserInteractions ?? initConfiguration.trackInteractions)
-  const trackFrustrations = !!initConfiguration.trackFrustrations
 
   return assign(
     {
@@ -148,8 +145,7 @@ export function validateAndBuildRumConfiguration(
       traceSampleRate,
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],
-      trackUserInteractions: trackUserInteractions || trackFrustrations,
-      trackFrustrations,
+      trackUserInteractions,
       trackViewsManually: !!initConfiguration.trackViewsManually,
       trackResources: initConfiguration.trackResources,
       trackLongTasks: initConfiguration.trackLongTasks,
@@ -290,7 +286,6 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration): 
       default_privacy_level: configuration.defaultPrivacyLevel,
       use_excluded_activity_urls:
         Array.isArray(configuration.allowedTracingOrigins) && configuration.allowedTracingOrigins.length > 0,
-      track_frustrations: configuration.trackFrustrations,
       track_views_manually: configuration.trackViewsManually,
       track_user_interactions: configuration.trackUserInteractions ?? configuration.trackInteractions,
     },

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -691,7 +691,7 @@ describe('recorder', () => {
 
   describe('frustration records', () => {
     createTest('should detect a dead click and match it to mouse interaction record')
-      .withRum({ trackFrustrations: true })
+      .withRum({ trackUserInteractions: true })
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .run(async ({ serverEvents }) => {
@@ -715,7 +715,7 @@ describe('recorder', () => {
       })
 
     createTest('should detect a rage click and match it to mouse interaction records')
-      .withRum({ trackFrustrations: true })
+      .withRum({ trackUserInteractions: true })
       .withRumInit(initRumAndStartRecording)
       .withSetup(bundleSetup)
       .withBody(

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -62,7 +62,7 @@ describe('action collection', () => {
     })
 
   createTest('compute action target information before the UI changes')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button style="position: relative">click me</button>
@@ -91,7 +91,7 @@ describe('action collection', () => {
   // click event. Skip this test.
   if (getBrowserName() !== 'firefox') {
     createTest('does not report a click on the body when the target element changes between mousedown and mouseup')
-      .withRum({ trackFrustrations: true })
+      .withRum({ trackUserInteractions: true })
       .withBody(
         html`
           <button style="position: relative">click me</button>
@@ -160,15 +160,13 @@ describe('action collection', () => {
       })
 
       expect(resourceEvents.length).toBe(1)
-      expect(resourceEvents[0].action!.id).toBe(actionEvents[0].action.id!)
+      // resource action id should contain the collected action id + the discarded rage click id
+      expect(resourceEvents[0].action!.id.length).toBe(2)
+      expect(resourceEvents[0].action!.id).toContain(actionEvents[0].action.id!)
     })
 
   createTest('increment the view.action.count of the view active when the action started')
-    .withRum({
-      // Frustrations need to be collected for this test case, else actions leading to a new view
-      // are ignored
-      trackFrustrations: true,
-    })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button>click me</button>
@@ -195,7 +193,7 @@ describe('action collection', () => {
     })
 
   createTest('collect an "error click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button>click me</button>
@@ -226,7 +224,7 @@ describe('action collection', () => {
     })
 
   createTest('collect a "dead click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(html` <button>click me</button> `)
     .run(async ({ serverEvents }) => {
       const button = await $('button')
@@ -241,7 +239,7 @@ describe('action collection', () => {
     })
 
   createTest('do not consider a click on a checkbox as "dead_click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(html` <input type="checkbox" /> `)
     .run(async ({ serverEvents }) => {
       const input = await $('input')
@@ -254,7 +252,7 @@ describe('action collection', () => {
     })
 
   createTest('do not consider a click to change the value of a "range" input as "dead_click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(html` <input type="range" /> `)
     .run(async ({ serverEvents }) => {
       const input = await $('input')
@@ -267,7 +265,7 @@ describe('action collection', () => {
     })
 
   createTest('consider a click on an already checked "radio" input as "dead_click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(html` <input type="radio" checked /> `)
     .run(async ({ serverEvents }) => {
       const input = await $('input')
@@ -280,7 +278,7 @@ describe('action collection', () => {
     })
 
   createTest('do not consider a click on text input as "dead_click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(html` <input type="text" /> `)
     .run(async ({ serverEvents }) => {
       const input = await $('input')
@@ -293,7 +291,7 @@ describe('action collection', () => {
     })
 
   createTest('do not consider a click that open a new window as "dead_click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button>click me</button>
@@ -322,7 +320,7 @@ describe('action collection', () => {
     })
 
   createTest('collect a "rage click"')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button>click me</button>
@@ -345,7 +343,7 @@ describe('action collection', () => {
     })
 
   createTest('collect multiple frustrations in one action')
-    .withRum({ trackFrustrations: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(
       html`
         <button>click me</button>


### PR DESCRIPTION
## Motivation

Since the introduction of frustration signals ([official doc](https://docs.datadoghq.com/real_user_monitoring/frustration_signals/)), we have different action behaviors depending on `trackFrustrations` value:

  | trackFrustrations: false | trackFrustrations: true
-- | -- | --
No action name | No action created | Action created
No activity after click | No action created | Action created
View started after click | No action created | Action created
Additional click while an action is ongoing | No additional action created | Additional action created

We want to promote `trackFrustrations: true` as the only behaviour when tracking user interactions to avoid confusion and maintenance cost.

## Changes

- Automatically collect frustrations with `trackUserInteractions: true`
- Remove `trackFrustrations` init parameter 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
