### PR TITLE
🐛 when bridge is present, send a final view update on page exit

### DIFF
--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -71,13 +71,13 @@ export function startRum(
   }
   const featureFlagContexts = startFeatureFlagContexts(lifeCycle)
 
-  const session = !canUseEventBridge() ? startRumSessionManager(configuration, lifeCycle) : startRumSessionManagerStub()
+  const pageExitObservable = createPageExitObservable()
+  pageExitObservable.subscribe((event) => {
+    lifeCycle.notify(LifeCycleEventType.PAGE_EXITED, event)
+  })
 
+  const session = !canUseEventBridge() ? startRumSessionManager(configuration, lifeCycle) : startRumSessionManagerStub()
   if (!canUseEventBridge()) {
-    const pageExitObservable = createPageExitObservable()
-    pageExitObservable.subscribe((event) => {
-      lifeCycle.notify(LifeCycleEventType.PAGE_EXITED, event)
-    })
     const batch = startRumBatch(
       configuration,
       lifeCycle,


### PR DESCRIPTION
## Motivation

No reason to not have this behaviour when bridge is present

## Changes

Start page exit behaviour regardless of bridge present or not

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
