### PR TITLE
🐛 [RUMF-1583][recorder] do not ignore empty text node during serialization

### DIFF
--- a/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
@@ -557,6 +557,17 @@ describe('startMutationCollection', () => {
       })
     })
 
+    it('emits a mutation when a empty text node is changed', () => {
+      textNode.data = ''
+      serializeDocumentWithDefaults()
+      const { mutationCallbackSpy } = startMutationCollection()
+
+      textNode.data = 'bar'
+      flushMutations()
+
+      expect(mutationCallbackSpy).toHaveBeenCalledTimes(1)
+    })
+
     it('does not emit a mutation when a text node keeps the same value', () => {
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()

--- a/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
@@ -557,7 +557,7 @@ describe('startMutationCollection', () => {
       })
     })
 
-    it('emits a mutation when a empty text node is changed', () => {
+    it('emits a mutation when an empty text node is changed', () => {
       textNode.data = ''
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -633,6 +633,18 @@ describe('serializeNodeWithId', () => {
       })
     })
 
+    it('serializes an empty text node', () => {
+      const parentEl = document.createElement('bar')
+      const textNode = document.createTextNode('')
+      parentEl.appendChild(textNode)
+      expect(serializeNodeWithId(textNode, DEFAULT_OPTIONS)).toEqual({
+        type: NodeType.Text,
+        id: jasmine.any(Number) as unknown as number,
+        isStyle: undefined,
+        textContent: '',
+      })
+    })
+
     it('does not serialize text nodes with only white space if the ignoreWhiteSpace option is specified', () => {
       expect(
         serializeNodeWithId(document.createTextNode('   '), { ...DEFAULT_OPTIONS, ignoreWhiteSpace: true })

--- a/packages/rum/src/domain/record/serialization/serializeNode.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.ts
@@ -203,7 +203,7 @@ function serializeTextNode(textNode: Text, options: SerializeOptions): TextNode 
   // So just let it be undefined which is ok in this use case.
   const parentTagName = textNode.parentElement?.tagName
   const textContent = getTextContent(textNode, options.ignoreWhiteSpace || false, options.parentNodePrivacyLevel)
-  if (!textContent) {
+  if (textContent === undefined) {
     return
   }
   return {


### PR DESCRIPTION


## Motivation

If we ignore empty text nodes during serialization, any 'characterData' mutation will be discarded because we wouldn't know about the corresponding serialized node.

## Changes

Don't ignore empty text nodes

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
