### PR TITLE
💥[RUMF-1554] Drop some deprecated config parameters

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -65,23 +65,6 @@ describe('validateAndBuildConfiguration', () => {
       expect(displaySpy).not.toHaveBeenCalled()
     })
 
-    it('requires deprecated sampleRate to be a percentage', () => {
-      expect(
-        validateAndBuildConfiguration({ clientToken, sampleRate: 'foo' } as unknown as InitConfiguration)
-      ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Session Sample Rate should be a number between 0 and 100')
-
-      displaySpy.calls.reset()
-      expect(
-        validateAndBuildConfiguration({ clientToken, sampleRate: 200 } as unknown as InitConfiguration)
-      ).toBeUndefined()
-      expect(displaySpy).toHaveBeenCalledOnceWith('Session Sample Rate should be a number between 0 and 100')
-
-      displaySpy.calls.reset()
-      validateAndBuildConfiguration({ clientToken: 'yes', sampleRate: 1 })
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
     it('requires sessionSampleRate to be a percentage', () => {
       expect(
         validateAndBuildConfiguration({ clientToken, sessionSampleRate: 'foo' } as unknown as InitConfiguration)

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -24,10 +24,6 @@ export interface InitConfiguration {
   // global options
   clientToken: string
   beforeSend?: GenericBeforeSendCallback | undefined
-  /**
-   * @deprecated use sessionSampleRate instead
-   */
-  sampleRate?: number | undefined
   sessionSampleRate?: number | undefined
   telemetrySampleRate?: number | undefined
   silentMultipleInit?: boolean | undefined
@@ -93,8 +89,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     return
   }
 
-  const sessionSampleRate = initConfiguration.sessionSampleRate ?? initConfiguration.sampleRate
-  if (sessionSampleRate !== undefined && !isPercentage(sessionSampleRate)) {
+  if (initConfiguration.sessionSampleRate !== undefined && !isPercentage(initConfiguration.sessionSampleRate)) {
     display.error('Session Sample Rate should be a number between 0 and 100')
     return
   }
@@ -126,7 +121,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       beforeSend:
         initConfiguration.beforeSend && catchUserErrors(initConfiguration.beforeSend, 'beforeSend threw an error:'),
       cookieOptions: buildCookieOptions(initConfiguration),
-      sessionSampleRate: sessionSampleRate ?? 100,
+      sessionSampleRate: initConfiguration.sessionSampleRate ?? 100,
       telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
       telemetryConfigurationSampleRate: initConfiguration.telemetryConfigurationSampleRate ?? 5,
       service: initConfiguration.service,
@@ -176,7 +171,7 @@ function mustUseSecureCookie(initConfiguration: InitConfiguration) {
 
 export function serializeConfiguration(configuration: InitConfiguration): Partial<RawTelemetryConfiguration> {
   return {
-    session_sample_rate: configuration.sessionSampleRate ?? configuration.sampleRate,
+    session_sample_rate: configuration.sessionSampleRate,
     telemetry_sample_rate: configuration.telemetrySampleRate,
     telemetry_configuration_sample_rate: configuration.telemetryConfigurationSampleRate,
     use_before_send: !!configuration.beforeSend,

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -36,10 +36,6 @@ export interface InitConfiguration {
 
   // transport options
   proxy?: string | undefined
-  /**
-   * @deprecated use `proxy` instead
-   */
-  proxyUrl?: string | undefined
   site?: string | undefined
 
   // tag and context options
@@ -179,7 +175,6 @@ function mustUseSecureCookie(initConfiguration: InitConfiguration) {
 }
 
 export function serializeConfiguration(configuration: InitConfiguration): Partial<RawTelemetryConfiguration> {
-  const proxy = configuration.proxy ?? configuration.proxyUrl
   return {
     session_sample_rate: configuration.sessionSampleRate ?? configuration.sampleRate,
     telemetry_sample_rate: configuration.telemetrySampleRate,
@@ -187,7 +182,7 @@ export function serializeConfiguration(configuration: InitConfiguration): Partia
     use_before_send: !!configuration.beforeSend,
     use_cross_site_session_cookie: configuration.useCrossSiteSessionCookie,
     use_secure_session_cookie: configuration.useSecureSessionCookie,
-    use_proxy: proxy !== undefined ? !!proxy : undefined,
+    use_proxy: !!configuration.proxy,
     silent_multiple_init: configuration.silentMultipleInit,
     track_session_across_subdomains: configuration.trackSessionAcrossSubdomains,
     track_resources: configuration.trackResources,

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -63,46 +63,6 @@ describe('endpointBuilder', () => {
         )
       ).toBeTrue()
     })
-
-    it('uses `proxy` over `proxyUrl`', () => {
-      expect(
-        createEndpointBuilder(
-          { ...initConfiguration, proxy: 'https://proxy.io/path', proxyUrl: 'https://legacy-proxy.io/path' },
-          'rum',
-          []
-        ).build('xhr')
-      ).toMatch(/^https:\/\/proxy.io\/path\?/)
-
-      expect(
-        createEndpointBuilder(
-          { ...initConfiguration, proxy: false as any, proxyUrl: 'https://legacy-proxy.io/path' },
-          'rum',
-          []
-        ).build('xhr')
-      ).toMatch(/^https:\/\/rum.browser-intake-datadoghq.com\//)
-    })
-  })
-
-  describe('deprecated proxyUrl configuration', () => {
-    it('should replace the full intake endpoint by the proxyUrl and set it in the attribute ddforward', () => {
-      expect(
-        createEndpointBuilder({ ...initConfiguration, proxyUrl: 'https://proxy.io/path' }, 'rum', []).build('xhr')
-      ).toMatch(
-        `https://proxy.io/path\\?ddforward=${encodeURIComponent(
-          `https://rum.browser-intake-datadoghq.com/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
-            '&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)&batch_time=(.*)'
-        )}`
-      )
-    })
-
-    it('normalizes the proxy url', () => {
-      expect(
-        startsWith(
-          createEndpointBuilder({ ...initConfiguration, proxyUrl: '/path' }, 'rum', []).build('xhr'),
-          `${location.origin}/path?ddforward`
-        )
-      ).toBeTrue()
-    })
   })
 
   describe('tags', () => {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -59,22 +59,12 @@ function createEndpointUrlWithParametersBuilder(
   endpointType: EndpointType
 ): (parameters: string) => string {
   const path = `/api/v2/${INTAKE_TRACKS[endpointType]}`
-
-  const { proxy, proxyUrl } = initConfiguration
+  const proxy = initConfiguration.proxy
   if (proxy) {
     const normalizedProxyUrl = normalizeUrl(proxy)
     return (parameters) => `${normalizedProxyUrl}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}`
   }
-
   const host = buildEndpointHost(initConfiguration, endpointType)
-
-  if (proxy === undefined && proxyUrl) {
-    // TODO: remove this in a future major.
-    const normalizedProxyUrl = normalizeUrl(proxyUrl)
-    return (parameters) =>
-      `${normalizedProxyUrl}?ddforward=${encodeURIComponent(`https://${host}${path}?${parameters}`)}`
-  }
-
   return (parameters) => `https://${host}${path}?${parameters}`
 }
 

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -97,44 +97,34 @@ describe('transportConfiguration', () => {
       const configuration = computeTransportConfiguration({ clientToken })
       expect(configuration.isIntakeUrl('https://www.foo.com')).toBe(false)
     })
-    ;[
-      {
-        proxyConfigurationName: 'proxy' as const,
-        intakeUrl: '/api/v2/rum',
-      },
-      {
-        proxyConfigurationName: 'proxyUrl' as const,
-        intakeUrl: 'https://rum.browser-intake-datadoghq.com/api/v2/rum',
-      },
-    ].forEach(({ proxyConfigurationName, intakeUrl }) => {
-      describe(`${proxyConfigurationName} configuration`, () => {
-        it('should detect proxy intake request', () => {
-          let configuration = computeTransportConfiguration({
-            clientToken,
-            [proxyConfigurationName]: 'https://www.proxy.com',
-          })
-          expect(
-            configuration.isIntakeUrl(`https://www.proxy.com/?ddforward=${encodeURIComponent(`${intakeUrl}?foo=bar`)}`)
-          ).toBe(true)
 
-          configuration = computeTransportConfiguration({
-            clientToken,
-            [proxyConfigurationName]: 'https://www.proxy.com/custom/path',
-          })
-          expect(
-            configuration.isIntakeUrl(
-              `https://www.proxy.com/custom/path?ddforward=${encodeURIComponent(`${intakeUrl}?foo=bar`)}`
-            )
-          ).toBe(true)
+    describe('proxy configuration', () => {
+      it('should detect proxy intake request', () => {
+        let configuration = computeTransportConfiguration({
+          clientToken,
+          proxy: 'https://www.proxy.com',
         })
+        expect(
+          configuration.isIntakeUrl(`https://www.proxy.com/?ddforward=${encodeURIComponent('/api/v2/rum?foo=bar')}`)
+        ).toBe(true)
 
-        it('should not detect request done on the same host as the proxy', () => {
-          const configuration = computeTransportConfiguration({
-            clientToken,
-            [proxyConfigurationName]: 'https://www.proxy.com',
-          })
-          expect(configuration.isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
+        configuration = computeTransportConfiguration({
+          clientToken,
+          proxy: 'https://www.proxy.com/custom/path',
         })
+        expect(
+          configuration.isIntakeUrl(
+            `https://www.proxy.com/custom/path?ddforward=${encodeURIComponent('/api/v2/rum?foo=bar')}`
+          )
+        ).toBe(true)
+      })
+
+      it('should not detect request done on the same host as the proxy', () => {
+        const configuration = computeTransportConfiguration({
+          clientToken,
+          proxy: 'https://www.proxy.com',
+        })
+        expect(configuration.isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
       })
     })
     ;[

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -278,30 +278,6 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('deprecated trackInteractions', () => {
-    it('defaults to false', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackUserInteractions).toBeFalse()
-    })
-
-    it('is set to provided value', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: true })!
-          .trackUserInteractions
-      ).toBeTrue()
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: false })!
-          .trackUserInteractions
-      ).toBeFalse()
-    })
-
-    it('the provided value is cast to boolean', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackInteractions: 'foo' as any })!
-          .trackUserInteractions
-      ).toBeTrue()
-    })
-  })
-
   describe('trackUserInteractions', () => {
     it('defaults to false', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackUserInteractions).toBeFalse()

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -189,47 +189,6 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('allowedTracingOrigins', () => {
-    it('is set to provided value', () => {
-      expect(
-        validateAndBuildRumConfiguration({
-          ...DEFAULT_INIT_CONFIGURATION,
-          allowedTracingOrigins: ['foo'],
-          service: 'bar',
-        })!.allowedTracingUrls
-      ).toEqual([{ match: 'foo', propagatorTypes: ['datadog'] }])
-    })
-
-    it('accepts functions', () => {
-      const originMatchSpy = jasmine.createSpy<(origin: string) => boolean>()
-
-      const tracingUrlOptionMatch = validateAndBuildRumConfiguration({
-        ...DEFAULT_INIT_CONFIGURATION,
-        allowedTracingOrigins: [originMatchSpy],
-        service: 'bar',
-      })!.allowedTracingUrls[0].match as (url: string) => boolean
-
-      expect(typeof tracingUrlOptionMatch).toBe('function')
-      // Replicating behavior from allowedTracingOrigins, new function will treat the origin part of the URL
-      tracingUrlOptionMatch('https://my.origin.com/api')
-      expect(originMatchSpy).toHaveBeenCalledWith('https://my.origin.com')
-    })
-
-    it('does not validate the configuration if a value is provided and service is undefined', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, allowedTracingOrigins: ['foo'] })
-      ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Service needs to be configured when tracing is enabled')
-    })
-
-    it('does not validate the configuration if an incorrect value is provided', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, allowedTracingOrigins: 'foo' as any })
-      ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Allowed Tracing Origins should be an array')
-    })
-  })
-
   describe('allowedTracingUrls', () => {
     it('defaults to an empty array', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.allowedTracingUrls).toEqual([])

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -141,31 +141,6 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
-  describe('deprecated tracingSampleRate', () => {
-    it('defaults to undefined if the option is not provided', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.traceSampleRate).toBeUndefined()
-    })
-
-    it('is set to provided value', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 50 })!.traceSampleRate
-      ).toBe(50)
-    })
-
-    it('does not validate the configuration if an incorrect value is provided', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 'foo' as any })
-      ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Trace Sample Rate should be a number between 0 and 100')
-
-      displayErrorSpy.calls.reset()
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, tracingSampleRate: 200 })
-      ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Trace Sample Rate should be a number between 0 and 100')
-    })
-  })
-
   describe('traceSampleRate', () => {
     it('defaults to undefined if the option is not provided', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.traceSampleRate).toBeUndefined()

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -149,7 +149,7 @@ export function validateAndBuildRumConfiguration(
 }
 
 /**
- * Validates allowedTracingUrls and convert match options to tracing options
+ * Validates allowedTracingUrls and converts match options to tracing options
  */
 function validateAndBuildTracingOptions(initConfiguration: RumInitConfiguration): TracingOption[] | undefined {
   // Handle allowedTracingUrls first

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -28,10 +28,6 @@ export interface RumInitConfiguration extends InitConfiguration {
 
   // tracing options
   allowedTracingUrls?: Array<MatchOption | TracingOption> | undefined
-  /**
-   * @deprecated use traceSampleRate instead
-   */
-  tracingSampleRate?: number | undefined
   traceSampleRate?: number | undefined
 
   // replay options
@@ -109,8 +105,7 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  const traceSampleRate = initConfiguration.traceSampleRate ?? initConfiguration.tracingSampleRate
-  if (traceSampleRate !== undefined && !isPercentage(traceSampleRate)) {
+  if (initConfiguration.traceSampleRate !== undefined && !isPercentage(initConfiguration.traceSampleRate)) {
     display.error('Trace Sample Rate should be a number between 0 and 100')
     return
   }
@@ -140,7 +135,7 @@ export function validateAndBuildRumConfiguration(
       actionNameAttribute: initConfiguration.actionNameAttribute,
       sessionReplaySampleRate: initConfiguration.sessionReplaySampleRate ?? premiumSampleRate ?? 100,
       oldPlansBehavior: initConfiguration.sessionReplaySampleRate === undefined,
-      traceSampleRate,
+      traceSampleRate: initConfiguration.traceSampleRate,
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],
       trackUserInteractions: trackUserInteractions || trackFrustrations,
@@ -221,7 +216,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration): 
       premium_sample_rate: configuration.premiumSampleRate,
       replay_sample_rate: configuration.replaySampleRate,
       session_replay_sample_rate: configuration.sessionReplaySampleRate,
-      trace_sample_rate: configuration.traceSampleRate ?? configuration.tracingSampleRate,
+      trace_sample_rate: configuration.traceSampleRate,
       action_name_attribute: configuration.actionNameAttribute,
       use_allowed_tracing_urls:
         Array.isArray(configuration.allowedTracingUrls) && configuration.allowedTracingUrls.length > 0,

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -152,7 +152,6 @@ export function validateAndBuildRumConfiguration(
  * Validates allowedTracingUrls and converts match options to tracing options
  */
 function validateAndBuildTracingOptions(initConfiguration: RumInitConfiguration): TracingOption[] | undefined {
-  // Handle allowedTracingUrls first
   if (initConfiguration.allowedTracingUrls !== undefined) {
     if (!Array.isArray(initConfiguration.allowedTracingUrls)) {
       display.error('Allowed Tracing URLs should be an array')

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -40,10 +40,6 @@ export interface RumInitConfiguration extends InitConfiguration {
   sessionReplaySampleRate?: number | undefined
 
   // action options
-  /**
-   * @deprecated use trackUserInteractions instead
-   */
-  trackInteractions?: boolean | undefined
   trackUserInteractions?: boolean | undefined
   trackFrustrations?: boolean | undefined
   actionNameAttribute?: string | undefined
@@ -125,7 +121,6 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  const trackUserInteractions = !!(initConfiguration.trackUserInteractions ?? initConfiguration.trackInteractions)
   const trackFrustrations = !!initConfiguration.trackFrustrations
 
   return assign(
@@ -138,7 +133,7 @@ export function validateAndBuildRumConfiguration(
       traceSampleRate: initConfiguration.traceSampleRate,
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],
-      trackUserInteractions: trackUserInteractions || trackFrustrations,
+      trackUserInteractions: !!initConfiguration.trackUserInteractions || trackFrustrations,
       trackFrustrations,
       trackViewsManually: !!initConfiguration.trackViewsManually,
       trackResources: initConfiguration.trackResources,
@@ -226,7 +221,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration): 
         Array.isArray(configuration.excludedActivityUrls) && configuration.excludedActivityUrls.length > 0,
       track_frustrations: configuration.trackFrustrations,
       track_views_manually: configuration.trackViewsManually,
-      track_user_interactions: configuration.trackUserInteractions ?? configuration.trackInteractions,
+      track_user_interactions: configuration.trackUserInteractions,
     },
     baseSerializedConfiguration
   )

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -81,7 +81,7 @@ async function setupSDK(page: Page, options: ProfilingOptions) {
             clientToken: 'xxx',
             applicationId: 'xxx',
             site: 'datadoghq.com',
-            trackInteractions: true,
+            trackUserInteractions: true,
             proxy: ${JSON.stringify(options.proxy.origin)}
           })
           ${options.startRecording ? 'window.DD_RUM.startSessionReplayRecording()' : ''}

--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -82,7 +82,7 @@ async function setupSDK(page: Page, options: ProfilingOptions) {
             applicationId: 'xxx',
             site: 'datadoghq.com',
             trackInteractions: true,
-            proxyUrl: ${JSON.stringify(options.proxy.origin)}
+            proxy: ${JSON.stringify(options.proxy.origin)}
           })
           ${options.startRecording ? 'window.DD_RUM.startSessionReplayRecording()' : ''}
         })

--- a/test/e2e/scenario/rum/tracing.scenario.ts
+++ b/test/e2e/scenario/rum/tracing.scenario.ts
@@ -4,7 +4,7 @@ import { browserExecuteAsync, sendXhr } from '../../lib/helpers/browser'
 
 describe('tracing', () => {
   createTest('trace xhr')
-    .withRum({ service: 'service', allowedTracingOrigins: ['LOCATION_ORIGIN'] })
+    .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
     .run(async ({ serverEvents }) => {
       const rawHeaders = await sendXhr('/headers', [
         ['x-foo', 'bar'],
@@ -16,7 +16,7 @@ describe('tracing', () => {
     })
 
   createTest('trace fetch')
-    .withRum({ service: 'service', allowedTracingOrigins: ['LOCATION_ORIGIN'] })
+    .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
     .run(async ({ serverEvents }) => {
       const rawHeaders = await browserExecuteAsync<string | Error>((done) => {
         window
@@ -39,7 +39,7 @@ describe('tracing', () => {
     })
 
   createTest('trace fetch with Request argument')
-    .withRum({ service: 'service', allowedTracingOrigins: ['LOCATION_ORIGIN'] })
+    .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
     .run(async ({ serverEvents }) => {
       const rawHeaders = await browserExecuteAsync<string | Error>((done) => {
         window


### PR DESCRIPTION
## Motivation

Some config parameters have been replaced by new ones

## Changes

- drop `proxyUrl` in favour of `proxy`
- drop `sampleRate` in favour of `sessionSampleRate`
- drop `allowedTracingOrigins` in favour of `allowedTracingUrls`
- drop `tracingSampleRate` in favour of `traceSampleRate`
- drop `trackInteractions` in favour of `trackUserInteractions`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
