### PR TITLE
💥 [RUMF-1554] Drop some deprecated public APIs

### DIFF
--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -61,12 +61,12 @@ async function getInfos(): Promise<SdkInfos> {
           version: window.DD_RUM?.version,
           config: window.DD_RUM?.getInitConfiguration?.(),
           internalContext: window.DD_RUM?.getInternalContext?.(),
-          globalContext: window.DD_RUM?.getRumGlobalContext?.(),
+          globalContext: window.DD_RUM?.getGlobalContext?.(),
         }
         const logs = window.DD_RUM && {
           version: window.DD_LOGS?.version,
           config: window.DD_LOGS?.getInitConfiguration?.(),
-          globalContext: window.DD_LOGS?.getLoggerGlobalContext?.(),
+          globalContext: window.DD_LOGS?.getGlobalContext?.(),
         }
         return { rum, logs, cookie }
       `

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -213,9 +213,9 @@ describe('logs entry', () => {
       })
 
       it('stores a deep copy of the global context', () => {
-        LOGS.addLoggerGlobalContext('foo', 'bar')
+        LOGS.setGlobalContextProperty('foo', 'bar')
         LOGS.logger.log('message')
-        LOGS.addLoggerGlobalContext('foo', 'baz')
+        LOGS.setGlobalContextProperty('foo', 'baz')
 
         LOGS.init(DEFAULT_INIT_CONFIGURATION)
 
@@ -322,7 +322,7 @@ describe('logs entry', () => {
         LOGS = makeLogsPublicApi(startLogs)
       })
 
-      it('should return undefined if not initalized', () => {
+      it('should return undefined if not initialized', () => {
         expect(LOGS.getInternalContext()).toBeUndefined()
       })
 

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -99,20 +99,12 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       isAlreadyInitialized = true
     }),
 
-    /** @deprecated: use getGlobalContext instead */
-    getLoggerGlobalContext: monitor(globalContextManager.get),
     getGlobalContext: monitor(globalContextManager.getContext),
 
-    /** @deprecated: use setGlobalContext instead */
-    setLoggerGlobalContext: monitor(globalContextManager.set),
     setGlobalContext: monitor(globalContextManager.setContext),
 
-    /** @deprecated: use setGlobalContextProperty instead */
-    addLoggerGlobalContext: monitor(globalContextManager.add),
     setGlobalContextProperty: monitor(globalContextManager.setContextProperty),
 
-    /** @deprecated: use removeGlobalContextProperty instead */
-    removeLoggerGlobalContext: monitor(globalContextManager.remove),
     removeGlobalContextProperty: monitor(globalContextManager.removeContextProperty),
 
     clearGlobalContext: monitor(globalContextManager.clearContext),

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -460,7 +460,7 @@ describe('rum public api', () => {
     it('should remove the user', () => {
       const user = { id: 'foo', name: 'bar', email: 'qux' }
       rumPublicApi.setUser(user)
-      rumPublicApi.removeUser()
+      rumPublicApi.clearUser()
       rumPublicApi.addAction('message')
 
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -263,9 +263,9 @@ describe('rum public api', () => {
       })
 
       it('stores a deep copy of the global context', () => {
-        rumPublicApi.addRumGlobalContext('foo', 'bar')
+        rumPublicApi.setGlobalContextProperty('foo', 'bar')
         rumPublicApi.addAction('message')
-        rumPublicApi.addRumGlobalContext('foo', 'baz')
+        rumPublicApi.setGlobalContextProperty('foo', 'baz')
 
         rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
@@ -365,9 +365,9 @@ describe('rum public api', () => {
       })
 
       it('stores a deep copy of the global context', () => {
-        rumPublicApi.addRumGlobalContext('foo', 'bar')
+        rumPublicApi.setGlobalContextProperty('foo', 'bar')
         rumPublicApi.addError(new Error('message'))
-        rumPublicApi.addRumGlobalContext('foo', 'baz')
+        rumPublicApi.setGlobalContextProperty('foo', 'baz')
 
         rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -249,8 +249,6 @@ export function makeRumPublicApi(
 
     removeUserProperty: monitor(userContextManager.removeContextProperty),
 
-    /** @deprecated: renamed to clearUser */
-    removeUser: monitor(userContextManager.clearContext),
     clearUser: monitor(userContextManager.clearContext),
 
     startView,

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -188,20 +188,12 @@ export function makeRumPublicApi(
   const rumPublicApi = makePublicApi({
     init: monitor(initRum),
 
-    /** @deprecated: use setGlobalContextProperty instead */
-    addRumGlobalContext: monitor(globalContextManager.add),
     setGlobalContextProperty: monitor(globalContextManager.setContextProperty),
 
-    /** @deprecated: use removeGlobalContextProperty instead */
-    removeRumGlobalContext: monitor(globalContextManager.remove),
     removeGlobalContextProperty: monitor(globalContextManager.removeContextProperty),
 
-    /** @deprecated: use getGlobalContext instead */
-    getRumGlobalContext: monitor(globalContextManager.get),
     getGlobalContext: monitor(globalContextManager.getContext),
 
-    /** @deprecated: use setGlobalContext instead */
-    setRumGlobalContext: monitor(globalContextManager.set),
     setGlobalContext: monitor(globalContextManager.setContext),
 
     clearGlobalContext: monitor(globalContextManager.clearContext),

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -131,8 +131,8 @@ describe('beforeSend', () => {
     .withRumSlim()
     .withRumInit((configuration) => {
       window.DD_RUM!.init(configuration)
-      window.DD_RUM!.addRumGlobalContext('foo', 'baz')
-      window.DD_RUM!.addRumGlobalContext('zig', 'zag')
+      window.DD_RUM!.setGlobalContextProperty('foo', 'baz')
+      window.DD_RUM!.setGlobalContextProperty('zig', 'zag')
     })
     .run(async ({ serverEvents }) => {
       await flushEvents()


### PR DESCRIPTION
## Motivation

Housekeeping

## Changes

- drop `DD_RUM.removeUser` in favour of `DD_RUM.clearUser`
- drop `DD_RUM.addRumGlobalContext` in favour of `DD_RUM.setGlobalContextProperty`
- drop `DD_RUM.removeRumGlobalContext` in favour of `DD_RUM.removeGlobalContextProperty`
- drop `DD_RUM.getRumGlobalContext` in favour of `DD_RUM.getGlobalContext`
- drop `DD_RUM.setRumGlobalContext` in favour of `DD_RUM.setGlobalContext`
- drop `DD_LOGS.addLoggerGlobalContext` in favour of `DD_LOGS.setGlobalContextProperty`
- drop `DD_LOGS.removeLoggerGlobalContext` in favour of `DD_LOGS.removeGlobalContextProperty`
- drop `DD_LOGS.getLoggerGlobalContext` in favour of `DD_LOGS.getGlobalContext`
- drop `DD_LOGS.setLoggerGlobalContext` in favour of `DD_LOGS.setGlobalContext`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
