### PR TITLE
🐛 [devext] unregister isolated content script listener

### DIFF
--- a/developer-extension/src/content-scripts/isolated.ts
+++ b/developer-extension/src/content-scripts/isolated.ts
@@ -5,10 +5,28 @@ import { createLogger } from '../common/logger'
 
 const logger = createLogger('content-script-isolated')
 
+interface IsolatedWindow {
+  unregisterIsolatedScript?(): void
+}
+
+const isolatedWindow = window as IsolatedWindow
+
+// Unregister any callback from a previously injected isolated content script
+if (isolatedWindow.unregisterIsolatedScript) {
+  isolatedWindow.unregisterIsolatedScript()
+}
+// Register the new callback
+window.addEventListener('__ddBrowserSdkMessage', browserSdkMessageListener)
+
+isolatedWindow.unregisterIsolatedScript = () => {
+  window.removeEventListener('__ddBrowserSdkMessage', browserSdkMessageListener)
+}
+
 // Listen to events from the "main" content script and relays them to the background script via the
 // webextension API.
-window.addEventListener('__ddBrowserSdkMessage', (event) => {
+function browserSdkMessageListener(event: unknown) {
   const detail = (event as CustomEvent).detail
+
   try {
     chrome.runtime.sendMessage(detail).catch((error) => logger.error('Failed to send message:', error))
   } catch (error) {
@@ -18,4 +36,4 @@ window.addEventListener('__ddBrowserSdkMessage', (event) => {
       logger.error('Failed to send message:', error)
     }
   }
-})
+}


### PR DESCRIPTION



## Motivation

Each time the extension is open, a new `isolated content script` is executed in the page. Each isolated content script transmit sdk messages to the background script, so if we two scripts are active at the same time, duplicated sdk messages are sent.

## Changes


This addresses the issue by unregistering previous isolated script logic. Luckily, all isolated scripts share the same "window" scope.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
