### PR TITLE
👷🐛 fix build_json2type

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -50,7 +50,13 @@ cmd_build_json2type () {
   set +e
   npm i
   npm run clean
-  npm run build:server
+
+  # With yarn 3, the 'test/' folder is not present, so all built files are put directly in the
+  # 'dist/' folder instead of 'dist/src/'.
+  #
+  # Using an explicit '--rootDir' fixes this issue.
+  npm exec -- tsc --declaration --rootDir .
+
   set -e
 }
 


### PR DESCRIPTION


## Motivation

With yarn 3, the 'test/' folder is not present, so all built files are put directly in the 'dist/' folder instead of 'dist/src/'.


## Changes


Using an explicit '--rootDir' fixes this issue.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
