### PR TITLE
🐛 [RUMF-1499] Don't send duration for resources crossing a page frozen state

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -16,6 +16,7 @@ export enum ExperimentalFeature {
   RESOURCE_PAGE_STATES = 'resource_page_states',
   PAGE_STATES = 'page_states',
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
+  NO_RESOURCE_DURATION_FROZEN_STATE = 'no_resource_duration_frozen_state',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.spec.ts
@@ -135,6 +135,33 @@ describe('resourceCollection', () => {
     expect(rawRumResourceEventEntry._dd.page_states).toEqual(jasmine.objectContaining(mockPageStates))
   })
 
+  it('should not have a duration if a frozen state happens during the request and no performance entry matches when NO_RESOURCE_DURATION_FROZEN_STATE enabled', () => {
+    addExperimentalFeatures([ExperimentalFeature.NO_RESOURCE_DURATION_FROZEN_STATE])
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+    const mockPageStates = [{ state: PageState.FROZEN, startTime: 0 as RelativeTime }]
+    const mockXHR = createCompletedRequest()
+
+    pageStateHistorySpy.and.returnValue(mockPageStates)
+
+    lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, mockXHR)
+
+    const rawRumResourceEventFetch = rawRumEvents[0].rawRumEvent as RawRumResourceEvent
+    expect(rawRumResourceEventFetch.resource.duration).toBeUndefined()
+  })
+
+  it('should have a duration if a frozen state happens during the request and no performance entry matches when NO_RESOURCE_DURATION_FROZEN_STATE disabled', () => {
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+    const mockPageStates = [{ state: PageState.FROZEN, startTime: 0 as RelativeTime }]
+    const mockXHR = createCompletedRequest()
+
+    pageStateHistorySpy.and.returnValue(mockPageStates)
+
+    lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, mockXHR)
+
+    const rawRumResourceEventFetch = rawRumEvents[0].rawRumEvent as RawRumResourceEvent
+    expect(rawRumResourceEventFetch.resource.duration).toBeDefined()
+  })
+
   it('should not collect page states on resources when ff resource_page_states disabled', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
     const mockPageStates = [{ state: PageState.ACTIVE, startTime: 0 as RelativeTime }]

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -25,7 +25,7 @@ export interface RawRumResourceEvent {
   resource: {
     type: ResourceType
     id: string
-    duration: ServerDuration
+    duration?: ServerDuration
     url: string
     method?: string
     status_code?: number


### PR DESCRIPTION
## Motivation

The resource duration for XHR and fetch is computed by the SDK if the corresponding resource timing isn’t found. If during the resource a page frozen state happens, we will wrongfully compute the duration:

![image](https://github.com/DataDog/browser-sdk/assets/4342515/0ba965c7-a14f-4f24-a965-67dbbda7bd84)


 In these cases the browser SDK will now send resources without duration.

## Changes

Check if the request crossed a frozen state in resourceCollection.ts

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
