### PR TITLE
💥 [RUMF-1587] Remove `premiumSampleRate` and `replaySampleRate`

### DIFF
--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -77,7 +77,7 @@ function startRumStub(
     noopRecorderApi
   )
 
-  startLongTaskCollection(lifeCycle, sessionManager)
+  startLongTaskCollection(lifeCycle, configuration, sessionManager)
   return {
     stop: () => {
       rumEventCollectionStop()

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -116,7 +116,7 @@ export function startRum(
 
   addTelemetryConfiguration(serializeRumConfiguration(initConfiguration))
 
-  startLongTaskCollection(lifeCycle, session)
+  startLongTaskCollection(lifeCycle, configuration, session)
   startResourceCollection(lifeCycle, configuration, session, pageStateHistory)
   const { addTiming, startView } = startViewCollection(
     lifeCycle,

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -36,38 +36,6 @@ describe('validateAndBuildRumConfiguration', () => {
       ).toBe(50)
     })
 
-    it('is set to `premiumSampleRate` provided value', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 50 })!
-          .sessionReplaySampleRate
-      ).toBe(50)
-    })
-
-    it('is set to `replaySampleRate` provided value', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 50 })!
-          .sessionReplaySampleRate
-      ).toBe(50)
-    })
-
-    it('is set with precedence `sessionReplaySampleRate` > `premiumSampleRate` > `replaySampleRate`', () => {
-      expect(
-        validateAndBuildRumConfiguration({
-          ...DEFAULT_INIT_CONFIGURATION,
-          replaySampleRate: 25,
-          premiumSampleRate: 50,
-          sessionReplaySampleRate: 75,
-        })!.sessionReplaySampleRate
-      ).toBe(75)
-      expect(
-        validateAndBuildRumConfiguration({
-          ...DEFAULT_INIT_CONFIGURATION,
-          replaySampleRate: 25,
-          premiumSampleRate: 50,
-        })!.sessionReplaySampleRate
-      ).toBe(50)
-    })
-
     it('does not validate the configuration if an incorrect value is provided', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 'foo' as any })
@@ -84,60 +52,6 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(displayErrorSpy).toHaveBeenCalledOnceWith(
         'Session Replay Sample Rate should be a number between 0 and 100'
       )
-
-      displayErrorSpy.calls.reset()
-
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 'foo' as any })
-      ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
-
-      displayErrorSpy.calls.reset()
-
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, premiumSampleRate: 200 })
-      ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
-
-      displayErrorSpy.calls.reset()
-
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 'foo' as any })
-      ).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
-
-      displayErrorSpy.calls.reset()
-
-      expect(validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, replaySampleRate: 200 })).toBeUndefined()
-      expect(displayErrorSpy).toHaveBeenCalledOnceWith('Premium Sample Rate should be a number between 0 and 100')
-
-      displayErrorSpy.calls.reset()
-    })
-
-    it('should validate and display a warn if both `sessionReplaySampleRate` and `premiumSampleRate` are set', () => {
-      expect(
-        validateAndBuildRumConfiguration({
-          ...DEFAULT_INIT_CONFIGURATION,
-          sessionReplaySampleRate: 100,
-          premiumSampleRate: 100,
-        })
-      ).toBeDefined()
-      expect(displayWarnSpy).toHaveBeenCalledOnceWith(
-        'Ignoring Premium Sample Rate because Session Replay Sample Rate is set'
-      )
-    })
-  })
-
-  describe('oldPlansBehavior', () => {
-    it('should be true by default', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.oldPlansBehavior).toBeTrue()
-    })
-
-    it('should be false if `sessionReplaySampleRate` is set', () => {
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 100 })!
-          .oldPlansBehavior
-      ).toBeFalse()
     })
   })
 
@@ -364,8 +278,8 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('trackResources', () => {
-    it('defaults to undefined', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackResources).toBeUndefined()
+    it('defaults to false', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackResources).toBeFalse()
     })
 
     it('is set to provided value', () => {
@@ -379,8 +293,8 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('trackLongTasks', () => {
-    it('defaults to undefined', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackLongTasks).toBeUndefined()
+    it('defaults to false', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackLongTasks).toBeFalse()
     })
 
     it('is set to provided value', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.spec.ts
@@ -18,12 +18,15 @@ const LONG_TASK: RumPerformanceLongTaskTiming = {
 describe('long task collection', () => {
   let setupBuilder: TestSetupBuilder
   let sessionManager: RumSessionManagerMock
+  let trackLongTasks: boolean
+
   beforeEach(() => {
+    trackLongTasks = true
     sessionManager = createRumSessionManagerMock()
     setupBuilder = setup()
       .withSessionManager(sessionManager)
-      .beforeBuild(({ lifeCycle, sessionManager }) => {
-        startLongTaskCollection(lifeCycle, sessionManager)
+      .beforeBuild(({ lifeCycle, sessionManager, configuration }) => {
+        startLongTaskCollection(lifeCycle, { ...configuration, trackLongTasks }, sessionManager)
       })
   })
 
@@ -43,16 +46,20 @@ describe('long task collection', () => {
     expect(rawRumEvents.length).toBe(1)
   })
 
-  it('should only collect when session allows long tasks', () => {
+  it('should collect when trackLongTasks=true', () => {
+    trackLongTasks = true
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
-    sessionManager.setLongTaskAllowed(true)
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
     expect(rawRumEvents.length).toBe(1)
+  })
 
-    sessionManager.setLongTaskAllowed(false)
+  it('should not collect when trackLongTasks=false', () => {
+    trackLongTasks = false
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
-    expect(rawRumEvents.length).toBe(1)
+    expect(rawRumEvents.length).toBe(0)
   })
 
   it('should create raw rum event from performance entry', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/longTask/longTaskCollection.ts
@@ -4,15 +4,20 @@ import { RumEventType } from '../../../rawRumEvent.types'
 import type { LifeCycle } from '../../lifeCycle'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumSessionManager } from '../../rumSessionManager'
+import type { RumConfiguration } from '../../configuration'
 
-export function startLongTaskCollection(lifeCycle: LifeCycle, sessionManager: RumSessionManager) {
+export function startLongTaskCollection(
+  lifeCycle: LifeCycle,
+  configuration: RumConfiguration,
+  sessionManager: RumSessionManager
+) {
   lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, (entries) => {
     for (const entry of entries) {
       if (entry.entryType !== 'longtask') {
         break
       }
       const session = sessionManager.findTrackedSession(entry.startTime)
-      if (!session || !session.longTaskAllowed) {
+      if (!session || !configuration.trackLongTasks) {
         break
       }
       const startClocks = relativeToClocks(entry.startTime)

--- a/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/resource/resourceCollection.ts
@@ -72,7 +72,7 @@ function processRequest(
   const correspondingTimingOverrides = matchingTiming ? computePerformanceEntryMetrics(matchingTiming) : undefined
 
   const tracingInfo = computeRequestTracingInfo(request, configuration)
-  const indexingInfo = computeIndexingInfo(sessionManager, startClocks)
+  const indexingInfo = computeIndexingInfo(configuration, sessionManager, startClocks)
 
   const duration = toServerDuration(request.duration)
   const pageStateInfo = computePageStateInfo(
@@ -125,7 +125,7 @@ function processResourceEntry(
   const startClocks = relativeToClocks(entry.startTime)
 
   const tracingInfo = computeEntryTracingInfo(entry, configuration)
-  const indexingInfo = computeIndexingInfo(sessionManager, startClocks)
+  const indexingInfo = computeIndexingInfo(configuration, sessionManager, startClocks)
   const pageStateInfo = computePageStateInfo(pageStateHistory, startClocks, entry.duration)
 
   const resourceEvent = combine(
@@ -203,11 +203,15 @@ function getRulePsr(configuration: RumConfiguration) {
   return isNumber(configuration.traceSampleRate) ? configuration.traceSampleRate / 100 : undefined
 }
 
-function computeIndexingInfo(sessionManager: RumSessionManager, resourceStart: ClocksState) {
+function computeIndexingInfo(
+  configuration: RumConfiguration,
+  sessionManager: RumSessionManager,
+  resourceStart: ClocksState
+) {
   const session = sessionManager.findTrackedSession(resourceStart.relative)
   return {
     _dd: {
-      discarded: !session || !session.resourceAllowed,
+      discarded: !session || !configuration.trackResources,
     },
   }
 }

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -192,31 +192,8 @@ describe('rum session manager', () => {
     ;[
       {
         description:
-          'WITH_SESSION_REPLAY plan without trackResources/LongTasks should have replay, no resources and no long tasks',
-        trackedWithSessionReplay: true,
-        oldPlansBehavior: false,
-        trackResources: undefined,
-        trackLongTasks: undefined,
-        expectSessionReplay: true,
-        expectResources: false,
-        expectLongTasks: false,
-      },
-      {
-        description:
-          'WITHOUT_SESSION_REPLAY plan without trackResources/LongTasks should have no replay, no resources and no long tasks',
-        trackedWithSessionReplay: false,
-        oldPlansBehavior: false,
-        trackResources: undefined,
-        trackLongTasks: undefined,
-        expectSessionReplay: false,
-        expectResources: false,
-        expectLongTasks: false,
-      },
-      {
-        description:
           'WITH_SESSION_REPLAY plan with trackResources/LongTasks=false should have replay, no resources and no long tasks',
         trackedWithSessionReplay: true,
-        oldPlansBehavior: false,
         trackResources: false,
         trackLongTasks: false,
         expectSessionReplay: true,
@@ -227,7 +204,6 @@ describe('rum session manager', () => {
         description:
           'WITHOUT_SESSION_REPLAY plan with trackResources/LongTasks=false should have no replay, no resources and no long tasks',
         trackedWithSessionReplay: false,
-        oldPlansBehavior: false,
         trackResources: false,
         trackLongTasks: false,
         expectSessionReplay: false,
@@ -238,7 +214,6 @@ describe('rum session manager', () => {
         description:
           'WITH_SESSION_REPLAY plan with trackResources/LongTasks=true should have replay, resources and long tasks',
         trackedWithSessionReplay: true,
-        oldPlansBehavior: true,
         trackResources: true,
         trackLongTasks: true,
         expectSessionReplay: true,
@@ -249,73 +224,6 @@ describe('rum session manager', () => {
         description:
           'WITHOUT_SESSION_REPLAY plan with trackResources/LongTasks=true should have no replay, resources and long tasks',
         trackedWithSessionReplay: false,
-        oldPlansBehavior: false,
-        trackResources: true,
-        trackLongTasks: true,
-        expectSessionReplay: false,
-        expectResources: true,
-        expectLongTasks: true,
-      },
-      {
-        description:
-          'old WITH_SESSION_REPLAY plan without trackResources/LongTasks should have replay, resources and long tasks',
-        trackedWithSessionReplay: true,
-        oldPlansBehavior: true,
-        trackResources: undefined,
-        trackLongTasks: undefined,
-        expectSessionReplay: true,
-        expectResources: true,
-        expectLongTasks: true,
-      },
-      {
-        description:
-          'old WITHOUT_SESSION_REPLAY plan without trackResources/LongTasks should have no replay, no resources and no long tasks',
-        trackedWithSessionReplay: false,
-        oldPlansBehavior: true,
-        trackResources: undefined,
-        trackLongTasks: undefined,
-        expectSessionReplay: false,
-        expectResources: false,
-        expectLongTasks: false,
-      },
-      {
-        description:
-          'old WITH_SESSION_REPLAY plan with trackResources/LongTasks=false should have replay, no resources and no long tasks',
-        trackedWithSessionReplay: true,
-        oldPlansBehavior: true,
-        trackResources: false,
-        trackLongTasks: false,
-        expectSessionReplay: true,
-        expectResources: false,
-        expectLongTasks: false,
-      },
-      {
-        description:
-          'old WITHOUT_SESSION_REPLAY plan with trackResources/LongTasks=false should have no replay, no resources and no long tasks',
-        trackedWithSessionReplay: false,
-        oldPlansBehavior: true,
-        trackResources: false,
-        trackLongTasks: false,
-        expectSessionReplay: false,
-        expectResources: false,
-        expectLongTasks: false,
-      },
-      {
-        description:
-          'old WITH_SESSION_REPLAY plan with trackResources/LongTasks=true should have replay, resources and long tasks',
-        trackedWithSessionReplay: true,
-        oldPlansBehavior: true,
-        trackResources: true,
-        trackLongTasks: true,
-        expectSessionReplay: true,
-        expectResources: true,
-        expectLongTasks: true,
-      },
-      {
-        description:
-          'old WITHOUT_SESSION_REPLAY plan with trackResources/LongTasks=true should have no replay, resources and long tasks',
-        trackedWithSessionReplay: false,
-        oldPlansBehavior: true,
         trackResources: true,
         trackLongTasks: true,
         expectSessionReplay: false,
@@ -326,7 +234,6 @@ describe('rum session manager', () => {
       ({
         description,
         trackedWithSessionReplay,
-        oldPlansBehavior,
         trackResources,
         trackLongTasks,
         expectSessionReplay,
@@ -335,9 +242,8 @@ describe('rum session manager', () => {
       }: {
         description: string
         trackedWithSessionReplay: boolean
-        oldPlansBehavior: boolean
-        trackResources: boolean | undefined
-        trackLongTasks: boolean | undefined
+        trackResources: boolean
+        trackLongTasks: boolean
         expectSessionReplay: boolean
         expectResources: boolean
         expectLongTasks: boolean
@@ -347,7 +253,6 @@ describe('rum session manager', () => {
             ...configuration,
             trackResources,
             trackLongTasks,
-            oldPlansBehavior,
           }
 
           setupDraws({ tracked: true, trackedWithSessionReplay })

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -194,73 +194,33 @@ describe('rum session manager', () => {
         description:
           'WITH_SESSION_REPLAY plan with trackResources/LongTasks=false should have replay, no resources and no long tasks',
         trackedWithSessionReplay: true,
-        trackResources: false,
-        trackLongTasks: false,
         expectSessionReplay: true,
-        expectResources: false,
-        expectLongTasks: false,
       },
       {
         description:
           'WITHOUT_SESSION_REPLAY plan with trackResources/LongTasks=false should have no replay, no resources and no long tasks',
         trackedWithSessionReplay: false,
-        trackResources: false,
-        trackLongTasks: false,
         expectSessionReplay: false,
-        expectResources: false,
-        expectLongTasks: false,
-      },
-      {
-        description:
-          'WITH_SESSION_REPLAY plan with trackResources/LongTasks=true should have replay, resources and long tasks',
-        trackedWithSessionReplay: true,
-        trackResources: true,
-        trackLongTasks: true,
-        expectSessionReplay: true,
-        expectResources: true,
-        expectLongTasks: true,
-      },
-      {
-        description:
-          'WITHOUT_SESSION_REPLAY plan with trackResources/LongTasks=true should have no replay, resources and long tasks',
-        trackedWithSessionReplay: false,
-        trackResources: true,
-        trackLongTasks: true,
-        expectSessionReplay: false,
-        expectResources: true,
-        expectLongTasks: true,
       },
     ].forEach(
       ({
         description,
         trackedWithSessionReplay,
-        trackResources,
-        trackLongTasks,
         expectSessionReplay,
-        expectResources,
-        expectLongTasks,
       }: {
         description: string
         trackedWithSessionReplay: boolean
-        trackResources: boolean
-        trackLongTasks: boolean
         expectSessionReplay: boolean
-        expectResources: boolean
-        expectLongTasks: boolean
       }) => {
         it(description, () => {
           configuration = {
             ...configuration,
-            trackResources,
-            trackLongTasks,
           }
 
           setupDraws({ tracked: true, trackedWithSessionReplay })
 
           const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
           expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBe(expectSessionReplay)
-          expect(rumSessionManager.findTrackedSession()!.resourceAllowed).toBe(expectResources)
-          expect(rumSessionManager.findTrackedSession()!.longTaskAllowed).toBe(expectLongTasks)
         })
       }
     )

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -213,10 +213,6 @@ describe('rum session manager', () => {
         expectSessionReplay: boolean
       }) => {
         it(description, () => {
-          configuration = {
-            ...configuration,
-          }
-
           setupDraws({ tracked: true, trackedWithSessionReplay })
 
           const rumSessionManager = startRumSessionManager(configuration, lifeCycle)

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -28,7 +28,7 @@ export const enum RumSessionPlan {
 export const enum RumTrackingType {
   NOT_TRACKED = '0',
   // Note: the "tracking type" value (stored in the session cookie) does not match the "session
-  // plan" value (sent in RUM events). This is expected, and was done to keep retrocompatibility
+  // plan" value (sent in RUM events). This is expected, and was done to keep retro-compatibility
   // with active sessions when upgrading the SDK.
   TRACKED_WITH_SESSION_REPLAY = '1',
   TRACKED_WITHOUT_SESSION_REPLAY = '2',
@@ -61,14 +61,8 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
         id: session.id,
         plan,
         sessionReplayAllowed: plan === RumSessionPlan.WITH_SESSION_REPLAY,
-        longTaskAllowed:
-          configuration.trackLongTasks !== undefined
-            ? configuration.trackLongTasks
-            : configuration.oldPlansBehavior && plan === RumSessionPlan.WITH_SESSION_REPLAY,
-        resourceAllowed:
-          configuration.trackResources !== undefined
-            ? configuration.trackResources
-            : configuration.oldPlansBehavior && plan === RumSessionPlan.WITH_SESSION_REPLAY,
+        longTaskAllowed: configuration.trackLongTasks,
+        resourceAllowed: configuration.trackResources,
       }
     },
     expire: sessionManager.expire,

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -28,7 +28,7 @@ export const enum RumSessionPlan {
 export const enum RumTrackingType {
   NOT_TRACKED = '0',
   // Note: the "tracking type" value (stored in the session cookie) does not match the "session
-  // plan" value (sent in RUM events). This is expected, and was done to keep retro-compatibility
+  // plan" value (sent in RUM events). This is expected, and was done to keep backward-compatibility
   // with active sessions when upgrading the SDK.
   TRACKED_WITH_SESSION_REPLAY = '1',
   TRACKED_WITHOUT_SESSION_REPLAY = '2',

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -16,8 +16,6 @@ export type RumSession = {
   id: string
   plan: RumSessionPlan
   sessionReplayAllowed: boolean
-  longTaskAllowed: boolean
-  resourceAllowed: boolean
 }
 
 export const enum RumSessionPlan {
@@ -61,8 +59,6 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
         id: session.id,
         plan,
         sessionReplayAllowed: plan === RumSessionPlan.WITH_SESSION_REPLAY,
-        longTaskAllowed: configuration.trackLongTasks,
-        resourceAllowed: configuration.trackResources,
       }
     },
     expire: sessionManager.expire,
@@ -78,8 +74,6 @@ export function startRumSessionManagerStub(): RumSessionManager {
     id: '00000000-aaaa-0000-aaaa-000000000000',
     plan: RumSessionPlan.WITHOUT_SESSION_REPLAY, // plan value should not be taken into account for mobile
     sessionReplayAllowed: false,
-    longTaskAllowed: true,
-    resourceAllowed: true,
   }
   return {
     findTrackedSession: () => session,

--- a/packages/rum-core/test/mockRumSessionManager.ts
+++ b/packages/rum-core/test/mockRumSessionManager.ts
@@ -7,8 +7,6 @@ export interface RumSessionManagerMock extends RumSessionManager {
   setNotTracked(): RumSessionManagerMock
   setPlanWithoutSessionReplay(): RumSessionManagerMock
   setPlanWithSessionReplay(): RumSessionManagerMock
-  setLongTaskAllowed(longTaskAllowed: boolean): RumSessionManagerMock
-  setResourceAllowed(resourceAllowed: boolean): RumSessionManagerMock
 }
 
 const DEFAULT_ID = 'session-id'
@@ -22,8 +20,6 @@ const enum SessionStatus {
 export function createRumSessionManagerMock(): RumSessionManagerMock {
   let id = DEFAULT_ID
   let sessionStatus: SessionStatus = SessionStatus.TRACKED_WITH_SESSION_REPLAY
-  let resourceAllowed = true
-  let longTaskAllowed = true
   return {
     findTrackedSession() {
       if (
@@ -39,8 +35,6 @@ export function createRumSessionManagerMock(): RumSessionManagerMock {
             ? RumSessionPlan.WITH_SESSION_REPLAY
             : RumSessionPlan.WITHOUT_SESSION_REPLAY,
         sessionReplayAllowed: sessionStatus === SessionStatus.TRACKED_WITH_SESSION_REPLAY,
-        longTaskAllowed,
-        resourceAllowed,
       }
     },
     expire() {
@@ -62,14 +56,6 @@ export function createRumSessionManagerMock(): RumSessionManagerMock {
     },
     setPlanWithSessionReplay() {
       sessionStatus = SessionStatus.TRACKED_WITH_SESSION_REPLAY
-      return this
-    },
-    setLongTaskAllowed(isAllowed: boolean) {
-      longTaskAllowed = isAllowed
-      return this
-    },
-    setResourceAllowed(isAllowed: boolean) {
-      resourceAllowed = isAllowed
       return this
     },
   }

--- a/packages/rum-core/test/testSetupBuilder.ts
+++ b/packages/rum-core/test/testSetupBuilder.ts
@@ -109,7 +109,12 @@ export function setup(): TestSetupBuilder {
   }
   const FAKE_APP_ID = 'appId'
   const configuration: RumConfiguration = {
-    ...validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: FAKE_APP_ID })!,
+    ...validateAndBuildRumConfiguration({
+      clientToken: 'xxx',
+      applicationId: FAKE_APP_ID,
+      trackResources: true,
+      trackLongTasks: true,
+    })!,
     ...SPEC_ENDPOINTS,
   }
 


### PR DESCRIPTION
## Motivation

Drop deprecated parameters in favour of `sessionReplaySampleRate`

## Changes

- Remove `premiumSampleRate` and `replaySampleRate`
- Remove old plans behaviour

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
