### PR TITLE
💥 [RUMF-1588] Update default session replay behaviour

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -842,17 +842,17 @@ describe('rum public api', () => {
 
     it('recording is started with the default defaultPrivacyLevel', () => {
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].defaultPrivacyLevel).toBe(
-        DefaultPrivacyLevel.MASK_USER_INPUT
-      )
+      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].defaultPrivacyLevel).toBe(DefaultPrivacyLevel.MASK)
     })
 
     it('recording is started with the configured defaultPrivacyLevel', () => {
       rumPublicApi.init({
         ...DEFAULT_INIT_CONFIGURATION,
-        defaultPrivacyLevel: DefaultPrivacyLevel.MASK,
+        defaultPrivacyLevel: DefaultPrivacyLevel.MASK_USER_INPUT,
       })
-      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].defaultPrivacyLevel).toBe(DefaultPrivacyLevel.MASK)
+      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].defaultPrivacyLevel).toBe(
+        DefaultPrivacyLevel.MASK_USER_INPUT
+      )
     })
   })
 

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -25,8 +25,8 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('sessionReplaySampleRate', () => {
-    it('defaults to 100 if the option is not provided', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.sessionReplaySampleRate).toBe(100)
+    it('defaults to 0 if the option is not provided', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.sessionReplaySampleRate).toBe(0)
     })
 
     it('is set to `sessionReplaySampleRate` provided value', () => {

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -254,9 +254,9 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('defaultPrivacyLevel', () => {
-    it('defaults to MASK_USER_INPUT', () => {
+    it('defaults to MASK', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.defaultPrivacyLevel).toBe(
-        DefaultPrivacyLevel.MASK_USER_INPUT
+        DefaultPrivacyLevel.MASK
       )
     })
 
@@ -273,7 +273,7 @@ describe('validateAndBuildRumConfiguration', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, defaultPrivacyLevel: 'foo' as any })!
           .defaultPrivacyLevel
-      ).toBe(DefaultPrivacyLevel.MASK_USER_INPUT)
+      ).toBe(DefaultPrivacyLevel.MASK)
     })
   })
 

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -114,7 +114,7 @@ export function validateAndBuildRumConfiguration(
       subdomain: initConfiguration.subdomain,
       defaultPrivacyLevel: objectHasValue(DefaultPrivacyLevel, initConfiguration.defaultPrivacyLevel)
         ? initConfiguration.defaultPrivacyLevel
-        : DefaultPrivacyLevel.MASK_USER_INPUT,
+        : DefaultPrivacyLevel.MASK,
       customerDataTelemetrySampleRate: 1,
     },
     baseConfiguration

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -103,7 +103,7 @@ export function validateAndBuildRumConfiguration(
       applicationId: initConfiguration.applicationId,
       version: initConfiguration.version,
       actionNameAttribute: initConfiguration.actionNameAttribute,
-      sessionReplaySampleRate: initConfiguration.sessionReplaySampleRate ?? 100,
+      sessionReplaySampleRate: initConfiguration.sessionReplaySampleRate ?? 0,
       traceSampleRate: initConfiguration.traceSampleRate,
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -1,5 +1,6 @@
 import type { LogsInitConfiguration } from '@datadog/browser-logs'
 import type { RumInitConfiguration } from '@datadog/browser-rum-core'
+import { DefaultPrivacyLevel } from '@datadog/browser-rum'
 import { getRunId } from '../../../envUtils'
 import { deleteAllCookies, getBrowserName, withBrowserLogs } from '../helpers/browser'
 import { APPLICATION_ID, CLIENT_TOKEN } from '../helpers/constants'
@@ -18,6 +19,7 @@ const DEFAULT_RUM_CONFIGURATION = {
   applicationId: APPLICATION_ID,
   clientToken: CLIENT_TOKEN,
   sessionReplaySampleRate: 100,
+  defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
   trackResources: true,
   trackLongTasks: true,
   telemetrySampleRate: 100,

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -83,11 +83,11 @@ describe('recorder', () => {
       .withSetup(bundleSetup)
       .withBody(
         html`
-          <div id="not-obfuscated">foo</div>
-          <p id="hidden-by-attribute" data-dd-privacy="hidden">bar</p>
-          <span id="hidden-by-classname" class="dd-privacy-hidden baz">baz</span>
-          <input id="input-ignored" data-dd-privacy="input-ignored" value="toto" />
-          <input id="input-masked" data-dd-privacy="input-masked" value="toto" />
+          <div id="not-obfuscated">displayed</div>
+          <p id="hidden-by-attribute" data-dd-privacy="hidden">hidden</p>
+          <span id="hidden-by-classname" class="dd-privacy-hidden">hidden</span>
+          <input id="input-not-obfuscated" value="displayed" />
+          <input id="input-masked" data-dd-privacy="mask" value="masked" />
         `
       )
       .run(async ({ serverEvents }) => {
@@ -99,7 +99,7 @@ describe('recorder', () => {
 
         const node = findElementWithIdAttribute(fullSnapshot.data.node, 'not-obfuscated')
         expect(node).toBeTruthy()
-        expect(findTextContent(node!)).toBe('foo')
+        expect(findTextContent(node!)).toBe('displayed')
 
         const hiddenNodeByAttribute = findElement(fullSnapshot.data.node, (node) => node.tagName === 'p')
         expect(hiddenNodeByAttribute).toBeTruthy()
@@ -107,15 +107,14 @@ describe('recorder', () => {
         expect(hiddenNodeByAttribute!.childNodes.length).toBe(0)
 
         const hiddenNodeByClassName = findElement(fullSnapshot.data.node, (node) => node.tagName === 'span')
-
         expect(hiddenNodeByClassName).toBeTruthy()
         expect(hiddenNodeByClassName!.attributes.class).toBeUndefined()
         expect(hiddenNodeByClassName!.attributes['data-dd-privacy']).toBe('hidden')
         expect(hiddenNodeByClassName!.childNodes.length).toBe(0)
 
-        const inputIgnored = findElementWithIdAttribute(fullSnapshot.data.node, 'input-ignored')
+        const inputIgnored = findElementWithIdAttribute(fullSnapshot.data.node, 'input-not-obfuscated')
         expect(inputIgnored).toBeTruthy()
-        expect(inputIgnored!.attributes.value).toBe('***')
+        expect(inputIgnored!.attributes.value).toBe('displayed')
 
         const inputMasked = findElementWithIdAttribute(fullSnapshot.data.node, 'input-masked')
         expect(inputMasked).toBeTruthy()
@@ -579,8 +578,8 @@ describe('recorder', () => {
       .withSetup(bundleSetup)
       .withBody(
         html`
-          <input type="text" id="by-data-attribute" data-dd-privacy="input-masked" />
-          <input type="text" id="by-classname" class="dd-privacy-input-masked" />
+          <input type="text" id="by-data-attribute" data-dd-privacy="mask" />
+          <input type="text" id="by-classname" class="dd-privacy-mask" />
         `
       )
       .run(async ({ serverEvents }) => {


### PR DESCRIPTION
## Motivation

Have a more predictable default session replay sampling rate and target privacy by default to mitigate potential privacy concerns with the auto-start functionality.

## Changes

- update default `sessionReplaySampleRate` from `100` to `0`
- update default `defaultPrivacyLevel` from `MASK_USER_INPUT` to `MASK`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
