### PR TITLE
👷 Renovate: Ignore AJV

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,13 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "excludePackageNames": ["puppeteer", "ajv", "ansi-regex"],
+      "excludePackageNames": ["puppeteer", "ansi-regex"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchPackageNames": ["ajv"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Motivation

AJV >6 does not work out-of-the-box with IE11 anymore. 
https://github.com/ajv-validator/ajv/issues/1585#issuecomment-832486204

## Changes

Ignore AJV major versions from Renovate

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
