### PR TITLE
🐛 Telemetry: do not scrub staging and canary frames

### DIFF
--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -182,6 +182,8 @@ describe('scrubCustomerFrames', () => {
     ;[
       { scrub: false, url: 'https://www.datadoghq-browser-agent.com/datadog-rum-v4.js' },
       { scrub: false, url: 'https://www.datad0g-browser-agent.com/datadog-rum-v5.js' },
+      { scrub: false, url: 'https://d3uc069fcn7uxw.cloudfront.net/datadog-logs-staging.js' },
+      { scrub: false, url: 'https://d20xtzwzcl0ceb.cloudfront.net/datadog-rum-canary.js' },
       { scrub: false, url: 'http://localhost/index.html' },
       { scrub: false, url: undefined },
       { scrub: false, url: '<anonymous>' },

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -25,6 +25,8 @@ declare const __BUILD_ENV__SDK_VERSION__: string
 const ALLOWED_FRAME_URLS = [
   'https://www.datadoghq-browser-agent.com',
   'https://www.datad0g-browser-agent.com',
+  'https://d3uc069fcn7uxw.cloudfront.net',
+  'https://d20xtzwzcl0ceb.cloudfront.net',
   'http://localhost',
   '<anonymous>',
 ]


### PR DESCRIPTION
## Motivation

Allow to collect stack of telemetry errors in staging and canary environments 🤦‍♂️

## Changes

Allow staging and canary domains

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
