### PR TITLE
♻️ [RUMF-1555] Remove deprecated context manager APIs

### DIFF
--- a/packages/core/src/tools/serialisation/contextManager.spec.ts
+++ b/packages/core/src/tools/serialisation/contextManager.spec.ts
@@ -20,42 +20,35 @@ describe('createContextManager', () => {
 
   it('starts with an empty context', () => {
     const manager = createContextManager(CustomerDataType.User)
-    expect(manager.get()).toEqual({})
+    expect(manager.getContext()).toEqual({})
   })
 
   it('updates the context', () => {
     const manager = createContextManager(CustomerDataType.User)
-    manager.set({ bar: 'foo' })
+    manager.setContext({ bar: 'foo' })
 
-    expect(manager.get()).toEqual({ bar: 'foo' })
-  })
-
-  it('updates the context without copy', () => {
-    const manager = createContextManager(CustomerDataType.User)
-    const context = {}
-    manager.set(context)
-    expect(manager.get()).toBe(context)
+    expect(manager.getContext()).toEqual({ bar: 'foo' })
   })
 
   it('completely replaces the context', () => {
     const manager = createContextManager(CustomerDataType.User)
-    manager.set({ a: 'foo' })
-    expect(manager.get()).toEqual({ a: 'foo' })
-    manager.set({ b: 'foo' })
-    expect(manager.get()).toEqual({ b: 'foo' })
+    manager.setContext({ a: 'foo' })
+    expect(manager.getContext()).toEqual({ a: 'foo' })
+    manager.setContext({ b: 'foo' })
+    expect(manager.getContext()).toEqual({ b: 'foo' })
   })
 
   it('sets a context value', () => {
     const manager = createContextManager(CustomerDataType.User)
-    manager.add('foo', 'bar')
-    expect(manager.get()).toEqual({ foo: 'bar' })
+    manager.setContextProperty('foo', 'bar')
+    expect(manager.getContext()).toEqual({ foo: 'bar' })
   })
 
   it('removes a context value', () => {
     const manager = createContextManager(CustomerDataType.User)
-    manager.set({ a: 'foo', b: 'bar' })
-    manager.remove('a')
-    expect(manager.get()).toEqual({ b: 'bar' })
+    manager.setContext({ a: 'foo', b: 'bar' })
+    manager.removeContextProperty('a')
+    expect(manager.getContext()).toEqual({ b: 'bar' })
     manager.removeContextProperty('b')
     expect(manager.getContext()).toEqual({})
   })
@@ -97,13 +90,13 @@ describe('createContextManager', () => {
       const computeBytesCountStub = jasmine.createSpy('computeBytesCountStub').and.returnValue(1)
       const manager = createContextManager(CustomerDataType.User, computeBytesCountStub)
 
-      manager.add('foo', 'bar')
+      manager.setContextProperty('foo', 'bar')
       clock.tick(BYTES_COMPUTATION_THROTTLING_DELAY)
 
-      manager.remove('foo')
+      manager.removeContextProperty('foo')
       clock.tick(BYTES_COMPUTATION_THROTTLING_DELAY)
 
-      manager.set({ foo: 'bar' })
+      manager.setContext({ foo: 'bar' })
       clock.tick(BYTES_COMPUTATION_THROTTLING_DELAY)
 
       manager.setContextProperty('foo', 'bar')

--- a/packages/core/src/tools/serialisation/contextManager.ts
+++ b/packages/core/src/tools/serialisation/contextManager.ts
@@ -5,7 +5,7 @@ import { jsonStringify } from './jsonStringify'
 import { sanitize } from './sanitize'
 import { warnIfCustomerDataLimitReached } from './heavyCustomerDataWarning'
 import type { CustomerDataType } from './heavyCustomerDataWarning'
-import type { Context, ContextValue } from './context'
+import type { Context } from './context'
 
 export const BYTES_COMPUTATION_THROTTLING_DELAY = 200
 
@@ -27,26 +27,6 @@ export function createContextManager(customerDataType: CustomerDataType, compute
 
   return {
     getBytesCount: () => bytesCountCache,
-    /** @deprecated use getContext instead */
-    get: () => context,
-
-    /** @deprecated use setContextProperty instead */
-    add: (key: string, value: any) => {
-      context[key] = value as ContextValue
-      computeBytesCountThrottled(context)
-    },
-
-    /** @deprecated renamed to removeContextProperty */
-    remove: (key: string) => {
-      delete context[key]
-      computeBytesCountThrottled(context)
-    },
-
-    /** @deprecated use setContext instead */
-    set: (newContext: object) => {
-      context = newContext as Context
-      computeBytesCountThrottled(context)
-    },
 
     getContext: () => deepClone(context),
 

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -5,7 +5,6 @@ import {
   ErrorHandling,
   computeStackTrace,
   CustomerDataType,
-  assign,
   combine,
   createContextManager,
   ErrorSource,
@@ -50,7 +49,10 @@ export class Logger {
     private level: StatusType = StatusType.debug,
     loggerContext: object = {}
   ) {
-    this.contextManager.set(assign({}, loggerContext, name ? { logger: { name } } : undefined))
+    this.contextManager.setContext(loggerContext as Context)
+    if (name) {
+      this.contextManager.setContextProperty('logger', { name })
+    }
   }
 
   @monitored
@@ -114,19 +116,19 @@ export class Logger {
   }
 
   setContext(context: object) {
-    this.contextManager.set(context)
+    this.contextManager.setContext(context as Context)
   }
 
   getContext() {
-    return this.contextManager.get()
+    return this.contextManager.getContext()
   }
 
   addContext(key: string, value: any) {
-    this.contextManager.add(key, value)
+    this.contextManager.setContextProperty(key, value)
   }
 
   removeContext(key: string) {
-    this.contextManager.remove(key)
+    this.contextManager.removeContextProperty(key)
   }
 
   setHandler(handler: HandlerType | HandlerType[]) {

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
@@ -43,7 +43,7 @@ describe('customerDataTelemetry', () => {
   }
 
   function spyOnContextManager(contextManager: ContextManager) {
-    spyOn(contextManager, 'get').and.callFake(() => fakeContext)
+    spyOn(contextManager, 'getContext').and.callFake(() => fakeContext)
     spyOn(contextManager, 'getBytesCount').and.callFake(() => fakeContextBytesCount)
   }
 

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
@@ -57,12 +57,12 @@ export function startCustomerDataTelemetry(
     batchHasRumEvent = true
     updateMeasure(
       currentBatchMeasures.globalContextBytes,
-      !isEmptyObject(globalContextManager.get()) ? globalContextManager.getBytesCount() : 0
+      !isEmptyObject(globalContextManager.getContext()) ? globalContextManager.getBytesCount() : 0
     )
 
     updateMeasure(
       currentBatchMeasures.userContextBytes,
-      !isEmptyObject(userContextManager.get()) ? userContextManager.getBytesCount() : 0
+      !isEmptyObject(userContextManager.getContext()) ? userContextManager.getBytesCount() : 0
     )
 
     const featureFlagContext = featureFlagContexts.findFeatureFlagEvaluations()


### PR DESCRIPTION
## Motivation

Ensure that input/output of `ContextManager` internal component can't be mutated by API user

## Changes

Replace internal usages:
- `get` -> `getContext`
- `set` -> `setContext`
- `add` -> `setContextProperty`
- `remove` -> `removeContextProperty`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
