### PR TITLE
💥 [RUMF-1555] Rework logger context APIs

### DIFF
--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -94,6 +94,37 @@ describe('Logger', () => {
     })
   })
 
+  describe('context methods', () => {
+    beforeEach(() => {
+      const loggerContext = { foo: 'bar' }
+      logger = new Logger(handleLogSpy, undefined, HandlerType.http, StatusType.debug, loggerContext)
+    })
+
+    it('getContext should return the context', () => {
+      expect(logger.getContext()).toEqual({ foo: 'bar' })
+    })
+
+    it('setContext should overwrite the whole context', () => {
+      logger.setContext({ qux: 'qix' })
+      expect(logger.getContext()).toEqual({ qux: 'qix' })
+    })
+
+    it('setContextProperty should set a context value', () => {
+      logger.setContextProperty('qux', 'qix')
+      expect(logger.getContext()).toEqual({ foo: 'bar', qux: 'qix' })
+    })
+
+    it('removeContextProperty should remove a context value', () => {
+      logger.removeContextProperty('foo')
+      expect(logger.getContext()).toEqual({})
+    })
+
+    it('clearContext should clear the context', () => {
+      logger.clearContext()
+      expect(logger.getContext()).toEqual({})
+    })
+  })
+
   describe('contexts', () => {
     it('logger context should be deep copied', () => {
       const loggerContext = { foo: 'bar' }

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -123,12 +123,16 @@ export class Logger {
     return this.contextManager.getContext()
   }
 
-  addContext(key: string, value: any) {
+  setContextProperty(key: string, value: any) {
     this.contextManager.setContextProperty(key, value)
   }
 
-  removeContext(key: string) {
+  removeContextProperty(key: string) {
     this.contextManager.removeContextProperty(key)
+  }
+
+  clearContext() {
+    this.contextManager.clearContext()
   }
 
   setHandler(handler: HandlerType | HandlerType[]) {


### PR DESCRIPTION
## Motivation

Consistency with other context APIs, cf https://github.com/DataDog/browser-sdk/pull/1641

## Changes

- rename `logger.addContext` in `logger.setContextProperty`
- rename `logger.removeContext` in `logger.removeContextProperty`
- introduce `logger.clearContext` to clear logger context

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
