### PR TITLE
💥 [RUMF-1555] Remove `event` in action domain context

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.spec.ts
@@ -91,7 +91,6 @@ describe('actionCollection', () => {
       },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
-      event,
       events: [event],
     })
   })

--- a/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/actionCollection.ts
@@ -106,7 +106,7 @@ function processAction(
     customerContext,
     rawRumEvent: actionEvent,
     startTime: action.startClocks.relative,
-    domainContext: isAutoAction(action) ? { event: action.event, events: action.events } : {},
+    domainContext: isAutoAction(action) ? { events: action.events } : {},
   }
 }
 

--- a/packages/rum-core/src/domainContext.types.ts
+++ b/packages/rum-core/src/domainContext.types.ts
@@ -21,10 +21,6 @@ export interface RumViewEventDomainContext {
 }
 
 export interface RumActionEventDomainContext {
-  /**
-   * @deprecated use events array instead
-   */
-  event?: Event
   events?: Event[]
 }
 

--- a/packages/rum/src/domain/record/observers/frustrationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/frustrationObserver.spec.ts
@@ -40,7 +40,7 @@ describe('initFrustrationObserver', () => {
           },
         },
       },
-      domainContext: { event: mouseEvent, events: [mouseEvent] },
+      domainContext: { events: [mouseEvent] },
     }
   })
 


### PR DESCRIPTION
## Motivation

Housekeeping

## Changes

In action domain context, cf [before send event contexts](https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/?tab=event#context), drop `event` in favour of `events`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
