### PR TITLE
🔥 [RUMF-1555] Remove `startTime` in xhr start context

### DIFF
--- a/packages/core/src/browser/xhrObservable.spec.ts
+++ b/packages/core/src/browser/xhrObservable.spec.ts
@@ -47,7 +47,6 @@ describe('xhr observable', () => {
         expect(request.url).toContain('/ok')
         expect(request.status).toBe(200)
         expect(request.isAborted).toBe(false)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         done()
       },
@@ -67,7 +66,6 @@ describe('xhr observable', () => {
         expect(request.url).toContain('/expected-404')
         expect(request.status).toBe(404)
         expect(request.isAborted).toBe(false)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         done()
       },
@@ -87,7 +85,6 @@ describe('xhr observable', () => {
         expect(request.url).toContain('/throw')
         expect(request.status).toBe(500)
         expect(request.isAborted).toBe(false)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         done()
       },
@@ -107,7 +104,6 @@ describe('xhr observable', () => {
         expect(request.url).toBe('http://foo.bar/qux')
         expect(request.status).toBe(0)
         expect(request.isAborted).toBe(false)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         done()
       },
@@ -133,7 +129,6 @@ describe('xhr observable', () => {
         expect(request.method).toBe('GET')
         expect(request.url).toContain('/ok')
         expect(request.status).toBe(200)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         expect(request.isAborted).toBe(false)
         expect(xhr.status).toBe(0)
@@ -155,7 +150,6 @@ describe('xhr observable', () => {
         expect(request.method).toBe('GET')
         expect(request.url).toContain('/ok')
         expect(request.status).toBe(0)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         expect(request.isAborted).toBe(true)
         expect(xhr.status).toBe(0)
@@ -178,7 +172,6 @@ describe('xhr observable', () => {
         expect(request.url).toContain('/ok')
         expect(request.status).toBe(200)
         expect(request.isAborted).toBe(false)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         expect(xhr.onreadystatechange).toHaveBeenCalled()
         done()
@@ -200,7 +193,6 @@ describe('xhr observable', () => {
         expect(request.url).toContain('/ok')
         expect(request.status).toBe(200)
         expect(request.isAborted).toBe(false)
-        expect(request.startTime).toEqual(jasmine.any(Number))
         expect(request.duration).toEqual(jasmine.any(Number))
         expect(xhr.onreadystatechange).toHaveBeenCalled()
         done()
@@ -273,7 +265,6 @@ describe('xhr observable', () => {
         expect(firstRequest.url).toContain('/ok?request=1')
         expect(firstRequest.status).toBe(200)
         expect(firstRequest.isAborted).toBe(false)
-        expect(firstRequest.startTime).toEqual(jasmine.any(Number))
         expect(firstRequest.duration).toEqual(jasmine.any(Number))
 
         const secondRequest = requests[1]
@@ -281,7 +272,6 @@ describe('xhr observable', () => {
         expect(secondRequest.url).toContain('/ok?request=2')
         expect(secondRequest.status).toBe(400)
         expect(secondRequest.isAborted).toBe(false)
-        expect(secondRequest.startTime).toEqual(jasmine.any(Number))
         expect(secondRequest.duration).toEqual(jasmine.any(Number))
 
         expect(xhr.onreadystatechange).toHaveBeenCalledTimes(2)

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -1,7 +1,7 @@
 import { instrumentMethodAndCallOriginal } from '../tools/instrumentMethod'
 import { Observable } from '../tools/observable'
-import type { Duration, RelativeTime, ClocksState } from '../tools/utils/timeUtils'
-import { elapsed, relativeNow, clocksNow, timeStampNow } from '../tools/utils/timeUtils'
+import type { Duration, ClocksState } from '../tools/utils/timeUtils'
+import { elapsed, clocksNow, timeStampNow } from '../tools/utils/timeUtils'
 import { normalizeUrl } from '../tools/utils/urlPolyfill'
 import { shallowClone } from '../tools/utils/objectUtils'
 import { addEventListener } from './addEventListener'
@@ -14,7 +14,6 @@ export interface XhrOpenContext {
 
 export interface XhrStartContext extends Omit<XhrOpenContext, 'state'> {
   state: 'start'
-  startTime: RelativeTime // deprecated
   startClocks: ClocksState
   isAborted: boolean
   xhr: XMLHttpRequest
@@ -79,7 +78,6 @@ function sendXhr(this: XMLHttpRequest, observable: Observable<XhrContext>) {
 
   const startContext = context as XhrStartContext
   startContext.state = 'start'
-  startContext.startTime = relativeNow()
   startContext.startClocks = clocksNow()
   startContext.isAborted = false
   startContext.xhr = this
@@ -91,7 +89,7 @@ function sendXhr(this: XMLHttpRequest, observable: Observable<XhrContext>) {
       if (this.readyState === XMLHttpRequest.DONE) {
         // Try to report the XHR as soon as possible, because the XHR may be mutated by the
         // application during a future event. For example, Angular is calling .abort() on
-        // completed requests during a onreadystatechange event, so the status becomes '0'
+        // completed requests during an onreadystatechange event, so the status becomes '0'
         // before the request is collected.
         onEnd()
       }


### PR DESCRIPTION
## Motivation

Housekeeping

## Changes

Drop `xhrStartContext.startTime` in favour of `xhrStartContext.startClocks`

Note: not a breaking change since we moved context reference from xhr instance to context by instance weak map.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
