### PR TITLE
💥[RUMF-1228] Remove console error message prefix

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.spec.ts
+++ b/packages/core/src/domain/console/consoleObservable.spec.ts
@@ -8,12 +8,12 @@ import { initConsoleObservable } from './consoleObservable'
 // prettier: avoid formatting issue
 // cf https://github.com/prettier/prettier/issues/12211
 ;[
-  { api: ConsoleApiName.log, prefix: '' },
-  { api: ConsoleApiName.info, prefix: '' },
-  { api: ConsoleApiName.warn, prefix: '' },
-  { api: ConsoleApiName.debug, prefix: '' },
-  { api: ConsoleApiName.error, prefix: 'console error: ' },
-].forEach(({ api, prefix }) => {
+  { api: ConsoleApiName.log },
+  { api: ConsoleApiName.info },
+  { api: ConsoleApiName.warn },
+  { api: ConsoleApiName.debug },
+  { api: ConsoleApiName.error },
+].forEach(({ api }) => {
   describe(`console ${api} observable`, () => {
     let consoleStub: jasmine.Spy
     let consoleSubscription: Subscription
@@ -37,7 +37,7 @@ import { initConsoleObservable } from './consoleObservable'
 
       expect(consoleLog).toEqual(
         jasmine.objectContaining({
-          message: `${prefix}foo bar`,
+          message: 'foo bar',
           api,
         })
       )
@@ -52,13 +52,13 @@ import { initConsoleObservable } from './consoleObservable'
     it('should format error instance', () => {
       console[api](new TypeError('hello'))
       const consoleLog = notifyLog.calls.mostRecent().args[0]
-      expect(consoleLog.message).toBe(`${prefix}TypeError: hello`)
+      expect(consoleLog.message).toBe('TypeError: hello')
     })
 
     it('should stringify object parameters', () => {
       console[api]('Hello', { foo: 'bar' })
       const consoleLog = notifyLog.calls.mostRecent().args[0]
-      expect(consoleLog.message).toBe(`${prefix}Hello {\n  "foo": "bar"\n}`)
+      expect(consoleLog.message).toBe('Hello {\n  "foo": "bar"\n}')
     })
 
     it('should allow multiple callers', () => {

--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -54,8 +54,7 @@ function createConsoleObservable(api: ConsoleApiName) {
 }
 
 function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: string): ConsoleLog {
-  // Todo: remove console error prefix in the next major version
-  let message = params.map((param) => formatConsoleParameters(param)).join(' ')
+  const message = params.map((param) => formatConsoleParameters(param)).join(' ')
   let stack
   let fingerprint
 
@@ -63,7 +62,6 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
     const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
     stack = firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined
     fingerprint = tryToGetFingerprint(firstErrorParam)
-    message = `console error: ${message}`
   }
 
   return {

--- a/test/e2e/scenario/logs.scenario.ts
+++ b/test/e2e/scenario/logs.scenario.ts
@@ -23,7 +23,7 @@ describe('logs', () => {
       })
       await flushEvents()
       expect(serverEvents.logs.length).toBe(1)
-      expect(serverEvents.logs[0].message).toBe('console error: oh snap')
+      expect(serverEvents.logs[0].message).toBe('oh snap')
       await withBrowserLogs((browserLogs) => {
         expect(browserLogs.length).toEqual(1)
       })

--- a/test/e2e/scenario/rum/errors.scenario.ts
+++ b/test/e2e/scenario/rum/errors.scenario.ts
@@ -30,7 +30,7 @@ describe('rum errors', () => {
       await flushEvents()
       expect(serverEvents.rumErrors.length).toBe(1)
       expectError(serverEvents.rumErrors[0].error, {
-        message: 'console error: oh snap',
+        message: 'oh snap',
         source: 'console',
         handlingStack: ['Error: ', `handler @ ${baseUrl}/:`],
         handling: 'handled',
@@ -50,7 +50,7 @@ describe('rum errors', () => {
       await flushEvents()
       expect(serverEvents.rumErrors.length).toBe(1)
       expectError(serverEvents.rumErrors[0].error, {
-        message: 'console error: Foo: Error: oh snap',
+        message: 'Foo: Error: oh snap',
         source: 'console',
         stack: ['Error: oh snap', `at foo @ ${baseUrl}/:`, `handler @ ${baseUrl}/:`],
         handlingStack: ['Error: ', `handler @ ${baseUrl}/:`],


### PR DESCRIPTION
## Motivation

The console error prefix was meant to be able to sort console error amongst other logs. Now that error.origin convey this information, we can remove the prefix.

## Changes

Remove console error prefix 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
