### PR TITLE
👷 Update TypeScript to 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ts-loader": "9.4.3",
     "ts-node": "10.9.1",
     "tsconfig-paths-webpack-plugin": "4.0.1",
-    "typescript": "5.0.4",
+    "typescript": "5.1.3",
     "webdriverio": "8.11.1",
     "webpack": "5.86.0",
     "webpack-cli": "5.1.4",

--- a/packages/core/src/domain/report/browser.types.ts
+++ b/packages/core/src/domain/report/browser.types.ts
@@ -1,47 +1,26 @@
-export interface BrowserWindow {
-  ReportingObserver?: ReportingObserverConstructor
+export type ReportType = DeprecationReport['type'] | InterventionReport['type']
+
+export interface DeprecationReport extends Report {
+  type: 'deprecation'
+  body: DeprecationReportBody
 }
-
-export interface ReportingObserver {
-  disconnect(): void
-  observe(): void
-  takeRecords(): Report[]
-}
-
-export interface ReportingObserverConstructor {
-  new (callback: ReportingObserverCallback, option: ReportingObserverOption): ReportingObserver
-}
-
-export type ReportType = 'intervention' | 'deprecation'
-
-export interface Report {
-  type: ReportType
-  url: string
-  body: DeprecationReportBody | InterventionReportBody
-}
-
-export interface ReportingObserverCallback {
-  (reports: Report[], observer: ReportingObserver): void
-}
-
-export interface ReportingObserverOption {
-  types: ReportType[]
-  buffered: boolean
-}
-
-interface DeprecationReportBody {
+export interface DeprecationReportBody extends ReportBody {
   id: string
   message: string
-  lineNumber: number
-  columnNumber: number
-  sourceFile: string
-  anticipatedRemoval?: Date
+  lineNumber: number | null
+  columnNumber: number | null
+  sourceFile: string | null
+  anticipatedRemoval: Date | null
 }
 
-interface InterventionReportBody {
+export interface InterventionReport extends Report {
+  type: 'intervention'
+  body: InterventionReportBody
+}
+export interface InterventionReportBody extends ReportBody {
   id: string
   message: string
-  lineNumber: number
-  columnNumber: number
-  sourceFile: string
+  lineNumber: number | null
+  columnNumber: number | null
+  sourceFile: string | null
 }

--- a/packages/core/src/domain/report/reportObservable.spec.ts
+++ b/packages/core/src/domain/report/reportObservable.spec.ts
@@ -3,8 +3,8 @@ import type { Subscription } from '../../tools/observable'
 import { initReportObservable, RawReportType } from './reportObservable'
 
 describe('report observable', () => {
-  let reportingObserverStub: { reset(): void; raiseReport(type: string): void }
-  let cspEventListenerStub: { dispatchEvent(): void }
+  let reportingObserverStub: ReturnType<typeof stubReportingObserver>
+  let cspEventListenerStub: ReturnType<typeof stubCspEventListener>
   let consoleSubscription: Subscription
   let notifyReport: jasmine.Spy
 

--- a/packages/core/src/domain/report/reportObservable.ts
+++ b/packages/core/src/domain/report/reportObservable.ts
@@ -4,7 +4,7 @@ import { mergeObservables, Observable } from '../../tools/observable'
 import { addEventListener, DOM_EVENT } from '../../browser/addEventListener'
 import { includes } from '../../tools/utils/polyfills'
 import { safeTruncate } from '../../tools/utils/stringUtils'
-import type { Report, BrowserWindow, ReportType } from './browser.types'
+import type { ReportType, InterventionReport, DeprecationReport } from './browser.types'
 
 export const RawReportType = {
   intervention: 'intervention',
@@ -38,17 +38,17 @@ export function initReportObservable(apis: RawReportType[]) {
 
 function createReportObservable(reportTypes: ReportType[]) {
   const observable = new Observable<RawReport>(() => {
-    if (!(window as BrowserWindow).ReportingObserver) {
+    if (!window.ReportingObserver) {
       return
     }
 
-    const handleReports = monitor((reports: Report[]) =>
+    const handleReports = monitor((reports: Array<DeprecationReport | InterventionReport>) =>
       reports.forEach((report) => {
         observable.notify(buildRawReportFromReport(report))
       })
-    )
+    ) as (reports: Report[]) => void
 
-    const observer = new (window as BrowserWindow).ReportingObserver!(handleReports, {
+    const observer = new window.ReportingObserver(handleReports, {
       types: reportTypes,
       buffered: true,
     })
@@ -73,7 +73,7 @@ function createCspViolationReportObservable() {
   return observable
 }
 
-function buildRawReportFromReport({ type, body }: Report): RawReport {
+function buildRawReportFromReport({ type, body }: DeprecationReport | InterventionReport): RawReport {
   return {
     type,
     subtype: body.id,
@@ -104,23 +104,22 @@ function buildRawReportFromCspViolation(event: SecurityPolicyViolationEvent): Ra
 function buildStack(
   name: string,
   message: string,
-  sourceFile: string | undefined,
-  lineNumber: number | undefined,
-  columnNumber: number | undefined
+  sourceFile: string | null,
+  lineNumber: number | null,
+  columnNumber: number | null
 ): string | undefined {
-  return (
-    sourceFile &&
-    toStackTraceString({
-      name,
-      message,
-      stack: [
-        {
-          func: '?',
-          url: sourceFile,
-          line: lineNumber,
-          column: columnNumber,
-        },
-      ],
-    })
-  )
+  return sourceFile
+    ? toStackTraceString({
+        name,
+        message,
+        stack: [
+          {
+            func: '?',
+            url: sourceFile,
+            line: lineNumber || undefined,
+            column: columnNumber || undefined,
+          },
+        ],
+      })
+    : undefined
 }

--- a/packages/core/src/domain/report/reportObservable.ts
+++ b/packages/core/src/domain/report/reportObservable.ts
@@ -116,8 +116,8 @@ function buildStack(
           {
             func: '?',
             url: sourceFile,
-            line: lineNumber !== null ? lineNumber : undefined,
-            column: columnNumber !== null ? columnNumber : undefined,
+            line: lineNumber ?? undefined,
+            column: columnNumber ?? undefined,
           },
         ],
       })

--- a/packages/core/src/domain/report/reportObservable.ts
+++ b/packages/core/src/domain/report/reportObservable.ts
@@ -42,11 +42,11 @@ function createReportObservable(reportTypes: ReportType[]) {
       return
     }
 
-    const handleReports = monitor((reports: Array<DeprecationReport | InterventionReport>) =>
+    const handleReports = monitor((reports: Array<DeprecationReport | InterventionReport>, _: ReportingObserver) =>
       reports.forEach((report) => {
         observable.notify(buildRawReportFromReport(report))
       })
-    ) as (reports: Report[]) => void
+    ) as ReportingObserverCallback
 
     const observer = new window.ReportingObserver(handleReports, {
       types: reportTypes,
@@ -116,8 +116,8 @@ function buildStack(
           {
             func: '?',
             url: sourceFile,
-            line: lineNumber || undefined,
-            column: columnNumber || undefined,
+            line: lineNumber !== null ? lineNumber : undefined,
+            column: columnNumber !== null ? columnNumber : undefined,
           },
         ],
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3878,7 +3878,7 @@ __metadata:
     ts-loader: 9.4.3
     ts-node: 10.9.1
     tsconfig-paths-webpack-plugin: 4.0.1
-    typescript: 5.0.4
+    typescript: 5.1.3
     webdriverio: 8.11.1
     webpack: 5.86.0
     webpack-cli: 5.1.4
@@ -14650,13 +14650,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.0.4":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:5.1.3":
+  version: 5.1.3
+  resolution: "typescript@npm:5.1.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
+  checksum: d9d51862d98efa46534f2800a1071a613751b1585dc78884807d0c179bcd93d6e9d4012a508e276742f5f33c480adefc52ffcafaf9e0e00ab641a14cde9a31c7
   languageName: node
   linkType: hard
 
@@ -14670,13 +14670,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.0.4#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+"typescript@patch:typescript@5.1.3#~builtin<compat/typescript>":
+  version: 5.1.3
+  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=5da071"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: 6f0a9dca6bf4ce9dcaf4e282aade55ef4c56ecb5fb98d0a4a5c0113398815aea66d871b5611e83353e5953a19ed9ef103cf5a76ac0f276d550d1e7cd5344f61e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

TypeScript 5.1 introduced `ReportingObserver` in `lib.dom.d.ts`. 

## Changes

Removed locally declared types around `ReportingObserver`, affecting `reportObservable.ts`

## Testing

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
