### PR TITLE
💥[RUMF-1229] Logs: remove `error.origin` attribute

### DIFF
--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -45,9 +45,6 @@ export function startLogs(
       rawLogsEvent: {
         message: error.message,
         date: error.startClocks.timeStamp,
-        error: {
-          origin: ErrorSource.AGENT, // Todo: Remove in the next major release
-        },
         origin: ErrorSource.AGENT,
         status: StatusType.error,
       },

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -386,6 +386,19 @@ describe('logs limitation', () => {
     clock.cleanup()
     serverLogs = []
   })
+  it('should not apply to agent logs', () => {
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
+      rawLogsEvent: { ...DEFAULT_MESSAGE, origin: ErrorSource.AGENT, status: 'error', message: 'foo' },
+    })
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
+      rawLogsEvent: { ...DEFAULT_MESSAGE, origin: ErrorSource.AGENT, status: 'error', message: 'bar' },
+    })
+
+    expect(serverLogs.length).toEqual(2)
+    expect(reportErrorSpy).not.toHaveBeenCalled()
+    expect(serverLogs[0].message).toBe('foo')
+    expect(serverLogs[1].message).toBe('bar')
+  })
   ;[
     { status: StatusType.error, messageContext: {}, message: 'Reached max number of errors by minute: 1' },
     { status: StatusType.warn, messageContext: {}, message: 'Reached max number of warns by minute: 1' },

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -63,7 +63,7 @@ export function startLogsAssembly(
         // Todo: [RUMF-1230] Move this check to the logger collection in the next major release
         !isAuthorized(rawLogsEvent.status, HandlerType.http, logger) ||
         configuration.beforeSend?.(log) === false ||
-        (log.error?.origin !== ErrorSource.AGENT &&
+        (log.origin !== ErrorSource.AGENT &&
           (logRateLimiters[log.status] ?? logRateLimiters['custom']).isLimitReached())
       ) {
         return

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -37,7 +37,6 @@ describe('Logger', () => {
 
         expect(getLoggedMessage(0).context).toEqual({
           error: {
-            origin: 'logger',
             kind: 'SyntaxError',
             message: 'My Error',
             stack: jasmine.stringMatching(/^SyntaxError: My Error/),
@@ -69,7 +68,6 @@ describe('Logger', () => {
         message: 'message',
         context: {
           error: {
-            origin: 'logger',
             kind: undefined,
             message: 'Provided "My Error"',
             stack: NO_ERROR_STACK_PRESENT_MESSAGE,
@@ -79,17 +77,13 @@ describe('Logger', () => {
       })
     })
 
-    it("'logger.error' should populate an error context with origin even if no Error object is provided", () => {
+    it("'logger.error' should have an empty context if no Error object is provided", () => {
       logger.error('message')
 
       expect(getLoggedMessage(0)).toEqual({
         message: 'message',
-        context: {
-          error: {
-            origin: 'logger',
-          },
-        },
         status: 'error',
+        context: undefined,
       })
     })
   })

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -59,11 +59,6 @@ export class Logger {
   log(message: string, messageContext?: object, status: StatusType = StatusType.info, error?: Error) {
     let errorContext: LogsEvent['error']
 
-    if (status === StatusType.error) {
-      // Always add origin if status is error (backward compatibility - Remove in next major)
-      errorContext = { origin: ErrorSource.LOGGER }
-    }
-
     if (error !== undefined && error !== null) {
       const stackTrace = error instanceof Error ? computeStackTrace(error) : undefined
       const rawError = computeRawError({
@@ -76,7 +71,6 @@ export class Logger {
       })
 
       errorContext = {
-        origin: ErrorSource.LOGGER, // Remove in next major
         stack: rawError.stack,
         kind: rawError.type,
         message: rawError.message,

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
@@ -58,7 +58,6 @@ describe('console collection', () => {
     console.error('foo', 'bar')
 
     expect(rawLogsEvents[0].rawLogsEvent.error).toEqual({
-      origin: ErrorSource.CONSOLE,
       stack: undefined,
       fingerprint: undefined,
     })
@@ -79,7 +78,6 @@ describe('console collection', () => {
     console.error(error)
 
     expect(rawLogsEvents[0].rawLogsEvent.error).toEqual({
-      origin: ErrorSource.CONSOLE,
       stack: jasmine.any(String),
       fingerprint: 'my-fingerprint',
     })

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.spec.ts
@@ -32,10 +32,6 @@ describe('console collection', () => {
     stopConsoleCollection()
   })
 
-  interface BrowserConsole extends Console {
-    [key: string]: (...data: any[]) => void
-  }
-
   objectEntries(LogStatusForApi).forEach(([api, status]) => {
     it(`should collect ${status} logs from console.${api}`, () => {
       ;({ stop: stopConsoleCollection } = startConsoleCollection(
@@ -44,7 +40,7 @@ describe('console collection', () => {
       ))
 
       /* eslint-disable-next-line no-console */
-      ;(console as BrowserConsole)[api]('foo', 'bar')
+      console[api as keyof typeof LogStatusForApi]('foo', 'bar')
 
       expect(rawLogsEvents[0].rawLogsEvent).toEqual({
         date: jasmine.any(Number),

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
@@ -12,7 +12,7 @@ export interface ProvidedError {
   handlingStack: string
 }
 
-const LogStatusForApi = {
+export const LogStatusForApi = {
   [ConsoleApiName.log]: StatusType.info,
   [ConsoleApiName.debug]: StatusType.debug,
   [ConsoleApiName.info]: StatusType.info,

--- a/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
+++ b/packages/logs/src/domain/logsCollection/console/consoleCollection.ts
@@ -29,7 +29,6 @@ export function startConsoleCollection(configuration: LogsConfiguration, lifeCyc
         error:
           log.api === ConsoleApiName.error
             ? {
-                origin: ErrorSource.CONSOLE, // Todo: Remove in the next major release
                 stack: log.stack,
                 fingerprint: log.fingerprint,
               }

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.spec.ts
@@ -72,7 +72,6 @@ describe('network error collection', () => {
         status: StatusType.error,
         origin: ErrorSource.NETWORK,
         error: {
-          origin: ErrorSource.NETWORK,
           stack: 'Server error',
         },
         http: {

--- a/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/logsCollection/networkError/networkErrorCollection.ts
@@ -50,7 +50,6 @@ export function startNetworkErrorCollection(configuration: LogsConfiguration, li
           message: `${format(type)} error ${request.method} ${request.url}`,
           date: request.startClocks.timeStamp,
           error: {
-            origin: ErrorSource.NETWORK, // Todo: Remove in the next major release
             stack: (responseData as string) || 'Failed to load',
           },
           http: {

--- a/packages/logs/src/domain/logsCollection/report/reportCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/report/reportCollection.spec.ts
@@ -39,7 +39,6 @@ describe('reports', () => {
     expect(rawLogsEvents[0].rawLogsEvent).toEqual({
       error: {
         kind: 'NavigatorVibrate',
-        origin: ErrorSource.REPORT,
         stack: jasmine.any(String),
       },
       date: jasmine.any(Number),

--- a/packages/logs/src/domain/logsCollection/report/reportCollection.ts
+++ b/packages/logs/src/domain/logsCollection/report/reportCollection.ts
@@ -32,7 +32,6 @@ export function startReportCollection(configuration: LogsConfiguration, lifeCycl
     if (status === StatusType.error) {
       error = {
         kind: report.subtype,
-        origin: ErrorSource.REPORT, // Todo: Remove in the next major release
         stack: report.stack,
       }
     } else if (report.stack) {

--- a/packages/logs/src/domain/logsCollection/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/runtimeError/runtimeErrorCollection.spec.ts
@@ -39,7 +39,7 @@ describe('runtime error collection', () => {
     setTimeout(() => {
       expect(rawLogsEvents[0].rawLogsEvent).toEqual({
         date: jasmine.any(Number),
-        error: { origin: ErrorSource.SOURCE, kind: 'Error', stack: jasmine.any(String) },
+        error: { kind: 'Error', stack: jasmine.any(String) },
         message: 'error!',
         status: StatusType.error,
         origin: ErrorSource.SOURCE,

--- a/packages/logs/src/domain/logsCollection/runtimeError/runtimeErrorCollection.ts
+++ b/packages/logs/src/domain/logsCollection/runtimeError/runtimeErrorCollection.ts
@@ -28,7 +28,6 @@ export function startRuntimeErrorCollection(configuration: LogsConfiguration, li
         date: rawError.startClocks.timeStamp,
         error: {
           kind: rawError.type,
-          origin: ErrorSource.SOURCE, // Todo: Remove in the next major release
           stack: rawError.stack,
         },
         origin: ErrorSource.SOURCE,

--- a/packages/logs/src/logsEvent.types.ts
+++ b/packages/logs/src/logsEvent.types.ts
@@ -14,7 +14,7 @@ export interface LogsEvent {
   /**
    * Origin of the log
    */
-  origin?: 'network' | 'source' | 'console' | 'logger' | 'agent' | 'report' | 'custom'
+  origin: 'network' | 'source' | 'console' | 'logger' | 'agent' | 'report'
   /**
    * UUID of the application
    */
@@ -65,10 +65,6 @@ export interface LogsEvent {
      * Kind of the error
      */
     kind?: string
-    /**
-     * Origin of the error
-     */
-    origin: 'network' | 'source' | 'console' | 'logger' | 'agent' | 'report' | 'custom'
     /**
      * Stacktrace of the error
      */

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -11,7 +11,6 @@ export type RawLogsEvent =
 
 type Error = {
   kind?: string
-  origin: ErrorSource // Todo: Remove in the next major release
   stack?: string
   fingerprint?: string
   [k: string]: unknown
@@ -22,6 +21,7 @@ interface CommonRawLogsEvent {
   message: string
   status: StatusType
   error?: Error
+  origin: 'network' | 'source' | 'console' | 'logger' | 'agent' | 'report'
 }
 
 export interface RawConsoleLogsEvent extends CommonRawLogsEvent {
@@ -57,7 +57,6 @@ export interface RawRuntimeLogsEvent extends CommonRawLogsEvent {
 export interface RawAgentLogsEvent extends CommonRawLogsEvent {
   origin: typeof ErrorSource.AGENT
   status: typeof StatusType.error
-  error: Error
 }
 
 export interface CommonContext {

--- a/test/e2e/scenario/logs.scenario.ts
+++ b/test/e2e/scenario/logs.scenario.ts
@@ -42,7 +42,7 @@ describe('logs', () => {
       await flushEvents()
       expect(serverEvents.logs.length).toBe(1)
       expect(serverEvents.logs[0].message).toBe(`XHR error GET ${UNREACHABLE_URL}`)
-      expect(serverEvents.logs[0].error?.origin).toBe('network')
+      expect(serverEvents.logs[0].origin).toBe('network')
 
       await withBrowserLogs((browserLogs) => {
         // Some browser report two errors:
@@ -64,7 +64,7 @@ describe('logs', () => {
       await flushEvents()
       expect(serverEvents.logs.length).toBe(1)
       expect(serverEvents.logs[0].message).toBe(`Fetch error GET ${UNREACHABLE_URL}`)
-      expect(serverEvents.logs[0].error?.origin).toBe('network')
+      expect(serverEvents.logs[0].origin).toBe('network')
 
       await withBrowserLogs((browserLogs) => {
         // Some browser report two errors:
@@ -84,7 +84,7 @@ describe('logs', () => {
       await flushEvents()
       expect(serverEvents.logs.length).toBe(1)
       expect(serverEvents.logs[0].message).toBe(`Fetch error GET ${baseUrl}/throw-large-response`)
-      expect(serverEvents.logs[0].error?.origin).toBe('network')
+      expect(serverEvents.logs[0].origin).toBe('network')
 
       const ellipsisSize = 3
       expect(serverEvents.logs[0].error?.stack?.length).toBe(DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT + ellipsisSize)


### PR DESCRIPTION
## Motivation

Since the introduction of the `origin` attribute on all logs, `error.origin` is redundant.

## Changes

- Drop logs `error.origin` attribute in favour of `origin` attribute.
- Improve logs types

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
