### PR TITLE
👷[Renovate] remove exclusion from all non major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,6 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "excludePackageNames": ["puppeteer", "ajv", "ansi-regex"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ]


### PR DESCRIPTION
## Motivation

Avoid to have PR for single package update:

- puppeteer could be updated with other packages
- ajv and ansi regex are waiting on major updates and minor updates for our versions seem unlikely

## Changes

Remove excluded packages from `all non-major dependencies` updates

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
