### PR TITLE
💥[RUMF-1230] Only apply main logger configuration to its own logs

### DIFF
--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -90,8 +90,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       ;({ handleLog: handleLogStrategy, getInternalContext: getInternalContextStrategy } = startLogsImpl(
         initConfiguration,
         configuration,
-        buildCommonContext,
-        mainLogger
+        buildCommonContext
       ))
 
       beforeInitLoggerLog.drain()

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -69,7 +69,7 @@ describe('logs', () => {
 
   describe('request', () => {
     it('should send the needed data', () => {
-      ;({ handleLog: handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog: handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
 
       handleLog({ message: 'message', status: StatusType.warn, context: { foo: 'bar' } }, logger, COMMON_CONTEXT)
 
@@ -94,8 +94,7 @@ describe('logs', () => {
       ;({ handleLog } = startLogs(
         initConfiguration,
         { ...baseConfiguration, batchMessagesLimit: 3 },
-        () => COMMON_CONTEXT,
-        logger
+        () => COMMON_CONTEXT
       ))
 
       handleLog(DEFAULT_MESSAGE, logger)
@@ -107,7 +106,7 @@ describe('logs', () => {
 
     it('should send bridge event when bridge is present', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
-      ;({ handleLog: handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog: handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
 
       handleLog(DEFAULT_MESSAGE, logger)
 
@@ -126,13 +125,13 @@ describe('logs', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
 
       let configuration = { ...baseConfiguration, sessionSampleRate: 0 }
-      ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT))
       handleLog(DEFAULT_MESSAGE, logger)
 
       expect(sendSpy).not.toHaveBeenCalled()
 
       configuration = { ...baseConfiguration, sessionSampleRate: 100 }
-      ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT))
       handleLog(DEFAULT_MESSAGE, logger)
 
       expect(sendSpy).toHaveBeenCalled()
@@ -144,8 +143,7 @@ describe('logs', () => {
     ;({ handleLog } = startLogs(
       initConfiguration,
       { ...baseConfiguration, forwardConsoleLogs: ['log'] },
-      () => COMMON_CONTEXT,
-      logger
+      () => COMMON_CONTEXT
     ))
 
     /* eslint-disable-next-line no-console */
@@ -161,21 +159,21 @@ describe('logs', () => {
     })
 
     it('creates a session on normal conditions', () => {
-      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
 
       expect(getCookie(SESSION_STORE_KEY)).not.toBeUndefined()
     })
 
     it('does not create a session if event bridge is present', () => {
       initEventBridgeStub()
-      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
 
       expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
     })
 
     it('does not create a session if synthetics worker will inject RUM', () => {
       mockSyntheticsWorkerValues({ injectsRum: true })
-      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT, logger))
+      ;({ handleLog } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
 
       expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
     })

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -25,15 +25,13 @@ import { startLoggerCollection } from '../domain/logsCollection/logger/loggerCol
 import type { CommonContext } from '../rawLogsEvent.types'
 import { startLogsBatch } from '../transport/startLogsBatch'
 import { startLogsBridge } from '../transport/startLogsBridge'
-import type { Logger } from '../domain/logger'
 import { StatusType } from '../domain/logger'
 import { startInternalContext } from '../domain/internalContext'
 
 export function startLogs(
   initConfiguration: LogsInitConfiguration,
   configuration: LogsConfiguration,
-  buildCommonContext: () => CommonContext,
-  mainLogger: Logger
+  buildCommonContext: () => CommonContext
 ) {
   const lifeCycle = new LifeCycle()
 
@@ -77,7 +75,7 @@ export function startLogs(
   startReportCollection(configuration, lifeCycle)
   const { handleLog } = startLoggerCollection(lifeCycle)
 
-  startLogsAssembly(session, configuration, lifeCycle, buildCommonContext, mainLogger, reportError)
+  startLogsAssembly(session, configuration, lifeCycle, buildCommonContext, reportError)
 
   if (!canUseEventBridge()) {
     startLogsBatch(configuration, lifeCycle, reportError, pageExitObservable, session.expireObservable)

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -153,14 +153,14 @@ describe('startLogsAssembly', () => {
       expect(serverLogs[0].common_context_key).toBeUndefined()
     })
 
-    it('should include main logger context', () => {
+    it('should not include main logger context', () => {
       mainLogger.setContext({ foo: 'from-main-logger' })
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
 
-      expect(serverLogs[0].foo).toEqual('from-main-logger')
+      expect(serverLogs[0].foo).toBeUndefined()
     })
 
-    it('should include logger context instead of main logger context when present', () => {
+    it('should include logger context when present', () => {
       const logger = new Logger(() => noop)
       mainLogger.setContext({ foo: 'from-main-logger', bar: 'from-main-logger' })
       logger.setContext({ foo: 'from-logger' })
@@ -236,14 +236,6 @@ describe('startLogsAssembly', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
 
       expect(serverLogs[0].message).toEqual('message')
-    })
-
-    it('logger context should take precedence over raw log', () => {
-      mainLogger.setContext({ message: 'from-main-logger' })
-
-      lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
-
-      expect(serverLogs[0].message).toEqual('from-main-logger')
     })
 
     it('message context should take precedence over logger context', () => {

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -62,7 +62,7 @@ describe('startLogsAssembly', () => {
     }
     beforeSend = noop
     mainLogger = new Logger(() => noop)
-    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, mainLogger, noop)
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, noop)
     window.DD_RUM = {
       getInternalContext: noop,
     }
@@ -288,7 +288,6 @@ describe('user management', () => {
   let serverLogs: Array<LogsEvent & Context> = []
 
   const beforeSend: (event: LogsEvent) => void | boolean = noop
-  const mainLogger = new Logger(() => noop)
   const configuration = {
     ...validateAndBuildLogsConfiguration(initConfiguration)!,
     beforeSend: (x: LogsEvent) => beforeSend(x),
@@ -306,14 +305,14 @@ describe('user management', () => {
   })
 
   it('should not output usr key if user is not set', () => {
-    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, mainLogger, noop)
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, noop)
 
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
     expect(serverLogs[0].usr).toBeUndefined()
   })
 
   it('should include user data when user has been set', () => {
-    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT_WITH_USER, mainLogger, noop)
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT_WITH_USER, noop)
 
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
     expect(serverLogs[0].usr).toEqual({
@@ -334,7 +333,7 @@ describe('user management', () => {
         },
       },
     }
-    startLogsAssembly(sessionManager, configuration, lifeCycle, () => globalContextWithUser, mainLogger, noop)
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => globalContextWithUser, noop)
 
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
     expect(serverLogs[0].usr).toEqual({
@@ -355,7 +354,6 @@ describe('logs limitation', () => {
   let beforeSend: (event: LogsEvent) => void | boolean
   let lifeCycle: LifeCycle
   let serverLogs: Array<LogsEvent & Context> = []
-  let mainLogger: Logger
   let reportErrorSpy: jasmine.Spy<jasmine.Func>
 
   beforeEach(() => {
@@ -368,9 +366,8 @@ describe('logs limitation', () => {
       beforeSend: (x: LogsEvent) => beforeSend(x),
     }
     beforeSend = noop
-    mainLogger = new Logger(() => noop)
     reportErrorSpy = jasmine.createSpy('reportError')
-    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, mainLogger, reportErrorSpy)
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, reportErrorSpy)
     clock = mockClock()
   })
 

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -160,17 +160,6 @@ describe('startLogsAssembly', () => {
       expect(serverLogs[0].foo).toBeUndefined()
     })
 
-    it('should include logger context when present', () => {
-      const logger = new Logger(() => noop)
-      mainLogger.setContext({ foo: 'from-main-logger', bar: 'from-main-logger' })
-      logger.setContext({ foo: 'from-logger' })
-
-      lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE, logger })
-
-      expect(serverLogs[0].foo).toEqual('from-logger')
-      expect(serverLogs[0].bar).toBeUndefined()
-    })
-
     it('should include rum internal context related to the error time', () => {
       window.DD_RUM = {
         getInternalContext(startTime) {
@@ -238,7 +227,7 @@ describe('startLogsAssembly', () => {
       expect(serverLogs[0].message).toEqual('message')
     })
 
-    it('message context should take precedence over logger context', () => {
+    it('message context should take precedence over raw log', () => {
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: DEFAULT_MESSAGE,
         messageContext: { message: 'from-message-context' },

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -14,9 +14,7 @@ import type { CommonContext } from '../rawLogsEvent.types'
 import type { LogsConfiguration } from './configuration'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
-import type { Logger } from './logger'
-import { STATUSES, HandlerType } from './logger'
-import { isAuthorized } from './logsCollection/logger/loggerCollection'
+import { STATUSES } from './logger'
 import type { LogsSessionManager } from './logsSessionManager'
 
 export function startLogsAssembly(
@@ -24,7 +22,6 @@ export function startLogsAssembly(
   configuration: LogsConfiguration,
   lifeCycle: LifeCycle,
   buildCommonContext: () => CommonContext,
-  mainLogger: Logger, // Todo: [RUMF-1230] Remove this parameter in the next major release
   reportError: (error: RawError) => void
 ) {
   const statusWithCustom = (STATUSES as string[]).concat(['custom'])
@@ -60,8 +57,6 @@ export function startLogsAssembly(
       )
 
       if (
-        // Todo: [RUMF-1230] Move this check to the logger collection in the next major release
-        !isAuthorized(rawLogsEvent.status, HandlerType.http, logger || mainLogger) ||
         configuration.beforeSend?.(log) === false ||
         (log.origin !== ErrorSource.AGENT &&
           (logRateLimiters[log.status] ?? logRateLimiters['custom']).isLimitReached())

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -32,7 +32,7 @@ export function startLogsAssembly(
 
   lifeCycle.subscribe(
     LifeCycleEventType.RAW_LOG_COLLECTED,
-    ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined, logger }) => {
+    ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined }) => {
       const startTime = getRelativeTime(rawLogsEvent.date)
       const session = sessionManager.findTrackedSession(startTime)
 
@@ -52,7 +52,6 @@ export function startLogsAssembly(
         commonContext.context,
         getRUMInternalContext(startTime),
         rawLogsEvent,
-        logger?.getContext(),
         messageContext
       )
 

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -35,7 +35,7 @@ export function startLogsAssembly(
 
   lifeCycle.subscribe(
     LifeCycleEventType.RAW_LOG_COLLECTED,
-    ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined, logger = mainLogger }) => {
+    ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined, logger }) => {
       const startTime = getRelativeTime(rawLogsEvent.date)
       const session = sessionManager.findTrackedSession(startTime)
 
@@ -55,13 +55,13 @@ export function startLogsAssembly(
         commonContext.context,
         getRUMInternalContext(startTime),
         rawLogsEvent,
-        logger.getContext(),
+        logger?.getContext(),
         messageContext
       )
 
       if (
         // Todo: [RUMF-1230] Move this check to the logger collection in the next major release
-        !isAuthorized(rawLogsEvent.status, HandlerType.http, logger) ||
+        !isAuthorized(rawLogsEvent.status, HandlerType.http, logger || mainLogger) ||
         configuration.beforeSend?.(log) === false ||
         (log.origin !== ErrorSource.AGENT &&
           (logRateLimiters[log.status] ?? logRateLimiters['custom']).isLimitReached())

--- a/packages/logs/src/domain/lifeCycle.ts
+++ b/packages/logs/src/domain/lifeCycle.ts
@@ -2,7 +2,6 @@ import { AbstractLifeCycle } from '@datadog/browser-core'
 import type { Context } from '@datadog/browser-core'
 import type { LogsEvent } from '../logsEvent.types'
 import type { CommonContext, RawLogsEvent } from '../rawLogsEvent.types'
-import type { Logger } from './logger'
 
 export const enum LifeCycleEventType {
   RAW_LOG_COLLECTED,
@@ -21,5 +20,4 @@ export interface RawLogsEventCollectedData<E extends RawLogsEvent = RawLogsEvent
   rawLogsEvent: E
   messageContext?: object
   savedCommonContext?: CommonContext
-  logger?: Logger
 }

--- a/packages/logs/src/domain/logsCollection/logger/loggerCollection.spec.ts
+++ b/packages/logs/src/domain/logsCollection/logger/loggerCollection.spec.ts
@@ -45,17 +45,17 @@ describe('logger collection', () => {
     })
 
     it('should print the log message and context to the console', () => {
-      logger.setContext({ 'logger-context': 'foo' })
+      logger.setContext({ foo: 'from-logger', bar: 'from-logger' })
 
       handleLog(
-        { message: 'message', status: StatusType.error, context: { 'log-context': 'bar' } },
+        { message: 'message', status: StatusType.error, context: { bar: 'from-message' } },
         logger,
         COMMON_CONTEXT
       )
 
       expect(display.error).toHaveBeenCalledOnceWith('message', {
-        'logger-context': 'foo',
-        'log-context': 'bar',
+        foo: 'from-logger',
+        bar: 'from-message',
       })
     })
 
@@ -96,23 +96,25 @@ describe('logger collection', () => {
     })
 
     it('should send the log message and context', () => {
-      logger.setContext({ 'logger-context': 'foo' })
+      logger.setContext({ foo: 'from-logger', bar: 'from-logger' })
 
       handleLog(
-        { message: 'message', status: StatusType.error, context: { 'log-context': 'bar' } },
+        { message: 'message', status: StatusType.error, context: { bar: 'from-message' } },
         logger,
         COMMON_CONTEXT
       )
 
       expect(rawLogsEvents[0]).toEqual({
-        logger,
         rawLogsEvent: {
           date: timeStampNow(),
           origin: ErrorSource.LOGGER,
           message: 'message',
           status: StatusType.error,
         },
-        messageContext: { 'log-context': 'bar' },
+        messageContext: {
+          foo: 'from-logger',
+          bar: 'from-message',
+        },
         savedCommonContext: COMMON_CONTEXT,
       })
     })

--- a/packages/logs/src/domain/logsCollection/logger/loggerCollection.ts
+++ b/packages/logs/src/domain/logsCollection/logger/loggerCollection.ts
@@ -20,10 +20,10 @@ export function startLoggerCollection(lifeCycle: LifeCycle) {
     savedCommonContext?: CommonContext,
     savedDate?: TimeStamp
   ) {
-    const messageContext = logsMessage.context
+    const messageContext = combine(logger.getContext(), logsMessage.context)
 
     if (isAuthorized(logsMessage.status, HandlerType.console, logger)) {
-      display(logsMessage.status, logsMessage.message, combine(logger.getContext(), messageContext))
+      display(logsMessage.status, logsMessage.message, messageContext)
     }
 
     if (isAuthorized(logsMessage.status, HandlerType.http, logger)) {
@@ -36,7 +36,6 @@ export function startLoggerCollection(lifeCycle: LifeCycle) {
         },
         messageContext,
         savedCommonContext,
-        logger,
       })
     }
   }

--- a/packages/logs/src/domain/logsCollection/logger/loggerCollection.ts
+++ b/packages/logs/src/domain/logsCollection/logger/loggerCollection.ts
@@ -26,17 +26,19 @@ export function startLoggerCollection(lifeCycle: LifeCycle) {
       display(logsMessage.status, logsMessage.message, combine(logger.getContext(), messageContext))
     }
 
-    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
-      rawLogsEvent: {
-        date: savedDate || timeStampNow(),
-        message: logsMessage.message,
-        status: logsMessage.status,
-        origin: ErrorSource.LOGGER,
-      },
-      messageContext,
-      savedCommonContext,
-      logger,
-    })
+    if (isAuthorized(logsMessage.status, HandlerType.http, logger)) {
+      lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
+        rawLogsEvent: {
+          date: savedDate || timeStampNow(),
+          message: logsMessage.message,
+          status: logsMessage.status,
+          origin: ErrorSource.LOGGER,
+        },
+        messageContext,
+        savedCommonContext,
+        logger,
+      })
+    }
   }
 
   return {


### PR DESCRIPTION
## Motivation

Main logger (`DD_LOGS.logger`) context and level impact logs generated by console, report, network error and runtime error which can lead to surprising behaviour. 

## Changes

- 💥 add main logger context only to main logger logs
- 💥 apply main logger level only to main logger logs
- ♻️ merge logger context with message context in logger collection

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
