### PR TITLE
✨ Collect replay privacy level in views

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.spec.ts
@@ -143,6 +143,7 @@ describe('viewCollection', () => {
         is_active: undefined,
       },
       feature_flags: undefined,
+      privacy: { replay_level: 'mask-user-input' },
     })
   })
 

--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewCollection.ts
@@ -35,7 +35,7 @@ export function startViewCollection(
   lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, (view) =>
     lifeCycle.notify(
       LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
-      processViewUpdate(view, foregroundContexts, featureFlagContexts, recorderApi, pageStateHistory)
+      processViewUpdate(view, configuration, foregroundContexts, featureFlagContexts, recorderApi, pageStateHistory)
     )
   )
   const trackViewResult = trackViews(
@@ -53,6 +53,7 @@ export function startViewCollection(
 
 function processViewUpdate(
   view: ViewEvent,
+  configuration: RumConfiguration,
   foregroundContexts: ForegroundContexts,
   featureFlagContexts: FeatureFlagContexts,
   recorderApi: RecorderApi,
@@ -108,6 +109,9 @@ function processViewUpdate(
     session: {
       has_replay: replayStats ? true : undefined,
       is_active: view.sessionIsActive ? undefined : false,
+    },
+    privacy: {
+      replay_level: configuration.defaultPrivacyLevel,
     },
   }
   if (!isEmptyObject(view.customTimings)) {

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -7,6 +7,7 @@ import type {
   ServerDuration,
   TimeStamp,
   RawErrorCause,
+  DefaultPrivacyLevel,
 } from '@datadog/browser-core'
 import type { PageState } from './domain/contexts/pageStateHistory'
 import type { RumSessionPlan } from './domain/rumSessionManager'
@@ -107,6 +108,9 @@ export interface RawRumViewEvent {
     is_active: false | undefined
   }
   feature_flags?: Context
+  privacy?: {
+    replay_level: DefaultPrivacyLevel
+  }
   _dd: {
     document_version: number
     replay_stats?: ReplayStats

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -765,6 +765,16 @@ export type RumViewEvent = CommonProperties & {
     [k: string]: unknown
   }
   /**
+   * Privacy properties
+   */
+  readonly privacy?: {
+    /**
+     * The replay privacy level
+     */
+    readonly replay_level: 'allow' | 'mask' | 'mask-user-input'
+    [k: string]: unknown
+  }
+  /**
    * Internal properties
    */
   readonly _dd: {
@@ -786,6 +796,24 @@ export type RumViewEvent = CommonProperties & {
       readonly start: number
       [k: string]: unknown
     }[]
+    /**
+     * Debug metadata for Replay Sessions
+     */
+    replay_stats?: {
+      /**
+       * The number of records produced during this view lifetime
+       */
+      records_count?: number
+      /**
+       * The number of segments sent during this view lifetime
+       */
+      segments_count?: number
+      /**
+       * The total size in bytes of the segments sent during this view lifetime
+       */
+      segments_total_raw_size?: number
+      [k: string]: unknown
+    }
     [k: string]: unknown
   }
   [k: string]: unknown


### PR DESCRIPTION
## Motivation

Some customers have privacy concerns about the PII potentially being collected by session replay and they want a way to ensure their usage complies with their policies. Because they can have multiple applications operated by different teams they want a central way to monitor their replay privacy level configured in their Browser RUM SDK. 

## Changes

Collect replay privacy level in views

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
