### PR TITLE
🐛 Handle local storage replication latency

### DIFF
--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -1,6 +1,5 @@
 import { setTimeout } from '../../tools/timer'
 import { generateUUID } from '../../tools/utils/stringUtils'
-import { isChromium } from '../../tools/utils/browserDetection'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import type { SessionState } from './sessionState'
 import { expandSessionState, isSessionInExpiredState } from './sessionState'
@@ -10,54 +9,89 @@ type Operations = {
   after?: (sessionState: SessionState) => void
 }
 
+// We check the session every 1000ms (STORAGE_POLL_DELAY). We must keep
+// (LOCK_RETRY_DELAY * LOCK_MAX_TRIES) under STORAGE_POLL_DELAY
+// In case of a stale lock, (LOCK_RETRY_DELAY * LOCK_MAX_TRIES) is the minimum
+// time taken by the system to reach stability.
 export const LOCK_RETRY_DELAY = 10
-export const LOCK_MAX_TRIES = 100
+export const LOCK_MAX_TRIES = 20
+
 const bufferedOperations: Operations[] = []
 let ongoingOperations: Operations | undefined
+let currentLock: string | undefined
 
 export function processSessionStoreOperations(
   operations: Operations,
   sessionStoreStrategy: SessionStoreStrategy,
   numberOfRetries = 0
 ) {
-  const { retrieveSession, persistSession, clearSession } = sessionStoreStrategy
-  const lockEnabled = isLockEnabled()
-
+  const { retrieveSession, persistSession, clearSession, lockOptions } = sessionStoreStrategy
+  // If we do not have an ongoing operation, set the received operations
+  // as the current one
   if (!ongoingOperations) {
     ongoingOperations = operations
   }
+
+  // If we have a pending ongoing operation, we should buffer the received
+  // operation. It will be executed later.
   if (operations !== ongoingOperations) {
     bufferedOperations.push(operations)
     return
   }
-  if (lockEnabled && numberOfRetries >= LOCK_MAX_TRIES) {
+
+  // Lets look into the storage if we have a session. If we do not, the
+  // currentSession will be an empty object.
+  let currentSession = retrieveSession()
+
+  // If we were not able to fullfill our operation in the max amount of tries,
+  // discard it. It will not be executed.
+  if (lockOptions.enabled && numberOfRetries >= LOCK_MAX_TRIES) {
     next(sessionStoreStrategy)
+    // However - If we cannot get a lock within a reasonable amount of time, the lock
+    // may be in an inconsistent state (aborted process, manually modified, ...). We remove it.
+    delete currentSession.lock
+    persistSession(currentSession)
     return
   }
-  let currentLock: string
-  let currentSession = retrieveSession()
-  if (lockEnabled) {
-    // if someone has lock, retry later
-    if (currentSession.lock) {
+
+  if (lockOptions.enabled) {
+    // If a lock has been set, and it is not ours, we want to
+    // postpone the operation and retry later
+    // TODO: Check that this case is properly tested
+    if (currentSession.lock && currentSession.lock !== currentLock) {
       retryLater(operations, sessionStoreStrategy, numberOfRetries)
       return
     }
-    // acquire lock
-    currentLock = generateUUID()
-    currentSession.lock = currentLock
-    persistSession(currentSession)
-    // if lock is not acquired, retry later
-    currentSession = retrieveSession()
-    if (currentSession.lock !== currentLock) {
-      retryLater(operations, sessionStoreStrategy, numberOfRetries)
-      return
+
+    // Try to acquire our lock
+    if (currentSession.lock === undefined) {
+      currentLock = generateUUID()
+      currentSession.lock = currentLock
+      persistSession(currentSession)
+
+      // Here, typically for local storage, we must WAIT before retrieving the lock. Else, there is a chance another
+      // process can unknowingly write to the storage. This happens because of a latency to replicate the written value.
+      if (lockOptions.synchronizationLatency > 0) {
+        retryLater(operations, sessionStoreStrategy, numberOfRetries, lockOptions.synchronizationLatency)
+        return
+      }
+
+      // If there is no latency, we retrieve our session to check we're still owner of our lock.
+      // If the lock has changed, postpone the operation
+      currentSession = retrieveSession()
+      if (currentSession.lock !== currentLock) {
+        retryLater(operations, sessionStoreStrategy, numberOfRetries)
+        return
+      }
     }
   }
+
   let processedSession = operations.process(currentSession)
-  if (lockEnabled) {
-    // if lock corrupted after process, retry later
+
+  if (lockOptions.enabled) {
+    // If the lock has changed after process, retry later
     currentSession = retrieveSession()
-    if (currentSession.lock !== currentLock!) {
+    if (currentSession.lock !== currentLock) {
       retryLater(operations, sessionStoreStrategy, numberOfRetries)
       return
     }
@@ -70,37 +104,37 @@ export function processSessionStoreOperations(
       persistSession(processedSession)
     }
   }
-  if (lockEnabled) {
-    // correctly handle lock around expiration would require to handle this case properly at several levels
-    // since we don't have evidence of lock issues around expiration, let's just not do the corruption check for it
+  if (lockOptions.enabled) {
+    // Correctly handling lock around expiration would require to handle this case properly at several levels
+    // Since we don't have evidence of lock issues around expiration, let's just not do the corruption check for it
     if (!(processedSession && isSessionInExpiredState(processedSession))) {
-      // if lock corrupted after persist, retry later
+      // If the lock is not our own after persist, retry later
       currentSession = retrieveSession()
       if (currentSession.lock !== currentLock!) {
         retryLater(operations, sessionStoreStrategy, numberOfRetries)
         return
       }
+      // Cleanup by removing lock information from the storage
       delete currentSession.lock
       persistSession(currentSession)
       processedSession = currentSession
     }
   }
-  // call after even if session is not persisted in order to perform operations on
+  // Call after() even if session is not persisted in order to perform operations on an
   // up-to-date session state value => the value could have been modified by another tab
   operations.after?.(processedSession || currentSession)
   next(sessionStoreStrategy)
 }
 
-/**
- * Lock strategy allows mitigating issues due to concurrent access to cookie.
- * This issue concerns only chromium browsers and enabling this on firefox increases cookie write failures.
- */
-export const isLockEnabled = () => isChromium()
-
-function retryLater(operations: Operations, sessionStore: SessionStoreStrategy, currentNumberOfRetries: number) {
+function retryLater(
+  operations: Operations,
+  sessionStore: SessionStoreStrategy,
+  currentNumberOfRetries: number,
+  retryDelay = LOCK_RETRY_DELAY
+) {
   setTimeout(() => {
     processSessionStoreOperations(operations, sessionStore, currentNumberOfRetries + 1)
-  }, LOCK_RETRY_DELAY)
+  }, retryDelay)
 }
 
 function next(sessionStore: SessionStoreStrategy) {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -5,6 +5,7 @@ import { tryOldCookiesMigration } from '../oldCookiesMigration'
 import { SESSION_EXPIRATION_DELAY } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
 import { toSessionString, toSessionState } from '../sessionState'
+import { isChromium } from '../../../tools/utils/browserDetection'
 import type { SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -15,6 +16,7 @@ export function selectCookieStrategy(initConfiguration: InitConfiguration): Sess
 
 export function initCookieStrategy(cookieOptions: CookieOptions): SessionStoreStrategy {
   const cookieStore = {
+    lockOptions: { enabled: isChromium(), synchronizationLatency: 0 },
     persistSession: persistSessionCookie(cookieOptions),
     retrieveSession: retrieveSessionCookie,
     clearSession: deleteSessionCookie(cookieOptions),

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -1,3 +1,4 @@
+import { isChromium } from '../../../tools/utils/browserDetection'
 import { generateUUID } from '../../../tools/utils/stringUtils'
 import type { SessionState } from '../sessionState'
 import { toSessionString, toSessionState } from '../sessionState'
@@ -21,6 +22,8 @@ export function selectLocalStorageStrategy(): SessionStoreStrategyType | undefin
 
 export function initLocalStorageStrategy(): SessionStoreStrategy {
   return {
+    // synchronizationLatency: 7ms determined as a safe value from a minimum of 5ms.
+    lockOptions: { enabled: isChromium(), synchronizationLatency: 7 },
     persistSession: persistInLocalStorage,
     retrieveSession: retrieveSessionFromLocalStorage,
     clearSession: clearSessionFromLocalStorage,

--- a/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
@@ -5,7 +5,26 @@ export const SESSION_STORE_KEY = '_dd_s'
 
 export type SessionStoreStrategyType = { type: 'Cookie'; cookieOptions: CookieOptions } | { type: 'LocalStorage' }
 
+type LockOptions = {
+  /**
+   * If enabled, lock strategy will be applied while processing store operations.
+   * Lock strategy allows mitigating issues due to concurrent access:
+   * - To cookies on chromium browsers. Enabling this on firefox increases cookie write failures.
+   * - To Local Storage on chromium browsers.
+   */
+  enabled: boolean
+
+  /**
+   * Some storages do not synchronize instantly between browser windows after a write operation.
+   * Lock strategy must be enabled for this property to be taken into account.
+   * - Cookies: Not affected
+   * - Local Storage: Chromium based browsers seem to require at least 5ms
+   */
+  synchronizationLatency: number
+}
+
 export interface SessionStoreStrategy {
+  lockOptions: LockOptions
   persistSession: (session: SessionState) => void
   retrieveSession: () => SessionState
   clearSession: () => void


### PR DESCRIPTION
## Motivation

When instantiating two browser windows within a short interval (<10ms), there is a high risk that the lock mechanism will not work for local storage. There is a replication latency between browser windows of ~5ms (according to tests).

## Changes

- Postpone reading the lock by 7ms in case local storage is used. This leaves time for the storage to synchronize.
- Remove the lock when we reach max tries. 
--  The chances for this situation to happen with cookies is extremely low as we'd need to kill the browser in the middle of processStoreOperations, with a lock acquired.
-- However, the chances for this to happen are much higher for local storage: around 7 out of 1000 per opened window.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
