### PR TITLE
💥 [RUMF-1556] Typings: consistent beforeSend return type

### DIFF
--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -73,6 +73,22 @@ describe('startLogsAssembly', () => {
     serverLogs = []
   })
 
+  it('should send if beforeSend returned true', () => {
+    beforeSend = () => true
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
+      rawLogsEvent: DEFAULT_MESSAGE,
+    })
+    expect(serverLogs.length).toEqual(1)
+  })
+
+  it('should send if beforeSend returned undefined', () => {
+    beforeSend = () => undefined
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
+      rawLogsEvent: DEFAULT_MESSAGE,
+    })
+    expect(serverLogs.length).toEqual(1)
+  })
+
   it('should not send if beforeSend returned false', () => {
     beforeSend = () => false
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -14,7 +14,7 @@ import {
 import type { LogsEvent } from '../logsEvent.types'
 
 export interface LogsInitConfiguration extends InitConfiguration {
-  beforeSend?: ((event: LogsEvent) => void | boolean) | undefined
+  beforeSend?: ((event: LogsEvent) => boolean) | undefined
   forwardErrorsToLogs?: boolean | undefined
   forwardConsoleLogs?: ConsoleApiName[] | 'all' | undefined
   forwardReports?: RawReportType[] | 'all' | undefined

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -329,6 +329,38 @@ describe('rum assembly', () => {
         expect(displaySpy).toHaveBeenCalledWith("Can't dismiss view events using beforeSend!")
       })
     })
+
+    it('should not dismiss when true is returned', () => {
+      const { lifeCycle } = setupBuilder
+        .withConfiguration({
+          beforeSend: () => true,
+        })
+        .build()
+
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION, {
+          view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+        }),
+      })
+
+      expect(serverRumEvents.length).toBe(1)
+    })
+
+    it('should not dismiss when undefined is returned', () => {
+      const { lifeCycle } = setupBuilder
+        .withConfiguration({
+          beforeSend: () => undefined,
+        })
+        .build()
+
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION, {
+          view: { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+        }),
+      })
+
+      expect(serverRumEvents.length).toBe(1)
+    })
   })
 
   describe('rum context', () => {

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -19,7 +19,7 @@ import type { PropagatorType, TracingOption } from './tracing/tracer.types'
 export interface RumInitConfiguration extends InitConfiguration {
   // global options
   applicationId: string
-  beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => void | boolean) | undefined
+  beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => boolean) | undefined
   excludedActivityUrls?: MatchOption[] | undefined
 
   // tracing options

--- a/test/e2e/scenario/logs.scenario.ts
+++ b/test/e2e/scenario/logs.scenario.ts
@@ -159,6 +159,7 @@ describe('logs', () => {
     .withLogs({
       beforeSend: (event) => {
         event.foo = 'bar'
+        return true
       },
     })
     .run(async ({ serverEvents }) => {

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -110,6 +110,7 @@ describe('beforeSend', () => {
     .withRum({
       beforeSend: (event: any) => {
         event.context!.foo = 'bar'
+        return true
       },
     })
     .withRumSlim()
@@ -126,6 +127,7 @@ describe('beforeSend', () => {
     .withRum({
       beforeSend: (event) => {
         event.context = { foo: 'bar' }
+        return true
       },
     })
     .withRumSlim()


### PR DESCRIPTION
## Motivation

Avoid confusing return type for `beforeSend`, cf https://github.com/DataDog/browser-sdk/issues/1605

## Changes

```diff
- beforeSend(event: any, context?: any) => boolean | void
+ beforeSend(event: any, context?: any) => boolean
```

**Nb:** No change on the implementation, if no value is returned, the event is **not** discarded. 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
