### PR TITLE
🐛 [RUM-231] Fix location.origin is "null" for file: URIs

### DIFF
--- a/packages/core/src/tools/utils/urlPolyfill.spec.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.spec.ts
@@ -1,5 +1,14 @@
 import { isFirefox } from '../../../test'
-import { getHash, getOrigin, getPathName, getSearch, isValidUrl, normalizeUrl, getLocationOrigin } from './urlPolyfill'
+import {
+  getHash,
+  getOrigin,
+  getPathName,
+  getSearch,
+  isValidUrl,
+  normalizeUrl,
+  getLocationOrigin,
+  getLinkElementOrigin,
+} from './urlPolyfill'
 
 describe('normalize url', () => {
   it('should add origin to relative path', () => {
@@ -15,8 +24,13 @@ describe('normalize url', () => {
   })
 
   it('should keep non http url unchanged', () => {
+    expect(normalizeUrl('ftp://foo.com/my/path')).toEqual('ftp://foo.com/my/path')
+  })
+
+  it('should keep file url unchanged', () => {
     if (isFirefox()) {
-      pending('https://bugzilla.mozilla.org/show_bug.cgi?id=1578787')
+      // On firefox, URL host is empty for file URI: 'https://bugzilla.mozilla.org/show_bug.cgi?id=1578787'
+      expect(normalizeUrl('file://foo.com/my/path')).toMatch(/^file:\/\/.*\/my\/path$/)
     }
     expect(normalizeUrl('file://foo.com/my/path')).toEqual('file://foo.com/my/path')
   })
@@ -64,5 +78,11 @@ describe('getHash', () => {
   it('should retrieve url hash', () => {
     expect(getHash('http://www.datadoghq.com')).toBe('')
     expect(getHash('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe('#hello')
+  })
+})
+
+describe('getLinkElementOrigin', () => {
+  it('should retrieve the url origin if URL origin is "null"', () => {
+    expect(getLinkElementOrigin({ origin: 'null', host: 'foo.bar', protocol: 'file:' } as URL)).toBe('file://foo.bar')
   })
 })

--- a/packages/core/src/tools/utils/urlPolyfill.spec.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.spec.ts
@@ -31,8 +31,9 @@ describe('normalize url', () => {
     if (isFirefox()) {
       // On firefox, URL host is empty for file URI: 'https://bugzilla.mozilla.org/show_bug.cgi?id=1578787'
       expect(normalizeUrl('file://foo.com/my/path')).toMatch(/^file:\/\/.*\/my\/path$/)
+    } else {
+      expect(normalizeUrl('file://foo.com/my/path')).toEqual('file://foo.com/my/path')
     }
-    expect(normalizeUrl('file://foo.com/my/path')).toEqual('file://foo.com/my/path')
   })
 })
 

--- a/packages/core/src/tools/utils/urlPolyfill.spec.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.spec.ts
@@ -30,7 +30,7 @@ describe('normalize url', () => {
   it('should keep file url unchanged', () => {
     if (isFirefox()) {
       // On firefox, URL host is empty for file URI: 'https://bugzilla.mozilla.org/show_bug.cgi?id=1578787'
-      expect(normalizeUrl('file://foo.com/my/path')).toMatch(/^file:\/\/.*\/my\/path$/)
+      expect(normalizeUrl('file://foo.com/my/path')).toEqual('file:///my/path')
     } else {
       expect(normalizeUrl('file://foo.com/my/path')).toEqual('file://foo.com/my/path')
     }

--- a/packages/core/src/tools/utils/urlPolyfill.spec.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.spec.ts
@@ -1,14 +1,6 @@
 import { isFirefox } from '../../../test'
-import {
-  getHash,
-  getOrigin,
-  getPathName,
-  getSearch,
-  isValidUrl,
-  normalizeUrl,
-  getLocationOrigin,
-  getLinkElementOrigin,
-} from './urlPolyfill'
+import { isIE } from './browserDetection'
+import { getHash, getOrigin, getPathName, getSearch, isValidUrl, normalizeUrl, getLocationOrigin } from './urlPolyfill'
 
 describe('normalize url', () => {
   it('should add origin to relative path', () => {
@@ -59,6 +51,15 @@ describe('getOrigin', () => {
     expect(getOrigin('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe('http://www.datadoghq.com')
     expect(getOrigin('http://localhost:8080')).toBe('http://localhost:8080')
   })
+
+  it('should retrieve file url origin', () => {
+    if (isIE()) {
+      // On IE, our origin fallback strategy contains the host
+      expect(getOrigin('file://foo.com/my/path')).toEqual('file://foo.com')
+    } else {
+      expect(getOrigin('file://foo.com/my/path')).toEqual('file://')
+    }
+  })
 })
 
 describe('getPathName', () => {
@@ -79,11 +80,5 @@ describe('getHash', () => {
   it('should retrieve url hash', () => {
     expect(getHash('http://www.datadoghq.com')).toBe('')
     expect(getHash('http://www.datadoghq.com/foo/bar?a=b#hello')).toBe('#hello')
-  })
-})
-
-describe('getLinkElementOrigin', () => {
-  it('should retrieve the url origin if URL origin is "null"', () => {
-    expect(getLinkElementOrigin({ origin: 'null', host: 'foo.bar', protocol: 'file:' } as URL)).toBe('file://foo.bar')
   })
 })

--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -12,10 +12,6 @@ export function isValidUrl(url: string) {
   }
 }
 
-export function haveSameOrigin(url1: string, url2: string) {
-  return getOrigin(url1) === getOrigin(url2)
-}
-
 export function getOrigin(url: string) {
   return getLinkElementOrigin(buildUrl(url))
 }
@@ -77,11 +73,12 @@ export function getLocationOrigin() {
 }
 
 /**
- * IE fallback
- * https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/origin
+ * Fallback
+ * On IE HTMLAnchorElement origin is not supported: https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/origin
+ * On Firefox window.location.origin is "null" for file: URIs: https://bugzilla.mozilla.org/show_bug.cgi?id=878297
  */
 export function getLinkElementOrigin(element: Location | HTMLAnchorElement | URL) {
-  if (element.origin) {
+  if (element.origin && element.origin !== 'null') {
     return element.origin
   }
   const sanitizedHost = element.host.replace(/(:80|:443)$/, '')


### PR DESCRIPTION
## Motivation

On Firefox window.location.origin is "null" for file: URIs, making our url normalisation fail.
(cf: https://bugzilla.mozilla.org/show_bug.cgi?id=878297)

## Changes

Update getLinkElementOrigin to handle "null" case

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
