### PR TITLE
Ignore untrusted event

### DIFF
--- a/packages/core/src/browser/addEventListener.spec.ts
+++ b/packages/core/src/browser/addEventListener.spec.ts
@@ -1,4 +1,4 @@
-import { stubZoneJs } from '../../test'
+import { createNewEvent, stubZoneJs } from '../../test'
 import { noop } from '../tools/utils/functionUtils'
 import { addEventListener, DOM_EVENT } from './addEventListener'
 
@@ -31,6 +31,29 @@ describe('addEventListener', () => {
       const { stop } = addEventListener(eventTarget, DOM_EVENT.CLICK, noop)
       stop()
       expect(zoneJsPatchedRemoveEventListener).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Untrusted event', () => {
+    it('should be ignored if __ddIsTrusted is false', () => {
+      const listener = jasmine.createSpy()
+      const eventTarget = document.createElement('div')
+      addEventListener(eventTarget, DOM_EVENT.CLICK, listener)
+
+      const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: false })
+      eventTarget.dispatchEvent(event)
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('should not be ignored if __ddIsTrusted is true', () => {
+      const listener = jasmine.createSpy()
+      const eventTarget = document.createElement('div')
+      addEventListener(eventTarget, DOM_EVENT.CLICK, listener)
+
+      const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: true })
+      eventTarget.dispatchEvent(event)
+
+      expect(listener).toHaveBeenCalled()
     })
   })
 })

--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -108,14 +108,15 @@ export function addEventListeners<Target extends EventTarget, EventName extends 
   listener: (event: EventMapFor<Target>[EventName]) => void,
   { once, capture, passive }: AddEventListenerOptions = {}
 ) {
-  const wrappedListener = monitor(
-    once
-      ? (event: Event) => {
-          stop()
-          listener(event as EventMapFor<Target>[EventName])
-        }
-      : (listener as (event: Event) => void)
-  )
+  const wrappedListener = monitor((event: Event & { __ddIsTrusted?: boolean }) => {
+    if (!event.isTrusted && !event.__ddIsTrusted) {
+      return
+    }
+    if (once) {
+      stop()
+    }
+    listener(event as EventMapFor<Target>[EventName])
+  })
 
   const options = passive ? { capture, passive } : capture
 

--- a/packages/core/src/browser/xhrObservable.spec.ts
+++ b/packages/core/src/browser/xhrObservable.spec.ts
@@ -247,7 +247,7 @@ describe('xhr observable', () => {
   })
 
   it('should track multiple requests with the same xhr instance', (done) => {
-    let listeners: { [k: string]: Array<() => void> }
+    let listeners: { [k: string]: Array<(event: Event & { __ddIsTrusted?: boolean }) => void> }
     withXhr({
       setup(xhr) {
         const secondOnload = () => {

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -160,7 +160,7 @@ describe('startSessionManager', () => {
       expectSessionIdToNotBeDefined(sessionManager)
       expectTrackingTypeToNotBeDefined(sessionManager, FIRST_PRODUCT_KEY)
 
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       expect(renewSessionSpy).toHaveBeenCalled()
       expectSessionIdToBeDefined(sessionManager)
@@ -196,7 +196,7 @@ describe('startSessionManager', () => {
       startSessionManager(STORE_TYPE, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
 
       // schedule an expandOrRenewSession
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       clock.tick(STORAGE_POLL_DELAY / 2)
 
@@ -244,7 +244,7 @@ describe('startSessionManager', () => {
       expect(renewSessionASpy).not.toHaveBeenCalled()
       expect(renewSessionBSpy).not.toHaveBeenCalled()
 
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       expect(renewSessionASpy).toHaveBeenCalled()
       expect(renewSessionBSpy).toHaveBeenCalled()
@@ -317,7 +317,7 @@ describe('startSessionManager', () => {
       expectSessionIdToBeDefined(sessionManager)
 
       clock.tick(SESSION_EXPIRATION_DELAY - 10)
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       clock.tick(10)
       expectSessionIdToBeDefined(sessionManager)
@@ -336,7 +336,7 @@ describe('startSessionManager', () => {
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
 
       clock.tick(SESSION_EXPIRATION_DELAY - 10)
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       clock.tick(10)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
@@ -432,7 +432,7 @@ describe('startSessionManager', () => {
 
       sessionManager.expire()
 
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       expectSessionIdToBeDefined(sessionManager)
     })
@@ -466,7 +466,7 @@ describe('startSessionManager', () => {
       clock.tick(10 * ONE_SECOND)
 
       // 20s to end: second session
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
       clock.tick(10 * ONE_SECOND)
       const secondSessionId = sessionManager.findActiveSession()!.id
       const secondSessionTrackingType = sessionManager.findActiveSession()!.trackingType

--- a/packages/core/src/tools/serialisation/sanitize.spec.ts
+++ b/packages/core/src/tools/serialisation/sanitize.spec.ts
@@ -1,5 +1,6 @@
 import { isIE } from '../utils/browserDetection'
 import { display } from '../display'
+import { createNewEvent } from '../../../test'
 import { sanitize } from './sanitize'
 
 describe('sanitize', () => {
@@ -72,13 +73,7 @@ describe('sanitize', () => {
     })
 
     it('should serialize events', () => {
-      let event: CustomEvent
-      if (isIE()) {
-        event = document.createEvent('CustomEvent')
-        event.initCustomEvent('MyEvent', false, false, {})
-      } else {
-        event = new CustomEvent('MyEvent')
-      }
+      const event = createNewEvent('click')
 
       expect(sanitize(event)).toEqual({
         isTrusted: false,

--- a/packages/core/test/emulate/createNewEvent.ts
+++ b/packages/core/test/emulate/createNewEvent.ts
@@ -7,13 +7,14 @@ export function createNewEvent<P extends Record<string, unknown>>(
 ): PointerEvent & P
 export function createNewEvent(eventName: string, properties?: { [name: string]: unknown }): Event
 export function createNewEvent(eventName: string, properties: { [name: string]: unknown } = {}) {
-  let event: Event
+  let event: Event & { __ddIsTrusted?: boolean }
   if (typeof Event === 'function') {
     event = new Event(eventName)
   } else {
     event = document.createEvent('Event')
     event.initEvent(eventName, true, true)
   }
+  event.__ddIsTrusted = true
   objectEntries(properties).forEach(([name, value]) => {
     // Setting values directly or with a `value` descriptor seems unsupported in IE11
     Object.defineProperty(event, name, {

--- a/packages/core/test/emulate/stubReportApis.ts
+++ b/packages/core/test/emulate/stubReportApis.ts
@@ -67,7 +67,8 @@ export const FAKE_CSP_VIOLATION_EVENT = {
   sourceFile: 'http://foo.bar/index.js',
   statusCode: 200,
   violatedDirective: 'worker-src',
-} as SecurityPolicyViolationEvent
+  __ddIsTrusted: true,
+} as SecurityPolicyViolationEvent & { __ddIsTrusted?: boolean }
 
 export const FAKE_REPORT: InterventionReport = {
   type: 'intervention',

--- a/packages/core/test/requests.ts
+++ b/packages/core/test/requests.ts
@@ -1,5 +1,6 @@
 import type { EndpointBuilder } from '../src'
 import { noop, isServerError } from '../src'
+import { createNewEvent } from './emulate/createNewEvent'
 
 export const SPEC_ENDPOINTS = {
   logsEndpointBuilder: stubEndpointBuilder('https://logs-intake.com/v1/input/abcde?foo=bar'),
@@ -249,7 +250,7 @@ export interface FetchStubPromise extends Promise<Response> {
 }
 
 class StubEventEmitter {
-  public listeners: { [k: string]: Array<() => void> } = {}
+  public listeners: { [k: string]: Array<(event: Event & { __ddIsTrusted?: boolean }) => void> } = {}
 
   addEventListener(name: string, callback: () => void) {
     if (!this.listeners[name]) {
@@ -271,7 +272,7 @@ class StubEventEmitter {
     if (!this.listeners[name]) {
       return
     }
-    this.listeners[name].forEach((listener) => listener.call(this))
+    this.listeners[name].forEach((listener) => listener.apply(this, [createNewEvent('loadend')]))
   }
 }
 

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -6,9 +6,10 @@ import {
   setCookie,
   stopSessionManager,
   ONE_SECOND,
+  DOM_EVENT,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock } from '@datadog/browser-core/test'
+import { createNewEvent, mockClock } from '@datadog/browser-core/test'
 
 import type { LogsConfiguration } from './configuration'
 import {
@@ -84,7 +85,7 @@ describe('logs session manager', () => {
     clock.tick(STORAGE_POLL_DELAY)
 
     tracked = true
-    document.body.click()
+    document.body.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
     expect(getCookie(SESSION_STORE_KEY)).toMatch(/id=[a-f0-9-]+/)
     expect(getCookie(SESSION_STORE_KEY)).toContain(`${LOGS_SESSION_KEY}=${LoggerTrackingType.TRACKED}`)

--- a/packages/rum-core/src/domain/contexts/foregroundContexts.ts
+++ b/packages/rum-core/src/domain/contexts/foregroundContexts.ts
@@ -65,19 +65,13 @@ export function closeForegroundPeriod() {
 }
 
 function trackFocus(onFocusChange: () => void) {
-  return addEventListener(window, DOM_EVENT.FOCUS, (event) => {
-    if (!event.isTrusted) {
-      return
-    }
+  return addEventListener(window, DOM_EVENT.FOCUS, () => {
     onFocusChange()
   })
 }
 
 function trackBlur(onBlurChange: () => void) {
-  return addEventListener(window, DOM_EVENT.BLUR, (event) => {
-    if (!event.isTrusted) {
-      return
-    }
+  return addEventListener(window, DOM_EVENT.BLUR, () => {
     onBlurChange()
   })
 }

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.ts
@@ -53,11 +53,7 @@ export function startPageStateHistory(
       DOM_EVENT.PAGE_HIDE,
     ],
     (event) => {
-      // Only get events fired by the browser to avoid false currentPageState changes done with custom events
-      // cf: developer extension auto flush: https://github.com/DataDog/browser-sdk/blob/2f72bf05a672794c9e33965351964382a94c72ba/developer-extension/src/panel/flushEvents.ts#L11-L12
-      if (event.isTrusted) {
-        addPageState(computePageState(event), event.timeStamp as RelativeTime)
-      }
+      addPageState(computePageState(event), event.timeStamp as RelativeTime)
     },
     { capture: true }
   )

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -7,9 +7,10 @@ import {
   setCookie,
   stopSessionManager,
   ONE_SECOND,
+  DOM_EVENT,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock } from '@datadog/browser-core/test'
+import { createNewEvent, mockClock } from '@datadog/browser-core/test'
 import type { RumConfiguration } from './configuration'
 import { validateAndBuildRumConfiguration } from './configuration'
 
@@ -134,7 +135,7 @@ describe('rum session manager', () => {
       clock.tick(STORAGE_POLL_DELAY)
 
       setupDraws({ tracked: true, trackedWithSessionReplay: true })
-      document.dispatchEvent(new CustomEvent('click'))
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       expect(expireSessionSpy).toHaveBeenCalled()
       expect(renewSessionSpy).toHaveBeenCalled()

--- a/packages/rum/src/domain/record/observers/mouseInteractionObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mouseInteractionObserver.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
+import { DOM_EVENT, DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import { createNewEvent } from '@datadog/browser-core/test'
 import { IncrementalSource, MouseInteractionType, RecordType } from '../../../types'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
@@ -26,7 +26,7 @@ describe('initMouseInteractionObserver', () => {
     a.setAttribute('tabindex', '0') // make the element focusable
     sandbox.appendChild(a)
     document.body.appendChild(sandbox)
-    a.focus()
+    a.dispatchEvent(createNewEvent(DOM_EVENT.FOCUS))
 
     serializeDocument(document, DEFAULT_CONFIGURATION, {
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
@@ -45,7 +45,7 @@ describe('initMouseInteractionObserver', () => {
   })
 
   it('should generate click record', () => {
-    a.click()
+    a.dispatchEvent(createNewEvent(DOM_EVENT.CLICK, { clientX: 0, clientY: 0 }))
 
     expect(mouseInteractionCallbackSpy).toHaveBeenCalledWith({
       id: jasmine.any(Number),
@@ -62,7 +62,7 @@ describe('initMouseInteractionObserver', () => {
   })
 
   it('should generate mouseup record on pointerup DOM event', () => {
-    const pointerupEvent = createNewEvent('pointerup', { clientX: 1, clientY: 2 })
+    const pointerupEvent = createNewEvent(DOM_EVENT.POINTER_UP, { clientX: 1, clientY: 2 })
     a.dispatchEvent(pointerupEvent)
 
     expect(mouseInteractionCallbackSpy).toHaveBeenCalledWith({
@@ -80,14 +80,14 @@ describe('initMouseInteractionObserver', () => {
   })
 
   it('should not generate click record if x/y are missing', () => {
-    const clickEvent = createNewEvent('click')
+    const clickEvent = createNewEvent(DOM_EVENT.CLICK)
     a.dispatchEvent(clickEvent)
 
     expect(mouseInteractionCallbackSpy).not.toHaveBeenCalled()
   })
 
   it('should generate blur record', () => {
-    a.blur()
+    a.dispatchEvent(createNewEvent(DOM_EVENT.BLUR))
 
     expect(mouseInteractionCallbackSpy).toHaveBeenCalledWith({
       id: jasmine.any(Number),
@@ -125,12 +125,12 @@ describe('initMouseInteractionObserver', () => {
     })
 
     it('should compute x/y coordinates for click record', () => {
-      a.click()
+      a.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
       expect(coordinatesComputed).toBeTrue()
     })
 
     it('should not compute x/y coordinates for blur record', () => {
-      a.blur()
+      a.dispatchEvent(createNewEvent(DOM_EVENT.BLUR))
       expect(coordinatesComputed).toBeFalse()
     })
   })

--- a/packages/rum/test/mockWorker.ts
+++ b/packages/rum/test/mockWorker.ts
@@ -68,7 +68,8 @@ export class MockWorker implements DeflateWorker {
               data: {
                 type: 'initialized',
               },
-            })
+              __ddIsTrusted: true,
+            } as any)
           )
           break
         case 'write':
@@ -82,7 +83,8 @@ export class MockWorker implements DeflateWorker {
                   compressedBytesCount: uint8ArraysSize(this.deflatedData),
                   additionalBytesCount,
                 },
-              })
+                __ddIsTrusted: true,
+              } as any)
             )
           }
           break
@@ -98,7 +100,8 @@ export class MockWorker implements DeflateWorker {
                   rawBytesCount: this.rawBytesCount,
                   additionalBytesCount,
                 },
-              })
+                __ddIsTrusted: true,
+              } as any)
             )
             this.deflatedData.length = 0
             this.rawBytesCount = 0
@@ -109,12 +112,15 @@ export class MockWorker implements DeflateWorker {
   }
 
   dispatchErrorEvent() {
-    const error = new ErrorEvent('worker')
+    const error = new ErrorEvent('worker') as ErrorEvent & { __ddIsTrusted?: boolean }
+    error.__ddIsTrusted = true
     this.listeners.error.forEach((listener) => listener(error))
   }
 
   dispatchErrorMessage(error: Error | string) {
-    this.listeners.message.forEach((listener) => listener({ data: { type: 'errored', error } }))
+    this.listeners.message.forEach((listener) =>
+      listener({ data: { type: 'errored', error }, __ddIsTrusted: true } as any)
+    )
   }
 
   private pushData(data?: string) {


### PR DESCRIPTION
## Motivation

Untrusted events are arbitrarily crafted by the application: some properties expected by the SDK might be missing or might not reflect legitimate data.


## Changes

Ignore untrusted events

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
