### PR TITLE
💥[RUMF-1564] remove intake subdomains

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -31,7 +31,7 @@ describe('endpointBuilder', () => {
 
     it('should not add batch_time for logs and replay endpoints', () => {
       expect(createEndpointBuilder(initConfiguration, 'logs', []).build('xhr')).not.toContain('&batch_time=')
-      expect(createEndpointBuilder(initConfiguration, 'sessionReplay', []).build('xhr')).not.toContain('&batch_time=')
+      expect(createEndpointBuilder(initConfiguration, 'replay', []).build('xhr')).not.toContain('&batch_time=')
     })
 
     it('should not start with ddsource for internal analytics mode', () => {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -4,39 +4,27 @@ import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../tools/experimentalFeatures'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { InitConfiguration } from './configuration'
-import { INTAKE_SITE_AP1, INTAKE_SITE_US1 } from './intakeSites'
+import { INTAKE_SITE_US1 } from './intakeSites'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
 
-export const ENDPOINTS = {
-  logs: 'logs',
-  rum: 'rum',
-  sessionReplay: 'session-replay',
-} as const
-
-const INTAKE_TRACKS = {
-  logs: 'logs',
-  rum: 'rum',
-  sessionReplay: 'replay',
-}
-
-export type EndpointType = keyof typeof ENDPOINTS
+export type TrackType = 'logs' | 'rum' | 'replay'
 
 export type EndpointBuilder = ReturnType<typeof createEndpointBuilder>
 
 export function createEndpointBuilder(
   initConfiguration: InitConfiguration,
-  endpointType: EndpointType,
+  trackType: TrackType,
   configurationTags: string[]
 ) {
-  const buildUrlWithParameters = createEndpointUrlWithParametersBuilder(initConfiguration, endpointType)
+  const buildUrlWithParameters = createEndpointUrlWithParametersBuilder(initConfiguration, trackType)
 
   return {
     build(api: 'xhr' | 'fetch' | 'beacon', flushReason?: FlushReason, retry?: RetryInfo) {
       const parameters = buildEndpointParameters(
         initConfiguration,
-        endpointType,
+        trackType,
         configurationTags,
         api,
         flushReason,
@@ -45,7 +33,7 @@ export function createEndpointBuilder(
       return buildUrlWithParameters(parameters)
     },
     urlPrefix: buildUrlWithParameters(''),
-    endpointType,
+    trackType,
   }
 }
 
@@ -56,19 +44,19 @@ export function createEndpointBuilder(
  */
 function createEndpointUrlWithParametersBuilder(
   initConfiguration: InitConfiguration,
-  endpointType: EndpointType
+  trackType: TrackType
 ): (parameters: string) => string {
-  const path = `/api/v2/${INTAKE_TRACKS[endpointType]}`
+  const path = `/api/v2/${trackType}`
   const proxy = initConfiguration.proxy
   if (proxy) {
     const normalizedProxyUrl = normalizeUrl(proxy)
     return (parameters) => `${normalizedProxyUrl}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}`
   }
-  const host = buildEndpointHost(initConfiguration, endpointType)
+  const host = buildEndpointHost(initConfiguration)
   return (parameters) => `https://${host}${path}?${parameters}`
 }
 
-function buildEndpointHost(initConfiguration: InitConfiguration, endpointType: EndpointType) {
+function buildEndpointHost(initConfiguration: InitConfiguration) {
   const { site = INTAKE_SITE_US1, internalAnalyticsSubdomain } = initConfiguration
 
   if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {
@@ -77,8 +65,7 @@ function buildEndpointHost(initConfiguration: InitConfiguration, endpointType: E
 
   const domainParts = site.split('.')
   const extension = domainParts.pop()
-  const subdomain = site !== INTAKE_SITE_AP1 ? `${ENDPOINTS[endpointType]}.` : ''
-  return `${subdomain}browser-intake-${domainParts.join('-')}.${extension!}`
+  return `browser-intake-${domainParts.join('-')}.${extension!}`
 }
 
 /**
@@ -87,7 +74,7 @@ function buildEndpointHost(initConfiguration: InitConfiguration, endpointType: E
  */
 function buildEndpointParameters(
   { clientToken, internalAnalyticsSubdomain }: InitConfiguration,
-  endpointType: EndpointType,
+  trackType: TrackType,
   configurationTags: string[],
   api: 'xhr' | 'fetch' | 'beacon',
   flushReason: FlushReason | undefined,
@@ -109,7 +96,7 @@ function buildEndpointParameters(
     `dd-request-id=${generateUUID()}`,
   ]
 
-  if (endpointType === 'rum') {
+  if (trackType === 'rum') {
     parameters.push(`batch_time=${timeStampNow()}`)
   }
   if (internalAnalyticsSubdomain) {

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -5,5 +5,5 @@ export {
   validateAndBuildConfiguration,
   serializeConfiguration,
 } from './configuration'
-export { createEndpointBuilder, EndpointBuilder, EndpointType } from './endpointBuilder'
+export { createEndpointBuilder, EndpointBuilder, TrackType } from './endpointBuilder'
 export * from './intakeSites'

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -1,5 +1,4 @@
 export const INTAKE_SITE_STAGING = 'datad0g.com'
 export const INTAKE_SITE_US1 = 'datadoghq.com'
 export const INTAKE_SITE_EU1 = 'datadoghq.eu'
-export const INTAKE_SITE_AP1 = 'ap1.datadoghq.com'
 export const INTAKE_SITE_US1_FED = 'ddog-gov.com'

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -63,25 +63,19 @@ describe('transportConfiguration', () => {
 
   describe('isIntakeUrl', () => {
     ;[
-      { expectSubdomain: true, site: 'datadoghq.eu', intakeDomain: 'browser-intake-datadoghq.eu' },
-      { expectSubdomain: true, site: 'datadoghq.com', intakeDomain: 'browser-intake-datadoghq.com' },
-      { expectSubdomain: true, site: 'us3.datadoghq.com', intakeDomain: 'browser-intake-us3-datadoghq.com' },
-      { expectSubdomain: true, site: 'us5.datadoghq.com', intakeDomain: 'browser-intake-us5-datadoghq.com' },
-      { expectSubdomain: true, site: 'ddog-gov.com', intakeDomain: 'browser-intake-ddog-gov.com' },
-      { expectSubdomain: false, site: 'ap1.datadoghq.com', intakeDomain: 'browser-intake-ap1-datadoghq.com' },
-    ].forEach(({ site, intakeDomain, expectSubdomain }) => {
+      { site: 'datadoghq.eu', intakeDomain: 'browser-intake-datadoghq.eu' },
+      { site: 'datadoghq.com', intakeDomain: 'browser-intake-datadoghq.com' },
+      { site: 'us3.datadoghq.com', intakeDomain: 'browser-intake-us3-datadoghq.com' },
+      { site: 'us5.datadoghq.com', intakeDomain: 'browser-intake-us5-datadoghq.com' },
+      { site: 'ddog-gov.com', intakeDomain: 'browser-intake-ddog-gov.com' },
+      { site: 'ap1.datadoghq.com', intakeDomain: 'browser-intake-ap1-datadoghq.com' },
+    ].forEach(({ site, intakeDomain }) => {
       it(`should detect intake request for ${site} site`, () => {
         const configuration = computeTransportConfiguration({ clientToken, site })
 
-        expect(configuration.isIntakeUrl(`https://rum.${intakeDomain}/api/v2/rum?xxx`)).toBe(expectSubdomain)
-        expect(configuration.isIntakeUrl(`https://logs.${intakeDomain}/api/v2/logs?xxx`)).toBe(expectSubdomain)
-        expect(configuration.isIntakeUrl(`https://session-replay.${intakeDomain}/api/v2/replay?xxx`)).toBe(
-          expectSubdomain
-        )
-
-        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/rum?xxx`)).toBe(!expectSubdomain)
-        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/logs?xxx`)).toBe(!expectSubdomain)
-        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/replay?xxx`)).toBe(!expectSubdomain)
+        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/rum?xxx`)).toBe(true)
+        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/logs?xxx`)).toBe(true)
+        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/replay?xxx`)).toBe(true)
       })
     })
 

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -42,7 +42,7 @@ function computeEndpointBuilders(initConfiguration: InitConfiguration, tags: str
   return {
     logsEndpointBuilder: createEndpointBuilder(initConfiguration, 'logs', tags),
     rumEndpointBuilder: createEndpointBuilder(initConfiguration, 'rum', tags),
-    sessionReplayEndpointBuilder: createEndpointBuilder(initConfiguration, 'sessionReplay', tags),
+    sessionReplayEndpointBuilder: createEndpointBuilder(initConfiguration, 'replay', tags),
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,6 @@ export {
   DefaultPrivacyLevel,
   EndpointBuilder,
   serializeConfiguration,
-  INTAKE_SITE_AP1,
   INTAKE_SITE_STAGING,
   INTAKE_SITE_US1,
   INTAKE_SITE_US1_FED,

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -46,7 +46,7 @@ export function createHttpRequest(
 
   return {
     send: (payload: Payload) => {
-      sendWithRetryStrategy(payload, retryState, sendStrategyForRetry, endpointBuilder.endpointType, reportError)
+      sendWithRetryStrategy(payload, retryState, sendStrategyForRetry, endpointBuilder.trackType, reportError)
     },
     /**
      * Since fetch keepalive behaves like regular fetch on Firefox,


### PR DESCRIPTION
## Motivation

Similarly to mobile SDKs, use subdomain-less intake domains for all products, cf [supported endpoints doc](https://docs.datadoghq.com/real_user_monitoring/#supported-endpoints-for-sdk-domains). 

## Changes

For us1 site:

```diff
- https://(rum|logs|session-replay).browser-intake-datadoghq.com/
+ https://browser-intake-datadoghq.com/
```

and similarly for other sites.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
