### PR TITLE
✨ Allow to pass custom tags

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -47,6 +47,9 @@ export interface InitConfiguration {
   env?: string | undefined
   version?: string | undefined
 
+  // custom tags
+  customTags?: Record<string, string> | undefined
+
   // cookie options
   useCrossSiteSessionCookie?: boolean | undefined
   useSecureSessionCookie?: boolean | undefined

--- a/packages/core/src/domain/configuration/tags.spec.ts
+++ b/packages/core/src/domain/configuration/tags.spec.ts
@@ -15,6 +15,37 @@ describe('buildTags', () => {
       } as InitConfiguration)
     ).toEqual(['env:bar', 'service:foo', 'version:baz', 'datacenter:us1.prod.dog'])
   })
+
+  it('should consider custom tags', () => {
+    expect(
+      buildTags({
+        service: 'foo',
+        customTags: {
+          tag1: 'value1',
+          tag2: 'value2',
+        },
+        clientToken: '',
+      } as InitConfiguration)
+    ).toEqual(['tag1:value1', 'tag2:value2', 'service:foo'])
+  })
+
+  it('should not allow overwriting tags from init configuration', () => {
+    expect(
+      buildTags({
+        service: 'foo',
+        env: 'bar',
+        version: 'baz',
+        datacenter: 'us1.prod.dog',
+        customTags: {
+          env: 'bar_override',
+          service: 'foo_override',
+          version: 'baz_override',
+          datacenter: 'us1.prod.dog_override',
+        },
+        clientToken: '',
+      } as InitConfiguration)
+    ).toEqual(['env:bar', 'service:foo', 'version:baz', 'datacenter:us1.prod.dog'])
+  })
 })
 
 describe('buildTag', () => {

--- a/packages/core/src/domain/configuration/tags.ts
+++ b/packages/core/src/domain/configuration/tags.ts
@@ -1,24 +1,28 @@
 import { display } from '../../tools/display'
+import { assign } from '../../tools/utils/polyfills'
 import type { InitConfiguration } from './configuration'
 
 export const TAG_SIZE_LIMIT = 200
 
 export function buildTags(configuration: InitConfiguration): string[] {
-  const { env, service, version, datacenter } = configuration
-  const tags = []
+  const { env, service, version, datacenter, customTags } = configuration
 
-  if (env) {
-    tags.push(buildTag('env', env))
-  }
-  if (service) {
-    tags.push(buildTag('service', service))
-  }
-  if (version) {
-    tags.push(buildTag('version', version))
-  }
-  if (datacenter) {
-    tags.push(buildTag('datacenter', datacenter))
-  }
+  const uniqueTags = assign({}, customTags, {
+    env,
+    service,
+    version,
+    datacenter,
+  })
+
+  const tags: string[] = []
+
+  Object.keys(uniqueTags).forEach((key) => {
+    const rawValue = uniqueTags[key]
+
+    if (rawValue) {
+      tags.push(buildTag(key, rawValue))
+    }
+  })
 
   return tags
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

The goal of this PR is to allow users to pass any custom tags along with the built-in ones. See the issue https://github.com/DataDog/browser-sdk/issues/462 for more details.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

This PR adds optional `customTags` property to the configuration object, so that logger or rum may be configured to send additional tags. This is completely optional configuration option that will not impact existing configurations. The changes also do not allow overwriting the built-in tags.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
