### PR TITLE
🐛 [RUMF-1613] fix session replay performance regression

### DIFF
--- a/packages/rum/src/domain/record/observers/inputObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/inputObserver.spec.ts
@@ -1,5 +1,6 @@
 import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
-import { createNewEvent } from '@datadog/browser-core/test'
+import type { Clock } from '@datadog/browser-core/test'
+import { createNewEvent, mockClock } from '@datadog/browser-core/test'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '../../../constants'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
@@ -12,6 +13,7 @@ describe('initInputObserver', () => {
   let inputCallbackSpy: jasmine.Spy<InputCallback>
   let sandbox: HTMLElement
   let input: HTMLInputElement
+  let clock: Clock | undefined
 
   beforeEach(() => {
     if (isIE()) {
@@ -34,6 +36,7 @@ describe('initInputObserver', () => {
   afterEach(() => {
     stopInputObserver()
     sandbox.remove()
+    clock?.cleanup()
   })
 
   it('collects input values when an "input" event is dispatched', () => {
@@ -44,6 +47,30 @@ describe('initInputObserver', () => {
       text: 'foo',
       id: jasmine.any(Number) as unknown as number,
     })
+  })
+
+  it('collects input values when a property setter is used', () => {
+    clock = mockClock()
+    stopInputObserver = initInputObserver(inputCallbackSpy, DefaultPrivacyLevel.ALLOW)
+    input.value = 'foo'
+
+    clock.tick(0)
+
+    expect(inputCallbackSpy).toHaveBeenCalledOnceWith({
+      text: 'foo',
+      id: jasmine.any(Number) as unknown as number,
+    })
+  })
+
+  it('does not invoke callback when the value does not change', () => {
+    clock = mockClock()
+    stopInputObserver = initInputObserver(inputCallbackSpy, DefaultPrivacyLevel.ALLOW)
+    input.value = 'foo'
+    clock.tick(0)
+
+    dispatchInputEvent('foo')
+
+    expect(inputCallbackSpy).toHaveBeenCalledTimes(1)
   })
 
   // cannot trigger a event in a Shadow DOM because event with `isTrusted:false` do not cross the root

--- a/packages/rum/src/domain/record/observers/inputObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/inputObserver.spec.ts
@@ -73,6 +73,18 @@ describe('initInputObserver', () => {
     expect(inputCallbackSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('does not instrument setters when observing a shadow DOM', () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set
+    const host = document.createElement('div')
+    host.attachShadow({ mode: 'open' })
+
+    stopInputObserver = initInputObserver(inputCallbackSpy, DefaultPrivacyLevel.ALLOW, host.shadowRoot!)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set).toBe(originalSetter)
+  })
+
   // cannot trigger a event in a Shadow DOM because event with `isTrusted:false` do not cross the root
   it('collects input values when an "input" event is composed', () => {
     stopInputObserver = initInputObserver(inputCallbackSpy, DefaultPrivacyLevel.ALLOW)

--- a/packages/rum/src/domain/record/shadowRootsController.ts
+++ b/packages/rum/src/domain/record/shadowRootsController.ts
@@ -1,4 +1,3 @@
-import { DOM_EVENT } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import type { InputCallback, MutationCallBack } from './observers'
 import { initInputObserver, initMutationObserver } from './observers'
@@ -38,10 +37,7 @@ export const initShadowRootsController = (
         shadowRoot
       )
       // the change event no do bubble up across the shadow root, we have to listen on the shadow root
-      const stopInputObserver = initInputObserver(inputCb, configuration.defaultPrivacyLevel, {
-        target: shadowRoot,
-        domEvents: [DOM_EVENT.CHANGE],
-      })
+      const stopInputObserver = initInputObserver(inputCb, configuration.defaultPrivacyLevel, shadowRoot)
       controllerByShadowRoot.set(shadowRoot, {
         flush,
         stop: () => {


### PR DESCRIPTION
## Motivation

Following the release of Shadow DOM support for Session Replay (#1969), users started to notice important performance regression on applications using session replay.

The identified issue was that we instrumented input Node property setters like `input.value` or `input.checked` multiple times (once per Shadow Root). Those instrumentations are stacking up, making a significant overhead when the application set those properties.

## Changes

Do not instrument setters when handling shadow roots.

Before:
![Screenshot 2023-06-29 at 16 52 40](https://github.com/DataDog/browser-sdk/assets/61787/10cb7de7-b698-4a7f-ad87-3fe3d37fb249)

After:
![Screenshot 2023-06-29 at 16 53 32](https://github.com/DataDog/browser-sdk/assets/61787/041cb9bb-e3be-4402-9634-8f9a6061d9c5)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
