### PR TITLE
💬 [RUMF-1605] Improve heavy customer data warning message

### DIFF
--- a/packages/core/src/tools/serialisation/heavyCustomerDataWarning.spec.ts
+++ b/packages/core/src/tools/serialisation/heavyCustomerDataWarning.spec.ts
@@ -11,7 +11,7 @@ describe('warnIfCustomerDataLimitReached', () => {
     const warned = warnIfCustomerDataLimitReached(CUSTOMER_DATA_BYTES_LIMIT + 1, CustomerDataType.User)
     expect(warned).toEqual(true)
     expect(displaySpy).toHaveBeenCalledWith(
-      "The user data is over 3KiB. On low connectivity, the SDK has the potential to exhaust the user's upload bandwidth."
+      'The user data exceeds the recommended 3KiB threshold. More details: https://docs.datadoghq.com/real_user_monitoring/browser/troubleshooting/#customer-data-exceeds-the-recommended-3kib-warning'
     )
   })
 

--- a/packages/core/src/tools/serialisation/heavyCustomerDataWarning.ts
+++ b/packages/core/src/tools/serialisation/heavyCustomerDataWarning.ts
@@ -16,9 +16,9 @@ export const enum CustomerDataType {
 export function warnIfCustomerDataLimitReached(bytesCount: number, customerDataType: CustomerDataType): boolean {
   if (bytesCount > CUSTOMER_DATA_BYTES_LIMIT) {
     display.warn(
-      `The ${customerDataType} data is over ${
+      `The ${customerDataType} data exceeds the recommended ${
         CUSTOMER_DATA_BYTES_LIMIT / ONE_KIBI_BYTE
-      }KiB. On low connectivity, the SDK has the potential to exhaust the user's upload bandwidth.`
+      }KiB threshold. More details: https://docs.datadoghq.com/real_user_monitoring/browser/troubleshooting/#customer-data-exceeds-the-recommended-3kib-warning`
     )
     return true
   }


### PR DESCRIPTION
## Motivation

When passing a large amount of data in global context, user info or feature flags (>3KiB) the browser SDK prints a warning. The warning was confusing and brought lot of question for customers.

## Changes

Before 

> The user data is over 3KiB. On low connectivity, the SDK has the potential to exhaust the user's upload bandwidth.  

After

> The user data exceeds the recommended 3KiB threshold. More details: https://docs.datadoghq.com/real_user_monitoring/browser/troubleshooting/#customer-data-exceeds-the-recommended-3kib-warning

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
