### PR TITLE
🐛 [RUMF-1436] fix crash when instrumenting readonly methods

### DIFF
--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -113,14 +113,14 @@ export function formatErrorMessage(stack: StackTrace) {
  - Has to be called at the utmost position of the call stack.
  - No monitored function should encapsulate it, that is why we need to use callMonitored inside it.
  */
-export function createHandlingStack(): string {
+export function createHandlingStack(extraFramesToSkip = 0): string {
   /**
    * Skip the two internal frames:
    * - SDK API (console.error, ...)
    * - this function
    * in order to keep only the user calls
    */
-  const internalFramesToSkip = 2
+  const internalFramesToSkip = 2 + extraFramesToSkip
   const error = new Error()
   let formattedStack: string
 

--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -54,6 +54,27 @@ describe('instrumentMethod', () => {
     expect(instrumentationSpy).toHaveBeenCalled()
   })
 
+  it('does not throw if the object is frozen', () => {
+    const object = { method: () => 1 }
+    Object.freeze(object)
+
+    expect(() => {
+      instrumentMethod(object, 'method', () => () => 2)
+    }).not.toThrow()
+  })
+
+  it('does not throw if the method is not writable', () => {
+    const object = { method: () => 1 }
+    Object.defineProperty(object, 'method', {
+      value: () => 1,
+      writable: false,
+    })
+
+    expect(() => {
+      instrumentMethod(object, 'method', () => () => 2)
+    }).not.toThrow()
+  })
+
   describe('stop()', () => {
     it('restores the original behavior', () => {
       const object = { method: () => 1 }

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -2,6 +2,13 @@ import { setTimeout } from './timer'
 import { callMonitored } from './monitor'
 import { noop } from './utils/functionUtils'
 
+/**
+ * Instrument an object method.
+ *
+ * This function works best when the method is an "own property" of the provided object, as it is
+ * able to check whether the method si actually writable before overriding it. When a method is
+ * declared on an instance prototype, prefer instrumenting the prototype rather than the instance.
+ */
 export function instrumentMethod<OBJECT extends { [key: string]: any }, METHOD extends keyof OBJECT>(
   object: OBJECT,
   method: METHOD,

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -9,6 +9,11 @@ export function instrumentMethod<OBJECT extends { [key: string]: any }, METHOD e
     original: OBJECT[METHOD]
   ) => (this: OBJECT, ...args: Parameters<OBJECT[METHOD]>) => ReturnType<OBJECT[METHOD]>
 ) {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(object, method)
+  if (originalDescriptor && originalDescriptor.writable === false) {
+    return { stop: noop }
+  }
+
   const original = object[method]
 
   let instrumentation = instrumentationFactory(original)

--- a/packages/core/test/emulate/location.ts
+++ b/packages/core/test/emulate/location.ts
@@ -2,7 +2,7 @@ import { assign, buildUrl } from '../../src'
 
 export function mockLocation(initialUrl: string) {
   const fakeLocation = buildLocation(initialUrl)
-  spyOn(history, 'pushState').and.callFake((_: any, __: string, pathname: string) => {
+  spyOn(History.prototype, 'pushState').and.callFake((_: any, __: string, pathname: string) => {
     assign(fakeLocation, buildLocation(pathname, fakeLocation.href))
   })
 

--- a/packages/rum-core/src/browser/locationChangeObservable.ts
+++ b/packages/rum-core/src/browser/locationChangeObservable.ts
@@ -38,10 +38,10 @@ export function createLocationChangeObservable(location: Location) {
 }
 
 function trackHistory(onHistoryChange: () => void) {
-  const { stop: stopInstrumentingPushState } = instrumentMethodAndCallOriginal(history, 'pushState', {
+  const { stop: stopInstrumentingPushState } = instrumentMethodAndCallOriginal(History.prototype, 'pushState', {
     after: onHistoryChange,
   })
-  const { stop: stopInstrumentingReplaceState } = instrumentMethodAndCallOriginal(history, 'replaceState', {
+  const { stop: stopInstrumentingReplaceState } = instrumentMethodAndCallOriginal(History.prototype, 'replaceState', {
     after: onHistoryChange,
   })
   const { stop: removeListener } = addEventListener(window, DOM_EVENT.POP_STATE, onHistoryChange)


### PR DESCRIPTION
## Motivation

In some rare cases, we observed that some methods (`window.open`, `XMLHttpRequest.prototype.send`) were defined as readonly, probably because of another thirdparty script. When instrumenting those methods, the Browser SDK crashed with the following telemetry error:

```
TypeError: Cannot assign to read only property 'open' of object '#<Window>'
```

## Changes

Make sure the method is writable before instrumenting it.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
