### PR TITLE
👷 Bump version to v5.0.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@
 
 ---
 
+## v5.0.0-alpha.0
+
+- 💥 [RUMF-1577] Stop collecting foreground periods ([#2311](https://github.com/DataDog/browser-sdk/pull/2311))
+- 💥 [RUMF-1473] Ignore untrusted event ([#2308](https://github.com/DataDog/browser-sdk/pull/2308))
+- 💥 [RUMF-1564] remove intake subdomains ([#2309](https://github.com/DataDog/browser-sdk/pull/2309))
+- 💥 [RUMF-1557] beforeSend domain context: use PerformanceEntry ([#2300](https://github.com/DataDog/browser-sdk/pull/2300))
+- 💥 [RUMF-1556] Typings: consistent beforeSend return type ([#2303](https://github.com/DataDog/browser-sdk/pull/2303))
+- 💥 [RUMF-1230] Only apply main logger configuration to its own logs ([#2298](https://github.com/DataDog/browser-sdk/pull/2298))
+- 💥 [RUMF-1229] Logs: remove `error.origin` attribute ([#2294](https://github.com/DataDog/browser-sdk/pull/2294))
+- 💥 [RUMF-1228] Remove console error message prefix ([#2289](https://github.com/DataDog/browser-sdk/pull/2289))
+- 💥 [RUMF-1555] Rework logger context APIs ([#2285](https://github.com/DataDog/browser-sdk/pull/2285))
+- 💥 [RUMF-1152] sanitize resource method names ([#2288](https://github.com/DataDog/browser-sdk/pull/2288))
+- 💥 [RUMF-1555] Remove `event` in action domain context ([#2286](https://github.com/DataDog/browser-sdk/pull/2286))
+- 💥 [RUMF-1589] automatically start recording ([#2275](https://github.com/DataDog/browser-sdk/pull/2275))
+- 💥 [RUMF-1588] Update default session replay behaviour ([#2257](https://github.com/DataDog/browser-sdk/pull/2257))
+- 💥 [RUMF-1587] Remove `premiumSampleRate` and `replaySampleRate` ([#2256](https://github.com/DataDog/browser-sdk/pull/2256))
+- 💥 [RUMF-1554] Drop some deprecated public APIs ([#2241](https://github.com/DataDog/browser-sdk/pull/2241))
+- 💥 [RUMF-1554] Drop some deprecated config parameters ([#2238](https://github.com/DataDog/browser-sdk/pull/2238))
+- 💥 [RUMF-1578] Promote track frustration as default action behaviour ([#2232](https://github.com/DataDog/browser-sdk/pull/2232))
+- 🐛 [RUMF-1499] Don't send duration for resources crossing a page frozen state ([#2271](https://github.com/DataDog/browser-sdk/pull/2271))
+- 🔥 [RUMF-1555] Remove `startTime` in xhr start context ([#2287](https://github.com/DataDog/browser-sdk/pull/2287))
+- ♻️ [RUMF-1555] Remove deprecated context manager APIs ([#2284](https://github.com/DataDog/browser-sdk/pull/2284))
+
 ## v4.43.0
 
 - ✨ [RUMF-1580] Implement storage fallback ([#2261](https://github.com/DataDog/browser-sdk/pull/2261))

--- a/developer-extension/package.json
+++ b/developer-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-sdk-developer-extension",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "private": true,
   "scripts": {
     "build": "rm -rf dist && webpack --mode production",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "yarn",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-core",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "license": "Apache-2.0",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-logs",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -13,10 +13,10 @@
     "replace-build-env": "node ../../scripts/build/replace-build-env.js"
   },
   "dependencies": {
-    "@datadog/browser-core": "4.43.0"
+    "@datadog/browser-core": "5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@datadog/browser-rum": "4.43.0"
+    "@datadog/browser-rum": "5.0.0-alpha.0"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-rum": {

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-core",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "license": "Apache-2.0",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -12,7 +12,7 @@
     "replace-build-env": "node ../../scripts/build/replace-build-env.js"
   },
   "dependencies": {
-    "@datadog/browser-core": "4.43.0"
+    "@datadog/browser-core": "5.0.0-alpha.0"
   },
   "devDependencies": {
     "ajv": "6.12.6"

--- a/packages/rum-slim/package.json
+++ b/packages/rum-slim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-slim",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -12,11 +12,11 @@
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
   },
   "dependencies": {
-    "@datadog/browser-core": "4.43.0",
-    "@datadog/browser-rum-core": "4.43.0"
+    "@datadog/browser-core": "5.0.0-alpha.0",
+    "@datadog/browser-rum-core": "5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@datadog/browser-logs": "4.43.0"
+    "@datadog/browser-logs": "5.0.0-alpha.0"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -12,11 +12,11 @@
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
   },
   "dependencies": {
-    "@datadog/browser-core": "4.43.0",
-    "@datadog/browser-rum-core": "4.43.0"
+    "@datadog/browser-core": "5.0.0-alpha.0",
+    "@datadog/browser-rum-core": "5.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@datadog/browser-logs": "4.43.0"
+    "@datadog/browser-logs": "5.0.0-alpha.0"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {

--- a/performances/package.json
+++ b/performances/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "performances",
-  "version": "4.43.0",
+  "version": "5.0.0-alpha.0",
   "scripts": {
     "start": "ts-node ./src/main.ts"
   },

--- a/test/app/yarn.lock
+++ b/test/app/yarn.lock
@@ -15,9 +15,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-logs@portal:../../packages/logs::locator=app%40workspace%3A."
   dependencies:
-    "@datadog/browser-core": 4.43.0
+    "@datadog/browser-core": 5.0.0-alpha.0
   peerDependencies:
-    "@datadog/browser-rum": 4.43.0
+    "@datadog/browser-rum": 5.0.0-alpha.0
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
@@ -28,7 +28,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-core@portal:../../packages/rum-core::locator=app%40workspace%3A."
   dependencies:
-    "@datadog/browser-core": 4.43.0
+    "@datadog/browser-core": 5.0.0-alpha.0
   languageName: node
   linkType: soft
 
@@ -36,10 +36,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum@portal:../../packages/rum::locator=app%40workspace%3A."
   dependencies:
-    "@datadog/browser-core": 4.43.0
-    "@datadog/browser-rum-core": 4.43.0
+    "@datadog/browser-core": 5.0.0-alpha.0
+    "@datadog/browser-rum-core": 5.0.0-alpha.0
   peerDependencies:
-    "@datadog/browser-logs": 4.43.0
+    "@datadog/browser-logs": 5.0.0-alpha.0
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,7 +391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@4.43.0, @datadog/browser-core@workspace:packages/core":
+"@datadog/browser-core@5.0.0-alpha.0, @datadog/browser-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-core@workspace:packages/core"
   languageName: unknown
@@ -401,20 +401,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-logs@workspace:packages/logs"
   dependencies:
-    "@datadog/browser-core": 4.43.0
+    "@datadog/browser-core": 5.0.0-alpha.0
   peerDependencies:
-    "@datadog/browser-rum": 4.43.0
+    "@datadog/browser-rum": 5.0.0-alpha.0
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-rum-core@4.43.0, @datadog/browser-rum-core@workspace:packages/rum-core":
+"@datadog/browser-rum-core@5.0.0-alpha.0, @datadog/browser-rum-core@workspace:packages/rum-core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-core@workspace:packages/rum-core"
   dependencies:
-    "@datadog/browser-core": 4.43.0
+    "@datadog/browser-core": 5.0.0-alpha.0
     ajv: 6.12.6
   languageName: unknown
   linkType: soft
@@ -423,10 +423,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-slim@workspace:packages/rum-slim"
   dependencies:
-    "@datadog/browser-core": 4.43.0
-    "@datadog/browser-rum-core": 4.43.0
+    "@datadog/browser-core": 5.0.0-alpha.0
+    "@datadog/browser-rum-core": 5.0.0-alpha.0
   peerDependencies:
-    "@datadog/browser-logs": 4.43.0
+    "@datadog/browser-logs": 5.0.0-alpha.0
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
@@ -437,12 +437,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum@workspace:packages/rum"
   dependencies:
-    "@datadog/browser-core": 4.43.0
-    "@datadog/browser-rum-core": 4.43.0
+    "@datadog/browser-core": 5.0.0-alpha.0
+    "@datadog/browser-rum-core": 5.0.0-alpha.0
     "@types/pako": 2.0.0
     pako: 2.1.0
   peerDependencies:
-    "@datadog/browser-logs": 4.43.0
+    "@datadog/browser-logs": 5.0.0-alpha.0
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true


### PR DESCRIPTION
## Motivation

In order to have backend behaviour corresponding to v5 SDK, use a 5.x.x version

## Changes

Create a lerna premajor release

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
