### PR TITLE
🔊 Add tracekit try parse message failing telemetry

### DIFF
--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -81,7 +81,14 @@ function tryToParseMessage(messageObj: unknown) {
     try {
       ;[, name, message] = ERROR_TYPES_RE.exec(messageObj as string)!
     } catch (error) {
-      throw new Error(`Tracekit try parse error: ${String(error)} ${jsonStringify({ messageObj })!}`)
+      throw new Error(
+        `Tracekit try parse error: ${String(error)} ${jsonStringify({
+          messageObj,
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          exec: String(RegExp.prototype.exec),
+          ERROR_TYPES_RE,
+        })!}`
+      )
     }
   }
   return { name, message }

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -86,7 +86,7 @@ function tryToParseMessage(messageObj: unknown) {
           messageObj,
           // eslint-disable-next-line @typescript-eslint/unbound-method
           exec: String(RegExp.prototype.exec),
-          ERROR_TYPES_RE,
+          ERROR_TYPES_RE: String(ERROR_TYPES_RE),
         })!}`
       )
     }

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -1,4 +1,5 @@
 import { instrumentMethodAndCallOriginal } from '../../tools/instrumentMethod'
+import { jsonStringify } from '../../tools/serialisation/jsonStringify'
 import { computeStackTrace } from './computeStackTrace'
 import type { UnhandledErrorCallback, StackTrace } from './types'
 
@@ -77,7 +78,11 @@ function tryToParseMessage(messageObj: unknown) {
   let name
   let message
   if ({}.toString.call(messageObj) === '[object String]') {
-    ;[, name, message] = ERROR_TYPES_RE.exec(messageObj as string)!
+    try {
+      ;[, name, message] = ERROR_TYPES_RE.exec(messageObj as string)!
+    } catch (error) {
+      throw new Error(`Tracekit try parse error: ${String(error)} ${jsonStringify({ messageObj })!}`)
+    }
   }
   return { name, message }
 }


### PR DESCRIPTION
## Motivation

Since https://github.com/DataDog/browser-sdk/pull/2181 the tracekit message parsing can fail:

![image](https://github.com/DataDog/browser-sdk/assets/4342515/426bda4d-bdb2-4eb5-ae56-9ed139a224a5)


## Changes

Add tracekit try parse message failing telemetry 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [X] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
