### PR TITLE
✨ [RUM-235] add sample rates fields

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -110,7 +110,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       replay_sample_rate?: number
       /**
-       * The percentage of sessions with Browser RUM & Session Replay pricing tracked
+       * The percentage of sessions with RUM & Session Replay pricing tracked
        */
       session_replay_sample_rate?: number
       /**

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -628,6 +628,35 @@ describe('rum assembly', () => {
     })
   })
 
+  describe('configuration context', () => {
+    it('should include the configured sample rates', () => {
+      const { lifeCycle } = setupBuilder.build()
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+      })
+      expect(serverRumEvents[0]._dd.configuration).toEqual({
+        session_replay_sample_rate: 100,
+        session_sample_rate: 100,
+      })
+    })
+
+    it('should round sample rates', () => {
+      const { lifeCycle } = setupBuilder
+        .withConfiguration({
+          sessionSampleRate: 1.2345,
+          sessionReplaySampleRate: 6.7891,
+        })
+        .build()
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+      })
+      expect(serverRumEvents[0]._dd.configuration).toEqual({
+        session_sample_rate: 1.234,
+        session_replay_sample_rate: 6.789,
+      })
+    })
+  })
+
   describe('synthetics context', () => {
     it('includes the synthetics context', () => {
       mockSyntheticsWorkerValues()

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -643,7 +643,7 @@ describe('rum assembly', () => {
     it('should round sample rates', () => {
       const { lifeCycle } = setupBuilder
         .withConfiguration({
-          sessionSampleRate: 1.2345,
+          sessionSampleRate: 1.2341,
           sessionReplaySampleRate: 6.7891,
         })
         .build()

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -8,6 +8,7 @@ import {
   createEventRateLimiter,
   canUseEventBridge,
   assign,
+  round,
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type {
@@ -125,6 +126,10 @@ export function startRumAssembly(
             drift: currentDrift(),
             session: {
               plan: session.plan,
+            },
+            configuration: {
+              session_sample_rate: round(configuration.sessionSampleRate, 3),
+              session_replay_sample_rate: round(configuration.sessionReplaySampleRate, 3),
             },
             browser_sdk_version: canUseEventBridge() ? __BUILD_ENV__SDK_VERSION__ : undefined,
           },

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -261,6 +261,10 @@ export interface RumContext {
     session: {
       plan: RumSessionPlan
     }
+    configuration: {
+      session_sample_rate: number
+      session_replay_sample_rate: number
+    }
     browser_sdk_version?: string
   }
 }

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1088,6 +1088,20 @@ export interface CommonProperties {
       [k: string]: unknown
     }
     /**
+     * Subset of the SDK configuration options in use during its execution
+     */
+    readonly configuration?: {
+      /**
+       * The percentage of sessions tracked
+       */
+      readonly session_sample_rate: number
+      /**
+       * The percentage of sessions with RUM & Session Replay pricing tracked
+       */
+      readonly session_replay_sample_rate: number
+      [k: string]: unknown
+    }
+    /**
      * Browser SDK version
      */
     readonly browser_sdk_version?: string

--- a/packages/rum-core/test/testSetupBuilder.ts
+++ b/packages/rum-core/test/testSetupBuilder.ts
@@ -216,6 +216,10 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
       session: {
         plan: RumSessionPlan.WITH_SESSION_REPLAY,
       },
+      configuration: {
+        session_sample_rate: 40,
+        session_replay_sample_rate: 60,
+      },
     },
     application: {
       id: fakeId,


### PR DESCRIPTION
## Motivation

This PR adds the following fields to all RUM events:

* `@_dd.configuration.session_sample_rate`
* `@_dd.configuration.session_replay_sample_rate`

Those fields are private and should not be used by customers. They will reflect the corresponding initialization parameter values.

See related rum-events-format PR: https://github.com/DataDog/rum-events-format/pull/153 

## Changes

* update format
* add fields

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
