### PR TITLE
🐛 Fix RUM slim npm package publication

### DIFF
--- a/packages/rum-slim/.npmignore
+++ b/packages/rum-slim/.npmignore
@@ -1,5 +1,5 @@
 *
-!/bundle/datadog-rum.js
+!/bundle/datadog-rum-slim.js
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*


### PR DESCRIPTION
## Motivation

`/bundle/datadog-rum-slim.js` is missing from RUM slim npm package.
https://github.com/DataDog/browser-sdk/issues/2320

## Changes

Don't ignore `datadog-rum-slim.js` in .npmignore

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
