### PR TITLE
🐛 [RUM-238] Handle tracekit multilines message parsing

### DIFF
--- a/packages/core/src/domain/tracekit/tracekit.spec.ts
+++ b/packages/core/src/domain/tracekit/tracekit.spec.ts
@@ -55,6 +55,13 @@ describe('startUnhandledErrorCollection', () => {
       expect(stack.message).toEqual('Undefined variable: foo')
     })
 
+    it('should separate name, message for error with multiline message', () => {
+      window.onerror!("TypeError: foo is not a function. (In 'my.function(\n foo)")
+      const [stack] = callbackSpy.calls.mostRecent().args
+      expect(stack.message).toEqual("foo is not a function. (In 'my.function(\n foo)")
+      expect(stack.name).toEqual('TypeError')
+    })
+
     it('should ignore unknown error types', () => {
       window.onerror!('CustomError: woo scary', 'http://example.com', testLineNo)
       // TODO: should we attempt to parse this?

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -78,18 +78,7 @@ function tryToParseMessage(messageObj: unknown) {
   let name
   let message
   if ({}.toString.call(messageObj) === '[object String]') {
-    try {
-      ;[, name, message] = ERROR_TYPES_RE.exec(messageObj as string)!
-    } catch (error) {
-      throw new Error(
-        `Tracekit try parse error: ${String(error)} ${jsonStringify({
-          messageObj,
-          // eslint-disable-next-line @typescript-eslint/unbound-method
-          exec: String(RegExp.prototype.exec),
-          ERROR_TYPES_RE: String(ERROR_TYPES_RE),
-        })!}`
-      )
-    }
+    ;[, name, message] = ERROR_TYPES_RE.exec(messageObj as string)!
   }
   return { name, message }
 }

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -4,7 +4,7 @@ import type { UnhandledErrorCallback, StackTrace } from './types'
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Error_types
 const ERROR_TYPES_RE =
-  /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?([\s\S]*)$/m
+  /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?([\s\S]*)$/
 
 /**
  * Cross-browser collection of unhandled errors

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -1,5 +1,4 @@
 import { instrumentMethodAndCallOriginal } from '../../tools/instrumentMethod'
-import { jsonStringify } from '../../tools/serialisation/jsonStringify'
 import { computeStackTrace } from './computeStackTrace'
 import type { UnhandledErrorCallback, StackTrace } from './types'
 

--- a/packages/core/src/domain/tracekit/tracekit.ts
+++ b/packages/core/src/domain/tracekit/tracekit.ts
@@ -5,7 +5,7 @@ import type { UnhandledErrorCallback, StackTrace } from './types'
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Error_types
 const ERROR_TYPES_RE =
-  /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/
+  /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?([\s\S]*)$/m
 
 /**
  * Cross-browser collection of unhandled errors


### PR DESCRIPTION
## Motivation

The tracekit error message parsing fails when the message contains new lines (\n)

## Changes

Update the tracekit `ERROR_TYPES_RE` regex to handle new lines.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
