### PR TITLE
👷 Fix scope packages npm publication

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,4 @@
 {
   "npmClient": "yarn",
-  "version": "4.44.2",
-  "publishConfig": {
-    "access": "public"
-  }
+  "version": "4.44.2"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,5 +19,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -30,5 +30,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -24,5 +24,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/rum-slim/package.json
+++ b/packages/rum-slim/package.json
@@ -30,5 +30,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -35,5 +35,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -14,5 +14,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Motivation

When publishing for the first time a scope package, npm assumes the access is private by default and we end up the error
`Package failed to publish. You must sign up for private packages`. 

## Changes

Specify the publish access `public` in package.json for all published packages 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
