### PR TITLE
🔉 monitor reported errors

### DIFF
--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -52,7 +52,7 @@ export function startLogs(
         status: StatusType.error,
       },
     })
-    addTelemetryDebug(`Error reported: ${error.message}`)
+    addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
   }
   const pageExitObservable = createPageExitObservable()
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -11,6 +11,7 @@ import {
   isTelemetryReplicationAllowed,
   ErrorSource,
   addTelemetryConfiguration,
+  addTelemetryDebug,
 } from '@datadog/browser-core'
 import { startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
 import type { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
@@ -39,7 +40,7 @@ export function startLogs(
 
   lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (log) => sendToExtension('logs', log))
 
-  const reportError = (error: RawError) =>
+  const reportError = (error: RawError) => {
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
       rawLogsEvent: {
         message: error.message,
@@ -51,6 +52,8 @@ export function startLogs(
         status: StatusType.error,
       },
     })
+    addTelemetryDebug(`Error reported: ${error.message}`)
+  }
   const pageExitObservable = createPageExitObservable()
 
   const session =

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -68,7 +68,7 @@ export function startRum(
 
   const reportError = (error: RawError) => {
     lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
-    addTelemetryDebug(`Error reported: ${error.message}`)
+    addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
   }
   const featureFlagContexts = startFeatureFlagContexts(lifeCycle)
 

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -7,6 +7,7 @@ import {
   startTelemetry,
   canUseEventBridge,
   getEventBridge,
+  addTelemetryDebug,
 } from '@datadog/browser-core'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { startPerformanceCollection } from '../browser/performanceCollection'
@@ -67,6 +68,7 @@ export function startRum(
 
   const reportError = (error: RawError) => {
     lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
+    addTelemetryDebug(`Error reported: ${error.message}`)
   }
   const featureFlagContexts = startFeatureFlagContexts(lifeCycle)
 

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -24,7 +24,7 @@ export function startRecording(
 ) {
   const reportError = (error: RawError) => {
     lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
-    addTelemetryDebug(`Error reported: ${error.message}`)
+    addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
   }
 
   const replayRequest =

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -1,5 +1,5 @@
 import type { RawError, HttpRequest } from '@datadog/browser-core'
-import { timeStampNow, createHttpRequest } from '@datadog/browser-core'
+import { timeStampNow, createHttpRequest, addTelemetryDebug } from '@datadog/browser-core'
 import type {
   LifeCycle,
   ViewContexts,
@@ -24,6 +24,7 @@ export function startRecording(
 ) {
   const reportError = (error: RawError) => {
     lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
+    addTelemetryDebug(`Error reported: ${error.message}`)
   }
 
   const replayRequest =


### PR DESCRIPTION
## Motivation

Have an idea on how frequently we are reporting SDK errors to customers.
For now, we only report when:

- an event limiter threshold is reached
- retry strategy queue was full

## Changes

Send telemetry debug when reporting an error

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
