### PR TITLE
🐛 Avoid setting non-object values for contexts

### DIFF
--- a/packages/core/src/tools/serialisation/contextManager.spec.ts
+++ b/packages/core/src/tools/serialisation/contextManager.spec.ts
@@ -92,6 +92,16 @@ describe('createContextManager', () => {
     expect(manager.getContext()).toEqual({})
   })
 
+  it('should prevent setting non object values', () => {
+    const manager = createContextManager(CustomerDataType.GlobalContext)
+    manager.setContext(null as any)
+    expect(manager.getContext()).toEqual({})
+    manager.setContext(undefined as any)
+    expect(manager.getContext()).toEqual({})
+    manager.setContext(2 as any)
+    expect(manager.getContext()).toEqual({})
+  })
+
   describe('bytes count computation', () => {
     it('should be done every time the context is updated', () => {
       const computeBytesCountStub = jasmine.createSpy('computeBytesCountStub').and.returnValue(1)

--- a/packages/core/src/tools/serialisation/contextManager.ts
+++ b/packages/core/src/tools/serialisation/contextManager.ts
@@ -1,6 +1,7 @@
 import { computeBytesCount } from '../utils/byteUtils'
 import { throttle } from '../utils/functionUtils'
 import { deepClone } from '../mergeInto'
+import { getType } from '../utils/typeUtils'
 import { jsonStringify } from './jsonStringify'
 import { sanitize } from './sanitize'
 import { warnIfCustomerDataLimitReached } from './heavyCustomerDataWarning'
@@ -51,8 +52,13 @@ export function createContextManager(customerDataType: CustomerDataType, compute
     getContext: () => deepClone(context),
 
     setContext: (newContext: Context) => {
-      context = sanitize(newContext)
-      computeBytesCountThrottled(context)
+      if (getType(newContext) === 'object') {
+        context = sanitize(newContext)
+        computeBytesCountThrottled(context)
+      } else {
+        context = {}
+        bytesCountCache = 0
+      }
     },
 
     setContextProperty: (key: string, property: any) => {

--- a/packages/core/src/tools/serialisation/contextManager.ts
+++ b/packages/core/src/tools/serialisation/contextManager.ts
@@ -26,7 +26,7 @@ export function createContextManager(customerDataType: CustomerDataType, compute
     }
   }, BYTES_COMPUTATION_THROTTLING_DELAY)
 
-  return {
+  const contextManager = {
     getBytesCount: () => bytesCountCache,
     /** @deprecated use getContext instead */
     get: () => context,
@@ -56,8 +56,7 @@ export function createContextManager(customerDataType: CustomerDataType, compute
         context = sanitize(newContext)
         computeBytesCountThrottled(context)
       } else {
-        context = {}
-        bytesCountCache = 0
+        contextManager.clearContext()
       }
     },
 
@@ -76,4 +75,5 @@ export function createContextManager(customerDataType: CustomerDataType, compute
       bytesCountCache = 0
     },
   }
+  return contextManager
 }


### PR DESCRIPTION
## Motivation

Telemetry errors `Cannot convert undefined or null to object` in [rum assembly](https://github.com/DataDog/browser-sdk/blob/c9ec11d/packages/rum-core/src/domain/assembly.ts#L171)

## Changes

If `setXXXContext()` is called with a non-object value, defaults context value to `{}`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
