### PR TITLE
👷Use SDK version format supported by backend

### DIFF
--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -34,7 +34,9 @@ switch (buildMode) {
     break
   case 'canary': {
     const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
-    sdkVersion = `${lernaJson.version}+${commitSha1}`
+    // TODO when tags would allow '+' characters
+    //  use build separator (+) instead of prerelease separator (-)
+    sdkVersion = `${lernaJson.version}-${commitSha1}`
     break
   }
   default:


### PR DESCRIPTION
## Motivation

In canary environment, the SDK version (`X.Y.Z+hash`) is not well supported by the backend since:

- [tags don't support](https://docs.datadoghq.com/getting_started/tagging/#define-tags) the `+` character and they are replace by `_`
- version are parsed using [semver regex](https://regex101.com/r/Ly7O1x/3/) that don't support the `_` character

## Changes

In canary environment, send the hash with the version using the prerelease separator instead of the build separator:

```diff
- X.Y.Z+hash
+ X.Y.Z-hash
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
