### PR TITLE
🐛 Fix release script by adding yarn.lock to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ rum-events-format
 .yarn
 developer-extension/dist
 test/app/dist
+yarn.lock


### PR DESCRIPTION
## Motivation

Lerna format files using prettier. Somehow since we upgrade to prettier v3 yarn.lock is no longer ignored and `yarn lerna version` craches 
![image](https://github.com/DataDog/browser-sdk/assets/4342515/93aaad58-88fa-4774-88e1-6b28fb73dc7f)


## Changes

Add yarn.lock to prettierignore

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
