### PR TITLE
🐛 Ignore workspace dependencies in check-release 

### DIFF
--- a/scripts/release/check-release.js
+++ b/scripts/release/check-release.js
@@ -69,6 +69,7 @@ function checkPackageDependencyVersions(packageJsonFile) {
       if (
         isBrowserSdkPublicPackageName(dependencyName) &&
         !dependencyVersion.startsWith('portal:') &&
+        !dependencyVersion.startsWith('workspace:') &&
         dependencyVersion !== releaseVersion
       ) {
         throw new Error(


### PR DESCRIPTION
## Motivation

Since https://github.com/DataDog/browser-sdk/pull/2337, browser logs and rum have been added as workspace dependencies which makes check-release fail.

## Changes

 Ignore workspace dependencies in check-release 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
