### PR TITLE
👷 [Extension][Monitoring] track views manually and consider each tab as a different view

### DIFF
--- a/developer-extension/src/common/constants.ts
+++ b/developer-extension/src/common/constants.ts
@@ -16,3 +16,12 @@ export const INTAKE_DOMAINS = [
     `browser-http-intake.logs.datadoghq.${tld}`,
   ]),
 ]
+
+export const enum PanelTabs {
+  Events = 'events',
+  Infos = 'infos',
+  Settings = 'settings',
+  Replay = 'replay',
+}
+
+export const DEFAULT_PANEL_TAB = PanelTabs.Events

--- a/developer-extension/src/panel/components/panel.tsx
+++ b/developer-extension/src/panel/components/panel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { Tabs, Text } from '@mantine/core'
 import { datadogRum } from '@datadog/browser-rum'
 
@@ -7,17 +7,11 @@ import { useAutoFlushEvents } from '../hooks/useAutoFlushEvents'
 import { useNetworkRules } from '../hooks/useNetworkRules'
 import type { Settings } from '../hooks/useSettings'
 import { useSettings } from '../hooks/useSettings'
+import { DEFAULT_PANEL_TAB, PanelTabs } from '../../common/constants'
 import { SettingsTab } from './tabs/settingsTab'
 import { InfosTab } from './tabs/infosTab'
 import { EventTab } from './tabs/eventsTab'
 import { ReplayTab } from './tabs/replayTab'
-
-const enum PanelTabs {
-  Events = 'events',
-  Infos = 'infos',
-  Settings = 'settings',
-  Replay = 'replay',
-}
 
 export function Panel() {
   const [settings] = useSettings()
@@ -27,17 +21,18 @@ export function Panel() {
 
   const { events, filters, setFilters, clear } = useEvents(settings)
 
-  const [activeTab, setActiveTab] = useState<string | null>(PanelTabs.Events)
-  useEffect(() => {
+  const [activeTab, setActiveTab] = useState<string | null>(DEFAULT_PANEL_TAB)
+  function updateActiveTab(activeTab: string | null) {
+    setActiveTab(activeTab)
     activeTab && datadogRum.startView(activeTab)
-  }, [activeTab])
+  }
 
   return (
     <Tabs
       color="violet"
       value={activeTab}
       sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}
-      onTabChange={setActiveTab}
+      onTabChange={updateActiveTab}
     >
       <Tabs.List className="dd-privacy-allow">
         <Tabs.Tab value={PanelTabs.Events}>Events</Tabs.Tab>

--- a/developer-extension/src/panel/components/panel.tsx
+++ b/developer-extension/src/panel/components/panel.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { Tabs, Text } from '@mantine/core'
+import { datadogRum } from '@datadog/browser-rum'
 
 import { useEvents } from '../hooks/useEvents'
 import { useAutoFlushEvents } from '../hooks/useAutoFlushEvents'
@@ -26,11 +27,17 @@ export function Panel() {
 
   const { events, filters, setFilters, clear } = useEvents(settings)
 
+  const [activeTab, setActiveTab] = useState<string | null>(PanelTabs.Events)
+  useEffect(() => {
+    activeTab && datadogRum.startView(activeTab)
+  }, [activeTab])
+
   return (
     <Tabs
       color="violet"
-      defaultValue={PanelTabs.Events}
+      value={activeTab}
       sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}
+      onTabChange={setActiveTab}
     >
       <Tabs.List className="dd-privacy-allow">
         <Tabs.Tab value={PanelTabs.Events}>Events</Tabs.Tab>

--- a/developer-extension/src/panel/monitoring.ts
+++ b/developer-extension/src/panel/monitoring.ts
@@ -1,6 +1,7 @@
 import { datadogRum } from '@datadog/browser-rum'
 import { datadogLogs } from '@datadog/browser-logs'
 import packageJson from '../../package.json'
+import { DEFAULT_PANEL_TAB } from '../common/constants'
 
 export function initMonitoring() {
   datadogRum.init({
@@ -21,6 +22,7 @@ export function initMonitoring() {
     defaultPrivacyLevel: 'mask',
   })
   datadogRum.startSessionReplayRecording()
+  datadogRum.startView(DEFAULT_PANEL_TAB)
 
   datadogLogs.init({
     clientToken: 'pub74fd472504982beb427b647893758040',

--- a/developer-extension/src/panel/monitoring.ts
+++ b/developer-extension/src/panel/monitoring.ts
@@ -15,6 +15,7 @@ export function initMonitoring() {
     sessionReplaySampleRate: 100,
     telemetrySampleRate: 100,
     trackUserInteractions: true,
+    trackViewsManually: true,
     trackResources: true,
     trackLongTasks: true,
     defaultPrivacyLevel: 'mask',


### PR DESCRIPTION
## Motivation

On the extension monitoring, differentiate collected events by tab

## Changes

track views manually and consider each tab as a different view

![Screenshot 2023-07-28 at 15 38 01](https://github.com/DataDog/browser-sdk/assets/1331991/80ac4f17-22e6-4a58-bee7-0e6df41b5c5f)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
