### PR TITLE
Remove scrollmap experimental flag

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/trackViewMetrics.ts
@@ -1,7 +1,5 @@
 import type { ClocksState, Duration, Observable, RelativeTime } from '@datadog/browser-core'
 import {
-  ExperimentalFeature,
-  isExperimentalFeatureEnabled,
   DOM_EVENT,
   ONE_SECOND,
   addEventListener,
@@ -63,15 +61,13 @@ export function trackViewMetrics(
 
       // We compute scroll metrics at loading time to ensure we have scroll data when loading the view initially
       // This is to ensure that we have the depth data even if the user didn't scroll or if the view is not scrollable.
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.SCROLLMAP)) {
-        const { scrollHeight, scrollDepth, scrollTop } = computeScrollValues()
+      const { scrollHeight, scrollDepth, scrollTop } = computeScrollValues()
 
-        scrollMetrics = {
-          maxDepth: scrollDepth,
-          maxDepthScrollHeight: scrollHeight,
-          maxDepthTime: newLoadingTime,
-          maxDepthScrollTop: scrollTop,
-        }
+      scrollMetrics = {
+        maxDepth: scrollDepth,
+        maxDepthScrollHeight: scrollHeight,
+        maxDepthTime: newLoadingTime,
+        maxDepthScrollTop: scrollTop,
       }
       scheduleViewUpdate()
     }
@@ -124,9 +120,6 @@ export function trackScrollMetrics(
   callback: (scrollMetrics: ScrollMetrics) => void,
   getScrollValues = computeScrollValues
 ) {
-  if (!isExperimentalFeatureEnabled(ExperimentalFeature.SCROLLMAP)) {
-    return { stop: noop }
-  }
   let maxDepth = 0
   const handleScrollEvent = throttle(
     () => {


### PR DESCRIPTION
## Motivation

Remove scrollmap experimental flag

## Changes

All customers will now send scroll data by default

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
