### PR TITLE
🐛[RUM-142] fix the generation of some invalid selectors

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.spec.ts
@@ -108,18 +108,26 @@ describe('getSelectorFromElement', () => {
   })
 
   describe('should escape CSS selectors', () => {
-    it('ID selector should take precedence over class selector', () => {
-      expect(getSelector('<div id="#bar"><button target class=".foo"></button></div>')).toBe('#\\#bar>BUTTON.\\.foo')
+    it('on ID value', () => {
+      expect(getSelector('<div id="#bar"></div>')).toBe('#\\#bar')
+    })
+
+    it('on attribute value', () => {
+      expect(getSelector('<div data-testid="&quot;foo bar&quot;"></div>')).toBe('DIV[data-testid="\\"foo\\ bar\\""]')
+    })
+
+    it('on class name', () => {
+      expect(getSelector('<div class="#bar"</div>')).toBe('BODY>DIV.\\#bar')
+    })
+
+    it('on tag name', () => {
+      expect(getSelector('<div&nbsp;span>></div&nbsp;span>')).toBe('BODY>DIV\\&NBSP\\;SPAN')
     })
   })
 
   describe('attribute selector', () => {
     it('uses a stable attribute if the element has one', () => {
       expect(getSelector('<div data-testid="foo"></div>')).toBe('DIV[data-testid="foo"]')
-    })
-
-    it('escapes the attribute value', () => {
-      expect(getSelector('<div data-testid="&quot;foo bar&quot;"></div>')).toBe('DIV[data-testid="\\"foo\\ bar\\""]')
     })
 
     it('attribute selector with the custom action name attribute takes precedence over other stable attribute selectors', () => {

--- a/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/action/getSelectorFromElement.ts
@@ -99,13 +99,13 @@ function getClassSelector(element: Element): string | undefined {
         continue
       }
 
-      return `${element.tagName}.${cssEscape(className)}`
+      return `${cssEscape(element.tagName)}.${cssEscape(className)}`
     }
   }
 }
 
 function getTagNameSelector(element: Element): string {
-  return element.tagName
+  return cssEscape(element.tagName)
 }
 
 function getStableAttributeSelector(element: Element, actionNameAttribute: string | undefined): string | undefined {
@@ -125,7 +125,7 @@ function getStableAttributeSelector(element: Element, actionNameAttribute: strin
 
   function getAttributeSelector(attributeName: string) {
     if (element.hasAttribute(attributeName)) {
-      return `${element.tagName}[${attributeName}="${cssEscape(element.getAttribute(attributeName)!)}"]`
+      return `${cssEscape(element.tagName)}[${attributeName}="${cssEscape(element.getAttribute(attributeName)!)}"]`
     }
   }
 }
@@ -141,7 +141,7 @@ function getPositionSelector(element: Element): string {
     sibling = sibling.nextElementSibling
   }
 
-  return `${element.tagName}:nth-of-type(${elementIndex})`
+  return `${cssEscape(element.tagName)}:nth-of-type(${elementIndex})`
 }
 
 function findSelector(

--- a/packages/rum/src/domain/record/observers/inputObserver.ts
+++ b/packages/rum/src/domain/record/observers/inputObserver.ts
@@ -1,5 +1,5 @@
 import type { ListenerHandler } from '@datadog/browser-core'
-import { instrumentSetter, assign, DOM_EVENT, addEventListeners, forEach, noop } from '@datadog/browser-core'
+import { instrumentSetter, assign, DOM_EVENT, addEventListeners, forEach, noop, cssEscape } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { NodePrivacyLevel } from '../../../constants'
 import type { InputState } from '../../../types'
@@ -91,7 +91,7 @@ export function initInputObserver(
     // If a radio was checked, other radios with the same name attribute will be unchecked.
     const name = target.name
     if (type === 'radio' && name && (target as HTMLInputElement).checked) {
-      forEach(document.querySelectorAll(`input[type="radio"][name="${name}"]`), (el: Element) => {
+      forEach(document.querySelectorAll(`input[type="radio"][name="${cssEscape(name)}"]`), (el: Element) => {
         if (el !== target) {
           // TODO: Consider the privacy implications for various differing input privacy levels
           cbWithDedup(el, { isChecked: false })


### PR DESCRIPTION
## Motivation

From the telemetry, several errors like:

    Failed to execute 'querySelectorAll' on {*}: {*} is not a valid selector.

## Changes

Add some extra escaping

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
