### PR TITLE
👷✅ fix unit-bs tests failing on Safari

### DIFF
--- a/test/unit/karma.bs.conf.js
+++ b/test/unit/karma.bs.conf.js
@@ -1,5 +1,5 @@
 const { browserConfigurations } = require('../browsers.conf')
-const { getBuildInfos, getIp } = require('../envUtils')
+const { getBuildInfos } = require('../envUtils')
 const karmaBaseConf = require('./karma.base.conf')
 
 module.exports = function (config) {
@@ -10,7 +10,6 @@ module.exports = function (config) {
     browsers: browserConfigurations.map((configuration) => configuration.sessionName),
     concurrency: 5,
     browserDisconnectTolerance: 3,
-    hostname: getIp(),
     browserStack: {
       username: process.env.BS_USERNAME,
       accessKey: process.env.BS_ACCESS_KEY,


### PR DESCRIPTION

## Motivation

Somehow, using the default hostname (localhost) to run karma tests on browserstacks works, and using the local network ip doesn't (unit-bs timeout when starting tests on Safari 14.1 / Big Sur).


## Changes

Use default hostname (localhost) in karma configuration

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
