### PR TITLE
👷 CI: add a deploy feature job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,6 +248,20 @@ e2e-bs:
 # Deploy
 ########################################################################################################################
 
+deploy-feature:
+  stage: deploy
+  when: manual
+  variables:
+    SUFFIX: 'my-feature' #/datadog-[product]-${SUFFIX}.js
+  extends:
+    - .base-configuration
+    - .feature-branches
+  script:
+    - export BUILD_MODE=canary
+    - yarn
+    - yarn build:bundle
+    - node ./scripts/deploy/deploy.js staging $SUFFIX root
+
 deploy-staging:
   stage: deploy
   extends:


### PR DESCRIPTION
## Motivation

In order to share SDK changes, it can be a bit restrictive to regularly merge to staging or to merge in main.

## Changes

Add an optional deploy step on feature branches to upload a sdk file on the staging environment.
Exemple:

    SUFFIX: prerelease-v5

generates on the staging CDN:

- /datadog-rum-prerelease-v5.js
- /datadog-logs-prerelease-v5.js
- ...


  


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] CI


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
