### PR TITLE
♻️ [RUM-253] refactor batch creation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,7 +54,6 @@ export {
   HttpRequest,
   Payload,
   createHttpRequest,
-  Batch,
   canUseEventBridge,
   getEventBridge,
   startBatchWithReplica,

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -13,7 +13,7 @@ export class Batch {
 
   constructor(
     private request: HttpRequest,
-    private flushController: FlushController,
+    public flushController: FlushController,
     private messageBytesLimit: number
   ) {
     this.flushController.flushObservable.subscribe((event) => this.flush(event))

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -1,5 +1,4 @@
 export { HttpRequest, createHttpRequest, Payload, RetryInfo } from './httpRequest'
-export { Batch } from './batch'
 export { canUseEventBridge, getEventBridge, BrowserWindowWithEventBridge } from './eventBridge'
 export { startBatchWithReplica } from './startBatchWithReplica'
 export { createFlushController, FlushController, FlushEvent, FlushReason } from './flushController'

--- a/packages/core/src/transport/startBatchWithReplica.spec.ts
+++ b/packages/core/src/transport/startBatchWithReplica.spec.ts
@@ -1,0 +1,126 @@
+import { stubEndpointBuilder } from '../../test'
+import type { PageExitEvent } from '../browser/pageExitObservable'
+import type { Configuration, EndpointBuilder } from '../domain/configuration'
+import type { RawError } from '../domain/error/error.types'
+import { Observable } from '../tools/observable'
+import { noop } from '../tools/utils/functionUtils'
+import { Batch } from './batch'
+import { startBatchWithReplica } from './startBatchWithReplica'
+
+describe('startBatchWithReplica', () => {
+  const DEFAULT_CONFIGURATION: Configuration = {} as Configuration
+  const reportError: (error: RawError) => void = noop
+  let pageExitObservable: Observable<PageExitEvent>
+  let sessionExpireObservable: Observable<void>
+  let endpoint: EndpointBuilder
+
+  beforeEach(() => {
+    pageExitObservable = new Observable()
+    sessionExpireObservable = new Observable()
+    endpoint = stubEndpointBuilder('https://example.com')
+  })
+
+  it('adds a message to a batch and its replica', () => {
+    const batchAddSpy = spyOn(Batch.prototype, 'add')
+
+    const batch = startBatchWithReplica(
+      DEFAULT_CONFIGURATION,
+      { endpoint },
+      { endpoint },
+      reportError,
+      pageExitObservable,
+      sessionExpireObservable
+    )
+    batch.add({ foo: true })
+    expect(batchAddSpy.calls.thisFor(0)).not.toBe(batchAddSpy.calls.thisFor(1))
+    expect(batchAddSpy).toHaveBeenCalledTimes(2)
+    expect(batchAddSpy.calls.argsFor(0)).toEqual([{ foo: true }])
+    expect(batchAddSpy.calls.argsFor(1)).toEqual([{ foo: true }])
+  })
+
+  it('does not add a message to the replica if no replica is specified', () => {
+    const batchAddSpy = spyOn(Batch.prototype, 'add')
+
+    const batch = startBatchWithReplica(
+      DEFAULT_CONFIGURATION,
+      { endpoint },
+      undefined,
+      reportError,
+      pageExitObservable,
+      sessionExpireObservable
+    )
+    batch.add({ foo: true })
+    expect(batchAddSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not add a message to the replica if it shouldn't be replicated", () => {
+    const batchAddSpy = spyOn(Batch.prototype, 'add')
+
+    const batch = startBatchWithReplica(
+      DEFAULT_CONFIGURATION,
+      { endpoint },
+      { endpoint },
+      reportError,
+      pageExitObservable,
+      sessionExpireObservable
+    )
+    batch.add({ foo: true }, false)
+    expect(batchAddSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('upserts a message to a batch and its replica', () => {
+    const batchUpsertSpy = spyOn(Batch.prototype, 'upsert')
+
+    const batch = startBatchWithReplica(
+      DEFAULT_CONFIGURATION,
+      { endpoint },
+      { endpoint },
+      reportError,
+      pageExitObservable,
+      sessionExpireObservable
+    )
+    batch.upsert({ foo: true }, 'message-id')
+    expect(batchUpsertSpy).toHaveBeenCalledTimes(2)
+    expect(batchUpsertSpy.calls.thisFor(0)).not.toBe(batchUpsertSpy.calls.thisFor(1))
+    expect(batchUpsertSpy.calls.argsFor(0)).toEqual([{ foo: true }, 'message-id'])
+    expect(batchUpsertSpy.calls.argsFor(1)).toEqual([{ foo: true }, 'message-id'])
+  })
+
+  it('transforms a message when adding it to the replica', () => {
+    const batchAddSpy = spyOn(Batch.prototype, 'add')
+
+    const batch = startBatchWithReplica(
+      DEFAULT_CONFIGURATION,
+      { endpoint },
+      {
+        endpoint,
+        transformMessage: (message) => ({ ...message, bar: true }),
+      },
+      reportError,
+      pageExitObservable,
+      sessionExpireObservable
+    )
+    batch.add({ foo: true })
+    expect(batchAddSpy.calls.argsFor(0)).toEqual([{ foo: true }])
+    expect(batchAddSpy.calls.argsFor(1)).toEqual([{ foo: true, bar: true }])
+  })
+
+  it('transforms a message when upserting it to the replica', () => {
+    const batchUpsertSpy = spyOn(Batch.prototype, 'upsert')
+
+    const batch = startBatchWithReplica(
+      DEFAULT_CONFIGURATION,
+      { endpoint },
+      {
+        endpoint,
+        transformMessage: (message) => ({ ...message, bar: true }),
+      },
+      reportError,
+      pageExitObservable,
+      sessionExpireObservable
+    )
+    batch.upsert({ foo: true }, 'message-id')
+    expect(batchUpsertSpy.calls.argsFor(0)).toEqual([{ foo: true }, 'message-id'])
+    expect(batchUpsertSpy.calls.argsFor(1)).toEqual([{ foo: true, bar: true }, 'message-id'])
+  })
+})

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -113,11 +113,15 @@ function startLogsTelemetry(
   } else {
     const telemetryBatch = startBatchWithReplica(
       configuration,
-      configuration.rumEndpointBuilder,
+      {
+        endpoint: configuration.rumEndpointBuilder,
+      },
+      configuration.replica && {
+        endpoint: configuration.replica.rumEndpointBuilder,
+      },
       reportError,
       pageExitObservable,
-      sessionExpireObservable,
-      configuration.replica?.rumEndpointBuilder
+      sessionExpireObservable
     )
     telemetry.observable.subscribe((event) => telemetryBatch.add(event, isTelemetryReplicationAllowed(configuration)))
   }

--- a/packages/logs/src/transport/startLogsBatch.ts
+++ b/packages/logs/src/transport/startLogsBatch.ts
@@ -14,11 +14,15 @@ export function startLogsBatch(
 ) {
   const batch = startBatchWithReplica(
     configuration,
-    configuration.logsEndpointBuilder,
+    {
+      endpoint: configuration.logsEndpointBuilder,
+    },
+    configuration.replica && {
+      endpoint: configuration.replica.logsEndpointBuilder,
+    },
     reportError,
     pageExitObservable,
-    sessionExpireObservable,
-    configuration.replica?.logsEndpointBuilder
+    sessionExpireObservable
   )
 
   lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (serverLogsEvent: LogsEvent & Context) => {

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -1,19 +1,5 @@
-import type {
-  Context,
-  EndpointBuilder,
-  TelemetryEvent,
-  Observable,
-  RawError,
-  PageExitEvent,
-  FlushEvent,
-} from '@datadog/browser-core'
-import {
-  createFlushController,
-  Batch,
-  combine,
-  createHttpRequest,
-  isTelemetryReplicationAllowed,
-} from '@datadog/browser-core'
+import type { Context, TelemetryEvent, Observable, RawError, PageExitEvent } from '@datadog/browser-core'
+import { combine, isTelemetryReplicationAllowed, startBatchWithReplica } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
 import { LifeCycleEventType } from '../domain/lifeCycle'
@@ -28,7 +14,21 @@ export function startRumBatch(
   pageExitObservable: Observable<PageExitEvent>,
   sessionExpireObservable: Observable<void>
 ) {
-  const batch = makeRumBatch(configuration, reportError, pageExitObservable, sessionExpireObservable)
+  const replica = configuration.replica
+
+  const batch = startBatchWithReplica<Context>(
+    configuration,
+    {
+      endpoint: configuration.rumEndpointBuilder,
+    },
+    replica && {
+      endpoint: replica.rumEndpointBuilder,
+      transformMessage: (message) => combine(message, { application: { id: replica.applicationId } }),
+    },
+    reportError,
+    pageExitObservable,
+    sessionExpireObservable
+  )
 
   lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (serverRumEvent: RumEvent & Context) => {
     if (serverRumEvent.type === RumEventType.VIEW) {
@@ -41,67 +41,4 @@ export function startRumBatch(
   telemetryEventObservable.subscribe((event) => batch.add(event, isTelemetryReplicationAllowed(configuration)))
 
   return batch
-}
-
-export interface RumBatch {
-  flushObservable: Observable<FlushEvent>
-  add: (message: Context, replicated?: boolean) => void
-  upsert: (message: Context, key: string) => void
-}
-
-function makeRumBatch(
-  configuration: RumConfiguration,
-  reportError: (error: RawError) => void,
-  pageExitObservable: Observable<PageExitEvent>,
-  sessionExpireObservable: Observable<void>
-): RumBatch {
-  const { batch: primaryBatch, flushController: primaryFlushController } = createRumBatch(
-    configuration.rumEndpointBuilder
-  )
-  let replicaBatch: Batch | undefined
-  const replica = configuration.replica
-  if (replica !== undefined) {
-    replicaBatch = createRumBatch(replica.rumEndpointBuilder).batch
-  }
-
-  function createRumBatch(endpointBuilder: EndpointBuilder) {
-    const flushController = createFlushController({
-      messagesLimit: configuration.batchMessagesLimit,
-      bytesLimit: configuration.batchBytesLimit,
-      durationLimit: configuration.flushTimeout,
-      pageExitObservable,
-      sessionExpireObservable,
-    })
-
-    const batch = new Batch(
-      createHttpRequest(configuration, endpointBuilder, configuration.batchBytesLimit, reportError),
-      flushController,
-      configuration.messageBytesLimit
-    )
-
-    return {
-      batch,
-      flushController,
-    }
-  }
-
-  function withReplicaApplicationId(message: Context) {
-    return combine(message, { application: { id: replica!.applicationId } })
-  }
-
-  return {
-    flushObservable: primaryFlushController.flushObservable,
-    add: (message: Context, replicated = true) => {
-      primaryBatch.add(message)
-      if (replicaBatch && replicated) {
-        replicaBatch.add(withReplicaApplicationId(message))
-      }
-    },
-    upsert: (message: Context, key: string) => {
-      primaryBatch.upsert(message, key)
-      if (replicaBatch) {
-        replicaBatch.upsert(withReplicaApplicationId(message), key)
-      }
-    },
-  }
 }

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -16,7 +16,7 @@ export function startRumBatch(
 ) {
   const replica = configuration.replica
 
-  const batch = startBatchWithReplica<Context>(
+  const batch = startBatchWithReplica(
     configuration,
     {
       endpoint: configuration.rumEndpointBuilder,


### PR DESCRIPTION
## Motivation

Currently, we create Batch instances in two places: `startBatchWithReplica` and `startRumBatch`. As I'm planning to change how Batch works, in order to avoid repeating myself, this PR factorize the two functions.

## Changes

* add missing features to `startBatchWithReplica` (upsert + transform replica message)
* use `startBatchWithReplica` in `startRumBatch`
* add some tests around `startBatchWithReplica`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
