### PR TITLE
🐛 fix dynamic style serialization

### DIFF
--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -181,10 +181,7 @@ export function getTextContent(
   } else if (nodePrivacyLevel === NodePrivacyLevel.HIDDEN) {
     // Should never occur, but just in case, we set to CENSORED_MARK.
     textContent = CENSORED_STRING_MARK
-  } else if (
-    shouldMaskNode(textNode, nodePrivacyLevel)
-    // Style tags are `overruled` (Use `hide` to enforce privacy)
-  ) {
+  } else if (shouldMaskNode(textNode, nodePrivacyLevel)) {
     if (
       // Scrambling the child list breaks text nodes for DATALIST/SELECT/OPTGROUP
       parentTagName === 'DATALIST' ||

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -173,7 +173,6 @@ export function getTextContent(
 
   const nodePrivacyLevel = parentNodePrivacyLevel
 
-  const isStyle = parentTagName === 'STYLE' ? true : undefined
   const isScript = parentTagName === 'SCRIPT'
 
   if (isScript) {
@@ -183,9 +182,8 @@ export function getTextContent(
     // Should never occur, but just in case, we set to CENSORED_MARK.
     textContent = CENSORED_STRING_MARK
   } else if (
-    shouldMaskNode(textNode, nodePrivacyLevel) &&
+    shouldMaskNode(textNode, nodePrivacyLevel)
     // Style tags are `overruled` (Use `hide` to enforce privacy)
-    !isStyle
   ) {
     if (
       // Scrambling the child list breaks text nodes for DATALIST/SELECT/OPTGROUP

--- a/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
+++ b/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
@@ -53,7 +53,7 @@ export const HTML = `
 <head>
     <link href="https://public.com/path/nested?query=param#hash" rel="stylesheet">
     <style>
-      .example {content: "anything";}
+      .example {color: red;}
     </style>
     <script>private</script>
     <meta>
@@ -142,7 +142,7 @@ export const AST_MASK = {
             {
               type: 2,
               tagName: 'style',
-              attributes: { _cssText: '.example { content: "anything"; }' },
+              attributes: { _cssText: '.example { color: red; }' },
               childNodes: [],
             },
             {
@@ -449,7 +449,7 @@ export const AST_MASK_USER_INPUT = {
             {
               type: 2,
               tagName: 'style',
-              attributes: { _cssText: '.example { content: "anything"; }' },
+              attributes: { _cssText: '.example { color: red; }' },
               childNodes: [],
             },
             {
@@ -756,7 +756,7 @@ export const AST_ALLOW = {
             {
               type: 2,
               tagName: 'style',
-              attributes: { _cssText: '.example { content: "anything"; }' },
+              attributes: { _cssText: '.example { color: red; }' },
               childNodes: [],
             },
             {

--- a/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
+++ b/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
@@ -142,7 +142,7 @@ export const AST_MASK = {
             {
               type: 2,
               tagName: 'style',
-              attributes: {},
+              attributes: { _cssText: '.example { content: "anything"; }' },
               childNodes: [
                 {
                   type: 3,
@@ -455,7 +455,7 @@ export const AST_MASK_USER_INPUT = {
             {
               type: 2,
               tagName: 'style',
-              attributes: {},
+              attributes: { _cssText: '.example { content: "anything"; }' },
               childNodes: [
                 {
                   type: 3,
@@ -768,7 +768,7 @@ export const AST_ALLOW = {
             {
               type: 2,
               tagName: 'style',
-              attributes: {},
+              attributes: { _cssText: '.example { content: "anything"; }' },
               childNodes: [
                 {
                   type: 3,

--- a/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
+++ b/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
@@ -143,13 +143,7 @@ export const AST_MASK = {
               type: 2,
               tagName: 'style',
               attributes: { _cssText: '.example { content: "anything"; }' },
-              childNodes: [
-                {
-                  type: 3,
-                  textContent: '\n      .example {content: "anything";}\n    ',
-                  isStyle: true,
-                },
-              ],
+              childNodes: [],
             },
             {
               type: 2,
@@ -456,13 +450,7 @@ export const AST_MASK_USER_INPUT = {
               type: 2,
               tagName: 'style',
               attributes: { _cssText: '.example { content: "anything"; }' },
-              childNodes: [
-                {
-                  type: 3,
-                  textContent: '\n      .example {content: "anything";}\n    ',
-                  isStyle: true,
-                },
-              ],
+              childNodes: [],
             },
             {
               type: 2,
@@ -769,13 +757,7 @@ export const AST_ALLOW = {
               type: 2,
               tagName: 'style',
               attributes: { _cssText: '.example { content: "anything"; }' },
-              childNodes: [
-                {
-                  type: 3,
-                  textContent: '\n      .example {content: "anything";}\n    ',
-                  isStyle: true,
-                },
-              ],
+              childNodes: [],
             },
             {
               type: 2,

--- a/packages/rum/src/domain/record/serialization/serializeAttributes.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttributes.ts
@@ -59,12 +59,7 @@ export function serializeAttributes(
   }
 
   // dynamic stylesheet
-  if (
-    tagName === 'style' &&
-    (element as HTMLStyleElement).sheet &&
-    // TODO: Currently we only try to get dynamic stylesheet when it is an empty style element
-    !((element as HTMLStyleElement).innerText || element.textContent || '').trim().length
-  ) {
+  if (tagName === 'style' && (element as HTMLStyleElement).sheet) {
     const cssText = getCssRulesString((element as HTMLStyleElement).sheet)
     if (cssText) {
       safeAttrs._cssText = cssText

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -688,7 +688,6 @@ describe('serializeNodeWithId', () => {
       expect(serializeNodeWithId(textNode, DEFAULT_OPTIONS)).toEqual({
         type: NodeType.Text,
         id: jasmine.any(Number) as unknown as number,
-        isStyle: undefined,
         textContent: 'foo',
       })
     })
@@ -700,7 +699,6 @@ describe('serializeNodeWithId', () => {
       expect(serializeNodeWithId(textNode, DEFAULT_OPTIONS)).toEqual({
         type: NodeType.Text,
         id: jasmine.any(Number) as unknown as number,
-        isStyle: undefined,
         textContent: '',
       })
     })
@@ -709,18 +707,6 @@ describe('serializeNodeWithId', () => {
       expect(
         serializeNodeWithId(document.createTextNode('   '), { ...DEFAULT_OPTIONS, ignoreWhiteSpace: true })
       ).toEqual(null)
-    })
-
-    it('serializes a text node contained in a <style> element', () => {
-      const style = document.createElement('style')
-      style.textContent = 'body { background-color: red }'
-
-      expect(serializeNodeWithId(style.childNodes[0], DEFAULT_OPTIONS)).toEqual(
-        jasmine.objectContaining({
-          textContent: 'body { background-color: red }',
-          isStyle: true,
-        })
-      )
     })
   })
 

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -572,14 +572,14 @@ describe('serializeNodeWithId', () => {
         const styleNode = document.createElement('style')
         styleNode.textContent = 'body { width: 100%; }'
         isolatedDom.document.head.appendChild(styleNode)
-        styleNode.sheet!.insertRule('body { background: red; }')
+        styleNode.sheet!.insertRule('body { color: red; }')
 
         expect(serializeElement(styleNode)).toEqual({
           type: NodeType.Element,
           tagName: 'style',
           id: jasmine.any(Number) as unknown as number,
           isSVG: undefined,
-          attributes: { _cssText: 'body { background: red; }body { width: 100%; }' },
+          attributes: { _cssText: 'body { color: red; }body { width: 100%; }' },
           childNodes: [],
         })
       })

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -563,7 +563,30 @@ describe('serializeNodeWithId', () => {
           tagName: 'style',
           id: jasmine.any(Number) as unknown as number,
           isSVG: undefined,
-          attributes: {},
+          attributes: { _cssText: 'body { width: 100%; }' },
+          childNodes: [
+            {
+              type: NodeType.Text,
+              textContent: 'body { width: 100%; }',
+              isStyle: true,
+              id: jasmine.any(Number) as unknown as number,
+            },
+          ],
+        })
+      })
+
+      it('serializes a node with CSS rules specified as inner text then dynamically edited', () => {
+        const styleNode = document.createElement('style')
+        styleNode.textContent = 'body { width: 100%; }'
+        isolatedDom.document.head.appendChild(styleNode)
+        styleNode.sheet!.insertRule('body { background: red; }')
+
+        expect(serializeElement(styleNode)).toEqual({
+          type: NodeType.Element,
+          tagName: 'style',
+          id: jasmine.any(Number) as unknown as number,
+          isSVG: undefined,
+          attributes: { _cssText: 'body { background: red; }body { width: 100%; }' },
           childNodes: [
             {
               type: NodeType.Text,

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -564,14 +564,7 @@ describe('serializeNodeWithId', () => {
           id: jasmine.any(Number) as unknown as number,
           isSVG: undefined,
           attributes: { _cssText: 'body { width: 100%; }' },
-          childNodes: [
-            {
-              type: NodeType.Text,
-              textContent: 'body { width: 100%; }',
-              isStyle: true,
-              id: jasmine.any(Number) as unknown as number,
-            },
-          ],
+          childNodes: [],
         })
       })
 
@@ -587,14 +580,7 @@ describe('serializeNodeWithId', () => {
           id: jasmine.any(Number) as unknown as number,
           isSVG: undefined,
           attributes: { _cssText: 'body { background: red; }body { width: 100%; }' },
-          childNodes: [
-            {
-              type: NodeType.Text,
-              textContent: 'body { width: 100%; }',
-              isStyle: true,
-              id: jasmine.any(Number) as unknown as number,
-            },
-          ],
+          childNodes: [],
         })
       })
     })
@@ -807,7 +793,7 @@ describe('serializeNodeWithId', () => {
       it('obfuscates all text content', () => {
         const serializedDoc = generateLeanSerializedDoc(HTML, 'mask')
         for (const textContents of getAllTextContents(serializedDoc)) {
-          expect(textContents).toEqual(jasmine.stringMatching(/^([*x\s]*|\.example {content: "anything";})$/))
+          expect(textContents).toEqual(jasmine.stringMatching(/^[*x\s]*$/))
         }
       })
 

--- a/packages/rum/src/domain/record/serialization/serializeNode.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.ts
@@ -203,9 +203,6 @@ function isSVGElement(el: Element): boolean {
  */
 
 function serializeTextNode(textNode: Text, options: SerializeOptions): TextNode | undefined {
-  // The parent node may not be a html element which has a tagName attribute.
-  // So just let it be undefined which is ok in this use case.
-  const parentTagName = textNode.parentElement?.tagName
   const textContent = getTextContent(textNode, options.ignoreWhiteSpace || false, options.parentNodePrivacyLevel)
   if (textContent === undefined) {
     return
@@ -213,7 +210,6 @@ function serializeTextNode(textNode: Text, options: SerializeOptions): TextNode 
   return {
     type: NodeType.Text,
     textContent,
-    isStyle: parentTagName === 'STYLE' ? true : undefined,
   }
 }
 

--- a/packages/rum/src/domain/record/serialization/serializeNode.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.ts
@@ -156,7 +156,11 @@ function serializeElementNode(element: Element, options: SerializeOptions): Elem
   const attributes = serializeAttributes(element, nodePrivacyLevel, options)
 
   let childNodes: SerializedNodeWithId[] = []
-  if (element.childNodes.length) {
+  if (
+    element.childNodes.length &&
+    // Do not serialize style children as the css rules are already in the _cssText attribute
+    tagName !== 'style'
+  ) {
     // OBJECT POOLING OPTIMIZATION:
     // We should not create a new object systematically as it could impact performances. Try to reuse
     // the same object as much as possible, and clone it only if we need to.


### PR DESCRIPTION
## Motivation

See #2380. When a website uses a non-empty `<style>` element, edits it with `insertRule` or `deleteRule`, and then starts recording with `startSessionReplayRecording()`, changes made to the style are lost. Example:

>  Let's assume the page contains this piece of HTML:
> ```html
> <style>
> body { color: red }
> </style>
> ```
> If a script is modifying the <style> state:
> ```js
> document.querySelector('style').sheet.insertRule('body { font-size: 10px }')
> ```
>
> And only then we are taking a full snapshot
> ```js
> DD_RUM.startSessionReplayRecording()
> ```
> The inserted rule will be ignored during serialization. The <style> will be serialized like this:
> ```js
> {
>   type: NodeType.Element,
>   tagName: 'style',
>   attributes: {},
>   childNodes: [{
>     type: NodeType.Text,
>     textContent: 'body { color: red }',
>     isStyle: true
>   }]
> }
> ```

This behavior is inherited from rrweb which [still has it](https://github.com/rrweb-io/rrweb/blob/58c9104eddc8b7994a067a97daae5684e42f892f/packages/rrweb-snapshot/src/snapshot.ts#L658). There is no justification on why this condition is here in the commit history.

## Changes

* Always use the `<style>` element state (from its associated StyleSheet) when serializing it.
* Do not serialize `<style>` element children anymore
* Do not define the `isStyle` property on serialized text nodes

> In the above example, the `<style>` will be serialized like this:
> ```js
> {
>   type: NodeType.Element,
>   tagName: 'style',
>   attributes: { _cssText: 'body { font-size: 10px } body {color: red }' },
>   childNodes: []
> }
> ```

This change is compatible with the current implementation of the player.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
