### PR TITLE
👷 add a separate step to deploy to EU1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -305,15 +305,21 @@ step-1_deploy-prod-minor-dcs:
   extends:
     - .deploy-prod
   variables:
-    UPLOAD_PATH: eu1,us3,us5,ap1
+    UPLOAD_PATH: us3,us5,ap1
 
-step-2_deploy-prod-us1:
+step-2_deploy-prod-eu1:
+  extends:
+    - .deploy-prod
+  variables:
+    UPLOAD_PATH: eu1
+
+step-3_deploy-prod-us1:
   extends:
     - .deploy-prod
   variables:
     UPLOAD_PATH: us1
 
-step-3_deploy-prod-root:
+step-4_deploy-prod-root:
   extends:
     - .deploy-prod
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -325,7 +325,7 @@ step-4_deploy-prod-root:
   variables:
     UPLOAD_PATH: root
 
-step-4_publish-npm:
+step-5_publish-npm:
   stage: deploy
   extends:
     - .base-configuration


### PR DESCRIPTION
## Motivation

More and more orgs are using `https://www.datadoghq-browser-agent.com/eu1/*`. Deploy bundles there separately from other DC.

## Changes

Add a separate step to deploy to EU1

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
