### PR TITLE
🐛 fix INP support detection

### DIFF
--- a/packages/rum-core/src/domain/rumEventsCollection/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/rumEventsCollection/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -110,5 +110,9 @@ export function trackViewInteractionCount(viewLoadingType: ViewLoadingType) {
 }
 
 export function isInteractionToNextPaintSupported() {
-  return supportPerformanceTimingEvent('event') && 'interactionId' in PerformanceEventTiming.prototype
+  return (
+    supportPerformanceTimingEvent('event') &&
+    window.PerformanceEventTiming &&
+    'interactionId' in PerformanceEventTiming.prototype
+  )
 }


### PR DESCRIPTION


## Motivation

On Firefox 88, `PerformanceObserver.supportedEntryTypes` includes `'event'`, but `PerformanceEventTiming` is not implemented.

## Changes

Test in `PerformanceEventTiming` exists before using it.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
