### PR TITLE
🔈 Add env information in telemetry

### DIFF
--- a/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
@@ -10,5 +10,10 @@ export const enum StatusType {
   error = 'error',
 }
 
+export interface RuntimeEnvInfo {
+  is_local_file: boolean
+  is_worker: boolean
+}
+
 export type RawTelemetryEvent = TelemetryEvent['telemetry']
 export type RawTelemetryConfiguration = TelemetryConfigurationEvent['telemetry']['configuration']

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -81,6 +81,19 @@ describe('telemetry', () => {
     expect(notifySpy.calls.mostRecent().args[0].experimental_features).toEqual(['foo'])
   })
 
+  it('should contains runtime env', () => {
+    addExperimentalFeatures(['foo' as ExperimentalFeature])
+    const { notifySpy } = startAndSpyTelemetry()
+    callMonitored(() => {
+      throw new Error('message')
+    })
+
+    expect(notifySpy.calls.mostRecent().args[0].telemetry.runtime_env).toEqual({
+      is_local_file: jasmine.any(Boolean),
+      is_worker: jasmine.any(Boolean),
+    })
+  })
+
   describe('telemetry context', () => {
     it('should be added to telemetry events', () => {
       const { telemetry, notifySpy } = startAndSpyTelemetry()

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -82,7 +82,6 @@ describe('telemetry', () => {
   })
 
   it('should contains runtime env', () => {
-    addExperimentalFeatures(['foo' as ExperimentalFeature])
     const { notifySpy } = startAndSpyTelemetry()
     callMonitored(() => {
       throw new Error('message')

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -87,7 +87,12 @@ export function startTelemetry(telemetryService: TelemetryService, configuration
         _dd: {
           format_version: 2 as const,
         },
-        telemetry: event as any, // https://github.com/microsoft/TypeScript/issues/48457
+        telemetry: combine(event, {
+          runtime_env: {
+            isLocalFile: isLocalFile(),
+            isWorker: isWorker(),
+          },
+        }) as any, // https://github.com/microsoft/TypeScript/issues/48457
         experimental_features: arrayFrom(getExperimentalFeatures()),
       },
       contextProvider !== undefined ? contextProvider() : {}
@@ -101,6 +106,14 @@ export function startTelemetry(telemetryService: TelemetryService, configuration
     observable,
     enabled: telemetryConfiguration.telemetryEnabled,
   }
+}
+
+function isLocalFile() {
+  return window.location.protocol === 'file:'
+}
+
+function isWorker() {
+  return 'WorkerGlobalScope' in self
 }
 
 export function startFakeTelemetry() {

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -94,11 +94,11 @@ export function startTelemetry(telemetryService: TelemetryService, configuration
         },
         telemetry: combine(event, {
           runtime_env: runtimeEnvInfo,
-        }) as any, // https://github.com/microsoft/TypeScript/issues/48457
+        }),
         experimental_features: arrayFrom(getExperimentalFeatures()),
       },
       contextProvider !== undefined ? contextProvider() : {}
-    )
+    ) as TelemetryEvent & Context
   }
 
   return {

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -570,15 +570,13 @@ describe('getRUMInternalContext', () => {
 
     it('adds a telemetry debug event when RUM has not been injected yet', () => {
       getRUMInternalContext()
-      expect(telemetrySpy).toHaveBeenCalledOnceWith(
+      expect(telemetrySpy.calls.mostRecent().args[0].telemetry).toEqual(
         jasmine.objectContaining({
-          telemetry: {
-            message: 'Logs sent before RUM is injected by the synthetics worker',
-            status: 'debug',
-            type: 'log',
-            testId: 'test-id',
-            resultId: 'result-id',
-          },
+          message: 'Logs sent before RUM is injected by the synthetics worker',
+          status: 'debug',
+          type: 'log',
+          testId: 'test-id',
+          resultId: 'result-id',
         })
       )
     })

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
@@ -97,17 +97,19 @@ describe('customerDataTelemetry', () => {
     generateBatch({ eventNumber: 1, contextBytesCount: 1, batchBytesCount: 1 })
     clock.tick(MEASURES_PERIOD_DURATION)
 
-    expect(telemetryEvents[0].telemetry).toEqual({
-      type: 'log',
-      status: 'debug',
-      message: 'Customer data measures',
-      batchCount: 2,
-      batchBytesCount: { min: 1, max: 10, sum: 11 },
-      batchMessagesCount: { min: 1, max: 10, sum: 11 },
-      globalContextBytes: { min: 1, max: 10, sum: 101 },
-      userContextBytes: { min: 1, max: 10, sum: 101 },
-      featureFlagBytes: { min: 1, max: 10, sum: 101 },
-    })
+    expect(telemetryEvents[0].telemetry).toEqual(
+      jasmine.objectContaining({
+        type: 'log',
+        status: 'debug',
+        message: 'Customer data measures',
+        batchCount: 2,
+        batchBytesCount: { min: 1, max: 10, sum: 11 },
+        batchMessagesCount: { min: 1, max: 10, sum: 11 },
+        globalContextBytes: { min: 1, max: 10, sum: 101 },
+        userContextBytes: { min: 1, max: 10, sum: 101 },
+        featureFlagBytes: { min: 1, max: 10, sum: 101 },
+      })
+    )
   })
 
   it('should collect empty contexts telemetry', () => {


### PR DESCRIPTION
## Motivation

From past instigation we've seen that some customers initialize the SDK from a worker using partytown. This generates telemetry errors hard to troubleshoot. This PR add env information to help:
```js
{
  runtime_env: {
    is_local_file: isLocalFile(),
    is_worker: isWorker(),
  }
}
 
```
## Changes

Add isLocalFile and isWorker to telemetry debugs and errors

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
