### PR TITLE
🐛 [RUM-89] Do not count discarded resources

### DIFF
--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -40,10 +40,16 @@ describe('trackEventCounts', () => {
     expect(eventCounts.actionCount).toBe(1)
   })
 
-  it('tracks resources', () => {
+  it('tracks non-discarded resources', () => {
     const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
     notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE })
     expect(eventCounts.resourceCount).toBe(1)
+  })
+
+  it('does not track discarded resources', () => {
+    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
+    notifyCollectedRawRumEvent({ type: RumEventType.RESOURCE, _dd: { discarded: true, format_version: 2 } })
+    expect(eventCounts.resourceCount).toBe(0)
   })
 
   it('tracks frustration counts', () => {

--- a/packages/rum-core/src/domain/trackEventCounts.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.ts
@@ -50,8 +50,10 @@ export function trackEventCounts({
         callback()
         break
       case RumEventType.RESOURCE:
-        eventCounts.resourceCount += 1
-        callback()
+        if (!event._dd?.discarded) {
+          eventCounts.resourceCount += 1
+          callback()
+        }
         break
     }
   })


### PR DESCRIPTION
## Motivation

With the introduction of `trackResources` (cf: [PR](https://github.com/DataDog/browser-sdk/pull/1744)), resources can now be discarded. They are still sent to the intake for tracing but not indexed in RUM. The discarded resource should be counted. 

## Changes

Check if the resources is not discarded in `trackEventCounts()`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
