### PR TITLE
✅ fix flaky e2e test on firefox

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,7 +187,7 @@ e2e:
       junit: test-report/e2e/*.xml
   script:
     - yarn
-    - yarn test:e2e
+    - FORCE_COLOR=1 yarn test:e2e
   after_script:
     - node ./scripts/test/export-test-result.js e2e
 
@@ -240,7 +240,7 @@ e2e-bs:
       junit: test-report/e2e-bs/*.xml
   script:
     - yarn
-    - ./scripts/test/ci-bs.sh test:e2e
+    - FORCE_COLOR=1 ./scripts/test/ci-bs.sh test:e2e
   after_script:
     - node ./scripts/test/export-test-result.js e2e-bs
 

--- a/test/e2e/scenario/recorder/shadowDom.scenario.ts
+++ b/test/e2e/scenario/recorder/shadowDom.scenario.ts
@@ -1,4 +1,4 @@
-import { IncrementalSource, NodeType } from '@datadog/browser-rum/src/types'
+import { MouseInteractionType, NodeType } from '@datadog/browser-rum/src/types'
 import type { DocumentFragmentNode, MouseInteractionData, SerializedNodeWithId } from '@datadog/browser-rum/src/types'
 
 import {
@@ -6,7 +6,7 @@ import {
   findElementWithIdAttribute,
   findElementWithTagName,
   findFullSnapshot,
-  findIncrementalSnapshot,
+  findMouseInteractionRecords,
   findNode,
   findTextContent,
   findTextNode,
@@ -208,12 +208,11 @@ describe('recorder with shadow DOM', () => {
       expect(intakeRegistry.replaySegments.length).toBe(1)
       const fullSnapshot = findFullSnapshot(intakeRegistry.replaySegments[0])!
       const divNode = findElementWithTagName(fullSnapshot.data.node, 'div')!
-      const mouseInteraction = findIncrementalSnapshot(
+      const mouseInteraction = findMouseInteractionRecords(
         intakeRegistry.replaySegments[0],
-        IncrementalSource.MouseInteraction
-      )!
+        MouseInteractionType.Click
+      )[0]
       expect(mouseInteraction).toBeTruthy()
-      expect(mouseInteraction.data.source).toBe(IncrementalSource.MouseInteraction)
       expect((mouseInteraction.data as MouseInteractionData).id).toBe(divNode.id)
     })
 


### PR DESCRIPTION
## Motivation

The test `recorder with shadow DOM can record click with target from inside the shadow root` was failing very often on Firefox. It's output is hard to read.

## Changes

* Improve e2e output readability by forcing colors
* Fix e2e test by selecting the "click" record (in some cases, a "focus" record was selected by mistake)

Before:

![Screenshot 2023-09-04 at 18 38 24](https://github.com/DataDog/browser-sdk/assets/61787/cce3eefc-f15e-486e-92eb-06b6f16d8bc1)

With improved output, it should look like this:

![Screenshot 2023-09-04 at 18 39 29](https://github.com/DataDog/browser-sdk/assets/61787/d70a3beb-d4ad-4f8b-9852-387164ceb1d0)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
