### PR TITLE
👷 Bump image version for extension publication

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   CURRENT_STAGING: staging-36
   APP: 'browser-sdk'
-  CURRENT_CI_IMAGE: 51
+  CURRENT_CI_IMAGE: 52
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
   GIT_REPOSITORY: 'git@github.com:DataDog/browser-sdk.git'


### PR DESCRIPTION
## Motivation

CI image bump of https://github.com/DataDog/browser-sdk/pull/2356 has been overridden by another change, so zip library is missing.

## Changes

Bump ci image

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
