### PR TITLE
🔊 [RUM-253] customize deflate worker failure logs

### DIFF
--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -126,6 +126,7 @@ export function makeRecorderApi(
 
           const worker = startDeflateWorker(
             configuration,
+            'Datadog Session Replay',
             () => {
               stopStrategy()
             },

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -47,7 +47,7 @@ describe('startRecording', () => {
     textField = document.createElement('input')
     sandbox.appendChild(textField)
 
-    const worker = startDeflateWorker(configuration, noop)
+    const worker = startDeflateWorker(configuration, 'Datadog Session Replay', noop)
 
     setupBuilder = setup()
       .withViewContexts({

--- a/packages/rum/src/domain/deflate/deflateWorker.spec.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.spec.ts
@@ -1,5 +1,5 @@
 import type { RawTelemetryEvent } from '@datadog/browser-core'
-import { display, isIE, noop, resetTelemetry, startFakeTelemetry } from '@datadog/browser-core'
+import { display, isIE, resetTelemetry, startFakeTelemetry } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
@@ -14,10 +14,23 @@ describe('startDeflateWorker', () => {
   let mockWorker: MockWorker
   let createDeflateWorkerSpy: jasmine.Spy<CreateDeflateWorker>
   let onInitializationFailureSpy: jasmine.Spy<() => void>
-  let configuration: RumConfiguration
+
+  function startDeflateWorkerWithDefaults({
+    configuration = {},
+    source = 'Datadog Session Replay',
+  }: {
+    configuration?: Partial<RumConfiguration>
+    source?: string
+  } = {}) {
+    return startDeflateWorker(
+      configuration as RumConfiguration,
+      source,
+      onInitializationFailureSpy,
+      createDeflateWorkerSpy
+    )
+  }
 
   beforeEach(() => {
-    configuration = {} as RumConfiguration
     mockWorker = new MockWorker()
     onInitializationFailureSpy = jasmine.createSpy('onInitializationFailureSpy')
     createDeflateWorkerSpy = jasmine.createSpy('createDeflateWorkerSpy').and.callFake(() => mockWorker)
@@ -28,7 +41,7 @@ describe('startDeflateWorker', () => {
   })
 
   it('creates a deflate worker', () => {
-    const worker = startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+    const worker = startDeflateWorkerWithDefaults()
     expect(createDeflateWorkerSpy).toHaveBeenCalledTimes(1)
     expect(worker).toBe(mockWorker)
 
@@ -37,17 +50,17 @@ describe('startDeflateWorker', () => {
   })
 
   it('uses the previously created worker during loading', () => {
-    const worker1 = startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
-    const worker2 = startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+    const worker1 = startDeflateWorkerWithDefaults()
+    const worker2 = startDeflateWorkerWithDefaults()
     expect(createDeflateWorkerSpy).toHaveBeenCalledTimes(1)
     expect(worker1).toBe(worker2)
   })
 
   it('uses the previously created worker once initialized', () => {
-    const worker1 = startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+    const worker1 = startDeflateWorkerWithDefaults()
     mockWorker.processAllMessages()
 
-    const worker2 = startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+    const worker2 = startDeflateWorkerWithDefaults()
     expect(createDeflateWorkerSpy).toHaveBeenCalledTimes(1)
     expect(worker1).toBe(worker2)
 
@@ -60,13 +73,11 @@ describe('startDeflateWorker', () => {
     // mimic Chrome behavior
     let CSP_ERROR: DOMException
     let displaySpy: jasmine.Spy
-    let configuration: RumConfiguration
 
     beforeEach(() => {
       if (isIE()) {
         pending('IE does not support CSP blocking worker creation')
       }
-      configuration = {} as RumConfiguration
       displaySpy = spyOn(display, 'error')
       telemetryEvents = startFakeTelemetry()
       CSP_ERROR = new DOMException(
@@ -80,40 +91,37 @@ describe('startDeflateWorker', () => {
 
     describe('Chrome and Safari behavior: exception during worker creation', () => {
       it('returns undefined when the worker creation throws an exception', () => {
-        const worker = startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        const worker = startDeflateWorkerWithDefaults()
         expect(worker).toBeUndefined()
       })
 
       it('displays CSP instructions when the worker creation throws a CSP error', () => {
-        startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        startDeflateWorkerWithDefaults()
         expect(displaySpy).toHaveBeenCalledWith(
           jasmine.stringContaining('Please make sure CSP is correctly configured')
         )
       })
 
       it('does not report CSP errors to telemetry', () => {
-        startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        startDeflateWorkerWithDefaults()
         expect(telemetryEvents).toEqual([])
       })
 
       it('does not try to create a worker again after the creation failed', () => {
-        startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        startDeflateWorkerWithDefaults()
+        createDeflateWorkerSpy.calls.reset()
+        startDeflateWorkerWithDefaults()
         expect(createDeflateWorkerSpy).not.toHaveBeenCalled()
       })
     })
 
     describe('Firefox behavior: error during worker loading', () => {
       it('displays ErrorEvent as CSP error', () => {
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
         expect(displaySpy).toHaveBeenCalledWith(
           jasmine.stringContaining('Please make sure CSP is correctly configured')
@@ -121,24 +129,28 @@ describe('startDeflateWorker', () => {
       })
 
       it('calls the initialization failure callback when of an error occurs during loading', () => {
-        startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
         expect(onInitializationFailureSpy).toHaveBeenCalledTimes(1)
       })
 
       it('returns undefined if an error occurred in a previous loading', () => {
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
+        onInitializationFailureSpy.calls.reset()
 
-        const worker = startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+        const worker = startDeflateWorkerWithDefaults()
 
         expect(worker).toBeUndefined()
         expect(onInitializationFailureSpy).not.toHaveBeenCalled()
       })
 
       it('adjusts the error message when a workerUrl is set', () => {
-        configuration.workerUrl = '/worker.js'
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults({
+          configuration: {
+            workerUrl: '/worker.js',
+          },
+        })
         mockWorker.dispatchErrorEvent()
         expect(displaySpy).toHaveBeenCalledWith(
           jasmine.stringContaining(
@@ -148,25 +160,25 @@ describe('startDeflateWorker', () => {
       })
 
       it('calls all registered callbacks when the worker initialization fails', () => {
-        const onInitializationFailureSpy1 = jasmine.createSpy()
-        const onInitializationFailureSpy2 = jasmine.createSpy()
-        startDeflateWorker(configuration, onInitializationFailureSpy1, createDeflateWorkerSpy)
-        startDeflateWorker(configuration, onInitializationFailureSpy2, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
-        expect(onInitializationFailureSpy1).toHaveBeenCalledTimes(1)
-        expect(onInitializationFailureSpy2).toHaveBeenCalledTimes(1)
+        expect(onInitializationFailureSpy).toHaveBeenCalledTimes(2)
       })
     })
   })
 
   describe('initialization timeout', () => {
     let displaySpy: jasmine.Spy
-    let configuration: RumConfiguration
     let clock: Clock
 
     beforeEach(() => {
-      configuration = {} as RumConfiguration
       displaySpy = spyOn(display, 'error')
+      createDeflateWorkerSpy.and.callFake(
+        () =>
+          // Creates a worker that does nothing
+          new Worker(URL.createObjectURL(new Blob([''])))
+      )
       clock = mockClock()
     })
 
@@ -175,16 +187,18 @@ describe('startDeflateWorker', () => {
     })
 
     it('displays an error message when the worker does not respond to the init action', () => {
-      startDeflateWorker(
-        configuration,
-        noop,
-        () =>
-          // Creates a worker that does nothing
-          new Worker(URL.createObjectURL(new Blob([''])))
-      )
+      startDeflateWorkerWithDefaults()
       clock.tick(INITIALIZATION_TIME_OUT_DELAY)
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Session Replay recording failed to start: a timeout occurred while initializing the Worker'
+        'Datadog Session Replay failed to start: a timeout occurred while initializing the Worker'
+      )
+    })
+
+    it('displays a customized error message', () => {
+      startDeflateWorkerWithDefaults({ source: 'Foo' })
+      clock.tick(INITIALIZATION_TIME_OUT_DELAY)
+      expect(displaySpy).toHaveBeenCalledOnceWith(
+        'Foo failed to start: a timeout occurred while initializing the Worker'
       )
     })
   })
@@ -193,10 +207,8 @@ describe('startDeflateWorker', () => {
     let telemetryEvents: RawTelemetryEvent[]
     const UNKNOWN_ERROR = new Error('boom')
     let displaySpy: jasmine.Spy
-    let configuration: RumConfiguration
 
     beforeEach(() => {
-      configuration = {} as RumConfiguration
       displaySpy = spyOn(display, 'error')
       telemetryEvents = startFakeTelemetry()
     })
@@ -206,19 +218,26 @@ describe('startDeflateWorker', () => {
     })
 
     it('displays an error message when the worker creation throws an unknown error', () => {
-      startDeflateWorker(configuration, noop, () => {
-        throw UNKNOWN_ERROR
-      })
+      createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
+      startDeflateWorkerWithDefaults()
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Session Replay recording failed to start: an error occurred while creating the Worker:',
+        'Datadog Session Replay failed to start: an error occurred while creating the Worker:',
+        UNKNOWN_ERROR
+      )
+    })
+
+    it('displays a customized error message', () => {
+      createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
+      startDeflateWorkerWithDefaults({ source: 'Foo' })
+      expect(displaySpy).toHaveBeenCalledOnceWith(
+        'Foo failed to start: an error occurred while creating the Worker:',
         UNKNOWN_ERROR
       )
     })
 
     it('reports unknown errors to telemetry', () => {
-      startDeflateWorker(configuration, noop, () => {
-        throw UNKNOWN_ERROR
-      })
+      createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
+      startDeflateWorkerWithDefaults()
       expect(telemetryEvents).toEqual([
         {
           type: 'log',
@@ -230,13 +249,13 @@ describe('startDeflateWorker', () => {
     })
 
     it('does not display error messages as CSP error', () => {
-      startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+      startDeflateWorkerWithDefaults()
       mockWorker.dispatchErrorMessage('foo')
       expect(displaySpy).not.toHaveBeenCalledWith(jasmine.stringContaining('CSP'))
     })
 
     it('reports errors occurring after loading to telemetry', () => {
-      startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+      startDeflateWorkerWithDefaults()
       mockWorker.processAllMessages()
 
       mockWorker.dispatchErrorMessage('boom', TEST_STREAM_ID)


### PR DESCRIPTION
## Motivation

In the coming PR, we'll want to start the deflate worker from different places (according to a
experimental flag/configuration option). The current error message mentioning "Session Replay" is
not adequate anymore.

## Changes

This PR add the ability to adjust the error message.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [x] End to end (see #2416)

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
