### PR TITLE
♻️ [RUM-253] adapt transport to send encoded data

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -5,8 +5,11 @@ import {
   addExperimentalFeatures,
 } from '../../tools/experimentalFeatures'
 import { startsWith } from '../../tools/utils/polyfills'
+import type { Payload } from '../../transport'
 import type { InitConfiguration } from './configuration'
 import { createEndpointBuilder } from './endpointBuilder'
+
+const DEFAULT_PAYLOAD = {} as Payload
 
 describe('endpointBuilder', () => {
   const clientToken = 'some_client_token'
@@ -20,23 +23,30 @@ describe('endpointBuilder', () => {
 
   describe('query parameters', () => {
     it('should add intake query parameters', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toMatch(
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toMatch(
         `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
       )
     })
 
     it('should add batch_time for rum endpoint', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toContain('&batch_time=')
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toContain(
+        '&batch_time='
+      )
     })
 
     it('should not add batch_time for logs and replay endpoints', () => {
-      expect(createEndpointBuilder(initConfiguration, 'logs', []).build('xhr')).not.toContain('&batch_time=')
-      expect(createEndpointBuilder(initConfiguration, 'sessionReplay', []).build('xhr')).not.toContain('&batch_time=')
+      expect(createEndpointBuilder(initConfiguration, 'logs', []).build('xhr', DEFAULT_PAYLOAD)).not.toContain(
+        '&batch_time='
+      )
+      expect(createEndpointBuilder(initConfiguration, 'sessionReplay', []).build('xhr', DEFAULT_PAYLOAD)).not.toContain(
+        '&batch_time='
+      )
     })
 
     it('should not start with ddsource for internal analytics mode', () => {
       const url = createEndpointBuilder({ ...initConfiguration, internalAnalyticsSubdomain: 'foo' }, 'rum', []).build(
-        'xhr'
+        'xhr',
+        DEFAULT_PAYLOAD
       )
       expect(url).not.toContain('/rum?ddsource')
       expect(url).toContain('ddsource=browser')
@@ -46,7 +56,10 @@ describe('endpointBuilder', () => {
   describe('proxy configuration', () => {
     it('should replace the intake endpoint by the proxy and set the intake path and parameters in the attribute ddforward', () => {
       expect(
-        createEndpointBuilder({ ...initConfiguration, proxy: 'https://proxy.io/path' }, 'rum', []).build('xhr')
+        createEndpointBuilder({ ...initConfiguration, proxy: 'https://proxy.io/path' }, 'rum', []).build(
+          'xhr',
+          DEFAULT_PAYLOAD
+        )
       ).toMatch(
         `https://proxy.io/path\\?ddforward=${encodeURIComponent(
           `/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
@@ -58,7 +71,7 @@ describe('endpointBuilder', () => {
     it('normalizes the proxy url', () => {
       expect(
         startsWith(
-          createEndpointBuilder({ ...initConfiguration, proxy: '/path' }, 'rum', []).build('xhr'),
+          createEndpointBuilder({ ...initConfiguration, proxy: '/path' }, 'rum', []).build('xhr', DEFAULT_PAYLOAD),
           `${location.origin}/path?ddforward`
         )
       ).toBeTrue()
@@ -70,7 +83,7 @@ describe('endpointBuilder', () => {
           { ...initConfiguration, proxy: 'https://proxy.io/path', proxyUrl: 'https://legacy-proxy.io/path' },
           'rum',
           []
-        ).build('xhr')
+        ).build('xhr', DEFAULT_PAYLOAD)
       ).toMatch(/^https:\/\/proxy.io\/path\?/)
 
       expect(
@@ -78,7 +91,7 @@ describe('endpointBuilder', () => {
           { ...initConfiguration, proxy: false as any, proxyUrl: 'https://legacy-proxy.io/path' },
           'rum',
           []
-        ).build('xhr')
+        ).build('xhr', DEFAULT_PAYLOAD)
       ).toMatch(/^https:\/\/rum.browser-intake-datadoghq.com\//)
     })
   })
@@ -86,7 +99,10 @@ describe('endpointBuilder', () => {
   describe('deprecated proxyUrl configuration', () => {
     it('should replace the full intake endpoint by the proxyUrl and set it in the attribute ddforward', () => {
       expect(
-        createEndpointBuilder({ ...initConfiguration, proxyUrl: 'https://proxy.io/path' }, 'rum', []).build('xhr')
+        createEndpointBuilder({ ...initConfiguration, proxyUrl: 'https://proxy.io/path' }, 'rum', []).build(
+          'xhr',
+          DEFAULT_PAYLOAD
+        )
       ).toMatch(
         `https://proxy.io/path\\?ddforward=${encodeURIComponent(
           `https://rum.browser-intake-datadoghq.com/api/v2/rum?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}` +
@@ -98,7 +114,7 @@ describe('endpointBuilder', () => {
     it('normalizes the proxy url', () => {
       expect(
         startsWith(
-          createEndpointBuilder({ ...initConfiguration, proxyUrl: '/path' }, 'rum', []).build('xhr'),
+          createEndpointBuilder({ ...initConfiguration, proxyUrl: '/path' }, 'rum', []).build('xhr', DEFAULT_PAYLOAD),
           `${location.origin}/path?ddforward`
         )
       ).toBeTrue()
@@ -107,39 +123,53 @@ describe('endpointBuilder', () => {
 
   describe('tags', () => {
     it('should contain sdk version', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toContain('sdk_version%3Asome_version')
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toContain(
+        'sdk_version%3Asome_version'
+      )
     })
 
     it('should contain api', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr')).toContain('api%3Axhr')
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toContain('api%3Axhr')
     })
 
     it('should be encoded', () => {
       expect(
-        createEndpointBuilder(initConfiguration, 'rum', ['service:bar:foo', 'datacenter:us1.prod.dog']).build('xhr')
+        createEndpointBuilder(initConfiguration, 'rum', ['service:bar:foo', 'datacenter:us1.prod.dog']).build(
+          'xhr',
+          DEFAULT_PAYLOAD
+        )
       ).toContain('service%3Abar%3Afoo%2Cdatacenter%3Aus1.prod.dog')
     })
 
     it('should contain retry infos', () => {
       expect(
-        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', 'bytes_limit', {
-          count: 5,
-          lastFailureStatus: 408,
+        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', {
+          ...DEFAULT_PAYLOAD,
+          retry: {
+            count: 5,
+            lastFailureStatus: 408,
+          },
         })
       ).toContain('retry_count%3A5%2Cretry_after%3A408')
     })
 
     it('should contain flush reason when ff collect_flush_reason is enabled', () => {
       addExperimentalFeatures([ExperimentalFeature.COLLECT_FLUSH_REASON])
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', 'bytes_limit')).toContain(
-        'flush_reason%3Abytes_limit'
-      )
+      expect(
+        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', {
+          ...DEFAULT_PAYLOAD,
+          flushReason: 'bytes_limit',
+        })
+      ).toContain('flush_reason%3Abytes_limit')
     })
 
-    it('should not contain flush reason when ff collect_flush_reason is disnabled', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', 'bytes_limit')).not.toContain(
-        'flush_reason'
-      )
+    it('should not contain flush reason when ff collect_flush_reason is disabled', () => {
+      expect(
+        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', {
+          ...DEFAULT_PAYLOAD,
+          flushReason: 'bytes_limit',
+        })
+      ).not.toContain('flush_reason')
     })
   })
 })

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -43,6 +43,12 @@ describe('endpointBuilder', () => {
       )
     })
 
+    it('should add the provided encoding', () => {
+      expect(
+        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', { ...DEFAULT_PAYLOAD, encoding: 'deflate' })
+      ).toContain('&dd-evp-encoding=deflate')
+    })
+
     it('should not start with ddsource for internal analytics mode', () => {
       const url = createEndpointBuilder({ ...initConfiguration, internalAnalyticsSubdomain: 'foo' }, 'rum', []).build(
         'xhr',

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -1,4 +1,4 @@
-import type { RetryInfo, FlushReason } from '../../transport'
+import type { Payload } from '../../transport'
 import { timeStampNow } from '../../tools/utils/timeUtils'
 import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../tools/experimentalFeatures'
@@ -33,15 +33,8 @@ export function createEndpointBuilder(
   const buildUrlWithParameters = createEndpointUrlWithParametersBuilder(initConfiguration, endpointType)
 
   return {
-    build(api: 'xhr' | 'fetch' | 'beacon', flushReason?: FlushReason, retry?: RetryInfo) {
-      const parameters = buildEndpointParameters(
-        initConfiguration,
-        endpointType,
-        configurationTags,
-        api,
-        flushReason,
-        retry
-      )
+    build(api: 'xhr' | 'fetch' | 'beacon', payload: Payload) {
+      const parameters = buildEndpointParameters(initConfiguration, endpointType, configurationTags, api, payload)
       return buildUrlWithParameters(parameters)
     },
     urlPrefix: buildUrlWithParameters(''),
@@ -100,8 +93,7 @@ function buildEndpointParameters(
   endpointType: EndpointType,
   configurationTags: string[],
   api: 'xhr' | 'fetch' | 'beacon',
-  flushReason: FlushReason | undefined,
-  retry: RetryInfo | undefined
+  { retry, flushReason }: Payload
 ) {
   const tags = [`sdk_version:${__BUILD_ENV__SDK_VERSION__}`, `api:${api}`].concat(configurationTags)
   if (flushReason && isExperimentalFeatureEnabled(ExperimentalFeature.COLLECT_FLUSH_REASON)) {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -93,7 +93,7 @@ function buildEndpointParameters(
   endpointType: EndpointType,
   configurationTags: string[],
   api: 'xhr' | 'fetch' | 'beacon',
-  { retry, flushReason }: Payload
+  { retry, flushReason, encoding }: Payload
 ) {
   const tags = [`sdk_version:${__BUILD_ENV__SDK_VERSION__}`, `api:${api}`].concat(configurationTags)
   if (flushReason && isExperimentalFeatureEnabled(ExperimentalFeature.COLLECT_FLUSH_REASON)) {
@@ -102,6 +102,7 @@ function buildEndpointParameters(
   if (retry) {
     tags.push(`retry_count:${retry.count}`, `retry_after:${retry.lastFailureStatus}`)
   }
+
   const parameters = [
     'ddsource=browser',
     `ddtags=${encodeURIComponent(tags.join(','))}`,
@@ -111,9 +112,14 @@ function buildEndpointParameters(
     `dd-request-id=${generateUUID()}`,
   ]
 
+  if (encoding) {
+    parameters.push(`dd-evp-encoding=${encoding}`)
+  }
+
   if (endpointType === 'rum') {
     parameters.push(`batch_time=${timeStampNow()}`)
   }
+
   if (internalAnalyticsSubdomain) {
     parameters.reverse()
   }

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -1,4 +1,7 @@
+import type { Payload } from '../../transport'
 import { computeTransportConfiguration } from './transportConfiguration'
+
+const DEFAULT_PAYLOAD = {} as Payload
 
 describe('transportConfiguration', () => {
   const clientToken = 'some_client_token'
@@ -6,13 +9,13 @@ describe('transportConfiguration', () => {
   describe('site', () => {
     it('should use US site by default', () => {
       const configuration = computeTransportConfiguration({ clientToken })
-      expect(configuration.rumEndpointBuilder.build('xhr')).toContain('datadoghq.com')
+      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('datadoghq.com')
       expect(configuration.site).toBe('datadoghq.com')
     })
 
     it('should use site value when set', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'foo.com' })
-      expect(configuration.rumEndpointBuilder.build('xhr')).toContain('foo.com')
+      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('foo.com')
       expect(configuration.site).toBe('foo.com')
     })
   })
@@ -23,7 +26,7 @@ describe('transportConfiguration', () => {
         clientToken,
         internalAnalyticsSubdomain,
       })
-      expect(configuration.rumEndpointBuilder.build('xhr')).toContain(internalAnalyticsSubdomain)
+      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain(internalAnalyticsSubdomain)
     })
 
     it('should not use internal analytics subdomain value when set for other sites', () => {
@@ -32,30 +35,42 @@ describe('transportConfiguration', () => {
         site: 'foo.bar',
         internalAnalyticsSubdomain,
       })
-      expect(configuration.rumEndpointBuilder.build('xhr')).not.toContain(internalAnalyticsSubdomain)
+      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).not.toContain(internalAnalyticsSubdomain)
     })
   })
 
   describe('sdk_version, env, version and service', () => {
     it('should not modify the logs and rum endpoints tags when not defined', () => {
       const configuration = computeTransportConfiguration({ clientToken })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',env:')
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',service:')
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',version:')
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).not.toContain(',datacenter:')
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(',env:')
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
+        ',service:'
+      )
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
+        ',version:'
+      )
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
+        ',datacenter:'
+      )
 
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',env:')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',service:')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',version:')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).not.toContain(',datacenter:')
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(',env:')
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
+        ',service:'
+      )
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
+        ',version:'
+      )
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
+        ',datacenter:'
+      )
     })
 
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = computeTransportConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr'))).toContain(
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).toContain(
         'env:foo,service:bar,version:baz'
       )
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr'))).toContain(
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).toContain(
         'env:foo,service:bar,version:baz'
       )
     })

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -28,6 +28,7 @@ export interface Payload {
   bytesCount: number
   retry?: RetryInfo
   flushReason?: FlushReason
+  encoding?: string
 }
 
 export interface RetryInfo {

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -28,7 +28,7 @@ export interface Payload {
   bytesCount: number
   retry?: RetryInfo
   flushReason?: FlushReason
-  encoding?: string
+  encoding?: 'deflate'
 }
 
 export interface RetryInfo {

--- a/packages/core/test/requests.ts
+++ b/packages/core/test/requests.ts
@@ -13,7 +13,7 @@ export const SPEC_ENDPOINTS = {
 }
 
 export function stubEndpointBuilder(url: string) {
-  return { build: (_: any) => url } as EndpointBuilder
+  return { build: (..._: any) => url } as EndpointBuilder
 }
 
 export interface Request {

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -1,3 +1,4 @@
+import type { Payload } from '@datadog/browser-core'
 import { ErrorSource, display, stopSessionManager, getCookie, SESSION_STORE_KEY } from '@datadog/browser-core'
 import type { Request } from '@datadog/browser-core/test'
 import {
@@ -37,6 +38,7 @@ const COMMON_CONTEXT = {
   context: {},
   user: {},
 }
+const DEFAULT_PAYLOAD = {} as Payload
 
 describe('logs', () => {
   const initConfiguration = { clientToken: 'xxx', service: 'service', telemetrySampleRate: 0 }
@@ -77,7 +79,7 @@ describe('logs', () => {
       handleLog({ message: 'message', status: StatusType.warn, context: { foo: 'bar' } }, logger, COMMON_CONTEXT)
 
       expect(requests.length).toEqual(1)
-      expect(requests[0].url).toContain(baseConfiguration.logsEndpointBuilder.build('xhr'))
+      expect(requests[0].url).toContain(baseConfiguration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))
       expect(getLoggedMessage(requests, 0)).toEqual({
         date: jasmine.any(Number),
         foo: 'bar',

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -1,3 +1,4 @@
+import type { Payload } from '@datadog/browser-core'
 import { isIE, RequestType } from '@datadog/browser-core'
 import type { FetchStub, FetchStubManager } from '@datadog/browser-core/test'
 import { SPEC_ENDPOINTS, stubFetch, stubXhr, withXhr } from '@datadog/browser-core/test'
@@ -8,6 +9,8 @@ import type { RequestCompleteEvent, RequestStartEvent } from './requestCollectio
 import { trackFetch, trackXhr } from './requestCollection'
 import type { Tracer } from './tracing/tracer'
 import { clearTracingIfNeeded, TraceIdentifier } from './tracing/tracer'
+
+const DEFAULT_PAYLOAD = {} as Payload
 
 describe('collect fetch', () => {
   let configuration: RumConfiguration
@@ -133,7 +136,10 @@ describe('collect fetch', () => {
   })
 
   it('should ignore intake requests', (done) => {
-    fetchStub(SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr')).resolveWith({ status: 200, responseText: 'foo' })
+    fetchStub(SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).resolveWith({
+      status: 200,
+      responseText: 'foo',
+    })
 
     fetchStubManager.whenAllComplete(() => {
       expect(startSpy).not.toHaveBeenCalled()
@@ -272,7 +278,7 @@ describe('collect xhr', () => {
   it('should ignore intake requests', (done) => {
     withXhr({
       setup(xhr) {
-        xhr.open('GET', SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr'))
+        xhr.open('GET', SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))
         xhr.send()
         xhr.complete(200)
       },

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -126,6 +126,7 @@ export function makeRecorderApi(
 
           const worker = startDeflateWorker(
             configuration,
+            'Datadog Session Replay',
             () => {
               stopStrategy()
             },

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -47,7 +47,7 @@ describe('startRecording', () => {
     textField = document.createElement('input')
     sandbox.appendChild(textField)
 
-    const worker = startDeflateWorker(configuration, noop)
+    const worker = startDeflateWorker(configuration, 'Datadog Session Replay', noop)
 
     setupBuilder = setup()
       .withViewContexts({

--- a/packages/rum/src/domain/deflate/deflateWorker.spec.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.spec.ts
@@ -1,5 +1,5 @@
 import type { RawTelemetryEvent } from '@datadog/browser-core'
-import { display, isIE, noop, resetTelemetry, startFakeTelemetry } from '@datadog/browser-core'
+import { display, isIE, resetTelemetry, startFakeTelemetry } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
@@ -14,10 +14,23 @@ describe('startDeflateWorker', () => {
   let mockWorker: MockWorker
   let createDeflateWorkerSpy: jasmine.Spy<CreateDeflateWorker>
   let onInitializationFailureSpy: jasmine.Spy<() => void>
-  let configuration: RumConfiguration
+
+  function startDeflateWorkerWithDefaults({
+    configuration = {},
+    source = 'Datadog Session Replay',
+  }: {
+    configuration?: Partial<RumConfiguration>
+    source?: string
+  } = {}) {
+    return startDeflateWorker(
+      configuration as RumConfiguration,
+      source,
+      onInitializationFailureSpy,
+      createDeflateWorkerSpy
+    )
+  }
 
   beforeEach(() => {
-    configuration = {} as RumConfiguration
     mockWorker = new MockWorker()
     onInitializationFailureSpy = jasmine.createSpy('onInitializationFailureSpy')
     createDeflateWorkerSpy = jasmine.createSpy('createDeflateWorkerSpy').and.callFake(() => mockWorker)
@@ -28,7 +41,7 @@ describe('startDeflateWorker', () => {
   })
 
   it('creates a deflate worker', () => {
-    const worker = startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+    const worker = startDeflateWorkerWithDefaults()
     expect(createDeflateWorkerSpy).toHaveBeenCalledTimes(1)
     expect(worker).toBe(mockWorker)
 
@@ -37,17 +50,17 @@ describe('startDeflateWorker', () => {
   })
 
   it('uses the previously created worker during loading', () => {
-    const worker1 = startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
-    const worker2 = startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+    const worker1 = startDeflateWorkerWithDefaults()
+    const worker2 = startDeflateWorkerWithDefaults()
     expect(createDeflateWorkerSpy).toHaveBeenCalledTimes(1)
     expect(worker1).toBe(worker2)
   })
 
   it('uses the previously created worker once initialized', () => {
-    const worker1 = startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+    const worker1 = startDeflateWorkerWithDefaults()
     mockWorker.processAllMessages()
 
-    const worker2 = startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+    const worker2 = startDeflateWorkerWithDefaults()
     expect(createDeflateWorkerSpy).toHaveBeenCalledTimes(1)
     expect(worker1).toBe(worker2)
 
@@ -60,13 +73,11 @@ describe('startDeflateWorker', () => {
     // mimic Chrome behavior
     let CSP_ERROR: DOMException
     let displaySpy: jasmine.Spy
-    let configuration: RumConfiguration
 
     beforeEach(() => {
       if (isIE()) {
         pending('IE does not support CSP blocking worker creation')
       }
-      configuration = {} as RumConfiguration
       displaySpy = spyOn(display, 'error')
       telemetryEvents = startFakeTelemetry()
       CSP_ERROR = new DOMException(
@@ -80,40 +91,37 @@ describe('startDeflateWorker', () => {
 
     describe('Chrome and Safari behavior: exception during worker creation', () => {
       it('returns undefined when the worker creation throws an exception', () => {
-        const worker = startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        const worker = startDeflateWorkerWithDefaults()
         expect(worker).toBeUndefined()
       })
 
       it('displays CSP instructions when the worker creation throws a CSP error', () => {
-        startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        startDeflateWorkerWithDefaults()
         expect(displaySpy).toHaveBeenCalledWith(
           jasmine.stringContaining('Please make sure CSP is correctly configured')
         )
       })
 
       it('does not report CSP errors to telemetry', () => {
-        startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        startDeflateWorkerWithDefaults()
         expect(telemetryEvents).toEqual([])
       })
 
       it('does not try to create a worker again after the creation failed', () => {
-        startDeflateWorker(configuration, noop, () => {
-          throw CSP_ERROR
-        })
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        createDeflateWorkerSpy.and.throwError(CSP_ERROR)
+        startDeflateWorkerWithDefaults()
+        createDeflateWorkerSpy.calls.reset()
+        startDeflateWorkerWithDefaults()
         expect(createDeflateWorkerSpy).not.toHaveBeenCalled()
       })
     })
 
     describe('Firefox behavior: error during worker loading', () => {
       it('displays ErrorEvent as CSP error', () => {
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
         expect(displaySpy).toHaveBeenCalledWith(
           jasmine.stringContaining('Please make sure CSP is correctly configured')
@@ -121,24 +129,28 @@ describe('startDeflateWorker', () => {
       })
 
       it('calls the initialization failure callback when of an error occurs during loading', () => {
-        startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
         expect(onInitializationFailureSpy).toHaveBeenCalledTimes(1)
       })
 
       it('returns undefined if an error occurred in a previous loading', () => {
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
+        onInitializationFailureSpy.calls.reset()
 
-        const worker = startDeflateWorker(configuration, onInitializationFailureSpy, createDeflateWorkerSpy)
+        const worker = startDeflateWorkerWithDefaults()
 
         expect(worker).toBeUndefined()
         expect(onInitializationFailureSpy).not.toHaveBeenCalled()
       })
 
       it('adjusts the error message when a workerUrl is set', () => {
-        configuration.workerUrl = '/worker.js'
-        startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults({
+          configuration: {
+            workerUrl: '/worker.js',
+          },
+        })
         mockWorker.dispatchErrorEvent()
         expect(displaySpy).toHaveBeenCalledWith(
           jasmine.stringContaining(
@@ -148,25 +160,25 @@ describe('startDeflateWorker', () => {
       })
 
       it('calls all registered callbacks when the worker initialization fails', () => {
-        const onInitializationFailureSpy1 = jasmine.createSpy()
-        const onInitializationFailureSpy2 = jasmine.createSpy()
-        startDeflateWorker(configuration, onInitializationFailureSpy1, createDeflateWorkerSpy)
-        startDeflateWorker(configuration, onInitializationFailureSpy2, createDeflateWorkerSpy)
+        startDeflateWorkerWithDefaults()
+        startDeflateWorkerWithDefaults()
         mockWorker.dispatchErrorEvent()
-        expect(onInitializationFailureSpy1).toHaveBeenCalledTimes(1)
-        expect(onInitializationFailureSpy2).toHaveBeenCalledTimes(1)
+        expect(onInitializationFailureSpy).toHaveBeenCalledTimes(2)
       })
     })
   })
 
   describe('initialization timeout', () => {
     let displaySpy: jasmine.Spy
-    let configuration: RumConfiguration
     let clock: Clock
 
     beforeEach(() => {
-      configuration = {} as RumConfiguration
       displaySpy = spyOn(display, 'error')
+      createDeflateWorkerSpy.and.callFake(
+        () =>
+          // Creates a worker that does nothing
+          new Worker(URL.createObjectURL(new Blob([''])))
+      )
       clock = mockClock()
     })
 
@@ -175,16 +187,18 @@ describe('startDeflateWorker', () => {
     })
 
     it('displays an error message when the worker does not respond to the init action', () => {
-      startDeflateWorker(
-        configuration,
-        noop,
-        () =>
-          // Creates a worker that does nothing
-          new Worker(URL.createObjectURL(new Blob([''])))
-      )
+      startDeflateWorkerWithDefaults()
       clock.tick(INITIALIZATION_TIME_OUT_DELAY)
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Session Replay recording failed to start: a timeout occurred while initializing the Worker'
+        'Datadog Session Replay failed to start: a timeout occurred while initializing the Worker'
+      )
+    })
+
+    it('displays a customized error message', () => {
+      startDeflateWorkerWithDefaults({ source: 'Foo' })
+      clock.tick(INITIALIZATION_TIME_OUT_DELAY)
+      expect(displaySpy).toHaveBeenCalledOnceWith(
+        'Foo failed to start: a timeout occurred while initializing the Worker'
       )
     })
   })
@@ -193,10 +207,8 @@ describe('startDeflateWorker', () => {
     let telemetryEvents: RawTelemetryEvent[]
     const UNKNOWN_ERROR = new Error('boom')
     let displaySpy: jasmine.Spy
-    let configuration: RumConfiguration
 
     beforeEach(() => {
-      configuration = {} as RumConfiguration
       displaySpy = spyOn(display, 'error')
       telemetryEvents = startFakeTelemetry()
     })
@@ -206,19 +218,26 @@ describe('startDeflateWorker', () => {
     })
 
     it('displays an error message when the worker creation throws an unknown error', () => {
-      startDeflateWorker(configuration, noop, () => {
-        throw UNKNOWN_ERROR
-      })
+      createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
+      startDeflateWorkerWithDefaults()
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Session Replay recording failed to start: an error occurred while creating the Worker:',
+        'Datadog Session Replay failed to start: an error occurred while creating the Worker:',
+        UNKNOWN_ERROR
+      )
+    })
+
+    it('displays a customized error message', () => {
+      createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
+      startDeflateWorkerWithDefaults({ source: 'Foo' })
+      expect(displaySpy).toHaveBeenCalledOnceWith(
+        'Foo failed to start: an error occurred while creating the Worker:',
         UNKNOWN_ERROR
       )
     })
 
     it('reports unknown errors to telemetry', () => {
-      startDeflateWorker(configuration, noop, () => {
-        throw UNKNOWN_ERROR
-      })
+      createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
+      startDeflateWorkerWithDefaults()
       expect(telemetryEvents).toEqual([
         {
           type: 'log',
@@ -230,13 +249,13 @@ describe('startDeflateWorker', () => {
     })
 
     it('does not display error messages as CSP error', () => {
-      startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+      startDeflateWorkerWithDefaults()
       mockWorker.dispatchErrorMessage('foo')
       expect(displaySpy).not.toHaveBeenCalledWith(jasmine.stringContaining('CSP'))
     })
 
     it('reports errors occurring after loading to telemetry', () => {
-      startDeflateWorker(configuration, noop, createDeflateWorkerSpy)
+      startDeflateWorkerWithDefaults()
       mockWorker.processAllMessages()
 
       mockWorker.dispatchErrorMessage('boom', TEST_STREAM_ID)


### PR DESCRIPTION
## Motivation

We'll need to send the encoding as a new intake URL parameter.

## Changes

- Light refactoring
- Add the ability to set the encoding through "payload" objects.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end (see #2416)

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
