### PR TITLE
✨ [RUM-1013] early exit when no configuration provided

### DIFF
--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -62,6 +62,12 @@ describe('logs entry', () => {
       expect(startLogs).toHaveBeenCalled()
     })
 
+    it('should not start when the configuration is missing', () => {
+      ;(LOGS.init as () => void)()
+      expect(displaySpy).toHaveBeenCalled()
+      expect(startLogs).not.toHaveBeenCalled()
+    })
+
     it('should not start when the configuration is invalid', () => {
       LOGS.init(INVALID_INIT_CONFIGURATION)
       expect(displaySpy).toHaveBeenCalled()

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -71,6 +71,10 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
     logger: mainLogger,
 
     init: monitor((initConfiguration: LogsInitConfiguration) => {
+      if (!initConfiguration) {
+        display.error('Missing configuration')
+        return
+      }
       // This function should be available, regardless of initialization success.
       getInitConfigurationStrategy = () => deepClone(initConfiguration)
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -46,6 +46,12 @@ describe('rum public api', () => {
       expect(startRumSpy).toHaveBeenCalled()
     })
 
+    it('should not start when the configuration is missing', () => {
+      ;(rumPublicApi.init as () => void)()
+      expect(displaySpy).toHaveBeenCalled()
+      expect(startRumSpy).not.toHaveBeenCalled()
+    })
+
     it('should not start when the configuration is invalid', () => {
       rumPublicApi.init(INVALID_INIT_CONFIGURATION)
       expect(displaySpy).toHaveBeenCalled()

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -99,6 +99,10 @@ export function makeRumPublicApi(
   }
 
   function initRum(initConfiguration: RumInitConfiguration) {
+    if (!initConfiguration) {
+      display.error('Missing configuration')
+      return
+    }
     // This function should be available, regardless of initialization success.
     getInitConfigurationStrategy = () => deepClone<InitConfiguration>(initConfiguration)
 


### PR DESCRIPTION
## Motivation

telemetry errors are generated when SDK init are called without configuration.

## Changes

When no init configuration is provided:

- display error message
- early exit

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
