### PR TITLE
✅🐛 don't blow up tests when leak detection triggers outside of a spec

### DIFF
--- a/packages/core/test/leakDetection.ts
+++ b/packages/core/test/leakDetection.ts
@@ -44,14 +44,18 @@ export function stopLeakDetection() {
 }
 
 function withLeakDetection(eventName: string, listener: EventListener) {
-  const specWhenAdded = getCurrentJasmineSpec()!.fullName
+  const specWhenAdded = getCurrentJasmineSpec()
+  if (!specWhenAdded) {
+    return listener
+  }
+
   return (event: Event) => {
-    const currentSpec = getCurrentJasmineSpec()!.fullName
-    if (specWhenAdded !== currentSpec) {
+    const currentSpec = getCurrentJasmineSpec()
+    if (!currentSpec || specWhenAdded.fullName !== currentSpec.fullName) {
       display.error(`Leaked listener
   event names: "${eventName}"
-  attached with: "${specWhenAdded}"        
-  executed with: "${currentSpec}"`)
+  attached with: "${specWhenAdded.fullName}"
+  ${currentSpec ? `executed with: "${currentSpec.fullName}"` : 'executed outside of a spec'}`)
     }
     listener(event)
   }


### PR DESCRIPTION
## Motivation

It appears that on some occasions, event listeners are called outside of specs, and the leak detection breaks


## Changes

Make sure the current jasmine spec is defined before using it

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
