### PR TITLE
♻️ Use performance entry fixtures in tests

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -66,6 +66,7 @@ export interface RumPerformanceResourceTiming {
   redirectEnd: RelativeTime
   decodedBodySize: number
   traceId?: string
+  toJSON(): PerformanceEntryRepresentation
 }
 
 export interface RumPerformanceLongTaskTiming {
@@ -228,6 +229,7 @@ export function retrieveInitialDocumentResourceTiming(
       entryType: RumPerformanceEntryType.RESOURCE as const,
       initiatorType: FAKE_INITIAL_DOCUMENT,
       traceId: getDocumentTraceId(document),
+      toJSON: () => assign({}, timing, { toJSON: undefined }),
     }
     if (
       supportPerformanceTimingEvent(RumPerformanceEntryType.NAVIGATION) &&

--- a/packages/rum-core/src/domain/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/longTask/longTaskCollection.spec.ts
@@ -1,23 +1,10 @@
-import type { Duration, RelativeTime, ServerDuration } from '@datadog/browser-core'
+import type { RelativeTime, ServerDuration } from '@datadog/browser-core'
 import type { RumSessionManagerMock, TestSetupBuilder } from '../../../test'
-import { createRumSessionManagerMock, setup } from '../../../test'
-import {
-  RumPerformanceEntryType,
-  type RumPerformanceEntry,
-  type RumPerformanceLongTaskTiming,
-} from '../../browser/performanceCollection'
+import { createPerformanceEntry, createRumSessionManagerMock, setup } from '../../../test'
+import { RumPerformanceEntryType, type RumPerformanceEntry } from '../../browser/performanceCollection'
 import { RumEventType } from '../../rawRumEvent.types'
 import { LifeCycleEventType } from '../lifeCycle'
 import { startLongTaskCollection } from './longTaskCollection'
-
-const LONG_TASK: RumPerformanceLongTaskTiming = {
-  duration: 100 as Duration,
-  entryType: RumPerformanceEntryType.LONG_TASK,
-  startTime: 1234 as RelativeTime,
-  toJSON() {
-    return { name: 'self', duration: 100, entryType: 'longtask', startTime: 1234 }
-  },
-}
 
 describe('long task collection', () => {
   let setupBuilder: TestSetupBuilder
@@ -38,10 +25,10 @@ describe('long task collection', () => {
   it('should only listen to long task performance entry', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      LONG_TASK,
-      { duration: 100 as Duration, entryType: 'navigation', startTime: 1234 },
-      { duration: 100 as Duration, entryType: 'resource', startTime: 1234 },
-      { duration: 100 as Duration, entryType: 'paint', startTime: 1234 },
+      createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
+      createPerformanceEntry(RumPerformanceEntryType.RESOURCE),
+      createPerformanceEntry(RumPerformanceEntryType.PAINT),
     ] as RumPerformanceEntry[])
 
     expect(rawRumEvents.length).toBe(1)
@@ -51,17 +38,23 @@ describe('long task collection', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
     sessionManager.setLongTaskAllowed(true)
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+      createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
+    ])
     expect(rawRumEvents.length).toBe(1)
 
     sessionManager.setLongTaskAllowed(false)
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+      createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
+    ])
     expect(rawRumEvents.length).toBe(1)
   })
 
   it('should create raw rum event from performance entry', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [LONG_TASK])
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+      createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
+    ])
 
     expect(rawRumEvents[0].startTime).toBe(1234 as RelativeTime)
     expect(rawRumEvents[0].rawRumEvent).toEqual({

--- a/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
@@ -12,7 +12,7 @@ describe('matchRequestTiming', () => {
     startClocks: relativeToClocks(100 as RelativeTime),
     duration: 500 as Duration,
   }
-  let entries: PerformanceResourceTiming[]
+  let entries: RumPerformanceResourceTiming[]
 
   beforeEach(() => {
     if (isIE()) {
@@ -23,25 +23,34 @@ describe('matchRequestTiming', () => {
   })
 
   it('should match single timing nested in the request ', () => {
-    const entry = createResourceEntry({ startTime: 200 as RelativeTime, duration: 300 as Duration })
+    const entry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 200 as RelativeTime,
+      duration: 300 as Duration,
+    })
     entries.push(entry)
 
     const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(matchingTiming).toEqual(entry.toJSON())
+    expect(matchingTiming).toEqual(entry.toJSON() as RumPerformanceResourceTiming)
   })
 
   it('should match single timing nested in the request with error margin', () => {
-    const entry = createResourceEntry({ startTime: 99 as RelativeTime, duration: 502 as Duration })
+    const entry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 99 as RelativeTime,
+      duration: 502 as Duration,
+    })
     entries.push(entry)
 
     const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(matchingTiming).toEqual(entry.toJSON())
+    expect(matchingTiming).toEqual(entry.toJSON() as RumPerformanceResourceTiming)
   })
 
   it('should not match single timing outside the request ', () => {
-    const entry = createResourceEntry({ startTime: 0 as RelativeTime, duration: 300 as Duration })
+    const entry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 0 as RelativeTime,
+      duration: 300 as Duration,
+    })
     entries.push(entry)
 
     const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
@@ -50,8 +59,14 @@ describe('matchRequestTiming', () => {
   })
 
   it('should not match two not following timings nested in the request ', () => {
-    const entry1 = createResourceEntry({ startTime: 150 as RelativeTime, duration: 100 as Duration })
-    const entry2 = createResourceEntry({ startTime: 200 as RelativeTime, duration: 100 as Duration })
+    const entry1 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 150 as RelativeTime,
+      duration: 100 as Duration,
+    })
+    const entry2 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 200 as RelativeTime,
+      duration: 100 as Duration,
+    })
     entries.push(entry1, entry2)
 
     const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
@@ -60,9 +75,18 @@ describe('matchRequestTiming', () => {
   })
 
   it('should not match multiple timings nested in the request', () => {
-    const entry1 = createResourceEntry({ startTime: 100 as RelativeTime, duration: 50 as Duration })
-    const entry2 = createResourceEntry({ startTime: 150 as RelativeTime, duration: 50 as Duration })
-    const entry3 = createResourceEntry({ startTime: 200 as RelativeTime, duration: 50 as Duration })
+    const entry1 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 100 as RelativeTime,
+      duration: 50 as Duration,
+    })
+    const entry2 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 150 as RelativeTime,
+      duration: 50 as Duration,
+    })
+    const entry3 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 200 as RelativeTime,
+      duration: 50 as Duration,
+    })
     entries.push(entry1, entry2, entry3)
 
     const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
@@ -71,7 +95,7 @@ describe('matchRequestTiming', () => {
   })
 
   it('should not match invalid timing nested in the request ', () => {
-    const entry = createResourceEntry({
+    const entry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
       // fetchStart < startTime is invalid
       fetchStart: 0 as RelativeTime,
       startTime: 200 as RelativeTime,
@@ -84,14 +108,3 @@ describe('matchRequestTiming', () => {
     expect(matchingTiming).toEqual(undefined)
   })
 })
-
-export function createResourceEntry(overrides?: Partial<RumPerformanceResourceTiming>): PerformanceResourceTiming {
-  const rumPerformanceResourceTiming: Partial<PerformanceResourceTiming> = createPerformanceEntry(
-    RumPerformanceEntryType.RESOURCE,
-    overrides
-  )
-  return {
-    ...rumPerformanceResourceTiming,
-    toJSON: () => rumPerformanceResourceTiming,
-  } as PerformanceResourceTiming
-}

--- a/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
@@ -1,7 +1,8 @@
 import type { Duration, RelativeTime } from '@datadog/browser-core'
 import { isIE, relativeToClocks } from '@datadog/browser-core'
-import { createResourceEntry } from '../../../test'
+import { createPerformanceEntry } from '../../../test'
 import type { RumPerformanceResourceTiming } from '../../browser/performanceCollection'
+import { RumPerformanceEntryType } from '../../browser/performanceCollection'
 import type { RequestCompleteEvent } from '../requestCollection'
 
 import { matchRequestTiming } from './matchRequestTiming'
@@ -11,7 +12,7 @@ describe('matchRequestTiming', () => {
     startClocks: relativeToClocks(100 as RelativeTime),
     duration: 500 as Duration,
   }
-  let entries: RumPerformanceResourceTiming[]
+  let entries: PerformanceResourceTiming[]
 
   beforeEach(() => {
     if (isIE()) {
@@ -22,63 +23,75 @@ describe('matchRequestTiming', () => {
   })
 
   it('should match single timing nested in the request ', () => {
-    const match = createResourceEntry({ startTime: 200 as RelativeTime, duration: 300 as Duration })
-    entries.push(match)
+    const entry = createResourceEntry({ startTime: 200 as RelativeTime, duration: 300 as Duration })
+    entries.push(entry)
 
-    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+    const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(match)
+    expect(matchingTiming).toEqual(entry.toJSON())
   })
 
   it('should match single timing nested in the request with error margin', () => {
-    const match = createResourceEntry({ startTime: 99 as RelativeTime, duration: 502 as Duration })
-    entries.push(match)
+    const entry = createResourceEntry({ startTime: 99 as RelativeTime, duration: 502 as Duration })
+    entries.push(entry)
 
-    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+    const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(match)
+    expect(matchingTiming).toEqual(entry.toJSON())
   })
 
   it('should not match single timing outside the request ', () => {
-    const match = createResourceEntry({ startTime: 0 as RelativeTime, duration: 300 as Duration })
-    entries.push(match)
+    const entry = createResourceEntry({ startTime: 0 as RelativeTime, duration: 300 as Duration })
+    entries.push(entry)
 
-    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+    const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(undefined)
+    expect(matchingTiming).toEqual(undefined)
   })
 
   it('should not match two not following timings nested in the request ', () => {
-    const match1 = createResourceEntry({ startTime: 150 as RelativeTime, duration: 100 as Duration })
-    const match2 = createResourceEntry({ startTime: 200 as RelativeTime, duration: 100 as Duration })
-    entries.push(match1, match2)
+    const entry1 = createResourceEntry({ startTime: 150 as RelativeTime, duration: 100 as Duration })
+    const entry2 = createResourceEntry({ startTime: 200 as RelativeTime, duration: 100 as Duration })
+    entries.push(entry1, entry2)
 
-    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+    const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(undefined)
+    expect(matchingTiming).toEqual(undefined)
   })
 
   it('should not match multiple timings nested in the request', () => {
-    const match1 = createResourceEntry({ startTime: 100 as RelativeTime, duration: 50 as Duration })
-    const match2 = createResourceEntry({ startTime: 150 as RelativeTime, duration: 50 as Duration })
-    const match3 = createResourceEntry({ startTime: 200 as RelativeTime, duration: 50 as Duration })
-    entries.push(match1, match2, match3)
+    const entry1 = createResourceEntry({ startTime: 100 as RelativeTime, duration: 50 as Duration })
+    const entry2 = createResourceEntry({ startTime: 150 as RelativeTime, duration: 50 as Duration })
+    const entry3 = createResourceEntry({ startTime: 200 as RelativeTime, duration: 50 as Duration })
+    entries.push(entry1, entry2, entry3)
 
-    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+    const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
-    expect(timing).toEqual(undefined)
+    expect(matchingTiming).toEqual(undefined)
   })
 
   it('should not match invalid timing nested in the request ', () => {
-    const match = createResourceEntry({
-      duration: 100 as Duration,
+    const entry = createResourceEntry({
+      // fetchStart < startTime is invalid
       fetchStart: 0 as RelativeTime,
       startTime: 200 as RelativeTime,
     })
-    entries.push(match)
 
-    const timing = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+    entries.push(entry)
 
-    expect(timing).toEqual(undefined)
+    const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+
+    expect(matchingTiming).toEqual(undefined)
   })
 })
+
+export function createResourceEntry(overrides?: Partial<RumPerformanceResourceTiming>): PerformanceResourceTiming {
+  const rumPerformanceResourceTiming: Partial<PerformanceResourceTiming> = createPerformanceEntry(
+    RumPerformanceEntryType.RESOURCE,
+    overrides
+  )
+  return {
+    ...rumPerformanceResourceTiming,
+    toJSON: () => rumPerformanceResourceTiming,
+  } as PerformanceResourceTiming
+}

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -8,7 +8,7 @@ import {
   ExperimentalFeature,
 } from '@datadog/browser-core'
 import type { RumFetchResourceEventDomainContext } from '../../domainContext.types'
-import { createResourceEntry, setup, createRumSessionManagerMock } from '../../../test'
+import { setup, createRumSessionManagerMock, createPerformanceEntry } from '../../../test'
 import type { TestSetupBuilder } from '../../../test'
 import type { RawRumResourceEvent } from '../../rawRumEvent.types'
 import { RumEventType } from '../../rawRumEvent.types'
@@ -17,6 +17,7 @@ import type { RequestCompleteEvent } from '../requestCollection'
 import { TraceIdentifier } from '../tracing/tracer'
 import { validateAndBuildRumConfiguration } from '../configuration'
 import { PageState } from '../contexts/pageStateHistory'
+import { RumPerformanceEntryType } from '../../browser/performanceCollection'
 import { startResourceCollection } from './resourceCollection'
 
 describe('resourceCollection', () => {
@@ -42,14 +43,12 @@ describe('resourceCollection', () => {
 
   it('should create resource from performance entry', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
-    const performanceEntry = createResourceEntry({
-      duration: 100 as Duration,
-      name: 'https://resource.com/valid',
-      startTime: 1234 as RelativeTime,
-    })
+
+    const performanceEntry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE)
+
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [performanceEntry])
 
-    expect(rawRumEvents[0].startTime).toBe(1234 as RelativeTime)
+    expect(rawRumEvents[0].startTime).toBe(200 as RelativeTime)
     expect(rawRumEvents[0].rawRumEvent).toEqual({
       date: jasmine.any(Number) as unknown as TimeStamp,
       resource: {
@@ -58,6 +57,8 @@ describe('resourceCollection', () => {
         size: undefined,
         type: ResourceType.OTHER,
         url: 'https://resource.com/valid',
+        download: jasmine.any(Object),
+        first_byte: jasmine.any(Object),
       },
       type: RumEventType.RESOURCE,
       _dd: {
@@ -116,7 +117,7 @@ describe('resourceCollection', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
     const mockPageStates = [{ state: PageState.ACTIVE, startTime: 0 as RelativeTime }]
     const mockXHR = createCompletedRequest()
-    const mockPerformanceEntry = createResourceEntry()
+    const mockPerformanceEntry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE)
 
     pageStateHistorySpy.and.returnValue(mockPageStates)
 
@@ -166,7 +167,7 @@ describe('resourceCollection', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
     const mockPageStates = [{ state: PageState.ACTIVE, startTime: 0 as RelativeTime }]
     const mockXHR = createCompletedRequest()
-    const mockPerformanceEntry = createResourceEntry()
+    const mockPerformanceEntry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE)
 
     pageStateHistorySpy.and.returnValue(mockPageStates)
 
@@ -264,9 +265,7 @@ describe('resourceCollection', () => {
     it('should be processed from traced initial document', () => {
       const { lifeCycle, rawRumEvents } = setupBuilder.build()
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-        createResourceEntry({
-          traceId: '1234',
-        }),
+        createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { traceId: '1234' }),
       ])
       const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields).toBeDefined()
@@ -389,7 +388,9 @@ describe('resourceCollection', () => {
       setupBuilder.withSessionManager(createRumSessionManagerMock().setNotTracked())
       const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+        createPerformanceEntry(RumPerformanceEntryType.RESOURCE),
+      ])
 
       expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd.discarded).toBeTrue()
     })
@@ -398,7 +399,9 @@ describe('resourceCollection', () => {
       setupBuilder.withSessionManager(createRumSessionManagerMock().setResourceAllowed(false))
       const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+        createPerformanceEntry(RumPerformanceEntryType.RESOURCE),
+      ])
 
       expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd.discarded).toBeTrue()
     })
@@ -407,7 +410,9 @@ describe('resourceCollection', () => {
       setupBuilder.withSessionManager(createRumSessionManagerMock().setResourceAllowed(true))
       const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [createResourceEntry()])
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+        createPerformanceEntry(RumPerformanceEntryType.RESOURCE),
+      ])
 
       expect((rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd.discarded).toBeFalse()
     })

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -45,7 +45,6 @@ describe('resourceCollection', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
 
     const performanceEntry = createPerformanceEntry(RumPerformanceEntryType.RESOURCE)
-
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [performanceEntry])
 
     expect(rawRumEvents[0].startTime).toBe(200 as RelativeTime)

--- a/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
+++ b/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
@@ -1,14 +1,6 @@
-import type { Duration, RelativeTime } from '@datadog/browser-core'
 import { noopWebVitalTelemetryDebug } from '../../../test'
 import type { BuildContext } from '../../../test'
 import { LifeCycleEventType } from '../lifeCycle'
-import { RumPerformanceEntryType } from '../../browser/performanceCollection'
-import type {
-  RumFirstInputTiming,
-  RumLargestContentfulPaintTiming,
-  RumPerformanceNavigationTiming,
-  RumPerformancePaintTiming,
-} from '../../browser/performanceCollection'
 import type { ViewEvent, ViewOptions } from './trackViews'
 import { trackViews } from './trackViews'
 
@@ -73,31 +65,4 @@ function spyOnViews(name?: string) {
   }
 
   return { handler, getViewEvent, getHandledCount }
-}
-
-export const FAKE_PAINT_ENTRY: RumPerformancePaintTiming = {
-  entryType: RumPerformanceEntryType.PAINT,
-  name: 'first-contentful-paint',
-  startTime: 123 as RelativeTime,
-}
-export const FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY: RumLargestContentfulPaintTiming = {
-  entryType: RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
-  startTime: 789 as RelativeTime,
-  size: 10,
-}
-
-export const FAKE_NAVIGATION_ENTRY: RumPerformanceNavigationTiming = {
-  responseStart: 123 as RelativeTime,
-  domComplete: 456 as RelativeTime,
-  domContentLoadedEventEnd: 345 as RelativeTime,
-  domInteractive: 234 as RelativeTime,
-  entryType: RumPerformanceEntryType.NAVIGATION,
-  loadEventEnd: 567 as RelativeTime,
-}
-
-export const FAKE_FIRST_INPUT_ENTRY: RumFirstInputTiming = {
-  entryType: RumPerformanceEntryType.FIRST_INPUT,
-  processingStart: 1100 as RelativeTime,
-  startTime: 1000 as RelativeTime,
-  duration: 0 as Duration,
 }

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -8,19 +8,15 @@ import {
   resetExperimentalFeatures,
 } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../test'
-import { setup } from '../../../test'
+import { createPerformanceEntry, setup } from '../../../test'
 import { RumEventType, ViewLoadingType } from '../../rawRumEvent.types'
 import type { RumEvent } from '../../rumEvent.types'
 import { LifeCycleEventType } from '../lifeCycle'
+import { RumPerformanceEntryType } from '../../browser/performanceCollection'
 import type { ViewEvent } from './trackViews'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD, KEEP_TRACKING_AFTER_VIEW_DELAY } from './trackViews'
 import type { ViewTest } from './setupViewTest.specHelper'
-import {
-  FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY,
-  FAKE_NAVIGATION_ENTRY,
-  FAKE_PAINT_ENTRY,
-  setupViewTest,
-} from './setupViewTest.specHelper'
+import { setupViewTest } from './setupViewTest.specHelper'
 
 describe('track views automatically', () => {
   let setupBuilder: TestSetupBuilder
@@ -121,12 +117,13 @@ describe('initial view', () => {
     it('should update initial view metrics when notified with a PERFORMANCE_ENTRY_COLLECTED event (throttled)', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdateCount, getViewUpdate } = viewTest
+      const performanceEntry = createPerformanceEntry(RumPerformanceEntryType.NAVIGATION)
 
       expect(getViewUpdateCount()).toEqual(1)
       expect(getViewUpdate(0).initialViewMetrics).toEqual({})
 
-      clock.tick(FAKE_NAVIGATION_ENTRY.responseStart) // ensure now > responseStart
-      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_NAVIGATION_ENTRY])
+      clock.tick(performanceEntry.responseStart) // ensure now > responseStart
+      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [performanceEntry])
 
       expect(getViewUpdateCount()).toEqual(1)
 
@@ -150,9 +147,9 @@ describe('initial view', () => {
       expect(getViewUpdate(0).initialViewMetrics).toEqual({})
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-        FAKE_PAINT_ENTRY,
-        FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY,
-        FAKE_NAVIGATION_ENTRY,
+        createPerformanceEntry(RumPerformanceEntryType.PAINT),
+        createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT),
+        createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
       ])
       expect(getViewUpdateCount()).toEqual(1)
 
@@ -195,9 +192,9 @@ describe('initial view', () => {
         expect(getViewUpdateCount()).toEqual(3)
 
         lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-          FAKE_PAINT_ENTRY,
-          FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY,
-          FAKE_NAVIGATION_ENTRY,
+          createPerformanceEntry(RumPerformanceEntryType.PAINT),
+          createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT),
+          createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
         ])
 
         clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
@@ -241,30 +238,29 @@ describe('initial view', () => {
       })
 
       it('should update the initial view loadingTime following the loadEventEnd value', () => {
-        expect(initialView.last.commonViewMetrics.loadingTime).toBe(FAKE_NAVIGATION_ENTRY.loadEventEnd)
+        expect(initialView.last.commonViewMetrics.loadingTime).toBe(567 as RelativeTime)
       })
     })
 
     it('should keep updating the initial view metrics for 5 min after view end', () => {
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewCreateCount, getViewUpdate, getViewUpdateCount, startView } = viewTest
+      const lcpEntry = createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT)
       startView()
       expect(getViewCreateCount()).toEqual(2)
 
       clock.tick(KEEP_TRACKING_AFTER_VIEW_DELAY - 1)
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-        FAKE_PAINT_ENTRY,
-        FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY,
-        FAKE_NAVIGATION_ENTRY,
+        createPerformanceEntry(RumPerformanceEntryType.PAINT),
+        lcpEntry,
+        createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
       ])
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       const latestUpdate = getViewUpdate(getViewUpdateCount() - 1)
       const firstView = getViewUpdate(0)
       expect(latestUpdate.id).toBe(firstView.id)
-      expect(latestUpdate.initialViewMetrics.largestContentfulPaint?.value).toEqual(
-        FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY.startTime
-      )
+      expect(latestUpdate.initialViewMetrics.largestContentfulPaint?.value).toEqual(lcpEntry.startTime)
     })
 
     it('should not update the initial view metrics 5 min after view end', () => {
@@ -275,9 +271,9 @@ describe('initial view', () => {
 
       clock.tick(KEEP_TRACKING_AFTER_VIEW_DELAY)
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-        FAKE_PAINT_ENTRY,
-        FAKE_LARGEST_CONTENTFUL_PAINT_ENTRY,
-        FAKE_NAVIGATION_ENTRY,
+        createPerformanceEntry(RumPerformanceEntryType.PAINT),
+        createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT),
+        createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
       ])
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
@@ -1,18 +1,12 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
-import { RumPerformanceEntryType, type RumPerformancePaintTiming } from '../../../browser/performanceCollection'
+import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { TestSetupBuilder } from '../../../../test'
-import { setup } from '../../../../test'
+import { createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
 import { FCP_MAXIMUM_DELAY, trackFirstContentfulPaint } from './trackFirstContentfulPaint'
 import { trackFirstHidden } from './trackFirstHidden'
-
-const FAKE_PAINT_ENTRY: RumPerformancePaintTiming = {
-  entryType: RumPerformanceEntryType.PAINT,
-  name: 'first-contentful-paint',
-  startTime: 123 as RelativeTime,
-}
 
 describe('trackFirstContentfulPaint', () => {
   let setupBuilder: TestSetupBuilder
@@ -42,7 +36,9 @@ describe('trackFirstContentfulPaint', () => {
   it('should provide the first contentful paint timing', () => {
     const { lifeCycle } = setupBuilder.build()
 
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_PAINT_ENTRY])
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+      createPerformanceEntry(RumPerformanceEntryType.PAINT),
+    ])
 
     expect(fcpCallback).toHaveBeenCalledTimes(1 as RelativeTime)
     expect(fcpCallback).toHaveBeenCalledWith(123 as RelativeTime)
@@ -51,7 +47,9 @@ describe('trackFirstContentfulPaint', () => {
   it('should be discarded if the page is hidden', () => {
     setPageVisibility('hidden')
     const { lifeCycle } = setupBuilder.build()
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_PAINT_ENTRY])
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+      createPerformanceEntry(RumPerformanceEntryType.PAINT),
+    ])
     expect(fcpCallback).not.toHaveBeenCalled()
   })
 
@@ -59,10 +57,7 @@ describe('trackFirstContentfulPaint', () => {
     const { lifeCycle } = setupBuilder.build()
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      {
-        ...FAKE_PAINT_ENTRY,
-        startTime: FCP_MAXIMUM_DELAY as RelativeTime,
-      },
+      createPerformanceEntry(RumPerformanceEntryType.PAINT, { startTime: FCP_MAXIMUM_DELAY as RelativeTime }),
     ])
     expect(fcpCallback).not.toHaveBeenCalled()
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
@@ -1,9 +1,9 @@
 import type { Duration, RelativeTime } from '@datadog/browser-core'
+import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { TestSetupBuilder } from '../../../../test'
-import { noopWebVitalTelemetryDebug, setup } from '../../../../test'
+import { createPerformanceEntry, noopWebVitalTelemetryDebug, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
-import { FAKE_FIRST_INPUT_ENTRY, FAKE_NAVIGATION_ENTRY, FAKE_PAINT_ENTRY } from '../setupViewTest.specHelper'
 import { trackInitialViewMetrics } from './trackInitialViewMetrics'
 
 describe('trackInitialViewMetrics', () => {
@@ -36,11 +36,10 @@ describe('trackInitialViewMetrics', () => {
 
   it('should merge metrics from various sources', () => {
     const { lifeCycle } = setupBuilder.build()
-
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      FAKE_NAVIGATION_ENTRY,
-      FAKE_PAINT_ENTRY,
-      FAKE_FIRST_INPUT_ENTRY,
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
+      createPerformanceEntry(RumPerformanceEntryType.PAINT),
+      createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT),
     ])
 
     expect(scheduleViewUpdateSpy).toHaveBeenCalledTimes(3)
@@ -65,9 +64,9 @@ describe('trackInitialViewMetrics', () => {
     const { lifeCycle } = setupBuilder.build()
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      FAKE_NAVIGATION_ENTRY,
-      FAKE_PAINT_ENTRY,
-      FAKE_FIRST_INPUT_ENTRY,
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
+      createPerformanceEntry(RumPerformanceEntryType.PAINT),
+      createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT),
     ])
 
     expect(setLoadEventSpy).toHaveBeenCalledOnceWith(567 as Duration)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -1,36 +1,21 @@
 import type { RelativeTime, Duration } from '@datadog/browser-core'
 import { addDuration } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
-import { setup } from '../../../../test'
-import type { RumPerformanceNavigationTiming } from '../../../browser/performanceCollection'
+import { createPerformanceEntry, setup } from '../../../../test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import { LifeCycleEventType } from '../../lifeCycle'
 import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitPageActivityEnd'
 import { THROTTLE_VIEW_UPDATE_PERIOD } from '../trackViews'
 import type { ViewTest } from '../setupViewTest.specHelper'
-import { FAKE_NAVIGATION_ENTRY, setupViewTest } from '../setupViewTest.specHelper'
+import { setupViewTest } from '../setupViewTest.specHelper'
 
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = (PAGE_ACTIVITY_VALIDATION_DELAY * 0.8) as Duration
 
 const AFTER_PAGE_ACTIVITY_END_DELAY = PAGE_ACTIVITY_END_DELAY * 1.1
 
-const FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_BEFORE_ACTIVITY_TIMING: RumPerformanceNavigationTiming = {
-  responseStart: 1 as RelativeTime,
-  domComplete: 2 as RelativeTime,
-  domContentLoadedEventEnd: 1 as RelativeTime,
-  domInteractive: 1 as RelativeTime,
-  entryType: RumPerformanceEntryType.NAVIGATION,
-  loadEventEnd: (BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY * 0.8) as RelativeTime,
-}
+const LOAD_EVENT_BEFORE_ACTIVITY_TIMING = (BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY * 0.8) as RelativeTime
 
-const FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING: RumPerformanceNavigationTiming = {
-  responseStart: 1 as RelativeTime,
-  domComplete: 2 as RelativeTime,
-  domContentLoadedEventEnd: 1 as RelativeTime,
-  domInteractive: 1 as RelativeTime,
-  entryType: RumPerformanceEntryType.NAVIGATION,
-  loadEventEnd: (BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY * 1.2) as RelativeTime,
-}
+const LOAD_EVENT_AFTER_ACTIVITY_TIMING = (BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY * 1.2) as RelativeTime
 
 describe('trackLoadingTime', () => {
   let setupBuilder: TestSetupBuilder
@@ -79,12 +64,12 @@ describe('trackLoadingTime', () => {
     const { getViewUpdate, getViewUpdateCount } = viewTest
 
     expect(getViewUpdateCount()).toEqual(1)
-
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_NAVIGATION_ENTRY])
+    const entry = createPerformanceEntry(RumPerformanceEntryType.NAVIGATION)
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [entry])
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
     expect(getViewUpdateCount()).toEqual(2)
-    expect(getViewUpdate(1).commonViewMetrics.loadingTime).toEqual(FAKE_NAVIGATION_ENTRY.loadEventEnd)
+    expect(getViewUpdate(1).commonViewMetrics.loadingTime).toEqual(entry.loadEventEnd)
   })
 
   it('should use loadEventEnd for initial view when load event is bigger than computed loading time', () => {
@@ -96,7 +81,9 @@ describe('trackLoadingTime', () => {
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING,
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION, {
+        loadEventEnd: LOAD_EVENT_AFTER_ACTIVITY_TIMING,
+      }),
     ])
 
     domMutationObservable.notify()
@@ -105,9 +92,7 @@ describe('trackLoadingTime', () => {
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
     expect(getViewUpdateCount()).toEqual(2)
-    expect(getViewUpdate(1).commonViewMetrics.loadingTime).toEqual(
-      FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING.loadEventEnd
-    )
+    expect(getViewUpdate(1).commonViewMetrics.loadingTime).toEqual(LOAD_EVENT_AFTER_ACTIVITY_TIMING)
   })
 
   it('should use computed loading time for initial view when load event is smaller than computed loading time', () => {
@@ -118,7 +103,9 @@ describe('trackLoadingTime', () => {
 
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_BEFORE_ACTIVITY_TIMING,
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION, {
+        loadEventEnd: LOAD_EVENT_BEFORE_ACTIVITY_TIMING,
+      }),
     ])
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
@@ -132,9 +119,7 @@ describe('trackLoadingTime', () => {
     // introduce a gap between time origin and tracking start
     // ensure that `load event > activity delay` and `load event < activity delay + clock gap`
     // to make the test fail if the clock gap is not correctly taken into account
-    const CLOCK_GAP = (FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING.loadEventEnd -
-      BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY +
-      1) as Duration
+    const CLOCK_GAP = (LOAD_EVENT_AFTER_ACTIVITY_TIMING - BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + 1) as Duration
 
     setupBuilder.clock!.tick(CLOCK_GAP)
 
@@ -146,7 +131,9 @@ describe('trackLoadingTime', () => {
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      FAKE_NAVIGATION_ENTRY_WITH_LOADEVENT_AFTER_ACTIVITY_TIMING,
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION, {
+        loadEventEnd: LOAD_EVENT_BEFORE_ACTIVITY_TIMING,
+      }),
     ])
 
     domMutationObservable.notify()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
@@ -1,8 +1,8 @@
 import type { Duration } from '@datadog/browser-core'
+import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { TestSetupBuilder } from '../../../../test'
-import { setup } from '../../../../test'
+import { createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
-import { FAKE_NAVIGATION_ENTRY } from '../setupViewTest.specHelper'
 import type { NavigationTimings } from './trackNavigationTimings'
 import { trackNavigationTimings } from './trackNavigationTimings'
 
@@ -23,7 +23,9 @@ describe('trackNavigationTimings', () => {
   it('should provide navigation timing', () => {
     const { lifeCycle } = setupBuilder.build()
 
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [FAKE_NAVIGATION_ENTRY])
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
+    ])
 
     expect(navigationTimingsCallback).toHaveBeenCalledTimes(1)
     expect(navigationTimingsCallback).toHaveBeenCalledWith({

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -171,7 +171,6 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
         },
         overrides
       ) as EntryTypeToReturnType[T]
-
     case RumPerformanceEntryType.PAINT:
       return assign(
         {
@@ -181,33 +180,55 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
         },
         overrides
       ) as EntryTypeToReturnType[T]
+    case RumPerformanceEntryType.NAVIGATION:
+      return assign(
+        {
+          entryType: RumPerformanceEntryType.NAVIGATION,
+          responseStart: 123 as RelativeTime,
+          domComplete: 456 as RelativeTime,
+          domContentLoadedEventEnd: 345 as RelativeTime,
+          domInteractive: 234 as RelativeTime,
+          loadEventEnd: 567 as RelativeTime,
+        },
+        overrides
+      ) as EntryTypeToReturnType[T]
+
+    case RumPerformanceEntryType.LONG_TASK:
+      return assign(
+        {
+          duration: 100 as Duration,
+          entryType: RumPerformanceEntryType.LONG_TASK,
+          startTime: 1234 as RelativeTime,
+          toJSON() {
+            return { name: 'self', duration: 100, entryType: RumPerformanceEntryType.LONG_TASK, startTime: 1234 }
+          },
+        },
+        overrides
+      ) as EntryTypeToReturnType[T]
+    case RumPerformanceEntryType.RESOURCE: {
+      return assign(
+        {
+          connectEnd: 200 as RelativeTime,
+          connectStart: 200 as RelativeTime,
+          decodedBodySize: 200,
+          domainLookupEnd: 200 as RelativeTime,
+          domainLookupStart: 200 as RelativeTime,
+          duration: 100 as Duration,
+          entryType: RumPerformanceEntryType.RESOURCE,
+          fetchStart: 200 as RelativeTime,
+          name: 'https://resource.com/valid',
+          redirectEnd: 200 as RelativeTime,
+          redirectStart: 200 as RelativeTime,
+          requestStart: 200 as RelativeTime,
+          responseEnd: 300 as RelativeTime,
+          responseStart: 200 as RelativeTime,
+          secureConnectionStart: 200 as RelativeTime,
+          startTime: 200 as RelativeTime,
+        },
+        overrides
+      ) as EntryTypeToReturnType[T]
+    }
     default:
       throw new Error(`Unsupported entryType fixture: ${entryType}`)
   }
-}
-
-export function createResourceEntry(
-  overrides?: Partial<RumPerformanceResourceTiming>
-): RumPerformanceResourceTiming & PerformanceResourceTiming {
-  const entry: Partial<RumPerformanceResourceTiming & PerformanceResourceTiming> = {
-    connectEnd: 200 as RelativeTime,
-    connectStart: 200 as RelativeTime,
-    decodedBodySize: 200,
-    domainLookupEnd: 200 as RelativeTime,
-    domainLookupStart: 200 as RelativeTime,
-    duration: 100 as Duration,
-    entryType: RumPerformanceEntryType.RESOURCE,
-    fetchStart: 200 as RelativeTime,
-    name: 'https://resource.com/valid',
-    redirectEnd: 200 as RelativeTime,
-    redirectStart: 200 as RelativeTime,
-    requestStart: 200 as RelativeTime,
-    responseEnd: 300 as RelativeTime,
-    responseStart: 200 as RelativeTime,
-    secureConnectionStart: 200 as RelativeTime,
-    startTime: 200 as RelativeTime,
-    ...overrides,
-  }
-  entry.toJSON = () => entry
-  return entry as RumPerformanceResourceTiming & PerformanceResourceTiming
 }

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -193,20 +193,21 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
         overrides
       ) as EntryTypeToReturnType[T]
 
-    case RumPerformanceEntryType.LONG_TASK:
-      return assign(
+    case RumPerformanceEntryType.LONG_TASK: {
+      const entry = assign(
         {
+          name: 'self',
           duration: 100 as Duration,
           entryType: RumPerformanceEntryType.LONG_TASK,
           startTime: 1234 as RelativeTime,
-          toJSON() {
-            return { name: 'self', duration: 100, entryType: RumPerformanceEntryType.LONG_TASK, startTime: 1234 }
-          },
         },
         overrides
       ) as EntryTypeToReturnType[T]
+
+      return { ...entry, toJSON: () => entry }
+    }
     case RumPerformanceEntryType.RESOURCE: {
-      return assign(
+      const entry = assign(
         {
           connectEnd: 200 as RelativeTime,
           connectStart: 200 as RelativeTime,
@@ -227,6 +228,8 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
         },
         overrides
       ) as EntryTypeToReturnType[T]
+
+      return { ...entry, toJSON: () => entry }
     }
     default:
       throw new Error(`Unsupported entryType fixture: ${entryType}`)


### PR DESCRIPTION
## Motivation

After introducing` createPerformanceEntry()` fixture builder  ([PR](https://github.com/DataDog/browser-sdk/pull/2418)). Let's use it with all tests playing with performance entries.

## Changes

Update tests:
![image](https://github.com/DataDog/browser-sdk/assets/4342515/13918569-d8d4-47d2-97f5-ffb3a189e849)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
