### PR TITLE
♻️ [RUM-1039] Harmonize view tests

### DIFF
--- a/packages/rum-core/src/domain/view/trackViewEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViewEventCounts.spec.ts
@@ -3,209 +3,42 @@ import type { RumEvent } from '../../rumEvent.types'
 import { LifeCycleEventType } from '../lifeCycle'
 import type { TestSetupBuilder } from '../../../test'
 import { setup } from '../../../test'
-import { FrustrationType, RumEventType } from '../../rawRumEvent.types'
-import { THROTTLE_VIEW_UPDATE_PERIOD } from './trackViews'
-import type { ViewTest } from './setupViewTest.specHelper'
-import { setupViewTest } from './setupViewTest.specHelper'
+import { RumEventType } from '../../rawRumEvent.types'
+import { trackViewEventCounts } from './trackViewEventCounts'
 
 describe('trackViewEventCounts', () => {
   let setupBuilder: TestSetupBuilder
-  let viewTest: ViewTest
+  let onChange: () => void
 
   beforeEach(() => {
-    setupBuilder = setup()
-      .withFakeLocation('/foo')
-      .beforeBuild((buildContext) => {
-        viewTest = setupViewTest(buildContext)
-        return viewTest
-      })
+    onChange = jasmine.createSpy('onChange')
+
+    setupBuilder = setup().beforeBuild(({ lifeCycle }) => trackViewEventCounts(lifeCycle, 'view-id', onChange))
   })
 
   afterEach(() => {
     setupBuilder.cleanup()
   })
 
-  it('should track error count', () => {
+  it('should track events count', () => {
     const { lifeCycle } = setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount, startView, getLatestViewContext } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts.errorCount).toEqual(0)
 
     lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
       type: RumEventType.ERROR,
-      view: getLatestViewContext(),
+      view: { id: 'view-id' },
     } as RumEvent & Context)
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.ERROR,
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    startView()
 
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(1).eventCounts.errorCount).toEqual(2)
-    expect(getViewUpdate(2).eventCounts.errorCount).toEqual(0)
-  })
-
-  it('should track long task count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount, startView, getLatestViewContext } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts.longTaskCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.LONG_TASK,
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    startView()
-
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(1).eventCounts.longTaskCount).toEqual(1)
-    expect(getViewUpdate(2).eventCounts.longTaskCount).toEqual(0)
-  })
-
-  it('should track resource count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount, startView, getLatestViewContext } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts.resourceCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.RESOURCE,
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    startView()
-
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(1).eventCounts.resourceCount).toEqual(1)
-    expect(getViewUpdate(2).eventCounts.resourceCount).toEqual(0)
-  })
-
-  it('should track action count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount, startView, getLatestViewContext } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts.actionCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.ACTION,
-      action: { type: 'custom' },
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    startView()
-
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(1).eventCounts.actionCount).toEqual(1)
-    expect(getViewUpdate(2).eventCounts.actionCount).toEqual(0)
-  })
-
-  it('should track frustration count', () => {
-    const { lifeCycle } = setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount, startView, getLatestViewContext } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts.frustrationCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.ACTION,
-      action: {
-        type: 'click',
-        id: '123',
-        frustration: {
-          type: [FrustrationType.DEAD_CLICK, FrustrationType.ERROR_CLICK],
-        },
-      },
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    startView()
-
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(1).eventCounts.frustrationCount).toEqual(2)
-    expect(getViewUpdate(2).eventCounts.frustrationCount).toEqual(0)
+    expect(onChange).toHaveBeenCalledTimes(1)
   })
 
   it('should not count child events unrelated to the view', () => {
     const { lifeCycle } = setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount, startView } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts.errorCount).toEqual(0)
 
     lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
       type: RumEventType.ERROR,
       view: { id: 'unrelated-view-id' },
     } as RumEvent & Context)
-    startView()
 
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(1).eventCounts.errorCount).toEqual(0)
-    expect(getViewUpdate(2).eventCounts.errorCount).toEqual(0)
-  })
-
-  it('should reset event count when the view changes', () => {
-    const { lifeCycle, changeLocation } = setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount, startView, getLatestViewContext } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts.resourceCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.RESOURCE,
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    startView()
-
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(1).eventCounts.resourceCount).toEqual(1)
-    expect(getViewUpdate(2).eventCounts.resourceCount).toEqual(0)
-
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.RESOURCE,
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.RESOURCE,
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-    changeLocation('/baz')
-
-    expect(getViewUpdateCount()).toEqual(5)
-    expect(getViewUpdate(3).eventCounts.resourceCount).toEqual(2)
-    expect(getViewUpdate(4).eventCounts.resourceCount).toEqual(0)
-  })
-
-  it('should update eventCounts when a resource event is collected (throttled)', () => {
-    const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    const { getViewUpdate, getViewUpdateCount, getLatestViewContext } = viewTest
-
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 0,
-      actionCount: 0,
-      frustrationCount: 0,
-    })
-
-    lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
-      type: RumEventType.RESOURCE,
-      view: getLatestViewContext(),
-    } as RumEvent & Context)
-
-    expect(getViewUpdateCount()).toEqual(1)
-
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-
-    expect(getViewUpdateCount()).toEqual(2)
-    expect(getViewUpdate(1).eventCounts).toEqual({
-      errorCount: 0,
-      longTaskCount: 0,
-      resourceCount: 1,
-      actionCount: 0,
-      frustrationCount: 0,
-    })
+    expect(onChange).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -17,6 +17,7 @@ import type { ViewEvent } from './trackViews'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD, KEEP_TRACKING_AFTER_VIEW_DELAY } from './trackViews'
 import type { ViewTest } from './setupViewTest.specHelper'
 import { setupViewTest } from './setupViewTest.specHelper'
+import { isLayoutShiftSupported } from './viewMetrics/trackCumulativeLayoutShift'
 
 describe('track views automatically', () => {
   let setupBuilder: TestSetupBuilder
@@ -380,6 +381,9 @@ describe('view metrics', () => {
 
   describe('common view metrics', () => {
     it('should be updated when notified with a PERFORMANCE_ENTRY_COLLECTED event (throttled)', () => {
+      if (!isLayoutShiftSupported()) {
+        pending('CLS web vital not supported')
+      }
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdateCount, getViewUpdate } = viewTest
 
@@ -402,6 +406,9 @@ describe('view metrics', () => {
     })
 
     it('should not be updated after view end', () => {
+      if (!isLayoutShiftSupported()) {
+        pending('CLS web vital not supported')
+      }
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
       const { getViewUpdate, getViewUpdateCount, getViewCreateCount, startView } = viewTest
       startView()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
@@ -1,5 +1,4 @@
 import type { ClocksState, Duration, Observable } from '@datadog/browser-core'
-import { noop } from '@datadog/browser-core'
 import type { ViewLoadingType } from '../../../rawRumEvent.types'
 import type { RumConfiguration } from '../../configuration'
 import type { LifeCycle } from '../../lifeCycle'
@@ -8,7 +7,7 @@ import type { ScrollMetrics } from './trackScrollMetrics'
 import { computeScrollValues, trackScrollMetrics } from './trackScrollMetrics'
 import { trackLoadingTime } from './trackLoadingTime'
 import type { CumulativeLayoutShift } from './trackCumulativeLayoutShift'
-import { isLayoutShiftSupported, trackCumulativeLayoutShift } from './trackCumulativeLayoutShift'
+import { trackCumulativeLayoutShift } from './trackCumulativeLayoutShift'
 import type { InteractionToNextPaint } from './trackInteractionToNextPaint'
 import { trackInteractionToNextPaint } from './trackInteractionToNextPaint'
 
@@ -62,21 +61,15 @@ export function trackCommonViewMetrics(
     computeScrollValues
   )
 
-  let stopCLSTracking: () => void
-  if (isLayoutShiftSupported()) {
-    commonViewMetrics.cumulativeLayoutShift = { value: 0 }
-    ;({ stop: stopCLSTracking } = trackCumulativeLayoutShift(
-      configuration,
-      lifeCycle,
-      webVitalTelemetryDebug,
-      (cumulativeLayoutShift) => {
-        commonViewMetrics.cumulativeLayoutShift = cumulativeLayoutShift
-        scheduleViewUpdate()
-      }
-    ))
-  } else {
-    stopCLSTracking = noop
-  }
+  const { stop: stopCLSTracking } = trackCumulativeLayoutShift(
+    configuration,
+    lifeCycle,
+    webVitalTelemetryDebug,
+    (cumulativeLayoutShift) => {
+      commonViewMetrics.cumulativeLayoutShift = cumulativeLayoutShift
+      scheduleViewUpdate()
+    }
+  )
 
   const { stop: stopINPTracking, getInteractionToNextPaint } = trackInteractionToNextPaint(
     configuration,

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -1,29 +1,27 @@
-import { ExperimentalFeature, addExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
+import { ExperimentalFeature, addExperimentalFeatures, noop, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
 import { appendElement, appendTextNode, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
-import { THROTTLE_VIEW_UPDATE_PERIOD } from '../trackViews'
-import type { ViewTest } from '../setupViewTest.specHelper'
-import { setupViewTest } from '../setupViewTest.specHelper'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
+import type { CumulativeLayoutShift } from './trackCumulativeLayoutShift'
+import { trackCumulativeLayoutShift } from './trackCumulativeLayoutShift'
 
 describe('trackCumulativeLayoutShift', () => {
   let setupBuilder: TestSetupBuilder
-  let viewTest: ViewTest
   let isLayoutShiftSupported: boolean
   let originalSupportedEntryTypes: PropertyDescriptor | undefined
+  let clsCallback: jasmine.Spy<(csl: CumulativeLayoutShift) => void>
 
   beforeEach(() => {
     if (!('PerformanceObserver' in window) || !('supportedEntryTypes' in PerformanceObserver)) {
       pending('No PerformanceObserver support')
     }
 
-    setupBuilder = setup()
-      .withFakeLocation('/foo')
-      .beforeBuild((buildContext) => {
-        viewTest = setupViewTest(buildContext)
-        return viewTest
-      })
+    clsCallback = jasmine.createSpy()
+    setupBuilder = setup().beforeBuild(({ lifeCycle, configuration }) =>
+      trackCumulativeLayoutShift(configuration, lifeCycle, { addWebVitalTelemetryDebug: noop }, clsCallback)
+    )
+
     originalSupportedEntryTypes = Object.getOwnPropertyDescriptor(PerformanceObserver, 'supportedEntryTypes')
     isLayoutShiftSupported = true
     Object.defineProperty(PerformanceObserver, 'supportedEntryTypes', {
@@ -40,24 +38,21 @@ describe('trackCumulativeLayoutShift', () => {
 
   it('should be initialized to 0', () => {
     setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
 
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).commonViewMetrics.cumulativeLayoutShift?.value).toBe(0)
+    expect(clsCallback).toHaveBeenCalledTimes(1)
+    expect(clsCallback).toHaveBeenCalledWith({ value: 0 })
   })
 
   it('should be initialized to undefined if layout-shift is not supported', () => {
     isLayoutShiftSupported = false
     setupBuilder.build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
 
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).commonViewMetrics.cumulativeLayoutShift?.value).toBe(undefined)
+    expect(clsCallback).not.toHaveBeenCalled()
   })
 
   it('should accumulate layout shift values for the first session window', () => {
     const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
+
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1 }),
     ])
@@ -65,15 +60,14 @@ describe('trackCumulativeLayoutShift', () => {
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.2 }),
     ])
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
-    expect(getViewUpdateCount()).toEqual(2)
-    expect(getViewUpdate(1).commonViewMetrics.cumulativeLayoutShift?.value).toBe(0.3)
+    expect(clsCallback).toHaveBeenCalledTimes(3)
+    expect(clsCallback.calls.mostRecent().args[0].value).toEqual(0.3)
   })
 
   it('should round the cumulative layout shift value to 4 decimals', () => {
     const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
+
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 1.23456789 }),
     ])
@@ -81,28 +75,24 @@ describe('trackCumulativeLayoutShift', () => {
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 1.11111111111 }),
     ])
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
-    expect(getViewUpdateCount()).toEqual(2)
-    expect(getViewUpdate(1).commonViewMetrics.cumulativeLayoutShift?.value).toBe(2.3457)
+    expect(clsCallback).toHaveBeenCalledTimes(3)
+    expect(clsCallback.calls.mostRecent().args[0].value).toEqual(2.3457)
   })
 
   it('should ignore entries with recent input', () => {
-    const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
+    const { lifeCycle } = setupBuilder.withFakeClock().build()
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1, hadRecentInput: true }),
     ])
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
-    expect(getViewUpdateCount()).toEqual(1)
-    expect(getViewUpdate(0).commonViewMetrics.cumulativeLayoutShift?.value).toBe(0)
+    expect(clsCallback).toHaveBeenCalledTimes(1)
+    expect(clsCallback.calls.mostRecent().args[0].value).toEqual(0)
   })
 
   it('should create a new session window if the gap is more than 1 second', () => {
     const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
     // first session window
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1 }),
@@ -116,31 +106,31 @@ describe('trackCumulativeLayoutShift', () => {
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1 }),
     ])
 
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-    expect(getViewUpdateCount()).toEqual(2)
-    expect(getViewUpdate(1).commonViewMetrics.cumulativeLayoutShift?.value).toBe(0.3)
+    expect(clsCallback).toHaveBeenCalledTimes(3)
+    expect(clsCallback.calls.mostRecent().args[0].value).toEqual(0.3)
   })
 
   it('should create a new session window if the current session window is more than 5 second', () => {
     const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
+
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0 }),
     ])
+
     for (let i = 0; i < 6; i += 1) {
       clock.tick(999)
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
         createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1 }),
       ])
     } // window 1: 0.5 | window 2: 0.1
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(2).commonViewMetrics.cumulativeLayoutShift?.value).toBe(0.5)
+
+    expect(clsCallback).toHaveBeenCalledTimes(6)
+    expect(clsCallback.calls.mostRecent().args[0].value).toEqual(0.5)
   })
 
   it('should get the max value sessions', () => {
     const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
-    const { getViewUpdate, getViewUpdateCount } = viewTest
+
     // first session window
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1 }),
@@ -168,9 +158,8 @@ describe('trackCumulativeLayoutShift', () => {
       createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.2 }),
     ])
 
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
-    expect(getViewUpdateCount()).toEqual(3)
-    expect(getViewUpdate(2).commonViewMetrics.cumulativeLayoutShift?.value).toBe(0.5)
+    expect(clsCallback).toHaveBeenCalledTimes(4)
+    expect(clsCallback.calls.mostRecent().args[0]).toEqual({ value: 0.5, targetSelector: undefined })
   })
 
   describe('cls target element', () => {
@@ -181,7 +170,6 @@ describe('trackCumulativeLayoutShift', () => {
     it('should return the first target element selector amongst all the shifted nodes when FF enabled', () => {
       addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
       const { lifeCycle } = setupBuilder.build()
-      const { getViewUpdate, getViewUpdateCount } = viewTest
 
       const textNode = appendTextNode('')
       const divElement = appendElement('div', { id: 'div-element' })
@@ -192,13 +180,12 @@ describe('trackCumulativeLayoutShift', () => {
         }),
       ])
 
-      expect(getViewUpdateCount()).toEqual(1)
-      expect(getViewUpdate(0).commonViewMetrics.cumulativeLayoutShift?.targetSelector).toBe('#div-element')
+      expect(clsCallback).toHaveBeenCalledTimes(2)
+      expect(clsCallback.calls.mostRecent().args[0].targetSelector).toEqual('#div-element')
     })
 
     it('should not return the target element selector when FF disabled', () => {
       const { lifeCycle } = setupBuilder.build()
-      const { getViewUpdate, getViewUpdateCount } = viewTest
 
       const divElement = appendElement('div', { id: 'div-element' })
 
@@ -208,8 +195,8 @@ describe('trackCumulativeLayoutShift', () => {
         }),
       ])
 
-      expect(getViewUpdateCount()).toEqual(1)
-      expect(getViewUpdate(0).commonViewMetrics.cumulativeLayoutShift?.targetSelector).toBe(undefined)
+      expect(clsCallback).toHaveBeenCalledTimes(2)
+      expect(clsCallback.calls.mostRecent().args[0].targetSelector).toEqual(undefined)
     })
   })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -39,8 +39,7 @@ describe('trackCumulativeLayoutShift', () => {
   it('should be initialized to 0', () => {
     setupBuilder.build()
 
-    expect(clsCallback).toHaveBeenCalledTimes(1)
-    expect(clsCallback).toHaveBeenCalledWith({ value: 0 })
+    expect(clsCallback).toHaveBeenCalledOnceWith({ value: 0 })
   })
 
   it('should be initialized to undefined if layout-shift is not supported', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -5,6 +5,7 @@ import {
   ONE_SECOND,
   isExperimentalFeatureEnabled,
   ExperimentalFeature,
+  noop,
 } from '@datadog/browser-core'
 import { isElementNode } from '../../../browser/htmlDomUtils'
 import type { LifeCycle } from '../../lifeCycle'
@@ -43,7 +44,18 @@ export function trackCumulativeLayoutShift(
   webVitalTelemetryDebug: WebVitalTelemetryDebug,
   callback: (cumulativeLayoutShift: CumulativeLayoutShift) => void
 ) {
+  if (!isLayoutShiftSupported()) {
+    return {
+      stop: noop,
+    }
+  }
+
   let maxClsValue = 0
+
+  // if no layout shift happen the value should be reported as 0
+  callback({
+    value: 0,
+  })
 
   const window = slidingSessionWindow()
   let clsAttributionCollected = false

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -57,8 +57,7 @@ describe('firstInputTimings', () => {
       createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT),
     ])
 
-    expect(fitCallback).toHaveBeenCalledTimes(1)
-    expect(fitCallback).toHaveBeenCalledWith({
+    expect(fitCallback).toHaveBeenCalledOnceWith({
       delay: 100 as Duration,
       time: 1000 as RelativeTime,
       targetSelector: undefined,
@@ -75,8 +74,7 @@ describe('firstInputTimings', () => {
       }),
     ])
 
-    expect(fitCallback).toHaveBeenCalledTimes(1)
-    expect(fitCallback).toHaveBeenCalledWith(
+    expect(fitCallback).toHaveBeenCalledOnceWith(
       jasmine.objectContaining({
         targetSelector: '#fid-target-element',
       })
@@ -93,7 +91,6 @@ describe('firstInputTimings', () => {
       }),
     ])
 
-    expect(fitCallback).toHaveBeenCalledTimes(1)
     expect(fitCallback).toHaveBeenCalledWith(
       jasmine.objectContaining({
         targetSelector: undefined,
@@ -123,8 +120,7 @@ describe('firstInputTimings', () => {
       }),
     ])
 
-    expect(fitCallback).toHaveBeenCalledTimes(1)
-    expect(fitCallback).toHaveBeenCalledWith(
+    expect(fitCallback).toHaveBeenCalledOnceWith(
       jasmine.objectContaining({
         delay: 0,
         time: 1000,

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -37,11 +37,13 @@ describe('trackInteractionToNextPaint', () => {
     interactionCountStub = subInteractionCount()
 
     setupBuilder = setup().beforeBuild(({ lifeCycle, configuration }) => {
-      ;({ getInteractionToNextPaint } = trackInteractionToNextPaint(
+      const interactionToNextPaintTracking = trackInteractionToNextPaint(
         configuration,
         ViewLoadingType.INITIAL_LOAD,
         lifeCycle
-      ))
+      )
+      getInteractionToNextPaint = interactionToNextPaintTracking.getInteractionToNextPaint
+      return interactionToNextPaintTracking
     })
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -6,7 +6,6 @@ import { createPerformanceEntry, setup } from '../../../../test'
 import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitPageActivityEnd'
 import { THROTTLE_VIEW_UPDATE_PERIOD } from '../trackViews'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
-import { LifeCycleEventType } from '../../lifeCycle'
 import { trackLoadingTime } from './trackLoadingTime'
 
 const BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY = (PAGE_ACTIVITY_VALIDATION_DELAY * 0.8) as Duration
@@ -59,22 +58,19 @@ describe('trackLoadingTime', () => {
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledTimes(1)
-    expect(loadingTimeCallback).toHaveBeenCalledWith(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
   })
 
   it('should use loadEventEnd for initial view when having no activity', () => {
     loadType = ViewLoadingType.INITIAL_LOAD
-    const { lifeCycle, clock } = setupBuilder.build()
+    const { clock } = setupBuilder.build()
 
     const entry = createPerformanceEntry(RumPerformanceEntryType.NAVIGATION)
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [entry])
 
     setLoadEvent(entry.loadEventEnd)
     clock.tick(PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledTimes(1)
-    expect(loadingTimeCallback).toHaveBeenCalledWith(entry.loadEventEnd)
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(entry.loadEventEnd)
   })
 
   it('should use loadEventEnd for initial view when load event is bigger than computed loading time', () => {
@@ -87,8 +83,7 @@ describe('trackLoadingTime', () => {
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledTimes(1)
-    expect(loadingTimeCallback).toHaveBeenCalledWith(LOAD_EVENT_AFTER_ACTIVITY_TIMING)
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(LOAD_EVENT_AFTER_ACTIVITY_TIMING)
   })
 
   it('should use computed loading time for initial view when load event is smaller than computed loading time', () => {
@@ -102,8 +97,7 @@ describe('trackLoadingTime', () => {
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledTimes(1)
-    expect(loadingTimeCallback).toHaveBeenCalledWith(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
   })
 
   it('should use computed loading time from time origin for initial view', () => {
@@ -125,7 +119,6 @@ describe('trackLoadingTime', () => {
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
-    expect(loadingTimeCallback).toHaveBeenCalledTimes(1)
-    expect(loadingTimeCallback).toHaveBeenCalledWith(addDuration(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY, CLOCK_GAP))
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(addDuration(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY, CLOCK_GAP))
   })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -1,5 +1,5 @@
 import type { RelativeTime, Duration } from '@datadog/browser-core'
-import { addDuration, clocksNow } from '@datadog/browser-core'
+import { addDuration, clocksOrigin } from '@datadog/browser-core'
 import { ViewLoadingType } from '../../../rawRumEvent.types'
 import type { TestSetupBuilder } from '../../../../test'
 import { createPerformanceEntry, setup } from '../../../../test'
@@ -32,7 +32,7 @@ describe('trackLoadingTime', () => {
           domMutationObservable,
           configuration,
           loadType,
-          clocksNow(),
+          clocksOrigin(),
           loadingTimeCallback
         )
         setLoadEvent = loadingTimeTracking.setLoadEvent
@@ -102,18 +102,19 @@ describe('trackLoadingTime', () => {
 
   it('should use computed loading time from time origin for initial view', () => {
     loadType = ViewLoadingType.INITIAL_LOAD
-    const { domMutationObservable, clock } = setupBuilder.build()
 
     // introduce a gap between time origin and tracking start
     // ensure that `load event > activity delay` and `load event < activity delay + clock gap`
     // to make the test fail if the clock gap is not correctly taken into account
     const CLOCK_GAP = (LOAD_EVENT_AFTER_ACTIVITY_TIMING - BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + 1) as Duration
 
-    clock.tick(CLOCK_GAP)
+    setupBuilder.clock!.tick(CLOCK_GAP)
+
+    const { domMutationObservable, clock } = setupBuilder.build()
 
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
 
-    setLoadEvent(LOAD_EVENT_AFTER_ACTIVITY_TIMING)
+    setLoadEvent(LOAD_EVENT_BEFORE_ACTIVITY_TIMING)
 
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -4,7 +4,6 @@ import { ViewLoadingType } from '../../../rawRumEvent.types'
 import type { TestSetupBuilder } from '../../../../test'
 import { createPerformanceEntry, setup } from '../../../../test'
 import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitPageActivityEnd'
-import { THROTTLE_VIEW_UPDATE_PERIOD } from '../trackViews'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import { trackLoadingTime } from './trackLoadingTime'
 
@@ -118,7 +117,6 @@ describe('trackLoadingTime', () => {
 
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
-    clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
     expect(loadingTimeCallback).toHaveBeenCalledOnceWith(addDuration(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY, CLOCK_GAP))
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
@@ -27,8 +27,7 @@ describe('trackNavigationTimings', () => {
       createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
     ])
 
-    expect(navigationTimingsCallback).toHaveBeenCalledTimes(1)
-    expect(navigationTimingsCallback).toHaveBeenCalledWith({
+    expect(navigationTimingsCallback).toHaveBeenCalledOnceWith({
       firstByte: 123 as Duration,
       domComplete: 456 as Duration,
       domContentLoaded: 345 as Duration,


### PR DESCRIPTION
## Motivation

Following the [view metrics splitting](https://github.com/DataDog/browser-sdk/pull/2386), this PR reorganize the view tracking tests so that every spec files tests its related module.

## Changes

- Cleanly stop INP tests
- Move CLS support check in trackCommonViewMetrics module
- Scope trackCumulativeLayoutShift tests
- Scope trackLoadingTime tests
- Scope trackViewEventCounts tests
- Reorganize trackViews tests

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
