### PR TITLE
✨ [RUM-1062] add a prefix to all console message displayed by the SDK

### DIFF
--- a/packages/core/src/tools/display.ts
+++ b/packages/core/src/tools/display.ts
@@ -43,9 +43,10 @@ export const display: Display = (api, ...args) => {
  * [2]: https://github.com/terser/terser#compress-options (look for drop_console)
  */
 export const globalConsole = console
+const PREFIX = 'Datadog Browser SDK:'
 
-display.debug = globalConsole.debug.bind(globalConsole)
-display.log = globalConsole.log.bind(globalConsole)
-display.info = globalConsole.info.bind(globalConsole)
-display.warn = globalConsole.warn.bind(globalConsole)
-display.error = globalConsole.error.bind(globalConsole)
+display.debug = globalConsole.debug.bind(globalConsole, PREFIX)
+display.log = globalConsole.log.bind(globalConsole, PREFIX)
+display.info = globalConsole.info.bind(globalConsole, PREFIX)
+display.warn = globalConsole.warn.bind(globalConsole, PREFIX)
+display.error = globalConsole.error.bind(globalConsole, PREFIX)

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -47,7 +47,7 @@ describe('startRecording', () => {
     textField = document.createElement('input')
     sandbox.appendChild(textField)
 
-    const worker = startDeflateWorker(configuration, 'Datadog Session Replay', noop)
+    const worker = startDeflateWorker(configuration, 'Session Replay', noop)
 
     setupBuilder = setup()
       .withViewContexts({

--- a/packages/rum/src/domain/deflate/deflateWorker.spec.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.spec.ts
@@ -17,7 +17,7 @@ describe('startDeflateWorker', () => {
 
   function startDeflateWorkerWithDefaults({
     configuration = {},
-    source = 'Datadog Session Replay',
+    source = 'Session Replay',
   }: {
     configuration?: Partial<RumConfiguration>
     source?: string
@@ -190,7 +190,7 @@ describe('startDeflateWorker', () => {
       startDeflateWorkerWithDefaults()
       clock.tick(INITIALIZATION_TIME_OUT_DELAY)
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Datadog Session Replay failed to start: a timeout occurred while initializing the Worker'
+        'Session Replay failed to start: a timeout occurred while initializing the Worker'
       )
     })
 
@@ -221,7 +221,7 @@ describe('startDeflateWorker', () => {
       createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
       startDeflateWorkerWithDefaults()
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Datadog Session Replay failed to start: an error occurred while creating the Worker:',
+        'Session Replay failed to start: an error occurred while creating the Worker:',
         UNKNOWN_ERROR
       )
     })

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -1,7 +1,21 @@
 import type { IntakeRegistry } from '../../lib/framework'
 import { flushEvents, createTest } from '../../lib/framework'
+import { withBrowserLogs } from '../../lib/helpers/browser'
 
 describe('API calls and events around init', () => {
+  createTest('should display a console log when calling init without configuration')
+    .withRum()
+    .withRumInit(() => {
+      ;(window.DD_RUM! as unknown as { init(): void }).init()
+    })
+    .run(async () => {
+      await withBrowserLogs((logs) => {
+        expect(logs.length).toBe(1)
+        expect(logs[0].message).toEqual(jasmine.stringContaining('Datadog Browser SDK'))
+        expect(logs[0].message).toEqual(jasmine.stringContaining('Missing configuration'))
+      })
+    })
+
   createTest('should be associated to corresponding views when views are automatically tracked')
     .withRum()
     .withRumSlim()


### PR DESCRIPTION
## Motivation

Mentioning that the message come from the Datadog Browser SDK could help users figure out what's wrong, especially when they are using multiple RUM SDKs at the same time.

See https://github.com/DataDog/browser-sdk/pull/2414#discussion_r1317323659


## Changes

Add a `Datadog Browser SDK:` prefix to all messages displayed by the SDK.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit -- no unit test as it's not easy to test: we would need to mock the console *before* binding its methods, but binding those methods during module evaluation is by design: we want to make sure we keep a reference to them before any instrumentation occurs.
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
