### PR TITLE
update reference implementation url in trackLargestContentfulPaint.ts

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
@@ -28,7 +28,7 @@ export interface LargestContentfulPaint {
  * Track the largest contentful paint (LCP) occurring during the initial View.  This can yield
  * multiple values, only the most recent one should be used.
  * Documentation: https://web.dev/lcp/
- * Reference implementation: https://github.com/GoogleChrome/web-vitals/blob/master/src/getLCP.ts
+ * Reference implementation: https://github.com/GoogleChrome/web-vitals/blob/master/src/onLCP.ts
  */
 export function trackLargestContentfulPaint(
   lifeCycle: LifeCycle,


### PR DESCRIPTION
Changed Reference implementation from src/getLCP.ts to src/onLCP.ts

## Motivation

corrects an incorrect link referencing the implementation 

## Changes

changes the lcp reference implementation from src/getLCP.ts to src/onLCP.ts