### PR TITLE
♻️ [RUM-1051] Harmonize DOM manipulation in tests

### DIFF
--- a/developer-extension/src/panel/sessionReplayPlayer/types.ts
+++ b/developer-extension/src/panel/sessionReplayPlayer/types.ts
@@ -97,14 +97,14 @@ export type MessageBridgeUp = {
 } & RawMessageBridgeUp
 
 /**
- * Message send by the sanboxing when iframe is ready
+ * Message sent by the sandboxing when iframe is ready
  */
 export type MessageBridgeUpReady = {
   type: MessageBridgeUpType.READY
 }
 
 /**
- * Message send by the sanboxing when a record has been applied
+ * `Message sent by the sandboxing when a record has been applied`
  */
 export type MessageBridgeUpRecordApplied = {
   type: MessageBridgeUpType.RECORD_APPLIED
@@ -115,7 +115,7 @@ export type MessageBridgeUpRecordApplied = {
 }
 
 /**
- * Message send by the sanboxing when a log is sent
+ * Message sent by the sandboxing when a log is sent
  */
 export type MessageBridgeUpLog = {
   type: MessageBridgeUpType.LOG
@@ -125,7 +125,7 @@ export type MessageBridgeUpLog = {
 }
 
 /**
- * Message send by the sanboxing iframe when there is an error
+ * Message sent by the sandboxing iframe when there is an error
  */
 export type MessageBridgeUpError = {
   type: MessageBridgeUpType.ERROR
@@ -134,7 +134,7 @@ export type MessageBridgeUpError = {
 }
 
 /**
- * Message send by the sanboxing iframe with a custom timing
+ * Message sent by the sandboxing iframe with a custom timing
  */
 export type MessageBridgeUpTiming = {
   type: MessageBridgeUpType.METRIC_TIMING
@@ -144,7 +144,7 @@ export type MessageBridgeUpTiming = {
 }
 
 /**
- * Message send by the sanboxing iframe with a custom count
+ * Message sent by the sandboxing iframe with a custom count
  */
 export type MessageBridgeUpIncrement = {
   type: MessageBridgeUpType.METRIC_INCREMENT

--- a/developer-extension/src/panel/sessionReplayPlayer/types.ts
+++ b/developer-extension/src/panel/sessionReplayPlayer/types.ts
@@ -97,14 +97,14 @@ export type MessageBridgeUp = {
 } & RawMessageBridgeUp
 
 /**
- * Message sent by the sandboxing when iframe is ready
+ * Message send by the sanboxing when iframe is ready
  */
 export type MessageBridgeUpReady = {
   type: MessageBridgeUpType.READY
 }
 
 /**
- * `Message sent by the sandboxing when a record has been applied`
+ * Message send by the sanboxing when a record has been applied
  */
 export type MessageBridgeUpRecordApplied = {
   type: MessageBridgeUpType.RECORD_APPLIED
@@ -115,7 +115,7 @@ export type MessageBridgeUpRecordApplied = {
 }
 
 /**
- * Message sent by the sandboxing when a log is sent
+ * Message send by the sanboxing when a log is sent
  */
 export type MessageBridgeUpLog = {
   type: MessageBridgeUpType.LOG
@@ -125,7 +125,7 @@ export type MessageBridgeUpLog = {
 }
 
 /**
- * Message sent by the sandboxing iframe when there is an error
+ * Message send by the sanboxing iframe when there is an error
  */
 export type MessageBridgeUpError = {
   type: MessageBridgeUpType.ERROR
@@ -134,7 +134,7 @@ export type MessageBridgeUpError = {
 }
 
 /**
- * Message sent by the sandboxing iframe with a custom timing
+ * Message send by the sanboxing iframe with a custom timing
  */
 export type MessageBridgeUpTiming = {
   type: MessageBridgeUpType.METRIC_TIMING
@@ -144,7 +144,7 @@ export type MessageBridgeUpTiming = {
 }
 
 /**
- * Message sent by the sandboxing iframe with a custom count
+ * Message send by the sanboxing iframe with a custom count
  */
 export type MessageBridgeUpIncrement = {
   type: MessageBridgeUpType.METRIC_INCREMENT

--- a/packages/rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/action/computeFrustration.spec.ts
@@ -160,7 +160,7 @@ describe('isDead', () => {
         isDead(
           createFakeClick({
             hasPageActivity: false,
-            event: { target: append(element) },
+            event: { target: append<Element>(element) },
           })
         )
       ).toBe(expected)

--- a/packages/rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/action/computeFrustration.spec.ts
@@ -2,8 +2,8 @@ import { ONE_SECOND } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
 import { FrustrationType } from '../../rawRumEvent.types'
-import type { FakeClick, IsolatedDom } from '../../../test'
-import { createFakeClick, createIsolatedDom } from '../../../test'
+import type { FakeClick } from '../../../test'
+import { append, createFakeClick } from '../../../test'
 import { computeFrustration, isRage, isDead } from './computeFrustration'
 
 describe('computeFrustration', () => {
@@ -131,16 +131,6 @@ describe('isRage', () => {
 })
 
 describe('isDead', () => {
-  let isolatedDom: IsolatedDom
-
-  beforeEach(() => {
-    isolatedDom = createIsolatedDom()
-  })
-
-  afterEach(() => {
-    isolatedDom.clear()
-  })
-
   it('considers as dead when the click has no page activity', () => {
     expect(isDead(createFakeClick({ hasPageActivity: false }))).toBe(true)
   })
@@ -170,7 +160,7 @@ describe('isDead', () => {
         isDead(
           createFakeClick({
             hasPageActivity: false,
-            event: { target: isolatedDom.append(element) },
+            event: { target: append(element) },
           })
         )
       ).toBe(expected)

--- a/packages/rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/action/computeFrustration.spec.ts
@@ -3,7 +3,7 @@ import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
 import { FrustrationType } from '../../rawRumEvent.types'
 import type { FakeClick } from '../../../test'
-import { append, createFakeClick } from '../../../test'
+import { appendElement, createFakeClick } from '../../../test'
 import { computeFrustration, isRage, isDead } from './computeFrustration'
 
 describe('computeFrustration', () => {
@@ -160,7 +160,7 @@ describe('isDead', () => {
         isDead(
           createFakeClick({
             hasPageActivity: false,
-            event: { target: append<Element>(element) },
+            event: { target: appendElement(element) },
           })
         )
       ).toBe(expected)

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -1,85 +1,79 @@
-import type { IsolatedDom } from '../../../test'
-import { createIsolatedDom } from '../../../test'
+import { append } from '../../../test'
 import { getActionNameFromElement } from './getActionNameFromElement'
 
 describe('getActionNameFromElement', () => {
-  let isolatedDom: IsolatedDom
-
-  beforeEach(() => {
-    isolatedDom = createIsolatedDom()
-  })
-
-  afterEach(() => {
-    isolatedDom.clear()
-  })
-
   it('extracts the textual content of an element', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<div>Foo <div>bar</div></div>`)).toBe('Foo bar')
+    expect(getActionNameFromElement(append('<div>Foo <div>bar</div></div>'))).toBe('Foo bar')
   })
 
   it('extracts the text of an input button', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<input type="button" value="Click" />`)).toBe('Click')
+    expect(getActionNameFromElement(append('<input type="button" value="Click" />'))).toBe('Click')
   })
 
   it('extracts the alt text of an image', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<img title="foo" alt="bar" />`)).toBe('bar')
+    expect(getActionNameFromElement(append('<img title="foo" alt="bar" />'))).toBe('bar')
   })
 
   it('extracts the title text of an image', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<img title="foo" />`)).toBe('foo')
+    expect(getActionNameFromElement(append('<img title="foo" />'))).toBe('foo')
   })
 
   it('extracts the text of an aria-label attribute', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<span aria-label="Foo" />`)).toBe('Foo')
+    expect(getActionNameFromElement(append('<span aria-label="Foo" />'))).toBe('Foo')
   })
 
   it('gets the parent element textual content if everything else fails', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<div>Foo <img target /></div>`)).toBe('Foo')
+    expect(getActionNameFromElement(append('<div>Foo <img target /></div>'))).toBe('Foo')
   })
 
   it("doesn't get the value of a text input", () => {
-    expect(getActionNameFromElement(isolatedDom.element`<input type="text" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(append('<input type="text" value="foo" />'))).toBe('')
   })
 
   it("doesn't get the value of a password input", () => {
-    expect(getActionNameFromElement(isolatedDom.element`<input type="password" value="foo" />`)).toBe('')
+    expect(getActionNameFromElement(append('<input type="password" value="foo" />'))).toBe('')
   })
 
   it('limits the name length to a reasonable size', () => {
     expect(
       getActionNameFromElement(
-        isolatedDom.element`<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>`
+        append(
+          '<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>'
+        )
       )
     ).toBe('Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]')
   })
 
   it('normalize white spaces', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<div>foo\tbar\n\n  baz</div>`)).toBe('foo bar baz')
+    expect(getActionNameFromElement(append('<div>foo\tbar\n\n  baz</div>'))).toBe('foo bar baz')
   })
 
   it('ignores the inline script textual content', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<div><script>console.log('toto')</script>b</div>`)).toBe('b')
+    expect(getActionNameFromElement(append("<div><script>console.log('toto')</script>b</div>"))).toBe('b')
   })
 
   it('extracts text from SVG elements', () => {
-    expect(getActionNameFromElement(isolatedDom.element`<svg><text>foo  bar</text></svg>`)).toBe('foo bar')
+    expect(getActionNameFromElement(append('<svg><text>foo  bar</text></svg>'))).toBe('foo bar')
   })
 
   it('extracts text from an associated label', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <label for="toto">label text</label>
           <div>ignored</div>
           <input id="toto" target />
         </div>
       `)
+      )
     ).toBe('label text')
   })
 
   it('extracts text from a parent label', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <label>
           foo
           <div>
@@ -88,35 +82,41 @@ describe('getActionNameFromElement', () => {
           </div>
         </label>
       `)
+      )
     ).toBe('foo bar')
   })
 
   it('extracts text from the first OPTION element when clicking on a SELECT', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <select>
           <option>foo</option>
           <option>bar</option>
         </select>
       `)
+      )
     ).toBe('foo')
   })
 
   it('extracts text from a aria-labelledby associated element', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <label id="toto">label text</label>
           <div>ignored</div>
           <input aria-labelledby="toto" target />
         </div>
       `)
+      )
     ).toBe('label text')
   })
 
   it('extracts text from multiple aria-labelledby associated elements', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <label id="toto1">label</label>
           <div>ignored</div>
@@ -125,34 +125,40 @@ describe('getActionNameFromElement', () => {
           <label id="toto2">text</label>
         </div>
       `)
+      )
     ).toBe('label text')
   })
 
   it('extracts text from a BUTTON element', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <div>ignored</div>
           <button target>foo</button>
         </div>
       `)
+      )
     ).toBe('foo')
   })
 
   it('extracts text from a role=button element', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <div>ignored</div>
           <div role="button" target>foo</div>
         </div>
       `)
+      )
     ).toBe('foo')
   })
 
   it('limits the recursion to the 10th parent', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <div>ignored</div>
           <i><i><i><i><i><i><i><i><i><i>
@@ -160,21 +166,25 @@ describe('getActionNameFromElement', () => {
           </i></i></i></i></i></i></i></i></i></i>
         </div>
       `)
+      )
     ).toBe('')
   })
 
   it('limits the recursion to the BODY element', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>ignored</div>
         <i target></i>
       `)
+      )
     ).toBe('')
   })
 
   it('limits the recursion to a FORM element', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <div>ignored</div>
           <form>
@@ -182,12 +192,14 @@ describe('getActionNameFromElement', () => {
           </form>
         </div>
       `)
+      )
     ).toBe('')
   })
 
   it('extracts the name from a parent FORM element', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div>
           <div>ignored</div>
           <form title="foo">
@@ -195,89 +207,102 @@ describe('getActionNameFromElement', () => {
           </form>
         </div>
       `)
+      )
     ).toBe('foo')
   })
 
   it('extracts the whole textual content of a button', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <button>
           foo
           <i target>bar</i>
         </button>
       `)
+      )
     ).toBe('foo bar')
   })
 
   it('ignores the textual content of contenteditable elements', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div contenteditable>
           <i target>ignored</i>
           ignored
         </div>
       `)
+      )
     ).toBe('')
   })
 
   it('extracts the name from attributes of contenteditable elements', () => {
     expect(
-      getActionNameFromElement(isolatedDom.element`
+      getActionNameFromElement(
+        append(`
         <div contenteditable>
           <i aria-label="foo" target>ignored</i>
           ignored
         </div>
       `)
+      )
     ).toBe('foo')
   })
 
   describe('programmatically declared action name', () => {
     it('extracts the name from the data-dd-action-name attribute', () => {
       expect(
-        getActionNameFromElement(isolatedDom.element`
+        getActionNameFromElement(
+          append(`
           <div data-dd-action-name="foo">ignored</div>
         `)
+        )
       ).toBe('foo')
     })
 
     it('considers any parent', () => {
-      const target = isolatedDom.element`
+      const target = append(`
         <form>
           <i><i><i><i><i><i><i><i><i><i><i><i>
             <span target>ignored</span>
           </i></i></i></i></i></i></i></i></i></i></i></i>
         </form>
-      `
+      `)
       target.closest('form')!.setAttribute('data-dd-action-name', 'foo')
       expect(getActionNameFromElement(target)).toBe('foo')
     })
 
     it('normalizes the value', () => {
       expect(
-        getActionNameFromElement(isolatedDom.element`
+        getActionNameFromElement(
+          append(`
           <div data-dd-action-name="   foo  \t bar  ">ignored</div>
         `)
+        )
       ).toBe('foo bar')
     })
 
     it('fallback on an automatic strategy if the attribute is empty', () => {
       expect(
-        getActionNameFromElement(isolatedDom.element`
+        getActionNameFromElement(
+          append(`
           <div data-dd-action-name="ignored">
             <div data-dd-action-name="">
               <span target>foo</span>
             </div>
           </div>
       `)
+        )
       ).toBe('foo')
     })
 
     it('extracts the name from a user-configured attribute', () => {
       expect(
         getActionNameFromElement(
-          isolatedDom.element`
+          append(`
           <div data-test-id="foo">ignored</div>
-        `,
+        `),
           'data-test-id'
         )
       ).toBe('foo')
@@ -286,26 +311,23 @@ describe('getActionNameFromElement', () => {
     it('favors data-dd-action-name over user-configured attribute', () => {
       expect(
         getActionNameFromElement(
-          isolatedDom.element`
+          append(`
           <div data-test-id="foo" data-dd-action-name="bar">ignored</div>
-        `,
+        `),
           'data-test-id'
         )
       ).toBe('bar')
     })
 
     it('remove children with programmatic action name in textual content', () => {
-      expect(
-        getActionNameFromElement(isolatedDom.element`<div>Foo <div data-dd-action-name="custom action">bar<div></div>`)
-      ).toBe('Foo')
+      expect(getActionNameFromElement(append('<div>Foo <div data-dd-action-name="custom action">bar<div></div>'))).toBe(
+        'Foo'
+      )
     })
 
     it('remove children with programmatic action name in textual content based on the user-configured attribute', () => {
       expect(
-        getActionNameFromElement(
-          isolatedDom.element`<div>Foo <div data-test-id="custom action">bar<div></div>`,
-          'data-test-id'
-        )
+        getActionNameFromElement(append('<div>Foo <div data-test-id="custom action">bar<div></div>'), 'data-test-id')
       ).toBe('Foo')
     })
   })

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -263,13 +263,12 @@ describe('getActionNameFromElement', () => {
 
     it('considers any parent', () => {
       const target = append(`
-        <form>
+        <form data-dd-action-name="foo">
           <i><i><i><i><i><i><i><i><i><i><i><i>
             <span target>ignored</span>
           </i></i></i></i></i></i></i></i></i></i></i></i>
         </form>
       `)
-      target.closest('form')!.setAttribute('data-dd-action-name', 'foo')
       expect(getActionNameFromElement(target)).toBe('foo')
     })
 

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -1,43 +1,43 @@
-import { append } from '../../../test'
+import { appendElement } from '../../../test'
 import { getActionNameFromElement } from './getActionNameFromElement'
 
 describe('getActionNameFromElement', () => {
   it('extracts the textual content of an element', () => {
-    expect(getActionNameFromElement(append('<div>Foo <div>bar</div></div>'))).toBe('Foo bar')
+    expect(getActionNameFromElement(appendElement('<div>Foo <div>bar</div></div>'))).toBe('Foo bar')
   })
 
   it('extracts the text of an input button', () => {
-    expect(getActionNameFromElement(append('<input type="button" value="Click" />'))).toBe('Click')
+    expect(getActionNameFromElement(appendElement('<input type="button" value="Click" />'))).toBe('Click')
   })
 
   it('extracts the alt text of an image', () => {
-    expect(getActionNameFromElement(append('<img title="foo" alt="bar" />'))).toBe('bar')
+    expect(getActionNameFromElement(appendElement('<img title="foo" alt="bar" />'))).toBe('bar')
   })
 
   it('extracts the title text of an image', () => {
-    expect(getActionNameFromElement(append('<img title="foo" />'))).toBe('foo')
+    expect(getActionNameFromElement(appendElement('<img title="foo" />'))).toBe('foo')
   })
 
   it('extracts the text of an aria-label attribute', () => {
-    expect(getActionNameFromElement(append('<span aria-label="Foo" />'))).toBe('Foo')
+    expect(getActionNameFromElement(appendElement('<span aria-label="Foo" />'))).toBe('Foo')
   })
 
   it('gets the parent element textual content if everything else fails', () => {
-    expect(getActionNameFromElement(append('<div>Foo <img target /></div>'))).toBe('Foo')
+    expect(getActionNameFromElement(appendElement('<div>Foo <img target /></div>'))).toBe('Foo')
   })
 
   it("doesn't get the value of a text input", () => {
-    expect(getActionNameFromElement(append('<input type="text" value="foo" />'))).toBe('')
+    expect(getActionNameFromElement(appendElement('<input type="text" value="foo" />'))).toBe('')
   })
 
   it("doesn't get the value of a password input", () => {
-    expect(getActionNameFromElement(append('<input type="password" value="foo" />'))).toBe('')
+    expect(getActionNameFromElement(appendElement('<input type="password" value="foo" />'))).toBe('')
   })
 
   it('limits the name length to a reasonable size', () => {
     expect(
       getActionNameFromElement(
-        append(
+        appendElement(
           '<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>'
         )
       )
@@ -45,21 +45,21 @@ describe('getActionNameFromElement', () => {
   })
 
   it('normalize white spaces', () => {
-    expect(getActionNameFromElement(append('<div>foo\tbar\n\n  baz</div>'))).toBe('foo bar baz')
+    expect(getActionNameFromElement(appendElement('<div>foo\tbar\n\n  baz</div>'))).toBe('foo bar baz')
   })
 
   it('ignores the inline script textual content', () => {
-    expect(getActionNameFromElement(append("<div><script>console.log('toto')</script>b</div>"))).toBe('b')
+    expect(getActionNameFromElement(appendElement("<div><script>console.log('toto')</script>b</div>"))).toBe('b')
   })
 
   it('extracts text from SVG elements', () => {
-    expect(getActionNameFromElement(append('<svg><text>foo  bar</text></svg>'))).toBe('foo bar')
+    expect(getActionNameFromElement(appendElement('<svg><text>foo  bar</text></svg>'))).toBe('foo bar')
   })
 
   it('extracts text from an associated label', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <label for="toto">label text</label>
           <div>ignored</div>
@@ -73,7 +73,7 @@ describe('getActionNameFromElement', () => {
   it('extracts text from a parent label', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <label>
           foo
           <div>
@@ -89,7 +89,7 @@ describe('getActionNameFromElement', () => {
   it('extracts text from the first OPTION element when clicking on a SELECT', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <select>
           <option>foo</option>
           <option>bar</option>
@@ -102,7 +102,7 @@ describe('getActionNameFromElement', () => {
   it('extracts text from a aria-labelledby associated element', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <label id="toto">label text</label>
           <div>ignored</div>
@@ -116,7 +116,7 @@ describe('getActionNameFromElement', () => {
   it('extracts text from multiple aria-labelledby associated elements', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <label id="toto1">label</label>
           <div>ignored</div>
@@ -132,7 +132,7 @@ describe('getActionNameFromElement', () => {
   it('extracts text from a BUTTON element', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <div>ignored</div>
           <button target>foo</button>
@@ -145,7 +145,7 @@ describe('getActionNameFromElement', () => {
   it('extracts text from a role=button element', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <div>ignored</div>
           <div role="button" target>foo</div>
@@ -158,7 +158,7 @@ describe('getActionNameFromElement', () => {
   it('limits the recursion to the 10th parent', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <div>ignored</div>
           <i><i><i><i><i><i><i><i><i><i>
@@ -173,7 +173,7 @@ describe('getActionNameFromElement', () => {
   it('limits the recursion to the BODY element', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>ignored</div>
         <i target></i>
       `)
@@ -184,7 +184,7 @@ describe('getActionNameFromElement', () => {
   it('limits the recursion to a FORM element', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <div>ignored</div>
           <form>
@@ -199,7 +199,7 @@ describe('getActionNameFromElement', () => {
   it('extracts the name from a parent FORM element', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div>
           <div>ignored</div>
           <form title="foo">
@@ -214,7 +214,7 @@ describe('getActionNameFromElement', () => {
   it('extracts the whole textual content of a button', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <button>
           foo
           <i target>bar</i>
@@ -227,7 +227,7 @@ describe('getActionNameFromElement', () => {
   it('ignores the textual content of contenteditable elements', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div contenteditable>
           <i target>ignored</i>
           ignored
@@ -240,7 +240,7 @@ describe('getActionNameFromElement', () => {
   it('extracts the name from attributes of contenteditable elements', () => {
     expect(
       getActionNameFromElement(
-        append(`
+        appendElement(`
         <div contenteditable>
           <i aria-label="foo" target>ignored</i>
           ignored
@@ -254,7 +254,7 @@ describe('getActionNameFromElement', () => {
     it('extracts the name from the data-dd-action-name attribute', () => {
       expect(
         getActionNameFromElement(
-          append(`
+          appendElement(`
           <div data-dd-action-name="foo">ignored</div>
         `)
         )
@@ -262,7 +262,7 @@ describe('getActionNameFromElement', () => {
     })
 
     it('considers any parent', () => {
-      const target = append(`
+      const target = appendElement(`
         <form data-dd-action-name="foo">
           <i><i><i><i><i><i><i><i><i><i><i><i>
             <span target>ignored</span>
@@ -275,7 +275,7 @@ describe('getActionNameFromElement', () => {
     it('normalizes the value', () => {
       expect(
         getActionNameFromElement(
-          append(`
+          appendElement(`
           <div data-dd-action-name="   foo  \t bar  ">ignored</div>
         `)
         )
@@ -285,7 +285,7 @@ describe('getActionNameFromElement', () => {
     it('fallback on an automatic strategy if the attribute is empty', () => {
       expect(
         getActionNameFromElement(
-          append(`
+          appendElement(`
           <div data-dd-action-name="ignored">
             <div data-dd-action-name="">
               <span target>foo</span>
@@ -299,7 +299,7 @@ describe('getActionNameFromElement', () => {
     it('extracts the name from a user-configured attribute', () => {
       expect(
         getActionNameFromElement(
-          append(`
+          appendElement(`
           <div data-test-id="foo">ignored</div>
         `),
           'data-test-id'
@@ -310,7 +310,7 @@ describe('getActionNameFromElement', () => {
     it('favors data-dd-action-name over user-configured attribute', () => {
       expect(
         getActionNameFromElement(
-          append(`
+          appendElement(`
           <div data-test-id="foo" data-dd-action-name="bar">ignored</div>
         `),
           'data-test-id'
@@ -319,14 +319,17 @@ describe('getActionNameFromElement', () => {
     })
 
     it('remove children with programmatic action name in textual content', () => {
-      expect(getActionNameFromElement(append('<div>Foo <div data-dd-action-name="custom action">bar<div></div>'))).toBe(
-        'Foo'
-      )
+      expect(
+        getActionNameFromElement(appendElement('<div>Foo <div data-dd-action-name="custom action">bar<div></div>'))
+      ).toBe('Foo')
     })
 
     it('remove children with programmatic action name in textual content based on the user-configured attribute', () => {
       expect(
-        getActionNameFromElement(append('<div>Foo <div data-test-id="custom action">bar<div></div>'), 'data-test-id')
+        getActionNameFromElement(
+          appendElement('<div>Foo <div data-test-id="custom action">bar<div></div>'),
+          'data-test-id'
+        )
       ).toBe('Foo')
     })
   })

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -248,8 +248,7 @@ describe('getActionNameFromElement', () => {
           </i></i></i></i></i></i></i></i></i></i></i></i>
         </form>
       `
-      // Set the attribute on the <HTML> element
-      target.ownerDocument.documentElement.setAttribute('data-dd-action-name', 'foo')
+      target.closest('form')!.setAttribute('data-dd-action-name', 'foo')
       expect(getActionNameFromElement(target)).toBe('foo')
     })
 

--- a/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
@@ -1,4 +1,4 @@
-import { append } from '../../test'
+import { appendElement } from '../../test'
 import { getSelectorFromElement, supportScopeSelector } from './getSelectorFromElement'
 
 describe('getSelectorFromElement', () => {
@@ -35,7 +35,7 @@ describe('getSelectorFromElement', () => {
     })
 
     it('should not use the class selector for body elements', () => {
-      const element = append('<div></div>')
+      const element = appendElement('<div></div>')
       document.body.classList.add('foo')
       expect(getSelector(element)).toBe('BODY>DIV')
     })
@@ -159,7 +159,7 @@ describe('getSelectorFromElement', () => {
 
   function getSelector(htmlOrElement: string | Element, actionNameAttribute?: string): string {
     return getSelectorFromElement(
-      typeof htmlOrElement === 'string' ? append(htmlOrElement) : htmlOrElement,
+      typeof htmlOrElement === 'string' ? appendElement(htmlOrElement) : htmlOrElement,
       actionNameAttribute
     )
   }

--- a/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
@@ -11,6 +11,7 @@ describe('getSelectorFromElement', () => {
 
   afterEach(() => {
     isolatedDom.clear()
+    document.body.classList.remove('foo')
   })
 
   describe('ID selector', () => {
@@ -43,7 +44,7 @@ describe('getSelectorFromElement', () => {
 
     it('should not use the class selector for body elements', () => {
       const element = isolatedDom.append('<div></div>')
-      element.ownerDocument.body.classList.add('foo')
+      document.body.classList.add('foo')
       expect(getSelector(element)).toBe('BODY>DIV')
     })
 

--- a/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
@@ -1,16 +1,8 @@
-import type { IsolatedDom } from '../../test'
-import { createIsolatedDom } from '../../test'
+import { append } from '../../test'
 import { getSelectorFromElement, supportScopeSelector } from './getSelectorFromElement'
 
 describe('getSelectorFromElement', () => {
-  let isolatedDom: IsolatedDom
-
-  beforeEach(() => {
-    isolatedDom = createIsolatedDom()
-  })
-
   afterEach(() => {
-    isolatedDom.clear()
     document.body.classList.remove('foo')
   })
 
@@ -43,7 +35,7 @@ describe('getSelectorFromElement', () => {
     })
 
     it('should not use the class selector for body elements', () => {
-      const element = isolatedDom.append('<div></div>')
+      const element = append('<div></div>')
       document.body.classList.add('foo')
       expect(getSelector(element)).toBe('BODY>DIV')
     })
@@ -167,7 +159,7 @@ describe('getSelectorFromElement', () => {
 
   function getSelector(htmlOrElement: string | Element, actionNameAttribute?: string): string {
     return getSelectorFromElement(
-      typeof htmlOrElement === 'string' ? isolatedDom.append(htmlOrElement) : htmlOrElement,
+      typeof htmlOrElement === 'string' ? append(htmlOrElement) : htmlOrElement,
       actionNameAttribute
     )
   }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -1,6 +1,6 @@
 import { ExperimentalFeature, addExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
-import { appendElement, appendTextNode, createPerformanceEntry, setup } from '../../../../test'
+import { append, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import { THROTTLE_VIEW_UPDATE_PERIOD } from '../trackViews'
 import type { ViewTest } from '../setupViewTest.specHelper'
@@ -183,8 +183,8 @@ describe('trackCumulativeLayoutShift', () => {
       const { lifeCycle } = setupBuilder.build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
 
-      const textNode = appendTextNode('')
-      const divElement = appendElement('div', { id: 'div-element' })
+      const textNode = append('text')
+      const divElement = append('<div id="div-element"></div>')
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
         createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, {
@@ -200,7 +200,7 @@ describe('trackCumulativeLayoutShift', () => {
       const { lifeCycle } = setupBuilder.build()
       const { getViewUpdate, getViewUpdateCount } = viewTest
 
-      const divElement = appendElement('div', { id: 'div-element' })
+      const divElement = append('<div id="div-element"></div>')
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
         createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -1,6 +1,6 @@
 import { ExperimentalFeature, addExperimentalFeatures, noop, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
-import { append, createPerformanceEntry, setup } from '../../../../test'
+import { appendElement, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { CumulativeLayoutShift } from './trackCumulativeLayoutShift'
@@ -170,8 +170,8 @@ describe('trackCumulativeLayoutShift', () => {
       addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
       const { lifeCycle } = setupBuilder.build()
 
-      const textNode = append('text')
-      const divElement = append('<div id="div-element"></div>')
+      const textNode = appendElement('text')
+      const divElement = appendElement('<div id="div-element"></div>')
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
         createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, {
@@ -186,7 +186,7 @@ describe('trackCumulativeLayoutShift', () => {
     it('should not return the target element selector when FF disabled', () => {
       const { lifeCycle } = setupBuilder.build()
 
-      const divElement = append('<div id="div-element"></div>')
+      const divElement = appendElement('<div id="div-element"></div>')
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
         createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -1,6 +1,6 @@
 import { ExperimentalFeature, addExperimentalFeatures, noop, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
-import { appendElement, createPerformanceEntry, setup } from '../../../../test'
+import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { CumulativeLayoutShift } from './trackCumulativeLayoutShift'
@@ -170,7 +170,7 @@ describe('trackCumulativeLayoutShift', () => {
       addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
       const { lifeCycle } = setupBuilder.build()
 
-      const textNode = appendElement('text')
+      const textNode = appendText('text')
       const divElement = appendElement('<div id="div-element"></div>')
 
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@datadog/browser-core'
 import { restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../../../test'
-import { appendElement, appendTextNode, createPerformanceEntry, setup } from '../../../../test'
+import { append, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
@@ -71,7 +71,7 @@ describe('firstInputTimings', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT, {
-        target: appendElement('button', { id: 'fid-target-element' }),
+        target: append('<button id="fid-target-element"></button>'),
       }),
     ])
 
@@ -89,7 +89,7 @@ describe('firstInputTimings', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT, {
-        target: appendTextNode(''),
+        target: append('text'),
       }),
     ])
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@datadog/browser-core'
 import { restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../../../test'
-import { appendElement, createPerformanceEntry, setup } from '../../../../test'
+import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
@@ -87,7 +87,7 @@ describe('firstInputTimings', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT, {
-        target: appendElement('text'),
+        target: appendText('text'),
       }),
     ])
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@datadog/browser-core'
 import { restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../../../test'
-import { append, createPerformanceEntry, setup } from '../../../../test'
+import { appendElement, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
@@ -70,7 +70,7 @@ describe('firstInputTimings', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT, {
-        target: append('<button id="fid-target-element"></button>'),
+        target: appendElement('<button id="fid-target-element"></button>'),
       }),
     ])
 
@@ -87,7 +87,7 @@ describe('firstInputTimings', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.FIRST_INPUT, {
-        target: append('text'),
+        target: appendElement('text'),
       }),
     ])
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -1,7 +1,7 @@
 import type { Duration } from '@datadog/browser-core'
 import { ExperimentalFeature, addExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
-import { appendElement, createPerformanceEntry, setup } from '../../../../test'
+import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type {
   BrowserWindow,
@@ -140,7 +140,7 @@ describe('trackInteractionToNextPaint', () => {
 
       newInteraction(lifeCycle, {
         interactionId: 2,
-        target: appendElement('text'),
+        target: appendText('text'),
       })
 
       expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -1,7 +1,7 @@
 import type { Duration } from '@datadog/browser-core'
 import { ExperimentalFeature, addExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
-import { append, createPerformanceEntry, setup } from '../../../../test'
+import { appendElement, createPerformanceEntry, setup } from '../../../../test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type {
   BrowserWindow,
@@ -128,7 +128,7 @@ describe('trackInteractionToNextPaint', () => {
 
       newInteraction(lifeCycle, {
         interactionId: 2,
-        target: append('<button id="inp-target-element"></button>'),
+        target: appendElement('<button id="inp-target-element"></button>'),
       })
 
       expect(getInteractionToNextPaint()?.targetSelector).toEqual('#inp-target-element')
@@ -140,7 +140,7 @@ describe('trackInteractionToNextPaint', () => {
 
       newInteraction(lifeCycle, {
         interactionId: 2,
-        target: append('text'),
+        target: appendElement('text'),
       })
 
       expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)
@@ -151,7 +151,7 @@ describe('trackInteractionToNextPaint', () => {
 
       newInteraction(lifeCycle, {
         interactionId: 2,
-        target: append('<button id="inp-target-element"></button>'),
+        target: appendElement('<button id="inp-target-element"></button>'),
       })
 
       expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -1,7 +1,7 @@
 import type { Duration } from '@datadog/browser-core'
 import { ExperimentalFeature, addExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
-import { appendElement, appendTextNode, createPerformanceEntry, setup } from '../../../../test'
+import { append, createPerformanceEntry, setup } from '../../../../test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type {
   BrowserWindow,
@@ -126,7 +126,7 @@ describe('trackInteractionToNextPaint', () => {
 
       newInteraction(lifeCycle, {
         interactionId: 2,
-        target: appendElement('button', { id: 'inp-target-element' }),
+        target: append('<button id="inp-target-element"></button>'),
       })
 
       expect(getInteractionToNextPaint()?.targetSelector).toEqual('#inp-target-element')
@@ -138,7 +138,7 @@ describe('trackInteractionToNextPaint', () => {
 
       newInteraction(lifeCycle, {
         interactionId: 2,
-        target: appendTextNode(''),
+        target: append('text'),
       })
 
       expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)
@@ -149,7 +149,7 @@ describe('trackInteractionToNextPaint', () => {
 
       newInteraction(lifeCycle, {
         interactionId: 2,
-        target: appendElement('button', { id: 'inp-target-element' }),
+        target: append('<button id="inp-target-element"></button>'),
       })
 
       expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -9,7 +9,7 @@ import {
 import { restorePageVisibility, setPageVisibility, createNewEvent } from '@datadog/browser-core/test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { TestSetupBuilder } from '../../../../test'
-import { appendElement, createPerformanceEntry, setup } from '../../../../test'
+import { append, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
 import type { LargestContentfulPaint } from './trackLargestContentfulPaint'
@@ -68,7 +68,7 @@ describe('trackLargestContentfulPaint', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
-        element: appendElement('button', { id: 'lcp-target-element' }),
+        element: append('<button id="lcp-target-element"></button>'),
       }),
     ])
 
@@ -81,7 +81,7 @@ describe('trackLargestContentfulPaint', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
-        element: appendElement('button', { id: 'lcp-target-element' }),
+        element: append('<button id="lcp-target-element"></button>'),
       }),
     ])
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -9,7 +9,7 @@ import {
 import { restorePageVisibility, setPageVisibility, createNewEvent } from '@datadog/browser-core/test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { TestSetupBuilder } from '../../../../test'
-import { append, createPerformanceEntry, setup } from '../../../../test'
+import { appendElement, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
 import type { LargestContentfulPaint } from './trackLargestContentfulPaint'
@@ -68,7 +68,7 @@ describe('trackLargestContentfulPaint', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
-        element: append<Element>('<button id="lcp-target-element"></button>'),
+        element: appendElement('<button id="lcp-target-element"></button>'),
       }),
     ])
 
@@ -81,7 +81,7 @@ describe('trackLargestContentfulPaint', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
-        element: append<Element>('<button id="lcp-target-element"></button>'),
+        element: appendElement('<button id="lcp-target-element"></button>'),
       }),
     ])
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -68,7 +68,7 @@ describe('trackLargestContentfulPaint', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
-        element: append('<button id="lcp-target-element"></button>'),
+        element: append<Element>('<button id="lcp-target-element"></button>'),
       }),
     ])
 
@@ -81,7 +81,7 @@ describe('trackLargestContentfulPaint', () => {
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
-        element: append('<button id="lcp-target-element"></button>'),
+        element: append<Element>('<button id="lcp-target-element"></button>'),
       }),
     ])
 

--- a/packages/rum-core/test/dom.ts
+++ b/packages/rum-core/test/dom.ts
@@ -1,34 +1,17 @@
 import { registerCleanupTask } from '@datadog/browser-core/test'
 
-export type IsolatedDom = ReturnType<typeof createIsolatedDom>
+export function append<E extends Element>(html: string, container = document.body): E {
+  const tmp = document.createElement('div')
+  tmp.innerHTML = html.trim()
 
-export function createIsolatedDom() {
-  function append<E extends Element>(html: string, container: HTMLElement): E {
-    const tmp = document.createElement('div')
-    tmp.innerHTML = html.trim()
+  const target = tmp.querySelector('[target]') || tmp.childNodes[0]
+  const nodes = Array.from(tmp.childNodes)
 
-    const target = tmp.querySelector('[target]') || tmp.childNodes[0]
-    const nodes = Array.from(tmp.childNodes)
+  nodes.forEach((node) => container.appendChild(node))
 
-    nodes.forEach((node) => container.appendChild(node))
+  registerCleanupTask(() => {
+    nodes.forEach((node) => node.remove())
+  })
 
-    registerCleanupTask(() => {
-      nodes.forEach((node) => node.remove())
-    })
-
-    return target as E
-  }
-
-  return {
-    element(s: TemplateStringsArray) {
-      return append(s[0], document.body)
-    },
-    append: <E extends Element>(html: string): E => append(html, document.body),
-    appendToHead: <E extends Element>(html: string): E => append<E>(html, document.head),
-    clear() {},
-  }
-}
-
-export function append(html: string) {
-  return createIsolatedDom().append(html)
+  return target as E
 }

--- a/packages/rum-core/test/dom.ts
+++ b/packages/rum-core/test/dom.ts
@@ -29,24 +29,6 @@ export function createIsolatedDom() {
   }
 }
 
-export function appendElement(tagName: string, attributes: { [key: string]: string }) {
-  const element = document.createElement(tagName)
-
-  for (const key in attributes) {
-    if (Object.prototype.hasOwnProperty.call(attributes, key)) {
-      element.setAttribute(key, attributes[key])
-    }
-  }
-
-  return append(element)
-}
-
-export function appendTextNode(text: string) {
-  return append(document.createTextNode(text))
-}
-
-function append<T extends Node = Node>(node: T): T {
-  document.body.appendChild(node)
-  registerCleanupTask(() => node.parentNode!.removeChild(node))
-  return node
+export function append(html: string) {
+  return createIsolatedDom().append(html)
 }

--- a/packages/rum-core/test/dom.ts
+++ b/packages/rum-core/test/dom.ts
@@ -1,6 +1,9 @@
 import { registerCleanupTask } from '@datadog/browser-core/test'
 
-export function append<E extends Element>(html: string, container = document.body): E {
+export function append<E extends Element | Text = Element>(
+  html: string,
+  container: Element | ShadowRoot = document.body
+): E {
   const tmp = document.createElement('div')
   tmp.innerHTML = html.trim()
 

--- a/packages/rum-core/test/dom.ts
+++ b/packages/rum-core/test/dom.ts
@@ -6,7 +6,7 @@ export function appendText(text: string, container: Element | ShadowRoot = docum
   container.appendChild(textNode)
 
   registerCleanupTask(() => {
-    container.removeChild(textNode)
+    textNode.parentElement?.removeChild(textNode)
   })
 
   return textNode
@@ -16,7 +16,7 @@ export function appendElement(html: string, container: Element | ShadowRoot = do
   const tmp = document.createElement('div')
   tmp.innerHTML = html.trim()
 
-  const target = tmp.querySelector('[target]') || tmp.childNodes[0]
+  const target = tmp.querySelector('[target]') || tmp.children[0]
   const nodes = arrayFrom(tmp.childNodes)
 
   nodes.forEach((node) => container.appendChild(node))

--- a/packages/rum-core/test/dom.ts
+++ b/packages/rum-core/test/dom.ts
@@ -1,10 +1,18 @@
 import { arrayFrom } from '@datadog/browser-core'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 
-export function append<E extends Element | Text = Element>(
-  html: string,
-  container: Element | ShadowRoot = document.body
-): E {
+export function appendText(text: string, container: Element | ShadowRoot = document.body): Text {
+  const textNode = document.createTextNode(text)
+  container.appendChild(textNode)
+
+  registerCleanupTask(() => {
+    container.removeChild(textNode)
+  })
+
+  return textNode
+}
+
+export function appendElement(html: string, container: Element | ShadowRoot = document.body): HTMLElement {
   const tmp = document.createElement('div')
   tmp.innerHTML = html.trim()
 
@@ -17,5 +25,5 @@ export function append<E extends Element | Text = Element>(
     nodes.forEach((node) => node.parentElement?.removeChild(node))
   })
 
-  return target as E
+  return target as HTMLElement
 }

--- a/packages/rum-core/test/dom.ts
+++ b/packages/rum-core/test/dom.ts
@@ -1,3 +1,4 @@
+import { arrayFrom } from '@datadog/browser-core'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 
 export function append<E extends Element | Text = Element>(
@@ -8,12 +9,12 @@ export function append<E extends Element | Text = Element>(
   tmp.innerHTML = html.trim()
 
   const target = tmp.querySelector('[target]') || tmp.childNodes[0]
-  const nodes = Array.from(tmp.childNodes)
+  const nodes = arrayFrom(tmp.childNodes)
 
   nodes.forEach((node) => container.appendChild(node))
 
   registerCleanupTask(() => {
-    nodes.forEach((node) => node.remove())
+    nodes.forEach((node) => node.parentElement?.removeChild(node))
   })
 
   return target as E

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -5,7 +5,7 @@ import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { collectAsyncCalls, createNewEvent, mockClock } from '@datadog/browser-core/test'
 import type { RumSessionManagerMock, TestSetupBuilder } from '../../../rum-core/test'
-import { createRumSessionManagerMock, setup } from '../../../rum-core/test'
+import { append, createRumSessionManagerMock, setup } from '../../../rum-core/test'
 
 import { recordsPerFullSnapshot, readReplayPayload } from '../../test'
 import { setSegmentBytesLimit } from '../domain/segmentCollection'
@@ -26,7 +26,6 @@ describe('startRecording', () => {
   let setupBuilder: TestSetupBuilder
   let sessionManager: RumSessionManagerMock
   let viewId: string
-  let sandbox: HTMLElement
   let textField: HTMLInputElement
   let requestSendSpy: jasmine.Spy<HttpRequest['sendOnExit']>
   let stopRecording: () => void
@@ -42,10 +41,7 @@ describe('startRecording', () => {
     sessionManager = createRumSessionManagerMock()
     viewId = 'view-id'
 
-    sandbox = document.createElement('div')
-    document.body.appendChild(sandbox)
-    textField = document.createElement('input')
-    sandbox.appendChild(textField)
+    textField = append('<input />')
 
     const worker = startDeflateWorker(configuration, 'Session Replay', noop)
 
@@ -86,7 +82,6 @@ describe('startRecording', () => {
   })
 
   afterEach(() => {
-    sandbox.remove()
     setSegmentBytesLimit()
     setupBuilder.cleanup()
     clock?.cleanup()
@@ -213,7 +208,7 @@ describe('startRecording', () => {
   it('flushes pending mutations before ending the view', async () => {
     const { lifeCycle } = setupBuilder.build()
 
-    sandbox.appendChild(document.createElement('hr'))
+    append('<hr/>')
     changeView(lifeCycle)
     flushSegment(lifeCycle)
 

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -5,7 +5,7 @@ import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { collectAsyncCalls, createNewEvent, mockClock } from '@datadog/browser-core/test'
 import type { RumSessionManagerMock, TestSetupBuilder } from '../../../rum-core/test'
-import { append, createRumSessionManagerMock, setup } from '../../../rum-core/test'
+import { appendElement, createRumSessionManagerMock, setup } from '../../../rum-core/test'
 
 import { recordsPerFullSnapshot, readReplayPayload } from '../../test'
 import { setSegmentBytesLimit } from '../domain/segmentCollection'
@@ -41,7 +41,7 @@ describe('startRecording', () => {
     sessionManager = createRumSessionManagerMock()
     viewId = 'view-id'
 
-    textField = append('<input />')
+    textField = appendElement('<input />') as HTMLInputElement
 
     const worker = startDeflateWorker(configuration, 'Session Replay', noop)
 
@@ -208,7 +208,7 @@ describe('startRecording', () => {
   it('flushes pending mutations before ending the view', async () => {
     const { lifeCycle } = setupBuilder.build()
 
-    append('<hr/>')
+    appendElement('<hr/>')
     changeView(lifeCycle)
     flushSegment(lifeCycle)
 

--- a/packages/rum/src/domain/record/observers/inputObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/inputObserver.spec.ts
@@ -2,7 +2,7 @@ import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, mockClock } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
-import { append } from '../../../../../rum-core/test'
+import { appendElement } from '../../../../../rum-core/test'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '../../../constants'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
@@ -23,7 +23,7 @@ describe('initInputObserver', () => {
     }
     configuration = { defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW } as RumConfiguration
     inputCallbackSpy = jasmine.createSpy()
-    input = append('<div><input target /></div>')
+    input = appendElement('<div><input target /></div>') as HTMLInputElement
 
     serializeDocument(document, DEFAULT_CONFIGURATION, {
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,

--- a/packages/rum/src/domain/record/observers/inputObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/inputObserver.spec.ts
@@ -2,6 +2,7 @@ import { DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, mockClock } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
+import { append } from '../../../../../rum-core/test'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '../../../constants'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
@@ -12,7 +13,6 @@ import { DEFAULT_CONFIGURATION, DEFAULT_SHADOW_ROOT_CONTROLLER } from './observe
 describe('initInputObserver', () => {
   let stopInputObserver: () => void
   let inputCallbackSpy: jasmine.Spy<InputCallback>
-  let sandbox: HTMLElement
   let input: HTMLInputElement
   let clock: Clock | undefined
   let configuration: RumConfiguration
@@ -23,11 +23,7 @@ describe('initInputObserver', () => {
     }
     configuration = { defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW } as RumConfiguration
     inputCallbackSpy = jasmine.createSpy()
-
-    sandbox = document.createElement('div')
-    input = document.createElement('input')
-    sandbox.appendChild(input)
-    document.body.appendChild(sandbox)
+    input = append('<div><input target /></div>')
 
     serializeDocument(document, DEFAULT_CONFIGURATION, {
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
@@ -38,7 +34,6 @@ describe('initInputObserver', () => {
 
   afterEach(() => {
     stopInputObserver()
-    sandbox.remove()
     clock?.cleanup()
   })
 
@@ -102,7 +97,7 @@ describe('initInputObserver', () => {
   it('masks input values according to the element privacy level', () => {
     configuration.defaultPrivacyLevel = DefaultPrivacyLevel.ALLOW
     stopInputObserver = initInputObserver(configuration, inputCallbackSpy)
-    sandbox.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
+    input.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
 
     dispatchInputEvent('foo')
 
@@ -112,7 +107,7 @@ describe('initInputObserver', () => {
   it('masks input values according to a parent element privacy level', () => {
     configuration.defaultPrivacyLevel = DefaultPrivacyLevel.ALLOW
     stopInputObserver = initInputObserver(configuration, inputCallbackSpy)
-    input.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
+    input.parentElement!.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
 
     dispatchInputEvent('foo')
 
@@ -138,7 +133,7 @@ describe('initInputObserver', () => {
     const host = document.createElement('div')
     host.attachShadow({ mode: 'open' })
     const event = createNewEvent('input', { target: host, composed: true })
-    event.composedPath = () => [input, host, sandbox, document.body]
+    event.composedPath = () => [input]
     input.dispatchEvent(event)
   }
 })

--- a/packages/rum/src/domain/record/observers/inputObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/inputObserver.spec.ts
@@ -133,7 +133,7 @@ describe('initInputObserver', () => {
     const host = document.createElement('div')
     host.attachShadow({ mode: 'open' })
     const event = createNewEvent('input', { target: host, composed: true })
-    event.composedPath = () => [input]
+    event.composedPath = () => [input, host, input.parentElement!, document.body]
     input.dispatchEvent(event)
   }
 })

--- a/packages/rum/src/domain/record/observers/mouseInteractionObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mouseInteractionObserver.spec.ts
@@ -1,6 +1,7 @@
 import { DOM_EVENT, DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import { createNewEvent } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
+import { append } from '../../../../../rum-core/test'
 import { IncrementalSource, MouseInteractionType, RecordType } from '../../../types'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
@@ -14,7 +15,6 @@ describe('initMouseInteractionObserver', () => {
   let mouseInteractionCallbackSpy: jasmine.Spy<MouseInteractionCallBack>
   let stopObserver: () => void
   let recordIds: RecordIds
-  let sandbox: HTMLDivElement
   let a: HTMLAnchorElement
   let configuration: RumConfiguration
 
@@ -24,11 +24,7 @@ describe('initMouseInteractionObserver', () => {
     }
 
     configuration = { defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW } as RumConfiguration
-    sandbox = document.createElement('div')
-    a = document.createElement('a')
-    a.setAttribute('tabindex', '0') // make the element focusable
-    sandbox.appendChild(a)
-    document.body.appendChild(sandbox)
+    a = append('<a tabindex="0"></a>') // tabindex 0 makes the element focusable
     a.dispatchEvent(createNewEvent(DOM_EVENT.FOCUS))
 
     serializeDocument(document, DEFAULT_CONFIGURATION, {
@@ -43,7 +39,6 @@ describe('initMouseInteractionObserver', () => {
   })
 
   afterEach(() => {
-    sandbox.remove()
     stopObserver()
   })
 

--- a/packages/rum/src/domain/record/observers/mouseInteractionObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mouseInteractionObserver.spec.ts
@@ -1,7 +1,7 @@
 import { DOM_EVENT, DefaultPrivacyLevel, isIE } from '@datadog/browser-core'
 import { createNewEvent } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
-import { append } from '../../../../../rum-core/test'
+import { appendElement } from '../../../../../rum-core/test'
 import { IncrementalSource, MouseInteractionType, RecordType } from '../../../types'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
@@ -24,7 +24,7 @@ describe('initMouseInteractionObserver', () => {
     }
 
     configuration = { defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW } as RumConfiguration
-    a = append('<a tabindex="0"></a>') // tabindex 0 makes the element focusable
+    a = appendElement('<a tabindex="0"></a>') as HTMLAnchorElement // tabindex 0 makes the element focusable
     a.dispatchEvent(createNewEvent(DOM_EVENT.FOCUS))
 
     serializeDocument(document, DEFAULT_CONFIGURATION, {

--- a/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
@@ -14,6 +14,7 @@ import { NodeType } from '../../../types'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import type { ShadowRootCallBack } from '../shadowRootsController'
+import { append } from '../../../../../rum-core/test'
 import { sortAddedAndMovedNodes, initMutationObserver } from './mutationObserver'
 import type { MutationCallBack } from './mutationObserver'
 import { DEFAULT_SHADOW_ROOT_CONTROLLER } from './observers.specHelper'
@@ -68,14 +69,11 @@ describe('startMutationCollection', () => {
       pending('IE not supported')
     }
 
-    sandbox = document.createElement('div')
-    sandbox.id = 'sandbox'
-    document.body.appendChild(sandbox)
+    sandbox = append('<div id="sandbox"></div>')
   })
 
   afterEach(() => {
     stopMutationCollection()
-    sandbox.remove()
   })
 
   describe('childList mutation records', () => {
@@ -83,7 +81,7 @@ describe('startMutationCollection', () => {
       const serializedDocument = serializeDocumentWithDefaults()
       const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
 
-      sandbox.appendChild(document.createElement('div'))
+      append('<div></div>', sandbox)
       flushMutations()
 
       expect(mutationCallbackSpy).toHaveBeenCalledTimes(1)
@@ -103,7 +101,7 @@ describe('startMutationCollection', () => {
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()
 
-      sandbox.appendChild(document.createElement('div'))
+      append('<div></div>', sandbox)
 
       expect(mutationCallbackSpy).not.toHaveBeenCalled()
 
@@ -114,7 +112,7 @@ describe('startMutationCollection', () => {
       // Here, we don't call serializeDocument(), so the sandbox is 'unknown'.
       const { mutationCallbackSpy } = startMutationCollection()
 
-      sandbox.appendChild(document.createElement('div'))
+      append('<div></div>', sandbox)
       flushMutations()
 
       expect(mutationCallbackSpy).not.toHaveBeenCalled()
@@ -124,7 +122,7 @@ describe('startMutationCollection', () => {
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()
 
-      sandbox.appendChild(document.createElement('div'))
+      append('<div></div>', sandbox)
 
       expect(mutationCallbackSpy).toHaveBeenCalledTimes(0)
 
@@ -135,8 +133,7 @@ describe('startMutationCollection', () => {
 
     describe('does not emit mutations on removed nodes and their descendants', () => {
       it('attribute mutations', () => {
-        const element = document.createElement('div')
-        sandbox.appendChild(element)
+        const element = append('<div></div>', sandbox)
         serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -149,8 +146,8 @@ describe('startMutationCollection', () => {
       })
 
       it('text mutations', () => {
-        const textNode = document.createTextNode('foo')
-        sandbox.appendChild(textNode)
+        const textNode = append<Text>('text', sandbox)
+
         serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -167,7 +164,7 @@ describe('startMutationCollection', () => {
 
         const { getLatestMutationPayload } = startMutationCollection()
 
-        sandbox.appendChild(document.createElement('div'))
+        append('<div><hr /></div>', sandbox)
         sandbox.remove()
         flushMutations()
 
@@ -175,8 +172,7 @@ describe('startMutationCollection', () => {
       })
 
       it('remove mutations', () => {
-        const element = document.createElement('div')
-        sandbox.appendChild(element)
+        const element = append('<div></div>', sandbox)
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -204,8 +200,7 @@ describe('startMutationCollection', () => {
       // document) during the processed mutation batched.
 
       it('attribute mutations', () => {
-        const element = document.createElement('div')
-        sandbox.appendChild(element)
+        const element = append('<div></div>', sandbox)
         serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -220,8 +215,7 @@ describe('startMutationCollection', () => {
       })
 
       it('text mutations', () => {
-        const textNode = document.createTextNode('foo')
-        sandbox.appendChild(textNode)
+        const textNode = append<Text>('foo', sandbox)
         serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -236,10 +230,8 @@ describe('startMutationCollection', () => {
       })
 
       it('add mutations', () => {
-        const parent = document.createElement('a')
-        const child = document.createElement('b')
-        sandbox.appendChild(parent)
-        parent.appendChild(child)
+        const child = append('<a><b target/></a>', sandbox)
+        const parent = child.parentElement!
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -281,10 +273,7 @@ describe('startMutationCollection', () => {
 
         const { getLatestMutationPayload } = startMutationCollection()
 
-        const parent = document.createElement('a')
-        const child = document.createElement('b')
-        parent.appendChild(child)
-        sandbox.appendChild(parent)
+        const child = append('<a><b target/></a>', sandbox)
 
         child.remove()
         flushMutations()
@@ -302,12 +291,12 @@ describe('startMutationCollection', () => {
     })
 
     it('emits only an "add" mutation when adding, removing then re-adding a child', () => {
-      const element = document.createElement('a')
       const serializedDocument = serializeDocumentWithDefaults()
 
       const { getLatestMutationPayload } = startMutationCollection()
 
-      sandbox.appendChild(element)
+      const element = append('<a></a>', sandbox)
+
       element.remove()
       sandbox.appendChild(element)
 
@@ -325,16 +314,13 @@ describe('startMutationCollection', () => {
     })
 
     it('emits an "add" and a "remove" mutation when moving a node', () => {
-      const elementA = document.createElement('a')
-      const elementB = document.createElement('b')
-      sandbox.appendChild(elementA)
-      sandbox.appendChild(elementB)
+      const a = append('<a></a><b/>', sandbox)
       const serializedDocument = serializeDocumentWithDefaults()
 
       const { getLatestMutationPayload } = startMutationCollection()
 
       // Moves 'a' after 'b'
-      sandbox.appendChild(elementA)
+      sandbox.appendChild(a)
 
       flushMutations()
 
@@ -356,18 +342,20 @@ describe('startMutationCollection', () => {
     })
 
     it('uses the initial parent id when removing a node from multiple places', () => {
-      const container1 = document.createElement('a')
-      const container2 = document.createElement('b')
-      const element = document.createElement('span')
-      sandbox.appendChild(element)
-      sandbox.appendChild(container1)
-      sandbox.appendChild(container2)
+      const span = append(
+        `<span></span>
+         <a></a>
+         <b></b>`,
+        sandbox
+      )
+      const a = span.nextElementSibling!
+      const b = a.nextElementSibling!
       const serializedDocument = serializeDocumentWithDefaults()
 
       const { getLatestMutationPayload } = startMutationCollection()
 
-      container1.appendChild(element)
-      container2.appendChild(element)
+      a.appendChild(span)
+      b.appendChild(span)
 
       flushMutations()
 
@@ -393,9 +381,7 @@ describe('startMutationCollection', () => {
 
       const { getLatestMutationPayload } = startMutationCollection()
 
-      sandbox.appendChild(document.createElement('a'))
-      sandbox.appendChild(document.createElement('b'))
-      sandbox.appendChild(document.createElement('c'))
+      append('<a></a><b></b><c></c>', sandbox)
 
       flushMutations()
 
@@ -448,10 +434,9 @@ describe('startMutationCollection', () => {
       it('should call addShadowRoot when host is added', () => {
         const serializedDocument = serializeDocumentWithDefaults()
         const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
-        const host = document.createElement('div')
+        const host = append('<div></div>', sandbox)
         const shadowRoot = host.attachShadow({ mode: 'open' })
-        shadowRoot.appendChild(document.createElement('span'))
-        sandbox.appendChild(host)
+        append('<span></span>', shadowRoot)
         flushMutations()
 
         expect(mutationCallbackSpy).toHaveBeenCalledTimes(1)
@@ -475,11 +460,9 @@ describe('startMutationCollection', () => {
       })
 
       it('should call removeShadowRoot when host is removed', () => {
-        const host = document.createElement('div')
-        host.id = 'host'
+        const host = append('<div id="host"></div>', sandbox)
         const shadowRoot = host.attachShadow({ mode: 'open' })
-        shadowRoot.appendChild(document.createElement('span'))
-        sandbox.appendChild(host)
+        append('<span></span>', shadowRoot)
         const serializedDocument = serializeDocumentWithDefaults()
         const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
         host.remove()
@@ -500,17 +483,13 @@ describe('startMutationCollection', () => {
       })
 
       it('should call removeShadowRoot when parent of host is removed', () => {
-        const parent = document.createElement('div')
-        parent.id = 'parent'
-        const host = document.createElement('div')
-        host.id = 'host'
-        parent.appendChild(host)
+        const host = append('<div id="parent"><div id="host" target></div></div>', sandbox)
         const shadowRoot = host.attachShadow({ mode: 'open' })
-        shadowRoot.appendChild(document.createElement('span'))
-        sandbox.appendChild(parent)
+        append('<span></span>', shadowRoot)
+
         const serializedDocument = serializeDocumentWithDefaults()
         const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
-        parent.remove()
+        host.parentElement!.remove()
         flushMutations()
         expect(mutationCallbackSpy).toHaveBeenCalledTimes(1)
 
@@ -533,8 +512,7 @@ describe('startMutationCollection', () => {
     let textNode: Text
 
     beforeEach(() => {
-      textNode = document.createTextNode('foo')
-      sandbox.appendChild(textNode)
+      textNode = append('foo', sandbox)
     })
 
     it('emits a mutation when a text node is changed', () => {
@@ -599,11 +577,7 @@ describe('startMutationCollection', () => {
 
     it('respects the parent privacy level when emitting a text node mutation', () => {
       sandbox.setAttribute('data-dd-privacy', 'allow')
-      document.body.appendChild(sandbox)
-
-      const div = document.createElement('div')
-      div.innerText = 'foo 81'
-      sandbox.appendChild(div)
+      const div = append('<div>foo 81</div>', sandbox)
 
       const serializedDocument = serializeDocumentWithDefaults()
       const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection(DefaultPrivacyLevel.MASK)
@@ -737,8 +711,7 @@ describe('startMutationCollection', () => {
     let ignoredElement: HTMLElement
 
     beforeEach(() => {
-      ignoredElement = document.createElement('script')
-      sandbox.appendChild(ignoredElement)
+      ignoredElement = append('<script></script>', sandbox)
     })
 
     it('skips ignored nodes when looking for the next id', () => {
@@ -792,7 +765,7 @@ describe('startMutationCollection', () => {
 
         const { mutationCallbackSpy } = startMutationCollection()
 
-        ignoredElement.appendChild(document.createTextNode('function foo() {}'))
+        append("'function foo() {}'", ignoredElement)
 
         flushMutations()
 
@@ -800,8 +773,8 @@ describe('startMutationCollection', () => {
       })
 
       it('when mutating a known child node', () => {
-        const textNode = document.createTextNode('function foo() {}')
-        sandbox.appendChild(textNode)
+        const textNode = append<Text>('function foo() {}', sandbox)
+
         serializeDocumentWithDefaults()
         ignoredElement.appendChild(textNode)
 
@@ -815,8 +788,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when adding a known child node', () => {
-        const textNode = document.createTextNode('function foo() {}')
-        sandbox.appendChild(textNode)
+        const textNode = append('function foo() {}', sandbox)
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -837,13 +809,8 @@ describe('startMutationCollection', () => {
       })
 
       it('when moving an ignored node', () => {
-        const a = document.createElement('a')
-        const b = document.createElement('b')
-        const script = document.createElement('script')
+        const script = append('<a></a><script target></script><b><b/>', sandbox)
 
-        sandbox.appendChild(a)
-        sandbox.appendChild(script)
-        sandbox.appendChild(b)
         serializeDocumentWithDefaults()
 
         const { mutationCallbackSpy } = startMutationCollection()
@@ -859,9 +826,7 @@ describe('startMutationCollection', () => {
   describe('hidden nodes', () => {
     let hiddenElement: HTMLElement
     beforeEach(() => {
-      hiddenElement = document.createElement('div')
-      hiddenElement.setAttribute('data-dd-privacy', 'hidden')
-      sandbox.appendChild(hiddenElement)
+      hiddenElement = append("<div data-dd-privacy='hidden'></div>", sandbox)
     })
 
     it('does not emit attribute mutations on hidden nodes', () => {
@@ -882,7 +847,7 @@ describe('startMutationCollection', () => {
 
         const { mutationCallbackSpy } = startMutationCollection()
 
-        hiddenElement.appendChild(document.createTextNode('function foo() {}'))
+        append('function foo() {}', hiddenElement)
 
         flushMutations()
 
@@ -890,8 +855,8 @@ describe('startMutationCollection', () => {
       })
 
       it('when mutating a known child node', () => {
-        const textNode = document.createTextNode('function foo() {}')
-        sandbox.appendChild(textNode)
+        const textNode = append<Text>('function foo() {}', sandbox)
+
         serializeDocumentWithDefaults()
         hiddenElement.appendChild(textNode)
 
@@ -905,8 +870,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when moving a known node into an hidden node', () => {
-        const textNode = document.createTextNode('function foo() {}')
-        sandbox.appendChild(textNode)
+        const textNode = append<Text>('function foo() {}', sandbox)
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()

--- a/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
@@ -788,7 +788,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when adding a known child node', () => {
-        const textNode = appendElement('function foo() {}', sandbox)
+        const textNode = appendText('function foo() {}', sandbox)
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()

--- a/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
@@ -14,7 +14,7 @@ import { NodeType } from '../../../types'
 import { serializeDocument, SerializationContextStatus } from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import type { ShadowRootCallBack } from '../shadowRootsController'
-import { append } from '../../../../../rum-core/test'
+import { appendElement, appendText } from '../../../../../rum-core/test'
 import { sortAddedAndMovedNodes, initMutationObserver } from './mutationObserver'
 import type { MutationCallBack } from './mutationObserver'
 import { DEFAULT_SHADOW_ROOT_CONTROLLER } from './observers.specHelper'
@@ -69,7 +69,7 @@ describe('startMutationCollection', () => {
       pending('IE not supported')
     }
 
-    sandbox = append('<div id="sandbox"></div>')
+    sandbox = appendElement('<div id="sandbox"></div>')
   })
 
   afterEach(() => {
@@ -81,7 +81,7 @@ describe('startMutationCollection', () => {
       const serializedDocument = serializeDocumentWithDefaults()
       const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
 
-      append('<div></div>', sandbox)
+      appendElement('<div></div>', sandbox)
       flushMutations()
 
       expect(mutationCallbackSpy).toHaveBeenCalledTimes(1)
@@ -101,7 +101,7 @@ describe('startMutationCollection', () => {
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()
 
-      append('<div></div>', sandbox)
+      appendElement('<div></div>', sandbox)
 
       expect(mutationCallbackSpy).not.toHaveBeenCalled()
 
@@ -112,7 +112,7 @@ describe('startMutationCollection', () => {
       // Here, we don't call serializeDocument(), so the sandbox is 'unknown'.
       const { mutationCallbackSpy } = startMutationCollection()
 
-      append('<div></div>', sandbox)
+      appendElement('<div></div>', sandbox)
       flushMutations()
 
       expect(mutationCallbackSpy).not.toHaveBeenCalled()
@@ -122,7 +122,7 @@ describe('startMutationCollection', () => {
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()
 
-      append('<div></div>', sandbox)
+      appendElement('<div></div>', sandbox)
 
       expect(mutationCallbackSpy).toHaveBeenCalledTimes(0)
 
@@ -133,7 +133,7 @@ describe('startMutationCollection', () => {
 
     describe('does not emit mutations on removed nodes and their descendants', () => {
       it('attribute mutations', () => {
-        const element = append('<div></div>', sandbox)
+        const element = appendElement('<div></div>', sandbox)
         serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -146,7 +146,7 @@ describe('startMutationCollection', () => {
       })
 
       it('text mutations', () => {
-        const textNode = append<Text>('text', sandbox)
+        const textNode = appendText('text', sandbox)
 
         serializeDocumentWithDefaults()
 
@@ -164,7 +164,7 @@ describe('startMutationCollection', () => {
 
         const { getLatestMutationPayload } = startMutationCollection()
 
-        append('<div><hr /></div>', sandbox)
+        appendElement('<div><hr /></div>', sandbox)
         sandbox.remove()
         flushMutations()
 
@@ -172,7 +172,7 @@ describe('startMutationCollection', () => {
       })
 
       it('remove mutations', () => {
-        const element = append('<div></div>', sandbox)
+        const element = appendElement('<div></div>', sandbox)
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -200,7 +200,7 @@ describe('startMutationCollection', () => {
       // document) during the processed mutation batched.
 
       it('attribute mutations', () => {
-        const element = append('<div></div>', sandbox)
+        const element = appendElement('<div></div>', sandbox)
         serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -215,7 +215,7 @@ describe('startMutationCollection', () => {
       })
 
       it('text mutations', () => {
-        const textNode = append<Text>('foo', sandbox)
+        const textNode = appendText('foo', sandbox)
         serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -230,7 +230,7 @@ describe('startMutationCollection', () => {
       })
 
       it('add mutations', () => {
-        const child = append('<a><b target/></a>', sandbox)
+        const child = appendElement('<a><b target/></a>', sandbox)
         const parent = child.parentElement!
         const serializedDocument = serializeDocumentWithDefaults()
 
@@ -273,7 +273,7 @@ describe('startMutationCollection', () => {
 
         const { getLatestMutationPayload } = startMutationCollection()
 
-        const child = append('<a><b target/></a>', sandbox)
+        const child = appendElement('<a><b target/></a>', sandbox)
 
         child.remove()
         flushMutations()
@@ -295,7 +295,7 @@ describe('startMutationCollection', () => {
 
       const { getLatestMutationPayload } = startMutationCollection()
 
-      const element = append('<a></a>', sandbox)
+      const element = appendElement('<a></a>', sandbox)
 
       element.remove()
       sandbox.appendChild(element)
@@ -314,7 +314,7 @@ describe('startMutationCollection', () => {
     })
 
     it('emits an "add" and a "remove" mutation when moving a node', () => {
-      const a = append('<a></a><b/>', sandbox)
+      const a = appendElement('<a></a><b/>', sandbox)
       const serializedDocument = serializeDocumentWithDefaults()
 
       const { getLatestMutationPayload } = startMutationCollection()
@@ -342,7 +342,7 @@ describe('startMutationCollection', () => {
     })
 
     it('uses the initial parent id when removing a node from multiple places', () => {
-      const span = append(
+      const span = appendElement(
         `<span></span>
          <a></a>
          <b></b>`,
@@ -381,7 +381,7 @@ describe('startMutationCollection', () => {
 
       const { getLatestMutationPayload } = startMutationCollection()
 
-      append('<a></a><b></b><c></c>', sandbox)
+      appendElement('<a></a><b></b><c></c>', sandbox)
 
       flushMutations()
 
@@ -434,9 +434,9 @@ describe('startMutationCollection', () => {
       it('should call addShadowRoot when host is added', () => {
         const serializedDocument = serializeDocumentWithDefaults()
         const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
-        const host = append('<div></div>', sandbox)
+        const host = appendElement('<div></div>', sandbox)
         const shadowRoot = host.attachShadow({ mode: 'open' })
-        append('<span></span>', shadowRoot)
+        appendElement('<span></span>', shadowRoot)
         flushMutations()
 
         expect(mutationCallbackSpy).toHaveBeenCalledTimes(1)
@@ -460,9 +460,9 @@ describe('startMutationCollection', () => {
       })
 
       it('should call removeShadowRoot when host is removed', () => {
-        const host = append('<div id="host"></div>', sandbox)
+        const host = appendElement('<div id="host"></div>', sandbox)
         const shadowRoot = host.attachShadow({ mode: 'open' })
-        append('<span></span>', shadowRoot)
+        appendElement('<span></span>', shadowRoot)
         const serializedDocument = serializeDocumentWithDefaults()
         const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
         host.remove()
@@ -483,9 +483,9 @@ describe('startMutationCollection', () => {
       })
 
       it('should call removeShadowRoot when parent of host is removed', () => {
-        const host = append('<div id="parent"><div id="host" target></div></div>', sandbox)
+        const host = appendElement('<div id="parent"><div id="host" target></div></div>', sandbox)
         const shadowRoot = host.attachShadow({ mode: 'open' })
-        append('<span></span>', shadowRoot)
+        appendElement('<span></span>', shadowRoot)
 
         const serializedDocument = serializeDocumentWithDefaults()
         const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection()
@@ -512,7 +512,7 @@ describe('startMutationCollection', () => {
     let textNode: Text
 
     beforeEach(() => {
-      textNode = append('foo', sandbox)
+      textNode = appendText('foo', sandbox)
     })
 
     it('emits a mutation when a text node is changed', () => {
@@ -577,7 +577,7 @@ describe('startMutationCollection', () => {
 
     it('respects the parent privacy level when emitting a text node mutation', () => {
       sandbox.setAttribute('data-dd-privacy', 'allow')
-      const div = append('<div>foo 81</div>', sandbox)
+      const div = appendElement('<div>foo 81</div>', sandbox)
 
       const serializedDocument = serializeDocumentWithDefaults()
       const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection(DefaultPrivacyLevel.MASK)
@@ -711,7 +711,7 @@ describe('startMutationCollection', () => {
     let ignoredElement: HTMLElement
 
     beforeEach(() => {
-      ignoredElement = append('<script></script>', sandbox)
+      ignoredElement = appendElement('<script></script>', sandbox)
     })
 
     it('skips ignored nodes when looking for the next id', () => {
@@ -765,7 +765,7 @@ describe('startMutationCollection', () => {
 
         const { mutationCallbackSpy } = startMutationCollection()
 
-        append("'function foo() {}'", ignoredElement)
+        appendElement("'function foo() {}'", ignoredElement)
 
         flushMutations()
 
@@ -773,7 +773,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when mutating a known child node', () => {
-        const textNode = append<Text>('function foo() {}', sandbox)
+        const textNode = appendText('function foo() {}', sandbox)
 
         serializeDocumentWithDefaults()
         ignoredElement.appendChild(textNode)
@@ -788,7 +788,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when adding a known child node', () => {
-        const textNode = append('function foo() {}', sandbox)
+        const textNode = appendElement('function foo() {}', sandbox)
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()
@@ -809,7 +809,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when moving an ignored node', () => {
-        const script = append('<a></a><script target></script><b><b/>', sandbox)
+        const script = appendElement('<a></a><script target></script><b><b/>', sandbox)
 
         serializeDocumentWithDefaults()
 
@@ -826,7 +826,7 @@ describe('startMutationCollection', () => {
   describe('hidden nodes', () => {
     let hiddenElement: HTMLElement
     beforeEach(() => {
-      hiddenElement = append("<div data-dd-privacy='hidden'></div>", sandbox)
+      hiddenElement = appendElement("<div data-dd-privacy='hidden'></div>", sandbox)
     })
 
     it('does not emit attribute mutations on hidden nodes', () => {
@@ -847,7 +847,7 @@ describe('startMutationCollection', () => {
 
         const { mutationCallbackSpy } = startMutationCollection()
 
-        append('function foo() {}', hiddenElement)
+        appendElement('function foo() {}', hiddenElement)
 
         flushMutations()
 
@@ -855,7 +855,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when mutating a known child node', () => {
-        const textNode = append<Text>('function foo() {}', sandbox)
+        const textNode = appendText('function foo() {}', sandbox)
 
         serializeDocumentWithDefaults()
         hiddenElement.appendChild(textNode)
@@ -870,7 +870,7 @@ describe('startMutationCollection', () => {
       })
 
       it('when moving a known node into an hidden node', () => {
-        const textNode = append<Text>('function foo() {}', sandbox)
+        const textNode = appendText('function foo() {}', sandbox)
         const serializedDocument = serializeDocumentWithDefaults()
 
         const { getLatestMutationPayload } = startMutationCollection()

--- a/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.spec.ts
@@ -598,13 +598,12 @@ describe('startMutationCollection', () => {
     })
 
     it('respects the parent privacy level when emitting a text node mutation', () => {
-      const wrapper = document.createElement('div')
-      wrapper.setAttribute('data-dd-privacy', 'allow')
-      document.body.appendChild(wrapper)
+      sandbox.setAttribute('data-dd-privacy', 'allow')
+      document.body.appendChild(sandbox)
 
       const div = document.createElement('div')
       div.innerText = 'foo 81'
-      wrapper.appendChild(div)
+      sandbox.appendChild(div)
 
       const serializedDocument = serializeDocumentWithDefaults()
       const { mutationCallbackSpy, getLatestMutationPayload } = startMutationCollection(DefaultPrivacyLevel.MASK)

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -13,7 +13,7 @@ import type {
   FocusRecord,
 } from '../../types'
 import { NodeType, RecordType, IncrementalSource } from '../../types'
-import { append } from '../../../../rum-core/test'
+import { appendElement } from '../../../../rum-core/test'
 import type { RecordAPI } from './record'
 import { record } from './record'
 
@@ -36,7 +36,7 @@ describe('record', () => {
   })
 
   it('captures stylesheet rules', (done) => {
-    const styleElement = append<HTMLStyleElement>('<style></style>')
+    const styleElement = appendElement('<style></style>') as HTMLStyleElement
 
     startRecording()
 
@@ -116,7 +116,7 @@ describe('record', () => {
   it('flushes pending mutation records before taking a full snapshot', (done) => {
     startRecording()
 
-    append('<hr/>')
+    appendElement('<hr/>')
 
     recordApi.takeSubsequentFullSnapshot()
 
@@ -199,7 +199,7 @@ describe('record', () => {
 
   describe('Shadow dom', () => {
     it('should record a simple mutation inside a shadow root', () => {
-      const element = append('<hr class="toto" />', createShadow())
+      const element = appendElement('<hr class="toto" />', createShadow())
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
@@ -215,7 +215,7 @@ describe('record', () => {
     })
 
     it('should record a direct removal inside a shadow root', () => {
-      const element = append('<hr/>', createShadow())
+      const element = appendElement('<hr/>', createShadow())
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
@@ -239,11 +239,11 @@ describe('record', () => {
 
     it('should record a direct addition inside a shadow root', () => {
       const shadowRoot = createShadow()
-      append('<hr/>', shadowRoot)
+      appendElement('<hr/>', shadowRoot)
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
-      append('<span></span>', shadowRoot)
+      appendElement('<span></span>', shadowRoot)
 
       recordApi.flushMutations()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot() + 1)
@@ -269,7 +269,7 @@ describe('record', () => {
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
       // shadow DOM mutation
-      const span = append('<span class="toto"></span>', createShadow())
+      const span = appendElement('<span class="toto"></span>', createShadow())
       recordApi.flushMutations()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot() + 1)
       const hostMutationData = getLastIncrementalSnapshotData<BrowserMutationData>(
@@ -295,7 +295,7 @@ describe('record', () => {
     })
 
     it('should record the change event inside a shadow root', () => {
-      const radio = append<HTMLInputElement>('<input type="radio"/>', createShadow())
+      const radio = appendElement('<input type="radio"/>', createShadow()) as HTMLInputElement
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
@@ -313,7 +313,7 @@ describe('record', () => {
 
     it('should clean the state once the shadow dom is removed to avoid memory leak', () => {
       const shadowRoot = createShadow()
-      append('<div class="toto"></div>', shadowRoot)
+      appendElement('<div class="toto"></div>', shadowRoot)
       startRecording()
       spyOn(recordApi.shadowRootsController, 'removeShadowRoot')
 
@@ -331,7 +331,7 @@ describe('record', () => {
     })
 
     it('should clean the state when both the parent and the shadow host is removed to avoid memory leak', () => {
-      const host = append(`
+      const host = appendElement(`
       <div id="grand-parent">
         <div id="parent">
           <div class="host" target></div>
@@ -340,7 +340,7 @@ describe('record', () => {
       host.attachShadow({ mode: 'open' })
       const parent = host.parentElement!
       const grandParent = parent.parentElement!
-      append('<div></div>', host.shadowRoot!)
+      appendElement('<div></div>', host.shadowRoot!)
 
       startRecording()
       spyOn(recordApi.shadowRootsController, 'removeShadowRoot')
@@ -360,7 +360,7 @@ describe('record', () => {
     })
 
     function createShadow() {
-      const host = append('<div></div>')
+      const host = appendElement('<div></div>')
       const shadowRoot = host.attachShadow({ mode: 'open' })
       return shadowRoot
     }

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -13,11 +13,11 @@ import type {
   FocusRecord,
 } from '../../types'
 import { NodeType, RecordType, IncrementalSource } from '../../types'
+import { append } from '../../../../rum-core/test'
 import type { RecordAPI } from './record'
 import { record } from './record'
 
 describe('record', () => {
-  let sandbox: HTMLElement
   let recordApi: RecordAPI
   let emitSpy: jasmine.Spy<(record: BrowserRecord) => void>
   let clock: Clock | undefined
@@ -28,18 +28,15 @@ describe('record', () => {
     }
 
     emitSpy = jasmine.createSpy()
-    sandbox = createDOMSandbox()
   })
 
   afterEach(() => {
     clock?.cleanup()
-    sandbox.remove()
     recordApi?.stop()
   })
 
   it('captures stylesheet rules', (done) => {
-    const styleElement = document.createElement('style')
-    sandbox.appendChild(styleElement)
+    const styleElement = append<HTMLStyleElement>('<style></style>')
 
     startRecording()
 
@@ -119,7 +116,7 @@ describe('record', () => {
   it('flushes pending mutation records before taking a full snapshot', (done) => {
     startRecording()
 
-    sandbox.appendChild(document.createElement('div'))
+    append('<hr/>')
 
     recordApi.takeSubsequentFullSnapshot()
 
@@ -201,26 +198,12 @@ describe('record', () => {
   })
 
   describe('Shadow dom', () => {
-    let sandbox: HTMLElement
-
-    beforeEach(() => {
-      sandbox = document.createElement('div')
-      sandbox.id = 'sandbox'
-      document.body.appendChild(sandbox)
-    })
-
-    afterEach(() => {
-      sandbox.remove()
-    })
-
     it('should record a simple mutation inside a shadow root', () => {
-      const div = document.createElement('div')
-      div.className = 'toto'
-      createShadow([div])
+      const element = append('<hr class="toto" />', createShadow())
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
-      div.className = 'titi'
+      element.className = 'titi'
 
       recordApi.flushMutations()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot() + 1)
@@ -232,12 +215,11 @@ describe('record', () => {
     })
 
     it('should record a direct removal inside a shadow root', () => {
-      const span = document.createElement('span')
-      createShadow([span])
+      const element = append('<hr/>', createShadow())
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
-      span.remove()
+      element.remove()
 
       recordApi.flushMutations()
       const fs = findFullSnapshot({ records: getEmittedRecords() })!
@@ -256,12 +238,12 @@ describe('record', () => {
     })
 
     it('should record a direct addition inside a shadow root', () => {
-      const span = document.createElement('span')
-      const shadowRoot = createShadow([span])
+      const shadowRoot = createShadow()
+      append('<hr/>', shadowRoot)
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
-      shadowRoot.appendChild(document.createElement('span'))
+      append('<span></span>', shadowRoot)
 
       recordApi.flushMutations()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot() + 1)
@@ -287,9 +269,7 @@ describe('record', () => {
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
       // shadow DOM mutation
-      const span = document.createElement('span')
-      span.className = 'toto'
-      createShadow([span])
+      const span = append('<span class="toto"></span>', createShadow())
       recordApi.flushMutations()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot() + 1)
       const hostMutationData = getLastIncrementalSnapshotData<BrowserMutationData>(
@@ -315,9 +295,7 @@ describe('record', () => {
     })
 
     it('should record the change event inside a shadow root', () => {
-      const radio = document.createElement('input')
-      radio.setAttribute('type', 'radio')
-      createShadow([radio])
+      const radio = append<HTMLInputElement>('<input type="radio"/>', createShadow())
       startRecording()
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
 
@@ -334,9 +312,8 @@ describe('record', () => {
     })
 
     it('should clean the state once the shadow dom is removed to avoid memory leak', () => {
-      const div = document.createElement('div')
-      div.className = 'toto'
-      const shadowRoot = createShadow([div])
+      const shadowRoot = createShadow()
+      append('<div class="toto"></div>', shadowRoot)
       startRecording()
       spyOn(recordApi.shadowRootsController, 'removeShadowRoot')
 
@@ -354,13 +331,17 @@ describe('record', () => {
     })
 
     it('should clean the state when both the parent and the shadow host is removed to avoid memory leak', () => {
-      const grandParent = document.createElement('div')
-      const parent = document.createElement('div')
-      grandParent.appendChild(parent)
-      const child = document.createElement('div')
-      child.className = 'toto'
-      createShadow([child], parent)
-      sandbox.appendChild(grandParent)
+      const host = append(`
+      <div id="grand-parent">
+        <div id="parent">
+          <div class="host" target></div>
+        </div>
+      </div>`)
+      host.attachShadow({ mode: 'open' })
+      const parent = host.parentElement!
+      const grandParent = parent.parentElement!
+      append('<div></div>', host.shadowRoot!)
+
       startRecording()
       spyOn(recordApi.shadowRootsController, 'removeShadowRoot')
       expect(getEmittedRecords().length).toBe(recordsPerFullSnapshot())
@@ -378,12 +359,9 @@ describe('record', () => {
       expect(mutationData.removes.length).toBe(1)
     })
 
-    function createShadow(children: Element[], parent = sandbox) {
-      const host = document.createElement('div')
-      host.setAttribute('id', 'host')
+    function createShadow() {
+      const host = append('<div></div>')
       const shadowRoot = host.attachShadow({ mode: 'open' })
-      children.forEach((child) => shadowRoot.appendChild(child))
-      parent.append(host)
       return shadowRoot
     }
   })
@@ -400,13 +378,6 @@ describe('record', () => {
     return emitSpy.calls.allArgs().map(([record]) => record)
   }
 })
-
-function createDOMSandbox() {
-  const sandbox = document.createElement('div')
-  sandbox.id = 'sandbox'
-  document.body.appendChild(sandbox)
-  return sandbox
-}
 
 export function getLastIncrementalSnapshotData<T extends BrowserIncrementalSnapshotRecord['data']>(
   records: BrowserRecord[],

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -149,7 +149,7 @@ describe('serializeNodeWithId', () => {
       let elementsScrollPositions: ElementsScrollPositions
 
       beforeEach(() => {
-        element = append<HTMLDivElement>(
+        element = append(
           '<div style="width: 100px; height: 100px; overflow: scroll"><div style="width: 200px; height: 200px"></div></div>'
         )
         element.scrollBy(10, 20)

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../constants'
 import type { ElementNode, SerializedNodeWithId } from '../../../types'
 import { NodeType } from '../../../types'
-import { append } from '../../../../../rum-core/test'
+import { appendElement } from '../../../../../rum-core/test'
 import type { ElementsScrollPositions } from '../elementsScrollPositions'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import type { ShadowRootCallBack, ShadowRootsController } from '../shadowRootsController'
@@ -134,7 +134,7 @@ describe('serializeNodeWithId', () => {
     })
 
     it('serializes attributes', () => {
-      const element = append<HTMLDivElement>('<div foo="bar" data-foo="data-bar"></div>')
+      const element = appendElement('<div foo="bar" data-foo="data-bar"></div>')
       element.className = 'zog'
       element.style.width = '10px'
 
@@ -147,11 +147,11 @@ describe('serializeNodeWithId', () => {
     })
 
     describe('rr scroll attributes', () => {
-      let element: HTMLDivElement
+      let element: HTMLElement
       let elementsScrollPositions: ElementsScrollPositions
 
       beforeEach(() => {
-        element = append(
+        element = appendElement(
           '<div style="width: 100px; height: 100px; overflow: scroll"><div style="width: 200px; height: 200px"></div></div>'
         )
         element.scrollBy(10, 20)
@@ -517,7 +517,7 @@ describe('serializeNodeWithId', () => {
 
     describe('<style> elements', () => {
       it('serializes a node with dynamically edited CSS rules', () => {
-        const styleNode = append<HTMLStyleElement>('<style></style>', document.head)
+        const styleNode = appendElement('<style></style>', document.head) as HTMLStyleElement
         styleNode.sheet!.insertRule('body { width: 100%; }')
 
         expect(serializeElement(styleNode)).toEqual({
@@ -531,7 +531,7 @@ describe('serializeNodeWithId', () => {
       })
 
       it('serializes a node with CSS rules specified as inner text', () => {
-        const styleNode = append<HTMLStyleElement>('<style>body { width: 100%; }</style>', document.head)
+        const styleNode = appendElement('<style>body { width: 100%; }</style>', document.head) as HTMLStyleElement
 
         expect(serializeElement(styleNode)).toEqual({
           type: NodeType.Element,
@@ -544,7 +544,7 @@ describe('serializeNodeWithId', () => {
       })
 
       it('serializes a node with CSS rules specified as inner text then dynamically edited', () => {
-        const styleNode = append<HTMLStyleElement>('<style>body { width: 100%; }</style>', document.head)
+        const styleNode = appendElement('<style>body { width: 100%; }</style>', document.head) as HTMLStyleElement
         styleNode.sheet!.insertRule('body { color: red; }')
 
         expect(serializeElement(styleNode)).toEqual({
@@ -565,7 +565,10 @@ describe('serializeNodeWithId', () => {
       })
 
       it('does not inline external CSS if it cannot be fetched', () => {
-        const linkNode = append("<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />", document.head)
+        const linkNode = appendElement(
+          "<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />",
+          document.head
+        )
         expect(serializeNodeWithId(linkNode, DEFAULT_OPTIONS)).toEqual({
           type: NodeType.Element,
           tagName: 'link',
@@ -577,7 +580,10 @@ describe('serializeNodeWithId', () => {
       })
 
       it('inlines external CSS it can be fetched', () => {
-        const linkNode = append("<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />", document.head)
+        const linkNode = appendElement(
+          "<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />",
+          document.head
+        )
         Object.defineProperty(document, 'styleSheets', {
           value: [
             {
@@ -604,7 +610,10 @@ describe('serializeNodeWithId', () => {
 
       it('does not inline external CSS when DISABLE_REPLAY_INLINE_CSS is enabled', () => {
         addExperimentalFeatures([ExperimentalFeature.DISABLE_REPLAY_INLINE_CSS])
-        const linkNode = append("<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />", document.head)
+        const linkNode = appendElement(
+          "<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />",
+          document.head
+        )
         Object.defineProperty(document, 'styleSheets', {
           value: [
             {
@@ -619,7 +628,10 @@ describe('serializeNodeWithId', () => {
       })
 
       it('does not inline external CSS if the style sheet is behind CORS', () => {
-        const linkNode = append("<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />", document.head)
+        const linkNode = appendElement(
+          "<link rel='stylesheet' href='https://datadoghq.com/some/style.css' />",
+          document.head
+        )
         class FakeCSSStyleSheet {
           get cssRules() {
             return []

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -568,15 +568,13 @@ describe('serializeNodeWithId', () => {
     })
 
     describe('<link rel="stylesheet"> elements', () => {
-      let originalDescriptor: PropertyDescriptor | undefined
+      let originalStyleSheets: StyleSheetList
 
       beforeEach(() => {
-        originalDescriptor = Object.getOwnPropertyDescriptor(document, 'styleSheets')
+        originalStyleSheets = document.styleSheets
       })
       afterEach(() => {
-        if (originalDescriptor) {
-          Object.defineProperty(document, 'styleSheets', originalDescriptor)
-        }
+        Object.defineProperty(document, 'styleSheets', { value: originalStyleSheets, configurable: true })
       })
 
       it('does not inline external CSS if it cannot be fetched', () => {

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -134,7 +134,9 @@ describe('serializeNodeWithId', () => {
     })
 
     it('serializes attributes', () => {
-      const element = append('<div foo="bar" data-foo="data-bar" class="zog" style="width: 10px;"></div>')
+      const element = append<HTMLDivElement>('<div foo="bar" data-foo="data-bar"></div>')
+      element.className = 'zog'
+      element.style.width = '10px'
 
       expect(serializeElement(element)!.attributes).toEqual({
         foo: 'bar',
@@ -557,13 +559,9 @@ describe('serializeNodeWithId', () => {
     })
 
     describe('<link rel="stylesheet"> elements', () => {
-      let originalStyleSheets: StyleSheetList
-
-      beforeEach(() => {
-        originalStyleSheets = document.styleSheets
-      })
       afterEach(() => {
-        Object.defineProperty(document, 'styleSheets', { value: originalStyleSheets, configurable: true })
+        // styleSheets is part of the document prototype so we can safely delete it
+        delete (document as { styleSheets?: StyleSheetList }).styleSheets
       })
 
       it('does not inline external CSS if it cannot be fetched', () => {

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -816,7 +816,9 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
 
   describe('with dynamic stylesheet', () => {
     afterEach(() => {
-      document.adoptedStyleSheets = []
+      if (isAdoptedStyleSheetsSupported()) {
+        document.adoptedStyleSheets = []
+      }
     })
 
     it('serializes a document with adoptedStyleSheets', () => {


### PR DESCRIPTION
## Motivation

After introducing `appendElement` to ease DOM manipulation in our tests (cf [PR](https://github.com/DataDog/browser-sdk/pull/2418)), let generalise its usage.

## Changes

- IsolatedDom is not isolated anymore (remove the iframe usage)
- Replace appendElement by append (we can also append text nodes)
- Replace isolatedDom by append
- Update sandbox pattern with append

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
