### PR TITLE
[RUM-1085] Remove lock usage from Local Storage strategy

### DIFF
--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -5,12 +5,7 @@ import { initCookieStrategy } from './storeStrategies/sessionInCookie'
 import { initLocalStorageStrategy } from './storeStrategies/sessionInLocalStorage'
 import type { SessionState } from './sessionState'
 import { expandSessionState, toSessionString } from './sessionState'
-import {
-  processSessionStoreOperations,
-  isLockEnabled,
-  LOCK_MAX_TRIES,
-  LOCK_RETRY_DELAY,
-} from './sessionStoreOperations'
+import { processSessionStoreOperations, LOCK_MAX_TRIES, LOCK_RETRY_DELAY } from './sessionStoreOperations'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 
 const cookieOptions: CookieOptions = {}
@@ -49,7 +44,7 @@ const cookieOptions: CookieOptions = {}
 
     describe('with lock access disabled', () => {
       beforeEach(() => {
-        isLockEnabled() && pending('lock-access required')
+        sessionStoreStrategy.isLockEnabled && pending('lock-access required')
       })
 
       it('should persist session when process returns a value', () => {
@@ -102,7 +97,7 @@ const cookieOptions: CookieOptions = {}
 
     describe('with lock access enabled', () => {
       beforeEach(() => {
-        !isLockEnabled() && pending('lock-access not enabled')
+        !sessionStoreStrategy.isLockEnabled && pending('lock-access not enabled')
       })
 
       it('should persist session when process returns a value', () => {
@@ -236,8 +231,8 @@ const cookieOptions: CookieOptions = {}
         stubStorage.getSpy.and.returnValue(buildSessionString({ ...initialSession, lock: 'locked' }))
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
-        const lockMaxTries = isLockEnabled() ? LOCK_MAX_TRIES : 0
-        const lockRetryDelay = isLockEnabled() ? LOCK_RETRY_DELAY : 0
+        const lockMaxTries = sessionStoreStrategy.isLockEnabled ? LOCK_MAX_TRIES : 0
+        const lockRetryDelay = sessionStoreStrategy.isLockEnabled ? LOCK_RETRY_DELAY : 0
 
         clock.tick(lockMaxTries * lockRetryDelay)
         expect(processSpy).not.toHaveBeenCalled()

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -1,3 +1,4 @@
+import { isChromium } from '../../../tools/utils/browserDetection'
 import type { CookieOptions } from '../../../browser/cookie'
 import { getCurrentSite, areCookiesAuthorized, deleteCookie, getCookie, setCookie } from '../../../browser/cookie'
 import type { InitConfiguration } from '../../configuration'
@@ -15,6 +16,11 @@ export function selectCookieStrategy(initConfiguration: InitConfiguration): Sess
 
 export function initCookieStrategy(cookieOptions: CookieOptions): SessionStoreStrategy {
   const cookieStore = {
+    /**
+     * Lock strategy allows mitigating issues due to concurrent access to cookie.
+     * This issue concerns only chromium browsers and enabling this on firefox increases cookie write failures.
+     */
+    isLockEnabled: isChromium(),
     persistSession: persistSessionCookie(cookieOptions),
     retrieveSession: retrieveSessionCookie,
     clearSession: deleteSessionCookie(cookieOptions),

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -21,6 +21,7 @@ export function selectLocalStorageStrategy(): SessionStoreStrategyType | undefin
 
 export function initLocalStorageStrategy(): SessionStoreStrategy {
   return {
+    isLockEnabled: false,
     persistSession: persistInLocalStorage,
     retrieveSession: retrieveSessionFromLocalStorage,
     clearSession: clearSessionFromLocalStorage,

--- a/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
@@ -6,6 +6,7 @@ export const SESSION_STORE_KEY = '_dd_s'
 export type SessionStoreStrategyType = { type: 'Cookie'; cookieOptions: CookieOptions } | { type: 'LocalStorage' }
 
 export interface SessionStoreStrategy {
+  isLockEnabled: boolean
   persistSession: (session: SessionState) => void
   retrieveSession: () => SessionState
   clearSession: () => void


### PR DESCRIPTION
## Motivation

Our lock mechanism does not work with Local Storage, as we have observed a latency with the replication of the data between several tabs. 
It is safer to remove it, as there is a risk to that the browser stops while the lock is set, preventing future events from being sent.

## Changes

- Move the lock eligibility to storage strategy
- Make Local Storage never eligible for the lock mechanism

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
