### PR TITLE
♻️ rename scroll fields

### DIFF
--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -51,8 +51,8 @@ const VIEW: ViewEvent = {
     interactionToNextPaint: { value: 10 as Duration },
     scroll: {
       maxDepth: 2000,
-      maxDepthScrollHeight: 3000,
-      maxDepthTime: 4000000000 as Duration,
+      maxScrollHeight: 3000,
+      maxScrollHeightTime: 4000000000 as Duration,
       maxDepthScrollTop: 1000,
     },
   },
@@ -167,9 +167,9 @@ describe('viewCollection', () => {
       display: {
         scroll: {
           max_depth: 2000,
-          max_depth_scroll_height: 3000,
-          max_depth_time: 4000000000000000 as ServerDuration,
           max_depth_scroll_top: 1000,
+          max_scroll_height: 3000,
+          max_scroll_height_time: 4000000000000000 as ServerDuration,
         },
       },
       privacy: { replay_level: 'mask-user-input' },

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -114,9 +114,9 @@ function processViewUpdate(
       ? {
           scroll: {
             max_depth: view.commonViewMetrics.scroll.maxDepth,
-            max_depth_scroll_height: view.commonViewMetrics.scroll.maxDepthScrollHeight,
             max_depth_scroll_top: view.commonViewMetrics.scroll.maxDepthScrollTop,
-            max_depth_time: toServerDuration(view.commonViewMetrics.scroll.maxDepthTime),
+            max_scroll_height: view.commonViewMetrics.scroll.maxScrollHeight,
+            max_scroll_height_time: toServerDuration(view.commonViewMetrics.scroll.maxScrollHeightTime),
           },
         }
       : undefined,

--- a/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
@@ -82,8 +82,8 @@ describe('trackScrollMetrics', () => {
     updateScrollValues({ scrollDepth: 700, scrollHeight: 2000, scrollTop: 100 })
     expect(scrollMetricsCallback).toHaveBeenCalledOnceWith({
       maxDepth: 700,
-      maxDepthScrollHeight: 2000,
-      maxDepthTime: 100 as Duration,
+      maxScrollHeight: 2000,
+      maxScrollHeightTime: 100 as Duration,
       maxDepthScrollTop: 100,
     })
   })
@@ -93,8 +93,8 @@ describe('trackScrollMetrics', () => {
     updateScrollValues({ scrollDepth: 700, scrollHeight: 1900, scrollTop: 100 })
     expect(scrollMetricsCallback).toHaveBeenCalledOnceWith({
       maxDepth: 700,
-      maxDepthScrollHeight: 2000,
-      maxDepthTime: 100 as Duration,
+      maxScrollHeight: 2000,
+      maxScrollHeightTime: 100 as Duration,
       maxDepthScrollTop: 100,
     })
   })
@@ -105,8 +105,8 @@ describe('trackScrollMetrics', () => {
     updateScrollValues({ scrollDepth: 600, scrollHeight: 2000, scrollTop: 0 })
     expect(scrollMetricsCallback).toHaveBeenCalledOnceWith({
       maxDepth: 700,
-      maxDepthScrollHeight: 2000,
-      maxDepthTime: 100 as Duration,
+      maxScrollHeight: 2000,
+      maxScrollHeightTime: 100 as Duration,
       maxDepthScrollTop: 100,
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.ts
@@ -18,9 +18,9 @@ export const THROTTLE_SCROLL_DURATION = ONE_SECOND
 
 export interface ScrollMetrics {
   maxDepth: number
-  maxDepthScrollHeight: number
+  maxScrollHeight: number
   maxDepthScrollTop: number
-  maxDepthTime: Duration
+  maxScrollHeightTime: Duration
 }
 
 export function trackScrollMetrics(
@@ -31,7 +31,7 @@ export function trackScrollMetrics(
 ) {
   let maxScrollDepth = 0
   let maxScrollHeight = 0
-  let maxScrollTime = 0 as Duration
+  let maxScrollHeightTime = 0 as Duration
 
   const subscription = scrollValues.subscribe(({ scrollDepth, scrollTop, scrollHeight }) => {
     let shouldUpdate = false
@@ -44,18 +44,16 @@ export function trackScrollMetrics(
     if (scrollHeight > maxScrollHeight) {
       maxScrollHeight = scrollHeight
       const now = relativeNow()
-      maxScrollTime = elapsed(viewStart.relative, now)
+      maxScrollHeightTime = elapsed(viewStart.relative, now)
       shouldUpdate = true
     }
 
     if (shouldUpdate) {
       callback({
         maxDepth: Math.min(maxScrollDepth, maxScrollHeight),
-        // TODO: This should be renamed to maxScrollHeight in the next major release
-        maxDepthScrollHeight: maxScrollHeight,
-        // TODO: This should be renamed to maxScrollTime in the next major release
-        maxDepthTime: maxScrollTime,
         maxDepthScrollTop: scrollTop,
+        maxScrollHeight,
+        maxScrollHeightTime,
       })
     }
   })

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -127,9 +127,9 @@ export interface RawRumViewEvent {
 interface ViewDisplay {
   scroll: {
     max_depth?: number
-    max_depth_scroll_height?: number
     max_depth_scroll_top?: number
-    max_depth_time?: ServerDuration
+    max_scroll_height?: number
+    max_scroll_height_time?: ServerDuration
   }
 }
 

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -871,17 +871,17 @@ export type RumViewEvent = CommonProperties & {
        */
       readonly max_depth: number
       /**
-       * Page scroll height (total height) when the maximum scroll depth was reached for this view (in pixels)
-       */
-      readonly max_depth_scroll_height: number
-      /**
        * Page scroll top (scrolled distance) when the maximum scroll depth was reached for this view (in pixels)
        */
       readonly max_depth_scroll_top: number
       /**
-       * Duration between the view start and the scroll event that reached the maximum scroll depth for this view (in nanoseconds)
+       * Maximum page scroll height (total height) for this view (in pixels)
        */
-      readonly max_depth_time: number
+      readonly max_scroll_height: number
+      /**
+       * Duration between the view start and the time the max scroll height was reached for this view (in nanoseconds)
+       */
+      readonly max_scroll_height_time: number
       [k: string]: unknown
     }
     [k: string]: unknown

--- a/packages/rum-core/test/formatValidation.ts
+++ b/packages/rum-core/test/formatValidation.ts
@@ -27,6 +27,15 @@ export function validateRumFormat(rumEvent: Context) {
     .validate('rum-events-schema.json', rumEvent)
 
   if (instance.errors) {
-    instance.errors.map((error) => fail(`${error.dataPath || 'event'} ${error.message!}`))
+    const errors = instance.errors
+      .map((error) => {
+        let message = error.message
+        if (error.keyword === 'const') {
+          message += ` '${(error.params as { allowedValue: string }).allowedValue}'`
+        }
+        return `  ${error.dataPath || 'event'} ${message}`
+      })
+      .join('\n')
+    fail(`Invalid RUM event format:\n${errors}`)
   }
 }


### PR DESCRIPTION
## Motivation

During #2180 we introduced a few View event fields to track scroll. The implementation had a few shortcomings addressed in #2399, which changed how some of those fields were computed. This PR rename the fields to be more explicit.

## Changes

* Improve validation error during unit test
* Update rum-events-format (see https://github.com/DataDog/rum-events-format/pull/163)
* Rename the fields:
  * `maxDepthTime` -> `maxScrollHeightTime`
  * `maxDepthScrollHeight` -> `maxScrollHeight`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
