### PR TITLE
🐛 [RUM-1196] Escape CSS rules containing a colon for Safari compatibility

### DIFF
--- a/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
+++ b/packages/core/src/domain/tracekit/computeStackTrace.spec.ts
@@ -1,4 +1,4 @@
-import { isSafari } from '../../../test'
+import { isSafari } from '../../tools/utils/browserDetection'
 import * as CapturedExceptions from './capturedExceptions.specHelper'
 import { computeStackTrace } from './computeStackTrace'
 

--- a/packages/core/src/tools/utils/browserDetection.ts
+++ b/packages/core/src/tools/utils/browserDetection.ts
@@ -1,7 +1,17 @@
+let browserIsIE: boolean | undefined
 export function isIE() {
-  return Boolean((document as any).documentMode)
+  return browserIsIE ?? (browserIsIE = Boolean((document as any).documentMode))
 }
 
+let browserIsChromium: boolean | undefined
 export function isChromium() {
-  return !!(window as any).chrome || /HeadlessChrome/.test(window.navigator.userAgent)
+  return (
+    browserIsChromium ??
+    (browserIsChromium = !!(window as any).chrome || /HeadlessChrome/.test(window.navigator.userAgent))
+  )
+}
+
+let browserIsSafari: boolean | undefined
+export function isSafari() {
+  return browserIsSafari ?? (browserIsSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent))
 }

--- a/packages/core/test/browserChecks.ts
+++ b/packages/core/test/browserChecks.ts
@@ -1,7 +1,3 @@
-export function isSafari() {
-  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
-}
-
 export function isFirefox() {
   return navigator.userAgent.toLowerCase().indexOf('firefox') > -1
 }

--- a/packages/rum/src/domain/record/serialization/serializeAttributes.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttributes.spec.ts
@@ -23,6 +23,12 @@ describe('getCssRulesString', () => {
     expect(getCssRulesString(styleNode.sheet)).toBe('body { color: red; }')
   })
 
+  it('properly escapes CSS rules selectors containing a colon', () => {
+    styleNode.sheet!.insertRule('[foo\\:bar] { display: none; }')
+
+    expect(getCssRulesString(styleNode.sheet)).toBe('[foo\\:bar] { display: none; }')
+  })
+
   it('inlines imported external stylesheets', () => {
     styleNode.sheet!.insertRule(`@import url("${CSS_FILE_URL}");`)
 

--- a/packages/rum/src/domain/record/serialization/serializeAttributes.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttributes.ts
@@ -140,6 +140,7 @@ export function getCssRulesString(cssStyleSheet: CSSStyleSheet | undefined | nul
 
 function getCssRuleString(rule: CSSRule): string {
   // Safari does not escape attribute selectors containing : properly
+  // https://bugs.webkit.org/show_bug.cgi?id=184604
   if (isCSSStyleRule(rule) && rule.selectorText.includes(':')) {
     // This regex replaces [foo:bar] by [foo\\:bar]
     const escapeColon = /(\[[\w-]+[^\\])(:[^\]]+\])/g


### PR DESCRIPTION
## Motivation

Safari does not escape colons in CSS selector Text ( such as [ng:cloak] ).
This causes issues during session replay, as the styles are not applied. 
https://bugs.webkit.org/show_bug.cgi?id=184604
https://github.com/rrweb-io/rrweb/pull/1253

## Changes

When a CSS rule selector contains a colon, ensure it is escaped.

## Testing

Record a page containing selectors with a colon using Safari. Check that the display is as expected in Session Replay.

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
