### PR TITLE
[RUM-1210] Change default propagator type to W3C tracecontext

### DIFF
--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -1,6 +1,6 @@
 import { DefaultPrivacyLevel, display } from '@datadog/browser-core'
 import type { RumInitConfiguration } from './configuration'
-import { serializeRumConfiguration, validateAndBuildRumConfiguration } from './configuration'
+import { DEFAULT_PROPAGATOR_TYPE, serializeRumConfiguration, validateAndBuildRumConfiguration } from './configuration'
 
 const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx', applicationId: 'xxx' }
 
@@ -90,7 +90,7 @@ describe('validateAndBuildRumConfiguration', () => {
           allowedTracingUrls: ['foo'],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: 'foo', propagatorTypes: ['datadog'] }])
+      ).toEqual([{ match: 'foo', propagatorTypes: [DEFAULT_PROPAGATOR_TYPE] }])
     })
 
     it('accepts functions', () => {
@@ -102,7 +102,7 @@ describe('validateAndBuildRumConfiguration', () => {
           allowedTracingUrls: [customOriginFunction],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: customOriginFunction, propagatorTypes: ['datadog'] }])
+      ).toEqual([{ match: customOriginFunction, propagatorTypes: [DEFAULT_PROPAGATOR_TYPE] }])
     })
 
     it('accepts RegExp', () => {
@@ -112,7 +112,7 @@ describe('validateAndBuildRumConfiguration', () => {
           allowedTracingUrls: [/az/i],
           service: 'bar',
         })!.allowedTracingUrls
-      ).toEqual([{ match: /az/i, propagatorTypes: ['datadog'] }])
+      ).toEqual([{ match: /az/i, propagatorTypes: [DEFAULT_PROPAGATOR_TYPE] }])
     })
 
     it('keeps headers', () => {
@@ -341,12 +341,14 @@ describe('validateAndBuildRumConfiguration', () => {
         expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).selected_tracing_propagators).toEqual([])
       })
 
-      it('should return Datadog propagator type', () => {
+      it('should return the default propagator type', () => {
         const simpleTracingConfig: RumInitConfiguration = {
           ...DEFAULT_INIT_CONFIGURATION,
           allowedTracingUrls: ['foo'],
         }
-        expect(serializeRumConfiguration(simpleTracingConfig).selected_tracing_propagators).toEqual(['datadog'])
+        expect(serializeRumConfiguration(simpleTracingConfig).selected_tracing_propagators).toEqual([
+          DEFAULT_PROPAGATOR_TYPE,
+        ])
       })
 
       it('should return all propagator types', () => {

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -16,6 +16,8 @@ import type { RumEvent } from '../rumEvent.types'
 import { isTracingOption } from './tracing/tracer'
 import type { PropagatorType, TracingOption } from './tracing/tracer.types'
 
+export const DEFAULT_PROPAGATOR_TYPE: PropagatorType = 'tracecontext'
+
 export interface RumInitConfiguration extends InitConfiguration {
   // global options
   applicationId: string
@@ -144,7 +146,7 @@ function validateAndBuildTracingOptions(initConfiguration: RumInitConfiguration)
     const tracingOptions: TracingOption[] = []
     initConfiguration.allowedTracingUrls.forEach((option) => {
       if (isMatchOption(option)) {
-        tracingOptions.push({ match: option, propagatorTypes: ['datadog'] })
+        tracingOptions.push({ match: option, propagatorTypes: [DEFAULT_PROPAGATOR_TYPE] })
       } else if (isTracingOption(option)) {
         tracingOptions.push(option)
       } else {
@@ -170,7 +172,7 @@ function getSelectedTracingPropagators(configuration: RumInitConfiguration): Pro
   if (Array.isArray(configuration.allowedTracingUrls) && configuration.allowedTracingUrls.length > 0) {
     configuration.allowedTracingUrls.forEach((option) => {
       if (isMatchOption(option)) {
-        usedTracingPropagators.add('datadog')
+        usedTracingPropagators.add(DEFAULT_PROPAGATOR_TYPE)
       } else if (getType(option) === 'object' && Array.isArray(option.propagatorTypes)) {
         // Ensure we have an array, as we cannot rely on types yet (configuration is provided by users)
         option.propagatorTypes.forEach((propagatorType) => usedTracingPropagators.add(propagatorType))


### PR DESCRIPTION
## Motivation

To promote the support and usage of OpenTelemetry, the default propagatorType is changed from `datadog` to `tracecontext`.

## Changes

While building the RUM configuration object, the SDK will now add `tracecontext` as the default propagatorType when the `allowedTracingURLs` parameter does not contain the `propagatorTypes` parameter. 

## Testing

Initialize the SDK with the `allowedTracingURLs`, such as: 
```
...
allowedTracingUrls: [/.*/]
...

Check in the network panel of your browser that the `traceparent` header is added to every resource requested through fetch or XHR. 

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
