### PR TITLE
🔈[RUM-58] Collect session start_precondition

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -7,11 +7,12 @@ import { DOM_EVENT, addEventListener, addEventListeners } from '../../browser/ad
 import { clearInterval, setInterval } from '../../tools/timer'
 import type { Configuration } from '../configuration'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
+import type { SessionStartPrecondition } from './sessionStore'
 import { startSessionStore } from './sessionStore'
 
 export interface SessionManager<TrackingType extends string> {
   findActiveSession: (startTime?: RelativeTime) => SessionContext<TrackingType> | undefined
-  renewObservable: Observable<void>
+  renewObservable: Observable<SessionStartPrecondition | undefined>
   expireObservable: Observable<void>
   expire: () => void
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export {
   // Exposed for tests
   stopSessionManager,
 } from './domain/session/sessionManager'
+export { SessionStartPrecondition } from './domain/session/sessionStore'
 export {
   SESSION_TIME_OUT_DELAY, // Exposed for tests
 } from './domain/session/sessionConstants'

--- a/packages/core/src/tools/abstractLifeCycle.ts
+++ b/packages/core/src/tools/abstractLifeCycle.ts
@@ -20,7 +20,7 @@ export class AbstractLifeCycle<EventMap> {
   private callbacks: { [key in keyof EventMap]?: Array<(data: any) => void> } = {}
 
   notify<EventType extends EventTypesWithoutData<EventMap>>(eventType: EventType): void
-  notify<EventType extends keyof EventMap>(eventType: EventType, data: EventMap[EventType]): void
+  notify<EventType extends keyof EventMap>(eventType: EventType, data?: EventMap[EventType]): void
   notify(eventType: keyof EventMap, data?: unknown) {
     const eventCallbacks = this.callbacks[eventType]
     if (eventCallbacks) {

--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -1,4 +1,4 @@
-import type { Context, PageExitEvent, RawError, RelativeTime } from '@datadog/browser-core'
+import type { Context, PageExitEvent, RawError, RelativeTime, SessionStartPrecondition } from '@datadog/browser-core'
 import { AbstractLifeCycle } from '@datadog/browser-core'
 import type { RumPerformanceEntry } from '../browser/performanceCollection'
 import type { RumEventDomainContext } from '../domainContext.types'
@@ -77,7 +77,7 @@ export interface LifeCycleEventMap {
   [LifeCycleEventTypeAsConst.REQUEST_STARTED]: RequestStartEvent
   [LifeCycleEventTypeAsConst.REQUEST_COMPLETED]: RequestCompleteEvent
   [LifeCycleEventTypeAsConst.SESSION_EXPIRED]: void
-  [LifeCycleEventTypeAsConst.SESSION_RENEWED]: void
+  [LifeCycleEventTypeAsConst.SESSION_RENEWED]: SessionStartPrecondition | undefined
   [LifeCycleEventTypeAsConst.PAGE_EXITED]: PageExitEvent
   [LifeCycleEventTypeAsConst.RAW_RUM_EVENT_COLLECTED]: RawRumEventCollectedData
   [LifeCycleEventTypeAsConst.RUM_EVENT_COLLECTED]: RumEvent & Context

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -43,8 +43,8 @@ export function startRumSessionManager(configuration: RumConfiguration, lifeCycl
     lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
   })
 
-  sessionManager.renewObservable.subscribe(() => {
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+  sessionManager.renewObservable.subscribe((sessionStartPrecondition) => {
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, sessionStartPrecondition)
   })
 
   return {

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -162,6 +162,7 @@ describe('viewCollection', () => {
       session: {
         has_replay: undefined,
         is_active: undefined,
+        start_precondition: undefined,
       },
       feature_flags: undefined,
       display: {

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -123,6 +123,7 @@ function processViewUpdate(
     session: {
       has_replay: replayStats ? true : undefined,
       is_active: view.sessionIsActive ? undefined : false,
+      start_precondition: view.sessionStartPrecondition,
     },
     privacy: {
       replay_level: configuration.defaultPrivacyLevel,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -8,6 +8,7 @@ import type {
   TimeStamp,
   RawErrorCause,
   DefaultPrivacyLevel,
+  SessionStartPrecondition,
 } from '@datadog/browser-core'
 import type { PageState } from './domain/contexts/pageStateHistory'
 import type { RumSessionPlan } from './domain/rumSessionManager'
@@ -109,6 +110,7 @@ export interface RawRumViewEvent {
     in_foreground_periods?: InForegroundPeriod[]
   }
   session: {
+    start_precondition?: SessionStartPrecondition
     has_replay: true | undefined
     is_active: false | undefined
   }


### PR DESCRIPTION
## Motivation

Collect session.start_precondition (inactivity_timeout, max_duration, explicit_stop)

Limitations:
- If a new tab renew the session the precondition is not computed
- A frozen tab can send a wrong precondition based on session it has cached

## Changes

- add session.start_precondition in view
- compute the precondition based on `sessionCache`
- notify `start_precondition`  in `renewObservable` 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
