### PR TITLE
✨ [RUM-1215] Collect INP #2355 

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,7 +18,6 @@ export enum ExperimentalFeature {
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
   NO_RESOURCE_DURATION_FROZEN_STATE = 'no_resource_duration_frozen_state',
   SCROLLMAP = 'scrollmap',
-  INTERACTION_TO_NEXT_PAINT = 'interaction_to_next_paint',
   WEB_VITALS_ATTRIBUTION = 'web_vitals_attribution',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
 }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -48,124 +48,105 @@ describe('trackInteractionToNextPaint', () => {
   })
 
   afterEach(() => {
+    resetExperimentalFeatures()
     interactionCountStub.clear()
   })
 
-  describe('if feature flag enabled', () => {
-    beforeEach(() => {
-      addExperimentalFeatures([ExperimentalFeature.INTERACTION_TO_NEXT_PAINT])
-    })
+  it('should return undefined when there are no interactions', () => {
+    setupBuilder.build()
+    expect(getInteractionToNextPaint()).toEqual(undefined)
+  })
 
-    afterEach(() => {
-      resetExperimentalFeatures()
+  it('should ignore entries without interactionId', () => {
+    const { lifeCycle } = setupBuilder.build()
+    createPerformanceEntry(RumPerformanceEntryType.EVENT)
+    newInteraction(lifeCycle, {
+      interactionId: undefined,
     })
+    expect(getInteractionToNextPaint()).toEqual(undefined)
+  })
 
-    it('should return undefined when there are no interactions', () => {
-      setupBuilder.build()
-      expect(getInteractionToNextPaint()).toEqual(undefined)
-    })
-
-    it('should ignore entries without interactionId', () => {
-      const { lifeCycle } = setupBuilder.build()
-      createPerformanceEntry(RumPerformanceEntryType.EVENT)
+  it('should return the p98 worst interaction', () => {
+    const { lifeCycle } = setupBuilder.build()
+    for (let index = 1; index <= 100; index++) {
       newInteraction(lifeCycle, {
-        interactionId: undefined,
+        duration: index as Duration,
+        interactionId: index,
       })
-      expect(getInteractionToNextPaint()).toEqual(undefined)
-    })
-
-    it('should return the p98 worst interaction', () => {
-      const { lifeCycle } = setupBuilder.build()
-      for (let index = 1; index <= 100; index++) {
-        newInteraction(lifeCycle, {
-          duration: index as Duration,
-          interactionId: index,
-        })
-      }
-      expect(getInteractionToNextPaint()).toEqual({
-        value: 98 as Duration,
-        targetSelector: undefined,
-      })
-    })
-
-    it('should return 0 when an interaction happened without generating a performance event (interaction duration below 40ms)', () => {
-      setupBuilder.build()
-      interactionCountStub.setInteractionCount(1 as Duration) // assumes an interaction happened but no PERFORMANCE_ENTRIES_COLLECTED have been triggered
-      expect(getInteractionToNextPaint()).toEqual({ value: 0 as Duration })
-    })
-
-    it('should take first-input entry into account', () => {
-      const { lifeCycle } = setupBuilder.build()
-      newInteraction(lifeCycle, {
-        interactionId: 1,
-        entryType: RumPerformanceEntryType.FIRST_INPUT,
-      })
-      expect(getInteractionToNextPaint()).toEqual({
-        value: 40 as Duration,
-        targetSelector: undefined,
-      })
-    })
-
-    it('should replace the entry in the list of worst interactions when an entry with the same interactionId exist', () => {
-      const { lifeCycle } = setupBuilder.build()
-
-      for (let index = 1; index <= 100; index++) {
-        newInteraction(lifeCycle, {
-          duration: index as Duration,
-          interactionId: 1,
-        })
-      }
-      // the p98 return 100 which shows that the entry has been updated
-      expect(getInteractionToNextPaint()).toEqual({
-        value: 100 as Duration,
-        targetSelector: undefined,
-      })
-    })
-
-    it('should return the target selector when FF web_vital_attribution is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
-      const { lifeCycle } = setupBuilder.build()
-
-      newInteraction(lifeCycle, {
-        interactionId: 2,
-        target: appendElement('<button id="inp-target-element"></button>'),
-      })
-
-      expect(getInteractionToNextPaint()?.targetSelector).toEqual('#inp-target-element')
-    })
-
-    it("should not return the target selector if it's not a DOM element when FF web_vital_attribution is enabled", () => {
-      addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
-      const { lifeCycle } = setupBuilder.build()
-
-      newInteraction(lifeCycle, {
-        interactionId: 2,
-        target: appendText('text'),
-      })
-
-      expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)
-    })
-
-    it('should not return the target selector when FF web_vital_attribution is disabled', () => {
-      const { lifeCycle } = setupBuilder.build()
-
-      newInteraction(lifeCycle, {
-        interactionId: 2,
-        target: appendElement('<button id="inp-target-element"></button>'),
-      })
-
-      expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)
+    }
+    expect(getInteractionToNextPaint()).toEqual({
+      value: 98 as Duration,
+      targetSelector: undefined,
     })
   })
 
-  describe('if feature flag disabled', () => {
-    it('should return undefined', () => {
-      const { lifeCycle } = setupBuilder.build()
+  it('should return 0 when an interaction happened without generating a performance event (interaction duration below 40ms)', () => {
+    setupBuilder.build()
+    interactionCountStub.setInteractionCount(1 as Duration) // assumes an interaction happened but no PERFORMANCE_ENTRIES_COLLECTED have been triggered
+    expect(getInteractionToNextPaint()).toEqual({ value: 0 as Duration })
+  })
+
+  it('should take first-input entry into account', () => {
+    const { lifeCycle } = setupBuilder.build()
+    newInteraction(lifeCycle, {
+      interactionId: 1,
+      entryType: RumPerformanceEntryType.FIRST_INPUT,
+    })
+    expect(getInteractionToNextPaint()).toEqual({
+      value: 40 as Duration,
+      targetSelector: undefined,
+    })
+  })
+
+  it('should replace the entry in the list of worst interactions when an entry with the same interactionId exist', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    for (let index = 1; index <= 100; index++) {
       newInteraction(lifeCycle, {
+        duration: index as Duration,
         interactionId: 1,
       })
-      expect(getInteractionToNextPaint()).toEqual(undefined)
+    }
+    // the p98 return 100 which shows that the entry has been updated
+    expect(getInteractionToNextPaint()).toEqual({
+      value: 100 as Duration,
+      targetSelector: undefined,
     })
+  })
+
+  it('should return the target selector when FF web_vital_attribution is enabled', () => {
+    addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+    const { lifeCycle } = setupBuilder.build()
+
+    newInteraction(lifeCycle, {
+      interactionId: 2,
+      target: appendElement('<button id="inp-target-element"></button>'),
+    })
+
+    expect(getInteractionToNextPaint()?.targetSelector).toEqual('#inp-target-element')
+  })
+
+  it("should not return the target selector if it's not a DOM element when FF web_vital_attribution is enabled", () => {
+    addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+    const { lifeCycle } = setupBuilder.build()
+
+    newInteraction(lifeCycle, {
+      interactionId: 2,
+      target: appendText('text'),
+    })
+
+    expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)
+  })
+
+  it('should not return the target selector when FF web_vital_attribution is disabled', () => {
+    const { lifeCycle } = setupBuilder.build()
+
+    newInteraction(lifeCycle, {
+      interactionId: 2,
+      target: appendElement('<button id="inp-target-element"></button>'),
+    })
+
+    expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)
   })
 })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -28,10 +28,7 @@ export function trackInteractionToNextPaint(
   viewLoadingType: ViewLoadingType,
   lifeCycle: LifeCycle
 ) {
-  if (
-    !isInteractionToNextPaintSupported() ||
-    !isExperimentalFeatureEnabled(ExperimentalFeature.INTERACTION_TO_NEXT_PAINT)
-  ) {
+  if (!isInteractionToNextPaintSupported()) {
     return {
       getInteractionToNextPaint: () => undefined,
       stop: noop,


### PR DESCRIPTION
## Motivation

[Interaction to Next Paint (INP)](https://web.dev/inp/) is a Core Web Vital metric that will [replace First Input Delay (FID)](https://web.dev/inp-cwv/) in March 2024. INP assesses a page's overall responsiveness to user interactions by observing the latency of all clicks, taps, and keyboard interactions that occur throughout the lifespan of a user's visit to a page

## Changes

Remove the feature flag

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
