### PR TITLE
 🔊 Add INP telemetry

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -102,17 +102,22 @@ export interface RumFirstInputTiming {
   entryType: RumPerformanceEntryType.FIRST_INPUT
   startTime: RelativeTime
   processingStart: RelativeTime
+  processingEnd: RelativeTime
   duration: Duration
   target?: Node
   interactionId?: number
+  name: string
 }
 
 export interface RumPerformanceEventTiming {
   entryType: RumPerformanceEntryType.EVENT
   startTime: RelativeTime
+  processingStart: RelativeTime
+  processingEnd: RelativeTime
   duration: Duration
   interactionId?: number
   target?: Node
+  name: string
 }
 
 export interface RumLayoutShiftTiming {
@@ -296,8 +301,10 @@ function retrieveFirstInputTiming(configuration: RumConfiguration, callback: (ti
       const timing: RumFirstInputTiming = {
         entryType: RumPerformanceEntryType.FIRST_INPUT,
         processingStart: relativeNow(),
+        processingEnd: relativeNow(),
         startTime: evt.timeStamp as RelativeTime,
         duration: 0 as Duration, // arbitrary value to avoid nullable duration and simplify INP logic
+        name: '',
       }
 
       if (evt.type === DOM_EVENT.POINTER_DOWN) {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -64,7 +64,7 @@ export function trackInteractionToNextPaint(
     const inpInteraction = longestInteractions.estimateP98Interaction()
     if (inpInteraction) {
       interactionToNextPaint = inpInteraction.duration
-      if (interactionToNextPaint > 10 * ONE_MINUTE && !telemetryCollected) {
+      if (!telemetryCollected) {
         telemetryCollected = true
         addTelemetryDebug('INP outlier', {
           inp: interactionToNextPaint,


### PR DESCRIPTION
## Motivation

There are some INP outliers that can exceed a day. Let's collect all the RumPerformanceEventTiming info to see if there is a issue on our side or on the browser API side.

## Changes

Collect telemetry on INP exceeding 10 min

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
