### PR TITLE
🐛 [RUM-1325] fix memory leak when using shadow dom 

### DIFF
--- a/packages/rum-core/src/browser/htmlDomUtils.spec.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.spec.ts
@@ -127,6 +127,10 @@ if (!isIE()) {
 
 describe('forEachChildNodes', () => {
   it('should iterate over the direct children for a normal node', () => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+
     const container = appendElement(`
       <div>toto<span></span><!-- --></div>
     `)

--- a/packages/rum-core/src/browser/htmlDomUtils.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.ts
@@ -19,8 +19,11 @@ export function isNodeShadowRoot(node: Node): node is ShadowRoot {
   return !!shadowRoot.host && shadowRoot.nodeType === Node.DOCUMENT_FRAGMENT_NODE && isElementNode(shadowRoot.host)
 }
 
-export function getChildNodes(node: Node) {
-  return isNodeShadowHost(node) ? node.shadowRoot.childNodes : node.childNodes
+export function forEachChildNodes(node: Node, callback: (child: Node) => void) {
+  node.childNodes.forEach(callback)
+  if (isNodeShadowHost(node)) {
+    callback(node.shadowRoot)
+  }
 }
 
 /**

--- a/packages/rum/src/domain/record/observers/mutationObserver.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.ts
@@ -77,8 +77,7 @@ export function initMutationObserver(
       mutations.concat(observer.takeRecords() as RumMutationRecord[]),
       mutationCallback,
       configuration,
-      shadowRootsController,
-      target
+      shadowRootsController
     )
   })
 
@@ -108,8 +107,7 @@ function processMutations(
   mutations: RumMutationRecord[],
   mutationCallback: MutationCallBack,
   configuration: RumConfiguration,
-  shadowRootsController: ShadowRootsController,
-  target: Node
+  shadowRootsController: ShadowRootsController
 ) {
   mutations
     .filter((mutation): mutation is RumChildListMutationRecord => mutation.type === 'childList')
@@ -125,7 +123,7 @@ function processMutations(
   // * should be hidden or ignored
   const filteredMutations = mutations.filter(
     (mutation): mutation is WithSerializedTarget<RumMutationRecord> =>
-      target.contains(mutation.target) &&
+      mutation.target.isConnected &&
       nodeAndAncestorsHaveSerializedNode(mutation.target) &&
       getNodePrivacyLevel(mutation.target, configuration.defaultPrivacyLevel) !== NodePrivacyLevel.HIDDEN
   )

--- a/packages/rum/src/domain/record/observers/mutationObserver.ts
+++ b/packages/rum/src/domain/record/observers/mutationObserver.ts
@@ -1,10 +1,10 @@
 import { monitor, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import {
-  getChildNodes,
   isNodeShadowHost,
   getMutationObserverConstructor,
   getParentNode,
+  forEachChildNodes,
 } from '@datadog/browser-rum-core'
 import { NodePrivacyLevel } from '../../../constants'
 import type {
@@ -389,9 +389,10 @@ export function sortAddedAndMovedNodes(nodes: Node[]) {
     return 0
   })
 }
+
 function traverseRemovedShadowDom(removedNode: Node, shadowDomRemovedCallback: ShadowRootCallBack) {
   if (isNodeShadowHost(removedNode)) {
     shadowDomRemovedCallback(removedNode.shadowRoot)
   }
-  getChildNodes(removedNode).forEach((child) => traverseRemovedShadowDom(child, shadowDomRemovedCallback))
+  forEachChildNodes(removedNode, (childNode) => traverseRemovedShadowDom(childNode, shadowDomRemovedCallback))
 }


### PR DESCRIPTION
## Motivation

See https://github.com/DataDog/browser-sdk/issues/2424

## Changes

When a node was removed from the DOM, we traverse all of its children to look for Shadow Roots to clean them up from the Shadow Root Controller. The traversing implementation had an issue and skipped some children.

I also noticed a small simplification opportunity to check whether an element is in the DOM by using `isConnected`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
