### PR TITLE
🐛 propagate privacy defined on shadow hosts

### DIFF
--- a/packages/rum-core/src/browser/htmlDomUtils.spec.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.spec.ts
@@ -1,5 +1,5 @@
 import { isIE } from '@datadog/browser-core'
-import { appendElement } from '../../test'
+import { appendElement, appendText } from '../../test'
 import {
   isTextNode,
   isCommentNode,
@@ -8,6 +8,7 @@ import {
   getParentNode,
   isNodeShadowHost,
   forEachChildNodes,
+  hasChildNodes,
 } from './htmlDomUtils'
 
 describe('isTextNode', () => {
@@ -124,6 +125,31 @@ if (!isIE()) {
     })
   })
 }
+
+describe('hasChildNode', () => {
+  beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+  })
+
+  it('should return `true` if the element has a direct child node', () => {
+    expect(hasChildNodes(appendElement('<div>foo</div>'))).toBe(true)
+    expect(hasChildNodes(appendElement('<div><hr /></div>'))).toBe(true)
+    expect(hasChildNodes(appendElement('<div><!--  --></div>'))).toBe(true)
+  })
+
+  it('should return `true` if the element is a shadow host', () => {
+    const container = appendElement('<div></div>')
+    container.attachShadow({ mode: 'open' })
+    expect(hasChildNodes(container)).toBe(true)
+  })
+
+  it('should return `false` otherwise', () => {
+    expect(hasChildNodes(appendElement('<div></div>'))).toBe(false)
+    expect(hasChildNodes(appendText('foo'))).toBe(false)
+  })
+})
 
 describe('forEachChildNodes', () => {
   it('should iterate over the direct children for a normal node', () => {

--- a/packages/rum-core/src/browser/htmlDomUtils.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.ts
@@ -19,6 +19,10 @@ export function isNodeShadowRoot(node: Node): node is ShadowRoot {
   return !!shadowRoot.host && shadowRoot.nodeType === Node.DOCUMENT_FRAGMENT_NODE && isElementNode(shadowRoot.host)
 }
 
+export function hasChildNodes(node: Node) {
+  return node.childNodes.length > 0 || isNodeShadowHost(node)
+}
+
 export function forEachChildNodes(node: Node, callback: (child: Node) => void) {
   node.childNodes.forEach(callback)
   if (isNodeShadowHost(node)) {


### PR DESCRIPTION
## Motivation

Setting a privacy attribute directly on a shadow host element does not propagate the privacy to its children.

## Changes

Factorize the way we serialize "normal" children with the way we serialize shadow roots.

Before:
<img width="216" alt="Screenshot 2023-10-06 at 14 39 27" src="https://github.com/DataDog/browser-sdk/assets/61787/5cb635e5-422e-4d78-bffb-a958a42e78d1">

After:
<img width="216" alt="Screenshot 2023-10-06 at 14 39 54" src="https://github.com/DataDog/browser-sdk/assets/61787/e1f2f383-e71a-4857-9adc-42c5a706b133">


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
