### PR TITLE
[RUM-1211] fix compatibility with TS4.6/4.7 using ES2022

### DIFF
--- a/packages/core/src/domain/error/error.types.ts
+++ b/packages/core/src/domain/error/error.types.ts
@@ -1,6 +1,15 @@
 import type { ClocksState } from '../../tools/utils/timeUtils'
 
-export interface ErrorWithCause extends Error {
+// TS v4.6 introduced Error.cause[1] typed as `Error`. TS v4.8 changed Error.cause to be
+// `unknown`[2].
+//
+// Because we still support TS 3.8, we need to declare our own type. We can remove it once we drop
+// support for TS v4.7 and before. The 'cause' property defined by TS needs to be omitted because
+// we define it with a type `unknown` which is incompatible with TS 4.6 and 4.7.
+//
+// [1]: https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/#target-es2022
+// [2]: https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#lib-d-ts-updates
+export interface ErrorWithCause extends Omit<Error, 'cause'> {
   cause?: unknown
 }
 

--- a/scripts/cli
+++ b/scripts/cli
@@ -96,6 +96,7 @@ check_typescript_3_compatibility () {
 check_typescript_latest_compatibility () {
   # Add typescript options only supported in newer versions
   insert_line_in_file tsconfig.json 3 '"exactOptionalPropertyTypes": true,'
+  sed -i '' 's/es2015/esnext/i' tsconfig.json
 
   yarn add --dev typescript@latest
   local succeeded=true


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/browser-sdk/issues/2442

## Changes

* Omit the 'cause' property to avoid compatiblity issues.
* We don't check TS 4.6 or 4.7 compatibility specifically, so this exact issue is not covered. I don't think we need to add compatibility checks for these specific versions, but I changed the "latest" compatibility check to include the "esnext" lib, so in the future we'll detect incompatibilities with newly introduced TS types sooner.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
