### PR TITLE
🔊 Update INP telemetry

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
@@ -50,6 +50,7 @@ export function trackCommonViewMetrics(
 
   const { stop: stopINPTracking, getInteractionToNextPaint } = trackInteractionToNextPaint(
     configuration,
+    viewStart,
     loadingType,
     lifeCycle
   )

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -1,5 +1,10 @@
 import type { Duration } from '@datadog/browser-core'
-import { ExperimentalFeature, addExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
+import {
+  ExperimentalFeature,
+  addExperimentalFeatures,
+  clocksNow,
+  resetExperimentalFeatures,
+} from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
 import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
@@ -39,6 +44,7 @@ describe('trackInteractionToNextPaint', () => {
     setupBuilder = setup().beforeBuild(({ lifeCycle, configuration }) => {
       const interactionToNextPaintTracking = trackInteractionToNextPaint(
         configuration,
+        clocksNow(),
         ViewLoadingType.INITIAL_LOAD,
         lifeCycle
       )

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -4,8 +4,9 @@ import {
   ExperimentalFeature,
   ONE_MINUTE,
   addTelemetryDebug,
+  elapsed,
 } from '@datadog/browser-core'
-import type { Duration } from '@datadog/browser-core'
+import type { ClocksState, Duration } from '@datadog/browser-core'
 import { RumPerformanceEntryType, supportPerformanceTimingEvent } from '../../../browser/performanceCollection'
 import type { RumFirstInputTiming, RumPerformanceEventTiming } from '../../../browser/performanceCollection'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -31,6 +32,7 @@ export interface InteractionToNextPaint {
  */
 export function trackInteractionToNextPaint(
   configuration: RumConfiguration,
+  viewStart: ClocksState,
   viewLoadingType: ViewLoadingType,
   lifeCycle: LifeCycle
 ) {
@@ -69,6 +71,7 @@ export function trackInteractionToNextPaint(
         addTelemetryDebug('INP outlier', {
           inp: interactionToNextPaint,
           interaction: {
+            timeFromViewStart: elapsed(viewStart.relative, newInteraction.startTime),
             duration: newInteraction.duration,
             startTime: newInteraction.startTime,
             processingStart: newInteraction.processingStart,


### PR DESCRIPTION
## Motivation

To identify if some of the PerformanceEventTiming contributing to the view INP start before the view start, let's collect the duration between the view start and the interaction start.

## Changes

Add timeFromViewStart in INP telemetry

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
