### PR TITLE
🐛 bridge action e2e: wait for click chain timeout

### DIFF
--- a/test/e2e/scenario/eventBridge.scenario.ts
+++ b/test/e2e/scenario/eventBridge.scenario.ts
@@ -17,6 +17,8 @@ describe('bridge present', () => {
     .run(async ({ intakeRegistry }) => {
       const button = await $('button')
       await button.click()
+      // wait for click chain to close
+      await browser.pause(1000)
       await flushEvents()
 
       expect(intakeRegistry.rumActionEvents.length).toBe(1)


### PR DESCRIPTION
## Motivation

Consistent failure on this test on firefox since the action behaviour update

## Changes

Wait for the click chain timeout before flusing

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
