### PR TITLE
⚗️🐛 [RUM-1561] Compute selector from a detached element

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -19,6 +19,7 @@ export enum ExperimentalFeature {
   INTERACTION_TO_NEXT_PAINT = 'interaction_to_next_paint',
   WEB_VITALS_ATTRIBUTION = 'web_vitals_attribution',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
+  DETACHED_ELEMENT_SELECTOR = 'detached_element_selector',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
@@ -1,3 +1,4 @@
+import { addExperimentalFeatures, resetExperimentalFeatures, ExperimentalFeature } from '@datadog/browser-core'
 import { appendElement } from '../../test'
 import { getSelectorFromElement, supportScopeSelector } from './getSelectorFromElement'
 
@@ -154,6 +155,29 @@ describe('getSelectorFromElement', () => {
             // chances of matching a completely unrelated element.
             'BODY>BUTTON:nth-of-type(1)'
       )
+    })
+  })
+
+  describe('detached element', () => {
+    let button: HTMLButtonElement
+
+    beforeEach(() => {
+      const div = document.createElement('div')
+      button = document.createElement('button')
+      div.append(button)
+    })
+
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
+
+    it('should be supported with FF enabled', () => {
+      addExperimentalFeatures([ExperimentalFeature.DETACHED_ELEMENT_SELECTOR])
+      expect(getSelectorFromElement(button, undefined)).toEqual('DETACHED>DIV>BUTTON')
+    })
+
+    it('should not be supported with FF disabled', () => {
+      expect(() => getSelectorFromElement(button, undefined)).toThrow()
     })
   })
 

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -1,4 +1,4 @@
-import { cssEscape } from '@datadog/browser-core'
+import { cssEscape, isExperimentalFeatureEnabled, ExperimentalFeature } from '@datadog/browser-core'
 import { DEFAULT_PROGRAMMATIC_ACTION_NAME_ATTRIBUTE } from './action/getActionNameFromElement'
 
 /**
@@ -52,6 +52,10 @@ export function getSelectorFromElement(targetElement: Element, actionNameAttribu
     )
     if (globallyUniqueSelector) {
       return globallyUniqueSelector
+    }
+
+    if (isExperimentalFeatureEnabled(ExperimentalFeature.DETACHED_ELEMENT_SELECTOR) && !element.parentElement) {
+      return getSelectorFromDetachedElement(element, targetElementSelector)
     }
 
     const uniqueSelectorAmongChildren = findSelector(
@@ -142,6 +146,10 @@ function getPositionSelector(element: Element): string {
   }
 
   return `${cssEscape(element.tagName)}:nth-of-type(${elementIndex})`
+}
+
+function getSelectorFromDetachedElement(element: Element, targetElementSelector: string) {
+  return combineSelector(`DETACHED>${cssEscape(element.tagName)}`, targetElementSelector)
 }
 
 function findSelector(


### PR DESCRIPTION
## Motivation

Telemetry errors where an element don't have parent during selector computation:

![Screenshot 2023-10-12 at 17 53 53](https://github.com/DataDog/browser-sdk/assets/1331991/f37e42ec-fb40-4642-964e-65ea6c08d571)

It seems to only occur during web vital attribution. 

## Changes

Behind `detached_element_selector` flag, stop selector algorithm when an element don't have parent and generate a `DETACHED>...` selector.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
