### PR TITLE
🔊 [RUM-1561] Add monitoring on selector from element without parent

### DIFF
--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -1,4 +1,4 @@
-import { cssEscape } from '@datadog/browser-core'
+import { cssEscape, addTelemetryDebug } from '@datadog/browser-core'
 import { DEFAULT_PROGRAMMATIC_ACTION_NAME_ATTRIBUTE } from './action/getActionNameFromElement'
 
 /**
@@ -52,6 +52,15 @@ export function getSelectorFromElement(targetElement: Element, actionNameAttribu
     )
     if (globallyUniqueSelector) {
       return globallyUniqueSelector
+    }
+
+    if (!element.parentElement) {
+      addTelemetryDebug('selector from element without parent', {
+        debug: {
+          selector: combineSelector(cssEscape(element.tagName), targetElementSelector),
+          isConnected: element.isConnected,
+        },
+      })
     }
 
     const uniqueSelectorAmongChildren = findSelector(


### PR DESCRIPTION
## Motivation

Telemetry errors where an element don't have parent during selector computation:

![Screenshot 2023-10-12 at 17 53 53](https://github.com/DataDog/browser-sdk/assets/1331991/f37e42ec-fb40-4642-964e-65ea6c08d571)

It seems to only occur during web vital attribution. 

## Changes

Add debug log with:

- selector of the element without parent
- element isConnected value

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
