### PR TITLE
🐛 [RUM-1360] Cap INP outliers

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -209,6 +209,7 @@ function newView(
   const {
     setLoadEvent,
     stop: stopCommonViewMetricsTracking,
+    stopINPTracking,
     getCommonViewMetrics,
   } = trackCommonViewMetrics(
     lifeCycle,
@@ -280,6 +281,7 @@ function newView(
     stop() {
       stopInitialViewMetricsTracking()
       stopEventCountsTracking()
+      stopINPTracking()
       stopObservable.notify()
     },
     addTiming(name: string, time: RelativeTime | TimeStamp) {

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -208,6 +208,7 @@ function newView(
 
   const {
     setLoadEvent,
+    setViewEnd,
     stop: stopCommonViewMetricsTracking,
     stopINPTracking,
     getCommonViewMetrics,
@@ -272,6 +273,7 @@ function newView(
 
       lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, { endClocks })
       clearInterval(keepAliveIntervalId)
+      setViewEnd(endClocks.relative)
       stopCommonViewMetricsTracking()
       triggerViewUpdate()
       setTimeout(() => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
@@ -50,7 +50,7 @@ export function trackCommonViewMetrics(
 
   const { stop: stopINPTracking, getInteractionToNextPaint } = trackInteractionToNextPaint(
     configuration,
-    viewStart,
+    viewStart.relative,
     loadingType,
     lifeCycle
   )
@@ -60,8 +60,8 @@ export function trackCommonViewMetrics(
       stopLoadingTimeTracking()
       stopCLSTracking()
       stopScrollMetricsTracking()
-      stopINPTracking()
     },
+    stopINPTracking,
     setLoadEvent,
     getCommonViewMetrics: () => {
       commonViewMetrics.interactionToNextPaint = getInteractionToNextPaint()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
@@ -48,12 +48,11 @@ export function trackCommonViewMetrics(
     scheduleViewUpdate()
   })
 
-  const { stop: stopINPTracking, getInteractionToNextPaint } = trackInteractionToNextPaint(
-    configuration,
-    viewStart.relative,
-    loadingType,
-    lifeCycle
-  )
+  const {
+    stop: stopINPTracking,
+    getInteractionToNextPaint,
+    setViewEnd,
+  } = trackInteractionToNextPaint(configuration, viewStart.relative, loadingType, lifeCycle)
 
   return {
     stop: () => {
@@ -63,6 +62,7 @@ export function trackCommonViewMetrics(
     },
     stopINPTracking,
     setLoadEvent,
+    setViewEnd,
     getCommonViewMetrics: () => {
       commonViewMetrics.interactionToNextPaint = getInteractionToNextPaint()
       return commonViewMetrics

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -22,6 +22,7 @@ import {
   trackInteractionToNextPaint,
   trackViewInteractionCount,
   isInteractionToNextPaintSupported,
+  MAX_INP_VALUE,
 } from './trackInteractionToNextPaint'
 
 describe('trackInteractionToNextPaint', () => {
@@ -115,7 +116,23 @@ describe('trackInteractionToNextPaint', () => {
         duration: 100 as Duration,
         startTime: 1 as RelativeTime,
       })
-      expect(getInteractionToNextPaint()?.value).toEqual(100 as Duration)
+      expect(getInteractionToNextPaint()).toEqual({
+        value: 100 as Duration,
+        targetSelector: undefined,
+      })
+    })
+
+    it('should cap INP value', () => {
+      const { lifeCycle } = setupBuilder.build()
+      newInteraction(lifeCycle, {
+        interactionId: 1,
+        duration: (MAX_INP_VALUE + 1) as Duration,
+      })
+
+      expect(getInteractionToNextPaint()).toEqual({
+        value: MAX_INP_VALUE,
+        targetSelector: undefined,
+      })
     })
 
     it('should return the p98 worst interaction', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -3,7 +3,6 @@ import {
   ExperimentalFeature,
   addExperimentalFeatures,
   relativeNow,
-  relativeToClocks,
   resetExperimentalFeatures,
 } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
@@ -17,7 +16,6 @@ import type {
 import { ViewLoadingType } from '../../../rawRumEvent.types'
 import type { LifeCycle } from '../../lifeCycle'
 import { LifeCycleEventType } from '../../lifeCycle'
-import type { ViewEndedEvent } from '../trackViews'
 import {
   trackInteractionToNextPaint,
   trackViewInteractionCount,
@@ -29,6 +27,8 @@ describe('trackInteractionToNextPaint', () => {
   let setupBuilder: TestSetupBuilder
   let interactionCountStub: ReturnType<typeof subInteractionCount>
   let getInteractionToNextPaint: ReturnType<typeof trackInteractionToNextPaint>['getInteractionToNextPaint']
+  let setViewEnd: ReturnType<typeof trackInteractionToNextPaint>['setViewEnd']
+
   function newInteraction(lifeCycle: LifeCycle, overrides: Partial<RumPerformanceEventTiming | RumFirstInputTiming>) {
     if (overrides.interactionId) {
       interactionCountStub.incrementInteractionCount()
@@ -53,6 +53,8 @@ describe('trackInteractionToNextPaint', () => {
           lifeCycle
         )
         getInteractionToNextPaint = interactionToNextPaintTracking.getInteractionToNextPaint
+        setViewEnd = interactionToNextPaintTracking.setViewEnd
+
         return interactionToNextPaintTracking
       })
   })
@@ -87,9 +89,7 @@ describe('trackInteractionToNextPaint', () => {
     it('should ignore entries that starts out of the view time bounds', () => {
       const { lifeCycle } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
-        endClocks: relativeToClocks(10 as RelativeTime),
-      } as ViewEndedEvent)
+      setViewEnd(10 as RelativeTime)
 
       newInteraction(lifeCycle, {
         interactionId: 1,
@@ -107,9 +107,7 @@ describe('trackInteractionToNextPaint', () => {
     it('should take into account entries that starts in view time bounds but finish after view end', () => {
       const { lifeCycle } = setupBuilder.build()
 
-      lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {
-        endClocks: relativeToClocks(10 as RelativeTime),
-      } as ViewEndedEvent)
+      setViewEnd(10 as RelativeTime)
 
       newInteraction(lifeCycle, {
         interactionId: 1,

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -126,6 +126,7 @@ export function trackInteractionToNextPaint(
         }
       }
     },
+    setViewEnd: () => {},
     stop,
   }
 }
@@ -177,24 +178,22 @@ function trackLongestInteractions(getViewInteractionCount: () => number) {
 export function trackViewInteractionCount(viewLoadingType: ViewLoadingType) {
   initInteractionCountPolyfill()
   const previousInteractionCount = viewLoadingType === ViewLoadingType.INITIAL_LOAD ? 0 : getInteractionCount()
-  let viewInteractionCount = 0
-  let stopped = false
+  let state: { stopped: false } | { stopped: true; interactionCount: number } = { stopped: false }
 
   function computeViewInteractionCount() {
-    viewInteractionCount = getInteractionCount()! - previousInteractionCount
+    return getInteractionCount()! - previousInteractionCount
   }
 
   return {
     getViewInteractionCount: () => {
-      if (!stopped) {
-        computeViewInteractionCount()
+      if (state.stopped) {
+        return state.interactionCount
       }
 
-      return viewInteractionCount
+      return computeViewInteractionCount()
     },
     stopViewInteractionCount: () => {
-      computeViewInteractionCount()
-      stopped = true
+      state = { stopped: true, interactionCount: computeViewInteractionCount() }
     },
   }
 }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -20,6 +20,8 @@ import { getInteractionCount, initInteractionCountPolyfill } from './interaction
 
 // Arbitrary value to prevent unnecessary memory usage on views with lots of interactions.
 const MAX_INTERACTION_ENTRIES = 10
+// Arbitrary value to cap INP outliers
+export const MAX_INP_VALUE = (1 * ONE_MINUTE) as Duration
 
 export interface InteractionToNextPaint {
   value: Duration
@@ -82,7 +84,7 @@ export function trackInteractionToNextPaint(
         addTelemetryDebug('INP outlier', {
           inp: interactionToNextPaint,
           interaction: {
-            timeFromViewStart: elapsed(viewStart.relative, newInteraction.startTime),
+            timeFromViewStart: elapsed(viewStart, newInteraction.startTime),
             duration: newInteraction.duration,
             startTime: newInteraction.startTime,
             processingStart: newInteraction.processingStart,
@@ -115,7 +117,7 @@ export function trackInteractionToNextPaint(
       // but the view interaction count > 0 then report 0
       if (interactionToNextPaint >= 0) {
         return {
-          value: interactionToNextPaint,
+          value: Math.min(interactionToNextPaint, MAX_INP_VALUE) as Duration,
           targetSelector: interactionToNextPaintTargetSelector,
         }
       } else if (getViewInteractionCount()) {


### PR DESCRIPTION
## Motivation

Fix 2 issues about INP:
- Some of the [PerformanceEventTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming) duration are outliers. So now we CAP INP values to 1 min maximum.
- Some of the [PerformanceEventTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming) reported on one view actually started on the previous view. We now attach them to the previous view.


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
