### PR TITLE
👷 Fix upload source maps for root files

### DIFF
--- a/scripts/deploy/upload-source-maps.js
+++ b/scripts/deploy/upload-source-maps.js
@@ -27,11 +27,15 @@ const siteByDatacenter = {
   us5: 'us5.datadoghq.com',
   ap1: 'ap1.datadoghq.com',
 }
-const sitesByVersion = {
-  staging: ['datad0g.com', 'datadoghq.com'],
-  canary: ['datadoghq.com'],
-  // TODO remove in next major
-  v4: Object.values(siteByDatacenter),
+function getSitesByVersion(version) {
+  switch (version) {
+    case 'staging':
+      return ['datad0g.com', 'datadoghq.com']
+    case 'canary':
+      return ['datadoghq.com']
+    default:
+      return Object.values(siteByDatacenter)
+  }
 }
 
 runMain(() => {
@@ -41,7 +45,7 @@ runMain(() => {
       let sites
       let uploadPath
       if (uploadPathType === 'root') {
-        sites = sitesByVersion[version]
+        sites = getSitesByVersion(version)
         uploadPath = buildRootUploadPath(packageName, version)
         renameFilesWithVersionSuffix(packageName, bundleFolder)
       } else {


### PR DESCRIPTION
## Motivation

With v5, upload source maps is broken for root files

## Changes

- Keep uploading source maps for all datacenter (just in case) 
- Since we could live with the root files for quite some time, don't rely on specific version anymore

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

On next release

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
