### PR TITLE
🐛Check hash not empty on route change

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -317,8 +317,8 @@ function areDifferentLocation(currentLocation: Location, otherLocation: Location
 }
 
 function isHashAnAnchor(hash: string) {
-  const correspondingId = hash.substr(1)
-  return !!document.getElementById(correspondingId)
+  const correspondingId = hash.substring(1)
+  return correspondingId !== '' && !!document.getElementById(correspondingId)
 }
 
 function getPathFromHash(hash: string) {


### PR DESCRIPTION
## Motivation

On firefox, when a route change and we check `isHashAnAnchor()`, if the hash is empty, `getElementById` is called with a empty string param which displays a console warning:
![image](https://github.com/DataDog/browser-sdk/assets/4342515/21b1d285-f34a-417a-9a3a-0bac0d4ae63d)

## Changes

Check if the hash is empty before trying `getElementById()`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
