### PR TITLE
🔊 Add CLS target selector telemetry

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -73,7 +73,11 @@ export function trackCumulativeLayoutShift(
           const clsTarget = window.largestLayoutShiftTarget()
           let cslTargetSelector
 
-          if (isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) && clsTarget) {
+          if (
+            isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) &&
+            clsTarget &&
+            clsTarget.parentElement
+          ) {
             const selectorComputationStart = relativeNow()
             cslTargetSelector = getSelectorFromElement(clsTarget, configuration.actionNameAttribute)
             const selectorComputationEnd = relativeNow()
@@ -139,7 +143,6 @@ function slidingSessionWindow() {
         largestLayoutShiftTarget = undefined
         maxEntriesAtOnceCount = 0
         updateCount = 0
-
         targetUpdates = []
       } else {
         value += entry.value

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -6,6 +6,8 @@ import {
   isExperimentalFeatureEnabled,
   ExperimentalFeature,
   noop,
+  addTelemetryDebug,
+  relativeNow,
 } from '@datadog/browser-core'
 import { isElementNode } from '../../../browser/htmlDomUtils'
 import type { LifeCycle } from '../../lifeCycle'
@@ -56,11 +58,14 @@ export function trackCumulativeLayoutShift(
   })
 
   const window = slidingSessionWindow()
-
+  let selectorComputationTelemetrySent = false
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, (entries) => {
-    for (const entry of entries) {
+    const shiftEntries = entries.filter(
+      (e) => e.entryType === RumPerformanceEntryType.LAYOUT_SHIFT && !e.hadRecentInput
+    )
+    for (const entry of shiftEntries) {
       if (entry.entryType === RumPerformanceEntryType.LAYOUT_SHIFT && !entry.hadRecentInput) {
-        window.update(entry)
+        window.update(entry, shiftEntries.length)
 
         if (window.value() > maxClsValue) {
           maxClsValue = window.value()
@@ -69,7 +74,17 @@ export function trackCumulativeLayoutShift(
           let cslTargetSelector
 
           if (isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) && clsTarget) {
+            const selectorComputationStart = relativeNow()
             cslTargetSelector = getSelectorFromElement(clsTarget, configuration.actionNameAttribute)
+            const selectorComputationEnd = relativeNow()
+
+            if (!selectorComputationTelemetrySent) {
+              addTelemetryDebug('CLS target selector computation time', {
+                duration: selectorComputationEnd - selectorComputationStart,
+                selector: cslTargetSelector,
+              })
+              selectorComputationTelemetrySent = true
+            }
           }
 
           callback({
@@ -86,6 +101,8 @@ export function trackCumulativeLayoutShift(
   }
 }
 
+let maxTargetUpdateTelemetry = 5
+
 function slidingSessionWindow() {
   let value = 0
   let startTime: RelativeTime
@@ -94,18 +111,36 @@ function slidingSessionWindow() {
   let largestLayoutShift = 0
   let largestLayoutShiftTarget: HTMLElement | undefined
   let largestLayoutShiftTime: RelativeTime
-
+  let targetUpdates: RelativeTime[] = []
+  let maxEntriesAtOnceCount = 0
+  let updateCount = 0
   return {
-    update: (entry: RumLayoutShiftTiming) => {
+    update: (entry: RumLayoutShiftTiming, entriesAtOnceCount: number) => {
       const shouldCreateNewWindow =
         startTime === undefined ||
         entry.startTime - endTime >= ONE_SECOND ||
         entry.startTime - startTime >= 5 * ONE_SECOND
+
+      maxEntriesAtOnceCount = Math.max(maxEntriesAtOnceCount, entriesAtOnceCount)
+      updateCount++
       if (shouldCreateNewWindow) {
         startTime = endTime = entry.startTime
+        if (startTime !== undefined && maxTargetUpdateTelemetry) {
+          maxTargetUpdateTelemetry--
+          addTelemetryDebug('CLS window', {
+            targetUpdates,
+            targetUpdatesCount: targetUpdates.length,
+            maxEntriesAtOnceCount,
+            updateCount,
+          })
+        }
         value = entry.value
         largestLayoutShift = 0
         largestLayoutShiftTarget = undefined
+        maxEntriesAtOnceCount = 0
+        updateCount = 0
+
+        targetUpdates = []
       } else {
         value += entry.value
         endTime = entry.startTime
@@ -114,8 +149,8 @@ function slidingSessionWindow() {
       if (entry.value > largestLayoutShift) {
         largestLayoutShift = entry.value
         largestLayoutShiftTime = entry.startTime
-
         if (entry.sources?.length) {
+          targetUpdates.push(relativeNow())
           largestLayoutShiftTarget = find(
             entry.sources,
             (s): s is { node: HTMLElement } => !!s.node && isElementNode(s.node)


### PR DESCRIPTION
## Motivation

The CLS target selector is computed  only when the CLS score increases.  It means that by the time the computation happens the target node might have been removed from the DOM making the selector computation fails.

This PR collects telemetry to assess if we could compute the selector each time the target is updated in the current CLS window.

This PR collects:
- The number of time the CLS target is updated in a CLS window
- The computation time of the target selector (`getSelectorFromElement`)


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
