### PR TITLE
👷 [RUM-1586] Use logs intake domain for fed staging

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -4,7 +4,7 @@ import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../tools/experimentalFeatures'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { InitConfiguration } from './configuration'
-import { INTAKE_SITE_US1 } from './intakeSites'
+import { INTAKE_SITE_US1, INTAKE_SITE_FED_STAGING } from './intakeSites'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
@@ -64,6 +64,10 @@ function buildEndpointHost(initConfiguration: InitConfiguration) {
 
   if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {
     return `${internalAnalyticsSubdomain}.${INTAKE_SITE_US1}`
+  }
+
+  if (site === INTAKE_SITE_FED_STAGING) {
+    return `http-intake.logs.${site}`
   }
 
   const domainParts = site.split('.')

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -1,4 +1,5 @@
 export const INTAKE_SITE_STAGING = 'datad0g.com'
+export const INTAKE_SITE_FED_STAGING = 'dd0g-gov.com'
 export const INTAKE_SITE_US1 = 'datadoghq.com'
 export const INTAKE_SITE_EU1 = 'datadoghq.eu'
 export const INTAKE_SITE_US1_FED = 'ddog-gov.com'

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -1,5 +1,6 @@
 import type { Payload } from '../../transport'
 import { computeTransportConfiguration } from './transportConfiguration'
+import { INTAKE_SITE_FED_STAGING } from './intakeSites'
 
 const DEFAULT_PAYLOAD = {} as Payload
 
@@ -11,6 +12,12 @@ describe('transportConfiguration', () => {
       const configuration = computeTransportConfiguration({ clientToken })
       expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('datadoghq.com')
       expect(configuration.site).toBe('datadoghq.com')
+    })
+
+    it('should use logs intake domain for fed staging', () => {
+      const configuration = computeTransportConfiguration({ clientToken, site: INTAKE_SITE_FED_STAGING })
+      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('http-intake.logs.dd0g-gov.com')
+      expect(configuration.site).toBe(INTAKE_SITE_FED_STAGING)
     })
 
     it('should use site value when set', () => {
@@ -84,6 +91,7 @@ describe('transportConfiguration', () => {
       { site: 'us5.datadoghq.com', intakeDomain: 'browser-intake-us5-datadoghq.com' },
       { site: 'ddog-gov.com', intakeDomain: 'browser-intake-ddog-gov.com' },
       { site: 'ap1.datadoghq.com', intakeDomain: 'browser-intake-ap1-datadoghq.com' },
+      { site: 'dd0g-gov.com', intakeDomain: 'http-intake.logs.dd0g-gov.com' },
     ].forEach(({ site, intakeDomain }) => {
       it(`should detect intake request for ${site} site`, () => {
         const configuration = computeTransportConfiguration({ clientToken, site })


### PR DESCRIPTION
## Motivation

Allow to use SDK in fed staging environment

## Changes

Use logs intake domain when site is fed staging

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
