### PR TITLE
🔉 [RUM-1658] Add extra field to identify sessions recorded manually

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -712,7 +712,7 @@ describe('rum assembly', () => {
     it('should include the configured sample rates', () => {
       const { lifeCycle } = setupBuilder.build()
       notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })
       expect(serverRumEvents[0]._dd.configuration).toEqual({
         session_replay_sample_rate: 0,
@@ -728,7 +728,7 @@ describe('rum assembly', () => {
         })
         .build()
       notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })
       expect(serverRumEvents[0]._dd.configuration).toEqual({
         session_sample_rate: 1.234,

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -116,6 +116,9 @@ describe('viewCollection', () => {
           { start: 0 as ServerDuration, state: PageState.ACTIVE },
           { start: 10 as ServerDuration, state: PageState.PASSIVE },
         ],
+        configuration: {
+          start_session_replay_recording_manually: jasmine.any(Boolean),
+        },
       },
       date: jasmine.any(Number),
       type: RumEventType.VIEW,
@@ -227,5 +230,24 @@ describe('viewCollection', () => {
     const rawRumViewEvent = rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent
 
     expect(rawRumViewEvent.display?.scroll).toBeUndefined()
+  })
+
+  it('should include configuration.start_session_replay_recording_manually value', () => {
+    let { lifeCycle, rawRumEvents } = setupBuilder
+      .withConfiguration({ startSessionReplayRecordingManually: false })
+      .build()
+    lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, VIEW)
+    expect(
+      (rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent)._dd.configuration
+        .start_session_replay_recording_manually
+    ).toBe(false)
+    ;({ lifeCycle, rawRumEvents } = setupBuilder
+      .withConfiguration({ startSessionReplayRecordingManually: true })
+      .build())
+    lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, VIEW)
+    expect(
+      (rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent)._dd.configuration
+        .start_session_replay_recording_manually
+    ).toBe(true)
   })
 })

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -233,6 +233,7 @@ describe('viewCollection', () => {
   })
 
   it('should include configuration.start_session_replay_recording_manually value', () => {
+    // when configured to false
     let { lifeCycle, rawRumEvents } = setupBuilder
       .withConfiguration({ startSessionReplayRecordingManually: false })
       .build()
@@ -241,6 +242,8 @@ describe('viewCollection', () => {
       (rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent)._dd.configuration
         .start_session_replay_recording_manually
     ).toBe(false)
+
+    // when configured to true
     ;({ lifeCycle, rawRumEvents } = setupBuilder
       .withConfiguration({ startSessionReplayRecordingManually: true })
       .build())

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -55,6 +55,9 @@ function processViewUpdate(
       document_version: view.documentVersion,
       replay_stats: replayStats,
       page_states: pageStates,
+      configuration: {
+        start_session_replay_recording_manually: configuration.startSessionReplayRecordingManually,
+      },
     },
     date: view.startClocks.timeStamp,
     type: RumEventType.VIEW,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -119,6 +119,9 @@ export interface RawRumViewEvent {
     document_version: number
     replay_stats?: ReplayStats
     page_states?: PageStateServerEntry[]
+    configuration: {
+      start_session_replay_recording_manually: boolean
+    }
   }
 }
 

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -856,6 +856,16 @@ export type RumViewEvent = CommonProperties & {
       segments_total_raw_size?: number
       [k: string]: unknown
     }
+    /**
+     * Subset of the SDK configuration options in use during its execution
+     */
+    readonly configuration?: {
+      /**
+       * Whether session replay recording configured to start manually
+       */
+      readonly start_session_replay_recording_manually?: boolean
+      [k: string]: unknown
+    }
     [k: string]: unknown
   }
   /**

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -93,6 +93,9 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
           type,
           _dd: {
             document_version: 0,
+            configuration: {
+              start_session_replay_recording_manually: false,
+            },
           },
           date: 0 as TimeStamp,
           view: {

--- a/packages/rum/src/types/sessionReplay.ts
+++ b/packages/rum/src/types/sessionReplay.ts
@@ -48,12 +48,21 @@ export type BrowserRecord =
 /**
  * Browser-specific. Schema of a Record type which contains the full snapshot of a screen.
  */
-export type BrowserFullSnapshotRecord = CommonRecordSchema & {
+export type BrowserFullSnapshotRecord = WebviewSupportedCommonRecordSchema & {
   /**
    * The type of this Record.
    */
   readonly type: 2
   data: BrowserNode
+}
+/**
+ * Schema of common properties for a Record event type that is supported by webviews.
+ */
+export type WebviewSupportedCommonRecordSchema = CommonRecordSchema & {
+  /**
+   * Defines the unique ID of the nested replay environment that generated this record.
+   */
+  readonly nestedEnvId?: number
 }
 /**
  * Serialized node contained by this Record.
@@ -68,7 +77,7 @@ export type SerializedNode = DocumentNode | DocumentFragmentNode | DocumentTypeN
 /**
  * Browser-specific. Schema of a Record type which contains mutations of a screen.
  */
-export type BrowserIncrementalSnapshotRecord = CommonRecordSchema & {
+export type BrowserIncrementalSnapshotRecord = WebviewSupportedCommonRecordSchema & {
   /**
    * The type of this Record.
    */
@@ -237,7 +246,7 @@ export type PointerInteractionData = {
 /**
  * Schema of a Record which contains the screen properties.
  */
-export type MetaRecord = CommonRecordSchema & {
+export type MetaRecord = WebviewSupportedCommonRecordSchema & {
   /**
    * The type of this Record.
    */
@@ -263,7 +272,7 @@ export type MetaRecord = CommonRecordSchema & {
 /**
  * Schema of a Record type which contains focus information.
  */
-export type FocusRecord = CommonRecordSchema & {
+export type FocusRecord = WebviewSupportedCommonRecordSchema & {
   /**
    * The type of this Record.
    */
@@ -278,7 +287,7 @@ export type FocusRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that view lifecycle ended.
  */
-export type ViewEndRecord = CommonRecordSchema & {
+export type ViewEndRecord = WebviewSupportedCommonRecordSchema & {
   /**
    * The type of this Record.
    */
@@ -287,7 +296,7 @@ export type ViewEndRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies that the viewport properties have changed.
  */
-export type VisualViewportRecord = CommonRecordSchema & {
+export type VisualViewportRecord = WebviewSupportedCommonRecordSchema & {
   data: {
     height: number
     offsetLeft: number
@@ -305,7 +314,7 @@ export type VisualViewportRecord = CommonRecordSchema & {
 /**
  * Schema of a Record which signifies a collection of frustration signals.
  */
-export type FrustrationRecord = CommonRecordSchema & {
+export type FrustrationRecord = WebviewSupportedCommonRecordSchema & {
   /**
    * The type of this Record.
    */


### PR DESCRIPTION
## Motivation

Monitor manual/automatic session replay recording usage.

## Changes

Add extra `_dd.configuration.start_session_replay_recording_manually` field to view events.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
