### PR TITLE
🐛 [RUM-1561] Fix CLS selector computation on detached node

### DIFF
--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -1,4 +1,4 @@
-import { cssEscape, addTelemetryDebug } from '@datadog/browser-core'
+import { cssEscape } from '@datadog/browser-core'
 import { DEFAULT_PROGRAMMATIC_ACTION_NAME_ATTRIBUTE } from './action/getActionNameFromElement'
 
 /**
@@ -52,15 +52,6 @@ export function getSelectorFromElement(targetElement: Element, actionNameAttribu
     )
     if (globallyUniqueSelector) {
       return globallyUniqueSelector
-    }
-
-    if (!element.parentElement) {
-      addTelemetryDebug('selector from element without parent', {
-        debug: {
-          selector: combineSelector(cssEscape(element.tagName), targetElementSelector),
-          isConnected: element.isConnected,
-        },
-      })
     }
 
     const uniqueSelectorAmongChildren = findSelector(

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -1,14 +1,5 @@
-import {
-  round,
-  type RelativeTime,
-  find,
-  ONE_SECOND,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
-  noop,
-  addTelemetryDebug,
-  relativeNow,
-} from '@datadog/browser-core'
+import { round, find, ONE_SECOND, isExperimentalFeatureEnabled, ExperimentalFeature, noop } from '@datadog/browser-core'
+import type { RelativeTime } from '@datadog/browser-core'
 import { isElementNode } from '../../../browser/htmlDomUtils'
 import type { LifeCycle } from '../../lifeCycle'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -58,14 +49,10 @@ export function trackCumulativeLayoutShift(
   })
 
   const window = slidingSessionWindow()
-  let selectorComputationTelemetrySent = false
   const { unsubscribe: stop } = lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, (entries) => {
-    const shiftEntries = entries.filter(
-      (e) => e.entryType === RumPerformanceEntryType.LAYOUT_SHIFT && !e.hadRecentInput
-    )
-    for (const entry of shiftEntries) {
+    for (const entry of entries) {
       if (entry.entryType === RumPerformanceEntryType.LAYOUT_SHIFT && !entry.hadRecentInput) {
-        window.update(entry, shiftEntries.length)
+        window.update(entry)
 
         if (window.value() > maxClsValue) {
           maxClsValue = window.value()
@@ -79,17 +66,7 @@ export function trackCumulativeLayoutShift(
             // Check if the CLS target have been removed from the DOM between the time we collect the target reference and when we compute the selector
             clsTarget.isConnected
           ) {
-            const selectorComputationStart = relativeNow()
             cslTargetSelector = getSelectorFromElement(clsTarget, configuration.actionNameAttribute)
-            const selectorComputationEnd = relativeNow()
-
-            if (!selectorComputationTelemetrySent) {
-              addTelemetryDebug('CLS target selector computation time', {
-                duration: selectorComputationEnd - selectorComputationStart,
-                selector: cslTargetSelector,
-              })
-              selectorComputationTelemetrySent = true
-            }
           }
 
           callback({
@@ -106,8 +83,6 @@ export function trackCumulativeLayoutShift(
   }
 }
 
-let maxTargetUpdateTelemetry = 5
-
 function slidingSessionWindow() {
   let value = 0
   let startTime: RelativeTime
@@ -116,35 +91,18 @@ function slidingSessionWindow() {
   let largestLayoutShift = 0
   let largestLayoutShiftTarget: HTMLElement | undefined
   let largestLayoutShiftTime: RelativeTime
-  let targetUpdates: RelativeTime[] = []
-  let maxEntriesAtOnceCount = 0
-  let updateCount = 0
   return {
-    update: (entry: RumLayoutShiftTiming, entriesAtOnceCount: number) => {
+    update: (entry: RumLayoutShiftTiming) => {
       const shouldCreateNewWindow =
         startTime === undefined ||
         entry.startTime - endTime >= ONE_SECOND ||
         entry.startTime - startTime >= 5 * ONE_SECOND
 
-      maxEntriesAtOnceCount = Math.max(maxEntriesAtOnceCount, entriesAtOnceCount)
-      updateCount++
       if (shouldCreateNewWindow) {
         startTime = endTime = entry.startTime
-        if (startTime !== undefined && maxTargetUpdateTelemetry) {
-          maxTargetUpdateTelemetry--
-          addTelemetryDebug('CLS window', {
-            targetUpdates,
-            targetUpdatesCount: targetUpdates.length,
-            maxEntriesAtOnceCount,
-            updateCount,
-          })
-        }
         value = entry.value
         largestLayoutShift = 0
         largestLayoutShiftTarget = undefined
-        maxEntriesAtOnceCount = 0
-        updateCount = 0
-        targetUpdates = []
       } else {
         value += entry.value
         endTime = entry.startTime
@@ -154,7 +112,6 @@ function slidingSessionWindow() {
         largestLayoutShift = entry.value
         largestLayoutShiftTime = entry.startTime
         if (entry.sources?.length) {
-          targetUpdates.push(relativeNow())
           largestLayoutShiftTarget = find(
             entry.sources,
             (s): s is { node: HTMLElement } => !!s.node && isElementNode(s.node)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -76,7 +76,8 @@ export function trackCumulativeLayoutShift(
           if (
             isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) &&
             clsTarget &&
-            clsTarget.parentElement
+            // Check if the CLS target have been removed from the DOM between the time we collect the target reference and when we compute the selector
+            clsTarget.isConnected
           ) {
             const selectorComputationStart = relativeNow()
             cslTargetSelector = getSelectorFromElement(clsTarget, configuration.actionNameAttribute)


### PR DESCRIPTION
## Motivation

The CLS target selector is computed only when the CLS score increases. It means that by the time the computation happens the target node might have been removed from the DOM making the selector computation fails.

## Changes

- Check that the node is attached before computing the CLS CSS selector
- Remove related telemetry

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
