### PR TITLE
👷 Exclude wdio from non-major deps PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["@wdio", "webdriverio"]
     }
   ]
 }


### PR DESCRIPTION
## Motivation

Prevent renovate from bumping wdio deps while we don't have a workaround for https://github.com/webdriverio/webdriverio/issues/11533

## Changes

Exclude from non-major deps PRs packages matching `@wdio` or `webdriverio`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

on next non-major deps PR

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
