### PR TITLE
⚡️[RUM-2017] optimize cookie accesses

### DIFF
--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -26,7 +26,7 @@ let initCookieParsed: Map<string, string> | undefined
 
 /**
  * Returns a cached value of the cookie. Use this during SDK initialization (and whenever possible)
- * to avoid parsing the document.cookie multiple times.
+ * to avoid accessing document.cookie multiple times.
  */
 export function getInitCookie(name: string) {
   if (!initCookieParsed) {

--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -1,6 +1,6 @@
 import { display } from '../tools/display'
 import { ONE_MINUTE, ONE_SECOND } from '../tools/utils/timeUtils'
-import { findCommaSeparatedValue, generateUUID } from '../tools/utils/stringUtils'
+import { findCommaSeparatedValue, findCommaSeparatedValues, generateUUID } from '../tools/utils/stringUtils'
 
 export interface CookieOptions {
   secure?: boolean
@@ -20,6 +20,23 @@ export function setCookie(name: string, value: string, expireDelay: number, opti
 
 export function getCookie(name: string) {
   return findCommaSeparatedValue(document.cookie, name)
+}
+
+let initCookieParsed: Map<string, string> | undefined
+
+/**
+ * Returns a cached value of the cookie. Use this during SDK initialization (and whenever possible)
+ * to avoid parsing the document.cookie multiple times.
+ */
+export function getInitCookie(name: string) {
+  if (!initCookieParsed) {
+    initCookieParsed = findCommaSeparatedValues(document.cookie)
+  }
+  return initCookieParsed.get(name)
+}
+
+export function resetInitCookies() {
+  initCookieParsed = undefined
 }
 
 export function deleteCookie(name: string, options?: CookieOptions) {

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -1,4 +1,4 @@
-import { getCookie, setCookie } from '../../browser/cookie'
+import { getCookie, resetInitCookies, setCookie } from '../../browser/cookie'
 import {
   OLD_LOGS_COOKIE_NAME,
   OLD_RUM_COOKIE_NAME,
@@ -7,10 +7,20 @@ import {
 } from './oldCookiesMigration'
 import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
 import { initCookieStrategy } from './storeStrategies/sessionInCookie'
+import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 
 describe('old cookies migration', () => {
-  const sessionStoreStrategy = initCookieStrategy({})
+  let sessionStoreStrategy: SessionStoreStrategy
+
+  beforeEach(() => {
+    sessionStoreStrategy = initCookieStrategy({})
+    resetInitCookies()
+  })
+
+  afterEach(() => {
+    resetInitCookies()
+  })
 
   it('should not touch current cookie', () => {
     setCookie(SESSION_STORE_KEY, 'id=abcde&rum=0&logs=1&expire=1234567890', SESSION_EXPIRATION_DELAY)

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -57,4 +57,18 @@ describe('old cookies migration', () => {
     tryOldCookiesMigration(sessionStoreStrategy)
     expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
   })
+
+  it('should behave correctly when performing the migration multiple times', () => {
+    setCookie(OLD_SESSION_COOKIE_NAME, 'abcde', SESSION_EXPIRATION_DELAY)
+    setCookie(OLD_LOGS_COOKIE_NAME, '1', SESSION_EXPIRATION_DELAY)
+    setCookie(OLD_RUM_COOKIE_NAME, '0', SESSION_EXPIRATION_DELAY)
+
+    tryOldCookiesMigration(sessionStoreStrategy)
+    tryOldCookiesMigration(sessionStoreStrategy)
+
+    expect(getCookie(SESSION_STORE_KEY)).toContain('id=abcde')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('rum=0')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('logs=1')
+    expect(getCookie(SESSION_STORE_KEY)).toMatch(/expire=\d+/)
+  })
 })

--- a/packages/core/src/domain/session/oldCookiesMigration.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.ts
@@ -1,4 +1,4 @@
-import { getCookie } from '../../browser/cookie'
+import { getInitCookie } from '../../browser/cookie'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 import type { SessionState } from './sessionState'
@@ -17,11 +17,11 @@ export const LOGS_SESSION_KEY = 'logs'
  * to allow older sdk versions to be upgraded to newer versions without compatibility issues.
  */
 export function tryOldCookiesMigration(cookieStoreStrategy: SessionStoreStrategy) {
-  const sessionString = getCookie(SESSION_STORE_KEY)
+  const sessionString = getInitCookie(SESSION_STORE_KEY)
   if (!sessionString) {
-    const oldSessionId = getCookie(OLD_SESSION_COOKIE_NAME)
-    const oldRumType = getCookie(OLD_RUM_COOKIE_NAME)
-    const oldLogsType = getCookie(OLD_LOGS_COOKIE_NAME)
+    const oldSessionId = getInitCookie(OLD_SESSION_COOKIE_NAME)
+    const oldRumType = getInitCookie(OLD_RUM_COOKIE_NAME)
+    const oldLogsType = getInitCookie(OLD_LOGS_COOKIE_NAME)
     const session: SessionState = {}
 
     if (oldSessionId) {

--- a/packages/core/src/domain/synthetics/syntheticsWorkerValues.ts
+++ b/packages/core/src/domain/synthetics/syntheticsWorkerValues.ts
@@ -1,4 +1,4 @@
-import { getCookie } from '../../browser/cookie'
+import { getInitCookie } from '../../browser/cookie'
 
 export const SYNTHETICS_TEST_ID_COOKIE_NAME = 'datadog-synthetics-public-id'
 export const SYNTHETICS_RESULT_ID_COOKIE_NAME = 'datadog-synthetics-result-id'
@@ -12,16 +12,17 @@ export interface BrowserWindow extends Window {
 
 export function willSyntheticsInjectRum(): boolean {
   return Boolean(
-    (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM || getCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
+    (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM || getInitCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
   )
 }
 
 export function getSyntheticsTestId(): string | undefined {
-  const value = (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID || getCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
+  const value = (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID || getInitCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
   return typeof value === 'string' ? value : undefined
 }
 
 export function getSyntheticsResultId(): string | undefined {
-  const value = (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID || getCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
+  const value =
+    (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID || getInitCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
   return typeof value === 'string' ? value : undefined
 }

--- a/packages/core/src/tools/utils/stringUtils.spec.ts
+++ b/packages/core/src/tools/utils/stringUtils.spec.ts
@@ -1,4 +1,4 @@
-import { safeTruncate, findCommaSeparatedValue } from './stringUtils'
+import { safeTruncate, findCommaSeparatedValue, findCommaSeparatedValues } from './stringUtils'
 
 describe('stringUtils', () => {
   describe('safeTruncate', () => {
@@ -46,6 +46,17 @@ describe('stringUtils', () => {
 
     it('returns undefined if the value is not found', () => {
       expect(findCommaSeparatedValue('foo=a;bar=b', 'baz')).toBe(undefined)
+    })
+  })
+
+  describe('findCommaSeparatedValues', () => {
+    it('returns the values from a comma separated hash', () => {
+      expect(findCommaSeparatedValues('foo=a;bar=b')).toEqual(
+        new Map([
+          ['foo', 'a'],
+          ['bar', 'b'],
+        ])
+      )
     })
   })
 })

--- a/packages/core/src/tools/utils/stringUtils.spec.ts
+++ b/packages/core/src/tools/utils/stringUtils.spec.ts
@@ -51,12 +51,10 @@ describe('stringUtils', () => {
 
   describe('findCommaSeparatedValues', () => {
     it('returns the values from a comma separated hash', () => {
-      expect(findCommaSeparatedValues('foo=a;bar=b')).toEqual(
-        new Map([
-          ['foo', 'a'],
-          ['bar', 'b'],
-        ])
-      )
+      const expectedValues = new Map<string, string>()
+      expectedValues.set('foo', 'a')
+      expectedValues.set('bar', 'b')
+      expect(findCommaSeparatedValues('foo=a;bar=b')).toEqual(expectedValues)
     })
   })
 })

--- a/packages/core/src/tools/utils/stringUtils.spec.ts
+++ b/packages/core/src/tools/utils/stringUtils.spec.ts
@@ -31,6 +31,19 @@ describe('stringUtils', () => {
       expect(findCommaSeparatedValue('foo=a;bar=b', 'bar')).toBe('b')
     })
 
+    it('is white-spaces tolerant', () => {
+      expect(findCommaSeparatedValue('   foo  =   a;  bar  =   b', 'foo')).toBe('a')
+      expect(findCommaSeparatedValue('   foo  =   a;  bar  =   b', 'bar')).toBe('b')
+    })
+
+    it('supports values containing an = character', () => {
+      expect(findCommaSeparatedValue('foo=a=b', 'foo')).toBe('a=b')
+    })
+
+    it('supports keys containing `-`', () => {
+      expect(findCommaSeparatedValue('foo-bar=baz', 'foo-bar')).toBe('baz')
+    })
+
     it('returns undefined if the value is not found', () => {
       expect(findCommaSeparatedValue('foo=a;bar=b', 'baz')).toBe(undefined)
     })

--- a/packages/core/src/tools/utils/stringUtils.ts
+++ b/packages/core/src/tools/utils/stringUtils.ts
@@ -9,10 +9,36 @@ export function generateUUID(placeholder?: string): string {
     : `${1e7}-${1e3}-${4e3}-${8e3}-${1e11}`.replace(/[018]/g, generateUUID)
 }
 
-export function findCommaSeparatedValue(rawString: string, name: string) {
-  const regex = new RegExp(`(?:^|;)\\s*${name}\\s*=\\s*([^;]+)`)
-  const matches = regex.exec(rawString)
-  return matches ? matches[1] : undefined
+const COMMA_SEPARATED_KEY_VALUE = /([\w-]+)\s*=\s*([^;]+)/g
+
+export function findCommaSeparatedValue(rawString: string, name: string): string | undefined {
+  COMMA_SEPARATED_KEY_VALUE.lastIndex = 0
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const match = COMMA_SEPARATED_KEY_VALUE.exec(rawString)
+    if (match) {
+      if (match[1] === name) {
+        return match[2]
+      }
+    } else {
+      break
+    }
+  }
+}
+
+export function findCommaSeparatedValues(rawString: string): Map<string, string> {
+  const result = new Map<string, string>()
+  COMMA_SEPARATED_KEY_VALUE.lastIndex = 0
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const match = COMMA_SEPARATED_KEY_VALUE.exec(rawString)
+    if (match) {
+      result.set(match[1], match[2])
+    } else {
+      break
+    }
+  }
+  return result
 }
 
 export function safeTruncate(candidate: string, length: number, suffix = '') {

--- a/packages/core/test/emulate/syntheticsWorkerValues.ts
+++ b/packages/core/test/emulate/syntheticsWorkerValues.ts
@@ -1,5 +1,5 @@
 import { ONE_MINUTE } from '../../src/tools/utils/timeUtils'
-import { deleteCookie, setCookie } from '../../src/browser/cookie'
+import { deleteCookie, resetInitCookies, setCookie } from '../../src/browser/cookie'
 import type { BrowserWindow } from '../../src/domain/synthetics/syntheticsWorkerValues'
 import {
   SYNTHETICS_INJECTS_RUM_COOKIE_NAME,
@@ -36,6 +36,7 @@ export function mockSyntheticsWorkerValues(
       }
       break
   }
+  resetInitCookies()
 }
 
 export function cleanupSyntheticsWorkerValues() {
@@ -45,4 +46,5 @@ export function cleanupSyntheticsWorkerValues() {
   deleteCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
   deleteCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
   deleteCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
+  resetInitCookies()
 }


### PR DESCRIPTION
## Motivation

We observed that the SDK is spending a significant amount of time reading from `document.cookie` during initialization.

## Changes

Introduce a alternative function to `getCookie` that caches cookies once,  and use it where it makes sense.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
