### PR TITLE
✨ [RUM-253] enable RUM request compression via the `compressIntakeRequests` parameter

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,7 +18,6 @@ export enum ExperimentalFeature {
   SCROLLMAP = 'scrollmap',
   WEB_VITALS_ATTRIBUTION = 'web_vitals_attribution',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
-  COMPRESS_BATCH = 'compress_batch',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -7,7 +7,6 @@ import {
   removeStorageListeners,
   noop,
   resetExperimentalFeatures,
-  ExperimentalFeature,
   createIdentityEncoder,
 } from '@datadog/browser-core'
 import {
@@ -195,7 +194,7 @@ describe('rum public api', () => {
         deleteEventBridgeStub()
       })
 
-      describe('without the COMPRESS_BATCH experimental flag', () => {
+      describe('with compressIntakeRequests: false', () => {
         it('does not create a deflate worker', () => {
           rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
@@ -204,11 +203,11 @@ describe('rum public api', () => {
         })
       })
 
-      describe('with the COMPRESS_BATCH experimental flag', () => {
+      describe('with compressIntakeRequests: true', () => {
         it('creates a deflate worker instance', () => {
           rumPublicApi.init({
             ...DEFAULT_INIT_CONFIGURATION,
-            enableExperimentalFeatures: [ExperimentalFeature.COMPRESS_BATCH],
+            compressIntakeRequests: true,
           })
 
           expect(startDeflateWorkerSpy).toHaveBeenCalledTimes(1)
@@ -220,7 +219,7 @@ describe('rum public api', () => {
 
           rumPublicApi.init({
             ...DEFAULT_INIT_CONFIGURATION,
-            enableExperimentalFeatures: [ExperimentalFeature.COMPRESS_BATCH],
+            compressIntakeRequests: true,
           })
 
           expect(startRumSpy).not.toHaveBeenCalled()
@@ -231,7 +230,7 @@ describe('rum public api', () => {
 
           rumPublicApi.init({
             ...DEFAULT_INIT_CONFIGURATION,
-            enableExperimentalFeatures: [ExperimentalFeature.COMPRESS_BATCH],
+            compressIntakeRequests: true,
           })
 
           expect(startDeflateWorkerSpy).not.toHaveBeenCalled()
@@ -241,7 +240,7 @@ describe('rum public api', () => {
         it('pass the worker to the recorder API', () => {
           rumPublicApi.init({
             ...DEFAULT_INIT_CONFIGURATION,
-            enableExperimentalFeatures: [ExperimentalFeature.COMPRESS_BATCH],
+            compressIntakeRequests: true,
           })
           expect(recorderApiOnRumStartSpy.calls.mostRecent().args[4]).toBe(FAKE_WORKER)
         })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -29,8 +29,6 @@ import {
   sanitize,
   createStoredContextManager,
   combine,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
   createIdentityEncoder,
 } from '@datadog/browser-core'
 import type { LifeCycle } from '../domain/lifeCycle'
@@ -168,11 +166,7 @@ export function makeRumPublicApi(
       return
     }
 
-    if (
-      isExperimentalFeatureEnabled(ExperimentalFeature.COMPRESS_BATCH) &&
-      !eventBridgeAvailable &&
-      startDeflateWorker
-    ) {
+    if (configuration.compressIntakeRequests && !eventBridgeAvailable && startDeflateWorker) {
       deflateWorker = startDeflateWorker(
         configuration,
         'Datadog RUM',
@@ -182,6 +176,7 @@ export function makeRumPublicApi(
         noop
       )
       if (!deflateWorker) {
+        // `startDeflateWorker` should have logged an error message explaining the issue
         return
       }
     }

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -24,6 +24,7 @@ export interface RumInitConfiguration extends InitConfiguration {
   beforeSend?: ((event: RumEvent, context: RumEventDomainContext) => boolean) | undefined
   excludedActivityUrls?: MatchOption[] | undefined
   workerUrl?: string
+  compressIntakeRequests?: boolean | undefined
 
   // tracing options
   allowedTracingUrls?: Array<MatchOption | TracingOption> | undefined
@@ -55,6 +56,7 @@ export interface RumConfiguration extends Configuration {
   allowedTracingUrls: TracingOption[]
   excludedActivityUrls: MatchOption[]
   workerUrl: string | undefined
+  compressIntakeRequests: boolean
   applicationId: string
   defaultPrivacyLevel: DefaultPrivacyLevel
   sessionReplaySampleRate: number
@@ -115,6 +117,7 @@ export function validateAndBuildRumConfiguration(
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],
       workerUrl: initConfiguration.workerUrl,
+      compressIntakeRequests: !!initConfiguration.compressIntakeRequests,
       trackUserInteractions: !!initConfiguration.trackUserInteractions,
       trackViewsManually: !!initConfiguration.trackViewsManually,
       trackResources: !!initConfiguration.trackResources,
@@ -199,6 +202,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration): 
       use_excluded_activity_urls:
         Array.isArray(configuration.excludedActivityUrls) && configuration.excludedActivityUrls.length > 0,
       use_worker_url: !!configuration.workerUrl,
+      compress_intake_requests: configuration.compressIntakeRequests,
       track_views_manually: configuration.trackViewsManually,
       track_user_interactions: configuration.trackUserInteractions,
       track_resources: configuration.trackResources,

--- a/test/e2e/scenario/transport.scenario.ts
+++ b/test/e2e/scenario/transport.scenario.ts
@@ -1,4 +1,3 @@
-import { ExperimentalFeature } from '@datadog/browser-core'
 import { createTest, flushEvents } from '../lib/framework'
 import { getBrowserName, getPlatformName, withBrowserLogs } from '../lib/helpers/browser'
 
@@ -6,7 +5,7 @@ describe('transport', () => {
   describe('data compression', () => {
     createTest('send RUM data compressed')
       .withRum({
-        enableExperimentalFeatures: [ExperimentalFeature.COMPRESS_BATCH],
+        compressIntakeRequests: true,
       })
       .run(async ({ intakeRegistry }) => {
         await flushEvents()
@@ -33,7 +32,7 @@ describe('transport', () => {
     if (!((getBrowserName() === 'safari' && getPlatformName() === 'macos') || getBrowserName() === 'firefox')) {
       createTest("displays a message if the worker can't be started")
         .withRum({
-          enableExperimentalFeatures: [ExperimentalFeature.COMPRESS_BATCH],
+          compressIntakeRequests: true,
         })
         .withBasePath('/no-blob-worker-csp')
         .run(async ({ intakeRegistry }) => {


### PR DESCRIPTION
## Motivation

Depending on how it is used, the Browser SDK can send a lot of data to the Datadog intake. This PR introduce a new `compressIntakeRequests` initialization parameter to allow users to opt-in to request compression. Before using it:

* if you are using the `proxy` initialization parameter, make sure your that your proxy supports binary payloads, regardless of the `Content-Encoding` or `Content-Type` headers

* if you are using `Content-Security-Policy` headers, make sure you allow blob workers (see [doc](https://docs.datadoghq.com/integrations/content_security_policy_logs/?tab=firefox#session-replay-worker))

## Changes

* follow-up of #2400 , replace the experimental flag with an initialization parameter

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
