### PR TITLE
✨[RUM-2158] Allow more flexible proxy URL

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -32,7 +32,7 @@ export interface InitConfiguration {
   storeContextsAcrossPages?: boolean | undefined
 
   // transport options
-  proxy?: string | undefined
+  proxy?: string | ProxyFn | undefined
   site?: string | undefined
 
   // tag and context options
@@ -49,6 +49,7 @@ export interface InitConfiguration {
   enableExperimentalFeatures?: string[] | undefined
   replica?: ReplicaUserConfiguration | undefined
   datacenter?: string
+  // TODO next major: remove this option and replace usages by proxyFn
   internalAnalyticsSubdomain?: string
 
   telemetryConfigurationSampleRate?: number
@@ -57,6 +58,12 @@ export interface InitConfiguration {
 // This type is only used to build the core configuration. Logs and RUM SDKs are using a proper type
 // for this option.
 type GenericBeforeSendCallback = (event: any, context?: any) => unknown
+
+/**
+ * path: /api/vX/product
+ * parameters: xxx=yyy&zzz=aaa
+ */
+type ProxyFn = (path: string, parameters: string) => string
 
 interface ReplicaUserConfiguration {
   applicationId?: string

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -63,7 +63,7 @@ type GenericBeforeSendCallback = (event: any, context?: any) => unknown
  * path: /api/vX/product
  * parameters: xxx=yyy&zzz=aaa
  */
-type ProxyFn = (path: string, parameters: string) => string
+type ProxyFn = (options: { path: string; parameters: string }) => string
 
 interface ReplicaUserConfiguration {
   applicationId?: string

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -84,7 +84,8 @@ describe('endpointBuilder', () => {
     })
 
     it('should allow to fully control the proxy url', () => {
-      const proxyFn = (path: string, parameters: string) => `https://proxy.io/prefix${path}/suffix?${parameters}`
+      const proxyFn = (options: { path: string; parameters: string }) =>
+        `https://proxy.io/prefix${options.path}/suffix?${options.parameters}`
       expect(
         createEndpointBuilder({ ...initConfiguration, proxy: proxyFn }, 'rum', []).build('xhr', DEFAULT_PAYLOAD)
       ).toMatch(

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -82,6 +82,15 @@ describe('endpointBuilder', () => {
         )
       ).toBeTrue()
     })
+
+    it('should allow to fully control the proxy url', () => {
+      const proxyFn = (path: string, parameters: string) => `https://proxy.io/prefix${path}/suffix?${parameters}`
+      expect(
+        createEndpointBuilder({ ...initConfiguration, proxy: proxyFn }, 'rum', []).build('xhr', DEFAULT_PAYLOAD)
+      ).toMatch(
+        `https://proxy.io/prefix/api/v2/rum/suffix\\?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)&batch_time=(.*)`
+      )
+    })
   })
 
   describe('tags', () => {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -46,7 +46,7 @@ function createEndpointUrlWithParametersBuilder(
     return (parameters) => `${normalizedProxyUrl}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}`
   }
   if (typeof proxy === 'function') {
-    return (parameters) => proxy(path, parameters)
+    return (parameters) => proxy({ path, parameters })
   }
   const host = buildEndpointHost(initConfiguration)
   return (parameters) => `https://${host}${path}?${parameters}`

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -41,9 +41,12 @@ function createEndpointUrlWithParametersBuilder(
 ): (parameters: string) => string {
   const path = `/api/v2/${trackType}`
   const proxy = initConfiguration.proxy
-  if (proxy) {
+  if (typeof proxy === 'string') {
     const normalizedProxyUrl = normalizeUrl(proxy)
     return (parameters) => `${normalizedProxyUrl}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}`
+  }
+  if (typeof proxy === 'function') {
+    return (parameters) => proxy(path, parameters)
   }
   const host = buildEndpointHost(initConfiguration)
   return (parameters) => `https://${host}${path}?${parameters}`


### PR DESCRIPTION
## Motivation

As discussed in #2429 and #2471, the [current proxy strategy](https://docs.datadoghq.com/real_user_monitoring/guide/proxy-rum-data/?tab=npm#proxy-setup) with the `ddforward` parameter, storing the target path and parameters, can be challenging to implement.

A solution allowing to have the path and parameters appended to the provided proxy URL was initially discarded since one of our URL pattern was already blocked, cf [easylist](https://github.com/easylist/easylist/blob/997fb6533c719a015c21723b34e0cedefcc0d83d/easyprivacy/easyprivacy_general.txt#L3840).
However, some customers may want to use a proxy regardless of the privacy blocking or could want to tweak themselves the final proxy url to prevent the blocking.

## Changes

Allow to pass a function to the `proxy` init parameter:
```ts
init({
  ...
  proxy: (options: {path: string, parameters: string}) => 
    `https://proxy.io/prefix${options.path}/suffix?${options.parameters}`
})
```
With:
* path: `/api/vX/product`
* parameters: `xxx=yyy&zzz=aaa`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
