### PR TITLE
✨ [RUM-1214] Collect core web vitals target selectors

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -16,7 +16,6 @@ export enum ExperimentalFeature {
   RESOURCE_PAGE_STATES = 'resource_page_states',
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
   SCROLLMAP = 'scrollmap',
-  WEB_VITALS_ATTRIBUTION = 'web_vitals_attribution',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
 }
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -1,4 +1,4 @@
-import { ExperimentalFeature, addExperimentalFeatures, resetExperimentalFeatures } from '@datadog/browser-core'
+import { resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
 import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -166,8 +166,7 @@ describe('trackCumulativeLayoutShift', () => {
       resetExperimentalFeatures()
     })
 
-    it('should return the first target element selector amongst all the shifted nodes when FF enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+    it('should return the first target element selector amongst all the shifted nodes', () => {
       const { lifeCycle } = setupBuilder.build()
 
       const textNode = appendText('text')
@@ -183,23 +182,7 @@ describe('trackCumulativeLayoutShift', () => {
       expect(clsCallback.calls.mostRecent().args[0].targetSelector).toEqual('#div-element')
     })
 
-    it('should not return the target element selector when FF disabled', () => {
-      const { lifeCycle } = setupBuilder.build()
-
-      const divElement = appendElement('<div id="div-element"></div>')
-
-      lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-        createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, {
-          sources: [{ node: divElement }],
-        }),
-      ])
-
-      expect(clsCallback).toHaveBeenCalledTimes(2)
-      expect(clsCallback.calls.mostRecent().args[0].targetSelector).toEqual(undefined)
-    })
-
     it('should not return the target element when the element is detached from the DOM', () => {
-      addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
 
       // first session window

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -1,4 +1,4 @@
-import { round, find, ONE_SECOND, isExperimentalFeatureEnabled, ExperimentalFeature, noop } from '@datadog/browser-core'
+import { round, find, ONE_SECOND, noop } from '@datadog/browser-core'
 import type { RelativeTime } from '@datadog/browser-core'
 import { isElementNode } from '../../../browser/htmlDomUtils'
 import type { LifeCycle } from '../../lifeCycle'
@@ -61,7 +61,6 @@ export function trackCumulativeLayoutShift(
           let cslTargetSelector
 
           if (
-            isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) &&
             clsTarget &&
             // Check if the CLS target have been removed from the DOM between the time we collect the target reference and when we compute the selector
             clsTarget.isConnected

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -1,10 +1,4 @@
-import {
-  type Duration,
-  type RelativeTime,
-  resetExperimentalFeatures,
-  ExperimentalFeature,
-  addExperimentalFeatures,
-} from '@datadog/browser-core'
+import { type Duration, type RelativeTime, resetExperimentalFeatures } from '@datadog/browser-core'
 import { restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../../../test'
 import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
@@ -57,8 +51,7 @@ describe('firstInputTimings', () => {
     })
   })
 
-  it('should provide the first input target selector when FF web_vital_attribution is enabled', () => {
-    addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+  it('should provide the first input target selector', () => {
     const { lifeCycle } = setupBuilder.build()
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
@@ -74,8 +67,7 @@ describe('firstInputTimings', () => {
     )
   })
 
-  it("should not provide the first input target if it's not a DOM element when FF web_vital_attribution is enabled", () => {
-    addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+  it("should not provide the first input target if it's not a DOM element", () => {
     const { lifeCycle } = setupBuilder.build()
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.ts
@@ -1,5 +1,5 @@
 import type { Duration, RelativeTime } from '@datadog/browser-core'
-import { elapsed, find, ExperimentalFeature, isExperimentalFeatureEnabled } from '@datadog/browser-core'
+import { elapsed, find } from '@datadog/browser-core'
 import { isElementNode } from '../../../browser/htmlDomUtils'
 import type { RumConfiguration } from '../../configuration'
 import type { LifeCycle } from '../../lifeCycle'
@@ -41,11 +41,7 @@ export function trackFirstInput(
         const firstInputDelay = elapsed(firstInputEntry.startTime, firstInputEntry.processingStart)
         let firstInputTargetSelector
 
-        if (
-          isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) &&
-          firstInputEntry.target &&
-          isElementNode(firstInputEntry.target)
-        ) {
+        if (firstInputEntry.target && isElementNode(firstInputEntry.target)) {
           firstInputTargetSelector = getSelectorFromElement(firstInputEntry.target, configuration.actionNameAttribute)
         }
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -1,10 +1,5 @@
 import type { Duration, RelativeTime } from '@datadog/browser-core'
-import {
-  ExperimentalFeature,
-  addExperimentalFeatures,
-  relativeNow,
-  resetExperimentalFeatures,
-} from '@datadog/browser-core'
+import { relativeNow, resetExperimentalFeatures } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../../test'
 import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
@@ -173,8 +168,7 @@ describe('trackInteractionToNextPaint', () => {
     })
   })
 
-  it('should return the target selector when FF web_vital_attribution is enabled', () => {
-    addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+  it('should return the target selector', () => {
     const { lifeCycle } = setupBuilder.build()
 
     newInteraction(lifeCycle, {
@@ -185,24 +179,12 @@ describe('trackInteractionToNextPaint', () => {
     expect(getInteractionToNextPaint()?.targetSelector).toEqual('#inp-target-element')
   })
 
-  it("should not return the target selector if it's not a DOM element when FF web_vital_attribution is enabled", () => {
-    addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+  it("should not return the target selector if it's not a DOM element", () => {
     const { lifeCycle } = setupBuilder.build()
 
     newInteraction(lifeCycle, {
       interactionId: 2,
       target: appendText('text'),
-    })
-
-    expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)
-  })
-
-  it('should not return the target selector when FF web_vital_attribution is disabled', () => {
-    const { lifeCycle } = setupBuilder.build()
-
-    newInteraction(lifeCycle, {
-      interactionId: 2,
-      target: appendElement('<button id="inp-target-element"></button>'),
     })
 
     expect(getInteractionToNextPaint()?.targetSelector).toEqual(undefined)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -1,4 +1,4 @@
-import { noop, isExperimentalFeatureEnabled, ExperimentalFeature, ONE_MINUTE } from '@datadog/browser-core'
+import { noop, ONE_MINUTE } from '@datadog/browser-core'
 import type { Duration, RelativeTime } from '@datadog/browser-core'
 import { RumPerformanceEntryType, supportPerformanceTimingEvent } from '../../../browser/performanceCollection'
 import type { RumFirstInputTiming, RumPerformanceEventTiming } from '../../../browser/performanceCollection'
@@ -65,11 +65,7 @@ export function trackInteractionToNextPaint(
     if (newInteraction) {
       interactionToNextPaint = newInteraction.duration
 
-      if (
-        isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) &&
-        newInteraction.target &&
-        isElementNode(newInteraction.target)
-      ) {
+      if (newInteraction.target && isElementNode(newInteraction.target)) {
         interactionToNextPaintTargetSelector = getSelectorFromElement(
           newInteraction.target,
           configuration.actionNameAttribute

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -1,10 +1,5 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import {
-  DOM_EVENT,
-  ExperimentalFeature,
-  addExperimentalFeatures,
-  resetExperimentalFeatures,
-} from '@datadog/browser-core'
+import { DOM_EVENT, resetExperimentalFeatures } from '@datadog/browser-core'
 import { restorePageVisibility, setPageVisibility, createNewEvent } from '@datadog/browser-core/test'
 import { RumPerformanceEntryType } from '../../../browser/performanceCollection'
 import type { TestSetupBuilder } from '../../../../test'
@@ -60,8 +55,7 @@ describe('trackLargestContentfulPaint', () => {
     expect(lcpCallback).toHaveBeenCalledWith({ value: 789 as RelativeTime, targetSelector: undefined })
   })
 
-  it('should provide the largest contentful paint target selector if FF enabled', () => {
-    addExperimentalFeatures([ExperimentalFeature.WEB_VITALS_ATTRIBUTION])
+  it('should provide the largest contentful paint target selector', () => {
     const { lifeCycle } = setupBuilder.build()
 
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
@@ -72,19 +66,6 @@ describe('trackLargestContentfulPaint', () => {
 
     expect(lcpCallback).toHaveBeenCalledTimes(1 as RelativeTime)
     expect(lcpCallback).toHaveBeenCalledWith({ value: 789 as RelativeTime, targetSelector: '#lcp-target-element' })
-  })
-
-  it('should not provide the largest contentful paint target selector if FF disabled', () => {
-    const { lifeCycle } = setupBuilder.build()
-
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
-        element: appendElement('<button id="lcp-target-element"></button>'),
-      }),
-    ])
-
-    expect(lcpCallback).toHaveBeenCalledTimes(1 as RelativeTime)
-    expect(lcpCallback).toHaveBeenCalledWith({ value: 789 as RelativeTime, targetSelector: undefined })
   })
 
   it('should be discarded if it is reported after a user interaction', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
@@ -1,12 +1,5 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import {
-  DOM_EVENT,
-  ExperimentalFeature,
-  ONE_MINUTE,
-  addEventListeners,
-  findLast,
-  isExperimentalFeatureEnabled,
-} from '@datadog/browser-core'
+import { DOM_EVENT, ONE_MINUTE, addEventListeners, findLast } from '@datadog/browser-core'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { LifeCycle } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
@@ -64,7 +57,7 @@ export function trackLargestContentfulPaint(
 
       if (lcpEntry) {
         let lcpTargetSelector
-        if (isExperimentalFeatureEnabled(ExperimentalFeature.WEB_VITALS_ATTRIBUTION) && lcpEntry.element) {
+        if (lcpEntry.element) {
           lcpTargetSelector = getSelectorFromElement(lcpEntry.element, configuration.actionNameAttribute)
         }
 


### PR DESCRIPTION
## Motivation

Currently the web vitals are reported with a single value representing the vital score. These scores provide valuable insights to customers, allowing them to determine the performance quality of their website. However, to effectively improve them, it is crucial to identify the specific component to which a vital refers.

## Changes

Remove `web_vitals_attribution` feature flag

![image](https://github.com/DataDog/browser-sdk/assets/4342515/a65017d5-d839-414b-8e75-7ec5dd2d719c)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [ ] Staging
- [X] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
