### PR TITLE
🔊[RUM-2324] Telemetry on LCP with startTime to 0

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -15,6 +15,7 @@ export enum ExperimentalFeature {
   FEATURE_FLAGS = 'feature_flags',
   RESOURCE_PAGE_STATES = 'resource_page_states',
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
+  ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
   SCROLLMAP = 'scrollmap',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
 }

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -96,6 +96,7 @@ export interface RumLargestContentfulPaintTiming {
   startTime: RelativeTime
   size: number
   element?: Element
+  toJSON(): Omit<PerformanceEntry, 'toJSON'>
 }
 
 export interface RumFirstInputTiming {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
@@ -27,6 +27,7 @@ export interface LargestContentfulPaint {
 }
 
 let zeroLcpReported = false
+let previousNonZeroLcp: Omit<PerformanceEntry, 'toJSON'> | undefined
 /**
  * Track the largest contentful paint (LCP) occurring during the initial View.  This can yield
  * multiple values, only the most recent one should be used.
@@ -72,19 +73,26 @@ export function trackLargestContentfulPaint(
           lcpTargetSelector = getSelectorFromElement(lcpEntry.element, configuration.actionNameAttribute)
         }
 
+        if (!zeroLcpReported && lcpEntry.startTime !== 0) {
+          previousNonZeroLcp = lcpEntry.toJSON()
+        }
+
         if (
           !zeroLcpReported &&
           lcpEntry.startTime === 0 &&
           isExperimentalFeatureEnabled(ExperimentalFeature.ZERO_LCP_TELEMETRY)
         ) {
           zeroLcpReported = true
+
           addTelemetryDebug('LCP with startTime = 0', {
             debug: {
               entry: lcpEntry.toJSON(),
+              previousNonZeroLcp,
               navigationStart: performance.timing.navigationStart,
               timeOrigin: performance.timeOrigin,
               now: relativeNow(),
               visibilityState: document.visibilityState,
+              prerendering: (document as any).prerendering,
             },
           })
         }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
@@ -1,5 +1,14 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import { DOM_EVENT, ONE_MINUTE, addEventListeners, findLast } from '@datadog/browser-core'
+import {
+  DOM_EVENT,
+  ExperimentalFeature,
+  ONE_MINUTE,
+  addEventListeners,
+  addTelemetryDebug,
+  findLast,
+  isExperimentalFeatureEnabled,
+  relativeNow,
+} from '@datadog/browser-core'
 import { LifeCycleEventType } from '../../lifeCycle'
 import type { LifeCycle } from '../../lifeCycle'
 import type { RumConfiguration } from '../../configuration'
@@ -16,6 +25,8 @@ export interface LargestContentfulPaint {
   value: RelativeTime
   targetSelector?: string
 }
+
+let zeroLcpReported = false
 /**
  * Track the largest contentful paint (LCP) occurring during the initial View.  This can yield
  * multiple values, only the most recent one should be used.
@@ -61,6 +72,22 @@ export function trackLargestContentfulPaint(
           lcpTargetSelector = getSelectorFromElement(lcpEntry.element, configuration.actionNameAttribute)
         }
 
+        if (
+          !zeroLcpReported &&
+          lcpEntry.startTime === 0 &&
+          isExperimentalFeatureEnabled(ExperimentalFeature.ZERO_LCP_TELEMETRY)
+        ) {
+          zeroLcpReported = true
+          addTelemetryDebug('LCP with startTime = 0', {
+            debug: {
+              entry: lcpEntry.toJSON(),
+              navigationStart: performance.timing.navigationStart,
+              timeOrigin: performance.timeOrigin,
+              now: relativeNow(),
+              visibilityState: document.visibilityState,
+            },
+          })
+        }
         callback({
           value: lcpEntry.startTime,
           targetSelector: lcpTargetSelector,

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -155,8 +155,8 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
         },
         overrides
       ) as EntryTypeToReturnType[T]
-    case RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT:
-      return assign(
+    case RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT: {
+      const entry = assign(
         {
           entryType: RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
           startTime: 789 as RelativeTime,
@@ -164,6 +164,8 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
         },
         overrides
       ) as EntryTypeToReturnType[T]
+      return { ...entry, toJSON: () => entry }
+    }
     case RumPerformanceEntryType.LAYOUT_SHIFT:
       return assign(
         {


### PR DESCRIPTION
## Motivation

Collect telemetry on LCP with startTime to 0:
```js
{
  entry // the entry reported by the performanceObserver API
  previousNonZeroLcp,
  navigationStart // check if there is an unexpected navigationStart
  timeOrigin // check if there is an unexpected timeOrigin
  now: performance.now() // check the diff between now and the entry timings,
  visibilityState // check if these reports happens when "hidden" | "visible" | "prerender",
  prerendering: document.prerendering,
}
```

## Changes

Add telemetry on LCP with a startTime at 0

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
