### PR TITLE
✅ import JSON schemas dynamically in tests

### DIFF
--- a/packages/rum-core/test/allJsonSchemas.d.ts
+++ b/packages/rum-core/test/allJsonSchemas.d.ts
@@ -1,0 +1,1 @@
+export const allJsonSchemas: object[]

--- a/packages/rum-core/test/allJsonSchemas.js
+++ b/packages/rum-core/test/allJsonSchemas.js
@@ -1,0 +1,19 @@
+/* global require */
+
+// This file is not in TypeScript because it uses 'require.context', and we cannot type it
+// correctly because:
+//
+// * We don't want to declare this type as a global (via TS `declare global`), because it would be
+// declared all across the project.
+//
+// * We can't use something like `(globalThis as Something).require.context` because Webpack is
+// looking for `require.context` as a standalone statement at build time.
+
+const requireSchema = require.context(
+  '../../../rum-events-format/schemas',
+  true /* use sub directories */,
+  /\.json*$/,
+  'sync'
+)
+
+export const allJsonSchemas = requireSchema.keys().map(requireSchema)

--- a/packages/rum-core/test/formatValidation.ts
+++ b/packages/rum-core/test/formatValidation.ts
@@ -1,30 +1,15 @@
 import type { Context } from '@datadog/browser-core'
 import ajv from 'ajv'
-import rumEventsSchemaJson from '../../../rum-events-format/schemas/rum-events-schema.json'
-import _commonSchemaJson from '../../../rum-events-format/schemas/rum/_common-schema.json'
-import _actionChildSchemaJson from '../../../rum-events-format/schemas/rum/_action-child-schema.json'
-import _perfMetricSchemaJson from '../../../rum-events-format/schemas/rum/_perf-metric-schema.json'
-import actionSchemaJson from '../../../rum-events-format/schemas/rum/action-schema.json'
-import errorSchemaJson from '../../../rum-events-format/schemas/rum/error-schema.json'
-import longTaskSchemaJson from '../../../rum-events-format/schemas/rum/long_task-schema.json'
-import resourceSchemaJson from '../../../rum-events-format/schemas/rum/resource-schema.json'
-import viewSchemaJson from '../../../rum-events-format/schemas/rum/view-schema.json'
+import { allJsonSchemas } from './allJsonSchemas'
 
 export function validateRumFormat(rumEvent: Context) {
   const instance = new ajv({
     allErrors: true,
   })
-  void instance
-    .addSchema(_commonSchemaJson, 'rum/_common-schema.json')
-    .addSchema(_actionChildSchemaJson, 'rum/_action-child-schema.json')
-    .addSchema(_perfMetricSchemaJson, 'rum/_perf-metric-schema.json')
-    .addSchema(viewSchemaJson, 'rum/view-schema.json')
-    .addSchema(actionSchemaJson, 'rum/action-schema.json')
-    .addSchema(resourceSchemaJson, 'rum/resource-schema.json')
-    .addSchema(longTaskSchemaJson, 'rum/long_task-schema.json')
-    .addSchema(errorSchemaJson, 'rum/error-schema.json')
-    .addSchema(rumEventsSchemaJson, 'rum-events-schema.json')
-    .validate('rum-events-schema.json', rumEvent)
+
+  instance.addSchema(allJsonSchemas)
+
+  void instance.validate('rum-events-schema.json', rumEvent)
 
   if (instance.errors) {
     const errors = instance.errors

--- a/test/e2e/lib/helpers/validation.ts
+++ b/test/e2e/lib/helpers/validation.ts
@@ -1,31 +1,19 @@
+import fs from 'fs'
 import type { RumEvent } from '@datadog/browser-rum'
 import ajv from 'ajv'
-import rumEventsSchemaJson from '../../../../rum-events-format/schemas/rum-events-schema.json'
-import _commonSchemaJson from '../../../../rum-events-format/schemas/rum/_common-schema.json'
-import _actionChildSchemaJson from '../../../../rum-events-format/schemas/rum/_action-child-schema.json'
-import _perfMetricSchemaJson from '../../../../rum-events-format/schemas/rum/_perf-metric-schema.json'
-import actionSchemaJson from '../../../../rum-events-format/schemas/rum/action-schema.json'
-import errorSchemaJson from '../../../../rum-events-format/schemas/rum/error-schema.json'
-import longTaskSchemaJson from '../../../../rum-events-format/schemas/rum/long_task-schema.json'
-import resourceSchemaJson from '../../../../rum-events-format/schemas/rum/resource-schema.json'
-import viewSchemaJson from '../../../../rum-events-format/schemas/rum/view-schema.json'
+import { globSync } from 'glob'
 
 export function validateRumFormat(events: RumEvent[]) {
+  const instance = new ajv({
+    allErrors: true,
+  })
+  const allJsonSchemas = globSync('./rum-events-format/schemas/**/*.json').map(
+    (path) => JSON.parse(fs.readFileSync(path, 'utf8')) as object
+  )
+  instance.addSchema(allJsonSchemas)
+
   events.forEach((rumEvent) => {
-    const instance = new ajv({
-      allErrors: true,
-    })
-    void instance
-      .addSchema(_commonSchemaJson, 'rum/_common-schema.json')
-      .addSchema(_actionChildSchemaJson, 'rum/_action-child-schema.json')
-      .addSchema(_perfMetricSchemaJson, 'rum/_perf-metric-schema.json')
-      .addSchema(viewSchemaJson, 'rum/view-schema.json')
-      .addSchema(actionSchemaJson, 'rum/action-schema.json')
-      .addSchema(resourceSchemaJson, 'rum/resource-schema.json')
-      .addSchema(longTaskSchemaJson, 'rum/long_task-schema.json')
-      .addSchema(errorSchemaJson, 'rum/error-schema.json')
-      .addSchema(rumEventsSchemaJson, 'rum-events-schema.json')
-      .validate('rum-events-schema.json', rumEvent)
+    void instance.validate('rum-events-schema.json', rumEvent)
     if (instance.errors) {
       instance.errors.map((error) => fail(`${error.dataPath || 'event'} ${error.message!}`))
     }


### PR DESCRIPTION
## Motivation

When adding a new JSON schema file, SDK tests are failing because file imports are hardcoded manually.

Ex in this PR: https://github.com/DataDog/rum-events-format/pull/170 (see [this CI job output](https://github.com/DataDog/rum-events-format/actions/runs/6906138216/job/18790474030#step:6:17))

## Changes

Load JSON schema files dynamically.

* In unit tests, uses webpack `require.context` ([doc](https://webpack.js.org/guides/dependency-management/#requirecontext))
* In e2e tests we can just use Node.js APIs

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
