### PR TITLE
👷 extract deploy step for us1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -301,19 +301,25 @@ deploy-prod-canary:
     - node ./scripts/deploy/deploy.js prod v${VERSION%%.*} $UPLOAD_PATH
     - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*} $UPLOAD_PATH
 
-step-1_deploy-prod-all-dcs:
+step-1_deploy-prod-minor-dcs:
   extends:
     - .deploy-prod
   variables:
-    UPLOAD_PATH: us3,us5,ap1,eu1,us1
+    UPLOAD_PATH: us3,us5,ap1,eu1
 
-step-2_deploy-prod-gov:
+step-2_deploy-prod-us1:
+  extends:
+    - .deploy-prod
+  variables:
+    UPLOAD_PATH: us1
+
+step-3_deploy-prod-gov:
   extends:
     - .deploy-prod
   variables:
     UPLOAD_PATH: root
 
-step-3_publish-npm:
+step-4_publish-npm:
   stage: deploy
   extends:
     - .base-configuration
@@ -324,7 +330,7 @@ step-3_publish-npm:
     - yarn
     - node ./scripts/deploy/publish-npm.js
 
-step-4_publish-developer-extension:
+step-5_publish-developer-extension:
   stage: deploy
   extends:
     - .base-configuration


### PR DESCRIPTION
## Motivation

Enough customers on us1 to extract a dedicated deploy step

## Changes

Split `step-1_deploy-prod-all-dcs` into:

- `step-1_deploy-prod-minor-dcs`
- `step-2_deploy-prod-us1`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

next release

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
