### PR TITLE
🐛 [RUM-2280] fix duplicated mutations when using Shadow DOM

### DIFF
--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -311,6 +311,22 @@ describe('record', () => {
       expect(innerMutationData.isChecked).toBe(true)
     })
 
+    it('should record the change event inside a shadow root only once, regardless if the DOM is serialized multiple times', () => {
+      const radio = appendElement('<input type="radio"/>', createShadow()) as HTMLInputElement
+      startRecording()
+
+      recordApi.takeSubsequentFullSnapshot()
+
+      radio.checked = true
+      radio.dispatchEvent(createNewEvent('change', { target: radio, composed: false }))
+
+      const inputRecords = getEmittedRecords().filter(
+        (record) => record.type === RecordType.IncrementalSnapshot && record.data.source === IncrementalSource.Input
+      )
+
+      expect(inputRecords.length).toBe(1)
+    })
+
     it('should clean the state once the shadow dom is removed to avoid memory leak', () => {
       const shadowRoot = createShadow()
       appendElement('<div class="toto"></div>', shadowRoot)

--- a/packages/rum/src/domain/record/shadowRootsController.ts
+++ b/packages/rum/src/domain/record/shadowRootsController.ts
@@ -30,6 +30,9 @@ export const initShadowRootsController = (
 
   const shadowRootsController: ShadowRootsController = {
     addShadowRoot: (shadowRoot: ShadowRoot) => {
+      if (controllerByShadowRoot.has(shadowRoot)) {
+        return
+      }
       const { stop: stopMutationObserver, flush } = initMutationObserver(
         mutationCb,
         configuration,


### PR DESCRIPTION
## Motivation

Shadow Roots need to be instrumented with a `MutationObserver` and an `input` event listener to properly generate incremental snapshots for changes happening inside of them. We do this instrumentation during serialization.

The issue is, when serializing the same Shadow Root multiple times (ex:  when a route_change view is created and a second Full Snapshot is taken), Shadow Roots are instrumented multiple times, so inner incremental snapshots are generated multiple times whenever a single change is done.

## Changes

Make sure we instrument Shadow Roots only once

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
