### PR TITLE
🔊[RUM-2324] Telemetry on other wrong LCP cases

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -16,7 +16,6 @@ export enum ExperimentalFeature {
   RESOURCE_PAGE_STATES = 'resource_page_states',
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
-  SCROLLMAP = 'scrollmap',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
 }
 

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -96,7 +96,7 @@ export interface RumLargestContentfulPaintTiming {
   startTime: RelativeTime
   size: number
   element?: Element
-  toJSON(): Omit<PerformanceEntry, 'toJSON'>
+  toJSON(): Omit<RumLargestContentfulPaintTiming, 'toJSON'>
 }
 
 export interface RumFirstInputTiming {


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/browser-sdk/pull/2515, some LCP data seemed wrong for other reasons than startTime = 0. 

## Changes

- collect debug logs for `LCP with startTime < previous LCP`
- collect debug logs for `LCP with size < previous LCP`
- remove some debug data:
  -  `visibilityState`: always visible
  - `prerendering`: always false
  - `navigationStart`: from one case, the value did not really make sense (~30s after timeOrigin) but not sure how reliable it is supposed to be anyway.
- add `lcpEntries` to the debug data, to double check if the implementation difference with google may have an impact


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
