### PR TITLE
🔊[RUM-2324] Telemetry on LCP add takeRecords entries

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
@@ -7,6 +7,7 @@ import {
   addTelemetryDebug,
   findLast,
   isExperimentalFeatureEnabled,
+  noop,
   relativeNow,
 } from '@datadog/browser-core'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -118,7 +119,8 @@ function monitorLcpEntries(lcpEntry: RumLargestContentfulPaintTiming, lcpEntries
 
   if (wrongLcpDetected) {
     wrongLcpReported = true
-
+    const po = new PerformanceObserver(noop)
+    po.observe({ type: 'largest-contentful-paint', buffered: true })
     addTelemetryDebug(wrongLcpDetected, {
       debug: {
         entry: toSerializableLCP(lcpEntry),
@@ -126,6 +128,9 @@ function monitorLcpEntries(lcpEntry: RumLargestContentfulPaintTiming, lcpEntries
         timeOrigin: performance.timeOrigin,
         now: relativeNow(),
         lcpEntries: lcpEntries.map(toSerializableLCP),
+        takeRecordsEntries: po
+          .takeRecords()
+          .map((lcp) => toSerializableLCP(lcp as unknown as RumLargestContentfulPaintTiming)),
       },
     })
   }


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/browser-sdk/pull/2515, some LCP data seemed wrong for other reasons than startTime = 0.

After seeing that we collect debug logs for LCP with startTime < previous LCP, check if the entries returned by [takeRecords](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/takeRecords) are ordered by timestamp

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
