### PR TITLE
♻️ [RUMF-1436] instrument method improvements

### DIFF
--- a/packages/core/src/browser/fetchObservable.ts
+++ b/packages/core/src/browser/fetchObservable.ts
@@ -1,5 +1,5 @@
 import type { InstrumentedMethodCall } from '../tools/instrumentMethod'
-import { instrumentMethodAndCallOriginal } from '../tools/instrumentMethod'
+import { instrumentMethod } from '../tools/instrumentMethod'
 import { monitor } from '../tools/monitor'
 import { Observable } from '../tools/observable'
 import type { ClocksState } from '../tools/utils/timeUtils'
@@ -44,7 +44,7 @@ function createFetchObservable() {
       return
     }
 
-    const { stop } = instrumentMethodAndCallOriginal(window, 'fetch', (call) => beforeSend(call, observable))
+    const { stop } = instrumentMethod(window, 'fetch', (call) => beforeSend(call, observable))
 
     return stop
   })

--- a/packages/core/src/browser/fetchObservable.ts
+++ b/packages/core/src/browser/fetchObservable.ts
@@ -1,5 +1,6 @@
-import { instrumentMethod } from '../tools/instrumentMethod'
-import { callMonitored, monitor } from '../tools/monitor'
+import type { InstrumentedMethodCall } from '../tools/instrumentMethod'
+import { instrumentMethodAndCallOriginal } from '../tools/instrumentMethod'
+import { monitor } from '../tools/monitor'
 import { Observable } from '../tools/observable'
 import type { ClocksState } from '../tools/utils/timeUtils'
 import { clocksNow } from '../tools/utils/timeUtils'
@@ -43,32 +44,17 @@ function createFetchObservable() {
       return
     }
 
-    const { stop } = instrumentMethod(
-      window,
-      'fetch',
-      (originalFetch) =>
-        function (input, init) {
-          let responsePromise: Promise<Response>
-
-          const context = callMonitored(beforeSend, null, [observable, input, init])
-          if (context) {
-            // casting should be `RequestInfo` but node types are ahead of DOM types, making `typecheck test/e2e` fail.
-            // it should be resolved with https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483
-            responsePromise = originalFetch.call(this, context.input as any, context.init)
-            callMonitored(afterSend, null, [observable, responsePromise, context])
-          } else {
-            responsePromise = originalFetch.call(this, input, init)
-          }
-
-          return responsePromise
-        }
-    )
+    const { stop } = instrumentMethodAndCallOriginal(window, 'fetch', (call) => beforeSend(call, observable))
 
     return stop
   })
 }
 
-function beforeSend(observable: Observable<FetchContext>, input: unknown, init?: RequestInit) {
+function beforeSend(
+  { parameters, onPostCall }: InstrumentedMethodCall<Window, 'fetch'>,
+  observable: Observable<FetchContext>
+) {
+  const [input, init] = parameters
   const methodFromParams = (init && init.method) || (input instanceof Request && input.method)
   const method = methodFromParams ? methodFromParams.toUpperCase() : 'GET'
   const url = input instanceof Request ? input.url : normalizeUrl(String(input))
@@ -85,7 +71,11 @@ function beforeSend(observable: Observable<FetchContext>, input: unknown, init?:
 
   observable.notify(context)
 
-  return context
+  // Those properties can be changed by observable subscribers
+  parameters[0] = context.input as RequestInfo | URL
+  parameters[1] = context.init
+
+  onPostCall((responsePromise) => afterSend(observable, responsePromise, context))
 }
 
 function afterSend(

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -1,3 +1,4 @@
+import type { InstrumentedMethodCall } from '../tools/instrumentMethod'
 import { instrumentMethodAndCallOriginal } from '../tools/instrumentMethod'
 import { Observable } from '../tools/observable'
 import type { Duration, ClocksState } from '../tools/utils/timeUtils'
@@ -40,19 +41,21 @@ export function initXhrObservable(configuration: Configuration) {
 
 function createXhrObservable(configuration: Configuration) {
   return new Observable<XhrContext>((observable) => {
-    const { stop: stopInstrumentingStart } = instrumentMethodAndCallOriginal(XMLHttpRequest.prototype, 'open', {
-      before: openXhr,
-    })
+    const { stop: stopInstrumentingStart } = instrumentMethodAndCallOriginal(XMLHttpRequest.prototype, 'open', openXhr)
 
-    const { stop: stopInstrumentingSend } = instrumentMethodAndCallOriginal(XMLHttpRequest.prototype, 'send', {
-      before() {
-        sendXhr.call(this, configuration, observable)
-      },
-    })
+    const { stop: stopInstrumentingSend } = instrumentMethodAndCallOriginal(
+      XMLHttpRequest.prototype,
+      'send',
+      (call) => {
+        sendXhr(call, configuration, observable)
+      }
+    )
 
-    const { stop: stopInstrumentingAbort } = instrumentMethodAndCallOriginal(XMLHttpRequest.prototype, 'abort', {
-      before: abortXhr,
-    })
+    const { stop: stopInstrumentingAbort } = instrumentMethodAndCallOriginal(
+      XMLHttpRequest.prototype,
+      'abort',
+      abortXhr
+    )
 
     return () => {
       stopInstrumentingStart()
@@ -62,16 +65,20 @@ function createXhrObservable(configuration: Configuration) {
   })
 }
 
-function openXhr(this: XMLHttpRequest, method: string, url: string | URL | undefined | null) {
-  xhrContexts.set(this, {
+function openXhr({ target: xhr, parameters: [method, url] }: InstrumentedMethodCall<XMLHttpRequest, 'open'>) {
+  xhrContexts.set(xhr, {
     state: 'open',
     method: method.toUpperCase(),
     url: normalizeUrl(String(url)),
   })
 }
 
-function sendXhr(this: XMLHttpRequest, configuration: Configuration, observable: Observable<XhrContext>) {
-  const context = xhrContexts.get(this)
+function sendXhr(
+  { target: xhr }: InstrumentedMethodCall<XMLHttpRequest, 'send'>,
+  configuration: Configuration,
+  observable: Observable<XhrContext>
+) {
+  const context = xhrContexts.get(xhr)
   if (!context) {
     return
   }
@@ -80,21 +87,23 @@ function sendXhr(this: XMLHttpRequest, configuration: Configuration, observable:
   startContext.state = 'start'
   startContext.startClocks = clocksNow()
   startContext.isAborted = false
-  startContext.xhr = this
+  startContext.xhr = xhr
 
   let hasBeenReported = false
 
-  const { stop: stopInstrumentingOnReadyStateChange } = instrumentMethodAndCallOriginal(this, 'onreadystatechange', {
-    before() {
-      if (this.readyState === XMLHttpRequest.DONE) {
+  const { stop: stopInstrumentingOnReadyStateChange } = instrumentMethodAndCallOriginal(
+    xhr,
+    'onreadystatechange',
+    () => {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
         // Try to report the XHR as soon as possible, because the XHR may be mutated by the
         // application during a future event. For example, Angular is calling .abort() on
         // completed requests during an onreadystatechange event, so the status becomes '0'
         // before the request is collected.
         onEnd()
       }
-    },
-  })
+    }
+  )
 
   const onEnd = () => {
     unsubscribeLoadEndListener()
@@ -107,17 +116,17 @@ function sendXhr(this: XMLHttpRequest, configuration: Configuration, observable:
     const completeContext = context as XhrCompleteContext
     completeContext.state = 'complete'
     completeContext.duration = elapsed(startContext.startClocks.timeStamp, timeStampNow())
-    completeContext.status = this.status
+    completeContext.status = xhr.status
     observable.notify(shallowClone(completeContext))
   }
 
-  const { stop: unsubscribeLoadEndListener } = addEventListener(configuration, this, 'loadend', onEnd)
+  const { stop: unsubscribeLoadEndListener } = addEventListener(configuration, xhr, 'loadend', onEnd)
 
   observable.notify(startContext)
 }
 
-function abortXhr(this: XMLHttpRequest) {
-  const context = xhrContexts.get(this) as XhrStartContext | undefined
+function abortXhr({ target: xhr }: InstrumentedMethodCall<XMLHttpRequest, 'abort'>) {
+  const context = xhrContexts.get(xhr) as XhrStartContext | undefined
   if (context) {
     context.isAborted = true
   }

--- a/packages/core/src/domain/error/trackRuntimeError.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.ts
@@ -1,4 +1,4 @@
-import { instrumentMethodAndCallOriginal } from '../../tools/instrumentMethod'
+import { instrumentMethod } from '../../tools/instrumentMethod'
 import type { Observable } from '../../tools/observable'
 import { clocksNow } from '../../tools/utils/timeUtils'
 import type { StackTrace } from './computeStackTrace'
@@ -33,23 +33,19 @@ export function trackRuntimeError(errorObservable: Observable<RawError>) {
 }
 
 export function instrumentOnError(callback: UnhandledErrorCallback) {
-  return instrumentMethodAndCallOriginal(
-    window,
-    'onerror',
-    ({ parameters: [messageObj, url, line, column, errorObj] }) => {
-      let stackTrace
-      if (errorObj instanceof Error) {
-        stackTrace = computeStackTrace(errorObj)
-      } else {
-        stackTrace = computeStackTraceFromOnErrorMessage(messageObj, url, line, column)
-      }
-      callback(stackTrace, errorObj ?? messageObj)
+  return instrumentMethod(window, 'onerror', ({ parameters: [messageObj, url, line, column, errorObj] }) => {
+    let stackTrace
+    if (errorObj instanceof Error) {
+      stackTrace = computeStackTrace(errorObj)
+    } else {
+      stackTrace = computeStackTraceFromOnErrorMessage(messageObj, url, line, column)
     }
-  )
+    callback(stackTrace, errorObj ?? messageObj)
+  })
 }
 
 export function instrumentUnhandledRejection(callback: UnhandledErrorCallback) {
-  return instrumentMethodAndCallOriginal(window, 'onunhandledrejection', ({ parameters: [e] }) => {
+  return instrumentMethod(window, 'onunhandledrejection', ({ parameters: [e] }) => {
     const reason = e.reason || 'Empty reason'
     const stack = computeStackTrace(reason)
     callback(stack, reason)

--- a/packages/core/src/domain/error/trackRuntimeError.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.ts
@@ -33,8 +33,10 @@ export function trackRuntimeError(errorObservable: Observable<RawError>) {
 }
 
 export function instrumentOnError(callback: UnhandledErrorCallback) {
-  return instrumentMethodAndCallOriginal(window, 'onerror', {
-    before(this: any, messageObj: unknown, url?: string, line?: number, column?: number, errorObj?: unknown) {
+  return instrumentMethodAndCallOriginal(
+    window,
+    'onerror',
+    ({ parameters: [messageObj, url, line, column, errorObj] }) => {
       let stackTrace
       if (errorObj instanceof Error) {
         stackTrace = computeStackTrace(errorObj)
@@ -42,16 +44,14 @@ export function instrumentOnError(callback: UnhandledErrorCallback) {
         stackTrace = computeStackTraceFromOnErrorMessage(messageObj, url, line, column)
       }
       callback(stackTrace, errorObj ?? messageObj)
-    },
-  })
+    }
+  )
 }
 
 export function instrumentUnhandledRejection(callback: UnhandledErrorCallback) {
-  return instrumentMethodAndCallOriginal(window, 'onunhandledrejection', {
-    before(e: PromiseRejectionEvent) {
-      const reason = e.reason || 'Empty reason'
-      const stack = computeStackTrace(reason)
-      callback(stack, reason)
-    },
+  return instrumentMethodAndCallOriginal(window, 'onunhandledrejection', ({ parameters: [e] }) => {
+    const reason = e.reason || 'Empty reason'
+    const stack = computeStackTrace(reason)
+    callback(stack, reason)
   })
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,12 +73,7 @@ export * from './tools/utils/browserDetection'
 export { sendToExtension } from './tools/sendToExtension'
 export { runOnReadyState } from './browser/runOnReadyState'
 export { getZoneJsOriginalValue } from './tools/getZoneJsOriginalValue'
-export {
-  instrumentMethod,
-  instrumentMethodAndCallOriginal,
-  instrumentSetter,
-  InstrumentedMethodCall,
-} from './tools/instrumentMethod'
+export { instrumentMethod, instrumentSetter, InstrumentedMethodCall } from './tools/instrumentMethod'
 export {
   computeRawError,
   createHandlingStack,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,7 +73,12 @@ export * from './tools/utils/browserDetection'
 export { sendToExtension } from './tools/sendToExtension'
 export { runOnReadyState } from './browser/runOnReadyState'
 export { getZoneJsOriginalValue } from './tools/getZoneJsOriginalValue'
-export { instrumentMethod, instrumentMethodAndCallOriginal, instrumentSetter } from './tools/instrumentMethod'
+export {
+  instrumentMethod,
+  instrumentMethodAndCallOriginal,
+  instrumentSetter,
+  InstrumentedMethodCall,
+} from './tools/instrumentMethod'
 export {
   computeRawError,
   createHandlingStack,

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -4,7 +4,7 @@ import { noop } from './utils/functionUtils'
 
 export type InstrumentedMethodCall<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET> = {
   target: TARGET
-  // parameters can be muted by the instrumentation
+  // parameters can be mutated by the instrumentation
   parameters: Parameters<TARGET[METHOD]>
   onPostCall: (callback: PostCallCallback<TARGET, METHOD>) => void
 }

--- a/packages/rum-core/src/browser/locationChangeObservable.ts
+++ b/packages/rum-core/src/browser/locationChangeObservable.ts
@@ -39,12 +39,20 @@ export function createLocationChangeObservable(configuration: RumConfiguration, 
 }
 
 function trackHistory(configuration: RumConfiguration, onHistoryChange: () => void) {
-  const { stop: stopInstrumentingPushState } = instrumentMethodAndCallOriginal(history, 'pushState', {
-    after: onHistoryChange,
-  })
-  const { stop: stopInstrumentingReplaceState } = instrumentMethodAndCallOriginal(history, 'replaceState', {
-    after: onHistoryChange,
-  })
+  const { stop: stopInstrumentingPushState } = instrumentMethodAndCallOriginal(
+    history,
+    'pushState',
+    ({ onPostCall }) => {
+      onPostCall(onHistoryChange)
+    }
+  )
+  const { stop: stopInstrumentingReplaceState } = instrumentMethodAndCallOriginal(
+    history,
+    'replaceState',
+    ({ onPostCall }) => {
+      onPostCall(onHistoryChange)
+    }
+  )
   const { stop: removeListener } = addEventListener(configuration, window, DOM_EVENT.POP_STATE, onHistoryChange)
 
   return {

--- a/packages/rum-core/src/browser/locationChangeObservable.ts
+++ b/packages/rum-core/src/browser/locationChangeObservable.ts
@@ -1,10 +1,4 @@
-import {
-  addEventListener,
-  DOM_EVENT,
-  instrumentMethodAndCallOriginal,
-  Observable,
-  shallowClone,
-} from '@datadog/browser-core'
+import { addEventListener, DOM_EVENT, instrumentMethod, Observable, shallowClone } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 
 export interface LocationChange {
@@ -39,20 +33,12 @@ export function createLocationChangeObservable(configuration: RumConfiguration, 
 }
 
 function trackHistory(configuration: RumConfiguration, onHistoryChange: () => void) {
-  const { stop: stopInstrumentingPushState } = instrumentMethodAndCallOriginal(
-    history,
-    'pushState',
-    ({ onPostCall }) => {
-      onPostCall(onHistoryChange)
-    }
-  )
-  const { stop: stopInstrumentingReplaceState } = instrumentMethodAndCallOriginal(
-    history,
-    'replaceState',
-    ({ onPostCall }) => {
-      onPostCall(onHistoryChange)
-    }
-  )
+  const { stop: stopInstrumentingPushState } = instrumentMethod(history, 'pushState', ({ onPostCall }) => {
+    onPostCall(onHistoryChange)
+  })
+  const { stop: stopInstrumentingReplaceState } = instrumentMethod(history, 'replaceState', ({ onPostCall }) => {
+    onPostCall(onHistoryChange)
+  })
   const { stop: removeListener } = addEventListener(configuration, window, DOM_EVENT.POP_STATE, onHistoryChange)
 
   return {

--- a/packages/rum-core/src/domain/waitPageActivityEnd.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.ts
@@ -178,5 +178,5 @@ function isExcludedUrl(configuration: RumConfiguration, requestUrl: string): boo
 }
 
 function trackWindowOpen(callback: () => void) {
-  return instrumentMethodAndCallOriginal(window, 'open', { before: callback })
+  return instrumentMethodAndCallOriginal(window, 'open', callback)
 }

--- a/packages/rum-core/src/domain/waitPageActivityEnd.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.ts
@@ -1,6 +1,6 @@
 import type { Subscription, TimeoutId, TimeStamp } from '@datadog/browser-core'
 import {
-  instrumentMethodAndCallOriginal,
+  instrumentMethod,
   matchList,
   monitor,
   Observable,
@@ -178,5 +178,5 @@ function isExcludedUrl(configuration: RumConfiguration, requestUrl: string): boo
 }
 
 function trackWindowOpen(callback: () => void) {
-  return instrumentMethodAndCallOriginal(window, 'open', callback)
+  return instrumentMethod(window, 'open', callback)
 }

--- a/packages/rum/src/domain/record/observers/styleSheetObserver.ts
+++ b/packages/rum/src/domain/record/observers/styleSheetObserver.ts
@@ -15,16 +15,21 @@ export function initStyleSheetObserver(cb: StyleSheetCallback): ListenerHandler 
   }
 
   const instrumentationStoppers = [
-    instrumentMethodAndCallOriginal(CSSStyleSheet.prototype, 'insertRule', {
-      before(rule, index) {
-        checkStyleSheetAndCallback(this, (id) => cb({ id, adds: [{ rule, index }] }))
-      },
-    }),
-    instrumentMethodAndCallOriginal(CSSStyleSheet.prototype, 'deleteRule', {
-      before(index) {
-        checkStyleSheetAndCallback(this, (id) => cb({ id, removes: [{ index }] }))
-      },
-    }),
+    instrumentMethodAndCallOriginal(
+      CSSStyleSheet.prototype,
+      'insertRule',
+      ({ target: styleSheet, parameters: [rule, index] }) => {
+        checkStyleSheetAndCallback(styleSheet, (id) => cb({ id, adds: [{ rule, index }] }))
+      }
+    ),
+
+    instrumentMethodAndCallOriginal(
+      CSSStyleSheet.prototype,
+      'deleteRule',
+      ({ target: styleSheet, parameters: [index] }) => {
+        checkStyleSheetAndCallback(styleSheet, (id) => cb({ id, removes: [{ index }] }))
+      }
+    ),
   ]
 
   if (typeof CSSGroupingRule !== 'undefined') {
@@ -36,27 +41,28 @@ export function initStyleSheetObserver(cb: StyleSheetCallback): ListenerHandler 
 
   function instrumentGroupingCSSRuleClass(cls: GroupingCSSRuleTypes) {
     instrumentationStoppers.push(
-      instrumentMethodAndCallOriginal(cls.prototype, 'insertRule', {
-        before(rule, index) {
-          checkStyleSheetAndCallback(this.parentStyleSheet, (id) => {
-            const path = getPathToNestedCSSRule(this)
+      instrumentMethodAndCallOriginal(
+        cls.prototype,
+        'insertRule',
+        ({ target: styleSheet, parameters: [rule, index] }) => {
+          checkStyleSheetAndCallback(styleSheet.parentStyleSheet, (id) => {
+            const path = getPathToNestedCSSRule(styleSheet)
             if (path) {
               path.push(index || 0)
               cb({ id, adds: [{ rule, index: path }] })
             }
           })
-        },
-      }),
-      instrumentMethodAndCallOriginal(cls.prototype, 'deleteRule', {
-        before(index) {
-          checkStyleSheetAndCallback(this.parentStyleSheet, (id) => {
-            const path = getPathToNestedCSSRule(this)
-            if (path) {
-              path.push(index)
-              cb({ id, removes: [{ index: path }] })
-            }
-          })
-        },
+        }
+      ),
+
+      instrumentMethodAndCallOriginal(cls.prototype, 'deleteRule', ({ target: styleSheet, parameters: [index] }) => {
+        checkStyleSheetAndCallback(styleSheet.parentStyleSheet, (id) => {
+          const path = getPathToNestedCSSRule(styleSheet)
+          if (path) {
+            path.push(index)
+            cb({ id, removes: [{ index: path }] })
+          }
+        })
       })
     )
   }


### PR DESCRIPTION
## Motivation

In the process of fixing RUM-211 (some methods are "readonly" and their instrumentation breaks the SDK), I wanted to use the functions to instrument methods in more places. This PR is a step in that direction: it revamps and factorizes our existing intrument methods functions into a single, more easily extendable one.

## Changes

This PR changes the `instrumentMethodAndCallOriginal` signature to call the intrumentation callback with a [`InstrumentedMethodCall`](https://github.com/DataDog/browser-sdk/blob/cd0ccb17cebd8d54fef0a168bcdcdb30e5a89508/packages/core/src/tools/instrumentMethod.ts#L5-L10) object containing the `target` and `parameters` properties instead of  passing them directly as `this` and function `arguments`.

This new `InstrumentedMethodCall` object also allows to:
* register a "post call" callback that will be called with the original method result
* mutate the parameters in-place

This allows to use `instrumentMethodAndCallOriginal` in `fetchObservable`. By doing so, the original `instrumentMethod` function isn't used anymore, and we can keep a single function for all our method instrumentations.

This new `InstrumentedMethodCall` object will also allow to transmit more information in the future, like the "handling stack" to allow using our instrumentation tooling for `console.*` methods.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
