### PR TITLE
🐛 [RUM-2689] fix recorder crash when restarted quickly

### DIFF
--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -1,4 +1,4 @@
-import type { DeflateEncoder, DeflateWorker } from '@datadog/browser-core'
+import type { DeflateEncoder, DeflateWorker, DeflateWorkerAction } from '@datadog/browser-core'
 import { display, isIE } from '@datadog/browser-core'
 import type { RecorderApi, ViewContexts, LifeCycle, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
@@ -162,19 +162,25 @@ describe('makeRecorderApi', () => {
       expect(stopRecordingSpy).toHaveBeenCalled()
     })
 
-    it('restarting the recording should keep using the same DeflateEncoder instance', () => {
+    it('restarting the recording should not reset the worker action id', () => {
       setupBuilder.build()
       rumInit()
       recorderApi.start()
 
+      const firstCallDeflateEncoder: DeflateEncoder = startRecordingSpy.calls.mostRecent().args[4]
+      firstCallDeflateEncoder.write('foo')
+
       recorderApi.stop()
       recorderApi.start()
 
-      // Types are specified to make sure we are getting the correct arguments
-      const firstCallDeflateEncoder: DeflateEncoder = startRecordingSpy.calls.argsFor(0)[4]
-      const secondCallDeflateEncoder: DeflateEncoder = startRecordingSpy.calls.argsFor(1)[4]
+      const secondCallDeflateEncoder: DeflateEncoder = startRecordingSpy.calls.mostRecent().args[4]
+      secondCallDeflateEncoder.write('foo')
 
-      expect(firstCallDeflateEncoder).toBe(secondCallDeflateEncoder)
+      const writeMessages = mockWorker.pendingMessages.filter(
+        (message): message is Extract<DeflateWorkerAction, { action: 'write' }> => message.action === 'write'
+      )
+      expect(writeMessages.length).toBe(2)
+      expect(writeMessages[0].id).toBeLessThan(writeMessages[1].id)
     })
 
     describe('if event bridge present', () => {

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -1,4 +1,4 @@
-import type { DeflateWorker } from '@datadog/browser-core'
+import type { DeflateEncoder, DeflateWorker } from '@datadog/browser-core'
 import { display, isIE } from '@datadog/browser-core'
 import type { RecorderApi, ViewContexts, LifeCycle, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
@@ -160,6 +160,21 @@ describe('makeRecorderApi', () => {
       mockWorker.dispatchErrorEvent()
 
       expect(stopRecordingSpy).toHaveBeenCalled()
+    })
+
+    it('restarting the recording should keep using the same DeflateEncoder instance', () => {
+      setupBuilder.build()
+      rumInit()
+      recorderApi.start()
+
+      recorderApi.stop()
+      recorderApi.start()
+
+      // Types are specified to make sure we are getting the correct arguments
+      const firstCallDeflateEncoder: DeflateEncoder = startRecordingSpy.calls.argsFor(0)[4]
+      const secondCallDeflateEncoder: DeflateEncoder = startRecordingSpy.calls.argsFor(1)[4]
+
+      expect(firstCallDeflateEncoder).toBe(secondCallDeflateEncoder)
     })
 
     describe('if event bridge present', () => {

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -807,6 +807,26 @@ describe('recorder', () => {
       })
   })
 
+  createTest('restarting recording should send a new full snapshot')
+    .withRum()
+    .withSetup(bundleSetup)
+    .run(async ({ intakeRegistry }) => {
+      await browserExecute(() => {
+        window.DD_RUM!.stopSessionReplayRecording()
+        window.DD_RUM!.startSessionReplayRecording()
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.replaySegments.length).toBe(2)
+
+      const firstSegment = intakeRegistry.replaySegments[0]
+      expect(findFullSnapshot(firstSegment)).toBeTruthy('first segment have a FullSnapshot record')
+
+      const secondSegment = intakeRegistry.replaySegments[1]
+      expect(findFullSnapshot(secondSegment)).toBeTruthy('second segment have a FullSnapshot record')
+    })
+
   createTest('workerUrl initialization parameter')
     .withRum({ workerUrl: '/worker.js' })
     .withSetup(bundleSetup)


### PR DESCRIPTION

## Motivation

When restarted quickly, the Session Replay recorder unexpectedly stops.

### To reproduce

* Run the following on an instrumented page with active session replay:

```js
DD_RUM.stopSessionReplayRecording()
DD_RUM.startSessionReplayRecording()
```

* Move the cursor a bit

* Look at the replay in Datadog (the issue is not visible in the Developer Extension because the extension receives the records before they are deflate-encoded)

### Expected

The last cursor movements should be visible

### Actual

The last cursor movements are missing


## Changes


This commit makes sure the recorder keeps using the same DeflateEncoder instance when restarted. This ensures the underlying stream (identified by `DeflateEncoderStreamId.REPLAY`) is emitting DeflateWorkerAction with continuous identifiers.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
