### PR TITLE
♻️ [RUM-2445] do not buffer early recorder API calls

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1015,18 +1015,18 @@ describe('rum public api', () => {
       )
     })
 
-    it('api calls before init are performed after onRumStart', () => {
-      // in order to let recording initial state to be defined by init configuration
-      const callOrders: string[] = []
-      spyOn(recorderApi, 'start').and.callFake(() => callOrders.push('start'))
-      spyOn(recorderApi, 'stop').and.callFake(() => callOrders.push('stop'))
-      recorderApiOnRumStartSpy.and.callFake(() => callOrders.push('onRumStart'))
+    it('public api calls are forwarded to the recorder api', () => {
+      spyOn(recorderApi, 'start')
+      spyOn(recorderApi, 'stop')
+      spyOn(recorderApi, 'getSessionReplayLink')
 
       rumPublicApi.startSessionReplayRecording()
       rumPublicApi.stopSessionReplayRecording()
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      rumPublicApi.getSessionReplayLink()
 
-      expect(callOrders).toEqual(['onRumStart', 'start', 'stop'])
+      expect(recorderApi.start).toHaveBeenCalledTimes(1)
+      expect(recorderApi.stop).toHaveBeenCalledTimes(1)
+      expect(recorderApi.getSessionReplayLink).toHaveBeenCalledTimes(1)
     })
 
     it('is started with the default startSessionReplayRecordingManually', () => {

--- a/packages/rum-slim/src/boot/stubRecorderApi.ts
+++ b/packages/rum-slim/src/boot/stubRecorderApi.ts
@@ -1,0 +1,17 @@
+import { noop } from '@datadog/browser-core'
+import type { LifeCycle, RumConfiguration } from '@datadog/browser-rum-core'
+import { getSessionReplayLink } from '../domain/getSessionReplayLink'
+
+export function makeStubRecorderApi() {
+  let getSessionReplayLinkStrategy = noop as () => string | undefined
+  return {
+    start: noop,
+    stop: noop,
+    onRumStart(_lifeCycle: LifeCycle, configuration: RumConfiguration) {
+      getSessionReplayLinkStrategy = () => getSessionReplayLink(configuration)
+    },
+    isRecording: () => false,
+    getReplayStats: () => undefined,
+    getSessionReplayLink: () => getSessionReplayLinkStrategy(),
+  }
+}

--- a/packages/rum-slim/src/entries/main.ts
+++ b/packages/rum-slim/src/entries/main.ts
@@ -1,8 +1,8 @@
 // Keep the following in sync with packages/rum/src/entries/main.ts
-import { defineGlobal, getGlobalObject, noop } from '@datadog/browser-core'
+import { defineGlobal, getGlobalObject } from '@datadog/browser-core'
 import type { RumPublicApi } from '@datadog/browser-rum-core'
 import { makeRumPublicApi, startRum } from '@datadog/browser-rum-core'
-import { getSessionReplayLink } from '../domain/getSessionReplayLink'
+import { makeStubRecorderApi } from '../boot/stubRecorderApi'
 
 export {
   CommonProperties,
@@ -27,14 +27,7 @@ export {
 } from '@datadog/browser-rum-core'
 export { DefaultPrivacyLevel } from '@datadog/browser-core'
 
-export const datadogRum = makeRumPublicApi(startRum, {
-  start: noop,
-  stop: noop,
-  onRumStart: noop,
-  isRecording: () => false,
-  getReplayStats: () => undefined,
-  getSessionReplayLink,
-})
+export const datadogRum = makeRumPublicApi(startRum, makeStubRecorderApi())
 
 interface BrowserWindow extends Window {
   DD_RUM?: RumPublicApi

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -74,12 +74,12 @@ export function makeRecorderApi(
   let stopStrategy = () => {
     state = { status: RecorderStatus.Stopped }
   }
+  let getSessionReplayLinkStrategy = noop as () => string | undefined
 
   return {
     start: () => startStrategy(),
     stop: () => stopStrategy(),
-    getSessionReplayLink: (configuration, sessionManager, viewContexts) =>
-      getSessionReplayLink(configuration, sessionManager, viewContexts, state.status !== RecorderStatus.Stopped),
+    getSessionReplayLink: () => getSessionReplayLinkStrategy(),
     onRumStart: (
       lifeCycle: LifeCycle,
       configuration: RumConfiguration,
@@ -177,6 +177,9 @@ export function makeRecorderApi(
           status: RecorderStatus.Stopped,
         }
       }
+
+      getSessionReplayLinkStrategy = () =>
+        getSessionReplayLink(configuration, sessionManager, viewContexts, state.status !== RecorderStatus.Stopped)
 
       if (state.status === RecorderStatus.IntentToStart) {
         startStrategy()


### PR DESCRIPTION


## Motivation

The goal of this commit is to simplify the rumPublicApi module by using the `recorderApi` directly, without buffering the calls.

## Changes


This is possible because the recorder api already has logic to support early calls to `start` and `stop`. The `getSessionReplayLink` implementation had to be slightly changed to work similarly to `start` and `stop`.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
