### PR TITLE
🐛[RUM-2752] Replay: generate censored images with custom dimensions

### DIFF
--- a/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
+++ b/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
@@ -249,7 +249,7 @@ export const AST_MASK = {
               type: 2,
               tagName: 'img',
               attributes: {
-                src: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='0' height='0' style='background-color:silver'%3E%3C/svg%3E",
+                src: 'data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==',
               },
               childNodes: [],
             },

--- a/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
+++ b/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
@@ -249,7 +249,7 @@ export const AST_MASK = {
               type: 2,
               tagName: 'img',
               attributes: {
-                src: 'data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==',
+                src: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='0' height='0' style='background-color:silver'%3E%3C/svg%3E",
               },
               childNodes: [],
             },

--- a/packages/rum/src/domain/record/serialization/serializationUtils.ts
+++ b/packages/rum/src/domain/record/serialization/serializationUtils.ts
@@ -119,3 +119,7 @@ export function getValidTagName(tagName: string): string {
 
   return processedTagName
 }
+
+export function censoredImageForSize(width: number, height: number) {
+  return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='${width}' height='${height}' style='background-color:silver'%3E%3C/svg%3E`
+}

--- a/packages/rum/src/domain/record/serialization/serializeAttribute.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.ts
@@ -40,7 +40,11 @@ export function serializeAttribute(
         return censoredImageForSize(image.naturalWidth, image.naturalHeight)
       }
       const { width, height } = element.getBoundingClientRect()
-      return censoredImageForSize(width, height)
+      if (width > 0 || height > 0) {
+        return censoredImageForSize(width, height)
+      }
+      // if we can't get the image size, fallback to the censored image
+      return CENSORED_IMG_MARK
     }
 
     // mask source URLs


### PR DESCRIPTION
## Motivation

Default censored image dimension is 1x1 which can cause rendering issue when the image size ratio is used by the browser to display the image.

<img width="1642" alt="Screenshot 2024-01-11 at 18 08 34" src="https://github.com/DataDog/browser-sdk/assets/1331991/72565962-f94a-4f91-862c-bc3c868f8b7e">

## Changes

Generate a censored image from the [natural dimensions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/naturalWidth) of the image, fallback to rendered dimension if not avialable. 

<img width="1641" alt="Screenshot 2024-01-11 at 18 10 04" src="https://github.com/DataDog/browser-sdk/assets/1331991/25f80849-1cc9-4afd-a0ea-d764982c4265">


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
