### PR TITLE
📝 Document addTiming API relative time issue

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -278,7 +278,12 @@ export function makeRumPublicApi(
       })
     },
 
+    /**
+     * Using a relative time is discouraged since it can be challenging for users to determine the relative time of the start of the view.
+     * see https://github.com/DataDog/browser-sdk/issues/2552
+     */
     addTiming: monitor((name: string, time?: number) => {
+      // TODO: next major decide to drop relative time support or update its behaviour
       addTimingStrategy(sanitize(name)!, time as RelativeTime | TimeStamp | undefined)
     }),
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -279,7 +279,14 @@ export function makeRumPublicApi(
     },
 
     /**
-     * Using a relative time is discouraged since it can be challenging for users to determine the relative time of the start of the view.
+     * Add a custom timing relative to the start of the current view,
+     * stored in @view.custom_timings.<timing_name>
+     *
+     * @param name name of the custom timing
+     * @param [time] epoch timestamp of the custom timing (if not set, will use current time)
+     *
+     * Note: passing a relative time is discouraged since it is actually used as-is but displayed relative to the view start.
+     * We currently don't provide a way to retrieve the view start time, so it can be challenging to provide a timing relative to the view start.
      * see https://github.com/DataDog/browser-sdk/issues/2552
      */
     addTiming: monitor((name: string, time?: number) => {


### PR DESCRIPTION
## Motivation

cf https://github.com/DataDog/browser-sdk/issues/2552, document add timing relative time issue
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

mention on the API doc that relative time usage is discouraged
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
