### PR TITLE
♻️ [RUM-2203] Move record logic from startRecording to the record module

### DIFF
--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,16 +1,9 @@
 import type { TimeStamp, HttpRequest, ClocksState } from '@datadog/browser-core'
-import {
-  PageExitReason,
-  DefaultPrivacyLevel,
-  noop,
-  isIE,
-  timeStampNow,
-  DeflateEncoderStreamId,
-} from '@datadog/browser-core'
+import { PageExitReason, DefaultPrivacyLevel, noop, isIE, DeflateEncoderStreamId } from '@datadog/browser-core'
 import type { LifeCycle, ViewCreatedEvent, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { collectAsyncCalls, createNewEvent, mockClock } from '@datadog/browser-core/test'
+import { collectAsyncCalls, createNewEvent } from '@datadog/browser-core/test'
 import type { RumSessionManagerMock, TestSetupBuilder } from '../../../rum-core/test'
 import { appendElement, createRumSessionManagerMock, setup } from '../../../rum-core/test'
 
@@ -163,48 +156,6 @@ describe('startRecording', () => {
     const requests = await readSentRequests(1)
     expect(requests[0].metadata.records_count).toBe(1)
     expect(requests[0].metadata.session.id).toBe('new-session-id')
-  })
-
-  it('takes a full snapshot when the view changes', async () => {
-    const { lifeCycle } = setupBuilder.build()
-
-    changeView(lifeCycle)
-    flushSegment(lifeCycle)
-
-    const requests = await readSentRequests(2)
-    expect(requests[1].metadata.has_full_snapshot).toBe(true)
-  })
-
-  it('full snapshot related records should have the view change date', async () => {
-    clock = mockClock()
-    const { lifeCycle } = setupBuilder.build()
-
-    changeView(lifeCycle)
-    flushSegment(lifeCycle)
-
-    const requests = await readSentRequests(2)
-    const firstSegment = requests[0].segment
-    expect(firstSegment.records[0].timestamp).toEqual(timeStampNow())
-    expect(firstSegment.records[1].timestamp).toEqual(timeStampNow())
-    expect(firstSegment.records[2].timestamp).toEqual(timeStampNow())
-    expect(firstSegment.records[3].timestamp).toEqual(timeStampNow())
-
-    const secondSegment = requests[1].segment
-    expect(secondSegment.records[0].timestamp).toEqual(VIEW_TIMESTAMP)
-    expect(secondSegment.records[1].timestamp).toEqual(VIEW_TIMESTAMP)
-    expect(secondSegment.records[2].timestamp).toEqual(VIEW_TIMESTAMP)
-  })
-
-  it('adds a ViewEnd record when the view ends', async () => {
-    const { lifeCycle } = setupBuilder.build()
-
-    changeView(lifeCycle)
-    flushSegment(lifeCycle)
-
-    const requests = await readSentRequests(2)
-    expect(requests[0].metadata.view.id).toBe('view-id')
-    const records = requests[0].segment.records
-    expect(records[records.length - 1].type).toBe(RecordType.ViewEnd)
   })
 
   it('flushes pending mutations before ending the view', async () => {

--- a/packages/rum/src/domain/record/observers/observers.ts
+++ b/packages/rum/src/domain/record/observers/observers.ts
@@ -23,6 +23,7 @@ import { initMutationObserver } from './mutationObserver'
 import type { FocusCallback } from './focusObserver'
 import { initFocusObserver } from './focusObserver'
 import { initRecordIds } from './recordIds'
+import { initViewEndObserver, type ViewEndCallback } from './viewEndObserver'
 
 interface ObserverParam {
   lifeCycle: LifeCycle
@@ -39,6 +40,7 @@ interface ObserverParam {
   styleSheetCb: StyleSheetCallback
   focusCb: FocusCallback
   frustrationCb: FrustrationCallback
+  viewEndCb: ViewEndCallback
   shadowRootsController: ShadowRootsController
 }
 
@@ -67,6 +69,7 @@ export function initObservers(
   const focusHandler = initFocusObserver(configuration, o.focusCb)
   const visualViewportResizeHandler = initVisualViewportResizeObserver(configuration, o.visualViewportResizeCb)
   const frustrationHandler = initFrustrationObserver(o.lifeCycle, o.frustrationCb, recordIds)
+  const viewEndHandler = initViewEndObserver(o.lifeCycle, o.viewEndCb)
 
   return {
     flush: () => {
@@ -84,6 +87,7 @@ export function initObservers(
       focusHandler()
       visualViewportResizeHandler()
       frustrationHandler()
+      viewEndHandler()
     },
   }
 }

--- a/packages/rum/src/domain/record/observers/viewEndObserver.spec.ts
+++ b/packages/rum/src/domain/record/observers/viewEndObserver.spec.ts
@@ -1,0 +1,29 @@
+import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
+import { RecordType } from '../../../types'
+import type { ViewEndCallback } from './viewEndObserver'
+import { initViewEndObserver } from './viewEndObserver'
+
+describe('initMoveObserver', () => {
+  let lifeCycle: LifeCycle
+  let viewEndCb: jasmine.Spy<ViewEndCallback>
+  let stopObserver: () => void
+
+  beforeEach(() => {
+    lifeCycle = new LifeCycle()
+    viewEndCb = jasmine.createSpy()
+    stopObserver = initViewEndObserver(lifeCycle, viewEndCb)
+  })
+
+  afterEach(() => {
+    stopObserver()
+  })
+
+  it('should generate view end record', () => {
+    lifeCycle.notify(LifeCycleEventType.VIEW_ENDED, {} as any)
+
+    expect(viewEndCb).toHaveBeenCalledWith({
+      timestamp: jasmine.any(Number),
+      type: RecordType.ViewEnd,
+    })
+  })
+})

--- a/packages/rum/src/domain/record/observers/viewEndObserver.ts
+++ b/packages/rum/src/domain/record/observers/viewEndObserver.ts
@@ -1,0 +1,16 @@
+import { timeStampNow, type ListenerHandler } from '@datadog/browser-core'
+import type { LifeCycle } from '@datadog/browser-rum-core'
+import { LifeCycleEventType } from '@datadog/browser-rum-core'
+import type { ViewEndRecord } from '../../../types'
+import { RecordType } from '../../../types'
+
+export type ViewEndCallback = (record: ViewEndRecord) => void
+
+export function initViewEndObserver(lifeCycle: LifeCycle, viewEndCb: ViewEndCallback): ListenerHandler {
+  return lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, () => {
+    viewEndCb({
+      timestamp: timeStampNow(),
+      type: RecordType.ViewEnd,
+    })
+  }).unsubscribe
+}

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../types'
 import { NodeType, RecordType, IncrementalSource } from '../../types'
 import { appendElement } from '../../../../rum-core/test'
+import { getReplayStats, resetReplayStats } from '../replayStats'
 import type { RecordAPI } from './record'
 import { record } from './record'
 
@@ -22,6 +23,7 @@ describe('record', () => {
   let lifeCycle: LifeCycle
   let emitSpy: jasmine.Spy<(record: BrowserRecord) => void>
   let clock: Clock | undefined
+  const FAKE_VIEW_ID = '123'
 
   beforeEach(() => {
     if (isIE()) {
@@ -387,12 +389,25 @@ describe('record', () => {
     }
   })
 
+  describe('updates record replay stats', () => {
+    it('when recording new records', () => {
+      resetReplayStats()
+      startRecording()
+
+      const records = getEmittedRecords()
+      expect(getReplayStats(FAKE_VIEW_ID)?.records_count).toEqual(records.length)
+    })
+  })
+
   function startRecording() {
     lifeCycle = new LifeCycle()
     recordApi = record({
       emit: emitSpy,
       configuration: { defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW } as RumConfiguration,
       lifeCycle,
+      viewContexts: {
+        findView: () => ({ id: FAKE_VIEW_ID, startClocks: {} }),
+      } as any,
     })
   }
 

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,6 +1,6 @@
 import { DefaultPrivacyLevel, findLast, isIE } from '@datadog/browser-core'
-import type { RumConfiguration } from '@datadog/browser-rum-core'
-import { LifeCycle } from '@datadog/browser-rum-core'
+import type { RumConfiguration, ViewCreatedEvent } from '@datadog/browser-rum-core'
+import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, collectAsyncCalls } from '@datadog/browser-core/test'
 import { findFullSnapshot, findNode, recordsPerFullSnapshot } from '../../../test'
@@ -19,6 +19,7 @@ import { record } from './record'
 
 describe('record', () => {
   let recordApi: RecordAPI
+  let lifeCycle: LifeCycle
   let emitSpy: jasmine.Spy<(record: BrowserRecord) => void>
   let clock: Clock | undefined
 
@@ -118,7 +119,8 @@ describe('record', () => {
 
     appendElement('<hr/>')
 
-    recordApi.takeSubsequentFullSnapshot()
+    // trigger full snapshot by starting a new view
+    newView()
 
     collectAsyncCalls(emitSpy, 1 + 2 * recordsPerFullSnapshot(), () => {
       const records = getEmittedRecords()
@@ -180,7 +182,9 @@ describe('record', () => {
       startRecording()
       emitSpy.calls.reset()
 
-      recordApi.takeSubsequentFullSnapshot()
+      // trigger full snapshot by starting a new view
+      newView()
+
       expect(getEmittedRecords()[1].type).toBe(RecordType.Focus)
     })
 
@@ -315,7 +319,8 @@ describe('record', () => {
       const radio = appendElement('<input type="radio"/>', createShadow()) as HTMLInputElement
       startRecording()
 
-      recordApi.takeSubsequentFullSnapshot()
+      // trigger full snapshot by starting a new view
+      newView()
 
       radio.checked = true
       radio.dispatchEvent(createNewEvent('change', { target: radio, composed: false }))
@@ -383,11 +388,18 @@ describe('record', () => {
   })
 
   function startRecording() {
+    lifeCycle = new LifeCycle()
     recordApi = record({
       emit: emitSpy,
       configuration: { defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW } as RumConfiguration,
-      lifeCycle: new LifeCycle(),
+      lifeCycle,
     })
+  }
+
+  function newView() {
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: { relative: 0, timeStamp: 0 },
+    } as ViewCreatedEvent)
   }
 
   function getEmittedRecords() {

--- a/packages/rum/src/domain/record/startFullSnapshots.spec.ts
+++ b/packages/rum/src/domain/record/startFullSnapshots.spec.ts
@@ -1,0 +1,54 @@
+import type { RumConfiguration, ViewCreatedEvent } from '@datadog/browser-rum-core'
+import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
+import type { TimeStamp } from '@datadog/browser-core'
+import { isIE, noop } from '@datadog/browser-core'
+import type { BrowserRecord } from '../../types'
+import { startFullSnapshots } from './startFullSnapshots'
+import { createElementsScrollPositions } from './elementsScrollPositions'
+import type { ShadowRootsController } from './shadowRootsController'
+
+describe('startFullSnapshots', () => {
+  const viewStartClock = { relative: 1, timeStamp: 1 as TimeStamp }
+  let lifeCycle: LifeCycle
+  let fullSnapshotCallback: jasmine.Spy<(records: BrowserRecord[]) => void>
+
+  beforeEach(() => {
+    if (isIE()) {
+      pending('IE not supported')
+    }
+
+    lifeCycle = new LifeCycle()
+    fullSnapshotCallback = jasmine.createSpy()
+    startFullSnapshots(
+      createElementsScrollPositions(),
+      {} as ShadowRootsController,
+      lifeCycle,
+      {} as RumConfiguration,
+      noop,
+      fullSnapshotCallback
+    )
+  })
+
+  it('takes a full snapshot when startFullSnapshots is called', () => {
+    expect(fullSnapshotCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('takes a full snapshot when the view changes', () => {
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: viewStartClock,
+    } as Partial<ViewCreatedEvent> as any)
+
+    expect(fullSnapshotCallback).toHaveBeenCalledTimes(2)
+  })
+
+  it('full snapshot related records should have the view change date', () => {
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, {
+      startClocks: viewStartClock,
+    } as Partial<ViewCreatedEvent> as any)
+
+    const records = fullSnapshotCallback.calls.mostRecent().args[0]
+    expect(records[0].timestamp).toEqual(1)
+    expect(records[1].timestamp).toEqual(1)
+    expect(records[2].timestamp).toEqual(1)
+  })
+})

--- a/packages/rum/src/domain/record/startFullSnapshots.ts
+++ b/packages/rum/src/domain/record/startFullSnapshots.ts
@@ -1,0 +1,84 @@
+import { LifeCycleEventType, getScrollX, getScrollY, getViewportDimension } from '@datadog/browser-rum-core'
+import type { RumConfiguration, LifeCycle } from '@datadog/browser-rum-core'
+import { timeStampNow } from '@datadog/browser-core'
+import type { BrowserRecord } from '../../types'
+import { RecordType } from '../../types'
+import type { ElementsScrollPositions } from './elementsScrollPositions'
+import type { ShadowRootsController } from './shadowRootsController'
+import { SerializationContextStatus, serializeDocument } from './serialization'
+import { getVisualViewport } from './viewports'
+
+export function startFullSnapshots(
+  elementsScrollPositions: ElementsScrollPositions,
+  shadowRootsController: ShadowRootsController,
+  lifeCycle: LifeCycle,
+  configuration: RumConfiguration,
+  flushMutations: () => void,
+  fullSnapshotCallback: (records: BrowserRecord[]) => void
+) {
+  const takeFullSnapshot = (
+    timestamp = timeStampNow(),
+    serializationContext = {
+      status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
+      elementsScrollPositions,
+      shadowRootsController,
+    }
+  ) => {
+    const { width, height } = getViewportDimension()
+    const records: BrowserRecord[] = [
+      {
+        data: {
+          height,
+          href: window.location.href,
+          width,
+        },
+        type: RecordType.Meta,
+        timestamp,
+      },
+      {
+        data: {
+          has_focus: document.hasFocus(),
+        },
+        type: RecordType.Focus,
+        timestamp,
+      },
+      {
+        data: {
+          node: serializeDocument(document, configuration, serializationContext),
+          initialOffset: {
+            left: getScrollX(),
+            top: getScrollY(),
+          },
+        },
+        type: RecordType.FullSnapshot,
+        timestamp,
+      },
+    ]
+
+    if (window.visualViewport) {
+      records.push({
+        data: getVisualViewport(window.visualViewport),
+        type: RecordType.VisualViewport,
+        timestamp,
+      })
+    }
+    return records
+  }
+
+  fullSnapshotCallback(takeFullSnapshot())
+
+  const { unsubscribe } = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
+    flushMutations()
+    fullSnapshotCallback(
+      takeFullSnapshot(view.startClocks.timeStamp, {
+        shadowRootsController,
+        status: SerializationContextStatus.SUBSEQUENT_FULL_SNAPSHOT,
+        elementsScrollPositions,
+      })
+    )
+  })
+
+  return {
+    stop: unsubscribe,
+  }
+}

--- a/packages/rum/src/domain/segmentCollection/segment.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.spec.ts
@@ -225,7 +225,7 @@ describe('Segment', () => {
     }
   })
 
-  describe('updates replay stats', () => {
+  describe('updates segment replay stats', () => {
     beforeEach(() => {
       resetReplayStats()
     })
@@ -233,23 +233,13 @@ describe('Segment', () => {
     it('when creating a segment', () => {
       createSegment()
       worker.processAllMessages()
-      expect(getReplayStats('b')).toEqual({
-        segments_count: 1,
-        records_count: 0,
-        segments_total_raw_size: 0,
-      })
-    })
-
-    it('when adding records', () => {
-      const segment = createSegment()
-      segment.addRecord(FULL_SNAPSHOT_RECORD, noop)
-      segment.addRecord(RECORD, noop)
-      worker.processAllMessages()
-      expect(getReplayStats('b')).toEqual({
-        segments_count: 1,
-        records_count: 2,
-        segments_total_raw_size: 0,
-      })
+      expect(getReplayStats('b')).toEqual(
+        jasmine.objectContaining({
+          segments_count: 1,
+          records_count: 0,
+          segments_total_raw_size: 0,
+        })
+      )
     })
 
     it('when flushing a segment', () => {
@@ -257,12 +247,13 @@ describe('Segment', () => {
       segment.addRecord(RECORD, noop)
       segment.flush(noop)
       worker.processAllMessages()
-      expect(getReplayStats('b')).toEqual({
-        segments_count: 1,
-        records_count: 1,
-        segments_total_raw_size:
-          ENCODED_SEGMENT_HEADER_BYTES_COUNT + ENCODED_RECORD_BYTES_COUNT + ENCODED_META_BYTES_COUNT,
-      })
+      expect(getReplayStats('b')).toEqual(
+        jasmine.objectContaining({
+          segments_count: 1,
+          segments_total_raw_size:
+            ENCODED_SEGMENT_HEADER_BYTES_COUNT + ENCODED_RECORD_BYTES_COUNT + ENCODED_META_BYTES_COUNT,
+        })
+      )
     })
   })
 

--- a/packages/rum/src/domain/segmentCollection/segment.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.ts
@@ -1,5 +1,5 @@
 import type { Encoder, EncoderResult } from '@datadog/browser-core'
-import { assign, sendToExtension } from '@datadog/browser-core'
+import { assign } from '@datadog/browser-core'
 import type { BrowserRecord, BrowserSegmentMetadata, CreationReason, SegmentContext } from '../../types'
 import { RecordType } from '../../types'
 import * as replayStats from '../replayStats'
@@ -40,9 +40,6 @@ export class Segment {
     this.metadata.end = Math.max(this.metadata.end, record.timestamp)
     this.metadata.records_count += 1
     this.metadata.has_full_snapshot ||= record.type === RecordType.FullSnapshot
-
-    sendToExtension('record', { record, segment: this.metadata })
-    replayStats.addRecord(this.metadata.view.id)
 
     const prefix = this.encoder.isEmpty ? '{"records":[' : ','
     this.encoder.write(prefix + JSON.stringify(record), (additionalEncodedBytesCount) => {


### PR DESCRIPTION
## Motivation

- Move record logic from `startRecording` to the record module
- Move the replay record stats from the `segment` to the `record` module to also work with the webview bridge

## Changes

- Move viewEnd record generation from `startRecording` to the `record` module
- Collocate fullsnapshot logic in its own `/record/startFullsnapshot` module
- Move the replay record stats from the `segment` to the `record` module to also work with the webview bridge

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [X] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
