### PR TITLE
🐛 [RUM-2940] fix normalize URL for relative paths

### DIFF
--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -1,7 +1,7 @@
 import { jsonStringify } from '../serialisation/jsonStringify'
 
 export function normalizeUrl(url: string) {
-  return buildUrl(url, getLocationOrigin()).href
+  return buildUrl(url, location.href).href
 }
 
 export function isValidUrl(url: string) {
@@ -12,21 +12,9 @@ export function isValidUrl(url: string) {
   }
 }
 
-export function getOrigin(url: string) {
-  return getLinkElementOrigin(buildUrl(url))
-}
-
 export function getPathName(url: string) {
   const pathname = buildUrl(url).pathname
   return pathname[0] === '/' ? pathname : `/${pathname}`
-}
-
-export function getSearch(url: string) {
-  return buildUrl(url).search
-}
-
-export function getHash(url: string) {
-  return buildUrl(url).hash
 }
 
 export function buildUrl(url: string, base?: string) {
@@ -66,21 +54,4 @@ function getSupportedUrl(): typeof URL | undefined {
     }
   }
   return isURLSupported ? originalURL : undefined
-}
-
-export function getLocationOrigin() {
-  return getLinkElementOrigin(window.location)
-}
-
-/**
- * Fallback
- * On IE HTMLAnchorElement origin is not supported: https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/origin
- * On Firefox window.location.origin is "null" for file: URIs: https://bugzilla.mozilla.org/show_bug.cgi?id=878297
- */
-export function getLinkElementOrigin(element: Location | HTMLAnchorElement | URL) {
-  if (element.origin && element.origin !== 'null') {
-    return element.origin
-  }
-  const sanitizedHost = element.host.replace(/(:80|:443)$/, '')
-  return `${element.protocol}//${sanitizedHost}`
 }

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -33,6 +33,7 @@ module.exports = {
     suppressErrorSummary: true,
     suppressPassed: true,
     suppressSkipped: true,
+    showBrowser: true,
   },
   junitReporter: {
     outputDir: testReportDirectory,


### PR DESCRIPTION
## Motivation

Relative URLs are wrongly “normalized”, and those incorrect URL are used:

* to define the `@resource.url` in Resource events, giving a wrong information to customers
* to match the corresponding `PerformanceTiming`, so the SDK fails to find the corresponding timing, so the Resource event lacks detailed timings and size

## Changes

Fix `normalizeUrl` and remove some unused functions

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
