### PR TITLE
⚡️ [RUM-2917] optimize getNodePrivacyLevel by adding a cache

### DIFF
--- a/packages/rum/src/domain/record/privacy.spec.ts
+++ b/packages/rum/src/domain/record/privacy.spec.ts
@@ -81,6 +81,46 @@ describe('getNodePrivacyLevel', () => {
       expect(getNodePrivacyLevel(node, NodePrivacyLevel.ALLOW)).toBe(NodePrivacyLevel.MASK)
     })
   })
+
+  describe('cache', () => {
+    it('fills the cache', () => {
+      const ancestor = document.createElement('div')
+      const node = document.createElement('div')
+      ancestor.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK)
+      ancestor.appendChild(node)
+
+      const cache = new Map()
+      getNodePrivacyLevel(node, NodePrivacyLevel.ALLOW, cache)
+
+      expect(cache.get(node)).toBe(NodePrivacyLevel.MASK)
+    })
+
+    it('uses the cache', () => {
+      const ancestor = document.createElement('div')
+      const node = document.createElement('div')
+      ancestor.appendChild(node)
+
+      const cache = new Map()
+      cache.set(node, NodePrivacyLevel.MASK_USER_INPUT)
+
+      expect(getNodePrivacyLevel(node, NodePrivacyLevel.ALLOW, cache)).toBe(NodePrivacyLevel.MASK_USER_INPUT)
+    })
+
+    it('does not recurse on ancestors if the node is already in the cache', () => {
+      const ancestor = document.createElement('div')
+      const node = document.createElement('div')
+      ancestor.appendChild(node)
+
+      const parentNodeGetterSpy = spyOnProperty(node, 'parentNode').and.returnValue(ancestor)
+
+      const cache = new Map()
+      cache.set(node, NodePrivacyLevel.MASK_USER_INPUT)
+
+      getNodePrivacyLevel(node, NodePrivacyLevel.ALLOW, cache)
+
+      expect(parentNodeGetterSpy).not.toHaveBeenCalled()
+    })
+  })
 })
 
 describe('getNodeSelfPrivacyLevel', () => {

--- a/packages/rum/src/domain/record/privacy.ts
+++ b/packages/rum/src/domain/record/privacy.ts
@@ -18,17 +18,32 @@ export const MAX_ATTRIBUTE_VALUE_CHAR_LENGTH = 100_000
 
 const TEXT_MASKING_CHAR = 'x'
 
+export type NodePrivacyLevelCache = Map<Node, NodePrivacyLevel>
+
 /**
  * Get node privacy level by iterating over its ancestors. When the direct parent privacy level is
  * know, it is best to use something like:
  *
  * derivePrivacyLevelGivenParent(getNodeSelfPrivacyLevel(node), parentNodePrivacyLevel)
  */
-export function getNodePrivacyLevel(node: Node, defaultPrivacyLevel: NodePrivacyLevel): NodePrivacyLevel {
+export function getNodePrivacyLevel(
+  node: Node,
+  defaultPrivacyLevel: NodePrivacyLevel,
+  cache?: NodePrivacyLevelCache
+): NodePrivacyLevel {
+  if (cache && cache.has(node)) {
+    return cache.get(node)!
+  }
   const parentNode = getParentNode(node)
-  const parentNodePrivacyLevel = parentNode ? getNodePrivacyLevel(parentNode, defaultPrivacyLevel) : defaultPrivacyLevel
+  const parentNodePrivacyLevel = parentNode
+    ? getNodePrivacyLevel(parentNode, defaultPrivacyLevel, cache)
+    : defaultPrivacyLevel
   const selfNodePrivacyLevel = getNodeSelfPrivacyLevel(node)
-  return reducePrivacyLevel(selfNodePrivacyLevel, parentNodePrivacyLevel)
+  const nodePrivacyLevel = reducePrivacyLevel(selfNodePrivacyLevel, parentNodePrivacyLevel)
+  if (cache) {
+    cache.set(node, nodePrivacyLevel)
+  }
+  return nodePrivacyLevel
 }
 
 /**


### PR DESCRIPTION
## Motivation

A customer reported that `getNodePrivacyLevel` was a big performance bottleneck on their application when the devtools were open. On our side, we didn't observe a huge performance impact caused by this function (with or without devtools open), but still find a way to optimize it, which might help the customer case.

## Changes

Cache the node privacy level when processing mutations. The cache is local to the `proccessMutations` function so we don't have to implement a complex way to invalidate it. Even with this simple cache, we observed a nice speedup while processing mutations (from ~10ms to ~1.5ms in a specific case on the Datadog App)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
