### PR TITLE
👷 Try to improve `unit:bs` stability

### DIFF
--- a/packages/core/test/leakDetection.ts
+++ b/packages/core/test/leakDetection.ts
@@ -45,6 +45,7 @@ export function stopLeakDetection() {
 
 function withLeakDetection(eventName: string, listener: EventListener) {
   const specWhenAdded = getCurrentJasmineSpec()
+  const stackWhenAdded = new Error().stack
   if (!specWhenAdded) {
     return listener
   }
@@ -55,7 +56,8 @@ function withLeakDetection(eventName: string, listener: EventListener) {
       display.error(`Leaked listener
   event names: "${eventName}"
   attached with: "${specWhenAdded.fullName}"
-  ${currentSpec ? `executed with: "${currentSpec.fullName}"` : 'executed outside of a spec'}`)
+  ${currentSpec ? `executed with: "${currentSpec.fullName}"` : 'executed outside of a spec'}
+  attachment stack: ${stackWhenAdded}`)
     }
     listener(event)
   }

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -155,7 +155,8 @@ export function startRum(
   const { addError } = startErrorCollection(lifeCycle, configuration, pageStateHistory, featureFlagContexts)
 
   startRequestCollection(lifeCycle, configuration, session)
-  startPerformanceCollection(lifeCycle, configuration)
+  const { stop: stopPerformanceCollection } = startPerformanceCollection(lifeCycle, configuration)
+  cleanupTasks.push(stopPerformanceCollection)
 
   const internalContext = startInternalContext(
     configuration.applicationId,

--- a/packages/rum/test/readReplayPayload.ts
+++ b/packages/rum/test/readReplayPayload.ts
@@ -22,8 +22,8 @@ export function readMetadataFromReplayPayload(payload: Payload) {
 }
 
 function readJsonBlob(blob: Blob, { decompress = false }: { decompress?: boolean } = {}) {
-  // Safari Mobile 12 does not support blob.text() or blob.arrayBuffer() yet, so we need to use a
-  // FileReader for now.
+  // Safari Mobile 14 should support blob.text() or blob.arrayBuffer() but the APIs are not defined on the safari
+  // provided by browserstack, so we still need to use a FileReader for now.
   // https://caniuse.com/mdn-api_blob_arraybuffer
   // https://caniuse.com/mdn-api_blob_text
   return new Promise((resolve) => {

--- a/scripts/lib/bs-utils.js
+++ b/scripts/lib/bs-utils.js
@@ -1,0 +1,15 @@
+const { fetch } = require('../lib/execution-utils')
+
+async function browserStackRequest(url, options) {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${process.env.BS_USERNAME}:${process.env.BS_ACCESS_KEY}`).toString('base64')}`,
+    },
+    ...options,
+  })
+  return JSON.parse(response)
+}
+
+module.exports = {
+  browserStackRequest,
+}

--- a/scripts/lib/execution-utils.js
+++ b/scripts/lib/execution-utils.js
@@ -52,10 +52,15 @@ async function fetchWrapper(url, options) {
   return response.text()
 }
 
+function timeout(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 module.exports = {
   spawnCommand,
   printError,
   printLog,
   runMain,
   fetch: fetchWrapper,
+  timeout,
 }

--- a/scripts/test/bs-kill.js
+++ b/scripts/test/bs-kill.js
@@ -1,0 +1,35 @@
+'use strict'
+/**
+ * This script stops all BrowserStack workers that are currently running.
+ * Useful when troubleshooting BrowserStack issues locally.
+ */
+const { printLog, runMain, timeout } = require('../lib/execution-utils')
+const { browserStackRequest } = require('../lib/bs-utils')
+
+const MINIMUM_WORKER_LIFE = 30_000
+
+const BS_WORKERS_URL = 'https://api.browserstack.com/5/workers'
+const BS_WORKER_URL = (workerId) => `https://api.browserstack.com/5/worker/${workerId}`
+
+runMain(async () => {
+  const workerIds = await getActiveWorkerIds()
+  printLog(`Stopping ${workerIds.length} workers`)
+  await Promise.all(workerIds.map((workerId) => stopWorker(workerId)))
+  process.exit(0)
+})
+
+async function getActiveWorkerIds() {
+  return (await browserStackRequest(BS_WORKERS_URL)).map((worker) => worker.id)
+}
+
+async function stopWorker(workerId) {
+  const stopResponse = await browserStackRequest(BS_WORKER_URL(workerId), { method: 'DELETE' })
+  // stopResponse:
+  // - when stopped: {"time":X.Y}
+  // - when worker not old enough: {"message":"worker is running for X.Y secs, minimum life is 30 sec"}
+  if (stopResponse.time === undefined) {
+    printLog(`Worker ${workerId} not stopped, retrying in 30s`)
+    await timeout(MINIMUM_WORKER_LIFE)
+    await stopWorker(workerId)
+  }
+}

--- a/scripts/test/bs-kill.js
+++ b/scripts/test/bs-kill.js
@@ -9,7 +9,7 @@ const { browserStackRequest } = require('../lib/bs-utils')
 const MINIMUM_WORKER_LIFE = 30_000
 
 const BS_WORKERS_URL = 'https://api.browserstack.com/5/workers'
-const BS_WORKER_URL = (workerId) => `https://api.browserstack.com/5/worker/${workerId}`
+const buildBsWorkerUrl = (workerId) => `https://api.browserstack.com/5/worker/${workerId}`
 
 runMain(async () => {
   const workerIds = await getActiveWorkerIds()
@@ -23,7 +23,7 @@ async function getActiveWorkerIds() {
 }
 
 async function stopWorker(workerId) {
-  const stopResponse = await browserStackRequest(BS_WORKER_URL(workerId), { method: 'DELETE' })
+  const stopResponse = await browserStackRequest(buildBsWorkerUrl(workerId), { method: 'DELETE' })
   // stopResponse:
   // - when stopped: {"time":X.Y}
   // - when worker not old enough: {"message":"worker is running for X.Y secs, minimum life is 30 sec"}

--- a/scripts/test/bs-wrapper.js
+++ b/scripts/test/bs-wrapper.js
@@ -14,12 +14,11 @@
 // after killing it. There might be a better way of prematurely aborting the test command if we need
 // to in the future.
 
-const { spawnCommand, printLog, runMain, fetch } = require('../lib/execution-utils')
+const { spawnCommand, printLog, runMain, timeout } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
+const { browserStackRequest } = require('../lib/bs-utils')
 
 const AVAILABILITY_CHECK_DELAY = 30_000
-const BS_USERNAME = process.env.BS_USERNAME
-const BS_ACCESS_KEY = process.env.BS_ACCESS_KEY
 const BS_BUILD_URL = 'https://api.browserstack.com/automate/builds.json?status=running'
 
 runMain(async () => {
@@ -40,18 +39,10 @@ async function waitForAvailability() {
 }
 
 async function hasRunningBuild() {
-  return (
-    (await fetch(BS_BUILD_URL, {
-      headers: { Authorization: `Basic ${Buffer.from(`${BS_USERNAME}:${BS_ACCESS_KEY}`).toString('base64')}` },
-    })) !== '[]'
-  )
+  return (await browserStackRequest(BS_BUILD_URL)).length > 0
 }
 
 function runTests() {
   const [command, ...args] = process.argv.slice(2)
   return spawnCommand(command, args)
-}
-
-function timeout(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/test/browsers.conf.js
+++ b/test/browsers.conf.js
@@ -18,7 +18,7 @@ const browserConfigurations = [
   {
     sessionName: 'Safari desktop',
     name: 'Safari',
-    version: '14.0',
+    version: '14.1',
     os: 'OS X',
     osVersion: 'Big Sur',
   },
@@ -33,8 +33,8 @@ const browserConfigurations = [
     sessionName: 'Safari mobile',
     name: 'safari',
     os: 'ios',
-    osVersion: '12',
-    device: 'iPhone XR',
+    osVersion: '13',
+    device: 'iPhone 8',
   },
   {
     sessionName: 'IE',

--- a/test/browsers.conf.js
+++ b/test/browsers.conf.js
@@ -33,8 +33,8 @@ const browserConfigurations = [
     sessionName: 'Safari mobile',
     name: 'safari',
     os: 'ios',
-    osVersion: '13',
-    device: 'iPhone 8',
+    osVersion: '14',
+    device: 'iPhone 11',
   },
   {
     sessionName: 'IE',

--- a/test/e2e/scenario/rum/views.scenario.ts
+++ b/test/e2e/scenario/rum/views.scenario.ts
@@ -15,7 +15,7 @@ describe('rum views', () => {
       expect(viewEvent.view.load_event).toBeGreaterThan(0)
     })
 
-  // When run via WebDriver, Safari 12 and 13 (at least) have an issue with `event.timeStamp`,
+  // When run via WebDriver, Safari <= 14 (at least) have an issue with `event.timeStamp`,
   // so the 'first-input' polyfill is ignoring it and doesn't send a performance entry.
   // See https://bugs.webkit.org/show_bug.cgi?id=211101
   if (getBrowserName() !== 'safari') {

--- a/test/e2e/wdio.bs.conf.ts
+++ b/test/e2e/wdio.bs.conf.ts
@@ -12,7 +12,7 @@ export const config: Options.Testrunner = {
     .filter(
       (configuration) =>
         configuration.sessionName !== 'IE' &&
-        // Safari mobile on iOS 12.0 does not support
+        // Safari mobile on iOS <= 14.0 does not support
         // the way we flush events on page change
         // TODO check newer version on browserstack
         configuration.sessionName !== 'Safari mobile'


### PR DESCRIPTION
## Motivation

Try to fix consistent `unit:bs` failure

## Changes

- Bump safari used versions
- Add a script to kill running bs workers while debugging
- Fix listener leak on safari

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
