### PR TITLE
✨[RUM-160] Collect PerformanceResourceTiming.responseStatus

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -49,6 +49,7 @@ export enum RumPerformanceEntryType {
 export interface RumPerformanceResourceTiming {
   entryType: RumPerformanceEntryType.RESOURCE
   initiatorType: string
+  responseStatus?: number
   name: string
   startTime: RelativeTime
   duration: Duration

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -55,6 +55,7 @@ describe('resourceCollection', () => {
         url: 'https://resource.com/valid',
         download: jasmine.any(Object),
         first_byte: jasmine.any(Object),
+        status_code: 200,
       },
       type: RumEventType.RESOURCE,
       _dd: {

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -102,7 +102,6 @@ function processRequest(
     correspondingTimingOverrides,
     pageStateInfo
   )
-
   return {
     startTime: startClocks.relative,
     rawRumEvent: resourceEvent,
@@ -142,6 +141,7 @@ function processResourceEntry(
         id: generateUUID(),
         type,
         url: entry.name,
+        status_code: entry.responseStatus,
       },
       type: RumEventType.RESOURCE as const,
       _dd: {

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -230,6 +230,7 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
           responseStart: 200 as RelativeTime,
           secureConnectionStart: 200 as RelativeTime,
           startTime: 200 as RelativeTime,
+          responseStatus: 200,
         },
         overrides
       ) as EntryTypeToReturnType[T]


### PR DESCRIPTION
## Motivation

To add a response status to resource other than xhr and fetch when available

## Changes

use PerformanceResourceTiming.responseStatus in the resource events.
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus

## Testing

- [ x] Local
- [ ] Staging
- [ x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
