### PR TITLE
⚗️✨ [RUM-2445] implement Tracking Consent management

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -10,6 +10,7 @@ import { objectHasValue } from '../../tools/utils/objectUtils'
 import { assign } from '../../tools/utils/polyfills'
 import { selectSessionStoreStrategyType } from '../session/sessionStore'
 import type { SessionStoreStrategyType } from '../session/storeStrategies/sessionStoreStrategy'
+import { TrackingConsent } from '../trackingConsent'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
 
@@ -30,6 +31,7 @@ export interface InitConfiguration {
   allowFallbackToLocalStorage?: boolean | undefined
   allowUntrustedEvents?: boolean | undefined
   storeContextsAcrossPages?: boolean | undefined
+  trackingConsent?: TrackingConsent | undefined
 
   // transport options
   proxy?: string | ProxyFn | undefined
@@ -84,6 +86,7 @@ export interface Configuration extends TransportConfiguration {
   service: string | undefined
   silentMultipleInit: boolean
   allowUntrustedEvents: boolean
+  trackingConsent: TrackingConsent
 
   // Event limits
   eventRateLimiterThreshold: number // Limit the maximum number of actions, errors and logs per minutes
@@ -120,6 +123,14 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     return
   }
 
+  if (
+    initConfiguration.trackingConsent !== undefined &&
+    !objectHasValue(TrackingConsent, initConfiguration.trackingConsent)
+  ) {
+    display.error('Tracking Consent should be either "granted" or "not-granted"')
+    return
+  }
+
   // Set the experimental feature flags as early as possible, so we can use them in most places
   if (Array.isArray(initConfiguration.enableExperimentalFeatures)) {
     addExperimentalFeatures(
@@ -140,6 +151,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       service: initConfiguration.service,
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
       allowUntrustedEvents: !!initConfiguration.allowUntrustedEvents,
+      trackingConsent: initConfiguration.trackingConsent ?? TrackingConsent.GRANTED,
 
       /**
        * beacon payload max queue size implementation is 64kb

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -508,7 +508,7 @@ describe('startSessionManager', () => {
       const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
       const sessionManager = startSessionManagerWithDefaults({ trackingConsentState })
 
-      trackingConsentState.set(TrackingConsent.NOT_GRANTED)
+      trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
       expectSessionIdToNotBeDefined(sessionManager)
       expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
@@ -518,7 +518,7 @@ describe('startSessionManager', () => {
       const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
       const sessionManager = startSessionManagerWithDefaults({ trackingConsentState })
 
-      trackingConsentState.set(TrackingConsent.NOT_GRANTED)
+      trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
@@ -530,11 +530,11 @@ describe('startSessionManager', () => {
       const sessionManager = startSessionManagerWithDefaults({ trackingConsentState })
       const initialSessionId = sessionManager.findActiveSession()!.id
 
-      trackingConsentState.set(TrackingConsent.NOT_GRANTED)
+      trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
       expectSessionIdToNotBeDefined(sessionManager)
 
-      trackingConsentState.set(TrackingConsent.GRANTED)
+      trackingConsentState.update(TrackingConsent.GRANTED)
 
       clock.tick(STORAGE_POLL_DELAY)
 

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -34,7 +34,6 @@ describe('startSessionManager', () => {
   const SECOND_PRODUCT_KEY = 'second'
   const STORE_TYPE: SessionStoreStrategyType = { type: 'Cookie', cookieOptions: {} }
   let clock: Clock
-  let configuration: Configuration
 
   function expireSessionCookie() {
     setCookie(SESSION_STORE_KEY, '', DURATION)
@@ -74,7 +73,6 @@ describe('startSessionManager', () => {
     if (isIE()) {
       pending('no full rum support')
     }
-    configuration = { sessionStoreStrategyType: STORE_TYPE } as Configuration
     clock = mockClock()
   })
 
@@ -88,14 +86,14 @@ describe('startSessionManager', () => {
 
   describe('cookie management', () => {
     it('when tracked, should store tracking type and session id', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
 
       expectSessionIdToBeDefined(sessionManager)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.TRACKED)
     })
 
     it('when not tracked should store tracking type', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => NOT_TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
 
       expectSessionIdToNotBeDefined(sessionManager)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
@@ -104,7 +102,7 @@ describe('startSessionManager', () => {
     it('when tracked should keep existing tracking type and session id', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&first=tracked', DURATION)
 
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
 
       expectSessionIdToBe(sessionManager, 'abcdef')
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.TRACKED)
@@ -113,7 +111,7 @@ describe('startSessionManager', () => {
     it('when not tracked should keep existing tracking type', () => {
       setCookie(SESSION_STORE_KEY, 'first=not-tracked', DURATION)
 
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => NOT_TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
 
       expectSessionIdToNotBeDefined(sessionManager)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
@@ -128,32 +126,32 @@ describe('startSessionManager', () => {
     })
 
     it('should be called with an empty value if the cookie is not defined', () => {
-      startSessionManager(configuration, FIRST_PRODUCT_KEY, spy)
+      startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(undefined)
     })
 
     it('should be called with an invalid value if the cookie has an invalid value', () => {
       setCookie(SESSION_STORE_KEY, 'first=invalid', DURATION)
-      startSessionManager(configuration, FIRST_PRODUCT_KEY, spy)
+      startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith('invalid')
     })
 
     it('should be called with TRACKED', () => {
       setCookie(SESSION_STORE_KEY, 'first=tracked', DURATION)
-      startSessionManager(configuration, FIRST_PRODUCT_KEY, spy)
+      startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.TRACKED)
     })
 
     it('should be called with NOT_TRACKED', () => {
       setCookie(SESSION_STORE_KEY, 'first=not-tracked', DURATION)
-      startSessionManager(configuration, FIRST_PRODUCT_KEY, spy)
+      startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.NOT_TRACKED)
     })
   })
 
   describe('session renewal', () => {
     it('should renew on activity after expiration', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const renewSessionSpy = jasmine.createSpy()
       sessionManager.renewObservable.subscribe(renewSessionSpy)
 
@@ -171,7 +169,7 @@ describe('startSessionManager', () => {
     })
 
     it('should not renew on visibility after expiration', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const renewSessionSpy = jasmine.createSpy()
       sessionManager.renewObservable.subscribe(renewSessionSpy)
 
@@ -186,17 +184,17 @@ describe('startSessionManager', () => {
 
   describe('multiple startSessionManager calls', () => {
     it('should re-use the same session id', () => {
-      const firstSessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const firstSessionManager = startSessionManagerWithDefaults({ productKey: FIRST_PRODUCT_KEY })
       const idA = firstSessionManager.findActiveSession()!.id
 
-      const secondSessionManager = startSessionManager(configuration, SECOND_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const secondSessionManager = startSessionManagerWithDefaults({ productKey: SECOND_PRODUCT_KEY })
       const idB = secondSessionManager.findActiveSession()!.id
 
       expect(idA).toBe(idB)
     })
 
     it('should not erase other session type', () => {
-      startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      startSessionManagerWithDefaults({ productKey: FIRST_PRODUCT_KEY })
 
       // schedule an expandOrRenewSession
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
@@ -206,7 +204,7 @@ describe('startSessionManager', () => {
       // expand first session cookie cache
       document.dispatchEvent(createNewEvent(DOM_EVENT.VISIBILITY_CHANGE))
 
-      startSessionManager(configuration, SECOND_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      startSessionManagerWithDefaults({ productKey: SECOND_PRODUCT_KEY })
 
       // cookie correctly set
       expect(getCookie(SESSION_STORE_KEY)).toContain('first')
@@ -220,25 +218,27 @@ describe('startSessionManager', () => {
     })
 
     it('should have independent tracking types', () => {
-      const firstSessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
-      const secondSessionManager = startSessionManager(
-        configuration,
-        SECOND_PRODUCT_KEY,
-        () => NOT_TRACKED_SESSION_STATE
-      )
+      const firstSessionManager = startSessionManagerWithDefaults({
+        productKey: FIRST_PRODUCT_KEY,
+        computeSessionState: () => TRACKED_SESSION_STATE,
+      })
+      const secondSessionManager = startSessionManagerWithDefaults({
+        productKey: SECOND_PRODUCT_KEY,
+        computeSessionState: () => NOT_TRACKED_SESSION_STATE,
+      })
 
       expect(firstSessionManager.findActiveSession()!.trackingType).toEqual(FakeTrackingType.TRACKED)
       expect(secondSessionManager.findActiveSession()!.trackingType).toEqual(FakeTrackingType.NOT_TRACKED)
     })
 
     it('should notify each expire and renew observables', () => {
-      const firstSessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const firstSessionManager = startSessionManagerWithDefaults({ productKey: FIRST_PRODUCT_KEY })
       const expireSessionASpy = jasmine.createSpy()
       firstSessionManager.expireObservable.subscribe(expireSessionASpy)
       const renewSessionASpy = jasmine.createSpy()
       firstSessionManager.renewObservable.subscribe(renewSessionASpy)
 
-      const secondSessionManager = startSessionManager(configuration, SECOND_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const secondSessionManager = startSessionManagerWithDefaults({ productKey: SECOND_PRODUCT_KEY })
       const expireSessionBSpy = jasmine.createSpy()
       secondSessionManager.expireObservable.subscribe(expireSessionBSpy)
       const renewSessionBSpy = jasmine.createSpy()
@@ -260,7 +260,7 @@ describe('startSessionManager', () => {
 
   describe('session timeout', () => {
     it('should expire the session when the time out delay is reached', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -276,7 +276,7 @@ describe('startSessionManager', () => {
     it('should renew an existing timed out session', () => {
       setCookie(SESSION_STORE_KEY, `id=abcde&first=tracked&created=${Date.now() - SESSION_TIME_OUT_DELAY}`, DURATION)
 
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -288,7 +288,7 @@ describe('startSessionManager', () => {
     it('should not add created date to an existing session from an older versions', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcde&first=tracked', DURATION)
 
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
 
       expect(sessionManager.findActiveSession()!.id).toBe('abcde')
       expect(getCookie(SESSION_STORE_KEY)).not.toContain('created=')
@@ -305,7 +305,7 @@ describe('startSessionManager', () => {
     })
 
     it('should expire the session after expiration delay', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -317,7 +317,7 @@ describe('startSessionManager', () => {
     })
 
     it('should expand duration on activity', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -336,7 +336,7 @@ describe('startSessionManager', () => {
     })
 
     it('should expand not tracked session duration on activity', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => NOT_TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -357,7 +357,7 @@ describe('startSessionManager', () => {
     it('should expand session on visibility', () => {
       setPageVisibility('visible')
 
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -378,7 +378,7 @@ describe('startSessionManager', () => {
     it('should expand not tracked session on visibility', () => {
       setPageVisibility('visible')
 
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => NOT_TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -399,7 +399,7 @@ describe('startSessionManager', () => {
 
   describe('manual session expiration', () => {
     it('expires the session when calling expire()', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -410,7 +410,7 @@ describe('startSessionManager', () => {
     })
 
     it('notifies expired session only once when calling expire() multiple times', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -422,7 +422,7 @@ describe('startSessionManager', () => {
     })
 
     it('notifies expired session only once when calling expire() after the session has been expired', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -434,7 +434,7 @@ describe('startSessionManager', () => {
     })
 
     it('renew the session on user activity', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       clock.tick(STORAGE_POLL_DELAY)
 
       sessionManager.expire()
@@ -447,21 +447,21 @@ describe('startSessionManager', () => {
 
   describe('session history', () => {
     it('should return undefined when there is no current session and no startTime', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
       expireSessionCookie()
 
       expect(sessionManager.findActiveSession()).toBeUndefined()
     })
 
     it('should return the current session context when there is no start time', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
 
       expect(sessionManager.findActiveSession()!.id).toBeDefined()
       expect(sessionManager.findActiveSession()!.trackingType).toBeDefined()
     })
 
     it('should return the session context corresponding to startTime', () => {
-      const sessionManager = startSessionManager(configuration, FIRST_PRODUCT_KEY, () => TRACKED_SESSION_STATE)
+      const sessionManager = startSessionManagerWithDefaults()
 
       // 0s to 10s: first session
       clock.tick(10 * ONE_SECOND - STORAGE_POLL_DELAY)
@@ -489,4 +489,23 @@ describe('startSessionManager', () => {
       )
     })
   })
+
+  function startSessionManagerWithDefaults({
+    configuration,
+    productKey = FIRST_PRODUCT_KEY,
+    computeSessionState = () => TRACKED_SESSION_STATE,
+  }: {
+    configuration?: Partial<Configuration>
+    productKey?: string
+    computeSessionState?: () => { trackingType: FakeTrackingType; isTracked: boolean }
+  } = {}) {
+    return startSessionManager(
+      {
+        sessionStoreStrategyType: STORE_TYPE,
+        ...configuration,
+      } as Configuration,
+      productKey,
+      computeSessionState
+    )
+  }
 })

--- a/packages/core/src/domain/trackingConsent.spec.ts
+++ b/packages/core/src/domain/trackingConsent.spec.ts
@@ -23,29 +23,29 @@ describe('createTrackingConsentState', () => {
       expect(trackingConsentState.isGranted()).toBeTrue()
     })
 
-    it('can be set to granted', () => {
+    it('can be updated to granted', () => {
       const trackingConsentState = createTrackingConsentState()
-      trackingConsentState.set(TrackingConsent.GRANTED)
+      trackingConsentState.update(TrackingConsent.GRANTED)
       expect(trackingConsentState.isGranted()).toBeTrue()
     })
 
-    it('notifies when the consent is set', () => {
+    it('notifies when the consent is updated', () => {
       const spy = jasmine.createSpy()
       const trackingConsentState = createTrackingConsentState()
       trackingConsentState.observable.subscribe(spy)
-      trackingConsentState.set(TrackingConsent.GRANTED)
+      trackingConsentState.update(TrackingConsent.GRANTED)
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it('can set a consent state if not defined', () => {
+    it('can init a consent state if not defined yet', () => {
       const trackingConsentState = createTrackingConsentState()
-      trackingConsentState.setIfNotDefined(TrackingConsent.GRANTED)
+      trackingConsentState.tryToInit(TrackingConsent.GRANTED)
       expect(trackingConsentState.isGranted()).toBeTrue()
     })
 
-    it('does not set a consent state if already defined', () => {
+    it('does not init a consent state if already defined', () => {
       const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
-      trackingConsentState.setIfNotDefined(TrackingConsent.NOT_GRANTED)
+      trackingConsentState.tryToInit(TrackingConsent.NOT_GRANTED)
       expect(trackingConsentState.isGranted()).toBeTrue()
     })
   })
@@ -64,7 +64,7 @@ describe('createTrackingConsentState', () => {
       expect(trackingConsentState.isGranted()).toBeTrue()
 
       trackingConsentState = createTrackingConsentState()
-      trackingConsentState.set(TrackingConsent.NOT_GRANTED)
+      trackingConsentState.update(TrackingConsent.NOT_GRANTED)
       expect(trackingConsentState.isGranted()).toBeTrue()
     })
   })

--- a/packages/core/src/domain/trackingConsent.spec.ts
+++ b/packages/core/src/domain/trackingConsent.spec.ts
@@ -1,0 +1,71 @@
+import { mockExperimentalFeatures } from '../../test'
+import { ExperimentalFeature } from '../tools/experimentalFeatures'
+import { TrackingConsent, createTrackingConsentState } from './trackingConsent'
+
+describe('createTrackingConsentState', () => {
+  describe('with tracking_consent enabled', () => {
+    beforeEach(() => {
+      mockExperimentalFeatures([ExperimentalFeature.TRACKING_CONSENT])
+    })
+
+    it('creates a tracking consent state', () => {
+      const trackingConsentState = createTrackingConsentState()
+      expect(trackingConsentState).toBeDefined()
+    })
+
+    it('defaults to not granted', () => {
+      const trackingConsentState = createTrackingConsentState()
+      expect(trackingConsentState.isGranted()).toBeFalse()
+    })
+
+    it('can be created with a default consent state', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+      expect(trackingConsentState.isGranted()).toBeTrue()
+    })
+
+    it('can be set to granted', () => {
+      const trackingConsentState = createTrackingConsentState()
+      trackingConsentState.set(TrackingConsent.GRANTED)
+      expect(trackingConsentState.isGranted()).toBeTrue()
+    })
+
+    it('notifies when the consent is set', () => {
+      const spy = jasmine.createSpy()
+      const trackingConsentState = createTrackingConsentState()
+      trackingConsentState.observable.subscribe(spy)
+      trackingConsentState.set(TrackingConsent.GRANTED)
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('can set a consent state if not defined', () => {
+      const trackingConsentState = createTrackingConsentState()
+      trackingConsentState.setIfNotDefined(TrackingConsent.GRANTED)
+      expect(trackingConsentState.isGranted()).toBeTrue()
+    })
+
+    it('does not set a consent state if already defined', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+      trackingConsentState.setIfNotDefined(TrackingConsent.NOT_GRANTED)
+      expect(trackingConsentState.isGranted()).toBeTrue()
+    })
+  })
+
+  describe('with tracking_consent disabled', () => {
+    it('creates a tracking consent state', () => {
+      const trackingConsentState = createTrackingConsentState()
+      expect(trackingConsentState).toBeDefined()
+    })
+
+    it('is always granted', () => {
+      let trackingConsentState = createTrackingConsentState()
+      expect(trackingConsentState.isGranted()).toBeTrue()
+
+      trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
+      expect(trackingConsentState.isGranted()).toBeTrue()
+
+      trackingConsentState = createTrackingConsentState()
+      trackingConsentState.set(TrackingConsent.NOT_GRANTED)
+      expect(trackingConsentState.isGranted()).toBeTrue()
+    })
+  })
+})

--- a/packages/core/src/domain/trackingConsent.ts
+++ b/packages/core/src/domain/trackingConsent.ts
@@ -1,0 +1,5 @@
+export const TrackingConsent = {
+  GRANTED: 'granted',
+  NOT_GRANTED: 'not-granted',
+} as const
+export type TrackingConsent = (typeof TrackingConsent)[keyof typeof TrackingConsent]

--- a/packages/core/src/domain/trackingConsent.ts
+++ b/packages/core/src/domain/trackingConsent.ts
@@ -8,8 +8,8 @@ export const TrackingConsent = {
 export type TrackingConsent = (typeof TrackingConsent)[keyof typeof TrackingConsent]
 
 export interface TrackingConsentState {
-  setIfNotDefined: (trackingConsent: TrackingConsent) => void
-  set: (trackingConsent: TrackingConsent) => void
+  tryToInit: (trackingConsent: TrackingConsent) => void
+  update: (trackingConsent: TrackingConsent) => void
   isGranted: () => boolean
   observable: Observable<void>
 }
@@ -18,12 +18,12 @@ export function createTrackingConsentState(currentConsent?: TrackingConsent): Tr
   const observable = new Observable<void>()
 
   return {
-    setIfNotDefined(trackingConsent: TrackingConsent) {
+    tryToInit(trackingConsent: TrackingConsent) {
       if (!currentConsent) {
         currentConsent = trackingConsent
       }
     },
-    set(trackingConsent: TrackingConsent) {
+    update(trackingConsent: TrackingConsent) {
       currentConsent = trackingConsent
       observable.notify()
     },

--- a/packages/core/src/domain/trackingConsent.ts
+++ b/packages/core/src/domain/trackingConsent.ts
@@ -1,5 +1,38 @@
+import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../tools/experimentalFeatures'
+import { Observable } from '../tools/observable'
+
 export const TrackingConsent = {
   GRANTED: 'granted',
   NOT_GRANTED: 'not-granted',
 } as const
 export type TrackingConsent = (typeof TrackingConsent)[keyof typeof TrackingConsent]
+
+export interface TrackingConsentState {
+  setIfNotDefined: (trackingConsent: TrackingConsent) => void
+  set: (trackingConsent: TrackingConsent) => void
+  isGranted: () => boolean
+  observable: Observable<void>
+}
+
+export function createTrackingConsentState(currentConsent?: TrackingConsent): TrackingConsentState {
+  const observable = new Observable<void>()
+
+  return {
+    setIfNotDefined(trackingConsent: TrackingConsent) {
+      if (!currentConsent) {
+        currentConsent = trackingConsent
+      }
+    },
+    set(trackingConsent: TrackingConsent) {
+      currentConsent = trackingConsent
+      observable.notify()
+    },
+    isGranted() {
+      return (
+        !isExperimentalFeatureEnabled(ExperimentalFeature.TRACKING_CONSENT) ||
+        currentConsent === TrackingConsent.GRANTED
+      )
+    },
+    observable,
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   INTAKE_SITE_US1_FED,
   INTAKE_SITE_EU1,
 } from './domain/configuration'
+export { TrackingConsent } from './domain/trackingConsent'
 export {
   isExperimentalFeatureEnabled,
   addExperimentalFeatures,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export {
   INTAKE_SITE_US1_FED,
   INTAKE_SITE_EU1,
 } from './domain/configuration'
-export { TrackingConsent } from './domain/trackingConsent'
+export { TrackingConsent, TrackingConsentState, createTrackingConsentState } from './domain/trackingConsent'
 export {
   isExperimentalFeatureEnabled,
   addExperimentalFeatures,

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,6 +18,7 @@ export enum ExperimentalFeature {
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
+  TRACKING_CONSENT = 'tracking_consent',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -1,4 +1,4 @@
-import type { Context, User } from '@datadog/browser-core'
+import type { Context, TrackingConsent, User } from '@datadog/browser-core'
 import {
   CustomerDataType,
   assign,
@@ -72,6 +72,20 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
     logger: mainLogger,
 
     init: monitor((initConfiguration: LogsInitConfiguration) => strategy.init(initConfiguration)),
+
+    /**
+     * Set the tracking consent of the current user.
+     *
+     * @param {"granted" | "not-granted"} trackingConsent The user tracking consent
+     *
+     * Logs will be sent only if it is set to "granted". This value won't be stored by the library
+     * across page loads: you will need to call this method or set the appropriate `trackingConsent`
+     * field in the init() method at each page load.
+     *
+     * If this method is called before the init() method, the provided value will take precedence
+     * over the one provided as initialization parameter.
+     */
+    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => strategy.setTrackingConsent(trackingConsent)),
 
     getGlobalContext: monitor(() => globalContextManager.getContext()),
 

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -12,6 +12,7 @@ import {
   storeContextManager,
   displayAlreadyInitializedError,
   deepClone,
+  createTrackingConsentState,
 } from '@datadog/browser-core'
 import type { LogsInitConfiguration } from '../domain/configuration'
 import type { HandlerType, StatusType } from '../domain/logger'
@@ -32,7 +33,6 @@ const LOGS_STORAGE_KEY = 'logs'
 
 export interface Strategy {
   init: (initConfiguration: LogsInitConfiguration) => void
-  setTrackingConsent: StartLogsResult['setTrackingConsent']
   initConfiguration: LogsInitConfiguration | undefined
   getInternalContext: StartLogsResult['getInternalContext']
   handleLog: StartLogsResult['handleLog']
@@ -44,18 +44,19 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.GlobalContext)
   )
   const userContextManager = createContextManager(customerDataTrackerManager.getOrCreateTracker(CustomerDataType.User))
+  const trackingConsentState = createTrackingConsentState()
 
   function getCommonContext() {
     return buildCommonContext(globalContextManager, userContextManager)
   }
 
-  let strategy = createPreStartStrategy(getCommonContext, (initConfiguration, configuration) => {
+  let strategy = createPreStartStrategy(getCommonContext, trackingConsentState, (initConfiguration, configuration) => {
     if (initConfiguration.storeContextsAcrossPages) {
       storeContextManager(configuration, globalContextManager, LOGS_STORAGE_KEY, CustomerDataType.GlobalContext)
       storeContextManager(configuration, userContextManager, LOGS_STORAGE_KEY, CustomerDataType.User)
     }
 
-    const startLogsResult = startLogsImpl(initConfiguration, configuration, getCommonContext)
+    const startLogsResult = startLogsImpl(initConfiguration, configuration, getCommonContext, trackingConsentState)
 
     strategy = createPostStartStrategy(initConfiguration, startLogsResult)
     return startLogsResult
@@ -85,7 +86,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
      * If this method is called before the init() method, the provided value will take precedence
      * over the one provided as initialization parameter.
      */
-    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => strategy.setTrackingConsent(trackingConsent)),
+    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => trackingConsentState.update(trackingConsent)),
 
     getGlobalContext: monitor(() => globalContextManager.getContext()),
 

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -32,6 +32,7 @@ const LOGS_STORAGE_KEY = 'logs'
 
 export interface Strategy {
   init: (initConfiguration: LogsInitConfiguration) => void
+  setTrackingConsent: StartLogsResult['setTrackingConsent']
   initConfiguration: LogsInitConfiguration | undefined
   getInternalContext: StartLogsResult['getInternalContext']
   handleLog: StartLogsResult['handleLog']

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -1,6 +1,12 @@
-import { mockClock, type Clock, deleteEventBridgeStub, initEventBridgeStub } from '@datadog/browser-core/test'
+import {
+  mockClock,
+  type Clock,
+  deleteEventBridgeStub,
+  initEventBridgeStub,
+  mockExperimentalFeatures,
+} from '@datadog/browser-core/test'
 import type { TimeStamp } from '@datadog/browser-core'
-import { ONE_SECOND, display } from '@datadog/browser-core'
+import { ExperimentalFeature, ONE_SECOND, TrackingConsent, display } from '@datadog/browser-core'
 import type { CommonContext } from '../rawLogsEvent.types'
 import type { HybridInitConfiguration, LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
 import { StatusType, type Logger } from '../domain/logger'
@@ -199,6 +205,31 @@ describe('preStartLogs', () => {
     it('should return undefined if not initialized', () => {
       const strategy = createPreStartStrategy(getCommonContextSpy, doStartLogsSpy)
       expect(strategy.getInternalContext()).toBeUndefined()
+    })
+  })
+
+  describe('tracking consent', () => {
+    describe('with tracking_consent enabled', () => {
+      it('does not start logs if tracking consent is not granted at init', () => {
+        mockExperimentalFeatures([ExperimentalFeature.TRACKING_CONSENT])
+        const strategy = createPreStartStrategy(getCommonContextSpy, doStartLogsSpy)
+        strategy.init({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackingConsent: TrackingConsent.NOT_GRANTED,
+        })
+        expect(doStartLogsSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('with tracking_consent disabled', () => {
+      it('ignores the trackingConsent init param', () => {
+        const strategy = createPreStartStrategy(getCommonContextSpy, doStartLogsSpy)
+        strategy.init({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackingConsent: TrackingConsent.NOT_GRANTED,
+        })
+        expect(doStartLogsSpy).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -210,12 +210,35 @@ describe('preStartLogs', () => {
 
   describe('tracking consent', () => {
     describe('with tracking_consent enabled', () => {
-      it('does not start logs if tracking consent is not granted at init', () => {
+      beforeEach(() => {
         mockExperimentalFeatures([ExperimentalFeature.TRACKING_CONSENT])
+      })
+
+      it('does not start logs if tracking consent is not granted at init', () => {
         const strategy = createPreStartStrategy(getCommonContextSpy, doStartLogsSpy)
         strategy.init({
           ...DEFAULT_INIT_CONFIGURATION,
           trackingConsent: TrackingConsent.NOT_GRANTED,
+        })
+        expect(doStartLogsSpy).not.toHaveBeenCalled()
+      })
+
+      it('starts logs if tracking consent is granted before init', () => {
+        const strategy = createPreStartStrategy(getCommonContextSpy, doStartLogsSpy)
+        strategy.setTrackingConsent(TrackingConsent.GRANTED)
+        strategy.init({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackingConsent: TrackingConsent.NOT_GRANTED,
+        })
+        expect(doStartLogsSpy).toHaveBeenCalledTimes(1)
+      })
+
+      it('does not start logs if tracking consent is not withdrawn before init', () => {
+        const strategy = createPreStartStrategy(getCommonContextSpy, doStartLogsSpy)
+        strategy.setTrackingConsent(TrackingConsent.NOT_GRANTED)
+        strategy.init({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackingConsent: TrackingConsent.GRANTED,
         })
         expect(doStartLogsSpy).not.toHaveBeenCalled()
       })
@@ -229,6 +252,13 @@ describe('preStartLogs', () => {
           trackingConsent: TrackingConsent.NOT_GRANTED,
         })
         expect(doStartLogsSpy).toHaveBeenCalled()
+      })
+
+      it('ignores setTrackingConsent', () => {
+        const strategy = createPreStartStrategy(getCommonContextSpy, doStartLogsSpy)
+        strategy.setTrackingConsent(TrackingConsent.NOT_GRANTED)
+        strategy.init(DEFAULT_INIT_CONFIGURATION)
+        expect(doStartLogsSpy).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -270,5 +270,14 @@ describe('preStartLogs', () => {
         expect(doStartLogsSpy).toHaveBeenCalledTimes(1)
       })
     })
+
+    it('do not call startLogs when tracking consent state is updated after init', () => {
+      strategy.init(DEFAULT_INIT_CONFIGURATION)
+      doStartLogsSpy.calls.reset()
+
+      trackingConsentState.update(TrackingConsent.GRANTED)
+
+      expect(doStartLogsSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/logs/src/boot/preStartLogs.ts
+++ b/packages/logs/src/boot/preStartLogs.ts
@@ -62,11 +62,11 @@ export function createPreStartStrategy(
       }
 
       cachedConfiguration = configuration
-      trackingConsentState.setIfNotDefined(configuration.trackingConsent)
+      trackingConsentState.tryToInit(configuration.trackingConsent)
       tryStartLogs()
     },
 
-    setTrackingConsent: trackingConsentState.set,
+    setTrackingConsent: trackingConsentState.update,
 
     get initConfiguration() {
       return cachedInitConfiguration

--- a/packages/logs/src/boot/preStartLogs.ts
+++ b/packages/logs/src/boot/preStartLogs.ts
@@ -2,6 +2,7 @@ import {
   BoundedBuffer,
   assign,
   canUseEventBridge,
+  createTrackingConsentState,
   display,
   displayAlreadyInitializedError,
   noop,
@@ -23,9 +24,11 @@ export function createPreStartStrategy(
   const bufferApiCalls = new BoundedBuffer<StartLogsResult>()
   let cachedInitConfiguration: LogsInitConfiguration | undefined
   let cachedConfiguration: LogsConfiguration | undefined
+  const trackingConsentState = createTrackingConsentState()
+  trackingConsentState.observable.subscribe(tryStartLogs)
 
   function tryStartLogs() {
-    if (!cachedConfiguration || !cachedInitConfiguration) {
+    if (!cachedConfiguration || !cachedInitConfiguration || !trackingConsentState.isGranted()) {
       return
     }
 
@@ -59,6 +62,7 @@ export function createPreStartStrategy(
       }
 
       cachedConfiguration = configuration
+      trackingConsentState.setIfNotDefined(configuration.trackingConsent)
       tryStartLogs()
     },
 

--- a/packages/logs/src/boot/preStartLogs.ts
+++ b/packages/logs/src/boot/preStartLogs.ts
@@ -66,6 +66,8 @@ export function createPreStartStrategy(
       tryStartLogs()
     },
 
+    setTrackingConsent: trackingConsentState.set,
+
     get initConfiguration() {
       return cachedInitConfiguration
     },

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -7,6 +7,8 @@ import {
   SESSION_STORE_KEY,
   createCustomerDataTracker,
   noop,
+  createTrackingConsentState,
+  TrackingConsent,
 } from '@datadog/browser-core'
 import type { Request } from '@datadog/browser-core/test'
 import {
@@ -81,7 +83,12 @@ describe('logs', () => {
 
   describe('request', () => {
     it('should send the needed data', () => {
-      ;({ handleLog, stop: stopLogs } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
+      ;({ handleLog, stop: stopLogs } = startLogs(
+        initConfiguration,
+        baseConfiguration,
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
+      ))
       registerCleanupTask(stopLogs)
 
       handleLog({ message: 'message', status: StatusType.warn, context: { foo: 'bar' } }, logger, COMMON_CONTEXT)
@@ -107,7 +114,8 @@ describe('logs', () => {
       ;({ handleLog, stop: stopLogs } = startLogs(
         initConfiguration,
         { ...baseConfiguration, batchMessagesLimit: 3 },
-        () => COMMON_CONTEXT
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
       ))
       registerCleanupTask(stopLogs)
 
@@ -120,7 +128,12 @@ describe('logs', () => {
 
     it('should send bridge event when bridge is present', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
-      ;({ handleLog, stop: stopLogs } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
+      ;({ handleLog, stop: stopLogs } = startLogs(
+        initConfiguration,
+        baseConfiguration,
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
+      ))
       registerCleanupTask(stopLogs)
 
       handleLog(DEFAULT_MESSAGE, logger)
@@ -140,14 +153,24 @@ describe('logs', () => {
       const sendSpy = spyOn(initEventBridgeStub(), 'send')
 
       let configuration = { ...baseConfiguration, sessionSampleRate: 0 }
-      ;({ handleLog, stop: stopLogs } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT))
+      ;({ handleLog, stop: stopLogs } = startLogs(
+        initConfiguration,
+        configuration,
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
+      ))
       registerCleanupTask(stopLogs)
       handleLog(DEFAULT_MESSAGE, logger)
 
       expect(sendSpy).not.toHaveBeenCalled()
 
       configuration = { ...baseConfiguration, sessionSampleRate: 100 }
-      ;({ handleLog, stop: stopLogs } = startLogs(initConfiguration, configuration, () => COMMON_CONTEXT))
+      ;({ handleLog, stop: stopLogs } = startLogs(
+        initConfiguration,
+        configuration,
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
+      ))
       registerCleanupTask(stopLogs)
       handleLog(DEFAULT_MESSAGE, logger)
 
@@ -160,7 +183,8 @@ describe('logs', () => {
     ;({ handleLog, stop: stopLogs } = startLogs(
       initConfiguration,
       { ...baseConfiguration, forwardConsoleLogs: ['log'] },
-      () => COMMON_CONTEXT
+      () => COMMON_CONTEXT,
+      createTrackingConsentState(TrackingConsent.GRANTED)
     ))
     registerCleanupTask(stopLogs)
 
@@ -177,7 +201,12 @@ describe('logs', () => {
     })
 
     it('creates a session on normal conditions', () => {
-      ;({ handleLog, stop: stopLogs } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
+      ;({ handleLog, stop: stopLogs } = startLogs(
+        initConfiguration,
+        baseConfiguration,
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
+      ))
       registerCleanupTask(stopLogs)
 
       expect(getCookie(SESSION_STORE_KEY)).not.toBeUndefined()
@@ -185,7 +214,12 @@ describe('logs', () => {
 
     it('does not create a session if event bridge is present', () => {
       initEventBridgeStub()
-      ;({ handleLog, stop: stopLogs } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
+      ;({ handleLog, stop: stopLogs } = startLogs(
+        initConfiguration,
+        baseConfiguration,
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
+      ))
       registerCleanupTask(stopLogs)
 
       expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
@@ -193,7 +227,12 @@ describe('logs', () => {
 
     it('does not create a session if synthetics worker will inject RUM', () => {
       mockSyntheticsWorkerValues({ injectsRum: true })
-      ;({ handleLog, stop: stopLogs } = startLogs(initConfiguration, baseConfiguration, () => COMMON_CONTEXT))
+      ;({ handleLog, stop: stopLogs } = startLogs(
+        initConfiguration,
+        baseConfiguration,
+        () => COMMON_CONTEXT,
+        createTrackingConsentState(TrackingConsent.GRANTED)
+      ))
       registerCleanupTask(stopLogs)
 
       expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -41,7 +41,7 @@ export function startLogs(
 
   const session =
     configuration.sessionStoreStrategyType && !canUseEventBridge() && !willSyntheticsInjectRum()
-      ? startLogsSessionManager(configuration)
+      ? startLogsSessionManager(configuration, trackingConsentState)
       : startLogsSessionManagerStub(configuration)
 
   const { stop: stopLogsTelemetry } = startLogsTelemetry(

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -1,8 +1,10 @@
 import {
+  TrackingConsent,
   sendToExtension,
   createPageExitObservable,
   willSyntheticsInjectRum,
   canUseEventBridge,
+  createTrackingConsentState,
 } from '@datadog/browser-core'
 import { startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
 import type { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
@@ -35,6 +37,7 @@ export function startLogs(
 
   const reportError = startReportError(lifeCycle)
   const pageExitObservable = createPageExitObservable(configuration)
+  const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
 
   const session =
     configuration.sessionStoreStrategyType && !canUseEventBridge() && !willSyntheticsInjectRum()
@@ -70,6 +73,7 @@ export function startLogs(
   return {
     handleLog,
     getInternalContext: internalContext.get,
+    setTrackingConsent: trackingConsentState.set,
     stop: () => {
       cleanupTasks.forEach((task) => task())
     },

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -73,7 +73,7 @@ export function startLogs(
   return {
     handleLog,
     getInternalContext: internalContext.get,
-    setTrackingConsent: trackingConsentState.set,
+    setTrackingConsent: trackingConsentState.update,
     stop: () => {
       cleanupTasks.forEach((task) => task())
     },

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -1,10 +1,9 @@
+import type { TrackingConsentState } from '@datadog/browser-core'
 import {
-  TrackingConsent,
   sendToExtension,
   createPageExitObservable,
   willSyntheticsInjectRum,
   canUseEventBridge,
-  createTrackingConsentState,
 } from '@datadog/browser-core'
 import { startLogsSessionManager, startLogsSessionManagerStub } from '../domain/logsSessionManager'
 import type { LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
@@ -28,7 +27,10 @@ export type StartLogsResult = ReturnType<StartLogs>
 export function startLogs(
   initConfiguration: LogsInitConfiguration,
   configuration: LogsConfiguration,
-  getCommonContext: () => CommonContext
+  getCommonContext: () => CommonContext,
+
+  // Tracking consent should always be granted when the startLogs is called.
+  trackingConsentState: TrackingConsentState
 ) {
   const lifeCycle = new LifeCycle()
   const cleanupTasks: Array<() => void> = []
@@ -37,7 +39,6 @@ export function startLogs(
 
   const reportError = startReportError(lifeCycle)
   const pageExitObservable = createPageExitObservable(configuration)
-  const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
 
   const session =
     configuration.sessionStoreStrategyType && !canUseEventBridge() && !willSyntheticsInjectRum()
@@ -73,7 +74,6 @@ export function startLogs(
   return {
     handleLog,
     getInternalContext: internalContext.get,
-    setTrackingConsent: trackingConsentState.update,
     stop: () => {
       cleanupTasks.forEach((task) => task())
     },

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -29,7 +29,9 @@ export function startLogs(
   configuration: LogsConfiguration,
   getCommonContext: () => CommonContext,
 
-  // Tracking consent should always be granted when the startLogs is called.
+  // `startLogs` and its subcomponents assume tracking consent is granted initially and starts
+  // collecting logs unconditionally. As such, `startLogs` should be called with a
+  // `trackingConsentState` set to "granted".
   trackingConsentState: TrackingConsentState
 ) {
   const lifeCycle = new LifeCycle()

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -7,6 +7,8 @@ import {
   stopSessionManager,
   ONE_SECOND,
   DOM_EVENT,
+  createTrackingConsentState,
+  TrackingConsent,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, mockClock } from '@datadog/browser-core/test'
@@ -111,11 +113,14 @@ describe('logs session manager', () => {
   })
 
   function startLogsSessionManagerWithDefaults({ configuration }: { configuration?: Partial<LogsConfiguration> } = {}) {
-    return startLogsSessionManager({
-      sessionSampleRate: 100,
-      sessionStoreStrategyType: { type: 'Cookie', cookieOptions: {} },
-      ...configuration,
-    } as LogsConfiguration)
+    return startLogsSessionManager(
+      {
+        sessionSampleRate: 100,
+        sessionStoreStrategyType: { type: 'Cookie', cookieOptions: {} },
+        ...configuration,
+      } as LogsConfiguration,
+      createTrackingConsentState(TrackingConsent.GRANTED)
+    )
   }
 })
 

--- a/packages/logs/src/domain/logsSessionManager.ts
+++ b/packages/logs/src/domain/logsSessionManager.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime } from '@datadog/browser-core'
+import type { RelativeTime, TrackingConsentState } from '@datadog/browser-core'
 import { Observable, performDraw, startSessionManager } from '@datadog/browser-core'
 import type { LogsConfiguration } from './configuration'
 
@@ -18,9 +18,15 @@ export const enum LoggerTrackingType {
   TRACKED = '1',
 }
 
-export function startLogsSessionManager(configuration: LogsConfiguration): LogsSessionManager {
-  const sessionManager = startSessionManager(configuration, LOGS_SESSION_KEY, (rawTrackingType) =>
-    computeSessionState(configuration, rawTrackingType)
+export function startLogsSessionManager(
+  configuration: LogsConfiguration,
+  trackingConsentState: TrackingConsentState
+): LogsSessionManager {
+  const sessionManager = startSessionManager(
+    configuration,
+    LOGS_SESSION_KEY,
+    (rawTrackingType) => computeSessionState(configuration, rawTrackingType),
+    trackingConsentState
   )
   return {
     findTrackedSession: (startTime) => {

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -577,5 +577,14 @@ describe('preStartRum', () => {
         expect(doStartRumSpy).toHaveBeenCalledTimes(1)
       })
     })
+
+    it('do not call startRum when tracking consent state is updated after init', () => {
+      strategy.init(DEFAULT_INIT_CONFIGURATION)
+      doStartRumSpy.calls.reset()
+
+      trackingConsentState.update(TrackingConsent.GRANTED)
+
+      expect(doStartRumSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -122,7 +122,7 @@ export function createPreStartStrategy(
       }
 
       cachedConfiguration = configuration
-      trackingConsentState.setIfNotDefined(configuration.trackingConsent)
+      trackingConsentState.tryToInit(configuration.trackingConsent)
       tryStartRum()
     },
 
@@ -130,7 +130,7 @@ export function createPreStartStrategy(
       return cachedInitConfiguration
     },
 
-    setTrackingConsent: trackingConsentState.set,
+    setTrackingConsent: trackingConsentState.update,
 
     getInternalContext: noop as () => undefined,
 

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -1,7 +1,6 @@
 import {
   BoundedBuffer,
   display,
-  type DeflateWorker,
   canUseEventBridge,
   displayAlreadyInitializedError,
   willSyntheticsInjectRum,
@@ -9,8 +8,8 @@ import {
   timeStampNow,
   clocksNow,
   assign,
-  createTrackingConsentState,
 } from '@datadog/browser-core'
+import type { TrackingConsentState, DeflateWorker } from '@datadog/browser-core'
 import {
   validateAndBuildRumConfiguration,
   type RumConfiguration,
@@ -24,6 +23,7 @@ import type { StartRumResult } from './startRum'
 export function createPreStartStrategy(
   { ignoreInitIfSyntheticsWillInjectRum, startDeflateWorker }: RumPublicApiOptions,
   getCommonContext: () => CommonContext,
+  trackingConsentState: TrackingConsentState,
   doStartRum: (
     initConfiguration: RumInitConfiguration,
     configuration: RumConfiguration,
@@ -39,13 +39,15 @@ export function createPreStartStrategy(
 
   let cachedInitConfiguration: RumInitConfiguration | undefined
   let cachedConfiguration: RumConfiguration | undefined
-  const trackingConsentState = createTrackingConsentState()
-  trackingConsentState.observable.subscribe(tryStartRum)
+
+  const trackingConsentStateSubscription = trackingConsentState.observable.subscribe(tryStartRum)
 
   function tryStartRum() {
     if (!cachedInitConfiguration || !cachedConfiguration || !trackingConsentState.isGranted()) {
       return
     }
+
+    trackingConsentStateSubscription.unsubscribe()
 
     let initialViewOptions: ViewOptions | undefined
 
@@ -129,8 +131,6 @@ export function createPreStartStrategy(
     get initConfiguration() {
       return cachedInitConfiguration
     },
-
-    setTrackingConsent: trackingConsentState.update,
 
     getInternalContext: noop as () => undefined,
 

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -130,6 +130,8 @@ export function createPreStartStrategy(
       return cachedInitConfiguration
     },
 
+    setTrackingConsent: trackingConsentState.set,
+
     getInternalContext: noop as () => undefined,
 
     stopSession: noop,

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -9,6 +9,7 @@ import {
   timeStampNow,
   clocksNow,
   assign,
+  createTrackingConsentState,
 } from '@datadog/browser-core'
 import {
   validateAndBuildRumConfiguration,
@@ -38,9 +39,11 @@ export function createPreStartStrategy(
 
   let cachedInitConfiguration: RumInitConfiguration | undefined
   let cachedConfiguration: RumConfiguration | undefined
+  const trackingConsentState = createTrackingConsentState()
+  trackingConsentState.observable.subscribe(tryStartRum)
 
   function tryStartRum() {
-    if (!cachedInitConfiguration || !cachedConfiguration) {
+    if (!cachedInitConfiguration || !cachedConfiguration || !trackingConsentState.isGranted()) {
       return
     }
 
@@ -119,6 +122,7 @@ export function createPreStartStrategy(
       }
 
       cachedConfiguration = configuration
+      trackingConsentState.setIfNotDefined(configuration.trackingConsent)
       tryStartRum()
     },
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -21,6 +21,7 @@ const noopStartRum = (): ReturnType<StartRum> => ({
   addFeatureFlagEvaluation: () => undefined,
   startView: () => undefined,
   getInternalContext: () => undefined,
+  setTrackingConsent: () => undefined,
   lifeCycle: {} as any,
   viewContexts: {} as any,
   session: {} as any,

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -21,7 +21,6 @@ const noopStartRum = (): ReturnType<StartRum> => ({
   addFeatureFlagEvaluation: () => undefined,
   startView: () => undefined,
   getInternalContext: () => undefined,
-  setTrackingConsent: () => undefined,
   lifeCycle: {} as any,
   viewContexts: {} as any,
   session: {} as any,

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -146,6 +146,18 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
   const rumPublicApi = makePublicApi({
     init: monitor((initConfiguration: RumInitConfiguration) => strategy.init(initConfiguration)),
 
+    /**
+     * Set the tracking consent of the current user.
+     *
+     * @param {"granted" | "not-granted"} trackingConsent The user tracking consent
+     *
+     * Data will be sent only if it is set to "granted". This value won't be stored by the library
+     * across page loads: you will need to call this method or set the appropriate `trackingConsent`
+     * field in the init() method at each page load.
+     *
+     * If this method is called before the init() method, the provided value will take precedence
+     * over the one provided as initialization parameter.
+     */
     setTrackingConsent: monitor((trackingConsent: TrackingConsent) => strategy.setTrackingConsent(trackingConsent)),
 
     setGlobalContextProperty: monitor((key, value) => globalContextManager.setContextProperty(key, value)),

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -6,6 +6,7 @@ import type {
   DeflateWorker,
   DeflateEncoderStreamId,
   DeflateEncoder,
+  TrackingConsent,
 } from '@datadog/browser-core'
 import {
   CustomerDataType,
@@ -72,6 +73,7 @@ const RUM_STORAGE_KEY = 'rum'
 
 export interface Strategy {
   init: (initConfiguration: RumInitConfiguration) => void
+  setTrackingConsent: StartRumResult['setTrackingConsent']
   initConfiguration: RumInitConfiguration | undefined
   getInternalContext: StartRumResult['getInternalContext']
   stopSession: StartRumResult['stopSession']
@@ -143,6 +145,8 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
 
   const rumPublicApi = makePublicApi({
     init: monitor((initConfiguration: RumInitConfiguration) => strategy.init(initConfiguration)),
+
+    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => strategy.setTrackingConsent(trackingConsent)),
 
     setGlobalContextProperty: monitor((key, value) => globalContextManager.setContextProperty(key, value)),
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -26,6 +26,7 @@ import {
   createCustomerDataTrackerManager,
   storeContextManager,
   displayAlreadyInitializedError,
+  createTrackingConsentState,
 } from '@datadog/browser-core'
 import type { LifeCycle } from '../domain/lifeCycle'
 import type { ViewContexts } from '../domain/contexts/viewContexts'
@@ -73,7 +74,6 @@ const RUM_STORAGE_KEY = 'rum'
 
 export interface Strategy {
   init: (initConfiguration: RumInitConfiguration) => void
-  setTrackingConsent: StartRumResult['setTrackingConsent']
   initConfiguration: RumInitConfiguration | undefined
   getInternalContext: StartRumResult['getInternalContext']
   stopSession: StartRumResult['stopSession']
@@ -90,6 +90,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.GlobalContext)
   )
   const userContextManager = createContextManager(customerDataTrackerManager.getOrCreateTracker(CustomerDataType.User))
+  const trackingConsentState = createTrackingConsentState()
 
   function getCommonContext() {
     return buildCommonContext(globalContextManager, userContextManager, recorderApi)
@@ -98,6 +99,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
   let strategy = createPreStartStrategy(
     options,
     getCommonContext,
+    trackingConsentState,
 
     (initConfiguration, configuration, deflateWorker, initialViewOptions) => {
       if (initConfiguration.storeContextsAcrossPages) {
@@ -118,7 +120,8 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
         initialViewOptions,
         deflateWorker && options.createDeflateEncoder
           ? (streamId) => options.createDeflateEncoder!(configuration, deflateWorker, streamId)
-          : createIdentityEncoder
+          : createIdentityEncoder,
+        trackingConsentState
       )
 
       recorderApi.onRumStart(
@@ -158,7 +161,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
      * If this method is called before the init() method, the provided value will take precedence
      * over the one provided as initialization parameter.
      */
-    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => strategy.setTrackingConsent(trackingConsent)),
+    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => trackingConsentState.update(trackingConsent)),
 
     setGlobalContextProperty: monitor((key, value) => globalContextManager.setContextProperty(key, value)),
 

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -9,6 +9,8 @@ import {
   relativeNow,
   createIdentityEncoder,
   createCustomerDataTracker,
+  createTrackingConsentState,
+  TrackingConsent,
 } from '@datadog/browser-core'
 import {
   createNewEvent,
@@ -334,7 +336,8 @@ describe('view events', () => {
         customerDataTrackerManager,
         () => ({ user: {}, context: {}, hasReplay: undefined }),
         undefined,
-        createIdentityEncoder
+        createIdentityEncoder,
+        createTrackingConsentState(TrackingConsent.GRANTED)
       )
     )
     interceptor = interceptRequests()

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -5,6 +5,7 @@ import type {
   DeflateEncoderStreamId,
   Encoder,
   CustomerDataTrackerManager,
+  TrackingConsentState,
 } from '@datadog/browser-core'
 import {
   sendToExtension,
@@ -16,8 +17,6 @@ import {
   getEventBridge,
   addTelemetryDebug,
   CustomerDataType,
-  createTrackingConsentState,
-  TrackingConsent,
 } from '@datadog/browser-core'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { startPerformanceCollection } from '../browser/performanceCollection'
@@ -58,7 +57,10 @@ export function startRum(
   customerDataTrackerManager: CustomerDataTrackerManager,
   getCommonContext: () => CommonContext,
   initialViewOptions: ViewOptions | undefined,
-  createEncoder: (streamId: DeflateEncoderStreamId) => Encoder
+  createEncoder: (streamId: DeflateEncoderStreamId) => Encoder,
+
+  // Tracking consent should always be granted when the startRum is called.
+  trackingConsentState: TrackingConsentState
 ) {
   const cleanupTasks: Array<() => void> = []
   const lifeCycle = new LifeCycle()
@@ -90,7 +92,6 @@ export function startRum(
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.FeatureFlag)
   )
 
-  const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
   const pageExitObservable = createPageExitObservable(configuration)
   const pageExitSubscription = pageExitObservable.subscribe((event) => {
     lifeCycle.notify(LifeCycleEventType.PAGE_EXITED, event)
@@ -179,7 +180,6 @@ export function startRum(
     addError,
     addTiming,
     addFeatureFlagEvaluation: featureFlagContexts.addFeatureFlagEvaluation,
-    setTrackingConsent: trackingConsentState.update,
     startView,
     lifeCycle,
     viewContexts,

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -59,7 +59,9 @@ export function startRum(
   initialViewOptions: ViewOptions | undefined,
   createEncoder: (streamId: DeflateEncoderStreamId) => Encoder,
 
-  // Tracking consent should always be granted when the startRum is called.
+  // `startRum` and its subcomponents assume tracking consent is granted initially and starts
+  // collecting logs unconditionally. As such, `startRum` should be called with a
+  // `trackingConsentState` set to "granted".
   trackingConsentState: TrackingConsentState
 ) {
   const cleanupTasks: Array<() => void> = []

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -179,7 +179,7 @@ export function startRum(
     addError,
     addTiming,
     addFeatureFlagEvaluation: featureFlagContexts.addFeatureFlagEvaluation,
-    setTrackingConsent: trackingConsentState.set,
+    setTrackingConsent: trackingConsentState.update,
     startView,
     lifeCycle,
     viewContexts,

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -16,6 +16,8 @@ import {
   getEventBridge,
   addTelemetryDebug,
   CustomerDataType,
+  createTrackingConsentState,
+  TrackingConsent,
 } from '@datadog/browser-core'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { startPerformanceCollection } from '../browser/performanceCollection'
@@ -88,6 +90,7 @@ export function startRum(
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.FeatureFlag)
   )
 
+  const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
   const pageExitObservable = createPageExitObservable(configuration)
   const pageExitSubscription = pageExitObservable.subscribe((event) => {
     lifeCycle.notify(LifeCycleEventType.PAGE_EXITED, event)
@@ -174,6 +177,7 @@ export function startRum(
     addError,
     addTiming,
     addFeatureFlagEvaluation: featureFlagContexts.addFeatureFlagEvaluation,
+    setTrackingConsent: trackingConsentState.set,
     startView,
     lifeCycle,
     viewContexts,

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -97,7 +97,9 @@ export function startRum(
   })
   cleanupTasks.push(() => pageExitSubscription.unsubscribe())
 
-  const session = !canUseEventBridge() ? startRumSessionManager(configuration, lifeCycle) : startRumSessionManagerStub()
+  const session = !canUseEventBridge()
+    ? startRumSessionManager(configuration, lifeCycle, trackingConsentState)
+    : startRumSessionManagerStub()
   if (!canUseEventBridge()) {
     const batch = startRumBatch(
       configuration,

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -19,33 +19,14 @@ import { RUM_SESSION_KEY, RumTrackingType, startRumSessionManager } from './rumS
 
 describe('rum session manager', () => {
   const DURATION = 123456
-  let configuration: RumConfiguration
   let lifeCycle: LifeCycle
   let expireSessionSpy: jasmine.Spy
   let renewSessionSpy: jasmine.Spy
   let clock: Clock
 
-  function setupDraws({
-    tracked,
-    trackedWithSessionReplay,
-  }: {
-    tracked?: boolean
-    trackedWithSessionReplay?: boolean
-  }) {
-    configuration.sessionSampleRate = tracked ? 100 : 0
-    configuration.sessionReplaySampleRate = trackedWithSessionReplay ? 100 : 0
-  }
-
   beforeEach(() => {
     if (isIE()) {
       pending('no full rum support')
-    }
-    configuration = {
-      ...validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: 'xxx' })!,
-      sessionSampleRate: 50,
-      sessionReplaySampleRate: 50,
-      trackResources: true,
-      trackLongTasks: true,
     }
     clock = mockClock()
     expireSessionSpy = jasmine.createSpy('expireSessionSpy')
@@ -65,9 +46,7 @@ describe('rum session manager', () => {
 
   describe('cookie storage', () => {
     it('when tracked with session replay should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithSessionReplay: true })
-
-      startRumSessionManager(configuration, lifeCycle)
+      startRumSessionManagerWithDefaults({ configuration: { sessionSampleRate: 100, sessionReplaySampleRate: 100 } })
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
@@ -78,9 +57,7 @@ describe('rum session manager', () => {
     })
 
     it('when tracked without session replay should store session type and id', () => {
-      setupDraws({ tracked: true, trackedWithSessionReplay: false })
-
-      startRumSessionManager(configuration, lifeCycle)
+      startRumSessionManagerWithDefaults({ configuration: { sessionSampleRate: 100, sessionReplaySampleRate: 0 } })
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
@@ -91,9 +68,7 @@ describe('rum session manager', () => {
     })
 
     it('when not tracked should store session type', () => {
-      setupDraws({ tracked: false })
-
-      startRumSessionManager(configuration, lifeCycle)
+      startRumSessionManagerWithDefaults({ configuration: { sessionSampleRate: 0 } })
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
@@ -104,7 +79,7 @@ describe('rum session manager', () => {
     it('when tracked should keep existing session type and id', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&rum=1', DURATION)
 
-      startRumSessionManager(configuration, lifeCycle)
+      startRumSessionManagerWithDefaults()
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
@@ -117,7 +92,7 @@ describe('rum session manager', () => {
     it('when not tracked should keep existing session type', () => {
       setCookie(SESSION_STORE_KEY, 'rum=0', DURATION)
 
-      startRumSessionManager(configuration, lifeCycle)
+      startRumSessionManagerWithDefaults()
 
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
@@ -126,7 +101,8 @@ describe('rum session manager', () => {
 
     it('should renew on activity after expiration', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&rum=1', DURATION)
-      startRumSessionManager(configuration, lifeCycle)
+
+      startRumSessionManagerWithDefaults({ configuration: { sessionSampleRate: 100, sessionReplaySampleRate: 100 } })
 
       setCookie(SESSION_STORE_KEY, '', DURATION)
       expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
@@ -134,7 +110,6 @@ describe('rum session manager', () => {
       expect(renewSessionSpy).not.toHaveBeenCalled()
       clock.tick(STORAGE_POLL_DELAY)
 
-      setupDraws({ tracked: true, trackedWithSessionReplay: true })
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       expect(expireSessionSpy).toHaveBeenCalled()
@@ -149,18 +124,18 @@ describe('rum session manager', () => {
   describe('findSession', () => {
     it('should return the current session', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&rum=1', DURATION)
-      const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
+      const rumSessionManager = startRumSessionManagerWithDefaults()
       expect(rumSessionManager.findTrackedSession()!.id).toBe('abcdef')
     })
 
     it('should return undefined if the session is not tracked', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&rum=0', DURATION)
-      const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
+      const rumSessionManager = startRumSessionManagerWithDefaults()
       expect(rumSessionManager.findTrackedSession()).toBe(undefined)
     })
 
     it('should return undefined if the session has expired', () => {
-      const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
+      const rumSessionManager = startRumSessionManagerWithDefaults()
       setCookie(SESSION_STORE_KEY, '', DURATION)
       clock.tick(STORAGE_POLL_DELAY)
       expect(rumSessionManager.findTrackedSession()).toBe(undefined)
@@ -168,7 +143,7 @@ describe('rum session manager', () => {
 
     it('should return session corresponding to start time', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&rum=1', DURATION)
-      const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
+      const rumSessionManager = startRumSessionManagerWithDefaults()
       clock.tick(10 * ONE_SECOND)
       setCookie(SESSION_STORE_KEY, '', DURATION)
       clock.tick(STORAGE_POLL_DELAY)
@@ -178,13 +153,13 @@ describe('rum session manager', () => {
 
     it('should return session TRACKED_WITH_SESSION_REPLAY', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&rum=1', DURATION)
-      const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
+      const rumSessionManager = startRumSessionManagerWithDefaults()
       expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBe(true)
     })
 
     it('should return session TRACKED_WITHOUT_SESSION_REPLAY', () => {
       setCookie(SESSION_STORE_KEY, 'id=abcdef&rum=2', DURATION)
-      const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
+      const rumSessionManager = startRumSessionManagerWithDefaults()
       expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBe(false)
     })
   })
@@ -193,31 +168,45 @@ describe('rum session manager', () => {
     ;[
       {
         description: 'TRACKED_WITH_SESSION_REPLAY should have replay',
-        trackedWithSessionReplay: true,
+        sessionReplaySampleRate: 100,
         expectSessionReplay: true,
       },
       {
         description: 'TRACKED_WITHOUT_SESSION_REPLAY should have no replay',
-        trackedWithSessionReplay: false,
+        sessionReplaySampleRate: 0,
         expectSessionReplay: false,
       },
     ].forEach(
       ({
         description,
-        trackedWithSessionReplay,
+        sessionReplaySampleRate,
         expectSessionReplay,
       }: {
         description: string
-        trackedWithSessionReplay: boolean
+        sessionReplaySampleRate: number
         expectSessionReplay: boolean
       }) => {
         it(description, () => {
-          setupDraws({ tracked: true, trackedWithSessionReplay })
-
-          const rumSessionManager = startRumSessionManager(configuration, lifeCycle)
+          const rumSessionManager = startRumSessionManagerWithDefaults({
+            configuration: { sessionSampleRate: 100, sessionReplaySampleRate },
+          })
           expect(rumSessionManager.findTrackedSession()!.sessionReplayAllowed).toBe(expectSessionReplay)
         })
       }
     )
   })
+
+  function startRumSessionManagerWithDefaults({ configuration }: { configuration?: Partial<RumConfiguration> } = {}) {
+    return startRumSessionManager(
+      {
+        ...validateAndBuildRumConfiguration({ clientToken: 'xxx', applicationId: 'xxx' })!,
+        sessionSampleRate: 50,
+        sessionReplaySampleRate: 50,
+        trackResources: true,
+        trackLongTasks: true,
+        ...configuration,
+      },
+      lifeCycle
+    )
+  }
 })

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -8,6 +8,8 @@ import {
   stopSessionManager,
   ONE_SECOND,
   DOM_EVENT,
+  createTrackingConsentState,
+  TrackingConsent,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, mockClock } from '@datadog/browser-core/test'
@@ -206,7 +208,8 @@ describe('rum session manager', () => {
         trackLongTasks: true,
         ...configuration,
       },
-      lifeCycle
+      lifeCycle,
+      createTrackingConsentState(TrackingConsent.GRANTED)
     )
   }
 })

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime } from '@datadog/browser-core'
+import type { RelativeTime, TrackingConsentState } from '@datadog/browser-core'
 import { Observable, noop, performDraw, startSessionManager } from '@datadog/browser-core'
 import type { RumConfiguration } from './configuration'
 import type { LifeCycle } from './lifeCycle'
@@ -23,9 +23,16 @@ export const enum RumTrackingType {
   TRACKED_WITHOUT_SESSION_REPLAY = '2',
 }
 
-export function startRumSessionManager(configuration: RumConfiguration, lifeCycle: LifeCycle): RumSessionManager {
-  const sessionManager = startSessionManager(configuration, RUM_SESSION_KEY, (rawTrackingType) =>
-    computeSessionState(configuration, rawTrackingType)
+export function startRumSessionManager(
+  configuration: RumConfiguration,
+  lifeCycle: LifeCycle,
+  trackingConsentState: TrackingConsentState
+): RumSessionManager {
+  const sessionManager = startSessionManager(
+    configuration,
+    RUM_SESSION_KEY,
+    (rawTrackingType) => computeSessionState(configuration, rawTrackingType),
+    trackingConsentState
   )
 
   sessionManager.expireObservable.subscribe(() => {

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -59,4 +59,17 @@ describe('tracking consent', () => {
       expect(firstView.view.id).not.toEqual(lastView.view.id)
       expect(await findSessionCookie()).not.toEqual(initialSessionId)
     })
+
+  createTest('using setTrackingConsent before init overrides the init parameter')
+    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+    .withRumInit((configuration) => {
+      window.DD_RUM!.setTrackingConsent('granted')
+      window.DD_RUM!.init(configuration)
+    })
+    .run(async ({ intakeRegistry }) => {
+      await flushEvents()
+
+      expect(intakeRegistry.isEmpty).toBe(false)
+      expect(await findSessionCookie()).toBeDefined()
+    })
 })

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -1,0 +1,62 @@
+import { createTest, flushEvents } from '../lib/framework'
+import { browserExecute } from '../lib/helpers/browser'
+import { findSessionCookie } from '../lib/helpers/session'
+
+describe('tracking consent', () => {
+  createTest('does not start the SDK if tracking consent is not given at init')
+    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+    .run(async ({ intakeRegistry }) => {
+      await flushEvents()
+
+      expect(intakeRegistry.isEmpty).toBe(true)
+      expect(await findSessionCookie()).toBeUndefined()
+    })
+
+  createTest('starts the SDK once tracking consent is granted')
+    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+    .run(async ({ intakeRegistry }) => {
+      await browserExecute(() => {
+        window.DD_RUM!.setTrackingConsent('granted')
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.isEmpty).toBe(false)
+      expect(await findSessionCookie()).toBeDefined()
+    })
+
+  createTest('stops sending events if tracking consent is revoked')
+    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackUserInteractions: true })
+    .run(async ({ intakeRegistry }) => {
+      await browserExecute(() => {
+        window.DD_RUM!.setTrackingConsent('not-granted')
+      })
+
+      const htmlElement = await $('html')
+      await htmlElement.click()
+
+      await flushEvents()
+
+      expect(intakeRegistry.rumActionEvents).toEqual([])
+      expect(await findSessionCookie()).toBeUndefined()
+    })
+
+  createTest('starts a new session when tracking consent is granted again')
+    .withRum({ enableExperimentalFeatures: ['tracking_consent'] })
+    .run(async ({ intakeRegistry }) => {
+      const initialSessionId = await findSessionCookie()
+
+      await browserExecute(() => {
+        window.DD_RUM!.setTrackingConsent('not-granted')
+        window.DD_RUM!.setTrackingConsent('granted')
+      })
+
+      await flushEvents()
+
+      const firstView = intakeRegistry.rumViewEvents[0]
+      const lastView = intakeRegistry.rumViewEvents.at(-1)!
+      expect(firstView.session.id).not.toEqual(lastView.session.id)
+      expect(firstView.view.id).not.toEqual(lastView.view.id)
+      expect(await findSessionCookie()).not.toEqual(initialSessionId)
+    })
+})

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -3,73 +3,99 @@ import { browserExecute } from '../lib/helpers/browser'
 import { findSessionCookie } from '../lib/helpers/session'
 
 describe('tracking consent', () => {
-  createTest('does not start the SDK if tracking consent is not given at init')
-    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
-    .run(async ({ intakeRegistry }) => {
-      await flushEvents()
+  describe('RUM', () => {
+    createTest('does not start the SDK if tracking consent is not given at init')
+      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .run(async ({ intakeRegistry }) => {
+        await flushEvents()
 
-      expect(intakeRegistry.isEmpty).toBe(true)
-      expect(await findSessionCookie()).toBeUndefined()
-    })
+        expect(intakeRegistry.isEmpty).toBe(true)
+        expect(await findSessionCookie()).toBeUndefined()
+      })
 
-  createTest('starts the SDK once tracking consent is granted')
-    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
-    .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+    createTest('starts the SDK once tracking consent is granted')
+      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .run(async ({ intakeRegistry }) => {
+        await browserExecute(() => {
+          window.DD_RUM!.setTrackingConsent('granted')
+        })
+
+        await flushEvents()
+
+        expect(intakeRegistry.isEmpty).toBe(false)
+        expect(await findSessionCookie()).toBeDefined()
+      })
+
+    createTest('stops sending events if tracking consent is revoked')
+      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackUserInteractions: true })
+      .run(async ({ intakeRegistry }) => {
+        await browserExecute(() => {
+          window.DD_RUM!.setTrackingConsent('not-granted')
+        })
+
+        const htmlElement = await $('html')
+        await htmlElement.click()
+
+        await flushEvents()
+
+        expect(intakeRegistry.rumActionEvents).toEqual([])
+        expect(await findSessionCookie()).toBeUndefined()
+      })
+
+    createTest('starts a new session when tracking consent is granted again')
+      .withRum({ enableExperimentalFeatures: ['tracking_consent'] })
+      .run(async ({ intakeRegistry }) => {
+        const initialSessionId = await findSessionCookie()
+
+        await browserExecute(() => {
+          window.DD_RUM!.setTrackingConsent('not-granted')
+          window.DD_RUM!.setTrackingConsent('granted')
+        })
+
+        await flushEvents()
+
+        const firstView = intakeRegistry.rumViewEvents[0]
+        const lastView = intakeRegistry.rumViewEvents.at(-1)!
+        expect(firstView.session.id).not.toEqual(lastView.session.id)
+        expect(firstView.view.id).not.toEqual(lastView.view.id)
+        expect(await findSessionCookie()).not.toEqual(initialSessionId)
+      })
+
+    createTest('using setTrackingConsent before init overrides the init parameter')
+      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .withRumInit((configuration) => {
         window.DD_RUM!.setTrackingConsent('granted')
+        window.DD_RUM!.init(configuration)
+      })
+      .run(async ({ intakeRegistry }) => {
+        await flushEvents()
+
+        expect(intakeRegistry.isEmpty).toBe(false)
+        expect(await findSessionCookie()).toBeDefined()
+      })
+  })
+
+  describe('Logs', () => {
+    createTest('does not start the SDK if tracking consent is not given at init')
+      .withLogs({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .run(async ({ intakeRegistry }) => {
+        await flushEvents()
+
+        expect(intakeRegistry.isEmpty).toBe(true)
+        expect(await findSessionCookie()).toBeUndefined()
       })
 
-      await flushEvents()
+    createTest('starts the SDK once tracking consent is granted')
+      .withLogs({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .run(async ({ intakeRegistry }) => {
+        await browserExecute(() => {
+          window.DD_LOGS!.setTrackingConsent('granted')
+        })
 
-      expect(intakeRegistry.isEmpty).toBe(false)
-      expect(await findSessionCookie()).toBeDefined()
-    })
+        await flushEvents()
 
-  createTest('stops sending events if tracking consent is revoked')
-    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackUserInteractions: true })
-    .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
-        window.DD_RUM!.setTrackingConsent('not-granted')
+        expect(intakeRegistry.isEmpty).toBe(false)
+        expect(await findSessionCookie()).toBeDefined()
       })
-
-      const htmlElement = await $('html')
-      await htmlElement.click()
-
-      await flushEvents()
-
-      expect(intakeRegistry.rumActionEvents).toEqual([])
-      expect(await findSessionCookie()).toBeUndefined()
-    })
-
-  createTest('starts a new session when tracking consent is granted again')
-    .withRum({ enableExperimentalFeatures: ['tracking_consent'] })
-    .run(async ({ intakeRegistry }) => {
-      const initialSessionId = await findSessionCookie()
-
-      await browserExecute(() => {
-        window.DD_RUM!.setTrackingConsent('not-granted')
-        window.DD_RUM!.setTrackingConsent('granted')
-      })
-
-      await flushEvents()
-
-      const firstView = intakeRegistry.rumViewEvents[0]
-      const lastView = intakeRegistry.rumViewEvents.at(-1)!
-      expect(firstView.session.id).not.toEqual(lastView.session.id)
-      expect(firstView.view.id).not.toEqual(lastView.view.id)
-      expect(await findSessionCookie()).not.toEqual(initialSessionId)
-    })
-
-  createTest('using setTrackingConsent before init overrides the init parameter')
-    .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
-    .withRumInit((configuration) => {
-      window.DD_RUM!.setTrackingConsent('granted')
-      window.DD_RUM!.init(configuration)
-    })
-    .run(async ({ intakeRegistry }) => {
-      await flushEvents()
-
-      expect(intakeRegistry.isEmpty).toBe(false)
-      expect(await findSessionCookie()).toBeDefined()
-    })
+  })
 })


### PR DESCRIPTION
## Motivation

Allows starting/stopping data collection based on user consent (ex: regarding to RGPD rules and such).

Related issue: https://github.com/DataDog/browser-sdk/issues/1008

## Changes

For both RUM and Logs SDKs:

* Introduce a `trackingConsent: "granted"/"not-granted"` initialization parameter (defaults to `"granted"` for backward compatibility)
* Add a `setTrackingConsent` method to set the consent state before or after calling `init()`. If called before `init()`, the initialization parameter will be ignored.
* On init, do not start collecting data until consent is granted
* When the consent is withdrawn, stops the session and clear the cookie. No new session will be created on user interaction.
* This change is behind an experimental flag and should not be used by customers yet.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
