### PR TITLE
♻️ register setupBuilder.cleanup as a cleanup task

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -163,10 +163,6 @@ describe('rum public api', () => {
       setupBuilder = setup()
     })
 
-    afterEach(() => {
-      setupBuilder.cleanup()
-    })
-
     it('allows sending actions before init', () => {
       rumPublicApi.addAction('foo', { bar: 'baz' })
 
@@ -254,10 +250,6 @@ describe('rum public api', () => {
       setupBuilder = setup()
     })
 
-    afterEach(() => {
-      setupBuilder.cleanup()
-    })
-
     it('allows capturing an error before init', () => {
       rumPublicApi.addError(new Error('foo'))
 
@@ -343,7 +335,6 @@ describe('rum public api', () => {
     let addActionSpy: jasmine.Spy<ReturnType<StartRum>['addAction']>
     let displaySpy: jasmine.Spy<() => void>
     let rumPublicApi: RumPublicApi
-    let setupBuilder: TestSetupBuilder
 
     beforeEach(() => {
       addActionSpy = jasmine.createSpy()
@@ -355,11 +346,6 @@ describe('rum public api', () => {
         }),
         noopRecorderApi
       )
-      setupBuilder = setup()
-    })
-
-    afterEach(() => {
-      setupBuilder.cleanup()
     })
 
     it('should attach valid objects', () => {
@@ -505,7 +491,6 @@ describe('rum public api', () => {
     let addTimingSpy: jasmine.Spy<ReturnType<StartRum>['addTiming']>
     let displaySpy: jasmine.Spy<() => void>
     let rumPublicApi: RumPublicApi
-    let setupBuilder: TestSetupBuilder
 
     beforeEach(() => {
       addTimingSpy = jasmine.createSpy()
@@ -517,11 +502,6 @@ describe('rum public api', () => {
         }),
         noopRecorderApi
       )
-      setupBuilder = setup()
-    })
-
-    afterEach(() => {
-      setupBuilder.cleanup()
     })
 
     it('should add custom timings', () => {
@@ -549,7 +529,6 @@ describe('rum public api', () => {
     let addFeatureFlagEvaluationSpy: jasmine.Spy<ReturnType<StartRum>['addFeatureFlagEvaluation']>
     let displaySpy: jasmine.Spy<() => void>
     let rumPublicApi: RumPublicApi
-    let setupBuilder: TestSetupBuilder
 
     beforeEach(() => {
       addFeatureFlagEvaluationSpy = jasmine.createSpy()
@@ -561,11 +540,6 @@ describe('rum public api', () => {
         }),
         noopRecorderApi
       )
-      setupBuilder = setup()
-    })
-
-    afterEach(() => {
-      setupBuilder.cleanup()
     })
 
     it('should add feature flag evaluation when ff feature_flags enabled', () => {
@@ -608,7 +582,6 @@ describe('rum public api', () => {
 
   describe('recording', () => {
     let recorderApiOnRumStartSpy: jasmine.Spy<RecorderApi['onRumStart']>
-    let setupBuilder: TestSetupBuilder
     let rumPublicApi: RumPublicApi
     let recorderApi: RecorderApi
 
@@ -616,11 +589,6 @@ describe('rum public api', () => {
       recorderApiOnRumStartSpy = jasmine.createSpy('recorderApiOnRumStart')
       recorderApi = { ...noopRecorderApi, onRumStart: recorderApiOnRumStartSpy }
       rumPublicApi = makeRumPublicApi(noopStartRum, recorderApi)
-      setupBuilder = setup()
-    })
-
-    afterEach(() => {
-      setupBuilder.cleanup()
     })
 
     it('is started with the default defaultPrivacyLevel', () => {

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -119,10 +119,6 @@ describe('rum session', () => {
     )
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('when the session is renewed, a new view event should be sent', () => {
     const session = createRumSessionManagerMock().setId('42')
     const { lifeCycle } = setupBuilder.withSessionManager(session).build()
@@ -182,10 +178,6 @@ describe('rum session keep alive', () => {
           )
         }
       )
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   it('should send a view update regularly', () => {
@@ -254,10 +246,6 @@ describe('rum events url', () => {
         )
       }
     )
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   it('should attach the url corresponding to the start of the event', () => {
@@ -343,7 +331,6 @@ describe('view events', () => {
   afterEach(() => {
     deleteEventBridgeStub()
     stopSessionManager()
-    setupBuilder.cleanup()
     interceptor.restore()
   })
 

--- a/packages/rum-core/src/browser/performanceCollection.spec.ts
+++ b/packages/rum-core/src/browser/performanceCollection.spec.ts
@@ -1,21 +1,15 @@
-import type { TestSetupBuilder } from '../../test'
 import { setup } from '../../test'
 import type { RumConfiguration } from '../domain/configuration'
 import { retrieveInitialDocumentResourceTiming, startPerformanceCollection } from './performanceCollection'
 
 describe('rum initial document resource', () => {
-  let setupBuilder: TestSetupBuilder
   let configuration: RumConfiguration
 
   beforeEach(() => {
     configuration = {} as RumConfiguration
-    setupBuilder = setup().beforeBuild(({ lifeCycle, configuration }) => {
+    setup().beforeBuild(({ lifeCycle, configuration }) => {
       startPerformanceCollection(lifeCycle, configuration)
     })
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   it('creates a resource timing for the initial document', (done) => {

--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -20,9 +20,6 @@ describe('actionCollection', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
   it('should create action from auto action', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
 

--- a/packages/rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.spec.ts
@@ -70,7 +70,6 @@ describe('trackClickActions', () => {
     button.parentNode!.removeChild(button)
     emptyElement.parentNode!.removeChild(emptyElement)
     input.parentNode!.removeChild(input)
-    setupBuilder.cleanup()
   })
 
   it('starts a click action when clicking on an element', () => {

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -77,7 +77,6 @@ describe('rum assembly', () => {
 
   afterEach(() => {
     deleteEventBridgeStub()
-    setupBuilder.cleanup()
     cleanupSyntheticsWorkerValues()
     cleanupCiVisibilityWindowValues()
   })

--- a/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
@@ -29,7 +29,6 @@ describe('featureFlagContexts', () => {
   afterEach(() => {
     featureFlagContexts.stop()
     resetExperimentalFeatures()
-    setupBuilder.cleanup()
   })
 
   it('should return undefined before the initial view', () => {

--- a/packages/rum-core/src/domain/contexts/internalContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/internalContext.spec.ts
@@ -36,10 +36,6 @@ describe('internal context', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should return current internal context', () => {
     const { fakeLocation } = setupBuilder.build()
 

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -21,10 +21,6 @@ describe('urlContexts', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should return undefined before the initial view', () => {
     setupBuilder.build()
 

--- a/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/viewContexts.spec.ts
@@ -31,10 +31,6 @@ describe('viewContexts', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   describe('findView', () => {
     it('should return undefined when there is no current view and no startTime', () => {
       setupBuilder.build()

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -28,10 +28,6 @@ describe('error collection', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   describe('addError', () => {
     ;[
       {

--- a/packages/rum-core/src/domain/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/longTask/longTaskCollection.spec.ts
@@ -21,10 +21,6 @@ describe('long task collection', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should only listen to long task performance entry', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -35,7 +35,6 @@ describe('resourceCollection', () => {
 
   afterEach(() => {
     resetExperimentalFeatures()
-    setupBuilder.cleanup()
   })
 
   it('should create resource from performance entry', () => {

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
@@ -72,7 +72,6 @@ describe('customerDataTelemetry', () => {
   })
 
   afterEach(() => {
-    setupBuilder.cleanup()
     resetExperimentalFeatures()
   })
 

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -1,6 +1,6 @@
 import { display, isIE, objectEntries } from '@datadog/browser-core'
-import type { TestSetupBuilder, RumSessionManagerMock } from '../../../test'
-import { setup, createRumSessionManagerMock } from '../../../test'
+import type { RumSessionManagerMock } from '../../../test'
+import { createRumSessionManagerMock } from '../../../test'
 import type { RumFetchResolveContext, RumFetchStartContext, RumXhrStartContext } from '../requestCollection'
 import type { RumConfiguration, RumInitConfiguration } from '../configuration'
 import { validateAndBuildRumConfiguration } from '../configuration'
@@ -14,7 +14,6 @@ describe('tracer', () => {
   const DISALLOWED_DOMAIN_CONTEXT: Partial<RumXhrStartContext | RumFetchStartContext> = {
     url: 'http://foo.com',
   }
-  let setupBuilder: TestSetupBuilder
   let sessionManager: RumSessionManagerMock
 
   const INIT_CONFIGURATION: RumInitConfiguration = {
@@ -26,12 +25,7 @@ describe('tracer', () => {
 
   beforeEach(() => {
     configuration = validateAndBuildRumConfiguration(INIT_CONFIGURATION)!
-    setupBuilder = setup()
     sessionManager = createRumSessionManagerMock()
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   describe('traceXhr', () => {

--- a/packages/rum-core/src/domain/view/trackViewEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViewEventCounts.spec.ts
@@ -16,10 +16,6 @@ describe('trackViewEventCounts', () => {
     setupBuilder = setup().beforeBuild(({ lifeCycle }) => trackViewEventCounts(lifeCycle, 'view-id', onChange))
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should track events count', () => {
     const { lifeCycle } = setupBuilder.build()
 

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -32,10 +32,6 @@ describe('track views automatically', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   describe('initial view', () => {
     it('should be created on start', () => {
       setupBuilder.build()
@@ -116,10 +112,6 @@ describe('view lifecycle', () => {
         })
         return viewTest
       })
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   describe('expire session', () => {
@@ -340,10 +332,6 @@ describe('view loading type', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should collect initial view type as "initial_load"', () => {
     setupBuilder.build()
     const { getViewUpdate } = viewTest
@@ -373,10 +361,6 @@ describe('view metrics', () => {
         viewTest = setupViewTest(buildContext)
         return viewTest
       })
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   describe('common view metrics', () => {
@@ -574,10 +558,6 @@ describe('view is active', () => {
     })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should set initial view as active', () => {
     setupBuilder.build()
     const { getViewUpdate } = viewTest
@@ -607,10 +587,6 @@ describe('view custom timings', () => {
         viewTest = setupViewTest(buildContext)
         return viewTest
       })
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   it('should add custom timing to current view', () => {
@@ -750,10 +726,6 @@ describe('start view', () => {
     })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should start a new view', () => {
     const { clock } = setupBuilder.withFakeClock().build()
     const { getViewUpdateCount, getViewUpdate, startView } = viewTest
@@ -841,10 +813,6 @@ describe('view event count', () => {
         viewTest = setupViewTest(buildContext)
         return viewTest
       })
-  })
-
-  afterEach(() => {
-    setupBuilder.cleanup()
   })
 
   it('should be updated when notified with a RUM_EVENT_COLLECTED event', () => {

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -99,7 +99,6 @@ describe('viewCollection', () => {
   })
 
   afterEach(() => {
-    setupBuilder.cleanup()
     resetExperimentalFeatures()
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -33,7 +33,6 @@ describe('trackCumulativeLayoutShift', () => {
     if (originalSupportedEntryTypes) {
       Object.defineProperty(PerformanceObserver, 'supportedEntryTypes', originalSupportedEntryTypes)
     }
-    setupBuilder.cleanup()
   })
 
   it('should be initialized to 0', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
@@ -29,7 +29,6 @@ describe('trackFirstContentfulPaint', () => {
   })
 
   afterEach(() => {
-    setupBuilder.cleanup()
     restorePageVisibility()
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -32,7 +32,6 @@ describe('firstInputTimings', () => {
   })
 
   afterEach(() => {
-    setupBuilder.cleanup()
     restorePageVisibility()
     resetExperimentalFeatures()
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
@@ -29,10 +29,6 @@ describe('trackInitialViewMetrics', () => {
     })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should merge metrics from various sources', () => {
     const { lifeCycle } = setupBuilder.build()
     lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -56,7 +56,6 @@ describe('trackInteractionToNextPaint', () => {
 
   afterEach(() => {
     resetExperimentalFeatures()
-    setupBuilder.cleanup()
     interactionCountStub.clear()
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -39,7 +39,6 @@ describe('trackLargestContentfulPaint', () => {
   })
 
   afterEach(() => {
-    setupBuilder.cleanup()
     restorePageVisibility()
     resetExperimentalFeatures()
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -40,10 +40,6 @@ describe('trackLoadingTime', () => {
       .withFakeClock()
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should have an undefined loading time if there is no activity on a route change', () => {
     setupBuilder.build()
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
@@ -16,10 +16,6 @@ describe('trackNavigationTimings', () => {
     setupBuilder = setup().beforeBuild(({ lifeCycle }) => trackNavigationTimings(lifeCycle, navigationTimingsCallback))
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('should provide navigation timing', () => {
     const { lifeCycle } = setupBuilder.build()
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
@@ -69,7 +69,6 @@ describe('trackScrollMetrics', () => {
 
   afterEach(() => {
     document.body.innerHTML = ''
-    setupBuilder.cleanup()
   })
 
   const updateScrollValues = (scrollValues: ScrollValues) => {

--- a/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
@@ -55,10 +55,6 @@ describe('createPageActivityObservable', () => {
       })
   })
 
-  afterEach(() => {
-    setupBuilder.cleanup()
-  })
-
   it('emits an activity event on dom mutation', () => {
     const { domMutationObservable } = setupBuilder.build()
     domMutationObservable.notify()

--- a/packages/rum-core/test/testSetupBuilder.ts
+++ b/packages/rum-core/test/testSetupBuilder.ts
@@ -40,11 +40,11 @@ export interface TestSetupBuilder {
   clock: Clock | undefined
   domMutationObservable: Observable<void>
 
-  cleanup: () => void
   build: () => TestIO
 }
 
 type BeforeBuildCallback = (buildContext: BuildContext) => void | { stop: () => void }
+
 export interface BuildContext {
   lifeCycle: LifeCycle
   domMutationObservable: Observable<void>
@@ -220,14 +220,13 @@ export function setup(): TestSetupBuilder {
         changeLocation,
       }
     },
-    cleanup() {
-      cleanupTasks.forEach((task) => task())
-      // perform these steps at the end to generate correct events in cleanup and validate them
-      clock?.cleanup()
-      rawRumEventsCollected.unsubscribe()
-    },
   }
-  registerCleanupTask(() => setupBuilder.cleanup())
+  registerCleanupTask(() => {
+    cleanupTasks.forEach((task) => task())
+    // perform these steps at the end to generate correct events in cleanup and validate them
+    clock?.cleanup()
+    rawRumEventsCollected.unsubscribe()
+  })
   return setupBuilder
 }
 

--- a/packages/rum-core/test/testSetupBuilder.ts
+++ b/packages/rum-core/test/testSetupBuilder.ts
@@ -9,7 +9,7 @@ import {
   Observable,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, buildLocation, SPEC_ENDPOINTS } from '@datadog/browser-core/test'
+import { registerCleanupTask, mockClock, buildLocation, SPEC_ENDPOINTS } from '@datadog/browser-core/test'
 import type { LocationChange } from '../src/browser/locationChangeObservable'
 import type { RumConfiguration } from '../src/domain/configuration'
 import { validateAndBuildRumConfiguration } from '../src/domain/configuration'
@@ -227,6 +227,7 @@ export function setup(): TestSetupBuilder {
       rawRumEventsCollected.unsubscribe()
     },
   }
+  registerCleanupTask(() => setupBuilder.cleanup())
   return setupBuilder
 }
 

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -53,7 +53,6 @@ describe('makeRecorderApi', () => {
   })
 
   afterEach(() => {
-    setupBuilder.cleanup()
     resetDeflateWorkerState()
     replayStats.resetReplayStats()
   })

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -78,7 +78,6 @@ describe('startRecording', () => {
 
   afterEach(() => {
     setSegmentBytesLimit()
-    setupBuilder.cleanup()
     clock?.cleanup()
     resetDeflateWorkerState()
   })


### PR DESCRIPTION
## Motivation

Remove some cleanup code

## Changes

- registerCleanupTask at testBuilder setup
- remove existing setupBuilder.cleanup calls

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
