### PR TITLE
⚗️[RUM-2889] Bootstrap custom vital APIs

### DIFF
--- a/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
+++ b/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
@@ -11,6 +11,7 @@ import type {
   RumLongTaskEvent,
   RumResourceEvent,
   RumViewEvent,
+  RumVitalEvent,
 } from '../../../../../../packages/rum-core/src/rumEvent.types'
 import type { SdkEvent } from '../../../sdkEvent'
 import { isTelemetryEvent, isLogEvent, isRumEvent } from '../../../sdkEvent'
@@ -32,6 +33,7 @@ const RUM_EVENT_TYPE_COLOR = {
   view: 'blue',
   resource: 'cyan',
   telemetry: 'teal',
+  vital: 'orange',
 }
 
 const LOG_STATUS_COLOR = {
@@ -260,6 +262,8 @@ export const EventDescription = React.memo(({ event }: { event: SdkEvent }) => {
         return <ResourceDescription event={event} />
       case 'action':
         return <ActionDescription event={event} />
+      case 'vital':
+        return <VitalDescription event={event} />
     }
   } else if (isLogEvent(event)) {
     return <LogDescription event={event} />
@@ -318,6 +322,17 @@ function LongTaskDescription({ event }: { event: RumLongTaskEvent }) {
   return (
     <>
       Long task of <Emphasis>{formatDuration(event.long_task.duration)}</Emphasis>
+    </>
+  )
+}
+
+function VitalDescription({ event }: { event: RumVitalEvent }) {
+  const vitalName = Object.keys(event.vital.custom!)[0]
+  const vitalValue = event.vital.custom![vitalName]
+  return (
+    <>
+      Custom <Emphasis>{event.vital.type}</Emphasis> vital: <Emphasis>{vitalName}</Emphasis> of{' '}
+      <Emphasis>{vitalValue}</Emphasis>
     </>
   )
 }

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,6 +18,7 @@ export enum ExperimentalFeature {
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
+  CUSTOM_VITALS = 'custom_vitals',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -486,5 +486,29 @@ describe('preStartRum', () => {
       strategy.init(DEFAULT_INIT_CONFIGURATION)
       expect(addFeatureFlagEvaluationSpy).toHaveBeenCalledOnceWith(key, value)
     })
+
+    it('startDurationVital', () => {
+      const startDurationVitalSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        startDurationVital: startDurationVitalSpy,
+      } as unknown as StartRumResult)
+
+      const vitalStart = { name: 'timing', startClocks: clocksNow() }
+      strategy.startDurationVital(vitalStart)
+      strategy.init(DEFAULT_INIT_CONFIGURATION)
+      expect(startDurationVitalSpy).toHaveBeenCalledOnceWith(vitalStart)
+    })
+
+    it('stopDurationVital', () => {
+      const stopDurationVitalSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        stopDurationVital: stopDurationVitalSpy,
+      } as unknown as StartRumResult)
+
+      const vitalStop = { name: 'timing', stopClocks: clocksNow() }
+      strategy.stopDurationVital(vitalStop)
+      strategy.init(DEFAULT_INIT_CONFIGURATION)
+      expect(stopDurationVitalSpy).toHaveBeenCalledOnceWith(vitalStop)
+    })
   })
 })

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -157,6 +157,14 @@ export function createPreStartStrategy(
     addFeatureFlagEvaluation(key, value) {
       bufferApiCalls.add((startRumResult) => startRumResult.addFeatureFlagEvaluation(key, value))
     },
+
+    startDurationVital(vitalStart) {
+      bufferApiCalls.add((startRumResult) => startRumResult.startDurationVital(vitalStart))
+    },
+
+    stopDurationVital(vitalStart) {
+      bufferApiCalls.add((startRumResult) => startRumResult.stopDurationVital(vitalStart))
+    },
   }
 }
 

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -44,6 +44,7 @@ import { startCustomerDataTelemetry } from '../domain/startCustomerDataTelemetry
 import { startPageStateHistory } from '../domain/contexts/pageStateHistory'
 import type { CommonContext } from '../domain/contexts/commonContext'
 import { startDisplayContext } from '../domain/contexts/displayContext'
+import { startVitalCollection } from '../domain/vital/vitalCollection'
 import type { RecorderApi } from './rumPublicApi'
 
 export type StartRum = typeof startRum
@@ -161,6 +162,7 @@ export function startRum(
   const { stop: stopPerformanceCollection } = startPerformanceCollection(lifeCycle, configuration)
   cleanupTasks.push(stopPerformanceCollection)
 
+  const vitalCollection = startVitalCollection(lifeCycle)
   const internalContext = startInternalContext(
     configuration.applicationId,
     session,
@@ -180,6 +182,8 @@ export function startRum(
     session,
     stopSession: () => session.expire(),
     getInternalContext: internalContext.get,
+    startDurationVital: vitalCollection.startDurationVital,
+    stopDurationVital: vitalCollection.stopDurationVital,
     stop: () => {
       cleanupTasks.forEach((task) => task())
     },

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -101,6 +101,7 @@ export function startRumAssembly(
       VIEW_MODIFIABLE_FIELD_PATHS
     ),
     [RumEventType.LONG_TASK]: assign({}, USER_CUSTOMIZABLE_FIELD_PATHS, VIEW_MODIFIABLE_FIELD_PATHS),
+    [RumEventType.VITAL]: assign({}, USER_CUSTOMIZABLE_FIELD_PATHS, VIEW_MODIFIABLE_FIELD_PATHS),
   }
   const eventRateLimiters = {
     [RumEventType.ERROR]: createEventRateLimiter(

--- a/packages/rum-core/src/domain/trackEventCounts.spec.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.spec.ts
@@ -27,11 +27,12 @@ describe('trackEventCounts', () => {
     notifyCollectedRawRumEvent({ type: RumEventType.LONG_TASK })
     expect(eventCounts.longTaskCount).toBe(1)
   })
-
-  it("doesn't track views", () => {
-    const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
-    notifyCollectedRawRumEvent({ type: RumEventType.VIEW })
-    expect(objectValues(eventCounts as unknown as { [key: string]: number }).every((value) => value === 0)).toBe(true)
+  ;[RumEventType.VIEW, RumEventType.VITAL].forEach((eventType) => {
+    it(`doesn't track ${eventType} events`, () => {
+      const { eventCounts } = trackEventCounts({ lifeCycle, isChildEvent: () => true })
+      notifyCollectedRawRumEvent({ type: eventType })
+      expect(objectValues(eventCounts as unknown as { [key: string]: number }).every((value) => value === 0)).toBe(true)
+    })
   })
 
   it('tracks actions', () => {

--- a/packages/rum-core/src/domain/trackEventCounts.ts
+++ b/packages/rum-core/src/domain/trackEventCounts.ts
@@ -30,7 +30,7 @@ export function trackEventCounts({
   }
 
   const subscription = lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event): void => {
-    if (event.type === 'view' || !isChildEvent(event)) {
+    if (event.type === 'view' || event.type === 'vital' || !isChildEvent(event)) {
       return
     }
     switch (event.type) {

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -1,0 +1,98 @@
+import { clocksNow } from '@datadog/browser-core'
+import type { TestSetupBuilder } from '../../../test'
+import { setup } from '../../../test'
+import type { RawRumVitalEvent } from '../../rawRumEvent.types'
+import { VitalType, RumEventType } from '../../rawRumEvent.types'
+import { startVitalCollection } from './vitalCollection'
+
+describe('vitalCollection', () => {
+  let setupBuilder: TestSetupBuilder
+  let vitalCollection: ReturnType<typeof startVitalCollection>
+
+  beforeEach(() => {
+    setupBuilder = setup()
+      .withFakeClock()
+      .beforeBuild(({ lifeCycle }) => {
+        vitalCollection = startVitalCollection(lifeCycle)
+      })
+  })
+
+  describe('custom duration', () => {
+    it('should create duration vital from start/stop API', () => {
+      const { rawRumEvents, clock } = setupBuilder.build()
+
+      vitalCollection.startDurationVital({ name: 'foo', startClocks: clocksNow() })
+      clock.tick(100)
+      vitalCollection.stopDurationVital({ name: 'foo', stopClocks: clocksNow() })
+
+      expect(rawRumEvents.length).toBe(1)
+      expect((rawRumEvents[0].rawRumEvent as RawRumVitalEvent).vital.custom.foo).toBe(100)
+    })
+
+    it('should not create duration vital without calling the stop API', () => {
+      const { rawRumEvents } = setupBuilder.build()
+
+      vitalCollection.startDurationVital({ name: 'foo', startClocks: clocksNow() })
+
+      expect(rawRumEvents.length).toBe(0)
+    })
+
+    it('should not create duration vital without calling the start API', () => {
+      const { rawRumEvents } = setupBuilder.build()
+
+      vitalCollection.stopDurationVital({ name: 'foo', stopClocks: clocksNow() })
+
+      expect(rawRumEvents.length).toBe(0)
+    })
+
+    it('should create multiple duration vitals from start/stop API', () => {
+      const { rawRumEvents, clock } = setupBuilder.build()
+
+      vitalCollection.startDurationVital({ name: 'foo', startClocks: clocksNow() })
+      clock.tick(100)
+      vitalCollection.startDurationVital({ name: 'bar', startClocks: clocksNow() })
+      clock.tick(100)
+      vitalCollection.stopDurationVital({ name: 'bar', stopClocks: clocksNow() })
+      clock.tick(100)
+      vitalCollection.stopDurationVital({ name: 'foo', stopClocks: clocksNow() })
+
+      expect(rawRumEvents.length).toBe(2)
+      expect((rawRumEvents[0].rawRumEvent as RawRumVitalEvent).vital.custom.bar).toBe(100)
+      expect((rawRumEvents[1].rawRumEvent as RawRumVitalEvent).vital.custom.foo).toBe(300)
+    })
+
+    it('should discard a previous start with the same name', () => {
+      const { rawRumEvents, clock } = setupBuilder.build()
+
+      vitalCollection.startDurationVital({ name: 'foo', startClocks: clocksNow() })
+      clock.tick(100)
+      vitalCollection.startDurationVital({ name: 'foo', startClocks: clocksNow() })
+      clock.tick(100)
+      vitalCollection.stopDurationVital({ name: 'foo', stopClocks: clocksNow() })
+
+      expect(rawRumEvents.length).toBe(1)
+      expect((rawRumEvents[0].rawRumEvent as RawRumVitalEvent).vital.custom.foo).toBe(100)
+    })
+  })
+
+  it('should collect raw rum event from duration vital', () => {
+    const { rawRumEvents } = setupBuilder.build()
+
+    vitalCollection.startDurationVital({ name: 'foo', startClocks: clocksNow() })
+    vitalCollection.stopDurationVital({ name: 'foo', stopClocks: clocksNow() })
+
+    expect(rawRumEvents[0].startTime).toEqual(jasmine.any(Number))
+    expect(rawRumEvents[0].rawRumEvent).toEqual({
+      date: jasmine.any(Number),
+      vital: {
+        id: jasmine.any(String),
+        type: VitalType.DURATION,
+        custom: {
+          foo: 0,
+        },
+      },
+      type: RumEventType.VITAL,
+    })
+    expect(rawRumEvents[0].domainContext).toEqual({})
+  })
+})

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -1,4 +1,4 @@
-import type { ClocksState } from '@datadog/browser-core'
+import type { ClocksState, Duration } from '@datadog/browser-core'
 import { elapsed, generateUUID } from '@datadog/browser-core'
 import { LifeCycleEventType } from '../lifeCycle'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
@@ -15,11 +15,11 @@ export interface DurationVitalStop {
   stopClocks: ClocksState
 }
 
-interface Vital {
+interface DurationVital {
   name: string
-  type: VitalType
+  type: VitalType.DURATION
   startClocks: ClocksState
-  value: number
+  value: Duration
 }
 
 export function startVitalCollection(lifeCycle: LifeCycle) {
@@ -44,7 +44,7 @@ export function startVitalCollection(lifeCycle: LifeCycle) {
   }
 }
 
-function processVital(vital: Vital): RawRumEventCollectedData<RawRumVitalEvent> {
+function processVital(vital: DurationVital): RawRumEventCollectedData<RawRumVitalEvent> {
   return {
     rawRumEvent: {
       date: vital.startClocks.timeStamp,

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -1,5 +1,9 @@
 import type { ClocksState } from '@datadog/browser-core'
-import type { LifeCycle } from '../lifeCycle'
+import { elapsed, generateUUID } from '@datadog/browser-core'
+import { LifeCycleEventType } from '../lifeCycle'
+import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
+import type { RawRumVitalEvent } from '../../rawRumEvent.types'
+import { RumEventType, VitalType } from '../../rawRumEvent.types'
 
 export interface DurationVitalStart {
   name: string
@@ -11,9 +15,49 @@ export interface DurationVitalStop {
   stopClocks: ClocksState
 }
 
-export function startVitalCollection(lifecycle: LifeCycle) {
+interface Vital {
+  name: string
+  type: VitalType
+  startClocks: ClocksState
+  value: number
+}
+
+export function startVitalCollection(lifeCycle: LifeCycle) {
+  const vitalStartsByName: { [name: string]: DurationVitalStart } = {}
   return {
-    startDurationVital: (vitalStart: DurationVitalStart) => {},
-    stopDurationVital: (vitalStop: DurationVitalStop) => {},
+    startDurationVital: (vitalStart: DurationVitalStart) => {
+      vitalStartsByName[vitalStart.name] = vitalStart
+    },
+    stopDurationVital: (vitalStop: DurationVitalStop) => {
+      const vitalStart = vitalStartsByName[vitalStop.name]
+      if (!vitalStart) {
+        return
+      }
+      const vital = {
+        name: vitalStart.name,
+        type: VitalType.DURATION,
+        startClocks: vitalStart.startClocks,
+        value: elapsed(vitalStart.startClocks.timeStamp, vitalStop.stopClocks.timeStamp),
+      }
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processVital(vital))
+    },
+  }
+}
+
+function processVital(vital: Vital): RawRumEventCollectedData<RawRumVitalEvent> {
+  return {
+    rawRumEvent: {
+      date: vital.startClocks.timeStamp,
+      vital: {
+        id: generateUUID(),
+        type: vital.type,
+        custom: {
+          [vital.name]: vital.value,
+        },
+      },
+      type: RumEventType.VITAL,
+    },
+    startTime: vital.startClocks.relative,
+    domainContext: {},
   }
 }

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -1,0 +1,19 @@
+import type { ClocksState } from '@datadog/browser-core'
+import type { LifeCycle } from '../lifeCycle'
+
+export interface DurationVitalStart {
+  name: string
+  startClocks: ClocksState
+}
+
+export interface DurationVitalStop {
+  name: string
+  stopClocks: ClocksState
+}
+
+export function startVitalCollection(lifecycle: LifeCycle) {
+  return {
+    startDurationVital: (vitalStart: DurationVitalStart) => {},
+    stopDurationVital: (vitalStop: DurationVitalStop) => {},
+  }
+}

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -23,13 +23,13 @@ interface Vital {
 }
 
 export function startVitalCollection(lifeCycle: LifeCycle) {
-  const vitalStartsByName: { [name: string]: DurationVitalStart } = {}
+  const vitalStartsByName = new Map<string, DurationVitalStart>()
   return {
     startDurationVital: (vitalStart: DurationVitalStart) => {
-      vitalStartsByName[vitalStart.name] = vitalStart
+      vitalStartsByName.set(vitalStart.name, vitalStart)
     },
     stopDurationVital: (vitalStop: DurationVitalStop) => {
-      const vitalStart = vitalStartsByName[vitalStop.name]
+      const vitalStart = vitalStartsByName.get(vitalStop.name)
       if (!vitalStart) {
         return
       }

--- a/packages/rum-core/src/domainContext.types.ts
+++ b/packages/rum-core/src/domainContext.types.ts
@@ -14,7 +14,9 @@ export type RumEventDomainContext<T extends RumEventType = any> = T extends RumE
         ? RumErrorEventDomainContext
         : T extends RumEventType.LONG_TASK
           ? RumLongTaskEventDomainContext
-          : never
+          : T extends RumEventType.VITAL
+            ? RumVitalEventDomainContext
+            : never
 
 export interface RumViewEventDomainContext {
   location: Readonly<Location>
@@ -48,3 +50,5 @@ export interface RumErrorEventDomainContext {
 export interface RumLongTaskEventDomainContext {
   performanceEntry: PerformanceEntry
 }
+
+export interface RumVitalEventDomainContext {}

--- a/packages/rum-core/src/index.ts
+++ b/packages/rum-core/src/index.ts
@@ -8,6 +8,7 @@ export {
   RumViewEvent,
   RumResourceEvent,
   RumLongTaskEvent,
+  RumVitalEvent,
 } from './rumEvent.types'
 export {
   RumLongTaskEventDomainContext,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -18,6 +18,7 @@ export const enum RumEventType {
   LONG_TASK = 'long_task',
   VIEW = 'view',
   RESOURCE = 'resource',
+  VITAL = 'vital',
 }
 
 export interface RawRumResourceEvent {
@@ -215,12 +216,29 @@ export const enum FrustrationType {
   DEAD_CLICK = 'dead_click',
 }
 
+export interface RawRumVitalEvent {
+  date: TimeStamp
+  type: RumEventType.VITAL
+  vital: {
+    id: string
+    type: VitalType
+    custom: {
+      [key: string]: number
+    }
+  }
+}
+
+export const enum VitalType {
+  DURATION = 'duration',
+}
+
 export type RawRumEvent =
   | RawRumErrorEvent
   | RawRumResourceEvent
   | RawRumViewEvent
   | RawRumLongTaskEvent
   | RawRumActionEvent
+  | RawRumVitalEvent
 
 export interface RumContext {
   date: TimeStamp

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -6,7 +6,13 @@
 /**
  * Schema of all properties of a RUM event
  */
-export type RumEvent = RumActionEvent | RumErrorEvent | RumLongTaskEvent | RumResourceEvent | RumViewEvent
+export type RumEvent =
+  | RumActionEvent
+  | RumErrorEvent
+  | RumLongTaskEvent
+  | RumResourceEvent
+  | RumViewEvent
+  | RumVitalEvent
 /**
  * Schema of all properties of an Action event
  */
@@ -233,7 +239,7 @@ export type RumErrorEvent = CommonProperties &
         /**
          * HTTP method of the resource
          */
-        readonly method: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH'
+        readonly method: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE' | 'OPTIONS' | 'CONNECT'
         /**
          * HTTP Status code of the resource
          */
@@ -274,6 +280,96 @@ export type RumErrorEvent = CommonProperties &
             | 'video'
           [k: string]: unknown
         }
+        [k: string]: unknown
+      }
+      /**
+       * Description of each thread in the process when error happened.
+       */
+      threads?: {
+        /**
+         * Name of the thread (e.g. 'Thread 0').
+         */
+        readonly name: string
+        /**
+         * Tells if the thread crashed.
+         */
+        readonly crashed: boolean
+        /**
+         * Unsymbolicated stack trace of the given thread.
+         */
+        readonly stack: string
+        /**
+         * Platform-specific state of the thread when its state was captured (CPU registers dump for iOS, thread state enum for Android, etc.).
+         */
+        readonly state?: string
+        [k: string]: unknown
+      }[]
+      /**
+       * Description of each binary image (native libraries; for Android: .so files) loaded or referenced by the process/application.
+       */
+      readonly binary_images?: {
+        /**
+         * Build UUID that uniquely identifies the binary image.
+         */
+        readonly uuid: string
+        /**
+         * Name of the library.
+         */
+        readonly name: string
+        /**
+         * Determines if it's a system or user library.
+         */
+        readonly is_system: boolean
+        /**
+         * Library's load address (hexadecimal).
+         */
+        readonly load_address?: string
+        /**
+         * Max value from the library address range (hexadecimal).
+         */
+        readonly max_address?: string
+        /**
+         * CPU architecture from the library.
+         */
+        readonly arch?: string
+        [k: string]: unknown
+      }[]
+      /**
+       * A boolean value saying if any of the stack traces was truncated due to minification.
+       */
+      readonly was_truncated?: boolean
+      /**
+       * Platform-specific metadata of the error event.
+       */
+      readonly meta?: {
+        /**
+         * The CPU architecture of the process that crashed.
+         */
+        readonly code_type?: string
+        /**
+         * Parent process information.
+         */
+        readonly parent_process?: string
+        /**
+         * A client-generated 16-byte UUID of the incident.
+         */
+        readonly incident_identifier?: string
+        /**
+         * The name of the crashed process.
+         */
+        readonly process?: string
+        /**
+         * The name of the corresponding BSD termination signal. (in case of iOS crash)
+         */
+        readonly exception_type?: string
+        /**
+         * CPU specific information about the exception encoded into 64-bit hexadecimal number preceded by the signal code.
+         */
+        readonly exception_codes?: string
+        /**
+         * The location of the executable.
+         */
+        readonly path?: string
         [k: string]: unknown
       }
       [k: string]: unknown
@@ -372,7 +468,7 @@ export type RumResourceEvent = CommonProperties &
       /**
        * HTTP method of the resource
        */
-      readonly method?: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH'
+      readonly method?: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH' | 'TRACE' | 'OPTIONS' | 'CONNECT'
       /**
        * URL of the resource
        */
@@ -889,6 +985,37 @@ export type RumViewEvent = CommonProperties &
          */
         readonly max_scroll_height_time: number
         [k: string]: unknown
+      }
+      [k: string]: unknown
+    }
+    [k: string]: unknown
+  }
+/**
+ * Schema of all properties of a Vital event
+ */
+export type RumVitalEvent = CommonProperties &
+  ViewContainerSchema & {
+    /**
+     * RUM event type
+     */
+    readonly type: 'vital'
+    /**
+     * Vital properties
+     */
+    readonly vital: {
+      /**
+       * Type of the vital
+       */
+      readonly type: 'duration'
+      /**
+       * UUID of the vital
+       */
+      readonly id: string
+      /**
+       * User custom vital. As vital name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
+       */
+      readonly custom?: {
+        [k: string]: number
       }
       [k: string]: unknown
     }

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -8,7 +8,6 @@ import {
   relativeNow,
   ResourceType,
 } from '@datadog/browser-core'
-import { RumPerformanceEntryType } from '../src/browser/performanceCollection'
 import type {
   RumFirstInputTiming,
   RumLargestContentfulPaintTiming,
@@ -19,8 +18,9 @@ import type {
   RumPerformancePaintTiming,
   RumPerformanceResourceTiming,
 } from '../src/browser/performanceCollection'
+import { RumPerformanceEntryType } from '../src/browser/performanceCollection'
 import type { RawRumEvent } from '../src/rawRumEvent.types'
-import { ActionType, RumEventType, ViewLoadingType } from '../src/rawRumEvent.types'
+import { VitalType, ActionType, RumEventType, ViewLoadingType } from '../src/rawRumEvent.types'
 
 export function createRawRumEvent(type: RumEventType, overrides?: Context): RawRumEvent {
   switch (type) {
@@ -36,6 +36,21 @@ export function createRawRumEvent(type: RumEventType, overrides?: Context): RawR
             type: ActionType.CUSTOM,
           },
           date: 0 as TimeStamp,
+        },
+        overrides
+      )
+    case RumEventType.VITAL:
+      return combine(
+        {
+          type,
+          date: 0 as TimeStamp,
+          vital: {
+            id: generateUUID(),
+            type: VitalType.DURATION,
+            custom: {
+              timing: 0 as ServerDuration,
+            },
+          },
         },
         overrides
       )

--- a/packages/rum/src/entries/main.ts
+++ b/packages/rum/src/entries/main.ts
@@ -18,6 +18,7 @@ export {
   RumLongTaskEvent,
   RumResourceEvent,
   RumViewEvent,
+  RumVitalEvent,
   // Events context
   RumEventDomainContext,
   RumViewEventDomainContext,

--- a/test/e2e/lib/framework/intakeRegistry.ts
+++ b/test/e2e/lib/framework/intakeRegistry.ts
@@ -1,5 +1,12 @@
 import type { LogsEvent } from '@datadog/browser-logs'
-import type { RumEvent, RumActionEvent, RumErrorEvent, RumResourceEvent, RumViewEvent } from '@datadog/browser-rum'
+import type {
+  RumEvent,
+  RumActionEvent,
+  RumErrorEvent,
+  RumResourceEvent,
+  RumViewEvent,
+  RumVitalEvent,
+} from '@datadog/browser-rum'
 import type { TelemetryEvent, TelemetryErrorEvent, TelemetryConfigurationEvent } from '@datadog/browser-core'
 import type { BrowserSegment } from '@datadog/browser-rum/src/types'
 import type { BrowserSegmentMetadataAndSegmentSizes } from '@datadog/browser-rum/src/domain/segmentCollection'
@@ -94,6 +101,10 @@ export class IntakeRegistry {
     return this.rumEvents.filter(isRumViewEvent)
   }
 
+  get rumVitalEvents() {
+    return this.rumEvents.filter(isRumVitalEvent)
+  }
+
   //
   // Telemetry
   //
@@ -153,6 +164,10 @@ function isRumViewEvent(event: RumEvent): event is RumViewEvent {
 
 function isRumErrorEvent(event: RumEvent): event is RumErrorEvent {
   return event.type === 'error'
+}
+
+function isRumVitalEvent(event: RumEvent): event is RumVitalEvent {
+  return event.type === 'vital'
 }
 
 function isTelemetryEvent(event: RumEvent | TelemetryEvent): event is TelemetryEvent {

--- a/test/e2e/scenario/rum/vitals.scenario.ts
+++ b/test/e2e/scenario/rum/vitals.scenario.ts
@@ -1,0 +1,26 @@
+import { createTest, flushEvents } from '../../lib/framework'
+import { browserExecuteAsync } from '../../lib/helpers/browser'
+
+describe('vital collection', () => {
+  createTest('send custom duration vital')
+    .withRum({
+      enableExperimentalFeatures: ['custom_vitals'],
+    })
+    .run(async ({ intakeRegistry }) => {
+      await browserExecuteAsync<void>((done) => {
+        // TODO remove cast and unsafe calls when removing the flag
+        const global = window.DD_RUM! as any
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        global.startDurationVital('foo')
+        setTimeout(() => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          global.stopDurationVital('foo')
+          done()
+        }, 5)
+      })
+      await flushEvents()
+
+      expect(intakeRegistry.rumVitalEvents.length).toBe(1)
+      expect(intakeRegistry.rumVitalEvents[0].vital.custom).toEqual({ foo: jasmine.any(Number) })
+    })
+})


### PR DESCRIPTION
## Motivation

Initial PR to provide APIs to track custom duration as vital events

## Changes

Behind `custom_vitals` flag, add APIs:

```js
DD_RUM.startDurationVital('foo')
// do some stuff
DD_RUM.stopDurationVital('foo')
```

and support the new event type across the code base:

![Screenshot 2024-02-05 at 15 17 25](https://github.com/DataDog/browser-sdk/assets/1331991/4e475776-8fd6-44cb-bdc5-799f82a24cdb)

**Note:** First PR with the simplest API, more features in following PRs (customer context, rate limiter, ...)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
