### PR TITLE
👷[RUM-3130] ignore karma-webpack updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
     open-pull-requests-limit: 0
     commit-message:
       prefix: '👷'
+    ignore:
+      # update karma-webpack: RUM-3130
+      - dependency-name: 'karma-webpack'


### PR DESCRIPTION
## Motivation

cf https://github.com/DataDog/browser-sdk/pull/2588, `karma-webpack` update is not working.

## Changes

Ignore update for now and revisit later

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
