### PR TITLE
test Report bundle sizes to logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ browserstack.err
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+.DS_Store
+.vscode/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,6 +136,7 @@ build-and-lint:
     - .test-allowed-branches
   interruptible: true
   script:
+    - echo "Target branch: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,7 @@ build-and-lint:
     - .test-allowed-branches
   interruptible: true
   script:
-    - echo "Target branch: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+    - echo ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,10 +135,7 @@ build-and-lint:
     - .base-configuration
     - .test-allowed-branches
   interruptible: true
-  only:
-    - merge_requests
   script:
-    - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,6 +135,9 @@ build-and-lint:
     - .base-configuration
     - .test-allowed-branches
   interruptible: true
+  only:
+    - merge_requests
+    - branches
   script:
     - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,7 @@ build-and-lint:
     - .test-allowed-branches
   interruptible: true
   script:
-    - echo ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}
+    - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,7 +137,6 @@ build-and-lint:
   interruptible: true
   only:
     - merge_requests
-    - branches
   script:
     - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,6 +140,7 @@ build-and-lint:
     - yarn build
     - yarn lint
     - node scripts/check-packages.js
+    - node scripts/export-bundles-sizes.js
 
 build-bundle:
   extends:

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -31,7 +31,7 @@ runMain(async () => {
       },
       version: getVersion(),
       commit: getGitInformation('git rev-parse HEAD'),
-      branch: getGitInformation('git rev-parse --abbrev-ref HEAD'),
+      branch: process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null,
     },
   ]
   await postBundleSize(URL, logData)

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -30,14 +30,14 @@ runMain(async () => {
         worker: getBundleSize(workerPath),
       },
       version: getVersion(),
-      commit: getGitInformation('git rev-parse HEAD'),
-      branch: process.env.CI_MERGE_REQUEST_TARGET_BRANCH_NAME,
+      commit: executeGitCommand('git rev-parse HEAD'),
+      branch: process.env.CI_COMMIT_REF_NAME,
     },
   ]
   await postBundleSize(URL, logData)
 })
 
-function getGitInformation(command) {
+function executeGitCommand(command) {
   try {
     return execSync(command)
       .toString('utf8')

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -10,7 +10,7 @@ const rumSlimPath = path.join(__dirname, '../packages/rum-slim/bundle/datadog-ru
 const workerPath = path.join(__dirname, '../packages/worker/bundle/worker.js')
 const versionPath = path.join(__dirname, '../packages/rum/package.json')
 
-runMain(() => {
+runMain(async () => {
   const logData = [
     {
       message: 'Browser SDK bundles sizes',
@@ -27,7 +27,7 @@ runMain(() => {
       commit: getCommitId(),
     },
   ]
-  PostBundleSize(url, logData)
+  await postBundleSize(url, logData)
 })
 
 const getCommitId = () => childProcess.execSync('git rev-parse HEAD').toString().trim()
@@ -42,7 +42,7 @@ function getBundleSize(pathBundle) {
   return file.size
 }
 
-async function PostBundleSize(url = '', bundleData = {}) {
+async function postBundleSize(url = '', bundleData = {}) {
   const response = await fetch(url, {
     method: 'POST',
     headers: {

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -31,7 +31,7 @@ runMain(async () => {
       },
       version: getVersion(),
       commit: getGitInformation('git rev-parse HEAD'),
-      branch: process.env.GITHUB_HEAD_REF || (process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null),
+      branch: process.env.CI_MERGE_REQUEST_TARGET_BRANCH_NAME,
     },
   ]
   await postBundleSize(URL, logData)

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -1,0 +1,55 @@
+const fs = require('fs')
+const path = require('path')
+const childProcess = require('child_process')
+const { getOrg2ApiKey } = require('./lib/secrets')
+const { runMain } = require('./lib/execution-utils')
+const url = 'https://http-intake.logs.datadoghq.com/api/v2/logs'
+const rumPath = path.join(__dirname, '../packages/rum/bundle/datadog-rum.js')
+const logsPath = path.join(__dirname, '../packages/logs/bundle/datadog-logs.js')
+const rumSlimPath = path.join(__dirname, '../packages/rum-slim/bundle/datadog-rum-slim.js')
+const workerPath = path.join(__dirname, '../packages/worker/bundle/worker.js')
+const versionPath = path.join(__dirname, '../packages/rum/package.json')
+
+runMain(() => {
+  const logData = [
+    {
+      message: 'Browser SDK bundles sizes',
+      service: 'browser-sdk',
+      env: 'ci',
+      bundle_sizes: {
+        rum: getBundleSize(rumPath),
+        logs: getBundleSize(logsPath),
+        rum_slim: getBundleSize(rumSlimPath),
+        worker: getBundleSize(workerPath),
+      },
+      version: getVersion(),
+      commit: getCommitId(),
+    },
+  ]
+  PostBundleSize(url, logData)
+})
+
+const getCommitId = () => childProcess.execSync('git rev-parse HEAD').toString().trim()
+
+function getVersion() {
+  const versionJson = fs.readFileSync(versionPath, 'utf8')
+  return JSON.parse(versionJson).version
+}
+
+function getBundleSize(pathBundle) {
+  const file = fs.statSync(pathBundle)
+  return file.size
+}
+
+function PostBundleSize(url = '', bundleData = {}) {
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'DD-API-KEY': getOrg2ApiKey(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(bundleData),
+  }).catch((error) => {
+    throw new Error(`Fetch request failed: ${error.message}`)
+  })
+}

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -31,7 +31,7 @@ runMain(async () => {
       },
       version: getVersion(),
       commit: getGitInformation('git rev-parse HEAD'),
-      branch: process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null,
+      branch: process.env.GITHUB_HEAD_REF || (process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null),
     },
   ]
   await postBundleSize(URL, logData)

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -15,6 +15,7 @@ runMain(() => {
     {
       message: 'Browser SDK bundles sizes',
       service: 'browser-sdk',
+      ddsource: 'browser-sdk',
       env: 'ci',
       bundle_sizes: {
         rum: getBundleSize(rumPath),
@@ -41,15 +42,14 @@ function getBundleSize(pathBundle) {
   return file.size
 }
 
-function PostBundleSize(url = '', bundleData = {}) {
-  fetch(url, {
+async function PostBundleSize(url = '', bundleData = {}) {
+  const response = await fetch(url, {
     method: 'POST',
     headers: {
       'DD-API-KEY': getOrg2ApiKey(),
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(bundleData),
-  }).catch((error) => {
-    throw new Error(`Fetch request failed: ${error.message}`)
   })
+  console.log(await response.text())
 }

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -1,14 +1,20 @@
 const fs = require('fs')
 const path = require('path')
-const childProcess = require('child_process')
+const { execSync } = require('child_process')
 const { getOrg2ApiKey } = require('./lib/secrets')
-const { runMain } = require('./lib/execution-utils')
-const url = 'https://http-intake.logs.datadoghq.com/api/v2/logs'
+const { runMain, fetch: fetchWrapper } = require('./lib/execution-utils')
+
 const rumPath = path.join(__dirname, '../packages/rum/bundle/datadog-rum.js')
 const logsPath = path.join(__dirname, '../packages/logs/bundle/datadog-logs.js')
 const rumSlimPath = path.join(__dirname, '../packages/rum-slim/bundle/datadog-rum-slim.js')
 const workerPath = path.join(__dirname, '../packages/worker/bundle/worker.js')
 const versionPath = path.join(__dirname, '../packages/rum/package.json')
+
+const URL = 'https://http-intake.logs.datadoghq.com/api/v2/logs'
+const HEADERS = {
+  'DD-API-KEY': getOrg2ApiKey(),
+  'Content-Type': 'application/json',
+}
 
 runMain(async () => {
   const logData = [
@@ -24,32 +30,48 @@ runMain(async () => {
         worker: getBundleSize(workerPath),
       },
       version: getVersion(),
-      commit: getCommitId(),
+      commit: getGitInformation('git rev-parse HEAD'),
+      branch: getGitInformation('git rev-parse --abbrev-ref HEAD'),
     },
   ]
-  await postBundleSize(url, logData)
+  await postBundleSize(URL, logData)
 })
 
-const getCommitId = () => childProcess.execSync('git rev-parse HEAD').toString().trim()
+function getGitInformation(command) {
+  try {
+    return execSync(command)
+      .toString('utf8')
+      .replace(/[\n\r\s]+$/, '')
+  } catch (error) {
+    console.error('Failed to execute git command:', error)
+    return null
+  }
+}
 
 function getVersion() {
-  const versionJson = fs.readFileSync(versionPath, 'utf8')
-  return JSON.parse(versionJson).version
+  try {
+    const versionJson = fs.readFileSync(versionPath, 'utf8')
+    return JSON.parse(versionJson).version
+  } catch (error) {
+    console.error('Failed to get version:', error)
+    return null
+  }
 }
 
 function getBundleSize(pathBundle) {
-  const file = fs.statSync(pathBundle)
-  return file.size
+  try {
+    const file = fs.statSync(pathBundle)
+    return file.size
+  } catch (error) {
+    console.error('Failed to get bundle size:', error)
+    return null
+  }
 }
 
 async function postBundleSize(url = '', bundleData = {}) {
-  const response = await fetch(url, {
+  await fetchWrapper(url, {
     method: 'POST',
-    headers: {
-      'DD-API-KEY': getOrg2ApiKey(),
-      'Content-Type': 'application/json',
-    },
+    headers: HEADERS,
     body: JSON.stringify(bundleData),
   })
-  console.log(await response.text())
 }


### PR DESCRIPTION
## Motivation

To send bundle sizes to logs and check the evolution with dashboard.

## Changes

Added a script to retrieve git commit Id, version and bundle size then send them to logs with fetch request.
<img width="506" alt="image" src="https://github.com/DataDog/browser-sdk/assets/158156364/ef969a24-f98f-483e-87a6-faf3713f19a6">


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] CI
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
