### PR TITLE
🔧 ignore karma-webpack for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# Note: While we mainly use Renovate, Dependabot is used for security updates
+
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["karma-webpack"]
     }
   ]
 }


### PR DESCRIPTION


## Motivation

karma-webpack introduced a breaking change in v5.0.1 that breaks our test suite: https://github.com/codymikol/karma-webpack/issues/587

## Changes

Ignore karma-webpack in renovate (for dependabot, it was done in https://github.com/DataDog/browser-sdk/pull/2592 )

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
