### PR TITLE
✨[RUM-3151] Report bundle sizes to logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,3 @@ browserstack.err
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-
-.DS_Store
-.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ browserstack.err
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+.DS_Store
+.vscode/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,6 +136,7 @@ build-and-lint:
     - .test-allowed-branches
   interruptible: true
   script:
+    - echo "Target branch: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,7 @@ build-and-lint:
     - .test-allowed-branches
   interruptible: true
   script:
-    - echo "Target branch: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+    - echo ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,10 +135,7 @@ build-and-lint:
     - .base-configuration
     - .test-allowed-branches
   interruptible: true
-  only:
-    - merge_requests
   script:
-    - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,6 +135,9 @@ build-and-lint:
     - .base-configuration
     - .test-allowed-branches
   interruptible: true
+  only:
+    - merge_requests
+    - branches
   script:
     - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,7 @@ build-and-lint:
     - .test-allowed-branches
   interruptible: true
   script:
-    - echo ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}
+    - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn
     - yarn build
     - yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,7 +137,6 @@ build-and-lint:
   interruptible: true
   only:
     - merge_requests
-    - branches
   script:
     - echo $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
     - yarn

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,6 +140,7 @@ build-and-lint:
     - yarn build
     - yarn lint
     - node scripts/check-packages.js
+    - node scripts/export-bundles-sizes.js
 
 build-bundle:
   extends:

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -31,7 +31,7 @@ runMain(async () => {
       },
       version: getVersion(),
       commit: getGitInformation('git rev-parse HEAD'),
-      branch: getGitInformation('git rev-parse --abbrev-ref HEAD'),
+      branch: process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null,
     },
   ]
   await postBundleSize(URL, logData)

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -30,14 +30,14 @@ runMain(async () => {
         worker: getBundleSize(workerPath),
       },
       version: getVersion(),
-      commit: getGitInformation('git rev-parse HEAD'),
-      branch: process.env.CI_MERGE_REQUEST_TARGET_BRANCH_NAME,
+      commit: executeGitCommand('git rev-parse HEAD'),
+      branch: process.env.CI_COMMIT_REF_NAME,
     },
   ]
   await postBundleSize(URL, logData)
 })
 
-function getGitInformation(command) {
+function executeGitCommand(command) {
   try {
     return execSync(command)
       .toString('utf8')

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -10,7 +10,7 @@ const rumSlimPath = path.join(__dirname, '../packages/rum-slim/bundle/datadog-ru
 const workerPath = path.join(__dirname, '../packages/worker/bundle/worker.js')
 const versionPath = path.join(__dirname, '../packages/rum/package.json')
 
-runMain(() => {
+runMain(async () => {
   const logData = [
     {
       message: 'Browser SDK bundles sizes',
@@ -27,7 +27,7 @@ runMain(() => {
       commit: getCommitId(),
     },
   ]
-  PostBundleSize(url, logData)
+  await postBundleSize(url, logData)
 })
 
 const getCommitId = () => childProcess.execSync('git rev-parse HEAD').toString().trim()
@@ -42,7 +42,7 @@ function getBundleSize(pathBundle) {
   return file.size
 }
 
-async function PostBundleSize(url = '', bundleData = {}) {
+async function postBundleSize(url = '', bundleData = {}) {
   const response = await fetch(url, {
     method: 'POST',
     headers: {

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -31,7 +31,7 @@ runMain(async () => {
       },
       version: getVersion(),
       commit: getGitInformation('git rev-parse HEAD'),
-      branch: process.env.GITHUB_HEAD_REF || (process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null),
+      branch: process.env.CI_MERGE_REQUEST_TARGET_BRANCH_NAME,
     },
   ]
   await postBundleSize(URL, logData)

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -1,0 +1,55 @@
+const fs = require('fs')
+const path = require('path')
+const childProcess = require('child_process')
+const { getOrg2ApiKey } = require('./lib/secrets')
+const { runMain } = require('./lib/execution-utils')
+const url = 'https://http-intake.logs.datadoghq.com/api/v2/logs'
+const rumPath = path.join(__dirname, '../packages/rum/bundle/datadog-rum.js')
+const logsPath = path.join(__dirname, '../packages/logs/bundle/datadog-logs.js')
+const rumSlimPath = path.join(__dirname, '../packages/rum-slim/bundle/datadog-rum-slim.js')
+const workerPath = path.join(__dirname, '../packages/worker/bundle/worker.js')
+const versionPath = path.join(__dirname, '../packages/rum/package.json')
+
+runMain(() => {
+  const logData = [
+    {
+      message: 'Browser SDK bundles sizes',
+      service: 'browser-sdk',
+      env: 'ci',
+      bundle_sizes: {
+        rum: getBundleSize(rumPath),
+        logs: getBundleSize(logsPath),
+        rum_slim: getBundleSize(rumSlimPath),
+        worker: getBundleSize(workerPath),
+      },
+      version: getVersion(),
+      commit: getCommitId(),
+    },
+  ]
+  PostBundleSize(url, logData)
+})
+
+const getCommitId = () => childProcess.execSync('git rev-parse HEAD').toString().trim()
+
+function getVersion() {
+  const versionJson = fs.readFileSync(versionPath, 'utf8')
+  return JSON.parse(versionJson).version
+}
+
+function getBundleSize(pathBundle) {
+  const file = fs.statSync(pathBundle)
+  return file.size
+}
+
+function PostBundleSize(url = '', bundleData = {}) {
+  fetch(url, {
+    method: 'POST',
+    headers: {
+      'DD-API-KEY': getOrg2ApiKey(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(bundleData),
+  }).catch((error) => {
+    throw new Error(`Fetch request failed: ${error.message}`)
+  })
+}

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { BrowserSdkVersion } = require('./lib/browser-sdk-version')
+const { browserSdkVersion } = require('./lib/browser-sdk-version')
 const { getOrg2ApiKey } = require('./lib/secrets')
 const { runMain, fetch } = require('./lib/execution-utils')
 
@@ -28,7 +28,7 @@ runMain(async () => {
         rum_slim: getBundleSize(rumSlimPath),
         worker: getBundleSize(workerPath),
       },
-      version: BrowserSdkVersion,
+      version: browserSdkVersion,
       commit: process.env.CI_COMMIT_SHORT_SHA,
       branch: process.env.CI_COMMIT_REF_NAME,
     },

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { getBrowserSdkVersion } = require('./lib/browser-sdk-version')
+const { BrowserSdkVersion } = require('./lib/browser-sdk-version')
 const { getOrg2ApiKey } = require('./lib/secrets')
 const { runMain, fetch } = require('./lib/execution-utils')
 
@@ -28,7 +28,7 @@ runMain(async () => {
         rum_slim: getBundleSize(rumSlimPath),
         worker: getBundleSize(workerPath),
       },
-      version: getBrowserSdkVersion,
+      version: BrowserSdkVersion,
       commit: process.env.CI_COMMIT_SHORT_SHA,
       branch: process.env.CI_COMMIT_REF_NAME,
     },

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -31,7 +31,7 @@ runMain(async () => {
       },
       version: getVersion(),
       commit: getGitInformation('git rev-parse HEAD'),
-      branch: process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null,
+      branch: process.env.GITHUB_HEAD_REF || (process.env.GITHUB_REF ? process.env.GITHUB_REF.split('/').pop() : null),
     },
   ]
   await postBundleSize(URL, logData)

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -15,6 +15,7 @@ runMain(() => {
     {
       message: 'Browser SDK bundles sizes',
       service: 'browser-sdk',
+      ddsource: 'browser-sdk',
       env: 'ci',
       bundle_sizes: {
         rum: getBundleSize(rumPath),
@@ -41,15 +42,14 @@ function getBundleSize(pathBundle) {
   return file.size
 }
 
-function PostBundleSize(url = '', bundleData = {}) {
-  fetch(url, {
+async function PostBundleSize(url = '', bundleData = {}) {
+  const response = await fetch(url, {
     method: 'POST',
     headers: {
       'DD-API-KEY': getOrg2ApiKey(),
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(bundleData),
-  }).catch((error) => {
-    throw new Error(`Fetch request failed: ${error.message}`)
   })
+  console.log(await response.text())
 }

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { execSync } = require('child_process')
-const lernaJson = require('../lerna.json')
+const { getBrowserSdkVersion } = require('./lib/browser-sdk-version')
 const { getOrg2ApiKey } = require('./lib/secrets')
 const { runMain, fetch: fetchWrapper } = require('./lib/execution-utils')
 
@@ -29,7 +28,7 @@ runMain(async () => {
         rum_slim: getBundleSize(rumSlimPath),
         worker: getBundleSize(workerPath),
       },
-      version: lernaJson.version,
+      version: getBrowserSdkVersion(),
       commit: process.env.CI_COMMIT_SHORT_SHA,
       branch: process.env.CI_COMMIT_REF_NAME,
     },

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const { getBrowserSdkVersion } = require('./lib/browser-sdk-version')
 const { getOrg2ApiKey } = require('./lib/secrets')
-const { runMain, fetch: fetchWrapper } = require('./lib/execution-utils')
+const { runMain, fetch } = require('./lib/execution-utils')
 
 const rumPath = path.join(__dirname, '../packages/rum/bundle/datadog-rum.js')
 const logsPath = path.join(__dirname, '../packages/logs/bundle/datadog-logs.js')
@@ -28,7 +28,7 @@ runMain(async () => {
         rum_slim: getBundleSize(rumSlimPath),
         worker: getBundleSize(workerPath),
       },
-      version: getBrowserSdkVersion(),
+      version: getBrowserSdkVersion,
       commit: process.env.CI_COMMIT_SHORT_SHA,
       branch: process.env.CI_COMMIT_REF_NAME,
     },
@@ -46,7 +46,7 @@ function getBundleSize(pathBundle) {
 }
 
 async function sendLogToOrg2(bundleData = {}) {
-  await fetchWrapper(LOG_INTAKE_URL, {
+  await fetch(LOG_INTAKE_URL, {
     method: 'POST',
     headers: LOG_INTAKE_REQUEST_HEADERS,
     body: JSON.stringify(bundleData),

--- a/scripts/export-bundles-sizes.js
+++ b/scripts/export-bundles-sizes.js
@@ -1,14 +1,20 @@
 const fs = require('fs')
 const path = require('path')
-const childProcess = require('child_process')
+const { execSync } = require('child_process')
 const { getOrg2ApiKey } = require('./lib/secrets')
-const { runMain } = require('./lib/execution-utils')
-const url = 'https://http-intake.logs.datadoghq.com/api/v2/logs'
+const { runMain, fetch: fetchWrapper } = require('./lib/execution-utils')
+
 const rumPath = path.join(__dirname, '../packages/rum/bundle/datadog-rum.js')
 const logsPath = path.join(__dirname, '../packages/logs/bundle/datadog-logs.js')
 const rumSlimPath = path.join(__dirname, '../packages/rum-slim/bundle/datadog-rum-slim.js')
 const workerPath = path.join(__dirname, '../packages/worker/bundle/worker.js')
 const versionPath = path.join(__dirname, '../packages/rum/package.json')
+
+const URL = 'https://http-intake.logs.datadoghq.com/api/v2/logs'
+const HEADERS = {
+  'DD-API-KEY': getOrg2ApiKey(),
+  'Content-Type': 'application/json',
+}
 
 runMain(async () => {
   const logData = [
@@ -24,32 +30,48 @@ runMain(async () => {
         worker: getBundleSize(workerPath),
       },
       version: getVersion(),
-      commit: getCommitId(),
+      commit: getGitInformation('git rev-parse HEAD'),
+      branch: getGitInformation('git rev-parse --abbrev-ref HEAD'),
     },
   ]
-  await postBundleSize(url, logData)
+  await postBundleSize(URL, logData)
 })
 
-const getCommitId = () => childProcess.execSync('git rev-parse HEAD').toString().trim()
+function getGitInformation(command) {
+  try {
+    return execSync(command)
+      .toString('utf8')
+      .replace(/[\n\r\s]+$/, '')
+  } catch (error) {
+    console.error('Failed to execute git command:', error)
+    return null
+  }
+}
 
 function getVersion() {
-  const versionJson = fs.readFileSync(versionPath, 'utf8')
-  return JSON.parse(versionJson).version
+  try {
+    const versionJson = fs.readFileSync(versionPath, 'utf8')
+    return JSON.parse(versionJson).version
+  } catch (error) {
+    console.error('Failed to get version:', error)
+    return null
+  }
 }
 
 function getBundleSize(pathBundle) {
-  const file = fs.statSync(pathBundle)
-  return file.size
+  try {
+    const file = fs.statSync(pathBundle)
+    return file.size
+  } catch (error) {
+    console.error('Failed to get bundle size:', error)
+    return null
+  }
 }
 
 async function postBundleSize(url = '', bundleData = {}) {
-  const response = await fetch(url, {
+  await fetchWrapper(url, {
     method: 'POST',
-    headers: {
-      'DD-API-KEY': getOrg2ApiKey(),
-      'Content-Type': 'application/json',
-    },
+    headers: HEADERS,
     body: JSON.stringify(bundleData),
   })
-  console.log(await response.text())
 }

--- a/scripts/lib/browser-sdk-version.js
+++ b/scripts/lib/browser-sdk-version.js
@@ -1,5 +1,5 @@
 const lernaJson = require('../../lerna.json')
 
 module.exports = {
-  BrowserSdkVersion: lernaJson.version,
+  browserSdkVersion: lernaJson.version,
 }

--- a/scripts/lib/browser-sdk-version.js
+++ b/scripts/lib/browser-sdk-version.js
@@ -1,9 +1,5 @@
 const lernaJson = require('../../lerna.json')
 
-function getBrowserSdkVersion() {
-  return lernaJson.version
-}
-
 module.exports = {
-  getBrowserSdkVersion,
+  getBrowserSdkVersion: lernaJson.version,
 }

--- a/scripts/lib/browser-sdk-version.js
+++ b/scripts/lib/browser-sdk-version.js
@@ -1,5 +1,5 @@
 const lernaJson = require('../../lerna.json')
 
 module.exports = {
-  getBrowserSdkVersion: lernaJson.version,
+  BrowserSdkVersion: lernaJson.version,
 }

--- a/scripts/lib/browser-sdk-version.js
+++ b/scripts/lib/browser-sdk-version.js
@@ -1,0 +1,9 @@
+const lernaJson = require('../../lerna.json')
+
+function getBrowserSdkVersion() {
+  return lernaJson.version
+}
+
+module.exports = {
+  getBrowserSdkVersion,
+}

--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -1,7 +1,7 @@
 const { readFileSync } = require('fs')
 const path = require('path')
 const execSync = require('child_process').execSync
-const { getBrowserSdkVersion } = require('./browser-sdk-version')
+const { BrowserSdkVersion } = require('./browser-sdk-version')
 const { command } = require('./command')
 
 /**
@@ -24,12 +24,12 @@ const buildEnvFactories = {
   SDK_VERSION: () => {
     switch (getBuildMode()) {
       case 'release':
-        return getBrowserSdkVersion
+        return BrowserSdkVersion
       case 'canary': {
         const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
         // TODO when tags would allow '+' characters
         //  use build separator (+) instead of prerelease separator (-)
-        return `${getBrowserSdkVersion}-${commitSha1}`
+        return `${BrowserSdkVersion}-${commitSha1}`
       }
       default:
         return 'dev'

--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -24,7 +24,7 @@ const buildEnvFactories = {
   SDK_VERSION: () => {
     switch (getBuildMode()) {
       case 'release':
-        return getBrowserSdkVersion()
+        return getBrowserSdkVersion
       case 'canary': {
         const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
         // TODO when tags would allow '+' characters

--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -29,7 +29,7 @@ const buildEnvFactories = {
         const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
         // TODO when tags would allow '+' characters
         //  use build separator (+) instead of prerelease separator (-)
-        return `${getBrowserSdkVersion()}-${commitSha1}`
+        return `${getBrowserSdkVersion}-${commitSha1}`
       }
       default:
         return 'dev'

--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -1,7 +1,7 @@
 const { readFileSync } = require('fs')
 const path = require('path')
 const execSync = require('child_process').execSync
-const { BrowserSdkVersion } = require('./browser-sdk-version')
+const { browserSdkVersion } = require('./browser-sdk-version')
 const { command } = require('./command')
 
 /**
@@ -24,12 +24,12 @@ const buildEnvFactories = {
   SDK_VERSION: () => {
     switch (getBuildMode()) {
       case 'release':
-        return BrowserSdkVersion
+        return browserSdkVersion
       case 'canary': {
         const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
         // TODO when tags would allow '+' characters
         //  use build separator (+) instead of prerelease separator (-)
-        return `${BrowserSdkVersion}-${commitSha1}`
+        return `${browserSdkVersion}-${commitSha1}`
       }
       default:
         return 'dev'

--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -1,7 +1,7 @@
 const { readFileSync } = require('fs')
 const path = require('path')
 const execSync = require('child_process').execSync
-const lernaJson = require('../../lerna.json')
+const { getBrowserSdkVersion } = require('./browser-sdk-version')
 const { command } = require('./command')
 
 /**
@@ -24,12 +24,12 @@ const buildEnvFactories = {
   SDK_VERSION: () => {
     switch (getBuildMode()) {
       case 'release':
-        return lernaJson.version
+        return getBrowserSdkVersion()
       case 'canary': {
         const commitSha1 = execSync('git rev-parse HEAD').toString().trim()
         // TODO when tags would allow '+' characters
         //  use build separator (+) instead of prerelease separator (-)
-        return `${lernaJson.version}-${commitSha1}`
+        return `${getBrowserSdkVersion()}-${commitSha1}`
       }
       default:
         return 'dev'

--- a/scripts/lib/execution-utils.js
+++ b/scripts/lib/execution-utils.js
@@ -27,6 +27,7 @@ function runMain(mainFunction) {
     .catch((error) => {
       printError('\nScript exited with error:')
       printError(error)
+      printError(error.cause)
       process.exit(1)
     })
 }

--- a/scripts/lib/execution-utils.js
+++ b/scripts/lib/execution-utils.js
@@ -26,8 +26,7 @@ function runMain(mainFunction) {
     .then(() => mainFunction())
     .catch((error) => {
       printError('\nScript exited with error:')
-      printError(error)
-      printError(error.cause)
+      printErrorWithCause(error)
       process.exit(1)
     })
 }
@@ -37,6 +36,14 @@ const resetColor = '\x1b[0m'
 function printError(...params) {
   const redColor = '\x1b[31;1m'
   console.log(redColor, ...params, resetColor)
+}
+
+function printErrorWithCause(error) {
+  printError(error)
+  if (error.cause) {
+    printError('Caused by:')
+    printErrorWithCause(error.cause)
+  }
 }
 
 function printLog(...params) {

--- a/scripts/release/generate-changelog.js
+++ b/scripts/release/generate-changelog.js
@@ -33,7 +33,7 @@ ${emojisLegend}
 
 ---
 
-## v${getBrowserSdkVersion()}
+## v${getBrowserSdkVersion}
 
 ${changesList}
 ${content.slice(content.indexOf('\n##'))}`

--- a/scripts/release/generate-changelog.js
+++ b/scripts/release/generate-changelog.js
@@ -5,7 +5,7 @@ const readFile = util.promisify(require('fs').readFile)
 
 const emojiNameMap = require('emoji-name-map')
 
-const { BrowserSdkVersion } = require('../lib/browser-sdk-version')
+const { browserSdkVersion } = require('../lib/browser-sdk-version')
 const { spawnCommand, printError, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { modifyFile } = require('../lib/files-utils')
@@ -33,7 +33,7 @@ ${emojisLegend}
 
 ---
 
-## v${BrowserSdkVersion}
+## v${browserSdkVersion}
 
 ${changesList}
 ${content.slice(content.indexOf('\n##'))}`

--- a/scripts/release/generate-changelog.js
+++ b/scripts/release/generate-changelog.js
@@ -5,7 +5,7 @@ const readFile = util.promisify(require('fs').readFile)
 
 const emojiNameMap = require('emoji-name-map')
 
-const { getBrowserSdkVersion } = require('../lib/browser-sdk-version')
+const { BrowserSdkVersion } = require('../lib/browser-sdk-version')
 const { spawnCommand, printError, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { modifyFile } = require('../lib/files-utils')
@@ -33,7 +33,7 @@ ${emojisLegend}
 
 ---
 
-## v${getBrowserSdkVersion}
+## v${BrowserSdkVersion}
 
 ${changesList}
 ${content.slice(content.indexOf('\n##'))}`

--- a/scripts/release/generate-changelog.js
+++ b/scripts/release/generate-changelog.js
@@ -5,7 +5,7 @@ const readFile = util.promisify(require('fs').readFile)
 
 const emojiNameMap = require('emoji-name-map')
 
-const lernaConfig = require('../../lerna.json')
+const { getBrowserSdkVersion } = require('../lib/browser-sdk-version')
 const { spawnCommand, printError, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { modifyFile } = require('../lib/files-utils')
@@ -33,7 +33,7 @@ ${emojisLegend}
 
 ---
 
-## v${lernaConfig.version}
+## v${getBrowserSdkVersion()}
 
 ${changesList}
 ${content.slice(content.indexOf('\n##'))}`

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -1,7 +1,7 @@
-const lernaConfig = require('../../lerna.json')
 const { runMain } = require('../lib/execution-utils')
 const { modifyFile } = require('../lib/files-utils')
 const { command } = require('../lib/command')
+const { getBrowserSdkVersion } = require('../lib/browser-sdk-version')
 
 const JSON_FILES = ['rum', 'rum-slim', 'logs'].map((packageName) => `./packages/${packageName}/package.json`)
 
@@ -25,7 +25,7 @@ runMain(async () => {
 function updateJsonPeerDependencies(content) {
   const json = JSON.parse(content)
   Object.keys(json.peerDependencies).forEach((key) => {
-    json.peerDependencies[key] = lernaConfig.version
+    json.peerDependencies[key] = getBrowserSdkVersion()
   })
   return `${JSON.stringify(json, null, 2)}\n`
 }

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -25,7 +25,7 @@ runMain(async () => {
 function updateJsonPeerDependencies(content) {
   const json = JSON.parse(content)
   Object.keys(json.peerDependencies).forEach((key) => {
-    json.peerDependencies[key] = getBrowserSdkVersion()
+    json.peerDependencies[key] = getBrowserSdkVersion
   })
   return `${JSON.stringify(json, null, 2)}\n`
 }

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -1,7 +1,7 @@
 const { runMain } = require('../lib/execution-utils')
 const { modifyFile } = require('../lib/files-utils')
 const { command } = require('../lib/command')
-const { BrowserSdkVersion } = require('../lib/browser-sdk-version')
+const { browserSdkVersion } = require('../lib/browser-sdk-version')
 
 const JSON_FILES = ['rum', 'rum-slim', 'logs'].map((packageName) => `./packages/${packageName}/package.json`)
 
@@ -25,7 +25,7 @@ runMain(async () => {
 function updateJsonPeerDependencies(content) {
   const json = JSON.parse(content)
   Object.keys(json.peerDependencies).forEach((key) => {
-    json.peerDependencies[key] = BrowserSdkVersion
+    json.peerDependencies[key] = browserSdkVersion
   })
   return `${JSON.stringify(json, null, 2)}\n`
 }

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -1,7 +1,7 @@
 const { runMain } = require('../lib/execution-utils')
 const { modifyFile } = require('../lib/files-utils')
 const { command } = require('../lib/command')
-const { getBrowserSdkVersion } = require('../lib/browser-sdk-version')
+const { BrowserSdkVersion } = require('../lib/browser-sdk-version')
 
 const JSON_FILES = ['rum', 'rum-slim', 'logs'].map((packageName) => `./packages/${packageName}/package.json`)
 
@@ -25,7 +25,7 @@ runMain(async () => {
 function updateJsonPeerDependencies(content) {
   const json = JSON.parse(content)
   Object.keys(json.peerDependencies).forEach((key) => {
-    json.peerDependencies[key] = getBrowserSdkVersion
+    json.peerDependencies[key] = BrowserSdkVersion
   })
   return `${JSON.stringify(json, null, 2)}\n`
 }


### PR DESCRIPTION
## Motivation

To send bundle sizes to logs and check the evolution with dashboard.

## Changes

Added a script to retrieve git commit Id, version, branch and bundle size then send them to logs with fetch request.
<img width="432" alt="image" src="https://github.com/DataDog/browser-sdk/assets/158156364/c6498db0-8fef-4f7a-814e-6aa3ed5ed954">


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] CI
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
