### PR TITLE
⚗️[RUM-2889] custom vitals improvements

### DIFF
--- a/packages/core/src/tools/utils/timeUtils.ts
+++ b/packages/core/src/tools/utils/timeUtils.ts
@@ -16,6 +16,10 @@ export function relativeToClocks(relative: RelativeTime) {
   return { relative, timeStamp: getCorrectedTimeStamp(relative) }
 }
 
+export function timeStampToClocks(timeStamp: TimeStamp) {
+  return { relative: getRelativeTime(timeStamp), timeStamp }
+}
+
 function getCorrectedTimeStamp(relativeTime: RelativeTime) {
   const correctedOrigin = (dateNow() - performance.now()) as TimeStamp
   // apply correction only for positive drift

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -744,8 +744,12 @@ describe('rum public api', () => {
       )
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).startDurationVital('foo')
-      expect(startDurationVitalSpy).toHaveBeenCalledWith({ name: 'foo', startClocks: jasmine.any(Object) })
+      ;(rumPublicApi as any).startDurationVital('foo', { context: { foo: 'bar' } })
+      expect(startDurationVitalSpy).toHaveBeenCalledWith({
+        name: 'foo',
+        startClocks: jasmine.any(Object),
+        context: { foo: 'bar' },
+      })
     })
   })
 
@@ -772,8 +776,12 @@ describe('rum public api', () => {
       )
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).stopDurationVital('foo')
-      expect(stopDurationVitalSpy).toHaveBeenCalledWith({ name: 'foo', stopClocks: jasmine.any(Object) })
+      ;(rumPublicApi as any).stopDurationVital('foo', { context: { foo: 'bar' } })
+      expect(stopDurationVitalSpy).toHaveBeenCalledWith({
+        name: 'foo',
+        stopClocks: jasmine.any(Object),
+        context: { foo: 'bar' },
+      })
     })
   })
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,5 +1,7 @@
-import type { RelativeTime, Context, DeflateWorker, CustomerDataTrackerManager } from '@datadog/browser-core'
+import type { RelativeTime, Context, DeflateWorker, CustomerDataTrackerManager, TimeStamp } from '@datadog/browser-core'
 import {
+  timeStampToClocks,
+  clocksNow,
   addExperimentalFeatures,
   ExperimentalFeature,
   resetExperimentalFeatures,
@@ -722,6 +724,10 @@ describe('rum public api', () => {
   })
 
   describe('startDurationVital', () => {
+    beforeEach(() => {
+      setup().withFakeClock().build()
+    })
+
     afterEach(() => {
       resetExperimentalFeatures()
     })
@@ -747,13 +753,38 @@ describe('rum public api', () => {
       ;(rumPublicApi as any).startDurationVital('foo', { context: { foo: 'bar' } })
       expect(startDurationVitalSpy).toHaveBeenCalledWith({
         name: 'foo',
-        startClocks: jasmine.any(Object),
+        startClocks: clocksNow(),
         context: { foo: 'bar' },
+      })
+    })
+
+    it('should call startDurationVital with provided startTime when ff is enabled', () => {
+      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+      const startDurationVitalSpy = jasmine.createSpy()
+      const rumPublicApi = makeRumPublicApi(
+        () => ({
+          ...noopStartRum(),
+          startDurationVital: startDurationVitalSpy,
+        }),
+        noopRecorderApi
+      )
+      const startTime = 1707755888000 as TimeStamp
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      ;(rumPublicApi as any).startDurationVital('foo', { startTime })
+      expect(startDurationVitalSpy).toHaveBeenCalledWith({
+        name: 'foo',
+        startClocks: timeStampToClocks(startTime),
+        context: undefined,
       })
     })
   })
 
   describe('stopDurationVital', () => {
+    beforeEach(() => {
+      setup().withFakeClock().build()
+    })
+
     afterEach(() => {
       resetExperimentalFeatures()
     })
@@ -779,8 +810,29 @@ describe('rum public api', () => {
       ;(rumPublicApi as any).stopDurationVital('foo', { context: { foo: 'bar' } })
       expect(stopDurationVitalSpy).toHaveBeenCalledWith({
         name: 'foo',
-        stopClocks: jasmine.any(Object),
+        stopClocks: clocksNow(),
         context: { foo: 'bar' },
+      })
+    })
+
+    it('should call stopDurationVital with provided stopTime when ff is enabled', () => {
+      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+      const stopDurationVitalSpy = jasmine.createSpy()
+      const rumPublicApi = makeRumPublicApi(
+        () => ({
+          ...noopStartRum(),
+          stopDurationVital: stopDurationVitalSpy,
+        }),
+        noopRecorderApi
+      )
+      const stopTime = 1707755888000 as TimeStamp
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      ;(rumPublicApi as any).stopDurationVital('foo', { stopTime })
+      expect(stopDurationVitalSpy).toHaveBeenCalledWith({
+        name: 'foo',
+        stopClocks: timeStampToClocks(stopTime),
+        context: undefined,
       })
     })
   })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -107,16 +107,18 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
 
     (initConfiguration, configuration, deflateWorker, initialViewOptions) => {
       if (isExperimentalFeatureEnabled(ExperimentalFeature.CUSTOM_VITALS)) {
-        ;(rumPublicApi as any).startDurationVital = monitor((name: string) => {
+        ;(rumPublicApi as any).startDurationVital = monitor((name: string, options?: { context?: object }) => {
           strategy.startDurationVital({
             name: sanitize(name)!,
             startClocks: clocksNow(),
+            context: sanitize(options?.context) as Context,
           })
         })
-        ;(rumPublicApi as any).stopDurationVital = monitor((name: string) => {
+        ;(rumPublicApi as any).stopDurationVital = monitor((name: string, options?: { context?: object }) => {
           strategy.stopDurationVital({
             name: sanitize(name)!,
             stopClocks: clocksNow(),
+            context: sanitize(options?.context) as Context,
           })
         })
       }

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -114,6 +114,11 @@ export function startRumAssembly(
       configuration.eventRateLimiterThreshold,
       reportError
     ),
+    [RumEventType.VITAL]: createEventRateLimiter(
+      RumEventType.VITAL,
+      configuration.eventRateLimiterThreshold,
+      reportError
+    ),
   }
 
   const syntheticsContext = getSyntheticsContext()

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -83,6 +83,43 @@ describe('vitalCollection', () => {
       expect(rawRumEvents.length).toBe(1)
       expect((rawRumEvents[0].rawRumEvent as RawRumVitalEvent).vital.custom.foo).toBe(100)
     })
+
+    it('should merge start and stop contexts', () => {
+      const { rawRumEvents } = setupBuilder.build()
+
+      vitalCollection.startDurationVital({ name: 'both-undefined', startClocks: clocksNow() })
+      vitalCollection.stopDurationVital({ name: 'both-undefined', stopClocks: clocksNow() })
+      vitalCollection.startDurationVital({
+        name: 'start-defined',
+        startClocks: clocksNow(),
+        context: { start: 'defined' },
+      })
+      vitalCollection.stopDurationVital({ name: 'start-defined', stopClocks: clocksNow() })
+      vitalCollection.startDurationVital({ name: 'stop-defined', startClocks: clocksNow() })
+      vitalCollection.stopDurationVital({ name: 'stop-defined', stopClocks: clocksNow(), context: { stop: 'defined' } })
+      vitalCollection.startDurationVital({
+        name: 'both-defined',
+        startClocks: clocksNow(),
+        context: { start: 'defined' },
+      })
+      vitalCollection.stopDurationVital({ name: 'both-defined', stopClocks: clocksNow(), context: { stop: 'defined' } })
+      vitalCollection.startDurationVital({
+        name: 'stop-precedence',
+        startClocks: clocksNow(),
+        context: { precedence: 'start' },
+      })
+      vitalCollection.stopDurationVital({
+        name: 'stop-precedence',
+        stopClocks: clocksNow(),
+        context: { precedence: 'stop' },
+      })
+
+      expect(rawRumEvents[0].customerContext).toEqual(undefined)
+      expect(rawRumEvents[1].customerContext).toEqual({ start: 'defined' })
+      expect(rawRumEvents[2].customerContext).toEqual({ stop: 'defined' })
+      expect(rawRumEvents[3].customerContext).toEqual({ start: 'defined', stop: 'defined' })
+      expect(rawRumEvents[4].customerContext).toEqual({ precedence: 'stop' })
+    })
   })
 
   it('should collect raw rum event from duration vital', () => {

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -45,6 +45,16 @@ describe('vitalCollection', () => {
       expect(rawRumEvents.length).toBe(0)
     })
 
+    it('should not create multiple duration vitals by calling the stop API multiple times', () => {
+      const { rawRumEvents } = setupBuilder.build()
+
+      vitalCollection.startDurationVital({ name: 'foo', startClocks: clocksNow() })
+      vitalCollection.stopDurationVital({ name: 'foo', stopClocks: clocksNow() })
+      vitalCollection.stopDurationVital({ name: 'foo', stopClocks: clocksNow() })
+
+      expect(rawRumEvents.length).toBe(1)
+    })
+
     it('should create multiple duration vitals from start/stop API', () => {
       const { rawRumEvents, clock } = setupBuilder.build()
 

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -1,5 +1,5 @@
-import type { ClocksState, Duration } from '@datadog/browser-core'
-import { elapsed, generateUUID } from '@datadog/browser-core'
+import type { ClocksState, Duration, Context } from '@datadog/browser-core'
+import { combine, elapsed, generateUUID } from '@datadog/browser-core'
 import { LifeCycleEventType } from '../lifeCycle'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
 import type { RawRumVitalEvent } from '../../rawRumEvent.types'
@@ -8,11 +8,13 @@ import { RumEventType, VitalType } from '../../rawRumEvent.types'
 export interface DurationVitalStart {
   name: string
   startClocks: ClocksState
+  context?: Context
 }
 
 export interface DurationVitalStop {
   name: string
   stopClocks: ClocksState
+  context?: Context
 }
 
 interface DurationVital {
@@ -20,6 +22,7 @@ interface DurationVital {
   type: VitalType.DURATION
   startClocks: ClocksState
   value: Duration
+  context?: Context
 }
 
 export function startVitalCollection(lifeCycle: LifeCycle) {
@@ -38,6 +41,7 @@ export function startVitalCollection(lifeCycle: LifeCycle) {
         type: VitalType.DURATION,
         startClocks: vitalStart.startClocks,
         value: elapsed(vitalStart.startClocks.timeStamp, vitalStop.stopClocks.timeStamp),
+        context: combine(vitalStart.context, vitalStop.context),
       }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processVital(vital))
       vitalStartsByName.delete(vitalStop.name)
@@ -59,6 +63,7 @@ function processVital(vital: DurationVital): RawRumEventCollectedData<RawRumVita
       type: RumEventType.VITAL,
     },
     startTime: vital.startClocks.relative,
+    customerContext: vital.context,
     domainContext: {},
   }
 }

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -40,6 +40,7 @@ export function startVitalCollection(lifeCycle: LifeCycle) {
         value: elapsed(vitalStart.startClocks.timeStamp, vitalStop.stopClocks.timeStamp),
       }
       lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processVital(vital))
+      vitalStartsByName.delete(vitalStop.name)
     },
   }
 }


### PR DESCRIPTION
## Motivation

Following #2591, add more features around custom vitals

## Changes

- 🐛 Fix multiple vital creation with multiple stop calls
- ✨ Add event limiter for vitals
- ✨ Add new API options:

```js
DD_RUM.startDurationVital('foo', { context, startTime })
// do some stuff
DD_RUM.stopDurationVital('foo', { context, stopTime })
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
