### PR TITLE
expose `isAborted` property to `beforeSend` callback

### DIFF
--- a/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
@@ -78,6 +78,7 @@ describe('network error collection', () => {
           method: 'GET',
           status_code: 503,
           url: 'http://fake.com/',
+          isAborted: false
         },
       })
       done()

--- a/packages/logs/src/domain/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.ts
@@ -56,6 +56,7 @@ export function startNetworkErrorCollection(configuration: LogsConfiguration, li
             method: request.method as any, // Cast resource method because of case mismatch cf issue RUMF-1152
             status_code: request.status,
             url: request.url,
+            isAborted: request.isAborted
           },
           status: StatusType.error,
           origin: ErrorSource.NETWORK,

--- a/packages/logs/src/logsEvent.types.ts
+++ b/packages/logs/src/logsEvent.types.ts
@@ -106,6 +106,8 @@ export interface LogsEvent {
      */
     url: string
 
+    isAborted: boolean
+
     [k: string]: unknown
   }
 

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -41,6 +41,7 @@ export interface RawNetworkLogsEvent extends CommonRawLogsEvent {
     method: 'POST' | 'GET' | 'HEAD' | 'PUT' | 'DELETE' | 'PATCH'
     status_code: number
     url: string
+    isAborted: boolean
     [k: string]: unknown
   }
 }


### PR DESCRIPTION
resolves #362

## Motivation

The current event passed to the `beforeSend` callback cannot differentiate (to my knowledge) between a network request that was aborted and a network request that failed (for example, tiimed out). The PR makes the `isAborted` property available to the callback so users can decide if they want to prevent cancelled requests from being sent to the logs.

## Changes

Exposes a new property `isAborted` on `event.http` object

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [X] Staging
- [X] Unit
- [X] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
