### PR TITLE
🐛 [RUM-2445] fix unexpected session renewal after explicit session expiration

### DIFF
--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -271,6 +271,22 @@ describe('session store', () => {
           expect(renewSpy).not.toHaveBeenCalled()
         }
       )
+
+      it('when throttled, expandOrRenewSession() should not renew the session if expire() is called right after', () => {
+        setSessionInStore(FakeTrackingType.TRACKED, FIRST_ID)
+        setupSessionStore()
+
+        // The first call is not throttled (leading execution)
+        sessionStoreManager.expandOrRenewSession()
+
+        sessionStoreManager.expandOrRenewSession()
+        sessionStoreManager.expire()
+
+        clock.tick(STORAGE_POLL_DELAY)
+
+        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(renewSpy).not.toHaveBeenCalled()
+      })
     })
 
     describe('expand session', () => {


### PR DESCRIPTION
## Motivation

When calling `stopSession` or `setTrackingConsent('not-granted')`, the session should expire. But if for some reason the session expand/renewal was scheduled (ex: after some user interaction), a new session was created.

## Changes

Cancel any scheduled session expand/renewal when expiring the session.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
