### PR TITLE
✨ [RUM-3349] introduce a Consent Management API

### DIFF
--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -1,10 +1,4 @@
-import {
-  createNewEvent,
-  mockClock,
-  mockExperimentalFeatures,
-  restorePageVisibility,
-  setPageVisibility,
-} from '../../../test'
+import { createNewEvent, mockClock, restorePageVisibility, setPageVisibility } from '../../../test'
 import type { Clock } from '../../../test'
 import { getCookie, setCookie } from '../../browser/cookie'
 import type { RelativeTime } from '../../tools/utils/timeUtils'
@@ -14,7 +8,6 @@ import { ONE_HOUR, ONE_SECOND } from '../../tools/utils/timeUtils'
 import type { Configuration } from '../configuration'
 import type { TrackingConsentState } from '../trackingConsent'
 import { TrackingConsent, createTrackingConsentState } from '../trackingConsent'
-import { ExperimentalFeature } from '../../tools/experimentalFeatures'
 import type { SessionManager } from './sessionManager'
 import { startSessionManager, stopSessionManager, VISIBILITY_CHECK_DELAY } from './sessionManager'
 import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionConstants'
@@ -525,10 +518,6 @@ describe('startSessionManager', () => {
   })
 
   describe('tracking consent', () => {
-    beforeEach(() => {
-      mockExperimentalFeatures([ExperimentalFeature.TRACKING_CONSENT])
-    })
-
     it('expires the session when tracking consent is withdrawn', () => {
       const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
       const sessionManager = startSessionManagerWithDefaults({ trackingConsentState })

--- a/packages/core/src/domain/trackingConsent.spec.ts
+++ b/packages/core/src/domain/trackingConsent.spec.ts
@@ -1,71 +1,44 @@
-import { mockExperimentalFeatures } from '../../test'
-import { ExperimentalFeature } from '../tools/experimentalFeatures'
 import { TrackingConsent, createTrackingConsentState } from './trackingConsent'
 
 describe('createTrackingConsentState', () => {
-  describe('with tracking_consent enabled', () => {
-    beforeEach(() => {
-      mockExperimentalFeatures([ExperimentalFeature.TRACKING_CONSENT])
-    })
-
-    it('creates a tracking consent state', () => {
-      const trackingConsentState = createTrackingConsentState()
-      expect(trackingConsentState).toBeDefined()
-    })
-
-    it('defaults to not granted', () => {
-      const trackingConsentState = createTrackingConsentState()
-      expect(trackingConsentState.isGranted()).toBeFalse()
-    })
-
-    it('can be created with a default consent state', () => {
-      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
-      expect(trackingConsentState.isGranted()).toBeTrue()
-    })
-
-    it('can be updated to granted', () => {
-      const trackingConsentState = createTrackingConsentState()
-      trackingConsentState.update(TrackingConsent.GRANTED)
-      expect(trackingConsentState.isGranted()).toBeTrue()
-    })
-
-    it('notifies when the consent is updated', () => {
-      const spy = jasmine.createSpy()
-      const trackingConsentState = createTrackingConsentState()
-      trackingConsentState.observable.subscribe(spy)
-      trackingConsentState.update(TrackingConsent.GRANTED)
-      expect(spy).toHaveBeenCalledTimes(1)
-    })
-
-    it('can init a consent state if not defined yet', () => {
-      const trackingConsentState = createTrackingConsentState()
-      trackingConsentState.tryToInit(TrackingConsent.GRANTED)
-      expect(trackingConsentState.isGranted()).toBeTrue()
-    })
-
-    it('does not init a consent state if already defined', () => {
-      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
-      trackingConsentState.tryToInit(TrackingConsent.NOT_GRANTED)
-      expect(trackingConsentState.isGranted()).toBeTrue()
-    })
+  it('creates a tracking consent state', () => {
+    const trackingConsentState = createTrackingConsentState()
+    expect(trackingConsentState).toBeDefined()
   })
 
-  describe('with tracking_consent disabled', () => {
-    it('creates a tracking consent state', () => {
-      const trackingConsentState = createTrackingConsentState()
-      expect(trackingConsentState).toBeDefined()
-    })
+  it('defaults to not granted', () => {
+    const trackingConsentState = createTrackingConsentState()
+    expect(trackingConsentState.isGranted()).toBeFalse()
+  })
 
-    it('is always granted', () => {
-      let trackingConsentState = createTrackingConsentState()
-      expect(trackingConsentState.isGranted()).toBeTrue()
+  it('can be created with a default consent state', () => {
+    const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+    expect(trackingConsentState.isGranted()).toBeTrue()
+  })
 
-      trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
-      expect(trackingConsentState.isGranted()).toBeTrue()
+  it('can be updated to granted', () => {
+    const trackingConsentState = createTrackingConsentState()
+    trackingConsentState.update(TrackingConsent.GRANTED)
+    expect(trackingConsentState.isGranted()).toBeTrue()
+  })
 
-      trackingConsentState = createTrackingConsentState()
-      trackingConsentState.update(TrackingConsent.NOT_GRANTED)
-      expect(trackingConsentState.isGranted()).toBeTrue()
-    })
+  it('notifies when the consent is updated', () => {
+    const spy = jasmine.createSpy()
+    const trackingConsentState = createTrackingConsentState()
+    trackingConsentState.observable.subscribe(spy)
+    trackingConsentState.update(TrackingConsent.GRANTED)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('can init a consent state if not defined yet', () => {
+    const trackingConsentState = createTrackingConsentState()
+    trackingConsentState.tryToInit(TrackingConsent.GRANTED)
+    expect(trackingConsentState.isGranted()).toBeTrue()
+  })
+
+  it('does not init a consent state if already defined', () => {
+    const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+    trackingConsentState.tryToInit(TrackingConsent.NOT_GRANTED)
+    expect(trackingConsentState.isGranted()).toBeTrue()
   })
 })

--- a/packages/core/src/domain/trackingConsent.ts
+++ b/packages/core/src/domain/trackingConsent.ts
@@ -1,4 +1,3 @@
-import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../tools/experimentalFeatures'
 import { Observable } from '../tools/observable'
 
 export const TrackingConsent = {
@@ -28,10 +27,7 @@ export function createTrackingConsentState(currentConsent?: TrackingConsent): Tr
       observable.notify()
     },
     isGranted() {
-      return (
-        !isExperimentalFeatureEnabled(ExperimentalFeature.TRACKING_CONSENT) ||
-        currentConsent === TrackingConsent.GRANTED
-      )
+      return currentConsent === TrackingConsent.GRANTED
     },
     observable,
   }

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,7 +18,6 @@ export enum ExperimentalFeature {
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  TRACKING_CONSENT = 'tracking_consent',
   CUSTOM_VITALS = 'custom_vitals',
 }
 

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -1,12 +1,6 @@
-import { mockClock, type Clock, initEventBridgeStub, mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { mockClock, type Clock, initEventBridgeStub } from '@datadog/browser-core/test'
 import type { TimeStamp, TrackingConsentState } from '@datadog/browser-core'
-import {
-  ExperimentalFeature,
-  ONE_SECOND,
-  TrackingConsent,
-  createTrackingConsentState,
-  display,
-} from '@datadog/browser-core'
+import { ONE_SECOND, TrackingConsent, createTrackingConsentState, display } from '@datadog/browser-core'
 import type { CommonContext } from '../rawLogsEvent.types'
 import type { HybridInitConfiguration, LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
 import { StatusType, type Logger } from '../domain/logger'
@@ -213,52 +207,30 @@ describe('preStartLogs', () => {
       strategy = createPreStartStrategy(getCommonContextSpy, trackingConsentState, doStartLogsSpy)
     })
 
-    describe('with tracking_consent enabled', () => {
-      beforeEach(() => {
-        mockExperimentalFeatures([ExperimentalFeature.TRACKING_CONSENT])
+    it('does not start logs if tracking consent is not granted at init', () => {
+      strategy.init({
+        ...DEFAULT_INIT_CONFIGURATION,
+        trackingConsent: TrackingConsent.NOT_GRANTED,
       })
-
-      it('does not start logs if tracking consent is not granted at init', () => {
-        strategy.init({
-          ...DEFAULT_INIT_CONFIGURATION,
-          trackingConsent: TrackingConsent.NOT_GRANTED,
-        })
-        expect(doStartLogsSpy).not.toHaveBeenCalled()
-      })
-
-      it('starts logs if tracking consent is granted before init', () => {
-        trackingConsentState.update(TrackingConsent.GRANTED)
-        strategy.init({
-          ...DEFAULT_INIT_CONFIGURATION,
-          trackingConsent: TrackingConsent.NOT_GRANTED,
-        })
-        expect(doStartLogsSpy).toHaveBeenCalledTimes(1)
-      })
-
-      it('does not start logs if tracking consent is not withdrawn before init', () => {
-        trackingConsentState.update(TrackingConsent.NOT_GRANTED)
-        strategy.init({
-          ...DEFAULT_INIT_CONFIGURATION,
-          trackingConsent: TrackingConsent.GRANTED,
-        })
-        expect(doStartLogsSpy).not.toHaveBeenCalled()
-      })
+      expect(doStartLogsSpy).not.toHaveBeenCalled()
     })
 
-    describe('with tracking_consent disabled', () => {
-      it('ignores the trackingConsent init param', () => {
-        strategy.init({
-          ...DEFAULT_INIT_CONFIGURATION,
-          trackingConsent: TrackingConsent.NOT_GRANTED,
-        })
-        expect(doStartLogsSpy).toHaveBeenCalled()
+    it('starts logs if tracking consent is granted before init', () => {
+      trackingConsentState.update(TrackingConsent.GRANTED)
+      strategy.init({
+        ...DEFAULT_INIT_CONFIGURATION,
+        trackingConsent: TrackingConsent.NOT_GRANTED,
       })
+      expect(doStartLogsSpy).toHaveBeenCalledTimes(1)
+    })
 
-      it('ignores setTrackingConsent', () => {
-        trackingConsentState.update(TrackingConsent.NOT_GRANTED)
-        strategy.init(DEFAULT_INIT_CONFIGURATION)
-        expect(doStartLogsSpy).toHaveBeenCalledTimes(1)
+    it('does not start logs if tracking consent is not withdrawn before init', () => {
+      trackingConsentState.update(TrackingConsent.NOT_GRANTED)
+      strategy.init({
+        ...DEFAULT_INIT_CONFIGURATION,
+        trackingConsent: TrackingConsent.GRANTED,
       })
+      expect(doStartLogsSpy).not.toHaveBeenCalled()
     })
 
     it('do not call startLogs when tracking consent state is updated after init', () => {

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -5,7 +5,7 @@ import { findSessionCookie } from '../lib/helpers/session'
 describe('tracking consent', () => {
   describe('RUM', () => {
     createTest('does not start the SDK if tracking consent is not given at init')
-      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .withRum({ trackingConsent: 'not-granted' })
       .run(async ({ intakeRegistry }) => {
         await flushEvents()
 
@@ -14,7 +14,7 @@ describe('tracking consent', () => {
       })
 
     createTest('starts the SDK once tracking consent is granted')
-      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .withRum({ trackingConsent: 'not-granted' })
       .run(async ({ intakeRegistry }) => {
         await browserExecute(() => {
           window.DD_RUM!.setTrackingConsent('granted')
@@ -27,7 +27,7 @@ describe('tracking consent', () => {
       })
 
     createTest('stops sending events if tracking consent is revoked')
-      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackUserInteractions: true })
+      .withRum({ trackUserInteractions: true })
       .run(async ({ intakeRegistry }) => {
         await browserExecute(() => {
           window.DD_RUM!.setTrackingConsent('not-granted')
@@ -43,7 +43,7 @@ describe('tracking consent', () => {
       })
 
     createTest('starts a new session when tracking consent is granted again')
-      .withRum({ enableExperimentalFeatures: ['tracking_consent'] })
+      .withRum()
       .run(async ({ intakeRegistry }) => {
         const initialSessionId = await findSessionCookie()
 
@@ -62,7 +62,7 @@ describe('tracking consent', () => {
       })
 
     createTest('using setTrackingConsent before init overrides the init parameter')
-      .withRum({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .withRum({ trackingConsent: 'not-granted' })
       .withRumInit((configuration) => {
         window.DD_RUM!.setTrackingConsent('granted')
         window.DD_RUM!.init(configuration)
@@ -77,7 +77,7 @@ describe('tracking consent', () => {
 
   describe('Logs', () => {
     createTest('does not start the SDK if tracking consent is not given at init')
-      .withLogs({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .withLogs({ trackingConsent: 'not-granted' })
       .run(async ({ intakeRegistry }) => {
         await flushEvents()
 
@@ -86,7 +86,7 @@ describe('tracking consent', () => {
       })
 
     createTest('starts the SDK once tracking consent is granted')
-      .withLogs({ enableExperimentalFeatures: ['tracking_consent'], trackingConsent: 'not-granted' })
+      .withLogs({ trackingConsent: 'not-granted' })
       .run(async ({ intakeRegistry }) => {
         await browserExecute(() => {
           window.DD_LOGS!.setTrackingConsent('granted')


### PR DESCRIPTION
## Motivation

This PR publicly exposes the API introduced in #2589 

## Changes

Remove the `tracking_consent` experimental flag.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
