### PR TITLE
🐛 [RUM-3502] fix `fetch(url)` tracing

### DIFF
--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -56,6 +56,24 @@ describe('instrumentMethod', () => {
     expect(instrumentationSpy.calls.mostRecent().args[0].parameters[1]).toBe(3)
   })
 
+  it('allows replacing a parameter', () => {
+    const object = { method: (a: number) => a }
+    instrumentMethod(object, 'method', ({ parameters }) => {
+      parameters[0] = 2
+    })
+
+    expect(object.method(1)).toBe(2)
+  })
+
+  it('allows adding a parameter', () => {
+    const object = { method: (a?: number) => a }
+    instrumentMethod(object, 'method', ({ parameters }) => {
+      parameters[0] = 2
+    })
+
+    expect(object.method()).toBe(2)
+  })
+
   it('calls the "onPostCall" callback with the original method result', () => {
     const object = { method: () => 1 }
     const onPostCallSpy = jasmine.createSpy()

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -1,6 +1,7 @@
 import { setTimeout } from './timer'
 import { callMonitored } from './monitor'
 import { noop } from './utils/functionUtils'
+import { arrayFrom } from './utils/polyfills'
 
 /**
  * Object passed to the callback of an instrumented method call. See `instrumentMethod` for more
@@ -13,9 +14,7 @@ export type InstrumentedMethodCall<TARGET extends { [key: string]: any }, METHOD
   target: TARGET
 
   /**
-   * The parameters with which the method was called. To avoid having to clone the argument list
-   * every time, this property is actually an instance of Argument, not Array, so not all methods
-   * are available (like .forEach).
+   * The parameters with which the method was called.
    *
    * Note: if needed, parameters can be mutated by the instrumentation
    */
@@ -86,7 +85,7 @@ function createInstrumentedMethod<TARGET extends { [key: string]: any }, METHOD 
 ): TARGET[METHOD] {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return function (this: TARGET) {
-    const parameters = arguments as unknown as Parameters<TARGET[METHOD]>
+    const parameters = arrayFrom(arguments) as Parameters<TARGET[METHOD]>
     let result
 
     let postCallCallback: PostCallCallback<TARGET, METHOD> | undefined

--- a/test/e2e/scenario/rum/tracing.scenario.ts
+++ b/test/e2e/scenario/rum/tracing.scenario.ts
@@ -10,7 +10,9 @@ describe('tracing', () => {
         ['x-foo', 'bar'],
         ['x-foo', 'baz'],
       ])
-      checkRequestHeaders(rawHeaders)
+      const headers = parseHeaders(rawHeaders)
+      checkRequestHeaders(headers)
+      expect(headers['x-foo']).toBe('bar, baz')
       await flushEvents()
       checkTraceAssociatedToRumEvent(intakeRegistry)
     })
@@ -30,10 +32,9 @@ describe('tracing', () => {
           .then(done)
           .catch(() => done(new Error('Fetch request failed!')))
       })
-      if (rawHeaders instanceof Error) {
-        return fail(rawHeaders)
-      }
-      checkRequestHeaders(rawHeaders)
+      const headers = parseHeaders(rawHeaders)
+      checkRequestHeaders(headers)
+      expect(headers['x-foo']).toBe('bar, baz')
       await flushEvents()
       checkTraceAssociatedToRumEvent(intakeRegistry)
     })
@@ -48,21 +49,47 @@ describe('tracing', () => {
           .then(done)
           .catch(() => done(new Error('Fetch request failed!')))
       })
-      if (rawHeaders instanceof Error) {
-        return fail(rawHeaders)
-      }
-      checkRequestHeaders(rawHeaders)
+      const headers = parseHeaders(rawHeaders)
+      checkRequestHeaders(headers)
+      expect(headers['x-foo']).toBe('bar, baz')
       await flushEvents()
       checkTraceAssociatedToRumEvent(intakeRegistry)
     })
 
+  createTest('trace single argument fetch')
+    .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
+    .run(async ({ intakeRegistry }) => {
+      const rawHeaders = await browserExecuteAsync<string | Error>((done) => {
+        window
+          .fetch('/headers')
+          .then((response) => response.text())
+          .then(done)
+          .catch(() => done(new Error('Fetch request failed!')))
+      })
+      const headers = parseHeaders(rawHeaders)
+      checkRequestHeaders(headers)
+      await flushEvents()
+      checkTraceAssociatedToRumEvent(intakeRegistry)
+    })
+
+  interface ParsedHeaders {
+    [key: string]: string
+  }
+
+  function parseHeaders(rawHeaders: string | Error): ParsedHeaders {
+    if (rawHeaders instanceof Error) {
+      fail(rawHeaders)
+      return {}
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return JSON.parse(rawHeaders)
+  }
+
   // By default, we send both Datadog and W3C tracecontext headers
-  function checkRequestHeaders(rawHeaders: string) {
-    const headers: { [key: string]: string } = JSON.parse(rawHeaders)
+  function checkRequestHeaders(headers: ParsedHeaders) {
     expect(headers['x-datadog-trace-id']).toMatch(/\d+/)
     expect(headers['x-datadog-origin']).toBe('rum')
     expect(headers['traceparent']).toMatch(/^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-01$/)
-    expect(headers['x-foo']).toBe('bar, baz')
   }
 
   function checkTraceAssociatedToRumEvent(intakeRegistry: IntakeRegistry) {


### PR DESCRIPTION
## Motivation

When running `fetch(url)`, the request is missing tracing headers, no matter the initialization parameters used.

This is a regression from https://github.com/DataDog/browser-sdk/pull/2551
 
## Changes

`parameters` was directly the [`arguments`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Functions/arguments) object from the function call. It turns out adding an entry to this kind of array does not work.

To fix this issue, convert the `arguments` to an actual array.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
