### PR TITLE
🔧 configure renovate to deduplicate subdependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
   "schedule": ["every weekend"],
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION


## Motivation

This should fix the issue we have with every single "update all non-major dependencies" regarding `@types/react` ending with different versions and failing the build.

It will also make installing dependencies a bit faster since it won't have to download as many versions as before. 

## Changes


I chose the "highest" strategy (instead of "fewest"), because:
* let's try to be as much up-to-date as possible
* renovate will use the official `yarn dedupe` instead of a third party package


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
