### PR TITLE
✨ [RUM-3495] Add Pr Commenter Threshold

### DIFF
--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -150,7 +150,7 @@ function createMessage(difference, resultsBaseQuery, localBundleSizes) {
 <details>
   <summary>Expand threshold legend</summary>
 
-  | 𝚫 < -0.5% | 𝚫 < -0.3% | 𝚫 < -0.15% | 𝚫 < 0 | 𝚫 > 0 | 𝚫 > 0.15% | 𝚫 > 0.3% | 𝚫 > 0.5% |
+  | 𝚫 < -0.5% | 𝚫 < -0.3% | 𝚫 < -0.15% | 𝚫 < 0 | 𝚫 ≥ 0 | 𝚫 > 0.15% | 𝚫 > 0.3% | 𝚫 > 0.5% |
   | --- | --- | --- | --- | --- | --- | --- | --- |
   | 🤩 | 😃 | 😀 | 🙂 | 😐 | 😠 | 😡 | ⛔ |
 </details>

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -163,15 +163,15 @@ function formatSize(bundleSize) {
 function getEmojiWithThreshold(percentageChange) {
   const absChange = Math.abs(percentageChange)
   const emojiMap = [
-    { threshold: 0.15, positive: '🟢', negative: '🎉' },
-    { threshold: 0.3, positive: '🟠', negative: '🥳' },
-    { threshold: 0.5, positive: '😡', negative: '🤩' },
-    { threshold: Infinity, positive: '⛔', negative: '🏆' },
+    { threshold: 0.15, increase: '😐', decrease: '🙂' },
+    { threshold: 0.3, increase: '😠', decrease: '😀' },
+    { threshold: 0.5, increase: '😡', decrease: '😃' },
+    { threshold: Infinity, increase: '⛔', decrease: '🤩' },
   ]
 
   for (let emoji of emojiMap) {
     if (absChange <= emoji.threshold) {
-      return percentageChange >= 0 ? emoji.positive : emoji.negative
+      return percentageChange >= 0 ? emoji.increase : emoji.decrease
     }
   }
 }

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -137,24 +137,23 @@ async function updateOrAddComment(difference, resultsBaseQuery, localBundleSizes
 }
 
 function createMessage(difference, resultsBaseQuery, localBundleSizes) {
-  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% |\n| --- | --- | --- | --- |\n'
+  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% | Status |\n| --- | --- | --- | --- | --- |\n'
+  let warningFlag = false
   difference.forEach((diff, index) => {
     const baseSize = formatSize(resultsBaseQuery[index].size)
     const localSize = formatSize(localBundleSizes[diff.name])
     const sign = diff.percentageChange > 0 ? '+' : ''
-    const emoji = getEmojiWithThreshold(diff.percentageChange)
-    message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% ${emoji} |\n`
+    let status = '✅'
+    if (diff.percentageChange > 5) {
+      status = '⚠️'
+      warningFlag = true
+    }
+    message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% | ${status} |\n`
   })
 
-  message += `
-<details>
-  <summary>Expand threshold legend</summary>
-
-  | 𝚫 < -1.5% | 𝚫 < -3% | 𝚫 < -5% | 𝚫 < 0 | 𝚫 ≥ 0 | 𝚫 > 1.5% | 𝚫 > 3% | 𝚫 > 5% |
-  | --- | --- | --- | --- | --- | --- | --- | --- |
-  | 🤩 | 😃 | 😀 | 🙂 | 😐 | 😠 | 😡 | ⛔ |
-</details>
-  `
+  if (warningFlag) {
+    message += '\n⚠️ The increase is particularly high and exceeds 5%. Please check the changes.'
+  }
 
   return message
 }
@@ -168,22 +167,6 @@ function formatBundleName(bundleName) {
 
 function formatSize(bundleSize) {
   return `${(bundleSize / 1024).toFixed(2)} kB`
-}
-
-function getEmojiWithThreshold(percentageChange) {
-  const absChange = Math.abs(percentageChange)
-  const emojiMap = [
-    { threshold: 1.5, increase: '😐', decrease: '🙂' },
-    { threshold: 3, increase: '😠', decrease: '😀' },
-    { threshold: 5, increase: '😡', decrease: '😃' },
-    { threshold: Infinity, increase: '⛔', decrease: '🤩' },
-  ]
-
-  for (let emoji of emojiMap) {
-    if (absChange <= emoji.threshold) {
-      return percentageChange >= 0 ? emoji.increase : emoji.decrease
-    }
-  }
 }
 
 module.exports = {

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -143,7 +143,7 @@ function createMessage(difference, resultsBaseQuery, localBundleSizes) {
     const baseSize = formatSize(resultsBaseQuery[index].size)
     const localSize = formatSize(localBundleSizes[diff.name])
     const sign = diff.percentageChange > 0 ? '+' : ''
-    let status = '✅'
+    let status = '  ✅  '
     if (diff.percentageChange > 5) {
       status = '⚠️'
       warningFlag = true

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -7,6 +7,8 @@ const LOCAL_BRANCH = process.env.CI_COMMIT_REF_NAME
 const PR_COMMENTER_AUTH_TOKEN = command`authanywhere`.run().split(' ')[2].trim()
 const GITHUB_TOKEN = getGithubAccessToken()
 const ONE_DAY_IN_SECOND = 24 * 60 * 60
+const SIZE_INCREASE_THRESHOLD = 5
+// The value is set to 5% as it's around 10 times the average value for small PRs.
 
 async function reportBundleSizesAsPrComment(localBundleSizes) {
   const lastCommonCommit = getLastCommonCommit(BASE_BRANCH, LOCAL_BRANCH)
@@ -137,22 +139,22 @@ async function updateOrAddComment(difference, resultsBaseQuery, localBundleSizes
 }
 
 function createMessage(difference, resultsBaseQuery, localBundleSizes) {
-  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% | Status |\n| --- | --- | --- | --- | --- |\n'
-  let warningFlag = false
+  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% | Status |\n| --- | --- | --- | --- | :---: |\n'
+  let highIncreaseDetected = false
   difference.forEach((diff, index) => {
     const baseSize = formatSize(resultsBaseQuery[index].size)
     const localSize = formatSize(localBundleSizes[diff.name])
     const sign = diff.percentageChange > 0 ? '+' : ''
-    let status = '  ✅  '
-    if (diff.percentageChange > 5) {
+    let status = '✅'
+    if (diff.percentageChange > SIZE_INCREASE_THRESHOLD) {
       status = '⚠️'
-      warningFlag = true
+      highIncreaseDetected = true
     }
     message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% | ${status} |\n`
   })
 
-  if (warningFlag) {
-    message += '\n⚠️ The increase is particularly high and exceeds 5%. Please check the changes.'
+  if (highIncreaseDetected) {
+    message += `\n⚠️ The increase is particularly high and exceeds ${SIZE_INCREASE_THRESHOLD}%. Please check the changes.`
   }
 
   return message

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -137,13 +137,13 @@ async function updateOrAddComment(difference, resultsBaseQuery, localBundleSizes
 }
 
 function createMessage(difference, resultsBaseQuery, localBundleSizes) {
-  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% | Impact |\n| --- | --- | --- | --- | --- |\n'
+  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% |\n| --- | --- | --- | --- |\n'
   difference.forEach((diff, index) => {
     const baseSize = formatSize(resultsBaseQuery[index].size)
     const localSize = formatSize(localBundleSizes[diff.name])
     const sign = diff.percentageChange > 0 ? '+' : ''
-    const emojiImpact = getEmojiWithThreshold(diff.percentageChange)
-    message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% | ${emojiImpact} |\n`
+    const emoji = getEmojiWithThreshold(diff.percentageChange)
+    message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% ${emoji} |\n`
   })
 
   return message

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -137,12 +137,13 @@ async function updateOrAddComment(difference, resultsBaseQuery, localBundleSizes
 }
 
 function createMessage(difference, resultsBaseQuery, localBundleSizes) {
-  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% |\n| --- | --- | --- | --- |\n'
+  let message = '| 📦 Bundle Name| Base Size | Local Size | 𝚫% | Impact |\n| --- | --- | --- | --- | --- |\n'
   difference.forEach((diff, index) => {
     const baseSize = formatSize(resultsBaseQuery[index].size)
     const localSize = formatSize(localBundleSizes[diff.name])
     const sign = diff.percentageChange > 0 ? '+' : ''
-    message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% |\n`
+    const emojiImpact = getEmojiWithThreshold(diff.percentageChange)
+    message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% | ${emojiImpact} |\n`
   })
 
   return message
@@ -157,6 +158,22 @@ function formatBundleName(bundleName) {
 
 function formatSize(bundleSize) {
   return `${(bundleSize / 1024).toFixed(2)} kB`
+}
+
+function getEmojiWithThreshold(percentageChange) {
+  const absChange = Math.abs(percentageChange)
+  const emojiMap = [
+    { threshold: 0.15, positive: '🟢', negative: '🎉' },
+    { threshold: 0.3, positive: '🟠', negative: '🥳' },
+    { threshold: 0.5, positive: '😡', negative: '🤩' },
+    { threshold: Infinity, positive: '⛔', negative: '🏆' },
+  ]
+
+  for (let emoji of emojiMap) {
+    if (absChange <= emoji.threshold) {
+      return percentageChange >= 0 ? emoji.positive : emoji.negative
+    }
+  }
 }
 
 module.exports = {

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -150,7 +150,7 @@ function createMessage(difference, resultsBaseQuery, localBundleSizes) {
 <details>
   <summary>Expand threshold legend</summary>
 
-  | 𝚫 < -0.5% | 𝚫 < -0.3% | 𝚫 < -0.15% | 𝚫 < 0 | 𝚫 ≥ 0 | 𝚫 > 0.15% | 𝚫 > 0.3% | 𝚫 > 0.5% |
+  | 𝚫 < -1.5% | 𝚫 < -3% | 𝚫 < -5% | 𝚫 < 0 | 𝚫 ≥ 0 | 𝚫 > 1.5% | 𝚫 > 3% | 𝚫 > 5% |
   | --- | --- | --- | --- | --- | --- | --- | --- |
   | 🤩 | 😃 | 😀 | 🙂 | 😐 | 😠 | 😡 | ⛔ |
 </details>
@@ -173,9 +173,9 @@ function formatSize(bundleSize) {
 function getEmojiWithThreshold(percentageChange) {
   const absChange = Math.abs(percentageChange)
   const emojiMap = [
-    { threshold: 0.15, increase: '😐', decrease: '🙂' },
-    { threshold: 0.3, increase: '😠', decrease: '😀' },
-    { threshold: 0.5, increase: '😡', decrease: '😃' },
+    { threshold: 1.5, increase: '😐', decrease: '🙂' },
+    { threshold: 3, increase: '😠', decrease: '😀' },
+    { threshold: 5, increase: '😡', decrease: '😃' },
     { threshold: Infinity, increase: '⛔', decrease: '🤩' },
   ]
 

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -146,6 +146,16 @@ function createMessage(difference, resultsBaseQuery, localBundleSizes) {
     message += `| ${formatBundleName(diff.name)} | ${baseSize} | ${localSize} | ${sign}${diff.percentageChange}% ${emoji} |\n`
   })
 
+  message += `
+<details>
+  <summary>Expand threshold legend</summary>
+
+  | 𝚫 < -0.5% | 𝚫 < -0.3% | 𝚫 < -0.15% | 𝚫 < 0 | 𝚫 > 0 | 𝚫 > 0.15% | 𝚫 > 0.3% | 𝚫 > 0.5% |
+  | --- | --- | --- | --- | --- | --- | --- | --- |
+  | 🤩 | 😃 | 😀 | 🙂 | 😐 | 😠 | 😡 | ⛔ |
+</details>
+  `
+
   return message
 }
 

--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -7,8 +7,8 @@ const LOCAL_BRANCH = process.env.CI_COMMIT_REF_NAME
 const PR_COMMENTER_AUTH_TOKEN = command`authanywhere`.run().split(' ')[2].trim()
 const GITHUB_TOKEN = getGithubAccessToken()
 const ONE_DAY_IN_SECOND = 24 * 60 * 60
-const SIZE_INCREASE_THRESHOLD = 5
 // The value is set to 5% as it's around 10 times the average value for small PRs.
+const SIZE_INCREASE_THRESHOLD = 5
 
 async function reportBundleSizesAsPrComment(localBundleSizes) {
   const lastCommonCommit = getLastCommonCommit(BASE_BRANCH, LOCAL_BRANCH)


### PR DESCRIPTION
## Motivation

We want to have a more precise indication of the difference change. 

## Changes

Added a threshold based on previous PR values, to set a status. If the value is below 5 % then the status is ✅ otherwise the status is a warning and message appear at the end of the Pr Commenter.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
