### PR TITLE
🔧 Enforce snake case for event type properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -186,9 +186,16 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/*.types.ts', '**/types.ts'],
+      files: ['**/*Event.types.ts'],
       rules: {
-        camelcase: 'off',
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            leadingUnderscore: 'allow',
+            selector: 'property',
+            format: ['snake_case'],
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
## Motivation

Events generated by the SDK should have snake_case properties but nothing is checking it.

## Changes

Add an eslint rule to check snake_case in `**/*Event.types.ts`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
