### PR TITLE
👷 check monitors before deploying to prod

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -299,6 +299,7 @@ deploy-prod-canary:
     - VERSION=$(node -p -e "require('./lerna.json').version")
     - yarn
     - yarn build:bundle
+    - node ./scripts/deploy/check-monitors.js $UPLOAD_PATH
     - node ./scripts/deploy/deploy.js prod v${VERSION%%.*} $UPLOAD_PATH
     - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*} $UPLOAD_PATH
 

--- a/scripts/deploy/check-monitors.js
+++ b/scripts/deploy/check-monitors.js
@@ -1,0 +1,48 @@
+/**
+ * Check monitors status
+ * Usage:
+ * node check-monitors.js us1,eu1,...
+ */
+const { printLog, runMain, fetch } = require('../lib/execution-utils')
+const { getTelemetryOrgApiKey, getTelemetryOrgApplicationKey } = require('../lib/secrets')
+const { siteByDatacenter } = require('../lib/datadog-sites')
+
+const monitorIdsByDatacenter = {
+  us1: [72055549, 68975047, 110519972],
+  eu1: [5855803, 5663834, 9896387],
+  us3: [164368, 160677, 329066],
+  us5: [22388, 20646, 96049],
+  ap1: [858, 859, 2757030],
+}
+
+const datacenters = process.argv[2].split(',')
+
+runMain(async () => {
+  for (const datacenter of datacenters) {
+    if (!monitorIdsByDatacenter[datacenter]) {
+      printLog(`No monitors configured for datacenter ${datacenter}`)
+      continue
+    }
+    const monitorIds = monitorIdsByDatacenter[datacenter]
+    const site = siteByDatacenter[datacenter]
+    const monitorStatuses = await Promise.all(monitorIds.map((monitorId) => fetchMonitorStatus(site, monitorId)))
+    for (const monitorStatus of monitorStatuses) {
+      printLog(`${monitorStatus.overall_state} - ${monitorStatus.name}`)
+      if (monitorStatus.overall_state !== 'OK') {
+        throw new Error(`Monitor ${monitorStatus.name} is in state ${monitorStatus.overall_state}`)
+      }
+    }
+  }
+})
+
+async function fetchMonitorStatus(site, monitorId) {
+  const response = await fetch(`https://api.${site}/api/v1/monitor/${monitorId}`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'DD-API-KEY': getTelemetryOrgApiKey(site),
+      'DD-APPLICATION-KEY': getTelemetryOrgApplicationKey(site),
+    },
+  })
+  return JSON.parse(response)
+}

--- a/scripts/deploy/upload-source-maps.js
+++ b/scripts/deploy/upload-source-maps.js
@@ -5,6 +5,7 @@ const { printLog, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { getBuildEnvValue } = require('../lib/build-env')
 const { getTelemetryOrgApiKey } = require('../lib/secrets')
+const { siteByDatacenter } = require('../lib/datadog-sites')
 const {
   buildRootUploadPath,
   buildDatacenterUploadPath,
@@ -20,13 +21,7 @@ const {
  */
 const version = process.argv[2]
 let uploadPathTypes = process.argv[3].split(',')
-const siteByDatacenter = {
-  us1: 'datadoghq.com',
-  eu1: 'datadoghq.eu',
-  us3: 'us3.datadoghq.com',
-  us5: 'us5.datadoghq.com',
-  ap1: 'ap1.datadoghq.com',
-}
+
 function getSitesByVersion(version) {
   switch (version) {
     case 'staging':

--- a/scripts/lib/datadog-sites.js
+++ b/scripts/lib/datadog-sites.js
@@ -1,0 +1,11 @@
+const siteByDatacenter = {
+  us1: 'datadoghq.com',
+  eu1: 'datadoghq.eu',
+  us3: 'us3.datadoghq.com',
+  us5: 'us5.datadoghq.com',
+  ap1: 'ap1.datadoghq.com',
+}
+
+module.exports = {
+  siteByDatacenter,
+}

--- a/scripts/lib/secrets.js
+++ b/scripts/lib/secrets.js
@@ -21,6 +21,11 @@ function getTelemetryOrgApiKey(site) {
   return getSecretKey(`ci.browser-sdk.source-maps.${normalizedSite}.ci_api_key`)
 }
 
+function getTelemetryOrgApplicationKey(site) {
+  const normalizedSite = site.replaceAll('.', '-')
+  return getSecretKey(`ci.browser-sdk.telemetry.${normalizedSite}.ci_app_key`)
+}
+
 function getNpmToken() {
   return getSecretKey('ci.browser-sdk.npm_token')
 }
@@ -55,4 +60,5 @@ module.exports = {
   getOrg2ApiKey,
   getOrg2AppKey,
   getTelemetryOrgApiKey,
+  getTelemetryOrgApplicationKey,
 }


### PR DESCRIPTION
## Motivation

Automate manual check, ensure that our monitors are green before deploying to avoid to deploy when there is an ongoing issue.
We could later introduce gate steps to automate completely the deployment process.

## Changes

- extract siteByDatacenter 
- introduce new script to check monitors
- add check monitors before CDN deployment

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
