### PR TITLE
🐛 [RUM-3598] Ignore collecting requests to logs PCI intake as RUM resources

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -4,7 +4,7 @@ import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../tools/experimentalFeatures'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { InitConfiguration } from './configuration'
-import { INTAKE_SITE_US1, INTAKE_SITE_FED_STAGING } from './intakeSites'
+import { INTAKE_SITE_US1, INTAKE_SITE_FED_STAGING, PCI_INTAKE_HOST_US1 } from './intakeSites'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
@@ -63,7 +63,7 @@ function buildEndpointHost(trackType: TrackType, initConfiguration: InitConfigur
   const { site = INTAKE_SITE_US1, internalAnalyticsSubdomain } = initConfiguration
 
   if (trackType === 'logs' && initConfiguration.usePciIntake && site === INTAKE_SITE_US1) {
-    return 'pci.browser-intake-datadoghq.com'
+    return PCI_INTAKE_HOST_US1
   }
 
   if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -3,3 +3,5 @@ export const INTAKE_SITE_FED_STAGING = 'dd0g-gov.com'
 export const INTAKE_SITE_US1 = 'datadoghq.com'
 export const INTAKE_SITE_EU1 = 'datadoghq.eu'
 export const INTAKE_SITE_US1_FED = 'ddog-gov.com'
+
+export const PCI_INTAKE_HOST_US1 = 'pci.browser-intake-datadoghq.com'

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -87,6 +87,7 @@ describe('transportConfiguration', () => {
     ;[
       { site: 'datadoghq.eu', intakeDomain: 'browser-intake-datadoghq.eu' },
       { site: 'datadoghq.com', intakeDomain: 'browser-intake-datadoghq.com' },
+      { site: 'datadoghq.com', intakeDomain: 'pci.browser-intake-datadoghq.com' },
       { site: 'us3.datadoghq.com', intakeDomain: 'browser-intake-us3-datadoghq.com' },
       { site: 'us5.datadoghq.com', intakeDomain: 'browser-intake-us5-datadoghq.com' },
       { site: 'ap1.datadoghq.com', intakeDomain: 'browser-intake-ap1-datadoghq.com' },
@@ -101,13 +102,6 @@ describe('transportConfiguration', () => {
         expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/logs?xxx`)).toBe(true)
         expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/replay?xxx`)).toBe(true)
       })
-    })
-
-    it('should detect PCI intake request of logs for datadoghq.com site', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.com' })
-      expect(configuration.isIntakeUrl('https://pci.browser-intake-datadoghq.com/api/v2/logs?xxx')).toBe(true)
-      expect(configuration.isIntakeUrl('https://pci.browser-intake-datadoghq.com/api/v2/rum?xxx')).toBe(false)
-      expect(configuration.isIntakeUrl('https://pci.browser-intake-datadoghq.com/api/v2/replay?xxx')).toBe(false)
     })
 
     it('should detect internal analytics intake request for datadoghq.com site', () => {

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -87,10 +87,12 @@ describe('transportConfiguration', () => {
     ;[
       { site: 'datadoghq.eu', intakeDomain: 'browser-intake-datadoghq.eu' },
       { site: 'datadoghq.com', intakeDomain: 'browser-intake-datadoghq.com' },
+      { site: 'datadoghq.com', intakeDomain: 'pci.browser-intake-datadoghq.com' },
       { site: 'us3.datadoghq.com', intakeDomain: 'browser-intake-us3-datadoghq.com' },
       { site: 'us5.datadoghq.com', intakeDomain: 'browser-intake-us5-datadoghq.com' },
-      { site: 'ddog-gov.com', intakeDomain: 'browser-intake-ddog-gov.com' },
       { site: 'ap1.datadoghq.com', intakeDomain: 'browser-intake-ap1-datadoghq.com' },
+      { site: 'ddog-gov.com', intakeDomain: 'browser-intake-ddog-gov.com' },
+      { site: 'datad0g.com', intakeDomain: 'browser-intake-datad0g.com' },
       { site: 'dd0g-gov.com', intakeDomain: 'http-intake.logs.dd0g-gov.com' },
     ].forEach(({ site, intakeDomain }) => {
       it(`should detect intake request for ${site} site`, () => {

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -87,7 +87,6 @@ describe('transportConfiguration', () => {
     ;[
       { site: 'datadoghq.eu', intakeDomain: 'browser-intake-datadoghq.eu' },
       { site: 'datadoghq.com', intakeDomain: 'browser-intake-datadoghq.com' },
-      { site: 'datadoghq.com', intakeDomain: 'pci.browser-intake-datadoghq.com' },
       { site: 'us3.datadoghq.com', intakeDomain: 'browser-intake-us3-datadoghq.com' },
       { site: 'us5.datadoghq.com', intakeDomain: 'browser-intake-us5-datadoghq.com' },
       { site: 'ap1.datadoghq.com', intakeDomain: 'browser-intake-ap1-datadoghq.com' },
@@ -102,6 +101,13 @@ describe('transportConfiguration', () => {
         expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/logs?xxx`)).toBe(true)
         expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/replay?xxx`)).toBe(true)
       })
+    })
+
+    it('should detect PCI intake request of logs for datadoghq.com site', () => {
+      const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.com' })
+      expect(configuration.isIntakeUrl('https://pci.browser-intake-datadoghq.com/api/v2/logs?xxx')).toBe(true)
+      expect(configuration.isIntakeUrl('https://pci.browser-intake-datadoghq.com/api/v2/rum?xxx')).toBe(false)
+      expect(configuration.isIntakeUrl('https://pci.browser-intake-datadoghq.com/api/v2/replay?xxx')).toBe(false)
     })
 
     it('should detect internal analytics intake request for datadoghq.com site', () => {

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -21,16 +21,12 @@ export interface ReplicaConfiguration {
 }
 
 export function computeTransportConfiguration(initConfiguration: InitConfiguration): TransportConfiguration {
-  const { site = INTAKE_SITE_US1 } = initConfiguration
+  const site = initConfiguration.site || INTAKE_SITE_US1
 
   const tags = buildTags(initConfiguration)
 
   const endpointBuilders = computeEndpointBuilders(initConfiguration, tags)
-  const intakeUrlPrefixes = objectValues(endpointBuilders).map((builder) => builder.urlPrefix)
-
-  if (site === INTAKE_SITE_US1) {
-    intakeUrlPrefixes.push(`https://${PCI_INTAKE_HOST_US1}/api/v2/logs?`)
-  }
+  const intakeUrlPrefixes = computeIntakeUrlPrefixes(endpointBuilders, site)
 
   const replicaConfiguration = computeReplicaConfiguration(initConfiguration, intakeUrlPrefixes, tags)
 
@@ -74,4 +70,14 @@ function computeReplicaConfiguration(
   intakeUrlPrefixes.push(...objectValues(replicaEndpointBuilders).map((builder) => builder.urlPrefix))
 
   return assign({ applicationId: initConfiguration.replica.applicationId }, replicaEndpointBuilders)
+}
+
+function computeIntakeUrlPrefixes(endpointBuilders: ReturnType<typeof computeEndpointBuilders>, site: string): string[] {
+  const intakeUrlPrefixes = objectValues(endpointBuilders).map((builder) => builder.urlPrefix)
+
+  if (site === INTAKE_SITE_US1) {
+    intakeUrlPrefixes.push(`https://${PCI_INTAKE_HOST_US1}/api/v2/logs?`)
+  }
+
+  return intakeUrlPrefixes
 }

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -79,7 +79,7 @@ function computeIntakeUrlPrefixes(
   const intakeUrlPrefixes = objectValues(endpointBuilders).map((builder) => builder.urlPrefix)
 
   if (site === INTAKE_SITE_US1) {
-    intakeUrlPrefixes.push(`https://${PCI_INTAKE_HOST_US1}/api/v2/logs?`)
+    intakeUrlPrefixes.push(`https://${PCI_INTAKE_HOST_US1}/`)
   }
 
   return intakeUrlPrefixes

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -72,7 +72,10 @@ function computeReplicaConfiguration(
   return assign({ applicationId: initConfiguration.replica.applicationId }, replicaEndpointBuilders)
 }
 
-function computeIntakeUrlPrefixes(endpointBuilders: ReturnType<typeof computeEndpointBuilders>, site: string): string[] {
+function computeIntakeUrlPrefixes(
+  endpointBuilders: ReturnType<typeof computeEndpointBuilders>,
+  site: string
+): string[] {
   const intakeUrlPrefixes = objectValues(endpointBuilders).map((builder) => builder.urlPrefix)
 
   if (site === INTAKE_SITE_US1) {


### PR DESCRIPTION
## Motivation
Requests to PCI compliant endpoint are captured by RUM as resources, while they shouldn't be.


## Changes
RUM initialisation doesn't have access to Logs config. Thus, PCI endpoint requests are not skipped and are captured as RUM resources.

When the provided site is `datadoghq.com`, push PCI intake url to the intake prefixes used to ignore resources 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
