### PR TITLE
✨ [RUM-3542] Add trace context injection control in rum configuration

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -21,6 +21,13 @@ export const DefaultPrivacyLevel = {
 } as const
 export type DefaultPrivacyLevel = (typeof DefaultPrivacyLevel)[keyof typeof DefaultPrivacyLevel]
 
+export const TraceContextInjection = {
+  ALL: 'all',
+  SAMPLED: 'sampled',
+} as const
+
+export type TraceContextInjection = (typeof TraceContextInjection)[keyof typeof TraceContextInjection]
+
 export interface InitConfiguration {
   // global options
   clientToken: string

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -2,6 +2,7 @@ export {
   Configuration,
   InitConfiguration,
   DefaultPrivacyLevel,
+  TraceContextInjection,
   validateAndBuildConfiguration,
   serializeConfiguration,
 } from './configuration'

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -102,6 +102,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       trace_sample_rate?: number
       /**
+       * The opt-in configuration to add trace context
+       */
+      trace_context_injection?: 'all' | 'sampled'
+      /**
        * The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
        */
       premium_sample_rate?: number

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export {
   InitConfiguration,
   validateAndBuildConfiguration,
   DefaultPrivacyLevel,
+  TraceContextInjection,
   EndpointBuilder,
   serializeConfiguration,
   INTAKE_SITE_STAGING,

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -1,10 +1,9 @@
 import type { InitConfiguration } from '@datadog/browser-core'
-import { DefaultPrivacyLevel, display } from '@datadog/browser-core'
+import { DefaultPrivacyLevel, display, TraceContextInjection } from '@datadog/browser-core'
 import { EXHAUSTIVE_INIT_CONFIGURATION, SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION } from '../../../core/test'
 import type { ExtractTelemetryConfiguration, CamelToSnakeCase, MapInitConfigurationKey } from '../../../core/test'
 import type { RumInitConfiguration } from './configuration'
 import { DEFAULT_PROPAGATOR_TYPES, serializeRumConfiguration, validateAndBuildRumConfiguration } from './configuration'
-import { TraceContextInjection } from './tracing/tracer'
 
 const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx', applicationId: 'xxx' }
 
@@ -410,7 +409,7 @@ describe('serializeRumConfiguration', () => {
       compressIntakeRequests: true,
       allowedTracingUrls: ['foo'],
       traceSampleRate: 50,
-      traceContextInjection: TraceContextInjection.All,
+      traceContextInjection: TraceContextInjection.ALL,
       defaultPrivacyLevel: 'allow',
       subdomain: 'foo',
       sessionReplaySampleRate: 60,
@@ -442,7 +441,7 @@ describe('serializeRumConfiguration', () => {
       ...SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION,
       session_replay_sample_rate: 60,
       trace_sample_rate: 50,
-      trace_context_injection: TraceContextInjection.All,
+      trace_context_injection: TraceContextInjection.ALL,
       use_allowed_tracing_urls: true,
       selected_tracing_propagators: ['tracecontext', 'datadog'],
       use_excluded_activity_urls: true,

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -4,6 +4,7 @@ import { EXHAUSTIVE_INIT_CONFIGURATION, SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION
 import type { ExtractTelemetryConfiguration, CamelToSnakeCase, MapInitConfigurationKey } from '../../../core/test'
 import type { RumInitConfiguration } from './configuration'
 import { DEFAULT_PROPAGATOR_TYPES, serializeRumConfiguration, validateAndBuildRumConfiguration } from './configuration'
+import { TraceContextInjection } from './tracing/tracer'
 
 const DEFAULT_INIT_CONFIGURATION = { clientToken: 'xxx', applicationId: 'xxx' }
 
@@ -409,6 +410,7 @@ describe('serializeRumConfiguration', () => {
       compressIntakeRequests: true,
       allowedTracingUrls: ['foo'],
       traceSampleRate: 50,
+      traceContextInjection: TraceContextInjection.All,
       defaultPrivacyLevel: 'allow',
       subdomain: 'foo',
       sessionReplaySampleRate: 60,
@@ -440,6 +442,7 @@ describe('serializeRumConfiguration', () => {
       ...SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION,
       session_replay_sample_rate: 60,
       trace_sample_rate: 50,
+      trace_context_injection: TraceContextInjection.All,
       use_allowed_tracing_urls: true,
       selected_tracing_propagators: ['tracecontext', 'datadog'],
       use_excluded_activity_urls: true,

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -81,6 +81,24 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
+  describe('traceContextInjection', () => {
+    it('defaults to all if no options provided', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.traceContextInjection).toBe('all')
+    })
+    it('is set to provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceContextInjection: 'sampled' })!
+          .traceContextInjection
+      ).toBe('sampled')
+    })
+    it('ignores incorrect value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceContextInjection: 'foo' as any })!
+          .traceContextInjection
+      ).toBe(TraceContextInjection.ALL)
+    })
+  })
+
   describe('allowedTracingUrls', () => {
     it('defaults to an empty array', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.allowedTracingUrls).toEqual([])

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -13,7 +13,7 @@ import {
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type { RumEvent } from '../rumEvent.types'
-import { isTracingOption } from './tracing/tracer'
+import { isTracingOption, TraceContextInjection } from './tracing/tracer'
 import type { PropagatorType, TracingOption } from './tracing/tracer.types'
 
 export const DEFAULT_PROPAGATOR_TYPES: PropagatorType[] = ['tracecontext', 'datadog']
@@ -48,22 +48,6 @@ export interface RumInitConfiguration extends InitConfiguration {
 }
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>
-
-/*
-Allows to control the behavior of trace context injection.
-This allows upstream services to inject trace context based on their sampling configuration.
-*/
-export enum TraceContextInjection {
-  /*
-  Default. Inject trace context to all network requests as per the sampling rate.
-  */
-  All,
-
-  /*
-  Inject trace context only if the trace is sampled.
-  */
-  Sampled,
-}
 
 export interface RumConfiguration extends Configuration {
   // Built from init configuration

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -49,6 +49,22 @@ export interface RumInitConfiguration extends InitConfiguration {
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>
 
+/*
+Allows to control the behavior of trace context injection.
+This allows upstream services to inject trace context based on their sampling configuration.
+*/
+export enum TraceContextInjection {
+  /*
+  Default. Inject trace context to all network requests as per the sampling rate.
+  */
+  All,
+
+  /*
+  Inject trace context only if the trace is sampled.
+  */
+  Sampled,
+}
+
 export interface RumConfiguration extends Configuration {
   // Built from init configuration
   actionNameAttribute: string | undefined
@@ -68,6 +84,7 @@ export interface RumConfiguration extends Configuration {
   version?: string
   subdomain?: string
   customerDataTelemetrySampleRate: number
+  traceContextInjection?: TraceContextInjection
 }
 
 export function validateAndBuildRumConfiguration(
@@ -127,6 +144,7 @@ export function validateAndBuildRumConfiguration(
         ? initConfiguration.defaultPrivacyLevel
         : DefaultPrivacyLevel.MASK,
       customerDataTelemetrySampleRate: 1,
+      traceContextInjection: TraceContextInjection.All,
     },
     baseConfiguration
   )

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -130,7 +130,9 @@ export function validateAndBuildRumConfiguration(
         ? initConfiguration.defaultPrivacyLevel
         : DefaultPrivacyLevel.MASK,
       customerDataTelemetrySampleRate: 1,
-      traceContextInjection: initConfiguration.traceContextInjection ?? TraceContextInjection.ALL,
+      traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
+        ? initConfiguration.traceContextInjection
+        : TraceContextInjection.ALL,
     },
     baseConfiguration
   )

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -6,6 +6,7 @@ import {
   serializeConfiguration,
   assign,
   DefaultPrivacyLevel,
+  TraceContextInjection,
   display,
   isPercentage,
   objectHasValue,
@@ -13,7 +14,7 @@ import {
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type { RumEvent } from '../rumEvent.types'
-import { isTracingOption, TraceContextInjection } from './tracing/tracer'
+import { isTracingOption } from './tracing/tracer'
 import type { PropagatorType, TracingOption } from './tracing/tracer.types'
 
 export const DEFAULT_PROPAGATOR_TYPES: PropagatorType[] = ['tracecontext', 'datadog']
@@ -129,7 +130,7 @@ export function validateAndBuildRumConfiguration(
         ? initConfiguration.defaultPrivacyLevel
         : DefaultPrivacyLevel.MASK,
       customerDataTelemetrySampleRate: 1,
-      traceContextInjection: initConfiguration.traceContextInjection ?? TraceContextInjection.All,
+      traceContextInjection: initConfiguration.traceContextInjection ?? TraceContextInjection.ALL,
     },
     baseConfiguration
   )

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -70,7 +70,7 @@ export interface RumConfiguration extends Configuration {
   version?: string
   subdomain?: string
   customerDataTelemetrySampleRate: number
-  traceContextInjection?: TraceContextInjection
+  traceContextInjection: TraceContextInjection
 }
 
 export function validateAndBuildRumConfiguration(

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -29,6 +29,7 @@ export interface RumInitConfiguration extends InitConfiguration {
   // tracing options
   allowedTracingUrls?: Array<MatchOption | TracingOption> | undefined
   traceSampleRate?: number | undefined
+  traceContextInjection?: TraceContextInjection | undefined
 
   // replay options
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
@@ -196,6 +197,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
       session_replay_sample_rate: configuration.sessionReplaySampleRate,
       start_session_replay_recording_manually: configuration.startSessionReplayRecordingManually,
       trace_sample_rate: configuration.traceSampleRate,
+      trace_context_injection: configuration.traceContextInjection,
       action_name_attribute: configuration.actionNameAttribute,
       use_allowed_tracing_urls:
         Array.isArray(configuration.allowedTracingUrls) && configuration.allowedTracingUrls.length > 0,

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -129,7 +129,7 @@ export function validateAndBuildRumConfiguration(
         ? initConfiguration.defaultPrivacyLevel
         : DefaultPrivacyLevel.MASK,
       customerDataTelemetrySampleRate: 1,
-      traceContextInjection: TraceContextInjection.All,
+      traceContextInjection: initConfiguration.traceContextInjection ?? TraceContextInjection.All,
     },
     baseConfiguration
   )

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -222,7 +222,7 @@ describe('tracer', () => {
       expect(xhrStub.headers['x-datadog-sampling-priority']).toBeUndefined()
     })
 
-    it('should add headers when trace sampled and config set to Sampled', () => {
+    it('should add headers when trace sampled and config set to sampled', () => {
       const configurationWithInjectionParam = {
         ...configuration,
         traceSampleRate: 100,

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -1,10 +1,10 @@
-import { display, isIE, objectEntries } from '@datadog/browser-core'
+import { display, isIE, objectEntries, TraceContextInjection } from '@datadog/browser-core'
 import type { RumSessionManagerMock } from '../../../test'
 import { createRumSessionManagerMock } from '../../../test'
 import type { RumFetchResolveContext, RumFetchStartContext, RumXhrStartContext } from '../requestCollection'
 import type { RumConfiguration, RumInitConfiguration } from '../configuration'
 import { validateAndBuildRumConfiguration } from '../configuration'
-import { startTracer, TraceIdentifier, TraceContextInjection } from './tracer'
+import { startTracer, TraceIdentifier } from './tracer'
 
 describe('tracer', () => {
   let configuration: RumConfiguration
@@ -211,7 +211,7 @@ describe('tracer', () => {
       const configurationWithInjectionParam = {
         ...configuration,
         traceSampleRate: 0,
-        traceContextInjection: TraceContextInjection.Sampled,
+        traceContextInjection: TraceContextInjection.SAMPLED,
       }
 
       const tracer = startTracer(configurationWithInjectionParam, sessionManager)
@@ -226,7 +226,7 @@ describe('tracer', () => {
       const configurationWithInjectionParam = {
         ...configuration,
         traceSampleRate: 100,
-        traceContextInjection: TraceContextInjection.Sampled,
+        traceContextInjection: TraceContextInjection.SAMPLED,
       }
 
       const tracer = startTracer(configurationWithInjectionParam, sessionManager)
@@ -241,7 +241,7 @@ describe('tracer', () => {
       const configurationWithInjectionParam = {
         ...configuration,
         traceSampleRate: 0,
-        traceContextInjection: TraceContextInjection.All,
+        traceContextInjection: TraceContextInjection.ALL,
       }
 
       const tracer = startTracer(configurationWithInjectionParam, sessionManager)
@@ -573,7 +573,7 @@ describe('tracer', () => {
     const configurationWithoutHeaders = validateAndBuildRumConfiguration({
       ...INIT_CONFIGURATION,
       traceSampleRate: 0,
-      traceContextInjection: TraceContextInjection.Sampled,
+      traceContextInjection: TraceContextInjection.SAMPLED,
     })!
 
     const tracer = startTracer(configurationWithoutHeaders, sessionManager)
@@ -587,7 +587,7 @@ describe('tracer', () => {
     const configurationWithoutHeaders = validateAndBuildRumConfiguration({
       ...INIT_CONFIGURATION,
       traceSampleRate: 100,
-      traceContextInjection: TraceContextInjection.Sampled,
+      traceContextInjection: TraceContextInjection.SAMPLED,
     })!
 
     const tracer = startTracer(configurationWithoutHeaders, sessionManager)
@@ -604,7 +604,7 @@ describe('tracer', () => {
     const configurationWithoutHeaders = validateAndBuildRumConfiguration({
       ...INIT_CONFIGURATION,
       traceSampleRate: 0,
-      traceContextInjection: TraceContextInjection.All,
+      traceContextInjection: TraceContextInjection.ALL,
     })!
 
     const tracer = startTracer(configurationWithoutHeaders, sessionManager)

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -567,7 +567,7 @@ describe('tracer', () => {
       expect(context.init!.headers).not.toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
       expect(context.init!.headers).not.toContain(jasmine.arrayContaining(['X-B3-TraceId']))
     })
-    it('should not init context when trace not sampled and config set to sampled only', () => {
+    it('should not add headers when trace not sampled and config set to sample', () => {
       const configurationWithHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
         traceSampleRate: 0,

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -598,7 +598,7 @@ describe('tracer', () => {
       expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-sampling-priority']))
     })
 
-    it('should add headers when trace not sampled yet config set to all', () => {
+    it('should add headers when trace not sampled and config set to all', () => {
       const configurationWithHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
         traceSampleRate: 0,

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -3,8 +3,8 @@ import type { RumSessionManagerMock } from '../../../test'
 import { createRumSessionManagerMock } from '../../../test'
 import type { RumFetchResolveContext, RumFetchStartContext, RumXhrStartContext } from '../requestCollection'
 import type { RumConfiguration, RumInitConfiguration } from '../configuration'
-import { TraceContextInjection, validateAndBuildRumConfiguration } from '../configuration'
-import { startTracer, TraceIdentifier } from './tracer'
+import { validateAndBuildRumConfiguration } from '../configuration'
+import { startTracer, TraceIdentifier, TraceContextInjection } from './tracer'
 
 describe('tracer', () => {
   let configuration: RumConfiguration

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -207,7 +207,7 @@ describe('tracer', () => {
       expect(xhrStub.headers['X-B3-TraceId']).toBeUndefined()
     })
 
-    it('should not add any headers when trace not sampled and config set to sampled only', () => {
+    it('should not add any headers when trace not sampled and config set to sampled', () => {
       const configurationWithInjectionParam = {
         ...configuration,
         traceSampleRate: 0,

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -567,54 +567,53 @@ describe('tracer', () => {
       expect(context.init!.headers).not.toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
       expect(context.init!.headers).not.toContain(jasmine.arrayContaining(['X-B3-TraceId']))
     })
-  })
+    it('should not init context when trace not sampled and config set to sampled only', () => {
+      const configurationWithHeaders = validateAndBuildRumConfiguration({
+        ...INIT_CONFIGURATION,
+        traceSampleRate: 0,
+        traceContextInjection: TraceContextInjection.SAMPLED,
+      })!
 
-  it('should not init context when trace not sampled and config set to sampled only', () => {
-    const configurationWithoutHeaders = validateAndBuildRumConfiguration({
-      ...INIT_CONFIGURATION,
-      traceSampleRate: 0,
-      traceContextInjection: TraceContextInjection.SAMPLED,
-    })!
+      const tracer = startTracer(configurationWithHeaders, sessionManager)
+      const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceFetch(context)
 
-    const tracer = startTracer(configurationWithoutHeaders, sessionManager)
-    const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
-    tracer.traceFetch(context)
+      expect(context.init).toBeUndefined()
+    })
 
-    expect(context.init).toBeUndefined()
-  })
+    it('should add headers when trace sampled and config set to sampled', () => {
+      const configurationWithHeaders = validateAndBuildRumConfiguration({
+        ...INIT_CONFIGURATION,
+        traceSampleRate: 100,
+        traceContextInjection: TraceContextInjection.SAMPLED,
+      })!
 
-  it('should add headers when trace sampled and config set to sampled', () => {
-    const configurationWithoutHeaders = validateAndBuildRumConfiguration({
-      ...INIT_CONFIGURATION,
-      traceSampleRate: 100,
-      traceContextInjection: TraceContextInjection.SAMPLED,
-    })!
+      const tracer = startTracer(configurationWithHeaders, sessionManager)
+      const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceFetch(context)
 
-    const tracer = startTracer(configurationWithoutHeaders, sessionManager)
-    const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
-    tracer.traceFetch(context)
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-origin']))
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-parent-id']))
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-sampling-priority']))
+    })
 
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-origin']))
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-parent-id']))
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-sampling-priority']))
-  })
+    it('should add headers when trace not sampled yet config set to all', () => {
+      const configurationWithHeaders = validateAndBuildRumConfiguration({
+        ...INIT_CONFIGURATION,
+        traceSampleRate: 0,
+        traceContextInjection: TraceContextInjection.ALL,
+      })!
 
-  it('should add headers when trace not sampled yet config set to all', () => {
-    const configurationWithoutHeaders = validateAndBuildRumConfiguration({
-      ...INIT_CONFIGURATION,
-      traceSampleRate: 0,
-      traceContextInjection: TraceContextInjection.ALL,
-    })!
+      const tracer = startTracer(configurationWithHeaders, sessionManager)
+      const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceFetch(context)
 
-    const tracer = startTracer(configurationWithoutHeaders, sessionManager)
-    const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
-    tracer.traceFetch(context)
-
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-origin']))
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-parent-id']))
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
-    expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-sampling-priority']))
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-origin']))
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-parent-id']))
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
+      expect(context.init!.headers).toContain(jasmine.arrayContaining(['x-datadog-sampling-priority']))
+    })
   })
 
   describe('clearTracingIfCancelled', () => {

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -567,7 +567,7 @@ describe('tracer', () => {
       expect(context.init!.headers).not.toContain(jasmine.arrayContaining(['x-datadog-trace-id']))
       expect(context.init!.headers).not.toContain(jasmine.arrayContaining(['X-B3-TraceId']))
     })
-    it('should not add headers when trace not sampled and config set to sample', () => {
+    it('should not add headers when trace not sampled and config set to sampled', () => {
       const configurationWithHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
         traceSampleRate: 0,

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -210,6 +210,7 @@ describe('tracer', () => {
     it('should not add any headers with sampled traceContextInjection', () => {
       const configurationWithInjectionParam = {
         ...configuration,
+        traceSampleRate: 0,
         traceContextInjection: TraceContextInjection.Sampled,
       }
 
@@ -221,6 +222,20 @@ describe('tracer', () => {
       expect(xhrStub.headers['traceparent']).toBeUndefined()
       expect(xhrStub.headers['x-datadog-trace-id']).toBeUndefined()
       expect(xhrStub.headers['X-B3-TraceId']).toBeUndefined()
+    })
+
+    it('should add headers when trace sampled', () => {
+      const configurationWithInjectionParam = {
+        ...configuration,
+        traceSampleRate: 100,
+        traceContextInjection: TraceContextInjection.Sampled,
+      }
+
+      const tracer = startTracer(configurationWithInjectionParam, sessionManager)
+      const context = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceXhr(context, xhrStub as unknown as XMLHttpRequest)
+
+      expect(xhrStub.headers['x-datadog-trace-id']).toBeDefined()
     })
 
     it('should ignore wrong propagator types', () => {

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -19,22 +19,6 @@ import type {
 import type { RumSessionManager } from '../rumSessionManager'
 import type { PropagatorType, TracingOption } from './tracer.types'
 
-/*
-Allows to control the behavior of trace context injection.
-This allows upstream services to inject trace context based on their sampling configuration.
-*/
-export const enum TraceContextInjection {
-  /*
-    Default. Inject trace context to all network requests as per the sampling rate.
-    */
-  All,
-
-  /*
-    Inject trace context only if the trace is sampled.
-    */
-  Sampled,
-}
-
 export interface Tracer {
   traceFetch: (context: Partial<RumFetchStartContext>) => void
   traceXhr: (context: Partial<RumXhrStartContext>, xhr: XMLHttpRequest) => void
@@ -139,8 +123,8 @@ function injectHeadersIfTracingAllowed(
   context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
 
   if (
-    (context.traceSampled && configuration.traceContextInjection === TraceContextInjection.Sampled) ||
-    configuration.traceContextInjection === TraceContextInjection.All
+    (context.traceSampled && configuration.traceContextInjection === 'sampled') ||
+    configuration.traceContextInjection === 'all'
   ) {
     inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
   }

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -118,14 +118,16 @@ function injectHeadersIfTracingAllowed(
   if (!tracingOption) {
     return
   }
+  context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
+
+  if (!context.traceSampled && configuration.traceContextInjection !== TraceContextInjection.ALL) {
+    return
+  }
 
   context.traceId = new TraceIdentifier()
   context.spanId = new TraceIdentifier()
-  context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
 
-  if (context.traceSampled || configuration.traceContextInjection === TraceContextInjection.ALL) {
-    inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
-  }
+  inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
 }
 
 export function isTracingSupported() {

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -123,8 +123,7 @@ function injectHeadersIfTracingAllowed(
   context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
 
   if (
-    (context.traceSampled && configuration.traceContextInjection === 'sampled') ||
-    configuration.traceContextInjection === 'all'
+    (context.traceSampled || configuration.traceContextInjection === TraceContextInjection.ALL)
   ) {
     inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
   }

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -137,7 +137,10 @@ function injectHeadersIfTracingAllowed(
   context.traceId = new TraceIdentifier()
   context.spanId = new TraceIdentifier()
   context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
-  if (configuration.traceContextInjection === TraceContextInjection.All) {
+  if (
+    (context.traceSampled && configuration.traceContextInjection === TraceContextInjection.Sampled) ||
+    configuration.traceContextInjection === TraceContextInjection.All
+  ) {
     inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
   }
 }

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -8,6 +8,7 @@ import {
   getType,
   isMatchOption,
   matchList,
+  TraceContextInjection,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type {
@@ -122,9 +123,7 @@ function injectHeadersIfTracingAllowed(
   context.spanId = new TraceIdentifier()
   context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
 
-  if (
-    (context.traceSampled || configuration.traceContextInjection === TraceContextInjection.ALL)
-  ) {
+  if (context.traceSampled || configuration.traceContextInjection === TraceContextInjection.ALL) {
     inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
   }
 }

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -9,7 +9,6 @@ import {
   isMatchOption,
   matchList,
 } from '@datadog/browser-core'
-import { TraceContextInjection } from '../configuration'
 import type { RumConfiguration } from '../configuration'
 import type {
   RumFetchResolveContext,
@@ -19,6 +18,22 @@ import type {
 } from '../requestCollection'
 import type { RumSessionManager } from '../rumSessionManager'
 import type { PropagatorType, TracingOption } from './tracer.types'
+
+/*
+Allows to control the behavior of trace context injection.
+This allows upstream services to inject trace context based on their sampling configuration.
+*/
+export const enum TraceContextInjection {
+  /*
+    Default. Inject trace context to all network requests as per the sampling rate.
+    */
+  All,
+
+  /*
+    Inject trace context only if the trace is sampled.
+    */
+  Sampled,
+}
 
 export interface Tracer {
   traceFetch: (context: Partial<RumFetchStartContext>) => void

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -137,6 +137,7 @@ function injectHeadersIfTracingAllowed(
   context.traceId = new TraceIdentifier()
   context.spanId = new TraceIdentifier()
   context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
+
   if (
     (context.traceSampled && configuration.traceContextInjection === TraceContextInjection.Sampled) ||
     configuration.traceContextInjection === TraceContextInjection.All

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -9,7 +9,7 @@ import {
   isMatchOption,
   matchList,
 } from '@datadog/browser-core'
-import type { RumConfiguration } from '../configuration'
+import { TraceContextInjection, type RumConfiguration } from '../configuration'
 import type {
   RumFetchResolveContext,
   RumFetchStartContext,
@@ -121,7 +121,9 @@ function injectHeadersIfTracingAllowed(
   context.traceId = new TraceIdentifier()
   context.spanId = new TraceIdentifier()
   context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
-  inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
+  if (configuration.traceContextInjection == TraceContextInjection.All) {
+    inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
+  }
 }
 
 export function isTracingSupported() {

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -9,7 +9,8 @@ import {
   isMatchOption,
   matchList,
 } from '@datadog/browser-core'
-import { TraceContextInjection, type RumConfiguration } from '../configuration'
+import { TraceContextInjection } from '../configuration'
+import type { RumConfiguration } from '../configuration'
 import type {
   RumFetchResolveContext,
   RumFetchStartContext,

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -121,7 +121,7 @@ function injectHeadersIfTracingAllowed(
   context.traceId = new TraceIdentifier()
   context.spanId = new TraceIdentifier()
   context.traceSampled = !isNumber(configuration.traceSampleRate) || performDraw(configuration.traceSampleRate)
-  if (configuration.traceContextInjection == TraceContextInjection.All) {
+  if (configuration.traceContextInjection === TraceContextInjection.All) {
     inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
   }
 }


### PR DESCRIPTION
## Motivation
APM is working on building more granular sampling control on the backend side which can't be applied if the sampling decision is already taken on the client side.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Added a field `traceContextInjection` in the configuration to control context injection. 

This new configuration allows more granular sampling at the backend and does not bring any break changes. It is available along with sampling rate configuration.

`traceContextInjection` is an opt-in configuration defaults to "all" which means no behavior changes. If opt-in for the "sampled" option, you would see only sampled requests having trace context attached to them.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing
| Sampling Decision | traceContextInjection | Expected Behavior | 
|--------|--------|--------|
| Sampled | all | Inject trace context with sampling priority 1 | 
| Sampled | sampled | Inject trace context with sampling priority 1 | 
| Not Sampled | all | Inject trace context with sampling priority 0 | 
| Not Sampled | sampled | Do not inject trace context | 


<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
