### PR TITLE
⚡ [RUM-2633] Optimize DOM iteration in the recorder

### DIFF
--- a/packages/rum-core/src/browser/htmlDomUtils.ts
+++ b/packages/rum-core/src/browser/htmlDomUtils.ts
@@ -24,7 +24,14 @@ export function hasChildNodes(node: Node) {
 }
 
 export function forEachChildNodes(node: Node, callback: (child: Node) => void) {
-  node.childNodes.forEach(callback)
+  let child = node.firstChild
+
+  while (child) {
+    callback(child)
+
+    child = child.nextSibling
+  }
+
   if (isNodeShadowHost(node)) {
     callback(node.shadowRoot)
   }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
It was suggesting that we could improve the performance of the child node iteration by using a more efficient method.

This [benchmark](https://measurethat.net/Benchmarks/Show/15720/0/fastest-way-to-list-children-childnodes-vs-children-vs) suggest that using `nextSibling` is 5 times faster than using `childNodes.forEach`.

In reality the improvement is not so significant for our use case (see below), however the change is pretty small and safe so it's can't hurt to implement.


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
Refactor `forEachChildNodes()` to use `nextSibling` instead of `childNodes.forEach`.


## Benchmark

I've ran some benchmarks locally to get numbers that matches better our use-case.
- ran the benchmark on https://app.datadoghq.com
- measure the time it takes to make a full session replay recording

results:

| | `childNodes.forEach` | `nextSibling` |
|--------|--------|--------|
| average time of a full snapshot | 136.7 ms | 131.8 ms |
| ops / sec | 7.4 | 7.6 |

We observe a ~4% improvement which is not very significant and suggests that the bottleneck is somewhere else.

<details><summary>test script</summary>

```js
const warmupStart = performance.now()

while (performance.now() - warmupStart < 2000) {
  DD_RUM.stopSessionReplayRecording()
  DD_RUM.startSessionReplayRecording()
}

const testStart = performance.now()
const measures = []

while (performance.now() - testStart < 5000) {
  const measureStart = performance.now()

  DD_RUM.stopSessionReplayRecording()
  DD_RUM.startSessionReplayRecording()

  measures.push(performance.now() - measureStart)
}
```
</details> 



## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->



- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
