### PR TITLE
👷 Rework fetch usages in ci scripts

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -63,7 +63,6 @@ dev,karma-spec-reporter,MIT,Copyright 2015 Michael Lex
 dev,karma-webpack,MIT,Copyright JS Foundation and other contributors
 dev,lerna,MIT,Copyright 2015-present Lerna Contributors
 dev,minimatch,ISC,Copyright (c) Isaac Z. Schlueter and Contributors
-dev,node-fetch,MIT,Copyright 2016-2020 Node Fetch Team
 dev,node-forge,BSD,Copyright (c) 2010, Digital Bazaar, Inc.
 dev,npm-run-all,MIT,Copyright 2015 Toru Nagashima
 dev,pako,MIT,(C) 2014-2017 Vitaly Puzrin and Andrey Tupitsin

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "karma-webpack": "5.0.0",
     "lerna": "8.1.2",
     "minimatch": "9.0.3",
-    "node-fetch": "3.3.2",
     "npm-run-all": "4.1.5",
     "prettier": "3.2.5",
     "terser-webpack-plugin": "5.3.10",

--- a/scripts/deploy/check-monitors.js
+++ b/scripts/deploy/check-monitors.js
@@ -3,7 +3,7 @@
  * Usage:
  * node check-monitors.js us1,eu1,...
  */
-const { printLog, runMain, fetch } = require('../lib/execution-utils')
+const { printLog, runMain, fetchHandlingError } = require('../lib/execution-utils')
 const { getTelemetryOrgApiKey, getTelemetryOrgApplicationKey } = require('../lib/secrets')
 const { siteByDatacenter } = require('../lib/datadog-sites')
 
@@ -38,7 +38,7 @@ runMain(async () => {
 })
 
 async function fetchMonitorStatus(site, monitorId) {
-  const response = await fetch(`https://api.${site}/api/v1/monitor/${monitorId}`, {
+  const response = await fetchHandlingError(`https://api.${site}/api/v1/monitor/${monitorId}`, {
     method: 'GET',
     headers: {
       Accept: 'application/json',
@@ -46,7 +46,7 @@ async function fetchMonitorStatus(site, monitorId) {
       'DD-APPLICATION-KEY': getTelemetryOrgApplicationKey(site),
     },
   })
-  return JSON.parse(response)
+  return response.json()
 }
 
 function computeMonitorLink(site, monitorId) {

--- a/scripts/lib/bs-utils.js
+++ b/scripts/lib/bs-utils.js
@@ -1,13 +1,13 @@
-const { fetch } = require('../lib/execution-utils')
+const { fetchHandlingError } = require('../lib/execution-utils')
 
 async function browserStackRequest(url, options) {
-  const response = await fetch(url, {
+  const response = await fetchHandlingError(url, {
     headers: {
       Authorization: `Basic ${Buffer.from(`${process.env.BS_USERNAME}:${process.env.BS_ACCESS_KEY}`).toString('base64')}`,
     },
     ...options,
   })
-  return JSON.parse(response)
+  return response.json()
 }
 
 module.exports = {

--- a/scripts/lib/execution-utils.js
+++ b/scripts/lib/execution-utils.js
@@ -1,7 +1,4 @@
 const spawn = require('child_process').spawn
-// node-fetch v3.x only support ESM syntax.
-// Todo: Remove node-fetch when node v18 LTS is released with fetch out of the box
-const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args))
 
 /**
  * Helper to run executables asynchronously, in a shell. This function does not prevent Shell

--- a/scripts/lib/execution-utils.js
+++ b/scripts/lib/execution-utils.js
@@ -48,13 +48,13 @@ function printLog(...params) {
   console.log(greenColor, ...params, resetColor)
 }
 
-async function fetchWrapper(url, options) {
+async function fetchHandlingError(url, options) {
   const response = await fetch(url, options)
   if (!response.ok) {
     throw new Error(`HTTP Error Response: ${response.status} ${response.statusText}`)
   }
 
-  return response.text()
+  return response
 }
 
 function timeout(ms) {
@@ -66,6 +66,6 @@ module.exports = {
   printError,
   printLog,
   runMain,
-  fetch: fetchWrapper,
+  fetchHandlingError,
   timeout,
 }

--- a/scripts/report-bundle-size/report-to-datadog.js
+++ b/scripts/report-bundle-size/report-to-datadog.js
@@ -1,4 +1,4 @@
-const { fetch } = require('../lib/execution-utils')
+const { fetchHandlingError } = require('../lib/execution-utils')
 const { getOrg2ApiKey } = require('../lib/secrets')
 const { browserSdkVersion } = require('../lib/browser-sdk-version')
 
@@ -29,7 +29,7 @@ function createLogData(bundleSizes, browserSdkVersion) {
 }
 
 async function sendLogToOrg2(bundleData = {}) {
-  await fetch(LOG_INTAKE_URL, {
+  await fetchHandlingError(LOG_INTAKE_URL, {
     method: 'POST',
     headers: LOG_INTAKE_REQUEST_HEADERS,
     body: JSON.stringify(bundleData),

--- a/scripts/test/bump-chrome-version.js
+++ b/scripts/test/bump-chrome-version.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fs = require('fs')
-const { printLog, runMain, fetch } = require('../lib/execution-utils')
+const { printLog, runMain, fetchHandlingError } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { CI_FILE, replaceCiFileVariable } = require('../lib/files-utils')
 const { initGitConfig } = require('../lib/git-utils')
@@ -57,7 +57,7 @@ runMain(async () => {
 })
 
 async function getPackageVersion() {
-  const packagePage = await fetch(CHROME_PACKAGE_URL)
+  const packagePage = await (await fetchHandlingError(CHROME_PACKAGE_URL)).text()
   const packageMatches = /<td>([0-9.-]+)<\/td>/.exec(packagePage)
 
   return packageMatches ? packageMatches[1] : null

--- a/yarn.lock
+++ b/yarn.lock
@@ -3289,7 +3289,6 @@ __metadata:
     karma-webpack: 5.0.0
     lerna: 8.1.2
     minimatch: 9.0.3
-    node-fetch: 3.3.2
     npm-run-all: 4.1.5
     prettier: 3.2.5
     terser-webpack-plugin: 5.3.10
@@ -9328,17 +9327,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:3.3.2, node-fetch@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "node-fetch@npm:3.3.2"
-  dependencies:
-    data-uri-to-buffer: ^4.0.0
-    fetch-blob: ^3.1.4
-    formdata-polyfill: ^4.0.10
-  checksum: 06a04095a2ddf05b0830a0d5302699704d59bda3102894ea64c7b9d4c865ecdff2d90fd042df7f5bc40337266961cb6183dcc808ea4f3000d024f422b462da92
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7":
   version: 2.6.12
   resolution: "node-fetch@npm:2.6.12"
@@ -9350,6 +9338,17 @@ __metadata:
     encoding:
       optional: true
   checksum: 3bc1655203d47ee8e313c0d96664b9673a3d4dd8002740318e9d27d14ef306693a4b2ef8d6525775056fd912a19e23f3ac0d7111ad8925877b7567b29a625592
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: ^4.0.0
+    fetch-blob: ^3.1.4
+    formdata-polyfill: ^4.0.10
+  checksum: 06a04095a2ddf05b0830a0d5302699704d59bda3102894ea64c7b9d4c865ecdff2d90fd042df7f5bc40337266961cb6183dcc808ea4f3000d024f422b462da92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

Inside ci scripts, mixed usage of native fetch and fetchWrapper as fetch with different APIs.

## Changes

- 🔥 remove node-fetch dependency, native fetch introduced in node 18
- ♻️ rework fetchWrapper, now exported as `fetchHandlingError` and letting the caller handle the response

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
