### PR TITLE
🐛 [RUM-3599] do not define undefined instrumented method

### DIFF
--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from './timer'
 import { callMonitored } from './monitor'
 import { noop } from './utils/functionUtils'
-import { arrayFrom } from './utils/polyfills'
+import { arrayFrom, startsWith } from './utils/polyfills'
 
 /**
  * Object passed to the callback of an instrumented method call. See `instrumentMethod` for more
@@ -58,7 +58,7 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
   let original = targetPrototype[method]
 
   if (typeof original !== 'function') {
-    if (method.startsWith('on')) {
+    if (startsWith(method, 'on')) {
       original = noop as TARGET[METHOD]
     } else {
       return { stop: noop }

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -35,10 +35,22 @@ type PostCallCallback<TARGET extends { [key: string]: any }, METHOD extends keyo
  * Instruments a method on a object, calling the given callback before the original method is
  * invoked. The callback receives an object with information about the method call.
  *
+ * This function makes sure that we are "good citizens" regarding third party instrumentations: when
+ * removing the instrumentation, the original method is usually restored, but if a third party
+ * instrumentation was set after ours, we keep it in place and just replace our instrumentation with
+ * a noop.
+ *
  * Note: it is generally better to instrument methods that are "owned" by the object instead of ones
  * that are inherited from the prototype chain. Example:
  * * do:    `instrumentMethod(Array.prototype, 'push', ...)`
  * * don't: `instrumentMethod([], 'push', ...)`
+ *
+ * This method is also used to set event handler properties (ex: window.onerror = ...), as it has
+ * the same requirements as instrumenting a method:
+ * * if the event handler is already set by a third party, we need to call it and not just blindly
+ * override it.
+ * * if the event handler is set by a third party after us, we need to keep it in place when
+ * removing ours.
  *
  * @example
  *


### PR DESCRIPTION
## Motivation

Some websites are removing native methods on purpose. Re-defining the method breaks them.

## Changes

Don't define undefined instrumented methods.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
