### PR TITLE
✨ [RUM-3387] forward isAborted  to beforeSend context

### DIFF
--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -23,7 +23,7 @@ export function startLogsAssembly(
 
   lifeCycle.subscribe(
     LifeCycleEventType.RAW_LOG_COLLECTED,
-    ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined }) => {
+    ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined, domainContext }) => {
       const startTime = getRelativeTime(rawLogsEvent.date)
       const session = sessionManager.findTrackedSession(startTime)
 
@@ -47,7 +47,7 @@ export function startLogsAssembly(
       )
 
       if (
-        configuration.beforeSend?.(log) === false ||
+        configuration.beforeSend?.(log, domainContext) === false ||
         (log.origin !== ErrorSource.AGENT &&
           (logRateLimiters[log.status] ?? logRateLimiters['custom']).isLimitReached())
       ) {

--- a/packages/logs/src/domain/lifeCycle.ts
+++ b/packages/logs/src/domain/lifeCycle.ts
@@ -1,5 +1,5 @@
 import { AbstractLifeCycle } from '@datadog/browser-core'
-import type { Context } from '@datadog/browser-core'
+import type { Context, ErrorSource } from '@datadog/browser-core'
 import type { LogsEvent } from '../logsEvent.types'
 import type { CommonContext, RawLogsEvent } from '../rawLogsEvent.types'
 
@@ -16,8 +16,17 @@ interface LifeCycleEventMap {
 export const LifeCycle = AbstractLifeCycle<LifeCycleEventMap>
 export type LifeCycle = AbstractLifeCycle<LifeCycleEventMap>
 
+export type LogsEventDomainContext<T extends ErrorSource> = T extends typeof ErrorSource.NETWORK
+  ? NetworkLogsEventDomainContext
+  : never
+
+type NetworkLogsEventDomainContext = {
+  isAborted: boolean
+}
+
 export interface RawLogsEventCollectedData<E extends RawLogsEvent = RawLogsEvent> {
   rawLogsEvent: E
   messageContext?: object
   savedCommonContext?: CommonContext
+  domainContext?: LogsEventDomainContext<E['origin']>
 }

--- a/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
@@ -110,6 +110,7 @@ describe('network error collection', () => {
 
     fetchStubManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(1)
+      expect(rawLogsEvents[0].domainContext).toEqual({ isAborted: true })
       done()
     })
   })

--- a/packages/logs/src/domain/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.ts
@@ -13,7 +13,7 @@ import {
   isServerError,
 } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../configuration'
-import type { LifeCycle } from '../lifeCycle'
+import type { LifeCycle, LogsEventDomainContext } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 import { StatusType } from '../logger'
 
@@ -45,6 +45,10 @@ export function startNetworkErrorCollection(configuration: LogsConfiguration, li
     }
 
     function onResponseDataAvailable(responseData: unknown) {
+      const domainContext: LogsEventDomainContext<typeof ErrorSource.NETWORK> = {
+        isAborted: request.isAborted,
+      }
+
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
         rawLogsEvent: {
           message: `${format(type)} error ${request.method} ${request.url}`,
@@ -60,6 +64,7 @@ export function startNetworkErrorCollection(configuration: LogsConfiguration, li
           status: StatusType.error,
           origin: ErrorSource.NETWORK,
         },
+        domainContext,
       })
     }
   }

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -22,7 +22,7 @@ interface CommonRawLogsEvent {
   message: string
   status: StatusType
   error?: Error
-  origin: 'network' | 'source' | 'console' | 'logger' | 'agent' | 'report'
+  origin: ErrorSource
 }
 
 export interface RawConsoleLogsEvent extends CommonRawLogsEvent {

--- a/packages/rum-core/src/domain/requestCollection.ts
+++ b/packages/rum-core/src/domain/requestCollection.ts
@@ -55,6 +55,7 @@ export interface RequestCompleteEvent {
   input?: unknown
   init?: RequestInit
   error?: Error
+  isAborted: boolean
 }
 
 let nextRequestIndex = 1
@@ -100,6 +101,7 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: RumConfiguration, 
           type: RequestType.XHR,
           url: context.url,
           xhr: context.xhr,
+          isAborted: context.isAborted,
         })
         break
     }
@@ -143,6 +145,7 @@ export function trackFetch(lifeCycle: LifeCycle, configuration: RumConfiguration
             response: context.response,
             init: context.init,
             input: context.input,
+            isAborted: context.isAborted,
           })
         })
         break

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -91,6 +91,7 @@ describe('resourceCollection', () => {
         type: RequestType.XHR,
         url: 'https://resource.com/valid',
         xhr,
+        isAborted: false,
       })
     )
 
@@ -117,6 +118,7 @@ describe('resourceCollection', () => {
       requestInput: undefined,
       requestInit: undefined,
       error: undefined,
+      isAborted: false,
     })
   })
 
@@ -263,6 +265,7 @@ describe('resourceCollection', () => {
         response,
         input: 'https://resource.com/valid',
         init: { headers: { foo: 'bar' } },
+        isAborted: false,
       })
     )
 
@@ -289,6 +292,7 @@ describe('resourceCollection', () => {
       requestInput: 'https://resource.com/valid',
       requestInit: { headers: { foo: 'bar' } },
       error: undefined,
+      isAborted: false,
     })
   })
   ;[null, undefined, 42, {}].forEach((input: any) => {

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -112,6 +112,7 @@ function processRequest(
       requestInput: request.input,
       requestInit: request.init,
       error: request.error,
+      isAborted: request.isAborted,
     } as RumFetchResourceEventDomainContext | RumXhrResourceEventDomainContext,
   }
 }

--- a/packages/rum-core/src/domainContext.types.ts
+++ b/packages/rum-core/src/domainContext.types.ts
@@ -32,11 +32,13 @@ export interface RumFetchResourceEventDomainContext {
   response?: Response
   error?: Error
   performanceEntry?: PerformanceEntry
+  isAborted: boolean
 }
 
 export interface RumXhrResourceEventDomainContext {
   xhr: XMLHttpRequest
   performanceEntry?: PerformanceEntry
+  isAborted: boolean
 }
 
 export interface RumOtherResourceEventDomainContext {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
Since we compute an isAborted property, we wanted to provide it as a beforeSend context attribute to allow customer to use it how they want, ex:

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

- implement the concept of domain context for Logs' `beforeSend` method
- forward `isAborted` so it's available in the beforeSend context for Logs and Rum

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
