### PR TITLE
✨ [RUM-3710] Update session ID handling to support cookie deletion

### DIFF
--- a/developer-extension/src/panel/components/tabs/infosTab.tsx
+++ b/developer-extension/src/panel/components/tabs/infosTab.tsx
@@ -259,7 +259,7 @@ function formatSessionType(value: string, ...labels: string[]) {
 function endSession() {
   evalInWindow(
     `
-      document.cookie = '_dd_s=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
+      DD_RUM.stopSession()
     `
   ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/developer-extension/src/panel/components/tabs/infosTab.tsx
+++ b/developer-extension/src/panel/components/tabs/infosTab.tsx
@@ -262,7 +262,7 @@ function endSession() {
 
   evalInWindow(
     `
-      document.cookie = '_dd_s=expired=0; expires=${expires}; path=/'
+      document.cookie = '_dd_s=isExpired=1; expires=${expires}; path=/'
     `
   ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/developer-extension/src/panel/components/tabs/infosTab.tsx
+++ b/developer-extension/src/panel/components/tabs/infosTab.tsx
@@ -259,7 +259,7 @@ function formatSessionType(value: string, ...labels: string[]) {
 function endSession() {
   evalInWindow(
     `
-      DD_RUM.stopSession()
+      document.cookie = '_dd_s=expired=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
     `
   ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/developer-extension/src/panel/components/tabs/infosTab.tsx
+++ b/developer-extension/src/panel/components/tabs/infosTab.tsx
@@ -257,9 +257,12 @@ function formatSessionType(value: string, ...labels: string[]) {
 }
 
 function endSession() {
+  const fourHours = 1000 * 60 * 60 * 4
+  const expires = new Date(Date.now() + fourHours).toUTCString()
+
   evalInWindow(
     `
-      document.cookie = '_dd_s=expired=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
+      document.cookie = '_dd_s=expired=0; expires=${expires}; path=/'
     `
   ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/packages/core/src/domain/session/README.md
+++ b/packages/core/src/domain/session/README.md
@@ -1,0 +1,182 @@
+## possible states:
+
+| state      | value                                                        |
+| ---------- | ------------------------------------------------------------ |
+| NotStarted | `{}`                                                         |
+| Expired    | `{expired: '1'}` or `expire >  15 minutes` or `created > 4H` |
+| Tracked    | `{id: 'xxxx-xx-xx}`                                          |
+| NotTracked | `{rum: 0}` or `{logs: 0}`                                    |
+
+## session initializion
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+state fork_state2 <<fork>>
+
+[*] --> fork_state
+
+fork_state --> NotStarted
+fork_state --> Expired
+fork_state --> Tracked
+fork_state --> NotTracked
+NotStarted --> Expired: initializeSession()
+
+Expired --> fork_state2
+Tracked --> fork_state2
+NotTracked --> fork_state2
+fork_state2 --> [*]: expandOrRenew()
+```
+
+## On User Activity
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+
+[*] --> fork_state
+
+fork_state --> [*]: expandOrRenew()
+```
+
+## On Visibility Change
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+state visibility <<choice>>
+
+[*] --> visibility: VisibilityChange
+
+visibility --> [*]: hidden
+visibility --> fork_state : visible
+
+fork_state --> [*]: extendOrExpire()
+```
+
+## On resume from frozen state
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+state fork_state2 <<fork>>
+
+[*] --> fork_state: Resume
+
+fork_state --> NotStarted
+fork_state --> Expired
+fork_state --> Tracked
+fork_state --> NotTracked
+
+NotStarted --> Expired: reinitializeSession()
+Expired --> fork_state2
+Tracked --> fork_state2
+NotTracked --> fork_state2
+
+fork_state2 --> [*]: extendOrExpire()
+```
+
+## Watch (every second)
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+
+
+[*] --> fork_state
+fork_state --> [*]: extendOrExpire()
+```
+
+## 3rd party cookie clearing
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+state join_state <<join>>
+NotStarted2: NotStarted
+
+[*] --> fork_state
+
+fork_state --> NotStarted
+fork_state --> Expired
+fork_state --> Tracked
+fork_state --> NotTracked
+
+Expired --> join_state
+Tracked --> join_state
+NotTracked --> join_state
+NotStarted --> join_state
+
+join_state --> NotStarted2 : clearCookies()
+
+NotStarted2 --> [*]
+```
+
+## Expand Or Renew
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+state fork_state2 <<fork>>
+state fork_state3 <<fork>>
+
+
+state expandOrRenew() {
+  [*] --> fork_state: expandOrRenew()
+  Tracked2: Tracked
+  NotTracked2: NotTracked
+
+  fork_state --> NotStarted
+  fork_state --> Expired
+  fork_state --> Tracked
+  fork_state --> NotTracked
+
+  NotStarted --> [*]
+
+  Expired --> fork_state2: renew()
+  Tracked --> fork_state2: extend()
+  NotTracked --> fork_state2: extend()
+
+  fork_state2 --> fork_state3: computeTrackingType()
+
+  fork_state3 --> Tracked2
+  fork_state3 --> NotTracked2
+
+  Tracked2 --> [*]
+  NotTracked2 --> [*]
+}
+```
+
+> [!NOTE]  
+> Because `computeTrackingType()` happens at every `expandOrRenew()`, it is in theory possible to switch from `Tracked` to `NotTracked` and vice versa within an active session. However, this is not expected to happen in practice at this time.
+
+## Extend Or Expire
+
+```mermaid
+stateDiagram-v2
+state fork_state <<fork>>
+
+state extendOrExpire() {
+  [*] --> fork_state : extendOrExpire()
+  Tracked2: Tracked
+  NotTracked2: NotTracked
+  Expired2: Expired
+
+  fork_state --> NotStarted
+  fork_state --> Expired
+  fork_state --> Tracked
+  fork_state --> NotTracked
+
+  Tracked --> Tracked2: extend()
+  NotTracked --> NotTracked2: extend()
+  Expired --> Expired2: expire()
+
+  NotStarted --> [*]
+  Tracked2 --> [*]
+  NotTracked2 --> [*]
+  Expired2 --> [*]
+}
+```
+
+> [!NOTE]  
+> Because the `Expired` state could happens because a session timed out, `expire()` will normalize explicitely the state to `isExpired=1`

--- a/packages/core/src/domain/session/README.md
+++ b/packages/core/src/domain/session/README.md
@@ -7,7 +7,7 @@
 | Tracked    | `{id: 'xxxx-xx-xx}`                                          |
 | NotTracked | `{rum: 0}` or `{logs: 0}`                                    |
 
-## session initializion
+## session initialization
 
 ```mermaid
 stateDiagram-v2

--- a/packages/core/src/domain/session/README.md
+++ b/packages/core/src/domain/session/README.md
@@ -7,7 +7,12 @@
 | Tracked    | `{id: 'xxxx-xx-xx}`                                          |
 | NotTracked | `{rum: 0}` or `{logs: 0}`                                    |
 
-## session initialization
+Other terminology:
+
+- A _started_ session is a session that is either `Expired`, `Tracked`, or `NotTracked`.
+- An _active_ session is a session that is either `Tracked` or `NotTracked`.
+
+## start session
 
 ```mermaid
 stateDiagram-v2
@@ -20,7 +25,7 @@ fork_state --> NotStarted
 fork_state --> Expired
 fork_state --> Tracked
 fork_state --> NotTracked
-NotStarted --> Expired: initializeSession()
+NotStarted --> Expired: start()
 
 Expired --> fork_state2
 Tracked --> fork_state2
@@ -68,7 +73,7 @@ fork_state --> Expired
 fork_state --> Tracked
 fork_state --> NotTracked
 
-NotStarted --> Expired: reinitializeSession()
+NotStarted --> Expired: restartSession()
 Expired --> fork_state2
 Tracked --> fork_state2
 NotTracked --> fork_state2

--- a/packages/core/src/domain/session/README.md
+++ b/packages/core/src/domain/session/README.md
@@ -1,11 +1,17 @@
 ## possible states:
 
-| state      | value                                                        |
-| ---------- | ------------------------------------------------------------ |
-| NotStarted | `{}`                                                         |
-| Expired    | `{expired: '1'}` or `expire >  15 minutes` or `created > 4H` |
-| Tracked    | `{id: 'xxxx-xx-xx}`                                          |
-| NotTracked | `{rum: 0}` or `{logs: 0}`                                    |
+| state                   | value                                                        |
+| ----------------------- | ------------------------------------------------------------ |
+| NotStarted<sup>\*</sup> | `{}`                                                         |
+| Expired                 | `{expired: '1'}` or `expire >  15 minutes` or `created > 4H` |
+| Tracked                 | `{id: 'xxxx-xx-xx}`                                          |
+| NotTracked              | `{rum: 0}` or `{logs: 0}`                                    |
+
+(<sup>\*</sup>) `NotStarted` is a state that can happen in a few different ways:
+
+- First load of the page if there is no cookie present already
+- After the cookie has been deleted by a 3rd party (user, ad blocker, ...)
+- After the cookie has expired (it is deleted by the browser)
 
 Other terminology:
 
@@ -25,7 +31,7 @@ fork_state --> NotStarted
 fork_state --> Expired
 fork_state --> Tracked
 fork_state --> NotTracked
-NotStarted --> Expired: start()
+NotStarted --> Expired: startSession()
 
 Expired --> fork_state2
 Tracked --> fork_state2

--- a/packages/core/src/domain/session/README.md
+++ b/packages/core/src/domain/session/README.md
@@ -184,4 +184,4 @@ state extendOrExpire() {
 ```
 
 > [!NOTE]  
-> Because the `Expired` state could happens because a session timed out, `expire()` will normalize explicitely the state to `isExpired=1`
+> Because a session time out can result in an `Expired` state, `expire()` explicitly normalizes the state to `isExpired=1`

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -49,7 +49,7 @@ describe('old cookies migration', () => {
 
     tryOldCookiesMigration(sessionStoreStrategy)
 
-    expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
     expect(getCookie(SESSION_STORE_KEY)).toContain('rum=0')
     expect(getCookie(SESSION_STORE_KEY)).toMatch(/expire=\d+/)
   })

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -15,7 +15,6 @@ describe('old cookies migration', () => {
 
   beforeEach(() => {
     sessionStoreStrategy = initCookieStrategy({})
-    setCookie(SESSION_STORE_KEY, '', SESSION_EXPIRATION_DELAY)
     resetInitCookies()
   })
 
@@ -49,7 +48,7 @@ describe('old cookies migration', () => {
 
     tryOldCookiesMigration(sessionStoreStrategy)
 
-    expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
+    expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
     expect(getCookie(SESSION_STORE_KEY)).toContain('rum=0')
     expect(getCookie(SESSION_STORE_KEY)).toMatch(/expire=\d+/)
   })

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -15,6 +15,7 @@ describe('old cookies migration', () => {
 
   beforeEach(() => {
     sessionStoreStrategy = initCookieStrategy({})
+    setCookie(SESSION_STORE_KEY, '', SESSION_EXPIRATION_DELAY)
     resetInitCookies()
   })
 

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -48,7 +48,7 @@ describe('old cookies migration', () => {
 
     tryOldCookiesMigration(sessionStoreStrategy)
 
-    expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
     expect(getCookie(SESSION_STORE_KEY)).toContain('rum=0')
     expect(getCookie(SESSION_STORE_KEY)).toMatch(/expire=\d+/)
   })

--- a/packages/core/src/domain/session/oldCookiesMigration.spec.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.spec.ts
@@ -49,7 +49,7 @@ describe('old cookies migration', () => {
 
     tryOldCookiesMigration(sessionStoreStrategy)
 
-    expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
     expect(getCookie(SESSION_STORE_KEY)).toContain('rum=0')
     expect(getCookie(SESSION_STORE_KEY)).toMatch(/expire=\d+/)
   })

--- a/packages/core/src/domain/session/oldCookiesMigration.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.ts
@@ -1,9 +1,8 @@
 import { getInitCookie } from '../../browser/cookie'
-import { isEmptyObject } from '../../tools/utils/objectUtils'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 import type { SessionState } from './sessionState'
-import { expandSessionState } from './sessionState'
+import { expandSessionState, isSessionStarted } from './sessionState'
 
 export const OLD_SESSION_COOKIE_NAME = '_dd'
 export const OLD_RUM_COOKIE_NAME = '_dd_r'
@@ -35,7 +34,7 @@ export function tryOldCookiesMigration(cookieStoreStrategy: SessionStoreStrategy
       session[RUM_SESSION_KEY] = oldRumType
     }
 
-    if (!isEmptyObject(session)) {
+    if (isSessionStarted(session)) {
       expandSessionState(session)
       cookieStoreStrategy.persistSession(session)
     }

--- a/packages/core/src/domain/session/oldCookiesMigration.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.ts
@@ -1,8 +1,7 @@
 import { getInitCookie } from '../../browser/cookie'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
-import type { SessionState } from './sessionState'
-import { expandSessionState, isSessionInExpiredState } from './sessionState'
+import { getInitialSessionState, expandSessionState, isSessionInExpiredState } from './sessionState'
 
 export const OLD_SESSION_COOKIE_NAME = '_dd'
 export const OLD_RUM_COOKIE_NAME = '_dd_r'
@@ -22,7 +21,7 @@ export function tryOldCookiesMigration(cookieStoreStrategy: SessionStoreStrategy
     const oldSessionId = getInitCookie(OLD_SESSION_COOKIE_NAME)
     const oldRumType = getInitCookie(OLD_RUM_COOKIE_NAME)
     const oldLogsType = getInitCookie(OLD_LOGS_COOKIE_NAME)
-    const session: SessionState = {}
+    const session = getInitialSessionState()
 
     if (oldSessionId) {
       session.id = oldSessionId

--- a/packages/core/src/domain/session/oldCookiesMigration.ts
+++ b/packages/core/src/domain/session/oldCookiesMigration.ts
@@ -1,7 +1,9 @@
 import { getInitCookie } from '../../browser/cookie'
+import { isEmptyObject } from '../../tools/utils/objectUtils'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
-import { getInitialSessionState, expandSessionState, isSessionInExpiredState } from './sessionState'
+import type { SessionState } from './sessionState'
+import { expandSessionState } from './sessionState'
 
 export const OLD_SESSION_COOKIE_NAME = '_dd'
 export const OLD_RUM_COOKIE_NAME = '_dd_r'
@@ -21,7 +23,7 @@ export function tryOldCookiesMigration(cookieStoreStrategy: SessionStoreStrategy
     const oldSessionId = getInitCookie(OLD_SESSION_COOKIE_NAME)
     const oldRumType = getInitCookie(OLD_RUM_COOKIE_NAME)
     const oldLogsType = getInitCookie(OLD_LOGS_COOKIE_NAME)
-    const session = getInitialSessionState()
+    const session: SessionState = {}
 
     if (oldSessionId) {
       session.id = oldSessionId
@@ -33,7 +35,7 @@ export function tryOldCookiesMigration(cookieStoreStrategy: SessionStoreStrategy
       session[RUM_SESSION_KEY] = oldRumType
     }
 
-    if (!isSessionInExpiredState(session)) {
+    if (!isEmptyObject(session)) {
       expandSessionState(session)
       cookieStoreStrategy.persistSession(session)
     }

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -303,8 +303,7 @@ describe('startSessionManager', () => {
       expect(getCookie(SESSION_STORE_KEY)).toBeDefined()
 
       clock.tick(SESSION_TIME_OUT_DELAY)
-      expect(sessionManager.findActiveSession()).toBeUndefined()
-      expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
+      expectSessionIdToNotBeDefined(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalled()
     })
 

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -99,6 +99,31 @@ describe('startSessionManager', () => {
     clock.cleanup()
   })
 
+  describe('resume from a frozen tab ', () => {
+    it('when session in store, do nothing', () => {
+      setCookie(SESSION_STORE_KEY, 'id=abcdef&first=tracked', DURATION)
+      const sessionManager = startSessionManagerWithDefaults()
+
+      window.dispatchEvent(createNewEvent(DOM_EVENT.RESUME))
+
+      expectSessionIdToBe(sessionManager, 'abcdef')
+      expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.TRACKED)
+    })
+
+    it('when session not in store, reinitialize a session in store', () => {
+      const sessionManager = startSessionManagerWithDefaults()
+
+      deleteSessionCookie()
+
+      expect(sessionManager.findActiveSession()).toBeUndefined()
+      expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
+
+      window.dispatchEvent(createNewEvent(DOM_EVENT.RESUME))
+
+      expectSessionToNotBeDefined(sessionManager)
+    })
+  })
+
   describe('cookie management', () => {
     it('when tracked, should store tracking type and session id', () => {
       const sessionManager = startSessionManagerWithDefaults()

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -38,7 +38,7 @@ describe('startSessionManager', () => {
   let clock: Clock
 
   function expireSessionCookie() {
-    setCookie(SESSION_STORE_KEY, '', DURATION)
+    setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
     clock.tick(STORAGE_POLL_DELAY)
   }
 
@@ -53,8 +53,13 @@ describe('startSessionManager', () => {
   }
 
   function expectSessionIdToNotBeDefined(sessionManager: SessionManager<FakeTrackingType>) {
-    expect(sessionManager.findActiveSession()?.id).toBeUndefined()
-    expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
+    expect(sessionManager.findActiveSession()).toBeUndefined()
+    expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
+  }
+
+  function expectSessionIdToBeNull(sessionManager: SessionManager<FakeTrackingType>) {
+    expect(sessionManager.findActiveSession()?.id).toBe('null')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
   }
 
   function expectTrackingTypeToBe(
@@ -97,7 +102,7 @@ describe('startSessionManager', () => {
     it('when not tracked should store tracking type', () => {
       const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
 
-      expectSessionIdToNotBeDefined(sessionManager)
+      expectSessionIdToBeNull(sessionManager)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
     })
 
@@ -115,7 +120,7 @@ describe('startSessionManager', () => {
 
       const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
 
-      expectSessionIdToNotBeDefined(sessionManager)
+      expectSessionIdToBeNull(sessionManager)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
     })
   })
@@ -133,19 +138,19 @@ describe('startSessionManager', () => {
     })
 
     it('should be called with an invalid value if the cookie has an invalid value', () => {
-      setCookie(SESSION_STORE_KEY, 'first=invalid', DURATION)
+      setCookie(SESSION_STORE_KEY, 'id=null&first=invalid', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith('invalid')
     })
 
     it('should be called with TRACKED', () => {
-      setCookie(SESSION_STORE_KEY, 'first=tracked', DURATION)
+      setCookie(SESSION_STORE_KEY, 'id=null&first=tracked', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.TRACKED)
     })
 
     it('should be called with NOT_TRACKED', () => {
-      setCookie(SESSION_STORE_KEY, 'first=not-tracked', DURATION)
+      setCookie(SESSION_STORE_KEY, 'id=null&first=not-tracked', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.NOT_TRACKED)
     })
@@ -160,6 +165,7 @@ describe('startSessionManager', () => {
       expireSessionCookie()
 
       expect(renewSessionSpy).not.toHaveBeenCalled()
+
       expectSessionIdToNotBeDefined(sessionManager)
       expectTrackingTypeToNotBeDefined(sessionManager, FIRST_PRODUCT_KEY)
 
@@ -271,7 +277,7 @@ describe('startSessionManager', () => {
 
       clock.tick(SESSION_TIME_OUT_DELAY)
       expect(sessionManager.findActiveSession()).toBeUndefined()
-      expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
+      expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
       expect(expireSessionSpy).toHaveBeenCalled()
     })
 
@@ -525,7 +531,7 @@ describe('startSessionManager', () => {
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
       expectSessionIdToNotBeDefined(sessionManager)
-      expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
+      expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
     })
 
     it('does not renew the session when tracking consent is withdrawn', () => {

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -60,7 +60,7 @@ describe('startSessionManager', () => {
     expect(getCookie(SESSION_STORE_KEY)).not.toContain('isExpired=1')
   }
 
-  function expectSessionToNotBeDefined(sessionManager: SessionManager<FakeTrackingType>) {
+  function expectSessionToBeExpired(sessionManager: SessionManager<FakeTrackingType>) {
     expect(sessionManager.findActiveSession()).toBeUndefined()
     expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
   }
@@ -120,7 +120,7 @@ describe('startSessionManager', () => {
 
       window.dispatchEvent(createNewEvent(DOM_EVENT.RESUME))
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
     })
   })
 
@@ -199,7 +199,7 @@ describe('startSessionManager', () => {
 
       expect(renewSessionSpy).not.toHaveBeenCalled()
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expectTrackingTypeToNotBeDefined(sessionManager, FIRST_PRODUCT_KEY)
 
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
@@ -219,7 +219,7 @@ describe('startSessionManager', () => {
       clock.tick(VISIBILITY_CHECK_DELAY)
 
       expect(renewSessionSpy).not.toHaveBeenCalled()
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
     })
 
     it('should not renew on activity if cookie is deleted by a 3rd party', () => {
@@ -328,7 +328,7 @@ describe('startSessionManager', () => {
       expect(getCookie(SESSION_STORE_KEY)).toBeDefined()
 
       clock.tick(SESSION_TIME_OUT_DELAY)
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalled()
     })
 
@@ -371,7 +371,7 @@ describe('startSessionManager', () => {
       expectSessionIdToBeDefined(sessionManager)
 
       clock.tick(SESSION_EXPIRATION_DELAY)
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalled()
     })
 
@@ -390,7 +390,7 @@ describe('startSessionManager', () => {
       expect(expireSessionSpy).not.toHaveBeenCalled()
 
       clock.tick(SESSION_EXPIRATION_DELAY)
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalled()
     })
 
@@ -430,7 +430,7 @@ describe('startSessionManager', () => {
       expect(expireSessionSpy).not.toHaveBeenCalled()
 
       clock.tick(10)
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalled()
     })
 
@@ -464,7 +464,7 @@ describe('startSessionManager', () => {
 
       sessionManager.expire()
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalled()
     })
 
@@ -476,7 +476,7 @@ describe('startSessionManager', () => {
       sessionManager.expire()
       sessionManager.expire()
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -488,7 +488,7 @@ describe('startSessionManager', () => {
       clock.tick(SESSION_EXPIRATION_DELAY)
       sessionManager.expire()
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(expireSessionSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -581,7 +581,7 @@ describe('startSessionManager', () => {
 
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
       expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
     })
 
@@ -593,7 +593,7 @@ describe('startSessionManager', () => {
 
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
     })
 
     it('renews the session when tracking consent is granted', () => {
@@ -603,7 +603,7 @@ describe('startSessionManager', () => {
 
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
-      expectSessionToNotBeDefined(sessionManager)
+      expectSessionToBeExpired(sessionManager)
 
       trackingConsentState.update(TrackingConsent.GRANTED)
 

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -38,7 +38,7 @@ describe('startSessionManager', () => {
   let clock: Clock
 
   function expireSessionCookie() {
-    setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
+    setCookie(SESSION_STORE_KEY, 'isExpired=1', DURATION)
     clock.tick(STORAGE_POLL_DELAY)
   }
 
@@ -54,20 +54,20 @@ describe('startSessionManager', () => {
 
   function expectSessionIdToBeDefined(sessionManager: SessionManager<FakeTrackingType>) {
     expect(sessionManager.findActiveSession()!.id).toMatch(/^[a-f0-9-]+$/)
-    expect(sessionManager.findActiveSession()?.expired).toBeUndefined()
+    expect(sessionManager.findActiveSession()?.isExpired).toBeUndefined()
 
     expect(getCookie(SESSION_STORE_KEY)).toMatch(/id=[a-f0-9-]+/)
-    expect(getCookie(SESSION_STORE_KEY)).not.toContain('expired=0')
+    expect(getCookie(SESSION_STORE_KEY)).not.toContain('isExpired=1')
   }
 
   function expectSessionToNotBeDefined(sessionManager: SessionManager<FakeTrackingType>) {
     expect(sessionManager.findActiveSession()).toBeUndefined()
-    expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
   }
 
   function expectSessionIdToNotBeDefined(sessionManager: SessionManager<FakeTrackingType>) {
     expect(sessionManager.findActiveSession()!.id).toBeUndefined()
-    expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
   }
 
   function expectTrackingTypeToBe(
@@ -146,19 +146,19 @@ describe('startSessionManager', () => {
     })
 
     it('should be called with an invalid value if the cookie has an invalid value', () => {
-      setCookie(SESSION_STORE_KEY, 'expired=0&first=invalid', DURATION)
+      setCookie(SESSION_STORE_KEY, 'isExpired=1&first=invalid', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith('invalid')
     })
 
     it('should be called with TRACKED', () => {
-      setCookie(SESSION_STORE_KEY, 'expired=0&first=tracked', DURATION)
+      setCookie(SESSION_STORE_KEY, 'isExpired=1&first=tracked', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.TRACKED)
     })
 
     it('should be called with NOT_TRACKED', () => {
-      setCookie(SESSION_STORE_KEY, 'expired=0&first=not-tracked', DURATION)
+      setCookie(SESSION_STORE_KEY, 'isExpired=1&first=not-tracked', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.NOT_TRACKED)
     })
@@ -557,7 +557,7 @@ describe('startSessionManager', () => {
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
       expectSessionToNotBeDefined(sessionManager)
-      expect(getCookie(SESSION_STORE_KEY)).toBe('expired=0')
+      expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
     })
 
     it('does not renew the session when tracking consent is withdrawn', () => {

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -67,7 +67,7 @@ describe('startSessionManager', () => {
 
   function expectSessionIdToNotBeDefined(sessionManager: SessionManager<FakeTrackingType>) {
     expect(sessionManager.findActiveSession()!.id).toBeUndefined()
-    expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
+    expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
   }
 
   function expectTrackingTypeToBe(
@@ -171,19 +171,19 @@ describe('startSessionManager', () => {
     })
 
     it('should be called with an invalid value if the cookie has an invalid value', () => {
-      setCookie(SESSION_STORE_KEY, 'isExpired=1&first=invalid', DURATION)
+      setCookie(SESSION_STORE_KEY, 'first=invalid', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith('invalid')
     })
 
     it('should be called with TRACKED', () => {
-      setCookie(SESSION_STORE_KEY, 'isExpired=1&first=tracked', DURATION)
+      setCookie(SESSION_STORE_KEY, 'first=tracked', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.TRACKED)
     })
 
     it('should be called with NOT_TRACKED', () => {
-      setCookie(SESSION_STORE_KEY, 'isExpired=1&first=not-tracked', DURATION)
+      setCookie(SESSION_STORE_KEY, 'first=not-tracked', DURATION)
       startSessionManagerWithDefaults({ computeSessionState: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.NOT_TRACKED)
     })

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -73,7 +73,7 @@ export function startSessionManager<TrackingType extends string>(
 
   function buildSessionContext() {
     return {
-      id: sessionStore.getSession().id!,
+      id: sessionStore.getSession().id,
       trackingType: sessionStore.getSession()[productKey] as TrackingType,
     }
   }

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -73,7 +73,7 @@ export function startSessionManager<TrackingType extends string>(
 
   function buildSessionContext() {
     return {
-      id: sessionStore.getSession().id,
+      id: sessionStore.getSession().id!,
       trackingType: sessionStore.getSession()[productKey] as TrackingType,
     }
   }

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -70,7 +70,7 @@ export function startSessionManager<TrackingType extends string>(
     }
   })
   trackVisibility(configuration, () => sessionStore.expandSession())
-  trackResume(configuration, () => sessionStore.reinitializeSession())
+  trackResume(configuration, () => sessionStore.restartSession())
 
   function buildSessionContext() {
     return {

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -120,6 +120,6 @@ function trackVisibility(configuration: Configuration, expandSession: () => void
 }
 
 function trackResume(configuration: Configuration, cb: () => void) {
-  const { stop } = addEventListener(configuration, window, DOM_EVENT.RESUME, cb)
+  const { stop } = addEventListener(configuration, window, DOM_EVENT.RESUME, cb, { capture: true })
   stopCallbacks.push(stop)
 }

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -70,6 +70,7 @@ export function startSessionManager<TrackingType extends string>(
     }
   })
   trackVisibility(configuration, () => sessionStore.expandSession())
+  trackResume(configuration, () => sessionStore.reinitializeSession())
 
   function buildSessionContext() {
     return {
@@ -116,4 +117,9 @@ function trackVisibility(configuration: Configuration, expandSession: () => void
   stopCallbacks.push(() => {
     clearInterval(visibilityCheckInterval)
   })
+}
+
+function trackResume(configuration: Configuration, cb: () => void) {
+  const { stop } = addEventListener(configuration, window, DOM_EVENT.RESUME, cb)
+  stopCallbacks.push(stop)
 }

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -6,24 +6,26 @@ import {
   isSessionInExpiredState,
   toSessionString,
   toSessionState,
-  isSessionStarted,
+  isSessionInNotStartedState,
   SessionExpiredReason,
 } from './sessionState'
 
 describe('session state utilities', () => {
+  const NOT_STARTED_SESSION: SessionState = {}
+  const SERIALIZED_NOT_STARTED_SESSION = ''
   const EXPIRED_SESSION: SessionState = { isExpired: SessionExpiredReason.UNKNOWN }
   const SERIALIZED_EXPIRED_SESSION = 'isExpired=1'
   const LIVE_SESSION: SessionState = { id: '123', first: 'tracked' }
   const SERIALIZED_LIVE_SESSION = 'id=123&first=tracked'
 
   describe('isSessionStarted', () => {
-    it('should correctly identify a session in an initialized state', () => {
-      expect(isSessionStarted(LIVE_SESSION)).toBe(true)
-      expect(isSessionStarted(EXPIRED_SESSION)).toBe(true)
+    it('should correctly identify a session in a started state', () => {
+      expect(isSessionInNotStartedState(LIVE_SESSION)).toBe(false)
+      expect(isSessionInNotStartedState(EXPIRED_SESSION)).toBe(false)
     })
 
-    it('should correctly identify a session not in an initialized state', () => {
-      expect(isSessionStarted({} as SessionState)).toBe(false)
+    it('should correctly identify a session in a not started state', () => {
+      expect(isSessionInNotStartedState(NOT_STARTED_SESSION)).toBe(true)
     })
   })
 
@@ -63,7 +65,7 @@ describe('session state utilities', () => {
     })
 
     it('should handle empty session strings', () => {
-      expect(toSessionState('')).toEqual({})
+      expect(toSessionState(SERIALIZED_NOT_STARTED_SESSION)).toEqual(NOT_STARTED_SESSION)
     })
 
     it('should handle expired session', () => {
@@ -72,7 +74,7 @@ describe('session state utilities', () => {
 
     it('should handle invalid session strings', () => {
       const sessionString = '{invalid: true}'
-      expect(toSessionState(sessionString)).toEqual({})
+      expect(toSessionState(sessionString)).toEqual(NOT_STARTED_SESSION)
     })
   })
 

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -4,7 +4,7 @@ import type { SessionState } from './sessionState'
 import { expandSessionState, isSessionInExpiredState, toSessionString, toSessionState } from './sessionState'
 
 describe('session state utilities', () => {
-  const EXPIRED_SESSION: SessionState = {}
+  const EXPIRED_SESSION: SessionState = { id: 'null' }
   const SERIALIZED_EXPIRED_SESSION = ''
   const LIVE_SESSION: SessionState = { created: '0', id: '123' }
   const SERIALIZED_LIVE_SESSION = 'created=0&id=123'

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -5,7 +5,7 @@ import { expandSessionState, isSessionInExpiredState, toSessionString, toSession
 
 describe('session state utilities', () => {
   const EXPIRED_SESSION: SessionState = { id: 'null' }
-  const SERIALIZED_EXPIRED_SESSION = ''
+  const SERIALIZED_EXPIRED_SESSION = 'id=null'
   const LIVE_SESSION: SessionState = { created: '0', id: '123' }
   const SERIALIZED_LIVE_SESSION = 'created=0&id=123'
 

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -39,9 +39,9 @@ describe('session state utilities', () => {
     })
 
     it('should correctly identify a session in live state', () => {
-      expect(
-        isSessionInExpiredState({ created: dateNowWithOffset(-1000), expire: dateNowWithOffset(1000) }, true)
-      ).toBe(false)
+      expect(isSessionInExpiredState({ created: dateNowWithOffset(-1000), expire: dateNowWithOffset(1000) })).toBe(
+        false
+      )
       expect(isSessionInExpiredState({ first: 'not-tracked' })).toBe(false)
       expect(isSessionInExpiredState({ first: 'tracked' })).toBe(false)
     })

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -7,13 +7,12 @@ import {
   toSessionString,
   toSessionState,
   isSessionInNotStartedState,
-  SessionExpiredReason,
 } from './sessionState'
 
 describe('session state utilities', () => {
   const NOT_STARTED_SESSION: SessionState = {}
   const SERIALIZED_NOT_STARTED_SESSION = ''
-  const EXPIRED_SESSION: SessionState = { isExpired: SessionExpiredReason.UNKNOWN }
+  const EXPIRED_SESSION: SessionState = { isExpired: '1' }
   const SERIALIZED_EXPIRED_SESSION = 'isExpired=1'
   const LIVE_SESSION: SessionState = { id: '123', first: 'tracked' }
   const SERIALIZED_LIVE_SESSION = 'id=123&first=tracked'

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -7,18 +7,19 @@ import {
   toSessionString,
   toSessionState,
   isSessionInitialized,
+  SessionExpiredReason,
 } from './sessionState'
 
 describe('session state utilities', () => {
-  const EXPIRED_SESSION: SessionState = { id: 'null' }
-  const SERIALIZED_EXPIRED_SESSION = 'id=null'
+  const EXPIRED_SESSION: SessionState = { expired: SessionExpiredReason.UNKNOWN }
+  const SERIALIZED_EXPIRED_SESSION = 'expired=0'
   const LIVE_SESSION: SessionState = { created: '0', id: '123' }
   const SERIALIZED_LIVE_SESSION = 'created=0&id=123'
 
   describe('isSessionInitialized', () => {
     it('should correctly identify a session in initialized state', () => {
       expect(isSessionInitialized({ id: '123' })).toBe(true)
-      expect(isSessionInitialized({ id: 'null' })).toBe(true)
+      expect(isSessionInitialized({ expired: SessionExpiredReason.UNKNOWN })).toBe(true)
       expect(isSessionInitialized({} as SessionState)).toBe(false)
     })
   })
@@ -26,6 +27,7 @@ describe('session state utilities', () => {
   describe('isSessionInExpiredState', () => {
     it('should correctly identify a session in expired state', () => {
       expect(isSessionInExpiredState(EXPIRED_SESSION)).toBe(true)
+      expect(isSessionInExpiredState({ expired: SessionExpiredReason.UNKNOWN, first: 'not-tracked' })).toBe(false)
     })
 
     it('should correctly identify a session in live state', () => {

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -1,13 +1,27 @@
 import { dateNow } from '../../tools/utils/timeUtils'
 import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
 import type { SessionState } from './sessionState'
-import { expandSessionState, isSessionInExpiredState, toSessionString, toSessionState } from './sessionState'
+import {
+  expandSessionState,
+  isSessionInExpiredState,
+  toSessionString,
+  toSessionState,
+  isSessionInitialized,
+} from './sessionState'
 
 describe('session state utilities', () => {
   const EXPIRED_SESSION: SessionState = { id: 'null' }
   const SERIALIZED_EXPIRED_SESSION = 'id=null'
   const LIVE_SESSION: SessionState = { created: '0', id: '123' }
   const SERIALIZED_LIVE_SESSION = 'created=0&id=123'
+
+  describe('isSessionInitialized', () => {
+    it('should correctly identify a session in initialized state', () => {
+      expect(isSessionInitialized({ id: '123' })).toBe(true)
+      expect(isSessionInitialized({ id: 'null' })).toBe(true)
+      expect(isSessionInitialized({} as SessionState)).toBe(false)
+    })
+  })
 
   describe('isSessionInExpiredState', () => {
     it('should correctly identify a session in expired state', () => {
@@ -40,7 +54,7 @@ describe('session state utilities', () => {
 
     it('should handle invalid session strings', () => {
       const sessionString = '{invalid: true}'
-      expect(toSessionState(sessionString)).toEqual(EXPIRED_SESSION)
+      expect(toSessionState(sessionString)).toEqual({})
     })
   })
 

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -11,23 +11,23 @@ import {
 } from './sessionState'
 
 describe('session state utilities', () => {
-  const EXPIRED_SESSION: SessionState = { expired: SessionExpiredReason.UNKNOWN }
-  const SERIALIZED_EXPIRED_SESSION = 'expired=0'
+  const EXPIRED_SESSION: SessionState = { isExpired: SessionExpiredReason.UNKNOWN }
+  const SERIALIZED_EXPIRED_SESSION = 'isExpired=1'
   const LIVE_SESSION: SessionState = { created: '0', id: '123' }
   const SERIALIZED_LIVE_SESSION = 'created=0&id=123'
 
   describe('isSessionInitialized', () => {
     it('should correctly identify a session in initialized state', () => {
       expect(isSessionInitialized({ id: '123' })).toBe(true)
-      expect(isSessionInitialized({ expired: SessionExpiredReason.UNKNOWN })).toBe(true)
+      expect(isSessionInitialized({ isExpired: SessionExpiredReason.UNKNOWN })).toBe(true)
       expect(isSessionInitialized({} as SessionState)).toBe(false)
     })
   })
 
   describe('isSessionInExpiredState', () => {
-    it('should correctly identify a session in expired state', () => {
+    it('should correctly identify a session in isExpired state', () => {
       expect(isSessionInExpiredState(EXPIRED_SESSION)).toBe(true)
-      expect(isSessionInExpiredState({ expired: SessionExpiredReason.UNKNOWN, first: 'not-tracked' })).toBe(false)
+      expect(isSessionInExpiredState({ isExpired: SessionExpiredReason.UNKNOWN, first: 'not-tracked' })).toBe(false)
     })
 
     it('should correctly identify a session in live state', () => {
@@ -51,6 +51,10 @@ describe('session state utilities', () => {
     })
 
     it('should handle empty session strings', () => {
+      expect(toSessionState('')).toEqual({})
+    })
+
+    it('should handle expired session', () => {
       expect(toSessionState(SERIALIZED_EXPIRED_SESSION)).toEqual(EXPIRED_SESSION)
     })
 

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -6,32 +6,44 @@ import {
   isSessionInExpiredState,
   toSessionString,
   toSessionState,
-  isSessionInitialized,
+  isSessionStarted,
   SessionExpiredReason,
 } from './sessionState'
 
 describe('session state utilities', () => {
   const EXPIRED_SESSION: SessionState = { isExpired: SessionExpiredReason.UNKNOWN }
   const SERIALIZED_EXPIRED_SESSION = 'isExpired=1'
-  const LIVE_SESSION: SessionState = { created: '0', id: '123' }
-  const SERIALIZED_LIVE_SESSION = 'created=0&id=123'
+  const LIVE_SESSION: SessionState = { id: '123', first: 'tracked' }
+  const SERIALIZED_LIVE_SESSION = 'id=123&first=tracked'
 
-  describe('isSessionInitialized', () => {
-    it('should correctly identify a session in initialized state', () => {
-      expect(isSessionInitialized({ id: '123' })).toBe(true)
-      expect(isSessionInitialized({ isExpired: SessionExpiredReason.UNKNOWN })).toBe(true)
-      expect(isSessionInitialized({} as SessionState)).toBe(false)
+  describe('isSessionStarted', () => {
+    it('should correctly identify a session in an initialized state', () => {
+      expect(isSessionStarted(LIVE_SESSION)).toBe(true)
+      expect(isSessionStarted(EXPIRED_SESSION)).toBe(true)
+    })
+
+    it('should correctly identify a session not in an initialized state', () => {
+      expect(isSessionStarted({} as SessionState)).toBe(false)
     })
   })
 
   describe('isSessionInExpiredState', () => {
-    it('should correctly identify a session in isExpired state', () => {
+    function dateNowWithOffset(offset = 0) {
+      return String(dateNow() + offset)
+    }
+
+    it('should correctly identify a session in expired state', () => {
       expect(isSessionInExpiredState(EXPIRED_SESSION)).toBe(true)
-      expect(isSessionInExpiredState({ isExpired: SessionExpiredReason.UNKNOWN, first: 'not-tracked' })).toBe(false)
+      expect(isSessionInExpiredState({ created: dateNowWithOffset(-1000 * 60 * 60 * 4) })).toBe(true)
+      expect(isSessionInExpiredState({ expire: dateNowWithOffset(-100) })).toBe(true)
     })
 
     it('should correctly identify a session in live state', () => {
-      expect(isSessionInExpiredState(LIVE_SESSION)).toBe(false)
+      expect(
+        isSessionInExpiredState({ created: dateNowWithOffset(-1000), expire: dateNowWithOffset(1000) }, true)
+      ).toBe(false)
+      expect(isSessionInExpiredState({ first: 'not-tracked' })).toBe(false)
+      expect(isSessionInExpiredState({ first: 'tracked' })).toBe(false)
     })
   })
 

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -5,30 +5,35 @@ import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
 const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
 const SESSION_ENTRY_SEPARATOR = '&'
 
+export const enum SessionExpiredReason {
+  UNKNOWN = '0',
+}
+
 export interface SessionState {
   id?: string
   created?: string
   expire?: string
   lock?: string
+  expired?: SessionExpiredReason
 
   [key: string]: string | undefined
 }
 
 export function getInitialSessionState(): SessionState {
   return {
-    id: 'null',
+    expired: SessionExpiredReason.UNKNOWN,
   }
 }
 
 export function isSessionInitialized(session: SessionState) {
-  return session.id !== undefined
+  return session.id !== undefined || session.expired !== undefined
 }
 
 export function isSessionInExpiredState(session: SessionState) {
-  // an expired session is `{id = null}` or `{id = null, lock = whatever}`
+  // // an expired session is `{expired = '0'}` or `{expired = '0', lock = whatever}`
   return (
-    (Object.keys(session).length === 1 && session.id === 'null') ||
-    (Object.keys(session).length === 2 && session.id === 'null' && session.lock !== undefined)
+    (Object.keys(session).length === 1 && session.expired !== undefined) ||
+    (Object.keys(session).length === 2 && session.expired !== undefined && session.lock !== undefined)
   )
 }
 

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -6,7 +6,7 @@ const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
 const SESSION_ENTRY_SEPARATOR = '&'
 
 export interface SessionState {
-  id: string
+  id?: string
   created?: string
   expire?: string
   lock?: string
@@ -43,7 +43,7 @@ export function toSessionString(session: SessionState) {
 }
 
 export function toSessionState(sessionString: string | undefined | null) {
-  const session: SessionState = { id: 'null' } as SessionState
+  const session: SessionState = {}
 
   if (isValidSessionString(sessionString)) {
     sessionString.split(SESSION_ENTRY_SEPARATOR).forEach((entry) => {

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -39,7 +39,7 @@ export function toSessionString(session: SessionState) {
 }
 
 export function toSessionState(sessionString: string | undefined | null) {
-  const session: SessionState = {} as SessionState
+  const session: SessionState = { id: 'null' } as SessionState
 
   if (isValidSessionString(sessionString)) {
     sessionString.split(SESSION_ENTRY_SEPARATOR).forEach((entry) => {

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -25,7 +25,11 @@ export function isSessionInitialized(session: SessionState) {
 }
 
 export function isSessionInExpiredState(session: SessionState) {
-  return session.id === 'null'
+  // an expired session is `{id = null}` or `{id = null, lock = whatever}`
+  return (
+    (Object.keys(session).length === 1 && session.id === 'null') ||
+    (Object.keys(session).length === 2 && session.id === 'null' && session.lock !== undefined)
+  )
 }
 
 export function expandSessionState(session: SessionState) {

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -44,7 +44,6 @@ export function toSessionString(session: SessionState) {
 
 export function toSessionState(sessionString: string | undefined | null) {
   const session: SessionState = {}
-
   if (isValidSessionString(sessionString)) {
     sessionString.split(SESSION_ENTRY_SEPARATOR).forEach((entry) => {
       const matches = SESSION_ENTRY_REGEXP.exec(entry)

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -1,4 +1,3 @@
-import { isEmptyObject } from '../../tools/utils/objectUtils'
 import { objectEntries } from '../../tools/utils/polyfills'
 import { dateNow } from '../../tools/utils/timeUtils'
 import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
@@ -7,7 +6,7 @@ const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
 const SESSION_ENTRY_SEPARATOR = '&'
 
 export interface SessionState {
-  id?: string
+  id: string
   created?: string
   expire?: string
   lock?: string
@@ -15,8 +14,18 @@ export interface SessionState {
   [key: string]: string | undefined
 }
 
+export function getInitialSessionState(): SessionState {
+  return {
+    id: 'null',
+  }
+}
+
+export function isSessionInitialized(session: SessionState) {
+  return session.id !== undefined
+}
+
 export function isSessionInExpiredState(session: SessionState) {
-  return isEmptyObject(session)
+  return session.id === 'null'
 }
 
 export function expandSessionState(session: SessionState) {
@@ -25,12 +34,13 @@ export function expandSessionState(session: SessionState) {
 
 export function toSessionString(session: SessionState) {
   return objectEntries(session)
-    .map(([key, value]) => `${key}=${value as string}`)
+    .map(([key, value]) => `${key}=${value}`)
     .join(SESSION_ENTRY_SEPARATOR)
 }
 
 export function toSessionState(sessionString: string | undefined | null) {
-  const session: SessionState = {}
+  const session: SessionState = {} as SessionState
+
   if (isValidSessionString(sessionString)) {
     sessionString.split(SESSION_ENTRY_SEPARATOR).forEach((entry) => {
       const matches = SESSION_ENTRY_REGEXP.exec(entry)

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -6,23 +6,21 @@ import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionConst
 const SESSION_ENTRY_REGEXP = /^([a-zA-Z]+)=([a-z0-9-]+)$/
 const SESSION_ENTRY_SEPARATOR = '&'
 
-export const enum SessionExpiredReason {
-  UNKNOWN = '1',
-}
+export const EXPIRED = '1'
 
 export interface SessionState {
   id?: string
   created?: string
   expire?: string
   lock?: string
-  isExpired?: SessionExpiredReason
+  isExpired?: typeof EXPIRED
 
   [key: string]: string | undefined
 }
 
 export function getExpiredSessionState({ lock }: SessionState = {}): SessionState {
   const session: SessionState = {
-    isExpired: SessionExpiredReason.UNKNOWN,
+    isExpired: EXPIRED,
   }
 
   if (lock) {

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -20,7 +20,7 @@ export interface SessionState {
   [key: string]: string | undefined
 }
 
-export function getInitialSessionState({ lock }: SessionState = {}): SessionState {
+export function getExpiredSessionState({ lock }: SessionState = {}): SessionState {
   const session: SessionState = {
     isExpired: SessionExpiredReason.UNKNOWN,
   }
@@ -32,14 +32,15 @@ export function getInitialSessionState({ lock }: SessionState = {}): SessionStat
   return session
 }
 
-export function isSessionStarted(session: SessionState) {
-  return !(isEmptyObject(session) || (Object.keys(session).length === 1 && 'lock' in session))
+export function isSessionInNotStartedState(session: SessionState) {
+  return isEmptyObject(session) || (Object.keys(session).length === 1 && 'lock' in session)
 }
 
 export function isSessionInExpiredState(session: SessionState) {
   return session.isExpired !== undefined || !isActiveSession(session)
 }
 
+// An active session is a session in either `Tracked` or `NotTracked` state
 function isActiveSession(sessionState: SessionState) {
   // created and expire can be undefined for versions which was not storing them
   // these checks could be removed when older versions will not be available/live anymore

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -2,11 +2,11 @@ import { objectEntries } from '../../tools/utils/polyfills'
 import { dateNow } from '../../tools/utils/timeUtils'
 import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
 
-const SESSION_ENTRY_REGEXP = /^([a-z]+)=([a-z0-9-]+)$/
+const SESSION_ENTRY_REGEXP = /^([a-zA-Z]+)=([a-z0-9-]+)$/
 const SESSION_ENTRY_SEPARATOR = '&'
 
 export const enum SessionExpiredReason {
-  UNKNOWN = '0',
+  UNKNOWN = '1',
 }
 
 export interface SessionState {
@@ -14,26 +14,26 @@ export interface SessionState {
   created?: string
   expire?: string
   lock?: string
-  expired?: SessionExpiredReason
+  isExpired?: SessionExpiredReason
 
   [key: string]: string | undefined
 }
 
 export function getInitialSessionState(): SessionState {
   return {
-    expired: SessionExpiredReason.UNKNOWN,
+    isExpired: SessionExpiredReason.UNKNOWN,
   }
 }
 
 export function isSessionInitialized(session: SessionState) {
-  return session.id !== undefined || session.expired !== undefined
+  return session.id !== undefined || session.isExpired !== undefined
 }
 
 export function isSessionInExpiredState(session: SessionState) {
-  // // an expired session is `{expired = '0'}` or `{expired = '0', lock = whatever}`
+  // // an isExpired session is `{isExpired = '0'}` or `{isExpired = '0', lock = whatever}`
   return (
-    (Object.keys(session).length === 1 && session.expired !== undefined) ||
-    (Object.keys(session).length === 2 && session.expired !== undefined && session.lock !== undefined)
+    (Object.keys(session).length === 1 && session.isExpired !== undefined) ||
+    (Object.keys(session).length === 2 && session.isExpired !== undefined && session.lock !== undefined)
   )
 }
 

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -12,7 +12,6 @@ export interface SessionState {
   id?: string
   created?: string
   expire?: string
-  lock?: string
   isExpired?: typeof EXPIRED
 
   [key: string]: string | undefined

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -25,7 +25,7 @@ export function getExpiredSessionState(): SessionState {
 }
 
 export function isSessionInNotStartedState(session: SessionState) {
-  return isEmptyObject(session) || (Object.keys(session).length === 1 && 'lock' in session)
+  return isEmptyObject(session)
 }
 
 export function isSessionStarted(session: SessionState) {

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -18,16 +18,10 @@ export interface SessionState {
   [key: string]: string | undefined
 }
 
-export function getExpiredSessionState({ lock }: SessionState = {}): SessionState {
-  const session: SessionState = {
+export function getExpiredSessionState(): SessionState {
+  return {
     isExpired: EXPIRED,
   }
-
-  if (lock) {
-    session.lock = lock
-  }
-
-  return session
 }
 
 export function isSessionInNotStartedState(session: SessionState) {

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -30,7 +30,7 @@ export function isSessionInitialized(session: SessionState) {
 }
 
 export function isSessionInExpiredState(session: SessionState) {
-  // // an isExpired session is `{isExpired = '0'}` or `{isExpired = '0', lock = whatever}`
+  // an expired session is `{isExpired = '0'}` or `{isExpired = '0', lock = whatever}`
   return (
     (Object.keys(session).length === 1 && session.isExpired !== undefined) ||
     (Object.keys(session).length === 2 && session.isExpired !== undefined && session.lock !== undefined)

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -36,6 +36,10 @@ export function isSessionInNotStartedState(session: SessionState) {
   return isEmptyObject(session) || (Object.keys(session).length === 1 && 'lock' in session)
 }
 
+export function isSessionStarted(session: SessionState) {
+  return !isSessionInNotStartedState(session)
+}
+
 export function isSessionInExpiredState(session: SessionState) {
   return session.isExpired !== undefined || !isActiveSession(session)
 }

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -5,6 +5,7 @@ import type { SessionStore } from './sessionStore'
 import { STORAGE_POLL_DELAY, startSessionStore, selectSessionStoreStrategyType } from './sessionStore'
 import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
+import type { SessionState } from './sessionState'
 
 const enum FakeTrackingType {
   TRACKED = 'tracked',
@@ -15,6 +16,8 @@ const DURATION = 123456
 const PRODUCT_KEY = 'product'
 const FIRST_ID = 'first'
 const SECOND_ID = 'second'
+
+const EXPIRED_SESSION: SessionState = { isExpired: '1' }
 
 function setSessionInStore(trackingType: FakeTrackingType = FakeTrackingType.TRACKED, id?: string, expire?: number) {
   setCookie(
@@ -135,7 +138,7 @@ describe('session store', () => {
       it('when session not in store, should initialize a new session', () => {
         setupSessionStore()
 
-        expect(sessionStoreManager.getSession().isExpired).toBe('1')
+        expect(sessionStoreManager.getSession()).toEqual(EXPIRED_SESSION)
       })
 
       it('when tracked session in store, should do nothing ', () => {
@@ -455,7 +458,7 @@ describe('session store', () => {
 
         sessionStoreManager.restartSession()
 
-        expect(sessionStoreManager.getSession().isExpired).toBe('1')
+        expect(sessionStoreManager.getSession()).toEqual(EXPIRED_SESSION)
       })
 
       it('when session in store, should do nothing', () => {

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -124,6 +124,23 @@ describe('session store', () => {
       sessionStoreManager.stop()
     })
 
+    describe('initialize session', () => {
+      it('when session not in store, should initialize a new session', () => {
+        setupSessionStore()
+
+        expect(sessionStoreManager.getSession()).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
+      })
+
+      it('when session in store, should do nothing ', () => {
+        setSessionInStore(FakeTrackingType.TRACKED, FIRST_ID)
+        setupSessionStore()
+
+        expect(sessionStoreManager.getSession().id).toBe(FIRST_ID)
+        expect(sessionStoreManager.getSession().isExpired).toBeUndefined()
+        expect(sessionStoreManager.getSession()[PRODUCT_KEY]).toBeDefined()
+      })
+    })
+
     describe('expand or renew session', () => {
       it(
         'when session not in cache, session not in store and new session tracked, ' +

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -20,7 +20,7 @@ const SECOND_ID = 'second'
 function setSessionInStore(trackingType: FakeTrackingType = FakeTrackingType.TRACKED, id?: string, expire?: number) {
   setCookie(
     SESSION_STORE_KEY,
-    `${id ? `id=${id}` : 'expired=0'}&${PRODUCT_KEY}=${trackingType}&created=${Date.now()}&expire=${
+    `${id ? `id=${id}` : 'isExpired=1'}&${PRODUCT_KEY}=${trackingType}&created=${Date.now()}&expire=${
       expire || Date.now() + SESSION_EXPIRATION_DELAY
     }`,
     DURATION
@@ -33,7 +33,7 @@ function expectTrackedSessionToBeInStore(id?: string) {
 }
 
 function expectNotTrackedSessionToBeInStore() {
-  expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
+  expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
   expect(getCookie(SESSION_STORE_KEY)).toContain(`${PRODUCT_KEY}=${FakeTrackingType.NOT_TRACKED}`)
 }
 
@@ -42,7 +42,7 @@ function getStoreExpiration() {
 }
 
 function resetSessionInStore() {
-  setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
+  setCookie(SESSION_STORE_KEY, 'isExpired=1', DURATION)
 }
 
 describe('session store', () => {
@@ -148,7 +148,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+          expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).not.toHaveBeenCalled()
           expect(renewSpy).not.toHaveBeenCalled()
@@ -196,7 +196,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+          expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
           expect(sessionStoreManager.getSession()[PRODUCT_KEY]).toBeDefined()
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).toHaveBeenCalled()
@@ -214,7 +214,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+          expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
           expect(sessionStoreManager.getSession()[PRODUCT_KEY]).toBeDefined()
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).toHaveBeenCalled()
@@ -266,7 +266,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+          expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).toHaveBeenCalled()
           expect(renewSpy).not.toHaveBeenCalled()
@@ -285,7 +285,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(renewSpy).not.toHaveBeenCalled()
       })
     })
@@ -296,7 +296,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -306,7 +306,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -317,7 +317,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).toHaveBeenCalled()
       })
 
@@ -340,7 +340,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expectTrackedSessionToBeInStore(SECOND_ID)
         expect(expireSpy).toHaveBeenCalled()
       })
@@ -352,7 +352,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -362,7 +362,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -373,7 +373,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).toHaveBeenCalled()
       })
 
@@ -396,7 +396,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).toHaveBeenCalled()
       })
 
@@ -407,7 +407,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
         expect(expireSpy).toHaveBeenCalled()
       })
     })
@@ -419,7 +419,7 @@ describe('session store', () => {
 
         sessionStoreManager.reinitializeSession()
 
-        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
       })
 
       it('when session in store, should do nothing', () => {
@@ -429,7 +429,7 @@ describe('session store', () => {
         sessionStoreManager.reinitializeSession()
 
         expect(sessionStoreManager.getSession().id).toBe(FIRST_ID)
-        expect(sessionStoreManager.getSession().expired).toBeUndefined()
+        expect(sessionStoreManager.getSession().isExpired).toBeUndefined()
       })
     })
   })

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -454,7 +454,7 @@ describe('session store', () => {
       it('when session not in store, should reinitialize the store', () => {
         setupSessionStore()
 
-        sessionStoreManager.reinitializeSession()
+        sessionStoreManager.restartSession()
 
         expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
       })
@@ -463,7 +463,7 @@ describe('session store', () => {
         setSessionInStore(FakeTrackingType.TRACKED, FIRST_ID)
         setupSessionStore()
 
-        sessionStoreManager.reinitializeSession()
+        sessionStoreManager.restartSession()
 
         expect(sessionStoreManager.getSession().id).toBe(FIRST_ID)
         expect(sessionStoreManager.getSession().isExpired).toBeUndefined()

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -136,10 +136,7 @@ describe('session store', () => {
       it('when session not in store, should initialize a new session', () => {
         setupSessionStore()
 
-        expect(sessionStoreManager.getSession()).toEqual({
-          isExpired: SessionExpiredReason.UNKNOWN,
-          lock: jasmine.any(String),
-        })
+        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
       })
 
       it('when tracked session in store, should do nothing ', () => {

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -32,7 +32,7 @@ function expectTrackedSessionToBeInStore(id?: string) {
 }
 
 function expectNotTrackedSessionToBeInStore() {
-  expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
+  expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
   expect(getCookie(SESSION_STORE_KEY)).toContain(`${PRODUCT_KEY}=${FakeTrackingType.NOT_TRACKED}`)
 }
 
@@ -147,7 +147,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().id).toBeUndefined()
+          expect(sessionStoreManager.getSession().id).toBe('null')
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).not.toHaveBeenCalled()
           expect(renewSpy).not.toHaveBeenCalled()
@@ -195,7 +195,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().id).toBeUndefined()
+          expect(sessionStoreManager.getSession().id).toBe('null')
           expect(sessionStoreManager.getSession()[PRODUCT_KEY]).toBeDefined()
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).toHaveBeenCalled()
@@ -213,7 +213,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().id).toBeUndefined()
+          expect(sessionStoreManager.getSession().id).toBe('null')
           expect(sessionStoreManager.getSession()[PRODUCT_KEY]).toBeDefined()
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).toHaveBeenCalled()
@@ -265,7 +265,7 @@ describe('session store', () => {
 
           sessionStoreManager.expandOrRenewSession()
 
-          expect(sessionStoreManager.getSession().id).toBeUndefined()
+          expect(sessionStoreManager.getSession().id).toBe('null')
           expectNotTrackedSessionToBeInStore()
           expect(expireSpy).toHaveBeenCalled()
           expect(renewSpy).not.toHaveBeenCalled()
@@ -284,7 +284,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(renewSpy).not.toHaveBeenCalled()
       })
     })
@@ -295,7 +295,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -305,7 +305,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -316,7 +316,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).toHaveBeenCalled()
       })
 
@@ -339,7 +339,7 @@ describe('session store', () => {
 
         sessionStoreManager.expandSession()
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expectTrackedSessionToBeInStore(SECOND_ID)
         expect(expireSpy).toHaveBeenCalled()
       })
@@ -351,7 +351,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -361,7 +361,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).not.toHaveBeenCalled()
       })
 
@@ -372,7 +372,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).toHaveBeenCalled()
       })
 
@@ -395,7 +395,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).toHaveBeenCalled()
       })
 
@@ -406,7 +406,7 @@ describe('session store', () => {
 
         clock.tick(STORAGE_POLL_DELAY)
 
-        expect(sessionStoreManager.getSession().id).toBeUndefined()
+        expect(sessionStoreManager.getSession().id).toBe('null')
         expect(expireSpy).toHaveBeenCalled()
       })
     })

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -5,7 +5,6 @@ import type { SessionStore } from './sessionStore'
 import { STORAGE_POLL_DELAY, startSessionStore, selectSessionStoreStrategyType } from './sessionStore'
 import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
-import { SessionExpiredReason } from './sessionState'
 
 const enum FakeTrackingType {
   TRACKED = 'tracked',
@@ -136,7 +135,7 @@ describe('session store', () => {
       it('when session not in store, should initialize a new session', () => {
         setupSessionStore()
 
-        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe('1')
       })
 
       it('when tracked session in store, should do nothing ', () => {
@@ -456,7 +455,7 @@ describe('session store', () => {
 
         sessionStoreManager.restartSession()
 
-        expect(sessionStoreManager.getSession().isExpired).toBe(SessionExpiredReason.UNKNOWN)
+        expect(sessionStoreManager.getSession().isExpired).toBe('1')
       })
 
       it('when session in store, should do nothing', () => {

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -16,10 +16,14 @@ const PRODUCT_KEY = 'product'
 const FIRST_ID = 'first'
 const SECOND_ID = 'second'
 
-function setSessionInStore(trackingType: FakeTrackingType = FakeTrackingType.TRACKED, id?: string, expire?: number) {
+function setSessionInStore(
+  trackingType: FakeTrackingType = FakeTrackingType.TRACKED,
+  id: string = 'null',
+  expire?: number
+) {
   setCookie(
     SESSION_STORE_KEY,
-    `${id ? `id=${id}&` : ''}${PRODUCT_KEY}=${trackingType}&created=${Date.now()}&expire=${
+    `id=${id}&${PRODUCT_KEY}=${trackingType}&created=${Date.now()}&expire=${
       expire || Date.now() + SESSION_EXPIRATION_DELAY
     }`,
     DURATION
@@ -41,7 +45,7 @@ function getStoreExpiration() {
 }
 
 function resetSessionInStore() {
-  setCookie(SESSION_STORE_KEY, '', DURATION)
+  setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
 }
 
 describe('session store', () => {
@@ -261,7 +265,7 @@ describe('session store', () => {
             isTracked: rawTrackingType === FakeTrackingType.TRACKED,
             trackingType: rawTrackingType as FakeTrackingType,
           }))
-          setSessionInStore(FakeTrackingType.NOT_TRACKED, '')
+          setSessionInStore(FakeTrackingType.NOT_TRACKED)
 
           sessionStoreManager.expandOrRenewSession()
 

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -411,5 +411,26 @@ describe('session store', () => {
         expect(expireSpy).toHaveBeenCalled()
       })
     })
+
+    describe('reinitialize session', () => {
+      it('when session not in store, should do reinitialize the store', () => {
+        setSessionInStore()
+        setupSessionStore()
+
+        sessionStoreManager.reinitializeSession()
+
+        expect(sessionStoreManager.getSession().expired).toBe(SessionExpiredReason.UNKNOWN)
+      })
+
+      it('when session in store, should do nothing', () => {
+        setSessionInStore(FakeTrackingType.TRACKED, FIRST_ID)
+        setupSessionStore()
+
+        sessionStoreManager.reinitializeSession()
+
+        expect(sessionStoreManager.getSession().id).toBe(FIRST_ID)
+        expect(sessionStoreManager.getSession().expired).toBeUndefined()
+      })
+    })
   })
 })

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -16,6 +16,7 @@ export interface SessionStore {
   expandOrRenewSession: () => void
   expandSession: () => void
   getSession: () => SessionState
+  reinitializeSession: () => void
   renewObservable: Observable<void>
   expireObservable: Observable<void>
   expire: () => void
@@ -131,6 +132,20 @@ export function startSessionStore<TrackingType extends string>(
     return sessionState
   }
 
+  function reinitializeSession() {
+    processSessionStoreOperations(
+      {
+        process: (sessionState) => {
+          if (!isSessionInitialized(sessionState)) {
+            return getInitialSessionState()
+          }
+        },
+        after: synchronizeSession,
+      },
+      sessionStoreStrategy
+    )
+  }
+
   function expandOrRenewSessionState(sessionState: SessionState) {
     if (!isSessionInitialized(sessionState)) {
       return false
@@ -189,6 +204,7 @@ export function startSessionStore<TrackingType extends string>(
     getSession: () => sessionCache,
     renewObservable,
     expireObservable,
+    reinitializeSession,
     expire: () => {
       cancelExpandOrRenewSession()
       clearSession()

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -180,9 +180,7 @@ export function startSessionStore<TrackingType extends string>(
     // these checks could be removed when older versions will not be available/live anymore
     return (
       (sessionState.created === undefined || dateNow() - Number(sessionState.created) < SESSION_TIME_OUT_DELAY) &&
-      (sessionState.expire === undefined || dateNow() < Number(sessionState.expire)) &&
-      sessionState.id &&
-      sessionState.id !== 'null'
+      (sessionState.expire === undefined || dateNow() < Number(sessionState.expire))
     )
   }
 

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -67,6 +67,8 @@ export function startSessionStore<TrackingType extends string>(
   const watchSessionTimeoutId = setInterval(watchSession, STORAGE_POLL_DELAY)
   let sessionCache: SessionState = retrieveActiveSession()
 
+  initializeSession()
+
   const { throttled: throttledExpandOrRenewSession, cancel: cancelExpandOrRenewSession } = throttle(() => {
     let isTracked: boolean
     processSessionStoreOperations(
@@ -132,7 +134,7 @@ export function startSessionStore<TrackingType extends string>(
     return sessionState
   }
 
-  function reinitializeSession() {
+  function initializeSession() {
     processSessionStoreOperations(
       {
         process: (sessionState) => {
@@ -140,7 +142,9 @@ export function startSessionStore<TrackingType extends string>(
             return getInitialSessionState()
           }
         },
-        after: synchronizeSession,
+        after: (sessionState) => {
+          sessionCache = sessionState
+        },
       },
       sessionStoreStrategy
     )
@@ -204,7 +208,7 @@ export function startSessionStore<TrackingType extends string>(
     getSession: () => sessionCache,
     renewObservable,
     expireObservable,
-    reinitializeSession,
+    reinitializeSession: initializeSession,
     expire: () => {
       cancelExpandOrRenewSession()
       clearSession()

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -61,7 +61,7 @@ export function startSessionStore<TrackingType extends string>(
     sessionStoreStrategyType.type === 'Cookie'
       ? initCookieStrategy(sessionStoreStrategyType.cookieOptions)
       : initLocalStorageStrategy()
-  const { clearSession } = sessionStoreStrategy
+  const { expireSession } = sessionStoreStrategy
 
   const watchSessionTimeoutId = setInterval(watchSession, STORAGE_POLL_DELAY)
   let sessionCache: SessionState
@@ -189,7 +189,7 @@ export function startSessionStore<TrackingType extends string>(
     restartSession: startSession,
     expire: () => {
       cancelExpandOrRenewSession()
-      clearSession()
+      expireSession()
       synchronizeSession(getExpiredSessionState())
     },
     stop: () => {

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -4,10 +4,12 @@ import { ONE_SECOND, dateNow } from '../../tools/utils/timeUtils'
 import { throttle } from '../../tools/utils/functionUtils'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { InitConfiguration } from '../configuration'
+import { assign } from '../../tools/utils/polyfills'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import { selectCookieStrategy, initCookieStrategy } from './storeStrategies/sessionInCookie'
 import type { SessionStoreStrategyType } from './storeStrategies/sessionStoreStrategy'
-import { getInitialSessionState, isSessionInitialized, type SessionState } from './sessionState'
+import { getInitialSessionState, isSessionInitialized } from './sessionState'
+import type { SessionState } from './sessionState'
 import { initLocalStorageStrategy, selectLocalStorageStrategy } from './storeStrategies/sessionInLocalStorage'
 import { processSessionStoreOperations } from './sessionStoreOperations'
 
@@ -117,7 +119,9 @@ export function startSessionStore<TrackingType extends string>(
     }
 
     if (!isActiveSession(sessionState)) {
-      sessionState = getInitialSessionState()
+      sessionState = assign(getInitialSessionState(), {
+        lock: sessionState.lock,
+      })
     }
 
     if (hasSessionInCache()) {

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -4,7 +4,6 @@ import { ONE_SECOND, dateNow } from '../../tools/utils/timeUtils'
 import { throttle } from '../../tools/utils/functionUtils'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { InitConfiguration } from '../configuration'
-import { assign } from '../../tools/utils/polyfills'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import { selectCookieStrategy, initCookieStrategy } from './storeStrategies/sessionInCookie'
 import type { SessionStoreStrategyType } from './storeStrategies/sessionStoreStrategy'
@@ -119,9 +118,7 @@ export function startSessionStore<TrackingType extends string>(
     }
 
     if (!isActiveSession(sessionState)) {
-      sessionState = assign(getInitialSessionState(), {
-        lock: sessionState.lock,
-      })
+      sessionState = getInitialSessionState()
     }
 
     if (hasSessionInCache()) {

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -109,8 +109,7 @@ export function startSessionStore<TrackingType extends string>(
   function watchSession() {
     processSessionStoreOperations(
       {
-        process: (sessionState) =>
-          isSessionInExpiredState(sessionState) ? getExpiredSessionState(sessionState) : undefined,
+        process: (sessionState) => (isSessionInExpiredState(sessionState) ? getExpiredSessionState() : undefined),
         after: synchronizeSession,
       },
       sessionStoreStrategy
@@ -119,7 +118,7 @@ export function startSessionStore<TrackingType extends string>(
 
   function synchronizeSession(sessionState: SessionState) {
     if (isSessionInExpiredState(sessionState)) {
-      sessionState = getExpiredSessionState(sessionState)
+      sessionState = getExpiredSessionState()
     }
     if (hasSessionInCache()) {
       if (isSessionInCacheOutdated(sessionState)) {
@@ -136,7 +135,7 @@ export function startSessionStore<TrackingType extends string>(
       {
         process: (sessionState) => {
           if (isSessionInNotStartedState(sessionState)) {
-            return getExpiredSessionState(sessionState)
+            return getExpiredSessionState()
           }
         },
         after: (sessionState) => {

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -156,7 +156,7 @@ export function startSessionStore<TrackingType extends string>(
     if (isTracked && !sessionState.id) {
       sessionState.id = generateUUID()
       sessionState.created = String(dateNow())
-      delete sessionState.expired
+      delete sessionState.isExpired
     }
 
     return isTracked

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -132,16 +132,18 @@ export function startSessionStore<TrackingType extends string>(
   }
 
   function expandOrRenewSessionState(sessionState: SessionState) {
-    if (!sessionState.id) {
+    if (!isSessionInitialized(sessionState)) {
       return false
     }
 
     const { trackingType, isTracked } = computeSessionState(sessionState[productKey])
     sessionState[productKey] = trackingType
-    if (isTracked && sessionState.id === 'null') {
+    if (isTracked && !sessionState.id) {
       sessionState.id = generateUUID()
       sessionState.created = String(dateNow())
+      delete sessionState.expired
     }
+
     return isTracked
   }
 

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -104,11 +104,11 @@ const EXPIRED_SESSION: SessionState = { isExpired: '1' }
 
       it('should persist session when process returns a value', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.callFake((session) => ({ ...otherSession, lock: session.lock }))
+        processSpy.and.returnValue({ ...otherSession })
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
-        expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
+        expect(processSpy).toHaveBeenCalledWith(initialSession)
         const expectedSession = { ...otherSession, expire: jasmine.any(String) }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
@@ -120,7 +120,7 @@ const EXPIRED_SESSION: SessionState = { isExpired: '1' }
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
-        expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
+        expect(processSpy).toHaveBeenCalledWith(initialSession)
 
         expect(sessionStoreStrategy.retrieveSession()).toEqual(EXPIRED_SESSION)
         expect(afterSpy).toHaveBeenCalledWith(EXPIRED_SESSION)
@@ -132,7 +132,7 @@ const EXPIRED_SESSION: SessionState = { isExpired: '1' }
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
-        expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
+        expect(processSpy).toHaveBeenCalledWith(initialSession)
         expect(sessionStoreStrategy.retrieveSession()).toEqual(initialSession)
         expect(afterSpy).toHaveBeenCalledWith(initialSession)
       })
@@ -203,7 +203,6 @@ const EXPIRED_SESSION: SessionState = { isExpired: '1' }
                 expect(processSpy).toHaveBeenCalledWith({
                   ...initialSession,
                   other: 'other',
-                  lock: jasmine.any(String),
                   expire: jasmine.any(String),
                 })
 

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -14,19 +14,20 @@ const cookieOptions: CookieOptions = {}
   [
     {
       title: 'Cookie Storage',
-      sessionStoreStrategy: initCookieStrategy(cookieOptions),
+      createSessionStoreStrategy: () => initCookieStrategy(cookieOptions),
       stubStorageProvider: stubCookieProvider,
       storageKey: SESSION_STORE_KEY,
     },
     {
       title: 'Local Storage',
-      sessionStoreStrategy: initLocalStorageStrategy(),
+      createSessionStoreStrategy: () => initLocalStorageStrategy(),
       stubStorageProvider: stubLocalStorageProvider,
       storageKey: SESSION_STORE_KEY,
     },
   ] as const
-).forEach(({ title, sessionStoreStrategy, stubStorageProvider, storageKey }) => {
+).forEach(({ title, createSessionStoreStrategy, stubStorageProvider, storageKey }) => {
   describe(`process operations mechanism with ${title}`, () => {
+    const sessionStoreStrategy = createSessionStoreStrategy()
     let initialSession: SessionState
     let otherSession: SessionState
     let processSpy: jasmine.Spy<jasmine.Func>
@@ -114,11 +115,12 @@ const cookieOptions: CookieOptions = {}
 
       it('should clear session when process returns an empty value', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({})
+        processSpy.and.returnValue({ id: 'null' })
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
+
         const expectedSession = { id: 'null' }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -60,7 +60,7 @@ const cookieOptions: CookieOptions = {}
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })
 
-      it('should clear session when process return an expired session', () => {
+      it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
         processSpy.and.returnValue({ id: 'null' })
 
@@ -113,7 +113,7 @@ const cookieOptions: CookieOptions = {}
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })
 
-      it('should clear session when process returns an empty value', () => {
+      it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
         processSpy.and.returnValue({ id: 'null' })
 

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -36,7 +36,7 @@ const cookieOptions: CookieOptions = {}
     const now = Date.now()
 
     beforeEach(() => {
-      sessionStoreStrategy.clearSession()
+      sessionStoreStrategy.expireSession()
       initialSession = { id: '123', created: String(now) }
       otherSession = { id: '456', created: String(now + 100) }
       processSpy = jasmine.createSpy('process')

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -62,12 +62,12 @@ const cookieOptions: CookieOptions = {}
 
       it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({ expired: SessionExpiredReason.UNKNOWN })
+        processSpy.and.returnValue({ isExpired: SessionExpiredReason.UNKNOWN })
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith(initialSession)
-        const expectedSession = { expired: SessionExpiredReason.UNKNOWN }
+        const expectedSession = { isExpired: SessionExpiredReason.UNKNOWN }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })
@@ -115,13 +115,13 @@ const cookieOptions: CookieOptions = {}
 
       it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({ expired: SessionExpiredReason.UNKNOWN })
+        processSpy.and.returnValue({ isExpired: SessionExpiredReason.UNKNOWN })
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
 
-        const expectedSession = { expired: SessionExpiredReason.UNKNOWN }
+        const expectedSession = { isExpired: SessionExpiredReason.UNKNOWN }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -4,7 +4,7 @@ import type { CookieOptions } from '../../browser/cookie'
 import { initCookieStrategy } from './storeStrategies/sessionInCookie'
 import { initLocalStorageStrategy } from './storeStrategies/sessionInLocalStorage'
 import type { SessionState } from './sessionState'
-import { expandSessionState, toSessionString } from './sessionState'
+import { SessionExpiredReason, expandSessionState, toSessionString } from './sessionState'
 import { processSessionStoreOperations, LOCK_MAX_TRIES, LOCK_RETRY_DELAY } from './sessionStoreOperations'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 
@@ -62,12 +62,12 @@ const cookieOptions: CookieOptions = {}
 
       it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({ id: 'null' })
+        processSpy.and.returnValue({ expired: SessionExpiredReason.UNKNOWN })
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith(initialSession)
-        const expectedSession = { id: 'null' }
+        const expectedSession = { expired: SessionExpiredReason.UNKNOWN }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })
@@ -115,13 +115,13 @@ const cookieOptions: CookieOptions = {}
 
       it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({ id: 'null' })
+        processSpy.and.returnValue({ expired: SessionExpiredReason.UNKNOWN })
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
 
-        const expectedSession = { id: 'null' }
+        const expectedSession = { expired: SessionExpiredReason.UNKNOWN }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -66,7 +66,7 @@ const cookieOptions: CookieOptions = {}
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith(initialSession)
-        const expectedSession = {}
+        const expectedSession = { id: 'null' }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })
@@ -119,7 +119,7 @@ const cookieOptions: CookieOptions = {}
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
-        const expectedSession = {}
+        const expectedSession = { id: 'null' }
         expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -60,9 +60,9 @@ const cookieOptions: CookieOptions = {}
         expect(afterSpy).toHaveBeenCalledWith(expectedSession)
       })
 
-      it('should clear session when process returns an empty value', () => {
+      it('should clear session when process return an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({})
+        processSpy.and.returnValue({ id: 'null' })
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -4,11 +4,12 @@ import type { CookieOptions } from '../../browser/cookie'
 import { initCookieStrategy } from './storeStrategies/sessionInCookie'
 import { initLocalStorageStrategy } from './storeStrategies/sessionInLocalStorage'
 import type { SessionState } from './sessionState'
-import { SessionExpiredReason, expandSessionState, toSessionString } from './sessionState'
+import { expandSessionState, toSessionString } from './sessionState'
 import { processSessionStoreOperations, LOCK_MAX_TRIES, LOCK_RETRY_DELAY } from './sessionStoreOperations'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 
 const cookieOptions: CookieOptions = {}
+const EXPIRED_SESSION: SessionState = { isExpired: '1' }
 
 ;(
   [
@@ -63,14 +64,13 @@ const cookieOptions: CookieOptions = {}
 
       it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({ isExpired: SessionExpiredReason.UNKNOWN })
+        processSpy.and.returnValue(EXPIRED_SESSION)
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith(initialSession)
-        const expectedSession = { isExpired: SessionExpiredReason.UNKNOWN }
-        expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
-        expect(afterSpy).toHaveBeenCalledWith(expectedSession)
+        expect(sessionStoreStrategy.retrieveSession()).toEqual(EXPIRED_SESSION)
+        expect(afterSpy).toHaveBeenCalledWith(EXPIRED_SESSION)
       })
 
       it('should not persist session when process returns undefined', () => {
@@ -116,15 +116,14 @@ const cookieOptions: CookieOptions = {}
 
       it('should clear session when process returns an expired session', () => {
         sessionStoreStrategy.persistSession(initialSession)
-        processSpy.and.returnValue({ isExpired: SessionExpiredReason.UNKNOWN })
+        processSpy.and.returnValue(EXPIRED_SESSION)
 
         processSessionStoreOperations({ process: processSpy, after: afterSpy }, sessionStoreStrategy)
 
         expect(processSpy).toHaveBeenCalledWith({ ...initialSession, lock: jasmine.any(String) })
 
-        const expectedSession = { isExpired: SessionExpiredReason.UNKNOWN }
-        expect(sessionStoreStrategy.retrieveSession()).toEqual(expectedSession)
-        expect(afterSpy).toHaveBeenCalledWith(expectedSession)
+        expect(sessionStoreStrategy.retrieveSession()).toEqual(EXPIRED_SESSION)
+        expect(afterSpy).toHaveBeenCalledWith(EXPIRED_SESSION)
       })
 
       it('should not persist session when process returns undefined', () => {

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -33,11 +33,12 @@ const cookieOptions: CookieOptions = {}
     let processSpy: jasmine.Spy<jasmine.Func>
     let afterSpy: jasmine.Spy<jasmine.Func>
     let stubStorage: StubStorage
+    const now = Date.now()
 
     beforeEach(() => {
       sessionStoreStrategy.clearSession()
-      initialSession = { id: '123', created: '0' }
-      otherSession = { id: '456', created: '100' }
+      initialSession = { id: '123', created: String(now) }
+      otherSession = { id: '456', created: String(now + 100) }
       processSpy = jasmine.createSpy('process')
       afterSpy = jasmine.createSpy('after')
       stubStorage = stubStorageProvider.get()

--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -2,7 +2,7 @@ import { setTimeout } from '../../tools/timer'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import type { SessionState } from './sessionState'
-import { expandSessionState, isSessionInExpiredState, isSessionInitialized } from './sessionState'
+import { expandSessionState, isSessionInExpiredState } from './sessionState'
 
 type Operations = {
   process: (sessionState: SessionState) => SessionState | undefined
@@ -63,7 +63,7 @@ export function processSessionStoreOperations(
   if (processedSession) {
     if (isSessionInExpiredState(processedSession)) {
       clearSession()
-    } else if (isSessionInitialized(processedSession)) {
+    } else {
       expandSessionState(processedSession)
       persistSession(processedSession)
     }

--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -2,7 +2,7 @@ import { setTimeout } from '../../tools/timer'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import type { SessionState } from './sessionState'
-import { expandSessionState, isSessionInExpiredState } from './sessionState'
+import { expandSessionState, isSessionInExpiredState, isSessionInitialized } from './sessionState'
 
 type Operations = {
   process: (sessionState: SessionState) => SessionState | undefined
@@ -63,7 +63,7 @@ export function processSessionStoreOperations(
   if (processedSession) {
     if (isSessionInExpiredState(processedSession)) {
       clearSession()
-    } else {
+    } else if (isSessionInitialized(processedSession)) {
       expandSessionState(processedSession)
       persistSession(processedSession)
     }

--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -19,7 +19,7 @@ export function processSessionStoreOperations(
   sessionStoreStrategy: SessionStoreStrategy,
   numberOfRetries = 0
 ) {
-  const { isLockEnabled, retrieveSession, persistSession, clearSession } = sessionStoreStrategy
+  const { isLockEnabled, retrieveSession, persistSession, expireSession } = sessionStoreStrategy
 
   if (!ongoingOperations) {
     ongoingOperations = operations
@@ -62,7 +62,7 @@ export function processSessionStoreOperations(
   }
   if (processedSession) {
     if (isSessionInExpiredState(processedSession)) {
-      clearSession()
+      expireSession()
     } else {
       expandSessionState(processedSession)
       persistSession(processedSession)

--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -67,7 +67,6 @@ export function processSessionStoreOperations(
   }
   let processedSession = operations.process(currentStore.session)
   if (isLockEnabled) {
-    assign
     // if lock corrupted after process, retry later
     currentStore = retrieveStore()
     if (currentStore.lock !== currentLock!) {

--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -1,5 +1,6 @@
 import { setTimeout } from '../../tools/timer'
 import { generateUUID } from '../../tools/utils/stringUtils'
+import { assign } from '../../tools/utils/polyfills'
 import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrategy'
 import type { SessionState } from './sessionState'
 import { expandSessionState, isSessionInExpiredState } from './sessionState'
@@ -19,7 +20,21 @@ export function processSessionStoreOperations(
   sessionStoreStrategy: SessionStoreStrategy,
   numberOfRetries = 0
 ) {
-  const { isLockEnabled, retrieveSession, persistSession, expireSession } = sessionStoreStrategy
+  const { isLockEnabled, persistSession, expireSession } = sessionStoreStrategy
+  const persistWithLock = (session: SessionState) => persistSession(assign({}, session, { lock: currentLock }))
+  const retrieveStore = () => {
+    const session = sessionStoreStrategy.retrieveSession()
+    const lock = session.lock
+
+    if (session.lock) {
+      delete session.lock
+    }
+
+    return {
+      session,
+      lock,
+    }
+  }
 
   if (!ongoingOperations) {
     ongoingOperations = operations
@@ -33,29 +48,29 @@ export function processSessionStoreOperations(
     return
   }
   let currentLock: string
-  let currentSession = retrieveSession()
+  let currentStore = retrieveStore()
   if (isLockEnabled) {
     // if someone has lock, retry later
-    if (currentSession.lock) {
+    if (currentStore.lock) {
       retryLater(operations, sessionStoreStrategy, numberOfRetries)
       return
     }
     // acquire lock
     currentLock = generateUUID()
-    currentSession.lock = currentLock
-    persistSession(currentSession)
+    persistWithLock(currentStore.session)
     // if lock is not acquired, retry later
-    currentSession = retrieveSession()
-    if (currentSession.lock !== currentLock) {
+    currentStore = retrieveStore()
+    if (currentStore.lock !== currentLock) {
       retryLater(operations, sessionStoreStrategy, numberOfRetries)
       return
     }
   }
-  let processedSession = operations.process(currentSession)
+  let processedSession = operations.process(currentStore.session)
   if (isLockEnabled) {
+    assign
     // if lock corrupted after process, retry later
-    currentSession = retrieveSession()
-    if (currentSession.lock !== currentLock!) {
+    currentStore = retrieveStore()
+    if (currentStore.lock !== currentLock!) {
       retryLater(operations, sessionStoreStrategy, numberOfRetries)
       return
     }
@@ -65,7 +80,7 @@ export function processSessionStoreOperations(
       expireSession()
     } else {
       expandSessionState(processedSession)
-      persistSession(processedSession)
+      isLockEnabled ? persistWithLock(processedSession) : persistSession(processedSession)
     }
   }
   if (isLockEnabled) {
@@ -73,19 +88,18 @@ export function processSessionStoreOperations(
     // since we don't have evidence of lock issues around expiration, let's just not do the corruption check for it
     if (!(processedSession && isSessionInExpiredState(processedSession))) {
       // if lock corrupted after persist, retry later
-      currentSession = retrieveSession()
-      if (currentSession.lock !== currentLock!) {
+      currentStore = retrieveStore()
+      if (currentStore.lock !== currentLock!) {
         retryLater(operations, sessionStoreStrategy, numberOfRetries)
         return
       }
-      delete currentSession.lock
-      persistSession(currentSession)
-      processedSession = currentSession
+      persistSession(currentStore.session)
+      processedSession = currentStore.session
     }
   }
   // call after even if session is not persisted in order to perform operations on
   // up-to-date session state value => the value could have been modified by another tab
-  operations.after?.(processedSession || currentSession)
+  operations.after?.(processedSession || currentStore.session)
   next(sessionStoreStrategy)
 }
 

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -16,6 +16,13 @@ describe('session in cookie strategy', () => {
     deleteCookie(SESSION_STORE_KEY)
   })
 
+  it('should initialize a new cookie', () => {
+    const session = cookieStorageStrategy.retrieveSession()
+
+    expect(session).toEqual({ id: 'null' })
+    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
+  })
+
   it('should persist a session in a cookie', () => {
     cookieStorageStrategy.persistSession(sessionState)
     const session = cookieStorageStrategy.retrieveSession()
@@ -34,7 +41,7 @@ describe('session in cookie strategy', () => {
   it('should return an empty object if session string is invalid', () => {
     setCookie(SESSION_STORE_KEY, '{test:42}', 1000)
     const session = cookieStorageStrategy.retrieveSession()
-    expect(session).toEqual({ id: 'null' })
+    expect(session).toEqual({})
   })
 
   describe('build cookie options', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -23,12 +23,12 @@ describe('session in cookie strategy', () => {
     expect(getCookie(SESSION_STORE_KEY)).toBe('id=123&created=0')
   })
 
-  it('should delete the cookie holding the session', () => {
+  it('should clear the cookie holding the session', () => {
     cookieStorageStrategy.persistSession(sessionState)
     cookieStorageStrategy.clearSession()
     const session = cookieStorageStrategy.retrieveSession()
     expect(session).toEqual({ id: 'null' })
-    expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
+    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
   })
 
   it('should return an empty object if session string is invalid', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -1,5 +1,5 @@
 import { setCookie, deleteCookie, getCookie, getCurrentSite } from '../../../browser/cookie'
-import type { SessionState } from '../sessionState'
+import { SessionExpiredReason, type SessionState } from '../sessionState'
 import { buildCookieOptions, selectCookieStrategy, initCookieStrategy } from './sessionInCookie'
 import type { SessionStoreStrategy } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
@@ -19,8 +19,8 @@ describe('session in cookie strategy', () => {
   it('should initialize a new cookie', () => {
     const session = cookieStorageStrategy.retrieveSession()
 
-    expect(session).toEqual({ id: 'null' })
-    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
+    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
+    expect(getCookie(SESSION_STORE_KEY)).toBe('expired=0')
   })
 
   it('should persist a session in a cookie', () => {
@@ -34,8 +34,8 @@ describe('session in cookie strategy', () => {
     cookieStorageStrategy.persistSession(sessionState)
     cookieStorageStrategy.clearSession()
     const session = cookieStorageStrategy.retrieveSession()
-    expect(session).toEqual({ id: 'null' })
-    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
+    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
+    expect(getCookie(SESSION_STORE_KEY)).toBe('expired=0')
   })
 
   it('should return an empty object if session string is invalid', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -19,8 +19,8 @@ describe('session in cookie strategy', () => {
   it('should initialize a new cookie', () => {
     const session = cookieStorageStrategy.retrieveSession()
 
-    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
-    expect(getCookie(SESSION_STORE_KEY)).toBe('expired=0')
+    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
+    expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
   })
 
   it('should persist a session in a cookie', () => {
@@ -34,8 +34,8 @@ describe('session in cookie strategy', () => {
     cookieStorageStrategy.persistSession(sessionState)
     cookieStorageStrategy.clearSession()
     const session = cookieStorageStrategy.retrieveSession()
-    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
-    expect(getCookie(SESSION_STORE_KEY)).toBe('expired=0')
+    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
+    expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
   })
 
   it('should return an empty object if session string is invalid', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -25,7 +25,7 @@ describe('session in cookie strategy', () => {
 
   it('should set `isExpired=1` to the cookie holding the session', () => {
     cookieStorageStrategy.persistSession(sessionState)
-    cookieStorageStrategy.clearSession()
+    cookieStorageStrategy.expireSession()
     const session = cookieStorageStrategy.retrieveSession()
     expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
     expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -16,13 +16,6 @@ describe('session in cookie strategy', () => {
     deleteCookie(SESSION_STORE_KEY)
   })
 
-  it('should initialize a new cookie', () => {
-    const session = cookieStorageStrategy.retrieveSession()
-
-    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
-    expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
-  })
-
   it('should persist a session in a cookie', () => {
     cookieStorageStrategy.persistSession(sessionState)
     const session = cookieStorageStrategy.retrieveSession()

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -1,5 +1,5 @@
 import { setCookie, deleteCookie, getCookie, getCurrentSite } from '../../../browser/cookie'
-import { SessionExpiredReason, type SessionState } from '../sessionState'
+import { type SessionState } from '../sessionState'
 import { buildCookieOptions, selectCookieStrategy, initCookieStrategy } from './sessionInCookie'
 import type { SessionStoreStrategy } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
@@ -27,7 +27,7 @@ describe('session in cookie strategy', () => {
     cookieStorageStrategy.persistSession(sessionState)
     cookieStorageStrategy.expireSession()
     const session = cookieStorageStrategy.retrieveSession()
-    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
+    expect(session).toEqual({ isExpired: '1' })
     expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
   })
 

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -23,7 +23,7 @@ describe('session in cookie strategy', () => {
     expect(getCookie(SESSION_STORE_KEY)).toBe('id=123&created=0')
   })
 
-  it('should clear the cookie holding the session', () => {
+  it('should set `isExpired=1` to the cookie holding the session', () => {
     cookieStorageStrategy.persistSession(sessionState)
     cookieStorageStrategy.clearSession()
     const session = cookieStorageStrategy.retrieveSession()

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -27,14 +27,14 @@ describe('session in cookie strategy', () => {
     cookieStorageStrategy.persistSession(sessionState)
     cookieStorageStrategy.clearSession()
     const session = cookieStorageStrategy.retrieveSession()
-    expect(session).toEqual({})
+    expect(session).toEqual({ id: 'null' })
     expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
   })
 
   it('should return an empty object if session string is invalid', () => {
     setCookie(SESSION_STORE_KEY, '{test:42}', 1000)
     const session = cookieStorageStrategy.retrieveSession()
-    expect(session).toEqual({})
+    expect(session).toEqual({ id: 'null' })
   })
 
   describe('build cookie options', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -5,7 +5,7 @@ import type { InitConfiguration } from '../../configuration'
 import { tryOldCookiesMigration } from '../oldCookiesMigration'
 import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
-import { toSessionString, toSessionState, isSessionInitialized, getInitialSessionState } from '../sessionState'
+import { toSessionString, toSessionState, getInitialSessionState } from '../sessionState'
 import type { SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -27,12 +27,6 @@ export function initCookieStrategy(cookieOptions: CookieOptions): SessionStoreSt
   }
 
   tryOldCookiesMigration(cookieStore)
-
-  const sessionCookie = retrieveSessionCookie()
-
-  if (!isSessionInitialized(sessionCookie)) {
-    setInitialSessionCookie(cookieOptions)
-  }
 
   return cookieStore
 }

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -26,13 +26,13 @@ export function initCookieStrategy(cookieOptions: CookieOptions): SessionStoreSt
     clearSession: () => setInitialSessionCookie(cookieOptions),
   }
 
+  tryOldCookiesMigration(cookieStore)
+
   const sessionCookie = retrieveSessionCookie()
 
   if (!isSessionInitialized(sessionCookie)) {
     setInitialSessionCookie(cookieOptions)
   }
-
-  tryOldCookiesMigration(cookieStore)
 
   return cookieStore
 }
@@ -43,13 +43,13 @@ function persistSessionCookie(options: CookieOptions) {
   }
 }
 
+function setInitialSessionCookie(options: CookieOptions) {
+  setCookie(SESSION_STORE_KEY, toSessionString(getInitialSessionState()), SESSION_TIME_OUT_DELAY, options)
+}
+
 function retrieveSessionCookie(): SessionState {
   const sessionString = getCookie(SESSION_STORE_KEY)
   return toSessionState(sessionString)
-}
-
-function setInitialSessionCookie(options: CookieOptions) {
-  setCookie(SESSION_STORE_KEY, toSessionString(getInitialSessionState()), SESSION_TIME_OUT_DELAY, options)
 }
 
 export function buildCookieOptions(initConfiguration: InitConfiguration) {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -23,7 +23,7 @@ export function initCookieStrategy(cookieOptions: CookieOptions): SessionStoreSt
     isLockEnabled: isChromium(),
     persistSession: persistSessionCookie(cookieOptions),
     retrieveSession: retrieveSessionCookie,
-    clearSession: () => setInitialSessionCookie(cookieOptions),
+    expireSession: () => expireSessionCookie(cookieOptions),
   }
 
   tryOldCookiesMigration(cookieStore)
@@ -37,7 +37,7 @@ function persistSessionCookie(options: CookieOptions) {
   }
 }
 
-function setInitialSessionCookie(options: CookieOptions) {
+function expireSessionCookie(options: CookieOptions) {
   setCookie(SESSION_STORE_KEY, toSessionString(getExpiredSessionState()), SESSION_TIME_OUT_DELAY, options)
 }
 

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -5,7 +5,7 @@ import type { InitConfiguration } from '../../configuration'
 import { tryOldCookiesMigration } from '../oldCookiesMigration'
 import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
-import { toSessionString, toSessionState, getInitialSessionState } from '../sessionState'
+import { toSessionString, toSessionState, getExpiredSessionState } from '../sessionState'
 import type { SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -38,7 +38,7 @@ function persistSessionCookie(options: CookieOptions) {
 }
 
 function setInitialSessionCookie(options: CookieOptions) {
-  setCookie(SESSION_STORE_KEY, toSessionString(getInitialSessionState()), SESSION_TIME_OUT_DELAY, options)
+  setCookie(SESSION_STORE_KEY, toSessionString(getExpiredSessionState()), SESSION_TIME_OUT_DELAY, options)
 }
 
 function retrieveSessionCookie(): SessionState {

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -33,7 +33,7 @@ describe('session in local storage strategy', () => {
     localStorageStrategy.persistSession(sessionState)
     localStorageStrategy.clearSession()
     const session = localStorageStrategy?.retrieveSession()
-    expect(session).toEqual({})
+    expect(session).toEqual({ id: 'null' })
     expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBeNull()
   })
 
@@ -50,6 +50,6 @@ describe('session in local storage strategy', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     localStorage.setItem(SESSION_STORE_KEY, '{test:42}')
     const session = localStorageStrategy?.retrieveSession()
-    expect(session).toEqual({})
+    expect(session).toEqual({ id: 'null' })
   })
 })

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -1,4 +1,4 @@
-import type { SessionState } from '../sessionState'
+import { SessionExpiredReason, type SessionState } from '../sessionState'
 import { selectLocalStorageStrategy, initLocalStorageStrategy } from './sessionInLocalStorage'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -24,8 +24,8 @@ describe('session in local storage strategy', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     const session = localStorageStrategy.retrieveSession()
 
-    expect(session).toEqual({ id: 'null' })
-    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('id=null')
+    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
+    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('expired=0')
   })
 
   it('should persist a session in local storage', () => {
@@ -41,8 +41,8 @@ describe('session in local storage strategy', () => {
     localStorageStrategy.persistSession(sessionState)
     localStorageStrategy.clearSession()
     const session = localStorageStrategy?.retrieveSession()
-    expect(session).toEqual({ id: 'null' })
-    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('id=null')
+    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
+    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('expired=0')
   })
 
   it('should not interfere with other keys present in local storage', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -20,14 +20,6 @@ describe('session in local storage strategy', () => {
     expect(available).toBeUndefined()
   })
 
-  it('should initialize a session in local storage', () => {
-    const localStorageStrategy = initLocalStorageStrategy()
-    const session = localStorageStrategy.retrieveSession()
-
-    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
-    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('isExpired=1')
-  })
-
   it('should persist a session in local storage', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     localStorageStrategy.persistSession(sessionState)

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -1,4 +1,4 @@
-import { SessionExpiredReason, type SessionState } from '../sessionState'
+import { type SessionState } from '../sessionState'
 import { selectLocalStorageStrategy, initLocalStorageStrategy } from './sessionInLocalStorage'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -33,7 +33,7 @@ describe('session in local storage strategy', () => {
     localStorageStrategy.persistSession(sessionState)
     localStorageStrategy.expireSession()
     const session = localStorageStrategy?.retrieveSession()
-    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
+    expect(session).toEqual({ isExpired: '1' })
     expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('isExpired=1')
   })
 

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -20,6 +20,14 @@ describe('session in local storage strategy', () => {
     expect(available).toBeUndefined()
   })
 
+  it('should initialize a session in local storage', () => {
+    const localStorageStrategy = initLocalStorageStrategy()
+    const session = localStorageStrategy.retrieveSession()
+
+    expect(session).toEqual({ id: 'null' })
+    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('id=null')
+  })
+
   it('should persist a session in local storage', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     localStorageStrategy.persistSession(sessionState)
@@ -34,7 +42,7 @@ describe('session in local storage strategy', () => {
     localStorageStrategy.clearSession()
     const session = localStorageStrategy?.retrieveSession()
     expect(session).toEqual({ id: 'null' })
-    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBeNull()
+    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('id=null')
   })
 
   it('should not interfere with other keys present in local storage', () => {
@@ -50,6 +58,6 @@ describe('session in local storage strategy', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     localStorage.setItem(SESSION_STORE_KEY, '{test:42}')
     const session = localStorageStrategy?.retrieveSession()
-    expect(session).toEqual({ id: 'null' })
+    expect(session).toEqual({})
   })
 })

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -24,8 +24,8 @@ describe('session in local storage strategy', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     const session = localStorageStrategy.retrieveSession()
 
-    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
-    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('expired=0')
+    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
+    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('isExpired=1')
   })
 
   it('should persist a session in local storage', () => {
@@ -41,8 +41,8 @@ describe('session in local storage strategy', () => {
     localStorageStrategy.persistSession(sessionState)
     localStorageStrategy.clearSession()
     const session = localStorageStrategy?.retrieveSession()
-    expect(session).toEqual({ expired: SessionExpiredReason.UNKNOWN })
-    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('expired=0')
+    expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
+    expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('isExpired=1')
   })
 
   it('should not interfere with other keys present in local storage', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -31,7 +31,7 @@ describe('session in local storage strategy', () => {
   it('should set `isExpired=1` to the local storage item holding the session', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     localStorageStrategy.persistSession(sessionState)
-    localStorageStrategy.clearSession()
+    localStorageStrategy.expireSession()
     const session = localStorageStrategy?.retrieveSession()
     expect(session).toEqual({ isExpired: SessionExpiredReason.UNKNOWN })
     expect(window.localStorage.getItem(SESSION_STORE_KEY)).toBe('isExpired=1')
@@ -42,7 +42,7 @@ describe('session in local storage strategy', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     localStorageStrategy.persistSession(sessionState)
     localStorageStrategy.retrieveSession()
-    localStorageStrategy.clearSession()
+    localStorageStrategy.expireSession()
     expect(window.localStorage.getItem('test')).toEqual('hello')
   })
 

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -28,7 +28,7 @@ describe('session in local storage strategy', () => {
     expect(window.localStorage.getItem(SESSION_STORE_KEY)).toMatch(/.*id=.*created/)
   })
 
-  it('should delete the local storage item holding the session', () => {
+  it('should set `isExpired=1` to the local storage item holding the session', () => {
     const localStorageStrategy = initLocalStorageStrategy()
     localStorageStrategy.persistSession(sessionState)
     localStorageStrategy.clearSession()

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -1,6 +1,6 @@
 import { generateUUID } from '../../../tools/utils/stringUtils'
 import type { SessionState } from '../sessionState'
-import { toSessionString, toSessionState } from '../sessionState'
+import { toSessionString, toSessionState, isSessionInitialized, getInitialSessionState } from '../sessionState'
 import type { SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -20,6 +20,12 @@ export function selectLocalStorageStrategy(): SessionStoreStrategyType | undefin
 }
 
 export function initLocalStorageStrategy(): SessionStoreStrategy {
+  const sessionState = retrieveSessionFromLocalStorage()
+
+  if (!isSessionInitialized(sessionState)) {
+    persistInLocalStorage(getInitialSessionState())
+  }
+
   return {
     isLockEnabled: false,
     persistSession: persistInLocalStorage,
@@ -38,5 +44,5 @@ function retrieveSessionFromLocalStorage(): SessionState {
 }
 
 function clearSessionFromLocalStorage() {
-  localStorage.removeItem(SESSION_STORE_KEY)
+  persistInLocalStorage(getInitialSessionState())
 }

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -1,6 +1,6 @@
 import { generateUUID } from '../../../tools/utils/stringUtils'
 import type { SessionState } from '../sessionState'
-import { toSessionString, toSessionState, getInitialSessionState } from '../sessionState'
+import { toSessionString, toSessionState, getExpiredSessionState } from '../sessionState'
 import type { SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -38,5 +38,5 @@ function retrieveSessionFromLocalStorage(): SessionState {
 }
 
 function clearSessionFromLocalStorage() {
-  persistInLocalStorage(getInitialSessionState())
+  persistInLocalStorage(getExpiredSessionState())
 }

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -24,7 +24,7 @@ export function initLocalStorageStrategy(): SessionStoreStrategy {
     isLockEnabled: false,
     persistSession: persistInLocalStorage,
     retrieveSession: retrieveSessionFromLocalStorage,
-    clearSession: clearSessionFromLocalStorage,
+    expireSession: expireSessionFromLocalStorage,
   }
 }
 
@@ -37,6 +37,6 @@ function retrieveSessionFromLocalStorage(): SessionState {
   return toSessionState(sessionString)
 }
 
-function clearSessionFromLocalStorage() {
+function expireSessionFromLocalStorage() {
   persistInLocalStorage(getExpiredSessionState())
 }

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -1,6 +1,6 @@
 import { generateUUID } from '../../../tools/utils/stringUtils'
 import type { SessionState } from '../sessionState'
-import { toSessionString, toSessionState, isSessionInitialized, getInitialSessionState } from '../sessionState'
+import { toSessionString, toSessionState, getInitialSessionState } from '../sessionState'
 import type { SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
 
@@ -20,12 +20,6 @@ export function selectLocalStorageStrategy(): SessionStoreStrategyType | undefin
 }
 
 export function initLocalStorageStrategy(): SessionStoreStrategy {
-  const sessionState = retrieveSessionFromLocalStorage()
-
-  if (!isSessionInitialized(sessionState)) {
-    persistInLocalStorage(getInitialSessionState())
-  }
-
   return {
     isLockEnabled: false,
     persistSession: persistInLocalStorage,

--- a/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
@@ -9,5 +9,5 @@ export interface SessionStoreStrategy {
   isLockEnabled: boolean
   persistSession: (session: SessionState) => void
   retrieveSession: () => SessionState
-  clearSession: () => void
+  expireSession: () => void
 }

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -48,7 +48,7 @@ describe('logs session manager', () => {
     startLogsSessionManagerWithDefaults({ configuration: { sessionSampleRate: 0 } })
 
     expect(getCookie(SESSION_STORE_KEY)).toContain(`${LOGS_SESSION_KEY}=${LoggerTrackingType.NOT_TRACKED}`)
-    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
   })
 
   it('when tracked should keep existing tracking type and session id', () => {

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -48,7 +48,7 @@ describe('logs session manager', () => {
     startLogsSessionManagerWithDefaults({ configuration: { sessionSampleRate: 0 } })
 
     expect(getCookie(SESSION_STORE_KEY)).toContain(`${LOGS_SESSION_KEY}=${LoggerTrackingType.NOT_TRACKED}`)
-    expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
+    expect(getCookie(SESSION_STORE_KEY)).not.toContain('isExpired=1')
   })
 
   it('when tracked should keep existing tracking type and session id', () => {
@@ -61,7 +61,7 @@ describe('logs session manager', () => {
   })
 
   it('when not tracked should keep existing tracking type', () => {
-    setCookie(SESSION_STORE_KEY, 'isExpired=1&logs=0', DURATION)
+    setCookie(SESSION_STORE_KEY, 'logs=0', DURATION)
 
     startLogsSessionManagerWithDefaults()
 

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -48,7 +48,7 @@ describe('logs session manager', () => {
     startLogsSessionManagerWithDefaults({ configuration: { sessionSampleRate: 0 } })
 
     expect(getCookie(SESSION_STORE_KEY)).toContain(`${LOGS_SESSION_KEY}=${LoggerTrackingType.NOT_TRACKED}`)
-    expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
   })
 
   it('when tracked should keep existing tracking type and session id', () => {
@@ -61,7 +61,7 @@ describe('logs session manager', () => {
   })
 
   it('when not tracked should keep existing tracking type', () => {
-    setCookie(SESSION_STORE_KEY, 'expired=0&logs=0', DURATION)
+    setCookie(SESSION_STORE_KEY, 'isExpired=1&logs=0', DURATION)
 
     startLogsSessionManagerWithDefaults()
 
@@ -71,8 +71,8 @@ describe('logs session manager', () => {
   it('should renew on activity after expiration', () => {
     startLogsSessionManagerWithDefaults()
 
-    setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
-    expect(getCookie(SESSION_STORE_KEY)).toBe('expired=0')
+    setCookie(SESSION_STORE_KEY, 'isExpired=1', DURATION)
+    expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
     clock.tick(STORAGE_POLL_DELAY)
 
     document.body.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -48,7 +48,7 @@ describe('logs session manager', () => {
     startLogsSessionManagerWithDefaults({ configuration: { sessionSampleRate: 0 } })
 
     expect(getCookie(SESSION_STORE_KEY)).toContain(`${LOGS_SESSION_KEY}=${LoggerTrackingType.NOT_TRACKED}`)
-    expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
+    expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
   })
 
   it('when tracked should keep existing tracking type and session id', () => {
@@ -61,7 +61,7 @@ describe('logs session manager', () => {
   })
 
   it('when not tracked should keep existing tracking type', () => {
-    setCookie(SESSION_STORE_KEY, 'id=null&logs=0', DURATION)
+    setCookie(SESSION_STORE_KEY, 'expired=0&logs=0', DURATION)
 
     startLogsSessionManagerWithDefaults()
 
@@ -71,8 +71,8 @@ describe('logs session manager', () => {
   it('should renew on activity after expiration', () => {
     startLogsSessionManagerWithDefaults()
 
-    setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
-    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
+    setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
+    expect(getCookie(SESSION_STORE_KEY)).toBe('expired=0')
     clock.tick(STORAGE_POLL_DELAY)
 
     document.body.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -48,7 +48,7 @@ describe('logs session manager', () => {
     startLogsSessionManagerWithDefaults({ configuration: { sessionSampleRate: 0 } })
 
     expect(getCookie(SESSION_STORE_KEY)).toContain(`${LOGS_SESSION_KEY}=${LoggerTrackingType.NOT_TRACKED}`)
-    expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
+    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
   })
 
   it('when tracked should keep existing tracking type and session id', () => {

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -61,7 +61,7 @@ describe('logs session manager', () => {
   })
 
   it('when not tracked should keep existing tracking type', () => {
-    setCookie(SESSION_STORE_KEY, 'logs=0', DURATION)
+    setCookie(SESSION_STORE_KEY, 'id=null&logs=0', DURATION)
 
     startLogsSessionManagerWithDefaults()
 
@@ -71,8 +71,8 @@ describe('logs session manager', () => {
   it('should renew on activity after expiration', () => {
     startLogsSessionManagerWithDefaults()
 
-    setCookie(SESSION_STORE_KEY, '', DURATION)
-    expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
+    setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
+    expect(getCookie(SESSION_STORE_KEY)).toBe('id=null')
     clock.tick(STORAGE_POLL_DELAY)
 
     document.body.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -81,7 +81,7 @@ describe('rum session manager', () => {
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
       expect(getCookie(SESSION_STORE_KEY)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.NOT_TRACKED}`)
-      expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
+      expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
     })
 
     it('when tracked should keep existing session type and id', () => {
@@ -98,7 +98,7 @@ describe('rum session manager', () => {
     })
 
     it('when not tracked should keep existing session type', () => {
-      setCookie(SESSION_STORE_KEY, 'rum=0', DURATION)
+      setCookie(SESSION_STORE_KEY, 'id=null&rum=0', DURATION)
 
       startRumSessionManagerWithDefaults()
 
@@ -112,8 +112,8 @@ describe('rum session manager', () => {
 
       startRumSessionManagerWithDefaults({ configuration: { sessionSampleRate: 100, sessionReplaySampleRate: 100 } })
 
-      setCookie(SESSION_STORE_KEY, '', DURATION)
-      expect(getCookie(SESSION_STORE_KEY)).toBeUndefined()
+      setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
+      expect(getCookie(SESSION_STORE_KEY)).toEqual('id=null')
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
       clock.tick(STORAGE_POLL_DELAY)
@@ -144,7 +144,7 @@ describe('rum session manager', () => {
 
     it('should return undefined if the session has expired', () => {
       const rumSessionManager = startRumSessionManagerWithDefaults()
-      setCookie(SESSION_STORE_KEY, '', DURATION)
+      setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
       clock.tick(STORAGE_POLL_DELAY)
       expect(rumSessionManager.findTrackedSession()).toBe(undefined)
     })

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -81,7 +81,7 @@ describe('rum session manager', () => {
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
       expect(getCookie(SESSION_STORE_KEY)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.NOT_TRACKED}`)
-      expect(getCookie(SESSION_STORE_KEY)).toContain('id=null')
+      expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
     })
 
     it('when tracked should keep existing session type and id', () => {
@@ -98,7 +98,7 @@ describe('rum session manager', () => {
     })
 
     it('when not tracked should keep existing session type', () => {
-      setCookie(SESSION_STORE_KEY, 'id=null&rum=0', DURATION)
+      setCookie(SESSION_STORE_KEY, 'expired=0&rum=0', DURATION)
 
       startRumSessionManagerWithDefaults()
 
@@ -112,8 +112,8 @@ describe('rum session manager', () => {
 
       startRumSessionManagerWithDefaults({ configuration: { sessionSampleRate: 100, sessionReplaySampleRate: 100 } })
 
-      setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
-      expect(getCookie(SESSION_STORE_KEY)).toEqual('id=null')
+      setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
+      expect(getCookie(SESSION_STORE_KEY)).toEqual('expired=0')
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
       clock.tick(STORAGE_POLL_DELAY)
@@ -144,7 +144,7 @@ describe('rum session manager', () => {
 
     it('should return undefined if the session has expired', () => {
       const rumSessionManager = startRumSessionManagerWithDefaults()
-      setCookie(SESSION_STORE_KEY, 'id=null', DURATION)
+      setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
       clock.tick(STORAGE_POLL_DELAY)
       expect(rumSessionManager.findTrackedSession()).toBe(undefined)
     })

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -81,7 +81,8 @@ describe('rum session manager', () => {
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
       expect(getCookie(SESSION_STORE_KEY)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.NOT_TRACKED}`)
-      expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
+      expect(getCookie(SESSION_STORE_KEY)).not.toContain('id=')
+      expect(getCookie(SESSION_STORE_KEY)).not.toContain('isExpired=1')
     })
 
     it('when tracked should keep existing session type and id', () => {
@@ -98,7 +99,7 @@ describe('rum session manager', () => {
     })
 
     it('when not tracked should keep existing session type', () => {
-      setCookie(SESSION_STORE_KEY, 'isExpired=1&rum=0', DURATION)
+      setCookie(SESSION_STORE_KEY, 'rum=0', DURATION)
 
       startRumSessionManagerWithDefaults()
 

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -81,7 +81,7 @@ describe('rum session manager', () => {
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
       expect(getCookie(SESSION_STORE_KEY)).toContain(`${RUM_SESSION_KEY}=${RumTrackingType.NOT_TRACKED}`)
-      expect(getCookie(SESSION_STORE_KEY)).toContain('expired=0')
+      expect(getCookie(SESSION_STORE_KEY)).toContain('isExpired=1')
     })
 
     it('when tracked should keep existing session type and id', () => {
@@ -98,7 +98,7 @@ describe('rum session manager', () => {
     })
 
     it('when not tracked should keep existing session type', () => {
-      setCookie(SESSION_STORE_KEY, 'expired=0&rum=0', DURATION)
+      setCookie(SESSION_STORE_KEY, 'isExpired=1&rum=0', DURATION)
 
       startRumSessionManagerWithDefaults()
 
@@ -112,8 +112,8 @@ describe('rum session manager', () => {
 
       startRumSessionManagerWithDefaults({ configuration: { sessionSampleRate: 100, sessionReplaySampleRate: 100 } })
 
-      setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
-      expect(getCookie(SESSION_STORE_KEY)).toEqual('expired=0')
+      setCookie(SESSION_STORE_KEY, 'isExpired=1', DURATION)
+      expect(getCookie(SESSION_STORE_KEY)).toEqual('isExpired=1')
       expect(expireSessionSpy).not.toHaveBeenCalled()
       expect(renewSessionSpy).not.toHaveBeenCalled()
       clock.tick(STORAGE_POLL_DELAY)
@@ -144,7 +144,7 @@ describe('rum session manager', () => {
 
     it('should return undefined if the session has expired', () => {
       const rumSessionManager = startRumSessionManagerWithDefaults()
-      setCookie(SESSION_STORE_KEY, 'expired=0', DURATION)
+      setCookie(SESSION_STORE_KEY, 'isExpired=1', DURATION)
       clock.tick(STORAGE_POLL_DELAY)
       expect(rumSessionManager.findTrackedSession()).toBe(undefined)
     })

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -16,13 +16,37 @@
         telemetryConfigurationSampleRate: 100,
         enableExperimentalFeatures: [],
       })
-      DD_LOGS.init({
-        clientToken: 'xxx',
-        telemetrySampleRate: 100,
-        telemetryConfigurationSampleRate: 100,
-        enableExperimentalFeatures: [],
-      })
+
+      // DD_LOGS.init({
+      //   clientToken: 'xxx',
+      //   telemetrySampleRate: 100,
+      //   telemetryConfigurationSampleRate: 100,
+      //   enableExperimentalFeatures: [],
+      // })
     </script>
   </head>
-  <body></body>
+  <body>
+    <script>
+      function addButton(label, id, handler) {
+        const button = document.createElement('button')
+        button.innerText = label
+        button.id = id
+        button.addEventListener('click', handler)
+
+        const container = document.createElement('p')
+        container.appendChild(button)
+        document.body.appendChild(container)
+      }
+
+      addButton('Send a user action', 'send-user-action', () => {
+        console.log('Sending a user action')
+        DD_RUM.addAction('one')
+        // document.cookie = '_dd_s=foo=bar;expires=Thu, 01 Jan 1970 00:00:00 GMT'
+        setTimeout(() => {
+          console.log('User action sent')
+          DD_RUM.addAction('two')
+        }, 1000)
+      })
+    </script>
+  </body>
 </html>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -16,37 +16,13 @@
         telemetryConfigurationSampleRate: 100,
         enableExperimentalFeatures: [],
       })
-
-      // DD_LOGS.init({
-      //   clientToken: 'xxx',
-      //   telemetrySampleRate: 100,
-      //   telemetryConfigurationSampleRate: 100,
-      //   enableExperimentalFeatures: [],
-      // })
-    </script>
-  </head>
-  <body>
-    <script>
-      function addButton(label, id, handler) {
-        const button = document.createElement('button')
-        button.innerText = label
-        button.id = id
-        button.addEventListener('click', handler)
-
-        const container = document.createElement('p')
-        container.appendChild(button)
-        document.body.appendChild(container)
-      }
-
-      addButton('Send a user action', 'send-user-action', () => {
-        console.log('Sending a user action')
-        DD_RUM.addAction('one')
-        // document.cookie = '_dd_s=foo=bar;expires=Thu, 01 Jan 1970 00:00:00 GMT'
-        setTimeout(() => {
-          console.log('User action sent')
-          DD_RUM.addAction('two')
-        }, 1000)
+      DD_LOGS.init({
+        clientToken: 'xxx',
+        telemetrySampleRate: 100,
+        telemetryConfigurationSampleRate: 100,
+        enableExperimentalFeatures: [],
       })
     </script>
-  </body>
+  </head>
+  <body></body>
 </html>

--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -1,8 +1,10 @@
 import * as os from 'os'
 
-// typing issue for execute https://github.com/webdriverio/webdriverio/issues/3796
-export function browserExecute(fn: any) {
-  return browser.execute(fn)
+export function browserExecute<ReturnValue, InnerArguments extends any[]>(
+  fn: (...args: InnerArguments) => ReturnValue,
+  ...args: InnerArguments
+): Promise<ReturnValue> {
+  return browser.execute(fn, ...args)
 }
 
 export function browserExecuteAsync<R, A, B>(fn: (a: A, b: B, done: (result: R) => void) => any, a: A, b: B): Promise<R>
@@ -101,6 +103,19 @@ export function deleteAllCookies() {
       document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;samesite=strict`
     }
   })
+}
+
+export function setCookie(name: string, value: string, expiresDelay: number = 0) {
+  return browserExecute(
+    (name, value, expiresDelay) => {
+      const expires = new Date(Date.now() + expiresDelay).toUTCString()
+
+      document.cookie = `${name}=${value};expires=${expires};`
+    },
+    name,
+    value,
+    expiresDelay
+  )
 }
 
 export async function sendXhr(url: string, headers: string[][] = []): Promise<string> {

--- a/test/e2e/lib/helpers/session.ts
+++ b/test/e2e/lib/helpers/session.ts
@@ -1,9 +1,4 @@
 import { SESSION_STORE_KEY, SESSION_TIME_OUT_DELAY } from '@datadog/browser-core'
-import {
-  getInitialSessionState,
-  toSessionState,
-  toSessionString,
-} from '@datadog/browser-core/src/domain/session/sessionState'
 import { setCookie } from './browser'
 
 export async function renewSession() {
@@ -11,14 +6,13 @@ export async function renewSession() {
   const documentElement = await $('html')
   await documentElement.click()
 
-  const session = await getSessionFromCookie()
-  expect(session.id).not.toBe('null')
+  expect(await findSessionCookie()).not.toContain('expired=0')
 }
 
 export async function expireSession() {
-  await setCookie(SESSION_STORE_KEY, toSessionString(getInitialSessionState()), SESSION_TIME_OUT_DELAY)
+  await setCookie(SESSION_STORE_KEY, 'expired=0', SESSION_TIME_OUT_DELAY)
 
-  expect(await getSessionFromCookie()).toEqual(getInitialSessionState())
+  expect(await findSessionCookie()).toBe('expired=0')
 
   // Cookies are cached for 1s, wait until the cache expires
   await browser.pause(1100)
@@ -31,8 +25,8 @@ export async function findSessionCookie() {
   return cookies[0]?.value || undefined
 }
 
-export async function getSessionFromCookie() {
-  const cookies = await browser.getCookies(SESSION_STORE_KEY)
+// export async function getSessionFromCookie() {
+//   const cookies = await browser.getCookies(SESSION_STORE_KEY)
 
-  return toSessionState(cookies[0]?.value)
-}
+//   return toSessionState(cookies[0]?.value)
+// }

--- a/test/e2e/lib/helpers/session.ts
+++ b/test/e2e/lib/helpers/session.ts
@@ -1,16 +1,26 @@
-import { SESSION_STORE_KEY } from '@datadog/browser-core'
-import { deleteAllCookies } from './browser'
+import { SESSION_STORE_KEY, SESSION_TIME_OUT_DELAY } from '@datadog/browser-core'
+import {
+  getInitialSessionState,
+  toSessionState,
+  toSessionString,
+} from '@datadog/browser-core/src/domain/session/sessionState'
+import { setCookie } from './browser'
 
 export async function renewSession() {
   await expireSession()
   const documentElement = await $('html')
   await documentElement.click()
-  expect(await findSessionCookie()).toBeDefined()
+
+  const session = await getSessionFromCookie()
+  expect(session.id).not.toBe('null')
 }
 
 export async function expireSession() {
-  await deleteAllCookies()
-  expect(await findSessionCookie()).toBeUndefined()
+  await setCookie(SESSION_STORE_KEY, toSessionString(getInitialSessionState()), SESSION_TIME_OUT_DELAY)
+
+  const session = await getSessionFromCookie()
+  expect(await getSessionFromCookie()).toEqual(session)
+
   // Cookies are cached for 1s, wait until the cache expires
   await browser.pause(1100)
 }
@@ -20,4 +30,10 @@ export async function findSessionCookie() {
   // In some case, the session cookie is returned but with an empty value. Let's consider it expired
   // in this case.
   return cookies[0]?.value || undefined
+}
+
+export async function getSessionFromCookie() {
+  const cookies = await browser.getCookies(SESSION_STORE_KEY)
+
+  return toSessionState(cookies[0]?.value)
 }

--- a/test/e2e/lib/helpers/session.ts
+++ b/test/e2e/lib/helpers/session.ts
@@ -18,8 +18,7 @@ export async function renewSession() {
 export async function expireSession() {
   await setCookie(SESSION_STORE_KEY, toSessionString(getInitialSessionState()), SESSION_TIME_OUT_DELAY)
 
-  const session = await getSessionFromCookie()
-  expect(await getSessionFromCookie()).toEqual(session)
+  expect(await getSessionFromCookie()).toEqual(getInitialSessionState())
 
   // Cookies are cached for 1s, wait until the cache expires
   await browser.pause(1100)

--- a/test/e2e/lib/helpers/session.ts
+++ b/test/e2e/lib/helpers/session.ts
@@ -6,13 +6,13 @@ export async function renewSession() {
   const documentElement = await $('html')
   await documentElement.click()
 
-  expect(await findSessionCookie()).not.toContain('expired=0')
+  expect(await findSessionCookie()).not.toContain('isExpired=1')
 }
 
 export async function expireSession() {
-  await setCookie(SESSION_STORE_KEY, 'expired=0', SESSION_TIME_OUT_DELAY)
+  await setCookie(SESSION_STORE_KEY, 'isExpired=1', SESSION_TIME_OUT_DELAY)
 
-  expect(await findSessionCookie()).toBe('expired=0')
+  expect(await findSessionCookie()).toBe('isExpired=1')
 
   // Cookies are cached for 1s, wait until the cache expires
   await browser.pause(1100)
@@ -24,9 +24,3 @@ export async function findSessionCookie() {
   // in this case.
   return cookies[0]?.value || undefined
 }
-
-// export async function getSessionFromCookie() {
-//   const cookies = await browser.getCookies(SESSION_STORE_KEY)
-
-//   return toSessionState(cookies[0]?.value)
-// }

--- a/test/e2e/scenario/recorder/shadowDom.scenario.ts
+++ b/test/e2e/scenario/recorder/shadowDom.scenario.ts
@@ -271,5 +271,5 @@ async function getNodeInsideShadowDom(hostTag: string, selector: string) {
 }
 
 function isAdoptedStyleSheetsSupported(): Promise<boolean> {
-  return browserExecute(() => document.adoptedStyleSheets !== undefined) as Promise<boolean>
+  return browserExecute(() => document.adoptedStyleSheets !== undefined)
 }

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -272,7 +272,7 @@ function getScrollbarThickness(): Promise<number> {
     // Removing temporary elements from the DOM
     document.body.removeChild(outer)
     return scrollbarThickness
-  }) as Promise<number>
+  })
 }
 
 // Mac OS X Chrome scrollbars are included here (~15px) which seems to be against spec

--- a/test/e2e/scenario/rum/sessions.scenario.ts
+++ b/test/e2e/scenario/rum/sessions.scenario.ts
@@ -79,7 +79,6 @@ describe('rum sessions', () => {
         await browserExecute(() => {
           window.DD_RUM!.stopSession()
         })
-
         await (await $('html')).click()
 
         // The session is not created right away, let's wait until we see a cookie

--- a/test/e2e/scenario/rum/sessions.scenario.ts
+++ b/test/e2e/scenario/rum/sessions.scenario.ts
@@ -118,12 +118,16 @@ describe('rum sessions', () => {
   })
 
   describe('third party cookie clearing', () => {
-    createTest('after a 3rd party clears the cookies, stop the session')
+    createTest('after a 3rd party clears the cookies, do not restart a session on user interaction')
       .withRum()
       .run(async ({ intakeRegistry }) => {
         await deleteAllCookies()
 
         // Cookies are cached for 1s, wait until the cache expires
+        await browser.pause(1100)
+
+        await (await $('html')).click()
+
         await browser.pause(1100)
 
         await browserExecute(() => {

--- a/test/e2e/scenario/rum/sessions.scenario.ts
+++ b/test/e2e/scenario/rum/sessions.scenario.ts
@@ -1,7 +1,7 @@
 import { RecordType } from '@datadog/browser-rum/src/types'
 import { expireSession, getSessionFromCookie, renewSession } from '../../lib/helpers/session'
 import { bundleSetup, createTest, flushEvents, waitForRequests } from '../../lib/framework'
-import { browserExecute, browserExecuteAsync, sendXhr } from '../../lib/helpers/browser'
+import { browserExecute, browserExecuteAsync, deleteAllCookies, sendXhr } from '../../lib/helpers/browser'
 
 describe('rum sessions', () => {
   describe('session renewal', () => {
@@ -116,6 +116,29 @@ describe('rum sessions', () => {
         expect(intakeRegistry.rumViewEvents[0].session.is_active).toBe(false)
         expect(intakeRegistry.logsEvents.length).toBe(1)
         expect(intakeRegistry.replaySegments.length).toBe(1)
+      })
+  })
+
+  describe('third party cookie clearing', () => {
+    createTest('after a 3rd party clears the cookies, stop the session')
+      .withRum()
+      .run(async ({ intakeRegistry }) => {
+        await deleteAllCookies()
+
+        // Cookies are cached for 1s, wait until the cache expires
+        await browser.pause(1100)
+
+        await browserExecute(() => {
+          window.DD_RUM!.addAction('foo')
+        })
+
+        await flushEvents()
+
+        const session = await getSessionFromCookie()
+        expect(session.id).toBeUndefined()
+        expect(intakeRegistry.rumActionEvents.length).toBe(0)
+        expect(intakeRegistry.rumViewEvents.length).toBe(1)
+        expect(intakeRegistry.rumViewEvents[0].session.is_active).toBe(false)
       })
   })
 })

--- a/test/e2e/scenario/rum/sessions.scenario.ts
+++ b/test/e2e/scenario/rum/sessions.scenario.ts
@@ -69,7 +69,7 @@ describe('rum sessions', () => {
         })
         await flushEvents()
 
-        expect(await findSessionCookie()).toBe('expired=0')
+        expect(await findSessionCookie()).toBe('isExpired=1')
         expect(intakeRegistry.rumActionEvents.length).toBe(0)
       })
 
@@ -91,7 +91,7 @@ describe('rum sessions', () => {
 
         await flushEvents()
 
-        expect(await findSessionCookie()).not.toContain('expired=0')
+        expect(await findSessionCookie()).not.toContain('isExpired=1')
         expect(await findSessionCookie()).toMatch(/id=[a-f0-9-]+/)
         expect(intakeRegistry.rumActionEvents.length).toBe(1)
       })

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -39,7 +39,7 @@ describe('tracking consent', () => {
         await flushEvents()
 
         expect(intakeRegistry.rumActionEvents).toEqual([])
-        expect(await findSessionCookie()).toContain('expired=0')
+        expect(await findSessionCookie()).toContain('isExpired=1')
       })
 
     createTest('starts a new session when tracking consent is granted again')

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -1,6 +1,6 @@
 import { createTest, flushEvents } from '../lib/framework'
 import { browserExecute } from '../lib/helpers/browser'
-import { findSessionCookie } from '../lib/helpers/session'
+import { findSessionCookie, getSessionFromCookie } from '../lib/helpers/session'
 
 describe('tracking consent', () => {
   describe('RUM', () => {
@@ -38,8 +38,10 @@ describe('tracking consent', () => {
 
         await flushEvents()
 
+        const session = await getSessionFromCookie()
+
         expect(intakeRegistry.rumActionEvents).toEqual([])
-        expect(await findSessionCookie()).toBeUndefined()
+        expect(session.id).toBe('null')
       })
 
     createTest('starts a new session when tracking consent is granted again')

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -1,6 +1,6 @@
 import { createTest, flushEvents } from '../lib/framework'
 import { browserExecute } from '../lib/helpers/browser'
-import { findSessionCookie, getSessionFromCookie } from '../lib/helpers/session'
+import { findSessionCookie } from '../lib/helpers/session'
 
 describe('tracking consent', () => {
   describe('RUM', () => {
@@ -38,10 +38,8 @@ describe('tracking consent', () => {
 
         await flushEvents()
 
-        const session = await getSessionFromCookie()
-
         expect(intakeRegistry.rumActionEvents).toEqual([])
-        expect(session.id).toBe('null')
+        expect(await findSessionCookie()).toContain('expired=0')
       })
 
     createTest('starts a new session when tracking consent is granted again')


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Makes session management resilient to clearing the cookie. If a cookie is deleted outside of the browser SDK, we do not create a new session automatically. 

This solves an issue with Adguard that delete the cookie every second. This had for effect to generate a large amount of short lived sessions.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

- When a session is expired, we set the cookie to `isExpired=1` with an expiration delay of 4h (instead of deleting the cookie)
- When the cookie is altered by a 3rd party, we can now differentiate it from an expired session and won't start a new session automatically after a user action.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
