### PR TITLE
👷 Exclude typescript updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackageNames": ["karma-webpack"]
+      "excludePackageNames": ["karma-webpack", "typescript"]
     }
   ]
 }


### PR DESCRIPTION
## Motivation

Typescript 5.4.0 introduced a change that breaks our local build, cf #2670 

## Changes

Exclude typescript from renovate updates

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
