### PR TITLE
🐛 fix beforeSend type definition for logs

### DIFF
--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -12,7 +12,7 @@ import {
   objectValues,
 } from '@datadog/browser-core'
 import type { LogsEvent } from '../logsEvent.types'
-import type { LogsEventDomainContext } from './lifeCycle'
+import type { LogsEventDomainContext } from '../domainContext.types'
 
 export interface LogsInitConfiguration extends InitConfiguration {
   beforeSend?: (<T extends LogsEvent>(event: T, context: LogsEventDomainContext<T['origin']>) => boolean) | undefined

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -12,9 +12,10 @@ import {
   objectValues,
 } from '@datadog/browser-core'
 import type { LogsEvent } from '../logsEvent.types'
+import type { LogsEventDomainContext } from './lifeCycle'
 
 export interface LogsInitConfiguration extends InitConfiguration {
-  beforeSend?: ((event: LogsEvent) => boolean) | undefined
+  beforeSend?: (<T extends LogsEvent>(event: T, context: LogsEventDomainContext<T['origin']>) => boolean) | undefined
   forwardErrorsToLogs?: boolean | undefined
   forwardConsoleLogs?: ConsoleApiName[] | 'all' | undefined
   forwardReports?: RawReportType[] | 'all' | undefined

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -15,7 +15,7 @@ import type { LogsEvent } from '../logsEvent.types'
 import type { LogsEventDomainContext } from '../domainContext.types'
 
 export interface LogsInitConfiguration extends InitConfiguration {
-  beforeSend?: (<T extends LogsEvent>(event: T, context: LogsEventDomainContext<T['origin']>) => boolean) | undefined
+  beforeSend?: ((event: LogsEvent, context: LogsEventDomainContext) => boolean) | undefined
   forwardErrorsToLogs?: boolean | undefined
   forwardConsoleLogs?: ConsoleApiName[] | 'all' | undefined
   forwardReports?: RawReportType[] | 'all' | undefined

--- a/packages/logs/src/domain/lifeCycle.ts
+++ b/packages/logs/src/domain/lifeCycle.ts
@@ -1,7 +1,8 @@
 import { AbstractLifeCycle } from '@datadog/browser-core'
-import type { Context, ErrorSource } from '@datadog/browser-core'
+import type { Context } from '@datadog/browser-core'
 import type { LogsEvent } from '../logsEvent.types'
 import type { CommonContext, RawLogsEvent } from '../rawLogsEvent.types'
+import type { LogsEventDomainContext } from '../domainContext.types'
 
 export const enum LifeCycleEventType {
   RAW_LOG_COLLECTED,
@@ -15,14 +16,6 @@ interface LifeCycleEventMap {
 
 export const LifeCycle = AbstractLifeCycle<LifeCycleEventMap>
 export type LifeCycle = AbstractLifeCycle<LifeCycleEventMap>
-
-export type LogsEventDomainContext<T extends ErrorSource> = T extends typeof ErrorSource.NETWORK
-  ? NetworkLogsEventDomainContext
-  : never
-
-type NetworkLogsEventDomainContext = {
-  isAborted: boolean
-}
 
 export interface RawLogsEventCollectedData<E extends RawLogsEvent = RawLogsEvent> {
   rawLogsEvent: E

--- a/packages/logs/src/domain/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.ts
@@ -13,7 +13,8 @@ import {
   isServerError,
 } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../configuration'
-import type { LifeCycle, LogsEventDomainContext } from '../lifeCycle'
+import type { LifeCycle } from '../lifeCycle'
+import type { LogsEventDomainContext } from '../../domainContext.types'
 import { LifeCycleEventType } from '../lifeCycle'
 import { StatusType } from '../logger'
 

--- a/packages/logs/src/domainContext.types.ts
+++ b/packages/logs/src/domainContext.types.ts
@@ -1,0 +1,9 @@
+import type { ErrorSource } from '@datadog/browser-core'
+
+export type LogsEventDomainContext<T extends ErrorSource> = T extends typeof ErrorSource.NETWORK
+  ? NetworkLogsEventDomainContext
+  : never
+
+export type NetworkLogsEventDomainContext = {
+  isAborted: boolean
+}

--- a/packages/logs/src/domainContext.types.ts
+++ b/packages/logs/src/domainContext.types.ts
@@ -1,6 +1,6 @@
 import type { ErrorSource } from '@datadog/browser-core'
 
-export type LogsEventDomainContext<T extends ErrorSource> = T extends typeof ErrorSource.NETWORK
+export type LogsEventDomainContext<T extends ErrorSource = any> = T extends typeof ErrorSource.NETWORK
   ? NetworkLogsEventDomainContext
   : never
 


### PR DESCRIPTION
## Motivation

fixes #2685 

## Changes

Add missing context argument to log's `beforeSend` type definition

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
