### PR TITLE
⚗ [RUM-2782] validate resource timings more granularly

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -19,6 +19,7 @@ export enum ExperimentalFeature {
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
   CUSTOM_VITALS = 'custom_vitals',
+  TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()


### PR DESCRIPTION


## Motivation

Before this PR, we dropped any `PerformanceResourceEntry` that had inconsistent timings. With this commit, when the experimental feature "tolerant_resource_timings" is enabled, the various timings are validated independently.

This should improve the situation on Chrome when a Service Worker is involved. In this case, most of the time, connection timings are unexpectedly set after the `requestStart` timing (see [Chromium issue][1]). Before this change, the whole `PerformanceResourceEntry` would be ignored, and no timings would be included. With this change (and the flag enabled), relevant timings will be correctly defined.

Related issue: #2566

[1]: https://issues.chromium.org/issues/323703325

## Changes

Before/without the flag:
![Screenshot 2024-04-04 at 18 24 54](https://github.com/DataDog/browser-sdk/assets/61787/bbf7b264-626f-4e3b-b5c5-8a2ba27b9e08)

After:
![Screenshot 2024-04-04 at 18 24 39](https://github.com/DataDog/browser-sdk/assets/61787/894be370-35ec-4320-a1c1-f539ee0734ea)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
