### PR TITLE
♻️ use browser.execute and browser.executeAsync directly

### DIFF
--- a/test/e2e/lib/framework/waitForRequests.ts
+++ b/test/e2e/lib/framework/waitForRequests.ts
@@ -1,18 +1,17 @@
-import { browserExecuteAsync } from '../helpers/browser'
 import { waitForServersIdle } from './httpServers'
 
 /**
  * Wait for browser requests to be sent and finished.
  *
- * Due to latency, a request (fetch, xhr, sendBeacon...) started inside a `browserExecute(...)`
- * callback might *not* have reached the local server when `browserExecute` finishes. Thus, calling
+ * Due to latency, a request (fetch, xhr, sendBeacon...) started inside a `browser.execute(...)`
+ * callback might *not* have reached the local server when `browser.execute` finishes. Thus, calling
  * `waitForServersIdle()` directly might be flaky, because no request might be pending yet.
  *
  * As a workaround, this function delays the `waitForServersIdle()` call by doing a browser
  * roundtrip, ensuring requests have plenty of time to reach the local server.
  */
 export async function waitForRequests() {
-  await browserExecuteAsync((done) =>
+  await browser.executeAsync((done) =>
     setTimeout(() => {
       done(undefined)
     }, 200)

--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -1,19 +1,5 @@
 import * as os from 'os'
 
-export function browserExecute<ReturnValue, InnerArguments extends any[]>(
-  fn: (...args: InnerArguments) => ReturnValue,
-  ...args: InnerArguments
-): Promise<ReturnValue> {
-  return browser.execute(fn, ...args)
-}
-
-export function browserExecuteAsync<R, A, B>(fn: (a: A, b: B, done: (result: R) => void) => any, a: A, b: B): Promise<R>
-export function browserExecuteAsync<R, A>(fn: (a: A, done: (result: R) => void) => any, arg: A): Promise<R>
-export function browserExecuteAsync<R>(fn: (done: (result: R) => void) => any): Promise<R>
-export function browserExecuteAsync<A extends any[]>(fn: (...params: A) => any, ...args: A) {
-  return browser.executeAsync(fn as any, ...args)
-}
-
 // To keep tests sane, ensure we got a fixed list of possible platforms and browser names.
 const validPlatformNames = ['windows', 'macos', 'linux', 'ios', 'android'] as const
 const validBrowserNames = ['edge', 'safari', 'chrome', 'firefox', 'ie'] as const
@@ -95,7 +81,7 @@ export async function flushBrowserLogs() {
 
 // wdio method does not work for some browsers
 export function deleteAllCookies() {
-  return browserExecute(() => {
+  return browser.execute(() => {
     const cookies = document.cookie.split(';')
     for (const cookie of cookies) {
       const eqPos = cookie.indexOf('=')
@@ -106,7 +92,7 @@ export function deleteAllCookies() {
 }
 
 export function setCookie(name: string, value: string, expiresDelay: number = 0) {
-  return browserExecute(
+  return browser.execute(
     (name, value, expiresDelay) => {
       const expires = new Date(Date.now() + expiresDelay).toUTCString()
 
@@ -121,7 +107,7 @@ export function setCookie(name: string, value: string, expiresDelay: number = 0)
 export async function sendXhr(url: string, headers: string[][] = []): Promise<string> {
   type State = { state: 'success'; response: string } | { state: 'error' }
 
-  const result: State = await browserExecuteAsync(
+  const result: State = await browser.executeAsync(
     (url, headers, done) => {
       const xhr = new XMLHttpRequest()
       let state: State = { state: 'error' }

--- a/test/e2e/scenario/eventBridge.scenario.ts
+++ b/test/e2e/scenario/eventBridge.scenario.ts
@@ -1,4 +1,4 @@
-import { browserExecute, flushBrowserLogs } from '../lib/helpers/browser'
+import { flushBrowserLogs } from '../lib/helpers/browser'
 import { createTest, flushEvents, html } from '../lib/framework'
 
 describe('bridge present', () => {
@@ -29,7 +29,7 @@ describe('bridge present', () => {
     .withRum()
     .withEventBridge()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         console.error('oh snap')
       })
 
@@ -64,7 +64,7 @@ describe('bridge present', () => {
     .withLogs()
     .withEventBridge()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         const context = {
           get foo() {
             throw new window.Error('bar')
@@ -83,7 +83,7 @@ describe('bridge present', () => {
     .withLogs()
     .withEventBridge()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         window.DD_LOGS!.logger.log('hello')
       })
       await flushEvents()
@@ -110,7 +110,7 @@ describe('bridge present', () => {
       await browser.pause(200)
 
       const preStopRecordsCount = intakeRegistry.replayRecords.length
-      await browserExecute(() => {
+      await browser.execute(() => {
         window.DD_RUM!.stopSessionReplayRecording()
 
         // trigger a new record

--- a/test/e2e/scenario/logs.scenario.ts
+++ b/test/e2e/scenario/logs.scenario.ts
@@ -1,13 +1,13 @@
 import { DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT } from '@datadog/browser-logs/cjs/domain/configuration'
 import { createTest, flushEvents } from '../lib/framework'
 import { APPLICATION_ID, UNREACHABLE_URL } from '../lib/helpers/constants'
-import { browserExecute, browserExecuteAsync, flushBrowserLogs, withBrowserLogs } from '../lib/helpers/browser'
+import { flushBrowserLogs, withBrowserLogs } from '../lib/helpers/browser'
 
 describe('logs', () => {
   createTest('send logs')
     .withLogs()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         window.DD_LOGS!.logger.log('hello')
       })
       await flushEvents()
@@ -18,7 +18,7 @@ describe('logs', () => {
   createTest('display logs in the console')
     .withLogs()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         window.DD_LOGS!.logger.setHandler('console')
         window.DD_LOGS!.logger.warn('hello')
       })
@@ -36,7 +36,7 @@ describe('logs', () => {
   createTest('send console errors')
     .withLogs({ forwardErrorsToLogs: true })
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         console.error('oh snap')
       })
       await flushEvents()
@@ -50,7 +50,7 @@ describe('logs', () => {
   createTest('send XHR network errors')
     .withLogs({ forwardErrorsToLogs: true })
     .run(async ({ intakeRegistry }) => {
-      await browserExecuteAsync((unreachableUrl, done) => {
+      await browser.executeAsync((unreachableUrl, done) => {
         const xhr = new XMLHttpRequest()
         xhr.addEventListener('error', () => done(undefined))
         xhr.open('GET', unreachableUrl)
@@ -73,7 +73,7 @@ describe('logs', () => {
   createTest('send fetch network errors')
     .withLogs({ forwardErrorsToLogs: true })
     .run(async ({ intakeRegistry }) => {
-      await browserExecuteAsync((unreachableUrl, done) => {
+      await browser.executeAsync((unreachableUrl, done) => {
         fetch(unreachableUrl).catch(() => {
           done(undefined)
         })
@@ -95,7 +95,7 @@ describe('logs', () => {
   createTest('keep only the first bytes of the response')
     .withLogs({ forwardErrorsToLogs: true })
     .run(async ({ intakeRegistry, baseUrl, servers }) => {
-      await browserExecuteAsync((done) => {
+      await browser.executeAsync((done) => {
         fetch('/throw-large-response').then(() => done(undefined), console.log)
       })
 
@@ -124,7 +124,7 @@ describe('logs', () => {
   createTest('track fetch error')
     .withLogs({ forwardErrorsToLogs: true })
     .run(async ({ intakeRegistry, baseUrl }) => {
-      await browserExecuteAsync((unreachableUrl, done) => {
+      await browser.executeAsync((unreachableUrl, done) => {
         let count = 0
         fetch('/throw')
           .then(() => (count += 1))
@@ -166,7 +166,7 @@ describe('logs', () => {
     .withRum()
     .withLogs()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         window.DD_LOGS!.logger.log('hello')
       })
       await flushEvents()
@@ -183,7 +183,7 @@ describe('logs', () => {
       },
     })
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         window.DD_LOGS!.logger.log('hello', {})
       })
       await flushEvents()

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -19,7 +19,6 @@ import {
   findElementWithTagName,
 } from '@datadog/browser-rum/test'
 import { flushEvents, createTest, bundleSetup, html } from '../../lib/framework'
-import { browserExecute, browserExecuteAsync } from '../../lib/helpers/browser'
 
 const TIMESTAMP_RE = /^\d{13}$/
 const UUID_RE = /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/
@@ -28,7 +27,7 @@ describe('recorder', () => {
   createTest('record mouse move')
     .withRum()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => document.documentElement.outerHTML)
+      await browser.execute(() => document.documentElement.outerHTML)
       const html = await $('html')
       await html.click()
       await flushEvents()
@@ -131,7 +130,7 @@ describe('recorder', () => {
         </ul>
       `)
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           const li = document.createElement('li')
           const ul = document.querySelector('ul') as HTMLUListElement
 
@@ -175,7 +174,7 @@ describe('recorder', () => {
         </ul>
       `)
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           const li = document.createElement('li')
           const ul = document.querySelector('ul') as HTMLUListElement
 
@@ -225,7 +224,7 @@ describe('recorder', () => {
         </ul>
       `)
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           const li = document.createElement('li')
           const ul = document.querySelector('ul') as HTMLUListElement
 
@@ -270,7 +269,7 @@ describe('recorder', () => {
         </div>
       `)
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           document.querySelector('div')!.setAttribute('foo', 'bar')
           document.querySelector('li')!.textContent = 'hop'
           document.querySelector('div')!.appendChild(document.createElement('p'))
@@ -295,7 +294,7 @@ describe('recorder', () => {
         `
       )
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           const div = document.querySelector('div')!
           const p = document.querySelector('p')!
           const span = document.querySelector('span')!
@@ -344,7 +343,7 @@ describe('recorder', () => {
         `
       )
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           const div = document.createElement('div')
           const span = document.querySelector('span')!
           document.body.appendChild(div)
@@ -395,7 +394,7 @@ describe('recorder', () => {
         `
       )
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           const ul = document.querySelector('ul') as HTMLUListElement
           let count = 3
           while (count > 0) {
@@ -596,7 +595,7 @@ describe('recorder', () => {
         </style>
       `)
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           document.styleSheets[0].deleteRule(0)
           document.styleSheets[0].insertRule('.added {}', 0)
         })
@@ -634,7 +633,7 @@ describe('recorder', () => {
         </style>
       `)
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           const supportsRule = document.styleSheets[0].cssRules[0] as CSSGroupingRule
           const mediaRule = document.styleSheets[0].cssRules[1] as CSSGroupingRule
 
@@ -740,7 +739,7 @@ describe('recorder', () => {
       `)
       .run(async ({ intakeRegistry }) => {
         function scroll({ windowY, containerX }: { windowY: number; containerX: number }) {
-          return browserExecuteAsync(
+          return browser.executeAsync(
             (windowY, containerX, done) => {
               let scrollCount = 0
 
@@ -767,7 +766,7 @@ describe('recorder', () => {
         // initial scroll positions
         await scroll({ windowY: 100, containerX: 10 })
 
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.startSessionReplayRecording()
         })
 
@@ -778,7 +777,7 @@ describe('recorder', () => {
         await scroll({ windowY: 150, containerX: 20 })
 
         // trigger new full snapshot
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.startView()
         })
 
@@ -811,7 +810,7 @@ describe('recorder', () => {
     .withRum()
     .withSetup(bundleSetup)
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         window.DD_RUM!.stopSessionReplayRecording()
         window.DD_RUM!.startSessionReplayRecording()
       })

--- a/test/e2e/scenario/recorder/shadowDom.scenario.ts
+++ b/test/e2e/scenario/recorder/shadowDom.scenario.ts
@@ -19,7 +19,6 @@ import {
 } from '@datadog/browser-rum/test'
 
 import { flushEvents, createTest, bundleSetup, html } from '../../lib/framework'
-import { browserExecute } from '../../lib/helpers/browser'
 
 /** Will generate the following HTML
  * ```html
@@ -115,7 +114,7 @@ const scrollableDivShadowDom = `<script>
 
     const button = document.createElement("button");
     button.textContent = 'scroll to 250';
-    
+
     button.onclick = () => {
       div.scrollTo({ top: 250 });
     }
@@ -268,7 +267,7 @@ describe('recorder with shadow DOM', () => {
       <my-div id="host" />
     `)
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         const host = document.body.querySelector('#host') as HTMLElement
         const div = host.shadowRoot!.querySelector('div') as HTMLElement
         div.innerText = 'titi'
@@ -345,5 +344,5 @@ async function getNodeInsideShadowDom(hostTag: string, selector: string) {
 }
 
 function isAdoptedStyleSheetsSupported(): Promise<boolean> {
-  return browserExecute(() => document.adoptedStyleSheets !== undefined)
+  return browser.execute(() => document.adoptedStyleSheets !== undefined)
 }

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -4,7 +4,7 @@ import { IncrementalSource } from '@datadog/browser-rum/cjs/types'
 import { findAllIncrementalSnapshots, findAllVisualViewports } from '@datadog/browser-rum/test'
 import type { IntakeRegistry } from '../../lib/framework'
 import { flushEvents, createTest, bundleSetup, html } from '../../lib/framework'
-import { browserExecute, getBrowserName, getPlatformName } from '../../lib/helpers/browser'
+import { getBrowserName, getPlatformName } from '../../lib/helpers/browser'
 
 const NAVBAR_HEIGHT_CHANGE_UPPER_BOUND = 30
 const VIEWPORT_META_TAGS = `
@@ -33,7 +33,7 @@ describe('recorder', () => {
         const { innerWidth, innerHeight } = await getWindowInnerDimensions()
         await performSignificantZoom()
 
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.dispatchEvent(new Event('resize'))
         })
 
@@ -211,7 +211,7 @@ async function visualScrollVerticallyDown(yChange: number) {
 }
 
 async function buildScrollablePage() {
-  await browserExecute(() => {
+  await browser.execute(() => {
     document.documentElement.style.setProperty('width', '5000px')
     document.documentElement.style.setProperty('height', '5000px')
     document.documentElement.style.setProperty('margin', '0px')
@@ -234,7 +234,7 @@ interface VisualViewportData {
 }
 
 function getVisualViewport(): Promise<VisualViewportData> {
-  return browserExecute(() => {
+  return browser.execute(() => {
     const visual = window.visualViewport || ({} as Record<string, undefined>)
     return {
       scale: visual.scale,
@@ -249,7 +249,7 @@ function getVisualViewport(): Promise<VisualViewportData> {
 }
 
 function getWindowScroll() {
-  return browserExecute(() => ({
+  return browser.execute(() => ({
     scrollX: window.scrollX,
     scrollY: window.scrollY,
   })) as Promise<{ scrollX: number; scrollY: number }>
@@ -257,7 +257,7 @@ function getWindowScroll() {
 
 function getScrollbarThickness(): Promise<number> {
   // https://stackoverflow.com/questions/13382516/getting-scroll-bar-width-using-javascript#answer-13382873
-  return browserExecute(() => {
+  return browser.execute(() => {
     // Creating invisible container
     const outer = document.createElement('div')
     outer.style.visibility = 'hidden'
@@ -293,14 +293,14 @@ async function getLastRecord<T>(intakeRegistry: IntakeRegistry, filterMethod: (s
 }
 
 function getWindowInnerDimensions() {
-  return browserExecute(() => ({
+  return browser.execute(() => ({
     innerWidth: window.innerWidth,
     innerHeight: window.innerHeight,
   })) as Promise<{ innerWidth: number; innerHeight: number }>
 }
 
 async function resetWindowScroll() {
-  await browserExecute(() => {
+  await browser.execute(() => {
     window.scrollTo(-500, -500)
   })
   const { scrollX: nextScrollX, scrollY: nextScrollY } = await getWindowScroll()

--- a/test/e2e/scenario/rum/errors.scenario.ts
+++ b/test/e2e/scenario/rum/errors.scenario.ts
@@ -2,7 +2,7 @@ import type { RumErrorEvent } from '@datadog/browser-rum-core'
 import { createTest, flushEvents, html } from '../../lib/framework'
 import { getBrowserName, getPlatformName, withBrowserLogs } from '../../lib/helpers/browser'
 
-// Note: using `browserExecute` to throw exceptions may result in "Script error." being reported,
+// Note: using `browser.execute` to throw exceptions may result in "Script error." being reported,
 // because WDIO is evaluating the script in a different context than the page.
 function createBody(errorGenerator: string) {
   return html`

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -1,7 +1,7 @@
 import type { RumResourceEvent } from '@datadog/browser-rum'
 import type { IntakeRegistry } from '../../lib/framework'
 import { flushEvents, bundleSetup, createTest, html } from '../../lib/framework'
-import { browserExecuteAsync, sendXhr } from '../../lib/helpers/browser'
+import { sendXhr } from '../../lib/helpers/browser'
 
 const REQUEST_DURATION = 200
 
@@ -82,7 +82,7 @@ describe('rum resources', () => {
       .withRum()
       .withSetup(bundleSetup)
       .run(async ({ intakeRegistry }) => {
-        await browserExecuteAsync((done) => {
+        await browser.executeAsync((done) => {
           const xhr = new XMLHttpRequest()
           xhr.open('GET', '/ok?duration=1000')
           xhr.send()
@@ -101,7 +101,7 @@ describe('rum resources', () => {
       .withRum()
       .withSetup(bundleSetup)
       .run(async ({ intakeRegistry }) => {
-        await browserExecuteAsync((done) => {
+        await browser.executeAsync((done) => {
           const xhr = new XMLHttpRequest()
           xhr.open('GET', '/ok')
           xhr.abort()
@@ -118,7 +118,7 @@ describe('rum resources', () => {
       .withRum()
       .withSetup(bundleSetup)
       .run(async ({ intakeRegistry }) => {
-        await browserExecuteAsync((done) => {
+        await browser.executeAsync((done) => {
           const xhr = new XMLHttpRequest()
           xhr.open('GET', '/ok')
           xhr.onreadystatechange = () => {
@@ -139,7 +139,7 @@ describe('rum resources', () => {
       .withRum()
       .withSetup(bundleSetup)
       .run(async ({ intakeRegistry }) => {
-        await browserExecuteAsync((done) => {
+        await browser.executeAsync((done) => {
           const xhr = new XMLHttpRequest()
           xhr.open('GET', '/ok')
           xhr.addEventListener('loadend', () => {
@@ -177,7 +177,7 @@ describe('rum resources', () => {
       .withRum()
       .withSetup(bundleSetup)
       .run(async ({ intakeRegistry }) => {
-        await browserExecuteAsync((done) => {
+        await browser.executeAsync((done) => {
           const controller = new AbortController()
           fetch('/ok?duration=1000', { signal: controller.signal }).catch(() => {
             // ignore abortion error
@@ -199,7 +199,7 @@ describe('rum resources', () => {
   createTest('track redirect fetch timings')
     .withRum()
     .run(async ({ intakeRegistry }) => {
-      await browserExecuteAsync((done) => {
+      await browser.executeAsync((done) => {
         fetch('/redirect?duration=200').then(
           () => done(undefined),
           () => {
@@ -222,7 +222,7 @@ describe('rum resources', () => {
       .withRum()
       .withSetup(bundleSetup)
       .run(async ({ intakeRegistry }) => {
-        await browserExecuteAsync((done) => {
+        await browser.executeAsync((done) => {
           const xhr = new XMLHttpRequest()
           const triggerSecondCall = () => {
             xhr.removeEventListener('loadend', triggerSecondCall)

--- a/test/e2e/scenario/rum/sessions.scenario.ts
+++ b/test/e2e/scenario/rum/sessions.scenario.ts
@@ -1,7 +1,7 @@
 import { RecordType } from '@datadog/browser-rum/src/types'
 import { expireSession, findSessionCookie, renewSession } from '../../lib/helpers/session'
 import { bundleSetup, createTest, flushEvents, waitForRequests } from '../../lib/framework'
-import { browserExecute, browserExecuteAsync, deleteAllCookies, sendXhr } from '../../lib/helpers/browser'
+import { deleteAllCookies, sendXhr } from '../../lib/helpers/browser'
 
 describe('rum sessions', () => {
   describe('session renewal', () => {
@@ -55,7 +55,7 @@ describe('rum sessions', () => {
     createTest('calling stopSession() stops the session')
       .withRum()
       .run(async ({ intakeRegistry }) => {
-        await browserExecuteAsync<void>((done) => {
+        await browser.executeAsync((done) => {
           window.DD_RUM!.stopSession()
           setTimeout(() => {
             // If called directly after `stopSession`, the action start time may be the same as the
@@ -76,7 +76,7 @@ describe('rum sessions', () => {
     createTest('after calling stopSession(), a user interaction starts a new session')
       .withRum()
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.stopSession()
         })
         await (await $('html')).click()
@@ -84,7 +84,7 @@ describe('rum sessions', () => {
         // The session is not created right away, let's wait until we see a cookie
         await browser.waitUntil(async () => Boolean(await findSessionCookie()))
 
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.addAction('foo')
         })
 
@@ -103,7 +103,7 @@ describe('rum sessions', () => {
         expect(intakeRegistry.logsEvents.length).toBe(0)
         expect(intakeRegistry.replaySegments.length).toBe(0)
 
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_LOGS!.logger.log('foo')
           window.DD_RUM!.stopSession()
         })
@@ -130,7 +130,7 @@ describe('rum sessions', () => {
 
         await browser.pause(1100)
 
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.addAction('foo')
         })
 

--- a/test/e2e/scenario/rum/tracing.scenario.ts
+++ b/test/e2e/scenario/rum/tracing.scenario.ts
@@ -1,6 +1,6 @@
 import type { IntakeRegistry } from '../../lib/framework'
 import { flushEvents, createTest } from '../../lib/framework'
-import { browserExecuteAsync, sendXhr } from '../../lib/helpers/browser'
+import { sendXhr } from '../../lib/helpers/browser'
 
 describe('tracing', () => {
   createTest('trace xhr')
@@ -20,7 +20,7 @@ describe('tracing', () => {
   createTest('trace fetch')
     .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
     .run(async ({ intakeRegistry }) => {
-      const rawHeaders = await browserExecuteAsync<string | Error>((done) => {
+      const rawHeaders = await browser.executeAsync<string | Error, []>((done) => {
         window
           .fetch('/headers', {
             headers: [
@@ -42,7 +42,7 @@ describe('tracing', () => {
   createTest('trace fetch with Request argument')
     .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
     .run(async ({ intakeRegistry }) => {
-      const rawHeaders = await browserExecuteAsync<string | Error>((done) => {
+      const rawHeaders = await browser.executeAsync<string | Error, []>((done) => {
         window
           .fetch(new Request('/headers', { headers: { 'x-foo': 'bar, baz' } }))
           .then((response) => response.text())
@@ -59,7 +59,7 @@ describe('tracing', () => {
   createTest('trace single argument fetch')
     .withRum({ service: 'service', allowedTracingUrls: ['LOCATION_ORIGIN'] })
     .run(async ({ intakeRegistry }) => {
-      const rawHeaders = await browserExecuteAsync<string | Error>((done) => {
+      const rawHeaders = await browser.executeAsync<string | Error, []>((done) => {
         window
           .fetch('/headers')
           .then((response) => response.text())

--- a/test/e2e/scenario/rum/views.scenario.ts
+++ b/test/e2e/scenario/rum/views.scenario.ts
@@ -1,5 +1,5 @@
 import { createTest, flushEvents, html } from '../../lib/framework'
-import { browserExecute, getBrowserName } from '../../lib/helpers/browser'
+import { getBrowserName } from '../../lib/helpers/browser'
 
 describe('rum views', () => {
   createTest('send performance timings along the view events')
@@ -51,7 +51,7 @@ describe('rum views', () => {
     createTest('create a new view on hash change')
       .withRum()
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.location.hash = '#bar'
         })
 

--- a/test/e2e/scenario/rum/vitals.scenario.ts
+++ b/test/e2e/scenario/rum/vitals.scenario.ts
@@ -1,5 +1,4 @@
 import { createTest, flushEvents } from '../../lib/framework'
-import { browserExecuteAsync } from '../../lib/helpers/browser'
 
 describe('vital collection', () => {
   createTest('send custom duration vital')
@@ -7,7 +6,7 @@ describe('vital collection', () => {
       enableExperimentalFeatures: ['custom_vitals'],
     })
     .run(async ({ intakeRegistry }) => {
-      await browserExecuteAsync<void>((done) => {
+      await browser.executeAsync((done) => {
         // TODO remove cast and unsafe calls when removing the flag
         const global = window.DD_RUM! as any
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -1,12 +1,11 @@
 import { bundleSetup, createTest, flushEvents } from '../lib/framework'
-import { browserExecute } from '../lib/helpers/browser'
 
 describe('telemetry', () => {
   createTest('send errors for logs')
     .withSetup(bundleSetup)
     .withLogs()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         const context = {
           get foo() {
             throw new window.Error('expected error')
@@ -28,7 +27,7 @@ describe('telemetry', () => {
     .withSetup(bundleSetup)
     .withRum()
     .run(async ({ intakeRegistry }) => {
-      await browserExecute(() => {
+      await browser.execute(() => {
         const context = {
           get foo() {
             throw new window.Error('expected error')

--- a/test/e2e/scenario/trackingConsent.scenario.ts
+++ b/test/e2e/scenario/trackingConsent.scenario.ts
@@ -1,5 +1,4 @@
 import { createTest, flushEvents } from '../lib/framework'
-import { browserExecute } from '../lib/helpers/browser'
 import { findSessionCookie } from '../lib/helpers/session'
 
 describe('tracking consent', () => {
@@ -16,7 +15,7 @@ describe('tracking consent', () => {
     createTest('starts the SDK once tracking consent is granted')
       .withRum({ trackingConsent: 'not-granted' })
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.setTrackingConsent('granted')
         })
 
@@ -29,7 +28,7 @@ describe('tracking consent', () => {
     createTest('stops sending events if tracking consent is revoked')
       .withRum({ trackUserInteractions: true })
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.setTrackingConsent('not-granted')
         })
 
@@ -47,7 +46,7 @@ describe('tracking consent', () => {
       .run(async ({ intakeRegistry }) => {
         const initialSessionId = await findSessionCookie()
 
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_RUM!.setTrackingConsent('not-granted')
           window.DD_RUM!.setTrackingConsent('granted')
         })
@@ -88,7 +87,7 @@ describe('tracking consent', () => {
     createTest('starts the SDK once tracking consent is granted')
       .withLogs({ trackingConsent: 'not-granted' })
       .run(async ({ intakeRegistry }) => {
-        await browserExecute(() => {
+        await browser.execute(() => {
           window.DD_LOGS!.setTrackingConsent('granted')
         })
 


### PR DESCRIPTION
## Motivation

Custom type definition where introduce to fix a [bug](https://github.com/webdriverio/webdriverio/issues/3796) in webdriverio. this bug is now fixed so there is no need to maintain our own custom types.

Moreover, the custom type was incomplete and I had to augment them in [this PR](https://github.com/DataDog/browser-sdk/pull/2673#discussion_r1547376370)

## Changes

Use `browser.execute` and `browser.executeAsync` instead of our custom wrapper.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
