### PR TITLE
⚡️ [RUM-3283] Do not fetch the entire git history in report-bundle-size

### DIFF
--- a/scripts/report-bundle-size/report-as-a-pr-comment.js
+++ b/scripts/report-bundle-size/report-as-a-pr-comment.js
@@ -27,7 +27,7 @@ async function reportBundleSizesAsPrComment(localBundleSizes) {
 
 function getLastCommonCommit(baseBranch) {
   try {
-    command`git fetch origin`.run()
+    command`git fetch --depth=100 origin ${baseBranch}`.run()
     const commandOutput = command`git merge-base origin/${baseBranch} HEAD`.run()
     // SHA commit is truncated to 8 characters as bundle sizes commit are exported in short format to logs for convenience and readability.
     return commandOutput.trim().substring(0, 8)


### PR DESCRIPTION
## Motivation

While running report-bundle-size, we do a git fetch origin to try to find the branch common commit with main.

We should not fetch the entire git history for that: not only it has performance implications, but also produces a huge output, cluttering the CI output. Also, sometimes [it fails](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/477865434)

## Changes

Use the --depth option to limit the number of commits to fetch (see [doc](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---depthltdepthgt))

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
