### PR TITLE
👷 [RUM-4029] Collect first usage telemetry

### DIFF
--- a/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
+++ b/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
@@ -280,6 +280,13 @@ function TelemetryDescription({ event }: { event: TelemetryEvent }) {
   if (event.telemetry.type === 'configuration') {
     return <Emphasis>Configuration</Emphasis>
   }
+  if (event.telemetry.type === 'usage') {
+    return (
+      <>
+        <Emphasis>Usage</Emphasis> of <Emphasis>{event.telemetry.usage.feature}</Emphasis>
+      </>
+    )
+  }
   return <>{event.telemetry.message}</>
 }
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -66,6 +66,7 @@ export interface InitConfiguration {
   internalAnalyticsSubdomain?: string
 
   telemetryConfigurationSampleRate?: number
+  telemetryUsageSampleRate?: number
 }
 
 // This type is only used to build the core configuration. Logs and RUM SDKs are using a proper type
@@ -90,6 +91,7 @@ export interface Configuration extends TransportConfiguration {
   sessionSampleRate: number
   telemetrySampleRate: number
   telemetryConfigurationSampleRate: number
+  telemetryUsageSampleRate: number
   service: string | undefined
   silentMultipleInit: boolean
   allowUntrustedEvents: boolean
@@ -131,6 +133,14 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
   }
 
   if (
+    initConfiguration.telemetryUsageSampleRate !== undefined &&
+    !isPercentage(initConfiguration.telemetryUsageSampleRate)
+  ) {
+    display.error('Telemetry Usage Sample Rate should be a number between 0 and 100')
+    return
+  }
+
+  if (
     initConfiguration.trackingConsent !== undefined &&
     !objectHasValue(TrackingConsent, initConfiguration.trackingConsent)
   ) {
@@ -155,6 +165,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       sessionSampleRate: initConfiguration.sessionSampleRate ?? 100,
       telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
       telemetryConfigurationSampleRate: initConfiguration.telemetryConfigurationSampleRate ?? 5,
+      telemetryUsageSampleRate: initConfiguration.telemetryUsageSampleRate ?? 5,
       service: initConfiguration.service,
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
       allowUntrustedEvents: !!initConfiguration.allowUntrustedEvents,
@@ -190,6 +201,7 @@ export function serializeConfiguration(initConfiguration: InitConfiguration) {
     session_sample_rate: initConfiguration.sessionSampleRate,
     telemetry_sample_rate: initConfiguration.telemetrySampleRate,
     telemetry_configuration_sample_rate: initConfiguration.telemetryConfigurationSampleRate,
+    telemetry_usage_sample_rate: initConfiguration.telemetryUsageSampleRate,
     use_before_send: !!initConfiguration.beforeSend,
     use_cross_site_session_cookie: initConfiguration.useCrossSiteSessionCookie,
     use_partitioned_cross_site_session_cookie: initConfiguration.usePartitionedCrossSiteSessionCookie,

--- a/packages/core/src/domain/telemetry/index.ts
+++ b/packages/core/src/domain/telemetry/index.ts
@@ -8,6 +8,7 @@ export {
   startTelemetry,
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
+  addTelemetryUsage,
 } from './telemetry'
 
 export * from './rawTelemetryEvent.types'

--- a/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/rawTelemetryEvent.types.ts
@@ -1,8 +1,9 @@
-import type { TelemetryEvent, TelemetryConfigurationEvent } from './telemetryEvent.types'
+import type { TelemetryEvent, TelemetryConfigurationEvent, TelemetryUsageEvent } from './telemetryEvent.types'
 
 export const TelemetryType = {
   log: 'log',
   configuration: 'configuration',
+  usage: 'usage',
 } as const
 
 export const enum StatusType {
@@ -17,3 +18,4 @@ export interface RuntimeEnvInfo {
 
 export type RawTelemetryEvent = TelemetryEvent['telemetry']
 export type RawTelemetryConfiguration = TelemetryConfigurationEvent['telemetry']['configuration']
+export type RawTelemetryUsage = TelemetryUsageEvent['telemetry']['usage']

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -12,6 +12,7 @@ import {
   scrubCustomerFrames,
   formatError,
   addTelemetryConfiguration,
+  addTelemetryUsage,
   TelemetryService,
 } from './telemetry'
 
@@ -67,6 +68,32 @@ describe('telemetry', () => {
       const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 0, telemetryConfigurationSampleRate: 100 })
 
       addTelemetryConfiguration({})
+
+      expect(notifySpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('addTelemetryUsage', () => {
+    it('should collects usage when sampled', () => {
+      const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryUsageSampleRate: 100 })
+
+      addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: 'granted' })
+
+      expect(notifySpy).toHaveBeenCalled()
+    })
+
+    it('should not notify usage when not sampled', () => {
+      const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryUsageSampleRate: 0 })
+
+      addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: 'granted' })
+
+      expect(notifySpy).not.toHaveBeenCalled()
+    })
+
+    it('should not notify usage when telemetrySampleRate is 0', () => {
+      const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 0, telemetryUsageSampleRate: 100 })
+
+      addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: 'granted' })
 
       expect(notifySpy).not.toHaveBeenCalled()
     })

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -6,7 +6,11 @@
 /**
  * Schema of all properties of a telemetry event
  */
-export type TelemetryEvent = TelemetryErrorEvent | TelemetryDebugEvent | TelemetryConfigurationEvent
+export type TelemetryEvent =
+  | TelemetryErrorEvent
+  | TelemetryDebugEvent
+  | TelemetryConfigurationEvent
+  | TelemetryUsageEvent
 /**
  * Schema of all properties of a telemetry error event
  */
@@ -98,6 +102,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       telemetry_configuration_sample_rate?: number
       /**
+       * The percentage of telemetry usage events sent after being sampled by telemetry_sample_rate
+       */
+      telemetry_usage_sample_rate?: number
+      /**
        * The percentage of requests traced
        */
       trace_sample_rate?: number
@@ -120,7 +128,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
       /**
        * The initial tracking consent value
        */
-      tracking_consent?: string
+      tracking_consent?: 'granted' | 'not-granted' | 'pending'
       /**
        * Whether the session replay start is handled manually
        */
@@ -302,7 +310,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       batch_upload_frequency?: number
       /**
-       * Maximum number of batches processed sequencially without a delay
+       * Maximum number of batches processed sequentially without a delay
        */
       batch_processing_level?: number
       /**
@@ -329,9 +337,8 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        * The threshold used for iOS App Hangs monitoring (in milliseconds)
        */
       app_hang_threshold?: number
-
       /**
-       * Either forward logs to the PCI compliant intake or not
+       * Whether logs are sent to the PCI-compliant intake
        */
       use_pci_intake?: boolean
       /**
@@ -346,6 +353,55 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
     }
     [k: string]: unknown
   }
+  [k: string]: unknown
+}
+/**
+ * Schema of all properties of a telemetry usage event
+ */
+export type TelemetryUsageEvent = CommonTelemetryProperties & {
+  /**
+   * The telemetry usage information
+   */
+  telemetry: {
+    /**
+     * Telemetry type
+     */
+    type: 'usage'
+    usage: TelemetryCommonFeaturesUsage | TelemetryBrowserFeaturesUsage
+    [k: string]: unknown
+  }
+  [k: string]: unknown
+}
+/**
+ * Schema of features usage common across SDKs
+ */
+export type TelemetryCommonFeaturesUsage =
+  | {
+      /**
+       * setTrackingConsent API
+       */
+      feature: 'set-tracking-consent'
+      /**
+       * The tracking consent value set by the user
+       */
+      tracking_consent: 'granted' | 'not-granted' | 'pending'
+      [k: string]: unknown
+    }
+  | {
+      /**
+       * stopSession API
+       */
+      feature: 'stop-session'
+      [k: string]: unknown
+    }
+/**
+ * Schema of browser specific features usage
+ */
+export type TelemetryBrowserFeaturesUsage = {
+  /**
+   * startSessionReplayRecording API
+   */
+  feature: 'start-session-replay-recording'
   [k: string]: unknown
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export {
   TelemetryService,
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
+  addTelemetryUsage,
 } from './domain/telemetry'
 export { monitored, monitor, callMonitored, setDebugMode } from './tools/monitor'
 export { Observable, Subscription } from './tools/observable'

--- a/packages/core/test/coreConfiguration.ts
+++ b/packages/core/test/coreConfiguration.ts
@@ -51,7 +51,7 @@ export const SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION = {
   allow_fallback_to_local_storage: true,
   store_contexts_across_pages: true,
   allow_untrusted_events: true,
-  tracking_consent: 'not-granted',
+  tracking_consent: 'not-granted' as const,
 }
 
 /**

--- a/packages/core/test/coreConfiguration.ts
+++ b/packages/core/test/coreConfiguration.ts
@@ -35,12 +35,14 @@ export const EXHAUSTIVE_INIT_CONFIGURATION: Required<InitConfiguration> = {
   datacenter: 'datacenter',
   internalAnalyticsSubdomain: 'internal-analytics-subdomain.com',
   telemetryConfigurationSampleRate: 70,
+  telemetryUsageSampleRate: 80,
 }
 
 export const SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION = {
   session_sample_rate: 50,
   telemetry_sample_rate: 60,
   telemetry_configuration_sample_rate: 70,
+  telemetry_usage_sample_rate: 80,
   use_before_send: true,
   use_cross_site_session_cookie: true,
   use_partitioned_cross_site_session_cookie: true,

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -1,5 +1,6 @@
 import type { Context, TrackingConsent, User } from '@datadog/browser-core'
 import {
+  addTelemetryUsage,
   CustomerDataType,
   assign,
   createContextManager,
@@ -86,7 +87,10 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
      * If this method is called before the init() method, the provided value will take precedence
      * over the one provided as initialization parameter.
      */
-    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => trackingConsentState.update(trackingConsent)),
+    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => {
+      trackingConsentState.update(trackingConsent)
+      addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
+    }),
 
     getGlobalContext: monitor(() => globalContextManager.getContext()),
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -9,6 +9,7 @@ import type {
   TrackingConsent,
 } from '@datadog/browser-core'
 import {
+  addTelemetryUsage,
   timeStampToClocks,
   isExperimentalFeatureEnabled,
   ExperimentalFeature,
@@ -204,7 +205,10 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
      * If this method is called before the init() method, the provided value will take precedence
      * over the one provided as initialization parameter.
      */
-    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => trackingConsentState.update(trackingConsent)),
+    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => {
+      trackingConsentState.update(trackingConsent)
+      addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
+    }),
 
     setGlobalContextProperty: monitor((key, value) => globalContextManager.setContextProperty(key, value)),
 
@@ -278,6 +282,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
 
     stopSession: monitor(() => {
       strategy.stopSession()
+      addTelemetryUsage({ feature: 'stop-session' })
     }),
 
     /**
@@ -288,7 +293,10 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     }),
 
     getSessionReplayLink: monitor(() => recorderApi.getSessionReplayLink()),
-    startSessionReplayRecording: monitor(() => recorderApi.start()),
+    startSessionReplayRecording: monitor(() => {
+      recorderApi.start()
+      addTelemetryUsage({ feature: 'start-session-replay-recording' })
+    }),
     stopSessionReplayRecording: monitor(() => recorderApi.stop()),
   })
 

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -395,6 +395,10 @@ export type RumErrorEvent = CommonProperties &
         readonly disposition?: 'enforce' | 'report'
         [k: string]: unknown
       }
+      /**
+       * Time since application start when error happened (in milliseconds)
+       */
+      readonly time_since_app_start?: number
       [k: string]: unknown
     }
     /**

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -14,12 +14,14 @@
         trackLongTasks: true,
         telemetrySampleRate: 100,
         telemetryConfigurationSampleRate: 100,
+        telemetryUsageSampleRate: 100,
         enableExperimentalFeatures: [],
       })
       DD_LOGS.init({
         clientToken: 'xxx',
         telemetrySampleRate: 100,
         telemetryConfigurationSampleRate: 100,
+        telemetryUsageSampleRate: 100,
         enableExperimentalFeatures: [],
       })
     </script>


### PR DESCRIPTION
## Motivation

Collect some API usage telemetry

<img width="737" alt="Screenshot 2024-04-16 at 17 11 23" src="https://github.com/DataDog/browser-sdk/assets/1331991/d5d6c37e-3cb4-47cc-a1ed-37d7528ecbc4">

## Changes

- introduce `addTelemetryUsage`
- monitor `set-tracking-consent`, `stop-session`, `start-session-replay-recording`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
