### PR TITLE
Revert "👷 Update dependency css-loader to v7"

### DIFF
--- a/developer-extension/package.json
+++ b/developer-extension/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "18.2.24",
     "@webextension-toolbox/webpack-webextension-plugin": "3.3.1",
     "copy-webpack-plugin": "12.0.2",
-    "css-loader": "7.1.0",
+    "css-loader": "6.11.0",
     "html-webpack-plugin": "5.6.0",
     "style-loader": "3.3.4",
     "webpack": "5.91.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,7 +381,7 @@ __metadata:
     "@webextension-toolbox/webpack-webextension-plugin": 3.3.1
     clsx: 2.1.0
     copy-webpack-plugin: 12.0.2
-    css-loader: 7.1.0
+    css-loader: 6.11.0
     html-webpack-plugin: 5.6.0
     react: 18.2.0
     react-dom: 18.2.0
@@ -4288,9 +4288,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-loader@npm:7.1.0":
-  version: 7.1.0
-  resolution: "css-loader@npm:7.1.0"
+"css-loader@npm:6.11.0":
+  version: 6.11.0
+  resolution: "css-loader@npm:6.11.0"
   dependencies:
     icss-utils: ^5.1.0
     postcss: ^8.4.33
@@ -4302,13 +4302,13 @@ __metadata:
     semver: ^7.5.4
   peerDependencies:
     "@rspack/core": 0.x || 1.x
-    webpack: ^5.27.0
+    webpack: ^5.0.0
   peerDependenciesMeta:
     "@rspack/core":
       optional: true
     webpack:
       optional: true
-  checksum: 247b07ca3f1369ec41e3c79cc59c6d97f0a473d767bf9ee563a2ee7ab404ff7f65ed4a2a3a108721250bc4055df82be6a88225f42adb360714533e37ea032da0
+  checksum: 5c8d35975a7121334905394e88e28f05df72f037dbed2fb8fec4be5f0b313ae73a13894ba791867d4a4190c35896da84a7fd0c54fb426db55d85ba5e714edbe3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Motivation

The update to css-loader@v7 broke the execution of the extension 😕

# Changes

Reverts css-loader to v6