### PR TITLE
🐛[RUM-4109] Mask iframe srcdoc with privacy override

### DIFF
--- a/packages/rum/src/domain/record/serialization/serializeAttribute.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.spec.ts
@@ -151,12 +151,5 @@ describe('serializeAttribute', () => {
       node.setAttribute(PRIVACY_ATTR_NAME, 'mask')
       expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'srcdoc', DEFAULT_CONFIGURATION)).toBe('***')
     })
-
-    it('should mask iframe src when privacy override set to mask', () => {
-      const node = document.createElement('iframe')
-      node.src = 'data:text/html, <html><body>data-foo</body></html>">'
-      node.setAttribute(PRIVACY_ATTR_NAME, 'mask')
-      expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'src', DEFAULT_CONFIGURATION)).toBe('***')
-    })
   })
 })

--- a/packages/rum/src/domain/record/serialization/serializeAttribute.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.spec.ts
@@ -143,4 +143,20 @@ describe('serializeAttribute', () => {
       )
     })
   })
+
+  describe('iframe srcdoc masking', () => {
+    it('should mask the srcdoc when privacy override set to mask', () => {
+      const node = document.createElement('iframe')
+      node.srcdoc = '<html><body>data-foo</body></html>">'
+      node.setAttribute(PRIVACY_ATTR_NAME, 'mask')
+      expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'srcdoc', DEFAULT_CONFIGURATION)).toBe('***')
+    })
+
+    it('should mask iframe src when privacy override set to mask', () => {
+      const node = document.createElement('iframe')
+      node.src = 'data:text/html, <html><body>data-foo</body></html>">'
+      node.setAttribute(PRIVACY_ATTR_NAME, 'mask')
+      expect(serializeAttribute(node, NodePrivacyLevel.MASK, 'src', DEFAULT_CONFIGURATION)).toBe('***')
+    })
+  })
 })

--- a/packages/rum/src/domain/record/serialization/serializeAttribute.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.ts
@@ -15,7 +15,6 @@ export function serializeAttribute(
     return null
   }
   const attributeValue = element.getAttribute(attributeName)
-
   if (
     nodePrivacyLevel === NodePrivacyLevel.MASK &&
     attributeName !== PRIVACY_ATTR_NAME &&
@@ -23,6 +22,7 @@ export function serializeAttribute(
     attributeName !== configuration.actionNameAttribute
   ) {
     const tagName = element.tagName
+
     switch (attributeName) {
       // Mask Attribute text content
       case 'title':

--- a/packages/rum/src/domain/record/serialization/serializeAttribute.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.ts
@@ -63,7 +63,7 @@ export function serializeAttribute(
     }
 
     // mask iframe srcdoc
-    if (tagName === 'IFRAME' && (attributeName === 'src' || attributeName === 'srcdoc')) {
+    if (tagName === 'IFRAME' && attributeName === 'srcdoc') {
       return CENSORED_STRING_MARK
     }
   }

--- a/packages/rum/src/domain/record/serialization/serializeAttribute.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.ts
@@ -27,7 +27,6 @@ export function serializeAttribute(
       // Mask Attribute text content
       case 'title':
       case 'alt':
-      case 'srcdoc' || 'srcDoc':
       case 'placeholder':
         return CENSORED_STRING_MARK
     }
@@ -60,6 +59,11 @@ export function serializeAttribute(
     // mask data-* attributes
     if (attributeValue && startsWith(attributeName, 'data-')) {
       // Exception: it's safe to reveal the `${PRIVACY_ATTR_NAME}` attr
+      return CENSORED_STRING_MARK
+    }
+
+    // mask iframe srcdoc
+    if (tagName === 'IFRAME' && (attributeName === 'src' || attributeName === 'srcdoc')) {
       return CENSORED_STRING_MARK
     }
   }

--- a/packages/rum/src/domain/record/serialization/serializeAttribute.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.ts
@@ -15,6 +15,7 @@ export function serializeAttribute(
     return null
   }
   const attributeValue = element.getAttribute(attributeName)
+
   if (
     nodePrivacyLevel === NodePrivacyLevel.MASK &&
     attributeName !== PRIVACY_ATTR_NAME &&
@@ -22,11 +23,11 @@ export function serializeAttribute(
     attributeName !== configuration.actionNameAttribute
   ) {
     const tagName = element.tagName
-
     switch (attributeName) {
       // Mask Attribute text content
       case 'title':
       case 'alt':
+      case 'srcdoc' || 'srcDoc':
       case 'placeholder':
         return CENSORED_STRING_MARK
     }


### PR DESCRIPTION
## Motivation
Currently HTML passed using the srdoc attribute of an iframe is not masked by session replay when `data-dd-privacy` set to `mask`.

Example:
```
<div data-dd-privacy="mask">
 <iframe srcdoc="<html><body>test</body></html>">
 </iframe>
</div>
```
We expect browser sdk to mask the iframe content with privacy override keyword "mask"
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Add `srcdoc` attribute to the masking list in `serializeAttribute`.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
