### PR TITLE
✨[RUM-4179] vital: collect `computed_value` property

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -202,6 +202,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       default_privacy_level?: string
       /**
+       * Privacy control for action name
+       */
+      enable_privacy_for_action_name?: boolean
+      /**
        * Whether the request origins list to ignore when computing the page activity is used
        */
       use_excluded_activity_urls?: boolean

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -165,6 +165,11 @@ describe('vitalCollection', () => {
         },
       },
       type: RumEventType.VITAL,
+      _dd: {
+        vital: {
+          computed_value: true,
+        },
+      },
     })
     expect(rawRumEvents[0].domainContext).toEqual({})
   })

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -51,7 +51,7 @@ export function startVitalCollection(lifeCycle: LifeCycle, pageStateHistory: Pag
       const vital = buildDurationVital(vitalStart, vitalStop)
       vitalStartsByName.delete(vital.name)
       if (isValid(vital)) {
-        lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processVital(vital))
+        lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processVital(vital, true))
       }
     },
   }
@@ -67,20 +67,30 @@ function buildDurationVital(vitalStart: DurationVitalStart, vitalStop: DurationV
   }
 }
 
-function processVital(vital: DurationVital): RawRumEventCollectedData<RawRumVitalEvent> {
-  return {
-    rawRumEvent: {
-      date: vital.startClocks.timeStamp,
-      vital: {
-        id: generateUUID(),
-        type: vital.type,
-        name: vital.name,
-        custom: {
-          [vital.name]: vital.value,
-        },
+function processVital(vital: DurationVital, valueComputedBySdk: boolean): RawRumEventCollectedData<RawRumVitalEvent> {
+  const rawRumEvent: RawRumVitalEvent = {
+    date: vital.startClocks.timeStamp,
+    vital: {
+      id: generateUUID(),
+      type: vital.type,
+      name: vital.name,
+      custom: {
+        [vital.name]: vital.value,
       },
-      type: RumEventType.VITAL,
     },
+    type: RumEventType.VITAL,
+  }
+
+  if (valueComputedBySdk) {
+    rawRumEvent._dd = {
+      vital: {
+        computed_value: true,
+      },
+    }
+  }
+
+  return {
+    rawRumEvent,
     startTime: vital.startClocks.relative,
     customerContext: vital.context,
     domainContext: {},

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -233,6 +233,11 @@ export interface RawRumVitalEvent {
       [key: string]: number
     }
   }
+  _dd?: {
+    vital: {
+      computed_value: true
+    }
+  }
 }
 
 export const enum VitalType {

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1076,6 +1076,22 @@ export type RumVitalEvent = CommonProperties &
       }
       [k: string]: unknown
     }
+    /**
+     * Internal properties
+     */
+    readonly _dd?: {
+      /**
+       * Internal vital properties
+       */
+      readonly vital?: {
+        /**
+         * Whether the value of the vital is computed by the SDK (as opposed to directly provided by the customer)
+         */
+        readonly computed_value?: boolean
+        [k: string]: unknown
+      }
+      [k: string]: unknown
+    }
     [k: string]: unknown
   }
 


### PR DESCRIPTION
## Motivation

Allow backend and app to make assumption on the vital value unit when it is computed by the SDK.

## Changes

Attach `_dd.vital.computed_value` to vital events

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
