### PR TITLE
✨ [RUM-4287] Enable feature flags API

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -12,7 +12,6 @@
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   PAGEHIDE = 'pagehide',
-  FEATURE_FLAGS = 'feature_flags',
   RESOURCE_PAGE_STATES = 'resource_page_states',
   COLLECT_FLUSH_REASON = 'collect_flush_reason',
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -189,7 +189,6 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     const sanitizedOptions = typeof options === 'object' ? options : { name: options }
     strategy.startView(sanitizedOptions)
   })
-
   const rumPublicApi = makePublicApi({
     init: monitor((initConfiguration: RumInitConfiguration) => strategy.init(initConfiguration)),
 
@@ -247,10 +246,10 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
 
     /**
      * Add a custom timing relative to the start of the current view,
-     * stored in @view.custom_timings.<timing_name>
+     * stored in `@view.custom_timings.<timing_name>`
      *
-     * @param name name of the custom timing
-     * @param [time] epoch timestamp of the custom timing (if not set, will use current time)
+     * @param name Name of the custom timing
+     * @param [time] Epoch timestamp of the custom timing (if not set, will use current time)
      *
      * Note: passing a relative time is discouraged since it is actually used as-is but displayed relative to the view start.
      * We currently don't provide a way to retrieve the view start time, so it can be challenging to provide a timing relative to the view start.
@@ -286,7 +285,14 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     }),
 
     /**
-     * This feature is currently in beta. For more information see the full [feature flag tracking guide](https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/).
+     * Add a feature flag evaluation,
+     * stored in `@feature_flags.<feature_flag_key>`
+     *
+     * @param {string} key The key of the feature flag.
+     * @param {any} value The value of the feature flag.
+     *
+     * We recommend enabling the intake request compression when using feature flags `compressIntakeRequests: true`.
+     * For more information see the full [feature flag tracking guide](https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/).
      */
     addFeatureFlagEvaluation: monitor((key: string, value: any) => {
       strategy.addFeatureFlagEvaluation(sanitize(key)!, sanitize(value))

--- a/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
@@ -1,12 +1,5 @@
 import type { CustomerDataTracker, RelativeTime } from '@datadog/browser-core'
-import {
-  ExperimentalFeature,
-  resetExperimentalFeatures,
-  addExperimentalFeatures,
-  relativeToClocks,
-  createCustomerDataTracker,
-  noop,
-} from '@datadog/browser-core'
+import { relativeToClocks, createCustomerDataTracker, noop } from '@datadog/browser-core'
 import type { TestSetupBuilder } from '../../../test'
 import { setup } from '../../../test'
 import { LifeCycleEventType } from '../lifeCycle'
@@ -28,7 +21,6 @@ describe('featureFlagContexts', () => {
 
   afterEach(() => {
     featureFlagContexts.stop()
-    resetExperimentalFeatures()
   })
 
   it('should return undefined before the initial view', () => {
@@ -38,9 +30,7 @@ describe('featureFlagContexts', () => {
   })
 
   describe('addFeatureFlagEvaluation', () => {
-    it('should add feature flag evaluations of any type when the ff feature_flags is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.FEATURE_FLAGS])
-
+    it('should add feature flag evaluations of any type', () => {
       const { lifeCycle } = setupBuilder.build()
 
       lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
@@ -62,9 +52,7 @@ describe('featureFlagContexts', () => {
       })
     })
 
-    it('should replace existing feature flag evaluation to the current context when the ff feature_flags is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.FEATURE_FLAGS])
-
+    it('should replace existing feature flag evaluation to the current context', () => {
       const { lifeCycle } = setupBuilder.build()
 
       lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
@@ -80,23 +68,7 @@ describe('featureFlagContexts', () => {
       expect(featureFlagContext).toEqual({ feature: 'bar', feature2: 'baz' })
     })
 
-    it('should not add feature flag evaluation when the ff feature_flags is disabled', () => {
-      const { lifeCycle } = setupBuilder.build()
-
-      lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
-        startClocks: relativeToClocks(0 as RelativeTime),
-      } as ViewCreatedEvent)
-
-      featureFlagContexts.addFeatureFlagEvaluation('feature', 'foo')
-
-      const featureFlagContext = featureFlagContexts.findFeatureFlagEvaluations()!
-
-      expect(featureFlagContext).toBeUndefined()
-    })
-
     it('should notify the customer data tracker on feature flag evaluation', () => {
-      addExperimentalFeatures([ExperimentalFeature.FEATURE_FLAGS])
-
       const { lifeCycle } = setupBuilder.build()
 
       const updateCustomerDataSpy = spyOn(customerDataTracker, 'updateCustomerData')
@@ -117,16 +89,12 @@ describe('featureFlagContexts', () => {
      * (which seems unlikely) and this event would anyway be rejected by lack of view id
      */
     it('should return undefined when no current view', () => {
-      addExperimentalFeatures([ExperimentalFeature.FEATURE_FLAGS])
-
       setupBuilder.build()
 
       expect(featureFlagContexts.findFeatureFlagEvaluations()).toBeUndefined()
     })
 
     it('should clear feature flag context on new view', () => {
-      addExperimentalFeatures([ExperimentalFeature.FEATURE_FLAGS])
-
       const { lifeCycle } = setupBuilder.build()
 
       lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
@@ -145,8 +113,6 @@ describe('featureFlagContexts', () => {
     })
 
     it('should return the feature flag context corresponding to the start time', () => {
-      addExperimentalFeatures([ExperimentalFeature.FEATURE_FLAGS])
-
       const { lifeCycle, clock } = setupBuilder.withFakeClock().build()
 
       lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {

--- a/packages/rum-core/src/domain/contexts/featureFlagContext.ts
+++ b/packages/rum-core/src/domain/contexts/featureFlagContext.ts
@@ -1,11 +1,5 @@
 import type { RelativeTime, ContextValue, Context, CustomerDataTracker } from '@datadog/browser-core'
-import {
-  noop,
-  isExperimentalFeatureEnabled,
-  SESSION_TIME_OUT_DELAY,
-  ValueHistory,
-  ExperimentalFeature,
-} from '@datadog/browser-core'
+import { SESSION_TIME_OUT_DELAY, ValueHistory } from '@datadog/browser-core'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 
@@ -32,14 +26,6 @@ export function startFeatureFlagContexts(
   lifeCycle: LifeCycle,
   customerDataTracker: CustomerDataTracker
 ): FeatureFlagContexts {
-  if (!isExperimentalFeatureEnabled(ExperimentalFeature.FEATURE_FLAGS)) {
-    return {
-      findFeatureFlagEvaluations: () => undefined,
-      addFeatureFlagEvaluation: noop,
-      stop: noop,
-    }
-  }
-
   const featureFlagContexts = new ValueHistory<FeatureFlagContext>(FEATURE_FLAG_CONTEXT_TIME_OUT_DELAY)
 
   lifeCycle.subscribe(LifeCycleEventType.BEFORE_VIEW_CREATED, ({ startClocks }) => {


### PR DESCRIPTION
## Motivation

This PR enables sending feature flags with the API introduced in https://github.com/DataDog/browser-sdk/pull/2096

## Changes

Remove the `feature_flags` experimental flag.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [X] Staging
- [X] Unit
- [X] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
