### PR TITLE
👷 [developer extension] Add a simple e2e test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,6 +201,15 @@ e2e:
   after_script:
     - node ./scripts/test/export-test-result.js e2e
 
+e2e-developer-extension:
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
+  interruptible: true
+  script:
+    - yarn
+    - yarn test:e2e:developer-extension
+
 check-licenses:
   extends:
     - .base-configuration

--- a/developer-extension/src/panel/index.tsx
+++ b/developer-extension/src/panel/index.tsx
@@ -12,8 +12,23 @@ import React from 'react'
 import { App } from './components/app'
 import { initMonitoring } from './monitoring'
 
+mockDevtoolsApiForTests()
+
 const main = document.createElement('main')
 document.body.append(main)
 const root = createRoot(main)
 root.render(<App />)
 initMonitoring()
+
+/**
+ * Allow to display the extension panel outside of chrome devtools for testing
+ */
+function mockDevtoolsApiForTests() {
+  if (!chrome.devtools) {
+    chrome.devtools = {
+      inspectedWindow: {
+        tabId: 0,
+      },
+    } as any
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:unit:bs": "node ./scripts/test/bs-wrapper.js karma start test/unit/karma.bs.conf.js",
     "test:e2e": "yarn build && (cd test/app && rm -rf node_modules && yarn && yarn build) && wdio test/e2e/wdio.local.conf.ts",
     "test:e2e:bs": "yarn build && (cd test/app && rm -rf node_modules && yarn && yarn build) && node ./scripts/test/bs-wrapper.js wdio test/e2e/wdio.bs.conf.ts",
+    "test:e2e:developer-extension": "yarn build && wdio test/e2e/wdio.developer-extension.conf.ts",
     "test:compat:tsc": "scripts/cli check_typescript_compatibility",
     "test:compat:ssr": "scripts/cli check_server_side_rendering_compatibility",
     "rum-events-format:sync": "scripts/cli update_submodule && scripts/cli build_json2type && node scripts/generate-schema-types.js",

--- a/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
+++ b/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
@@ -12,6 +12,8 @@ describe('developer-extension', () => {
 class DeveloperExtensionPanel {
   async open() {
     await browser.url('chrome://extensions')
+    // extensions page is built with custom elements, >>> selector to traverse shadow DOM
+    // cf https://webdriver.io/docs/selectors/#deep-selectors
     const extensionId = await $('>>>extensions-item').getAttribute('id')
     const url = `chrome-extension://${extensionId}/panel.html`
     await browser.url(url)

--- a/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
+++ b/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
@@ -1,0 +1,28 @@
+describe('developer-extension', () => {
+  it('should switch between tabs', async () => {
+    const panel = new DeveloperExtensionPanel()
+    await panel.open()
+    expect(await panel.getSelectedTab()).toEqual('Events')
+
+    await panel.getTab('Infos').click()
+    expect(await panel.getSelectedTab()).toEqual('Infos')
+  })
+})
+
+class DeveloperExtensionPanel {
+  async open() {
+    await browser.url('chrome://extensions')
+    const extensionId = await $('>>>extensions-item').getAttribute('id')
+    const url = `chrome-extension://${extensionId}/panel.html`
+    await browser.url(url)
+    expect(await browser.getUrl()).toEqual(url)
+  }
+
+  getSelectedTab() {
+    return $("button[role='tab'][aria-selected='true']").getText()
+  }
+
+  getTab(content: string) {
+    return $(`button[role='tab']=${content}`)
+  }
+}

--- a/test/e2e/wdio.base.conf.ts
+++ b/test/e2e/wdio.base.conf.ts
@@ -37,6 +37,7 @@ export const config: OptionsWithLogsPath = {
   // We do not inject @wdio globals to keep Jasmine's expect
   injectGlobals: false,
   specs: ['./scenario/**/*.scenario.ts'],
+  exclude: ['./scenario/developer-extension/*.scenario.ts'],
   capabilities: [],
   maxInstances: 5,
   logLevel: 'warn',

--- a/test/e2e/wdio.developer-extension.conf.ts
+++ b/test/e2e/wdio.developer-extension.conf.ts
@@ -1,0 +1,25 @@
+import path from 'path'
+import type { Options } from '@wdio/types'
+import { config as baseConfig } from './wdio.base.conf'
+
+export const config: Options.Testrunner = {
+  ...baseConfig,
+
+  specs: ['./scenario/developer-extension/*.scenario.ts'],
+  exclude: [],
+
+  capabilities: [
+    {
+      browserName: 'chrome',
+      'goog:chromeOptions': {
+        args: [
+          `--load-extension=${path.join(process.cwd(), 'developer-extension', 'dist')}`,
+          '--headless=new', // "new" headless needed for extensions https://www.selenium.dev/blog/2023/headless-is-going-away/
+          '--no-sandbox',
+        ],
+      },
+    },
+  ],
+
+  onPrepare() {},
+}


### PR DESCRIPTION
## Motivation

Avoid to break the developer extension without noticing it

## Changes

Introduce a simple e2e test ensuring that the extension is usable

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
