### PR TITLE
✨⚗️ [RUM-4275] Expose custom vitals API for beta phase

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,7 +18,6 @@ export enum ExperimentalFeature {
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  CUSTOM_VITALS = 'custom_vitals',
   TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
 }
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,9 +1,6 @@
 import type { RelativeTime, Context, DeflateWorker, CustomerDataTrackerManager, TimeStamp } from '@datadog/browser-core'
 import {
   clocksNow,
-  addExperimentalFeatures,
-  ExperimentalFeature,
-  resetExperimentalFeatures,
   ONE_SECOND,
   display,
   DefaultPrivacyLevel,
@@ -728,18 +725,7 @@ describe('rum public api', () => {
       setup().withFakeClock().build()
     })
 
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should not expose startDurationVital when ff is disabled', () => {
-      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).startDurationVital).toBeUndefined()
-    })
-
     it('should call startDurationVital on the startRum result when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const startDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -759,7 +745,6 @@ describe('rum public api', () => {
     })
 
     it('should call startDurationVital with provided startTime when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const startDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -785,18 +770,7 @@ describe('rum public api', () => {
       setup().withFakeClock().build()
     })
 
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should not expose stopDurationVital when ff is disabled', () => {
-      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).stopDurationVital).toBeUndefined()
-    })
-
     it('should call stopDurationVital on the startRum result when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const stopDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -816,7 +790,6 @@ describe('rum public api', () => {
     })
 
     it('should call stopDurationVital with provided stopTime when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const stopDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -11,8 +11,6 @@ import type {
 import {
   addTelemetryUsage,
   timeStampToClocks,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
   CustomerDataType,
   assign,
   createContextManager,
@@ -108,44 +106,6 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     trackingConsentState,
 
     (initConfiguration, configuration, deflateWorker, initialViewOptions) => {
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.CUSTOM_VITALS)) {
-        /**
-         * Start a custom duration vital
-         * stored in @vital.custom.<name>
-         *
-         * @param name name of the custom vital
-         * @param options.context custom context attached to the vital
-         * @param options.startTime epoch timestamp of the start of the custom vital (if not set, will use current time)
-         */
-        ;(rumPublicApi as any).startDurationVital = monitor(
-          (name: string, options?: { context?: object; startTime?: number }) => {
-            strategy.startDurationVital({
-              name: sanitize(name)!,
-              startClocks: options?.startTime ? timeStampToClocks(options.startTime as TimeStamp) : clocksNow(),
-              context: sanitize(options?.context) as Context,
-            })
-          }
-        )
-
-        /**
-         * Stop a custom duration vital
-         * stored in @vital.custom.<name>
-         *
-         * @param name name of the custom vital
-         * @param options.context custom context attached to the vital
-         * @param options.stopTime epoch timestamp of the stop of the custom vital (if not set, will use current time)
-         */
-        ;(rumPublicApi as any).stopDurationVital = monitor(
-          (name: string, options?: { context?: object; stopTime?: number }) => {
-            strategy.stopDurationVital({
-              name: sanitize(name)!,
-              stopClocks: options?.stopTime ? timeStampToClocks(options.stopTime as TimeStamp) : clocksNow(),
-              context: sanitize(options?.context) as Context,
-            })
-          }
-        )
-      }
-
       if (initConfiguration.storeContextsAcrossPages) {
         storeContextManager(configuration, globalContextManager, RUM_STORAGE_KEY, CustomerDataType.GlobalContext)
         storeContextManager(configuration, userContextManager, RUM_STORAGE_KEY, CustomerDataType.User)
@@ -259,6 +219,38 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     addTiming: monitor((name: string, time?: number) => {
       // TODO: next major decide to drop relative time support or update its behaviour
       strategy.addTiming(sanitize(name)!, time as RelativeTime | TimeStamp | undefined)
+    }),
+
+    /**
+     * Beta feature - Start a custom duration vital
+     * stored in @vital.custom.<name>
+     *
+     * @param name name of the custom vital
+     * @param options.context custom context attached to the vital
+     * @param options.startTime epoch timestamp of the start of the custom vital (if not set, will use current time)
+     */
+    startDurationVital: monitor((name: string, options?: { context?: object; startTime?: number }) => {
+      strategy.startDurationVital({
+        name: sanitize(name)!,
+        startClocks: options?.startTime ? timeStampToClocks(options.startTime as TimeStamp) : clocksNow(),
+        context: sanitize(options?.context) as Context,
+      })
+    }),
+
+    /**
+     * Beta feature - Stop a custom duration vital
+     * stored in @vital.custom.<name>
+     *
+     * @param name name of the custom vital
+     * @param options.context custom context attached to the vital
+     * @param options.stopTime epoch timestamp of the stop of the custom vital (if not set, will use current time)
+     */
+    stopDurationVital: monitor((name: string, options?: { context?: object; stopTime?: number }) => {
+      strategy.stopDurationVital({
+        name: sanitize(name)!,
+        stopClocks: options?.stopTime ? timeStampToClocks(options.stopTime as TimeStamp) : clocksNow(),
+        context: sanitize(options?.context) as Context,
+      })
     }),
 
     setUser: monitor((newUser: User) => {

--- a/test/e2e/scenario/rum/vitals.scenario.ts
+++ b/test/e2e/scenario/rum/vitals.scenario.ts
@@ -2,18 +2,12 @@ import { createTest, flushEvents } from '../../lib/framework'
 
 describe('vital collection', () => {
   createTest('send custom duration vital')
-    .withRum({
-      enableExperimentalFeatures: ['custom_vitals'],
-    })
+    .withRum()
     .run(async ({ intakeRegistry }) => {
       await browser.executeAsync((done) => {
-        // TODO remove cast and unsafe calls when removing the flag
-        const global = window.DD_RUM! as any
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        global.startDurationVital('foo')
+        window.DD_RUM!.startDurationVital('foo')
         setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          global.stopDurationVital('foo')
+          window.DD_RUM!.stopDurationVital('foo')
           done()
         }, 5)
       })


### PR DESCRIPTION
## Motivation

Provide **beta** APIs to track custom durations as vital events

## Changes

```js
DD_RUM.startDurationVital('foo', { context, startTime })
// do some stuff
DD_RUM.stopDurationVital('foo', { context, stopTime })
```


![Screenshot 2024-02-05 at 15 17 25](https://github.com/DataDog/browser-sdk/assets/1331991/4e475776-8fd6-44cb-bdc5-799f82a24cdb)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
