### PR TITLE
🐛 [performance] handle synthetics API error

### DIFF
--- a/scripts/performance/cpu-performance/compute-cpu-performance.js
+++ b/scripts/performance/cpu-performance/compute-cpu-performance.js
@@ -51,6 +51,10 @@ async function waitForSyntheticsTestToFinish(resultId, RETRIES_NUMBER) {
         'DD-APPLICATION-KEY': APP_KEY,
       },
     })
+    // do not use response.ok as we can have 404 responses
+    if (response.status >= 500) {
+      throw new Error(`HTTP Error Response: ${response.status} ${response.statusText}`)
+    }
     const data = await response.json()
     if (data.length !== 0 && data.status === 0) {
       await timeout(TIMEOUT_IN_MS) // Wait for logs ingestion


### PR DESCRIPTION
## Motivation

Script failure that seems to happen after a server error returning a html response:
```
Script exited with error: 
 SyntaxError: Unexpected token '<', "<html>
<h"... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:5584:19)
    at successSteps (node:internal/deps/undici/undici:5555:27)
    at fullyReadBody (node:internal/deps/undici/undici:1665:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async specConsumeBody (node:internal/deps/undici/undici:5564:7)
    at async waitForSyntheticsTestToFinish (/go/src/github.com/DataDog/browser-sdk/scripts/performance/cpu-performance/compute-cpu-performance.js:54:18)
    at async computeCpuPerformance (/go/src/github.com/DataDog/browser-sdk/scripts/performance/cpu-performance/compute-cpu-performance.js:17:3)
    at async /go/src/github.com/DataDog/browser-sdk/scripts/performance/index.js:9:3 
```
## Changes

Throw and log in case of server errors

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
