### PR TITLE
✨ [RUM-4052] Sanitize `site` parameter in configuration

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -10,7 +10,6 @@ import {
 import { TrackingConsent } from '../trackingConsent'
 import type { InitConfiguration } from './configuration'
 import { serializeConfiguration, validateAndBuildConfiguration } from './configuration'
-import { INTAKE_SITE_US1 } from './intakeSites'
 
 describe('validateAndBuildConfiguration', () => {
   const clientToken = 'some_client_token'
@@ -214,9 +213,7 @@ describe('validateAndBuildConfiguration', () => {
   describe('site parameter validation', () => {
     it('should validate the site parameter', () => {
       validateAndBuildConfiguration({ clientToken, site: 'foo.com' })
-      expect(displaySpy).toHaveBeenCalledOnceWith(
-        `Site should be a valid Datadog site. We will fall back to US1 region: ${INTAKE_SITE_US1}`
-      )
+      expect(displaySpy).toHaveBeenCalledOnceWith('Site should be a valid Datadog site.')
     })
   })
 

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -213,9 +213,7 @@ describe('validateAndBuildConfiguration', () => {
   describe('site parameter validation', () => {
     it('should validate the site parameter', () => {
       validateAndBuildConfiguration({ clientToken, site: 'foo.com' })
-      expect(displaySpy).toHaveBeenCalledOnceWith(
-        `Site should be a valid Datadog site. Refer to our documentation for more information: ${DOC_LINK}.`
-      )
+      expect(displaySpy).toHaveBeenCalledOnceWith(`Site should be a valid Datadog site. Learn more here: ${DOC_LINK}.`)
     })
   })
 

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -10,6 +10,7 @@ import {
 import { TrackingConsent } from '../trackingConsent'
 import type { InitConfiguration } from './configuration'
 import { serializeConfiguration, validateAndBuildConfiguration } from './configuration'
+import { INTAKE_SITE_US1 } from './intakeSites'
 
 describe('validateAndBuildConfiguration', () => {
   const clientToken = 'some_client_token'
@@ -207,6 +208,15 @@ describe('validateAndBuildConfiguration', () => {
     it('rejects invalid values', () => {
       expect(validateAndBuildConfiguration({ clientToken: 'yes', trackingConsent: 'foo' as any })).toBeUndefined()
       expect(displaySpy).toHaveBeenCalledOnceWith('Tracking Consent should be either "granted" or "not-granted"')
+    })
+  })
+
+  describe('site parameter validation', () => {
+    it('should validate the site parameter', () => {
+      validateAndBuildConfiguration({ clientToken, site: 'foo.com' })
+      expect(displaySpy).toHaveBeenCalledOnceWith(
+        `Site should be a valid Datadog site. We will fall back to US1 region: ${INTAKE_SITE_US1}`
+      )
     })
   })
 

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../tools/experimentalFeatures'
 import { TrackingConsent } from '../trackingConsent'
 import type { InitConfiguration } from './configuration'
-import { serializeConfiguration, validateAndBuildConfiguration } from './configuration'
+import { DOC_LINK, serializeConfiguration, validateAndBuildConfiguration } from './configuration'
 
 describe('validateAndBuildConfiguration', () => {
   const clientToken = 'some_client_token'
@@ -213,7 +213,9 @@ describe('validateAndBuildConfiguration', () => {
   describe('site parameter validation', () => {
     it('should validate the site parameter', () => {
       validateAndBuildConfiguration({ clientToken, site: 'foo.com' })
-      expect(displaySpy).toHaveBeenCalledOnceWith('Site should be a valid Datadog site.')
+      expect(displaySpy).toHaveBeenCalledOnceWith(
+        `Site should be a valid Datadog site. Refer to our documentation for more information: ${DOC_LINK}.`
+      )
     })
   })
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -13,7 +13,6 @@ import type { SessionStoreStrategyType } from '../session/storeStrategies/sessio
 import { TrackingConsent } from '../trackingConsent'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
-import { INTAKE_SITE_US1 } from './intakeSites'
 
 export const DefaultPrivacyLevel = {
   ALLOW: 'allow',

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -153,7 +153,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
   }
 
   if (initConfiguration.site && !isDatadogSite(initConfiguration.site)) {
-    display.error(`Site should be a valid Datadog site. Refer to our documentation for more information: ${DOC_LINK}.`)
+    display.error(`Site should be a valid Datadog site. Learn more here: ${DOC_LINK}.`)
     return
   }
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -13,6 +13,7 @@ import type { SessionStoreStrategyType } from '../session/storeStrategies/sessio
 import { TrackingConsent } from '../trackingConsent'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
+import { INTAKE_SITE_US1 } from './intakeSites'
 
 export const DefaultPrivacyLevel = {
   ALLOW: 'allow',
@@ -107,6 +108,9 @@ export interface Configuration extends TransportConfiguration {
   batchMessagesLimit: number
   messageBytesLimit: number
 }
+function isDatadogSite(site: string) {
+  return /(datadog|ddog|datad0g|dd0g)/.test(site)
+}
 
 export function validateAndBuildConfiguration(initConfiguration: InitConfiguration): Configuration | undefined {
   if (!initConfiguration || !initConfiguration.clientToken) {
@@ -145,6 +149,11 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     !objectHasValue(TrackingConsent, initConfiguration.trackingConsent)
   ) {
     display.error('Tracking Consent should be either "granted" or "not-granted"')
+    return
+  }
+
+  if (initConfiguration.site && !isDatadogSite(initConfiguration.site)) {
+    display.error(`Site should be a valid Datadog site. We will fall back to US1 region: ${INTAKE_SITE_US1}`)
     return
   }
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -153,7 +153,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
   }
 
   if (initConfiguration.site && !isDatadogSite(initConfiguration.site)) {
-    display.error(`Site should be a valid Datadog site. We will fall back to US1 region: ${INTAKE_SITE_US1}`)
+    display.error('Site should be a valid Datadog site.')
     return
   }
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -14,6 +14,7 @@ import { TrackingConsent } from '../trackingConsent'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
 
+export const DOC_LINK = 'https://docs.datadoghq.com/getting_started/site/'
 export const DefaultPrivacyLevel = {
   ALLOW: 'allow',
   MASK: 'mask',
@@ -152,7 +153,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
   }
 
   if (initConfiguration.site && !isDatadogSite(initConfiguration.site)) {
-    display.error('Site should be a valid Datadog site.')
+    display.error(`Site should be a valid Datadog site. Refer to our documentation for more information: ${DOC_LINK}.`)
     return
   }
 


### PR DESCRIPTION
## Motivation
site is a [Datadog-wide parameter](https://docs.datadoghq.com/getting_started/site/). The current non-sanitized implementation of site config parameter offers backward compatibility when a new datacenter is created. But in the context of a browser, site has a completely different meaning and could be mistaken for “my website”.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Add a non-breaking change to only accept values meeting a pattern like:`/(datadog|ddog|datad0g|dd0g)/`.

This would allow to retain backward compatibility and some degree of flexibility, while adding an extra protection layer.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
