### PR TITLE
Revert "✨⚗️ [RUM-4275] Expose custom vitals API for beta phase"

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,6 +18,7 @@ export enum ExperimentalFeature {
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
+  CUSTOM_VITALS = 'custom_vitals',
   TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
 }
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,6 +1,9 @@
 import type { RelativeTime, Context, DeflateWorker, CustomerDataTrackerManager, TimeStamp } from '@datadog/browser-core'
 import {
   clocksNow,
+  addExperimentalFeatures,
+  ExperimentalFeature,
+  resetExperimentalFeatures,
   ONE_SECOND,
   display,
   DefaultPrivacyLevel,
@@ -725,7 +728,18 @@ describe('rum public api', () => {
       setup().withFakeClock().build()
     })
 
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
+
+    it('should not expose startDurationVital when ff is disabled', () => {
+      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      expect((rumPublicApi as any).startDurationVital).toBeUndefined()
+    })
+
     it('should call startDurationVital on the startRum result when ff is enabled', () => {
+      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const startDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -745,6 +759,7 @@ describe('rum public api', () => {
     })
 
     it('should call startDurationVital with provided startTime when ff is enabled', () => {
+      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const startDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -770,7 +785,18 @@ describe('rum public api', () => {
       setup().withFakeClock().build()
     })
 
+    afterEach(() => {
+      resetExperimentalFeatures()
+    })
+
+    it('should not expose stopDurationVital when ff is disabled', () => {
+      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      expect((rumPublicApi as any).stopDurationVital).toBeUndefined()
+    })
+
     it('should call stopDurationVital on the startRum result when ff is enabled', () => {
+      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const stopDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -790,6 +816,7 @@ describe('rum public api', () => {
     })
 
     it('should call stopDurationVital with provided stopTime when ff is enabled', () => {
+      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
       const stopDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({

--- a/test/e2e/scenario/rum/vitals.scenario.ts
+++ b/test/e2e/scenario/rum/vitals.scenario.ts
@@ -2,12 +2,18 @@ import { createTest, flushEvents } from '../../lib/framework'
 
 describe('vital collection', () => {
   createTest('send custom duration vital')
-    .withRum()
+    .withRum({
+      enableExperimentalFeatures: ['custom_vitals'],
+    })
     .run(async ({ intakeRegistry }) => {
       await browser.executeAsync((done) => {
-        window.DD_RUM!.startDurationVital('foo')
+        // TODO remove cast and unsafe calls when removing the flag
+        const global = window.DD_RUM! as any
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        global.startDurationVital('foo')
         setTimeout(() => {
-          window.DD_RUM!.stopDurationVital('foo')
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          global.stopDurationVital('foo')
           done()
         }, 5)
       })


### PR DESCRIPTION
# Motivation

In the end, wait a bit more and GA directly

# Changes

Revert "✨⚗️ [RUM-4275] Expose custom vitals API for beta phase"

[RUM-4275]: https://datadoghq.atlassian.net/browse/RUM-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ