### PR TITLE
🐛 [RUM-97] Sanitize tags parameter in configuration

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -217,6 +217,20 @@ describe('validateAndBuildConfiguration', () => {
     })
   })
 
+  describe('env parameter validation', () => {
+    it('should not validate the env parameter', () => {
+      validateAndBuildConfiguration({ clientToken, env: 1 as any })
+      expect(displaySpy).toHaveBeenCalledOnceWith('Env must be defined as a string')
+    })
+  })
+
+  describe('service parameter validation', () => {
+    it('should not validate the service parameter', () => {
+      validateAndBuildConfiguration({ clientToken, service: 1 as any })
+      expect(displaySpy).toHaveBeenCalledOnceWith('Service must be defined as a string')
+    })
+  })
+
   describe('version parameter validation', () => {
     it('should not validate the version parameter', () => {
       validateAndBuildConfiguration({ clientToken, version: 1 as any })

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -219,7 +219,7 @@ describe('validateAndBuildConfiguration', () => {
 
   describe('env parameter validation', () => {
     it('should not validate the env parameter', () => {
-      validateAndBuildConfiguration({ clientToken, env: 1 as any })
+      validateAndBuildConfiguration({ clientToken, env: false as any })
       expect(displaySpy).toHaveBeenCalledOnceWith('Env must be defined as a string')
     })
   })
@@ -233,7 +233,7 @@ describe('validateAndBuildConfiguration', () => {
 
   describe('version parameter validation', () => {
     it('should not validate the version parameter', () => {
-      validateAndBuildConfiguration({ clientToken, version: 1 as any })
+      validateAndBuildConfiguration({ clientToken, version: 0 as any })
       expect(displaySpy).toHaveBeenCalledOnceWith('Version must be defined as a string')
     })
   })

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -217,6 +217,13 @@ describe('validateAndBuildConfiguration', () => {
     })
   })
 
+  describe('version parameter validation', () => {
+    it('should not validate the version parameter', () => {
+      validateAndBuildConfiguration({ clientToken, version: 1 as any })
+      expect(displaySpy).toHaveBeenCalledOnceWith('Version must be defined as a string')
+    })
+  })
+
   describe('serializeConfiguration', () => {
     it('should serialize the configuration', () => {
       // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -108,6 +108,15 @@ export interface Configuration extends TransportConfiguration {
   batchMessagesLimit: number
   messageBytesLimit: number
 }
+
+function checkIfString(tag: any, tagName: string) {
+  if (tag && typeof tag !== 'string') {
+    display.error(`${tagName} must be defined as a string`)
+    return false
+  }
+  return true
+}
+
 function isDatadogSite(site: string) {
   return /(datadog|ddog|datad0g|dd0g)/.test(site)
 }
@@ -144,8 +153,15 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     return
   }
 
-  if (initConfiguration.version && typeof initConfiguration.version !== 'string') {
-    display.error('Version must be defined as a string')
+  if (!checkIfString(initConfiguration.version, 'Version')) {
+    return
+  }
+
+  if (!checkIfString(initConfiguration.env, 'Env')) {
+    return
+  }
+
+  if (!checkIfString(initConfiguration.service, 'Service')) {
     return
   }
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -144,6 +144,11 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
     return
   }
 
+  if (initConfiguration.version && typeof initConfiguration.version !== 'string') {
+    display.error('Version must be defined as a string')
+    return
+  }
+
   if (
     initConfiguration.trackingConsent !== undefined &&
     !objectHasValue(TrackingConsent, initConfiguration.trackingConsent)

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -109,8 +109,8 @@ export interface Configuration extends TransportConfiguration {
   messageBytesLimit: number
 }
 
-function checkIfString(tag: any, tagName: string) {
-  if (tag && typeof tag !== 'string') {
+function checkIfString(tag: unknown, tagName: string) {
+  if (tag !== undefined && typeof tag !== 'string') {
     display.error(`${tagName} must be defined as a string`)
     return false
   }


### PR DESCRIPTION
## Motivation

Setting a non-string value for the customer provided tags init option causes the SDK to fail silently.

## Changes

Add validation to ensure that the tags parameters are properly defined as strings.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
