### PR TITLE
🔊[RUM-4360] monitor more API usages

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -398,16 +398,70 @@ export type TelemetryCommonFeaturesUsage =
       feature: 'stop-session'
       [k: string]: unknown
     }
+  | {
+      /**
+       * startView API
+       */
+      feature: 'start-view'
+      [k: string]: unknown
+    }
+  | {
+      /**
+       * addAction API
+       */
+      feature: 'add-action'
+      [k: string]: unknown
+    }
+  | {
+      /**
+       * addError API
+       */
+      feature: 'add-error'
+      [k: string]: unknown
+    }
+  | {
+      /**
+       * setGlobalContext, setGlobalContextProperty, addAttribute APIs
+       */
+      feature: 'set-global-context'
+      [k: string]: unknown
+    }
+  | {
+      /**
+       * setUser, setUserProperty, setUserInfo APIs
+       */
+      feature: 'set-user'
+      [k: string]: unknown
+    }
+  | {
+      /**
+       * addFeatureFlagEvaluation API
+       */
+      feature: 'add-feature-flag-evaluation'
+      [k: string]: unknown
+    }
 /**
  * Schema of browser specific features usage
  */
-export type TelemetryBrowserFeaturesUsage = {
-  /**
-   * startSessionReplayRecording API
-   */
-  feature: 'start-session-replay-recording'
-  [k: string]: unknown
-}
+export type TelemetryBrowserFeaturesUsage =
+  | {
+      /**
+       * startSessionReplayRecording API
+       */
+      feature: 'start-session-replay-recording'
+      /**
+       * Whether the recording is allowed to start even on sessions sampled out of replay
+       */
+      is_forced?: boolean
+      [k: string]: unknown
+    }
+  | {
+      /**
+       * startDurationVital API
+       */
+      feature: 'start-duration-vital'
+      [k: string]: unknown
+    }
 
 /**
  * Schema of common properties of Telemetry events
@@ -487,5 +541,44 @@ export interface CommonTelemetryProperties {
    * Enabled experimental features
    */
   readonly experimental_features?: string[]
+  telemetry?: {
+    /**
+     * Device properties
+     */
+    device?: {
+      /**
+       * Architecture of the device
+       */
+      architecture?: string
+      /**
+       * Brand of the device
+       */
+      brand?: string
+      /**
+       * Model of the device
+       */
+      model?: string
+      [k: string]: unknown
+    }
+    /**
+     * OS properties
+     */
+    os?: {
+      /**
+       * Build of the OS
+       */
+      build?: string
+      /**
+       * Name of the OS
+       */
+      name?: string
+      /**
+       * Version of the OS
+       */
+      version?: string
+      [k: string]: unknown
+    }
+    [k: string]: unknown
+  }
   [k: string]: unknown
 }

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -124,6 +124,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
               startClocks: options?.startTime ? timeStampToClocks(options.startTime as TimeStamp) : clocksNow(),
               context: sanitize(options?.context) as Context,
             })
+            addTelemetryUsage({ feature: 'start-duration-vital' })
           }
         )
 
@@ -188,6 +189,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
   } = monitor((options?: string | ViewOptions) => {
     const sanitizedOptions = typeof options === 'object' ? options : { name: options }
     strategy.startView(sanitizedOptions)
+    addTelemetryUsage({ feature: 'start-view' })
   })
   const rumPublicApi = makePublicApi({
     init: monitor((initConfiguration: RumInitConfiguration) => strategy.init(initConfiguration)),
@@ -209,13 +211,19 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
     }),
 
-    setGlobalContextProperty: monitor((key, value) => globalContextManager.setContextProperty(key, value)),
+    setGlobalContextProperty: monitor((key, value) => {
+      globalContextManager.setContextProperty(key, value)
+      addTelemetryUsage({ feature: 'set-global-context' })
+    }),
 
     removeGlobalContextProperty: monitor((key) => globalContextManager.removeContextProperty(key)),
 
     getGlobalContext: monitor(() => globalContextManager.getContext()),
 
-    setGlobalContext: monitor((context) => globalContextManager.setContext(context)),
+    setGlobalContext: monitor((context) => {
+      globalContextManager.setContext(context)
+      addTelemetryUsage({ feature: 'set-global-context' })
+    }),
 
     clearGlobalContext: monitor(() => globalContextManager.clearContext()),
 
@@ -230,6 +238,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
         startClocks: clocksNow(),
         type: ActionType.CUSTOM,
       })
+      addTelemetryUsage({ feature: 'add-action' })
     }),
 
     addError: (error: unknown, context?: object) => {
@@ -241,6 +250,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
           context: sanitize(context) as Context,
           startClocks: clocksNow(),
         })
+        addTelemetryUsage({ feature: 'add-error' })
       })
     },
 
@@ -264,6 +274,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
       if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
       }
+      addTelemetryUsage({ feature: 'set-user' })
     }),
 
     getUser: monitor(() => userContextManager.getContext()),
@@ -271,6 +282,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     setUserProperty: monitor((key, property) => {
       const sanitizedProperty = sanitizeUser({ [key]: property })[key]
       userContextManager.setContextProperty(key, sanitizedProperty)
+      addTelemetryUsage({ feature: 'set-user' })
     }),
 
     removeUserProperty: monitor((key) => userContextManager.removeContextProperty(key)),
@@ -296,6 +308,7 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
      */
     addFeatureFlagEvaluation: monitor((key: string, value: any) => {
       strategy.addFeatureFlagEvaluation(sanitize(key)!, sanitize(value))
+      addTelemetryUsage({ feature: 'add-feature-flag-evaluation' })
     }),
 
     getSessionReplayLink: monitor(() => recorderApi.getSessionReplayLink()),


### PR DESCRIPTION
## Motivation

Provide more visibility on how some SDK APIs are used

## Changes

Monitor usage of:

- startView
- addAction
- addError
- addFeatureFlagEvaluation
- startDurationVital
- setGlobalContext
- setUser


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
