### PR TITLE
🔊 Deduplicate telemetry events

### DIFF
--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -184,7 +184,7 @@ describe('telemetry', () => {
   })
 
   describe('deduplicating', () => {
-    it('should discard already seen telemetry', () => {
+    it('should discard already sent telemetry', () => {
       const { notifySpy } = startAndSpyTelemetry()
       const fooError = new Error('foo')
       const barError = new Error('bar')

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -147,13 +147,13 @@ describe('telemetry', () => {
         foo: 'bar',
       }))
       callMonitored(() => {
-        throw new Error('message')
+        throw new Error('foo')
       })
       expect(notifySpy.calls.mostRecent().args[0].foo).toEqual('bar')
 
       telemetry.setContextProvider(() => ({}))
       callMonitored(() => {
-        throw new Error('message')
+        throw new Error('bar')
       })
       expect(notifySpy.calls.mostRecent().args[0].foo).not.toBeDefined()
     })

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -7,6 +7,7 @@ import type { Configuration } from '../configuration'
 import { INTAKE_SITE_US1, INTAKE_SITE_US1_FED } from '../configuration'
 import { setNavigatorOnLine, setNavigatorConnection } from '../../../test'
 import {
+  addTelemetryError,
   resetTelemetry,
   startTelemetry,
   scrubCustomerFrames,
@@ -20,6 +21,7 @@ function startAndSpyTelemetry(configuration?: Partial<Configuration>) {
   const telemetry = startTelemetry(TelemetryService.RUM, {
     maxTelemetryEventsPerPage: 7,
     telemetrySampleRate: 100,
+    telemetryUsageSampleRate: 100,
     ...configuration,
   } as Configuration)
   const notifySpy = jasmine.createSpy('notified')
@@ -178,6 +180,34 @@ describe('telemetry', () => {
       })
 
       expect(notifySpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deduplicating', () => {
+    it('should discard already seen telemetry', () => {
+      const { notifySpy } = startAndSpyTelemetry()
+      const fooError = new Error('foo')
+      const barError = new Error('bar')
+
+      addTelemetryError(fooError)
+      addTelemetryError(fooError)
+      addTelemetryError(barError)
+
+      expect(notifySpy).toHaveBeenCalledTimes(2)
+      expect(notifySpy.calls.argsFor(0)[0].telemetry.message).toEqual('foo')
+      expect(notifySpy.calls.argsFor(1)[0].telemetry.message).toEqual('bar')
+    })
+
+    it('should not consider a discarded event for the maxTelemetryEventsPerPage', () => {
+      const { notifySpy } = startAndSpyTelemetry({ maxTelemetryEventsPerPage: 2 })
+
+      addTelemetryUsage({ feature: 'stop-session' })
+      addTelemetryUsage({ feature: 'stop-session' })
+      addTelemetryUsage({ feature: 'start-session-replay-recording' })
+
+      expect(notifySpy).toHaveBeenCalledTimes(2)
+      expect(notifySpy.calls.argsFor(0)[0].telemetry.usage.feature).toEqual('stop-session')
+      expect(notifySpy.calls.argsFor(1)[0].telemetry.usage.feature).toEqual('start-session-replay-recording')
     })
   })
 

--- a/packages/logs/src/domain/configuration.spec.ts
+++ b/packages/logs/src/domain/configuration.spec.ts
@@ -84,7 +84,7 @@ describe('validateAndBuildLogsConfiguration', () => {
     it('should display warning with wrong PCI intake configuration', () => {
       validateAndBuildLogsConfiguration({
         ...DEFAULT_INIT_CONFIGURATION,
-        site: 'some-site',
+        site: 'us3.datadoghq.com',
         usePciIntake: true,
       })
       expect(warnSpy).toHaveBeenCalledOnceWith(


### PR DESCRIPTION
## Motivation

Avoid to loose some telemetry when a single event is spammed, ex:
![Screenshot 2024-05-07 at 16 51 42](https://github.com/DataDog/browser-sdk/assets/1331991/33d315cd-045f-44f4-a13c-7d72e06ec6bf)

## Changes

Discard already seen telemetry events

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
