### PR TITLE
🐛 [RUM-4434] fix timing matching for the same resource requested twice at the same time

### DIFF
--- a/packages/rum-core/src/browser/polyfills.spec.ts
+++ b/packages/rum-core/src/browser/polyfills.spec.ts
@@ -1,5 +1,5 @@
 import { appendElement } from '../../test'
-import { cssEscape, elementMatches, getClassList, getParentElement } from './polyfills'
+import { WeakSet, cssEscape, elementMatches, getClassList, getParentElement } from './polyfills'
 
 describe('cssEscape', () => {
   it('should escape a string', () => {
@@ -60,5 +60,33 @@ describe('getClassList', () => {
     const classList = getClassList(svgElement)
     expect(classList[0]).toEqual('foo')
     expect(classList[1]).toEqual('bar')
+  })
+})
+
+describe('WeakSet', () => {
+  it('should support add and has', () => {
+    const set = new WeakSet()
+    const obj = {}
+
+    set.add(obj)
+    expect(set.has(obj)).toEqual(true)
+    expect(set.has({})).toEqual(false)
+  })
+
+  it('should support delete', () => {
+    const set = new WeakSet()
+    const obj = {}
+
+    set.add(obj)
+    expect(set.has(obj)).toEqual(true)
+    set.delete(obj)
+    expect(set.has(obj)).toEqual(false)
+  })
+
+  it('should support initial values', () => {
+    const obj = {}
+    const set = new WeakSet([obj])
+
+    expect(set.has(obj)).toEqual(true)
   })
 })

--- a/packages/rum-core/src/browser/polyfills.ts
+++ b/packages/rum-core/src/browser/polyfills.ts
@@ -76,3 +76,29 @@ export function getClassList(element: Element): DOMTokenList | string[] {
   const classes = element.getAttribute('class')?.trim()
   return classes ? classes.split(/\s+/) : []
 }
+
+// ie11 supports WeakMap but not WeakSet
+const PLACEHOLDER = 1
+export class WeakSet<T extends object> {
+  private map = new WeakMap<T, typeof PLACEHOLDER>()
+
+  constructor(initialValues?: T[]) {
+    if (initialValues) {
+      initialValues.forEach((value) => this.map.set(value, PLACEHOLDER))
+    }
+  }
+
+  add(value: T) {
+    this.map.set(value, PLACEHOLDER)
+
+    return this
+  }
+
+  delete(value: T) {
+    return this.map.delete(value)
+  }
+
+  has(value: T) {
+    return this.map.has(value)
+  }
+}

--- a/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
@@ -20,7 +20,7 @@ describe('matchRequestTiming', () => {
       pending('no full rum support')
     }
     entries = []
-    spyOn(performance, 'getEntriesByName').and.returnValues(entries as unknown as PerformanceResourceTiming[])
+    spyOn(performance, 'getEntriesByName').and.returnValue(entries)
   })
 
   it('should match single timing nested in the request ', () => {
@@ -57,6 +57,28 @@ describe('matchRequestTiming', () => {
     const matchingTiming = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
 
     expect(matchingTiming).toEqual(undefined)
+  })
+
+  it('should match all timings to the same request done at the same time', () => {
+    const entry1 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 200 as RelativeTime,
+      duration: 300 as Duration,
+    })
+    entries.push(entry1)
+
+    const matchingTiming1 = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+
+    expect(matchingTiming1).toEqual(entry1.toJSON() as RumPerformanceResourceTiming)
+
+    const entry2 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
+      startTime: 99 as RelativeTime,
+      duration: 502 as Duration,
+    })
+    entries.push(entry2)
+
+    const matchingTiming2 = matchRequestTiming(FAKE_REQUEST as RequestCompleteEvent)
+
+    expect(matchingTiming2).toEqual(entry2.toJSON() as RumPerformanceResourceTiming)
   })
 
   it('should not match two not following timings nested in the request ', () => {

--- a/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
+++ b/packages/rum-core/src/domain/resource/matchRequestTiming.spec.ts
@@ -59,7 +59,7 @@ describe('matchRequestTiming', () => {
     expect(matchingTiming).toEqual(undefined)
   })
 
-  it('should match all timings to the same request done at the same time', () => {
+  it('should discard already matched timings when multiple identical requests are done conurently', () => {
     const entry1 = createPerformanceEntry(RumPerformanceEntryType.RESOURCE, {
       startTime: 200 as RelativeTime,
       duration: 300 as Duration,

--- a/packages/rum-core/src/domain/resource/matchRequestTiming.ts
+++ b/packages/rum-core/src/domain/resource/matchRequestTiming.ts
@@ -9,7 +9,9 @@ interface Timing {
   duration: Duration
 }
 
-const matchedResourceTimingEntries = new WeakSet<PerformanceEntry>()
+// we use a WeakMap because WeakSet is not supported in ie11
+const PLACEHOLDER = 1
+const matchedResourceTimingEntries = new WeakMap<PerformanceEntry, typeof PLACEHOLDER>()
 
 /**
  * Look for corresponding timing in resource timing buffer
@@ -49,7 +51,7 @@ export function matchRequestTiming(request: RequestCompleteEvent) {
     )
 
   if (candidates.length === 1) {
-    matchedResourceTimingEntries.add(candidates[0].original)
+    matchedResourceTimingEntries.set(candidates[0].original, PLACEHOLDER)
 
     return candidates[0].serialized
   }

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -89,9 +89,7 @@ export function computePerformanceResourceDuration(entry: RumPerformanceResource
 export function computePerformanceResourceDetails(
   entry: RumPerformanceResourceTiming
 ): PerformanceResourceDetails | undefined {
-  const validEntry = toValidEntry(entry)
-
-  if (!validEntry) {
+  if (!isValidEntry(entry)) {
     return undefined
   }
   const {
@@ -107,7 +105,7 @@ export function computePerformanceResourceDetails(
     requestStart,
     responseStart,
     responseEnd,
-  } = validEntry
+  } = entry
 
   const details: PerformanceResourceDetails = {
     download: formatTiming(startTime, responseStart, responseEnd),
@@ -137,9 +135,9 @@ export function computePerformanceResourceDetails(
   return details
 }
 
-export function toValidEntry(entry: RumPerformanceResourceTiming) {
+export function isValidEntry(entry: RumPerformanceResourceTiming) {
   if (isExperimentalFeatureEnabled(ExperimentalFeature.TOLERANT_RESOURCE_TIMINGS)) {
-    return entry
+    return true
   }
 
   // Ensure timings are in the right order. On top of filtering out potential invalid
@@ -163,8 +161,10 @@ export function toValidEntry(entry: RumPerformanceResourceTiming) {
     : true
 
   if (areCommonTimingsInOrder && areRedirectionTimingsInOrder) {
-    return entry
+    return true
   }
+
+  return false
 }
 
 function hasRedirection(entry: RumPerformanceResourceTiming) {

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -160,11 +160,7 @@ export function isValidEntry(entry: RumPerformanceResourceTiming) {
     ? areInOrder(entry.startTime, entry.redirectStart, entry.redirectEnd, entry.fetchStart)
     : true
 
-  if (areCommonTimingsInOrder && areRedirectionTimingsInOrder) {
-    return true
-  }
-
-  return false
+  return areCommonTimingsInOrder && areRedirectionTimingsInOrder
 }
 
 function hasRedirection(entry: RumPerformanceResourceTiming) {

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -217,6 +217,27 @@ describe('rum resources', () => {
       expect(resourceEvent.resource.redirect!.duration).toBeGreaterThan(0)
     })
 
+  createTest('track concurent fetch to same resource')
+    .withRum()
+    .withSetup(bundleSetup)
+    .run(async ({ intakeRegistry }) => {
+      await browser.executeAsync((done) => {
+        Promise.all([fetch('/ok'), fetch('/ok')])
+          .then(() => done())
+          .catch(() => done())
+      })
+
+      await flushEvents()
+
+      const resourceEvents = intakeRegistry.rumResourceEvents.filter((event) => event.resource.type === 'fetch')
+
+      expect(resourceEvents[0]).toBeTruthy()
+      expect(resourceEvents[0]?.resource.size).toBeDefined()
+
+      expect(resourceEvents[1]).toBeTruthy()
+      expect(resourceEvents[1]?.resource.size).toBeDefined()
+    })
+
   describe('support XHRs with same XMLHttpRequest instance', () => {
     createTest('track XHRs when calling requests one after another')
       .withRum()

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -217,7 +217,7 @@ describe('rum resources', () => {
       expect(resourceEvent.resource.redirect!.duration).toBeGreaterThan(0)
     })
 
-  createTest('track concurent fetch to same resource')
+  createTest('track concurrent fetch to same resource')
     .withRum()
     .withSetup(bundleSetup)
     .run(async ({ intakeRegistry }) => {
@@ -226,6 +226,10 @@ describe('rum resources', () => {
           .then(() => done())
           .catch(() => done())
       })
+
+      if (!browser.isChromium) {
+        pending('Only Chromium based browsers will emit predictable timings events for concurrent fetches')
+      }
 
       await flushEvents()
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
Fixes an issue where resource timing where not matched to a resource when the same resource is requested twice at the same time.

e.g.
```js
Promise.all([
    fetch("http://localhost:8080/"),
    fetch("http://localhost:8080/")
])
```

The issue is that when the second request resolves, we have 2 resource timings matching the request hence we were not able to decide which one is the correct one.


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

When a match is found between a resource timing and a request, we store the timing in a `WeakMap`, that way we can filter it out of the available timings when the 2nd resource resolve.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
