### PR TITLE
👷 review feature request process

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,4 +6,4 @@ labels: enhancement
 assignees: ''
 ---
 
-Please contact [support](https://www.datadoghq.com/support/) and fill a FEATURE_REQUEST with them.
+Please contact [support](https://www.datadoghq.com/support/) to open a feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,15 +6,4 @@ labels: enhancement
 assignees: ''
 ---
 
-<!-- Guidelines -->
-<!-- Please check if an issue does not exist already for it: https://github.com/DataDog/browser-sdk/issues -->
-<!-- Please check if the issue happens with latest version -->
-
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+Please contact [support](https://www.datadoghq.com/support/) and fill a FEATURE_REQUEST with them.


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

We have a GitHub issue template for feature requests but we redirect them to support. Maybe we can tell people to contact support directly in the template to optimize the process.

