### PR TITLE
🔊 collect pre start telemetry

### DIFF
--- a/packages/core/src/domain/telemetry/index.ts
+++ b/packages/core/src/domain/telemetry/index.ts
@@ -9,6 +9,7 @@ export {
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
   addTelemetryUsage,
+  drainPreStartTelemetry,
 } from './telemetry'
 
 export * from './rawTelemetryEvent.types'

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -15,6 +15,7 @@ import {
   addTelemetryConfiguration,
   addTelemetryUsage,
   TelemetryService,
+  drainPreStartTelemetry,
 } from './telemetry'
 
 function startAndSpyTelemetry(configuration?: Partial<Configuration>) {
@@ -137,6 +138,16 @@ describe('telemetry', () => {
       interfaces: ['wifi'],
       effective_type: '4g',
     })
+  })
+
+  it('should collect pre start events', () => {
+    addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: 'granted' })
+
+    const { notifySpy } = startAndSpyTelemetry({ telemetrySampleRate: 100, telemetryUsageSampleRate: 100 })
+    expect(notifySpy).not.toHaveBeenCalled()
+
+    drainPreStartTelemetry()
+    expect(notifySpy).toHaveBeenCalled()
   })
 
   describe('telemetry context', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export {
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
   addTelemetryUsage,
+  drainPreStartTelemetry,
 } from './domain/telemetry'
 export { monitored, monitor, callMonitored, setDebugMode } from './tools/monitor'
 export { Observable, Subscription } from './tools/observable'

--- a/packages/logs/src/domain/logsTelemetry.ts
+++ b/packages/logs/src/domain/logsTelemetry.ts
@@ -8,6 +8,7 @@ import {
   createIdentityEncoder,
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
+  drainPreStartTelemetry,
 } from '@datadog/browser-core'
 import type { LogsConfiguration, LogsInitConfiguration } from './configuration'
 import { getRUMInternalContext } from './contexts/rumInternalContext'
@@ -62,6 +63,7 @@ export function startLogsTelemetry(
     )
     cleanupTasks.push(() => telemetrySubscription.unsubscribe())
   }
+  drainPreStartTelemetry()
   addTelemetryConfiguration(serializeLogsConfiguration(initConfiguration))
   return {
     telemetry,

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -17,6 +17,7 @@ import {
   getEventBridge,
   addTelemetryDebug,
   CustomerDataType,
+  drainPreStartTelemetry,
 } from '@datadog/browser-core'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { startPerformanceCollection } from '../browser/performanceCollection'
@@ -143,6 +144,7 @@ export function startRum(
   )
   cleanupTasks.push(stopRumEventCollection)
 
+  drainPreStartTelemetry()
   addTelemetryConfiguration(serializeRumConfiguration(initConfiguration))
 
   startLongTaskCollection(lifeCycle, configuration, session)


### PR DESCRIPTION
## Motivation

Avoid to loose telemetry events happening before the start of the SDK.

## Changes

Use a `BoundedBuffer` to store early events and drain it when the telemetry is properly configured.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
