### PR TITLE
✨ [RUM-4368] Expose custom vitals API

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -17,7 +17,6 @@ export enum ExperimentalFeature {
   ZERO_LCP_TELEMETRY = 'zero_lcp_telemetry',
   DISABLE_REPLAY_INLINE_CSS = 'disable_replay_inline_css',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  CUSTOM_VITALS = 'custom_vitals',
   TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
 }
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,9 +1,6 @@
 import type { RelativeTime, Context, DeflateWorker, CustomerDataTrackerManager, TimeStamp } from '@datadog/browser-core'
 import {
   clocksNow,
-  addExperimentalFeatures,
-  ExperimentalFeature,
-  resetExperimentalFeatures,
   ONE_SECOND,
   display,
   DefaultPrivacyLevel,
@@ -728,18 +725,7 @@ describe('rum public api', () => {
       setup().withFakeClock().build()
     })
 
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should not expose startDurationVital when ff is disabled', () => {
-      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).startDurationVital).toBeUndefined()
-    })
-
-    it('should call startDurationVital on the startRum result when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+    it('should call startDurationVital on the startRum result', () => {
       const startDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -749,8 +735,7 @@ describe('rum public api', () => {
         noopRecorderApi
       )
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).startDurationVital('foo', { context: { foo: 'bar' } })
+      rumPublicApi.startDurationVital('foo', { context: { foo: 'bar' } })
       expect(startDurationVitalSpy).toHaveBeenCalledWith({
         name: 'foo',
         startClocks: clocksNow(),
@@ -758,8 +743,7 @@ describe('rum public api', () => {
       })
     })
 
-    it('should call startDurationVital with provided startTime when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+    it('should call startDurationVital with provided startTime', () => {
       const startDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -770,8 +754,7 @@ describe('rum public api', () => {
       )
       const startTime = 1707755888000 as TimeStamp
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).startDurationVital('foo', { startTime })
+      rumPublicApi.startDurationVital('foo', { startTime })
       expect(startDurationVitalSpy).toHaveBeenCalledWith({
         name: 'foo',
         startClocks: timeStampToClocks(startTime),
@@ -785,18 +768,7 @@ describe('rum public api', () => {
       setup().withFakeClock().build()
     })
 
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should not expose stopDurationVital when ff is disabled', () => {
-      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).stopDurationVital).toBeUndefined()
-    })
-
-    it('should call stopDurationVital on the startRum result when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+    it('should call stopDurationVital on the startRum result', () => {
       const stopDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -806,8 +778,7 @@ describe('rum public api', () => {
         noopRecorderApi
       )
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).stopDurationVital('foo', { context: { foo: 'bar' } })
+      rumPublicApi.stopDurationVital('foo', { context: { foo: 'bar' } })
       expect(stopDurationVitalSpy).toHaveBeenCalledWith({
         name: 'foo',
         stopClocks: clocksNow(),
@@ -815,8 +786,7 @@ describe('rum public api', () => {
       })
     })
 
-    it('should call stopDurationVital with provided stopTime when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+    it('should call stopDurationVital with provided stopTime', () => {
       const stopDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -827,8 +797,7 @@ describe('rum public api', () => {
       )
       const stopTime = 1707755888000 as TimeStamp
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).stopDurationVital('foo', { stopTime })
+      rumPublicApi.stopDurationVital('foo', { stopTime })
       expect(stopDurationVitalSpy).toHaveBeenCalledWith({
         name: 'foo',
         stopClocks: timeStampToClocks(stopTime),

--- a/test/e2e/scenario/rum/vitals.scenario.ts
+++ b/test/e2e/scenario/rum/vitals.scenario.ts
@@ -2,18 +2,12 @@ import { createTest, flushEvents } from '../../lib/framework'
 
 describe('vital collection', () => {
   createTest('send custom duration vital')
-    .withRum({
-      enableExperimentalFeatures: ['custom_vitals'],
-    })
+    .withRum()
     .run(async ({ intakeRegistry }) => {
       await browser.executeAsync((done) => {
-        // TODO remove cast and unsafe calls when removing the flag
-        const global = window.DD_RUM! as any
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        global.startDurationVital('foo')
+        window.DD_RUM!.startDurationVital('foo')
         setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          global.stopDurationVital('foo')
+          window.DD_RUM!.stopDurationVital('foo')
           done()
         }, 5)
       })


### PR DESCRIPTION
## Motivation

Provide APIs to track custom durations as vital events

## Changes

```js
DD_RUM.startDurationVital('foo', { context, startTime })
// do some stuff
DD_RUM.stopDurationVital('foo', { context, stopTime })
```


![Screenshot 2024-02-05 at 15 17 25](https://github.com/DataDog/browser-sdk/assets/1331991/4e475776-8fd6-44cb-bdc5-799f82a24cdb)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
