### PR TITLE
✏️ various comment fixes

### DIFF
--- a/packages/rum-core/src/browser/polyfills.ts
+++ b/packages/rum-core/src/browser/polyfills.ts
@@ -50,17 +50,6 @@ export function getParentElement(node: Node): HTMLElement | null {
   return null
 }
 
-// let parentNode = node.parentNode
-// while (parentNode !== null && parentNode.nodeType !== Node.ELEMENT_NODE) {
-//   parentNode = node.parentNode
-// }
-
-// let parentNode = document.querySelector('span').parentNode
-// while (parentNode !== null && parentNode.nodeType !== Node.ELEMENT_NODE) {
-//   parentNode = node.parentNode
-// }
-// console.log(parentNode)
-
 /**
  * Return the classList of an element or an array of classes if classList is not supported
  *

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -77,8 +77,7 @@ function isGeneratedValue(value: string) {
   //
   // Here, we use the same strategy: if the value contains a digit, we consider it generated. This
   // strategy might be a bit naive and fail in some cases, but there are many fallbacks to generate
-  // CSS selectors so it should be fine most of the time. We might want to allow customers to
-  // provide their own `isGeneratedValue` at some point.
+  // CSS selectors so it should be fine most of the time.
   return /[0-9]/.test(value)
 }
 

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -75,7 +75,7 @@ function isGeneratedValue(value: string) {
   // if it thinks the part is an identifier. The condition it uses is to checks whether a digit is
   // present.
   //
-  // Here, we use the same strategy: if a the value contains a digit, we consider it generated. This
+  // Here, we use the same strategy: if the value contains a digit, we consider it generated. This
   // strategy might be a bit naive and fail in some cases, but there are many fallbacks to generate
   // CSS selectors so it should be fine most of the time. We might want to allow customers to
   // provide their own `isGeneratedValue` at some point.


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
Some small cleanup opportunities I stumbled upon within the last few days

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
- Remove some commented code and fix a small typo.
- Remove reference to possibly expose `isGeneratedValue` as this came up in #2751 and commented that it might not be a good idea after all.

  > Ideally, we should tackle it internally and find a way to improve the performance for everyone without requiring users to fine tune the internals of the SDK.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
