### PR TITLE
👷 add link to conflict resolution documentation in confluence

### DIFF
--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -28,7 +28,10 @@ runMain(() => {
     command`git merge --no-ff ${CI_COMMIT_SHA}`.run()
   } catch (error) {
     const diff = command`git diff`.run()
-    printError(`Conflicts:\n${diff}`)
+    printError(
+      `Conflicts:\n${diff}\n` +
+        'See "How to fix staging" in Confluence for help: https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2548269306/How+to+fix+staging+conflicts'
+    )
     throw error
   }
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

When the `check-staging-merge` job fails on a PR, the logs suggest a way to fix it:  https://github.com/DataDog/browser-sdk/blob/f221bc91ebe8010eb2d86ee9d48c1d1d7e39d7ae/scripts/staging-ci/check-staging-merge.js#L30-L32

I'm adding similar help message when `check-staging-merge` fails on the `main` branch.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Add a link to [How to fix staging](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2548269306/How+to+fix+staging+conflicts) in confluence as instructions are a bit different than for a PR branch.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
