### PR TITLE
🐛 [RUM-1666] Don't set negative action loading time 

### DIFF
--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -118,7 +118,7 @@ describe('actionCollection', () => {
     })
     expect(rawRumEvents[0].domainContext).toEqual({})
   })
-  it('should discard negative action loading time', () => {
+  it('should not set the loading time field of the action', () => {
     const { lifeCycle, rawRumEvents } = setupBuilder.build()
     const event = createNewEvent('pointerup', { target: document.createElement('button') })
     lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, {

--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -1,5 +1,6 @@
 import type { Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
 import { createNewEvent } from '@datadog/browser-core/test'
+import type { RawRumActionEvent } from '@datadog/browser-rum-core'
 import type { TestSetupBuilder } from '../../../test'
 import { setup } from '../../../test'
 import { RumEventType, ActionType } from '../../rawRumEvent.types'
@@ -116,5 +117,25 @@ describe('actionCollection', () => {
       },
     })
     expect(rawRumEvents[0].domainContext).toEqual({})
+  })
+  it('should discard negative action loading time', () => {
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+    const event = createNewEvent('pointerup', { target: document.createElement('button') })
+    lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, {
+      counts: {
+        errorCount: 0,
+        longTaskCount: 0,
+        resourceCount: 0,
+      },
+      duration: -10 as Duration,
+      event,
+      events: [event],
+      frustrationTypes: [],
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      name: 'foo',
+      startClocks: { relative: 0 as RelativeTime, timeStamp: 0 as TimeStamp },
+      type: ActionType.CLICK,
+    })
+    expect((rawRumEvents[0].rawRumEvent as RawRumActionEvent).action.loading_time).toBeUndefined()
   })
 })

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -1,5 +1,5 @@
-import type { ClocksState, Context, Observable } from '@datadog/browser-core'
-import { noop, assign, combine, toServerDuration, generateUUID } from '@datadog/browser-core'
+import type { ClocksState, Context, Observable, ServerDuration } from '@datadog/browser-core'
+import { noop, assign, combine, toServerDuration, generateUUID, isNumber } from '@datadog/browser-core'
 
 import type { RawRumActionEvent } from '../../rawRumEvent.types'
 import { ActionType, RumEventType } from '../../rawRumEvent.types'
@@ -62,7 +62,7 @@ function processAction(
     ? {
         action: {
           id: action.id,
-          loading_time: toServerDuration(action.duration),
+          loading_time: discardNegativeLoadingTime(toServerDuration(action.duration)),
           frustration: {
             type: action.frustrationTypes,
           },
@@ -111,4 +111,8 @@ function processAction(
 
 function isAutoAction(action: AutoAction | CustomAction): action is AutoAction {
   return action.type !== ActionType.CUSTOM
+}
+
+function discardNegativeLoadingTime(duration: ServerDuration | undefined): ServerDuration | undefined {
+  return isNumber(duration) && duration < 0 ? undefined : duration
 }

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -1,6 +1,7 @@
-import type { ClocksState, Context, Observable, ServerDuration } from '@datadog/browser-core'
-import { noop, assign, combine, toServerDuration, generateUUID, isNumber } from '@datadog/browser-core'
+import type { ClocksState, Context, Observable } from '@datadog/browser-core'
+import { noop, assign, combine, toServerDuration, generateUUID } from '@datadog/browser-core'
 
+import { discardNegativeDuration } from '../view/viewCollection'
 import type { RawRumActionEvent } from '../../rawRumEvent.types'
 import { ActionType, RumEventType } from '../../rawRumEvent.types'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
@@ -62,7 +63,7 @@ function processAction(
     ? {
         action: {
           id: action.id,
-          loading_time: discardNegativeLoadingTime(toServerDuration(action.duration)),
+          loading_time: discardNegativeDuration(toServerDuration(action.duration)),
           frustration: {
             type: action.frustrationTypes,
           },
@@ -111,8 +112,4 @@ function processAction(
 
 function isAutoAction(action: AutoAction | CustomAction): action is AutoAction {
   return action.type !== ActionType.CUSTOM
-}
-
-function discardNegativeLoadingTime(duration: ServerDuration | undefined): ServerDuration | undefined {
-  return isNumber(duration) && duration < 0 ? undefined : duration
 }

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -1,7 +1,7 @@
 import type { ClocksState, Context, Observable } from '@datadog/browser-core'
 import { noop, assign, combine, toServerDuration, generateUUID } from '@datadog/browser-core'
 
-import { discardNegativeDuration } from '../view/viewCollection'
+import { discardNegativeDuration } from '../discardNegativeDuration'
 import type { RawRumActionEvent } from '../../rawRumEvent.types'
 import { ActionType, RumEventType } from '../../rawRumEvent.types'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'

--- a/packages/rum-core/src/domain/discardNegativeDuration.ts
+++ b/packages/rum-core/src/domain/discardNegativeDuration.ts
@@ -1,0 +1,6 @@
+import type { ServerDuration } from '@datadog/browser-core'
+import { isNumber } from '@datadog/browser-core'
+
+export function discardNegativeDuration(duration: ServerDuration | undefined): ServerDuration | undefined {
+  return isNumber(duration) && duration < 0 ? undefined : duration
+}

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -1,5 +1,6 @@
 import type { Duration, ServerDuration, Observable } from '@datadog/browser-core'
-import { isEmptyObject, mapValues, toServerDuration, isNumber } from '@datadog/browser-core'
+import { isEmptyObject, mapValues, toServerDuration } from '@datadog/browser-core'
+import { discardNegativeDuration } from '../discardNegativeDuration'
 import type { RecorderApi } from '../../boot/rumPublicApi'
 import type { RawRumViewEvent } from '../../rawRumEvent.types'
 import { RumEventType } from '../../rawRumEvent.types'
@@ -130,8 +131,4 @@ function processViewUpdate(
       location: view.location,
     },
   }
-}
-
-export function discardNegativeDuration(duration: ServerDuration | undefined): ServerDuration | undefined {
-  return isNumber(duration) && duration < 0 ? undefined : duration
 }

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -132,6 +132,6 @@ function processViewUpdate(
   }
 }
 
-function discardNegativeDuration(duration: ServerDuration | undefined): ServerDuration | undefined {
+export function discardNegativeDuration(duration: ServerDuration | undefined): ServerDuration | undefined {
   return isNumber(duration) && duration < 0 ? undefined : duration
 }


### PR DESCRIPTION
## Motivation

We noticed that we have actions with negative actions negative loading time. This is probably due to the fact that Date.now() is not monotonic and sometimes goes “back in time” 

## Changes

If that's the case, we could just not set the loading time of the action event.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
