### PR TITLE
👷 make failed unit test stack trace clickable

### DIFF
--- a/test/unit/karma.local.conf.js
+++ b/test/unit/karma.local.conf.js
@@ -20,6 +20,9 @@ module.exports = function (config) {
       ...karmaBaseConf.webpack,
       module: withIstanbulRule(karmaBaseConf.webpack.module),
     },
+    sourceMapLoader: {
+      remapSource: (source) => source.replace(/webpack:\/\//g, path.join(__dirname, '../../')),
+    },
   })
 }
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

When working on unit test, I'm using `yarn test:unit:watch` on a terminal window, however when a test fail, it is not possible to `cmd` + click on the filename to open the file at the correct line on your editor.

| Before | After |
|--------|--------|
| ![Screenshot 2024-05-17 at 12 03 10](https://github.com/DataDog/browser-sdk/assets/1926949/3e9fd953-c546-4f1e-b76b-33d205502d51) | ![Screenshot 2024-05-17 at 12 02 55](https://github.com/DataDog/browser-sdk/assets/1926949/f4137cf6-49a9-454f-a775-b4bbcee42175) |

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Configure karma-sourcemap-loader to remap file path from `webpack:///*` to `<project_root>/*`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

tested with:
- iTerm2 and VSCode
- VSCode's integrated terminal

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
