### PR TITLE
🐛 [RUM-4493] do not compute selectors for detached elements

### DIFF
--- a/packages/rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.ts
@@ -38,8 +38,7 @@ export interface ClickAction {
   id: string
   name: string
   target?: {
-    selector: string
-    selector_with_stable_attributes?: string
+    selector: string | undefined
     width: number
     height: number
   }

--- a/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
@@ -6,6 +6,11 @@ describe('getSelectorFromElement', () => {
     document.body.classList.remove('foo')
   })
 
+  it('returns undefined for detached elements', () => {
+    const element = document.createElement('div')
+    expect(getSelector(element)).toBeUndefined()
+  })
+
   describe('ID selector', () => {
     it('should use the ID selector when the element as an ID', () => {
       expect(getSelector('<div id="foo"></div>')).toBe('#foo')
@@ -162,7 +167,7 @@ describe('getSelectorFromElement', () => {
     expect(getSelector(element)).toBe('BODY>svg.foo')
   })
 
-  function getSelector(htmlOrElement: string | Element, actionNameAttribute?: string): string {
+  function getSelector(htmlOrElement: string | Element, actionNameAttribute?: string): string | undefined {
     return getSelectorFromElement(
       typeof htmlOrElement === 'string' ? appendElement(htmlOrElement) : htmlOrElement,
       actionNameAttribute

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -38,7 +38,15 @@ const UNIQUE_AMONG_CHILDREN_SELECTOR_GETTERS: SelectorGetter[] = [
   getTagNameSelector,
 ]
 
-export function getSelectorFromElement(targetElement: Element, actionNameAttribute: string | undefined) {
+export function getSelectorFromElement(
+  targetElement: Element,
+  actionNameAttribute: string | undefined
+): string | undefined {
+  if (!targetElement.isConnected) {
+    // We cannot compute a selector for a detached element, as we don't have access to all of its
+    // parents, and we cannot determine if it's unique in the document.
+    return
+  }
   let targetElementSelector = ''
   let element: Element | null = targetElement
 

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -42,7 +42,7 @@ export function getSelectorFromElement(
   targetElement: Element,
   actionNameAttribute: string | undefined
 ): string | undefined {
-  if (!targetElement.isConnected) {
+  if (!isConnected(targetElement)) {
     // We cannot compute a selector for a detached element, as we don't have access to all of its
     // parents, and we cannot determine if it's unique in the document.
     return
@@ -208,4 +208,16 @@ export function supportScopeSelector() {
     }
   }
   return supportScopeSelectorCache
+}
+
+function isConnected(element: Element): boolean {
+  if (
+    'isConnected' in
+    // cast is to make sure `element` is not inferred as `never` after the check
+    (element as { isConnected?: boolean })
+  ) {
+    return element.isConnected
+  }
+
+  return element.ownerDocument.documentElement.contains(element)
 }

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -210,6 +210,9 @@ export function supportScopeSelector() {
   return supportScopeSelectorCache
 }
 
+/**
+ * Polyfill-utility for the `isConnected` property not supported in IE11
+ */
 function isConnected(element: Element): boolean {
   if (
     'isConnected' in

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -69,9 +69,7 @@ export function trackCumulativeLayoutShift(
 
           callback({
             value: round(maxClsValue, 4),
-            targetSelector: target?.isConnected
-              ? getSelectorFromElement(target, configuration.actionNameAttribute)
-              : undefined,
+            targetSelector: target && getSelectorFromElement(target, configuration.actionNameAttribute),
           })
         }
       }


### PR DESCRIPTION
## Motivation

Sometimes we compute CSS selectors on detached nodes (ex: when an LCP occurs but the LCP target element is quickly removed from the DOM before we get the PerformanceEntry), making the Browser SDK crash.

## Changes

Make sure we never compute CSS selectors on detached nodes.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
