### PR TITLE
👷 add option to enable debug mode in the developer extension

### DIFF
--- a/developer-extension/src/common/types.ts
+++ b/developer-extension/src/common/types.ts
@@ -54,4 +54,5 @@ export interface Settings {
   eventCollectionStrategy: EventCollectionStrategy
   rumConfigurationOverride: object | null
   logsConfigurationOverride: object | null
+  debugMode: boolean
 }

--- a/developer-extension/src/content-scripts/main.ts
+++ b/developer-extension/src/content-scripts/main.ts
@@ -31,6 +31,11 @@ function main() {
     const ddRumGlobal = instrumentGlobal('DD_RUM')
     const ddLogsGlobal = instrumentGlobal('DD_LOGS')
 
+    if (settings.debugMode) {
+      ddRumGlobal.onSet((sdkInstance) => sdkInstance._setDebug(settings.debugMode))
+      ddLogsGlobal.onSet((sdkInstance) => sdkInstance._setDebug(settings.debugMode))
+    }
+
     if (settings.rumConfigurationOverride) {
       overrideInitConfiguration(ddRumGlobal, settings.rumConfigurationOverride)
     }

--- a/developer-extension/src/panel/components/panel.tsx
+++ b/developer-extension/src/panel/components/panel.tsx
@@ -8,6 +8,7 @@ import { useNetworkRules } from '../hooks/useNetworkRules'
 import { useSettings } from '../hooks/useSettings'
 import { DEFAULT_PANEL_TAB, PanelTabs } from '../../common/constants'
 import type { Settings } from '../../common/types'
+import { useDebugMode } from '../hooks/useDebugMode'
 import { SettingsTab } from './tabs/settingsTab'
 import { InfosTab } from './tabs/infosTab'
 import { EventsTab, DEFAULT_COLUMNS } from './tabs/eventsTab'
@@ -20,6 +21,7 @@ export function Panel() {
 
   useAutoFlushEvents(settings.autoFlush)
   useNetworkRules(settings)
+  useDebugMode(settings.debugMode)
 
   const { events, filters, setFilters, clear, facetRegistry } = useEvents(settings)
 

--- a/developer-extension/src/panel/components/tabs/settingsTab.tsx
+++ b/developer-extension/src/panel/components/tabs/settingsTab.tsx
@@ -9,7 +9,15 @@ import type { DevBundlesOverride, EventCollectionStrategy } from '../../../commo
 export function SettingsTab() {
   const devServerStatus = useDevServerStatus()
   const [
-    { useDevBundles, useRumSlim, blockIntakeRequests, preserveEvents, eventCollectionStrategy, autoFlush },
+    {
+      useDevBundles,
+      useRumSlim,
+      blockIntakeRequests,
+      preserveEvents,
+      eventCollectionStrategy,
+      autoFlush,
+      debugMode: debug,
+    },
     setSetting,
   ] = useSettings()
 
@@ -136,6 +144,19 @@ export function SettingsTab() {
                 />
               }
               description={<>Force the SDK to flush events periodically.</>}
+            />
+          </Columns.Column>
+          <Columns.Column title="Other">
+            <SettingItem
+              input={
+                <Checkbox
+                  label="Debug mode"
+                  checked={debug}
+                  onChange={(e) => setSetting('debugMode', isChecked(e.target))}
+                  color="violet"
+                />
+              }
+              description={<>Enable the SDK logs in the developer console</>}
             />
           </Columns.Column>
         </Columns>

--- a/developer-extension/src/panel/hooks/useDebugMode.ts
+++ b/developer-extension/src/panel/hooks/useDebugMode.ts
@@ -1,0 +1,8 @@
+import { useEffect } from 'react'
+import { setDebugMode } from '../setDebugMode'
+
+export function useDebugMode(enabled: boolean) {
+  useEffect(() => {
+    setDebugMode(enabled)
+  }, [enabled])
+}

--- a/developer-extension/src/panel/hooks/useSettings.ts
+++ b/developer-extension/src/panel/hooks/useSettings.ts
@@ -16,6 +16,7 @@ const DEFAULT_SETTINGS: Readonly<Settings> = {
   eventCollectionStrategy: 'sdk',
   rumConfigurationOverride: null,
   logsConfigurationOverride: null,
+  debugMode: false,
 }
 
 let settings: Settings | undefined

--- a/developer-extension/src/panel/setDebugMode.ts
+++ b/developer-extension/src/panel/setDebugMode.ts
@@ -1,0 +1,13 @@
+import { createLogger } from '../common/logger'
+import { evalInWindow } from './evalInWindow'
+
+const logger = createLogger('setDebug')
+
+export function setDebugMode(enabled: boolean) {
+  evalInWindow(
+    `
+      DD_RUM?._setDebug(${enabled})
+      DD_LOGS?._setDebug(${enabled})
+    `
+  ).catch((error) => logger.error('Error while setting debug mode:', error))
+}


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Errors happening in RUM and LOGS are monitored but not displayed in the developer console by default. Both SDKs exposes an API (`_setDebug(value: boolean)`) to allow these error to be displayed in the developer console.

This PR adds and option to enable this debug mode from the developer extension.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
![Screenshot 2024-05-22 at 12 34 14](https://github.com/DataDog/browser-sdk/assets/1926949/111e9147-e46d-4d21-801c-85736848e325)
![Screenshot 2024-05-22 at 12 34 22](https://github.com/DataDog/browser-sdk/assets/1926949/1e73d76f-c5e8-4b1a-9b17-0aeb41248b21)



## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
