### PR TITLE
👷 Add extension usage tips doc and link in ui

### DIFF
--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -85,7 +85,7 @@ Info tab contains information about Session and RUM SDK configurations
 
 - **Debug Mode**: This option enables debug mode from the developer extension to display errors happening in RUM and LOGS in the developer console.
 
-## Contribution Tips
+## Contribution tips
 
 To work on the developer extension and debug it easily:
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -51,7 +51,7 @@ The Event Tab contains a list of events sent by the SDK and a menu of event type
 
 We support a basic `key:value` search syntax, which means you can search within the limits of [RUM event structures](https://docs.datadoghq.com/real_user_monitoring/explorer/search/), such as `action.target.name:action_name`.
 
-We split each search key based on whitespaces. To search with multiple conditions, simply add whitespaces in between, such as:
+We split each search key based on whitespace. To search with multiple conditions, simply add whitespace characters in between, such as:
 
 ```
 type:view application.id:2 action.target.name:my_action_name

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -93,6 +93,6 @@ To work on the developer extension and debug it easily:
 
 2. Run `yarn dev`.
 
-- In Chrome, load the `developer-extension/dist` folder as an unpacked extension
+3. In Chrome, load the `developer-extension/dist` folder as an unpacked extension.
 
 - After you make a change, you can right-click on the extension UI and “Reload frame”

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -49,7 +49,7 @@ The Event Tab contains a list of events sent by the SDK and a menu of event type
 
 #### Search Syntax
 
-We support a basic `key:value` search syntax which means you can search within the limits of [RUM event structures](https://docs.datadoghq.com/real_user_monitoring/explorer/search/), such as `action.target.name:action_name`. While all the fields can be added as columns in the event list, it does not mean the existing ones are valid fields: the `Description` summary is not part of RUM event structure. You can click on any `Description` cell for details of the event to look for correct key to search with.
+We support a basic `key:value` search syntax which means you can search within the limits of [RUM event structures](https://docs.datadoghq.com/real_user_monitoring/explorer/search/), such as `action.target.name:action_name`.
 
 We split each search key based on whitespaces. To search with multiple conditions, simply add whitespaces in between, such as:
 
@@ -78,7 +78,7 @@ Info tab contains information about Session and RUM SDK configurations
 
 ### Setting Tab
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Don’t forget to reset everything in the Setting Tab after experimenting.
 
 - **Request Interception**: override the current SDK bundle with local build, or ​​switch between `rum` and `rum-slim` bundles on any site that is using RUM SDK. (note: if the SDK is installed from NPM, this override might not work, as it is still in an experimental stage.)

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -91,7 +91,7 @@ To work on the developer extension and debug it easily:
 
 1. In a terminal, cd into the `developer-extension` folder.
 
-- Run `yarn dev`
+2. Run `yarn dev`.
 
 - In Chrome, load the `developer-extension/dist` folder as an unpacked extension
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -95,4 +95,4 @@ To work on the developer extension and debug it easily:
 
 3. In Chrome, load the `developer-extension/dist` folder as an unpacked extension.
 
-- After you make a change, you can right-click on the extension UI and “Reload frame”
+4. After you make a change, right-click on the extension UI and “Reload frame”.

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -41,7 +41,7 @@ Then, in Google Chrome:
 
 For now, only Google Chrome is supported.
 
-## Usage Tips
+## Usage tips
 
 ### Event Tab
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -47,7 +47,7 @@ For now, only Google Chrome is supported.
 
 The Event Tab contains a list of events sent by the SDK and a menu of event types for quick filtering.
 
-#### Search Syntax
+#### Search syntax
 
 We support a basic `key:value` search syntax which means you can search within the limits of [RUM event structures](https://docs.datadoghq.com/real_user_monitoring/explorer/search/), such as `action.target.name:action_name`.
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -89,7 +89,7 @@ Info tab contains information about Session and RUM SDK configurations
 
 To work on the developer extension and debug it easily:
 
-- In a terminal, cd into the `developer-extension` folder
+1. In a terminal, cd into the `developer-extension` folder.
 
 - Run `yarn dev`
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -78,7 +78,8 @@ Info tab contains information about Session and RUM SDK configurations
 
 ### Setting Tab
 
-**⚠️Don’t forget to reset everything in the Setting Tab after experimenting.**
+> [!IMPORTANT]  
+> Don’t forget to reset everything in the Setting Tab after experimenting.
 
 - **Request Interception**: override the current SDK bundle with local build, or ​​switch between `rum` and `rum-slim` bundles on any site that is using RUM SDK. (note: if the SDK is installed from NPM, this override might not work, as it is still in an experimental stage.)
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -57,7 +57,7 @@ We split each search key based on whitespace. To search with multiple conditions
 type:view application.id:2 action.target.name:my_action_name
 ```
 
-#### Event Columns
+#### Event columns
 
 The Events List offers an interactive experience to visualize RUM events:
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -40,3 +40,58 @@ Then, in Google Chrome:
 ## Browser compatibility
 
 For now, only Google Chrome is supported.
+
+## Usage Tips
+
+### Event Tab
+
+The Event Tab contains a list of events sent by the SDK and a menu of event types for quick filtering.
+
+#### Search Syntax
+
+We support a basic `key:value` search syntax which means you can search within the limits of [RUM event structures](https://docs.datadoghq.com/real_user_monitoring/explorer/search/), such as `action.target.name:action_name`. While all the fields can be added as columns in the event list, it does not mean the existing ones are valid fields: the `Description` summary is not part of RUM event structure. You can click on any `Description` cell for details of the event to look for correct key to search with.
+
+We split each search key based on whitespaces. To search with multiple conditions, simply add whitespaces in between, such as:
+
+```
+type:view application.id:2 action.target.name:my_action_name
+```
+
+#### Event Columns
+
+The Events List offers an interactive experience to visualize RUM events:
+
+- Drag and drop to reorder columns in the event list
+- Remove (by clicking on `x` in the column title) or add new columns:
+  - Add a new column from searching for a field by clicking on the `+column` icon at the right side of the header row.
+  - Add a new column from values in existing columns by right clicking on any attribute in the event json.
+- Copy queries and objects from the list by right clicking on any cell
+
+### Info Tab
+
+**⚠️Don’t forget to reset everything in the Info Tab after experimenting.**
+
+Info tab contains information about Session and RUM SDK configurations
+
+- **RUM/LOGS Configuration**: edit configuration files on the fly. When configuration changes apply, the extension will automatically reload the page. But for some configurations you might want to click on End Current Session to ensure that the changes kicked in.
+- **End current session**: manually end the current session within the extension. This will also end the current replay session.
+
+### Setting Tab
+
+**⚠️Don’t forget to reset everything in the Setting Tab after experimenting.**
+
+- **Request Interception**: override the current SDK bundle with local build, or ​​switch between `rum` and `rum-slim` bundles on any site that is using RUM SDK. (note: if the SDK is installed from NPM, this override might not work, as it is still in an experimental stage.)
+
+- **Debug Mode**: This option enables debug mode from the developer extension to display errors happening in RUM and LOGS in the developer console.
+
+## Contribution Tips
+
+To work on the developer extension and debug it easily:
+
+- In a terminal, cd into the `developer-extension` folder
+
+- Run `yarn dev`
+
+- In Chrome, load the `developer-extension/dist` folder as an unpacked extension
+
+- After you make a change, you can right-click on the extension UI and “Reload frame”

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -65,7 +65,7 @@ The Events List offers an interactive experience to visualize RUM events:
 - Remove (by clicking on `x` in the column title) or add new columns:
   - Add a new column from searching for a field by clicking on the `+column` icon at the right side of the header row.
   - Add a new column from values in existing columns by right clicking on any attribute in the event json.
-- Copy queries and objects from the list by right clicking on any cell
+- Copy queries and objects from the list by clicking on any cell
 
 ### Info Tab
 

--- a/developer-extension/README.md
+++ b/developer-extension/README.md
@@ -49,7 +49,7 @@ The Event Tab contains a list of events sent by the SDK and a menu of event type
 
 #### Search syntax
 
-We support a basic `key:value` search syntax which means you can search within the limits of [RUM event structures](https://docs.datadoghq.com/real_user_monitoring/explorer/search/), such as `action.target.name:action_name`.
+We support a basic `key:value` search syntax, which means you can search within the limits of [RUM event structures](https://docs.datadoghq.com/real_user_monitoring/explorer/search/), such as `action.target.name:action_name`.
 
 We split each search key based on whitespaces. To search with multiple conditions, simply add whitespaces in between, such as:
 

--- a/developer-extension/src/panel/components/panel.module.css
+++ b/developer-extension/src/panel/components/panel.module.css
@@ -8,3 +8,20 @@
   flex: 1;
   min-height: 0;
 }
+
+.link {
+  align-self: center;
+  padding-right: 2%;
+  flex-shrink: 0;
+}
+
+.topBox {
+  justify-content: space-between;
+  flex-wrap: unset;
+}
+
+.tabBox {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+}

--- a/developer-extension/src/panel/components/panel.tsx
+++ b/developer-extension/src/panel/components/panel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Tabs, Text } from '@mantine/core'
+import { Tabs, Text, Anchor } from '@mantine/core'
 import { datadogRum } from '@datadog/browser-rum'
 
 import { useEvents } from '../hooks/useEvents'
@@ -63,6 +63,15 @@ export function Panel() {
           }
         >
           Settings
+        </Tabs.Tab>
+        <Tabs.Tab
+          color='blue'
+          value={activeTab ?? PanelTabs.Events}
+          rightSection={
+            <Anchor href="https://github.com/DataDog/browser-sdk/tree/main/developer-extension#browser-sdk-developer-extension" target="_blank">
+              🔗 Docs
+            </Anchor>
+          }>
         </Tabs.Tab>
       </Tabs.List>
       <Tabs.Panel value={PanelTabs.Events} className={classes.tab}>

--- a/developer-extension/src/panel/components/panel.tsx
+++ b/developer-extension/src/panel/components/panel.tsx
@@ -65,14 +65,17 @@ export function Panel() {
           Settings
         </Tabs.Tab>
         <Tabs.Tab
-          color='blue'
+          color="blue"
           value={activeTab ?? PanelTabs.Events}
           rightSection={
-            <Anchor href="https://github.com/DataDog/browser-sdk/tree/main/developer-extension#browser-sdk-developer-extension" target="_blank">
+            <Anchor
+              href="https://github.com/DataDog/browser-sdk/tree/main/developer-extension#browser-sdk-developer-extension"
+              target="_blank"
+            >
               🔗 Docs
             </Anchor>
-          }>
-        </Tabs.Tab>
+          }
+        ></Tabs.Tab>
       </Tabs.List>
       <Tabs.Panel value={PanelTabs.Events} className={classes.tab}>
         <EventsTab

--- a/developer-extension/src/panel/components/panel.tsx
+++ b/developer-extension/src/panel/components/panel.tsx
@@ -35,48 +35,49 @@ export function Panel() {
 
   return (
     <Tabs color="violet" value={activeTab} className={classes.tabs} onChange={updateActiveTab}>
-      <Tabs.List className="dd-privacy-allow">
-        <Tabs.Tab value={PanelTabs.Events}>Events</Tabs.Tab>
-        <Tabs.Tab
-          value={PanelTabs.Infos}
-          rightSection={
-            isOverridingInitConfiguration(settings) && (
-              <Text c="orange" fw="bold" title="Overriding init configuration">
-                ⚠
-              </Text>
-            )
-          }
+      <Tabs.List className={classes.topBox} data-dd-privacy="allow">
+        <div className={classes.tabBox}>
+          <Tabs.Tab value={PanelTabs.Events}>Events</Tabs.Tab>
+          <Tabs.Tab
+            value={PanelTabs.Infos}
+            rightSection={
+              isOverridingInitConfiguration(settings) && (
+                <Text c="orange" fw="bold" title="Overriding init configuration">
+                  ⚠
+                </Text>
+              )
+            }
+          >
+            <Text>Infos</Text>
+          </Tabs.Tab>
+          <Tabs.Tab value={PanelTabs.Replay}>
+            <Text>Live replay</Text>
+          </Tabs.Tab>
+          <Tabs.Tab
+            value={PanelTabs.Settings}
+            rightSection={
+              isInterceptingNetworkRequests(settings) && (
+                <Text c="orange" fw="bold" title="Intercepting network requests">
+                  ⚠
+                </Text>
+              )
+            }
+          >
+            Settings
+          </Tabs.Tab>
+        </div>
+        <Anchor
+          className={classes.link}
+          href="https://github.com/DataDog/browser-sdk/tree/main/developer-extension#browser-sdk-developer-extension"
+          target="_blank"
         >
-          <Text>Infos</Text>
-        </Tabs.Tab>
-        <Tabs.Tab value={PanelTabs.Replay}>
-          <Text>Live replay</Text>
-        </Tabs.Tab>
-        <Tabs.Tab
-          value={PanelTabs.Settings}
-          rightSection={
-            isInterceptingNetworkRequests(settings) && (
-              <Text c="orange" fw="bold" title="Intercepting network requests">
-                ⚠
-              </Text>
-            )
-          }
-        >
-          Settings
-        </Tabs.Tab>
-        <Tabs.Tab
-          color="blue"
-          value={activeTab ?? PanelTabs.Events}
-          rightSection={
-            <Anchor
-              href="https://github.com/DataDog/browser-sdk/tree/main/developer-extension#browser-sdk-developer-extension"
-              target="_blank"
-            >
-              🔗 Docs
-            </Anchor>
-          }
-        ></Tabs.Tab>
+          🔗 Documentation
+        </Anchor>
       </Tabs.List>
+
+
+
+
       <Tabs.Panel value={PanelTabs.Events} className={classes.tab}>
         <EventsTab
           events={events}
@@ -97,7 +98,7 @@ export function Panel() {
       <Tabs.Panel value={PanelTabs.Settings} className={classes.tab}>
         <SettingsTab />
       </Tabs.Panel>
-    </Tabs>
+    </Tabs >
   )
 }
 

--- a/developer-extension/src/panel/components/panel.tsx
+++ b/developer-extension/src/panel/components/panel.tsx
@@ -75,9 +75,6 @@ export function Panel() {
         </Anchor>
       </Tabs.List>
 
-
-
-
       <Tabs.Panel value={PanelTabs.Events} className={classes.tab}>
         <EventsTab
           events={events}
@@ -98,7 +95,7 @@ export function Panel() {
       <Tabs.Panel value={PanelTabs.Settings} className={classes.tab}>
         <SettingsTab />
       </Tabs.Panel>
-    </Tabs >
+    </Tabs>
   )
 }
 


### PR DESCRIPTION
## Motivation
Help users to navigate using the extension.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Added usage tips in extension readme file and direct users to it in the extension.
<img width="647" alt="Screenshot 2024-05-24 at 13 23 27" src="https://github.com/DataDog/browser-sdk/assets/9922567/1c27dc44-4227-44d7-b30d-425577eb8de5">

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
