### PR TITLE
📝 [RUM-158] Add jscdoc to public APIs

### DIFF
--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -19,7 +19,7 @@ export interface PublicApi {
   onReady: (callback: () => void) => void
 }
 
-export function makePublicApi<T>(stub: T): T & PublicApi {
+export function makePublicApi<T extends PublicApi>(stub: Omit<T, keyof PublicApi>): T {
   const publicApi = assign(
     {
       version: __BUILD_ENV__SDK_VERSION__,
@@ -43,7 +43,7 @@ export function makePublicApi<T>(stub: T): T & PublicApi {
     enumerable: false,
   })
 
-  return publicApi
+  return publicApi as T
 }
 
 export function defineGlobal<Global, Name extends keyof Global>(global: Global, name: Name, api: Global[Name]) {

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -5,7 +5,21 @@ import { assign } from '../tools/utils/polyfills'
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
 
-export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): void; version: string } {
+export interface PublicApi {
+  /**
+   * Version of the Logs browser SDK
+   */
+  version: string
+
+  /**
+   * [For CDN async setup] Early RUM API calls must be wrapped in the `window.DD_RUM.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+   *
+   * See [CDN async setup](https://docs.datadoghq.com/real_user_monitoring/browser/#cdn-async) for further information.
+   */
+  onReady: (callback: () => void) => void
+}
+
+export function makePublicApi<T>(stub: T): T & PublicApi {
   const publicApi = assign(
     {
       version: __BUILD_ENV__SDK_VERSION__,

--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -1,7 +1,7 @@
 import type { RumEvent } from '../../../../rum-core/src'
 import { EXHAUSTIVE_INIT_CONFIGURATION, SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION } from '../../../test'
 import type { ExtractTelemetryConfiguration, MapInitConfigurationKey } from '../../../test'
-import { display } from '../../tools/display'
+import { DOCS_ORIGIN, display } from '../../tools/display'
 import {
   ExperimentalFeature,
   isExperimentalFeatureEnabled,
@@ -9,7 +9,7 @@ import {
 } from '../../tools/experimentalFeatures'
 import { TrackingConsent } from '../trackingConsent'
 import type { InitConfiguration } from './configuration'
-import { DOC_LINK, serializeConfiguration, validateAndBuildConfiguration } from './configuration'
+import { serializeConfiguration, validateAndBuildConfiguration } from './configuration'
 
 describe('validateAndBuildConfiguration', () => {
   const clientToken = 'some_client_token'
@@ -213,7 +213,9 @@ describe('validateAndBuildConfiguration', () => {
   describe('site parameter validation', () => {
     it('should validate the site parameter', () => {
       validateAndBuildConfiguration({ clientToken, site: 'foo.com' })
-      expect(displaySpy).toHaveBeenCalledOnceWith(`Site should be a valid Datadog site. Learn more here: ${DOC_LINK}.`)
+      expect(displaySpy).toHaveBeenCalledOnceWith(
+        `Site should be a valid Datadog site. Learn more here: ${DOCS_ORIGIN}/getting_started/site/.`
+      )
     })
   })
 

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -1,5 +1,5 @@
 import { catchUserErrors } from '../../tools/catchUserErrors'
-import { display } from '../../tools/display'
+import { DOCS_ORIGIN, display } from '../../tools/display'
 import type { RawTelemetryConfiguration } from '../telemetry'
 import { ExperimentalFeature, addExperimentalFeatures } from '../../tools/experimentalFeatures'
 import type { Duration } from '../../tools/utils/timeUtils'
@@ -14,7 +14,6 @@ import { TrackingConsent } from '../trackingConsent'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
 
-export const DOC_LINK = 'https://docs.datadoghq.com/getting_started/site/'
 export const DefaultPrivacyLevel = {
   ALLOW: 'allow',
   MASK: 'mask',
@@ -174,7 +173,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
   }
 
   if (initConfiguration.site && !isDatadogSite(initConfiguration.site)) {
-    display.error(`Site should be a valid Datadog site. Learn more here: ${DOC_LINK}.`)
+    display.error(`Site should be a valid Datadog site. Learn more here: ${DOCS_ORIGIN}/getting_started/site/.`)
     return
   }
 

--- a/packages/core/src/domain/configuration/tags.spec.ts
+++ b/packages/core/src/domain/configuration/tags.spec.ts
@@ -44,6 +44,8 @@ describe('buildTag', () => {
   })
 
   function expectWarning() {
-    expect(displaySpy).toHaveBeenCalledOnceWith("env value doesn't meet tag requirements and will be sanitized")
+    expect(displaySpy).toHaveBeenCalledOnceWith(
+      jasmine.stringContaining("env value doesn't meet tag requirements and will be sanitized")
+    )
   }
 })

--- a/packages/core/src/domain/configuration/tags.ts
+++ b/packages/core/src/domain/configuration/tags.ts
@@ -32,7 +32,9 @@ export function buildTag(key: string, rawValue: string) {
   const valueSizeLimit = TAG_SIZE_LIMIT - key.length - 1
 
   if (rawValue.length > valueSizeLimit || FORBIDDEN_CHARACTERS.test(rawValue)) {
-    display.warn(`${key} value doesn't meet tag requirements and will be sanitized`)
+    display.warn(
+      `${key} value doesn't meet tag requirements and will be sanitized. More details: https://docs.datadoghq.com/getting_started/tagging/#defining-tags`
+    )
   }
 
   // Let the backend do most of the sanitization, but still make sure multiple tags can't be crafted

--- a/packages/core/src/domain/configuration/tags.ts
+++ b/packages/core/src/domain/configuration/tags.ts
@@ -1,4 +1,4 @@
-import { display } from '../../tools/display'
+import { DOCS_ORIGIN, display } from '../../tools/display'
 import type { InitConfiguration } from './configuration'
 
 export const TAG_SIZE_LIMIT = 200
@@ -33,7 +33,7 @@ export function buildTag(key: string, rawValue: string) {
 
   if (rawValue.length > valueSizeLimit || FORBIDDEN_CHARACTERS.test(rawValue)) {
     display.warn(
-      `${key} value doesn't meet tag requirements and will be sanitized. More details: https://docs.datadoghq.com/getting_started/tagging/#defining-tags`
+      `${key} value doesn't meet tag requirements and will be sanitized. More details: ${DOCS_ORIGIN}/getting_started/tagging/#defining-tags`
     )
   }
 

--- a/packages/core/src/domain/context/customerDataTracker.ts
+++ b/packages/core/src/domain/context/customerDataTracker.ts
@@ -2,7 +2,7 @@ import { ONE_KIBI_BYTE, computeBytesCount } from '../../tools/utils/byteUtils'
 import { throttle } from '../../tools/utils/functionUtils'
 import type { Context } from '../../tools/serialisation/context'
 import { jsonStringify } from '../../tools/serialisation/jsonStringify'
-import { display } from '../../tools/display'
+import { DOCS_ORIGIN, display } from '../../tools/display'
 import { isEmptyObject } from '../../tools/utils/objectUtils'
 import type { CustomerDataType } from './contextConstants'
 
@@ -129,6 +129,6 @@ function displayCustomerDataLimitReachedWarning(bytesCountLimit: number) {
   display.warn(
     `Customer data exceeds the recommended ${
       bytesCountLimit / ONE_KIBI_BYTE
-    }KiB threshold. More details: https://docs.datadoghq.com/real_user_monitoring/browser/troubleshooting/#customer-data-exceeds-the-recommended-threshold-warning`
+    }KiB threshold. More details: ${DOCS_ORIGIN}/real_user_monitoring/browser/troubleshooting/#customer-data-exceeds-the-recommended-threshold-warning`
   )
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,7 @@ export {
 } from './tools/experimentalFeatures'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'
 export { computeStackTrace, StackTrace } from './tools/stackTrace/computeStackTrace'
-export { defineGlobal, makePublicApi } from './boot/init'
+export { defineGlobal, makePublicApi, PublicApi } from './boot/init'
 export { displayAlreadyInitializedError } from './boot/displayAlreadyInitializedError'
 export { initReportObservable, RawReport, RawReportType } from './domain/report/reportObservable'
 export {

--- a/packages/core/src/tools/display.ts
+++ b/packages/core/src/tools/display.ts
@@ -50,3 +50,5 @@ export const display: Display = {
   warn: originalConsoleMethods.warn.bind(globalConsole, PREFIX),
   error: originalConsoleMethods.error.bind(globalConsole, PREFIX),
 }
+
+export const DOCS_ORIGIN = 'https://docs.datadoghq.com'

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -82,7 +82,7 @@ export class Batch {
 
     if (estimatedMessageBytesCount >= this.messageBytesLimit) {
       display.warn(
-        `Discarded a message whose size was bigger than the maximum allowed size ${this.messageBytesLimit}KB.`
+        `Discarded a message whose size was bigger than the maximum allowed size ${this.messageBytesLimit}KB. More details: https://docs.datadoghq.com/real_user_monitoring/browser/troubleshooting/#technical-limitations`
       )
       return
     }

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -1,4 +1,4 @@
-import { display } from '../tools/display'
+import { DOCS_ORIGIN, display } from '../tools/display'
 import type { Context } from '../tools/serialisation/context'
 import { objectValues } from '../tools/utils/polyfills'
 import { isPageExitReason } from '../browser/pageExitObservable'
@@ -82,7 +82,7 @@ export class Batch {
 
     if (estimatedMessageBytesCount >= this.messageBytesLimit) {
       display.warn(
-        `Discarded a message whose size was bigger than the maximum allowed size ${this.messageBytesLimit}KB. More details: https://docs.datadoghq.com/real_user_monitoring/browser/troubleshooting/#technical-limitations`
+        `Discarded a message whose size was bigger than the maximum allowed size ${this.messageBytesLimit}KB. More details: ${DOCS_ORIGIN}/real_user_monitoring/browser/troubleshooting/#technical-limitations`
       )
       return
     }

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -73,6 +73,12 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
   return makePublicApi({
     logger: mainLogger,
 
+    /**
+     * Init the Logs browser SDK.
+     * @param initConfiguration Configuration options of the SDK
+     *
+     * See [Browser Log Collection](https://docs.datadoghq.com/logs/log_collection/javascript) for further information.
+     */
     init: monitor((initConfiguration: LogsInitConfiguration) => strategy.init(initConfiguration)),
 
     /**
@@ -92,16 +98,51 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
     }),
 
+    /**
+     * Get the global Context
+     *
+     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+     */
     getGlobalContext: monitor(() => globalContextManager.getContext()),
 
+    /**
+     * Set the global context information to all logs, stored in `@context`
+     *
+     * @param context Global context
+     *
+     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+     */
     setGlobalContext: monitor((context) => globalContextManager.setContext(context)),
 
+    /**
+     * Set or update a global context property, stored in `@context.<key>`
+     *
+     * @param key Key of the property
+     * @param property Value of the property
+     *
+     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+     */
     setGlobalContextProperty: monitor((key, value) => globalContextManager.setContextProperty(key, value)),
 
+    /**
+     * Remove a global context property
+     *
+     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+     */
     removeGlobalContextProperty: monitor((key) => globalContextManager.removeContextProperty(key)),
 
+    /**
+     * Clear the global context
+     *
+     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+     */
     clearGlobalContext: monitor(() => globalContextManager.clearContext()),
 
+    /**
+     * The Datadog browser logs SDK contains a default logger `DD_LOGS.logger`, but this API allows to create different ones.
+     *
+     * See [Define multiple loggers](https://docs.datadoghq.com/logs/log_collection/javascript/#define-multiple-loggers) for further information.
+     */
     createLogger: monitor((name: string, conf: LoggerConfiguration = {}) => {
       customLoggers[name] = new Logger(
         (...params) => strategy.handleLog(...params),
@@ -115,27 +156,68 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       return customLoggers[name]!
     }),
 
+    /**
+     * Get a logger
+     *
+     * See [Define multiple loggers](https://docs.datadoghq.com/logs/log_collection/javascript/#define-multiple-loggers) for further information.
+     */
     getLogger: monitor((name: string) => customLoggers[name]),
 
+    /**
+     * Get the init configuration
+     */
     getInitConfiguration: monitor(() => deepClone(strategy.initConfiguration)),
 
+    /**
+     * [Internal API] Get the internal SDK context
+     *
+     * See [Access internal context](https://docs.datadoghq.com/logs/log_collection/javascript/#access-internal-context) for further information.
+     */
     getInternalContext: monitor((startTime?: number | undefined) => strategy.getInternalContext(startTime)),
 
+    /**
+     * Set user information to all events, stored in `@usr`
+     *
+     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+     */
     setUser: monitor((newUser: User) => {
       if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
       }
     }),
 
+    /**
+     * Get user information
+     *
+     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+     */
     getUser: monitor(() => userContextManager.getContext()),
 
+    /**
+     * Set or update the user property, stored in `@usr.<key>`
+     *
+     * @param key Key of the property
+     * @param property Value of the property
+     *
+     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+     */
     setUserProperty: monitor((key, property) => {
       const sanitizedProperty = sanitizeUser({ [key]: property })[key]
       userContextManager.setContextProperty(key, sanitizedProperty)
     }),
 
+    /**
+     * Remove a user property
+     *
+     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+     */
     removeUserProperty: monitor((key) => userContextManager.removeContextProperty(key)),
 
+    /**
+     * Clear all user information
+     *
+     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+     */
     clearUser: monitor(() => userContextManager.clearContext()),
   })
 }

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -19,6 +19,7 @@ import type { LogsInitConfiguration } from '../domain/configuration'
 import type { HandlerType, StatusType } from '../domain/logger'
 import { Logger } from '../domain/logger'
 import { buildCommonContext } from '../domain/contexts/commonContext'
+import type { InternalContext } from '../domain/contexts/internalContext'
 import type { StartLogs, StartLogsResult } from './startLogs'
 import { createPreStartStrategy } from './preStartLogs'
 
@@ -28,7 +29,135 @@ export interface LoggerConfiguration {
   context?: object
 }
 
-export type LogsPublicApi = ReturnType<typeof makeLogsPublicApi>
+export interface LogsPublicApi {
+  logger: Logger
+
+  /**
+   * Init the Logs browser SDK.
+   * @param initConfiguration Configuration options of the SDK
+   *
+   * See [Browser Log Collection](https://docs.datadoghq.com/logs/log_collection/javascript) for further information.
+   */
+  init: (initConfiguration: LogsInitConfiguration) => void
+
+  /**
+   * Set the tracking consent of the current user.
+   *
+   * @param {"granted" | "not-granted"} trackingConsent The user tracking consent
+   *
+   * Logs will be sent only if it is set to "granted". This value won't be stored by the library
+   * across page loads: you will need to call this method or set the appropriate `trackingConsent`
+   * field in the init() method at each page load.
+   *
+   * If this method is called before the init() method, the provided value will take precedence
+   * over the one provided as initialization parameter.
+   */
+  setTrackingConsent: (trackingConsent: TrackingConsent) => void
+
+  /**
+   * Get the global Context
+   *
+   * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+   */
+  getGlobalContext: () => Context
+
+  /**
+   * Set the global context information to all logs, stored in `@context`
+   *
+   * @param context Global context
+   *
+   * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+   */
+  setGlobalContext: (context: any) => void
+
+  /**
+   * Set or update a global context property, stored in `@context.<key>`
+   *
+   * @param key Key of the property
+   * @param property Value of the property
+   *
+   * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+   */
+  setGlobalContextProperty: (key: any, value: any) => void
+
+  /**
+   * Remove a global context property
+   *
+   * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+   */
+  removeGlobalContextProperty: (key: any) => void
+
+  /**
+   * Clear the global context
+   *
+   * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
+   */
+  clearGlobalContext: () => void
+
+  /**
+   * The Datadog browser logs SDK contains a default logger `DD_LOGS.logger`, but this API allows to create different ones.
+   *
+   * See [Define multiple loggers](https://docs.datadoghq.com/logs/log_collection/javascript/#define-multiple-loggers) for further information.
+   */
+  createLogger: (name: string, conf?: LoggerConfiguration) => Logger
+
+  /**
+   * Get a logger
+   *
+   * See [Define multiple loggers](https://docs.datadoghq.com/logs/log_collection/javascript/#define-multiple-loggers) for further information.
+   */
+  getLogger: (name: string) => Logger | undefined
+
+  /**
+   * Get the init configuration
+   */
+  getInitConfiguration: () => LogsInitConfiguration | undefined
+
+  /**
+   * [Internal API] Get the internal SDK context
+   *
+   * See [Access internal context](https://docs.datadoghq.com/logs/log_collection/javascript/#access-internal-context) for further information.
+   */
+  getInternalContext: (startTime?: number | undefined) => InternalContext | undefined
+
+  /**
+   * Set user information to all events, stored in `@usr`
+   *
+   * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+   */
+  setUser: (newUser: User) => void
+
+  /**
+   * Get user information
+   *
+   * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+   */
+  getUser: () => Context
+
+  /**
+   * Set or update the user property, stored in `@usr.<key>`
+   *
+   * @param key Key of the property
+   * @param property Value of the property
+   *
+   * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+   */
+  setUserProperty: (key: any, property: any) => void
+
+  /**
+   * Remove a user property
+   *
+   * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+   */
+  removeUserProperty: (key: any) => void
+
+  /**
+   * Clear all user information
+   *
+   * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
+   */
+  clearUser: () => void
+}
 
 const LOGS_STORAGE_KEY = 'logs'
 
@@ -39,7 +168,7 @@ export interface Strategy {
   handleLog: StartLogsResult['handleLog']
 }
 
-export function makeLogsPublicApi(startLogsImpl: StartLogs) {
+export function makeLogsPublicApi(startLogsImpl: StartLogs): LogsPublicApi {
   const customerDataTrackerManager = createCustomerDataTrackerManager()
   const globalContextManager = createContextManager(
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.GlobalContext)
@@ -73,76 +202,23 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
   return makePublicApi({
     logger: mainLogger,
 
-    /**
-     * Init the Logs browser SDK.
-     * @param initConfiguration Configuration options of the SDK
-     *
-     * See [Browser Log Collection](https://docs.datadoghq.com/logs/log_collection/javascript) for further information.
-     */
     init: monitor((initConfiguration: LogsInitConfiguration) => strategy.init(initConfiguration)),
 
-    /**
-     * Set the tracking consent of the current user.
-     *
-     * @param {"granted" | "not-granted"} trackingConsent The user tracking consent
-     *
-     * Logs will be sent only if it is set to "granted". This value won't be stored by the library
-     * across page loads: you will need to call this method or set the appropriate `trackingConsent`
-     * field in the init() method at each page load.
-     *
-     * If this method is called before the init() method, the provided value will take precedence
-     * over the one provided as initialization parameter.
-     */
     setTrackingConsent: monitor((trackingConsent: TrackingConsent) => {
       trackingConsentState.update(trackingConsent)
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
     }),
 
-    /**
-     * Get the global Context
-     *
-     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
-     */
     getGlobalContext: monitor(() => globalContextManager.getContext()),
 
-    /**
-     * Set the global context information to all logs, stored in `@context`
-     *
-     * @param context Global context
-     *
-     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
-     */
     setGlobalContext: monitor((context) => globalContextManager.setContext(context)),
 
-    /**
-     * Set or update a global context property, stored in `@context.<key>`
-     *
-     * @param key Key of the property
-     * @param property Value of the property
-     *
-     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
-     */
     setGlobalContextProperty: monitor((key, value) => globalContextManager.setContextProperty(key, value)),
 
-    /**
-     * Remove a global context property
-     *
-     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
-     */
     removeGlobalContextProperty: monitor((key) => globalContextManager.removeContextProperty(key)),
 
-    /**
-     * Clear the global context
-     *
-     * See [Overwrite context](https://docs.datadoghq.com/logs/log_collection/javascript/#overwrite-context) for further information.
-     */
     clearGlobalContext: monitor(() => globalContextManager.clearContext()),
 
-    /**
-     * The Datadog browser logs SDK contains a default logger `DD_LOGS.logger`, but this API allows to create different ones.
-     *
-     * See [Define multiple loggers](https://docs.datadoghq.com/logs/log_collection/javascript/#define-multiple-loggers) for further information.
-     */
     createLogger: monitor((name: string, conf: LoggerConfiguration = {}) => {
       customLoggers[name] = new Logger(
         (...params) => strategy.handleLog(...params),
@@ -156,68 +232,27 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       return customLoggers[name]!
     }),
 
-    /**
-     * Get a logger
-     *
-     * See [Define multiple loggers](https://docs.datadoghq.com/logs/log_collection/javascript/#define-multiple-loggers) for further information.
-     */
     getLogger: monitor((name: string) => customLoggers[name]),
 
-    /**
-     * Get the init configuration
-     */
     getInitConfiguration: monitor(() => deepClone(strategy.initConfiguration)),
 
-    /**
-     * [Internal API] Get the internal SDK context
-     *
-     * See [Access internal context](https://docs.datadoghq.com/logs/log_collection/javascript/#access-internal-context) for further information.
-     */
     getInternalContext: monitor((startTime?: number | undefined) => strategy.getInternalContext(startTime)),
 
-    /**
-     * Set user information to all events, stored in `@usr`
-     *
-     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
-     */
     setUser: monitor((newUser: User) => {
       if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
       }
     }),
 
-    /**
-     * Get user information
-     *
-     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
-     */
     getUser: monitor(() => userContextManager.getContext()),
 
-    /**
-     * Set or update the user property, stored in `@usr.<key>`
-     *
-     * @param key Key of the property
-     * @param property Value of the property
-     *
-     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
-     */
     setUserProperty: monitor((key, property) => {
       const sanitizedProperty = sanitizeUser({ [key]: property })[key]
       userContextManager.setContextProperty(key, sanitizedProperty)
     }),
 
-    /**
-     * Remove a user property
-     *
-     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
-     */
     removeUserProperty: monitor((key) => userContextManager.removeContextProperty(key)),
 
-    /**
-     * Clear all user information
-     *
-     * See [User context](https://docs.datadoghq.com/logs/log_collection/javascript/#user-context) for further information.
-     */
     clearUser: monitor(() => userContextManager.clearContext()),
   })
 }

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -168,7 +168,7 @@ export interface Strategy {
   handleLog: StartLogsResult['handleLog']
 }
 
-export function makeLogsPublicApi(startLogsImpl: StartLogs) {
+export function makeLogsPublicApi(startLogsImpl: StartLogs): LogsPublicApi {
   const customerDataTrackerManager = createCustomerDataTrackerManager()
   const globalContextManager = createContextManager(
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.GlobalContext)
@@ -199,12 +199,12 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
     customerDataTrackerManager.createDetachedTracker()
   )
 
-  return makePublicApi({
+  return makePublicApi<LogsPublicApi>({
     logger: mainLogger,
 
-    init: monitor((initConfiguration: LogsInitConfiguration) => strategy.init(initConfiguration)),
+    init: monitor((initConfiguration) => strategy.init(initConfiguration)),
 
-    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => {
+    setTrackingConsent: monitor((trackingConsent) => {
       trackingConsentState.update(trackingConsent)
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
     }),
@@ -219,7 +219,7 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
 
     clearGlobalContext: monitor(() => globalContextManager.clearContext()),
 
-    createLogger: monitor((name: string, conf: LoggerConfiguration = {}) => {
+    createLogger: monitor((name, conf = {}) => {
       customLoggers[name] = new Logger(
         (...params) => strategy.handleLog(...params),
         customerDataTrackerManager.createDetachedTracker(),
@@ -232,13 +232,13 @@ export function makeLogsPublicApi(startLogsImpl: StartLogs) {
       return customLoggers[name]!
     }),
 
-    getLogger: monitor((name: string) => customLoggers[name]),
+    getLogger: monitor((name) => customLoggers[name]),
 
     getInitConfiguration: monitor(() => deepClone(strategy.initConfiguration)),
 
-    getInternalContext: monitor((startTime?: number | undefined) => strategy.getInternalContext(startTime)),
+    getInternalContext: monitor((startTime) => strategy.getInternalContext(startTime)),
 
-    setUser: monitor((newUser: User) => {
+    setUser: monitor((newUser) => {
       if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
       }

--- a/packages/logs/src/boot/logsPublicApi.ts
+++ b/packages/logs/src/boot/logsPublicApi.ts
@@ -1,4 +1,4 @@
-import type { Context, TrackingConsent, User } from '@datadog/browser-core'
+import type { Context, TrackingConsent, User, PublicApi } from '@datadog/browser-core'
 import {
   addTelemetryUsage,
   CustomerDataType,
@@ -29,7 +29,7 @@ export interface LoggerConfiguration {
   context?: object
 }
 
-export interface LogsPublicApi {
+export interface LogsPublicApi extends PublicApi {
   logger: Logger
 
   /**
@@ -168,7 +168,7 @@ export interface Strategy {
   handleLog: StartLogsResult['handleLog']
 }
 
-export function makeLogsPublicApi(startLogsImpl: StartLogs): LogsPublicApi {
+export function makeLogsPublicApi(startLogsImpl: StartLogs) {
   const customerDataTrackerManager = createCustomerDataTrackerManager()
   const globalContextManager = createContextManager(
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.GlobalContext)

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -40,10 +40,208 @@ import { ActionType } from '../rawRumEvent.types'
 import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
 import type { ViewOptions } from '../domain/view/trackViews'
 import { buildCommonContext } from '../domain/contexts/commonContext'
+import type { InternalContext } from '../domain/contexts/internalContext'
 import { createPreStartStrategy } from './preStartRum'
 import type { StartRum, StartRumResult } from './startRum'
 
-export type RumPublicApi = ReturnType<typeof makeRumPublicApi>
+export interface RumPublicApi {
+  /**
+   * Init the RUM browser SDK.
+   * @param initConfiguration Configuration options of the SDK
+   *
+   * See [RUM Browser Monitoring Setup](https://docs.datadoghq.com/real_user_monitoring/browser) for further information.
+   */
+  init: (initConfiguration: RumInitConfiguration) => void
+
+  /**
+   * Set the tracking consent of the current user.
+   *
+   * @param {"granted" | "not-granted"} trackingConsent The user tracking consent
+   *
+   * Data will be sent only if it is set to "granted". This value won't be stored by the library
+   * across page loads: you will need to call this method or set the appropriate `trackingConsent`
+   * field in the init() method at each page load.
+   *
+   * If this method is called before the init() method, the provided value will take precedence
+   * over the one provided as initialization parameter.
+   *
+   * See [User tracking consent](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-tracking-consent) for further information.
+   */
+  setTrackingConsent: (trackingConsent: TrackingConsent) => void
+  /**
+   * Set the global context information to all events, stored in `@context`
+   *
+   * @param context Global context
+   *
+   * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
+   */
+  setGlobalContext: (context: any) => void
+
+  /**
+   * Get the global Context
+   *
+   * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
+   */
+  getGlobalContext: () => Context
+
+  /**
+   * Set or update a global context property, stored in `@context.<key>`
+   *
+   * @param key Key of the property
+   * @param property Value of the property
+   *
+   * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
+   */
+  setGlobalContextProperty: (key: any, value: any) => void
+
+  /**
+   * Remove a global context property
+   *
+   * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
+   */
+  removeGlobalContextProperty: (key: any, value: any) => void
+
+  /**
+   * Clear the global context
+   *
+   * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
+   */
+  clearGlobalContext: () => void
+
+  /**
+   * [Internal API] Get the internal SDK context
+   */
+  getInternalContext: (startTime?: number) => InternalContext | undefined
+
+  /**
+   * Get the init configuration
+   */
+  getInitConfiguration: () => RumInitConfiguration | undefined
+
+  /**
+   * Add a custom action, stored in `@action`
+   * @param name Name of the action
+   * @param context Context of the action
+   *
+   * See [Send RUM Custom Actions](https://docs.datadoghq.com/real_user_monitoring/guide/send-rum-custom-actions) for further information.
+   */
+  addAction: (name: string, context?: object) => void
+
+  /**
+   * Add a custom error, stored in `@error`.
+   * @param error Error. Favor sending a [Javascript Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) to have a stack trace attached to the error event.
+   * @param context Context of the error
+   *
+   * See [Send RUM Custom Actions](https://docs.datadoghq.com/real_user_monitoring/guide/send-rum-custom-actions) for further information.
+   */
+  addError: (error: unknown, context?: object) => void
+
+  /**
+   * Add a custom timing relative to the start of the current view,
+   * stored in `@view.custom_timings.<timing_name>`
+   *
+   * @param name Name of the custom timing
+   * @param [time] Epoch timestamp of the custom timing (if not set, will use current time)
+   *
+   * Note: passing a relative time is discouraged since it is actually used as-is but displayed relative to the view start.
+   * We currently don't provide a way to retrieve the view start time, so it can be challenging to provide a timing relative to the view start.
+   * see https://github.com/DataDog/browser-sdk/issues/2552
+   */
+  addTiming: (name: string, time?: number) => void
+
+  /**
+   * Set user information to all events, stored in `@usr`
+   *
+   * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
+   */
+  setUser: (newUser: User) => void
+
+  /**
+   * Get user information
+   *
+   * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
+   */
+  getUser: () => Context
+
+  /**
+   * Set or update the user property, stored in `@usr.<key>`
+   *
+   * @param key Key of the property
+   * @param property Value of the property
+   *
+   * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
+   */
+  setUserProperty: (key: any, property: any) => void
+
+  /**
+   * Remove a user property
+   *
+   * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
+   */
+  removeUserProperty: (key: any) => void
+
+  /**
+   * Clear all user information
+   *
+   * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
+   */
+  clearUser: () => void
+
+  /**
+   * Start a view manually.
+   * Enable to manual start a view, use `trackViewManually: true` init parameter and call `startView()` to create RUM views and be aligned with how you’ve defined them in your SPA application routing.
+   *
+   * @param options.name name of the view
+   * @param options.service service of the view
+   * @param options.version version of the view
+   *
+   * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
+   */
+  startView: {
+    (name?: string): void
+    (options: ViewOptions): void
+  }
+
+  /**
+   * Stop the session. A new session will start at the next user interaction with the page.
+   */
+  stopSession: () => void
+
+  /**
+   * Add a feature flag evaluation,
+   * stored in `@feature_flags.<feature_flag_key>`
+   *
+   * @param {string} key The key of the feature flag.
+   * @param {any} value The value of the feature flag.
+   *
+   * We recommend enabling the intake request compression when using feature flags `compressIntakeRequests: true`.
+   *
+   * See [Feature Flag Tracking](https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/) for further information.
+   */
+  addFeatureFlagEvaluation: (key: string, value: any) => void
+
+  /**
+   * Get the Session Replay Link.
+   *
+   * See [Connect Session Replay To Your Third-Party Tools](https://docs.datadoghq.com/real_user_monitoring/guide/connect-session-replay-to-your-third-party-tools) for further information.
+   */
+  getSessionReplayLink: () => string | undefined
+
+  /**
+   * Start Session Replay recording.
+   * Enable to conditionally start the recording, use the `startSessionReplayRecordingManually:true` init parameter and call `startSessionReplayRecording()`
+   *
+   * See [Browser Session Replay](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser) for further information.
+   */
+  startSessionReplayRecording: () => void
+
+  /**
+   * Stop Session Replay recording.
+   *
+   * See [Browser Session Replay](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser) for further information.
+   */
+  stopSessionReplayRecording: () => void
+}
 
 export interface RecorderApi {
   start: () => void
@@ -90,7 +288,11 @@ export interface Strategy {
   stopDurationVital: StartRumResult['stopDurationVital']
 }
 
-export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderApi, options: RumPublicApiOptions = {}) {
+export function makeRumPublicApi(
+  startRumImpl: StartRum,
+  recorderApi: RecorderApi,
+  options: RumPublicApiOptions = {}
+): RumPublicApi {
   const customerDataTrackerManager = createCustomerDataTrackerManager(CustomerDataCompressionStatus.Unknown)
   const globalContextManager = createContextManager(
     customerDataTrackerManager.getOrCreateTracker(CustomerDataType.GlobalContext)
@@ -192,96 +394,33 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
     addTelemetryUsage({ feature: 'start-view' })
   })
   const rumPublicApi = makePublicApi({
-    /**
-     * Init the RUM browser SDK.
-     * @param initConfiguration Configuration options of the SDK
-     *
-     * See [RUM Browser Monitoring Setup](https://docs.datadoghq.com/real_user_monitoring/browser) for further information.
-     */
     init: monitor((initConfiguration: RumInitConfiguration) => strategy.init(initConfiguration)),
 
-    /**
-     * Set the tracking consent of the current user.
-     *
-     * @param {"granted" | "not-granted"} trackingConsent The user tracking consent
-     *
-     * Data will be sent only if it is set to "granted". This value won't be stored by the library
-     * across page loads: you will need to call this method or set the appropriate `trackingConsent`
-     * field in the init() method at each page load.
-     *
-     * If this method is called before the init() method, the provided value will take precedence
-     * over the one provided as initialization parameter.
-     *
-     * See [User tracking consent](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-tracking-consent) for further information.
-     */
     setTrackingConsent: monitor((trackingConsent: TrackingConsent) => {
       trackingConsentState.update(trackingConsent)
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
     }),
 
-    /**
-     * Set the global context information to all events, stored in `@context`
-     *
-     * @param context Global context
-     *
-     * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
-     */
     setGlobalContext: monitor((context) => {
       globalContextManager.setContext(context)
       addTelemetryUsage({ feature: 'set-global-context' })
     }),
 
-    /**
-     * Get the global Context
-     *
-     * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
-     */
     getGlobalContext: monitor(() => globalContextManager.getContext()),
 
-    /**
-     * Set or update a global context property, stored in `@context.<key>`
-     *
-     * @param key Key of the property
-     * @param property Value of the property
-     *
-     * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
-     */
     setGlobalContextProperty: monitor((key, value) => {
       globalContextManager.setContextProperty(key, value)
       addTelemetryUsage({ feature: 'set-global-context' })
     }),
 
-    /**
-     * Remove a global context property
-     *
-     * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
-     */
     removeGlobalContextProperty: monitor((key) => globalContextManager.removeContextProperty(key)),
 
-    /**
-     * Clear the global context
-     *
-     * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
-     */
     clearGlobalContext: monitor(() => globalContextManager.clearContext()),
 
-    /**
-     * [Internal API] Get the internal SDK context
-     */
     getInternalContext: monitor((startTime?: number) => strategy.getInternalContext(startTime)),
 
-    /**
-     * Get the init configuration
-     */
     getInitConfiguration: monitor(() => deepClone(strategy.initConfiguration)),
 
-    /**
-     * Add a custom action, stored in `@action`
-     * @param name Name of the action
-     * @param context Context of the action
-     *
-     * See [Send RUM Custom Actions](https://docs.datadoghq.com/real_user_monitoring/guide/send-rum-custom-actions) for further information.
-     */
     addAction: monitor((name: string, context?: object) => {
       strategy.addAction({
         name: sanitize(name)!,
@@ -292,13 +431,6 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
       addTelemetryUsage({ feature: 'add-action' })
     }),
 
-    /**
-     * Add a custom error, stored in `@error`.
-     * @param error Error. Favor sending a [Javascript Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) to have a stack trace attached to the error event.
-     * @param context Context of the error
-     *
-     * See [Send RUM Custom Actions](https://docs.datadoghq.com/real_user_monitoring/guide/send-rum-custom-actions) for further information.
-     */
     addError: (error: unknown, context?: object) => {
       const handlingStack = createHandlingStack()
       callMonitored(() => {
@@ -312,27 +444,11 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
       })
     },
 
-    /**
-     * Add a custom timing relative to the start of the current view,
-     * stored in `@view.custom_timings.<timing_name>`
-     *
-     * @param name Name of the custom timing
-     * @param [time] Epoch timestamp of the custom timing (if not set, will use current time)
-     *
-     * Note: passing a relative time is discouraged since it is actually used as-is but displayed relative to the view start.
-     * We currently don't provide a way to retrieve the view start time, so it can be challenging to provide a timing relative to the view start.
-     * see https://github.com/DataDog/browser-sdk/issues/2552
-     */
     addTiming: monitor((name: string, time?: number) => {
       // TODO: next major decide to drop relative time support or update its behaviour
       strategy.addTiming(sanitize(name)!, time as RelativeTime | TimeStamp | undefined)
     }),
 
-    /**
-     * Set user information to all events, stored in `@usr`
-     *
-     * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
-     */
     setUser: monitor((newUser: User) => {
       if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
@@ -340,100 +456,37 @@ export function makeRumPublicApi(startRumImpl: StartRum, recorderApi: RecorderAp
       addTelemetryUsage({ feature: 'set-user' })
     }),
 
-    /**
-     * Get user information
-     *
-     * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
-     */
     getUser: monitor(() => userContextManager.getContext()),
 
-    /**
-     * Set or update the user property, stored in `@usr.<key>`
-     *
-     * @param key Key of the property
-     * @param property Value of the property
-     *
-     * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
-     */
     setUserProperty: monitor((key, property) => {
       const sanitizedProperty = sanitizeUser({ [key]: property })[key]
       userContextManager.setContextProperty(key, sanitizedProperty)
       addTelemetryUsage({ feature: 'set-user' })
     }),
 
-    /**
-     * Remove a user property
-     *
-     * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
-     */
     removeUserProperty: monitor((key) => userContextManager.removeContextProperty(key)),
 
-    /**
-     * Clear all user information
-     *
-     * See [User session](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-session) for further information.
-     */
     clearUser: monitor(() => userContextManager.clearContext()),
 
-    /**
-     * Start a view manually.
-     * Enable to manual start a view, use `trackViewManually: true` init parameter and call `startView()` to create RUM views and be aligned with how you’ve defined them in your SPA application routing.
-     *
-     * @param options.name name of the view
-     * @param options.service service of the view
-     * @param options.version version of the view
-     *
-     * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
-     */
     startView,
 
-    /**
-     * Stop the session. A new session will start at the next user interaction with the page.
-     */
     stopSession: monitor(() => {
       strategy.stopSession()
       addTelemetryUsage({ feature: 'stop-session' })
     }),
 
-    /**
-     * Add a feature flag evaluation,
-     * stored in `@feature_flags.<feature_flag_key>`
-     *
-     * @param {string} key The key of the feature flag.
-     * @param {any} value The value of the feature flag.
-     *
-     * We recommend enabling the intake request compression when using feature flags `compressIntakeRequests: true`.
-     *
-     * See [Feature Flag Tracking](https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/) for further information.
-     */
     addFeatureFlagEvaluation: monitor((key: string, value: any) => {
       strategy.addFeatureFlagEvaluation(sanitize(key)!, sanitize(value))
       addTelemetryUsage({ feature: 'add-feature-flag-evaluation' })
     }),
 
-    /**
-     * Get the Session Replay Link.
-     *
-     * See [Connect Session Replay To Your Third-Party Tools](https://docs.datadoghq.com/real_user_monitoring/guide/connect-session-replay-to-your-third-party-tools) for further information.
-     */
     getSessionReplayLink: monitor(() => recorderApi.getSessionReplayLink()),
 
-    /**
-     * Start Session Replay recording.
-     * Enable to conditionally start the recording, use the `startSessionReplayRecordingManually:true` init parameter and call `startSessionReplayRecording()`
-     *
-     * See [Browser Session Replay](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser) for further information.
-     */
     startSessionReplayRecording: monitor(() => {
       recorderApi.start()
       addTelemetryUsage({ feature: 'start-session-replay-recording' })
     }),
 
-    /**
-     * Stop Session Replay recording.
-     *
-     * See [Browser Session Replay](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser) for further information.
-     */
     stopSessionReplayRecording: monitor(() => recorderApi.stop()),
   })
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -394,10 +394,10 @@ export function makeRumPublicApi(
     strategy.startView(sanitizedOptions)
     addTelemetryUsage({ feature: 'start-view' })
   })
-  const rumPublicApi = makePublicApi({
-    init: monitor((initConfiguration: RumInitConfiguration) => strategy.init(initConfiguration)),
+  const rumPublicApi = makePublicApi<RumPublicApi>({
+    init: monitor((initConfiguration) => strategy.init(initConfiguration)),
 
-    setTrackingConsent: monitor((trackingConsent: TrackingConsent) => {
+    setTrackingConsent: monitor((trackingConsent) => {
       trackingConsentState.update(trackingConsent)
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
     }),
@@ -418,11 +418,11 @@ export function makeRumPublicApi(
 
     clearGlobalContext: monitor(() => globalContextManager.clearContext()),
 
-    getInternalContext: monitor((startTime?: number) => strategy.getInternalContext(startTime)),
+    getInternalContext: monitor((startTime) => strategy.getInternalContext(startTime)),
 
     getInitConfiguration: monitor(() => deepClone(strategy.initConfiguration)),
 
-    addAction: monitor((name: string, context?: object) => {
+    addAction: monitor((name, context) => {
       strategy.addAction({
         name: sanitize(name)!,
         context: sanitize(context) as Context,
@@ -432,7 +432,7 @@ export function makeRumPublicApi(
       addTelemetryUsage({ feature: 'add-action' })
     }),
 
-    addError: (error: unknown, context?: object) => {
+    addError: (error, context) => {
       const handlingStack = createHandlingStack()
       callMonitored(() => {
         strategy.addError({
@@ -445,12 +445,12 @@ export function makeRumPublicApi(
       })
     },
 
-    addTiming: monitor((name: string, time?: number) => {
+    addTiming: monitor((name, time) => {
       // TODO: next major decide to drop relative time support or update its behaviour
       strategy.addTiming(sanitize(name)!, time as RelativeTime | TimeStamp | undefined)
     }),
 
-    setUser: monitor((newUser: User) => {
+    setUser: monitor((newUser) => {
       if (checkUser(newUser)) {
         userContextManager.setContext(sanitizeUser(newUser as Context))
       }
@@ -476,7 +476,7 @@ export function makeRumPublicApi(
       addTelemetryUsage({ feature: 'stop-session' })
     }),
 
-    addFeatureFlagEvaluation: monitor((key: string, value: any) => {
+    addFeatureFlagEvaluation: monitor((key, value) => {
       strategy.addFeatureFlagEvaluation(sanitize(key)!, sanitize(value))
       addTelemetryUsage({ feature: 'add-feature-flag-evaluation' })
     }),

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -7,6 +7,7 @@ import type {
   DeflateEncoderStreamId,
   DeflateEncoder,
   TrackingConsent,
+  PublicApi,
 } from '@datadog/browser-core'
 import {
   addTelemetryUsage,
@@ -44,7 +45,7 @@ import type { InternalContext } from '../domain/contexts/internalContext'
 import { createPreStartStrategy } from './preStartRum'
 import type { StartRum, StartRumResult } from './startRum'
 
-export interface RumPublicApi {
+export interface RumPublicApi extends PublicApi {
   /**
    * Init the RUM browser SDK.
    * @param initConfiguration Configuration options of the SDK
@@ -99,7 +100,7 @@ export interface RumPublicApi {
    *
    * See [Global context](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#global-context) for further information.
    */
-  removeGlobalContextProperty: (key: any, value: any) => void
+  removeGlobalContextProperty: (key: any) => void
 
   /**
    * Clear the global context

--- a/packages/rum/src/domain/deflate/deflateWorker.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.ts
@@ -1,5 +1,13 @@
 import type { DeflateWorker, DeflateWorkerResponse } from '@datadog/browser-core'
-import { addTelemetryError, display, includes, addEventListener, setTimeout, ONE_SECOND } from '@datadog/browser-core'
+import {
+  addTelemetryError,
+  display,
+  includes,
+  addEventListener,
+  setTimeout,
+  ONE_SECOND,
+  DOCS_ORIGIN,
+} from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 
 export const INITIALIZATION_TIME_OUT_DELAY = 10 * ONE_SECOND
@@ -146,7 +154,7 @@ function onError(configuration: RumConfiguration, source: string, error: unknown
         baseMessage = 'Please make sure CSP is correctly configured.'
       }
       display.error(
-        `${baseMessage} See documentation at https://docs.datadoghq.com/integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay`
+        `${baseMessage} See documentation at ${DOCS_ORIGIN}/integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay`
       )
     } else {
       addTelemetryError(error)


### PR DESCRIPTION
## Motivation

JSDoc annotations are visible through the IDE, providing developers with immediate and comprehensive documentation as they integrate with our SDK.

## Changes

- Document all public APIs
- Add links to the public doc in browser SDK warnings when useful
 
## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
