### PR TITLE
✅ fix clearing cookies between tests

### DIFF
--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -9,10 +9,13 @@ beforeEach(() => {
   // prevent 'Some of your tests did a full page reload!' issue
   window.onbeforeunload = () => 'stop'
   startLeakDetection()
+  // Note: clearing cookies should be done in `beforeEach` rather than `afterEach`, because in some
+  // cases the test patches the `document.cookie` getter (ex: `spyOnProperty(document, 'cookie',
+  // 'get')`), which would prevent the `clearAllCookies` function from working properly.
+  clearAllCookies()
 })
 
 afterEach(() => {
-  clearAllCookies()
   stopLeakDetection()
 })
 


### PR DESCRIPTION
## Motivation

Unit tests were failing because the cookies were not correctly cleared prior to some tests (see https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/518528355)

## Changes

Clear cookies *before* tests rather than after.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
