### PR TITLE
🐛 [RUM-4629] accept `null` as env/version/service

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -218,21 +218,27 @@ describe('validateAndBuildConfiguration', () => {
   })
 
   describe('env parameter validation', () => {
-    it('should not validate the env parameter', () => {
+    it('should validate the env parameter', () => {
       validateAndBuildConfiguration({ clientToken, env: false as any })
       expect(displaySpy).toHaveBeenCalledOnceWith('Env must be defined as a string')
     })
   })
 
   describe('service parameter validation', () => {
-    it('should not validate the service parameter', () => {
+    it('should validate the service parameter', () => {
       validateAndBuildConfiguration({ clientToken, service: 1 as any })
       expect(displaySpy).toHaveBeenCalledOnceWith('Service must be defined as a string')
+    })
+
+    it('should not reject null', () => {
+      const configuration = validateAndBuildConfiguration({ clientToken, service: null })
+      expect(displaySpy).not.toHaveBeenCalled()
+      expect(configuration!.service).toBeUndefined()
     })
   })
 
   describe('version parameter validation', () => {
-    it('should not validate the version parameter', () => {
+    it('should validate the version parameter', () => {
       validateAndBuildConfiguration({ clientToken, version: 0 as any })
       expect(displaySpy).toHaveBeenCalledOnceWith('Version must be defined as a string')
     })

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -46,9 +46,9 @@ export interface InitConfiguration {
   site?: string | undefined
 
   // tag and context options
-  service?: string | undefined
-  env?: string | undefined
-  version?: string | undefined
+  service?: string | undefined | null
+  env?: string | undefined | null
+  version?: string | undefined | null
 
   // cookie options
   /**
@@ -109,8 +109,8 @@ export interface Configuration extends TransportConfiguration {
   messageBytesLimit: number
 }
 
-function checkIfString(tag: unknown, tagName: string) {
-  if (tag !== undefined && typeof tag !== 'string') {
+function checkIfString(tag: unknown, tagName: string): tag is string | undefined | null {
+  if (tag !== undefined && tag !== null && typeof tag !== 'string') {
     display.error(`${tagName} must be defined as a string`)
     return false
   }
@@ -196,7 +196,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       telemetrySampleRate: initConfiguration.telemetrySampleRate ?? 20,
       telemetryConfigurationSampleRate: initConfiguration.telemetryConfigurationSampleRate ?? 5,
       telemetryUsageSampleRate: initConfiguration.telemetryUsageSampleRate ?? 5,
-      service: initConfiguration.service,
+      service: initConfiguration.service || undefined,
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
       allowUntrustedEvents: !!initConfiguration.allowUntrustedEvents,
       trackingConsent: initConfiguration.trackingConsent ?? TrackingConsent.GRANTED,

--- a/packages/rum-core/src/domain/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration.spec.ts
@@ -414,6 +414,14 @@ describe('validateAndBuildRumConfiguration', () => {
       ).toBe('https://example.org/worker.js')
     })
   })
+
+  describe('version parameter validation', () => {
+    it('should not reject null', () => {
+      const configuration = validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, version: null })
+      expect(displayErrorSpy).not.toHaveBeenCalled()
+      expect(configuration!.version).toBeUndefined()
+    })
+  })
 })
 
 describe('serializeRumConfiguration', () => {

--- a/packages/rum-core/src/domain/configuration.ts
+++ b/packages/rum-core/src/domain/configuration.ts
@@ -112,7 +112,7 @@ export function validateAndBuildRumConfiguration(
   return assign(
     {
       applicationId: initConfiguration.applicationId,
-      version: initConfiguration.version,
+      version: initConfiguration.version || undefined,
       actionNameAttribute: initConfiguration.actionNameAttribute,
       sessionReplaySampleRate: initConfiguration.sessionReplaySampleRate ?? 0,
       startSessionReplayRecordingManually: !!initConfiguration.startSessionReplayRecordingManually,


### PR DESCRIPTION
## Motivation

Some customer pass `null` as version. Now that we validate that parameter, the initialization fails.

See https://github.com/DataDog/dd-sdk-flutter/issues/616
Regression caused by https://github.com/DataDog/browser-sdk/pull/2744

## Changes

Do not reject `null` for tags.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
