### PR TITLE
🐛 [RUM-98] Warn when SDK is loaded multiple times

### DIFF
--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -35,8 +35,8 @@ export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): 
 
 export function defineGlobal<Global, Name extends keyof Global>(global: Global, name: Name, api: Global[Name]) {
   const existingGlobalVariable = global[name] as { q?: Array<() => void>; version?: string } | undefined
-  if (global[name] && existingGlobalVariable && !existingGlobalVariable.q && existingGlobalVariable.version) {
-    display.warn('SDK is loaded more than once')
+  if (existingGlobalVariable && !existingGlobalVariable.q && existingGlobalVariable.version) {
+    display.warn('SDK is loaded more than once. This is unsupported and might have unexpected behavior.')
   }
   global[name] = api
   if (existingGlobalVariable && existingGlobalVariable.q) {

--- a/packages/core/src/boot/init.ts
+++ b/packages/core/src/boot/init.ts
@@ -1,6 +1,7 @@
 import { catchUserErrors } from '../tools/catchUserErrors'
 import { setDebugMode } from '../tools/monitor'
 import { assign } from '../tools/utils/polyfills'
+import { display } from '../tools/display'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
@@ -33,7 +34,10 @@ export function makePublicApi<T>(stub: T): T & { onReady(callback: () => void): 
 }
 
 export function defineGlobal<Global, Name extends keyof Global>(global: Global, name: Name, api: Global[Name]) {
-  const existingGlobalVariable = global[name] as { q?: Array<() => void> } | undefined
+  const existingGlobalVariable = global[name] as { q?: Array<() => void>; version?: string } | undefined
+  if (global[name] && existingGlobalVariable && !existingGlobalVariable.q && existingGlobalVariable.version) {
+    display.warn('SDK is loaded more than once')
+  }
   global[name] = api
   if (existingGlobalVariable && existingGlobalVariable.q) {
     existingGlobalVariable.q.forEach((fn) => catchUserErrors(fn, 'onReady callback threw an error:')())


### PR DESCRIPTION
## Motivation

We should warn when the SDK is loaded multiple times as it can lead to unexpected behaviour. 

## Changes

As we don't want a breaking change for now, we can just send a warning if the sdk is already loaded in the define global function.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
