### PR TITLE
[RUM-4652] Update url after playground changes

### DIFF
--- a/scripts/performance/cpu-performance/compute-cpu-performance.js
+++ b/scripts/performance/cpu-performance/compute-cpu-performance.js
@@ -22,7 +22,7 @@ async function triggerSyntheticsTest(prNumber, commitId) {
     tests: [
       {
         public_id: `${TEST_PUBLIC_ID}`,
-        startUrl: `https://datadoghq.dev/browser-sdk-test-playground/performance/?prNumber=${prNumber}&commitId=${commitId}`,
+        startUrl: `https://datadoghq.dev/browser-sdk-test-playground/performance/cpu/?prNumber=${prNumber}&commitId=${commitId}`,
       },
     ],
   }

--- a/scripts/performance/cpu-performance/compute-cpu-performance.js
+++ b/scripts/performance/cpu-performance/compute-cpu-performance.js
@@ -22,7 +22,7 @@ async function triggerSyntheticsTest(prNumber, commitId) {
     tests: [
       {
         public_id: `${TEST_PUBLIC_ID}`,
-        startUrl: `https://datadoghq.dev/browser-sdk-test-playground/performance/cpu/?prNumber=${prNumber}&commitId=${commitId}`,
+        startUrl: `https://datadoghq.dev/browser-sdk-test-playground/performance/cpu?prNumber=${prNumber}&commitId=${commitId}`,
       },
     ],
   }

--- a/scripts/performance/memory-performance/compute-memory-performance.js
+++ b/scripts/performance/memory-performance/compute-memory-performance.js
@@ -1,8 +1,6 @@
 const puppeteer = require('puppeteer')
-const { timeout } = require('../../lib/execution-utils')
 const { fetchPR, LOCAL_BRANCH } = require('../../lib/git-utils')
 const NUMBER_OF_RUNS = 30 // Rule of thumb: this should be enough to get a good average
-const TEST_DURATION = 1000 // Duration of the test in the micro-benchmark
 const TESTS = [
   {
     name: 'RUM - add global context',
@@ -45,8 +43,8 @@ async function computeMemoryPerformance() {
   const results = []
   const pr = await fetchPR(LOCAL_BRANCH)
   const benchmarkUrl = pr
-    ? `https://datadoghq.dev/browser-sdk-test-playground/performance/?prNumber=${pr.number}`
-    : 'https://datadoghq.dev/browser-sdk-test-playground/performance/'
+    ? `https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${pr.number}`
+    : 'https://datadoghq.dev/browser-sdk-test-playground/performance/memory'
   for (const test of TESTS) {
     const testName = test.name
     const testButton = test.button
@@ -92,7 +90,6 @@ async function runTest(testButton, benchmarkUrl) {
 
   console.log(`Running test for: ${testButton}`)
   await button.click()
-  await timeout(TEST_DURATION)
   const { profile } = await client.send('HeapProfiler.stopSampling')
   const measurementsPercentage = []
   const measurementsBytes = []


### PR DESCRIPTION
## Motivation

I added a new page on the sdk playground for the memory as it was linked to the cpu benchmark previously. We need to modify the url in the performance test to match with the new one

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
