### PR TITLE
♻️ Sends the conf telemetry from preStartRum

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -96,6 +96,7 @@ export interface Configuration extends TransportConfiguration {
   silentMultipleInit: boolean
   allowUntrustedEvents: boolean
   trackingConsent: TrackingConsent
+  storeContextsAcrossPages: boolean
 
   // Event limits
   eventRateLimiterThreshold: number // Limit the maximum number of actions, errors and logs per minutes
@@ -199,7 +200,7 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
       silentMultipleInit: !!initConfiguration.silentMultipleInit,
       allowUntrustedEvents: !!initConfiguration.allowUntrustedEvents,
       trackingConsent: initConfiguration.trackingConsent ?? TrackingConsent.GRANTED,
-
+      storeContextsAcrossPages: !!initConfiguration.storeContextsAcrossPages,
       /**
        * beacon payload max queue size implementation is 64kb
        * ensure that we leave room for logs, rum and potential other users

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -34,7 +34,6 @@ const FAKE_WORKER = {} as DeflateWorker
 describe('preStartRum', () => {
   let doStartRumSpy: jasmine.Spy<
     (
-      initConfiguration: RumInitConfiguration,
       configuration: RumConfiguration,
       deflateWorker: DeflateWorker | undefined,
       initialViewOptions?: ViewOptions
@@ -220,7 +219,7 @@ describe('preStartRum', () => {
           strategy.init(DEFAULT_INIT_CONFIGURATION)
 
           expect(startDeflateWorkerSpy).not.toHaveBeenCalled()
-          const worker: DeflateWorker | undefined = doStartRumSpy.calls.mostRecent().args[2]
+          const worker: DeflateWorker | undefined = doStartRumSpy.calls.mostRecent().args[1]
           expect(worker).toBeUndefined()
         })
       })
@@ -233,7 +232,7 @@ describe('preStartRum', () => {
           })
 
           expect(startDeflateWorkerSpy).toHaveBeenCalledTimes(1)
-          const worker: DeflateWorker | undefined = doStartRumSpy.calls.mostRecent().args[2]
+          const worker: DeflateWorker | undefined = doStartRumSpy.calls.mostRecent().args[1]
           expect(worker).toBeDefined()
         })
 
@@ -325,7 +324,7 @@ describe('preStartRum', () => {
 
           strategy.init(MANUAL_CONFIGURATION)
           expect(doStartRumSpy).toHaveBeenCalled()
-          const initialViewOptions: ViewOptions | undefined = doStartRumSpy.calls.argsFor(0)[3]
+          const initialViewOptions: ViewOptions | undefined = doStartRumSpy.calls.argsFor(0)[2]
           expect(initialViewOptions).toEqual({ name: 'foo' })
           expect(startViewSpy).not.toHaveBeenCalled()
         })
@@ -352,7 +351,7 @@ describe('preStartRum', () => {
           strategy.init(MANUAL_CONFIGURATION)
 
           expect(doStartRumSpy).toHaveBeenCalled()
-          const initialViewOptions: ViewOptions | undefined = doStartRumSpy.calls.argsFor(0)[3]
+          const initialViewOptions: ViewOptions | undefined = doStartRumSpy.calls.argsFor(0)[2]
           expect(initialViewOptions).toEqual({ name: 'foo' })
           expect(startViewSpy).toHaveBeenCalledOnceWith({ name: 'bar' }, relativeToClocks(20 as RelativeTime))
         })
@@ -364,7 +363,7 @@ describe('preStartRum', () => {
 
           strategy.startView({ name: 'foo' })
           expect(doStartRumSpy).toHaveBeenCalled()
-          const initialViewOptions: ViewOptions | undefined = doStartRumSpy.calls.argsFor(0)[3]
+          const initialViewOptions: ViewOptions | undefined = doStartRumSpy.calls.argsFor(0)[2]
           expect(initialViewOptions).toEqual({ name: 'foo' })
           expect(startViewSpy).not.toHaveBeenCalled()
         })

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -9,6 +9,7 @@ import {
   clocksNow,
   assign,
   getEventBridge,
+  addTelemetryConfiguration,
 } from '@datadog/browser-core'
 import type { TrackingConsentState, DeflateWorker } from '@datadog/browser-core'
 import {
@@ -18,6 +19,7 @@ import {
 } from '../domain/configuration'
 import type { CommonContext } from '../domain/contexts/commonContext'
 import type { ViewOptions } from '../domain/view/trackViews'
+import { serializeRumConfiguration } from '../domain/configuration'
 import type { RumPublicApiOptions, Strategy } from './rumPublicApi'
 import type { StartRumResult } from './startRum'
 
@@ -26,7 +28,6 @@ export function createPreStartStrategy(
   getCommonContext: () => CommonContext,
   trackingConsentState: TrackingConsentState,
   doStartRum: (
-    initConfiguration: RumInitConfiguration,
     configuration: RumConfiguration,
     deflateWorker: DeflateWorker | undefined,
     initialViewOptions?: ViewOptions
@@ -66,7 +67,7 @@ export function createPreStartStrategy(
       initialViewOptions = firstStartViewCall.options
     }
 
-    const startRumResult = doStartRum(cachedInitConfiguration, cachedConfiguration, deflateWorker, initialViewOptions)
+    const startRumResult = doStartRum(cachedConfiguration, deflateWorker, initialViewOptions)
 
     bufferApiCalls.drain(startRumResult)
   }
@@ -85,6 +86,7 @@ export function createPreStartStrategy(
 
       // Expose the initial configuration regardless of initialization success.
       cachedInitConfiguration = initConfiguration
+      addTelemetryConfiguration(serializeRumConfiguration(initConfiguration))
 
       if (cachedConfiguration) {
         displayAlreadyInitializedError('DD_RUM', initConfiguration)

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -88,7 +88,7 @@ describe('rum public api', () => {
           compressIntakeRequests: false,
         })
 
-        const customerDataTrackerManager: CustomerDataTrackerManager = startRumSpy.calls.mostRecent().args[3]
+        const customerDataTrackerManager: CustomerDataTrackerManager = startRumSpy.calls.mostRecent().args[2]
         expect(customerDataTrackerManager.getCompressionStatus()).toBe(CustomerDataCompressionStatus.Disabled)
       })
 
@@ -102,7 +102,7 @@ describe('rum public api', () => {
           compressIntakeRequests: true,
         })
 
-        const customerDataTrackerManager: CustomerDataTrackerManager = startRumSpy.calls.mostRecent().args[3]
+        const customerDataTrackerManager: CustomerDataTrackerManager = startRumSpy.calls.mostRecent().args[2]
         expect(customerDataTrackerManager.getCompressionStatus()).toBe(CustomerDataCompressionStatus.Enabled)
       })
     })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -382,7 +382,7 @@ export function makeRumPublicApi(
         deflateWorker
       )
 
-      strategy = createPostStartStrategy(strategy.initConfiguration!, startRumResult)
+      strategy = createPostStartStrategy(strategy, startRumResult)
 
       return startRumResult
     }
@@ -500,13 +500,13 @@ export function makeRumPublicApi(
   return rumPublicApi
 }
 
-function createPostStartStrategy(initConfiguration: RumInitConfiguration, startRumResult: StartRumResult): Strategy {
+function createPostStartStrategy(preStartStrategy: Strategy, startRumResult: StartRumResult): Strategy {
   return assign(
     {
       init: (initConfiguration: RumInitConfiguration) => {
         displayAlreadyInitializedError('DD_RUM', initConfiguration)
       },
-      initConfiguration,
+      initConfiguration: preStartStrategy.initConfiguration,
     },
     startRumResult
   )

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -313,7 +313,7 @@ export function makeRumPublicApi(
     getCommonContext,
     trackingConsentState,
 
-    (initConfiguration, configuration, deflateWorker, initialViewOptions) => {
+    (configuration, deflateWorker, initialViewOptions) => {
       if (isExperimentalFeatureEnabled(ExperimentalFeature.CUSTOM_VITALS)) {
         /**
          * Start a custom duration vital
@@ -353,7 +353,7 @@ export function makeRumPublicApi(
         )
       }
 
-      if (initConfiguration.storeContextsAcrossPages) {
+      if (configuration.storeContextsAcrossPages) {
         storeContextManager(configuration, globalContextManager, RUM_STORAGE_KEY, CustomerDataType.GlobalContext)
         storeContextManager(configuration, userContextManager, RUM_STORAGE_KEY, CustomerDataType.User)
       }
@@ -363,7 +363,6 @@ export function makeRumPublicApi(
       )
 
       const startRumResult = startRumImpl(
-        initConfiguration,
         configuration,
         recorderApi,
         customerDataTrackerManager,
@@ -383,7 +382,7 @@ export function makeRumPublicApi(
         deflateWorker
       )
 
-      strategy = createPostStartStrategy(initConfiguration, startRumResult)
+      strategy = createPostStartStrategy(strategy.initConfiguration!, startRumResult)
 
       return startRumResult
     }

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -24,7 +24,7 @@ import type { RumEvent, RumViewEvent } from '../rumEvent.types'
 import type { LocationChange } from '../browser/locationChangeObservable'
 import { startLongTaskCollection } from '../domain/longTask/longTaskCollection'
 import type { RumSessionManager } from '..'
-import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
+import type { RumConfiguration } from '../domain/configuration'
 import { RumEventType } from '../rawRumEvent.types'
 import { startFeatureFlagContexts } from '../domain/contexts/featureFlagContext'
 import type { PageStateHistory } from '../domain/contexts/pageStateHistory'
@@ -313,7 +313,6 @@ describe('view events', () => {
   beforeEach(() => {
     setupBuilder = setup().beforeBuild(({ configuration, customerDataTrackerManager }) =>
       startRum(
-        {} as RumInitConfiguration,
         configuration,
         noopRecorderApi,
         customerDataTrackerManager,

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -11,7 +11,6 @@ import {
   sendToExtension,
   createPageExitObservable,
   TelemetryService,
-  addTelemetryConfiguration,
   startTelemetry,
   canUseEventBridge,
   getEventBridge,
@@ -38,8 +37,7 @@ import { startRumEventBridge } from '../transport/startRumEventBridge'
 import { startUrlContexts } from '../domain/contexts/urlContexts'
 import type { LocationChange } from '../browser/locationChangeObservable'
 import { createLocationChangeObservable } from '../browser/locationChangeObservable'
-import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
-import { serializeRumConfiguration } from '../domain/configuration'
+import type { RumConfiguration } from '../domain/configuration'
 import type { ViewOptions } from '../domain/view/trackViews'
 import { startFeatureFlagContexts } from '../domain/contexts/featureFlagContext'
 import { startCustomerDataTelemetry } from '../domain/startCustomerDataTelemetry'
@@ -54,7 +52,6 @@ export type StartRum = typeof startRum
 export type StartRumResult = ReturnType<StartRum>
 
 export function startRum(
-  initConfiguration: RumInitConfiguration,
   configuration: RumConfiguration,
   recorderApi: RecorderApi,
   customerDataTrackerManager: CustomerDataTrackerManager,
@@ -145,7 +142,6 @@ export function startRum(
   cleanupTasks.push(stopRumEventCollection)
 
   drainPreStartTelemetry()
-  addTelemetryConfiguration(serializeRumConfiguration(initConfiguration))
 
   startLongTaskCollection(lifeCycle, configuration)
   startResourceCollection(lifeCycle, configuration, pageStateHistory)


### PR DESCRIPTION
## Motivation

Now that we collect pre start telemetry (cf [PR](https://github.com/DataDog/browser-sdk/pull/2755)) we can move configuration sending to `preStartRum`. This avoid passing the `initConfiguration` down to [startRum](https://github.com/DataDog/browser-sdk/blob/94d4fbc152286d7dbdc4938bde9e83d3bb2e8dac/packages/rum-core/src/boot/startRum.ts#L54).

## Changes

Sends configuration telemetry from preStartRum

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
