### PR TITLE
♻️ Set the experimental feature flags as early as possible

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -35,11 +35,6 @@ describe('validateAndBuildConfiguration', () => {
       delete (ExperimentalFeature as any).FOO
     })
 
-    it('updates experimental feature flags', () => {
-      validateAndBuildConfiguration({ clientToken, enableExperimentalFeatures: ['foo'] })
-      expect(isExperimentalFeatureEnabled(TEST_FEATURE_FLAG)).toBeTrue()
-    })
-
     it('ignores unknown experimental features', () => {
       validateAndBuildConfiguration({
         clientToken,

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -1,7 +1,6 @@
 import { catchUserErrors } from '../../tools/catchUserErrors'
 import { DOCS_ORIGIN, display } from '../../tools/display'
 import type { RawTelemetryConfiguration } from '../telemetry'
-import { ExperimentalFeature, addExperimentalFeatures } from '../../tools/experimentalFeatures'
 import type { Duration } from '../../tools/utils/timeUtils'
 import { ONE_SECOND } from '../../tools/utils/timeUtils'
 import { isPercentage } from '../../tools/utils/numberUtils'
@@ -175,15 +174,6 @@ export function validateAndBuildConfiguration(initConfiguration: InitConfigurati
   if (initConfiguration.site && !isDatadogSite(initConfiguration.site)) {
     display.error(`Site should be a valid Datadog site. Learn more here: ${DOCS_ORIGIN}/getting_started/site/.`)
     return
-  }
-
-  // Set the experimental feature flags as early as possible, so we can use them in most places
-  if (Array.isArray(initConfiguration.enableExperimentalFeatures)) {
-    addExperimentalFeatures(
-      initConfiguration.enableExperimentalFeatures.filter((flag): flag is ExperimentalFeature =>
-        objectHasValue(ExperimentalFeature, flag)
-      )
-    )
   }
 
   return assign(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   addExperimentalFeatures,
   resetExperimentalFeatures,
   getExperimentalFeatures,
+  initFeatureFlags,
   ExperimentalFeature,
 } from './tools/experimentalFeatures'
 export { trackRuntimeError } from './domain/error/trackRuntimeError'

--- a/packages/core/src/tools/experimentalFeatures.spec.ts
+++ b/packages/core/src/tools/experimentalFeatures.spec.ts
@@ -1,6 +1,7 @@
-import type { ExperimentalFeature } from './experimentalFeatures'
 import {
+  ExperimentalFeature,
   addExperimentalFeatures,
+  initFeatureFlags,
   isExperimentalFeatureEnabled,
   resetExperimentalFeatures,
 } from './experimentalFeatures'
@@ -30,5 +31,29 @@ describe('experimentalFeatures', () => {
 
     expect(isExperimentalFeatureEnabled(TEST_FEATURE_FLAG_ONE)).toBeTrue()
     expect(isExperimentalFeatureEnabled(TEST_FEATURE_FLAG_TWO)).toBeTrue()
+  })
+})
+
+describe('initFeatureFlags', () => {
+  beforeEach(() => {
+    ;(ExperimentalFeature as any).FOO = TEST_FEATURE_FLAG_ONE
+  })
+
+  afterEach(() => {
+    delete (ExperimentalFeature as any).FOO
+  })
+
+  it('ignores unknown experimental features', () => {
+    initFeatureFlags(['bar', undefined as any, null as any, 11 as any])
+
+    expect(isExperimentalFeatureEnabled('bar' as any)).toBeFalse()
+    expect(isExperimentalFeatureEnabled(undefined as any)).toBeFalse()
+    expect(isExperimentalFeatureEnabled(null as any)).toBeFalse()
+    expect(isExperimentalFeatureEnabled(11 as any)).toBeFalse()
+  })
+
+  it('updates experimental feature flags', () => {
+    initFeatureFlags(['foo'])
+    expect(isExperimentalFeatureEnabled(TEST_FEATURE_FLAG_ONE)).toBeTrue()
   })
 })

--- a/packages/core/src/tools/experimentalFeatures.spec.ts
+++ b/packages/core/src/tools/experimentalFeatures.spec.ts
@@ -41,6 +41,7 @@ describe('initFeatureFlags', () => {
 
   afterEach(() => {
     delete (ExperimentalFeature as any).FOO
+    resetExperimentalFeatures()
   })
 
   it('ignores unknown experimental features', () => {

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -9,6 +9,9 @@
  */
 // We want to use a real enum (i.e. not a const enum) here, to be able to check whether an arbitrary
 // string is an expected feature flag
+
+import { objectHasValue } from './utils/objectUtils'
+
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
@@ -18,6 +21,16 @@ export enum ExperimentalFeature {
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()
+
+export function initFeatureFlags(enableExperimentalFeatures?: string[] | undefined) {
+  if (Array.isArray(enableExperimentalFeatures)) {
+    addExperimentalFeatures(
+      enableExperimentalFeatures.filter((flag): flag is ExperimentalFeature =>
+        objectHasValue(ExperimentalFeature, flag)
+      )
+    )
+  }
+}
 
 export function addExperimentalFeatures(enabledFeatures: ExperimentalFeature[]): void {
   enabledFeatures.forEach((flag) => {

--- a/packages/logs/src/boot/preStartLogs.ts
+++ b/packages/logs/src/boot/preStartLogs.ts
@@ -5,6 +5,7 @@ import {
   canUseEventBridge,
   display,
   displayAlreadyInitializedError,
+  initFeatureFlags,
   noop,
   timeStampNow,
 } from '@datadog/browser-core'
@@ -44,6 +45,8 @@ export function createPreStartStrategy(
         display.error('Missing configuration')
         return
       }
+      // Set the experimental feature flags as early as possible, so we can use them in most places
+      initFeatureFlags(initConfiguration.enableExperimentalFeatures)
 
       if (canUseEventBridge()) {
         initConfiguration = overrideInitConfigurationForBridge(initConfiguration)

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -9,6 +9,7 @@ import {
   clocksNow,
   assign,
   getEventBridge,
+  initFeatureFlags,
 } from '@datadog/browser-core'
 import type { TrackingConsentState, DeflateWorker } from '@datadog/browser-core'
 import {
@@ -77,6 +78,9 @@ export function createPreStartStrategy(
         display.error('Missing configuration')
         return
       }
+
+      // Set the experimental feature flags as early as possible, so we can use them in most places
+      initFeatureFlags(initConfiguration.enableExperimentalFeatures)
 
       const eventBridgeAvailable = canUseEventBridge()
       if (eventBridgeAvailable) {


### PR DESCRIPTION
## Motivation

Being able to use experimental features early in the SDK lifecycle

## Changes

Initialize the experimental feature in the `preStartRum` instead of waiting the `startRum`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
