### PR TITLE
[RUM-4895] Add link to playground with pr's bundle

### DIFF
--- a/scripts/performance/memory-performance/compute-memory-performance.js
+++ b/scripts/performance/memory-performance/compute-memory-performance.js
@@ -1,6 +1,6 @@
 const puppeteer = require('puppeteer')
 const { fetchPR, LOCAL_BRANCH } = require('../../lib/git-utils')
-const NUMBER_OF_RUNS = 40 // Rule of thumb: this should be enough to get a good average
+const NUMBER_OF_RUNS = 1 // Rule of thumb: this should be enough to get a good average
 const TESTS = [
   {
     name: 'RUM - add global context',

--- a/scripts/performance/memory-performance/compute-memory-performance.js
+++ b/scripts/performance/memory-performance/compute-memory-performance.js
@@ -1,6 +1,6 @@
 const puppeteer = require('puppeteer')
 const { fetchPR, LOCAL_BRANCH } = require('../../lib/git-utils')
-const NUMBER_OF_RUNS = 1 // Rule of thumb: this should be enough to get a good average
+const NUMBER_OF_RUNS = 40 // Rule of thumb: this should be enough to get a good average
 const TESTS = [
   {
     name: 'RUM - add global context',

--- a/scripts/performance/report-as-a-pr-comment.js
+++ b/scripts/performance/report-as-a-pr-comment.js
@@ -113,9 +113,6 @@ function createMessage(
   cpuLocalPerformance,
   prNumber
 ) {
-  let message = `<div style="background-color: #FF9800; padding: 10px; margin-bottom: 10px;">
-  🔗 <a href="https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${prNumber}">Playground</a>
-</div>\n\n`
   let highIncreaseDetected = false
   const bundleRows = differenceBundle.map((diff, index) => {
     const baseSize = formatSize(baseBundleSizes[index].value)
@@ -130,7 +127,7 @@ function createMessage(
     return [formatBundleName(diff.name), baseSize, localSize, diffSize, `${sign}${diff.percentageChange}%`, status]
   })
 
-  message += markdownArray({
+  let message = markdownArray({
     headers: ['📦 Bundle Name', 'Base Size', 'Local Size', '𝚫', '𝚫%', 'Status'],
     rows: bundleRows,
   })
@@ -179,9 +176,7 @@ function createMessage(
   })
   message += '\n</details>\n\n'
 
-  message += '<details>\n<summary>ℹ️ Useful Testing Links</summary>\n\n'
-  message += `- [Playground with PR Bundle](https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${prNumber})\n`
-  message += '\n</details>\n\n'
+  message += `🔗 [Playground](https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${prNumber})\n\n`
 
   return message
 }

--- a/scripts/performance/report-as-a-pr-comment.js
+++ b/scripts/performance/report-as-a-pr-comment.js
@@ -113,6 +113,9 @@ function createMessage(
   cpuLocalPerformance,
   prNumber
 ) {
+  let message = `<div style="background-color: #FF9800; padding: 10px; margin-bottom: 10px;">
+  🔗 <a href="https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${prNumber}">Playground</a>
+</div>\n\n`
   let highIncreaseDetected = false
   const bundleRows = differenceBundle.map((diff, index) => {
     const baseSize = formatSize(baseBundleSizes[index].value)
@@ -127,7 +130,7 @@ function createMessage(
     return [formatBundleName(diff.name), baseSize, localSize, diffSize, `${sign}${diff.percentageChange}%`, status]
   })
 
-  let message = markdownArray({
+  message += markdownArray({
     headers: ['📦 Bundle Name', 'Base Size', 'Local Size', '𝚫', '𝚫%', 'Status'],
     rows: bundleRows,
   })

--- a/scripts/performance/report-as-a-pr-comment.js
+++ b/scripts/performance/report-as-a-pr-comment.js
@@ -176,7 +176,7 @@ function createMessage(
   })
   message += '\n</details>\n\n'
 
-  message += `🔗 [Playground](https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${prNumber})\n\n`
+  message += `🔗 [RealWorld](https://datadoghq.dev/browser-sdk-test-playground/realworld-scenario/?prNumber=${prNumber})\n\n`
 
   return message
 }

--- a/scripts/performance/report-as-a-pr-comment.js
+++ b/scripts/performance/report-as-a-pr-comment.js
@@ -32,7 +32,8 @@ async function reportAsPrComment(localBundleSizes, memoryLocalPerformance) {
     memoryBasePerformance,
     memoryLocalPerformance,
     cpuBasePerformance,
-    cpuLocalPerformance
+    cpuLocalPerformance,
+    pr.number
   )
   await updateOrAddComment(message, pr.number, commentId)
 }
@@ -109,7 +110,8 @@ function createMessage(
   memoryBasePerformance,
   memoryLocalPerformance,
   cpuBasePerformance,
-  cpuLocalPerformance
+  cpuLocalPerformance,
+  prNumber
 ) {
   let highIncreaseDetected = false
   const bundleRows = differenceBundle.map((diff, index) => {
@@ -172,6 +174,10 @@ function createMessage(
     headers: ['Action Name', 'Base Consumption Memory (bytes)', 'Local Consumption Memory (bytes)', '𝚫 (bytes)'],
     rows: memoryRows,
   })
+  message += '\n</details>\n\n'
+
+  message += '<details>\n<summary>ℹ️ Useful Testing Links</summary>\n\n'
+  message += `- [Playground with PR Bundle](https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${prNumber})\n`
   message += '\n</details>\n\n'
 
   return message


### PR DESCRIPTION
## Motivation

Add a link at the beginning of the pr commenter bot to directly test on a playground environment (realworld) the local bundle.

## Changes

Some changes made on playground to support prNumber in url to access to correct rum bundle / logs bundle. 
Added a link to redirect to realworld

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
