### PR TITLE
Use the same service/version type in `init()` and `startView()`

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -799,6 +799,19 @@ describe('start view', () => {
     )
   })
 
+  it('should ignore null service/version', () => {
+    setupBuilder.build()
+    const { getViewUpdate, startView } = viewTest
+
+    startView({ service: null, version: null })
+    expect(getViewUpdate(2)).toEqual(
+      jasmine.objectContaining({
+        service: undefined,
+        version: undefined,
+      })
+    )
+  })
+
   it('should use the provided clock to stop the current view and start the new one', () => {
     const { clock } = setupBuilder.withFakeClock().build()
     const { getViewUpdate, startView } = viewTest

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -25,7 +25,7 @@ import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 import type { EventCounts } from '../trackEventCounts'
 import type { LocationChange } from '../../browser/locationChangeObservable'
-import type { RumConfiguration } from '../configuration'
+import type { RumConfiguration, RumInitConfiguration } from '../configuration'
 import { trackViewEventCounts } from './trackViewEventCounts'
 import { trackInitialViewMetrics } from './viewMetrics/trackInitialViewMetrics'
 import type { InitialViewMetrics } from './viewMetrics/trackInitialViewMetrics'
@@ -75,8 +75,8 @@ export const KEEP_TRACKING_AFTER_VIEW_DELAY = 5 * ONE_MINUTE
 
 export interface ViewOptions {
   name?: string
-  service?: string
-  version?: string
+  service?: RumInitConfiguration['service']
+  version?: RumInitConfiguration['version']
 }
 
 export function trackViews(
@@ -185,8 +185,8 @@ function newView(
   let version: string | undefined
   if (viewOptions) {
     name = viewOptions.name
-    service = viewOptions.service
-    version = viewOptions.version
+    service = viewOptions.service || undefined
+    version = viewOptions.version || undefined
   }
 
   const viewCreatedEvent = {


### PR DESCRIPTION
## Motivation

There is no reason why we shouldn't accept different types there. See https://github.com/DataDog/browser-sdk/pull/2781#issuecomment-2150324514

## Changes

Change types, convert falsy values to undefined

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
