### PR TITLE
⚡️[RUM-3570] Batch the records for 16ms minimum before processing them

### DIFF
--- a/packages/rum/src/domain/record/mutationBatch.spec.ts
+++ b/packages/rum/src/domain/record/mutationBatch.spec.ts
@@ -31,6 +31,7 @@ describe('createMutationBatch', () => {
     mutationBatch.addMutations([mutation])
 
     expect(requestIdleCallbackSpy).toHaveBeenCalled()
+    expect(processMutationBatchSpy).not.toHaveBeenCalled()
     clock.tick(MUTATION_PROCESS_MIN_DELAY)
     expect(processMutationBatchSpy).toHaveBeenCalledWith([mutation])
   })

--- a/packages/rum/src/domain/record/mutationBatch.ts
+++ b/packages/rum/src/domain/record/mutationBatch.ts
@@ -8,6 +8,11 @@ import type { RumMutationRecord } from './trackers'
  * browser is busy executing a longer task, mutations will be processed after this task.
  */
 const MUTATION_PROCESS_MAX_DELAY = 100
+/**
+ * Minimum duration to wait before processing mutations. This is used to batch mutations together
+ * and be able to deduplicate them to save processing time and bandwidth.
+ * 16ms is the duration of a frame at 60fps that ensure fluid UI.
+ */
 export const MUTATION_PROCESS_MIN_DELAY = 16
 
 export function createMutationBatch(processMutationBatch: (mutations: RumMutationRecord[]) => void) {


### PR DESCRIPTION
## Motivation

When recording for Session Replay, [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) objects are batched together (see [mutationBatch](https://github.com/DataDog/browser-sdk/blob/fd44db8f0a9e6b0e08396deb182eebf69a3ef4d3/packages/rum/src/domain/record/mutationBatch.ts#L1)), then deduplicated on processing (ex: [here](https://github.com/DataDog/browser-sdk/blob/d48922fe03946c67412665a2976e4b4f978c28b6/packages/rum/src/domain/record/trackers/trackMutation.ts#L337)).

When the same mutation happens continuously on the same element, for example with JS-driven animations, a lot of MutationRecords can be notified by the browser in a very short amount of time, which can significantly inflate the data sent to Datadog, and have a performance impact both on the recorder side and on the player side (see below). Those mutations could be deduplicated if they were batched together.

## Changes

Batch the records for 16ms minimum before processing them

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
