### PR TITLE
🐛 fix developer extension crashing when dev mode enabled

### DIFF
--- a/developer-extension/src/content-scripts/main.ts
+++ b/developer-extension/src/content-scripts/main.ts
@@ -32,8 +32,8 @@ function main() {
     const ddLogsGlobal = instrumentGlobal('DD_LOGS')
 
     if (settings.debugMode) {
-      ddRumGlobal.onSet((sdkInstance) => sdkInstance._setDebug(settings.debugMode))
-      ddLogsGlobal.onSet((sdkInstance) => sdkInstance._setDebug(settings.debugMode))
+      setDebug(ddRumGlobal)
+      setDebug(ddLogsGlobal)
     }
 
     if (settings.rumConfigurationOverride) {
@@ -90,6 +90,15 @@ function injectDevBundle(url: string, global: GlobalInstrumentation) {
     global.onSet((sdkInstance) => proxySdk(sdkInstance, devInstance))
     global.returnValue(devInstance)
   }
+}
+
+function setDebug(global: GlobalInstrumentation) {
+  global.onSet((sdkInstance) => {
+    // Ensure the sdkInstance has a '_setDebug' method, excluding async stubs.
+    if ('_setDebug' in sdkInstance) {
+      sdkInstance._setDebug(true)
+    }
+  })
 }
 
 function overrideInitConfiguration(global: GlobalInstrumentation, configurationOverride: object) {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Fix issue with the developer extension when dev mode option is enabled:

![Screenshot 2024-06-14 at 12 36 36](https://github.com/DataDog/browser-sdk/assets/1926949/3f5b40e6-865b-4f8f-9d5c-121c8c85fc5c)


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Makes sure `_setDebug` exists before calling it (same as in `overrideInitConfiguration`)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
