### PR TITLE
👷 disable canary deployment during production freeze

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -302,17 +302,17 @@ deploy-staging:
     - node ./scripts/deploy/deploy.js staging staging root
     - node ./scripts/deploy/upload-source-maps.js staging root
 
-deploy-prod-canary:
-  stage: deploy:canary
-  extends:
-    - .base-configuration
-    - .main
-  script:
-    - export BUILD_MODE=canary
-    - yarn
-    - yarn build:bundle
-    - node ./scripts/deploy/deploy.js prod canary root
-    - node ./scripts/deploy/upload-source-maps.js canary root
+# deploy-prod-canary:
+#   stage: deploy:canary
+#   extends:
+#     - .base-configuration
+#     - .main
+#   script:
+#     - export BUILD_MODE=canary
+#     - yarn
+#     - yarn build:bundle
+#     - node ./scripts/deploy/deploy.js prod canary root
+#     - node ./scripts/deploy/upload-source-maps.js canary root
 
 deploy-manual:
   stage: deploy


### PR DESCRIPTION
## Motivation

Allow merging PRs on `main` during the production freeze.

## Changes

Disable canary deployment in the CI

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
