### PR TITLE
👷‍♀ Remove experimental feature flag for action name privacy control

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -17,7 +17,6 @@ export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
   CUSTOM_VITALS = 'custom_vitals',
   TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
-  ENABLE_PRIVACY_FOR_ACTION_NAME = 'enable_privacy_for_action_name',
   MICRO_FRONTEND = 'micro_frontend',
   REMOTE_CONFIGURATION = 'remote_configuration',
   PLUGINS = 'plugins',

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -338,11 +338,13 @@ describe('validateAndBuildRumConfiguration', () => {
     it('defaults to false', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.enablePrivacyForActionName).toBeFalse()
     })
-    it('is false when the feature is not enabled and the option is true', () => {
+
+    it('is true when the option is true', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.enablePrivacyForActionName).toBeFalse()
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, enablePrivacyForActionName: true })!
           .enablePrivacyForActionName
-      ).toBeFalse()
+      ).toBeTrue()
     })
   })
 

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -344,15 +344,6 @@ describe('validateAndBuildRumConfiguration', () => {
           .enablePrivacyForActionName
       ).toBeFalse()
     })
-
-    it('is only true when the feature is enabled and the option is true', () => {
-      mockExperimentalFeatures([ExperimentalFeature.ENABLE_PRIVACY_FOR_ACTION_NAME])
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.enablePrivacyForActionName).toBeFalse()
-      expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, enablePrivacyForActionName: true })!
-          .enablePrivacyForActionName
-      ).toBeTrue()
-    })
   })
 
   describe('trackResources', () => {

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -216,9 +216,7 @@ export function validateAndBuildRumConfiguration(
       defaultPrivacyLevel: objectHasValue(DefaultPrivacyLevel, initConfiguration.defaultPrivacyLevel)
         ? initConfiguration.defaultPrivacyLevel
         : DefaultPrivacyLevel.MASK,
-      enablePrivacyForActionName:
-        isExperimentalFeatureEnabled(ExperimentalFeature.ENABLE_PRIVACY_FOR_ACTION_NAME) &&
-        !!initConfiguration.enablePrivacyForActionName,
+      enablePrivacyForActionName: !!initConfiguration.enablePrivacyForActionName,
       customerDataTelemetrySampleRate: 1,
       traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
         ? initConfiguration.traceContextInjection


### PR DESCRIPTION
## Motivation
Make `enablePrivacyForActionName` feature not behind experimental feature flag.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Remove experimental feature flag `enable_privacy_for_action_name` and remove the checks.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
