### PR TITLE
👷‍♀️ Skip typechecks during unit tests

### DIFF
--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -56,7 +56,7 @@ module.exports = {
     ignoreWarnings: [
       // we will see warnings about missing exports in some files
       // this is because we set transpileOnly option in ts-loader
-      { message: /export .* was not found in/ }
+      { message: /export .* was not found in/ },
     ],
   },
   webpackMiddleware: {

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -40,7 +40,7 @@ module.exports = {
   singleRun: true,
   webpack: {
     stats: 'minimal',
-    module: webpackConfig.module,
+    module: overrideTsLoaderRule(webpackConfig.module),
     resolve: webpackConfig.resolve,
     target: webpackConfig.target,
     devtool: false,
@@ -53,6 +53,11 @@ module.exports = {
       runtimeChunk: false,
       splitChunks: false,
     },
+    ignoreWarnings: [
+      // we will see warnings about missing exports in some files
+      // this is because we set transpileOnly option in ts-loader
+      { message: /export .* was not found in/ }
+    ],
   },
   webpackMiddleware: {
     stats: 'errors-only',
@@ -65,4 +70,21 @@ module.exports = {
   // Socket.io) does not consider that the browser crashed.
   pingTimeout: 60_000,
   browserNoActivityTimeout: 60_000,
+}
+
+function overrideTsLoaderRule(module) {
+  // We set transpileOnly to true to avoid type checking in unit tests
+  module.rules = module.rules.map((rule) => {
+    if (rule.loader === 'ts-loader') {
+      return {
+        ...rule,
+        options: {
+          ...rule.options,
+          transpileOnly: true,
+        },
+      }
+    }
+    return rule
+  })
+  return module
 }

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -6,7 +6,7 @@ const { buildEnvKeys, getBuildEnvValue } = require('./scripts/lib/build-env')
 
 const tsconfigPath = path.join(__dirname, 'tsconfig.webpack.json')
 
-module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables }) => ({
+module.exports = ({ entry, mode, filename, types, ignoreWarnings, keepBuildEnvVariables }) => ({
   entry,
   mode,
   output: {
@@ -33,6 +33,7 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables }) => ({
       },
     ],
   },
+  ignoreWarnings,
 
   resolve: {
     extensions: ['.ts', '.js'],

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -6,7 +6,7 @@ const { buildEnvKeys, getBuildEnvValue } = require('./scripts/lib/build-env')
 
 const tsconfigPath = path.join(__dirname, 'tsconfig.webpack.json')
 
-module.exports = ({ entry, mode, filename, types, ignoreWarnings, keepBuildEnvVariables }) => ({
+module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables }) => ({
   entry,
   mode,
   output: {
@@ -33,7 +33,6 @@ module.exports = ({ entry, mode, filename, types, ignoreWarnings, keepBuildEnvVa
       },
     ],
   },
-  ignoreWarnings,
 
   resolve: {
     extensions: ['.ts', '.js'],


### PR DESCRIPTION
## Motivation
There are misleading TS errors during tests due to the extension using a different `tsconfig` than the default one set in webpack base configuration, which is used by karma. 
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
We use `transpileOnly` option for ts-loader in webpack to avoid type-checking during unit tests. We ignore the warnings caused by this setting. 
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
