### PR TITLE
🎨 Instrument fetch and XHR before trying to init consent

### DIFF
--- a/packages/core/src/browser/fetchObservable.ts
+++ b/packages/core/src/browser/fetchObservable.ts
@@ -39,6 +39,10 @@ export function initFetchObservable() {
   return fetchObservable
 }
 
+export function resetFetchObservable() {
+  fetchObservable = undefined
+}
+
 function createFetchObservable() {
   return new Observable<FetchContext>((observable) => {
     if (!window.fetch) {

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -40,10 +40,6 @@ export function initXhrObservable(configuration: Configuration) {
   return xhrObservable
 }
 
-export function resetXhrObservable() {
-  xhrObservable = undefined
-}
-
 function createXhrObservable(configuration: Configuration) {
   return new Observable<XhrContext>((observable) => {
     const { stop: stopInstrumentingStart } = instrumentMethod(XMLHttpRequest.prototype, 'open', openXhr)

--- a/packages/core/src/browser/xhrObservable.ts
+++ b/packages/core/src/browser/xhrObservable.ts
@@ -40,6 +40,10 @@ export function initXhrObservable(configuration: Configuration) {
   return xhrObservable
 }
 
+export function resetXhrObservable() {
+  xhrObservable = undefined
+}
+
 function createXhrObservable(configuration: Configuration) {
   return new Observable<XhrContext>((observable) => {
     const { stop: stopInstrumentingStart } = instrumentMethod(XMLHttpRequest.prototype, 'open', openXhr)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,8 +94,14 @@ export {
   resetInitCookies,
 } from './browser/cookie'
 export { CookieStore, WeakRef, WeakRefConstructor } from './browser/types'
-export { initXhrObservable, XhrCompleteContext, XhrStartContext } from './browser/xhrObservable'
-export { initFetchObservable, FetchResolveContext, FetchStartContext, FetchContext } from './browser/fetchObservable'
+export { initXhrObservable, resetXhrObservable, XhrCompleteContext, XhrStartContext } from './browser/xhrObservable'
+export {
+  initFetchObservable,
+  resetFetchObservable,
+  FetchResolveContext,
+  FetchStartContext,
+  FetchContext,
+} from './browser/fetchObservable'
 export { createPageExitObservable, PageExitEvent, PageExitReason, isPageExitReason } from './browser/pageExitObservable'
 export * from './browser/addEventListener'
 export * from './tools/timer'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,7 +94,7 @@ export {
   resetInitCookies,
 } from './browser/cookie'
 export { CookieStore, WeakRef, WeakRefConstructor } from './browser/types'
-export { initXhrObservable, resetXhrObservable, XhrCompleteContext, XhrStartContext } from './browser/xhrObservable'
+export { initXhrObservable, XhrCompleteContext, XhrStartContext } from './browser/xhrObservable'
 export {
   initFetchObservable,
   resetFetchObservable,

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -1,6 +1,13 @@
 import { mockClock, type Clock, mockEventBridge } from '@datadog/browser-core/test'
 import type { TimeStamp, TrackingConsentState } from '@datadog/browser-core'
-import { ONE_SECOND, TrackingConsent, createTrackingConsentState, display, isIE, resetFetchObservable } from '@datadog/browser-core'
+import {
+  ONE_SECOND,
+  TrackingConsent,
+  createTrackingConsentState,
+  display,
+  isIE,
+  resetFetchObservable,
+} from '@datadog/browser-core'
 import type { CommonContext } from '../rawLogsEvent.types'
 import type { HybridInitConfiguration, LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
 import type { Logger } from '../domain/logger'

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -1,6 +1,6 @@
 import { mockClock, type Clock, mockEventBridge } from '@datadog/browser-core/test'
 import type { TimeStamp, TrackingConsentState } from '@datadog/browser-core'
-import { ONE_SECOND, TrackingConsent, createTrackingConsentState, display } from '@datadog/browser-core'
+import { ONE_SECOND, TrackingConsent, createTrackingConsentState, display, isIE, resetFetchObservable } from '@datadog/browser-core'
 import type { CommonContext } from '../rawLogsEvent.types'
 import type { HybridInitConfiguration, LogsConfiguration, LogsInitConfiguration } from '../domain/configuration'
 import type { Logger } from '../domain/logger'
@@ -37,6 +37,7 @@ describe('preStartLogs', () => {
   })
 
   afterEach(() => {
+    resetFetchObservable()
     clock.cleanup()
   })
 
@@ -206,6 +207,25 @@ describe('preStartLogs', () => {
     beforeEach(() => {
       trackingConsentState = createTrackingConsentState()
       strategy = createPreStartStrategy(getCommonContextSpy, trackingConsentState, doStartLogsSpy)
+    })
+
+    describe('basic methods instrumentation', () => {
+      beforeEach(() => {
+        if (isIE()) {
+          pending('No support for IE')
+        }
+      })
+
+      it('should instrument fetch even if tracking consent is not granted', () => {
+        const originalFetch = window.fetch
+
+        strategy.init({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackingConsent: TrackingConsent.NOT_GRANTED,
+        })
+
+        expect(window.fetch).not.toBe(originalFetch)
+      })
     })
 
     it('does not start logs if tracking consent is not granted at init', () => {

--- a/packages/logs/src/boot/preStartLogs.ts
+++ b/packages/logs/src/boot/preStartLogs.ts
@@ -6,6 +6,7 @@ import {
   display,
   displayAlreadyInitializedError,
   initFeatureFlags,
+  initFetchObservable,
   noop,
   timeStampNow,
 } from '@datadog/browser-core'
@@ -66,6 +67,12 @@ export function createPreStartStrategy(
       }
 
       cachedConfiguration = configuration
+      // Instrumuent fetch to track network requests
+      // This is needed in case the consent is not granted and some cutsomer
+      // library (Apollo Client) is storing uninstrumented fetch to be used later
+      // The subscrption is needed so that the instrumentation process is completed
+      initFetchObservable().subscribe(noop)
+
       trackingConsentState.tryToInit(configuration.trackingConsent)
       tryStartLogs()
     },

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -13,6 +13,7 @@ import {
   resetExperimentalFeatures,
   resetFetchObservable,
   resetXhrObservable,
+  isIE,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import {
@@ -700,29 +701,37 @@ describe('preStartRum', () => {
       strategy = createPreStartStrategy({}, getCommonContextSpy, trackingConsentState, doStartRumSpy)
     })
 
-    it('should instrument fetch and XHR even if tracking consent is not granted', () => {
-      const originalFetch = window.fetch
-      /* eslint-disable @typescript-eslint/unbound-method */
-      const originalXHROpen = XMLHttpRequest.prototype.open
-      const originalXHRSend = XMLHttpRequest.prototype.send
-      const originalXHRAbort = XMLHttpRequest.prototype.abort
-      /* eslint-disable @typescript-eslint/unbound-method */
+    describe('basic methods instrumentation', () => {
+      beforeEach(() => {
+        if (isIE()) {
+          pending('No support for IE')
+        }
+      })
 
-      strategy.init(
-        {
-          ...DEFAULT_INIT_CONFIGURATION,
-          trackingConsent: TrackingConsent.NOT_GRANTED,
-        },
-        PUBLIC_API
-      )
+      it('should instrument fetch and XHR even if tracking consent is not granted', () => {
+        const originalFetch = window.fetch
+        /* eslint-disable @typescript-eslint/unbound-method */
+        const originalXHROpen = XMLHttpRequest.prototype.open
+        const originalXHRSend = XMLHttpRequest.prototype.send
+        const originalXHRAbort = XMLHttpRequest.prototype.abort
+        /* eslint-disable @typescript-eslint/unbound-method */
 
-      expect(window.fetch).not.toBe(originalFetch)
+        strategy.init(
+          {
+            ...DEFAULT_INIT_CONFIGURATION,
+            trackingConsent: TrackingConsent.NOT_GRANTED,
+          },
+          PUBLIC_API
+        )
 
-      /* eslint-disable @typescript-eslint/unbound-method */
-      expect(XMLHttpRequest.prototype.open).not.toBe(originalXHROpen)
-      expect(XMLHttpRequest.prototype.send).not.toBe(originalXHRSend)
-      expect(XMLHttpRequest.prototype.abort).not.toBe(originalXHRAbort)
-      /* eslint-disable @typescript-eslint/unbound-method */
+        expect(window.fetch).not.toBe(originalFetch)
+
+        /* eslint-disable @typescript-eslint/unbound-method */
+        expect(XMLHttpRequest.prototype.open).not.toBe(originalXHROpen)
+        expect(XMLHttpRequest.prototype.send).not.toBe(originalXHRSend)
+        expect(XMLHttpRequest.prototype.abort).not.toBe(originalXHRAbort)
+        /* eslint-disable @typescript-eslint/unbound-method */
+      })
     })
 
     it('does not start rum if tracking consent is not granted at init', () => {

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -43,7 +43,6 @@ const oldXHROpen = XMLHttpRequest.prototype.open
 const oldXHRSend = XMLHttpRequest.prototype.send
 const oldXHRAbort = XMLHttpRequest.prototype.abort
 
-
 describe('preStartRum', () => {
   let doStartRumSpy: jasmine.Spy<
     (

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -12,7 +12,6 @@ import {
   ExperimentalFeature,
   resetExperimentalFeatures,
   resetFetchObservable,
-  resetXhrObservable,
   isIE,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
@@ -58,7 +57,6 @@ describe('preStartRum', () => {
 
   afterEach(() => {
     resetFetchObservable()
-    resetXhrObservable()
   })
 
   describe('configuration validation', () => {
@@ -708,13 +706,8 @@ describe('preStartRum', () => {
         }
       })
 
-      it('should instrument fetch and XHR even if tracking consent is not granted', () => {
+      it('should instrument fetch even if tracking consent is not granted', () => {
         const originalFetch = window.fetch
-        /* eslint-disable @typescript-eslint/unbound-method */
-        const originalXHROpen = XMLHttpRequest.prototype.open
-        const originalXHRSend = XMLHttpRequest.prototype.send
-        const originalXHRAbort = XMLHttpRequest.prototype.abort
-        /* eslint-disable @typescript-eslint/unbound-method */
 
         strategy.init(
           {
@@ -725,12 +718,6 @@ describe('preStartRum', () => {
         )
 
         expect(window.fetch).not.toBe(originalFetch)
-
-        /* eslint-disable @typescript-eslint/unbound-method */
-        expect(XMLHttpRequest.prototype.open).not.toBe(originalXHROpen)
-        expect(XMLHttpRequest.prototype.send).not.toBe(originalXHRSend)
-        expect(XMLHttpRequest.prototype.abort).not.toBe(originalXHRAbort)
-        /* eslint-disable @typescript-eslint/unbound-method */
       })
     })
 

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -98,10 +98,6 @@ export function createPreStartStrategy(
       return
     }
 
-    // Instrumuent fetch and XHR to track network requests
-    initFetchObservable()
-    initXhrObservable(configuration)
-
     if (!eventBridgeAvailable && !configuration.sessionStoreStrategyType) {
       display.warn('No storage available for session. We will not send any data.')
       return
@@ -123,6 +119,13 @@ export function createPreStartStrategy(
     }
 
     cachedConfiguration = configuration
+    // Instrumuent fetch and XHR to track network requests
+    // This is needed in case the consent is not granted and some cutsomer
+    // library (Apollo Client) is storing uninstrumented fetch or XHR to be used later
+    // The subscrption is needed so that the instrumentation process is completed
+    initFetchObservable().subscribe(noop)
+    initXhrObservable(configuration).subscribe(noop)
+
     trackingConsentState.tryToInit(configuration.trackingConsent)
     tryStartRum()
   }

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -126,7 +126,7 @@ export function createPreStartStrategy(
     trackingConsentState.tryToInit(configuration.trackingConsent)
     tryStartRum()
   }
-  
+
   return {
     init(initConfiguration, publicApi) {
       if (!initConfiguration) {

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -118,9 +118,9 @@ export function createPreStartStrategy(
     }
 
     cachedConfiguration = configuration
-    // Instrumuent fetch and XHR to track network requests
+    // Instrumuent fetch to track network requests
     // This is needed in case the consent is not granted and some cutsomer
-    // library (Apollo Client) is storing uninstrumented fetch or XHR to be used later
+    // library (Apollo Client) is storing uninstrumented fetch to be used later
     // The subscrption is needed so that the instrumentation process is completed
     initFetchObservable().subscribe(noop)
 

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -14,7 +14,6 @@ import {
   initFeatureFlags,
   addTelemetryConfiguration,
   initFetchObservable,
-  initXhrObservable,
 } from '@datadog/browser-core'
 import type { TrackingConsentState, DeflateWorker } from '@datadog/browser-core'
 import {
@@ -124,7 +123,6 @@ export function createPreStartStrategy(
     // library (Apollo Client) is storing uninstrumented fetch or XHR to be used later
     // The subscrption is needed so that the instrumentation process is completed
     initFetchObservable().subscribe(noop)
-    initXhrObservable(configuration).subscribe(noop)
 
     trackingConsentState.tryToInit(configuration.trackingConsent)
     tryStartRum()

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -13,6 +13,8 @@ import {
   isExperimentalFeatureEnabled,
   initFeatureFlags,
   addTelemetryConfiguration,
+  initFetchObservable,
+  initXhrObservable,
 } from '@datadog/browser-core'
 import type { TrackingConsentState, DeflateWorker } from '@datadog/browser-core'
 import {
@@ -96,6 +98,10 @@ export function createPreStartStrategy(
       return
     }
 
+    // Instrumuent fetch and XHR to track network requests
+    initFetchObservable()
+    initXhrObservable(configuration)
+
     if (!eventBridgeAvailable && !configuration.sessionStoreStrategyType) {
       display.warn('No storage available for session. We will not send any data.')
       return
@@ -120,7 +126,7 @@ export function createPreStartStrategy(
     trackingConsentState.tryToInit(configuration.trackingConsent)
     tryStartRum()
   }
-
+  
   return {
     init(initConfiguration, publicApi) {
       if (!initConfiguration) {


### PR DESCRIPTION
## Motivation
When RUM's initialisation is delayed because of consent not being granted initially, some libraries (such as Apollo Client) do store some methods aside to be re-used (mainly `window.fetch`), which leads to the un-instrumented method being used for http requests, even after consent being granted.


## Changes
Instrument `fetch` method on sdk initialisation. The instrumentation process is idempotent.


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
