### PR TITLE
👷‍♀ Remove experimental flag for micro frontend

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -17,7 +17,6 @@ export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
   CUSTOM_VITALS = 'custom_vitals',
   TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
-  MICRO_FRONTEND = 'micro_frontend',
   REMOTE_CONFIGURATION = 'remote_configuration',
   PLUGINS = 'plugins',
 }

--- a/packages/logs/src/domain/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/console/consoleCollection.spec.ts
@@ -1,6 +1,5 @@
 import type { ErrorWithCause } from '@datadog/browser-core'
-import { ErrorSource, ExperimentalFeature, noop, objectEntries } from '@datadog/browser-core'
-import { mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { ErrorSource, noop, objectEntries } from '@datadog/browser-core'
 import type { RawConsoleLogsEvent } from '../../rawLogsEvent.types'
 import { validateAndBuildLogsConfiguration } from '../configuration'
 import type { RawLogsEventCollectedData } from '../lifeCycle'
@@ -51,23 +50,6 @@ describe('console collection', () => {
         origin: ErrorSource.CONSOLE,
         error: whatever(),
       })
-
-      expect(rawLogsEvents[0].domainContext).not.toBeDefined()
-
-      expect(consoleSpies[api]).toHaveBeenCalled()
-    })
-  })
-
-  objectEntries(LogStatusForApi).forEach(([api]) => {
-    it(`should add domainContext to logs from console.${api}`, () => {
-      mockExperimentalFeatures([ExperimentalFeature.MICRO_FRONTEND])
-      ;({ stop: stopConsoleCollection } = startConsoleCollection(
-        validateAndBuildLogsConfiguration({ ...initConfiguration, forwardConsoleLogs: 'all' })!,
-        lifeCycle
-      ))
-
-      /* eslint-disable-next-line no-console */
-      console[api as keyof typeof LogStatusForApi]('foo', 'bar')
 
       expect(rawLogsEvents[0].domainContext).toEqual({
         handlingStack: jasmine.any(String),

--- a/packages/logs/src/domain/console/consoleCollection.ts
+++ b/packages/logs/src/domain/console/consoleCollection.ts
@@ -1,12 +1,5 @@
 import type { Context, ClocksState, ConsoleLog } from '@datadog/browser-core'
-import {
-  timeStampNow,
-  ConsoleApiName,
-  ErrorSource,
-  initConsoleObservable,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
-} from '@datadog/browser-core'
+import { timeStampNow, ConsoleApiName, ErrorSource, initConsoleObservable } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../configuration'
 import type { LifeCycle, RawLogsEventCollectedData } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
@@ -44,12 +37,9 @@ export function startConsoleCollection(configuration: LogsConfiguration, lifeCyc
             : undefined,
         status: LogStatusForApi[log.api],
       },
-    }
-
-    if (isExperimentalFeatureEnabled(ExperimentalFeature.MICRO_FRONTEND)) {
-      collectedData.domainContext = {
+      domainContext: {
         handlingStack: log.handlingStack,
-      }
+      },
     }
 
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, collectedData)

--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -1,11 +1,5 @@
-import {
-  ExperimentalFeature,
-  type Duration,
-  type RelativeTime,
-  type ServerDuration,
-  type TimeStamp,
-} from '@datadog/browser-core'
-import { createNewEvent, mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { type Duration, type RelativeTime, type ServerDuration, type TimeStamp } from '@datadog/browser-core'
+import { createNewEvent } from '@datadog/browser-core/test'
 import type { RawRumActionEvent } from '@datadog/browser-rum-core'
 import type { TestSetupBuilder } from '../../../test'
 import { setup } from '../../../test'
@@ -147,8 +141,6 @@ describe('actionCollection', () => {
 
   it('should create action with handling stack', () => {
     const { rawRumEvents } = setupBuilder.build()
-
-    mockExperimentalFeatures([ExperimentalFeature.MICRO_FRONTEND])
 
     addAction({
       name: 'foo',

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -1,13 +1,5 @@
 import type { ClocksState, Context, Observable } from '@datadog/browser-core'
-import {
-  noop,
-  assign,
-  combine,
-  toServerDuration,
-  generateUUID,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
-} from '@datadog/browser-core'
+import { noop, assign, combine, toServerDuration, generateUUID } from '@datadog/browser-core'
 
 import { discardNegativeDuration } from '../discardNegativeDuration'
 import type { RawRumActionEvent } from '../../rawRumEvent.types'
@@ -114,11 +106,7 @@ function processAction(
 
   const domainContext: RumActionEventDomainContext = isAutoAction(action) ? { events: action.events } : {}
 
-  if (
-    !isAutoAction(action) &&
-    action.handlingStack &&
-    isExperimentalFeatureEnabled(ExperimentalFeature.MICRO_FRONTEND)
-  ) {
+  if (!isAutoAction(action) && action.handlingStack) {
     domainContext.handlingStack = action.handlingStack
   }
 

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -605,29 +605,7 @@ describe('rum assembly', () => {
     })
 
     describe('fields service and version', () => {
-      it('by default, it should not be modifiable', () => {
-        const { lifeCycle } = setupBuilder
-          .withConfiguration({
-            beforeSend: (event) => {
-              event.service = 'bar'
-              event.version = '0.2.0'
-
-              return true
-            },
-          })
-          .build()
-
-        notifyRawRumEvent(lifeCycle, {
-          rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, { resource: { url: '/path?foo=bar' } }),
-        })
-
-        expect((serverRumEvents[0] as RumResourceEvent).service).toBe('default service')
-        expect((serverRumEvents[0] as RumResourceEvent).version).toBe('default version')
-      })
-
-      it('when the micro_frontend experimental flag is set, it should be modifiable', () => {
-        mockExperimentalFeatures([ExperimentalFeature.MICRO_FRONTEND])
-
+      it('it should be modifiable', () => {
         const { lifeCycle } = setupBuilder
           .withConfiguration({
             beforeSend: (event) => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -56,6 +56,11 @@ const USER_CUSTOMIZABLE_FIELD_PATHS: ModifiableFieldPaths = {
   context: 'object',
 }
 
+const ROOT_MODIFIABLE_FIELD_PATHS: ModifiableFieldPaths = {
+  service: 'string',
+  version: 'string',
+}
+
 let modifiableFieldPathsByEvent: { [key in RumEventType]: ModifiableFieldPaths }
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] }
@@ -72,16 +77,6 @@ export function startRumAssembly(
   getCommonContext: () => CommonContext,
   reportError: (error: RawError) => void
 ) {
-  // TODO: lift this declaration to module level once feature flag is removed
-  const ROOT_MODIFIABLE_FIELD_PATHS: ModifiableFieldPaths = isExperimentalFeatureEnabled(
-    ExperimentalFeature.MICRO_FRONTEND
-  )
-    ? {
-        service: 'string',
-        version: 'string',
-      }
-    : {}
-
   modifiableFieldPathsByEvent = {
     [RumEventType.VIEW]: VIEW_MODIFIABLE_FIELD_PATHS,
     [RumEventType.ERROR]: assign(

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -1,6 +1,6 @@
 import type { RelativeTime, TimeStamp, ErrorWithCause } from '@datadog/browser-core'
-import { ErrorHandling, ErrorSource, ExperimentalFeature, NO_ERROR_STACK_PRESENT_MESSAGE } from '@datadog/browser-core'
-import { FAKE_CSP_VIOLATION_EVENT, mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { ErrorHandling, ErrorSource, NO_ERROR_STACK_PRESENT_MESSAGE } from '@datadog/browser-core'
+import { FAKE_CSP_VIOLATION_EVENT } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../../test'
 import { setup } from '../../../test'
 import type { RawRumErrorEvent } from '../../rawRumEvent.types'
@@ -87,7 +87,10 @@ describe('error collection', () => {
           },
           savedCommonContext: undefined,
           startTime: 1234 as RelativeTime,
-          domainContext: { error },
+          domainContext: {
+            error,
+            handlingStack: 'Error: handling foo',
+          },
         })
       })
     })
@@ -202,6 +205,7 @@ describe('error collection', () => {
       })
       expect(rawRumEvents[0].domainContext).toEqual({
         error: { foo: 'bar' },
+        handlingStack: 'Error: handling foo',
       })
     })
 
@@ -223,8 +227,6 @@ describe('error collection', () => {
 
     it('should include handling stack', () => {
       const { rawRumEvents } = setupBuilder.build()
-
-      mockExperimentalFeatures([ExperimentalFeature.MICRO_FRONTEND])
 
       addError({
         error: new Error('foo'),
@@ -250,6 +252,7 @@ describe('error collection', () => {
           startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
           type: 'foo',
           originalError: error,
+          handlingStack: 'Error: handling foo',
         },
       })
 
@@ -261,7 +264,7 @@ describe('error collection', () => {
           message: 'hello',
           source: ErrorSource.CUSTOM,
           stack: 'bar',
-          handling_stack: undefined,
+          handling_stack: 'Error: handling foo',
           type: 'foo',
           handling: undefined,
           source_type: 'browser',
@@ -276,6 +279,7 @@ describe('error collection', () => {
       })
       expect(rawRumEvents[0].domainContext).toEqual({
         error,
+        handlingStack: 'Error: handling foo',
       })
     })
 

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -10,8 +10,6 @@ import {
   Observable,
   trackRuntimeError,
   NonErrorPrefix,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type { RawRumErrorEvent } from '../../rawRumEvent.types'
@@ -124,10 +122,7 @@ function processError(
 
   const domainContext: RumErrorEventDomainContext = {
     error: error.originalError,
-  }
-
-  if (isExperimentalFeatureEnabled(ExperimentalFeature.MICRO_FRONTEND)) {
-    domainContext.handlingStack = error.handlingStack
+    handlingStack: error.handlingStack,
   }
 
   return {

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -1,6 +1,5 @@
 import type { Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
-import { isIE, RequestType, ResourceType, ExperimentalFeature } from '@datadog/browser-core'
-import { mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { isIE, RequestType, ResourceType } from '@datadog/browser-core'
 import type { RumFetchResourceEventDomainContext, RumXhrResourceEventDomainContext } from '../../domainContext.types'
 import { setup, createPerformanceEntry } from '../../../test'
 import type { TestSetupBuilder } from '../../../test'
@@ -12,6 +11,8 @@ import { TraceIdentifier } from '../tracing/tracer'
 import { validateAndBuildRumConfiguration } from '../configuration'
 import { RumPerformanceEntryType } from '../../browser/performanceCollection'
 import { startResourceCollection } from './resourceCollection'
+
+const HANDLING_STACK_REGEX = /^Error: \n\s+at <anonymous> @/
 
 describe('resourceCollection', () => {
   let setupBuilder: TestSetupBuilder
@@ -106,6 +107,7 @@ describe('resourceCollection', () => {
       requestInit: undefined,
       error: undefined,
       isAborted: false,
+      handlingStack: jasmine.stringMatching(HANDLING_STACK_REGEX),
     })
   })
 
@@ -226,6 +228,7 @@ describe('resourceCollection', () => {
       requestInit: { headers: { foo: 'bar' } },
       error: undefined,
       isAborted: false,
+      handlingStack: jasmine.stringMatching(HANDLING_STACK_REGEX),
     })
   })
   ;[null, undefined, 42, {}].forEach((input: any) => {
@@ -387,35 +390,27 @@ describe('resourceCollection', () => {
     })
   })
 
-  describe('with micro-frontend feature flag enabled', () => {
-    const HANDLING_STACK_REGEX = /^Error: \n\s+at <anonymous> @/
+  it('should collect handlingStack from completed fetch request', () => {
+    if (isIE()) {
+      pending('No IE support')
+    }
 
-    beforeEach(() => {
-      mockExperimentalFeatures([ExperimentalFeature.MICRO_FRONTEND])
-    })
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+    const response = new Response()
+    lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, createCompletedRequest({ response }))
+    const domainContext = rawRumEvents[0].domainContext as RumFetchResourceEventDomainContext
 
-    it('should collect handlingStack from completed fetch request', () => {
-      if (isIE()) {
-        pending('No IE support')
-      }
+    expect(domainContext.handlingStack).toMatch(HANDLING_STACK_REGEX)
+  })
 
-      const { lifeCycle, rawRumEvents } = setupBuilder.build()
-      const response = new Response()
-      lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, createCompletedRequest({ response }))
-      const domainContext = rawRumEvents[0].domainContext as RumFetchResourceEventDomainContext
+  it('should collect handlingStack from completed XHR request', () => {
+    const { lifeCycle, rawRumEvents } = setupBuilder.build()
+    const xhr = new XMLHttpRequest()
+    lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, createCompletedRequest({ xhr }))
 
-      expect(domainContext.handlingStack).toMatch(HANDLING_STACK_REGEX)
-    })
+    const domainContext = rawRumEvents[0].domainContext as RumXhrResourceEventDomainContext
 
-    it('should collect handlingStack from completed XHR request', () => {
-      const { lifeCycle, rawRumEvents } = setupBuilder.build()
-      const xhr = new XMLHttpRequest()
-      lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, createCompletedRequest({ xhr }))
-
-      const domainContext = rawRumEvents[0].domainContext as RumXhrResourceEventDomainContext
-
-      expect(domainContext.handlingStack).toMatch(HANDLING_STACK_REGEX)
-    })
+    expect(domainContext.handlingStack).toMatch(HANDLING_STACK_REGEX)
   })
 })
 

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -8,8 +8,6 @@ import {
   relativeToClocks,
   assign,
   isNumber,
-  ExperimentalFeature,
-  isExperimentalFeatureEnabled,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type { RumPerformanceResourceTiming } from '../../browser/performanceCollection'
@@ -94,7 +92,8 @@ function processRequest(
     tracingInfo,
     correspondingTimingOverrides
   )
-  const collectedData = {
+
+  return {
     startTime: startClocks.relative,
     rawRumEvent: resourceEvent,
     domainContext: {
@@ -105,14 +104,9 @@ function processRequest(
       requestInit: request.init,
       error: request.error,
       isAborted: request.isAborted,
+      handlingStack: request.handlingStack,
     } as RumFetchResourceEventDomainContext | RumXhrResourceEventDomainContext,
   }
-
-  if (isExperimentalFeatureEnabled(ExperimentalFeature.MICRO_FRONTEND)) {
-    collectedData.domainContext.handlingStack = request.handlingStack
-  }
-
-  return collectedData
 }
 
 function processResourceEntry(

--- a/test/e2e/scenario/microfrontend.scenario.ts
+++ b/test/e2e/scenario/microfrontend.scenario.ts
@@ -8,7 +8,6 @@ const HANDLING_STACK_REGEX = /^Error: \n\s+at testHandlingStack @/
 const RUM_CONFIG: Partial<RumInitConfiguration> = {
   service: 'main-service',
   version: '1.0.0',
-  enableExperimentalFeatures: ['micro_frontend'],
   beforeSend: (event: RumEvent, domainContext: RumEventDomainContext) => {
     if ('handlingStack' in domainContext) {
       event.context!.handlingStack = domainContext.handlingStack
@@ -20,7 +19,6 @@ const RUM_CONFIG: Partial<RumInitConfiguration> = {
 
 const LOGS_CONFIG: Partial<LogsInitConfiguration> = {
   forwardConsoleLogs: 'all',
-  enableExperimentalFeatures: ['micro_frontend'],
   beforeSend: (event: LogsEvent, domainContext: LogsEventDomainContext) => {
     if (domainContext && 'handlingStack' in domainContext) {
       event.context = { handlingStack: domainContext.handlingStack }


### PR DESCRIPTION
## Motivation

Enable Micro frontend for private beta

## Changes

remove the `micro_frontend` experimental feature flag 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
