### PR TITLE
🐛 [RUM-5209] provide a span id for the initial document trace

### DIFF
--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -280,6 +280,7 @@ describe('resourceCollection', () => {
       const privateFields = (rawRumEvents[0].rawRumEvent as RawRumResourceEvent)._dd
       expect(privateFields).toBeDefined()
       expect(privateFields.trace_id).toBe('1234')
+      expect(privateFields.span_id).toEqual(jasmine.any(String))
     })
 
     it('should be processed from sampled completed request', () => {

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -20,6 +20,7 @@ import type { RawRumEventCollectedData, LifeCycle } from '../lifeCycle'
 import type { RequestCompleteEvent } from '../requestCollection'
 import type { PageStateHistory } from '../contexts/pageStateHistory'
 import { PageState } from '../contexts/pageStateHistory'
+import { TraceIdentifier } from '../tracing/tracer'
 import { matchRequestTiming } from './matchRequestTiming'
 import {
   computePerformanceResourceDetails,
@@ -184,6 +185,7 @@ function computeEntryTracingInfo(entry: RumPerformanceResourceTiming, configurat
   return {
     _dd: {
       trace_id: entry.traceId,
+      span_id: new TraceIdentifier().toDecimalString(),
       rule_psr: getRulePsr(configuration),
     },
   }


### PR DESCRIPTION
## Motivation

Without a span id, the backend does not create the RUM span

## Changes

Generate a random span id for the RUM span.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
