### PR TITLE
🐛 [RUM-958] Fix performance observable compatibility with old browser version

### DIFF
--- a/packages/rum-core/src/browser/performanceObservable.spec.ts
+++ b/packages/rum-core/src/browser/performanceObservable.spec.ts
@@ -26,7 +26,7 @@ describe('performanceObservable', () => {
 
   afterEach(() => {
     performanceSubscription?.unsubscribe()
-    clock.cleanup()
+    clock?.cleanup()
   })
 
   describe('primary strategy when type supported', () => {

--- a/packages/rum-core/src/browser/performanceObservable.spec.ts
+++ b/packages/rum-core/src/browser/performanceObservable.spec.ts
@@ -8,7 +8,7 @@ import { RumPerformanceEntryType, createPerformanceObservable } from './performa
 
 describe('performanceObservable', () => {
   let configuration: RumConfiguration
-  let performanceSubscription: Subscription
+  let performanceSubscription: Subscription | undefined
   const forbiddenUrl = 'https://forbidden.url'
   const allowedUrl = 'https://allowed.url'
   let notifyPerformanceEntries: (entries: RumPerformanceEntry[]) => void
@@ -21,46 +21,85 @@ describe('performanceObservable', () => {
     }
     observableCallback = jasmine.createSpy()
     configuration = { isIntakeUrl: (url: string) => url === forbiddenUrl } as unknown as RumConfiguration
-    ;({ notifyPerformanceEntries } = mockPerformanceObserver())
     clock = mockClock()
   })
 
   afterEach(() => {
-    performanceSubscription.unsubscribe()
+    performanceSubscription?.unsubscribe()
     clock.cleanup()
   })
 
-  it('should notify performance resources', () => {
-    const performanceResourceObservable = createPerformanceObservable(configuration, {
-      type: RumPerformanceEntryType.RESOURCE,
+  describe('primary strategy when type supported', () => {
+    beforeEach(() => {
+      ;({ notifyPerformanceEntries } = mockPerformanceObserver())
     })
-    performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
 
-    notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: allowedUrl })])
-    expect(observableCallback).toHaveBeenCalledWith([jasmine.objectContaining({ name: allowedUrl })])
+    it('should notify performance resources', () => {
+      const performanceResourceObservable = createPerformanceObservable(configuration, {
+        type: RumPerformanceEntryType.RESOURCE,
+      })
+      performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
+
+      notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: allowedUrl })])
+      expect(observableCallback).toHaveBeenCalledWith([jasmine.objectContaining({ name: allowedUrl })])
+    })
+
+    it('should not notify forbidden performance resources', () => {
+      const performanceResourceObservable = createPerformanceObservable(configuration, {
+        type: RumPerformanceEntryType.RESOURCE,
+      })
+      performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
+
+      notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: forbiddenUrl })])
+      expect(observableCallback).not.toHaveBeenCalled()
+    })
+
+    it('should notify buffered performance resources asynchronously', () => {
+      // add the performance entry to the buffer
+      notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: allowedUrl })])
+
+      const performanceResourceObservable = createPerformanceObservable(configuration, {
+        type: RumPerformanceEntryType.RESOURCE,
+        buffered: true,
+      })
+      performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
+      expect(observableCallback).not.toHaveBeenCalled()
+      clock.tick(0)
+      expect(observableCallback).toHaveBeenCalledWith([jasmine.objectContaining({ name: allowedUrl })])
+    })
   })
 
-  it('should not notify forbidden performance resources', () => {
-    const performanceResourceObservable = createPerformanceObservable(configuration, {
-      type: RumPerformanceEntryType.RESOURCE,
+  describe('fallback strategy when type not supported', () => {
+    let bufferedEntries: PerformanceEntryList
+
+    beforeEach(() => {
+      bufferedEntries = []
+      spyOn(performance, 'getEntriesByType').and.callFake(() => bufferedEntries)
+      ;({ notifyPerformanceEntries } = mockPerformanceObserver({ typeSupported: false }))
     })
-    performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
 
-    notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: forbiddenUrl })])
-    expect(observableCallback).not.toHaveBeenCalled()
-  })
+    it('should notify performance resources when type not supported', () => {
+      const performanceResourceObservable = createPerformanceObservable(configuration, {
+        type: RumPerformanceEntryType.RESOURCE,
+      })
+      performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
 
-  it('should notify buffered performance resources asynchronously', () => {
-    // add the performance entry to the buffer
-    notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: allowedUrl })])
-
-    const performanceResourceObservable = createPerformanceObservable(configuration, {
-      type: RumPerformanceEntryType.RESOURCE,
-      buffered: true,
+      notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: allowedUrl })])
+      expect(observableCallback).toHaveBeenCalledWith([jasmine.objectContaining({ name: allowedUrl })])
     })
-    performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
-    expect(observableCallback).not.toHaveBeenCalled()
-    clock.tick(0)
-    expect(observableCallback).toHaveBeenCalledWith([jasmine.objectContaining({ name: allowedUrl })])
+
+    it('should notify buffered performance resources when type not supported', () => {
+      // add the performance entry to the buffer
+      bufferedEntries = [createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: allowedUrl })]
+
+      const performanceResourceObservable = createPerformanceObservable(configuration, {
+        type: RumPerformanceEntryType.RESOURCE,
+        buffered: true,
+      })
+      performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
+      expect(observableCallback).not.toHaveBeenCalled()
+      clock.tick(0)
+      expect(observableCallback).toHaveBeenCalledWith([jasmine.objectContaining({ name: allowedUrl })])
+    })
   })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -16,8 +16,8 @@ describe('trackCumulativeLayoutShift', () => {
 
   beforeEach(() => {
     if (
-      !('PerformanceObserver' in window) ||
-      !('supportedEntryTypes' in PerformanceObserver) ||
+      !window.PerformanceObserver ||
+      !PerformanceObserver.supportedEntryTypes ||
       !PerformanceObserver.supportedEntryTypes.includes('layout-shift')
     ) {
       pending('No LayoutShift API support')

--- a/packages/rum-core/test/emulate/mockPerformanceObserver.ts
+++ b/packages/rum-core/test/emulate/mockPerformanceObserver.ts
@@ -7,7 +7,7 @@ type PerformanceObserverInstance = {
   entryTypes: string[]
 }
 
-export function mockPerformanceObserver() {
+export function mockPerformanceObserver({ typeSupported } = { typeSupported: true }) {
   const originalPerformanceObserver = window.PerformanceObserver
   const instances = new Set<PerformanceObserverInstance>()
   let performanceObserver: PerformanceObserver
@@ -21,6 +21,9 @@ export function mockPerformanceObserver() {
         instances.delete(instance)
       },
       observe({ entryTypes, type, buffered }: PerformanceObserverInit) {
+        if (!typeSupported && type) {
+          throw new Error("Uncaught TypeError: Failed to execute 'observe' on 'PerformanceObserver")
+        }
         instance.entryTypes = entryTypes || (type ? [type] : [])
         instances.add(instance)
         if (buffered) {


### PR DESCRIPTION
## Motivation

Looking at the telemetry, it seems that users still use very old version of Chrome (<75) and Apple Mail which do not support performance observer [buffered](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe#buffered) and [type](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe#type) parameters. This PR adds a fallback strategy for these cases using:
- performance observer [entryTypes](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe#entrytypes) and 
- [performance.getEntriesByType()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType) for the buffered entries

## Changes

Add fallback strategy to createPerformanceObservable

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
