### PR TITLE
♻️ [RUM-159] Categorize changes as public or internal in the CHANGELOG

### DIFF
--- a/scripts/release/generate-changelog.js
+++ b/scripts/release/generate-changelog.js
@@ -10,10 +10,22 @@ const { spawnCommand, printError, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { modifyFile } = require('../lib/files-utils')
 
-const CHANGELOG_FILE = 'CHANGELOG.md'
-const CONTRIBUTING_FILE = 'CONTRIBUTING.md'
+const CHANGELOG_FILE = '../../CHANGELOG.md'
+const CONTRIBUTING_FILE = '../../CONTRIBUTING.md'
 const PUBLIC_EMOJI_PRIORITY = ['💥', '✨', '🐛', '⚡️', '📝', '⚗️']
-const INTERNAL_EMOJI_PRIORITY = ['👷', '🎨', '🧪', '✅', '👌', '♻️', '🔧', '📄', '🔇', '🔊', '📦']
+const INTERNAL_EMOJI_PRIORITY = [
+  '👷',
+  '🔧',
+  '📦', // build conf
+  '♻️',
+  '🎨', // refactoring
+  '🧪',
+  '✅', // tests
+  '🔇',
+  '🔊', // telemetry
+  '👌',
+  '📄',
+]
 const EMOJI_REGEX = /^\p{Emoji_Presentation}/u
 runMain(async () => {
   if (!process.env.EDITOR) {

--- a/scripts/release/generate-changelog.js
+++ b/scripts/release/generate-changelog.js
@@ -10,8 +10,8 @@ const { spawnCommand, printError, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { modifyFile } = require('../lib/files-utils')
 
-const CHANGELOG_FILE = '../../CHANGELOG.md'
-const CONTRIBUTING_FILE = '../../CONTRIBUTING.md'
+const CHANGELOG_FILE = 'CHANGELOG.md'
+const CONTRIBUTING_FILE = 'CONTRIBUTING.md'
 const PUBLIC_EMOJI_PRIORITY = ['💥', '✨', '🐛', '⚡️', '📝', '⚗️']
 const INTERNAL_EMOJI_PRIORITY = ['👷', '🎨', '🧪', '✅', '👌', '♻️']
 const EMOJI_REGEX = /^\p{Emoji_Presentation}/u

--- a/scripts/release/generate-changelog.js
+++ b/scripts/release/generate-changelog.js
@@ -10,8 +10,8 @@ const { spawnCommand, printError, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 const { modifyFile } = require('../lib/files-utils')
 
-const CHANGELOG_FILE = 'CHANGELOG.md'
-const CONTRIBUTING_FILE = 'CONTRIBUTING.md'
+const CHANGELOG_FILE = '../../CHANGELOG.md'
+const CONTRIBUTING_FILE = '../../CONTRIBUTING.md'
 const PUBLIC_EMOJI_PRIORITY = ['💥', '✨', '🐛', '⚡️', '📝', '⚗️']
 const INTERNAL_EMOJI_PRIORITY = ['👷', '🎨', '🧪', '✅', '👌', '♻️']
 const EMOJI_REGEX = /^\p{Emoji_Presentation}/u
@@ -108,7 +108,7 @@ ${internalChanges.join('\n')}
 
 function sortByEmojiPriority(a, b, priorityList) {
   const getFirstRelevantEmoji = (text) => {
-    const matches = text.match(EMOJI_REGEX) || [] // Ensures only the first emoji is matched
+    const matches = text.match(EMOJI_REGEX) || []
     return matches.find((emoji) => priorityList.includes(emoji))
   }
 
@@ -116,8 +116,6 @@ function sortByEmojiPriority(a, b, priorityList) {
   const emojiB = getFirstRelevantEmoji(b)
   const indexA = emojiA ? priorityList.indexOf(emojiA) : Number.MAX_VALUE
   const indexB = emojiB ? priorityList.indexOf(emojiB) : Number.MAX_VALUE
-
-  console.log(`Comparing ${a} (index ${indexA}) to ${b} (index ${indexB})`) // Debugging line
 
   return indexA - indexB
 }


### PR DESCRIPTION
## Motivation

When we created the CHANGELOG, we chose to only show public changes (bug fixes, new features, …).

In practice, this is not always respected. Sometimes, it’s not clear whether it is a public or internal change. We are a bit hesitant to show experimental features or not. Sometimes we do releases with only internal changes, and having an empty entry is not ideal.

## Changes

Let’s add everything, but to help the reading, split changes into two sections (ex: public/internal changes). The generate_changelog script should handle the formating based on gitmojis.




## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
