### PR TITLE
🎨 Get rid of setupBuilder from simple unit tests

### DIFF
--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -9,13 +9,13 @@ import type { UrlContexts } from './urlContexts'
 import { startUrlContexts } from './urlContexts'
 
 describe('urlContexts', () => {
-  const fakeLocation = buildLocation('http://fake-url.com')
   const lifeCycle = new LifeCycle()
   let clock: Clock
   let changeLocation: (to: string) => void
   let urlContexts: UrlContexts
 
   beforeEach(() => {
+    const fakeLocation = buildLocation('http://fake-url.com')
     clock = mockClock()
     const setupResult = setupLocationObserver()
     changeLocation = (to: string) => setupResult.changeLocation(fakeLocation, to)

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -1,43 +1,43 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { relativeToClocks } from '@datadog/browser-core'
-import type { TestSetupBuilder } from '../../../test'
-import { setup } from '../../../test'
-import { LifeCycleEventType } from '../lifeCycle'
+import type { Clock } from '@datadog/browser-core/test'
+import { buildLocation, mockClock } from '@datadog/browser-core/test'
+import { setupLocationObserver } from '../../../test'
+import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { ViewCreatedEvent, ViewEndedEvent } from '../view/trackViews'
 import type { UrlContexts } from './urlContexts'
 import { startUrlContexts } from './urlContexts'
 
 describe('urlContexts', () => {
-  let setupBuilder: TestSetupBuilder
+  const fakeLocation = buildLocation('http://fake-url.com')
+  const lifeCycle = new LifeCycle()
+  let clock: Clock
+  let changeLocation: (to: string) => void
   let urlContexts: UrlContexts
 
   beforeEach(() => {
-    setupBuilder = setup()
-      .withFakeLocation('http://fake-url.com')
-      .withFakeClock()
-      .beforeBuild(({ lifeCycle, locationChangeObservable, location }) => {
-        urlContexts = startUrlContexts(lifeCycle, locationChangeObservable, location)
-        return urlContexts
-      })
+    clock = mockClock()
+    const setupResult = setupLocationObserver()
+    changeLocation = (to: string) => setupResult.changeLocation(fakeLocation, to)
+    urlContexts = startUrlContexts(lifeCycle, setupResult.observable, fakeLocation)
+  })
+
+  afterEach(() => {
+    urlContexts.stop()
+    clock.cleanup()
   })
 
   it('should return undefined before the initial view', () => {
-    setupBuilder.build()
-
     expect(urlContexts.findUrl()).toBeUndefined()
   })
 
   it('should not create url context on location change before the initial view', () => {
-    const { changeLocation } = setupBuilder.build()
-
     changeLocation('/foo')
 
     expect(urlContexts.findUrl()).toBeUndefined()
   })
 
   it('should return current url and document referrer for initial view', () => {
-    const { lifeCycle } = setupBuilder.build()
-
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
       startClocks: relativeToClocks(0 as RelativeTime),
     } as ViewCreatedEvent)
@@ -48,8 +48,6 @@ describe('urlContexts', () => {
   })
 
   it('should update url context on location change', () => {
-    const { lifeCycle, changeLocation } = setupBuilder.build()
-
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
       startClocks: relativeToClocks(0 as RelativeTime),
     } as ViewCreatedEvent)
@@ -61,8 +59,6 @@ describe('urlContexts', () => {
   })
 
   it('should update url context on new view', () => {
-    const { lifeCycle, changeLocation } = setupBuilder.build()
-
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
       startClocks: relativeToClocks(0 as RelativeTime),
     } as ViewCreatedEvent)
@@ -80,8 +76,6 @@ describe('urlContexts', () => {
   })
 
   it('should return the url context corresponding to the start time', () => {
-    const { lifeCycle, changeLocation, clock } = setupBuilder.build()
-
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
       startClocks: relativeToClocks(0 as RelativeTime),
     } as ViewCreatedEvent)
@@ -130,8 +124,6 @@ describe('urlContexts', () => {
    * (which seems unlikely) and this event would anyway be rejected by lack of view id
    */
   it('should return undefined when no current view', () => {
-    const { lifeCycle } = setupBuilder.build()
-
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
       startClocks: relativeToClocks(0 as RelativeTime),
     } as ViewCreatedEvent)


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
