### PR TITLE
🐛 Handle non-object response and error

### DIFF
--- a/packages/core/src/browser/fetchObservable.spec.ts
+++ b/packages/core/src/browser/fetchObservable.spec.ts
@@ -82,6 +82,23 @@ describe('fetch proxy', () => {
     })
   })
 
+  it('should track fetch aborted by AbortController', (done) => {
+    const controller = new AbortController()
+    void fetch(FAKE_URL, { signal: controller.signal })
+    controller.abort('AbortError')
+
+    mockFetchManager.whenAllComplete(() => {
+      const request = requests[0]
+      expect(request.method).toEqual('GET')
+      expect(request.url).toEqual(FAKE_URL)
+      expect(request.status).toEqual(0)
+      expect(request.isAborted).toBe(true)
+      expect(request.error).toEqual(controller.signal.reason)
+      expect(request.handlingStack).toBeDefined()
+      done()
+    })
+  })
+
   it('should track opaque fetch', (done) => {
     // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
     fetch(FAKE_URL).resolveWith({ status: 0, type: 'opaque' })

--- a/packages/core/src/browser/fetchObservable.spec.ts
+++ b/packages/core/src/browser/fetchObservable.spec.ts
@@ -162,7 +162,7 @@ describe('fetch proxy', () => {
     })
   })
 
-  it('should keep promise resolved behavior', (done) => {
+  it('should keep promise resolved behavior for Response', (done) => {
     const mockFetchPromise = fetch(FAKE_URL)
     const spy = jasmine.createSpy()
     mockFetchPromise.then(spy).catch(() => {
@@ -176,11 +176,37 @@ describe('fetch proxy', () => {
     })
   })
 
-  it('should keep promise rejected behavior', (done) => {
+  it('should keep promise resolved behavior for any other type', (done) => {
+    const mockFetchPromise = fetch(FAKE_URL)
+    const spy = jasmine.createSpy()
+    mockFetchPromise.then(spy).catch(() => {
+      fail('Should not have thrown an error!')
+    })
+    mockFetchPromise.resolveWith('response' as any)
+
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should keep promise rejected behavior for Error', (done) => {
     const mockFetchPromise = fetch(FAKE_URL)
     const spy = jasmine.createSpy()
     mockFetchPromise.catch(spy)
     mockFetchPromise.rejectWith(new Error('fetch error'))
+
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('should keep promise rejected behavior for any other type', (done) => {
+    const mockFetchPromise = fetch(FAKE_URL)
+    const spy = jasmine.createSpy()
+    mockFetchPromise.catch(spy)
+    mockFetchPromise.rejectWith('fetch error' as any)
 
     setTimeout(() => {
       expect(spy).toHaveBeenCalled()

--- a/packages/core/src/browser/fetchObservable.ts
+++ b/packages/core/src/browser/fetchObservable.ts
@@ -115,11 +115,10 @@ function afterSend(
       })
     }),
     monitor((error: Error) => {
-      const isAborted =
-        context.init?.signal?.aborted || (error instanceof DOMException && error.code === DOMException.ABORT_ERR)
       reportFetch({
         status: 0,
-        isAborted,
+        isAborted:
+          context.init?.signal?.aborted || (error instanceof DOMException && error.code === DOMException.ABORT_ERR),
         error,
       })
     })

--- a/packages/core/test/emulate/mockFetch.ts
+++ b/packages/core/test/emulate/mockFetch.ts
@@ -14,7 +14,7 @@ export function mockFetch() {
     }
   }
 
-  window.fetch = (() => {
+  window.fetch = ((...[, init]) => {
     pendingRequests += 1
     let resolve: (response: Response) => unknown
     let reject: (error: Error) => unknown
@@ -33,6 +33,10 @@ export function mockFetch() {
     promise.abort = () => {
       promise.rejectWith(new DOMException('The user aborted a request', 'AbortError'))
     }
+
+    init?.signal?.addEventListener('abort', () => {
+      promise.rejectWith(init.signal?.reason)
+    })
 
     return promise
   }) as typeof window.fetch

--- a/packages/core/test/emulate/mockFetch.ts
+++ b/packages/core/test/emulate/mockFetch.ts
@@ -14,7 +14,7 @@ export function mockFetch() {
     }
   }
 
-  window.fetch = ((...[, init]) => {
+  window.fetch = ((_input, init) => {
     pendingRequests += 1
     let resolve: (response: Response) => unknown
     let reject: (error: Error) => unknown


### PR DESCRIPTION
## Motivation

We have a lot of telemetry errors concerning Fetch error that are not an Error object but a string or undefined.

## Changes

- Handling the non-object Fetch Error and Response
- Supporting abort status from AbortController

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end
