### PR TITLE
Revert  "♻️ [RUM-5101] Use registerCleanupTask instead of afterEach for test cleanup"

### DIFF
--- a/packages/core/src/browser/addEventListener.spec.ts
+++ b/packages/core/src/browser/addEventListener.spec.ts
@@ -15,6 +15,10 @@ describe('addEventListener', () => {
       zoneJs = mockZoneJs()
     })
 
+    afterEach(() => {
+      zoneJs.restore()
+    })
+
     it('uses the original addEventListener method instead of the method patched by Zone.js', () => {
       const zoneJsPatchedAddEventListener = jasmine.createSpy()
       const eventTarget = document.createElement('div')

--- a/packages/core/src/browser/fetchObservable.spec.ts
+++ b/packages/core/src/browser/fetchObservable.spec.ts
@@ -34,6 +34,7 @@ describe('fetch proxy', () => {
     registerCleanupTask(() => {
       requestsTrackingSubscription.unsubscribe()
       contextEditionSubscription?.unsubscribe()
+      mockFetchManager.reset()
     })
   })
 

--- a/packages/core/src/browser/pageExitObservable.spec.ts
+++ b/packages/core/src/browser/pageExitObservable.spec.ts
@@ -1,5 +1,5 @@
 import type { Configuration } from '../domain/configuration'
-import { createNewEvent, setPageVisibility, registerCleanupTask } from '../../test'
+import { createNewEvent, restorePageVisibility, setPageVisibility, registerCleanupTask } from '../../test'
 import type { PageExitEvent } from './pageExitObservable'
 import { PageExitReason, createPageExitObservable } from './pageExitObservable'
 
@@ -11,6 +11,10 @@ describe('createPageExitObservable', () => {
     onExitSpy = jasmine.createSpy()
     configuration = {} as Configuration
     registerCleanupTask(createPageExitObservable(configuration).subscribe(onExitSpy).unsubscribe)
+  })
+
+  afterEach(() => {
+    restorePageVisibility()
   })
 
   it('notifies when the page fires beforeunload', () => {

--- a/packages/core/src/browser/xhrObservable.spec.ts
+++ b/packages/core/src/browser/xhrObservable.spec.ts
@@ -9,11 +9,12 @@ describe('xhr observable', () => {
   let requestsTrackingSubscription: Subscription
   let contextEditionSubscription: Subscription | undefined
   let requests: XhrCompleteContext[]
+  let mockXhrManager: { reset(): void }
   let originalMockXhrSend: XMLHttpRequest['send']
   let configuration: Configuration
 
   beforeEach(() => {
-    mockXhr()
+    mockXhrManager = mockXhr()
     configuration = {} as Configuration
     // eslint-disable-next-line @typescript-eslint/unbound-method
     originalMockXhrSend = XMLHttpRequest.prototype.send
@@ -25,6 +26,7 @@ describe('xhr observable', () => {
   afterEach(() => {
     requestsTrackingSubscription.unsubscribe()
     contextEditionSubscription?.unsubscribe()
+    mockXhrManager.reset()
   })
 
   function startTrackingRequests() {

--- a/packages/core/src/domain/context/customerDataTracker.spec.ts
+++ b/packages/core/src/domain/context/customerDataTracker.spec.ts
@@ -23,6 +23,10 @@ describe('customerDataTracker', () => {
     displaySpy = spyOn(display, 'warn')
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   it('should warn if the context bytes limit is reached', () => {
     const customerDataTracker = createCustomerDataTrackerManager(
       CustomerDataCompressionStatus.Disabled

--- a/packages/core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
+++ b/packages/core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
@@ -16,6 +16,10 @@ describe('createEventRateLimiter', () => {
     resetNavigationStart()
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   it('returns false if the limit is not reached', () => {
     eventLimiter = createEventRateLimiter('error', limit, noop)
 

--- a/packages/core/src/domain/report/reportObservable.spec.ts
+++ b/packages/core/src/domain/report/reportObservable.spec.ts
@@ -19,6 +19,7 @@ describe('report observable', () => {
   })
 
   afterEach(() => {
+    reportingObserver.reset()
     consoleSubscription.unsubscribe()
   })
   ;[RawReportType.deprecation, RawReportType.intervention].forEach((type) => {

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -1,4 +1,11 @@
-import { createNewEvent, expireCookie, mockClock, registerCleanupTask, setPageVisibility } from '../../../test'
+import {
+  createNewEvent,
+  expireCookie,
+  mockClock,
+  registerCleanupTask,
+  restorePageVisibility,
+  setPageVisibility,
+} from '../../../test'
 import type { Clock } from '../../../test'
 import { getCookie, setCookie } from '../../browser/cookie'
 import type { RelativeTime } from '../../tools/utils/timeUtils'
@@ -88,14 +95,14 @@ describe('startSessionManager', () => {
     if (isIE()) {
       pending('no full rum support')
     }
-    clock = mockClock(() => {
-      // flush pending callbacks to avoid random failures
-      clock.tick(ONE_HOUR)
-    })
+    clock = mockClock()
 
     registerCleanupTask(() => {
       // remove intervals first
       stopSessionManager()
+      // flush pending callbacks to avoid random failures
+      clock.tick(ONE_HOUR)
+      clock.cleanup()
     })
   })
 
@@ -357,6 +364,10 @@ describe('startSessionManager', () => {
   describe('automatic session expiration', () => {
     beforeEach(() => {
       setPageVisibility('hidden')
+    })
+
+    afterEach(() => {
+      restorePageVisibility()
     })
 
     it('should expire the session after expiration delay', () => {

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -130,6 +130,7 @@ describe('session store', () => {
 
     afterEach(() => {
       resetSessionInStore()
+      clock.cleanup()
       sessionStoreManager.stop()
     })
 
@@ -507,6 +508,7 @@ describe('session store', () => {
 
     afterEach(() => {
       resetSessionInStore()
+      clock.cleanup()
       sessionStoreManager.stop()
       otherSessionStoreManager.stop()
     })

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -239,6 +239,8 @@ const EXPIRED_SESSION: SessionState = { isExpired: '1' }
         expect(processSpy).not.toHaveBeenCalled()
         expect(afterSpy).not.toHaveBeenCalled()
         expect(storage.setSpy).not.toHaveBeenCalled()
+
+        clock.cleanup()
       })
 
       it('should execute cookie accesses in order', (done) => {

--- a/packages/core/src/domain/synthetics/syntheticsWorkerValues.spec.ts
+++ b/packages/core/src/domain/synthetics/syntheticsWorkerValues.spec.ts
@@ -1,7 +1,11 @@
-import { mockSyntheticsWorkerValues } from '../../../test'
+import { mockSyntheticsWorkerValues, cleanupSyntheticsWorkerValues } from '../../../test'
 import { getSyntheticsResultId, getSyntheticsTestId, willSyntheticsInjectRum } from './syntheticsWorkerValues'
 
 describe('syntheticsWorkerValues', () => {
+  afterEach(() => {
+    cleanupSyntheticsWorkerValues()
+  })
+
   describe('willSyntheticsInjectRum', () => {
     it('returns false if nothing is defined', () => {
       mockSyntheticsWorkerValues({}, 'globals')

--- a/packages/core/src/tools/getZoneJsOriginalValue.spec.ts
+++ b/packages/core/src/tools/getZoneJsOriginalValue.spec.ts
@@ -1,9 +1,13 @@
+import type { MockZoneJs } from '../../test'
 import { mockZoneJs } from '../../test'
+
 import type { BrowserWindowWithZoneJs } from './getZoneJsOriginalValue'
 import { getZoneJsOriginalValue } from './getZoneJsOriginalValue'
 import { noop } from './utils/functionUtils'
 
 describe('getZoneJsOriginalValue', () => {
+  let zoneJs: MockZoneJs | undefined
+
   function originalValue() {
     // just a function that does nothing but different than 'noop' as we'll want to differentiate
     // them.
@@ -12,23 +16,28 @@ describe('getZoneJsOriginalValue', () => {
     name: originalValue,
   }
 
+  afterEach(() => {
+    zoneJs?.restore()
+  })
+
   it('returns the original value directly if Zone is not not defined', () => {
     expect(getZoneJsOriginalValue(object, 'name')).toBe(originalValue)
   })
 
   it("returns the original value if Zone is defined but didn't patch that method", () => {
-    mockZoneJs()
+    zoneJs = mockZoneJs()
     expect(getZoneJsOriginalValue(object, 'name')).toBe(originalValue)
   })
 
   it('returns the original value if Zone is defined but does not define the __symbol__ function', () => {
-    mockZoneJs()
+    zoneJs = mockZoneJs()
     delete (window as BrowserWindowWithZoneJs).Zone!.__symbol__
     expect(getZoneJsOriginalValue(object, 'name')).toBe(originalValue)
   })
 
   it('returns the original value if Zone did patch the method', () => {
-    mockZoneJs().replaceProperty(object, 'name', noop)
+    zoneJs = mockZoneJs()
+    zoneJs.replaceProperty(object, 'name', noop)
     expect(getZoneJsOriginalValue(object, 'name')).toBe(originalValue)
   })
 })

--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -194,8 +194,12 @@ describe('instrumentSetter', () => {
   let zoneJs: MockZoneJs
 
   beforeEach(() => {
-    zoneJs = mockZoneJs()
     clock = mockClock()
+    zoneJs = mockZoneJs()
+  })
+  afterEach(() => {
+    zoneJs.restore()
+    clock.cleanup()
   })
 
   it('replaces the original setter', () => {

--- a/packages/core/src/tools/timer.spec.ts
+++ b/packages/core/src/tools/timer.spec.ts
@@ -20,11 +20,13 @@ import { noop } from './utils/functionUtils'
     let zoneJs: MockZoneJs
 
     beforeEach(() => {
-      zoneJs = mockZoneJs()
       clock = mockClock()
+      zoneJs = mockZoneJs()
     })
 
     afterEach(() => {
+      zoneJs.restore()
+      clock.cleanup()
       resetMonitor()
     })
 

--- a/packages/core/src/tools/utils/functionUtils.spec.ts
+++ b/packages/core/src/tools/utils/functionUtils.spec.ts
@@ -14,6 +14,10 @@ describe('functionUtils', () => {
       spy = jasmine.createSpy()
     })
 
+    afterEach(() => {
+      clock.cleanup()
+    })
+
     describe('when {leading: false, trailing:false}', () => {
       beforeEach(() => {
         throttled = throttle(spy, 2, { leading: false, trailing: false }).throttled

--- a/packages/core/src/tools/valueHistory.spec.ts
+++ b/packages/core/src/tools/valueHistory.spec.ts
@@ -18,6 +18,7 @@ describe('valueHistory', () => {
 
   afterEach(() => {
     valueHistory.stop()
+    clock.cleanup()
   })
 
   describe('find', () => {

--- a/packages/core/src/transport/flushController.spec.ts
+++ b/packages/core/src/transport/flushController.spec.ts
@@ -34,6 +34,10 @@ describe('flushController', () => {
     flushController.flushObservable.subscribe(flushSpy)
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   it('when flushing, the event contains a reason, the bytes count and the messages count', () => {
     const messagesCount = 3
     for (let i = 0; i < messagesCount; i += 1) {

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -49,6 +49,10 @@ describe('sendWithRetryStrategy', () => {
     }
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   describe('nominal cases:', () => {
     it('should send request when no bandwidth limit reached', () => {
       sendRequest()

--- a/packages/core/test/emulate/mockClock.ts
+++ b/packages/core/test/emulate/mockClock.ts
@@ -1,29 +1,20 @@
 import { resetNavigationStart } from '../../src/tools/utils/timeUtils'
-import { registerCleanupTask } from '../registerCleanupTask'
 
-export type Clock = {
-  tick: (ms: number) => void
-  setDate: (date: Date) => void
-}
+export type Clock = ReturnType<typeof mockClock>
 
-export function mockClock(beforeCleanup?: () => void): Clock {
+export function mockClock(date?: Date) {
   jasmine.clock().install()
-  jasmine.clock().mockDate()
+  jasmine.clock().mockDate(date)
   const start = Date.now()
   spyOn(performance, 'now').and.callFake(() => Date.now() - start)
   spyOnProperty(performance.timing, 'navigationStart', 'get').and.callFake(() => start)
   resetNavigationStart()
-
-  registerCleanupTask(() => {
-    if (beforeCleanup) {
-      beforeCleanup()
-    }
-    jasmine.clock().uninstall()
-    resetNavigationStart()
-  })
-
   return {
     tick: (ms: number) => jasmine.clock().tick(ms),
     setDate: (date: Date) => jasmine.clock().mockDate(date),
+    cleanup: () => {
+      jasmine.clock().uninstall()
+      resetNavigationStart()
+    },
   }
 }

--- a/packages/core/test/emulate/mockFetch.ts
+++ b/packages/core/test/emulate/mockFetch.ts
@@ -1,5 +1,4 @@
 import { noop } from '../../src'
-import { registerCleanupTask } from '../registerCleanupTask'
 
 export type MockFetchManager = ReturnType<typeof mockFetch>
 
@@ -38,14 +37,13 @@ export function mockFetch() {
     return promise
   }) as typeof window.fetch
 
-  registerCleanupTask(() => {
-    window.fetch = originalFetch
-    allFetchCompleteCallback = noop
-  })
-
   return {
     whenAllComplete(callback: () => void) {
       allFetchCompleteCallback = callback
+    },
+    reset() {
+      window.fetch = originalFetch
+      allFetchCompleteCallback = noop
     },
   }
 }

--- a/packages/core/test/emulate/mockLocation.ts
+++ b/packages/core/test/emulate/mockLocation.ts
@@ -1,5 +1,4 @@
 import { assign, buildUrl } from '../../src'
-import { registerCleanupTask } from '../registerCleanupTask'
 
 export function mockLocation(initialUrl: string) {
   const fakeLocation = buildLocation(initialUrl)
@@ -13,14 +12,12 @@ export function mockLocation(initialUrl: string) {
   }
 
   window.addEventListener('hashchange', hashchangeCallBack)
-
-  registerCleanupTask(() => {
-    window.removeEventListener('hashchange', hashchangeCallBack)
-    window.location.hash = ''
-  })
-
   return {
     location: fakeLocation,
+    cleanup: () => {
+      window.removeEventListener('hashchange', hashchangeCallBack)
+      window.location.hash = ''
+    },
   }
 }
 

--- a/packages/core/test/emulate/mockReportingObserver.ts
+++ b/packages/core/test/emulate/mockReportingObserver.ts
@@ -1,6 +1,5 @@
 import type { InterventionReport, ReportType } from '../../src/domain/report/browser.types'
 import { noop } from '../../src/tools/utils/functionUtils'
-import { registerCleanupTask } from '../registerCleanupTask'
 import { createNewEvent } from './createNewEvent'
 
 export type MockReportingObserver = ReturnType<typeof mockReportingObserver>
@@ -33,15 +32,15 @@ export function mockReportingObserver() {
     return reportingObserver
   } as unknown as typeof originalReportingObserver
 
-  registerCleanupTask(() => {
-    window.ReportingObserver = originalReportingObserver
-    callbacks = {}
-  })
   return {
     raiseReport(type: ReportType) {
       if (callbacks[type]) {
         callbacks[type].forEach((callback) => callback([{ ...FAKE_REPORT, type }], reportingObserver))
       }
+    },
+    reset() {
+      window.ReportingObserver = originalReportingObserver
+      callbacks = {}
     },
   }
 }

--- a/packages/core/test/emulate/mockSyntheticsWorkerValues.ts
+++ b/packages/core/test/emulate/mockSyntheticsWorkerValues.ts
@@ -6,7 +6,6 @@ import {
   SYNTHETICS_RESULT_ID_COOKIE_NAME,
   SYNTHETICS_TEST_ID_COOKIE_NAME,
 } from '../../src/domain/synthetics/syntheticsWorkerValues'
-import { registerCleanupTask } from '../registerCleanupTask'
 
 // Duration to create a cookie lasting at least until the end of the test
 const COOKIE_DURATION = ONE_MINUTE
@@ -38,14 +37,14 @@ export function mockSyntheticsWorkerValues(
       break
   }
   resetInitCookies()
+}
 
-  registerCleanupTask(() => {
-    delete (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID
-    delete (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID
-    delete (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM
-    deleteCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
-    deleteCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
-    deleteCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
-    resetInitCookies()
-  })
+export function cleanupSyntheticsWorkerValues() {
+  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID
+  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID
+  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM
+  deleteCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
+  deleteCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
+  deleteCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
+  resetInitCookies()
 }

--- a/packages/core/test/emulate/mockVisibilityState.ts
+++ b/packages/core/test/emulate/mockVisibilityState.ts
@@ -1,5 +1,3 @@
-import { registerCleanupTask } from '../registerCleanupTask'
-
 export function setPageVisibility(visibility: 'visible' | 'hidden') {
   Object.defineProperty(document, 'visibilityState', {
     get() {
@@ -7,7 +5,8 @@ export function setPageVisibility(visibility: 'visible' | 'hidden') {
     },
     configurable: true,
   })
-  registerCleanupTask(() => {
-    delete (document as any).visibilityState
-  })
+}
+
+export function restorePageVisibility() {
+  delete (document as any).visibilityState
 }

--- a/packages/core/test/emulate/mockXhr.ts
+++ b/packages/core/test/emulate/mockXhr.ts
@@ -1,15 +1,18 @@
 import { isServerError, noop } from '../../src'
-import { registerCleanupTask } from '../registerCleanupTask'
 import { createNewEvent } from './createNewEvent'
+
+export type MockXhrManager = ReturnType<typeof mockXhr>
 
 export function mockXhr() {
   const originalXhr = XMLHttpRequest
 
   window.XMLHttpRequest = MockXhr as any
 
-  registerCleanupTask(() => {
-    window.XMLHttpRequest = originalXhr
-  })
+  return {
+    reset() {
+      window.XMLHttpRequest = originalXhr
+    },
+  }
 }
 
 export function withXhr({

--- a/packages/core/test/emulate/mockZoneJs.ts
+++ b/packages/core/test/emulate/mockZoneJs.ts
@@ -1,5 +1,4 @@
 import type { BrowserWindowWithZoneJs } from '../../src/tools/getZoneJsOriginalValue'
-import { registerCleanupTask } from '../registerCleanupTask'
 
 export type MockZoneJs = ReturnType<typeof mockZoneJs>
 
@@ -13,12 +12,11 @@ export function mockZoneJs() {
 
   browserWindow.Zone = { __symbol__: getSymbol }
 
-  registerCleanupTask(() => {
-    delete browserWindow.Zone
-    restorers.forEach((restorer) => restorer())
-  })
-
   return {
+    restore: () => {
+      delete browserWindow.Zone
+      restorers.forEach((restorer) => restorer())
+    },
     getSymbol,
     replaceProperty<Target, Name extends keyof Target & string>(target: Target, name: Name, replacement: Target[Name]) {
       const original = target[name]

--- a/packages/core/test/interceptRequests.ts
+++ b/packages/core/test/interceptRequests.ts
@@ -27,6 +27,7 @@ export function interceptRequests() {
   const originalSendBeacon = isSendBeaconSupported() && navigator.sendBeacon.bind(navigator)
   const originalRequest = window.Request
   const originalFetch = window.fetch
+  let xhrManager: { reset(): void } | undefined
 
   spyOn(XMLHttpRequest.prototype, 'open').and.callFake((_, url) => requests.push({ type: 'xhr', url } as Request))
   spyOn(XMLHttpRequest.prototype, 'send').and.callFake((body) => (requests[requests.length - 1].body = body as string))
@@ -65,7 +66,7 @@ export function interceptRequests() {
       window.fetch = newFetch
     },
     withMockXhr(onSend: (xhr: MockXhr) => void) {
-      mockXhr()
+      xhrManager = mockXhr()
       MockXhr.onSend = onSend
     },
     restore() {
@@ -78,6 +79,7 @@ export function interceptRequests() {
       if (originalFetch) {
         window.fetch = originalFetch
       }
+      xhrManager?.reset()
       MockXhr.onSend = noop
     },
   }

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -1,5 +1,4 @@
-import { mockClock, mockEventBridge } from '@datadog/browser-core/test'
-import type { Clock } from '@datadog/browser-core/test'
+import { mockClock, type Clock, mockEventBridge } from '@datadog/browser-core/test'
 import type { TimeStamp, TrackingConsentState } from '@datadog/browser-core'
 import {
   ONE_SECOND,
@@ -46,6 +45,7 @@ describe('preStartLogs', () => {
 
   afterEach(() => {
     resetFetchObservable()
+    clock.cleanup()
   })
 
   describe('configuration validation', () => {

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -18,6 +18,7 @@ import {
   interceptRequests,
   mockEndpointBuilder,
   mockEventBridge,
+  cleanupSyntheticsWorkerValues,
   mockSyntheticsWorkerValues,
   registerCleanupTask,
   mockClock,
@@ -204,6 +205,10 @@ describe('logs', () => {
   })
 
   describe('logs session creation', () => {
+    afterEach(() => {
+      cleanupSyntheticsWorkerValues()
+    })
+
     it('creates a session on normal conditions', () => {
       ;({ handleLog, stop: stopLogs } = startLogs(
         initConfiguration,
@@ -247,6 +252,9 @@ describe('logs', () => {
     let clock: Clock
     beforeEach(() => {
       clock = mockClock()
+    })
+    afterEach(() => {
+      clock.cleanup()
     })
 
     it('sends logs without session id when the session expires ', () => {

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -415,9 +415,9 @@ describe('logs limitation', () => {
   })
 
   afterEach(() => {
+    clock.cleanup()
     serverLogs = []
   })
-
   it('should not apply to agent logs', () => {
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
       rawLogsEvent: { ...DEFAULT_MESSAGE, origin: ErrorSource.AGENT, status: 'error', message: 'foo' },

--- a/packages/logs/src/domain/contexts/rumInternalContext.spec.ts
+++ b/packages/logs/src/domain/contexts/rumInternalContext.spec.ts
@@ -1,6 +1,6 @@
 import type { TelemetryEvent } from '@datadog/browser-core'
 import { startTelemetry, TelemetryService } from '@datadog/browser-core'
-import { mockSyntheticsWorkerValues } from '@datadog/browser-core/test'
+import { mockSyntheticsWorkerValues, cleanupSyntheticsWorkerValues } from '@datadog/browser-core/test'
 import { validateAndBuildLogsConfiguration } from '../configuration'
 import { resetRUMInternalContext, getRUMInternalContext } from './rumInternalContext'
 
@@ -40,6 +40,10 @@ describe('getRUMInternalContext', () => {
       )
       telemetrySpy = jasmine.createSpy()
       telemetry.observable.subscribe(telemetrySpy)
+    })
+
+    afterEach(() => {
+      cleanupSyntheticsWorkerValues()
     })
 
     it('uses the global variable created when the synthetics worker is injecting RUM', () => {

--- a/packages/logs/src/domain/logger/loggerCollection.spec.ts
+++ b/packages/logs/src/domain/logger/loggerCollection.spec.ts
@@ -7,6 +7,7 @@ import {
   createCustomerDataTracker,
   noop,
 } from '@datadog/browser-core'
+import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
 import type { CommonContext, RawLoggerLogsEvent } from '../../rawLogsEvent.types'
 import type { RawLogsEventCollectedData } from '../lifeCycle'
@@ -24,6 +25,7 @@ describe('logger collection', () => {
   let handleLog: ReturnType<typeof startLoggerCollection>['handleLog']
   let logger: Logger
   let rawLogsEvents: Array<RawLogsEventCollectedData<RawLoggerLogsEvent>>
+  let clock: Clock
 
   beforeEach(() => {
     rawLogsEvents = []
@@ -34,7 +36,11 @@ describe('logger collection', () => {
     spyOn(console, 'error').and.callFake(() => true)
     logger = new Logger((...params) => handleLog(...params), createCustomerDataTracker(noop))
     ;({ handleLog: handleLog } = startLoggerCollection(lifeCycle))
-    mockClock()
+    clock = mockClock()
+  })
+
+  afterEach(() => {
+    clock.cleanup()
   })
 
   describe('when handle type is set to "console"', () => {

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -27,15 +27,15 @@ describe('logs session manager', () => {
   let clock: Clock
 
   beforeEach(() => {
-    clock = mockClock(() => {
-      // flush pending callbacks to avoid random failures
-      clock.tick(new Date().getTime())
-    })
+    clock = mockClock()
   })
 
   afterEach(() => {
     // remove intervals first
     stopSessionManager()
+    // flush pending callbacks to avoid random failures
+    clock.tick(new Date().getTime())
+    clock.cleanup()
   })
 
   it('when tracked should store tracking type and session id', () => {

--- a/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
@@ -56,6 +56,7 @@ describe('network error collection', () => {
 
     registerCleanupTask(() => {
       stopNetworkErrorCollection()
+      mockFetchManager.reset()
     })
   })
 

--- a/packages/logs/src/domain/report/reportCollection.spec.ts
+++ b/packages/logs/src/domain/report/reportCollection.spec.ts
@@ -26,6 +26,7 @@ describe('reports', () => {
   })
 
   afterEach(() => {
+    reportingObserver.reset()
     stopReportCollection()
   })
 

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import {
+  cleanupSyntheticsWorkerValues,
   mockEventBridge,
   interceptRequests,
   mockClock,
@@ -167,6 +168,10 @@ describe('preStartRum', () => {
   })
 
   describe('init', () => {
+    afterEach(() => {
+      cleanupSyntheticsWorkerValues()
+    })
+
     it('should not initialize if session cannot be handled and bridge is not present', () => {
       spyOnProperty(document, 'cookie', 'get').and.returnValue('')
       const displaySpy = spyOn(display, 'warn')
@@ -301,6 +306,12 @@ describe('preStartRum', () => {
           updateViewName: updateViewNameSpy,
         } as unknown as StartRumResult)
         strategy = createPreStartStrategy({}, getCommonContextSpy, createTrackingConsentState(), doStartRumSpy)
+      })
+
+      afterEach(() => {
+        if (clock) {
+          clock.cleanup()
+        }
       })
 
       describe('when auto', () => {
@@ -535,6 +546,7 @@ describe('preStartRum', () => {
     })
 
     afterEach(() => {
+      cleanupSyntheticsWorkerValues()
       interceptor.restore()
       resetExperimentalFeatures()
     })

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -10,7 +10,7 @@ import {
   CustomerDataCompressionStatus,
   timeStampToClocks,
 } from '@datadog/browser-core'
-import { mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { cleanupSyntheticsWorkerValues, mockExperimentalFeatures } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../test'
 import { setup, noopRecorderApi } from '../../test'
 import { ActionType, VitalType } from '../rawRumEvent.types'
@@ -44,6 +44,10 @@ describe('rum public api', () => {
 
     beforeEach(() => {
       startRumSpy = jasmine.createSpy().and.callFake(noopStartRum)
+    })
+
+    afterEach(() => {
+      cleanupSyntheticsWorkerValues()
     })
 
     describe('deflate worker', () => {

--- a/packages/rum-core/src/browser/cookieObservable.spec.ts
+++ b/packages/rum-core/src/browser/cookieObservable.spec.ts
@@ -22,6 +22,7 @@ describe('cookieObservable', () => {
     if (originalSupportedEntryTypes) {
       Object.defineProperty(window, 'cookieStore', originalSupportedEntryTypes)
     }
+    clock.cleanup()
     deleteCookie(COOKIE_NAME)
   })
 

--- a/packages/rum-core/src/browser/domMutationObservable.spec.ts
+++ b/packages/rum-core/src/browser/domMutationObservable.spec.ts
@@ -1,5 +1,6 @@
 import { isIE } from '@datadog/browser-core'
-import { mockZoneJs, registerCleanupTask, type MockZoneJs } from '@datadog/browser-core/test'
+import type { MockZoneJs } from '@datadog/browser-core/test'
+import { registerCleanupTask, mockZoneJs } from '@datadog/browser-core/test'
 import { createDOMMutationObservable, getMutationObserverConstructor } from './domMutationObservable'
 
 // The MutationObserver invokes its callback in an event loop microtask, making this asynchronous.
@@ -119,6 +120,7 @@ describe('domMutationObservable', () => {
       zoneJs = mockZoneJs()
 
       registerCleanupTask(() => {
+        zoneJs.restore()
         window.MutationObserver = OriginalMutationObserverConstructor
       })
     })

--- a/packages/rum-core/src/browser/locationChangeObservable.spec.ts
+++ b/packages/rum-core/src/browser/locationChangeObservable.spec.ts
@@ -9,10 +9,11 @@ describe('locationChangeObservable', () => {
   let observer: jasmine.Spy<(locationChange: LocationChange) => void>
   let subscription: Subscription
   let fakeLocation: Partial<Location>
+  let cleanupLocation: () => void
   let configuration: RumConfiguration
 
   beforeEach(() => {
-    ;({ location: fakeLocation } = mockLocation('/foo'))
+    ;({ location: fakeLocation, cleanup: cleanupLocation } = mockLocation('/foo'))
     configuration = {} as RumConfiguration
     observable = createLocationChangeObservable(configuration, fakeLocation as Location)
     observer = jasmine.createSpy('obs')
@@ -21,6 +22,7 @@ describe('locationChangeObservable', () => {
 
   afterEach(() => {
     subscription.unsubscribe()
+    cleanupLocation()
   })
 
   it('should notify observers on history change', () => {

--- a/packages/rum-core/src/browser/performanceObservable.spec.ts
+++ b/packages/rum-core/src/browser/performanceObservable.spec.ts
@@ -26,6 +26,7 @@ describe('performanceObservable', () => {
 
   afterEach(() => {
     performanceSubscription?.unsubscribe()
+    clock?.cleanup()
   })
 
   describe('primary strategy when type supported', () => {

--- a/packages/rum-core/src/browser/viewportObservable.spec.ts
+++ b/packages/rum-core/src/browser/viewportObservable.spec.ts
@@ -21,6 +21,7 @@ describe('viewportObservable', () => {
 
   afterEach(() => {
     viewportSubscription.unsubscribe()
+    clock.cleanup()
   })
 
   const addVerticalScrollBar = () => {

--- a/packages/rum-core/src/domain/action/clickChain.spec.ts
+++ b/packages/rum-core/src/domain/action/clickChain.spec.ts
@@ -16,6 +16,7 @@ describe('createClickChain', () => {
 
   afterEach(() => {
     clickChain?.stop()
+    clock.cleanup()
   })
 
   it('creates a click chain', () => {

--- a/packages/rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/action/computeFrustration.spec.ts
@@ -87,6 +87,10 @@ describe('isRage', () => {
     clock = mockClock()
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   it('considers as rage three clicks happening at the same time', () => {
     expect(isRage([createFakeClick(), createFakeClick(), createFakeClick()])).toBe(true)
   })

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -2,6 +2,7 @@ import type { ClocksState, RelativeTime, TimeStamp } from '@datadog/browser-core
 import { ErrorSource, ExperimentalFeature, ONE_MINUTE, display } from '@datadog/browser-core'
 import {
   mockEventBridge,
+  cleanupSyntheticsWorkerValues,
   mockSyntheticsWorkerValues,
   mockExperimentalFeatures,
   setNavigatorOnLine,
@@ -71,6 +72,10 @@ describe('rum assembly', () => {
           )
         }
       )
+  })
+
+  afterEach(() => {
+    cleanupSyntheticsWorkerValues()
   })
 
   describe('beforeSend', () => {

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
@@ -17,6 +17,10 @@ describe('pageStateHistory', () => {
     registerCleanupTask(pageStateHistory.stop)
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   describe('findAll', () => {
     it('should have the current state when starting', () => {
       expect(pageStateHistory.findAll(0 as RelativeTime, 10 as RelativeTime)).toBeDefined()

--- a/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
@@ -1,7 +1,11 @@
-import { mockSyntheticsWorkerValues } from '../../../../core/test'
+import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../../core/test'
 import { getSyntheticsContext } from './syntheticsContext'
 
 describe('getSyntheticsContext', () => {
+  afterEach(() => {
+    cleanupSyntheticsWorkerValues()
+  })
+
   it('sets the synthetics context defined by global variables', () => {
     mockSyntheticsWorkerValues({ publicId: 'foo', resultId: 'bar' }, 'globals')
 

--- a/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
@@ -1,5 +1,6 @@
 import type { RawError, Subscription } from '@datadog/browser-core'
 import { ErrorHandling, ErrorSource, Observable, clocksNow, resetConsoleObservable } from '@datadog/browser-core'
+import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
 import { trackConsoleError } from './trackConsoleError'
 
@@ -7,6 +8,7 @@ describe('trackConsoleError', () => {
   let errorObservable: Observable<RawError>
   let subscription: Subscription
   let notifyLog: jasmine.Spy
+  let clock: Clock
 
   beforeEach(() => {
     spyOn(console, 'error').and.callFake(() => true)
@@ -14,12 +16,13 @@ describe('trackConsoleError', () => {
     notifyLog = jasmine.createSpy('notifyLog')
     trackConsoleError(errorObservable)
     subscription = errorObservable.subscribe(notifyLog)
-    mockClock()
+    clock = mockClock()
   })
 
   afterEach(() => {
     resetConsoleObservable()
     subscription.unsubscribe()
+    clock.cleanup()
   })
 
   it('should track console error', () => {

--- a/packages/rum-core/src/domain/error/trackReportError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackReportError.spec.ts
@@ -1,6 +1,6 @@
 import type { RawError, Subscription } from '@datadog/browser-core'
 import { ErrorHandling, ErrorSource, Observable, clocksNow } from '@datadog/browser-core'
-import type { MockCspEventListener, MockReportingObserver } from '@datadog/browser-core/test'
+import type { Clock, MockCspEventListener, MockReportingObserver } from '@datadog/browser-core/test'
 import {
   FAKE_CSP_VIOLATION_EVENT,
   FAKE_REPORT,
@@ -15,6 +15,7 @@ describe('trackReportError', () => {
   let errorObservable: Observable<RawError>
   let subscription: Subscription
   let notifyLog: jasmine.Spy
+  let clock: Clock
   let reportingObserver: MockReportingObserver
   let cspEventListener: MockCspEventListener
   let configuration: RumConfiguration
@@ -26,11 +27,13 @@ describe('trackReportError', () => {
     reportingObserver = mockReportingObserver()
     subscription = errorObservable.subscribe(notifyLog)
     cspEventListener = mockCspEventListener()
-    mockClock()
+    clock = mockClock()
   })
 
   afterEach(() => {
     subscription.unsubscribe()
+    clock.cleanup()
+    reportingObserver.reset()
   })
 
   it('should track reports', () => {

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -1,7 +1,7 @@
 import type { Payload } from '@datadog/browser-core'
 import { isIE, RequestType } from '@datadog/browser-core'
-import type { MockFetch, MockFetchManager } from '@datadog/browser-core/test'
-import { SPEC_ENDPOINTS, mockFetch, mockXhr, registerCleanupTask, withXhr } from '@datadog/browser-core/test'
+import type { MockFetch, MockFetchManager, MockXhrManager } from '@datadog/browser-core/test'
+import { registerCleanupTask, SPEC_ENDPOINTS, mockFetch, mockXhr, withXhr } from '@datadog/browser-core/test'
 import type { RumConfiguration } from './configuration'
 import { validateAndBuildRumConfiguration } from './configuration'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
@@ -53,6 +53,7 @@ describe('collect fetch', () => {
 
     registerCleanupTask(() => {
       stopFetchTracking()
+      mockFetchManager.reset()
       window.onunhandledrejection = null
     })
   })
@@ -192,6 +193,7 @@ describe('collect xhr', () => {
   let configuration: RumConfiguration
   let startSpy: jasmine.Spy<(requestStartEvent: RequestStartEvent) => void>
   let completeSpy: jasmine.Spy<(requestCompleteEvent: RequestCompleteEvent) => void>
+  let mockXhrManager: MockXhrManager
   let stopXhrTracking: () => void
 
   beforeEach(() => {
@@ -203,7 +205,7 @@ describe('collect xhr', () => {
       ...SPEC_ENDPOINTS,
       batchMessagesLimit: 1,
     }
-    mockXhr()
+    mockXhrManager = mockXhr()
     startSpy = jasmine.createSpy('requestStart')
     completeSpy = jasmine.createSpy('requestComplete')
     const lifeCycle = new LifeCycle()
@@ -220,6 +222,7 @@ describe('collect xhr', () => {
 
     registerCleanupTask(() => {
       stopXhrTracking()
+      mockXhrManager.reset()
     })
   })
 

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -13,7 +13,13 @@ import {
   BridgeCapability,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { createNewEvent, expireCookie, mockEventBridge, mockClock } from '@datadog/browser-core/test'
+import {
+  createNewEvent,
+  expireCookie,
+  mockEventBridge,
+  mockClock,
+  registerCleanupTask,
+} from '@datadog/browser-core/test'
 import type { RumConfiguration } from './configuration'
 import { validateAndBuildRumConfiguration } from './configuration'
 
@@ -37,17 +43,20 @@ describe('rum session manager', () => {
     if (isIE()) {
       pending('no full rum support')
     }
-    clock = mockClock(() => {
-      // remove intervals first
-      stopSessionManager()
-      // flush pending callbacks to avoid random failures
-      clock.tick(new Date().getTime())
-    })
+    clock = mockClock()
     expireSessionSpy = jasmine.createSpy('expireSessionSpy')
     renewSessionSpy = jasmine.createSpy('renewSessionSpy')
     lifeCycle = new LifeCycle()
     lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, expireSessionSpy)
     lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, renewSessionSpy)
+
+    registerCleanupTask(() => {
+      // remove intervals first
+      stopSessionManager()
+      // flush pending callbacks to avoid random failures
+      clock.tick(new Date().getTime())
+      clock.cleanup()
+    })
   })
 
   describe('cookie storage', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
@@ -1,5 +1,5 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import { setPageVisibility } from '@datadog/browser-core/test'
+import { restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import { RumPerformanceEntryType } from '../../../browser/performanceObservable'
 import type { TestSetupBuilder } from '../../../../test'
 import { createPerformanceEntry, setup } from '../../../../test'
@@ -26,6 +26,10 @@ describe('trackFirstContentfulPaint', () => {
         },
       }
     })
+  })
+
+  afterEach(() => {
+    restorePageVisibility()
   })
 
   it('should provide the first contentful paint timing', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -1,6 +1,6 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { DOM_EVENT } from '@datadog/browser-core'
-import { createNewEvent, setPageVisibility } from '@datadog/browser-core/test'
+import { createNewEvent, restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '../../configuration'
 import { trackFirstHidden } from './trackFirstHidden'
 
@@ -13,6 +13,7 @@ describe('trackFirstHidden', () => {
   })
 
   afterEach(() => {
+    restorePageVisibility()
     firstHidden.stop()
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -1,5 +1,5 @@
 import { type Duration, type RelativeTime, resetExperimentalFeatures } from '@datadog/browser-core'
-import { setPageVisibility } from '@datadog/browser-core/test'
+import { restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { TestSetupBuilder } from '../../../../test'
 import { appendElement, appendText, createPerformanceEntry, setup } from '../../../../test'
 import { LifeCycleEventType } from '../../lifeCycle'
@@ -32,6 +32,7 @@ describe('firstInputTimings', () => {
   })
 
   afterEach(() => {
+    restorePageVisibility()
     resetExperimentalFeatures()
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -1,6 +1,6 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { DOM_EVENT, resetExperimentalFeatures } from '@datadog/browser-core'
-import { setPageVisibility, createNewEvent } from '@datadog/browser-core/test'
+import { restorePageVisibility, setPageVisibility, createNewEvent } from '@datadog/browser-core/test'
 import { RumPerformanceEntryType } from '../../../browser/performanceObservable'
 import type { TestSetupBuilder } from '../../../../test'
 import { appendElement, createPerformanceEntry, setup } from '../../../../test'
@@ -20,7 +20,6 @@ describe('trackLargestContentfulPaint', () => {
     configuration = {} as RumConfiguration
     lcpCallback = jasmine.createSpy()
     eventTarget = document.createElement('div') as unknown as Window
-    setPageVisibility('visible')
     setupBuilder = setup().beforeBuild(({ lifeCycle }) => {
       const firstHidden = trackFirstHidden(configuration)
       const largestContentfulPaint = trackLargestContentfulPaint(
@@ -40,6 +39,7 @@ describe('trackLargestContentfulPaint', () => {
   })
 
   afterEach(() => {
+    restorePageVisibility()
     resetExperimentalFeatures()
   })
 

--- a/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
@@ -184,6 +184,10 @@ describe('doWaitPageActivityEnd', () => {
     clock = mockClock()
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   it('should notify the callback after `EXPIRE_DELAY` when there is no activity', () => {
     doWaitPageActivityEnd(new Observable(), idlPageActivityCallbackSpy)
 

--- a/packages/rum-core/test/testSetupBuilder.ts
+++ b/packages/rum-core/test/testSetupBuilder.ts
@@ -223,6 +223,8 @@ export function setup(): TestSetupBuilder {
   }
   registerCleanupTask(() => {
     cleanupTasks.forEach((task) => task())
+    // perform these steps at the end to generate correct events in cleanup and validate them
+    clock?.cleanup()
     rawRumEventsCollected.unsubscribe()
   })
   return setupBuilder

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -2,12 +2,15 @@ import type { TimeStamp, HttpRequest } from '@datadog/browser-core'
 import { PageExitReason, DefaultPrivacyLevel, noop, isIE, DeflateEncoderStreamId } from '@datadog/browser-core'
 import type { LifeCycle, ViewCreatedEvent, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycleEventType, startViewContexts } from '@datadog/browser-rum-core'
+import type { Clock } from '@datadog/browser-core/test'
 import { collectAsyncCalls, createNewEvent, mockEventBridge, registerCleanupTask } from '@datadog/browser-core/test'
 import type { ViewEndedEvent } from 'packages/rum-core/src/domain/view/trackViews'
 import type { RumSessionManagerMock, TestSetupBuilder } from '../../../rum-core/test'
 import { appendElement, createRumSessionManagerMock, setup } from '../../../rum-core/test'
+
 import { recordsPerFullSnapshot, readReplayPayload } from '../../test'
 import { setSegmentBytesLimit } from '../domain/segmentCollection'
+
 import { RecordType } from '../types'
 import { resetReplayStats } from '../domain/replayStats'
 import { createDeflateEncoder, resetDeflateWorkerState, startDeflateWorker } from '../domain/deflate'
@@ -22,6 +25,7 @@ describe('startRecording', () => {
   let textField: HTMLInputElement
   let requestSendSpy: jasmine.Spy<HttpRequest['sendOnExit']>
   let stopRecording: () => void
+  let clock: Clock | undefined
   let configuration: RumConfiguration
 
   beforeEach(() => {
@@ -72,6 +76,7 @@ describe('startRecording', () => {
 
     registerCleanupTask(() => {
       setSegmentBytesLimit()
+      clock?.cleanup()
       resetDeflateWorkerState()
     })
   })

--- a/packages/rum/src/domain/deflate/deflateWorker.spec.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.spec.ts
@@ -182,6 +182,10 @@ describe('startDeflateWorker', () => {
       clock = mockClock()
     })
 
+    afterEach(() => {
+      clock.cleanup()
+    })
+
     it('displays an error message when the worker does not respond to the init action', () => {
       startDeflateWorkerWithDefaults()
       clock.tick(INITIALIZATION_TIME_OUT_DELAY)

--- a/packages/rum/src/domain/record/mutationBatch.spec.ts
+++ b/packages/rum/src/domain/record/mutationBatch.spec.ts
@@ -23,6 +23,7 @@ describe('createMutationBatch', () => {
 
   afterEach(() => {
     mutationBatch.stop()
+    clock.cleanup()
   })
 
   it('calls the callback asynchronously after MUTATION_PROCESS_MIN_DELAY', () => {

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,6 +1,7 @@
 import { DefaultPrivacyLevel, findLast, isIE } from '@datadog/browser-core'
 import type { RumConfiguration, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
+import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, collectAsyncCalls, registerCleanupTask } from '@datadog/browser-core/test'
 import { findElement, findFullSnapshot, findNode, recordsPerFullSnapshot } from '../../../test'
 import type {
@@ -22,6 +23,7 @@ describe('record', () => {
   let recordApi: RecordAPI
   let lifeCycle: LifeCycle
   let emitSpy: jasmine.Spy<(record: BrowserRecord) => void>
+  let clock: Clock | undefined
   const FAKE_VIEW_ID = '123'
 
   beforeEach(() => {
@@ -32,6 +34,7 @@ describe('record', () => {
     emitSpy = jasmine.createSpy()
 
     registerCleanupTask(() => {
+      clock?.cleanup()
       recordApi?.stop()
     })
   })

--- a/packages/rum/src/domain/record/trackers/trackInput.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackInput.spec.ts
@@ -35,6 +35,7 @@ describe('trackInput', () => {
 
     registerCleanupTask(() => {
       inputTracker.stop()
+      clock?.cleanup()
     })
   })
 

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -3,7 +3,7 @@ import { DeflateEncoderStreamId, PageExitReason, isIE } from '@datadog/browser-c
 import type { ViewContexts, ViewContext, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock, registerCleanupTask, restorePageVisibility } from '@datadog/browser-core/test'
 import { createRumSessionManagerMock } from '../../../../rum-core/test'
 import type { BrowserRecord, SegmentContext } from '../../types'
 import { RecordType } from '../../types'
@@ -77,6 +77,7 @@ describe('startSegmentCollection', () => {
     ))
 
     registerCleanupTask(() => {
+      clock?.cleanup()
       stopSegmentCollection()
     })
   })
@@ -113,6 +114,10 @@ describe('startSegmentCollection', () => {
   })
 
   describe('segment flush strategy', () => {
+    afterEach(() => {
+      restorePageVisibility()
+    })
+
     it('does not flush empty segments', () => {
       emulatePageUnload()
       worker.processAllMessages()


### PR DESCRIPTION
## Motivation

This PR causes timeout in unit-bs.

## Changes

Revert https://github.com/DataDog/browser-sdk/pull/2837

## Testing

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
