### PR TITLE
Update rum-react peerDependencies

### DIFF
--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -3,7 +3,9 @@ const { modifyFile } = require('../lib/files-utils')
 const { command } = require('../lib/command')
 const { browserSdkVersion } = require('../lib/browser-sdk-version')
 
-const JSON_FILES = ['rum', 'rum-slim', 'logs'].map((packageName) => `./packages/${packageName}/package.json`)
+const JSON_FILES = ['rum', 'rum-slim', 'logs', 'rum-react'].map(
+  (packageName) => `./packages/${packageName}/package.json`
+)
 
 // This script updates the peer dependency versions between rum and logs packages to match the new
 // version during a release.
@@ -24,8 +26,10 @@ runMain(async () => {
 
 function updateJsonPeerDependencies(content) {
   const json = JSON.parse(content)
-  Object.keys(json.peerDependencies).forEach((key) => {
-    json.peerDependencies[key] = browserSdkVersion
-  })
+  Object.keys(json.peerDependencies)
+    .filter((key) => key.startsWith('@datadog'))
+    .forEach((key) => {
+      json.peerDependencies[key] = browserSdkVersion
+    })
   return `${JSON.stringify(json, null, 2)}\n`
 }

--- a/scripts/release/update-peer-dependency-versions.js
+++ b/scripts/release/update-peer-dependency-versions.js
@@ -1,11 +1,10 @@
+const { readdirSync } = require('fs')
 const { runMain } = require('../lib/execution-utils')
 const { modifyFile } = require('../lib/files-utils')
 const { command } = require('../lib/command')
 const { browserSdkVersion } = require('../lib/browser-sdk-version')
 
-const JSON_FILES = ['rum', 'rum-slim', 'logs', 'rum-react'].map(
-  (packageName) => `./packages/${packageName}/package.json`
-)
+const JSON_FILES = readdirSync('./packages').map((packageName) => `./packages/${packageName}/package.json`)
 
 // This script updates the peer dependency versions between rum and logs packages to match the new
 // version during a release.
@@ -26,7 +25,7 @@ runMain(async () => {
 
 function updateJsonPeerDependencies(content) {
   const json = JSON.parse(content)
-  Object.keys(json.peerDependencies)
+  Object.keys(json.peerDependencies || [])
     .filter((key) => key.startsWith('@datadog'))
     .forEach((key) => {
       json.peerDependencies[key] = browserSdkVersion


### PR DESCRIPTION
## Motivation

`rum-react` package peerDependencies on `@datadog/browser-core` and `@datadog/browser-rum-core` are not updated by release script.

## Changes

- Reading the content of `./packages` to retrieve packages name. 
- Update packages with peerDependencies on `@datadog` modules.

## Testing

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
