### PR TITLE
⚗️ enable plugins as a beta feature

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -19,7 +19,6 @@ export enum ExperimentalFeature {
   TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
   REMOTE_CONFIGURATION = 'remote_configuration',
   UPDATE_VIEW_NAME = 'update_view_name',
-  PLUGINS = 'plugins',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -477,10 +477,6 @@ describe('preStartRum', () => {
     })
 
     describe('plugins', () => {
-      beforeEach(() => {
-        mockExperimentalFeatures([ExperimentalFeature.PLUGINS])
-      })
-
       it('calls the onInit method on provided plugins', () => {
         const plugin = { name: 'a', onInit: jasmine.createSpy() }
         const strategy = createPreStartStrategy({}, getCommonContextSpy, createTrackingConsentState(), doStartRumSpy)
@@ -504,7 +500,7 @@ describe('preStartRum', () => {
         const strategy = createPreStartStrategy({}, getCommonContextSpy, createTrackingConsentState(), doStartRumSpy)
         strategy.init(
           {
-            plugins: [plugin],
+            betaPlugins: [plugin],
           } as RumInitConfiguration,
           PUBLIC_API
         )

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -480,7 +480,7 @@ describe('preStartRum', () => {
       it('calls the onInit method on provided plugins', () => {
         const plugin = { name: 'a', onInit: jasmine.createSpy() }
         const strategy = createPreStartStrategy({}, getCommonContextSpy, createTrackingConsentState(), doStartRumSpy)
-        const initConfiguration = { ...DEFAULT_INIT_CONFIGURATION, plugins: [plugin] }
+        const initConfiguration: RumInitConfiguration = { ...DEFAULT_INIT_CONFIGURATION, betaPlugins: [plugin] }
         strategy.init(initConfiguration, PUBLIC_API)
 
         expect(plugin.onInit).toHaveBeenCalledWith({

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -154,9 +154,7 @@ export function createPreStartStrategy(
         return
       }
 
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.PLUGINS)) {
-        callPluginsMethod(initConfiguration.plugins, 'onInit', { initConfiguration, publicApi })
-      }
+      callPluginsMethod(initConfiguration.betaPlugins, 'onInit', { initConfiguration, publicApi })
 
       if (
         initConfiguration.remoteConfigurationId &&

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -1,10 +1,6 @@
 import type { InitConfiguration } from '@datadog/browser-core'
-import { DefaultPrivacyLevel, display, ExperimentalFeature, TraceContextInjection } from '@datadog/browser-core'
-import {
-  EXHAUSTIVE_INIT_CONFIGURATION,
-  mockExperimentalFeatures,
-  SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION,
-} from '@datadog/browser-core/test'
+import { DefaultPrivacyLevel, display, TraceContextInjection } from '@datadog/browser-core'
+import { EXHAUSTIVE_INIT_CONFIGURATION, SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION } from '@datadog/browser-core/test'
 import type {
   ExtractTelemetryConfiguration,
   CamelToSnakeCase,

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -446,28 +446,15 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('plugins', () => {
-    it('with `plugins` enabled: should be set in the configuration', () => {
-      mockExperimentalFeatures([ExperimentalFeature.PLUGINS])
-
+    it('should be set in the configuration', () => {
       const plugin = {
         name: 'foo',
       }
       const configuration = validateAndBuildRumConfiguration({
         ...DEFAULT_INIT_CONFIGURATION,
-        plugins: [plugin],
+        betaPlugins: [plugin],
       })
       expect(configuration!.plugins).toEqual([plugin])
-    })
-
-    it('without `plugins` enabled: should not be set in the configuration', () => {
-      const plugin = {
-        name: 'foo',
-      }
-      const configuration = validateAndBuildRumConfiguration({
-        ...DEFAULT_INIT_CONFIGURATION,
-        plugins: [plugin],
-      })
-      expect(configuration!.plugins).toEqual([])
     })
   })
 })
@@ -495,7 +482,7 @@ describe('serializeRumConfiguration', () => {
       trackResources: true,
       trackLongTasks: true,
       remoteConfigurationId: '123',
-      plugins: [{ name: 'foo', getConfigurationTelemetry: () => ({ bar: true }) }],
+      betaPlugins: [{ name: 'foo', getConfigurationTelemetry: () => ({ bar: true }) }],
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -506,7 +493,9 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // oops
           : Key extends 'applicationId' | 'subdomain' | 'remoteConfigurationId'
             ? never
-            : CamelToSnakeCase<Key>
+            : Key extends 'betaPlugins' // renamed during public beta
+              ? 'plugins'
+              : CamelToSnakeCase<Key>
 
     // By specifying the type here, we can ensure that serializeConfiguration is returning an
     // object containing all expected properties.

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -11,8 +11,6 @@ import {
   isPercentage,
   objectHasValue,
   validateAndBuildConfiguration,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../../domainContext.types'
 import type { RumEvent } from '../../rumEvent.types'

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -131,7 +131,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * notice. Please use only plugins provided by Datadog matching the version of the SDK you are
    * using.
    */
-  plugins?: RumPlugin[] | undefined
+  betaPlugins?: RumPlugin[] | undefined
 }
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>
@@ -221,7 +221,7 @@ export function validateAndBuildRumConfiguration(
       traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
         ? initConfiguration.traceContextInjection
         : TraceContextInjection.ALL,
-      plugins: (isExperimentalFeatureEnabled(ExperimentalFeature.PLUGINS) && initConfiguration.plugins) || [],
+      plugins: initConfiguration.betaPlugins || [],
     },
     baseConfiguration
   )
@@ -304,7 +304,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
       track_user_interactions: configuration.trackUserInteractions,
       track_resources: configuration.trackResources,
       track_long_task: configuration.trackLongTasks,
-      plugins: configuration.plugins?.map((plugin) =>
+      plugins: configuration.betaPlugins?.map((plugin) =>
         assign({ name: plugin.name }, plugin.getConfigurationTelemetry?.())
       ),
     },

--- a/sandbox/react-app/main.tsx
+++ b/sandbox/react-app/main.tsx
@@ -8,8 +8,7 @@ import { reactPlugin, ErrorBoundary } from '@datadog/browser-rum-react'
 datadogRum.init({
   applicationId: 'xxx',
   clientToken: 'xxx',
-  enableExperimentalFeatures: ['plugins'],
-  plugins: [reactPlugin({ router: true })],
+  betaPlugins: [reactPlugin({ router: true })],
 })
 
 const router = createBrowserRouter(


### PR DESCRIPTION
## Motivation

We want to expose plugins to customers, but this should still be considered as "beta".

## Changes

* Remove "PLUGINS" feature flag
* rename init config "plugins" to "betaPlugins"

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
