### PR TITLE
👷 retry gitlab jobs on runner_system_failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,10 @@ stages:
 .base-configuration:
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
 
 ########################################################################################################################
 # Branch selection helpers


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Sometime some gitlab job are failing to setup properly, (e.g: [test-performance](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/581316267)) and re-running the job works. This PR attempt to retry automatically when the job fail because of a [runner_system_failure](https://docs.gitlab.com/ee/ci/yaml/?query=runner_system_failure#retrywhen)

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Edit gitlab config to retry automatically on runner system failure

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
