### PR TITLE
🐛 fix unexpected exception when no entry type is supported in PerformanceObserver

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.spec.ts
+++ b/packages/rum-core/src/browser/performanceCollection.spec.ts
@@ -2,16 +2,14 @@ import type { TestSetupBuilder } from '../../test'
 import { createPerformanceEntry, mockPerformanceObserver, setup } from '../../test'
 import { LifeCycleEventType } from '../domain/lifeCycle'
 import { startPerformanceCollection } from './performanceCollection'
-import { RumPerformanceEntryType, type RumPerformanceEntry } from './performanceObservable'
+import { RumPerformanceEntryType } from './performanceObservable'
 
 describe('startPerformanceCollection', () => {
-  let notifyPerformanceEntries: (entry: RumPerformanceEntry[]) => void
   let entryCollectedCallback: jasmine.Spy
   let setupBuilder: TestSetupBuilder
 
   beforeEach(() => {
     entryCollectedCallback = jasmine.createSpy()
-    ;({ notifyPerformanceEntries } = mockPerformanceObserver())
 
     setupBuilder = setup().beforeBuild(({ lifeCycle, configuration }) => {
       const { stop } = startPerformanceCollection(lifeCycle, configuration)
@@ -33,6 +31,7 @@ describe('startPerformanceCollection', () => {
     RumPerformanceEntryType.EVENT,
   ].forEach((entryType) => {
     it(`should notify ${entryType}`, () => {
+      const { notifyPerformanceEntries } = mockPerformanceObserver()
       setupBuilder.build()
 
       notifyPerformanceEntries([createPerformanceEntry(entryType)])
@@ -42,11 +41,23 @@ describe('startPerformanceCollection', () => {
   })
   ;[(RumPerformanceEntryType.NAVIGATION, RumPerformanceEntryType.RESOURCE)].forEach((entryType) => {
     it(`should not notify ${entryType} timings`, () => {
+      const { notifyPerformanceEntries } = mockPerformanceObserver()
       setupBuilder.build()
 
       notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE)])
 
       expect(entryCollectedCallback).not.toHaveBeenCalled()
     })
+  })
+
+  it('should handle exceptions coming from performance observer .observe()', () => {
+    const { notifyPerformanceEntries } = mockPerformanceObserver({
+      emulateAllEntryTypesUnsupported: true,
+    })
+    setupBuilder.build()
+
+    expect(() => notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE)])).not.toThrow()
+
+    expect(entryCollectedCallback).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -71,8 +71,18 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: 
     }
 
     const mainObserver = new PerformanceObserver(handlePerformanceEntryList)
-    mainObserver.observe({ entryTypes: mainEntries })
-    cleanupTasks.push(() => mainObserver.disconnect())
+    try {
+      mainObserver.observe({ entryTypes: mainEntries })
+      cleanupTasks.push(() => mainObserver.disconnect())
+    } catch {
+      // Old versions of Safari are throwing "entryTypes contained only unsupported types"
+      // errors when observing only unsupported entry types.
+      //
+      // We could use `supportPerformanceTimingEvent` to make sure we don't invoke
+      // `observer.observe` with an unsupported entry type, but Safari 11 and 12 don't support
+      // `Performance.supportedEntryTypes`, so doing so would lose support for these versions
+      // even if they do support the entry type.
+    }
 
     if (supportPerformanceObject() && 'addEventListener' in performance) {
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1559377

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -186,7 +186,18 @@ export function createPerformanceObservable<T extends RumPerformanceEntryType>(
         if (options.buffered) {
           timeoutId = setTimeout(() => handlePerformanceEntries(performance.getEntriesByType(options.type)))
         }
-        observer.observe({ entryTypes: [options.type] })
+        try {
+          observer.observe({ entryTypes: [options.type] })
+        } catch {
+          // Old versions of Safari are throwing "entryTypes contained only unsupported types"
+          // errors when observing only unsupported entry types.
+          //
+          // We could use `supportPerformanceTimingEvent` to make sure we don't invoke
+          // `observer.observe` with an unsupported entry type, but Safari 11 and 12 don't support
+          // `Performance.supportedEntryTypes`, so doing so would lose support for these versions
+          // even if they do support the entry type.
+          return
+        }
       }
     }
     isObserverInitializing = false

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -143,62 +143,59 @@ export function createPerformanceObservable<T extends RumPerformanceEntryType>(
   options: { type: T; buffered?: boolean; durationThreshold?: number }
 ) {
   return new Observable<Array<EntryTypeToReturnType[T]>>((observable) => {
-    let observer: PerformanceObserver | undefined
-    let timeoutId: TimeoutId | undefined
-
-    if (window.PerformanceObserver) {
-      let isObserverInitializing = true
-      const handlePerformanceEntries = (entries: PerformanceEntryList) => {
-        const rumPerformanceEntries = filterRumPerformanceEntries(
-          configuration,
-          entries as Array<EntryTypeToReturnType[T]>
-        )
-        if (rumPerformanceEntries.length > 0) {
-          observable.notify(rumPerformanceEntries)
-        }
-      }
-      observer = new PerformanceObserver(
-        monitor((entries) => {
-          // In Safari the performance observer callback is synchronous.
-          // Because the buffered performance entry list can be quite large we delay the computation to prevent the SDK from blocking the main thread on init
-          if (isObserverInitializing) {
-            timeoutId = setTimeout(() => handlePerformanceEntries(entries.getEntries()))
-          } else {
-            handlePerformanceEntries(entries.getEntries())
-          }
-        })
-      )
-      try {
-        observer.observe(options)
-      } catch {
-        // Some old browser versions (<= chrome 74 ) don't support the PerformanceObserver type and buffered options
-        // In these cases, fallback to getEntriesByType and PerformanceObserver with entryTypes
-        // TODO: remove this fallback in the next major version
-        const fallbackSupportedEntryTypes = [
-          RumPerformanceEntryType.RESOURCE,
-          RumPerformanceEntryType.NAVIGATION,
-          RumPerformanceEntryType.LONG_TASK,
-          RumPerformanceEntryType.PAINT,
-        ]
-        if (includes(fallbackSupportedEntryTypes, options.type)) {
-          if (options.buffered) {
-            timeoutId = setTimeout(() => handlePerformanceEntries(performance.getEntriesByType(options.type)))
-          }
-          observer.observe({ entryTypes: [options.type] })
-        }
-      }
-      isObserverInitializing = false
+    if (!window.PerformanceObserver) {
+      return
     }
+
+    const handlePerformanceEntries = (entries: PerformanceEntryList) => {
+      const rumPerformanceEntries = filterRumPerformanceEntries(
+        configuration,
+        entries as Array<EntryTypeToReturnType[T]>
+      )
+      if (rumPerformanceEntries.length > 0) {
+        observable.notify(rumPerformanceEntries)
+      }
+    }
+
+    let timeoutId: TimeoutId | undefined
+    let isObserverInitializing = true
+    const observer = new PerformanceObserver(
+      monitor((entries) => {
+        // In Safari the performance observer callback is synchronous.
+        // Because the buffered performance entry list can be quite large we delay the computation to prevent the SDK from blocking the main thread on init
+        if (isObserverInitializing) {
+          timeoutId = setTimeout(() => handlePerformanceEntries(entries.getEntries()))
+        } else {
+          handlePerformanceEntries(entries.getEntries())
+        }
+      })
+    )
+    try {
+      observer.observe(options)
+    } catch {
+      // Some old browser versions (<= chrome 74 ) don't support the PerformanceObserver type and buffered options
+      // In these cases, fallback to getEntriesByType and PerformanceObserver with entryTypes
+      // TODO: remove this fallback in the next major version
+      const fallbackSupportedEntryTypes = [
+        RumPerformanceEntryType.RESOURCE,
+        RumPerformanceEntryType.NAVIGATION,
+        RumPerformanceEntryType.LONG_TASK,
+        RumPerformanceEntryType.PAINT,
+      ]
+      if (includes(fallbackSupportedEntryTypes, options.type)) {
+        if (options.buffered) {
+          timeoutId = setTimeout(() => handlePerformanceEntries(performance.getEntriesByType(options.type)))
+        }
+        observer.observe({ entryTypes: [options.type] })
+      }
+    }
+    isObserverInitializing = false
 
     manageResourceTimingBufferFull(configuration)
 
     return () => {
-      if (observer) {
-        observer.disconnect()
-      }
-      if (timeoutId) {
-        clearTimeout(timeoutId)
-      }
+      observer.disconnect()
+      clearTimeout(timeoutId)
     }
   })
 }

--- a/packages/rum-core/test/emulate/mockPerformanceObserver.ts
+++ b/packages/rum-core/test/emulate/mockPerformanceObserver.ts
@@ -7,7 +7,7 @@ type PerformanceObserverInstance = {
   entryTypes: string[]
 }
 
-export function mockPerformanceObserver({ typeSupported } = { typeSupported: true }) {
+export function mockPerformanceObserver({ typeSupported = true, emulateAllEntryTypesUnsupported = false } = {}) {
   const originalPerformanceObserver = window.PerformanceObserver
   const instances = new Set<PerformanceObserverInstance>()
   let performanceObserver: PerformanceObserver
@@ -22,7 +22,10 @@ export function mockPerformanceObserver({ typeSupported } = { typeSupported: tru
       },
       observe({ entryTypes, type, buffered }: PerformanceObserverInit) {
         if (!typeSupported && type) {
-          throw new Error("Uncaught TypeError: Failed to execute 'observe' on 'PerformanceObserver")
+          throw new TypeError("Failed to execute 'observe' on 'PerformanceObserver")
+        }
+        if (emulateAllEntryTypesUnsupported) {
+          throw new TypeError('entryTypes contained only unsupported types')
         }
         instance.entryTypes = entryTypes || (type ? [type] : [])
         instances.add(instance)


### PR DESCRIPTION
## Motivation

Following #2855 and #2818, we are using more granular PerformanceObserver. We observe less entry types in the PerformanceObserver from `performanceCollection`, and  in the new `performanceObservable`, we observe a single type at once.

We observed that in old versions of Safari, if all entry types supplied to `.observe(..)` are unsupported, an exception is thrown: `entryTypes contained only unsupported types`. Illustration:

```ts
// assuming 'resource' is supported but not 'longtask'
new PerformanceObserver().observe({ entryTypes: ['resource', 'longtask'] }) // succeeds
new PerformanceObserver().observe({ entryTypes: ['longtask'] }) // throws
```

## Changes

To work around this issue, this PR wraps `.observe(..)` calls in `try/catch` blocks to prevent the SDK from crashing.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local: even on BrowserStack we don't have the exact Safari version that triggers this issue (it should be Safari 11 with OSX 10.11 or below, see notes [here](https://caniuse.com/resource-timing)). But I tested that we still collect performance resource entries in the Safari 11 version provided by BrowserStack. 
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
