### PR TITLE
🐛 bundle size: calculate diff from PR base instead of main

### DIFF
--- a/scripts/lib/git-utils.js
+++ b/scripts/lib/git-utils.js
@@ -54,7 +54,6 @@ module.exports = {
   initGitConfig,
   fetchPR,
   getLastCommonCommit,
-  BASE_BRANCH: process.env.MAIN_BRANCH,
   LOCAL_BRANCH: process.env.CI_COMMIT_REF_NAME,
   GITHUB_TOKEN,
 }

--- a/scripts/performance/report-as-a-pr-comment.js
+++ b/scripts/performance/report-as-a-pr-comment.js
@@ -1,6 +1,6 @@
 const { command } = require('../lib/command')
 const { fetchHandlingError } = require('../lib/execution-utils')
-const { LOCAL_BRANCH, BASE_BRANCH, GITHUB_TOKEN, getLastCommonCommit, fetchPR } = require('../lib/git-utils')
+const { LOCAL_BRANCH, GITHUB_TOKEN, getLastCommonCommit, fetchPR } = require('../lib/git-utils')
 const { fetchPerformanceMetrics } = require('./fetch-performance-metrics')
 const PR_COMMENT_HEADER = 'Bundles Sizes Evolution'
 const PR_COMMENTER_AUTH_TOKEN = command`authanywhere`.run().split(' ')[2].trim()
@@ -9,12 +9,12 @@ const SIZE_INCREASE_THRESHOLD = 5
 const LOCAL_COMMIT_SHA = process.env.CI_COMMIT_SHORT_SHA
 
 async function reportAsPrComment(localBundleSizes, memoryLocalPerformance) {
-  const lastCommonCommit = getLastCommonCommit(BASE_BRANCH, LOCAL_BRANCH)
   const pr = await fetchPR(LOCAL_BRANCH)
   if (!pr) {
     console.log('No pull requests found for the branch')
     return
   }
+  const lastCommonCommit = getLastCommonCommit(pr.base.ref, LOCAL_BRANCH)
   const packageNames = Object.keys(localBundleSizes)
   const testNames = memoryLocalPerformance.map((obj) => obj.testProperty)
   const baseBundleSizes = await fetchPerformanceMetrics('bundle', packageNames, lastCommonCommit)


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

I'm doing PRs to the `v6` feature branch, however the bundle size comment on the PR ar comparing to the main branch instead of the base branch of the PR.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Calculate the size difference using the PR's base branch instead of the main branch

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

see [this PR](https://github.com/DataDog/browser-sdk/pull/2909#issuecomment-2260675178) for an example in actions

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
