### PR TITLE
♻️ remove duplicate pageStateHistory.stop()

### DIFF
--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -257,7 +257,6 @@ export function startRumEventCollection(
     stop: () => {
       ciVisibilityContext.stop()
       displayContext.stop()
-      pageStateHistory.stop()
       urlContexts.stop()
       viewContexts.stop()
       pageStateHistory.stop()


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

`pageStateHistory.stop()` is called twice. I believe this is a mistake!

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
