### PR TITLE
 ✨ [RUM-5712] add error.handling to logs 

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.spec.ts
+++ b/packages/core/src/domain/console/consoleObservable.spec.ts
@@ -2,7 +2,7 @@
 import { isIE } from '../../tools/utils/browserDetection'
 import { ConsoleApiName } from '../../tools/display'
 import type { Subscription } from '../../tools/observable'
-import type { ConsoleLog } from './consoleObservable'
+import type { ErrorConsoleLog } from './consoleObservable'
 import { initConsoleObservable } from './consoleObservable'
 
 // prettier: avoid formatting issue
@@ -79,7 +79,7 @@ import { initConsoleObservable } from './consoleObservable'
 
 describe('console error observable', () => {
   let consoleSubscription: Subscription
-  let notifyLog: jasmine.Spy<(consoleLog: ConsoleLog) => void>
+  let notifyLog: jasmine.Spy<(consoleLog: ErrorConsoleLog) => void>
 
   beforeEach(() => {
     spyOn(console, 'error').and.callFake(() => true)
@@ -103,7 +103,7 @@ describe('console error observable', () => {
 
   it('should extract stack from first error', () => {
     console.error(new TypeError('foo'), new TypeError('bar'))
-    const stack = notifyLog.calls.mostRecent().args[0].error!.stack
+    const stack = notifyLog.calls.mostRecent().args[0].error.stack
     if (!isIE()) {
       expect(stack).toMatch(/^TypeError: foo\s+at/)
     } else {
@@ -122,7 +122,7 @@ describe('console error observable', () => {
     console.error(error)
 
     const consoleLog = notifyLog.calls.mostRecent().args[0]
-    expect(consoleLog.error!.fingerprint).toBe('my-fingerprint')
+    expect(consoleLog.error.fingerprint).toBe('my-fingerprint')
   })
 
   it('should sanitize error fingerprint', () => {
@@ -133,6 +133,6 @@ describe('console error observable', () => {
     console.error(error)
 
     const consoleLog = notifyLog.calls.mostRecent().args[0]
-    expect(consoleLog.error!.fingerprint).toBe('2')
+    expect(consoleLog.error.fingerprint).toBe('2')
   })
 })

--- a/packages/core/src/domain/console/consoleObservable.spec.ts
+++ b/packages/core/src/domain/console/consoleObservable.spec.ts
@@ -79,7 +79,7 @@ import { initConsoleObservable } from './consoleObservable'
 
 describe('console error observable', () => {
   let consoleSubscription: Subscription
-  let notifyLog: jasmine.Spy
+  let notifyLog: jasmine.Spy<(consoleLog: ConsoleLog) => void>
 
   beforeEach(() => {
     spyOn(console, 'error').and.callFake(() => true)
@@ -103,7 +103,7 @@ describe('console error observable', () => {
 
   it('should extract stack from first error', () => {
     console.error(new TypeError('foo'), new TypeError('bar'))
-    const stack = (notifyLog.calls.mostRecent().args[0] as ConsoleLog).stack
+    const stack = notifyLog.calls.mostRecent().args[0].error!.stack
     if (!isIE()) {
       expect(stack).toMatch(/^TypeError: foo\s+at/)
     } else {
@@ -122,7 +122,7 @@ describe('console error observable', () => {
     console.error(error)
 
     const consoleLog = notifyLog.calls.mostRecent().args[0]
-    expect(consoleLog.fingerprint).toBe('my-fingerprint')
+    expect(consoleLog.error!.fingerprint).toBe('my-fingerprint')
   })
 
   it('should sanitize error fingerprint', () => {
@@ -133,6 +133,6 @@ describe('console error observable', () => {
     console.error(error)
 
     const consoleLog = notifyLog.calls.mostRecent().args[0]
-    expect(consoleLog.fingerprint).toBe('2')
+    expect(consoleLog.error!.fingerprint).toBe('2')
   })
 })

--- a/packages/core/src/domain/report/reportObservable.ts
+++ b/packages/core/src/domain/report/reportObservable.ts
@@ -2,9 +2,12 @@ import { toStackTraceString } from '../../tools/stackTrace/handlingStack'
 import { monitor } from '../../tools/monitor'
 import { mergeObservables, Observable } from '../../tools/observable'
 import { addEventListener, DOM_EVENT } from '../../browser/addEventListener'
-import { includes } from '../../tools/utils/polyfills'
+import { assign, includes } from '../../tools/utils/polyfills'
 import { safeTruncate } from '../../tools/utils/stringUtils'
 import type { Configuration } from '../configuration'
+import type { RawError } from '../error/error.types'
+import { ErrorHandling, ErrorSource } from '../error/error.types'
+import { clocksNow } from '../../tools/utils/timeUtils'
 import type { ReportType, InterventionReport, DeprecationReport } from './browser.types'
 
 export const RawReportType = {
@@ -15,16 +18,12 @@ export const RawReportType = {
 
 export type RawReportType = (typeof RawReportType)[keyof typeof RawReportType]
 
-export interface RawReport {
-  type: RawReportType
-  subtype: string
-  message: string
-  originalReport: SecurityPolicyViolationEvent | DeprecationReport | InterventionReport
-  stack?: string
+export type RawReportError = RawError & {
+  originalError: SecurityPolicyViolationEvent | DeprecationReport | InterventionReport
 }
 
 export function initReportObservable(configuration: Configuration, apis: RawReportType[]) {
-  const observables: Array<Observable<RawReport>> = []
+  const observables: Array<Observable<RawReportError>> = []
 
   if (includes(apis, RawReportType.cspViolation)) {
     observables.push(createCspViolationReportObservable(configuration))
@@ -35,19 +34,17 @@ export function initReportObservable(configuration: Configuration, apis: RawRepo
     observables.push(createReportObservable(reportTypes))
   }
 
-  return mergeObservables<RawReport>(...observables)
+  return mergeObservables(...observables)
 }
 
 function createReportObservable(reportTypes: ReportType[]) {
-  return new Observable<RawReport>((observable) => {
+  return new Observable<RawReportError>((observable) => {
     if (!window.ReportingObserver) {
       return
     }
 
     const handleReports = monitor((reports: Array<DeprecationReport | InterventionReport>, _: ReportingObserver) =>
-      reports.forEach((report) => {
-        observable.notify(buildRawReportFromReport(report))
-      })
+      reports.forEach((report) => observable.notify(buildRawReportErrorFromReport(report)))
     ) as ReportingObserverCallback
 
     const observer = new window.ReportingObserver(handleReports, {
@@ -63,34 +60,35 @@ function createReportObservable(reportTypes: ReportType[]) {
 }
 
 function createCspViolationReportObservable(configuration: Configuration) {
-  return new Observable<RawReport>((observable) => {
+  return new Observable<RawReportError>((observable) => {
     const { stop } = addEventListener(configuration, document, DOM_EVENT.SECURITY_POLICY_VIOLATION, (event) => {
-      observable.notify(buildRawReportFromCspViolation(event))
+      observable.notify(buildRawReportErrorFromCspViolation(event))
     })
 
     return stop
   })
 }
 
-function buildRawReportFromReport(report: DeprecationReport | InterventionReport): RawReport {
+function buildRawReportErrorFromReport(report: DeprecationReport | InterventionReport): RawReportError {
   const { type, body } = report
 
-  return {
-    type,
-    subtype: body.id,
+  return buildRawReportError({
+    type: body.id,
     message: `${type}: ${body.message}`,
-    originalReport: report,
+    originalError: report,
     stack: buildStack(body.id, body.message, body.sourceFile, body.lineNumber, body.columnNumber),
-  }
+  })
 }
 
-function buildRawReportFromCspViolation(event: SecurityPolicyViolationEvent): RawReport {
-  const type = RawReportType.cspViolation
+function buildRawReportErrorFromCspViolation(event: SecurityPolicyViolationEvent): RawReportError {
   const message = `'${event.blockedURI}' blocked by '${event.effectiveDirective}' directive`
-  return {
-    type: RawReportType.cspViolation,
-    subtype: event.effectiveDirective,
-    message: `${type}: ${message}`,
+  return buildRawReportError({
+    type: event.effectiveDirective,
+    message: `${RawReportType.cspViolation}: ${message}`,
+    originalError: event,
+    csp: {
+      disposition: event.disposition,
+    },
     stack: buildStack(
       event.effectiveDirective,
       event.originalPolicy
@@ -100,8 +98,18 @@ function buildRawReportFromCspViolation(event: SecurityPolicyViolationEvent): Ra
       event.lineNumber,
       event.columnNumber
     ),
-    originalReport: event,
-  }
+  })
+}
+
+function buildRawReportError(partial: Omit<RawReportError, 'startClocks' | 'source' | 'handling'>): RawReportError {
+  return assign(
+    {
+      startClocks: clocksNow(),
+      source: ErrorSource.REPORT,
+      handling: ErrorHandling.UNHANDLED,
+    },
+    partial
+  )
 }
 
 function buildStack(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,7 @@ export { trackRuntimeError } from './domain/error/trackRuntimeError'
 export { computeStackTrace, StackTrace } from './tools/stackTrace/computeStackTrace'
 export { defineGlobal, makePublicApi, PublicApi } from './boot/init'
 export { displayAlreadyInitializedError } from './boot/displayAlreadyInitializedError'
-export { initReportObservable, RawReport, RawReportType } from './domain/report/reportObservable'
+export { initReportObservable, RawReportType } from './domain/report/reportObservable'
 export {
   startTelemetry,
   Telemetry,

--- a/packages/logs/src/domain/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/console/consoleCollection.spec.ts
@@ -1,5 +1,5 @@
 import type { ErrorWithCause } from '@datadog/browser-core'
-import { ErrorSource, noop, objectEntries } from '@datadog/browser-core'
+import { ErrorHandling, ErrorSource, noop, objectEntries } from '@datadog/browser-core'
 import type { RawConsoleLogsEvent } from '../../rawLogsEvent.types'
 import { validateAndBuildLogsConfiguration } from '../configuration'
 import type { RawLogsEventCollectedData } from '../lifeCycle'
@@ -72,6 +72,7 @@ describe('console collection', () => {
       stack: undefined,
       fingerprint: undefined,
       causes: undefined,
+      handling: ErrorHandling.HANDLED,
       kind: undefined,
       message: undefined,
     })
@@ -95,6 +96,7 @@ describe('console collection', () => {
       stack: jasmine.any(String),
       fingerprint: 'my-fingerprint',
       causes: undefined,
+      handling: ErrorHandling.HANDLED,
       kind: undefined,
       message: undefined,
     })
@@ -122,6 +124,7 @@ describe('console collection', () => {
 
     expect(rawLogsEvents[0].rawLogsEvent.error).toEqual({
       stack: jasmine.any(String),
+      handling: ErrorHandling.HANDLED,
       causes: [
         {
           source: ErrorSource.CONSOLE,

--- a/packages/logs/src/domain/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/console/consoleCollection.spec.ts
@@ -72,6 +72,8 @@ describe('console collection', () => {
       stack: undefined,
       fingerprint: undefined,
       causes: undefined,
+      kind: undefined,
+      message: undefined,
     })
   })
 
@@ -93,6 +95,8 @@ describe('console collection', () => {
       stack: jasmine.any(String),
       fingerprint: 'my-fingerprint',
       causes: undefined,
+      kind: undefined,
+      message: undefined,
     })
   })
 
@@ -118,7 +122,6 @@ describe('console collection', () => {
 
     expect(rawLogsEvents[0].rawLogsEvent.error).toEqual({
       stack: jasmine.any(String),
-      fingerprint: undefined,
       causes: [
         {
           source: ErrorSource.CONSOLE,
@@ -133,6 +136,9 @@ describe('console collection', () => {
           message: 'Low level error',
         },
       ],
+      fingerprint: undefined,
+      kind: undefined,
+      message: undefined,
     })
   })
 })

--- a/packages/logs/src/domain/console/consoleCollection.ts
+++ b/packages/logs/src/domain/console/consoleCollection.ts
@@ -27,14 +27,13 @@ export function startConsoleCollection(configuration: LogsConfiguration, lifeCyc
         date: timeStampNow(),
         message: log.message,
         origin: ErrorSource.CONSOLE,
-        error:
-          log.api === ConsoleApiName.error
-            ? {
-                stack: log.stack,
-                fingerprint: log.fingerprint,
-                causes: log.causes,
-              }
-            : undefined,
+        error: log.error
+          ? {
+              stack: log.error.stack,
+              fingerprint: log.error.fingerprint,
+              causes: log.error.causes,
+            }
+          : undefined,
         status: LogStatusForApi[log.api],
       },
       domainContext: {

--- a/packages/logs/src/domain/console/consoleCollection.ts
+++ b/packages/logs/src/domain/console/consoleCollection.ts
@@ -5,6 +5,7 @@ import type { LifeCycle, RawLogsEventCollectedData } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 import { StatusType } from '../logger/isAuthorized'
 import type { RawLogsEvent } from '../../rawLogsEvent.types'
+import { createErrorFieldFromRawError } from '../createErrorFieldFromRawError'
 
 export interface ProvidedError {
   startClocks: ClocksState
@@ -27,13 +28,7 @@ export function startConsoleCollection(configuration: LogsConfiguration, lifeCyc
         date: timeStampNow(),
         message: log.message,
         origin: ErrorSource.CONSOLE,
-        error: log.error
-          ? {
-              stack: log.error.stack,
-              fingerprint: log.error.fingerprint,
-              causes: log.error.causes,
-            }
-          : undefined,
+        error: log.error && createErrorFieldFromRawError(log.error),
         status: LogStatusForApi[log.api],
       },
       domainContext: {

--- a/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
+++ b/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
@@ -28,6 +28,7 @@ describe('createErrorFieldFromRawError', () => {
       stack: 'quuz',
       causes: [],
       fingerprint: 'corge',
+      handling: ErrorHandling.HANDLED,
     })
   })
 

--- a/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
+++ b/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
@@ -1,0 +1,37 @@
+import { ErrorHandling, ErrorSource, type RawError, type RelativeTime, type TimeStamp } from '@datadog/browser-core'
+import { createErrorFieldFromRawError } from './createErrorFieldFromRawError'
+
+describe('createErrorFieldFromRawError', () => {
+  const exhaustiveRawError: Required<RawError> = {
+    startClocks: {
+      relative: 0 as RelativeTime,
+      timeStamp: 0 as TimeStamp,
+    },
+    source: ErrorSource.LOGGER,
+    handling: ErrorHandling.HANDLED,
+    handlingStack: 'Error\n    at foo (bar)',
+    originalError: new Error('baz'),
+    type: 'qux',
+    message: 'quux',
+    stack: 'quuz',
+    causes: [],
+    fingerprint: 'corge',
+    csp: {
+      disposition: 'enforce',
+    },
+  }
+
+  it('creates an error field from a raw error', () => {
+    expect(createErrorFieldFromRawError(exhaustiveRawError)).toEqual({
+      message: undefined,
+      kind: 'qux',
+      stack: 'quuz',
+      causes: [],
+      fingerprint: 'corge',
+    })
+  })
+
+  it('includes the message if includeMessage is true', () => {
+    expect(createErrorFieldFromRawError(exhaustiveRawError, { includeMessage: true }).message).toBe('quux')
+  })
+})

--- a/packages/logs/src/domain/createErrorFieldFromRawError.ts
+++ b/packages/logs/src/domain/createErrorFieldFromRawError.ts
@@ -1,0 +1,21 @@
+import type { RawError } from '@datadog/browser-core'
+import type { RawLoggerLogsEvent } from '../rawLogsEvent.types'
+
+export function createErrorFieldFromRawError(
+  rawError: RawError,
+  {
+    /**
+     * Set this to `true` to include the error message in the error field. In most cases, the error
+     * message is already included in the log message, so we don't need to include it again.
+     */
+    includeMessage = false,
+  } = {}
+): NonNullable<RawLoggerLogsEvent['error']> {
+  return {
+    stack: rawError.stack,
+    kind: rawError.type,
+    message: includeMessage ? rawError.message : undefined,
+    causes: rawError.causes,
+    fingerprint: rawError.fingerprint,
+  }
+}

--- a/packages/logs/src/domain/createErrorFieldFromRawError.ts
+++ b/packages/logs/src/domain/createErrorFieldFromRawError.ts
@@ -17,5 +17,6 @@ export function createErrorFieldFromRawError(
     message: includeMessage ? rawError.message : undefined,
     causes: rawError.causes,
     fingerprint: rawError.fingerprint,
+    handling: rawError.handling,
   }
 }

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -1,5 +1,5 @@
 import type { ErrorWithCause } from '@datadog/browser-core'
-import { NO_ERROR_STACK_PRESENT_MESSAGE, createCustomerDataTracker, noop } from '@datadog/browser-core'
+import { ErrorHandling, NO_ERROR_STACK_PRESENT_MESSAGE, createCustomerDataTracker, noop } from '@datadog/browser-core'
 import type { LogsMessage } from './logger'
 import { HandlerType, Logger, STATUSES } from './logger'
 import { StatusType } from './logger/isAuthorized'
@@ -51,6 +51,7 @@ describe('Logger', () => {
             message: 'My Error',
             stack: jasmine.stringMatching(/^SyntaxError: My Error/),
             causes: undefined,
+            handling: ErrorHandling.HANDLED,
             fingerprint: undefined,
           },
         })
@@ -113,6 +114,7 @@ describe('Logger', () => {
             stack: NO_ERROR_STACK_PRESENT_MESSAGE,
             kind: undefined,
             causes: undefined,
+            handling: ErrorHandling.HANDLED,
             fingerprint: undefined,
           },
         },
@@ -154,6 +156,7 @@ describe('Logger', () => {
               stack: 'Error: High level error',
               kind: 'Error',
               message: 'High level error',
+              handling: ErrorHandling.HANDLED,
               causes: [
                 { message: 'Mid level error', source: 'logger', type: 'Error', stack: 'Error: Mid level error' },
                 {

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -51,6 +51,7 @@ describe('Logger', () => {
             message: 'My Error',
             stack: jasmine.stringMatching(/^SyntaxError: My Error/),
             causes: undefined,
+            fingerprint: undefined,
           },
         })
       })
@@ -108,10 +109,11 @@ describe('Logger', () => {
         message: 'message',
         context: {
           error: {
-            kind: undefined,
             message: 'Provided "My Error"',
             stack: NO_ERROR_STACK_PRESENT_MESSAGE,
+            kind: undefined,
             causes: undefined,
+            fingerprint: undefined,
           },
         },
         status: 'error',
@@ -161,6 +163,7 @@ describe('Logger', () => {
                   stack: 'TypeError: Low level error',
                 },
               ],
+              fingerprint: undefined,
             },
           },
         })

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -13,7 +13,6 @@ import {
   createHandlingStack,
 } from '@datadog/browser-core'
 
-import type { RawLoggerLogsEvent } from '../rawLogsEvent.types'
 import { isAuthorized, StatusType } from './logger/isAuthorized'
 import { createErrorFieldFromRawError } from './createErrorFieldFromRawError'
 
@@ -60,12 +59,12 @@ export class Logger {
     error?: Error,
     handlingStack?: string
   ) {
-    let errorContext: RawLoggerLogsEvent['error']
+    const sanitizedMessageContext = sanitize(messageContext) as Context
+    let context: Context
 
     if (error !== undefined && error !== null) {
-      const stackTrace = error instanceof Error ? computeStackTrace(error) : undefined
       const rawError = computeRawError({
-        stackTrace,
+        stackTrace: error instanceof Error ? computeStackTrace(error) : undefined,
         originalError: error,
         nonErrorPrefix: NonErrorPrefix.PROVIDED,
         source: ErrorSource.LOGGER,
@@ -73,14 +72,15 @@ export class Logger {
         startClocks: clocksNow(),
       })
 
-      errorContext = createErrorFieldFromRawError(rawError, { includeMessage: true })
+      context = combine(
+        {
+          error: createErrorFieldFromRawError(rawError, { includeMessage: true }),
+        },
+        sanitizedMessageContext
+      )
+    } else {
+      context = sanitizedMessageContext
     }
-
-    const sanitizedMessageContext = sanitize(messageContext) as Context
-
-    const context = errorContext
-      ? (combine({ error: errorContext }, sanitizedMessageContext) as Context)
-      : sanitizedMessageContext
 
     this.handleLogStrategy(
       {

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -15,6 +15,7 @@ import {
 
 import type { RawLoggerLogsEvent } from '../rawLogsEvent.types'
 import { isAuthorized, StatusType } from './logger/isAuthorized'
+import { createErrorFieldFromRawError } from './createErrorFieldFromRawError'
 
 export interface LogsMessage {
   message: string
@@ -72,12 +73,7 @@ export class Logger {
         startClocks: clocksNow(),
       })
 
-      errorContext = {
-        stack: rawError.stack,
-        kind: rawError.type,
-        message: rawError.message,
-        causes: rawError.causes,
-      }
+      errorContext = createErrorFieldFromRawError(rawError, { includeMessage: true })
     }
 
     const sanitizedMessageContext = sanitize(messageContext) as Context

--- a/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
@@ -72,6 +72,7 @@ describe('network error collection', () => {
         origin: ErrorSource.NETWORK,
         error: {
           stack: 'Server error',
+          handling: undefined,
         },
         http: {
           method: 'GET',

--- a/packages/logs/src/domain/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.ts
@@ -57,6 +57,8 @@ export function startNetworkErrorCollection(configuration: LogsConfiguration, li
           date: request.startClocks.timeStamp,
           error: {
             stack: (responseData as string) || 'Failed to load',
+            // We don't know if the error was handled or not, so we set it to undefined
+            handling: undefined,
           },
           http: {
             method: request.method as any, // Cast resource method because of case mismatch cf issue RUMF-1152

--- a/packages/logs/src/domain/report/reportCollection.spec.ts
+++ b/packages/logs/src/domain/report/reportCollection.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorSource, noop } from '@datadog/browser-core'
+import { ErrorHandling, ErrorSource, noop } from '@datadog/browser-core'
 import type { MockReportingObserver } from '@datadog/browser-core/test'
 import { mockReportingObserver } from '@datadog/browser-core/test'
 import type { RawReportLogsEvent } from '../../rawLogsEvent.types'
@@ -41,6 +41,7 @@ describe('reports', () => {
       error: {
         kind: 'NavigatorVibrate',
         stack: jasmine.any(String),
+        handling: ErrorHandling.UNHANDLED,
         causes: undefined,
         fingerprint: undefined,
         message: undefined,

--- a/packages/logs/src/domain/report/reportCollection.spec.ts
+++ b/packages/logs/src/domain/report/reportCollection.spec.ts
@@ -41,6 +41,9 @@ describe('reports', () => {
       error: {
         kind: 'NavigatorVibrate',
         stack: jasmine.any(String),
+        causes: undefined,
+        fingerprint: undefined,
+        message: undefined,
       },
       date: jasmine.any(Number),
       message: 'intervention: foo bar',

--- a/packages/logs/src/domain/report/reportCollection.ts
+++ b/packages/logs/src/domain/report/reportCollection.ts
@@ -1,10 +1,10 @@
-import type { Context, ClocksState, RawReport } from '@datadog/browser-core'
+import type { Context, ClocksState } from '@datadog/browser-core'
 import {
   timeStampNow,
   ErrorSource,
-  RawReportType,
   getFileFromStackTraceString,
   initReportObservable,
+  ErrorHandling,
 } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../configuration'
 import type { LifeCycle } from '../lifeCycle'
@@ -18,38 +18,31 @@ export interface ProvidedError {
   handlingStack: string
 }
 
-const LogStatusForReport = {
-  [RawReportType.cspViolation]: StatusType.error,
-  [RawReportType.intervention]: StatusType.error,
-  [RawReportType.deprecation]: StatusType.warn,
-}
-
 export function startReportCollection(configuration: LogsConfiguration, lifeCycle: LifeCycle) {
-  const reportSubscription = initReportObservable(configuration, configuration.forwardReports).subscribe(
-    (report: RawReport) => {
-      let message = report.message
-      const status = LogStatusForReport[report.type]
-      let error
-      if (status === StatusType.error) {
-        error = {
-          kind: report.subtype,
-          stack: report.stack,
-        }
-      } else if (report.stack) {
-        message += ` Found in ${getFileFromStackTraceString(report.stack)!}`
-      }
+  const reportSubscription = initReportObservable(configuration, configuration.forwardReports).subscribe((rawError) => {
+    let message = rawError.message
+    let error
+    const status = rawError.originalError.type === 'deprecation' ? StatusType.warn : StatusType.error
 
-      lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
-        rawLogsEvent: {
-          date: timeStampNow(),
-          message,
-          origin: ErrorSource.REPORT,
-          error,
-          status,
-        },
-      })
+    if (status === StatusType.error) {
+      error = {
+        kind: rawError.type,
+        stack: rawError.stack,
+      }
+    } else if (rawError.stack) {
+      message += ` Found in ${getFileFromStackTraceString(rawError.stack)!}`
     }
-  )
+
+    lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
+      rawLogsEvent: {
+        date: timeStampNow(),
+        message,
+        origin: ErrorSource.REPORT,
+        error,
+        status,
+      },
+    })
+  })
 
   return {
     stop: () => {

--- a/packages/logs/src/domain/report/reportCollection.ts
+++ b/packages/logs/src/domain/report/reportCollection.ts
@@ -1,15 +1,10 @@
 import type { Context, ClocksState } from '@datadog/browser-core'
-import {
-  timeStampNow,
-  ErrorSource,
-  getFileFromStackTraceString,
-  initReportObservable,
-  ErrorHandling,
-} from '@datadog/browser-core'
+import { timeStampNow, ErrorSource, getFileFromStackTraceString, initReportObservable } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../configuration'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 import { StatusType } from '../logger/isAuthorized'
+import { createErrorFieldFromRawError } from '../createErrorFieldFromRawError'
 
 export interface ProvidedError {
   startClocks: ClocksState
@@ -25,10 +20,7 @@ export function startReportCollection(configuration: LogsConfiguration, lifeCycl
     const status = rawError.originalError.type === 'deprecation' ? StatusType.warn : StatusType.error
 
     if (status === StatusType.error) {
-      error = {
-        kind: rawError.type,
-        stack: rawError.stack,
-      }
+      error = createErrorFieldFromRawError(rawError)
     } else if (rawError.stack) {
       message += ` Found in ${getFileFromStackTraceString(rawError.stack)!}`
     }

--- a/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
@@ -1,5 +1,5 @@
 import type { ErrorWithCause } from '@datadog/browser-core'
-import { ErrorSource } from '@datadog/browser-core'
+import { ErrorSource, ErrorHandling } from '@datadog/browser-core'
 import type { RawRuntimeLogsEvent } from '../../rawLogsEvent.types'
 import type { LogsConfiguration } from '../configuration'
 import { StatusType } from '../logger/isAuthorized'

--- a/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
@@ -40,7 +40,13 @@ describe('runtime error collection', () => {
     setTimeout(() => {
       expect(rawLogsEvents[0].rawLogsEvent).toEqual({
         date: jasmine.any(Number),
-        error: { kind: 'Error', stack: jasmine.any(String), causes: undefined },
+        error: {
+          kind: 'Error',
+          stack: jasmine.any(String),
+          causes: undefined,
+          fingerprint: undefined,
+          message: undefined,
+        },
         message: 'error!',
         status: StatusType.error,
         origin: ErrorSource.SOURCE,
@@ -86,6 +92,8 @@ describe('runtime error collection', () => {
               message: 'Low level error',
             },
           ],
+          fingerprint: undefined,
+          message: undefined,
         },
         message: 'High level error',
         status: StatusType.error,

--- a/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
@@ -44,6 +44,7 @@ describe('runtime error collection', () => {
           kind: 'Error',
           stack: jasmine.any(String),
           causes: undefined,
+          handling: ErrorHandling.UNHANDLED,
           fingerprint: undefined,
           message: undefined,
         },
@@ -78,6 +79,7 @@ describe('runtime error collection', () => {
         error: {
           kind: 'Error',
           stack: jasmine.any(String),
+          handling: ErrorHandling.UNHANDLED,
           causes: [
             {
               source: ErrorSource.SOURCE,

--- a/packages/logs/src/domain/runtimeError/runtimeErrorCollection.ts
+++ b/packages/logs/src/domain/runtimeError/runtimeErrorCollection.ts
@@ -4,6 +4,7 @@ import type { LogsConfiguration } from '../configuration'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 import { StatusType } from '../logger/isAuthorized'
+import { createErrorFieldFromRawError } from '../createErrorFieldFromRawError'
 
 export interface ProvidedError {
   startClocks: ClocksState
@@ -26,11 +27,7 @@ export function startRuntimeErrorCollection(configuration: LogsConfiguration, li
       rawLogsEvent: {
         message: rawError.message,
         date: rawError.startClocks.timeStamp,
-        error: {
-          kind: rawError.type,
-          stack: rawError.stack,
-          causes: rawError.causes,
-        },
+        error: createErrorFieldFromRawError(rawError),
         origin: ErrorSource.SOURCE,
         status: StatusType.error,
       },

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -1,4 +1,4 @@
-import type { Context, ErrorSource, RawErrorCause, TimeStamp, User } from '@datadog/browser-core'
+import type { Context, ErrorSource, RawErrorCause, TimeStamp, User, ErrorHandling } from '@datadog/browser-core'
 import type { StatusType } from './domain/logger/isAuthorized'
 
 export type RawLogsEvent =
@@ -15,6 +15,7 @@ type Error = {
   stack?: string
   fingerprint?: string
   causes?: RawErrorCause[]
+  handling: ErrorHandling | undefined
 }
 
 interface CommonRawLogsEvent {

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -294,6 +294,7 @@ describe('error collection', () => {
           startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
           type: 'foo',
           originalError: FAKE_CSP_VIOLATION_EVENT,
+          handling: ErrorHandling.HANDLED,
           csp: {
             disposition: FAKE_CSP_VIOLATION_EVENT.disposition,
           },

--- a/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
@@ -37,6 +37,7 @@ describe('trackConsoleError', () => {
       source: ErrorSource.CONSOLE,
       handling: ErrorHandling.HANDLED,
       handlingStack: jasmine.any(String),
+      causes: undefined,
     })
   })
 
@@ -58,6 +59,7 @@ describe('trackConsoleError', () => {
       handling: ErrorHandling.HANDLED,
       handlingStack: jasmine.any(String),
       fingerprint: 'my-fingerprint',
+      causes: undefined,
     })
   })
 })

--- a/packages/rum-core/src/domain/error/trackConsoleError.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.ts
@@ -1,18 +1,12 @@
 import type { Observable, RawError } from '@datadog/browser-core'
-import { clocksNow, ErrorHandling, initConsoleObservable, ErrorSource, ConsoleApiName } from '@datadog/browser-core'
+import { initConsoleObservable, ConsoleApiName } from '@datadog/browser-core'
 
 export function trackConsoleError(errorObservable: Observable<RawError>) {
-  const subscription = initConsoleObservable([ConsoleApiName.error]).subscribe((consoleError) =>
-    errorObservable.notify({
-      startClocks: clocksNow(),
-      message: consoleError.message,
-      stack: consoleError.stack,
-      fingerprint: consoleError.fingerprint,
-      source: ErrorSource.CONSOLE,
-      handling: ErrorHandling.HANDLED,
-      handlingStack: consoleError.handlingStack,
-    })
-  )
+  const subscription = initConsoleObservable([ConsoleApiName.error]).subscribe((consoleLog) => {
+    if (consoleLog.error) {
+      errorObservable.notify(consoleLog.error)
+    }
+  })
 
   return {
     stop: () => {

--- a/packages/rum-core/src/domain/error/trackConsoleError.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.ts
@@ -2,11 +2,9 @@ import type { Observable, RawError } from '@datadog/browser-core'
 import { initConsoleObservable, ConsoleApiName } from '@datadog/browser-core'
 
 export function trackConsoleError(errorObservable: Observable<RawError>) {
-  const subscription = initConsoleObservable([ConsoleApiName.error]).subscribe((consoleLog) => {
-    if (consoleLog.error) {
-      errorObservable.notify(consoleLog.error)
-    }
-  })
+  const subscription = initConsoleObservable([ConsoleApiName.error]).subscribe((consoleLog) =>
+    errorObservable.notify(consoleLog.error)
+  )
 
   return {
     stop: () => {

--- a/packages/rum-core/src/domain/error/trackReportError.ts
+++ b/packages/rum-core/src/domain/error/trackReportError.ts
@@ -1,30 +1,12 @@
 import type { Observable, RawError } from '@datadog/browser-core'
-import { clocksNow, ErrorHandling, ErrorSource, initReportObservable, RawReportType } from '@datadog/browser-core'
+import { initReportObservable, RawReportType } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 
 export function trackReportError(configuration: RumConfiguration, errorObservable: Observable<RawError>) {
   const subscription = initReportObservable(configuration, [
     RawReportType.cspViolation,
     RawReportType.intervention,
-  ]).subscribe((reportError) => {
-    const rawError: RawError = {
-      startClocks: clocksNow(),
-      message: reportError.message,
-      stack: reportError.stack,
-      type: reportError.subtype,
-      source: ErrorSource.REPORT,
-      handling: ErrorHandling.UNHANDLED,
-      originalError: reportError.originalReport,
-    }
-
-    if (reportError.originalReport.type === 'securitypolicyviolation') {
-      rawError.csp = {
-        disposition: reportError.originalReport.disposition,
-      }
-    }
-
-    return errorObservable.notify(rawError)
-  })
+  ]).subscribe((rawError) => errorObservable.notify(rawError))
 
   return {
     stop: () => {


### PR DESCRIPTION
**Please review commit by commit**

## Motivation

This PR implements error.handling to logs, similarly to RUM error events.

## Changes

This PR contains a bit of refactoring in order to unify how we define the `error` field in logs. The idea is to format all kind of errors as `RawError` objects, then use `RawError` objects in RUM (to create RUM Error events) and Logs (to define the `error` field). This `RawError` creation logic was already present in RUM, so I just had to move it in `core`. 

**Note:** Network errors are kind of special and only supported in logs, so I didn't use `RawError` there. Also, we can't be sure whether they are handled or not by the customer app, so to avoid any confusion, they don't have `error.handling`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
