### PR TITLE
Revert "👷 use devflow to merge main into staging (#2917)"

### DIFF
--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -1,31 +1,55 @@
 'use strict'
 
-const { printLog, runMain, fetchHandlingError } = require('../lib/execution-utils')
+const { printLog, printError, runMain } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
+const { initGitConfig } = require('../lib/git-utils')
 
-const REPOSITORY = process.env.APP
-const CURRENT_STAGING = process.env.CURRENT_STAGING
-const DEVFLOW_AUTH_TOKEN = command`authanywhere --audience sdm`.run().split(' ')[2].trim()
-const DEVFLOW_API_URL = 'https://devflow-api.us1.ddbuild.io/internal/api/v2/devflow/execute/'
-const SUCESS_FEEDBACK_LEVEL = 'FEEDBACK_LEVEL_INFO'
+const REPOSITORY = process.env.GIT_REPOSITORY
+const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
+const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
+const CI_COMMIT_SHORT_SHA = process.env.CI_COMMIT_SHORT_SHA
+const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
 
-runMain(async () => {
-  const rawResponse = await fetchHandlingError(
-    `${DEVFLOW_API_URL}/update-branch?repository=${REPOSITORY}&branch=${CURRENT_STAGING}`,
-    {
-      headers: {
-        Authorization: `Bearer ${DEVFLOW_AUTH_TOKEN}`,
-      },
-    }
-  )
-  const jsonResponse = await rawResponse.json()
+runMain(() => {
+  initGitConfig(REPOSITORY)
+  command`git fetch --no-tags origin ${CURRENT_STAGING_BRANCH}`.run()
+  command`git checkout ${CURRENT_STAGING_BRANCH} -f`.run()
+  command`git pull origin ${CURRENT_STAGING_BRANCH}`.run()
 
-  const isSuccess = jsonResponse.state.feedbacks[0].level === SUCESS_FEEDBACK_LEVEL
-  const message = jsonResponse.state.feedbacks[0].message
-
-  if (!isSuccess) {
-    throw new Error(message)
+  // Commit can already be merged if someone merge main into his branch and
+  // run to-staging before the end of this scripts
+  if (isCommitAlreadyMerged()) {
+    printLog('Already merged.')
+    return
   }
 
-  printLog(message)
+  printLog(`Merging branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA}) into ${CURRENT_STAGING_BRANCH}...`)
+  try {
+    command`git merge --no-ff ${CI_COMMIT_SHA}`.run()
+  } catch (error) {
+    const diff = command`git diff`.run()
+    printError(
+      `Conflicts:\n${diff}\n` +
+        'See "How to fix staging" in Confluence for help: https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2548269306/How+to+fix+staging+conflicts'
+    )
+    throw error
+  }
+
+  const commitMessage = command`git show -s --format=%B`.run()
+  const newSummary = `Merge branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA}) with ${CURRENT_STAGING_BRANCH}`
+  const message = `${newSummary}\n\n${commitMessage}`
+
+  command`git commit --amend -m ${message}`.run()
+  command`git push origin ${CURRENT_STAGING_BRANCH}`.run()
+
+  printLog('Merge done.')
 })
+
+function isCommitAlreadyMerged() {
+  try {
+    command`git merge-base --is-ancestor ${CI_COMMIT_SHA} ${CURRENT_STAGING_BRANCH}`.run()
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
This reverts commit 6b867f7b003fcc5d529edc35cc055f0490f94e70.

## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

The token on the CI does not seems to work, reverting for now.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
