### PR TITLE
👷 use devflow to merge main into staging

### DIFF
--- a/scripts/performance/report-as-a-pr-comment.js
+++ b/scripts/performance/report-as-a-pr-comment.js
@@ -3,7 +3,7 @@ const { fetchHandlingError } = require('../lib/execution-utils')
 const { LOCAL_BRANCH, GITHUB_TOKEN, getLastCommonCommit, fetchPR } = require('../lib/git-utils')
 const { fetchPerformanceMetrics } = require('./fetch-performance-metrics')
 const PR_COMMENT_HEADER = 'Bundles Sizes Evolution'
-const PR_COMMENTER_AUTH_TOKEN = command`authanywhere`.run().split(' ')[2].trim()
+const PR_COMMENTER_AUTH_TOKEN = command`authanywhere --raw`.run()
 // The value is set to 5% as it's around 10 times the average value for small PRs.
 const SIZE_INCREASE_THRESHOLD = 5
 const LOCAL_COMMIT_SHA = process.env.CI_COMMIT_SHORT_SHA

--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { printLog, printError, runMain, fetchHandlingError } = require('../lib/execution-utils')
+const { printLog, runMain, fetchHandlingError } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
 
 const REPOSITORY = process.env.APP
@@ -20,13 +20,10 @@ runMain(async () => {
   )
   const jsonResponse = await rawResponse.json()
 
-  printLog(jsonResponse)
-
   const isSuccess = jsonResponse.state.feedbacks[0].level === SUCESS_FEEDBACK_LEVEL
   const message = jsonResponse.state.feedbacks[0].message
 
   if (!isSuccess) {
-    printError(message)
     throw new Error(message)
   }
 

--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -1,55 +1,34 @@
 'use strict'
 
-const { printLog, printError, runMain } = require('../lib/execution-utils')
+const { printLog, printError, runMain, fetchHandlingError } = require('../lib/execution-utils')
 const { command } = require('../lib/command')
-const { initGitConfig } = require('../lib/git-utils')
 
-const REPOSITORY = process.env.GIT_REPOSITORY
-const CURRENT_STAGING_BRANCH = process.env.CURRENT_STAGING
-const CI_COMMIT_SHA = process.env.CI_COMMIT_SHA
-const CI_COMMIT_SHORT_SHA = process.env.CI_COMMIT_SHORT_SHA
-const CI_COMMIT_REF_NAME = process.env.CI_COMMIT_REF_NAME
+const REPOSITORY = process.env.APP
+const CURRENT_STAGING = process.env.CURRENT_STAGING
+const DEVFLOW_AUTH_TOKEN = command`authanywhere --audience sdm`.run().split(' ')[2].trim()
+const DEVFLOW_API_URL = 'https://devflow-api.us1.ddbuild.io/internal/api/v2/devflow/execute/'
+const SUCESS_FEEDBACK_LEVEL = 'FEEDBACK_LEVEL_INFO'
 
-runMain(() => {
-  initGitConfig(REPOSITORY)
-  command`git fetch --no-tags origin ${CURRENT_STAGING_BRANCH}`.run()
-  command`git checkout ${CURRENT_STAGING_BRANCH} -f`.run()
-  command`git pull origin ${CURRENT_STAGING_BRANCH}`.run()
+runMain(async () => {
+  const rawResponse = await fetchHandlingError(
+    `${DEVFLOW_API_URL}/update-branch?repository=${REPOSITORY}&branch=${CURRENT_STAGING}`,
+    {
+      headers: {
+        Authorization: `Bearer ${DEVFLOW_AUTH_TOKEN}`,
+      },
+    }
+  )
+  const jsonResponse = await rawResponse.json()
 
-  // Commit can already be merged if someone merge main into his branch and
-  // run to-staging before the end of this scripts
-  if (isCommitAlreadyMerged()) {
-    printLog('Already merged.')
-    return
+  printLog(jsonResponse)
+
+  const isSuccess = jsonResponse.state.feedbacks[0].level === SUCESS_FEEDBACK_LEVEL
+  const message = jsonResponse.state.feedbacks[0].message
+
+  if (!isSuccess) {
+    printError(message)
+    throw new Error(message)
   }
 
-  printLog(`Merging branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA}) into ${CURRENT_STAGING_BRANCH}...`)
-  try {
-    command`git merge --no-ff ${CI_COMMIT_SHA}`.run()
-  } catch (error) {
-    const diff = command`git diff`.run()
-    printError(
-      `Conflicts:\n${diff}\n` +
-        'See "How to fix staging" in Confluence for help: https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2548269306/How+to+fix+staging+conflicts'
-    )
-    throw error
-  }
-
-  const commitMessage = command`git show -s --format=%B`.run()
-  const newSummary = `Merge branch '${CI_COMMIT_REF_NAME}' (${CI_COMMIT_SHORT_SHA}) with ${CURRENT_STAGING_BRANCH}`
-  const message = `${newSummary}\n\n${commitMessage}`
-
-  command`git commit --amend -m ${message}`.run()
-  command`git push origin ${CURRENT_STAGING_BRANCH}`.run()
-
-  printLog('Merge done.')
+  printLog(message)
 })
-
-function isCommitAlreadyMerged() {
-  try {
-    command`git merge-base --is-ancestor ${CI_COMMIT_SHA} ${CURRENT_STAGING_BRANCH}`.run()
-    return true
-  } catch {
-    return false
-  }
-}

--- a/scripts/staging-ci/merge-into-staging.js
+++ b/scripts/staging-ci/merge-into-staging.js
@@ -5,7 +5,7 @@ const { command } = require('../lib/command')
 
 const REPOSITORY = process.env.APP
 const CURRENT_STAGING = process.env.CURRENT_STAGING
-const DEVFLOW_AUTH_TOKEN = command`authanywhere --audience sdm`.run().split(' ')[2].trim()
+const DEVFLOW_AUTH_TOKEN = command`authanywhere --audience sdm --raw`.run()
 const DEVFLOW_API_URL = 'https://devflow-api.us1.ddbuild.io/internal/api/v2/devflow/execute/'
 const SUCESS_FEEDBACK_LEVEL = 'FEEDBACK_LEVEL_INFO'
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Use [devflow](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/2905376710/Devflow) to merge `main` back into `staging-XX`. 
If this fails, it will create a [fix PR](https://github.com/DataDog/browser-sdk/pull/2916) and log something like this:

```
couldn't merge the [main](https://github.com/DataDog/browser-sdk/tree/main) branch of [browser-sdk](https://github.com/DataDog/browser-sdk) into [thomas.lebeau/test-devflow-conflic](https://github.com/DataDog/browser-sdk/tree/thomas.lebeau/test-devflow-conflic), there was a conflict...

We have created a conflict resolution PR for you [#2916](https://github.com/DataDog/browser-sdk/pull/2916)
Alternatively, you can also reset the integration branch by using the following slack command: `/devflow reset-branch -r browser-sdk -b thomas.lebeau/test-devflow-conflic`

To get help about command usage, write `update-branch --help`
```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
