### PR TITLE
👷 upgrade gitlab runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,8 @@ stages:
   - notify
 
 .base-configuration:
-  tags: ['arch:amd64', 'size:large']
+  tags:
+    - 'arch:amd64'
   image: $CI_IMAGE
   retry:
     max: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
   - notify
 
 .base-configuration:
-  tags: ['runner:main', 'size:large']
+  tags: ['arch:amd64', 'size:large']
   image: $CI_IMAGE
   retry:
     max: 2


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

`runner:main` is deprecated, use `arch:amd64` as per the [documentation](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/2411528655/Onboarding+To+Gitlab+CI#Gitlab-runner-tags--%3Agitlab-runner%3A)

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
