### PR TITLE
👷 add job to merge main into next major feature branch (v6)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
   GIT_REPOSITORY: 'git@github.com:DataDog/browser-sdk.git'
   MAIN_BRANCH: 'main'
+  NEXT_MAJOR_BRANCH: 'v6'
   CHROME_PACKAGE_VERSION: 127.0.6533.72-1
 
 cache:
@@ -433,7 +434,18 @@ merge-into-staging:
     - eval $(ssh-agent -s)
   script:
     - yarn
-    - node scripts/staging-ci/merge-into-staging.js
+    - node scripts/update-branch.js $CURRENT_STAGING
+
+merge-into-next-major:
+  stage: pre-deploy
+  extends:
+    - .base-configuration
+    - .main
+  before_script:
+    - eval $(ssh-agent -s)
+  script:
+    - yarn
+    - node scripts/update-branch.js $NEXT_MAJOR_BRANCH
 
 check-staging-merge:
   stage: test

--- a/scripts/update-branch.js
+++ b/scripts/update-branch.js
@@ -1,17 +1,20 @@
 'use strict'
 
-const { printLog, runMain, fetchHandlingError } = require('../lib/execution-utils')
-const { command } = require('../lib/command')
+const { parseArgs } = require('node:util')
+const { printLog, runMain, fetchHandlingError } = require('./lib/execution-utils')
+const { command } = require('./lib/command')
 
 const REPOSITORY = process.env.APP
-const CURRENT_STAGING = process.env.CURRENT_STAGING
 const DEVFLOW_AUTH_TOKEN = command`authanywhere --audience sdm --raw`.run()
 const DEVFLOW_API_URL = 'https://devflow-api.us1.ddbuild.io/internal/api/v2/devflow/execute/'
 const SUCESS_FEEDBACK_LEVEL = 'FEEDBACK_LEVEL_INFO'
 
 runMain(async () => {
+  const args = parseArgs({ allowPositionals: true })
+  const [branch] = args.positionals
+
   const rawResponse = await fetchHandlingError(
-    `${DEVFLOW_API_URL}/update-branch?repository=${REPOSITORY}&branch=${CURRENT_STAGING}`,
+    `${DEVFLOW_API_URL}/update-branch?repository=${REPOSITORY}&branch=${branch}`,
     {
       headers: {
         Authorization: `Bearer ${DEVFLOW_AUTH_TOKEN}`,


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

The next major feature branch (`v6`) will be a long living branch, we need to make sure we're merging main into it regularly to avoid larger conflicts resolution later.

This job will merge main into v6 and trigger the CI.
If merging fails, devflow will create a fix PR (link in the logs). We will need to follow the created PR's instruction (i.e. fixing the conflict ant resuming the job) and then re-run the job to continue the pipeline


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

- Add a CI job to automatically merge the main branch into the next major feature branch (currently `v6`)
- refactor `update-branch` to trigger the CI after updating the branch

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
