### PR TITLE
🐛 [RUM-5921] Fix history API instrumentation

### DIFF
--- a/packages/core/test/emulate/mockLocation.ts
+++ b/packages/core/test/emulate/mockLocation.ts
@@ -2,7 +2,7 @@ import { assign, buildUrl } from '../../src'
 
 export function mockLocation(initialUrl: string) {
   const fakeLocation = buildLocation(initialUrl)
-  spyOn(history, 'pushState').and.callFake((_: any, __: string, pathname: string) => {
+  spyOn(History.prototype, 'pushState').and.callFake((_: any, __: string, pathname: string) => {
     assign(fakeLocation, buildLocation(pathname, fakeLocation.href))
   })
 

--- a/packages/rum-core/src/browser/locationChangeObservable.ts
+++ b/packages/rum-core/src/browser/locationChangeObservable.ts
@@ -33,12 +33,16 @@ export function createLocationChangeObservable(configuration: RumConfiguration, 
 }
 
 function trackHistory(configuration: RumConfiguration, onHistoryChange: () => void) {
-  const { stop: stopInstrumentingPushState } = instrumentMethod(history, 'pushState', ({ onPostCall }) => {
+  const { stop: stopInstrumentingPushState } = instrumentMethod(History.prototype, 'pushState', ({ onPostCall }) => {
     onPostCall(onHistoryChange)
   })
-  const { stop: stopInstrumentingReplaceState } = instrumentMethod(history, 'replaceState', ({ onPostCall }) => {
-    onPostCall(onHistoryChange)
-  })
+  const { stop: stopInstrumentingReplaceState } = instrumentMethod(
+    History.prototype,
+    'replaceState',
+    ({ onPostCall }) => {
+      onPostCall(onHistoryChange)
+    }
+  )
   const { stop: removeListener } = addEventListener(configuration, window, DOM_EVENT.POP_STATE, onHistoryChange)
 
   return {


### PR DESCRIPTION
## Motivation

We wrongly instrument history API, potentially breaking the instrumentation of other vendors, cf: #2943 

## Changes

Wrap `History.prototype.pushState` instead of `history.pushState`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
