### PR TITLE
Revert "[RUM-5590] Add telemetry for INP null target (#2895)"

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -1,11 +1,4 @@
-import {
-  addTelemetryDebug,
-  elapsed,
-  ExperimentalFeature,
-  isExperimentalFeatureEnabled,
-  noop,
-  ONE_MINUTE,
-} from '@datadog/browser-core'
+import { elapsed, noop, ONE_MINUTE } from '@datadog/browser-core'
 import type { Duration, RelativeTime } from '@datadog/browser-core'
 import { RumPerformanceEntryType, supportPerformanceTimingEvent } from '../../../browser/performanceObservable'
 import type { RumFirstInputTiming, RumPerformanceEventTiming } from '../../../browser/performanceObservable'
@@ -72,25 +65,16 @@ export function trackInteractionToNextPaint(
 
     const newInteraction = longestInteractions.estimateP98Interaction()
     if (newInteraction && newInteraction.duration !== interactionToNextPaint) {
-      const inpTarget = newInteraction.target
       interactionToNextPaint = newInteraction.duration
       interactionToNextPaintStartTime = elapsed(viewStart, newInteraction.startTime)
 
-      if (inpTarget && isElementNode(inpTarget)) {
-        interactionToNextPaintTargetSelector = getSelectorFromElement(inpTarget, configuration.actionNameAttribute)
+      if (newInteraction.target && isElementNode(newInteraction.target)) {
+        interactionToNextPaintTargetSelector = getSelectorFromElement(
+          newInteraction.target,
+          configuration.actionNameAttribute
+        )
       } else {
         interactionToNextPaintTargetSelector = undefined
-      }
-      if (
-        !interactionToNextPaintTargetSelector &&
-        isExperimentalFeatureEnabled(ExperimentalFeature.NULL_INP_TELEMETRY)
-      ) {
-        addTelemetryDebug('Fail to get INP target selector', {
-          hasTarget: !!inpTarget,
-          targetIsConnected: inpTarget ? inpTarget.isConnected : undefined,
-          targetIsElementNode: inpTarget ? isElementNode(inpTarget) : undefined,
-          inp: newInteraction.duration,
-        })
       }
     }
   })


### PR DESCRIPTION
This reverts commit 68d89a1e35ec029d9147f76ea3151a119f4607fd.

## Motivation
Testing of INP Null target has finished. We do not need to include this in the release.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
revert INP null target telemetry
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
