### PR TITLE
Remove custom_vitals FF

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -15,7 +15,6 @@ import { objectHasValue } from './utils/objectUtils'
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  CUSTOM_VITALS = 'custom_vitals',
   TOLERANT_RESOURCE_TIMINGS = 'tolerant_resource_timings',
   REMOTE_CONFIGURATION = 'remote_configuration',
   UPDATE_VIEW_NAME = 'update_view_name',

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,8 +1,6 @@
 import type { RelativeTime, Context, DeflateWorker, CustomerDataTrackerManager, TimeStamp } from '@datadog/browser-core'
 import {
-  addExperimentalFeatures,
   ExperimentalFeature,
-  resetExperimentalFeatures,
   ONE_SECOND,
   display,
   DefaultPrivacyLevel,
@@ -741,22 +739,7 @@ describe('rum public api', () => {
   })
 
   describe('startDurationVital', () => {
-    beforeEach(() => {
-      setup().withFakeClock().build()
-    })
-
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should not expose startDurationVital when ff is disabled', () => {
-      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).startDurationVital).toBeUndefined()
-    })
-
-    it('should call startDurationVital on the startRum result when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+    it('should call startDurationVital on the startRum result', () => {
       const startDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -766,8 +749,7 @@ describe('rum public api', () => {
         noopRecorderApi
       )
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).startDurationVital('foo', { context: { foo: 'bar' }, description: 'description-value' })
+      rumPublicApi.startDurationVital('foo', { context: { foo: 'bar' }, description: 'description-value' })
       expect(startDurationVitalSpy).toHaveBeenCalledWith('foo', {
         description: 'description-value',
         context: { foo: 'bar' },
@@ -775,23 +757,46 @@ describe('rum public api', () => {
     })
   })
 
-  describe('addDurationVital', () => {
-    beforeEach(() => {
-      setup().withFakeClock().build()
-    })
-
-    afterEach(() => {
-      resetExperimentalFeatures()
-    })
-
-    it('should not expose addDurationVital when ff is disabled', () => {
-      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
+  describe('stopDurationVital', () => {
+    it('should call stopDurationVital with a name on the startRum result', () => {
+      const stopDurationVitalSpy = jasmine.createSpy()
+      const rumPublicApi = makeRumPublicApi(
+        () => ({
+          ...noopStartRum(),
+          stopDurationVital: stopDurationVitalSpy,
+        }),
+        noopRecorderApi
+      )
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).addDurationVital).toBeUndefined()
+      rumPublicApi.startDurationVital('foo', { context: { foo: 'bar' }, description: 'description-value' })
+      rumPublicApi.stopDurationVital('foo', { context: { foo: 'bar' }, description: 'description-value' })
+      expect(stopDurationVitalSpy).toHaveBeenCalledWith('foo', {
+        description: 'description-value',
+        context: { foo: 'bar' },
+      })
     })
 
-    it('should call addDurationVital on the startRum result when ff is enabled', () => {
-      addExperimentalFeatures([ExperimentalFeature.CUSTOM_VITALS])
+    it('should call stopDurationVital with a reference on the startRum result', () => {
+      const stopDurationVitalSpy = jasmine.createSpy()
+      const rumPublicApi = makeRumPublicApi(
+        () => ({
+          ...noopStartRum(),
+          stopDurationVital: stopDurationVitalSpy,
+        }),
+        noopRecorderApi
+      )
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      const ref = rumPublicApi.startDurationVital('foo', { context: { foo: 'bar' }, description: 'description-value' })
+      rumPublicApi.stopDurationVital(ref, { context: { foo: 'bar' }, description: 'description-value' })
+      expect(stopDurationVitalSpy).toHaveBeenCalledWith(ref, {
+        description: 'description-value',
+        context: { foo: 'bar' },
+      })
+    })
+  })
+
+  describe('addDurationVital', () => {
+    it('should call addDurationVital on the startRum result', () => {
       const addDurationVitalSpy = jasmine.createSpy()
       const rumPublicApi = makeRumPublicApi(
         () => ({
@@ -802,8 +807,7 @@ describe('rum public api', () => {
       )
       const startTime = 1707755888000 as TimeStamp
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).addDurationVital('foo', {
+      rumPublicApi.addDurationVital('foo', {
         startTime,
         duration: 100,
         context: { foo: 'bar' },

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -251,11 +251,10 @@ export interface RumPublicApi extends PublicApi {
 
   /**
    * Add a custom duration vital
-   * stored in @vital.custom.<name>
    *
    * @param name name of the custom vital
    * @param options.startTime epoch timestamp of the start of the custom vital
-   * @param options.duration duration of the custom vital
+   * @param options.duration duration of the custom vital in millisecond
    * @param options.context custom context attached to the vital
    * @param options.description  Description of the vital
    */
@@ -269,8 +268,6 @@ export interface RumPublicApi extends PublicApi {
    *
    * If you plan to have multiple durations for the same vital, you should use the reference returned by this method.
    *
-   * stored in @vital.custom.<name>
-   *
    * @param name name of the custom vital
    * @param options.context custom context attached to the vital
    * @param options.description Description of the vital
@@ -280,7 +277,6 @@ export interface RumPublicApi extends PublicApi {
 
   /**
    * Stop a custom duration vital
-   * stored in @vital.custom.<name>
    *
    * @param nameOrRef name of the custom vital or the reference to it
    * @param options.context custom context attached to the vital
@@ -519,21 +515,19 @@ export function makeRumPublicApi(
 
     stopSessionReplayRecording: monitor(() => recorderApi.stop()),
 
-    addDurationVital: monitor(
-      (name: string, options: { startTime: number; duration: number; context?: object; description?: string }) => {
-        addTelemetryUsage({ feature: 'add-duration-vital' })
-        strategy.addDurationVital({
-          name: sanitize(name)!,
-          type: VitalType.DURATION,
-          startClocks: timeStampToClocks(options.startTime as TimeStamp),
-          duration: options.duration as Duration,
-          context: sanitize(options && options.context) as Context,
-          description: sanitize(options && options.description) as string | undefined,
-        })
-      }
-    ),
+    addDurationVital: monitor((name, options) => {
+      addTelemetryUsage({ feature: 'add-duration-vital' })
+      strategy.addDurationVital({
+        name: sanitize(name)!,
+        type: VitalType.DURATION,
+        startClocks: timeStampToClocks(options.startTime as TimeStamp),
+        duration: options.duration as Duration,
+        context: sanitize(options && options.context) as Context,
+        description: sanitize(options && options.description) as string | undefined,
+      })
+    }),
 
-    startDurationVital: monitor((name: string, options?: { context?: object; description?: string }) => {
+    startDurationVital: monitor((name, options) => {
       addTelemetryUsage({ feature: 'start-duration-vital' })
       return strategy.startDurationVital(sanitize(name)!, {
         context: sanitize(options && options.context) as Context,
@@ -541,15 +535,13 @@ export function makeRumPublicApi(
       })
     }),
 
-    stopDurationVital: monitor(
-      (nameOrRef: string | DurationVitalReference, options?: { context?: object; description?: string }) => {
-        addTelemetryUsage({ feature: 'stop-duration-vital' })
-        strategy.stopDurationVital(typeof nameOrRef === 'string' ? sanitize(nameOrRef)! : nameOrRef, {
-          context: sanitize(options && options.context) as Context,
-          description: sanitize(options && options.description) as string | undefined,
-        })
-      }
-    ),
+    stopDurationVital: monitor((nameOrRef, options) => {
+      addTelemetryUsage({ feature: 'stop-duration-vital' })
+      strategy.stopDurationVital(typeof nameOrRef === 'string' ? sanitize(nameOrRef)! : nameOrRef, {
+        context: sanitize(options && options.context) as Context,
+        description: sanitize(options && options.description) as string | undefined,
+      })
+    }),
   })
 
   return rumPublicApi

--- a/test/e2e/scenario/rum/vitals.scenario.ts
+++ b/test/e2e/scenario/rum/vitals.scenario.ts
@@ -2,18 +2,12 @@ import { createTest, flushEvents } from '../../lib/framework'
 
 describe('vital collection', () => {
   createTest('send custom duration vital')
-    .withRum({
-      enableExperimentalFeatures: ['custom_vitals'],
-    })
+    .withRum()
     .run(async ({ intakeRegistry }) => {
       await browser.executeAsync((done) => {
-        // TODO remove cast and unsafe calls when removing the flag
-        const global = window.DD_RUM! as any
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        const vital = global.startDurationVital('foo')
+        const vital = window.DD_RUM!.startDurationVital('foo')
         setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          global.stopDurationVital(vital)
+          window.DD_RUM!.stopDurationVital(vital)
           done()
         }, 5)
       })


### PR DESCRIPTION
## Motivation

Exposing the Custom Vital API.

## Changes

Remove custom_vitals FF.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
