### PR TITLE
👷 don't print log messages twice in unit tests

### DIFF
--- a/test/unit/karmaSkippedFailedReporterPlugin.js
+++ b/test/unit/karmaSkippedFailedReporterPlugin.js
@@ -1,9 +1,7 @@
-function KarmaSkippedFailedReporter(baseReporterDecorator, logger) {
+function KarmaSkippedFailedReporter(logger) {
   var log = logger.create('karma-skipped-failed')
 
-  baseReporterDecorator(this)
-
-  this.specSkipped = this.specFailure = (browser, result) => {
+  this.onSpecComplete = (browser, result) => {
     if (result.skipped && !result.success) {
       log.warn('Failing skipped test:')
       log.warn(browser.name)
@@ -13,7 +11,7 @@ function KarmaSkippedFailedReporter(baseReporterDecorator, logger) {
   }
 }
 
-KarmaSkippedFailedReporter.$inject = ['baseReporterDecorator', 'logger']
+KarmaSkippedFailedReporter.$inject = ['logger']
 
 module.exports = {
   'reporter:karma-skipped-failed': ['type', KarmaSkippedFailedReporter],


### PR DESCRIPTION



## Motivation

`baseReporterDecorator` implements a bunch of methods that display messages in the console. Since we already have a reporter for that, messages are displayed twice.

## Changes

Remove `baseReporterDecorator` usage from our karma "skipped failed reporter" plugin.  Without `baseReporterDecorator`, `specSkipped` and `specFailure` "hooks" don't exist anymore, so let's use `onSpecComplete` instead.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
