### PR TITLE
:sparkles: Discard loading time when page is hidden

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -1,7 +1,7 @@
 import type { RelativeTime, Duration } from '@datadog/browser-core'
 import { addDuration, clocksOrigin, Observable } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock } from '@datadog/browser-core/test'
+import { mockClock, setPageVisibility, restorePageVisibility } from '@datadog/browser-core/test'
 import { ViewLoadingType } from '../../../rawRumEvent.types'
 import { createPerformanceEntry } from '../../../../test'
 import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitPageActivityEnd'
@@ -47,6 +47,7 @@ describe('trackLoadingTime', () => {
 
   afterEach(() => {
     stopLoadingTimeTracking()
+    restorePageVisibility()
     clock.cleanup()
   })
 
@@ -124,5 +125,12 @@ describe('trackLoadingTime', () => {
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
     expect(loadingTimeCallback).toHaveBeenCalledOnceWith(addDuration(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY, CLOCK_GAP))
+  })
+
+  it('should discard loading time if page is hidden before activity', () => {
+    setPageVisibility('hidden')
+    startLoadingTimeTracking()
+
+    expect(loadingTimeCallback).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -20,13 +20,11 @@ export function trackLoadingTime(
   const firstHidden = trackFirstHidden(configuration)
 
   function invokeCallbackIfAllCandidatesAreReceived() {
-    if (
-      firstHidden.timeStamp !== 0 &&
-      !isWaitingForActivityLoadingTime &&
-      !isWaitingForLoadEvent &&
-      loadingTimeCandidates.length > 0
-    ) {
-      callback(Math.max(...loadingTimeCandidates) as Duration)
+    if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
+      const loadingTime = Math.max(...loadingTimeCandidates)
+      if (loadingTime < firstHidden.timeStamp) {
+        callback(loadingTime as Duration)
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation
When a view created in background, its loading time can be inflated due to the browser pausing the javascript execution, which leads to data inconsistencies. It's better to not send the loading time of those views, rather than sending an erroneous value.


## Changes
If the page is initially hidden, discard attaching `loading_time` to view event

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
