### PR TITLE
✅♻️ do not mock `navigationStart` in `mockClock`

### DIFF
--- a/packages/core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
+++ b/packages/core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
@@ -1,7 +1,6 @@
 import type { Clock } from '../../../test'
 import { mockClock } from '../../../test'
-import type { RelativeTime } from '../../tools/utils/timeUtils'
-import { relativeToClocks, resetNavigationStart, ONE_MINUTE } from '../../tools/utils/timeUtils'
+import { relativeToClocks, ONE_MINUTE } from '../../tools/utils/timeUtils'
 import { noop } from '../../tools/utils/functionUtils'
 import type { RawError } from '../error/error.types'
 import { createEventRateLimiter } from './createEventRateLimiter'
@@ -13,7 +12,6 @@ describe('createEventRateLimiter', () => {
   const limit = 1
   beforeEach(() => {
     clock = mockClock()
-    resetNavigationStart()
   })
 
   afterEach(() => {
@@ -51,7 +49,7 @@ describe('createEventRateLimiter', () => {
     expect(onLimitReachedSpy).toHaveBeenCalledOnceWith({
       message: 'Reached max number of errors by minute: 1',
       source: 'agent',
-      startClocks: relativeToClocks(0 as RelativeTime),
+      startClocks: relativeToClocks(clock.relative(0)),
     })
   })
 

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../test'
 import type { Clock } from '../../../test'
 import { getCookie, setCookie } from '../../browser/cookie'
-import type { RelativeTime } from '../../tools/utils/timeUtils'
 import { isIE } from '../../tools/utils/browserDetection'
 import { DOM_EVENT } from '../../browser/addEventListener'
 import { ONE_HOUR, ONE_SECOND } from '../../tools/utils/timeUtils'
@@ -544,13 +543,11 @@ describe('startSessionManager', () => {
       const secondSessionId = sessionManager.findSession()!.id
       const secondSessionTrackingType = sessionManager.findSession()!.trackingType
 
-      expect(sessionManager.findSession((5 * ONE_SECOND) as RelativeTime)!.id).toBe(firstSessionId)
-      expect(sessionManager.findSession((5 * ONE_SECOND) as RelativeTime)!.trackingType).toBe(firstSessionTrackingType)
-      expect(sessionManager.findSession((15 * ONE_SECOND) as RelativeTime)).toBeUndefined()
-      expect(sessionManager.findSession((25 * ONE_SECOND) as RelativeTime)!.id).toBe(secondSessionId)
-      expect(sessionManager.findSession((25 * ONE_SECOND) as RelativeTime)!.trackingType).toBe(
-        secondSessionTrackingType
-      )
+      expect(sessionManager.findSession(clock.relative(5 * ONE_SECOND))!.id).toBe(firstSessionId)
+      expect(sessionManager.findSession(clock.relative(5 * ONE_SECOND))!.trackingType).toBe(firstSessionTrackingType)
+      expect(sessionManager.findSession(clock.relative(15 * ONE_SECOND))).toBeUndefined()
+      expect(sessionManager.findSession(clock.relative(25 * ONE_SECOND))!.id).toBe(secondSessionId)
+      expect(sessionManager.findSession(clock.relative(25 * ONE_SECOND))!.trackingType).toBe(secondSessionTrackingType)
     })
 
     describe('option `returnInactive` is true', () => {
@@ -565,9 +562,9 @@ describe('startSessionManager', () => {
         // 10s to 20s: no session
         clock.tick(10 * ONE_SECOND)
 
-        expect(sessionManager.findSession((15 * ONE_SECOND) as RelativeTime, { returnInactive: true })).toBeDefined()
+        expect(sessionManager.findSession(clock.relative(15 * ONE_SECOND), { returnInactive: true })).toBeDefined()
 
-        expect(sessionManager.findSession((15 * ONE_SECOND) as RelativeTime, { returnInactive: false })).toBeUndefined()
+        expect(sessionManager.findSession(clock.relative(15 * ONE_SECOND), { returnInactive: false })).toBeUndefined()
       })
     })
 

--- a/packages/core/src/tools/utils/timeUtils.ts
+++ b/packages/core/src/tools/utils/timeUtils.ts
@@ -110,7 +110,3 @@ function getNavigationStart() {
   }
   return navigationStart
 }
-
-export function resetNavigationStart() {
-  navigationStart = undefined
-}

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -1,4 +1,4 @@
-import type { DeflateWorker, Duration, RelativeTime, TimeStamp, TrackingConsentState } from '@datadog/browser-core'
+import type { DeflateWorker, Duration, TimeStamp, TrackingConsentState } from '@datadog/browser-core'
 import {
   display,
   getTimeStamp,
@@ -357,8 +357,8 @@ describe('preStartRum', () => {
           expect(startViewSpy).toHaveBeenCalled()
           expect(startViewSpy.calls.argsFor(0)[0]).toEqual({ name: 'foo' })
           expect(startViewSpy.calls.argsFor(0)[1]).toEqual({
-            relative: 10 as RelativeTime,
-            timeStamp: jasmine.any(Number) as unknown as TimeStamp,
+            relative: clock.relative(10),
+            timeStamp: clock.timeStamp(10),
           })
         })
       })
@@ -415,7 +415,7 @@ describe('preStartRum', () => {
           expect(doStartRumSpy).toHaveBeenCalled()
           const initialViewOptions: ViewOptions | undefined = doStartRumSpy.calls.argsFor(0)[2]
           expect(initialViewOptions).toEqual({ name: 'foo' })
-          expect(startViewSpy).toHaveBeenCalledOnceWith({ name: 'bar' }, relativeToClocks(20 as RelativeTime))
+          expect(startViewSpy).toHaveBeenCalledOnceWith({ name: 'bar' }, relativeToClocks(clock.relative(20)))
         })
 
         it('calling init then startView should start rum', () => {
@@ -448,10 +448,10 @@ describe('preStartRum', () => {
           expect(addTimingSpy).toHaveBeenCalledTimes(2)
 
           expect(addTimingSpy.calls.argsFor(0)[0]).toEqual('first')
-          expect(addTimingSpy.calls.argsFor(0)[1]).toEqual(getTimeStamp(10 as RelativeTime))
+          expect(addTimingSpy.calls.argsFor(0)[1]).toEqual(getTimeStamp(clock.relative(10)))
 
           expect(addTimingSpy.calls.argsFor(1)[0]).toEqual('second')
-          expect(addTimingSpy.calls.argsFor(1)[1]).toEqual(getTimeStamp(30 as RelativeTime))
+          expect(addTimingSpy.calls.argsFor(1)[1]).toEqual(getTimeStamp(clock.relative(30)))
         })
       })
     })

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -217,7 +217,7 @@ describe('rum public api', () => {
         clock.tick(ONE_SECOND)
         rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
-        expect(addActionSpy.calls.argsFor(0)[0].startClocks.relative as number).toEqual(ONE_SECOND)
+        expect(addActionSpy.calls.argsFor(0)[0].startClocks.relative as number).toEqual(clock.relative(ONE_SECOND))
       })
 
       it('stores a deep copy of the global context', () => {
@@ -319,7 +319,7 @@ describe('rum public api', () => {
         clock.tick(ONE_SECOND)
         rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
-        expect(addErrorSpy.calls.argsFor(0)[0].startClocks.relative as number).toEqual(ONE_SECOND)
+        expect(addErrorSpy.calls.argsFor(0)[0].startClocks.relative as number).toEqual(clock.relative(ONE_SECOND))
       })
 
       it('stores a deep copy of the global context', () => {

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -351,7 +351,7 @@ describe('view events', () => {
 
     setupViewCollectionTest()
 
-    clock.tick(VIEW_DURATION)
+    clock.tick(VIEW_DURATION - relativeNow())
     window.dispatchEvent(createNewEvent('beforeunload'))
 
     const lastRumEvents = interceptor.requests[interceptor.requests.length - 1].body
@@ -373,7 +373,7 @@ describe('view events', () => {
 
     setupViewCollectionTest()
 
-    clock.tick(VIEW_DURATION)
+    clock.tick(VIEW_DURATION - relativeNow())
     window.dispatchEvent(createNewEvent('beforeunload'))
 
     const lastBridgeMessage = JSON.parse(sendSpy.calls.mostRecent().args[0]) as {

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime, ServerDuration, Duration } from '@datadog/browser-core'
+import type { ServerDuration, Duration } from '@datadog/browser-core'
 import type { Clock } from '../../../../core/test'
 import { mockClock, registerCleanupTask } from '../../../../core/test'
 import { mockRumConfiguration } from '../../../test'
@@ -22,11 +22,11 @@ describe('pageStateHistory', () => {
 
   describe('findAll', () => {
     it('should have the current state when starting', () => {
-      expect(pageStateHistory.findAll(0 as RelativeTime, 10 as RelativeTime)).toBeDefined()
+      expect(pageStateHistory.findAll(clock.relative(0), 10 as Duration)).toBeDefined()
     })
 
     it('should return undefined if the time period is out of history bounds', () => {
-      expect(pageStateHistory.findAll(-10 as RelativeTime, 0 as RelativeTime)).not.toBeDefined()
+      expect(pageStateHistory.findAll(clock.relative(-10), 0 as Duration)).not.toBeDefined()
     })
 
     it('should return the correct page states for the given time period', () => {
@@ -49,8 +49,8 @@ describe('pageStateHistory', () => {
       event time                  15<-------->35
       */
       const event = {
-        startTime: 15 as RelativeTime,
-        duration: 20 as RelativeTime,
+        startTime: clock.relative(15),
+        duration: 20 as Duration,
       }
       expect(pageStateHistory.findAll(event.startTime, event.duration)).toEqual([
         {
@@ -77,7 +77,7 @@ describe('pageStateHistory', () => {
       clock.tick(10)
       pageStateHistory.addPageState(PageState.PASSIVE)
 
-      expect(pageStateHistory.findAll(0 as RelativeTime, Infinity as RelativeTime)?.length).toEqual(
+      expect(pageStateHistory.findAll(clock.relative(0), Infinity as Duration)?.length).toEqual(
         maxPageStateEntriesSelectable
       )
     })
@@ -90,7 +90,7 @@ describe('pageStateHistory', () => {
       clock.tick(10)
       pageStateHistory.addPageState(PageState.PASSIVE)
 
-      expect(pageStateHistory.wasInPageStateAt(PageState.ACTIVE, 0 as RelativeTime)).toEqual(true)
+      expect(pageStateHistory.wasInPageStateAt(PageState.ACTIVE, clock.relative(0))).toEqual(true)
     })
 
     it('should return false if the page was not in the given state at the given time', () => {
@@ -101,7 +101,7 @@ describe('pageStateHistory', () => {
       pageStateHistory.addPageState(PageState.ACTIVE)
       clock.tick(10)
       pageStateHistory.addPageState(PageState.PASSIVE)
-      expect(pageStateHistory.wasInPageStateAt(PageState.ACTIVE, 11 as RelativeTime)).toEqual(false)
+      expect(pageStateHistory.wasInPageStateAt(PageState.ACTIVE, clock.relative(11))).toEqual(false)
     })
   })
 
@@ -114,7 +114,7 @@ describe('pageStateHistory', () => {
       pageStateHistory.addPageState(PageState.HIDDEN)
       clock.tick(10)
 
-      expect(pageStateHistory.wasInPageStateDuringPeriod(PageState.PASSIVE, 0 as RelativeTime, 30 as Duration)).toEqual(
+      expect(pageStateHistory.wasInPageStateDuringPeriod(PageState.PASSIVE, clock.relative(0), 30 as Duration)).toEqual(
         true
       )
     })
@@ -127,7 +127,7 @@ describe('pageStateHistory', () => {
       pageStateHistory.addPageState(PageState.HIDDEN)
       clock.tick(10)
 
-      expect(pageStateHistory.wasInPageStateDuringPeriod(PageState.FROZEN, 0 as RelativeTime, 30 as Duration)).toEqual(
+      expect(pageStateHistory.wasInPageStateDuringPeriod(PageState.FROZEN, clock.relative(0), 30 as Duration)).toEqual(
         false
       )
     })
@@ -136,7 +136,7 @@ describe('pageStateHistory', () => {
       // pageStateHistory is initialized with the current page state
       // look for a period before the initialization to make sure there is no page state
       expect(
-        pageStateHistory.wasInPageStateDuringPeriod(PageState.ACTIVE, -40 as RelativeTime, 30 as Duration)
+        pageStateHistory.wasInPageStateDuringPeriod(PageState.ACTIVE, clock.relative(-40), 30 as Duration)
       ).toEqual(false)
     })
   })

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -1,6 +1,6 @@
 import { mockClock, registerCleanupTask, type Clock } from '@datadog/browser-core/test'
 import type { RelativeTime } from '@datadog/browser-core'
-import { relativeToClocks } from '@datadog/browser-core'
+import { clocksNow, relativeToClocks } from '@datadog/browser-core'
 import { setupLocationObserver } from '../../../test'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { ViewCreatedEvent, ViewEndedEvent } from '../view/trackViews'
@@ -75,16 +75,16 @@ describe('urlContexts', () => {
 
   it('should return the url context corresponding to the start time', () => {
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
-      startClocks: relativeToClocks(0 as RelativeTime),
+      startClocks: clocksNow(),
     } as ViewCreatedEvent)
 
     clock.tick(10)
     changeLocation('/foo')
     lifeCycle.notify(LifeCycleEventType.AFTER_VIEW_ENDED, {
-      endClocks: relativeToClocks(10 as RelativeTime),
+      endClocks: clocksNow(),
     } as ViewEndedEvent)
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
-      startClocks: relativeToClocks(10 as RelativeTime),
+      startClocks: clocksNow(),
     } as ViewCreatedEvent)
 
     clock.tick(10)
@@ -93,25 +93,25 @@ describe('urlContexts', () => {
     clock.tick(10)
     changeLocation('/qux')
     lifeCycle.notify(LifeCycleEventType.AFTER_VIEW_ENDED, {
-      endClocks: relativeToClocks(30 as RelativeTime),
+      endClocks: clocksNow(),
     } as ViewEndedEvent)
     lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
-      startClocks: relativeToClocks(30 as RelativeTime),
+      startClocks: clocksNow(),
     } as ViewCreatedEvent)
 
-    expect(urlContexts.findUrl(5 as RelativeTime)).toEqual({
+    expect(urlContexts.findUrl(clock.relative(5))).toEqual({
       url: 'http://fake-url.com/',
       referrer: document.referrer,
     })
-    expect(urlContexts.findUrl(15 as RelativeTime)).toEqual({
+    expect(urlContexts.findUrl(clock.relative(15))).toEqual({
       url: 'http://fake-url.com/foo',
       referrer: 'http://fake-url.com/',
     })
-    expect(urlContexts.findUrl(25 as RelativeTime)).toEqual({
+    expect(urlContexts.findUrl(clock.relative(25))).toEqual({
       url: 'http://fake-url.com/foo#bar',
       referrer: 'http://fake-url.com/',
     })
-    expect(urlContexts.findUrl(35 as RelativeTime)).toEqual({
+    expect(urlContexts.findUrl(clock.relative(35))).toEqual({
       url: 'http://fake-url.com/qux',
       referrer: 'http://fake-url.com/foo',
     })

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -266,24 +266,26 @@ describe('view lifecycle', () => {
   describe('session keep alive', () => {
     it('should emit a view update periodically', () => {
       const { getViewUpdateCount } = viewTest
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD) // make sure we don't have pending update
 
-      expect(getViewUpdateCount()).toEqual(1)
+      const previousViewUpdateCount = getViewUpdateCount()
 
       clock.tick(SESSION_KEEP_ALIVE_INTERVAL)
 
-      expect(getViewUpdateCount()).toEqual(2)
+      expect(getViewUpdateCount()).toEqual(previousViewUpdateCount + 1)
     })
 
     it('should not send periodical updates after the session has expired', () => {
       const { getViewUpdateCount } = viewTest
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD) // make sure we don't have pending update
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
 
-      expect(getViewUpdateCount()).toBe(2)
+      const previousViewUpdateCount = getViewUpdateCount()
 
       clock.tick(SESSION_KEEP_ALIVE_INTERVAL)
 
-      expect(getViewUpdateCount()).toBe(2)
+      expect(getViewUpdateCount()).toBe(previousViewUpdateCount)
     })
   })
 
@@ -606,9 +608,11 @@ describe('view custom timings', () => {
   })
 
   it('should add custom timing to current view', () => {
+    clock.tick(0)
     const { getViewUpdate, startView, addTiming } = viewTest
 
     startView()
+
     const currentViewId = getViewUpdate(2).id
     clock.tick(20)
     addTiming('foo')
@@ -710,6 +714,7 @@ describe('view custom timings', () => {
   })
 
   it('should not add custom timing when the session has expired', () => {
+    clock.tick(0)
     const { getViewUpdateCount, addTiming } = viewTest
 
     lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -17,6 +17,7 @@ import type { RumEvent } from '../../rumEvent.types'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { RumPerformanceEntry } from '../../browser/performanceObservable'
 import { RumPerformanceEntryType } from '../../browser/performanceObservable'
+import { PAGE_ACTIVITY_END_DELAY } from '../waitPageActivityEnd'
 import type { ViewEvent } from './trackViews'
 import { SESSION_KEEP_ALIVE_INTERVAL, THROTTLE_VIEW_UPDATE_PERIOD, KEEP_TRACKING_AFTER_VIEW_DELAY } from './trackViews'
 import type { ViewTest } from './setupViewTest.specHelper'
@@ -402,7 +403,7 @@ describe('view metrics', () => {
       expect(getViewUpdate(1).commonViewMetrics.cumulativeLayoutShift).toEqual({
         value: 0.1,
         targetSelector: undefined,
-        time: 0 as Duration,
+        time: clock.relative(0),
       })
     })
 
@@ -433,7 +434,6 @@ describe('view metrics', () => {
       expect(getViewUpdate(0).initialViewMetrics).toEqual({})
 
       const navigationEntry = createPerformanceEntry(RumPerformanceEntryType.NAVIGATION)
-      clock.tick(navigationEntry.responseStart) // ensure now > responseStart
       notifyPerformanceEntries([navigationEntry])
 
       expect(getViewUpdateCount()).toEqual(1)
@@ -492,18 +492,20 @@ describe('view metrics', () => {
     describe('when load event happening after initial view end', () => {
       let initialView: { init: ViewEvent; end: ViewEvent; last: ViewEvent }
       let secondView: { init: ViewEvent; last: ViewEvent }
-      const VIEW_DURATION = 100 as Duration
+      let viewDuration: Duration
 
       beforeEach(() => {
         const { getViewUpdateCount, getViewUpdate, startView } = viewTest
 
         expect(getViewUpdateCount()).toEqual(1)
 
-        clock.tick(VIEW_DURATION)
+        // `loadingTime` relies on the "page activity". To make sure we have a valid value, we need
+        // to wait for the page activity time to be known.
+        clock.tick(PAGE_ACTIVITY_END_DELAY)
+
+        viewDuration = relativeNow()
 
         startView()
-
-        clock.tick(VIEW_DURATION)
 
         expect(getViewUpdateCount()).toEqual(3)
 
@@ -549,8 +551,8 @@ describe('view metrics', () => {
       })
 
       it('should not update the initial view duration when updating it with new timings', () => {
-        expect(initialView.end.duration).toBe(VIEW_DURATION)
-        expect(initialView.last.duration).toBe(VIEW_DURATION)
+        expect(initialView.end.duration).toBe(viewDuration)
+        expect(initialView.last.duration).toBe(viewDuration)
       })
 
       it('should update the initial view loadingTime following the loadEventEnd value', () => {
@@ -631,8 +633,8 @@ describe('view custom timings', () => {
 
     const view = getViewUpdate(1)
     expect(view.customTimings).toEqual({
-      bar: 30 as Duration,
-      foo: 20 as Duration,
+      bar: clock.relative(30),
+      foo: clock.relative(20),
     })
   })
 
@@ -649,8 +651,8 @@ describe('view custom timings', () => {
 
     let view = getViewUpdate(1)
     expect(view.customTimings).toEqual({
-      bar: 30 as Duration,
-      foo: 20 as Duration,
+      bar: clock.relative(30),
+      foo: clock.relative(20),
     })
 
     clock.tick(20)
@@ -660,8 +662,8 @@ describe('view custom timings', () => {
 
     view = getViewUpdate(2)
     expect(view.customTimings).toEqual({
-      bar: 30 as Duration,
-      foo: (THROTTLE_VIEW_UPDATE_PERIOD + 50) as Duration,
+      bar: clock.relative(30),
+      foo: clock.relative(THROTTLE_VIEW_UPDATE_PERIOD + 50),
     })
   })
 
@@ -674,7 +676,7 @@ describe('view custom timings', () => {
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
     expect(getViewUpdate(1).customTimings).toEqual({
-      foo: 1234 as Duration,
+      foo: clock.relative(1234),
     })
   })
 
@@ -687,7 +689,7 @@ describe('view custom timings', () => {
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
     expect(getViewUpdate(1).customTimings).toEqual({
-      foo: 1234 as Duration,
+      foo: clock.relative(1234),
     })
   })
 
@@ -702,7 +704,7 @@ describe('view custom timings', () => {
     clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
     expect(getViewUpdate(1).customTimings).toEqual({
-      'foo_bar-qux.@zip_21_$____': 1234 as Duration,
+      'foo_bar-qux.@zip_21_$____': clock.relative(1234),
     })
     expect(displaySpy).toHaveBeenCalled()
   })
@@ -751,11 +753,11 @@ describe('start view', () => {
     expect(getViewUpdate(1).id).toBe(initialViewId)
     expect(getViewUpdate(1).isActive).toBe(false)
     expect(getViewUpdate(1).startClocks.relative).toBe(0 as RelativeTime)
-    expect(getViewUpdate(1).duration).toBe(10 as Duration)
+    expect(getViewUpdate(1).duration).toBe(clock.relative(10))
 
     expect(getViewUpdate(2).id).not.toBe(initialViewId)
     expect(getViewUpdate(2).isActive).toBe(true)
-    expect(getViewUpdate(2).startClocks.relative).toBe(10 as RelativeTime)
+    expect(getViewUpdate(2).startClocks.relative).toBe(clock.relative(10))
   })
 
   it('should name the view', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -1,5 +1,5 @@
 import type { RelativeTime, Duration } from '@datadog/browser-core'
-import { addDuration, clocksOrigin, Observable } from '@datadog/browser-core'
+import { clocksOrigin, Observable } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, setPageVisibility, restorePageVisibility } from '@datadog/browser-core/test'
 import { ViewLoadingType } from '../../../rawRumEvent.types'
@@ -62,7 +62,7 @@ describe('trackLoadingTime', () => {
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(clock.relative(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY))
   })
 
   it('should use loadEventEnd for initial view when having no activity', () => {
@@ -83,11 +83,11 @@ describe('trackLoadingTime', () => {
 
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
 
-    setLoadEvent(LOAD_EVENT_AFTER_ACTIVITY_TIMING)
+    setLoadEvent(clock.relative(LOAD_EVENT_AFTER_ACTIVITY_TIMING))
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(LOAD_EVENT_AFTER_ACTIVITY_TIMING)
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(clock.relative(LOAD_EVENT_AFTER_ACTIVITY_TIMING))
   })
 
   it('should use computed loading time for initial view when load event is smaller than computed loading time', () => {
@@ -96,12 +96,12 @@ describe('trackLoadingTime', () => {
 
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
 
-    setLoadEvent(LOAD_EVENT_BEFORE_ACTIVITY_TIMING)
+    setLoadEvent(clock.relative(LOAD_EVENT_BEFORE_ACTIVITY_TIMING))
 
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(clock.relative(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY))
   })
 
   it('should use computed loading time from time origin for initial view', () => {
@@ -118,12 +118,14 @@ describe('trackLoadingTime', () => {
 
     clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
 
-    setLoadEvent(LOAD_EVENT_BEFORE_ACTIVITY_TIMING)
+    setLoadEvent(clock.relative(LOAD_EVENT_BEFORE_ACTIVITY_TIMING))
 
     domMutationObservable.notify()
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(addDuration(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY, CLOCK_GAP))
+    expect(loadingTimeCallback).toHaveBeenCalledOnceWith(
+      clock.relative(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + CLOCK_GAP)
+    )
   })
 
   it('should discard loading time if page is hidden before activity', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
@@ -58,14 +58,14 @@ describe('trackNavigationTimings', () => {
   })
 
   it('should provide navigation timing when navigation timing is not supported ', () => {
-    clock = mockClock(new Date(0))
+    clock = mockClock()
     mockPerformanceTiming()
     removePerformanceObserver()
     ;({ stop } = trackNavigationTimings(mockRumConfiguration(), navigationTimingsCallback))
     clock.tick(0)
 
     expect(navigationTimingsCallback).toHaveBeenCalledOnceWith({
-      firstByte: undefined,
+      firstByte: 123 as Duration,
       domComplete: 456 as Duration,
       domContentLoaded: 345 as Duration,
       domInteractive: 234 as Duration,

--- a/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
@@ -1,4 +1,4 @@
-import type { Duration, RelativeTime, Subscription, TimeStamp } from '@datadog/browser-core'
+import type { RelativeTime, Subscription, TimeStamp } from '@datadog/browser-core'
 import { DOM_EVENT, Observable, isIE } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, mockClock, registerCleanupTask } from '@datadog/browser-core/test'
@@ -79,7 +79,7 @@ describe('trackScrollMetrics', () => {
     expect(scrollMetricsCallback).toHaveBeenCalledOnceWith({
       maxDepth: 700,
       maxScrollHeight: 2000,
-      maxScrollHeightTime: 100 as Duration,
+      maxScrollHeightTime: clock.relative(100),
       maxDepthScrollTop: 100,
     })
   })
@@ -89,7 +89,7 @@ describe('trackScrollMetrics', () => {
     expect(scrollMetricsCallback).toHaveBeenCalledOnceWith({
       maxDepth: 700,
       maxScrollHeight: 2000,
-      maxScrollHeightTime: 100 as Duration,
+      maxScrollHeightTime: clock.relative(100),
       maxDepthScrollTop: 100,
     })
   })
@@ -100,7 +100,7 @@ describe('trackScrollMetrics', () => {
     expect(scrollMetricsCallback).toHaveBeenCalledOnceWith({
       maxDepth: 700,
       maxScrollHeight: 2000,
-      maxScrollHeightTime: 100 as Duration,
+      maxScrollHeightTime: clock.relative(100),
       maxDepthScrollTop: 100,
     })
   })

--- a/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
@@ -1,5 +1,5 @@
-import type { RelativeTime, Subscription } from '@datadog/browser-core'
-import { Observable, ONE_SECOND, getTimeStamp } from '@datadog/browser-core'
+import type { Subscription } from '@datadog/browser-core'
+import { Observable, ONE_SECOND } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
 import { createPerformanceEntry, mockPerformanceObserver, mockRumConfiguration } from '../../test'
@@ -219,7 +219,7 @@ describe('doWaitPageActivityEnd', () => {
 
     expect(idlPageActivityCallbackSpy).toHaveBeenCalledOnceWith({
       hadActivity: true,
-      end: getTimeStamp(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY as RelativeTime),
+      end: clock.timeStamp(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY),
     })
   })
 
@@ -240,7 +240,7 @@ describe('doWaitPageActivityEnd', () => {
 
       expect(idlPageActivityCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        end: getTimeStamp((extendCount * BEFORE_PAGE_ACTIVITY_END_DELAY) as RelativeTime),
+        end: clock.timeStamp(extendCount * BEFORE_PAGE_ACTIVITY_END_DELAY),
       })
     })
 
@@ -265,7 +265,7 @@ describe('doWaitPageActivityEnd', () => {
 
       expect(idlPageActivityCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        end: getTimeStamp(MAX_DURATION as RelativeTime),
+        end: clock.timeStamp(MAX_DURATION),
       })
     })
   })
@@ -285,7 +285,7 @@ describe('doWaitPageActivityEnd', () => {
 
       expect(idlPageActivityCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        end: getTimeStamp((BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + PAGE_ACTIVITY_END_DELAY * 2) as RelativeTime),
+        end: clock.timeStamp(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY + PAGE_ACTIVITY_END_DELAY * 2),
       })
     })
 
@@ -300,7 +300,7 @@ describe('doWaitPageActivityEnd', () => {
 
       expect(idlPageActivityCallbackSpy).toHaveBeenCalledOnceWith({
         hadActivity: true,
-        end: getTimeStamp(MAX_DURATION as RelativeTime),
+        end: clock.timeStamp(MAX_DURATION),
       })
     })
   })

--- a/packages/rum-core/test/emulate/mockPerformanceObserver.ts
+++ b/packages/rum-core/test/emulate/mockPerformanceObserver.ts
@@ -89,6 +89,8 @@ export function mockPerformanceTiming() {
   const properties = Object.keys(timings) as Array<keyof typeof performance.timing>
 
   for (const propertyName of properties) {
-    spyOnProperty(performance.timing, propertyName, 'get').and.callFake(() => timings[propertyName])
+    spyOnProperty(performance.timing, propertyName, 'get').and.callFake(
+      () => performance.timing.navigationStart + (timings[propertyName] as number)
+    )
   }
 }


### PR DESCRIPTION

## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Before this commit, `mockClock` was adjusting the `navigationStart` value so calling `performance.now()` before any `clock.tick()` returned 0. This was useful for assertions on relative times, ex:

```js
clock = mockClock()
clock.tick(10)
expect(relativeNow()).toEqual(10)
```

Unfortunately, it lead to incoherences because some other timings were not adjusted. For example `performance.timing.responseStart` was not adjusted, so it was before `navigationStart`, which is unexpected.

To work around this, we locally tweak the mocked clock (ex: (here)[1] and (here)[2]). Those tweaks are hard to understand, especially on "integration tests" where those incoherences are deeply nested into lower-level code.

So, this leaves us we two solutions to make things coherent again:

* Mock more things: replace values with hardcoded coherent values. This is tricky because more tests will need to mock more things. Also, we don't know where we'll need to stop mocking things, and at this rate is it still worth to execute the unit tests in real browsers?

* Mock less things: keep values provided by the browser


[1]: https://github.com/DataDog/browser-sdk/blob/c6c0ad6125b825cb4755782a59e1593968707d55/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts#L61
[2]: https://github.com/DataDog/browser-sdk/blob/c6c0ad6125b825cb4755782a59e1593968707d55/packages/rum-core/src/domain/view/trackViews.spec.ts#L436


## Changes


This commit chose the latter solution. We don't mock `navigationStart` anymore, so `performance.now()` now returns an arbitrary value influenced by the page load duration. To workaround this, the `Clock` object now exposes helpers to compute times (relative time and timestamp) relative to when `mockClock()` was invoked (a.k.a the start of the test case). The above example should now look like this:

```js
clock = mockClock()
clock.tick(10)
expect(relativeNow()).toEqual(clock.relative(10))
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
