### PR TITLE
👷 allow job 'test-performance' to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,6 +151,7 @@ test-performance:
     - .base-configuration
     - .test-allowed-branches
   interruptible: true
+  allow_failure: true
   script:
     - yarn
     - yarn build:bundle


### PR DESCRIPTION



## Motivation

This job randomly fail for various reason. While it is not required to merge PRs at the GitHub level, it still blocks the gitlab pipeline, so in practice it is required.


Because we only use this job to notify performance benchmark changes on PRs, it is acceptable to bypass it sometimes. We'll need to figure out how we can make this more stable in the future.

## Changes

Allow `test-performance` to fail at gitlab level.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
