### PR TITLE
✨ Add records caching logic and cache records if session is sampled out

### DIFF
--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -144,7 +144,7 @@ export function makeRecorderApi(
 
       startStrategy = (options?: StartRecordingOptions) => {
         const session = sessionManager.findTrackedSession()
-        if (!session || (session.sessionReplay === SessionReplayState.OFF && (!options || !options.force))) {
+        if (!session) {
           state = { status: RecorderStatus.IntentToStart }
           return
         }
@@ -168,13 +168,16 @@ export function makeRecorderApi(
             return
           }
 
-          const { stop: stopRecording } = startRecordingImpl(
+          const { stop: stopRecording, flushCachedRecords } = startRecordingImpl(
             lifeCycle,
             configuration,
             sessionManager,
             viewHistory,
             deflateEncoder
           )
+          if (options && options.force && session.sessionReplay === SessionReplayState.OFF) {
+            flushCachedRecords()
+          }
           state = {
             status: RecorderStatus.Started,
             stopRecording,

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -56,7 +56,7 @@ export function startRecording(
 
   function flushCachedRecords() {
     if (getCachedRecords) {
-      const {addRecord: addRecordToSegment} = initSegemntCollection()
+      const { addRecord: addRecordToSegment } = initSegemntCollection()
       const records = getCachedRecords()
       records.forEach(addRecordToSegment)
 

--- a/packages/rum/src/domain/recordsCaching/index.ts
+++ b/packages/rum/src/domain/recordsCaching/index.ts
@@ -1,0 +1,1 @@
+export * from './recordsCaching'

--- a/packages/rum/src/domain/recordsCaching/recordsCaching.ts
+++ b/packages/rum/src/domain/recordsCaching/recordsCaching.ts
@@ -1,0 +1,18 @@
+import type { BrowserRecord } from '../../types'
+
+export function startRecordsCaching() {
+  const records: BrowserRecord[] = []
+
+  function addRecord(record: BrowserRecord) {
+    records.push(record)
+  }
+
+  function getRecords() {
+    return records
+  }
+
+  return {
+    addRecord,
+    getRecords,
+  }
+}


### PR DESCRIPTION
## Motivation
Implementation of Error Mode Replay recorder.

## Changes
- Initialise records caching module
- Start session replay recording as long as session is tracked (no matter what sample state)
- If session is sampled in for replay, start segments collection, otherwise forward records to cache
- When session replay is forced to start, start segment collection from cache

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
