### PR TITLE
👷 fix next major deploy job config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,8 +67,8 @@ stages:
 
 .next-major-branch:
   only:
-    refs:
-      - $NEXT_MAJOR_BRANCH
+    variables:
+      - $CI_COMMIT_REF_NAME == $NEXT_MAJOR_BRANCH
 
 .staging:
   only:


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

to use variables, we need to use `variables` instead of `refs`, like for `.staging`:
https://github.com/DataDog/browser-sdk/blob/73ae1f5caaa04c2659d5eee2c4f2a5222742beb0/.gitlab-ci.yml#L68-L71

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
