### PR TITLE
♻️ [RUM-6180] Use performanceObserver for long-task entries

### DIFF
--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -268,13 +268,15 @@ describe('rum events url', () => {
 
   it('should attach the url corresponding to the start of the event', () => {
     clock = mockClock()
+    const { notifyPerformanceEntries } = mockPerformanceObserver()
+
     setupViewUrlTest()
     clock.tick(10)
     changeLocation('http://foo.com/?bar=bar')
     clock.tick(10)
     changeLocation('http://foo.com/?bar=qux')
 
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+    notifyPerformanceEntries([
       createPerformanceEntry(RumPerformanceEntryType.LONG_TASK, {
         startTime: (relativeNow() - 5) as RelativeTime,
       }),

--- a/packages/rum-core/src/browser/performanceCollection.spec.ts
+++ b/packages/rum-core/src/browser/performanceCollection.spec.ts
@@ -20,7 +20,6 @@ describe('startPerformanceCollection', () => {
   }
 
   ;[
-    RumPerformanceEntryType.LONG_TASK,
     RumPerformanceEntryType.PAINT,
     RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
     RumPerformanceEntryType.FIRST_INPUT,
@@ -36,16 +35,18 @@ describe('startPerformanceCollection', () => {
       expect(entryCollectedCallback).toHaveBeenCalledWith([jasmine.objectContaining({ entryType })])
     })
   })
-  ;[(RumPerformanceEntryType.NAVIGATION, RumPerformanceEntryType.RESOURCE)].forEach((entryType) => {
-    it(`should not notify ${entryType} timings`, () => {
-      const { notifyPerformanceEntries } = mockPerformanceObserver()
-      setupStartPerformanceCollection()
+  ;[(RumPerformanceEntryType.NAVIGATION, RumPerformanceEntryType.RESOURCE, RumPerformanceEntryType.LONG_TASK)].forEach(
+    (entryType) => {
+      it(`should not notify ${entryType} timings`, () => {
+        const { notifyPerformanceEntries } = mockPerformanceObserver()
+        setupStartPerformanceCollection()
 
-      notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE)])
+        notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE)])
 
-      expect(entryCollectedCallback).not.toHaveBeenCalled()
-    })
-  })
+        expect(entryCollectedCallback).not.toHaveBeenCalled()
+      })
+    }
+  )
 
   it('should handle exceptions coming from performance observer .observe()', () => {
     const { notifyPerformanceEntries } = mockPerformanceObserver({

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -41,7 +41,7 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: 
     const handlePerformanceEntryList = monitor((entries: PerformanceObserverEntryList) =>
       handleRumPerformanceEntries(lifeCycle, entries.getEntries())
     )
-    const mainEntries = [RumPerformanceEntryType.LONG_TASK, RumPerformanceEntryType.PAINT]
+    const mainEntries = [RumPerformanceEntryType.PAINT]
     const experimentalEntries = [
       RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
       RumPerformanceEntryType.FIRST_INPUT,

--- a/packages/rum-core/src/domain/longTask/longTaskCollection.spec.ts
+++ b/packages/rum-core/src/domain/longTask/longTaskCollection.spec.ts
@@ -5,6 +5,7 @@ import {
   mockPerformanceObserver,
   mockRumConfiguration,
 } from '../../../test'
+import type { RumPerformanceEntry } from '../../browser/performanceObservable'
 import { RumPerformanceEntryType } from '../../browser/performanceObservable'
 import type { RawRumEvent } from '../../rawRumEvent.types'
 import { RumEventType, RumLongTaskEntryType } from '../../rawRumEvent.types'
@@ -15,8 +16,11 @@ import { startLongTaskCollection } from './longTaskCollection'
 describe('long task collection', () => {
   let lifeCycle = new LifeCycle()
   let rawRumEvents: Array<RawRumEventCollectedData<RawRumEvent>> = []
+  let notifyPerformanceEntries: (entries: RumPerformanceEntry[]) => void
 
   function setupLongTaskCollection(trackLongTasks = true) {
+    ;({ notifyPerformanceEntries } = mockPerformanceObserver())
+
     lifeCycle = new LifeCycle()
     startLongTaskCollection(lifeCycle, mockRumConfiguration({ trackLongTasks }))
 
@@ -24,12 +28,13 @@ describe('long task collection', () => {
   }
 
   it('should only listen to long task performance entry', () => {
-    const { notifyPerformanceEntries } = mockPerformanceObserver()
     setupLongTaskCollection()
 
-    notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.NAVIGATION)])
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
+    notifyPerformanceEntries([
+      createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
       createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
+    ])
+    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
       createPerformanceEntry(RumPerformanceEntryType.PAINT),
     ])
 
@@ -39,26 +44,21 @@ describe('long task collection', () => {
   it('should collect when trackLongTasks=true', () => {
     setupLongTaskCollection()
 
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
-    ])
+    notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.LONG_TASK)])
     expect(rawRumEvents.length).toBe(1)
   })
 
   it('should not collect when trackLongTasks=false', () => {
     setupLongTaskCollection(false)
 
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
-    ])
+    notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.LONG_TASK)])
+
     expect(rawRumEvents.length).toBe(0)
   })
 
   it('should create raw rum event from performance entry', () => {
     setupLongTaskCollection()
-    lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
-      createPerformanceEntry(RumPerformanceEntryType.LONG_TASK),
-    ])
+    notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.LONG_TASK)])
 
     expect(rawRumEvents[0].startTime).toBe(1234 as RelativeTime)
     expect(rawRumEvents[0].rawRumEvent).toEqual({

--- a/packages/rum-core/src/domain/longTask/longTaskCollection.ts
+++ b/packages/rum-core/src/domain/longTask/longTaskCollection.ts
@@ -3,11 +3,13 @@ import type { RawRumLongTaskEvent } from '../../rawRumEvent.types'
 import { RumEventType, RumLongTaskEntryType } from '../../rawRumEvent.types'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
-import { RumPerformanceEntryType } from '../../browser/performanceObservable'
+import { createPerformanceObservable, RumPerformanceEntryType } from '../../browser/performanceObservable'
 import type { RumConfiguration } from '../configuration'
-
 export function startLongTaskCollection(lifeCycle: LifeCycle, configuration: RumConfiguration) {
-  lifeCycle.subscribe(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, (entries) => {
+  const performanceLongTaskSubscription = createPerformanceObservable(configuration, {
+    type: RumPerformanceEntryType.LONG_TASK,
+    buffered: true,
+  }).subscribe((entries) => {
     for (const entry of entries) {
       if (entry.entryType !== RumPerformanceEntryType.LONG_TASK) {
         break
@@ -35,4 +37,10 @@ export function startLongTaskCollection(lifeCycle: LifeCycle, configuration: Rum
       })
     }
   })
+
+  return {
+    stop() {
+      performanceLongTaskSubscription.unsubscribe()
+    },
+  }
 }


### PR DESCRIPTION
## Motivation

Following the introduction of `performanceObservable` to move away from `performanceCollection`: [PR](https://github.com/DataDog/browser-sdk/pull/2818)
Let use `performanceObservable` for long-task entries.

## Changes
- Remove long-task from `performanceCollection`
- Use `perfomanceObservable` in `startLongTaskCollection`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
