### PR TITLE
♻️ [RUM-6181] Use performanceObserver for LCP entries

### DIFF
--- a/packages/rum-core/src/browser/performanceCollection.spec.ts
+++ b/packages/rum-core/src/browser/performanceCollection.spec.ts
@@ -22,7 +22,6 @@ describe('startPerformanceCollection', () => {
   ;[
     RumPerformanceEntryType.LONG_TASK,
     RumPerformanceEntryType.PAINT,
-    RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
     RumPerformanceEntryType.FIRST_INPUT,
     RumPerformanceEntryType.LAYOUT_SHIFT,
     RumPerformanceEntryType.EVENT,
@@ -36,7 +35,11 @@ describe('startPerformanceCollection', () => {
       expect(entryCollectedCallback).toHaveBeenCalledWith([jasmine.objectContaining({ entryType })])
     })
   })
-  ;[(RumPerformanceEntryType.NAVIGATION, RumPerformanceEntryType.RESOURCE)].forEach((entryType) => {
+  ;[
+    (RumPerformanceEntryType.NAVIGATION,
+    RumPerformanceEntryType.RESOURCE,
+    RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT),
+  ].forEach((entryType) => {
     it(`should not notify ${entryType} timings`, () => {
       const { notifyPerformanceEntries } = mockPerformanceObserver()
       setupStartPerformanceCollection()

--- a/packages/rum-core/src/browser/performanceCollection.ts
+++ b/packages/rum-core/src/browser/performanceCollection.ts
@@ -43,7 +43,6 @@ export function startPerformanceCollection(lifeCycle: LifeCycle, configuration: 
     )
     const mainEntries = [RumPerformanceEntryType.LONG_TASK, RumPerformanceEntryType.PAINT]
     const experimentalEntries = [
-      RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
       RumPerformanceEntryType.FIRST_INPUT,
       RumPerformanceEntryType.LAYOUT_SHIFT,
       RumPerformanceEntryType.EVENT,

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -461,9 +461,8 @@ describe('view metrics', () => {
       clock.tick(KEEP_TRACKING_AFTER_VIEW_DELAY - 1)
       lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
         createPerformanceEntry(RumPerformanceEntryType.PAINT),
-        lcpEntry,
       ])
-      notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.NAVIGATION)])
+      notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.NAVIGATION), lcpEntry])
 
       clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
@@ -513,9 +512,11 @@ describe('view metrics', () => {
 
         lifeCycle.notify(LifeCycleEventType.PERFORMANCE_ENTRIES_COLLECTED, [
           createPerformanceEntry(RumPerformanceEntryType.PAINT),
+        ])
+        notifyPerformanceEntries([
+          createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
           createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT),
         ])
-        notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.NAVIGATION)])
 
         clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -38,7 +38,6 @@ export function trackInitialViewMetrics(
   })
 
   const { stop: stopLCPTracking } = trackLargestContentfulPaint(
-    lifeCycle,
     configuration,
     firstHidden,
     window,


### PR DESCRIPTION
## Motivation

Following the introduction of `performanceObservable` to move away from `performanceCollection`: [PR](https://github.com/DataDog/browser-sdk/pull/2818)
Let use `performanceObservable` for LCP entries.

## Changes
- Remove LCP from `performanceCollection`
- Use `perfomanceObservable` in `trackLargestContentfulPaint`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
