### PR TITLE
👷 timeout e2e-bs ci job after 30 minutes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -268,6 +268,7 @@ e2e-bs:
     - .bs-allowed-branches
   interruptible: true
   resource_group: browserstack
+  timeout: 30 minutes
   artifacts:
     when: always
     paths: ['test-report/e2e-bs/specs.log']


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Sometime the e2e-bs job is losing connection to Browserstack ([example](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/640299576)), this result is the job not doing anything until it times out, after 1 hour.
In the past month, no successful job has taken more that 30 minutes ([query](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fbrowser-sdk%22%20%40ci.job.name%3Ae2e-bs%20-%40ci.status%3A%28skipped%20OR%20canceled%29%20%40duration%3A%3E1800000000000&agg_m=%40duration&agg_m_source=base&agg_q=%40ci.status&agg_q_source=base&agg_t=avg&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=time%2Cdesc&colorBy=meta%5B%27ci.stage.name%27%5D&colorByAttr=meta%5B%27ci.stage.name%27%5D&currentTab=json&filterErrors=false&fromUser=false&index=cipipeline&mode=sliding&spanViewType=overview&top_n=10&top_o=top&viz=stream&x_missing=true&start=1723905889597&end=1726497889597&paused=false), except one, but seems like a fluke)


Reducing the timeout for this job to 30 minutes will reduce the unnecessary waiting time

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
