### PR TITLE
🎨 RUM-6203: Expose experimental features in init method

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -360,42 +360,6 @@ export function makeRumPublicApi(
     trackingConsentState,
     customVitalsState,
     (configuration, deflateWorker, initialViewOptions) => {
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.UPDATE_VIEW_NAME)) {
-        /**
-         * Update View Name.
-         *
-         * Enable to manually change the name of the current view.
-         * @param name name of the view
-         * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
-         */
-        ;(rumPublicApi as any).updateViewName = monitor((name: string) => {
-          strategy.updateViewName(name)
-        })
-      }
-
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.VIEW_SPECIFIC_CONTEXT)) {
-        /**
-         * Set View Context.
-         *
-         * Enable to manually set the context of the current view.
-         * @param context context of the view
-         */
-        ;(rumPublicApi as any).setViewContext = monitor((context: Context) => {
-          strategy.setViewContext(context)
-        })
-
-        /**
-         * Set View Context Property.
-         *
-         * Enable to manually set a property of the context of the current view.
-         * @param key key of the property
-         * @param value value of the property
-         */
-        ;(rumPublicApi as any).setViewContextProperty = monitor((key: string, value: any) => {
-          strategy.setViewContextProperty(key, value)
-        })
-      }
-
       if (configuration.storeContextsAcrossPages) {
         storeContextManager(configuration, globalContextManager, RUM_STORAGE_KEY, CustomerDataType.GlobalContext)
         storeContextManager(configuration, userContextManager, RUM_STORAGE_KEY, CustomerDataType.User)
@@ -445,7 +409,45 @@ export function makeRumPublicApi(
   })
 
   const rumPublicApi: RumPublicApi = makePublicApi<RumPublicApi>({
-    init: monitor((initConfiguration) => strategy.init(initConfiguration, rumPublicApi)),
+    init: monitor((initConfiguration) => {
+      strategy.init(initConfiguration, rumPublicApi)
+
+      // Add experimental features here
+      if (isExperimentalFeatureEnabled(ExperimentalFeature.UPDATE_VIEW_NAME)) {
+        /**
+         * Update View Name.
+         *
+         * Enable to manually change the name of the current view.
+         * @param name name of the view
+         * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
+         */
+        ;(rumPublicApi as any).updateViewName = monitor((name: string) => {
+          strategy.updateViewName(name)
+        })
+      }
+      if (isExperimentalFeatureEnabled(ExperimentalFeature.VIEW_SPECIFIC_CONTEXT)) {
+        /**
+         * Set View Context.
+         *
+         * Enable to manually set the context of the current view.
+         * @param context context of the view
+         */
+        ;(rumPublicApi as any).setViewContext = monitor((context: Context) => {
+          strategy.setViewContext(context)
+        })
+
+        /**
+         * Set View Context Property.
+         *
+         * Enable to manually set a property of the context of the current view.
+         * @param key key of the property
+         * @param value value of the property
+         */
+        ;(rumPublicApi as any).setViewContextProperty = monitor((key: string, value: any) => {
+          strategy.setViewContextProperty(key, value)
+        })
+      }
+    }),
 
     setTrackingConsent: monitor((trackingConsent) => {
       trackingConsentState.update(trackingConsent)


### PR DESCRIPTION
## Motivation
Experimental Features are added to `RumPublicApi` when RUM is started. This could be improved by exposing them right after the initialisation of the SDK

## Changes
Move `updateViewName` exposure to init method

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
