### PR TITLE
[RUM-6053] Increase INITIALIZATION_TIME_OUT_DELAY

### DIFF
--- a/packages/rum/src/domain/deflate/deflateWorker.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.ts
@@ -10,7 +10,7 @@ import {
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 
-export const INITIALIZATION_TIME_OUT_DELAY = 10 * ONE_SECOND
+export const INITIALIZATION_TIME_OUT_DELAY = 30 * ONE_SECOND
 
 declare const __BUILD_ENV__WORKER_STRING__: string
 


### PR DESCRIPTION
## Motivation

Some customers using the SDK in environment with slow network are experiencing timeout in DeflateWorker loading. Increasing the value fixed the issue.

## Changes

Increase INITIALIZATION_TIME_OUT_DELAY to 30 seconds

## Testing

- [*] Local
- [ ] Staging
- [*] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
