### PR TITLE
🐛 fix to redirect v6-canary bundles urls to local dev bundles

### DIFF
--- a/developer-extension/src/background/domain/syncRules.ts
+++ b/developer-extension/src/background/domain/syncRules.ts
@@ -62,11 +62,11 @@ function buildRules(
     const devRumUrl = useRumSlim ? DEV_RUM_SLIM_URL : DEV_RUM_URL
     logger.log('add redirect to dev bundles rules')
     rules.push(
-      createRedirectRule(/^https:\/\/.*\/datadog-rum(-v\d|-canary|-staging|-v\d-canary)?\.js$/, { url: devRumUrl }),
-      createRedirectRule(/^https:\/\/.*\/datadog-rum-slim(-v\d|-canary|-staging|-v\d-canary)?\.js$/, {
+      createRedirectRule(/^https:\/\/.*\/datadog-rum(-[\w-]+)?\.js$/, { url: devRumUrl }),
+      createRedirectRule(/^https:\/\/.*\/datadog-rum-slim(-[\w-]+)?\.js$/, {
         url: DEV_RUM_SLIM_URL,
       }),
-      createRedirectRule(/^https:\/\/.*\/datadog-logs(-v\d|-canary|-staging|-v\d-canary)?\.js$/, { url: DEV_LOGS_URL }),
+      createRedirectRule(/^https:\/\/.*\/datadog-logs(-[\w-]+)?\.js$/, { url: DEV_LOGS_URL }),
       createRedirectRule('https://localhost:8443/static/datadog-rum-hotdog.js', { url: devRumUrl })
     )
   } else if (useRumSlim) {

--- a/developer-extension/src/background/domain/syncRules.ts
+++ b/developer-extension/src/background/domain/syncRules.ts
@@ -62,11 +62,11 @@ function buildRules(
     const devRumUrl = useRumSlim ? DEV_RUM_SLIM_URL : DEV_RUM_URL
     logger.log('add redirect to dev bundles rules')
     rules.push(
-      createRedirectRule(/^https:\/\/.*\/datadog-rum(-v\d|-canary|-staging)?\.js$/, { url: devRumUrl }),
-      createRedirectRule(/^https:\/\/.*\/datadog-rum-slim(-v\d|-canary|-staging)?\.js$/, {
+      createRedirectRule(/^https:\/\/.*\/datadog-rum(-v\d|-canary|-staging|-v\d-canary)?\.js$/, { url: devRumUrl }),
+      createRedirectRule(/^https:\/\/.*\/datadog-rum-slim(-v\d|-canary|-staging|-v\d-canary)?\.js$/, {
         url: DEV_RUM_SLIM_URL,
       }),
-      createRedirectRule(/^https:\/\/.*\/datadog-logs(-v\d|-canary|-staging)?\.js$/, { url: DEV_LOGS_URL }),
+      createRedirectRule(/^https:\/\/.*\/datadog-logs(-v\d|-canary|-staging|-v\d-canary)?\.js$/, { url: DEV_LOGS_URL }),
       createRedirectRule('https://localhost:8443/static/datadog-rum-hotdog.js', { url: devRumUrl })
     )
   } else if (useRumSlim) {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Enable local dev bundle to be loaded properly even when the `browser_sdk_next_major_version` is enabled

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Tweak the redirect rules to account for the `v6-canary` bundles loaded when the next major feature flags is enabled

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
