### PR TITLE
✨replace react-router wildcard routes with their actual path name

### DIFF
--- a/packages/rum-react/src/domain/reactRouterV6/createRouter.spec.ts
+++ b/packages/rum-react/src/domain/reactRouterV6/createRouter.spec.ts
@@ -49,7 +49,7 @@ describe('createRouter', () => {
   it('creates a new view with the fallback route', async () => {
     startViewSpy.calls.reset()
     await router.navigate('/non-existent')
-    expect(startViewSpy).toHaveBeenCalledWith('/*')
+    expect(startViewSpy).toHaveBeenCalledWith('/non-existent')
   })
 
   it('does not create a new view when the router navigates to the same URL', async () => {

--- a/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.spec.ts
+++ b/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.spec.ts
@@ -81,4 +81,18 @@ describe('computeViewName', () => {
       ] as RouteMatch[])
     ).toBe('/foo/bar/:id/')
   })
+
+  it('replaces match-all routes with the actual path', () => {
+    expect(
+      computeViewName([
+        { route: { path: '/foo' } },
+        {
+          params: { '*': 'bar' },
+          pathname: '/bar',
+          pathnameBase: '/',
+          route: { path: '*' },
+        },
+      ] as RouteMatch[])
+    ).toBe('/foo/bar')
+  })
 })

--- a/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.ts
+++ b/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.ts
@@ -26,12 +26,18 @@ export function computeViewName(routeMatches: RouteMatch[]) {
     }
 
     if (path.startsWith('/')) {
+      // Absolute path, replace the current view name
       viewName = path
     } else {
+      // Relative path, append to the current view name
       if (!viewName.endsWith('/')) {
         viewName += '/'
       }
-      viewName += path
+      if (path === '*') {
+        viewName += routeMatch.params['*']!
+      } else {
+        viewName += path
+      }
     }
   }
 

--- a/sandbox/react-app/main.tsx
+++ b/sandbox/react-app/main.tsx
@@ -29,6 +29,10 @@ const router = createBrowserRouter(
           path: 'test-error-boundary',
           Component: TestErrorBoundaryPage,
         },
+        {
+          path: '*',
+          Component: WildCardPage,
+        },
       ],
     },
   ],
@@ -63,6 +67,11 @@ function HomePage() {
 function UserPage() {
   const { id } = useParams()
   return <h1>User {id}</h1>
+}
+
+function WildCardPage() {
+  const path = useParams()['*']
+  return <h1>Wildcard: {path}</h1>
 }
 
 export function TestErrorBoundaryPage() {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,9 @@
 
     "paths": {
       "@datadog/browser-core": ["./packages/core/src"],
-      "@datadog/browser-rum-core": ["./packages/rum-core/src"]
+      "@datadog/browser-rum-core": ["./packages/rum-core/src"],
+      "@datadog/browser-rum-react": ["./packages/rum-react/src/entries/main"],
+      "@datadog/browser-rum-react/react-router-v6": ["./packages/rum-react/src/entries/reactRouterV6"]
     }
   }
 }


### PR DESCRIPTION
## Motivation

React Router routes defined with a '*' as a path are often used to create custom routing logic. It doesn't bring much value within a View name, as it could lead to very different pages. 

## Changes

Replace the wildcards with the actual path they are matching. For example, with the following router:

```
router = ceateBrowserRouter(
  [
    {
      path: '/foo',
      children: [{ path: '*' }]
    }
  ]
)
```

Accessing `/foo/bar` will create the view name `/foo/bar` instead of `/foo/*`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
