### PR TITLE
[RUM 6237] Add e2e test for view context API init

### DIFF
--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -129,7 +129,13 @@ describe('API calls and events around init', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       ;(window.DD_RUM as any).setViewContext({ foo: 'bar' })
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(window.DD_RUM as any).setViewContextProperty('foo', 'baz')
+      ;(window.DD_RUM as any).setViewContextProperty('bar', 'foo')
+    })
+    .run(async ({ intakeRegistry }) => {
+      await flushEvents()
+
+      const initialView = intakeRegistry.rumViewEvents[0]
+      expect(initialView.context).toEqual(jasmine.objectContaining({ foo: 'bar', bar: 'foo' }))
     })
 })
 

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -120,6 +120,17 @@ describe('API calls and events around init', () => {
         { name: 'after manual view', viewId: initialView.view.id, viewName: 'after manual view' }
       )
     })
+
+  createTest('should be able to set view context')
+    .withRum({ enableExperimentalFeatures: ['view_specific_context'] })
+    .withRumSlim()
+    .withRumInit((configuration) => {
+      window.DD_RUM!.init(configuration)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      ;(window.DD_RUM as any).setViewContext({ foo: 'bar' })
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      ;(window.DD_RUM as any).setViewContextProperty('foo', 'baz')
+    })
 })
 
 describe('beforeSend', () => {


### PR DESCRIPTION
## Motivation
We want to have e2e tests to ensure the new APIs loaded and will not break the page.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Add view context api check in init e2e test file.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
