### PR TITLE
Don't mark page exit on beforeUnload rather stop it on unload

### DIFF
--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -6,6 +6,7 @@ export type TrustableEvent<E extends Event = Event> = E & { __ddIsTrusted?: bool
 
 export const enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
+  UNLOAD = 'unload',
   CLICK = 'click',
   DBL_CLICK = 'dblclick',
   KEY_DOWN = 'keydown',


### PR DESCRIPTION
## Motivation

🐛 stop datadog tracking on actual unload event rather than beforeUnload. This is because the user could decide to stay on page and closing it just on beforeUnload stops RUM/logs tracking
## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
