### PR TITLE
[RUM 4813] Remove feature flag for view specific context

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,7 +18,6 @@ export enum ExperimentalFeature {
   REMOTE_CONFIGURATION = 'remote_configuration',
   UPDATE_VIEW_NAME = 'update_view_name',
   LONG_ANIMATION_FRAME = 'long_animation_frame',
-  VIEW_SPECIFIC_CONTEXT = 'view_specific_context',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -891,8 +891,6 @@ describe('rum public api', () => {
     })
 
     it('should set view specific context with setViewContext', () => {
-      mockExperimentalFeatures([ExperimentalFeature.VIEW_SPECIFIC_CONTEXT])
-
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
       /* eslint-disable @typescript-eslint/no-unsafe-call */
       ;(rumPublicApi as any).setViewContext({ foo: 'bar' })
@@ -901,20 +899,11 @@ describe('rum public api', () => {
     })
 
     it('should set view specific context with setViewContextProperty', () => {
-      mockExperimentalFeatures([ExperimentalFeature.VIEW_SPECIFIC_CONTEXT])
-
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
       /* eslint-disable @typescript-eslint/no-unsafe-call */
       ;(rumPublicApi as any).setViewContextProperty('foo', 'bar')
 
       expect(setViewContextPropertySpy).toHaveBeenCalledWith('foo', 'bar')
-    })
-
-    it('should not expose view specific context when ff is disabled', () => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).setViewContext).toBeUndefined()
-      expect((rumPublicApi as any).setViewContextProperty).toBeUndefined()
     })
   })
 })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -75,6 +75,22 @@ export interface RumPublicApi extends PublicApi {
    * See [User tracking consent](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#user-tracking-consent) for further information.
    */
   setTrackingConsent: (trackingConsent: TrackingConsent) => void
+
+  /**
+   * Set View Context.
+   *
+   * Enable to manually set the context of the current view.
+   * @param context context of the view
+   */
+  setViewContext: (context: Context) => void
+  /**
+   * Set View Context Property.
+   *
+   * Enable to manually set a property of the context of the current view.
+   * @param key key of the property
+   * @param value value of the property
+   */
+  setViewContextProperty: (key: string, value: any) => void
   /**
    * Set the global context information to all events, stored in `@context`
    *
@@ -425,33 +441,19 @@ export function makeRumPublicApi(
           strategy.updateViewName(name)
         })
       }
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.VIEW_SPECIFIC_CONTEXT)) {
-        /**
-         * Set View Context.
-         *
-         * Enable to manually set the context of the current view.
-         * @param context context of the view
-         */
-        ;(rumPublicApi as any).setViewContext = monitor((context: Context) => {
-          strategy.setViewContext(context)
-        })
-
-        /**
-         * Set View Context Property.
-         *
-         * Enable to manually set a property of the context of the current view.
-         * @param key key of the property
-         * @param value value of the property
-         */
-        ;(rumPublicApi as any).setViewContextProperty = monitor((key: string, value: any) => {
-          strategy.setViewContextProperty(key, value)
-        })
-      }
     }),
 
     setTrackingConsent: monitor((trackingConsent) => {
       trackingConsentState.update(trackingConsent)
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
+    }),
+
+    setViewContext: monitor((context: Context) => {
+      strategy.setViewContext(context)
+    }),
+
+    setViewContextProperty: monitor((key: string, value: any) => {
+      strategy.setViewContextProperty(key, value)
     }),
 
     setGlobalContext: monitor((context) => {

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -197,7 +197,6 @@ describe('rum assembly', () => {
         })
 
         it('should accept modification on context field for view events', () => {
-          mockExperimentalFeatures([ExperimentalFeature.VIEW_SPECIFIC_CONTEXT])
           const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
@@ -211,22 +210,6 @@ describe('rum assembly', () => {
           })
 
           expect(serverRumEvents[0].context).toEqual({ foo: 'bar' })
-        })
-
-        it('should reject modification on context field for view events', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-            partialConfiguration: {
-              beforeSend: (event) => {
-                event.context.foo = 'bar'
-              },
-            },
-          })
-
-          notifyRawRumEvent(lifeCycle, {
-            rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-          })
-
-          expect(serverRumEvents[0].context).toBeUndefined()
         })
 
         it('should reject replacing the context field to non-object', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -78,9 +78,7 @@ export function startRumAssembly(
   reportError: (error: RawError) => void
 ) {
   modifiableFieldPathsByEvent = {
-    [RumEventType.VIEW]: isExperimentalFeatureEnabled(ExperimentalFeature.VIEW_SPECIFIC_CONTEXT)
-      ? assign({}, USER_CUSTOMIZABLE_FIELD_PATHS, VIEW_MODIFIABLE_FIELD_PATHS)
-      : VIEW_MODIFIABLE_FIELD_PATHS,
+    [RumEventType.VIEW]: assign({}, USER_CUSTOMIZABLE_FIELD_PATHS, VIEW_MODIFIABLE_FIELD_PATHS),
     [RumEventType.ERROR]: assign(
       {
         'error.message': 'string',

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -904,7 +904,6 @@ describe('view event count', () => {
 
   describe('view specific context', () => {
     it('should update view context if startView has context parameter', () => {
-      mockExperimentalFeatures([ExperimentalFeature.VIEW_SPECIFIC_CONTEXT])
       viewTest = setupViewTest({ lifeCycle })
       const { getViewUpdate, startView } = viewTest
 
@@ -913,7 +912,6 @@ describe('view event count', () => {
     })
 
     it('should replace current context set on view event', () => {
-      mockExperimentalFeatures([ExperimentalFeature.VIEW_SPECIFIC_CONTEXT])
       viewTest = setupViewTest({ lifeCycle })
       const { getViewUpdate, startView } = viewTest
 
@@ -924,16 +922,7 @@ describe('view event count', () => {
       expect(getViewUpdate(4).context).toEqual({ bar: 'baz' })
     })
 
-    it('should not update view context if the feature is not enabled', () => {
-      viewTest = setupViewTest({ lifeCycle })
-      const { getViewUpdate, startView } = viewTest
-
-      startView({ context: { foo: 'bar' } })
-      expect(getViewUpdate(2).context).toBeUndefined()
-    })
-
     it('should set view context with setViewContext', () => {
-      mockExperimentalFeatures([ExperimentalFeature.VIEW_SPECIFIC_CONTEXT])
       viewTest = setupViewTest({ lifeCycle })
       const { getViewUpdate, setViewContext } = viewTest
 
@@ -942,7 +931,6 @@ describe('view event count', () => {
     })
 
     it('should set view context with setViewContextProperty', () => {
-      mockExperimentalFeatures([ExperimentalFeature.VIEW_SPECIFIC_CONTEXT])
       viewTest = setupViewTest({ lifeCycle })
       const { getViewUpdate, setViewContextProperty } = viewTest
 

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -215,7 +215,7 @@ function newView(
     name = viewOptions.name
     service = viewOptions.service || undefined
     version = viewOptions.version || undefined
-    if (isExperimentalFeatureEnabled(ExperimentalFeature.VIEW_SPECIFIC_CONTEXT) && viewOptions.context) {
+    if (viewOptions.context) {
       context = viewOptions.context
       // use ContextManager to update the context so we always sanitize it
       contextManager.setContext(context)
@@ -282,9 +282,7 @@ function newView(
       name,
       service,
       version,
-      context: isExperimentalFeatureEnabled(ExperimentalFeature.VIEW_SPECIFIC_CONTEXT)
-        ? contextManager.getContext()
-        : undefined,
+      context: contextManager.getContext(),
       loadingType,
       location,
       startClocks,

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -128,9 +128,9 @@ describe('API calls and events around init', () => {
     .withRumInit((configuration) => {
       window.DD_RUM!.init(configuration)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(window.DD_RUM as any).setViewContext({ foo: 'bar' })
+      window.DD_RUM!.setViewContext({ foo: 'bar' })
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(window.DD_RUM as any).setViewContextProperty('bar', 'foo')
+      window.DD_RUM!.setViewContextProperty('bar', 'foo')
 
       // context should populate the context of the children events
       window.DD_RUM!.addAction('custom action')

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -125,7 +125,6 @@ describe('API calls and events around init', () => {
 describe('beforeSend', () => {
   createTest('allows to edit events context with feature flag')
     .withRum({
-      enableExperimentalFeatures: ['view_specific_context'],
       beforeSend: (event: any) => {
         event.context!.foo = 'bar'
         return true
@@ -143,7 +142,6 @@ describe('beforeSend', () => {
 
   createTest('allows to replace events context')
     .withRum({
-      enableExperimentalFeatures: ['view_specific_context'],
       beforeSend: (event) => {
         event.context = { foo: 'bar' }
         return true


### PR DESCRIPTION
## Motivation
Make view specific context apis public without experimental feature flag.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Removed feature flag and set APIs public by defualt.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
