### PR TITLE
Stop RUM event publishing on unload instead of beforeUnload

### DIFF
--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -6,6 +6,7 @@ export type TrustableEvent<E extends Event = Event> = E & { __ddIsTrusted?: bool
 
 export const enum DOM_EVENT {
   BEFORE_UNLOAD = 'beforeunload',
+  UNLOAD = 'unload',
   CLICK = 'click',
   DBL_CLICK = 'dblclick',
   KEY_DOWN = 'keydown',

--- a/packages/core/src/browser/pageExitObservable.spec.ts
+++ b/packages/core/src/browser/pageExitObservable.spec.ts
@@ -17,8 +17,8 @@ describe('createPageExitObservable', () => {
     restorePageVisibility()
   })
 
-  it('notifies when the page fires beforeunload', () => {
-    window.dispatchEvent(createNewEvent('beforeunload'))
+  it('notifies when the page fires unload', () => {
+    window.dispatchEvent(createNewEvent('unload'))
 
     expect(onExitSpy).toHaveBeenCalledOnceWith({ reason: PageExitReason.UNLOADING })
   })

--- a/packages/core/src/browser/pageExitObservable.ts
+++ b/packages/core/src/browser/pageExitObservable.ts
@@ -5,7 +5,7 @@ import { addEventListeners, addEventListener, DOM_EVENT } from './addEventListen
 
 export const PageExitReason = {
   HIDDEN: 'visibility_hidden',
-  UNLOADING: 'before_unload',
+  UNLOADING: 'unload',
   PAGEHIDE: 'page_hide',
   FROZEN: 'page_frozen',
 } as const
@@ -40,7 +40,7 @@ export function createPageExitObservable(configuration: Configuration): Observab
       { capture: true }
     )
 
-    const stopBeforeUnloadListener = addEventListener(configuration, window, DOM_EVENT.BEFORE_UNLOAD, () => {
+    const stopBeforeUnloadListener = addEventListener(configuration, window, DOM_EVENT.UNLOAD, () => {
       observable.notify({ reason: PageExitReason.UNLOADING })
     }).stop
 


### PR DESCRIPTION
## Motivation

To fix the issues with beforeUnload event. 

## Changes

Changed stopping of RUM events from beforeUnload to unload
## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
