### PR TITLE
👷 bump e2e-bs ci job timeout to 35 minutes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -268,7 +268,7 @@ e2e-bs:
     - .bs-allowed-branches
   interruptible: true
   resource_group: browserstack
-  timeout: 30 minutes
+  timeout: 35 minutes
   artifacts:
     when: always
     paths: ['test-report/e2e-bs/specs.log']


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Bump timeout a bit as job can sometimes take a bit longer, especially when waiting for the job to start the runner.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
