### PR TITLE
🔊 Add SDK setup telemetry

### DIFF
--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -29,6 +29,7 @@ import { StatusType, TelemetryType } from './rawTelemetryEvent.types'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
+declare const __BUILD_ENV__SDK_SETUP__: string
 
 const ALLOWED_FRAME_URLS = [
   'https://www.datadoghq-browser-agent.com',
@@ -106,6 +107,7 @@ export function startTelemetry(telemetryService: TelemetryService, configuration
         telemetry: combine(event, {
           runtime_env: runtimeEnvInfo,
           connectivity: getConnectivity(),
+          sdk_setup: __BUILD_ENV__SDK_SETUP__,
         }),
         experimental_features: arrayFrom(getExperimentalFeatures()),
       },

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -7,7 +7,7 @@
   "types": "cjs/entries/main.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rm -rf bundle && webpack --mode=production",
+    "build:bundle": "rm -rf bundle && SDK_SETUP=cdn webpack --mode=production",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
     "replace-build-env": "node ../../scripts/build/replace-build-env.js"

--- a/packages/rum-slim/package.json
+++ b/packages/rum-slim/package.json
@@ -7,7 +7,7 @@
   "types": "cjs/entries/main.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rm -rf bundle && webpack --mode=production",
+    "build:bundle": "rm -rf bundle && SDK_SETUP=cdn webpack --mode=production",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
   },

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -7,7 +7,7 @@
   "types": "cjs/entries/main.d.ts",
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rm -rf bundle && webpack --mode=production",
+    "build:bundle": "rm -rf bundle && SDK_SETUP=cdn webpack --mode=production",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json && yarn replace-build-env cjs",
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json && yarn replace-build-env esm",
     "replace-build-env": "node ../../scripts/build/replace-build-env.js"

--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -84,6 +84,6 @@ function getSdkSetup() {
   if (SDK_SETUPS.includes(process.env.SDK_SETUP)) {
     return process.env.SDK_SETUP
   }
-  console.log(`Invalid SDK setup "${process.env.SDK_SETUP}". Possible build modes are: ${SDK_SETUPS.join(', ')}`)
+  console.log(`Invalid SDK setup "${process.env.SDK_SETUP}". Possible SDK setups are: ${SDK_SETUPS.join(', ')}`)
   process.exit(1)
 }

--- a/scripts/lib/build-env.js
+++ b/scripts/lib/build-env.js
@@ -18,6 +18,11 @@ const BUILD_MODES = [
   'canary',
 ]
 
+/**
+ * Allows to define which sdk setup to send to the telemetry.
+ */
+const SDK_SETUPS = ['npm', 'cdn']
+
 const buildEnvCache = new Map()
 
 const buildEnvFactories = {
@@ -35,6 +40,7 @@ const buildEnvFactories = {
         return 'dev'
     }
   },
+  SDK_SETUP: () => getSdkSetup(),
   WORKER_STRING: () => {
     const workerPath = path.join(__dirname, '../../packages/worker')
     // Make sure the worker is built
@@ -68,5 +74,16 @@ function getBuildMode() {
     return process.env.BUILD_MODE
   }
   console.log(`Invalid build mode "${process.env.BUILD_MODE}". Possible build modes are: ${BUILD_MODES.join(', ')}`)
+  process.exit(1)
+}
+
+function getSdkSetup() {
+  if (!process.env.SDK_SETUP) {
+    return SDK_SETUPS[0] // npm
+  }
+  if (SDK_SETUPS.includes(process.env.SDK_SETUP)) {
+    return process.env.SDK_SETUP
+  }
+  console.log(`Invalid SDK setup "${process.env.SDK_SETUP}". Possible build modes are: ${SDK_SETUPS.join(', ')}`)
   process.exit(1)
 }


### PR DESCRIPTION
## Motivation

Add SDK setup to the telemetry events

## Changes
```js
telemetry: {
  sdk_setup: 'npm' | 'cdn'
}
```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
