### PR TITLE
🧪 add missing start_time

### DIFF
--- a/packages/rum-core/src/domain/longAnimationFrame/longAnimationFrameCollection.spec.ts
+++ b/packages/rum-core/src/domain/longAnimationFrame/longAnimationFrameCollection.spec.ts
@@ -29,6 +29,7 @@ describe('long animation frames collection', () => {
         first_ui_event_timestamp: 0 as ServerDuration,
         render_start: 1_421_500_000 as ServerDuration,
         style_and_layout_start: 1_428_000_000 as ServerDuration,
+        start_time: 1_234_000_000 as ServerDuration,
         scripts: [
           {
             duration: (6 * 1e6) as ServerDuration,

--- a/packages/rum-core/src/domain/longAnimationFrame/longAnimationFrameCollection.ts
+++ b/packages/rum-core/src/domain/longAnimationFrame/longAnimationFrameCollection.ts
@@ -24,6 +24,7 @@ export function startLongAnimationFrameCollection(lifeCycle: LifeCycle, configur
           first_ui_event_timestamp: toServerDuration(entry.firstUIEventTimestamp),
           render_start: toServerDuration(entry.renderStart),
           style_and_layout_start: toServerDuration(entry.styleAndLayoutStart),
+          start_time: toServerDuration(entry.startTime),
           scripts: entry.scripts.map((script) => ({
             duration: toServerDuration(script.duration),
             pause_duration: toServerDuration(script.pauseDuration),

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -202,6 +202,7 @@ export interface RawRumLongAnimationFrameEvent {
     first_ui_event_timestamp: ServerDuration
     render_start: ServerDuration
     style_and_layout_start: ServerDuration
+    start_time: ServerDuration
     scripts: Array<{
       duration: ServerDuration
       pause_duration: ServerDuration


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

We need to send the _raw_ `start_time` property as it serve as a reference for calculating various timings:

![Screenshot 2024-10-03 at 15 55 35](https://github.com/user-attachments/assets/1fb4bf4b-8711-451b-a5d6-d6d9592a503c)

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
