### PR TITLE
🐛 ignore layout shifts that happen before view start

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -23,12 +23,10 @@ describe('trackCumulativeLayoutShift', () => {
   let clsCallback: jasmine.Spy<(csl: CumulativeLayoutShift) => void>
   let notifyPerformanceEntries: (entries: RumPerformanceEntry[]) => void
 
-  function startCLSTracking(
-    { viewStart, isLayoutShiftSupported }: StartCLSTrackingArgs = {
-      viewStart: 0 as RelativeTime,
-      isLayoutShiftSupported: true,
-    }
-  ) {
+  function startCLSTracking({
+    viewStart = 0 as RelativeTime,
+    isLayoutShiftSupported = true,
+  }: Partial<StartCLSTrackingArgs> = {}) {
     ;({ notifyPerformanceEntries } = mockPerformanceObserver())
 
     clsCallback = jasmine.createSpy()
@@ -79,6 +77,18 @@ describe('trackCumulativeLayoutShift', () => {
       value: 0.3,
       time: 2 as RelativeTime,
       targetSelector: undefined,
+    })
+  })
+
+  it('should ignore layout shifts that happen before the view start', () => {
+    startCLSTracking({ viewStart: 100 as RelativeTime })
+    notifyPerformanceEntries([
+      createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1, startTime: 1 as RelativeTime }),
+    ])
+
+    expect(clsCallback).toHaveBeenCalledTimes(1)
+    expect(clsCallback.calls.mostRecent().args[0]).toEqual({
+      value: 0,
     })
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -61,25 +61,27 @@ export function trackCumulativeLayoutShift(
     buffered: true,
   }).subscribe((entries) => {
     for (const entry of entries) {
-      if (!entry.hadRecentInput) {
-        const { cumulatedValue, isMaxValue } = window.update(entry)
+      if (entry.hadRecentInput || entry.startTime < viewStart) {
+        continue
+      }
 
-        if (isMaxValue) {
-          const target = getTargetFromSource(entry.sources)
-          maxClsTarget = target ? new WeakRef(target) : undefined
-          maxClsStartTime = elapsed(viewStart, entry.startTime)
-        }
+      const { cumulatedValue, isMaxValue } = window.update(entry)
 
-        if (cumulatedValue > maxClsValue) {
-          maxClsValue = cumulatedValue
-          const target = maxClsTarget?.deref()
+      if (isMaxValue) {
+        const target = getTargetFromSource(entry.sources)
+        maxClsTarget = target ? new WeakRef(target) : undefined
+        maxClsStartTime = elapsed(viewStart, entry.startTime)
+      }
 
-          callback({
-            value: round(maxClsValue, 4),
-            targetSelector: target && getSelectorFromElement(target, configuration.actionNameAttribute),
-            time: maxClsStartTime,
-          })
-        }
+      if (cumulatedValue > maxClsValue) {
+        maxClsValue = cumulatedValue
+        const target = maxClsTarget?.deref()
+
+        callback({
+          value: round(maxClsValue, 4),
+          targetSelector: target && getSelectorFromElement(target, configuration.actionNameAttribute),
+          time: maxClsStartTime,
+        })
       }
     }
   })


### PR DESCRIPTION


## Motivation

On "route change" views, the CLS computation took any buffered layout shift entry into account, so in some cases it reflected the CLS of an anterior view. 

## Changes

This commit fixes the issue by ignoring layout shifts that happened before the view start.

We still use the buffered entries so we can use layout shift entries that happens before the SDK is initialized.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
