### PR TITLE
👷[IR-30972] Include older version intake urls matching

### DIFF
--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -9,4 +9,4 @@ export {
 } from './configuration'
 export { createEndpointBuilder, EndpointBuilder, TrackType } from './endpointBuilder'
 export * from './intakeSites'
-export { computeTransportConfiguration } from './transportConfiguration'
+export { computeTransportConfiguration, isIntakeUrl } from './transportConfiguration'

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -5,4 +5,4 @@ export const INTAKE_SITE_EU1 = 'datadoghq.eu'
 export const INTAKE_SITE_US1_FED = 'ddog-gov.com'
 
 export const PCI_INTAKE_HOST_US1 = 'pci.browser-intake-datadoghq.com'
-export const INTAKE_TAGS = ['ddsource', 'ddtags']
+export const INTAKE_URL_PARAMETERS = ['ddsource', 'ddtags']

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -5,3 +5,4 @@ export const INTAKE_SITE_EU1 = 'datadoghq.eu'
 export const INTAKE_SITE_US1_FED = 'ddog-gov.com'
 
 export const PCI_INTAKE_HOST_US1 = 'pci.browser-intake-datadoghq.com'
+export const INTAKE_TAGS = ['ddsource', 'ddtags']

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -1,5 +1,5 @@
 import type { Payload } from '../../transport'
-import { computeTransportConfiguration } from './transportConfiguration'
+import { computeTransportConfiguration, isIntakeUrl } from './transportConfiguration'
 import { INTAKE_SITE_FED_STAGING } from './intakeSites'
 
 const DEFAULT_PAYLOAD = {} as Payload
@@ -99,77 +99,49 @@ describe('transportConfiguration', () => {
       { site: 'dd0g-gov.com', intakeDomain: 'http-intake.logs.dd0g-gov.com' },
     ].forEach(({ site, intakeDomain }) => {
       it(`should detect intake request for ${site} site`, () => {
-        const configuration = computeTransportConfiguration({ clientToken, site })
-
-        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/rum?${intakeParameters}`)).toBe(true)
-        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/logs?${intakeParameters}`)).toBe(true)
-        expect(configuration.isIntakeUrl(`https://${intakeDomain}/api/v2/replay?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://${intakeDomain}/api/v2/rum?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://${intakeDomain}/api/v2/logs?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://${intakeDomain}/api/v2/replay?${intakeParameters}`)).toBe(true)
       })
 
       it(`should detect older versions of the ${site} site`, () => {
-        const configuration = computeTransportConfiguration({ clientToken, site })
-
         // v4 intake endpoints
-        expect(configuration.isIntakeUrl(`https://rum.${intakeDomain}/api/v2/rum?${intakeParameters}`)).toBe(true)
-        expect(configuration.isIntakeUrl(`https://logs.${intakeDomain}/api/v2/logs?${intakeParameters}`)).toBe(true)
-        expect(configuration.isIntakeUrl(`https://replay.${intakeDomain}/api/v2/replay?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://rum.${intakeDomain}/api/v2/rum?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://logs.${intakeDomain}/api/v2/logs?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://replay.${intakeDomain}/api/v2/replay?${intakeParameters}`)).toBe(true)
 
         // pre-v4 intake endpoints
-        expect(configuration.isIntakeUrl(`https://rum.${intakeDomain}${v1IntakePath}?${intakeParameters}`)).toBe(true)
-        expect(configuration.isIntakeUrl(`https://logs.${intakeDomain}${v1IntakePath}?${intakeParameters}`)).toBe(true)
-        expect(
-          configuration.isIntakeUrl(`https://rum-http-intake.logs.${site}${v1IntakePath}?${intakeParameters}`)
-        ).toBe(true)
-        expect(
-          configuration.isIntakeUrl(`https://browser-http-intake.logs.${site}${v1IntakePath}?${intakeParameters}`)
-        ).toBe(true)
+        expect(isIntakeUrl(`https://rum.${intakeDomain}${v1IntakePath}?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://logs.${intakeDomain}${v1IntakePath}?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://rum-http-intake.logs.${site}${v1IntakePath}?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://browser-http-intake.logs.${site}${v1IntakePath}?${intakeParameters}`)).toBe(true)
       })
     })
 
     it('should detect internal analytics intake request for datadoghq.com site', () => {
-      const configuration = computeTransportConfiguration({
-        clientToken,
-        internalAnalyticsSubdomain,
-      })
-      expect(
-        configuration.isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/rum?${intakeParameters}`)
-      ).toBe(true)
+      expect(isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/rum?${intakeParameters}`)).toBe(
+        true
+      )
     })
 
     it('should not detect non intake request', () => {
-      const configuration = computeTransportConfiguration({ clientToken })
-      expect(configuration.isIntakeUrl('https://www.foo.com')).toBe(false)
+      expect(isIntakeUrl('https://www.foo.com')).toBe(false)
     })
 
     describe('proxy configuration', () => {
       it('should detect proxy intake request', () => {
-        let configuration = computeTransportConfiguration({
-          clientToken,
-          proxy: 'https://www.proxy.com',
-        })
         expect(
-          configuration.isIntakeUrl(
-            `https://www.proxy.com/?ddforward=${encodeURIComponent(`/api/v2/rum?${intakeParameters}`)}`
-          )
+          isIntakeUrl(`https://www.proxy.com/?ddforward=${encodeURIComponent(`/api/v2/rum?${intakeParameters}`)}`)
         ).toBe(true)
-
-        configuration = computeTransportConfiguration({
-          clientToken,
-          proxy: 'https://www.proxy.com/custom/path',
-        })
         expect(
-          configuration.isIntakeUrl(
+          isIntakeUrl(
             `https://www.proxy.com/custom/path?ddforward=${encodeURIComponent(`/api/v2/rum?${intakeParameters}`)}`
           )
         ).toBe(true)
       })
 
       it('should not detect request done on the same host as the proxy', () => {
-        const configuration = computeTransportConfiguration({
-          clientToken,
-          proxy: 'https://www.proxy.com',
-        })
-        expect(configuration.isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
+        expect(isIntakeUrl('https://www.proxy.com/foo')).toBe(false)
       })
     })
     ;[
@@ -179,27 +151,14 @@ describe('transportConfiguration', () => {
       { site: 'ap1.datadoghq.com' },
     ].forEach(({ site }) => {
       it(`should detect replica intake request for site ${site}`, () => {
-        const configuration = computeTransportConfiguration({
-          clientToken,
-          site,
-          replica: { clientToken },
-          internalAnalyticsSubdomain,
-        })
-
+        expect(isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/rum?${intakeParameters}`)).toBe(
+          true
+        )
+        expect(isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/logs?${intakeParameters}`)).toBe(
+          true
+        )
         expect(
-          configuration.isIntakeUrl(
-            `https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/rum?${intakeParameters}`
-          )
-        ).toBe(true)
-        expect(
-          configuration.isIntakeUrl(
-            `https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/logs?${intakeParameters}`
-          )
-        ).toBe(true)
-        expect(
-          configuration.isIntakeUrl(
-            `https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/replay?${intakeParameters}`
-          )
+          isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/replay?${intakeParameters}`)
         ).toBe(true)
       })
     })

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -3,7 +3,7 @@ import type { InitConfiguration } from './configuration'
 import type { EndpointBuilder } from './endpointBuilder'
 import { createEndpointBuilder } from './endpointBuilder'
 import { buildTags } from './tags'
-import { INTAKE_SITE_US1, INTAKE_TAGS } from './intakeSites'
+import { INTAKE_SITE_US1, INTAKE_URL_PARAMETERS } from './intakeSites'
 
 export interface TransportConfiguration {
   logsEndpointBuilder: EndpointBuilder
@@ -67,5 +67,5 @@ function computeReplicaConfiguration(
 
 export function isIntakeUrl(url: string): boolean {
   // check if tags is present in the query string
-  return INTAKE_TAGS.every((param) => includes(url, param))
+  return INTAKE_URL_PARAMETERS.every((param) => includes(url, param))
 }

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -3,13 +3,12 @@ import type { InitConfiguration } from './configuration'
 import type { EndpointBuilder } from './endpointBuilder'
 import { createEndpointBuilder } from './endpointBuilder'
 import { buildTags } from './tags'
-import { INTAKE_SITE_US1 } from './intakeSites'
+import { INTAKE_SITE_US1, INTAKE_TAGS } from './intakeSites'
 
 export interface TransportConfiguration {
   logsEndpointBuilder: EndpointBuilder
   rumEndpointBuilder: EndpointBuilder
   sessionReplayEndpointBuilder: EndpointBuilder
-  isIntakeUrl: (url: string) => boolean
   replica?: ReplicaConfiguration
   site: string
 }
@@ -30,7 +29,6 @@ export function computeTransportConfiguration(initConfiguration: InitConfigurati
 
   return assign(
     {
-      isIntakeUrl,
       replica: replicaConfiguration,
       site,
     },
@@ -67,7 +65,7 @@ function computeReplicaConfiguration(
   return assign({ applicationId: initConfiguration.replica.applicationId }, replicaEndpointBuilders)
 }
 
-export function isIntakeUrl(url: string) {
+export function isIntakeUrl(url: string): boolean {
   // check if tags is present in the query string
-  return includes(url, 'ddsource') && includes(url, 'ddtags')
+  return INTAKE_TAGS.every((param) => includes(url, param))
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ export {
   INTAKE_SITE_US1,
   INTAKE_SITE_US1_FED,
   INTAKE_SITE_EU1,
-  INTAKE_TAGS,
+  INTAKE_URL_PARAMETERS,
   isIntakeUrl,
 } from './domain/configuration'
 export { TrackingConsent, TrackingConsentState, createTrackingConsentState } from './domain/trackingConsent'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,8 @@ export {
   INTAKE_SITE_US1,
   INTAKE_SITE_US1_FED,
   INTAKE_SITE_EU1,
+  INTAKE_TAGS,
+  isIntakeUrl,
 } from './domain/configuration'
 export { TrackingConsent, TrackingConsentState, createTrackingConsentState } from './domain/trackingConsent'
 export {

--- a/packages/core/test/interceptRequests.ts
+++ b/packages/core/test/interceptRequests.ts
@@ -1,8 +1,8 @@
 import type { EndpointBuilder } from '../src'
-import { INTAKE_TAGS, noop } from '../src'
+import { INTAKE_URL_PARAMETERS, noop } from '../src'
 import { mockXhr, MockXhr } from './emulate/mockXhr'
 
-const INTAKE_PARAMS = INTAKE_TAGS.join('&')
+const INTAKE_PARAMS = INTAKE_URL_PARAMETERS.join('&')
 
 export const SPEC_ENDPOINTS = {
   logsEndpointBuilder: mockEndpointBuilder(`https://mock.com/abcde?${INTAKE_PARAMS}`),

--- a/packages/core/test/interceptRequests.ts
+++ b/packages/core/test/interceptRequests.ts
@@ -1,15 +1,12 @@
 import type { EndpointBuilder } from '../src'
-import { noop } from '../src'
+import { INTAKE_TAGS, noop } from '../src'
 import { mockXhr, MockXhr } from './emulate/mockXhr'
 
-export const SPEC_ENDPOINTS = {
-  logsEndpointBuilder: mockEndpointBuilder('https://logs-intake.com/v1/input/abcde?foo=bar'),
-  rumEndpointBuilder: mockEndpointBuilder('https://rum-intake.com/v1/input/abcde?foo=bar'),
+const INTAKE_PARAMS = INTAKE_TAGS.join('&')
 
-  isIntakeUrl: (url: string) => {
-    const intakeUrls = ['https://logs-intake.com/v1/input/', 'https://rum-intake.com/v1/input/']
-    return intakeUrls.some((intakeUrl) => url.indexOf(intakeUrl) === 0)
-  },
+export const SPEC_ENDPOINTS = {
+  logsEndpointBuilder: mockEndpointBuilder(`https://mock.com/abcde?${INTAKE_PARAMS}`),
+  rumEndpointBuilder: mockEndpointBuilder(`https://mock.com/abcde?${INTAKE_PARAMS}`),
 }
 
 export function mockEndpointBuilder(url: string) {

--- a/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.spec.ts
@@ -96,7 +96,7 @@ describe('network error collection', () => {
 
   it('should not track intake error', (done) => {
     startCollection()
-    fetch('https://logs-intake.com/v1/input/send?foo=bar').resolveWith(DEFAULT_REQUEST)
+    fetch('https://logs-intake.com/v1/input/send?ddsource=browser&ddtags=sdk_version').resolveWith(DEFAULT_REQUEST)
 
     mockFetchManager.whenAllComplete(() => {
       expect(rawLogsEvents.length).toEqual(0)

--- a/packages/logs/src/domain/networkError/networkErrorCollection.ts
+++ b/packages/logs/src/domain/networkError/networkErrorCollection.ts
@@ -11,6 +11,7 @@ import {
   readBytesFromStream,
   tryToClone,
   isServerError,
+  isIntakeUrl,
 } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../configuration'
 import type { LifeCycle } from '../lifeCycle'
@@ -35,7 +36,7 @@ export function startNetworkErrorCollection(configuration: LogsConfiguration, li
   })
 
   function handleResponse(type: RequestType, request: XhrCompleteContext | FetchResolveContext) {
-    if (!configuration.isIntakeUrl(request.url) && (isRejected(request) || isServerError(request.status))) {
+    if (!isIntakeUrl(request.url) && (isRejected(request) || isServerError(request.status))) {
       if ('xhr' in request) {
         computeXhrResponseData(request.xhr, configuration, onResponseDataAvailable)
       } else if (request.response) {

--- a/packages/rum-core/src/browser/performanceObservable.spec.ts
+++ b/packages/rum-core/src/browser/performanceObservable.spec.ts
@@ -12,8 +12,8 @@ import { RumPerformanceEntryType, createPerformanceObservable } from './performa
 
 describe('performanceObservable', () => {
   let performanceSubscription: Subscription | undefined
-  const configuration = mockRumConfiguration({ isIntakeUrl: (url: string) => url === forbiddenUrl })
-  const forbiddenUrl = 'https://forbidden.url'
+  const configuration = mockRumConfiguration()
+  const forbiddenUrl = 'https://forbidden.url/abce?ddsource=browser&ddtags=sdk_version'
   const allowedUrl = 'https://allowed.url'
   let observableCallback: jasmine.Spy
   let clock: Clock
@@ -43,7 +43,7 @@ describe('performanceObservable', () => {
       expect(observableCallback).toHaveBeenCalledWith([jasmine.objectContaining({ name: allowedUrl })])
     })
 
-    it('should not notify performance resources with forbidden url', () => {
+    it('should not notify performance resources with intake url', () => {
       const { notifyPerformanceEntries } = mockPerformanceObserver()
       const performanceResourceObservable = createPerformanceObservable(configuration, {
         type: RumPerformanceEntryType.RESOURCE,

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -192,10 +192,7 @@ export function createPerformanceObservable<T extends RumPerformanceEntryType>(
     }
 
     const handlePerformanceEntries = (entries: PerformanceEntryList) => {
-      const rumPerformanceEntries = filterRumPerformanceEntries(
-        configuration,
-        entries as Array<EntryTypeToReturnType[T]>
-      )
+      const rumPerformanceEntries = filterRumPerformanceEntries(entries as Array<EntryTypeToReturnType[T]>)
       if (rumPerformanceEntries.length > 0) {
         observable.notify(rumPerformanceEntries)
       }
@@ -293,16 +290,13 @@ export function supportPerformanceTimingEvent(entryType: RumPerformanceEntryType
   )
 }
 
-function filterRumPerformanceEntries<T extends RumPerformanceEntryType>(
-  configuration: RumConfiguration,
-  entries: Array<EntryTypeToReturnType[T]>
-) {
-  return entries.filter((entry) => !isForbiddenResource(configuration, entry))
+function filterRumPerformanceEntries<T extends RumPerformanceEntryType>(entries: Array<EntryTypeToReturnType[T]>) {
+  return entries.filter((entry) => !isForbiddenResource(entry))
 }
 
-function isForbiddenResource(configuration: RumConfiguration, entry: RumPerformanceEntry) {
+function isForbiddenResource(entry: RumPerformanceEntry) {
   return (
     entry.entryType === RumPerformanceEntryType.RESOURCE &&
-    (!isAllowedRequestUrl(configuration, entry.name) || !hasValidResourceEntryDuration(entry))
+    (!isAllowedRequestUrl(entry.name) || !hasValidResourceEntryDuration(entry))
   )
 }

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -23,7 +23,6 @@ describe('collect fetch', () => {
     if (isIE()) {
       pending('no fetch support')
     }
-    const configuration = mockRumConfiguration({ batchMessagesLimit: 1 })
     mockFetchManager = mockFetch()
 
     startSpy = jasmine.createSpy('requestStart')
@@ -38,7 +37,7 @@ describe('collect fetch', () => {
         context.spanId = createTraceIdentifier()
       },
     }
-    ;({ stop: stopFetchTracking } = trackFetch(lifeCycle, configuration, tracerStub as Tracer))
+    ;({ stop: stopFetchTracking } = trackFetch(lifeCycle, tracerStub as Tracer))
 
     fetch = window.fetch as MockFetch
 

--- a/packages/rum-core/src/domain/requestCollection.ts
+++ b/packages/rum-core/src/domain/requestCollection.ts
@@ -68,13 +68,13 @@ export function startRequestCollection(
 ) {
   const tracer = startTracer(configuration, sessionManager)
   trackXhr(lifeCycle, configuration, tracer)
-  trackFetch(lifeCycle, configuration, tracer)
+  trackFetch(lifeCycle, tracer)
 }
 
 export function trackXhr(lifeCycle: LifeCycle, configuration: RumConfiguration, tracer: Tracer) {
   const subscription = initXhrObservable(configuration).subscribe((rawContext) => {
     const context = rawContext as RumXhrStartContext | RumXhrCompleteContext
-    if (!isAllowedRequestUrl(configuration, context.url)) {
+    if (!isAllowedRequestUrl(context.url)) {
       return
     }
 
@@ -112,10 +112,10 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: RumConfiguration, 
   return { stop: () => subscription.unsubscribe() }
 }
 
-export function trackFetch(lifeCycle: LifeCycle, configuration: RumConfiguration, tracer: Tracer) {
+export function trackFetch(lifeCycle: LifeCycle, tracer: Tracer) {
   const subscription = initFetchObservable().subscribe((rawContext) => {
     const context = rawContext as RumFetchResolveContext | RumFetchStartContext
-    if (!isAllowedRequestUrl(configuration, context.url)) {
+    if (!isAllowedRequestUrl(context.url)) {
       return
     }
 

--- a/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
@@ -1,7 +1,5 @@
 import { type Duration, type RelativeTime, type ServerDuration } from '@datadog/browser-core'
 import { RumPerformanceEntryType, type RumPerformanceResourceTiming } from '../../browser/performanceObservable'
-import type { RumConfiguration } from '../configuration'
-import { mockRumConfiguration } from '../../../test'
 import {
   MAX_ATTRIBUTE_VALUE_CHAR_LENGTH,
   computeResourceEntryDetails,
@@ -274,22 +272,17 @@ describe('computeResourceEntryDuration', () => {
 })
 
 describe('shouldTrackResource', () => {
-  let configuration: RumConfiguration
-
-  beforeEach(() => {
-    configuration = mockRumConfiguration()
-  })
-
+  const intakeParameters = 'ddsource=browser&ddtags=sdk_version'
   it('should exclude requests on intakes endpoints', () => {
-    expect(isAllowedRequestUrl(configuration, 'https://rum-intake.com/v1/input/abcde?foo=bar')).toBe(false)
+    expect(isAllowedRequestUrl(`https://rum-intake.com/v1/input/abcde?${intakeParameters}`)).toBe(false)
   })
 
   it('should exclude requests on intakes endpoints with different client parameters', () => {
-    expect(isAllowedRequestUrl(configuration, 'https://rum-intake.com/v1/input/wxyz?foo=qux')).toBe(false)
+    expect(isAllowedRequestUrl(`https://rum-intake.com/v1/input/wxyz?${intakeParameters}`)).toBe(false)
   })
 
   it('should allow requests on non intake domains', () => {
-    expect(isAllowedRequestUrl(configuration, 'https://my-domain.com/hello?a=b')).toBe(true)
+    expect(isAllowedRequestUrl('https://my-domain.com/hello?a=b')).toBe(true)
   })
 })
 

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -7,12 +7,12 @@ import {
   isValidUrl,
   ResourceType,
   toServerDuration,
+  isIntakeUrl,
 } from '@datadog/browser-core'
 
 import type { RumPerformanceResourceTiming } from '../../browser/performanceObservable'
 
 import type { ResourceEntryDetailsElement } from '../../rawRumEvent.types'
-import type { RumConfiguration } from '../configuration'
 
 export interface ResourceEntryDetails {
   redirect?: ResourceEntryDetailsElement
@@ -196,8 +196,8 @@ export function computeResourceEntrySize(entry: RumPerformanceResourceTiming) {
   }
 }
 
-export function isAllowedRequestUrl(configuration: RumConfiguration, url: string) {
-  return url && !configuration.isIntakeUrl(url)
+export function isAllowedRequestUrl(url: string) {
+  return url && !isIntakeUrl(url)
 }
 
 const DATA_URL_REGEX = /data:(.+)?(;base64)?,/g

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -1,3 +1,4 @@
+import { INTAKE_URL_PARAMETERS } from '@datadog/browser-core'
 import type { LogsInitConfiguration } from '@datadog/browser-logs'
 import type { RumInitConfiguration } from '@datadog/browser-rum-core'
 import type { Servers } from './httpServers'
@@ -183,7 +184,7 @@ function setupEventBridge(servers: Servers) {
   // needs to be similar to the normal Datadog intake (through proxy) to make the SDK completely
   // ignore them.
   const eventBridgeIntake = `${servers.intake.url}/?${new URLSearchParams({
-    ddforward: '/api/v2/rum?',
+    ddforward: `/api/v2/rum?${INTAKE_URL_PARAMETERS.join('&')}`,
     bridge: 'true',
   }).toString()}`
 


### PR DESCRIPTION
## Motivation
We collect network errors from older version sdks, because the intake urls have different prefixes. 
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
We check `isIntakeUrl` on parameter keywords instead of the full prefix.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
