### PR TITLE
♻️ Use registerCleanupTask for mock cleanups

### DIFF
--- a/packages/core/src/browser/xhrObservable.spec.ts
+++ b/packages/core/src/browser/xhrObservable.spec.ts
@@ -9,12 +9,11 @@ describe('xhr observable', () => {
   let requestsTrackingSubscription: Subscription
   let contextEditionSubscription: Subscription | undefined
   let requests: XhrCompleteContext[]
-  let mockXhrManager: { reset(): void }
   let originalMockXhrSend: XMLHttpRequest['send']
   let configuration: Configuration
 
   beforeEach(() => {
-    mockXhrManager = mockXhr()
+    mockXhr()
     configuration = {} as Configuration
     // eslint-disable-next-line @typescript-eslint/unbound-method
     originalMockXhrSend = XMLHttpRequest.prototype.send
@@ -26,7 +25,6 @@ describe('xhr observable', () => {
   afterEach(() => {
     requestsTrackingSubscription.unsubscribe()
     contextEditionSubscription?.unsubscribe()
-    mockXhrManager.reset()
   })
 
   function startTrackingRequests() {

--- a/packages/core/src/domain/synthetics/syntheticsWorkerValues.spec.ts
+++ b/packages/core/src/domain/synthetics/syntheticsWorkerValues.spec.ts
@@ -1,11 +1,7 @@
-import { mockSyntheticsWorkerValues, cleanupSyntheticsWorkerValues } from '../../../test'
+import { mockSyntheticsWorkerValues } from '../../../test'
 import { getSyntheticsResultId, getSyntheticsTestId, willSyntheticsInjectRum } from './syntheticsWorkerValues'
 
 describe('syntheticsWorkerValues', () => {
-  afterEach(() => {
-    cleanupSyntheticsWorkerValues()
-  })
-
   describe('willSyntheticsInjectRum', () => {
     it('returns false if nothing is defined', () => {
       mockSyntheticsWorkerValues({}, 'globals')

--- a/packages/core/test/emulate/mockSyntheticsWorkerValues.ts
+++ b/packages/core/test/emulate/mockSyntheticsWorkerValues.ts
@@ -6,6 +6,7 @@ import {
   SYNTHETICS_RESULT_ID_COOKIE_NAME,
   SYNTHETICS_TEST_ID_COOKIE_NAME,
 } from '../../src/domain/synthetics/syntheticsWorkerValues'
+import { registerCleanupTask } from '../registerCleanupTask'
 
 // Duration to create a cookie lasting at least until the end of the test
 const COOKIE_DURATION = ONE_MINUTE
@@ -37,14 +38,14 @@ export function mockSyntheticsWorkerValues(
       break
   }
   resetInitCookies()
-}
 
-export function cleanupSyntheticsWorkerValues() {
-  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID
-  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID
-  delete (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM
-  deleteCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
-  deleteCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
-  deleteCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
-  resetInitCookies()
+  registerCleanupTask(() => {
+    delete (window as BrowserWindow)._DATADOG_SYNTHETICS_PUBLIC_ID
+    delete (window as BrowserWindow)._DATADOG_SYNTHETICS_RESULT_ID
+    delete (window as BrowserWindow)._DATADOG_SYNTHETICS_INJECTS_RUM
+    deleteCookie(SYNTHETICS_TEST_ID_COOKIE_NAME)
+    deleteCookie(SYNTHETICS_RESULT_ID_COOKIE_NAME)
+    deleteCookie(SYNTHETICS_INJECTS_RUM_COOKIE_NAME)
+    resetInitCookies()
+  })
 }

--- a/packages/core/test/emulate/mockXhr.ts
+++ b/packages/core/test/emulate/mockXhr.ts
@@ -2,8 +2,6 @@ import { isServerError, noop } from '../../src'
 import { registerCleanupTask } from '../registerCleanupTask'
 import { createNewEvent } from './createNewEvent'
 
-export type MockXhrManager = ReturnType<typeof mockXhr>
-
 export function mockXhr() {
   const originalXhr = XMLHttpRequest
 

--- a/packages/core/test/emulate/mockXhr.ts
+++ b/packages/core/test/emulate/mockXhr.ts
@@ -1,4 +1,5 @@
 import { isServerError, noop } from '../../src'
+import { registerCleanupTask } from '../registerCleanupTask'
 import { createNewEvent } from './createNewEvent'
 
 export type MockXhrManager = ReturnType<typeof mockXhr>
@@ -8,11 +9,9 @@ export function mockXhr() {
 
   window.XMLHttpRequest = MockXhr as any
 
-  return {
-    reset() {
-      window.XMLHttpRequest = originalXhr
-    },
-  }
+  registerCleanupTask(() => {
+    window.XMLHttpRequest = originalXhr
+  })
 }
 
 export function withXhr({

--- a/packages/core/test/interceptRequests.ts
+++ b/packages/core/test/interceptRequests.ts
@@ -28,7 +28,6 @@ export function interceptRequests() {
   const originalSendBeacon = isSendBeaconSupported() && navigator.sendBeacon.bind(navigator)
   const originalRequest = window.Request
   const originalFetch = window.fetch
-  let xhrManager: { reset(): void } | undefined
 
   spyOn(XMLHttpRequest.prototype, 'open').and.callFake((_, url) => requests.push({ type: 'xhr', url } as Request))
   spyOn(XMLHttpRequest.prototype, 'send').and.callFake((body) => (requests[requests.length - 1].body = body as string))
@@ -63,9 +62,6 @@ export function interceptRequests() {
     if (originalFetch) {
       window.fetch = originalFetch
     }
-    if (xhrManager) {
-      xhrManager.reset()
-    }
     MockXhr.onSend = noop
   })
 
@@ -83,7 +79,7 @@ export function interceptRequests() {
       window.fetch = newFetch
     },
     withMockXhr(onSend: (xhr: MockXhr) => void) {
-      xhrManager = mockXhr()
+      mockXhr()
       MockXhr.onSend = onSend
     },
   }

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -18,7 +18,6 @@ import {
   interceptRequests,
   mockEndpointBuilder,
   mockEventBridge,
-  cleanupSyntheticsWorkerValues,
   mockSyntheticsWorkerValues,
   registerCleanupTask,
   mockClock,
@@ -204,10 +203,6 @@ describe('logs', () => {
   })
 
   describe('logs session creation', () => {
-    afterEach(() => {
-      cleanupSyntheticsWorkerValues()
-    })
-
     it('creates a session on normal conditions', () => {
       ;({ handleLog, stop: stopLogs } = startLogs(
         initConfiguration,

--- a/packages/logs/src/domain/contexts/rumInternalContext.spec.ts
+++ b/packages/logs/src/domain/contexts/rumInternalContext.spec.ts
@@ -1,6 +1,6 @@
 import type { TelemetryEvent } from '@datadog/browser-core'
 import { startTelemetry, TelemetryService } from '@datadog/browser-core'
-import { mockSyntheticsWorkerValues, cleanupSyntheticsWorkerValues } from '@datadog/browser-core/test'
+import { mockSyntheticsWorkerValues } from '@datadog/browser-core/test'
 import { validateAndBuildLogsConfiguration } from '../configuration'
 import { resetRUMInternalContext, getRUMInternalContext } from './rumInternalContext'
 
@@ -40,10 +40,6 @@ describe('getRUMInternalContext', () => {
       )
       telemetrySpy = jasmine.createSpy()
       telemetry.observable.subscribe(telemetrySpy)
-    })
-
-    afterEach(() => {
-      cleanupSyntheticsWorkerValues()
     })
 
     it('uses the global variable created when the synthetics worker is injecting RUM', () => {

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -16,7 +16,6 @@ import {
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import {
-  cleanupSyntheticsWorkerValues,
   mockEventBridge,
   interceptRequests,
   mockClock,
@@ -175,10 +174,6 @@ describe('preStartRum', () => {
   })
 
   describe('init', () => {
-    afterEach(() => {
-      cleanupSyntheticsWorkerValues()
-    })
-
     it('should not initialize if session cannot be handled and bridge is not present', () => {
       spyOnProperty(document, 'cookie', 'get').and.returnValue('')
       const displaySpy = spyOn(display, 'warn')
@@ -608,7 +603,6 @@ describe('preStartRum', () => {
     })
 
     afterEach(() => {
-      cleanupSyntheticsWorkerValues()
       resetExperimentalFeatures()
     })
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -9,12 +9,7 @@ import {
   timeStampToClocks,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import {
-  cleanupSyntheticsWorkerValues,
-  mockClock,
-  mockExperimentalFeatures,
-  registerCleanupTask,
-} from '@datadog/browser-core/test'
+import { mockClock, mockExperimentalFeatures, registerCleanupTask } from '@datadog/browser-core/test'
 import { noopRecorderApi } from '../../test'
 import { ActionType, VitalType } from '../rawRumEvent.types'
 import type { DurationVitalReference } from '../domain/vital/vitalCollection'
@@ -50,7 +45,6 @@ describe('rum public api', () => {
 
     beforeEach(() => {
       startRumSpy = jasmine.createSpy().and.callFake(noopStartRum)
-      registerCleanupTask(cleanupSyntheticsWorkerValues)
     })
 
     describe('deflate worker', () => {

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -3,7 +3,6 @@ import { ErrorSource, ExperimentalFeature, ONE_MINUTE, display } from '@datadog/
 import type { Clock } from '@datadog/browser-core/test'
 import {
   mockEventBridge,
-  cleanupSyntheticsWorkerValues,
   mockSyntheticsWorkerValues,
   mockExperimentalFeatures,
   setNavigatorOnLine,
@@ -1018,7 +1017,6 @@ function setupAssemblyTestWithDefaults({
 
   registerCleanupTask(() => {
     subscription.unsubscribe()
-    cleanupSyntheticsWorkerValues()
   })
 
   return { lifeCycle, reportErrorSpy, serverRumEvents, commonContext }

--- a/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
@@ -1,11 +1,7 @@
-import { cleanupSyntheticsWorkerValues, mockSyntheticsWorkerValues } from '../../../../core/test'
+import { mockSyntheticsWorkerValues } from '../../../../core/test'
 import { getSyntheticsContext } from './syntheticsContext'
 
 describe('getSyntheticsContext', () => {
-  afterEach(() => {
-    cleanupSyntheticsWorkerValues()
-  })
-
   it('sets the synthetics context defined by global variables', () => {
     mockSyntheticsWorkerValues({ publicId: 'foo', resultId: 'bar' }, 'globals')
 

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -181,7 +181,6 @@ describe('collect fetch', () => {
 describe('collect xhr', () => {
   let startSpy: jasmine.Spy<(requestStartEvent: RequestStartEvent) => void>
   let completeSpy: jasmine.Spy<(requestCompleteEvent: RequestCompleteEvent) => void>
-  let mockXhrManager: MockXhrManager
   let stopXhrTracking: () => void
 
   beforeEach(() => {
@@ -189,7 +188,7 @@ describe('collect xhr', () => {
       pending('no fetch support')
     }
     const configuration = mockRumConfiguration({ batchMessagesLimit: 1 })
-    mockXhrManager = mockXhr()
+    mockXhr()
     startSpy = jasmine.createSpy('requestStart')
     completeSpy = jasmine.createSpy('requestComplete')
     const lifeCycle = new LifeCycle()
@@ -206,7 +205,6 @@ describe('collect xhr', () => {
 
     registerCleanupTask(() => {
       stopXhrTracking()
-      mockXhrManager.reset()
     })
   })
 

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -1,6 +1,6 @@
 import type { Payload } from '@datadog/browser-core'
 import { isIE, RequestType } from '@datadog/browser-core'
-import type { MockFetch, MockFetchManager, MockXhrManager } from '@datadog/browser-core/test'
+import type { MockFetch, MockFetchManager } from '@datadog/browser-core/test'
 import { registerCleanupTask, SPEC_ENDPOINTS, mockFetch, mockXhr, withXhr } from '@datadog/browser-core/test'
 import { mockRumConfiguration } from '../../test'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'


### PR DESCRIPTION
## Motivation

- Use registerCleanupTask for mockXhr cleanup
- Use registerCleanupTask for mockSyntheticsWorkerValues cleanup

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
