### PR TITLE
👷 skip merge into next major on scheduled pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,6 +445,9 @@ merge-into-next-major:
   only:
     refs:
       - main
+  except:
+    refs:
+      - schedules
   before_script:
     - eval $(ssh-agent -s)
   script:


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

We don't need to merge main into the next major branch on scheduled pipelines as it's only eventually creating a PR to bump the Chrome version if new version is available.

When the bump Chrome PR is merged, it will be normally merged into the next major.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
