### PR TITLE
🐛 [RUM-6483] Investigate reducing the batch time limit for Replay

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,6 +18,7 @@ export enum ExperimentalFeature {
   REMOTE_CONFIGURATION = 'remote_configuration',
   UPDATE_VIEW_NAME = 'update_view_name',
   LONG_ANIMATION_FRAME = 'long_animation_frame',
+  REDUCE_SEGMENT_LIMIT_BATCH_TIME = 'reduce_segment_limit_batch_time',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -13,7 +13,7 @@ import {
   computeSegmentContext,
   doStartSegmentCollection,
   SEGMENT_BYTES_LIMIT,
-  SEGMENT_DURATION_LIMIT,
+  getSegmentDurationLimit,
 } from './segmentCollection'
 
 const CONTEXT: SegmentContext = { application: { id: 'a' }, view: { id: 'b' }, session: { id: 'c' } }
@@ -26,7 +26,7 @@ const VERY_BIG_RECORD: BrowserRecord = {
   data: Array(SEGMENT_BYTES_LIMIT).join('a') as any,
 }
 
-const BEFORE_SEGMENT_DURATION_LIMIT = SEGMENT_DURATION_LIMIT() * 0.9
+const BEFORE_SEGMENT_DURATION_LIMIT = getSegmentDurationLimit() * 0.9
 
 describe('startSegmentCollection', () => {
   let stopSegmentCollection: () => void
@@ -240,7 +240,7 @@ describe('startSegmentCollection', () => {
       it('uses `httpRequest.send` when sending the segment', () => {
         clock = mockClock()
         addRecordAndFlushSegment(() => {
-          clock!.tick(SEGMENT_DURATION_LIMIT())
+          clock!.tick(getSegmentDurationLimit())
         })
         expect(httpRequestSpy.send).toHaveBeenCalled()
       })
@@ -248,7 +248,7 @@ describe('startSegmentCollection', () => {
       it('next segment is created because of the segment duration limit has been reached', async () => {
         clock = mockClock()
         addRecordAndFlushSegment(() => {
-          clock!.tick(SEGMENT_DURATION_LIMIT())
+          clock!.tick(getSegmentDurationLimit())
         })
         addRecordAndFlushSegment()
         expect((await readMostRecentMetadata(httpRequestSpy.sendOnExit)).creation_reason).toBe('segment_duration_limit')

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -26,7 +26,7 @@ const VERY_BIG_RECORD: BrowserRecord = {
   data: Array(SEGMENT_BYTES_LIMIT).join('a') as any,
 }
 
-const BEFORE_SEGMENT_DURATION_LIMIT = SEGMENT_DURATION_LIMIT * 0.9
+const BEFORE_SEGMENT_DURATION_LIMIT = SEGMENT_DURATION_LIMIT() * 0.9
 
 describe('startSegmentCollection', () => {
   let stopSegmentCollection: () => void
@@ -240,7 +240,7 @@ describe('startSegmentCollection', () => {
       it('uses `httpRequest.send` when sending the segment', () => {
         clock = mockClock()
         addRecordAndFlushSegment(() => {
-          clock!.tick(SEGMENT_DURATION_LIMIT)
+          clock!.tick(SEGMENT_DURATION_LIMIT())
         })
         expect(httpRequestSpy.send).toHaveBeenCalled()
       })
@@ -248,7 +248,7 @@ describe('startSegmentCollection', () => {
       it('next segment is created because of the segment duration limit has been reached', async () => {
         clock = mockClock()
         addRecordAndFlushSegment(() => {
-          clock!.tick(SEGMENT_DURATION_LIMIT)
+          clock!.tick(SEGMENT_DURATION_LIMIT())
         })
         addRecordAndFlushSegment()
         expect((await readMostRecentMetadata(httpRequestSpy.sendOnExit)).creation_reason).toBe('segment_duration_limit')

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -14,8 +14,11 @@ import { buildReplayPayload } from './buildReplayPayload'
 import type { FlushReason, Segment } from './segment'
 import { createSegment } from './segment'
 
-export const SEGMENT_DURATION_LIMIT = () =>
-  isExperimentalFeatureEnabled(ExperimentalFeature.REDUCE_SEGMENT_LIMIT_BATCH_TIME) ? 5 * ONE_SECOND : 30 * ONE_SECOND
+export function getSegmentDurationLimit() {
+  return isExperimentalFeatureEnabled(ExperimentalFeature.REDUCE_SEGMENT_LIMIT_BATCH_TIME)
+    ? 5 * ONE_SECOND
+    : 30 * ONE_SECOND
+}
 /**
  * beacon payload max queue size implementation is 64kb
  * ensure that we leave room for logs, rum and potential other users
@@ -147,7 +150,7 @@ export function doStartSegmentCollection(
           segment: createSegment({ encoder, context, creationReason: state.nextSegmentCreationReason }),
           expirationTimeoutId: setTimeout(() => {
             flushSegment('segment_duration_limit')
-          }, SEGMENT_DURATION_LIMIT()),
+          }, getSegmentDurationLimit()),
         }
       }
 

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.ts
@@ -1,5 +1,12 @@
 import type { DeflateEncoder, HttpRequest, TimeoutId } from '@datadog/browser-core'
-import { isPageExitReason, ONE_SECOND, clearTimeout, setTimeout } from '@datadog/browser-core'
+import {
+  isPageExitReason,
+  ONE_SECOND,
+  clearTimeout,
+  setTimeout,
+  isExperimentalFeatureEnabled,
+  ExperimentalFeature,
+} from '@datadog/browser-core'
 import type { LifeCycle, ViewHistory, RumSessionManager, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { BrowserRecord, CreationReason, SegmentContext } from '../../types'
@@ -7,7 +14,8 @@ import { buildReplayPayload } from './buildReplayPayload'
 import type { FlushReason, Segment } from './segment'
 import { createSegment } from './segment'
 
-export const SEGMENT_DURATION_LIMIT = 30 * ONE_SECOND
+export const SEGMENT_DURATION_LIMIT = () =>
+  isExperimentalFeatureEnabled(ExperimentalFeature.REDUCE_SEGMENT_LIMIT_BATCH_TIME) ? 5 * ONE_SECOND : 30 * ONE_SECOND
 /**
  * beacon payload max queue size implementation is 64kb
  * ensure that we leave room for logs, rum and potential other users
@@ -139,7 +147,7 @@ export function doStartSegmentCollection(
           segment: createSegment({ encoder, context, creationReason: state.nextSegmentCreationReason }),
           expirationTimeoutId: setTimeout(() => {
             flushSegment('segment_duration_limit')
-          }, SEGMENT_DURATION_LIMIT),
+          }, SEGMENT_DURATION_LIMIT()),
         }
       }
 


### PR DESCRIPTION
## Motivation

There's some missing replay segment, because most likely the browser/javascript execution stop before data is compressed or uploaded.

## Changes

Flush data more often, like every 5 seconds instead of 30 seconds could increase the chances to send Replay data

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
