### PR TITLE
👷 CI - Enable yarn strategy on the repository

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -3,3 +3,10 @@ schema-version: v1
 kind: mergequeue
 team: rum-browser
 to_staging_enable: true
+---
+schema-version: v1
+kind: buildimpactanalysis
+team: ci-platforms
+enabled_strategies:
+  - yarn_berry_strategy
+preprocess: true


### PR DESCRIPTION
## Motivation

[Build Impact Analysis](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/2907573392/Build+Impact+Analysis) service supports indexing native yarn packages.
BIA integrates with the mergequeue, to enable parallel merge of prs that don't have any overlap in changed or impacted packages.
The "yarn strategy" is mature: it has been enabled in web-ui repository as well for several months, and used at scale to parallelize merges.
Other use cases can also consume this data (e.g. adding labels on every pull requests with the list of changed packages, viewing the dependency graph of a service)

## Changes
Enable indexing the repository with yarn strategy.
This is a CI-only change, that should not impact this repository in any way visible to users (enabler for activation of new features in the future)

## Testing
Visualisation of the dependency graph for `browser-sdk` package - [link](https://devflow.static-app.us1.prod.dog/deps-explorer?repoName=browser-sdk&ref=1a0b5ca22fc7c2279531c2e4da0d1661598bb73d&rootId=browser-sdk)