### PR TITLE
👷 CI - assign static resources for e2e-bs job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,19 @@ stages:
     refs:
       - tags
 
+###########################################################################################################################
+# Resource allocation
+###########################################################################################################################
+
+.resource-allocation-4-cpus:
+  variables:
+    WORKERS: 2
+    KUBERNETES_CPU_REQUEST: 4
+    KUBERNETES_CPU_LIMIT: 4
+    KUBERNETES_MEMORY_REQUEST: 16Gi
+    KUBERNETES_MEMORY_LIMIT: 16Gi
+    NODE_OPTIONS: '--max-old-space-size=16000'
+
 ########################################################################################################################
 # CI image
 ########################################################################################################################
@@ -266,6 +279,7 @@ e2e-bs:
   extends:
     - .base-configuration
     - .bs-allowed-branches
+    - .resource-allocation-4-cpus
   interruptible: true
   resource_group: browserstack
   timeout: 35 minutes


### PR DESCRIPTION
## Motivation

Hi, Devx team here - I started investigating OOM kills in CI, and the `e2e-bs` job showed up fairly often.
No variable is defined explicitly, so each job uses the [default values](https://github.com/DataDog/dd-source/blob/main/domains/devex/ci/gitlab/config/k8s/gitlab-runner/values/resources-managed.template.yaml#L12-L17) (currently, 1 cpu request, no cpu limit, 2Gi ram request and 6Gi ram limit).
It seems like allocating more memory would help.
For example, another pr I opened this morning (#3079) is currently blocked because of this test, and it appears that 40 processes were killed by k8s during the job execution - [events](https://app.datadoghq.com/event/explorer?query=source%3Aoom_kill%20ci-job-name%3Ae2e-bs%20ci-job-id%3A676670230%20&cols=&fromUser=false&index=%2A&messageDisplay=expanded-lg&options=&refresh_mode=sliding&sort=DESC&type=feed&from_ts=1729238160519&to_ts=1729252560519&live=true).

## Changes
Setup the `e2e-bs` job to use 4 cpus and 16Gi RAM - adapted from the [setup](https://github.com/DataDog/web-ui/blob/preprod/.gitlab/_resources.gitlab-ci.yml) used in web-ui, which I think is relevant here as well, given the tech stack is pretty much the same.

## Testing
Post-merge: check the [oom-kill events](https://app.datadoghq.com/event/explorer?query=source%3Aoom_kill%20ci-job-name%3Ae2e-bs%20&cols=&fromUser=false&index=%2A&messageDisplay=expanded-lg&options=&refresh_mode=sliding&sort=DESC&type=feed&from_ts=1728647155658&to_ts=1729251955658&live=true) and confirm this job does not fail anymore.

Note: you may want to right-size the resources for that job, and use static allocation for other jobs as well.
Feel free to ping us on #ci-infra-support if you need help with that.