### PR TITLE
👷 publish chrome extension to all users

### DIFF
--- a/scripts/deploy/publish-developer-extension.js
+++ b/scripts/deploy/publish-developer-extension.js
@@ -41,8 +41,8 @@ async function uploadAndPublish() {
     printLog('Uploading the archive')
     await api.uploadExisting(zipFile, token)
 
-    printLog('Publishing to trusted testers')
-    await api.publish('trustedTesters')
+    printLog('Publishing')
+    await api.publish()
   } catch (err) {
     const body = err?.response?.body
     if (body) {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

The developer extension is now public, hence it's no longer possible to publish it to `trustedTesters` only anymore

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
