### PR TITLE
👷 [RUM-6366] disable browserStack tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -263,41 +263,41 @@ check-schemas:
     - yarn
     - node scripts/check-schemas.js
 
-unit-bs:
-  stage: browserstack
-  extends:
-    - .base-configuration
-    - .bs-allowed-branches
-  interruptible: true
-  resource_group: browserstack
-  artifacts:
-    reports:
-      junit: test-report/unit-bs/*.xml
-  script:
-    - yarn
-    - ./scripts/test/ci-bs.sh test:unit
-  after_script:
-    - node ./scripts/test/export-test-result.js unit-bs
+# unit-bs:
+#   stage: browserstack
+#   extends:
+#     - .base-configuration
+#     - .bs-allowed-branches
+#   interruptible: true
+#   resource_group: browserstack
+#   artifacts:
+#     reports:
+#       junit: test-report/unit-bs/*.xml
+#   script:
+#     - yarn
+#     - ./scripts/test/ci-bs.sh test:unit
+#   after_script:
+#     - node ./scripts/test/export-test-result.js unit-bs
 
-e2e-bs:
-  stage: browserstack
-  extends:
-    - .base-configuration
-    - .bs-allowed-branches
-    - .resource-allocation-4-cpus
-  interruptible: true
-  resource_group: browserstack
-  timeout: 35 minutes
-  artifacts:
-    when: always
-    paths: ['test-report/e2e-bs/specs.log']
-    reports:
-      junit: test-report/e2e-bs/*.xml
-  script:
-    - yarn
-    - FORCE_COLOR=1 ./scripts/test/ci-bs.sh test:e2e
-  after_script:
-    - node ./scripts/test/export-test-result.js e2e-bs
+# e2e-bs:
+#   stage: browserstack
+#   extends:
+#     - .base-configuration
+#     - .bs-allowed-branches
+#     - .resource-allocation-4-cpus
+#   interruptible: true
+#   resource_group: browserstack
+#   timeout: 35 minutes
+#   artifacts:
+#     when: always
+#     paths: ['test-report/e2e-bs/specs.log']
+#     reports:
+#       junit: test-report/e2e-bs/*.xml
+#   script:
+#     - yarn
+#     - FORCE_COLOR=1 ./scripts/test/ci-bs.sh test:e2e
+#   after_script:
+#     - node ./scripts/test/export-test-result.js e2e-bs
 
 ########################################################################################################################
 # Deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,8 @@ stages:
       - /^staging-[0-9]+$/
       - /^release\//
       - schedules
+    variables:
+      - $CI_COMMIT_REF_NAME == $NEXT_MAJOR_BRANCH
 
 .next-major-branch:
   only:
@@ -263,41 +265,41 @@ check-schemas:
     - yarn
     - node scripts/check-schemas.js
 
-# unit-bs:
-#   stage: browserstack
-#   extends:
-#     - .base-configuration
-#     - .bs-allowed-branches
-#   interruptible: true
-#   resource_group: browserstack
-#   artifacts:
-#     reports:
-#       junit: test-report/unit-bs/*.xml
-#   script:
-#     - yarn
-#     - ./scripts/test/ci-bs.sh test:unit
-#   after_script:
-#     - node ./scripts/test/export-test-result.js unit-bs
+unit-bs:
+  stage: browserstack
+  extends:
+    - .base-configuration
+    - .bs-allowed-branches
+  interruptible: true
+  resource_group: browserstack
+  artifacts:
+    reports:
+      junit: test-report/unit-bs/*.xml
+  script:
+    - yarn
+    - ./scripts/test/ci-bs.sh test:unit
+  after_script:
+    - node ./scripts/test/export-test-result.js unit-bs
 
-# e2e-bs:
-#   stage: browserstack
-#   extends:
-#     - .base-configuration
-#     - .bs-allowed-branches
-#     - .resource-allocation-4-cpus
-#   interruptible: true
-#   resource_group: browserstack
-#   timeout: 35 minutes
-#   artifacts:
-#     when: always
-#     paths: ['test-report/e2e-bs/specs.log']
-#     reports:
-#       junit: test-report/e2e-bs/*.xml
-#   script:
-#     - yarn
-#     - FORCE_COLOR=1 ./scripts/test/ci-bs.sh test:e2e
-#   after_script:
-#     - node ./scripts/test/export-test-result.js e2e-bs
+e2e-bs:
+  stage: browserstack
+  extends:
+    - .base-configuration
+    - .bs-allowed-branches
+    - .resource-allocation-4-cpus
+  interruptible: true
+  resource_group: browserstack
+  timeout: 35 minutes
+  artifacts:
+    when: always
+    paths: ['test-report/e2e-bs/specs.log']
+    reports:
+      junit: test-report/e2e-bs/*.xml
+  script:
+    - yarn
+    - FORCE_COLOR=1 ./scripts/test/ci-bs.sh test:e2e
+  after_script:
+    - node ./scripts/test/export-test-result.js e2e-bs
 
 ########################################################################################################################
 # Deploy


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Temporarily disable browserStack tests on the v6 branch.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
