### PR TITLE
✨ add new privacy rule for autocomplete password value

### DIFF
--- a/packages/rum-core/src/domain/privacy.spec.ts
+++ b/packages/rum-core/src/domain/privacy.spec.ts
@@ -176,6 +176,11 @@ describe('getNodeSelfPrivacyLevel', () => {
       expected: NodePrivacyLevel.MASK,
     },
     {
+      msg: 'is an "input" element and has an autocomplete attribute ending with "-password" (forced override)',
+      html: '<input type="text" class="dd-privacy-allow" autocomplete="foo-password">',
+      expected: NodePrivacyLevel.MASK,
+    },
+    {
       msg: 'is an "input" element and has an autocomplete attribute not starting with "cc-"',
       html: '<input type="text" autocomplete="email">',
       expected: undefined,

--- a/packages/rum-core/src/domain/privacy.ts
+++ b/packages/rum-core/src/domain/privacy.ts
@@ -115,8 +115,11 @@ export function getNodeSelfPrivacyLevel(node: Node): NodePrivacyLevel | undefine
       return NodePrivacyLevel.MASK
     }
     const autocomplete = inputElement.getAttribute('autocomplete')
-    // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year]
-    if (autocomplete && autocomplete.indexOf('cc-') === 0) {
+      // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year/new-password/current-password]
+    if (autocomplete && (
+      autocomplete.startsWith('cc-') ||
+      autocomplete.endsWith('-password')
+    )) {
       return NodePrivacyLevel.MASK
     }
   }

--- a/packages/rum-core/src/domain/privacy.ts
+++ b/packages/rum-core/src/domain/privacy.ts
@@ -115,11 +115,8 @@ export function getNodeSelfPrivacyLevel(node: Node): NodePrivacyLevel | undefine
       return NodePrivacyLevel.MASK
     }
     const autocomplete = inputElement.getAttribute('autocomplete')
-      // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year/new-password/current-password]
-    if (autocomplete && (
-      autocomplete.startsWith('cc-') ||
-      autocomplete.endsWith('-password')
-    )) {
+    // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year/new-password/current-password]
+    if (autocomplete && (autocomplete.startsWith('cc-') || autocomplete.endsWith('-password'))) {
       return NodePrivacyLevel.MASK
     }
   }


### PR DESCRIPTION
Hello,

## Motivation

There are multiple ways to hide an element from RUM Session Replay ([documentation](https://docs.datadoghq.com/fr/real_user_monitoring/session_replay/browser/privacy_options/)):
- Using an HTML attribute: `data-dd-privacy="allow" | "mask" | "hidden" | "mask-user-input"`
- Using CSS classes: `class="dd-privacy-allow" | "dd-privacy-mask-user-input" | "dd-privacy-mask" | "dd-privacy-hidden"`

By default, some HTML elements are automatically masked:
- Input elements of type password, email, and tel
- Elements with autocomplete attributes for credit card numbers, expiration dates, and security codes

However, this doesn't currently handle [new-password](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#new-password) and [current-password](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#current-password) autocomplete attributes.

Why isn't `type="password"` sufficient?
This is mainly due to password visibility toggle components, where libraries and custom code temporarily change the input type from `password` to `text` to show the password, then revert it back to `password`.

![image](https://github.com/user-attachments/assets/cf9ca23e-ac7c-45ab-b578-2ce5c09a763e)

## Changes

I have updated the condition for `autocomplete` attributes using the same logic as `cc-` prefixes.
My main question is whether we should use an `endsWith` logic? This would match the current `cc-` implementation, or we could be more explicit:

```js
if (autocomplete && (
    autocomplete.indexOf('cc-') === 0 ||
    autocomplete === 'new-password' ||
    autocomplete === 'current-password'
)) {
    return NodePrivacyLevel.MASK
}
```

Can you update the documentation too?

## Testing

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
