### PR TITLE
✅👷 kill browserstack execution early

### DIFF
--- a/scripts/test/bs-wrapper.js
+++ b/scripts/test/bs-wrapper.js
@@ -14,11 +14,13 @@
 // after killing it. There might be a better way of prematurely aborting the test command if we need
 // to in the future.
 
-const { spawnCommand, printLog, runMain, timeout } = require('../lib/executionUtils')
+const spawn = require('child_process').spawn
+const { printLog, runMain, timeout, printError } = require('../lib/executionUtils')
 const { command } = require('../lib/command')
 const { browserStackRequest } = require('../lib/bsUtils')
 
 const AVAILABILITY_CHECK_DELAY = 30_000
+const NO_OUTPUT_TIMEOUT = 5 * 60_000
 const BS_BUILD_URL = 'https://api.browserstack.com/automate/builds.json?status=running'
 
 runMain(async () => {
@@ -27,8 +29,8 @@ runMain(async () => {
     return
   }
   await waitForAvailability()
-  const exitCode = await runTests()
-  process.exit(exitCode)
+  const isSuccess = await runTests()
+  process.exit(isSuccess ? 0 : 1)
 })
 
 async function waitForAvailability() {
@@ -43,6 +45,49 @@ async function hasRunningBuild() {
 }
 
 function runTests() {
-  const [command, ...args] = process.argv.slice(2)
-  return spawnCommand(command, args)
+  return new Promise((resolve) => {
+    const [command, ...args] = process.argv.slice(2)
+
+    const child = spawn(command, args, {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      env: { ...process.env, FORCE_COLOR: true },
+    })
+
+    let output = ''
+    let isKilled = false
+    let timeoutId
+
+    child.stdout.pipe(process.stdout)
+    child.stdout.on('data', onOutput)
+
+    child.stderr.pipe(process.stderr)
+    child.stderr.on('data', onOutput)
+
+    child.on('exit', (code) => {
+      resolve(!isKilled && code === 0)
+    })
+
+    function onOutput(data) {
+      output += data
+
+      if (hasUnrecoverableFailure(output)) {
+        killIt('unrecoverable failure')
+      }
+
+      clearTimeout(timeoutId)
+      setTimeout(() => killIt('no output timeout'), NO_OUTPUT_TIMEOUT)
+    }
+
+    function killIt(message) {
+      if (!isKilled) {
+        printError(`Killing the browserstack job because of ${message}`)
+        isKilled = true
+        child.kill('SIGTERM')
+      }
+    }
+  })
+}
+
+function hasUnrecoverableFailure(stdout) {
+  return stdout.includes('is set to true but local testing through BrowserStack is not connected.')
 }


### PR DESCRIPTION

## Motivation

e2e-bs tests are still quite flaky, sometimes because of a BrowserStack issue (?). Because we can run a single e2e-bs job at a time, we should detect and stop the jobs as soon as possible so other can be run.

## Changes

When detecting an unrecoverable error in the command output, or if the command doesn't print anything within 5 minutes, let's kill it early, we don't wait for nothing.

For now, we don't implement a retry mechanism, but it could be done later.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
