### PR TITLE
👷 [RUM-6562] Enable and rename update view name API

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -16,7 +16,6 @@ import { objectHasValue } from './utils/objectUtils'
 export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
   REMOTE_CONFIGURATION = 'remote_configuration',
-  UPDATE_VIEW_NAME = 'update_view_name',
   LONG_ANIMATION_FRAME = 'long_animation_frame',
 }
 

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -305,16 +305,16 @@ describe('preStartRum', () => {
       let strategy: Strategy
       let startViewSpy: jasmine.Spy<StartRumResult['startView']>
       let addTimingSpy: jasmine.Spy<StartRumResult['addTiming']>
-      let updateViewNameSpy: jasmine.Spy<StartRumResult['updateViewName']>
+      let setViewNameSpy: jasmine.Spy<StartRumResult['setViewName']>
 
       beforeEach(() => {
         startViewSpy = jasmine.createSpy('startView')
         addTimingSpy = jasmine.createSpy('addTiming')
-        updateViewNameSpy = jasmine.createSpy('updateViewName')
+        setViewNameSpy = jasmine.createSpy('setViewName')
         doStartRumSpy.and.returnValue({
           startView: startViewSpy,
           addTiming: addTimingSpy,
-          updateViewName: updateViewNameSpy,
+          setViewName: setViewNameSpy,
         } as unknown as StartRumResult)
         strategy = createPreStartStrategy(
           {},
@@ -741,14 +741,14 @@ describe('preStartRum', () => {
       expect(setViewContextPropertySpy).toHaveBeenCalledOnceWith('foo', 'bar')
     })
 
-    it('updateViewName', () => {
-      const updateViewNameSpy = jasmine.createSpy()
-      doStartRumSpy.and.returnValue({ updateViewName: updateViewNameSpy } as unknown as StartRumResult)
+    it('setViewName', () => {
+      const setViewNameSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({ setViewName: setViewNameSpy } as unknown as StartRumResult)
 
       const name = 'foo'
-      strategy.updateViewName(name)
+      strategy.setViewName(name)
       strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
-      expect(updateViewNameSpy).toHaveBeenCalledOnceWith(name)
+      expect(setViewNameSpy).toHaveBeenCalledOnceWith(name)
     })
 
     it('addFeatureFlagEvaluation', () => {

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -192,8 +192,8 @@ export function createPreStartStrategy(
       }
     },
 
-    updateViewName(name) {
-      bufferApiCalls.add((startRumResult) => startRumResult.updateViewName(name))
+    setViewName(name) {
+      bufferApiCalls.add((startRumResult) => startRumResult.setViewName(name))
     },
 
     setViewContext(context) {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,6 +1,5 @@
 import type { RelativeTime, Context, DeflateWorker, CustomerDataTrackerManager, TimeStamp } from '@datadog/browser-core'
 import {
-  ExperimentalFeature,
   ONE_SECOND,
   display,
   DefaultPrivacyLevel,
@@ -9,7 +8,7 @@ import {
   timeStampToClocks,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, mockExperimentalFeatures, registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import { noopRecorderApi } from '../../test'
 import { ActionType, VitalType } from '../rawRumEvent.types'
 import type { DurationVitalReference } from '../domain/vital/vitalCollection'
@@ -25,7 +24,7 @@ const noopStartRum = (): ReturnType<StartRum> => ({
   startView: () => undefined,
   setViewContext: () => undefined,
   setViewContextProperty: () => undefined,
-  updateViewName: () => undefined,
+  setViewName: () => undefined,
   getInternalContext: () => undefined,
   lifeCycle: {} as any,
   viewHistory: {} as any,
@@ -836,34 +835,27 @@ describe('rum public api', () => {
     expect(rumPublicApi.version).toBe('test')
   })
 
-  describe('updateViewName', () => {
-    let updateViewNameSpy: jasmine.Spy<ReturnType<StartRum>['updateViewName']>
+  describe('setViewName', () => {
+    let setViewNameSpy: jasmine.Spy<ReturnType<StartRum>['setViewName']>
     let rumPublicApi: RumPublicApi
 
     beforeEach(() => {
-      updateViewNameSpy = jasmine.createSpy()
+      setViewNameSpy = jasmine.createSpy()
       rumPublicApi = makeRumPublicApi(
         () => ({
           ...noopStartRum(),
-          updateViewName: updateViewNameSpy,
+          setViewName: setViewNameSpy,
         }),
         noopRecorderApi
       )
     })
 
-    it('should not expose update view name api when ff is disabled', () => {
-      const rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect((rumPublicApi as any).updateViewName).toBeUndefined()
-    })
-
     it('should update the view name', () => {
-      mockExperimentalFeatures([ExperimentalFeature.UPDATE_VIEW_NAME])
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).updateViewName('foo')
+      ;(rumPublicApi as any).setViewName('foo')
 
-      expect(updateViewNameSpy).toHaveBeenCalledWith('foo')
+      expect(setViewNameSpy).toHaveBeenCalledWith('foo')
     })
   })
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -850,7 +850,7 @@ describe('rum public api', () => {
       )
     })
 
-    it('should update the view name', () => {
+    it('should set the view name', () => {
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
       rumPublicApi.setViewName('foo')
 

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -852,8 +852,7 @@ describe('rum public api', () => {
 
     it('should update the view name', () => {
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      ;(rumPublicApi as any).setViewName('foo')
+      rumPublicApi.setViewName('foo')
 
       expect(setViewNameSpy).toHaveBeenCalledWith('foo')
     })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -75,6 +75,15 @@ export interface RumPublicApi extends PublicApi {
   setTrackingConsent: (trackingConsent: TrackingConsent) => void
 
   /**
+   * Update View Name.
+   *
+   * Enable to manually change the name of the current view.
+   * @param name name of the view
+   * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
+   */
+  setViewName: (name: string) => void
+
+  /**
    * Set View Context.
    *
    * Enable to manually set the context of the current view.
@@ -425,23 +434,15 @@ export function makeRumPublicApi(
   const rumPublicApi: RumPublicApi = makePublicApi<RumPublicApi>({
     init: monitor((initConfiguration) => {
       strategy.init(initConfiguration, rumPublicApi)
-
-      // Add experimental features here
-      /**
-       * Update View Name.
-       *
-       * Enable to manually change the name of the current view.
-       * @param name name of the view
-       * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
-       */
-      ;(rumPublicApi as any).setViewName = monitor((name: string) => {
-        strategy.setViewName(name)
-      })
     }),
 
     setTrackingConsent: monitor((trackingConsent) => {
       trackingConsentState.update(trackingConsent)
       addTelemetryUsage({ feature: 'set-tracking-consent', tracking_consent: trackingConsent })
+    }),
+
+    setViewName: monitor((name: string) => {
+      strategy.setViewName(name)
     }),
 
     setViewContext: monitor((context: Context) => {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -12,8 +12,6 @@ import type {
 } from '@datadog/browser-core'
 import {
   addTelemetryUsage,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
   CustomerDataType,
   assign,
   createContextManager,
@@ -342,7 +340,7 @@ export interface Strategy {
   stopSession: StartRumResult['stopSession']
   addTiming: StartRumResult['addTiming']
   startView: StartRumResult['startView']
-  updateViewName: StartRumResult['updateViewName']
+  setViewName: StartRumResult['setViewName']
   setViewContext: StartRumResult['setViewContext']
   setViewContextProperty: StartRumResult['setViewContextProperty']
   addAction: StartRumResult['addAction']
@@ -429,18 +427,16 @@ export function makeRumPublicApi(
       strategy.init(initConfiguration, rumPublicApi)
 
       // Add experimental features here
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.UPDATE_VIEW_NAME)) {
-        /**
-         * Update View Name.
-         *
-         * Enable to manually change the name of the current view.
-         * @param name name of the view
-         * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
-         */
-        ;(rumPublicApi as any).updateViewName = monitor((name: string) => {
-          strategy.updateViewName(name)
-        })
-      }
+      /**
+       * Update View Name.
+       *
+       * Enable to manually change the name of the current view.
+       * @param name name of the view
+       * See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#override-default-rum-view-names) for further information.
+       */
+      ;(rumPublicApi as any).setViewName = monitor((name: string) => {
+        strategy.setViewName(name)
+      })
     }),
 
     setTrackingConsent: monitor((trackingConsent) => {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -75,7 +75,7 @@ export interface RumPublicApi extends PublicApi {
   setTrackingConsent: (trackingConsent: TrackingConsent) => void
 
   /**
-   * Update View Name.
+   * Set View Name.
    *
    * Enable to manually change the name of the current view.
    * @param name name of the view

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -151,7 +151,7 @@ export function startRum(
   const {
     addTiming,
     startView,
-    updateViewName,
+    setViewName,
     setViewContext,
     setViewContextProperty,
     stop: stopViewCollection,
@@ -201,7 +201,7 @@ export function startRum(
     startView,
     setViewContext,
     setViewContextProperty,
-    updateViewName,
+    setViewName,
     lifeCycle,
     viewHistory,
     session,

--- a/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
+++ b/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
@@ -38,7 +38,7 @@ export function setupViewTest({ lifeCycle, initialLocation }: ViewTrackingContex
   } = spyOnViews<ViewEndedEvent>()
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, viewEndHandler)
 
-  const { stop, startView, updateViewName, setViewContext, setViewContextProperty, addTiming } = trackViews(
+  const { stop, startView, setViewName, setViewContext, setViewContextProperty, addTiming } = trackViews(
     location,
     lifeCycle,
     domMutationObservable,
@@ -53,7 +53,7 @@ export function setupViewTest({ lifeCycle, initialLocation }: ViewTrackingContex
     setViewContext,
     setViewContextProperty,
     changeLocation,
-    updateViewName,
+    setViewName,
     addTiming,
     getViewUpdate,
     getViewUpdateCount,

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -5,12 +5,11 @@ import {
   display,
   relativeToClocks,
   relativeNow,
-  ExperimentalFeature,
   resetExperimentalFeatures,
 } from '@datadog/browser-core'
 
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, mockExperimentalFeatures, registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import { createPerformanceEntry, mockPerformanceObserver } from '../../../test'
 import { RumEventType, ViewLoadingType } from '../../rawRumEvent.types'
 import type { RumEvent } from '../../rumEvent.types'
@@ -936,35 +935,33 @@ describe('view event count', () => {
   })
 
   describe('update view name', () => {
-    it('should update an undefined view name if the experimental feature is enabled', () => {
-      mockExperimentalFeatures([ExperimentalFeature.UPDATE_VIEW_NAME])
+    it('should update an undefined view name', () => {
       viewTest = setupViewTest({ lifeCycle })
 
-      const { getViewUpdate, startView, updateViewName } = viewTest
+      const { getViewUpdate, startView, setViewName } = viewTest
 
       startView()
-      updateViewName('foo')
+      setViewName('foo')
       expect(getViewUpdate(3).name).toEqual('foo')
     })
 
     it('should update a defined view name if the experimental feature is enabled', () => {
-      mockExperimentalFeatures([ExperimentalFeature.UPDATE_VIEW_NAME])
       viewTest = setupViewTest({ lifeCycle })
 
-      const { getViewUpdate, startView, updateViewName } = viewTest
+      const { getViewUpdate, startView, setViewName } = viewTest
 
       startView({ name: 'initial view name' })
-      updateViewName('foo')
+      setViewName('foo')
       expect(getViewUpdate(3).name).toEqual('foo')
     })
 
     it('should not update a defined view name if the experimental feature is not enabled', () => {
       viewTest = setupViewTest({ lifeCycle })
 
-      const { getViewUpdate, startView, updateViewName } = viewTest
+      const { getViewUpdate, startView, setViewName } = viewTest
 
       startView({ name: 'initial view name' })
-      updateViewName('foo')
+      setViewName('foo')
       expect(getViewUpdate(2).name).toEqual('initial view name')
     })
   })

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -935,7 +935,7 @@ describe('view event count', () => {
   })
 
   describe('set view name', () => {
-    it('should update an undefined view name', () => {
+    it('should set an undefined view name', () => {
       viewTest = setupViewTest({ lifeCycle })
 
       const { getViewUpdate, startView, setViewName } = viewTest

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -934,7 +934,7 @@ describe('view event count', () => {
     })
   })
 
-  describe('update view name', () => {
+  describe('set view name', () => {
     it('should update an undefined view name', () => {
       viewTest = setupViewTest({ lifeCycle })
 
@@ -945,7 +945,7 @@ describe('view event count', () => {
       expect(getViewUpdate(3).name).toEqual('foo')
     })
 
-    it('should update a defined view name if the experimental feature is enabled', () => {
+    it('should set a defined view name', () => {
       viewTest = setupViewTest({ lifeCycle })
 
       const { getViewUpdate, startView, setViewName } = viewTest
@@ -953,16 +953,6 @@ describe('view event count', () => {
       startView({ name: 'initial view name' })
       setViewName('foo')
       expect(getViewUpdate(3).name).toEqual('foo')
-    })
-
-    it('should not update a defined view name if the experimental feature is not enabled', () => {
-      viewTest = setupViewTest({ lifeCycle })
-
-      const { getViewUpdate, startView, setViewName } = viewTest
-
-      startView({ name: 'initial view name' })
-      setViewName('foo')
-      expect(getViewUpdate(2).name).toEqual('initial view name')
     })
   })
 })

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -24,8 +24,6 @@ import {
   clearInterval,
   setTimeout,
   Observable,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
   createContextManager,
 } from '@datadog/browser-core'
 import type { ViewCustomTimings } from '../../rawRumEvent.types'
@@ -173,8 +171,8 @@ export function trackViews(
     setViewContextProperty: (key: string, value: ContextValue) => {
       currentView.contextManager.setContextProperty(key, value)
     },
-    updateViewName: (name: string) => {
-      currentView.updateViewName(name)
+    setViewName: (name: string) => {
+      currentView.setViewName(name)
     },
 
     stop: () => {
@@ -335,10 +333,7 @@ function newView(
       customTimings[sanitizeTiming(name)] = relativeTime
       scheduleViewUpdate()
     },
-    updateViewName(updatedName: string) {
-      if (!isExperimentalFeatureEnabled(ExperimentalFeature.UPDATE_VIEW_NAME)) {
-        return
-      }
+    setViewName(updatedName: string) {
       name = updatedName
       triggerViewUpdate()
     },

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -89,8 +89,7 @@ describe('API calls and events around init', () => {
         window.DD_RUM!.addError('after manual view')
         window.DD_RUM!.addAction('after manual view')
         window.DD_RUM!.addTiming('after manual view')
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(window.DD_RUM as any).setViewName('after manual view')
+        window.DD_RUM!.setViewName('after manual view')
       }, 40)
     })
     .run(async ({ intakeRegistry }) => {

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -67,7 +67,7 @@ describe('API calls and events around init', () => {
     })
 
   createTest('should be associated to corresponding views when views are manually tracked')
-    .withRum({ trackViewsManually: true, enableExperimentalFeatures: ['update_view_name'] })
+    .withRum({ trackViewsManually: true })
     .withRumSlim()
     .withRumInit((configuration) => {
       window.DD_RUM!.addError('before init')
@@ -90,7 +90,7 @@ describe('API calls and events around init', () => {
         window.DD_RUM!.addAction('after manual view')
         window.DD_RUM!.addTiming('after manual view')
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        ;(window.DD_RUM as any).updateViewName('after manual view')
+        ;(window.DD_RUM as any).setViewName('after manual view')
       }, 40)
     })
     .run(async ({ intakeRegistry }) => {


### PR DESCRIPTION
## Motivation
An "updateViewName" function has been introduced in [RUM-4819](https://github.com/DataDog/browser-sdk/pull/2808) 
This function has been dogfooded by RUM-apps, and was proven useful.

## Changes

Rename it to setViewName to match the newly introduced setViewContext / remove the experimental flag

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.


[RUM-4819]: https://datadoghq.atlassian.net/browse/RUM-4819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ