### PR TITLE
[Test CI] add privacy rule for autocomplete password value

### DIFF
--- a/packages/rum-core/src/domain/privacy.spec.ts
+++ b/packages/rum-core/src/domain/privacy.spec.ts
@@ -176,6 +176,11 @@ describe('getNodeSelfPrivacyLevel', () => {
       expected: NodePrivacyLevel.MASK,
     },
     {
+      msg: 'is an "input" element and has an autocomplete attribute ending with "-password" (forced override)',
+      html: '<input type="text" class="dd-privacy-allow" autocomplete="foo-password">',
+      expected: NodePrivacyLevel.MASK,
+    },
+    {
       msg: 'is an "input" element and has an autocomplete attribute not starting with "cc-"',
       html: '<input type="text" autocomplete="email">',
       expected: undefined,

--- a/packages/rum-core/src/domain/privacy.ts
+++ b/packages/rum-core/src/domain/privacy.ts
@@ -115,8 +115,11 @@ export function getNodeSelfPrivacyLevel(node: Node): NodePrivacyLevel | undefine
       return NodePrivacyLevel.MASK
     }
     const autocomplete = inputElement.getAttribute('autocomplete')
-    // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year]
-    if (autocomplete && autocomplete.indexOf('cc-') === 0) {
+      // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year/new-password/current-password]
+    if (autocomplete && (
+      autocomplete.startsWith('cc-') ||
+      autocomplete.endsWith('-password')
+    )) {
       return NodePrivacyLevel.MASK
     }
   }

--- a/packages/rum-core/src/domain/privacy.ts
+++ b/packages/rum-core/src/domain/privacy.ts
@@ -115,11 +115,8 @@ export function getNodeSelfPrivacyLevel(node: Node): NodePrivacyLevel | undefine
       return NodePrivacyLevel.MASK
     }
     const autocomplete = inputElement.getAttribute('autocomplete')
-      // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year/new-password/current-password]
-    if (autocomplete && (
-      autocomplete.startsWith('cc-') ||
-      autocomplete.endsWith('-password')
-    )) {
+    // Handle input[autocomplete=cc-number/cc-csc/cc-exp/cc-exp-month/cc-exp-year/new-password/current-password]
+    if (autocomplete && (autocomplete.startsWith('cc-') || autocomplete.endsWith('-password'))) {
       return NodePrivacyLevel.MASK
     }
   }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
