### PR TITLE
✨ - New feature: Set global tags in init configuration.

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -97,7 +97,10 @@ export interface InitConfiguration {
    * The application’s version, for example: 1.2.3, 6c44da20, and 2020.02.13. Follows the [tag syntax requirements](https://docs.datadoghq.com/getting_started/tagging/#define-tags).
    */
   version?: string | undefined | null
-
+  /**
+   * Tags to add to all events. Follows the [tag syntax requirements](https://docs.datadoghq.com/getting_started/tagging/#define-tags).
+   */
+  ddtags?: string[] | undefined
   // cookie options
   /**
    * Whether a secure cross-site session cookie is used

--- a/packages/core/src/domain/configuration/tags.ts
+++ b/packages/core/src/domain/configuration/tags.ts
@@ -4,7 +4,7 @@ import type { InitConfiguration } from './configuration'
 export const TAG_SIZE_LIMIT = 200
 
 export function buildTags(configuration: InitConfiguration): string[] {
-  const { env, service, version, datacenter } = configuration
+  const { env, service, version, datacenter,ddtags } = configuration
   const tags = []
 
   if (env) {
@@ -19,7 +19,14 @@ export function buildTags(configuration: InitConfiguration): string[] {
   if (datacenter) {
     tags.push(buildTag('datacenter', datacenter))
   }
-
+  if (ddtags) {
+    ddtags.forEach((tag) =>{
+        const [key, value] = tag.split(':');
+        if (key && value) {
+            tags.push(buildTag(key, value));
+        }
+    })
+  }
   return tags
 }
 


### PR DESCRIPTION
## Motivation

We have a complex distributed infrastructure segmented into many business and technical components. In the aim to better account for ownership of telemetry data we have a number of required tags that need to be present. This sdk was lacking a way to set global tags. setting attributes with the setGlobalContext in logging for example would not suffice for our business goals. 

## Changes
- Add `ddtags` as an optional string array parameter in the interface `InitConfiguration`.
- Add `ddtags` as an optional configuration parameter to `buildTags` function 
## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

Example test for NextJs

```
import { datadogLogs } from '@datadog/browser-logs';
...
  useEffect(() => {
    datadogLogs.init({
      clientToken: process.env.NEXT_PUBLIC_DD_CLIENT_TOKEN || '',
      site: 'datadoghq.com',
      forwardErrorsToLogs: true,
      sessionSampleRate: 100,
      env: process.env.NEXT_PUBLIC_DD_ENV || 'test',
      service: 'my-fancy-service',
      version: process.env.NEXT_PUBLIC_DD_VERSION || '0.0.1',
      forwardConsoleLogs: "all",
      ddtags: [
        'team:my_team',
        'org_id:007',
        'source:nextjs',
        'location_number:007'
      ],
    });
  }
...
```

- [X] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
