### PR TITLE
✨ [RUM-6956] Add action name source

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,6 +18,7 @@ export enum ExperimentalFeature {
   REMOTE_CONFIGURATION = 'remote_configuration',
   UPDATE_VIEW_NAME = 'update_view_name',
   LONG_ANIMATION_FRAME = 'long_animation_frame',
+  ACTION_NAME_MASKING = 'action_name_masking',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -1,6 +1,6 @@
 import type { Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
-import { Observable } from '@datadog/browser-core'
-import { createNewEvent } from '@datadog/browser-core/test'
+import { ExperimentalFeature, Observable } from '@datadog/browser-core'
+import { createNewEvent, mockExperimentalFeatures } from '@datadog/browser-core/test'
 import type { RawRumActionEvent, RawRumEventCollectedData } from '@datadog/browser-rum-core'
 import { collectAndValidateRawRumEvents, mockPageStateHistory, mockRumConfiguration } from '../../../test'
 import type { RawRumEvent } from '../../rawRumEvent.types'
@@ -28,7 +28,8 @@ describe('actionCollection', () => {
     rawRumEvents = collectAndValidateRawRumEvents(lifeCycle)
   })
 
-  it('should create action from auto action', () => {
+  it('should create action from auto action with name source', () => {
+    mockExperimentalFeatures([ExperimentalFeature.ACTION_NAME_MASKING])
     const event = createNewEvent('pointerup', { target: document.createElement('button') })
     lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, {
       counts: {
@@ -40,6 +41,7 @@ describe('actionCollection', () => {
       duration: 100 as Duration,
       id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       name: 'foo',
+      namingSource: 'text_content',
       startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
       type: ActionType.CLICK,
       event,
@@ -86,6 +88,7 @@ describe('actionCollection', () => {
             width: 1,
             height: 2,
           },
+          name_source: 'text_content',
           position: {
             x: 1,
             y: 2,
@@ -136,6 +139,7 @@ describe('actionCollection', () => {
       frustrationTypes: [],
       id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       name: 'foo',
+      namingSource: 'text_content',
       startClocks: { relative: 0 as RelativeTime, timeStamp: 0 as TimeStamp },
       type: ActionType.CLICK,
     })

--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -41,7 +41,7 @@ describe('actionCollection', () => {
       duration: 100 as Duration,
       id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       name: 'foo',
-      namingSource: 'text_content',
+      nameSource: 'text_content',
       startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
       type: ActionType.CLICK,
       event,
@@ -139,7 +139,7 @@ describe('actionCollection', () => {
       frustrationTypes: [],
       id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       name: 'foo',
-      namingSource: 'text_content',
+      nameSource: 'text_content',
       startClocks: { relative: 0 as RelativeTime, timeStamp: 0 as TimeStamp },
       type: ActionType.CLICK,
     })

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -92,7 +92,7 @@ function processAction(
             target: action.target,
             position: action.position,
             name_source: isExperimentalFeatureEnabled(ExperimentalFeature.ACTION_NAME_MASKING)
-              ? action.namingSource
+              ? action.nameSource
               : undefined,
           },
         },

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -1,5 +1,13 @@
 import type { ClocksState, Context, Observable } from '@datadog/browser-core'
-import { noop, assign, combine, toServerDuration, generateUUID } from '@datadog/browser-core'
+import {
+  noop,
+  assign,
+  combine,
+  toServerDuration,
+  generateUUID,
+  ExperimentalFeature,
+  isExperimentalFeatureEnabled,
+} from '@datadog/browser-core'
 
 import { discardNegativeDuration } from '../discardNegativeDuration'
 import type { RawRumActionEvent } from '../../rawRumEvent.types'
@@ -83,6 +91,9 @@ function processAction(
           action: {
             target: action.target,
             position: action.position,
+            name_source: isExperimentalFeatureEnabled(ExperimentalFeature.ACTION_NAME_MASKING)
+              ? action.namingSource
+              : undefined,
           },
         },
       }

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -6,76 +6,76 @@ const defaultConfiguration = mockRumConfiguration()
 
 describe('getActionNameFromElement', () => {
   it('extracts the textual content of an element', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<div>Foo <div>bar</div></div>'),
       defaultConfiguration
     )
     expect(name).toBe('Foo bar')
-    expect(namingSource).toBe('text_content')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts the text of an input button', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<input type="button" value="Click" />'),
       defaultConfiguration
     )
     expect(name).toBe('Click')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts the alt text of an image', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<img title="foo" alt="bar" />'),
       defaultConfiguration
     )
     expect(name).toBe('bar')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('standard_attribute')
   })
 
   it('extracts the title text of an image', () => {
-    const { name, namingSource } = getActionNameFromElement(appendElement('<img title="foo" />'), defaultConfiguration)
+    const { name, nameSource } = getActionNameFromElement(appendElement('<img title="foo" />'), defaultConfiguration)
     expect(name).toBe('foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('standard_attribute')
   })
 
   it('extracts the text of an aria-label attribute', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<span aria-label="Foo" />'),
       defaultConfiguration
     )
     expect(name).toBe('Foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('standard_attribute')
   })
 
   it('gets the parent element textual content if everything else fails', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<div>Foo <img target /></div>'),
       defaultConfiguration
     )
     expect(name).toBe('Foo')
-    expect(namingSource).toBe('text_content')
+    expect(nameSource).toBe('text_content')
   })
 
   it("doesn't get the value of a text input", () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<input type="text" value="foo" />'),
       defaultConfiguration
     )
     expect(name).toBe('')
-    expect(namingSource).toBe('blank_placeholder')
+    expect(nameSource).toBe('blank')
   })
 
   it("doesn't get the value of a password input", () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<input type="password" value="foo" />'),
       defaultConfiguration
     )
     expect(name).toBe('')
-    expect(namingSource).toBe('blank_placeholder')
+    expect(nameSource).toBe('blank')
   })
 
-  it('limits the { name, namingSource } length to a reasonable size', () => {
-    const { name, namingSource } = getActionNameFromElement(
+  it('limits the { name, nameSource } length to a reasonable size', () => {
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(
         '<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>'
       ),
@@ -84,38 +84,38 @@ describe('getActionNameFromElement', () => {
     expect(name).toBe(
       'Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]'
     )
-    expect(namingSource).toBe('text_content')
+    expect(nameSource).toBe('text_content')
   })
 
   it('normalize white spaces', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<div>foo\tbar\n\n  baz</div>'),
       defaultConfiguration
     )
     expect(name).toBe('foo bar baz')
-    expect(namingSource).toBe('text_content')
+    expect(nameSource).toBe('text_content')
   })
 
   it('ignores the inline script textual content', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement("<div><script>console.log('toto')</script>b</div>"),
       defaultConfiguration
     )
     expect(name).toBe('b')
-    expect(namingSource).toBe('text_content')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from SVG elements', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement('<svg><text>foo  bar</text></svg>'),
       defaultConfiguration
     )
     expect(name).toBe('foo bar')
-    expect(namingSource).toBe('text_content')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from an associated label', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <label for="toto">label text</label>
@@ -126,11 +126,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('label text')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from a parent label', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <label>
         foo
@@ -143,11 +143,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo bar')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from the first OPTION element when clicking on a SELECT', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <select>
         <option>foo</option>
@@ -157,11 +157,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from a aria-labelledby associated element', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <label id="toto">label text</label>
@@ -172,11 +172,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('label text')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from multiple aria-labelledby associated elements', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <label id="toto1">label</label>
@@ -189,11 +189,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('label text')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from a BUTTON element', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -203,11 +203,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('extracts text from a role=button element', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -217,11 +217,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('limits the recursion to the 10th parent', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -233,11 +233,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
-    expect(namingSource).toBe('blank_placeholder')
+    expect(nameSource).toBe('blank')
   })
 
   it('limits the recursion to the BODY element', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>ignored</div>
       <i target></i>
@@ -245,11 +245,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
-    expect(namingSource).toBe('blank_placeholder')
+    expect(nameSource).toBe('blank')
   })
 
   it('limits the recursion to a FORM element', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -261,11 +261,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
-    expect(namingSource).toBe('blank_placeholder')
+    expect(nameSource).toBe('blank')
   })
 
-  it('extracts the { name, namingSource } from a parent FORM element', () => {
-    const { name, namingSource } = getActionNameFromElement(
+  it('extracts the { name, nameSource } from a parent FORM element', () => {
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -277,11 +277,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('standard_attribute')
   })
 
   it('extracts the whole textual content of a button', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <button>
         foo
@@ -291,11 +291,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo bar')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   it('ignores the textual content of contenteditable elements', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div contenteditable>
         <i target>ignored</i>
@@ -305,11 +305,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
-    expect(namingSource).toBe('blank_placeholder')
+    expect(nameSource).toBe('blank')
   })
 
-  it('extracts the { name, namingSource } from attributes of contenteditable elements', () => {
-    const { name, namingSource } = getActionNameFromElement(
+  it('extracts the { name, nameSource } from attributes of contenteditable elements', () => {
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
       <div contenteditable>
         <i aria-label="foo" target>ignored</i>
@@ -319,11 +319,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('standard_attribute')
   })
 
   it('computes an action name on SVG elements (IE does not support parentElement property on them)', () => {
-    const { name, namingSource } = getActionNameFromElement(
+    const { name, nameSource } = getActionNameFromElement(
       appendElement(`
        <button>
         foo <svg target></svg>
@@ -332,23 +332,23 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
-    expect(namingSource).toBe('standard_attribute')
+    expect(nameSource).toBe('text_content')
   })
 
   describe('programmatically declared action name', () => {
     it('extracts the name from the data-dd-action-name attribute', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
         <div data-dd-action-name="foo">ignored</div>
       `),
         defaultConfiguration
       )
       expect(name).toBe('foo')
-      expect(namingSource).toBe('custom_attribute')
+      expect(nameSource).toBe('custom_attribute')
     })
 
     it('considers any parent', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
         <form data-dd-action-name="foo">
           <i><i><i><i><i><i><i><i><i><i><i><i>
@@ -359,22 +359,22 @@ describe('getActionNameFromElement', () => {
         defaultConfiguration
       )
       expect(name).toBe('foo')
-      expect(namingSource).toBe('custom_attribute')
+      expect(nameSource).toBe('custom_attribute')
     })
 
     it('normalizes the value', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
         <div data-dd-action-name="   foo  \t bar  ">ignored</div>
       `),
         defaultConfiguration
       )
       expect(name).toBe('foo bar')
-      expect(namingSource).toBe('custom_attribute')
+      expect(nameSource).toBe('custom_attribute')
     })
 
     it('fallback on an automatic strategy if the attribute is empty', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
         <div data-dd-action-name="ignored">
           <div data-dd-action-name="">
@@ -385,11 +385,11 @@ describe('getActionNameFromElement', () => {
         defaultConfiguration
       )
       expect(name).toBe('foo')
-      expect(namingSource).toBe('text_content')
+      expect(nameSource).toBe('text_content')
     })
 
     it('extracts the name from a user-configured attribute', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
         <div data-test-id="foo">ignored</div>
       `),
@@ -400,11 +400,11 @@ describe('getActionNameFromElement', () => {
         undefined
       )
       expect(name).toBe('foo')
-      expect(namingSource).toBe('custom_attribute')
+      expect(nameSource).toBe('custom_attribute')
     })
 
     it('favors data-dd-action-name over user-configured attribute', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
         <div data-test-id="foo" data-dd-action-name="bar">ignored</div>
       `),
@@ -415,21 +415,21 @@ describe('getActionNameFromElement', () => {
         undefined
       )
       expect(name).toBe('bar')
-      expect(namingSource).toBe('custom_attribute')
+      expect(nameSource).toBe('custom_attribute')
     })
 
     it('remove children with programmatic action name in textual content', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement('<div>Foo <div data-dd-action-name="custom action">bar<div></div>'),
         defaultConfiguration
       )
 
       expect(name).toBe('Foo')
-      expect(namingSource).toBe('text_content')
+      expect(nameSource).toBe('text_content')
     })
 
     it('remove children with programmatic action name in textual content based on the user-configured attribute', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement('<div>Foo <div data-test-id="custom action">bar<div></div>'),
         {
           ...defaultConfiguration,
@@ -438,13 +438,13 @@ describe('getActionNameFromElement', () => {
         undefined
       )
       expect(name).toBe('Foo')
-      expect(namingSource).toBe('text_content')
+      expect(nameSource).toBe('text_content')
     })
   })
 
   describe('with privacyEnabledForActionName', () => {
     it('extracts attribute text when privacyEnabledActionName is false', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
           <div data-dd-action-name="foo">
             <span target>ignored</span>
@@ -454,11 +454,11 @@ describe('getActionNameFromElement', () => {
         NodePrivacyLevel.MASK
       )
       expect(name).toBe('foo')
-      expect(namingSource).toBe('custom_attribute')
+      expect(nameSource).toBe('custom_attribute')
     })
 
     it('extracts user defined attribute text when privacyEnabledActionName is false', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
           <div data-test-id="foo">
             <span target>ignored</span>
@@ -471,11 +471,11 @@ describe('getActionNameFromElement', () => {
         NodePrivacyLevel.MASK
       )
       expect(name).toBe('foo')
-      expect(namingSource).toBe('custom_attribute')
+      expect(nameSource).toBe('custom_attribute')
     })
 
     it('extracts inner text when privacyEnabledActionName is false and custom action name set to empty', () => {
-      const { name, namingSource } = getActionNameFromElement(
+      const { name, nameSource } = getActionNameFromElement(
         appendElement(`
           <div data-test-id="">
             <span target>foo</span>
@@ -488,7 +488,7 @@ describe('getActionNameFromElement', () => {
         NodePrivacyLevel.ALLOW
       )
       expect(name).toBe('foo')
-      expect(namingSource).toBe('text_content')
+      expect(nameSource).toBe('text_content')
     })
 
     it('returns placeholder when privacyEnabledActionName is true and custom action name set to empty', () => {
@@ -506,7 +506,7 @@ describe('getActionNameFromElement', () => {
           },
           NodePrivacyLevel.MASK
         )
-      ).toEqual({ name: 'Masked Element', namingSource: 'mask_placeholder' })
+      ).toEqual({ name: 'Masked Element', nameSource: 'mask_placeholder' })
     })
 
     it('extracts default attribute text when privacyEnabledActionName is true', () => {
@@ -520,7 +520,7 @@ describe('getActionNameFromElement', () => {
           defaultConfiguration,
           NodePrivacyLevel.ALLOW
         )
-      ).toEqual({ name: 'foo', namingSource: 'custom_attribute' })
+      ).toEqual({ name: 'foo', nameSource: 'custom_attribute' })
     })
 
     it('extracts user defined attribute text when privacyEnabledActionName is true', () => {
@@ -537,7 +537,7 @@ describe('getActionNameFromElement', () => {
           },
           NodePrivacyLevel.ALLOW
         )
-      ).toEqual({ name: 'foo', namingSource: 'custom_attribute' })
+      ).toEqual({ name: 'foo', nameSource: 'custom_attribute' })
     })
 
     describe('with html tag privacy override when privacyEnabledActionName is true', () => {
@@ -552,7 +552,7 @@ describe('getActionNameFromElement', () => {
             defaultConfiguration,
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'foo', namingSource: 'text_content' })
+        ).toEqual({ name: 'foo', nameSource: 'text_content' })
       })
 
       it('returns placeholder when privacy level is mask', () => {
@@ -569,7 +569,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.MASK
           )
-        ).toEqual({ name: 'Masked Element', namingSource: 'mask_placeholder' })
+        ).toEqual({ name: 'Masked Element', nameSource: 'mask_placeholder' })
       })
 
       it('inherit privacy level and does not fallback to masked child text', () => {
@@ -592,7 +592,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'foo', namingSource: 'text_content' })
+        ).toEqual({ name: 'foo', nameSource: 'text_content' })
       })
       it('fallback to children but not the masked one with mixed class name and attribute', () => {
         expect(
@@ -614,7 +614,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'bar foo', namingSource: 'text_content' })
+        ).toEqual({ name: 'bar foo', nameSource: 'text_content' })
       })
 
       it('inherit privacy level and does not fallback to masked child text with mixed classname and attribute', () => {
@@ -637,7 +637,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'foo', namingSource: 'text_content' })
+        ).toEqual({ name: 'foo', nameSource: 'text_content' })
       })
       it('fallback to children but not the masked one with class names', () => {
         expect(
@@ -659,7 +659,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'bar foo', namingSource: 'text_content' })
+        ).toEqual({ name: 'bar foo', nameSource: 'text_content' })
       })
     })
   })

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -1,6 +1,6 @@
 import { appendElement, mockRumConfiguration } from '../../../test'
 import { NodePrivacyLevel } from '../privacy'
-import { getActionNameFromElement } from './getActionNameFromElement'
+import { ActionNameSource, getActionNameFromElement } from './getActionNameFromElement'
 
 const defaultConfiguration = mockRumConfiguration()
 
@@ -506,7 +506,7 @@ describe('getActionNameFromElement', () => {
           },
           NodePrivacyLevel.MASK
         )
-      ).toEqual({ name: 'Masked Element', nameSource: 'mask_placeholder' })
+      ).toEqual({ name: 'Masked Element', nameSource: ActionNameSource.MASK_PLACEHOLDER })
     })
 
     it('extracts default attribute text when privacyEnabledActionName is true', () => {
@@ -520,7 +520,7 @@ describe('getActionNameFromElement', () => {
           defaultConfiguration,
           NodePrivacyLevel.ALLOW
         )
-      ).toEqual({ name: 'foo', nameSource: 'custom_attribute' })
+      ).toEqual({ name: 'foo', nameSource: ActionNameSource.CUSTOM_ATTRIBUTE })
     })
 
     it('extracts user defined attribute text when privacyEnabledActionName is true', () => {
@@ -537,7 +537,7 @@ describe('getActionNameFromElement', () => {
           },
           NodePrivacyLevel.ALLOW
         )
-      ).toEqual({ name: 'foo', nameSource: 'custom_attribute' })
+      ).toEqual({ name: 'foo', nameSource: ActionNameSource.CUSTOM_ATTRIBUTE })
     })
 
     describe('with html tag privacy override when privacyEnabledActionName is true', () => {
@@ -552,7 +552,7 @@ describe('getActionNameFromElement', () => {
             defaultConfiguration,
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'foo', nameSource: 'text_content' })
+        ).toEqual({ name: 'foo', nameSource: ActionNameSource.TEXT_CONTENT })
       })
 
       it('returns placeholder when privacy level is mask', () => {
@@ -569,7 +569,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.MASK
           )
-        ).toEqual({ name: 'Masked Element', nameSource: 'mask_placeholder' })
+        ).toEqual({ name: 'Masked Element', nameSource: ActionNameSource.MASK_PLACEHOLDER })
       })
 
       it('inherit privacy level and does not fallback to masked child text', () => {
@@ -592,7 +592,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'foo', nameSource: 'text_content' })
+        ).toEqual({ name: 'foo', nameSource: ActionNameSource.TEXT_CONTENT })
       })
       it('fallback to children but not the masked one with mixed class name and attribute', () => {
         expect(
@@ -614,7 +614,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'bar foo', nameSource: 'text_content' })
+        ).toEqual({ name: 'bar foo', nameSource: ActionNameSource.TEXT_CONTENT })
       })
 
       it('inherit privacy level and does not fallback to masked child text with mixed classname and attribute', () => {
@@ -637,7 +637,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'foo', nameSource: 'text_content' })
+        ).toEqual({ name: 'foo', nameSource: ActionNameSource.TEXT_CONTENT })
       })
       it('fallback to children but not the masked one with class names', () => {
         expect(
@@ -659,7 +659,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual({ name: 'bar foo', nameSource: 'text_content' })
+        ).toEqual({ name: 'bar foo', nameSource: ActionNameSource.TEXT_CONTENT })
       })
     })
   })

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.spec.ts
@@ -6,47 +6,76 @@ const defaultConfiguration = mockRumConfiguration()
 
 describe('getActionNameFromElement', () => {
   it('extracts the textual content of an element', () => {
-    const name = getActionNameFromElement(appendElement('<div>Foo <div>bar</div></div>'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<div>Foo <div>bar</div></div>'),
+      defaultConfiguration
+    )
     expect(name).toBe('Foo bar')
+    expect(namingSource).toBe('text_content')
   })
 
   it('extracts the text of an input button', () => {
-    const name = getActionNameFromElement(appendElement('<input type="button" value="Click" />'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<input type="button" value="Click" />'),
+      defaultConfiguration
+    )
     expect(name).toBe('Click')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts the alt text of an image', () => {
-    const name = getActionNameFromElement(appendElement('<img title="foo" alt="bar" />'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<img title="foo" alt="bar" />'),
+      defaultConfiguration
+    )
     expect(name).toBe('bar')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts the title text of an image', () => {
-    const name = getActionNameFromElement(appendElement('<img title="foo" />'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(appendElement('<img title="foo" />'), defaultConfiguration)
     expect(name).toBe('foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts the text of an aria-label attribute', () => {
-    const name = getActionNameFromElement(appendElement('<span aria-label="Foo" />'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<span aria-label="Foo" />'),
+      defaultConfiguration
+    )
     expect(name).toBe('Foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('gets the parent element textual content if everything else fails', () => {
-    const name = getActionNameFromElement(appendElement('<div>Foo <img target /></div>'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<div>Foo <img target /></div>'),
+      defaultConfiguration
+    )
     expect(name).toBe('Foo')
+    expect(namingSource).toBe('text_content')
   })
 
   it("doesn't get the value of a text input", () => {
-    const name = getActionNameFromElement(appendElement('<input type="text" value="foo" />'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<input type="text" value="foo" />'),
+      defaultConfiguration
+    )
     expect(name).toBe('')
+    expect(namingSource).toBe('blank_placeholder')
   })
 
   it("doesn't get the value of a password input", () => {
-    const name = getActionNameFromElement(appendElement('<input type="password" value="foo" />'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<input type="password" value="foo" />'),
+      defaultConfiguration
+    )
     expect(name).toBe('')
+    expect(namingSource).toBe('blank_placeholder')
   })
 
-  it('limits the name length to a reasonable size', () => {
-    const name = getActionNameFromElement(
+  it('limits the { name, namingSource } length to a reasonable size', () => {
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(
         '<div>Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz</div>'
       ),
@@ -55,28 +84,38 @@ describe('getActionNameFromElement', () => {
     expect(name).toBe(
       'Foooooooooooooooooo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [...]'
     )
+    expect(namingSource).toBe('text_content')
   })
 
   it('normalize white spaces', () => {
-    const name = getActionNameFromElement(appendElement('<div>foo\tbar\n\n  baz</div>'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<div>foo\tbar\n\n  baz</div>'),
+      defaultConfiguration
+    )
     expect(name).toBe('foo bar baz')
+    expect(namingSource).toBe('text_content')
   })
 
   it('ignores the inline script textual content', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement("<div><script>console.log('toto')</script>b</div>"),
       defaultConfiguration
     )
     expect(name).toBe('b')
+    expect(namingSource).toBe('text_content')
   })
 
   it('extracts text from SVG elements', () => {
-    const name = getActionNameFromElement(appendElement('<svg><text>foo  bar</text></svg>'), defaultConfiguration)
+    const { name, namingSource } = getActionNameFromElement(
+      appendElement('<svg><text>foo  bar</text></svg>'),
+      defaultConfiguration
+    )
     expect(name).toBe('foo bar')
+    expect(namingSource).toBe('text_content')
   })
 
   it('extracts text from an associated label', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <label for="toto">label text</label>
@@ -87,10 +126,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('label text')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts text from a parent label', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <label>
         foo
@@ -103,10 +143,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo bar')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts text from the first OPTION element when clicking on a SELECT', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <select>
         <option>foo</option>
@@ -116,10 +157,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts text from a aria-labelledby associated element', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <label id="toto">label text</label>
@@ -130,10 +172,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('label text')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts text from multiple aria-labelledby associated elements', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <label id="toto1">label</label>
@@ -146,10 +189,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('label text')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts text from a BUTTON element', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -159,10 +203,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts text from a role=button element', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -172,10 +217,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('limits the recursion to the 10th parent', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -187,10 +233,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
+    expect(namingSource).toBe('blank_placeholder')
   })
 
   it('limits the recursion to the BODY element', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>ignored</div>
       <i target></i>
@@ -198,10 +245,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
+    expect(namingSource).toBe('blank_placeholder')
   })
 
   it('limits the recursion to a FORM element', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -213,10 +261,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
+    expect(namingSource).toBe('blank_placeholder')
   })
 
-  it('extracts the name from a parent FORM element', () => {
-    const name = getActionNameFromElement(
+  it('extracts the { name, namingSource } from a parent FORM element', () => {
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div>
         <div>ignored</div>
@@ -228,10 +277,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('extracts the whole textual content of a button', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <button>
         foo
@@ -241,10 +291,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo bar')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('ignores the textual content of contenteditable elements', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div contenteditable>
         <i target>ignored</i>
@@ -254,10 +305,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('')
+    expect(namingSource).toBe('blank_placeholder')
   })
 
-  it('extracts the name from attributes of contenteditable elements', () => {
-    const name = getActionNameFromElement(
+  it('extracts the { name, namingSource } from attributes of contenteditable elements', () => {
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
       <div contenteditable>
         <i aria-label="foo" target>ignored</i>
@@ -267,10 +319,11 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   it('computes an action name on SVG elements (IE does not support parentElement property on them)', () => {
-    const name = getActionNameFromElement(
+    const { name, namingSource } = getActionNameFromElement(
       appendElement(`
        <button>
         foo <svg target></svg>
@@ -279,21 +332,23 @@ describe('getActionNameFromElement', () => {
       defaultConfiguration
     )
     expect(name).toBe('foo')
+    expect(namingSource).toBe('standard_attribute')
   })
 
   describe('programmatically declared action name', () => {
     it('extracts the name from the data-dd-action-name attribute', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
         <div data-dd-action-name="foo">ignored</div>
       `),
         defaultConfiguration
       )
       expect(name).toBe('foo')
+      expect(namingSource).toBe('custom_attribute')
     })
 
     it('considers any parent', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
         <form data-dd-action-name="foo">
           <i><i><i><i><i><i><i><i><i><i><i><i>
@@ -304,20 +359,22 @@ describe('getActionNameFromElement', () => {
         defaultConfiguration
       )
       expect(name).toBe('foo')
+      expect(namingSource).toBe('custom_attribute')
     })
 
     it('normalizes the value', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
         <div data-dd-action-name="   foo  \t bar  ">ignored</div>
       `),
         defaultConfiguration
       )
       expect(name).toBe('foo bar')
+      expect(namingSource).toBe('custom_attribute')
     })
 
     it('fallback on an automatic strategy if the attribute is empty', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
         <div data-dd-action-name="ignored">
           <div data-dd-action-name="">
@@ -328,10 +385,11 @@ describe('getActionNameFromElement', () => {
         defaultConfiguration
       )
       expect(name).toBe('foo')
+      expect(namingSource).toBe('text_content')
     })
 
     it('extracts the name from a user-configured attribute', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
         <div data-test-id="foo">ignored</div>
       `),
@@ -342,10 +400,11 @@ describe('getActionNameFromElement', () => {
         undefined
       )
       expect(name).toBe('foo')
+      expect(namingSource).toBe('custom_attribute')
     })
 
     it('favors data-dd-action-name over user-configured attribute', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
         <div data-test-id="foo" data-dd-action-name="bar">ignored</div>
       `),
@@ -356,19 +415,21 @@ describe('getActionNameFromElement', () => {
         undefined
       )
       expect(name).toBe('bar')
+      expect(namingSource).toBe('custom_attribute')
     })
 
     it('remove children with programmatic action name in textual content', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement('<div>Foo <div data-dd-action-name="custom action">bar<div></div>'),
         defaultConfiguration
       )
 
       expect(name).toBe('Foo')
+      expect(namingSource).toBe('text_content')
     })
 
     it('remove children with programmatic action name in textual content based on the user-configured attribute', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement('<div>Foo <div data-test-id="custom action">bar<div></div>'),
         {
           ...defaultConfiguration,
@@ -377,12 +438,13 @@ describe('getActionNameFromElement', () => {
         undefined
       )
       expect(name).toBe('Foo')
+      expect(namingSource).toBe('text_content')
     })
   })
 
   describe('with privacyEnabledForActionName', () => {
     it('extracts attribute text when privacyEnabledActionName is false', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
           <div data-dd-action-name="foo">
             <span target>ignored</span>
@@ -392,10 +454,11 @@ describe('getActionNameFromElement', () => {
         NodePrivacyLevel.MASK
       )
       expect(name).toBe('foo')
+      expect(namingSource).toBe('custom_attribute')
     })
 
     it('extracts user defined attribute text when privacyEnabledActionName is false', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
           <div data-test-id="foo">
             <span target>ignored</span>
@@ -408,10 +471,11 @@ describe('getActionNameFromElement', () => {
         NodePrivacyLevel.MASK
       )
       expect(name).toBe('foo')
+      expect(namingSource).toBe('custom_attribute')
     })
 
     it('extracts inner text when privacyEnabledActionName is false and custom action name set to empty', () => {
-      const name = getActionNameFromElement(
+      const { name, namingSource } = getActionNameFromElement(
         appendElement(`
           <div data-test-id="">
             <span target>foo</span>
@@ -424,6 +488,7 @@ describe('getActionNameFromElement', () => {
         NodePrivacyLevel.ALLOW
       )
       expect(name).toBe('foo')
+      expect(namingSource).toBe('text_content')
     })
 
     it('returns placeholder when privacyEnabledActionName is true and custom action name set to empty', () => {
@@ -441,7 +506,7 @@ describe('getActionNameFromElement', () => {
           },
           NodePrivacyLevel.MASK
         )
-      ).toEqual('Masked Element')
+      ).toEqual({ name: 'Masked Element', namingSource: 'mask_placeholder' })
     })
 
     it('extracts default attribute text when privacyEnabledActionName is true', () => {
@@ -455,7 +520,7 @@ describe('getActionNameFromElement', () => {
           defaultConfiguration,
           NodePrivacyLevel.ALLOW
         )
-      ).toEqual('foo')
+      ).toEqual({ name: 'foo', namingSource: 'custom_attribute' })
     })
 
     it('extracts user defined attribute text when privacyEnabledActionName is true', () => {
@@ -472,7 +537,7 @@ describe('getActionNameFromElement', () => {
           },
           NodePrivacyLevel.ALLOW
         )
-      ).toEqual('foo')
+      ).toEqual({ name: 'foo', namingSource: 'custom_attribute' })
     })
 
     describe('with html tag privacy override when privacyEnabledActionName is true', () => {
@@ -487,7 +552,7 @@ describe('getActionNameFromElement', () => {
             defaultConfiguration,
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual('foo')
+        ).toEqual({ name: 'foo', namingSource: 'text_content' })
       })
 
       it('returns placeholder when privacy level is mask', () => {
@@ -504,7 +569,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.MASK
           )
-        ).toEqual('Masked Element')
+        ).toEqual({ name: 'Masked Element', namingSource: 'mask_placeholder' })
       })
 
       it('inherit privacy level and does not fallback to masked child text', () => {
@@ -527,7 +592,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual('foo')
+        ).toEqual({ name: 'foo', namingSource: 'text_content' })
       })
       it('fallback to children but not the masked one with mixed class name and attribute', () => {
         expect(
@@ -549,7 +614,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual('bar foo')
+        ).toEqual({ name: 'bar foo', namingSource: 'text_content' })
       })
 
       it('inherit privacy level and does not fallback to masked child text with mixed classname and attribute', () => {
@@ -572,7 +637,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual('foo')
+        ).toEqual({ name: 'foo', namingSource: 'text_content' })
       })
       it('fallback to children but not the masked one with class names', () => {
         expect(
@@ -594,7 +659,7 @@ describe('getActionNameFromElement', () => {
             },
             NodePrivacyLevel.ALLOW
           )
-        ).toEqual('bar foo')
+        ).toEqual({ name: 'bar foo', namingSource: 'text_content' })
       })
     })
   })

--- a/packages/rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.spec.ts
@@ -114,6 +114,7 @@ describe('trackClickActions', () => {
         duration: BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY as Duration,
         id: jasmine.any(String),
         name: 'Click me',
+        namingSource: 'standard_attribute',
         startClocks: {
           relative: addDuration(pointerDownClocks.relative, EMULATED_CLICK_DURATION),
           timeStamp: addDuration(pointerDownClocks.timeStamp, EMULATED_CLICK_DURATION),

--- a/packages/rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.spec.ts
@@ -114,7 +114,7 @@ describe('trackClickActions', () => {
         duration: BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY as Duration,
         id: jasmine.any(String),
         name: 'Click me',
-        namingSource: 'standard_attribute',
+        nameSource: 'text_content',
         startClocks: {
           relative: addDuration(pointerDownClocks.relative, EMULATED_CLICK_DURATION),
           timeStamp: addDuration(pointerDownClocks.timeStamp, EMULATED_CLICK_DURATION),

--- a/packages/rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.ts
@@ -38,6 +38,7 @@ export interface ClickAction {
   type: ActionType.CLICK
   id: string
   name: string
+  namingSource: string
   target?: {
     selector: string | undefined
     width: number
@@ -219,7 +220,7 @@ function startClickAction(
   })
 }
 
-type ClickActionBase = Pick<ClickAction, 'type' | 'name' | 'target' | 'position'>
+type ClickActionBase = Pick<ClickAction, 'type' | 'name' | 'namingSource' | 'target' | 'position'>
 
 function computeClickActionBase(
   event: MouseEventOnElement,
@@ -231,6 +232,7 @@ function computeClickActionBase(
   if (selector) {
     updateInteractionSelector(event.timeStamp, selector)
   }
+  const actionName = getActionNameFromElement(event.target, configuration, nodePrivacyLevel)
 
   return {
     type: ActionType.CLICK,
@@ -244,7 +246,8 @@ function computeClickActionBase(
       x: Math.round(event.clientX - rect.left),
       y: Math.round(event.clientY - rect.top),
     },
-    name: getActionNameFromElement(event.target, configuration, nodePrivacyLevel),
+    name: actionName.name,
+    namingSource: actionName.namingSource,
   }
 }
 

--- a/packages/rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.ts
@@ -38,7 +38,7 @@ export interface ClickAction {
   type: ActionType.CLICK
   id: string
   name: string
-  namingSource: string
+  nameSource: string
   target?: {
     selector: string | undefined
     width: number
@@ -220,7 +220,7 @@ function startClickAction(
   })
 }
 
-type ClickActionBase = Pick<ClickAction, 'type' | 'name' | 'namingSource' | 'target' | 'position'>
+type ClickActionBase = Pick<ClickAction, 'type' | 'name' | 'nameSource' | 'target' | 'position'>
 
 function computeClickActionBase(
   event: MouseEventOnElement,
@@ -247,7 +247,7 @@ function computeClickActionBase(
       y: Math.round(event.clientY - rect.top),
     },
     name: actionName.name,
-    namingSource: actionName.namingSource,
+    nameSource: actionName.nameSource,
   }
 }
 

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -250,6 +250,7 @@ export interface RawRumActionEvent {
         width?: number
         height?: number
       }
+      name_source?: string
       position?: {
         x: number
         y: number

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -49,7 +49,7 @@ describe('action collection', () => {
                 width: jasmine.any(Number),
                 height: jasmine.any(Number),
               }),
-              name_source: 'standard_attribute',
+              name_source: 'text_content',
               position: {
                 x: jasmine.any(Number),
                 y: jasmine.any(Number),

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -3,7 +3,7 @@ import { createTest, flushEvents, html, waitForServersIdle } from '../../lib/fra
 
 describe('action collection', () => {
   createTest('track a click action')
-    .withRum({ trackUserInteractions: true })
+    .withRum({ trackUserInteractions: true, enableExperimentalFeatures: ['action_name_masking'] })
     .withBody(html`
       <button>click me</button>
       <script>
@@ -49,6 +49,7 @@ describe('action collection', () => {
                 width: jasmine.any(Number),
                 height: jasmine.any(Number),
               }),
+              name_source: 'standard_attribute',
               position: {
                 x: jasmine.any(Number),
                 y: jasmine.any(Number),


### PR DESCRIPTION
## Motivation
We want to add a field to indicate from which source the action names are generated.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Add a `name_source` field in `@_dd.action` object
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
