### PR TITLE
[RUM-6801] Collect resource worker processing time

### DIFF
--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -46,6 +46,7 @@ export interface RumPerformanceResourceTiming {
   startTime: RelativeTime
   duration: Duration
   fetchStart: RelativeTime
+  workerStart: RelativeTime
   domainLookupStart: RelativeTime
   domainLookupEnd: RelativeTime
   connectStart: RelativeTime

--- a/packages/rum-core/src/browser/performanceUtils.spec.ts
+++ b/packages/rum-core/src/browser/performanceUtils.spec.ts
@@ -21,6 +21,7 @@ describe('getNavigationEntry', () => {
       duration: jasmine.any(Number),
 
       fetchStart: jasmine.any(Number),
+      workerStart: jasmine.any(Number),
       domainLookupStart: jasmine.any(Number),
       domainLookupEnd: jasmine.any(Number),
       connectStart: jasmine.any(Number),

--- a/packages/rum-core/src/browser/performanceUtils.ts
+++ b/packages/rum-core/src/browser/performanceUtils.ts
@@ -27,6 +27,7 @@ export function getNavigationEntry(): RumPerformanceNavigationTiming {
       decodedBodySize: 0,
       encodedBodySize: 0,
       transferSize: 0,
+      workerStart: 0 as RelativeTime,
       toJSON: () => assign({}, entry, { toJSON: undefined }),
     },
     timings

--- a/packages/rum-core/src/domain/resource/matchRequestResourceEntry.spec.ts
+++ b/packages/rum-core/src/domain/resource/matchRequestResourceEntry.spec.ts
@@ -148,6 +148,7 @@ describe('matchRequestResourceEntry', () => {
       name: FAKE_URL,
       // fetchStart < startTime is invalid
       fetchStart: 0 as RelativeTime,
+      workerStart: 0 as RelativeTime,
       startTime: 200 as RelativeTime,
     })
     globalPerformanceObjectMock.addPerformanceEntry(entry)

--- a/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
@@ -105,6 +105,23 @@ describe('computeResourceEntryDetails', () => {
     })
   })
 
+  it('should compute worker timing when workerStart < fetchStart', () => {
+    const resourceTiming = generateResourceWith({
+      workerStart: 11 as RelativeTime,
+      fetchStart: 12 as RelativeTime,
+    })
+    const details = computeResourceEntryDetails(resourceTiming)
+    expect(details).toEqual({
+      worker: { start: 1e6 as ServerDuration, duration: 1e6 as ServerDuration },
+      connect: { start: 5e6 as ServerDuration, duration: 2e6 as ServerDuration },
+      dns: { start: 3e6 as ServerDuration, duration: 1e6 as ServerDuration },
+      download: { start: 40e6 as ServerDuration, duration: 10e6 as ServerDuration },
+      first_byte: { start: 10e6 as ServerDuration, duration: 30e6 as ServerDuration },
+      redirect: { start: 0 as ServerDuration, duration: 1e6 as ServerDuration },
+      ssl: { start: 6e6 as ServerDuration, duration: 1e6 as ServerDuration },
+    })
+  })
+
   it('should not compute redirect timing when no redirect', () => {
     expect(
       computeResourceEntryDetails(

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -155,7 +155,7 @@ export function hasValidResourceEntryTimings(entry: RumPerformanceResourceTiming
   // it.
   const areCommonTimingsInOrder = areInOrder(
     entry.startTime,
-    entry.workerStart,
+    ...(entry.workerStart > 0 ? [entry.workerStart] : []),
     entry.fetchStart,
     entry.domainLookupStart,
     entry.domainLookupEnd,

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -169,6 +169,7 @@ export function hasValidResourceEntryTimings(entry: RumPerformanceResourceTiming
   const areRedirectionTimingsInOrder = hasRedirection(entry)
     ? areInOrder(entry.startTime, entry.redirectStart, entry.redirectEnd, entry.fetchStart)
     : true
+
   return areCommonTimingsInOrder && areRedirectionTimingsInOrder
 }
 

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -155,7 +155,6 @@ export function hasValidResourceEntryTimings(entry: RumPerformanceResourceTiming
   // it.
   const areCommonTimingsInOrder = areInOrder(
     entry.startTime,
-    ...(entry.workerStart > 0 ? [entry.workerStart] : []),
     entry.fetchStart,
     entry.domainLookupStart,
     entry.domainLookupEnd,

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -15,6 +15,7 @@ import type { RumPerformanceResourceTiming } from '../../browser/performanceObse
 import type { ResourceEntryDetailsElement } from '../../rawRumEvent.types'
 
 export interface ResourceEntryDetails {
+  worker?: ResourceEntryDetailsElement
   redirect?: ResourceEntryDetailsElement
   dns?: ResourceEntryDetailsElement
   connect?: ResourceEntryDetailsElement
@@ -91,6 +92,7 @@ export function computeResourceEntryDetails(entry: RumPerformanceResourceTiming)
   const {
     startTime,
     fetchStart,
+    workerStart,
     redirectStart,
     redirectEnd,
     domainLookupStart,
@@ -106,6 +108,11 @@ export function computeResourceEntryDetails(entry: RumPerformanceResourceTiming)
   const details: ResourceEntryDetails = {
     download: formatTiming(startTime, responseStart, responseEnd),
     first_byte: formatTiming(startTime, requestStart, responseStart),
+  }
+
+  // Make sure a worker processing time is recorded
+  if (workerStart < fetchStart) {
+    details.worker = formatTiming(startTime, workerStart, fetchStart)
   }
 
   // Make sure a connection occurred
@@ -149,6 +156,7 @@ export function hasValidResourceEntryTimings(entry: RumPerformanceResourceTiming
   const areCommonTimingsInOrder = areInOrder(
     entry.startTime,
     entry.fetchStart,
+    entry.workerStart,
     entry.domainLookupStart,
     entry.domainLookupEnd,
     entry.connectStart,

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -155,8 +155,8 @@ export function hasValidResourceEntryTimings(entry: RumPerformanceResourceTiming
   // it.
   const areCommonTimingsInOrder = areInOrder(
     entry.startTime,
-    entry.fetchStart,
     entry.workerStart,
+    entry.fetchStart,
     entry.domainLookupStart,
     entry.domainLookupEnd,
     entry.connectStart,
@@ -169,7 +169,6 @@ export function hasValidResourceEntryTimings(entry: RumPerformanceResourceTiming
   const areRedirectionTimingsInOrder = hasRedirection(entry)
     ? areInOrder(entry.startTime, entry.redirectStart, entry.redirectEnd, entry.fetchStart)
     : true
-
   return areCommonTimingsInOrder && areRedirectionTimingsInOrder
 }
 

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -42,6 +42,7 @@ export interface RawRumResourceEvent {
     decoded_body_size?: number
     transfer_size?: number
     render_blocking_status?: string
+    worker?: ResourceEntryDetailsElement
     redirect?: ResourceEntryDetailsElement
     dns?: ResourceEntryDetailsElement
     connect?: ResourceEntryDetailsElement

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -42,11 +42,11 @@ export interface RawRumResourceEvent {
     decoded_body_size?: number
     transfer_size?: number
     render_blocking_status?: string
-    worker?: ResourceEntryDetailsElement
     redirect?: ResourceEntryDetailsElement
     dns?: ResourceEntryDetailsElement
     connect?: ResourceEntryDetailsElement
     ssl?: ResourceEntryDetailsElement
+    worker?: ResourceEntryDetailsElement
     first_byte?: ResourceEntryDetailsElement
     download?: ResourceEntryDetailsElement
     protocol?: string

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -619,6 +619,20 @@ export type RumResourceEvent = CommonProperties &
        */
       readonly render_blocking_status?: 'blocking' | 'non-blocking'
       /**
+       * Worker phase properties
+       */
+      readonly worker?: {
+        /**
+         * Duration in nanoseconds of the resource worker phase
+         */
+        readonly duration: number
+        /**
+         * Duration in nanoseconds between start of the request and start of the worker phase
+         */
+        readonly start: number
+        [k: string]: unknown
+      }
+      /**
        * Redirect phase properties
        */
       readonly redirect?: {
@@ -803,6 +817,14 @@ export type RumViewEvent = CommonProperties &
        * Duration in ns to the view is considered loaded
        */
       readonly loading_time?: number
+      /**
+       * Duration in ns from the moment the view was started until all the initial network requests settled
+       */
+      readonly network_settled_time?: number
+      /**
+       * Duration in ns to from the last interaction on previous view to the moment the current view was displayed
+       */
+      readonly interaction_to_next_view_time?: number
       /**
        * Type of the loading of the view
        */

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -249,6 +249,7 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
           domainLookupStart: 200 as RelativeTime,
           duration: 100 as Duration,
           entryType: RumPerformanceEntryType.RESOURCE,
+          workerStart: 200 as RelativeTime,
           fetchStart: 200 as RelativeTime,
           name: 'https://resource.com/valid',
           redirectEnd: 200 as RelativeTime,


### PR DESCRIPTION
## Motivation

Resource performent entries have a workerStart property
Worker processing time is defined as workerProcessingTime = entry.fetchStart - entry.workerStart

## Changes

Similarly to @resource.connect etc. we could have @resource.worker where:

@resource.worker.start would be workerStart

@resource.worker.duration would be fetchStart - workerStart

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
