### PR TITLE
🐛 allow untrusted event for httpRequest xhr event listeners

### DIFF
--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -1,6 +1,6 @@
 import { collectAsyncCalls, mockEndpointBuilder, interceptRequests } from '../../test'
 import type { Request } from '../../test'
-import type { EndpointBuilder, Configuration } from '../domain/configuration'
+import type { EndpointBuilder } from '../domain/configuration'
 import { createEndpointBuilder } from '../domain/configuration'
 import { noop } from '../tools/utils/functionUtils'
 import { createHttpRequest, fetchKeepAliveStrategy, sendXHR } from './httpRequest'
@@ -13,14 +13,12 @@ describe('httpRequest', () => {
   let requests: Request[]
   let endpointBuilder: EndpointBuilder
   let request: HttpRequest
-  let configuration: Configuration
 
   beforeEach(() => {
-    configuration = {} as Configuration
     interceptor = interceptRequests()
     requests = interceptor.requests
     endpointBuilder = mockEndpointBuilder(ENDPOINT_URL)
-    request = createHttpRequest(configuration, endpointBuilder, BATCH_BYTES_LIMIT, noop)
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT, noop)
   })
 
   describe('send', () => {
@@ -105,7 +103,6 @@ describe('httpRequest', () => {
       interceptor.withFetch(() => Promise.resolve({ status: 429, type: 'cors' }))
 
       fetchKeepAliveStrategy(
-        configuration,
         endpointBuilder,
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 },
@@ -129,7 +126,6 @@ describe('httpRequest', () => {
       })
 
       fetchKeepAliveStrategy(
-        configuration,
         endpointBuilder,
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 },
@@ -148,7 +144,6 @@ describe('httpRequest', () => {
       })
 
       fetchKeepAliveStrategy(
-        configuration,
         endpointBuilder,
         BATCH_BYTES_LIMIT,
         { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: BATCH_BYTES_LIMIT },
@@ -177,7 +172,7 @@ describe('httpRequest', () => {
         })
       })
 
-      sendXHR(configuration, 'foo', '', onResponseSpy)
+      sendXHR('foo', '', onResponseSpy)
 
       setTimeout(() => {
         expect(onResponseSpy).toHaveBeenCalledTimes(1)
@@ -257,14 +252,12 @@ describe('httpRequest intake parameters', () => {
   let requests: Request[]
   let endpointBuilder: EndpointBuilder
   let request: HttpRequest
-  let configuration: Configuration
 
   beforeEach(() => {
-    configuration = {} as Configuration
     interceptor = interceptRequests()
     requests = interceptor.requests
     endpointBuilder = createEndpointBuilder({ clientToken }, 'logs', [])
-    request = createHttpRequest(configuration, endpointBuilder, BATCH_BYTES_LIMIT, noop)
+    request = createHttpRequest(endpointBuilder, BATCH_BYTES_LIMIT, noop)
   })
 
   it('should have a unique request id', () => {

--- a/packages/core/src/transport/startBatchWithReplica.ts
+++ b/packages/core/src/transport/startBatchWithReplica.ts
@@ -32,7 +32,7 @@ export function startBatchWithReplica<T extends Context>(
   function createBatchFromConfig(configuration: Configuration, { endpoint, encoder }: BatchConfiguration) {
     return batchFactoryImp({
       encoder,
-      request: createHttpRequest(configuration, endpoint, configuration.batchBytesLimit, reportError),
+      request: createHttpRequest(endpoint, configuration.batchBytesLimit, reportError),
       flushController: createFlushController({
         messagesLimit: configuration.batchMessagesLimit,
         bytesLimit: configuration.batchBytesLimit,

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -24,8 +24,7 @@ export function startRecording(
   }
 
   const replayRequest =
-    httpRequest ||
-    createHttpRequest(configuration, configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT, reportError)
+    httpRequest || createHttpRequest(configuration.sessionReplayEndpointBuilder, SEGMENT_BYTES_LIMIT, reportError)
 
   let addRecord: (record: BrowserRecord) => void
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Fixes an issue where a non native XMLHttpRequest override is dispatching synthetic events (i.e. non-trusted) result in the callback not being executed, and breaking session replay ingestion.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

allow untrusted event in that particular use-case. This is safe as we're not using any properties from the event.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
