### PR TITLE
[RUM-6560] Add @session.id in Logs events

### DIFF
--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -108,6 +108,9 @@ describe('logs', () => {
         message: 'message',
         service: 'service',
         session_id: jasmine.any(String),
+        session: {
+          id: jasmine.any(String),
+        },
         status: StatusType.warn,
         view: {
           referrer: 'common_referrer',

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -40,6 +40,7 @@ export function startLogsAssembly(
         {
           service: configuration.service,
           session_id: session ? session.id : undefined,
+          session: session ? { id: session.id } : undefined,
           // Insert user first to allow overrides from global context
           usr: !isEmptyObject(commonContext.user) ? commonContext.user : undefined,
           view: commonContext.view,

--- a/packages/logs/src/logsEvent.types.ts
+++ b/packages/logs/src/logsEvent.types.ts
@@ -24,9 +24,20 @@ export interface LogsEvent {
    */
   service?: string
   /**
-   * UUID of the session
+   * UUID of the session (deprecated in favor of session.id)
    */
   session_id?: string
+  /**
+   * Session properties
+   */
+  session?: {
+    /**
+     * UUID of the session
+     */
+    id?: string
+
+    [k: string]: unknown
+  }
   /**
    * View properties
    */


### PR DESCRIPTION
## Motivation

In Logs, we would like to migrate @session_id to @session.id like we did in RUM.

## Changes

As first step, adding session.id in Logs events and keep session_id.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
