### PR TITLE
✅ Fix test cleanup tasks order

### DIFF
--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -204,11 +204,10 @@ describe('instrumentSetter', () => {
 
   beforeEach(() => {
     clock = mockClock()
-    zoneJs = mockZoneJs()
-
     registerCleanupTask(() => {
       clock.cleanup()
     })
+    zoneJs = mockZoneJs()
   })
 
   it('replaces the original setter', () => {

--- a/packages/core/src/tools/timer.spec.ts
+++ b/packages/core/src/tools/timer.spec.ts
@@ -21,11 +21,11 @@ import { noop } from './utils/functionUtils'
 
     beforeEach(() => {
       clock = mockClock()
-      zoneJs = mockZoneJs()
       registerCleanupTask(() => {
         clock.cleanup()
         resetMonitor()
       })
+      zoneJs = mockZoneJs()
     })
 
     it('executes the callback asynchronously', () => {

--- a/packages/core/test/emulate/mockReportingObserver.ts
+++ b/packages/core/test/emulate/mockReportingObserver.ts
@@ -50,16 +50,8 @@ export function mockReportingObserver() {
 export type MockCspEventListener = ReturnType<typeof mockCspEventListener>
 
 export function mockCspEventListener() {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const originalAddEventListener = EventTarget.prototype.addEventListener
-  EventTarget.prototype.addEventListener = jasmine
-    .createSpy()
-    .and.callFake((_type: string, listener: EventListener) => {
-      listeners.push(listener)
-    })
-
-  registerCleanupTask(() => {
-    EventTarget.prototype.addEventListener = originalAddEventListener
+  spyOn(document, 'addEventListener').and.callFake((_type: string, listener: EventListener) => {
+    listeners.push(listener)
   })
 
   const listeners: EventListener[] = []

--- a/packages/core/test/emulate/mockReportingObserver.ts
+++ b/packages/core/test/emulate/mockReportingObserver.ts
@@ -50,8 +50,16 @@ export function mockReportingObserver() {
 export type MockCspEventListener = ReturnType<typeof mockCspEventListener>
 
 export function mockCspEventListener() {
-  spyOn(document, 'addEventListener').and.callFake((_type: string, listener: EventListener) => {
-    listeners.push(listener)
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalAddEventListener = EventTarget.prototype.addEventListener
+  EventTarget.prototype.addEventListener = jasmine
+    .createSpy()
+    .and.callFake((_type: string, listener: EventListener) => {
+      listeners.push(listener)
+    })
+
+  registerCleanupTask(() => {
+    EventTarget.prototype.addEventListener = originalAddEventListener
   })
 
   const listeners: EventListener[] = []

--- a/packages/core/test/registerCleanupTask.ts
+++ b/packages/core/test/registerCleanupTask.ts
@@ -1,7 +1,7 @@
 const cleanupTasks: Array<() => void> = []
 
 export function registerCleanupTask(task: () => void) {
-  cleanupTasks.push(task)
+  cleanupTasks.unshift(task)
 }
 
 afterEach(() => {

--- a/packages/rum-core/src/domain/error/trackReportError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackReportError.spec.ts
@@ -7,6 +7,7 @@ import {
   mockClock,
   mockCspEventListener,
   mockReportingObserver,
+  registerCleanupTask,
 } from '@datadog/browser-core/test'
 import { mockRumConfiguration } from '../../../test'
 import type { RumConfiguration } from '../configuration'
@@ -27,13 +28,12 @@ describe('trackReportError', () => {
     notifyLog = jasmine.createSpy('notifyLog')
     reportingObserver = mockReportingObserver()
     subscription = errorObservable.subscribe(notifyLog)
-    cspEventListener = mockCspEventListener()
     clock = mockClock()
-  })
-
-  afterEach(() => {
-    subscription.unsubscribe()
-    clock.cleanup()
+    registerCleanupTask(() => {
+      subscription.unsubscribe()
+      clock.cleanup()
+    })
+    cspEventListener = mockCspEventListener()
   })
 
   it('should track reports', () => {


### PR DESCRIPTION
## Motivation

We are transitionning from using `afterEach` to `registerCleanupTask` API to clean our tests. However with `registerCleanupTask`, tasks are executed in the wrong order:

<table>
<tr><th>afterEach</th><th>registerCleanupTask</th></tr>
<tr><td>

```ts
describe('Test', () => {
  beforeEach(() => { 
    console.log('instrument')
  })

  afterEach(() => { 
    console.log('clean instrumentation')
  })

  describe('Nested test', () => {
    beforeEach(() => {
      console.log('instrument 2')
    })

    afterEach(() => { 
      console.log('clean instrumentation 2')
    })
  })
})
```

</td><td>

```ts
describe('Test', () => {
  beforeEach(() => {
    console.log('instrument')
    registerCleanupTask(() => {
      console.log('clean instrumentation')
    })
  })

  describe('Nested test', () => {
    beforeEach(() => {
      console.log('instrument 2')
      registerCleanupTask(() => {
        console.log('clean instrumentation 2 ')
      })
    })
  })
})
```

</td></tr>
<tr><td>

```
LOG LOG: 'instrument'
LOG LOG: 'instrument 2'
LOG LOG: 'clean instrumentation 2'
LOG LOG: 'clean instrumentation'
```

</td><td>
Before

```
LOG LOG: 'instrument'
LOG LOG: 'instrument 2'
LOG LOG: 'clean instrumentation'
LOG LOG: 'clean instrumentation 2'
```

After

```
LOG LOG: 'instrument'
LOG LOG: 'instrument 2'
LOG LOG: 'clean instrumentation 2'
LOG LOG: 'clean instrumentation'
```
</td></tr>
</table>

## Changes

- Fix cleanup tasks order: <img width="1010" alt="image" src="https://github.com/user-attachments/assets/4462ec40-ecb5-4df7-8d95-c15a9bdac9b1">
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
- Fix tests

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
