### PR TITLE
⚗️🐛 [rum-react][RUM-6226] fix for empty splats

### DIFF
--- a/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.spec.ts
+++ b/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.spec.ts
@@ -70,9 +70,11 @@ describe('computeViewName', () => {
 
       // Splats
       ['*',                   '/foo/1',       '/foo/1'],
+      ['*',                   '/',            '/'],
       ['/foo/*',              '/foo/1',       '/foo/1'],
       ['/foo > *',            '/foo/1',       '/foo/1'],
       ['* > *',               '/foo/1',       '/foo/1'],
+      ['* > *',               '/',            '/'],
       ['/foo/* > *',          '/foo/1',       '/foo/1'],
       ['* > foo/*',           '/foo/1',       '/foo/1'],
       ['/foo/* > bar/*',      '/foo/bar/1',   '/foo/bar/1'],

--- a/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.ts
+++ b/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.ts
@@ -58,7 +58,7 @@ function substitutePathSplats(path: string, params: Record<string, string | unde
     !path.includes('*') ||
     // In some edge cases, react-router does not provide the `*` parameter, so we don't know what to
     // replace it with. In this case, we keep the asterisk.
-    !params['*']
+    params['*'] === undefined
   ) {
     return path
   }


### PR DESCRIPTION
## Motivation

When the react router route `/*` is matched with the `/` (root) path, the produced view name is `/*` instead of the expected `/`.

## Changes


When matching the route `/*` with the path `/`, the `*` param is an empty string (obviously). In that case, we shouldn't consider the `*` as missing and proceed with replacing the star.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
