### PR TITLE
🐛 [RUM-87] AddError should support Error instances coming from other JS contexts

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -1,4 +1,4 @@
-import { flattenErrorCauses, tryToGetFingerprint } from '../error/error'
+import { flattenErrorCauses, isError, tryToGetFingerprint } from '../error/error'
 import { mergeObservables, Observable } from '../../tools/observable'
 import { ConsoleApiName, globalConsole } from '../../tools/display'
 import { callMonitored } from '../../tools/monitor'
@@ -74,7 +74,7 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
   let error: RawError | undefined
 
   if (api === ConsoleApiName.error) {
-    const firstErrorParam = find(params, (param: unknown): param is Error => param instanceof Error)
+    const firstErrorParam = find(params, (param: unknown): param is Error => isError(param))
 
     error = {
       stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,
@@ -100,7 +100,7 @@ function formatConsoleParameters(param: unknown) {
   if (typeof param === 'string') {
     return sanitize(param)
   }
-  if (param instanceof Error) {
+  if (isError(param)) {
     return formatErrorMessage(computeStackTrace(param))
   }
   return jsonStringify(sanitize(param), undefined, 2)

--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -74,7 +74,7 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
   let error: RawError | undefined
 
   if (api === ConsoleApiName.error) {
-    const firstErrorParam = find(params, (param: unknown): param is Error => isError(param))
+    const firstErrorParam = find(params, isError)
 
     error = {
       stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,

--- a/packages/core/src/domain/error/error.spec.ts
+++ b/packages/core/src/domain/error/error.spec.ts
@@ -1,9 +1,9 @@
 import { clocksNow } from '../../tools/utils/timeUtils'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
+import { registerCleanupTask } from '../../../test'
 import { computeRawError, getFileFromStackTraceString, flattenErrorCauses, isError } from './error'
 import type { RawErrorCause, ErrorWithCause } from './error.types'
 import { ErrorHandling, ErrorSource, NonErrorPrefix } from './error.types'
-import { registerCleanupTask } from '../../../test'
 
 describe('computeRawError', () => {
   const ERROR_INSTANCE = new TypeError('oh snap!')

--- a/packages/core/src/domain/error/error.spec.ts
+++ b/packages/core/src/domain/error/error.spec.ts
@@ -1,8 +1,9 @@
 import { clocksNow } from '../../tools/utils/timeUtils'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
-import { computeRawError, getFileFromStackTraceString, flattenErrorCauses } from './error'
+import { computeRawError, getFileFromStackTraceString, flattenErrorCauses, isError } from './error'
 import type { RawErrorCause, ErrorWithCause } from './error.types'
 import { ErrorHandling, ErrorSource, NonErrorPrefix } from './error.types'
+import { registerCleanupTask } from '../../../test'
 
 describe('computeRawError', () => {
   const ERROR_INSTANCE = new TypeError('oh snap!')
@@ -298,5 +299,17 @@ describe('flattenErrorCauses', () => {
     error.cause = error
     const errorCauses = flattenErrorCauses(error, ErrorSource.LOGGER)
     expect(errorCauses?.length).toEqual(10)
+  })
+})
+
+describe('isError', () => {
+  it('should correctly identify an error object from a different window context', () => {
+    const iframe = document.createElement('iframe')
+    document.body.appendChild(iframe)
+    registerCleanupTask(() => document.body.removeChild(iframe))
+
+    const iframeWindow = iframe.contentWindow as Window & { Error: ErrorConstructor }
+
+    expect(isError(new iframeWindow.Error())).toBe(true)
   })
 })

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -28,7 +28,7 @@ export function computeRawError({
   source,
   handling,
 }: RawErrorParams): RawError {
-  const isErrorInstance = originalError instanceof Error
+  const isErrorInstance = isError(originalError)
 
   const message = computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError)
   const stack = hasUsableStack(isErrorInstance, stackTrace)
@@ -80,19 +80,21 @@ function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stac
 }
 
 export function tryToGetFingerprint(originalError: unknown) {
-  return originalError instanceof Error && 'dd_fingerprint' in originalError
-    ? String(originalError.dd_fingerprint)
-    : undefined
+  return isError(originalError) && 'dd_fingerprint' in originalError ? String(originalError.dd_fingerprint) : undefined
 }
 
 export function getFileFromStackTraceString(stack: string) {
   return /@ (.+)/.exec(stack)?.[1]
 }
 
+export function isError(error: unknown): error is Error {
+  return Object.prototype.toString.call(error) === '[object Error]'
+}
+
 export function flattenErrorCauses(error: ErrorWithCause, parentSource: ErrorSource): RawErrorCause[] | undefined {
   let currentError = error
   const causes: RawErrorCause[] = []
-  while (currentError?.cause instanceof Error && causes.length < 10) {
+  while (isError(currentError?.cause) && causes.length < 10) {
     const stackTrace = computeStackTrace(currentError.cause)
     causes.push({
       message: currentError.cause.message,

--- a/packages/core/src/domain/error/trackRuntimeError.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.ts
@@ -3,7 +3,7 @@ import type { Observable } from '../../tools/observable'
 import { clocksNow } from '../../tools/utils/timeUtils'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
 import { computeStackTrace, computeStackTraceFromOnErrorMessage } from '../../tools/stackTrace/computeStackTrace'
-import { computeRawError } from './error'
+import { computeRawError, isError } from './error'
 import type { RawError } from './error.types'
 import { ErrorHandling, ErrorSource, NonErrorPrefix } from './error.types'
 
@@ -35,7 +35,7 @@ export function trackRuntimeError(errorObservable: Observable<RawError>) {
 export function instrumentOnError(callback: UnhandledErrorCallback) {
   return instrumentMethod(window, 'onerror', ({ parameters: [messageObj, url, line, column, errorObj] }) => {
     let stackTrace
-    if (errorObj instanceof Error) {
+    if (isError(errorObj)) {
       stackTrace = computeStackTrace(errorObj)
     } else {
       stackTrace = computeStackTraceFromOnErrorMessage(messageObj, url, line, column)

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../../tools/serialisation/context'
 import { ConsoleApiName } from '../../tools/display'
-import { NO_ERROR_STACK_PRESENT_MESSAGE } from '../error/error'
+import { NO_ERROR_STACK_PRESENT_MESSAGE, isError } from '../error/error'
 import { toStackTraceString } from '../../tools/stackTrace/handlingStack'
 import { getExperimentalFeatures } from '../../tools/experimentalFeatures'
 import type { Configuration } from '../configuration'
@@ -202,7 +202,7 @@ export function addTelemetryUsage(usage: RawTelemetryUsage) {
 }
 
 export function formatError(e: unknown) {
-  if (e instanceof Error) {
+  if (isError(e)) {
     const stackTrace = computeStackTrace(e)
     return {
       error: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,7 +85,12 @@ export { sendToExtension } from './tools/sendToExtension'
 export { runOnReadyState } from './browser/runOnReadyState'
 export { getZoneJsOriginalValue } from './tools/getZoneJsOriginalValue'
 export { instrumentMethod, instrumentSetter, InstrumentedMethodCall } from './tools/instrumentMethod'
-export { computeRawError, getFileFromStackTraceString, NO_ERROR_STACK_PRESENT_MESSAGE } from './domain/error/error'
+export {
+  computeRawError,
+  getFileFromStackTraceString,
+  isError,
+  NO_ERROR_STACK_PRESENT_MESSAGE,
+} from './domain/error/error'
 export { NonErrorPrefix } from './domain/error/error.types'
 export { Context, ContextArray, ContextValue } from './tools/serialisation/context'
 export {

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -249,6 +249,47 @@ describe('Logger', () => {
     })
   })
 
+  describe('error handling in logImplementation', () => {
+    it('should compute stackTrace when error is an instance of Error', () => {
+      const error = new Error('Test error')
+      logger.log('Test message', undefined, StatusType.error, error)
+
+      const loggedError = getLoggedMessage(0).context?.error
+
+      expect(loggedError).toEqual({
+        message: 'Test error',
+        stack: jasmine.stringMatching(/^Error: Test error/),
+        kind: 'Error',
+        causes: undefined,
+        handling: ErrorHandling.HANDLED,
+        fingerprint: undefined,
+      })
+    })
+
+    it('should not compute stackTrace when error is not an instance of Error', () => {
+      const nonErrorObject = { message: 'Not an Error instance', stack: 'Fake stack trace' }
+      logger.log('Test message', undefined, StatusType.error, nonErrorObject as any)
+
+      const loggedError = getLoggedMessage(0).context?.error
+
+      expect(loggedError).toEqual({
+        message: 'Provided {"message":"Not an Error instance","stack":"Fake stack trace"}',
+        stack: NO_ERROR_STACK_PRESENT_MESSAGE,
+        kind: undefined,
+        causes: undefined,
+        handling: ErrorHandling.HANDLED,
+        fingerprint: undefined,
+      })
+    })
+
+    it('should not include error context when error is undefined', () => {
+      logger.log('Test message', undefined, StatusType.error, undefined)
+
+      const loggedMessage = getLoggedMessage(0)
+      expect(loggedMessage.context).toBeUndefined()
+    })
+  })
+
   describe('handler type', () => {
     it('should be "http" by default', () => {
       logger.debug('message')

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -11,6 +11,7 @@ import {
   sanitize,
   NonErrorPrefix,
   createHandlingStack,
+  isError,
 } from '@datadog/browser-core'
 
 import { isAuthorized, StatusType } from './logger/isAuthorized'
@@ -64,7 +65,7 @@ export class Logger {
 
     if (error !== undefined && error !== null) {
       const rawError = computeRawError({
-        stackTrace: error instanceof Error ? computeStackTrace(error) : undefined,
+        stackTrace: isError(error) ? computeStackTrace(error) : undefined,
         originalError: error,
         nonErrorPrefix: NonErrorPrefix.PROVIDED,
         source: ErrorSource.LOGGER,

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -10,6 +10,7 @@ import {
   Observable,
   trackRuntimeError,
   NonErrorPrefix,
+  isError,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type { RawRumErrorEvent } from '../../rawRumEvent.types'
@@ -71,7 +72,7 @@ export function doStartErrorCollection(
       { error, handlingStack, startClocks, context: customerContext }: ProvidedError,
       savedCommonContext?: CommonContext
     ) => {
-      const stackTrace = error instanceof Error ? computeStackTrace(error) : undefined
+      const stackTrace = isError(error) ? computeStackTrace(error) : undefined
       const rawError = computeRawError({
         stackTrace,
         originalError: error,


### PR DESCRIPTION
## Motivation

using DD_RUM.addError(error) but the error comes from a different context than the document (ex: created insde an iframe or a window.open), the SDK doesn not consider it as an Error instance and serializes it as JSON.

## Changes

Use class object to determine if it's an error or not.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
