### PR TITLE
✨ [RUM-7371] move React integration out of beta

### DIFF
--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -517,7 +517,7 @@ describe('preStartRum', () => {
           createCustomVitalsState(),
           doStartRumSpy
         )
-        const initConfiguration: RumInitConfiguration = { ...DEFAULT_INIT_CONFIGURATION, betaPlugins: [plugin] }
+        const initConfiguration: RumInitConfiguration = { ...DEFAULT_INIT_CONFIGURATION, plugins: [plugin] }
         strategy.init(initConfiguration, PUBLIC_API)
 
         expect(plugin.onInit).toHaveBeenCalledWith({
@@ -543,7 +543,7 @@ describe('preStartRum', () => {
         )
         strategy.init(
           {
-            betaPlugins: [plugin],
+            plugins: [plugin],
           } as RumInitConfiguration,
           PUBLIC_API
         )

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -156,7 +156,7 @@ export function createPreStartStrategy(
         return
       }
 
-      callPluginsMethod(initConfiguration.betaPlugins, 'onInit', { initConfiguration, publicApi })
+      callPluginsMethod(initConfiguration.plugins, 'onInit', { initConfiguration, publicApi })
 
       if (
         initConfiguration.remoteConfigurationId &&

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -448,7 +448,7 @@ describe('validateAndBuildRumConfiguration', () => {
       }
       const configuration = validateAndBuildRumConfiguration({
         ...DEFAULT_INIT_CONFIGURATION,
-        betaPlugins: [plugin],
+        plugins: [plugin],
       })
       expect(configuration!.plugins).toEqual([plugin])
     })
@@ -478,7 +478,7 @@ describe('serializeRumConfiguration', () => {
       trackResources: true,
       trackLongTasks: true,
       remoteConfigurationId: '123',
-      betaPlugins: [{ name: 'foo', getConfigurationTelemetry: () => ({ bar: true }) }],
+      plugins: [{ name: 'foo', getConfigurationTelemetry: () => ({ bar: true }) }],
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -489,9 +489,7 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // oops
           : Key extends 'applicationId' | 'subdomain' | 'remoteConfigurationId'
             ? never
-            : Key extends 'betaPlugins' // renamed during public beta
-              ? 'plugins'
-              : CamelToSnakeCase<Key>
+            : CamelToSnakeCase<Key>
 
     // By specifying the type here, we can ensure that serializeConfiguration is returning an
     // object containing all expected properties.

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -129,7 +129,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * notice. Please use only plugins provided by Datadog matching the version of the SDK you are
    * using.
    */
-  betaPlugins?: RumPlugin[] | undefined
+  plugins?: RumPlugin[] | undefined
 }
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>
@@ -213,7 +213,7 @@ export function validateAndBuildRumConfiguration(
       traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
         ? initConfiguration.traceContextInjection
         : TraceContextInjection.ALL,
-      plugins: initConfiguration.betaPlugins || [],
+      plugins: initConfiguration.plugins || [],
     },
     baseConfiguration
   )
@@ -295,7 +295,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
       track_user_interactions: configuration.trackUserInteractions,
       track_resources: configuration.trackResources,
       track_long_task: configuration.trackLongTasks,
-      plugins: configuration.betaPlugins?.map((plugin) =>
+      plugins: configuration.plugins?.map((plugin) =>
         assign({ name: plugin.name }, plugin.getConfigurationTelemetry?.())
       ),
     },

--- a/packages/rum-react/README.md
+++ b/packages/rum-react/README.md
@@ -12,7 +12,7 @@ npm install @datadog/browser-rum @datadog/browser-rum-react
 
 ### Initialization
 
-To enable the React integration, pass the `reactPlugin` to the `betaPlugins` option of the `datadogRum.init` method:
+To enable the React integration, pass the `reactPlugin` to the `plugins` option of the `datadogRum.init` method:
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum'
@@ -22,7 +22,7 @@ datadogRum.init({
   applicationId: ...,
   clientToken: ...,
   ...
-  betaPlugins: [reactPlugin()],
+  plugins: [reactPlugin()],
 })
 ```
 
@@ -91,7 +91,7 @@ import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v6'
 
 datadogRum.init({
   ...
-  betaPlugins: [reactPlugin({ router: true })],
+  plugins: [reactPlugin({ router: true })],
 })
 
 const router = createBrowserRouter([

--- a/packages/rum-react/README.md
+++ b/packages/rum-react/README.md
@@ -1,8 +1,5 @@
 # RUM Browser Monitoring - React integration
 
-> [!CAUTION]
-> This package is experimental. Use at your own risk.
-
 This package provides React and React ecosystem integrations for Datadog Browser RUM.
 
 ## Installation

--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@datadog/browser-rum-react",
-  "private": true,
   "version": "5.31.1",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",

--- a/sandbox/react-app/main.tsx
+++ b/sandbox/react-app/main.tsx
@@ -8,7 +8,7 @@ import { reactPlugin, ErrorBoundary } from '@datadog/browser-rum-react'
 datadogRum.init({
   applicationId: 'xxx',
   clientToken: 'xxx',
-  betaPlugins: [reactPlugin({ router: true })],
+  plugins: [reactPlugin({ router: true })],
 })
 
 const router = createBrowserRouter(


### PR DESCRIPTION
## Motivation

The React integration have been dogfooded and is ready for prime time.

## Changes

* Remove the `private: true` flag so the package will be published along other packages in the next release
* Remove the warning note in the README
* Remove the `beta` prefix from `betaPlugins`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
