### PR TITLE
✨ [RUM-6814] strongly type site parameter

### DIFF
--- a/packages/core/src/domain/configuration/configuration.spec.ts
+++ b/packages/core/src/domain/configuration/configuration.spec.ts
@@ -207,7 +207,7 @@ describe('validateAndBuildConfiguration', () => {
 
   describe('site parameter validation', () => {
     it('should validate the site parameter', () => {
-      validateAndBuildConfiguration({ clientToken, site: 'foo.com' })
+      validateAndBuildConfiguration({ clientToken, site: 'foo.com' as any })
       expect(displaySpy).toHaveBeenCalledOnceWith(
         `Site should be a valid Datadog site. ${MORE_DETAILS} ${DOCS_ORIGIN}/getting_started/site/.`
       )

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -11,6 +11,7 @@ import type { SessionStoreStrategyType } from '../session/storeStrategies/sessio
 import { TrackingConsent } from '../trackingConsent'
 import type { TransportConfiguration } from './transportConfiguration'
 import { computeTransportConfiguration } from './transportConfiguration'
+import type { Site } from './intakeSites'
 
 export const DefaultPrivacyLevel = {
   ALLOW: 'allow',
@@ -81,7 +82,7 @@ export interface InitConfiguration {
    * The Datadog [site](https://docs.datadoghq.com/getting_started/site) parameter of your organization.
    * @default datadoghq.com
    */
-  site?: string | undefined
+  site?: Site | undefined
 
   // tag and context options
   /**

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -6,10 +6,8 @@ export type Site =
   | 'ddog-gov.com'
   | 'ap1.datadoghq.com'
 
-export type SiteWithStaging = Site | 'dd0g-gov.com' | 'datad0g.com'
-
-export const INTAKE_SITE_STAGING: SiteWithStaging = 'datad0g.com'
-export const INTAKE_SITE_FED_STAGING: SiteWithStaging = 'dd0g-gov.com'
+export const INTAKE_SITE_STAGING: Site = 'datad0g.com' as Site
+export const INTAKE_SITE_FED_STAGING: Site = 'dd0g-gov.com' as Site
 export const INTAKE_SITE_US1: Site = 'datadoghq.com'
 export const INTAKE_SITE_EU1: Site = 'datadoghq.eu'
 export const INTAKE_SITE_US1_FED: Site = 'ddog-gov.com'

--- a/packages/core/src/domain/configuration/intakeSites.ts
+++ b/packages/core/src/domain/configuration/intakeSites.ts
@@ -1,8 +1,18 @@
-export const INTAKE_SITE_STAGING = 'datad0g.com'
-export const INTAKE_SITE_FED_STAGING = 'dd0g-gov.com'
-export const INTAKE_SITE_US1 = 'datadoghq.com'
-export const INTAKE_SITE_EU1 = 'datadoghq.eu'
-export const INTAKE_SITE_US1_FED = 'ddog-gov.com'
+export type Site =
+  | 'datadoghq.com'
+  | 'us3.datadoghq.com'
+  | 'us5.datadoghq.com'
+  | 'datadoghq.eu'
+  | 'ddog-gov.com'
+  | 'ap1.datadoghq.com'
+
+export type SiteWithStaging = Site | 'dd0g-gov.com' | 'datad0g.com'
+
+export const INTAKE_SITE_STAGING: SiteWithStaging = 'datad0g.com'
+export const INTAKE_SITE_FED_STAGING: SiteWithStaging = 'dd0g-gov.com'
+export const INTAKE_SITE_US1: Site = 'datadoghq.com'
+export const INTAKE_SITE_EU1: Site = 'datadoghq.eu'
+export const INTAKE_SITE_US1_FED: Site = 'ddog-gov.com'
 
 export const PCI_INTAKE_HOST_US1 = 'pci.browser-intake-datadoghq.com'
 export const INTAKE_URL_PARAMETERS = ['ddsource', 'ddtags']

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -1,6 +1,5 @@
 import type { Payload } from '../../transport'
 import { computeTransportConfiguration, isIntakeUrl } from './transportConfiguration'
-import type { Site } from './intakeSites'
 import { INTAKE_SITE_FED_STAGING } from './intakeSites'
 
 const DEFAULT_PAYLOAD = {} as Payload
@@ -18,7 +17,7 @@ describe('transportConfiguration', () => {
     })
 
     it('should use logs intake domain for fed staging', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: INTAKE_SITE_FED_STAGING as Site })
+      const configuration = computeTransportConfiguration({ clientToken, site: INTAKE_SITE_FED_STAGING })
       expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('http-intake.logs.dd0g-gov.com')
       expect(configuration.site).toBe(INTAKE_SITE_FED_STAGING)
     })

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -1,5 +1,6 @@
 import type { Payload } from '../../transport'
 import { computeTransportConfiguration, isIntakeUrl } from './transportConfiguration'
+import type { Site } from './intakeSites'
 import { INTAKE_SITE_FED_STAGING } from './intakeSites'
 
 const DEFAULT_PAYLOAD = {} as Payload
@@ -17,15 +18,15 @@ describe('transportConfiguration', () => {
     })
 
     it('should use logs intake domain for fed staging', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: INTAKE_SITE_FED_STAGING })
+      const configuration = computeTransportConfiguration({ clientToken, site: INTAKE_SITE_FED_STAGING as Site })
       expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('http-intake.logs.dd0g-gov.com')
       expect(configuration.site).toBe(INTAKE_SITE_FED_STAGING)
     })
 
     it('should use site value when set', () => {
-      const configuration = computeTransportConfiguration({ clientToken, site: 'foo.com' })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('foo.com')
-      expect(configuration.site).toBe('foo.com')
+      const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.com' })
+      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('datadoghq.com')
+      expect(configuration.site).toBe('datadoghq.com')
     })
   })
 
@@ -41,7 +42,7 @@ describe('transportConfiguration', () => {
     it('should not use internal analytics subdomain value when set for other sites', () => {
       const configuration = computeTransportConfiguration({
         clientToken,
-        site: 'foo.bar',
+        site: 'us3.datadoghq.com',
         internalAnalyticsSubdomain,
       })
       expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).not.toContain(internalAnalyticsSubdomain)

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -2,6 +2,7 @@ import type { InitConfiguration } from './configuration'
 import type { EndpointBuilder } from './endpointBuilder'
 import { createEndpointBuilder } from './endpointBuilder'
 import { buildTags } from './tags'
+import type { SiteWithStaging } from './intakeSites'
 import { INTAKE_SITE_US1, INTAKE_URL_PARAMETERS } from './intakeSites'
 
 export interface TransportConfiguration {
@@ -9,7 +10,7 @@ export interface TransportConfiguration {
   rumEndpointBuilder: EndpointBuilder
   sessionReplayEndpointBuilder: EndpointBuilder
   replica?: ReplicaConfiguration
-  site: string
+  site: SiteWithStaging
 }
 
 export interface ReplicaConfiguration {

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -2,7 +2,7 @@ import type { InitConfiguration } from './configuration'
 import type { EndpointBuilder } from './endpointBuilder'
 import { createEndpointBuilder } from './endpointBuilder'
 import { buildTags } from './tags'
-import type { SiteWithStaging } from './intakeSites'
+import type { Site } from './intakeSites'
 import { INTAKE_SITE_US1, INTAKE_URL_PARAMETERS } from './intakeSites'
 
 export interface TransportConfiguration {
@@ -10,7 +10,7 @@ export interface TransportConfiguration {
   rumEndpointBuilder: EndpointBuilder
   sessionReplayEndpointBuilder: EndpointBuilder
   replica?: ReplicaConfiguration
-  site: SiteWithStaging
+  site: Site
 }
 
 export interface ReplicaConfiguration {

--- a/packages/core/test/coreConfiguration.ts
+++ b/packages/core/test/coreConfiguration.ts
@@ -20,7 +20,7 @@ export const EXHAUSTIVE_INIT_CONFIGURATION: Required<InitConfiguration> = {
   storeContextsAcrossPages: true,
   trackingConsent: 'not-granted',
   proxy: 'proxy',
-  site: 'site',
+  site: 'datadoghq.com',
   service: 'service',
   env: 'env',
   version: 'version',

--- a/packages/rum-slim/src/domain/getSessionReplayLink.spec.ts
+++ b/packages/rum-slim/src/domain/getSessionReplayLink.spec.ts
@@ -2,13 +2,13 @@ import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { getSessionReplayLink } from './getSessionReplayLink'
 
 const DEFAULT_CONFIGURATION = {
-  site: 'datad0g.com',
+  site: 'datadoghq.com',
 } as RumConfiguration
 
 describe('getReplayLink (slim package)', () => {
   it('should return the replay link with a "slim-package" error type', () => {
     const link = getSessionReplayLink(DEFAULT_CONFIGURATION)
 
-    expect(link).toBe('https://dd.datad0g.com/rum/replay/sessions/no-session-id?error-type=slim-package')
+    expect(link).toBe('https://app.datadoghq.com/rum/replay/sessions/no-session-id?error-type=slim-package')
   })
 })

--- a/packages/rum/src/domain/getSessionReplayLink.spec.ts
+++ b/packages/rum/src/domain/getSessionReplayLink.spec.ts
@@ -5,7 +5,7 @@ import { getSessionReplayLink } from './getSessionReplayLink'
 import { addRecord, resetReplayStats } from './replayStats'
 
 const DEFAULT_CONFIGURATION = {
-  site: 'datad0g.com',
+  site: 'datadoghq.com',
 } as RumConfiguration
 
 describe('getReplayLink', () => {
@@ -18,7 +18,7 @@ describe('getReplayLink', () => {
 
     const link = getSessionReplayLink(DEFAULT_CONFIGURATION, sessionManager, viewHistory, true)
 
-    expect(link).toBe('https://dd.datad0g.com/rum/replay/sessions/session-id-1?')
+    expect(link).toBe('https://app.datadoghq.com/rum/replay/sessions/session-id-1?')
   })
 
   it('should return the replay link', () => {
@@ -34,7 +34,7 @@ describe('getReplayLink', () => {
     addRecord('view-id-1')
 
     const link = getSessionReplayLink(
-      { ...DEFAULT_CONFIGURATION, site: 'datadoghq.com', subdomain: 'toto' },
+      { ...DEFAULT_CONFIGURATION, subdomain: 'toto' },
       sessionManager,
       viewHistory,
       true
@@ -60,7 +60,7 @@ describe('getReplayLink', () => {
     addRecord('view-id-1')
 
     const link = getSessionReplayLink(
-      { ...DEFAULT_CONFIGURATION, site: 'datadoghq.com', subdomain: 'toto' },
+      { ...DEFAULT_CONFIGURATION, subdomain: 'toto' },
       sessionManager,
       viewHistory,
       true
@@ -80,12 +80,7 @@ describe('getReplayLink', () => {
       }),
     } as ViewHistory
 
-    const link = getSessionReplayLink(
-      { ...DEFAULT_CONFIGURATION, site: 'datadoghq.com' },
-      sessionManager,
-      viewHistory,
-      true
-    )
+    const link = getSessionReplayLink(DEFAULT_CONFIGURATION, sessionManager, viewHistory, true)
     expect(link).toBe(
       'https://app.datadoghq.com/rum/replay/sessions/session-id-1?error-type=incorrect-session-plan&seed=view-id-1&from=123456'
     )
@@ -97,12 +92,7 @@ describe('getReplayLink', () => {
       findView: () => undefined,
     } as ViewHistory
 
-    const link = getSessionReplayLink(
-      { ...DEFAULT_CONFIGURATION, site: 'datadoghq.com' },
-      sessionManager,
-      viewHistory,
-      true
-    )
+    const link = getSessionReplayLink(DEFAULT_CONFIGURATION, sessionManager, viewHistory, true)
 
     expect(link).toBe('https://app.datadoghq.com/rum/replay/sessions/no-session-id?error-type=rum-not-tracked')
   })
@@ -118,12 +108,7 @@ describe('getReplayLink', () => {
       }),
     } as ViewHistory
 
-    const link = getSessionReplayLink(
-      { ...DEFAULT_CONFIGURATION, site: 'datadoghq.com' },
-      sessionManager,
-      viewHistory,
-      false
-    )
+    const link = getSessionReplayLink(DEFAULT_CONFIGURATION, sessionManager, viewHistory, false)
 
     expect(link).toBe(
       'https://app.datadoghq.com/rum/replay/sessions/session-id-1?error-type=replay-not-started&seed=view-id-1&from=123456'
@@ -152,12 +137,7 @@ describe('getReplayLink', () => {
         }),
       } as ViewHistory
 
-      const link = getSessionReplayLink(
-        { ...DEFAULT_CONFIGURATION, site: 'datadoghq.com' },
-        sessionManager,
-        viewContexts,
-        false
-      )
+      const link = getSessionReplayLink(DEFAULT_CONFIGURATION, sessionManager, viewContexts, false)
 
       expect(link).toBe(
         'https://app.datadoghq.com/rum/replay/sessions/session-id-1?error-type=browser-not-supported&seed=view-id-1&from=123456'


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Strongly type the site parameter, this will allow customer using typescript to have better autocompletion and avoid misconfiguration. This is not a bulletproof solution, especially if user are not using typescript, but it will help the ones that do.

If we were to add new datacenters, we would need to add them to the type definition, release a new minor and have customer update to the latest SDK.

Customer wanting to use the new datacenters without using the new SDK will still have the option to ignore the type error using `// @ts-expect-error` or `as any`

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
