### PR TITLE
✨ [RUM-6182] don't start recording automatically when replay sample is 0

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -652,15 +652,15 @@ describe('rum public api', () => {
 
     it('is started with the default startSessionReplayRecordingManually', () => {
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].startSessionReplayRecordingManually).toBe(false)
+      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].startSessionReplayRecordingManually).toBe(true)
     })
 
     it('is started with the configured startSessionReplayRecordingManually', () => {
       rumPublicApi.init({
         ...DEFAULT_INIT_CONFIGURATION,
-        startSessionReplayRecordingManually: true,
+        startSessionReplayRecordingManually: false,
       })
-      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].startSessionReplayRecordingManually).toBe(true)
+      expect(recorderApiOnRumStartSpy.calls.mostRecent().args[1].startSessionReplayRecordingManually).toBe(false)
     })
   })
 

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -266,9 +266,17 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('startSessionReplayRecordingManually', () => {
-    it('defaults to false', () => {
+    it('defaults to true if sessionReplaySampleRate is 0', () => {
       expect(
-        validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.startSessionReplayRecordingManually
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 0 })!
+          .startSessionReplayRecordingManually
+      ).toBeTrue()
+    })
+
+    it('defaults to false if sessionReplaySampleRate is not 0', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, sessionReplaySampleRate: 50 })!
+          .startSessionReplayRecordingManually
       ).toBeFalse()
     })
 

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -90,7 +90,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    */
   sessionReplaySampleRate?: number | undefined
   /**
-   * If the session is sampled for Session Replay, only start the recording when `startSessionReplayRecording()` is called, instead of at the beginning of the session.
+   * If the session is sampled for Session Replay, only start the recording when `startSessionReplayRecording()` is called, instead of at the beginning of the session. Default: if startSessionReplayRecording is 0, true; otherwise, false.
    * See [Session Replay Usage](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/#usage) for further information.
    */
   startSessionReplayRecordingManually?: boolean | undefined
@@ -188,13 +188,18 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
+  const sessionReplaySampleRate = initConfiguration.sessionReplaySampleRate ?? 0
+
   return assign(
     {
       applicationId: initConfiguration.applicationId,
       version: initConfiguration.version || undefined,
       actionNameAttribute: initConfiguration.actionNameAttribute,
-      sessionReplaySampleRate: initConfiguration.sessionReplaySampleRate ?? 0,
-      startSessionReplayRecordingManually: !!initConfiguration.startSessionReplayRecordingManually,
+      sessionReplaySampleRate,
+      startSessionReplayRecordingManually:
+        initConfiguration.startSessionReplayRecordingManually !== undefined
+          ? !!initConfiguration.startSessionReplayRecordingManually
+          : sessionReplaySampleRate === 0,
       traceSampleRate: initConfiguration.traceSampleRate,
       allowedTracingUrls,
       excludedActivityUrls: initConfiguration.excludedActivityUrls ?? [],


### PR DESCRIPTION
## Motivation

We had some customer cases where they have seen some sessions being recorded even if they were specifically set `sessionReplaySampling: 0`. This was caused by another SDK instance (injected via an extension) setting the session type to "replay", so it worked "as expected" but was still pretty confusing to the customer as they specifically didn't want to collect replay (for privacy reasons).

## Changes

Set the default value of `startSessionReplayRecordingManually` to `true` if `sessionReplaySampleRate` is `0`, keep it `false` otherwise.

Technically, this is a small breaking change: a customer could want to record sessions only for users visiting a given page `/foo`. In that case, they could set a `sessionReplaySampleRate: 0`, and only in `/foo` they would run `startSessionReplayRecording({ force: true })`. After that they would expect that subsequent pages are recorded (even with `sessionReplaySampleRate: 0` ).

In practice, it seems this usecase is not used by our customers based on our telemetry.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
