### PR TITLE
💥 [RUM-6815] remove internalAnalyticsSubdomain option

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -134,11 +134,6 @@ export interface InitConfiguration {
    */
   datacenter?: string
   /**
-   * [Internal option] Datadog internal analytics subdomain
-   */
-  // TODO next major: remove this option and replace usages by proxyFn
-  internalAnalyticsSubdomain?: string
-  /**
    * [Internal option] The percentage of telemetry configuration sent. A value between 0 and 100.
    * @default 5
    */

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -126,11 +126,11 @@ export interface InitConfiguration {
    */
   enableExperimentalFeatures?: string[] | undefined
   /**
-   * [Internal option] Configure the dual chipping to another datacenter
+   * [Internal option] Configure the dual shipping to another datacenter
    */
   replica?: ReplicaUserConfiguration | undefined
   /**
-   * [Internal option] Set the datacenter from where the data is dual chipped
+   * [Internal option] Set the datacenter from where the data is dual shipped
    */
   datacenter?: string
   /**
@@ -150,10 +150,11 @@ export interface InitConfiguration {
 type GenericBeforeSendCallback = (event: any, context?: any) => unknown
 
 /**
+ * host: datadoghq.com
  * path: /api/vX/product
  * parameters: xxx=yyy&zzz=aaa
  */
-type ProxyFn = (options: { path: string; parameters: string }) => string
+type ProxyFn = (options: { host: string; path: string; parameters: string }) => string
 
 export interface ReplicaUserConfiguration {
   applicationId?: string

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -41,15 +41,6 @@ describe('endpointBuilder', () => {
         createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', { ...DEFAULT_PAYLOAD, encoding: 'deflate' })
       ).toContain('&dd-evp-encoding=deflate')
     })
-
-    it('should not start with ddsource for internal analytics mode', () => {
-      const url = createEndpointBuilder({ ...initConfiguration, internalAnalyticsSubdomain: 'foo' }, 'rum', []).build(
-        'xhr',
-        DEFAULT_PAYLOAD
-      )
-      expect(url).not.toContain('/rum?ddsource')
-      expect(url).toContain('ddsource=browser')
-    })
   })
 
   describe('proxy configuration', () => {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -47,14 +47,17 @@ function createEndpointUrlWithParametersBuilder(
 ): (parameters: string) => string {
   const path = `/api/v2/${trackType}`
   const proxy = initConfiguration.proxy
+  const host = buildEndpointHost(trackType, initConfiguration)
+
   if (typeof proxy === 'string') {
     const normalizedProxyUrl = normalizeUrl(proxy)
     return (parameters) => `${normalizedProxyUrl}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}`
   }
+
   if (typeof proxy === 'function') {
-    return (parameters) => proxy({ path, parameters })
+    return (parameters) => proxy({ host, path, parameters })
   }
-  const host = buildEndpointHost(trackType, initConfiguration)
+
   return (parameters) => `https://${host}${path}?${parameters}`
 }
 

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -59,14 +59,10 @@ function createEndpointUrlWithParametersBuilder(
 }
 
 function buildEndpointHost(trackType: TrackType, initConfiguration: InitConfiguration & { usePciIntake?: boolean }) {
-  const { site = INTAKE_SITE_US1, internalAnalyticsSubdomain } = initConfiguration
+  const { site = INTAKE_SITE_US1 } = initConfiguration
 
   if (trackType === 'logs' && initConfiguration.usePciIntake && site === INTAKE_SITE_US1) {
     return PCI_INTAKE_HOST_US1
-  }
-
-  if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {
-    return `${internalAnalyticsSubdomain}.${INTAKE_SITE_US1}`
   }
 
   if (site === INTAKE_SITE_FED_STAGING) {
@@ -83,7 +79,7 @@ function buildEndpointHost(trackType: TrackType, initConfiguration: InitConfigur
  * request, as they change randomly.
  */
 function buildEndpointParameters(
-  { clientToken, internalAnalyticsSubdomain }: InitConfiguration,
+  { clientToken }: InitConfiguration,
   trackType: TrackType,
   configurationTags: string[],
   api: ApiType,
@@ -109,10 +105,6 @@ function buildEndpointParameters(
 
   if (trackType === 'rum') {
     parameters.push(`batch_time=${timeStampNow()}`)
-  }
-
-  if (internalAnalyticsSubdomain) {
-    parameters.reverse()
   }
 
   return parameters.join('&')

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -6,7 +6,6 @@ const DEFAULT_PAYLOAD = {} as Payload
 
 describe('transportConfiguration', () => {
   const clientToken = 'some_client_token'
-  const internalAnalyticsSubdomain = 'ia-rum-intake'
   const intakeParameters = 'ddsource=browser&ddtags=sdk_version'
 
   describe('site', () => {
@@ -26,25 +25,6 @@ describe('transportConfiguration', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'foo.com' })
       expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('foo.com')
       expect(configuration.site).toBe('foo.com')
-    })
-  })
-
-  describe('internalAnalyticsSubdomain', () => {
-    it('should use internal analytics subdomain value when set for datadoghq.com site', () => {
-      const configuration = computeTransportConfiguration({
-        clientToken,
-        internalAnalyticsSubdomain,
-      })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain(internalAnalyticsSubdomain)
-    })
-
-    it('should not use internal analytics subdomain value when set for other sites', () => {
-      const configuration = computeTransportConfiguration({
-        clientToken,
-        site: 'foo.bar',
-        internalAnalyticsSubdomain,
-      })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).not.toContain(internalAnalyticsSubdomain)
     })
   })
 
@@ -119,9 +99,7 @@ describe('transportConfiguration', () => {
     })
 
     it('should detect internal analytics intake request for datadoghq.com site', () => {
-      expect(isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/rum?${intakeParameters}`)).toBe(
-        true
-      )
+      expect(isIntakeUrl(`https://app.datadoghq.com/api/v2/rum?${intakeParameters}`)).toBe(true)
     })
 
     it('should not detect non intake request', () => {
@@ -151,15 +129,9 @@ describe('transportConfiguration', () => {
       { site: 'ap1.datadoghq.com' },
     ].forEach(({ site }) => {
       it(`should detect replica intake request for site ${site}`, () => {
-        expect(isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/rum?${intakeParameters}`)).toBe(
-          true
-        )
-        expect(isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/logs?${intakeParameters}`)).toBe(
-          true
-        )
-        expect(
-          isIntakeUrl(`https://${internalAnalyticsSubdomain}.datadoghq.com/api/v2/replay?${intakeParameters}`)
-        ).toBe(true)
+        expect(isIntakeUrl(`https://app.datadoghq.com/api/v2/rum?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://app.datadoghq.com/api/v2/logs?${intakeParameters}`)).toBe(true)
+        expect(isIntakeUrl(`https://app.datadoghq.com/api/v2/replay?${intakeParameters}`)).toBe(true)
       })
     })
   })

--- a/packages/core/test/coreConfiguration.ts
+++ b/packages/core/test/coreConfiguration.ts
@@ -33,7 +33,6 @@ export const EXHAUSTIVE_INIT_CONFIGURATION: Required<InitConfiguration> = {
     clientToken: 'yes',
   },
   datacenter: 'datacenter',
-  internalAnalyticsSubdomain: 'internal-analytics-subdomain.com',
   telemetryConfigurationSampleRate: 70,
   telemetryUsageSampleRate: 80,
 }
@@ -71,7 +70,6 @@ export type MapInitConfigurationKey<Key extends string> =
           | 'env'
           | 'version'
           | 'datacenter'
-          | 'internalAnalyticsSubdomain'
           | 'replica'
           | 'enableExperimentalFeatures'
       ? never


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Remove internal-only option `internalAnalyticsSubdomain`. It can be replaced by 
```js
proxy: ({ path, parameters }) =>  {
  // make sure `dd-source` is not the first param for internal analytics. see https://datadoghq.atlassian.net/browse/RUMF-1464
  const params = parameters.split('&').reverse().join('&');

  return `https://${internalAnalyticsSubdomain}.datadoghq.com${path}?${params}`
}
```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
