### PR TITLE
✨ [RUM-6799] Add new delivery type property

### DIFF
--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -63,7 +63,7 @@ export interface RumPerformanceResourceTiming {
   nextHopProtocol?: string
   renderBlockingStatus?: string
   traceId?: string
-  deliveryType?: string
+  deliveryType: 'cache' | 'navigational-prefetch' | ''
   toJSON(): Omit<PerformanceEntry, 'toJSON'>
 }
 

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -2,7 +2,6 @@ import type { Duration, RelativeTime, TimeoutId } from '@datadog/browser-core'
 import { addEventListener, Observable, setTimeout, clearTimeout, monitor, includes } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import { hasValidResourceEntryDuration, isAllowedRequestUrl } from '../domain/resource/resourceUtils'
-import type { deliveryType } from '../rawRumEvent.types'
 import { retrieveFirstInputTiming } from './firstInputPolyfill'
 
 type RumPerformanceObserverConstructor = new (callback: PerformanceObserverCallback) => RumPerformanceObserver
@@ -64,7 +63,7 @@ export interface RumPerformanceResourceTiming {
   nextHopProtocol?: string
   renderBlockingStatus?: string
   traceId?: string
-  deliveryType?: deliveryType
+  deliveryType?: string
   toJSON(): Omit<PerformanceEntry, 'toJSON'>
 }
 

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -63,7 +63,7 @@ export interface RumPerformanceResourceTiming {
   nextHopProtocol?: string
   renderBlockingStatus?: string
   traceId?: string
-  deliveryType: 'cache' | 'navigational-prefetch' | ''
+  deliveryType?: 'cache' | 'navigational-prefetch' | ''
   toJSON(): Omit<PerformanceEntry, 'toJSON'>
 }
 

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -2,6 +2,7 @@ import type { Duration, RelativeTime, TimeoutId } from '@datadog/browser-core'
 import { addEventListener, Observable, setTimeout, clearTimeout, monitor, includes } from '@datadog/browser-core'
 import type { RumConfiguration } from '../domain/configuration'
 import { hasValidResourceEntryDuration, isAllowedRequestUrl } from '../domain/resource/resourceUtils'
+import type { deliveryType } from '../rawRumEvent.types'
 import { retrieveFirstInputTiming } from './firstInputPolyfill'
 
 type RumPerformanceObserverConstructor = new (callback: PerformanceObserverCallback) => RumPerformanceObserver
@@ -63,6 +64,7 @@ export interface RumPerformanceResourceTiming {
   nextHopProtocol?: string
   renderBlockingStatus?: string
   traceId?: string
+  deliveryType?: deliveryType
   toJSON(): Omit<PerformanceEntry, 'toJSON'>
 }
 

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -65,6 +65,7 @@ describe('resourceCollection', () => {
       decodedBodySize: 51,
       transferSize: 63,
       renderBlockingStatus: 'blocking',
+      deliveryType: 'cache',
       responseStart: 250 as RelativeTime,
     })
     notifyPerformanceEntries([performanceEntry])
@@ -85,6 +86,7 @@ describe('resourceCollection', () => {
         first_byte: jasmine.any(Object),
         status_code: 200,
         protocol: 'HTTP/1.0',
+        delivery_type: 'cache',
         render_blocking_status: 'blocking',
       },
       type: RumEventType.RESOURCE,
@@ -122,6 +124,7 @@ describe('resourceCollection', () => {
         duration: (100 * 1e6) as ServerDuration,
         method: 'GET',
         status_code: 200,
+        delivery_type: undefined,
         protocol: undefined,
         type: ResourceType.XHR,
         url: 'https://resource.com/valid',
@@ -236,6 +239,7 @@ describe('resourceCollection', () => {
         duration: (100 * 1e6) as ServerDuration,
         method: 'GET',
         status_code: 200,
+        delivery_type: undefined,
         protocol: undefined,
         type: ResourceType.FETCH,
         url: 'https://resource.com/valid',

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -32,6 +32,7 @@ import {
   computeResourceEntryType,
   computeResourceEntrySize,
   computeResourceEntryProtocol,
+  computeResourceEntryDeliveryType,
   isResourceEntryRequestType,
   isLongDataUrl,
   sanitizeDataUrl,
@@ -109,6 +110,7 @@ function processRequest(
         status_code: request.status,
         protocol: matchingTiming && computeResourceEntryProtocol(matchingTiming),
         url: isLongDataUrl(request.url) ? sanitizeDataUrl(request.url) : request.url,
+        delivery_type: matchingTiming && computeResourceEntryDeliveryType(matchingTiming),
       },
       type: RumEventType.RESOURCE as const,
       _dd: {
@@ -157,6 +159,7 @@ function processResourceEntry(
         url: entry.name,
         status_code: discardZeroStatus(entry.responseStatus),
         protocol: computeResourceEntryProtocol(entry),
+        delivery_type: computeResourceEntryDeliveryType(entry),
       },
       type: RumEventType.RESOURCE as const,
       _dd: {

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -12,7 +12,7 @@ import {
 
 import type { RumPerformanceResourceTiming } from '../../browser/performanceObservable'
 
-import type { DeliveryType, ResourceEntryDetailsElement } from '../../rawRumEvent.types'
+import type { ResourceEntryDetailsElement, DeliveryType } from '../../rawRumEvent.types'
 
 export interface ResourceEntryDetails {
   worker?: ResourceEntryDetailsElement
@@ -195,11 +195,11 @@ export function computeResourceEntryProtocol(entry: RumPerformanceResourceTiming
 
 /**
  * Handles the 'deliveryType' property to distinguish between supported values ('cache', 'navigational-prefetch'),
- * undefined (unsupported in some browsers), and other cases ('-' for unknown or unrecognized values).
+ * undefined (unsupported in some browsers), and other cases ('other' for unknown or unrecognized values).
  * see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
  */
 export function computeResourceEntryDeliveryType(entry: RumPerformanceResourceTiming): DeliveryType | undefined {
-  return entry.deliveryType === '' ? 'other' : (entry.deliveryType as DeliveryType)
+  return entry.deliveryType === '' ? 'other' : entry.deliveryType
 }
 
 export function computeResourceEntrySize(entry: RumPerformanceResourceTiming) {

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -12,7 +12,7 @@ import {
 
 import type { RumPerformanceResourceTiming } from '../../browser/performanceObservable'
 
-import type { ResourceEntryDetailsElement } from '../../rawRumEvent.types'
+import type { deliveryType, ResourceEntryDetailsElement } from '../../rawRumEvent.types'
 
 export interface ResourceEntryDetails {
   worker?: ResourceEntryDetailsElement
@@ -191,6 +191,10 @@ function formatTiming(origin: RelativeTime, start: RelativeTime, end: RelativeTi
  */
 export function computeResourceEntryProtocol(entry: RumPerformanceResourceTiming) {
   return entry.nextHopProtocol === '' ? undefined : entry.nextHopProtocol
+}
+
+export function computeResourceEntryDeliveryType(entry: RumPerformanceResourceTiming): deliveryType | undefined {
+  return entry.deliveryType === '' ? undefined : entry.deliveryType
 }
 
 export function computeResourceEntrySize(entry: RumPerformanceResourceTiming) {

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -196,7 +196,7 @@ export function computeResourceEntryProtocol(entry: RumPerformanceResourceTiming
 /**
  * Handles the 'deliveryType' property to distinguish between supported values ('cache', 'navigational-prefetch'),
  * undefined (unsupported in some browsers), and other cases ('-' for unknown or unrecognized values).
- * see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
+ * see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
  */
 export function computeResourceEntryDeliveryType(entry: RumPerformanceResourceTiming): DeliveryType | undefined {
   return entry.deliveryType === '' ? 'other' : (entry.deliveryType as DeliveryType)

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -12,7 +12,7 @@ import {
 
 import type { RumPerformanceResourceTiming } from '../../browser/performanceObservable'
 
-import type { deliveryType, ResourceEntryDetailsElement } from '../../rawRumEvent.types'
+import type { DeliveryType, ResourceEntryDetailsElement } from '../../rawRumEvent.types'
 
 export interface ResourceEntryDetails {
   worker?: ResourceEntryDetailsElement
@@ -196,20 +196,10 @@ export function computeResourceEntryProtocol(entry: RumPerformanceResourceTiming
 /**
  * Handles the 'deliveryType' property to distinguish between supported values ('cache', 'navigational-prefetch'),
  * undefined (unsupported in some browsers), and other cases ('-' for unknown or unrecognized values).
- * https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
+ * see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
  */
-export function computeResourceEntryDeliveryType(entry: RumPerformanceResourceTiming): deliveryType | undefined {
-  const deliveryType = entry.deliveryType
-
-  if (deliveryType === undefined) {
-    return undefined
-  }
-
-  if (deliveryType === 'cache' || deliveryType === 'navigational-prefetch') {
-    return deliveryType
-  }
-
-  return '-'
+export function computeResourceEntryDeliveryType(entry: RumPerformanceResourceTiming): DeliveryType | undefined {
+  return entry.deliveryType === '' ? 'other' : (entry.deliveryType as DeliveryType)
 }
 
 export function computeResourceEntrySize(entry: RumPerformanceResourceTiming) {

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -193,8 +193,23 @@ export function computeResourceEntryProtocol(entry: RumPerformanceResourceTiming
   return entry.nextHopProtocol === '' ? undefined : entry.nextHopProtocol
 }
 
+/**
+ * Handles the 'deliveryType' property to distinguish between supported values ('cache', 'navigational-prefetch'),
+ * undefined (unsupported in some browsers), and other cases ('-' for unknown or unrecognized values).
+ * https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
+ */
 export function computeResourceEntryDeliveryType(entry: RumPerformanceResourceTiming): deliveryType | undefined {
-  return entry.deliveryType === '' ? undefined : entry.deliveryType
+  const deliveryType = entry.deliveryType
+
+  if (deliveryType === undefined) {
+    return undefined
+  }
+
+  if (deliveryType === 'cache' || deliveryType === 'navigational-prefetch') {
+    return deliveryType
+  }
+
+  return '-'
 }
 
 export function computeResourceEntrySize(entry: RumPerformanceResourceTiming) {

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -50,7 +50,7 @@ export interface RawRumResourceEvent {
     first_byte?: ResourceEntryDetailsElement
     download?: ResourceEntryDetailsElement
     protocol?: string
-    delivery_type?: deliveryType
+    delivery_type?: DeliveryType
   }
   _dd: {
     trace_id?: string
@@ -186,7 +186,7 @@ export interface RawRumLongTaskEvent {
   }
 }
 
-export type deliveryType = 'cache' | 'navigational-prefetch' | '-' | undefined
+export type DeliveryType = 'cache' | 'navigational-prefetch' | 'other'
 
 export type InvokerType =
   | 'user-callback'

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -186,7 +186,7 @@ export interface RawRumLongTaskEvent {
   }
 }
 
-export type deliveryType = 'cache' | 'navigational-prefetch' | 'unknown' | ''
+export type deliveryType = 'cache' | 'navigational-prefetch' | '-' | undefined
 
 export type InvokerType =
   | 'user-callback'

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -50,6 +50,7 @@ export interface RawRumResourceEvent {
     first_byte?: ResourceEntryDetailsElement
     download?: ResourceEntryDetailsElement
     protocol?: string
+    delivery_type?: deliveryType
   }
   _dd: {
     trace_id?: string
@@ -184,6 +185,8 @@ export interface RawRumLongTaskEvent {
     discarded: boolean
   }
 }
+
+export type deliveryType = 'cache' | 'navigational-prefetch' | 'unknown' | ''
 
 export type InvokerType =
   | 'user-callback'

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -150,6 +150,16 @@ export type RumActionEvent = CommonProperties &
           readonly height?: number
           [k: string]: unknown
         }
+        /**
+         * The strategy of how the auto click action name is computed
+         */
+        name_source?:
+          | 'custom_attribute'
+          | 'mask_placeholder'
+          | 'standard_attribute'
+          | 'text_content'
+          | 'mask_disallowed'
+          | 'blank'
         [k: string]: unknown
       }
       [k: string]: unknown
@@ -720,6 +730,10 @@ export type RumResourceEvent = CommonProperties &
        * Network protocol used to fetch the resource (e.g., 'http/1.1', 'h2')
        */
       readonly protocol?: string
+      /**
+       * Delivery type of the resource
+       */
+      readonly delivery_type?: 'cache' | 'navigational-prefetch' | 'other'
       /**
        * The provider for this resource
        */

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -245,6 +245,7 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
           connectEnd: 200 as RelativeTime,
           connectStart: 200 as RelativeTime,
           renderBlockingStatus: 'non-blocking',
+          deliveryType: 'cache',
           domainLookupEnd: 200 as RelativeTime,
           domainLookupStart: 200 as RelativeTime,
           duration: 100 as Duration,


### PR DESCRIPTION
## Motivation

The “delivery type” has been introduced on resources performance entries: [PerformanceResourceTiming: deliveryType property - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType)

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
