### PR TITLE
✅ [RUM-6813] Use promise in `collectAsyncCalls` instead of a callback

### DIFF
--- a/packages/core/src/domain/error/trackRuntimeError.spec.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.spec.ts
@@ -36,7 +36,7 @@ describe('trackRuntimeError', () => {
       throw new Error(ERROR_MESSAGE)
     })
 
-    await collectAsyncCalls(onErrorSpy, 1)
+    await collectAsyncCalls(onErrorSpy)
     expect(notifyError).toHaveBeenCalledOnceWith(jasmine.objectContaining({ message: ERROR_MESSAGE }))
   })
 
@@ -51,7 +51,7 @@ describe('trackRuntimeError', () => {
       void Promise.reject(new Error(ERROR_MESSAGE))
     })
 
-    await collectAsyncCalls(onUnhandledrejectionSpy, 1)
+    await collectAsyncCalls(onUnhandledrejectionSpy)
     expect(notifyError).toHaveBeenCalledOnceWith(jasmine.objectContaining({ message: ERROR_MESSAGE }))
   })
 })
@@ -84,7 +84,7 @@ describe('instrumentOnError', () => {
       throw new Error(ERROR_MESSAGE)
     })
 
-    await collectAsyncCalls(onErrorSpy, 1)
+    await collectAsyncCalls(onErrorSpy)
     expect(onErrorSpy).toHaveBeenCalled()
   })
 
@@ -94,7 +94,7 @@ describe('instrumentOnError', () => {
       throw error
     })
 
-    await collectAsyncCalls(onErrorSpy, 1)
+    await collectAsyncCalls(onErrorSpy)
     expect(onErrorSpy).toHaveBeenCalled()
     const [stack, originalError] = callbackSpy.calls.mostRecent().args
     expect(originalError).toBe(error)
@@ -107,7 +107,7 @@ describe('instrumentOnError', () => {
       // eslint-disable-next-line no-throw-literal
       throw error
     })
-    await collectAsyncCalls(onErrorSpy, 1)
+    await collectAsyncCalls(onErrorSpy)
     const [stack, originalError] = callbackSpy.calls.mostRecent().args
     expect(originalError).toBe(error)
     expect(stack).toBeDefined()
@@ -119,7 +119,7 @@ describe('instrumentOnError', () => {
       // eslint-disable-next-line no-throw-literal
       throw error
     })
-    await collectAsyncCalls(onErrorSpy, 1)
+    await collectAsyncCalls(onErrorSpy)
     const [stack, originalError] = callbackSpy.calls.mostRecent().args
     expect(originalError).toBe(error)
     expect(stack).toBeDefined()
@@ -162,7 +162,7 @@ describe('instrumentOnError', () => {
         window.onerror!(error)
       })
 
-      await collectAsyncCalls(onErrorSpy, 1)
+      await collectAsyncCalls(onErrorSpy)
       const [stack, originalError] = callbackSpy.calls.mostRecent().args
       expect(originalError).toBe(error)
       expect(stack).toBeDefined()

--- a/packages/core/src/domain/error/trackRuntimeError.spec.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.spec.ts
@@ -31,17 +31,16 @@ describe('trackRuntimeError', () => {
     window.onerror = originalOnErrorHandler
   })
 
-  it('should collect unhandled error', (done) => {
+  it('should collect unhandled error', async () => {
     setTimeout(() => {
       throw new Error(ERROR_MESSAGE)
     })
-    collectAsyncCalls(onErrorSpy, 1, () => {
-      expect(notifyError).toHaveBeenCalledOnceWith(jasmine.objectContaining({ message: ERROR_MESSAGE }))
-      done()
-    })
+
+    await collectAsyncCalls(onErrorSpy, 1)
+    expect(notifyError).toHaveBeenCalledOnceWith(jasmine.objectContaining({ message: ERROR_MESSAGE }))
   })
 
-  it('should collect unhandled rejection', (done) => {
+  it('should collect unhandled rejection', async () => {
     if (!('onunhandledrejection' in window)) {
       pending('onunhandledrejection not supported')
     }
@@ -52,10 +51,8 @@ describe('trackRuntimeError', () => {
       void Promise.reject(new Error(ERROR_MESSAGE))
     })
 
-    collectAsyncCalls(onUnhandledrejectionSpy, 1, () => {
-      expect(notifyError).toHaveBeenCalledOnceWith(jasmine.objectContaining({ message: ERROR_MESSAGE }))
-      done()
-    })
+    await collectAsyncCalls(onUnhandledrejectionSpy, 1)
+    expect(notifyError).toHaveBeenCalledOnceWith(jasmine.objectContaining({ message: ERROR_MESSAGE }))
   })
 })
 
@@ -82,55 +79,50 @@ describe('instrumentOnError', () => {
     stopCollectingUnhandledError()
   })
 
-  it('should call original error handler', (done) => {
+  it('should call original error handler', async () => {
     setTimeout(() => {
       throw new Error(ERROR_MESSAGE)
     })
-    collectAsyncCalls(onErrorSpy, 1, () => {
-      expect(onErrorSpy).toHaveBeenCalled()
-      done()
-    })
+
+    await collectAsyncCalls(onErrorSpy, 1)
+    expect(onErrorSpy).toHaveBeenCalled()
   })
 
-  it('should notify unhandled error instance', (done) => {
+  it('should notify unhandled error instance', async () => {
     const error = new Error(ERROR_MESSAGE)
     setTimeout(() => {
       throw error
     })
-    collectAsyncCalls(onErrorSpy, 1, () => {
-      const [stack, originalError] = callbackSpy.calls.mostRecent().args
-      expect(originalError).toBe(error)
-      expect(stack).toBeDefined()
-      done()
-    })
+
+    await collectAsyncCalls(onErrorSpy, 1)
+    expect(onErrorSpy).toHaveBeenCalled()
+    const [stack, originalError] = callbackSpy.calls.mostRecent().args
+    expect(originalError).toBe(error)
+    expect(stack).toBeDefined()
   })
 
-  it('should notify unhandled string', (done) => {
+  it('should notify unhandled string', async () => {
     const error = 'foo' as any
     setTimeout(() => {
       // eslint-disable-next-line no-throw-literal
       throw error
     })
-    collectAsyncCalls(onErrorSpy, 1, () => {
-      const [stack, originalError] = callbackSpy.calls.mostRecent().args
-      expect(originalError).toBe(error)
-      expect(stack).toBeDefined()
-      done()
-    })
+    await collectAsyncCalls(onErrorSpy, 1)
+    const [stack, originalError] = callbackSpy.calls.mostRecent().args
+    expect(originalError).toBe(error)
+    expect(stack).toBeDefined()
   })
 
-  it('should notify unhandled object', (done) => {
+  it('should notify unhandled object', async () => {
     const error = { a: 'foo' } as any
     setTimeout(() => {
       // eslint-disable-next-line no-throw-literal
       throw error
     })
-    collectAsyncCalls(onErrorSpy, 1, () => {
-      const [stack, originalError] = callbackSpy.calls.mostRecent().args
-      expect(originalError).toBe(error)
-      expect(stack).toBeDefined()
-      done()
-    })
+    await collectAsyncCalls(onErrorSpy, 1)
+    const [stack, originalError] = callbackSpy.calls.mostRecent().args
+    expect(originalError).toBe(error)
+    expect(stack).toBeDefined()
   })
 
   describe('uncaught exception handling', () => {
@@ -164,18 +156,16 @@ describe('instrumentOnError', () => {
   })
 
   describe('should handle direct onerror calls', () => {
-    it('with objects', (done) => {
+    it('with objects', async () => {
       const error = { foo: 'bar' } as any
       setTimeout(() => {
         window.onerror!(error)
       })
 
-      collectAsyncCalls(onErrorSpy, 1, () => {
-        const [stack, originalError] = callbackSpy.calls.mostRecent().args
-        expect(originalError).toBe(error)
-        expect(stack).toBeDefined()
-        done()
-      })
+      await collectAsyncCalls(onErrorSpy, 1)
+      const [stack, originalError] = callbackSpy.calls.mostRecent().args
+      expect(originalError).toBe(error)
+      expect(stack).toBeDefined()
     })
 
     describe('with undefined arguments', () => {

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -70,7 +70,7 @@ describe('httpRequest', () => {
       })
     })
 
-    it('should use retry strategy', (done) => {
+    it('should use retry strategy', async () => {
       if (!interceptor.isFetchKeepAliveSupported()) {
         pending('no fetch keepalive support')
       }
@@ -90,7 +90,7 @@ describe('httpRequest', () => {
 
       request.send({ data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 })
 
-      collectAsyncCalls(fetchSpy, 2, () => done())
+      await collectAsyncCalls(fetchSpy, 2)
     })
   })
 

--- a/packages/core/test/collectAsyncCalls.ts
+++ b/packages/core/test/collectAsyncCalls.ts
@@ -2,7 +2,7 @@ import { getCurrentJasmineSpec } from './getCurrentJasmineSpec'
 
 export function collectAsyncCalls<F extends jasmine.Func>(
   spy: jasmine.Spy<F>,
-  expectedCallsCount: number
+  expectedCallsCount = 1
 ): Promise<jasmine.Calls<F>> {
   return new Promise((resolve, reject) => {
     const currentSpec = getCurrentJasmineSpec()
@@ -27,7 +27,9 @@ export function collectAsyncCalls<F extends jasmine.Func>(
     }) as F)
 
     function extraCallDetected() {
-      reject(new Error(`Unexpected extra call for spec '${currentSpec!.fullName}'`))
+      const message = `Unexpected extra call for spec '${currentSpec!.fullName}'`
+      fail(message)
+      reject(new Error(message))
     }
   })
 }

--- a/packages/core/test/collectAsyncCalls.ts
+++ b/packages/core/test/collectAsyncCalls.ts
@@ -2,29 +2,32 @@ import { getCurrentJasmineSpec } from './getCurrentJasmineSpec'
 
 export function collectAsyncCalls<F extends jasmine.Func>(
   spy: jasmine.Spy<F>,
-  expectedCallsCount: number,
-  callback: (calls: jasmine.Calls<F>) => void
-) {
-  const currentSpec = getCurrentJasmineSpec()
-  if (!currentSpec) {
-    throw new Error('collectAsyncCalls should be called within jasmine code')
-  }
+  expectedCallsCount: number
+): Promise<jasmine.Calls<F>> {
+  return new Promise((resolve, reject) => {
+    const currentSpec = getCurrentJasmineSpec()
+    if (!currentSpec) {
+      reject(new Error('collectAsyncCalls should be called within jasmine code'))
+      return
+    }
 
-  if (spy.calls.count() === expectedCallsCount) {
-    spy.and.callFake(extraCallDetected as F)
-    callback(spy.calls)
-  } else if (spy.calls.count() > expectedCallsCount) {
-    extraCallDetected()
-  } else {
-    spy.and.callFake((() => {
+    const checkCalls = () => {
       if (spy.calls.count() === expectedCallsCount) {
         spy.and.callFake(extraCallDetected as F)
-        callback(spy.calls)
+        resolve(spy.calls)
+      } else if (spy.calls.count() > expectedCallsCount) {
+        extraCallDetected()
       }
-    }) as F)
-  }
+    }
 
-  function extraCallDetected() {
-    fail(`Unexpected extra call for spec '${currentSpec!.fullName}'`)
-  }
+    checkCalls()
+
+    spy.and.callFake((() => {
+      checkCalls()
+    }) as F)
+
+    function extraCallDetected() {
+      reject(new Error(`Unexpected extra call for spec '${currentSpec!.fullName}'`))
+    }
+  })
 }

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -252,9 +252,7 @@ describe('startRecording', () => {
   }
 
   async function readSentRequests(expectedSentRequestCount: number) {
-    const calls = await new Promise<jasmine.Calls<HttpRequest['sendOnExit']>>((resolve) =>
-      collectAsyncCalls(requestSendSpy, expectedSentRequestCount, resolve)
-    )
+    const calls = await collectAsyncCalls(requestSendSpy, expectedSentRequestCount)
     return Promise.all(calls.all().map((call) => readReplayPayload(call.args[0])))
   }
 })

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -40,7 +40,7 @@ describe('record', () => {
     })
   })
 
-  it('captures stylesheet rules', (done) => {
+  it('captures stylesheet rules', async () => {
     const styleElement = appendElement('<style></style>') as HTMLStyleElement
 
     startRecording()
@@ -59,66 +59,64 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    collectAsyncCalls(emitSpy, recordsPerFullSnapshot() + 6, () => {
-      const records = getEmittedRecords()
-      let i = 0
+    await collectAsyncCalls(emitSpy, recordsPerFullSnapshot() + 6)
 
-      expect(records[i++].type).toEqual(RecordType.Meta)
-      expect(records[i++].type).toEqual(RecordType.Focus)
-      expect(records[i++].type).toEqual(RecordType.FullSnapshot)
+    const records = getEmittedRecords()
+    let i = 0
 
-      if (window.visualViewport) {
-        expect(records[i++].type).toEqual(RecordType.VisualViewport)
-      }
+    expect(records[i++].type).toEqual(RecordType.Meta)
+    expect(records[i++].type).toEqual(RecordType.Focus)
+    expect(records[i++].type).toEqual(RecordType.FullSnapshot)
 
-      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { background: #000; }', index: undefined }],
-        })
-      )
-      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { background: #111; }', index: undefined }],
-        })
-      )
-      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          removes: [{ index: 0 }],
-        })
-      )
-      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { color: #fff; }', index: undefined }],
-        })
-      )
-      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          removes: [{ index: 0 }],
-        })
-      )
-      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-        jasmine.objectContaining({
-          source: IncrementalSource.StyleSheetRule,
-          adds: [{ rule: 'body { color: #ccc; }', index: undefined }],
-        })
-      )
+    if (window.visualViewport) {
+      expect(records[i++].type).toEqual(RecordType.VisualViewport)
+    }
 
-      done()
-    })
+    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
+      jasmine.objectContaining({
+        source: IncrementalSource.StyleSheetRule,
+        adds: [{ rule: 'body { background: #000; }', index: undefined }],
+      })
+    )
+    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
+      jasmine.objectContaining({
+        source: IncrementalSource.StyleSheetRule,
+        adds: [{ rule: 'body { background: #111; }', index: undefined }],
+      })
+    )
+    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
+      jasmine.objectContaining({
+        source: IncrementalSource.StyleSheetRule,
+        removes: [{ index: 0 }],
+      })
+    )
+    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
+      jasmine.objectContaining({
+        source: IncrementalSource.StyleSheetRule,
+        adds: [{ rule: 'body { color: #fff; }', index: undefined }],
+      })
+    )
+    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
+      jasmine.objectContaining({
+        source: IncrementalSource.StyleSheetRule,
+        removes: [{ index: 0 }],
+      })
+    )
+    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
+      jasmine.objectContaining({
+        source: IncrementalSource.StyleSheetRule,
+        adds: [{ rule: 'body { color: #ccc; }', index: undefined }],
+      })
+    )
   })
 
-  it('flushes pending mutation records before taking a full snapshot', (done) => {
+  it('flushes pending mutation records before taking a full snapshot', async () => {
     startRecording()
 
     appendElement('<hr/>')
@@ -126,25 +124,23 @@ describe('record', () => {
     // trigger full snapshot by starting a new view
     newView()
 
-    collectAsyncCalls(emitSpy, 1 + 2 * recordsPerFullSnapshot(), () => {
-      const records = getEmittedRecords()
-      let i = 0
+    await collectAsyncCalls(emitSpy, 1 + 2 * recordsPerFullSnapshot())
 
-      expect(records[i++].type).toEqual(RecordType.Meta)
-      expect(records[i++].type).toEqual(RecordType.Focus)
-      expect(records[i++].type).toEqual(RecordType.FullSnapshot)
+    const records = getEmittedRecords()
+    let i = 0
 
-      if (window.visualViewport) {
-        expect(records[i++].type).toEqual(RecordType.VisualViewport)
-      }
-      expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-      expect((records[i++] as BrowserIncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
-      expect(records[i++].type).toEqual(RecordType.Meta)
-      expect(records[i++].type).toEqual(RecordType.Focus)
-      expect(records[i++].type).toEqual(RecordType.FullSnapshot)
+    expect(records[i++].type).toEqual(RecordType.Meta)
+    expect(records[i++].type).toEqual(RecordType.Focus)
+    expect(records[i++].type).toEqual(RecordType.FullSnapshot)
 
-      done()
-    })
+    if (window.visualViewport) {
+      expect(records[i++].type).toEqual(RecordType.VisualViewport)
+    }
+    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
+    expect((records[i++] as BrowserIncrementalSnapshotRecord).data.source).toEqual(IncrementalSource.Mutation)
+    expect(records[i++].type).toEqual(RecordType.Meta)
+    expect(records[i++].type).toEqual(RecordType.Focus)
+    expect(records[i++].type).toEqual(RecordType.FullSnapshot)
   })
 
   describe('Shadow dom', () => {

--- a/packages/rum/src/domain/record/trackers/trackMutation.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackMutation.spec.ts
@@ -100,7 +100,7 @@ describe('trackMutation', () => {
 
       expect(mutationCallbackSpy).not.toHaveBeenCalled()
 
-      await collectAsyncCalls(mutationCallbackSpy, 1)
+      await collectAsyncCalls(mutationCallbackSpy)
     })
 
     it('does not emit a mutation when a node is appended to a unknown node', () => {

--- a/packages/rum/src/domain/record/trackers/trackMutation.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackMutation.spec.ts
@@ -92,7 +92,7 @@ describe('trackMutation', () => {
       })
     })
 
-    it('processes mutations asynchronously', (done) => {
+    it('processes mutations asynchronously', async () => {
       serializeDocumentWithDefaults()
       const { mutationCallbackSpy } = startMutationCollection()
 
@@ -100,7 +100,7 @@ describe('trackMutation', () => {
 
       expect(mutationCallbackSpy).not.toHaveBeenCalled()
 
-      collectAsyncCalls(mutationCallbackSpy, 1, () => done())
+      await collectAsyncCalls(mutationCallbackSpy, 1)
     })
 
     it('does not emit a mutation when a node is appended to a unknown node', () => {


### PR DESCRIPTION
## Motivation

Use promise in collectAsyncCalls instead of a callback.
This will also benefit for the replay lazy loading tests: [PR](https://github.com/DataDog/browser-sdk/pull/3152)

## Changes

- Use promise in `collectAsyncCalls` instead of a callback. 
- Use the async await syntax in the corresponding tests.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
