### PR TITLE
👷 [RUM-6819] fix comment on browser support for unicode character escape

### DIFF
--- a/packages/core/src/domain/configuration/tags.ts
+++ b/packages/core/src/domain/configuration/tags.ts
@@ -44,7 +44,8 @@ export function buildTag(key: string, rawValue: string) {
 
 function hasForbiddenCharacters(rawValue: string) {
   // Unicode property escapes is not supported in all browsers, so we use a try/catch.
-  // Todo: Remove the try/catch when dropping IE11.
+  // Todo: Remove the try/catch when dropping support for Chrome 63 and Firefox 67
+  // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape#browser_compatibility
   if (!supportUnicodePropertyEscapes()) {
     return false
   }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Fix comment as we still support browser that don't support unicode character escape in regex.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
