### PR TITLE
👷 [RUM-6820] fix comment about performance.timing.navigationStart

### DIFF
--- a/packages/core/src/tools/utils/timeUtils.ts
+++ b/packages/core/src/tools/utils/timeUtils.ts
@@ -80,13 +80,7 @@ export function addDuration(a: number, b: number) {
   return a + b
 }
 
-/**
- * Get the time since the navigation was started.
- *
- * Note: this does not use `performance.timeOrigin` because it doesn't seem to reflect the actual
- * time on which the navigation has started: it may be much farther in the past, at least in Firefox 71.
- * Related issue in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1429926
- */
+// Get the time since the navigation was started.
 export function getRelativeTime(timestamp: TimeStamp) {
   return (timestamp - getNavigationStart()) as RelativeTime
 }
@@ -104,6 +98,12 @@ export function looksLikeRelativeTime(time: RelativeTime | TimeStamp): time is R
  */
 let navigationStart: TimeStamp | undefined
 
+/**
+ * Notes: this does not use `performance.timeOrigin` because:
+ * - It doesn't seem to reflect the actual time on which the navigation has started: it may be much farther in the past,
+ * at least in Firefox 71. (see: https://bugzilla.mozilla.org/show_bug.cgi?id=1429926)
+ * - It is not supported in Safari <15
+ */
 function getNavigationStart() {
   if (navigationStart === undefined) {
     navigationStart = performance.timing.navigationStart as TimeStamp

--- a/packages/core/test/emulate/mockClock.ts
+++ b/packages/core/test/emulate/mockClock.ts
@@ -6,7 +6,7 @@ export function mockClock() {
   jasmine.clock().install()
   jasmine.clock().mockDate()
 
-  const timeOrigin = performance.timing.navigationStart // TODO: use performance.timeOrigin when we drop IE11 support
+  const timeOrigin = performance.timing.navigationStart // @see getNavigationStart() in timeUtils.ts
   const timeStampStart = Date.now()
   const relativeStart = timeStampStart - timeOrigin
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Edit comment about the browser support of `performance.timeOrigin`

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
