### PR TITLE
♻️ [RUM-6813] Split the recorder API module

### DIFF
--- a/packages/rum/src/boot/postStartStrategy.ts
+++ b/packages/rum/src/boot/postStartStrategy.ts
@@ -1,0 +1,103 @@
+import {
+  SessionReplayState,
+  type LifeCycle,
+  type RumConfiguration,
+  type RumSessionManager,
+  type StartRecordingOptions,
+  type ViewHistory,
+} from '@datadog/browser-rum-core'
+import { runOnReadyState, type DeflateEncoder } from '@datadog/browser-core'
+import { getSessionReplayLink } from '../domain/getSessionReplayLink'
+import type { startRecording } from './startRecording'
+
+export type StartRecording = typeof startRecording
+
+export const enum RecorderStatus {
+  // The recorder is stopped.
+  Stopped,
+  // The user started the recording while it wasn't possible yet. The recorder should start as soon
+  // as possible.
+  IntentToStart,
+  // The recorder is starting. It does not record anything yet.
+  Starting,
+  // The recorder is started, it records the session.
+  Started,
+}
+export type RecorderState = {
+  status: RecorderStatus
+  setStatus: (status: RecorderStatus) => void
+  statusEqual: (status: RecorderStatus) => boolean
+}
+
+export interface Strategy {
+  startStrategy: (options?: StartRecordingOptions) => void
+  stopStrategy: () => void
+  getSessionReplayLinkStrategy: () => string | undefined
+}
+
+export function createPostStartStrategy(
+  configuration: RumConfiguration,
+  lifeCycle: LifeCycle,
+  sessionManager: RumSessionManager,
+  viewHistory: ViewHistory,
+  startRecordingImpl: StartRecording,
+  getOrCreateDeflateEncoder: () => DeflateEncoder | undefined,
+  state: RecorderState
+): Strategy {
+  let stopRecording: () => void
+  return {
+    startStrategy(options?: StartRecordingOptions) {
+      const session = sessionManager.findTrackedSession()
+      if (!session || (session.sessionReplay === SessionReplayState.OFF && (!options || !options.force))) {
+        state.setStatus(RecorderStatus.IntentToStart)
+        return
+      }
+
+      if (state.statusEqual(RecorderStatus.Starting) || state.statusEqual(RecorderStatus.Started)) {
+        return
+      }
+
+      state.setStatus(RecorderStatus.Starting)
+
+      runOnReadyState(configuration, 'interactive', () => {
+        if (state.status !== RecorderStatus.Starting) {
+          return
+        }
+
+        const deflateEncoder = getOrCreateDeflateEncoder()
+        if (!deflateEncoder) {
+          state.setStatus(RecorderStatus.Stopped)
+          return
+        }
+
+        ;({ stop: stopRecording } = startRecordingImpl(
+          lifeCycle,
+          configuration,
+          sessionManager,
+          viewHistory,
+          deflateEncoder
+        ))
+
+        state.setStatus(RecorderStatus.Started)
+      })
+
+      if (options && options.force && session.sessionReplay === SessionReplayState.OFF) {
+        sessionManager.setForcedReplay()
+      }
+    },
+
+    stopStrategy() {
+      if (state.statusEqual(RecorderStatus.Stopped)) {
+        return
+      }
+
+      stopRecording?.()
+
+      state.setStatus(RecorderStatus.Stopped)
+    },
+
+    getSessionReplayLinkStrategy() {
+      return getSessionReplayLink(configuration, sessionManager, viewHistory, state.status !== RecorderStatus.Stopped)
+    },
+  }
+}

--- a/packages/rum/src/boot/preStartStrategy.ts
+++ b/packages/rum/src/boot/preStartStrategy.ts
@@ -1,0 +1,34 @@
+import { noop } from '@datadog/browser-core'
+import type { RumConfiguration } from '@datadog/browser-rum-core'
+import type { Strategy } from './postStartStrategy'
+
+const enum PreStartRecorderStatus {
+  None,
+  HadManualStart,
+  HadManualStop,
+}
+
+export function createPreStartStrategy(): {
+  strategy: Strategy
+  shouldStartImmediately: (configuration: RumConfiguration) => boolean
+} {
+  let status = PreStartRecorderStatus.None
+  return {
+    strategy: {
+      start() {
+        status = PreStartRecorderStatus.HadManualStart
+      },
+      stop() {
+        status = PreStartRecorderStatus.HadManualStop
+      },
+      isRecording: () => false,
+      getSessionReplayLink: noop as () => string | undefined,
+    },
+    shouldStartImmediately(configuration) {
+      return (
+        status === PreStartRecorderStatus.HadManualStart ||
+        (status === PreStartRecorderStatus.None && !configuration.startSessionReplayRecordingManually)
+      )
+    },
+  }
+}

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -14,8 +14,8 @@ import type { CreateDeflateWorker } from '../domain/deflate'
 import { MockWorker } from '../../test'
 import { resetDeflateWorkerState } from '../domain/deflate'
 import * as replayStats from '../domain/replayStats'
-import type { StartRecording } from './recorderApi'
 import { makeRecorderApi } from './recorderApi'
+import type { StartRecording } from './postStartStrategy'
 
 describe('makeRecorderApi', () => {
   let lifeCycle: LifeCycle

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -1,12 +1,11 @@
-import type { DeflateEncoder } from '@datadog/browser-core'
+import type { DeflateEncoder, DeflateWorker } from '@datadog/browser-core'
 import {
-  DeflateEncoderStreamId,
   canUseEventBridge,
   noop,
-  runOnReadyState,
   PageExitReason,
   BridgeCapability,
   bridgeSupports,
+  DeflateEncoderStreamId,
 } from '@datadog/browser-core'
 import type {
   LifeCycle,
@@ -16,49 +15,18 @@ import type {
   RumConfiguration,
   StartRecordingOptions,
 } from '@datadog/browser-rum-core'
-import { LifeCycleEventType, SessionReplayState } from '@datadog/browser-rum-core'
+import { LifeCycleEventType } from '@datadog/browser-rum-core'
 import { getReplayStats as getReplayStatsImpl } from '../domain/replayStats'
-import { getSessionReplayLink } from '../domain/getSessionReplayLink'
 import type { CreateDeflateWorker } from '../domain/deflate'
 import {
   createDeflateEncoder,
-  startDeflateWorker,
   DeflateWorkerStatus,
   getDeflateWorkerStatus,
+  startDeflateWorker,
 } from '../domain/deflate'
-
-import type { startRecording } from './startRecording'
 import { isBrowserSupported } from './isBrowserSupported'
-
-export type StartRecording = typeof startRecording
-
-const enum RecorderStatus {
-  // The recorder is stopped.
-  Stopped,
-  // The user started the recording while it wasn't possible yet. The recorder should start as soon
-  // as possible.
-  IntentToStart,
-  // The recorder is starting. It does not record anything yet.
-  Starting,
-  // The recorder is started, it records the session.
-  Started,
-}
-type RecorderState =
-  | {
-      status: RecorderStatus.Stopped
-    }
-  | {
-      status: RecorderStatus.IntentToStart
-    }
-  | {
-      status: RecorderStatus.Starting
-    }
-  | {
-      status: RecorderStatus.Started
-      stopRecording: () => void
-    }
-
-type StartStrategyFn = (options?: StartRecordingOptions) => void
+import type { RecorderState, StartRecording, Strategy } from './postStartStrategy'
+import { createPostStartStrategy, RecorderStatus } from './postStartStrategy'
 
 export function makeRecorderApi(
   startRecordingImpl: StartRecording,
@@ -75,139 +43,23 @@ export function makeRecorderApi(
     }
   }
 
-  let state: RecorderState = {
+  const state: RecorderState = {
     status: RecorderStatus.IntentToStart,
+    setStatus(updatedStatus: RecorderStatus) {
+      state.status = updatedStatus
+    },
+    statusEqual(status: RecorderStatus) {
+      return state.status === status
+    },
   }
 
-  let startStrategy: StartStrategyFn = () => {
-    state = { status: RecorderStatus.IntentToStart }
-  }
-  let stopStrategy = () => {
-    state = { status: RecorderStatus.Stopped }
-  }
-  let getSessionReplayLinkStrategy = noop as () => string | undefined
+  let strategies: Strategy = createPreStartStrategy(state)
 
   return {
-    start: (options?: StartRecordingOptions) => startStrategy(options),
-    stop: () => stopStrategy(),
-    getSessionReplayLink: () => getSessionReplayLinkStrategy(),
-    onRumStart: (
-      lifeCycle: LifeCycle,
-      configuration: RumConfiguration,
-      sessionManager: RumSessionManager,
-      viewHistory: ViewHistory,
-      worker
-    ) => {
-      if (configuration.startSessionReplayRecordingManually) {
-        state = { status: RecorderStatus.Stopped }
-      }
-      lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
-        if (state.status === RecorderStatus.Starting || state.status === RecorderStatus.Started) {
-          stopStrategy()
-          state = { status: RecorderStatus.IntentToStart }
-        }
-      })
-
-      // Stop the recorder on page unload to avoid sending records after the page is ended.
-      lifeCycle.subscribe(LifeCycleEventType.PAGE_EXITED, (pageExitEvent) => {
-        if (pageExitEvent.reason === PageExitReason.UNLOADING) {
-          stopStrategy()
-        }
-      })
-
-      lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
-        if (state.status === RecorderStatus.IntentToStart) {
-          startStrategy()
-        }
-      })
-
-      let cachedDeflateEncoder: DeflateEncoder | undefined
-
-      function getOrCreateDeflateEncoder() {
-        if (!cachedDeflateEncoder) {
-          if (!worker) {
-            worker = startDeflateWorker(
-              configuration,
-              'Datadog Session Replay',
-              () => {
-                stopStrategy()
-              },
-              createDeflateWorkerImpl
-            )
-          }
-          if (worker) {
-            cachedDeflateEncoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
-          }
-        }
-        return cachedDeflateEncoder
-      }
-
-      startStrategy = (options?: StartRecordingOptions) => {
-        const session = sessionManager.findTrackedSession()
-        if (!session || (session.sessionReplay === SessionReplayState.OFF && (!options || !options.force))) {
-          state = { status: RecorderStatus.IntentToStart }
-          return
-        }
-
-        if (state.status === RecorderStatus.Starting || state.status === RecorderStatus.Started) {
-          return
-        }
-
-        state = { status: RecorderStatus.Starting }
-
-        runOnReadyState(configuration, 'interactive', () => {
-          if (state.status !== RecorderStatus.Starting) {
-            return
-          }
-
-          const deflateEncoder = getOrCreateDeflateEncoder()
-          if (!deflateEncoder) {
-            state = {
-              status: RecorderStatus.Stopped,
-            }
-            return
-          }
-
-          const { stop: stopRecording } = startRecordingImpl(
-            lifeCycle,
-            configuration,
-            sessionManager,
-            viewHistory,
-            deflateEncoder
-          )
-          state = {
-            status: RecorderStatus.Started,
-            stopRecording,
-          }
-        })
-
-        if (options && options.force && session.sessionReplay === SessionReplayState.OFF) {
-          sessionManager.setForcedReplay()
-        }
-      }
-
-      stopStrategy = () => {
-        if (state.status === RecorderStatus.Stopped) {
-          return
-        }
-
-        if (state.status === RecorderStatus.Started) {
-          state.stopRecording()
-        }
-
-        state = {
-          status: RecorderStatus.Stopped,
-        }
-      }
-
-      getSessionReplayLinkStrategy = () =>
-        getSessionReplayLink(configuration, sessionManager, viewHistory, state.status !== RecorderStatus.Stopped)
-
-      if (state.status === RecorderStatus.IntentToStart) {
-        startStrategy()
-      }
-    },
-
+    start: (options?: StartRecordingOptions) => strategies.startStrategy(options),
+    stop: () => strategies.stopStrategy(),
+    getSessionReplayLink: () => strategies.getSessionReplayLinkStrategy(),
+    onRumStart,
     isRecording: () =>
       // The worker is started optimistically, meaning we could have started to record but its
       // initialization fails a bit later. This could happen when:
@@ -235,5 +87,82 @@ export function makeRecorderApi(
 
     getReplayStats: (viewId) =>
       getDeflateWorkerStatus() === DeflateWorkerStatus.Initialized ? getReplayStatsImpl(viewId) : undefined,
+  }
+
+  function onRumStart(
+    lifeCycle: LifeCycle,
+    configuration: RumConfiguration,
+    sessionManager: RumSessionManager,
+    viewHistory: ViewHistory,
+    worker: DeflateWorker | undefined
+  ) {
+    if (configuration.startSessionReplayRecordingManually) {
+      state.setStatus(RecorderStatus.Stopped)
+    }
+    lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
+      if (state.status === RecorderStatus.Starting || state.status === RecorderStatus.Started) {
+        strategies.stopStrategy()
+        state.setStatus(RecorderStatus.IntentToStart)
+      }
+    })
+
+    // Stop the recorder on page unload to avoid sending records after the page is ended.
+    lifeCycle.subscribe(LifeCycleEventType.PAGE_EXITED, (pageExitEvent) => {
+      if (pageExitEvent.reason === PageExitReason.UNLOADING) {
+        strategies.stopStrategy()
+      }
+    })
+
+    lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
+      if (state.status === RecorderStatus.IntentToStart) {
+        strategies.startStrategy()
+      }
+    })
+
+    let cachedDeflateEncoder: DeflateEncoder | undefined
+
+    function getOrCreateDeflateEncoder() {
+      if (!cachedDeflateEncoder) {
+        worker ??= startDeflateWorker(
+          configuration,
+          'Datadog Session Replay',
+          () => {
+            strategies.stopStrategy()
+          },
+          createDeflateWorkerImpl
+        )
+
+        if (worker) {
+          cachedDeflateEncoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+        }
+      }
+      return cachedDeflateEncoder
+    }
+
+    strategies = createPostStartStrategy(
+      configuration,
+      lifeCycle,
+      sessionManager,
+      viewHistory,
+      startRecordingImpl,
+      getOrCreateDeflateEncoder,
+      state
+    )
+
+    if (state.status === RecorderStatus.IntentToStart) {
+      strategies.startStrategy()
+    }
+  }
+}
+
+export function createPreStartStrategy(state: RecorderState): Strategy {
+  return {
+    startStrategy(_options?: StartRecordingOptions) {
+      state.setStatus(RecorderStatus.IntentToStart)
+    },
+    stopStrategy() {
+      state.setStatus(RecorderStatus.Stopped)
+    },
+    getSessionReplayLinkStrategy: noop as () => string | undefined,
   }
 }


### PR DESCRIPTION
## Motivation

The recorderApi module is a bit large and we want to add more logic before starting to lazy load the recorder. It is a good time to extract the "pre start" logic like we did with RUM and Logs: https://github.com/DataDog/browser-sdk/pull/2575.


## Changes

- Introduce a `Strategy` interface for behaviors that differs before and after starting the SDK.
- Introduce a `createPreStartStrategy` to initialize the strategy before the SDK is started
- Introduce a `createPostStartStrategy` to update the strategy after the SDK is started


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
