### PR TITLE
Adds a prepare script to @datadog/browser-rum-react

### DIFF
--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "run-p build:cjs build:esm",
     "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json",
-    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
+    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json",
+    "prepack": "yarn ../.. build"
   },
   "dependencies": {
     "@datadog/browser-core": "5.32.0",


### PR DESCRIPTION
## Motivation

The standard `prepare` script is called by Yarn when a repository is installed as a dependency. Its purpose is to let the package describe how its sources should be compiled when `yarn pack` is called. Since the script was missing, Yarn was packing the original TypeScript source files rather than the JavaScript ones.

## Changes

Adds a `prepack` script that delegates to the top-level `build` script. It'd be better if the workspace could build its files and only its files, but the existing `build` script didn't seem to work (`command not found: run-p`) so I preferred to leverage the existing build pipeline.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
