### PR TITLE
💥 [RUM-6816] remove sendLogsAfterSessionExpiration

### DIFF
--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -258,7 +258,7 @@ describe('logs', () => {
       setCookie(SESSION_STORE_KEY, 'id=foo&logs=1', ONE_MINUTE)
       ;({ handleLog, stop: stopLogs } = startLogs(
         initConfiguration,
-        { ...baseConfiguration, sendLogsAfterSessionExpiration: true },
+        baseConfiguration,
         () => COMMON_CONTEXT,
         createTrackingConsentState(TrackingConsent.GRANTED)
       ))
@@ -280,30 +280,6 @@ describe('logs', () => {
 
       expect(secondRequest.message).toEqual('message 2')
       expect(secondRequest.session_id).toBeUndefined()
-    })
-
-    it('does not send logs with session id when session is expired and sendLogsAfterSessionExpiration is false', () => {
-      setCookie(SESSION_STORE_KEY, 'id=foo&logs=1', ONE_MINUTE)
-      ;({ handleLog, stop: stopLogs } = startLogs(
-        initConfiguration,
-        baseConfiguration,
-        () => COMMON_CONTEXT,
-        createTrackingConsentState(TrackingConsent.GRANTED)
-      ))
-      registerCleanupTask(stopLogs)
-
-      handleLog({ status: StatusType.info, message: 'message 1' }, logger)
-
-      expireCookie()
-      clock.tick(STORAGE_POLL_DELAY * 2)
-
-      handleLog({ status: StatusType.info, message: 'message 2' }, logger)
-
-      const firstRequest = getLoggedMessage(requests, 0)
-
-      expect(requests.length).toEqual(1)
-      expect(firstRequest.message).toEqual('message 1')
-      expect(firstRequest.session_id).toEqual('foo')
     })
   })
 })

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -43,10 +43,11 @@ const COMMON_CONTEXT_WITH_USER: CommonContext = {
 
 describe('startLogsAssembly', () => {
   const sessionManager: LogsSessionManager = {
-    findTrackedSession: (_startTime, options) =>
-      (sessionIsActive && sessionIsTracked) || options?.returnInactive
-        ? { id: sessionIsTracked ? SESSION_ID : undefined }
-        : undefined,
+    findTrackedSession: (_startTime, options) => {
+      if (sessionIsTracked && (sessionIsActive || options?.returnInactive)) {
+        return { id: SESSION_ID }
+      }
+    },
     expireObservable: new Observable(),
   }
 
@@ -124,14 +125,6 @@ describe('startLogsAssembly', () => {
     })
 
     it('should send log without session id if session has expired', () => {
-      startLogsAssembly(
-        sessionManager,
-        { ...configuration, sendLogsAfterSessionExpiration: true },
-        lifeCycle,
-        () => COMMON_CONTEXT,
-        noop
-      )
-
       sessionIsTracked = true
       sessionIsActive = false
 

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -26,8 +26,7 @@ export function startLogsAssembly(
     ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined, domainContext }) => {
       const startTime = getRelativeTime(rawLogsEvent.date)
       const session = sessionManager.findTrackedSession(startTime)
-      const hasInactiveSession = sessionManager.findTrackedSession(startTime, { returnInactive: true })
-      const shouldSendLog = session || hasInactiveSession
+      const shouldSendLog = sessionManager.findTrackedSession(startTime, { returnInactive: true })
 
       if (!shouldSendLog) {
         return

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -26,12 +26,10 @@ export function startLogsAssembly(
     ({ rawLogsEvent, messageContext = undefined, savedCommonContext = undefined, domainContext }) => {
       const startTime = getRelativeTime(rawLogsEvent.date)
       const session = sessionManager.findTrackedSession(startTime)
+      const hasInactiveSession = sessionManager.findTrackedSession(startTime, { returnInactive: true })
+      const shouldSendLog = session || hasInactiveSession
 
-      if (
-        !session &&
-        (!configuration.sendLogsAfterSessionExpiration ||
-          !sessionManager.findTrackedSession(startTime, { returnInactive: true }))
-      ) {
+      if (!shouldSendLog) {
         return
       }
 

--- a/packages/logs/src/domain/configuration.spec.ts
+++ b/packages/logs/src/domain/configuration.spec.ts
@@ -138,7 +138,6 @@ describe('serializeLogsConfiguration', () => {
       forwardConsoleLogs: 'all',
       forwardReports: 'all',
       usePciIntake: false,
-      sendLogsAfterSessionExpiration: false,
     }
 
     type MapLogsInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -157,7 +156,6 @@ describe('serializeLogsConfiguration', () => {
       forward_console_logs: 'all',
       forward_reports: 'all',
       use_pci_intake: false,
-      send_logs_after_session_expiration: false,
     })
   })
 })

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -39,11 +39,6 @@ export interface LogsInitConfiguration extends InitConfiguration {
    * @default false
    */
   usePciIntake?: boolean
-  /**
-   * Keep sending logs after the session expiration.
-   * @default false
-   */
-  sendLogsAfterSessionExpiration?: boolean | undefined // TODO next major: remove this option and make it the default behaviour
 }
 
 export type HybridInitConfiguration = Omit<LogsInitConfiguration, 'clientToken'>
@@ -53,7 +48,6 @@ export interface LogsConfiguration extends Configuration {
   forwardConsoleLogs: ConsoleApiName[]
   forwardReports: RawReportType[]
   requestErrorResponseLengthLimit: number
-  sendLogsAfterSessionExpiration: boolean
 }
 
 /**
@@ -97,7 +91,6 @@ export function validateAndBuildLogsConfiguration(
     forwardConsoleLogs,
     forwardReports,
     requestErrorResponseLengthLimit: DEFAULT_REQUEST_ERROR_RESPONSE_LENGTH_LIMIT,
-    sendLogsAfterSessionExpiration: !!initConfiguration.sendLogsAfterSessionExpiration,
     ...baseConfiguration,
   }
 }
@@ -127,7 +120,6 @@ export function serializeLogsConfiguration(configuration: LogsInitConfiguration)
     forward_console_logs: configuration.forwardConsoleLogs,
     forward_reports: configuration.forwardReports,
     use_pci_intake: configuration.usePciIntake,
-    send_logs_after_session_expiration: configuration.sendLogsAfterSessionExpiration,
     ...baseSerializedInitConfiguration,
   } satisfies RawTelemetryConfiguration
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Remove `sendLogsAfterSessionExpiration` option and makes sending logs after session expiration the default behavior

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
