### PR TITLE
✅ [RUM-6813]Fix recorder tests

### DIFF
--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -463,8 +463,10 @@ describe('makeRecorderApi', () => {
 
   describe('isRecording', () => {
     it('is false when recording has not been started', () => {
-      setupRecorderApi()
+      setupRecorderApi({ startSessionReplayRecordingManually: true })
       rumInit()
+
+      mockWorker.processAllMessages()
 
       expect(recorderApi.isRecording()).toBeFalse()
     })
@@ -518,8 +520,11 @@ describe('makeRecorderApi', () => {
     const VIEW_ID = 'xxx'
 
     it('is undefined when recording has not been started', () => {
-      setupRecorderApi()
+      setupRecorderApi({ startSessionReplayRecordingManually: true })
       rumInit()
+
+      replayStats.addSegment(VIEW_ID)
+      mockWorker.processAllMessages()
 
       expect(recorderApi.getReplayStats(VIEW_ID)).toBeUndefined()
     })


### PR DESCRIPTION
## Motivation

I spotted that two Recorder tests where broken after we automatically started the recorder https://github.com/DataDog/browser-sdk/pull/2275.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
