### PR TITLE
✨ Support custom schema for Electron

### DIFF
--- a/packages/core/src/tools/stackTrace/capturedExceptions.specHelper.ts
+++ b/packages/core/src/tools/stackTrace/capturedExceptions.specHelper.ts
@@ -37,6 +37,15 @@ export const CHROME_XX_WEBPACK = {
    at TESTTESTTEST.proxiedMethod(webpack:///./~/react-proxy/modules/createPrototypeProxy.js?:44:30)`,
 }
 
+export const ELECTRON = {
+  message: 'Default error',
+  name: 'Error',
+  stack: `Error: Default error
+    at dumpExceptionError (electron://-/file.js:41:27)
+    at HTMLButtonElement.onclick (electron://-/file.js:107:146)
+    at I.e.fn.(anonymous function) [as index] (electron://-/file.js:10:3651)`,
+}
+
 export const FIREFOX_3 = {
   fileName: 'http://127.0.0.1:8000/js/stacktrace.js',
   lineNumber: 44,

--- a/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
@@ -623,6 +623,33 @@ Error: foo
     })
   })
 
+  it('should parse Electron schema with Chrome error', () => {
+    const stackFrames = computeStackTrace(CapturedExceptions.ELECTRON)
+
+    expect(stackFrames.stack.length).toEqual(3)
+    expect(stackFrames.stack[0]).toEqual({
+      args: [],
+      column: 27,
+      func: 'dumpExceptionError',
+      line: 41,
+      url: 'electron://-/file.js',
+    })
+    expect(stackFrames.stack[1]).toEqual({
+      args: [],
+      column: 146,
+      func: 'HTMLButtonElement.onclick',
+      line: 107,
+      url: 'electron://-/file.js',
+    })
+    expect(stackFrames.stack[2]).toEqual({
+      args: [],
+      column: 3651,
+      func: 'I.e.fn.(anonymous function) [as index]',
+      line: 10,
+      url: 'electron://-/file.js',
+    })
+  })
+
   it('should parse nested eval() from Chrome', () => {
     const stackFrames = computeStackTrace(CapturedExceptions.CHROME_48_EVAL)
 

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -56,7 +56,8 @@ export function computeStackTrace(ex: unknown): StackTrace {
     stack,
   }
 }
-const fileUrl = '((?:file|https?|blob|chrome-extension|native|eval|webpack|snippet|<anonymous>|\\w+\\.|\\/).*?)'
+const fileUrl =
+  '((?:file|https?|blob|chrome-extension|electron|native|eval|webpack|snippet|<anonymous>|\\w+\\.|\\/).*?)'
 const filePosition = '(?::(\\d+))'
 const CHROME_LINE_RE = new RegExp(`^\\s*at (.*?) ?\\(${fileUrl}${filePosition}?${filePosition}?\\)?\\s*$`, 'i')
 


### PR DESCRIPTION
## Motivation

Support Electron apps when using custom schema. 
https://github.com/DataDog/browser-sdk/issues/3131

## Changes

Add new work to the regex that parses error URLs.

## Testing

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
