### PR TITLE
[RUM-6075] Test anonymous id on staging behind ff

### DIFF
--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -9,7 +9,7 @@ export interface CookieOptions {
   domain?: string
 }
 
-export function setCookie(name: string, value: string, expireDelay: number, options?: CookieOptions) {
+export function setCookie(name: string, value: string, expireDelay: number = 0, options?: CookieOptions) {
   const date = new Date()
   date.setTime(date.getTime() + expireDelay)
   const expires = `expires=${date.toUTCString()}`

--- a/packages/core/src/domain/session/sessionConstants.ts
+++ b/packages/core/src/domain/session/sessionConstants.ts
@@ -1,4 +1,5 @@
-import { ONE_HOUR, ONE_MINUTE } from '../../tools/utils/timeUtils'
+import { ONE_HOUR, ONE_MINUTE, ONE_YEAR } from '../../tools/utils/timeUtils'
 
 export const SESSION_TIME_OUT_DELAY = 4 * ONE_HOUR
 export const SESSION_EXPIRATION_DELAY = 15 * ONE_MINUTE
+export const SESSION_COOKIE_EXPIRATION_DELAY = ONE_YEAR

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -27,6 +27,7 @@ export interface SessionContext<TrackingType extends string> extends Context {
   id: string
   trackingType: TrackingType
   isReplayForced: boolean
+  anonymousId: string | undefined
 }
 
 export const VISIBILITY_CHECK_DELAY = ONE_MINUTE
@@ -86,6 +87,7 @@ export function startSessionManager<TrackingType extends string>(
       id: sessionStore.getSession().id!,
       trackingType: sessionStore.getSession()[productKey] as TrackingType,
       isReplayForced: !!sessionStore.getSession().forcedReplay,
+      anonymousId: sessionStore.getSession().anonymousId,
     }
   }
 

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -1,11 +1,10 @@
+import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../tools/experimentalFeatures'
 import { isEmptyObject } from '../../tools/utils/objectUtils'
 import { objectEntries } from '../../tools/utils/polyfills'
 import { dateNow } from '../../tools/utils/timeUtils'
+import { generateAnonymousId } from '../user'
 import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionConstants'
-
-const SESSION_ENTRY_REGEXP = /^([a-zA-Z]+)=([a-z0-9-]+)$/
-const SESSION_ENTRY_SEPARATOR = '&'
-
+import { isValidSessionString, SESSION_ENTRY_REGEXP, SESSION_ENTRY_SEPARATOR } from './sessionStateValidation'
 export const EXPIRED = '1'
 
 export interface SessionState {
@@ -17,10 +16,18 @@ export interface SessionState {
   [key: string]: string | undefined
 }
 
-export function getExpiredSessionState(): SessionState {
-  return {
+export function getExpiredSessionState(previousSessionState: SessionState | undefined): SessionState {
+  const expiredSessionState: SessionState = {
     isExpired: EXPIRED,
   }
+  if (isExperimentalFeatureEnabled(ExperimentalFeature.ANONYMOUS_USER_TRACKING)) {
+    if (previousSessionState?.anonymousId) {
+      expiredSessionState.anonymousId = previousSessionState?.anonymousId
+    } else {
+      expiredSessionState.anonymousId = generateAnonymousId()
+    }
+  }
+  return expiredSessionState
 }
 
 export function isSessionInNotStartedState(session: SessionState) {
@@ -50,9 +57,12 @@ export function expandSessionState(session: SessionState) {
 }
 
 export function toSessionString(session: SessionState) {
-  return objectEntries(session)
-    .map(([key, value]) => `${key}=${value}`)
-    .join(SESSION_ENTRY_SEPARATOR)
+  return (
+    objectEntries(session)
+      // we use `aid` as a key for anonymousId
+      .map(([key, value]) => (key === 'anonymousId' ? `aid=${value}` : `${key}=${value}`))
+      .join(SESSION_ENTRY_SEPARATOR)
+  )
 }
 
 export function toSessionState(sessionString: string | undefined | null) {
@@ -62,16 +72,14 @@ export function toSessionState(sessionString: string | undefined | null) {
       const matches = SESSION_ENTRY_REGEXP.exec(entry)
       if (matches !== null) {
         const [, key, value] = matches
-        session[key] = value
+        if (key === 'aid') {
+          // we use `aid` as a key for anonymousId
+          session.anonymousId = value
+        } else {
+          session[key] = value
+        }
       }
     })
   }
   return session
-}
-
-function isValidSessionString(sessionString: string | undefined | null): sessionString is string {
-  return (
-    !!sessionString &&
-    (sessionString.indexOf(SESSION_ENTRY_SEPARATOR) !== -1 || SESSION_ENTRY_REGEXP.test(sessionString))
-  )
 }

--- a/packages/core/src/domain/session/sessionStateValidation.ts
+++ b/packages/core/src/domain/session/sessionStateValidation.ts
@@ -1,0 +1,9 @@
+export const SESSION_ENTRY_REGEXP = /^([a-zA-Z]+)=([a-z0-9-]+)$/
+export const SESSION_ENTRY_SEPARATOR = '&'
+
+export function isValidSessionString(sessionString: string | undefined | null): sessionString is string {
+  return (
+    !!sessionString &&
+    (sessionString.indexOf(SESSION_ENTRY_SEPARATOR) !== -1 || SESSION_ENTRY_REGEXP.test(sessionString))
+  )
+}

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -117,7 +117,8 @@ export function startSessionStore<TrackingType extends string>(
   function watchSession() {
     processSessionStoreOperations(
       {
-        process: (sessionState) => (isSessionInExpiredState(sessionState) ? getExpiredSessionState() : undefined),
+        process: (sessionState) =>
+          isSessionInExpiredState(sessionState) ? getExpiredSessionState(sessionState) : undefined,
         after: synchronizeSession,
       },
       sessionStoreStrategy
@@ -126,7 +127,7 @@ export function startSessionStore<TrackingType extends string>(
 
   function synchronizeSession(sessionState: SessionState) {
     if (isSessionInExpiredState(sessionState)) {
-      sessionState = getExpiredSessionState()
+      sessionState = getExpiredSessionState(sessionState)
     }
     if (hasSessionInCache()) {
       if (isSessionInCacheOutdated(sessionState)) {
@@ -144,7 +145,7 @@ export function startSessionStore<TrackingType extends string>(
       {
         process: (sessionState) => {
           if (isSessionInNotStartedState(sessionState)) {
-            return getExpiredSessionState()
+            return getExpiredSessionState(sessionState)
           }
         },
         after: (sessionState) => {
@@ -178,7 +179,7 @@ export function startSessionStore<TrackingType extends string>(
   }
 
   function expireSessionInCache() {
-    sessionCache = getExpiredSessionState()
+    sessionCache = getExpiredSessionState(sessionCache)
     expireObservable.notify()
   }
 
@@ -207,8 +208,8 @@ export function startSessionStore<TrackingType extends string>(
     restartSession: startSession,
     expire: () => {
       cancelExpandOrRenewSession()
-      expireSession()
-      synchronizeSession(getExpiredSessionState())
+      expireSession(sessionCache)
+      synchronizeSession(getExpiredSessionState(sessionCache))
     },
     stop: () => {
       clearInterval(watchSessionTimeoutId)

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -37,7 +37,7 @@ const EXPIRED_SESSION: SessionState = { isExpired: '1' }
     const now = Date.now()
 
     beforeEach(() => {
-      sessionStoreStrategy.expireSession()
+      sessionStoreStrategy.expireSession(initialSession)
       initialSession = { id: '123', created: String(now) }
       otherSession = { id: '456', created: String(now + 100) }
       processSpy = jasmine.createSpy('process')

--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -76,7 +76,7 @@ export function processSessionStoreOperations(
   }
   if (processedSession) {
     if (isSessionInExpiredState(processedSession)) {
-      expireSession()
+      expireSession(processedSession)
     } else {
       expandSessionState(processedSession)
       isLockEnabled ? persistWithLock(processedSession) : persistSession(processedSession)

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -1,3 +1,5 @@
+import { ExperimentalFeature, resetExperimentalFeatures } from '../../../tools/experimentalFeatures'
+import { mockExperimentalFeatures } from '../../../../test'
 import { setCookie, deleteCookie, getCookie, getCurrentSite } from '../../../browser/cookie'
 import { type SessionState } from '../sessionState'
 import { buildCookieOptions, selectCookieStrategy, initCookieStrategy } from './sessionInCookie'
@@ -25,7 +27,7 @@ describe('session in cookie strategy', () => {
 
   it('should set `isExpired=1` to the cookie holding the session', () => {
     cookieStorageStrategy.persistSession(sessionState)
-    cookieStorageStrategy.expireSession()
+    cookieStorageStrategy.expireSession(sessionState)
     const session = cookieStorageStrategy.retrieveSession()
     expect(session).toEqual({ isExpired: '1' })
     expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1')
@@ -106,5 +108,35 @@ describe('session in cookie strategy', () => {
         expect(cookieSetSpy.calls.argsFor(0)[0]).toMatch(cookieString)
       })
     })
+  })
+})
+describe('session in cookie strategy with anonymous user tracking', () => {
+  const anonymousId = 'device-123'
+  const sessionState: SessionState = { id: '123', created: '0' }
+  let cookieStorageStrategy: SessionStoreStrategy
+
+  beforeEach(() => {
+    mockExperimentalFeatures([ExperimentalFeature.ANONYMOUS_USER_TRACKING])
+    cookieStorageStrategy = initCookieStrategy({})
+  })
+
+  afterEach(() => {
+    resetExperimentalFeatures()
+    deleteCookie(SESSION_STORE_KEY)
+  })
+
+  it('should persist a session with anonymous id in a cookie', () => {
+    cookieStorageStrategy.persistSession({ ...sessionState, anonymousId })
+    const session = cookieStorageStrategy.retrieveSession()
+    expect(session).toEqual({ ...sessionState, anonymousId })
+    expect(getCookie(SESSION_STORE_KEY)).toBe(`id=123&created=0&aid=${anonymousId}`)
+  })
+
+  it('should expire a session with anonymous id in a cookie', () => {
+    cookieStorageStrategy.persistSession({ ...sessionState, anonymousId })
+    cookieStorageStrategy.expireSession({ ...sessionState, anonymousId })
+    const session = cookieStorageStrategy.retrieveSession()
+    expect(session).toEqual({ isExpired: '1', anonymousId })
+    expect(getCookie(SESSION_STORE_KEY)).toBe(`isExpired=1&aid=${anonymousId}`)
   })
 })

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -1,9 +1,10 @@
 import { isChromium } from '../../../tools/utils/browserDetection'
+import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../../tools/experimentalFeatures'
 import type { CookieOptions } from '../../../browser/cookie'
 import { getCurrentSite, areCookiesAuthorized, getCookie, setCookie } from '../../../browser/cookie'
 import type { InitConfiguration } from '../../configuration'
 import { tryOldCookiesMigration } from '../oldCookiesMigration'
-import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from '../sessionConstants'
+import { SESSION_COOKIE_EXPIRATION_DELAY, SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
 import { toSessionString, toSessionState, getExpiredSessionState } from '../sessionState'
 import type { SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
@@ -23,7 +24,7 @@ export function initCookieStrategy(cookieOptions: CookieOptions): SessionStoreSt
     isLockEnabled: isChromium(),
     persistSession: persistSessionCookie(cookieOptions),
     retrieveSession: retrieveSessionCookie,
-    expireSession: () => expireSessionCookie(cookieOptions),
+    expireSession: (sessionState: SessionState) => expireSessionCookie(cookieOptions, sessionState),
   }
 
   tryOldCookiesMigration(cookieStore)
@@ -37,13 +38,22 @@ function persistSessionCookie(options: CookieOptions) {
   }
 }
 
-function expireSessionCookie(options: CookieOptions) {
-  setCookie(SESSION_STORE_KEY, toSessionString(getExpiredSessionState()), SESSION_TIME_OUT_DELAY, options)
+function expireSessionCookie(options: CookieOptions, sessionState: SessionState) {
+  const expiredSessionState = getExpiredSessionState(sessionState)
+  setCookie(
+    SESSION_STORE_KEY,
+    toSessionString(expiredSessionState),
+    isExperimentalFeatureEnabled(ExperimentalFeature.ANONYMOUS_USER_TRACKING)
+      ? SESSION_COOKIE_EXPIRATION_DELAY
+      : SESSION_TIME_OUT_DELAY,
+    options
+  )
 }
 
 function retrieveSessionCookie(): SessionState {
   const sessionString = getCookie(SESSION_STORE_KEY)
-  return toSessionState(sessionString)
+  const sessionState = toSessionState(sessionString)
+  return sessionState
 }
 
 export function buildCookieOptions(initConfiguration: InitConfiguration) {

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -37,6 +37,6 @@ function retrieveSessionFromLocalStorage(): SessionState {
   return toSessionState(sessionString)
 }
 
-function expireSessionFromLocalStorage() {
-  persistInLocalStorage(getExpiredSessionState())
+function expireSessionFromLocalStorage(previousSessionState: SessionState) {
+  persistInLocalStorage(getExpiredSessionState(previousSessionState))
 }

--- a/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
@@ -9,5 +9,5 @@ export interface SessionStoreStrategy {
   isLockEnabled: boolean
   persistSession: (session: SessionState) => void
   retrieveSession: () => SessionState
-  expireSession: () => void
+  expireSession: (previousSessionState: SessionState) => void
 }

--- a/packages/core/src/domain/user/user.spec.ts
+++ b/packages/core/src/domain/user/user.spec.ts
@@ -1,5 +1,5 @@
 import { display } from '../../tools/display'
-import { checkUser, sanitizeUser } from './user'
+import { checkUser, generateAnonymousId, sanitizeUser } from './user'
 import type { User } from './user.types'
 
 describe('sanitize user function', () => {
@@ -35,5 +35,11 @@ describe('check user function', () => {
     expect(checkUser(nullUser)).toBe(false)
     expect(checkUser(invalidUser)).toBe(false)
     expect(display.error).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('check anonymous id storage functions', () => {
+  it('should generate a random anonymous id', () => {
+    expect(generateAnonymousId()).toMatch(/^[a-z0-9]+$/)
   })
 })

--- a/packages/core/src/domain/user/user.ts
+++ b/packages/core/src/domain/user/user.ts
@@ -31,3 +31,7 @@ export function checkUser(newUser: User): boolean {
   }
   return isValid
 }
+
+export function generateAnonymousId() {
+  return Math.floor(Math.random() * Math.pow(2, 53)).toString(36)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,7 @@ export {
   deleteCookie,
   resetInitCookies,
 } from './browser/cookie'
+export { generateAnonymousId } from './domain/user'
 export { CookieStore, WeakRef, WeakRefConstructor } from './browser/browser.types'
 export { initXhrObservable, XhrCompleteContext, XhrStartContext } from './browser/xhrObservable'
 export {

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -17,6 +17,7 @@ export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
   REMOTE_CONFIGURATION = 'remote_configuration',
   LONG_ANIMATION_FRAME = 'long_animation_frame',
+  ANONYMOUS_USER_TRACKING = 'anonymous_user_tracking',
   ACTION_NAME_MASKING = 'action_name_masking',
 }
 

--- a/packages/core/test/emulate/mockStorages.ts
+++ b/packages/core/test/emulate/mockStorages.ts
@@ -5,9 +5,7 @@ export interface MockStorage {
   setCurrentValue: (key: string, value: string) => void
 }
 
-export function mockCookie(): MockStorage {
-  let cookie = ''
-
+export function mockCookie(cookie: string = ''): MockStorage {
   return {
     getSpy: spyOnProperty(document, 'cookie', 'get').and.callFake(() => cookie),
     setSpy: spyOnProperty(document, 'cookie', 'set').and.callFake((newCookie) => (cookie = newCookie)),

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -9,6 +9,7 @@ import {
   setNavigatorConnection,
   registerCleanupTask,
   mockClock,
+  mockCookie,
 } from '@datadog/browser-core/test'
 import {
   createRumSessionManagerMock,
@@ -819,7 +820,6 @@ describe('rum assembly', () => {
       expect(serverRumEvents[0].synthetics).toBeTruthy()
     })
   })
-
   describe('if event bridge detected', () => {
     it('includes the browser sdk version', () => {
       const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults()
@@ -844,6 +844,22 @@ describe('rum assembly', () => {
       })
 
       expect(serverRumEvents[0].ci_test).toBeTruthy()
+    })
+  })
+
+  describe('anonymous user id context', () => {
+    it('includes the anonymous user id context', () => {
+      mockExperimentalFeatures([ExperimentalFeature.ANONYMOUS_USER_TRACKING])
+
+      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults()
+
+      mockCookie('expired=1&aid=123')
+
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+      })
+
+      expect(serverRumEvents[0].usr!.anonymous_id).toBeDefined()
     })
   })
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -192,6 +192,13 @@ export function startRumAssembly(
             session.sessionReplay === SessionReplayState.SAMPLED
         }
 
+        if (
+          // TODO: remove ff and should always add anonymous user id
+          isExperimentalFeatureEnabled(ExperimentalFeature.ANONYMOUS_USER_TRACKING) &&
+          !commonContext.user.anonymous_id
+        ) {
+          commonContext.user.anonymous_id = session.anonymousId
+        }
         if (!isEmptyObject(commonContext.user)) {
           ;(serverRumEvent.usr as Mutable<RumEvent['usr']>) = commonContext.user as User & Context
         }

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -23,6 +23,7 @@ export interface RumSessionManager {
 export type RumSession = {
   id: string
   sessionReplay: SessionReplayState
+  anonymousId?: string
 }
 
 export const enum RumTrackingType {
@@ -65,7 +66,6 @@ export function startRumSessionManager(
       }
     }
   })
-
   return {
     findTrackedSession: (startTime) => {
       const session = sessionManager.findSession(startTime)
@@ -80,6 +80,7 @@ export function startRumSessionManager(
             : session.isReplayForced
               ? SessionReplayState.FORCED
               : SessionReplayState.OFF,
+        anonymousId: session.anonymousId,
       }
     },
     expire: sessionManager.expire,

--- a/packages/rum-core/test/mockRumSessionManager.ts
+++ b/packages/rum-core/test/mockRumSessionManager.ts
@@ -37,6 +37,7 @@ export function createRumSessionManagerMock(): RumSessionManagerMock {
             : forcedReplay
               ? SessionReplayState.FORCED
               : SessionReplayState.OFF,
+        anonymousId: 'device-123',
       }
     },
     expire() {


### PR DESCRIPTION
## Motivation
Add device id as anonymous id in session cookie behind a feature flag.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Maintain anonymous id when session expires.
Extend cookie age.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing
Same as previous PR. Already tested on staging.
<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
