### PR TITLE
👷 [RUM-7634] Add deploy and source maps upload scripts tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -199,8 +199,15 @@ module.exports = {
       },
     },
     {
-      files: ['scripts/**/*.js', 'packages/*/scripts/**/*.js'],
+      files: ['scripts/**/*.spec.js', 'packages/*/scripts/**/*.spec.js'],
       excludedFiles: ['**/lib/**'],
+      rules: {
+        'unicorn/filename-case': ['error', { case: 'kebabCase' }],
+      },
+    },
+    {
+      files: ['scripts/**/*.js', 'packages/*/scripts/**/*.js'],
+      excludedFiles: ['**/lib/**', '*.spec.js'],
       rules: {
         'unicorn/filename-case': ['error', { case: 'kebabCase' }],
         'local-rules/secure-command-execution': 'error',

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -294,6 +294,14 @@ e2e-bs:
   after_script:
     - node ./scripts/test/export-test-result.js e2e-bs
 
+script-tests:
+  extends:
+    - .base-configuration
+    - .test-allowed-branches
+  interruptible: true
+  script:
+    - yarn
+    - yarn test:script
 ########################################################################################################################
 # Deploy
 ########################################################################################################################

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "version": "scripts/cli version",
     "test": "yarn test:unit:watch",
     "test:unit": "karma start ./test/unit/karma.local.conf.js",
+    "test:script": "node --test --experimental-test-module-mocks './scripts/**/*.spec.*'",
     "test:unit:watch": "yarn test:unit --no-single-run",
     "test:unit:bs": "node ./scripts/test/bs-wrapper.js karma start test/unit/karma.bs.conf.js",
     "test:e2e": "yarn build && (cd test/app && rm -rf node_modules && yarn && yarn build) && wdio test/e2e/wdio.local.conf.ts",

--- a/scripts/deploy/deploy.spec.js
+++ b/scripts/deploy/deploy.spec.js
@@ -122,7 +122,7 @@ void describe('deploy', () => {
   })
 
   void it('should deploy PR packages', async () => {
-    // mack the PR number fetch
+    // mock the PR number fetch
     fetchPRMock.mock.mockImplementation(() => Promise.resolve({ ['number']: 123 }))
 
     await deploy('staging', 'pull-request', ['pull-request'])

--- a/scripts/deploy/deploy.spec.js
+++ b/scripts/deploy/deploy.spec.js
@@ -1,156 +1,156 @@
-// const assert = require('node:assert/strict')
-// const { beforeEach, before, describe, it, mock } = require('node:test')
-// const path = require('node:path')
-// const { mockModule, mockCommandImplementation, FAKE_AWS_ENV_CREDENTIALS } = require('./lib/testHelpers.js')
+const assert = require('node:assert/strict')
+const { beforeEach, before, describe, it, mock } = require('node:test')
+const path = require('node:path')
+const { mockModule, mockCommandImplementation, FAKE_AWS_ENV_CREDENTIALS } = require('./lib/testHelpers.js')
 
-// void describe('deploy', () => {
-//   let commandMock = mock.fn()
-//   let fetchPRMock = mock.fn()
-//   let deploy
-//   const env = FAKE_AWS_ENV_CREDENTIALS
+void describe('deploy', () => {
+  let commandMock = mock.fn()
+  let fetchPRMock = mock.fn()
+  let deploy
+  const env = FAKE_AWS_ENV_CREDENTIALS
 
-//   let commands
+  let commands
 
-//   function getS3Commands() {
-//     return commands.filter(({ command }) => command.includes('aws s3 cp'))
-//   }
+  function getS3Commands() {
+    return commands.filter(({ command }) => command.includes('aws s3 cp'))
+  }
 
-//   function getCloudfrontCommands() {
-//     return commands.filter(({ command }) => command.includes('aws cloudfront create-invalidation'))
-//   }
+  function getCloudfrontCommands() {
+    return commands.filter(({ command }) => command.includes('aws cloudfront create-invalidation'))
+  }
 
-//   before(async () => {
-//     await mockModule(path.resolve(__dirname, '../lib/command.js'), { command: commandMock })
-//     await mockModule(path.resolve(__dirname, '../lib/gitUtils.js'), { fetchPR: fetchPRMock })
+  before(async () => {
+    await mockModule(path.resolve(__dirname, '../lib/command.js'), { command: commandMock })
+    await mockModule(path.resolve(__dirname, '../lib/gitUtils.js'), { fetchPR: fetchPRMock })
 
-//     // This MUST be a dynamic import because that is the only way to ensure the
-//     // import starts after the mock has been set up.
-//     ;({ main: deploy } = await import('./deploy.js'))
-//   })
+    // This MUST be a dynamic import because that is the only way to ensure the
+    // import starts after the mock has been set up.
+    ;({ main: deploy } = await import('./deploy.js'))
+  })
 
-//   beforeEach(() => {
-//     commands = mockCommandImplementation(commandMock)
-//   })
+  beforeEach(() => {
+    commands = mockCommandImplementation(commandMock)
+  })
 
-//   void it('should deploy root packages', async () => {
-//     await deploy('prod', 'v6', ['root'])
+  void it('should deploy root packages', async () => {
+    await deploy('prod', 'v6', ['root'])
 
-//     assert.deepEqual(getS3Commands(), [
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/datadog-logs-v6.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/datadog-rum-v6.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-v6.js',
-//         env,
-//       },
-//     ])
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/datadog-logs-v6.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/datadog-rum-v6.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-v6.js',
+        env,
+      },
+    ])
 
-//     assert.deepEqual(getCloudfrontCommands(), [
-//       {
-//         command:
-//           'aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v6.js,/datadog-rum-v6.js,/datadog-rum-slim-v6.js',
-//         env,
-//       },
-//     ])
-//   })
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command:
+          'aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v6.js,/datadog-rum-v6.js,/datadog-rum-slim-v6.js',
+        env,
+      },
+    ])
+  })
 
-//   void it('should deploy datacenter packages', async () => {
-//     await deploy('prod', 'v6', ['us1'])
+  void it('should deploy datacenter packages', async () => {
+    await deploy('prod', 'v6', ['us1'])
 
-//     assert.deepEqual(getS3Commands(), [
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/us1/v6/datadog-logs.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/us1/v6/datadog-rum.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/us1/v6/datadog-rum-slim.js',
-//         env,
-//       },
-//     ])
-//     assert.deepEqual(getCloudfrontCommands(), [
-//       {
-//         command:
-//           'aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /us1/v6/datadog-logs.js,/us1/v6/datadog-rum.js,/us1/v6/datadog-rum-slim.js',
-//         env,
-//       },
-//     ])
-//   })
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/us1/v6/datadog-logs.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/us1/v6/datadog-rum.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/us1/v6/datadog-rum-slim.js',
+        env,
+      },
+    ])
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command:
+          'aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /us1/v6/datadog-logs.js,/us1/v6/datadog-rum.js,/us1/v6/datadog-rum-slim.js',
+        env,
+      },
+    ])
+  })
 
-//   void it('should deploy staging packages', async () => {
-//     await deploy('staging', 'staging', ['root'])
+  void it('should deploy staging packages', async () => {
+    await deploy('staging', 'staging', ['root'])
 
-//     assert.deepEqual(getS3Commands(), [
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-staging/datadog-logs-staging.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-staging/datadog-rum-staging.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/datadog-rum-slim-staging.js',
-//         env,
-//       },
-//     ])
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-staging/datadog-logs-staging.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-staging/datadog-rum-staging.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/datadog-rum-slim-staging.js',
+        env,
+      },
+    ])
 
-//     assert.deepEqual(getCloudfrontCommands(), [
-//       {
-//         command:
-//           'aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /datadog-logs-staging.js,/datadog-rum-staging.js,/datadog-rum-slim-staging.js',
-//         env,
-//       },
-//     ])
-//   })
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command:
+          'aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /datadog-logs-staging.js,/datadog-rum-staging.js,/datadog-rum-slim-staging.js',
+        env,
+      },
+    ])
+  })
 
-//   void it('should deploy PR packages', async () => {
-//     // mack the PR number fetch
-//     fetchPRMock.mock.mockImplementation(() => Promise.resolve({ ['number']: 123 }))
+  void it('should deploy PR packages', async () => {
+    // mack the PR number fetch
+    fetchPRMock.mock.mockImplementation(() => Promise.resolve({ ['number']: 123 }))
 
-//     await deploy('staging', 'pull-request', ['pull-request'])
+    await deploy('staging', 'pull-request', ['pull-request'])
 
-//     assert.deepEqual(getS3Commands(), [
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-logs.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-rum.js',
-//         env,
-//       },
-//       {
-//         command:
-//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-rum-slim.js',
-//         env,
-//       },
-//     ])
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-logs.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-rum.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-rum-slim.js',
+        env,
+      },
+    ])
 
-//     assert.deepEqual(getCloudfrontCommands(), [
-//       {
-//         command:
-//           'aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /pull-request/123/datadog-logs.js,/pull-request/123/datadog-rum.js,/pull-request/123/datadog-rum-slim.js',
-//         env,
-//       },
-//     ])
-//   })
-// })
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command:
+          'aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /pull-request/123/datadog-logs.js,/pull-request/123/datadog-rum.js,/pull-request/123/datadog-rum-slim.js',
+        env,
+      },
+    ])
+  })
+})

--- a/scripts/deploy/deploy.spec.js
+++ b/scripts/deploy/deploy.spec.js
@@ -1,0 +1,156 @@
+// const assert = require('node:assert/strict')
+// const { beforeEach, before, describe, it, mock } = require('node:test')
+// const path = require('node:path')
+// const { mockModule, mockCommandImplementation, FAKE_AWS_ENV_CREDENTIALS } = require('./lib/testHelpers.js')
+
+// void describe('deploy', () => {
+//   let commandMock = mock.fn()
+//   let fetchPRMock = mock.fn()
+//   let deploy
+//   const env = FAKE_AWS_ENV_CREDENTIALS
+
+//   let commands
+
+//   function getS3Commands() {
+//     return commands.filter(({ command }) => command.includes('aws s3 cp'))
+//   }
+
+//   function getCloudfrontCommands() {
+//     return commands.filter(({ command }) => command.includes('aws cloudfront create-invalidation'))
+//   }
+
+//   before(async () => {
+//     await mockModule(path.resolve(__dirname, '../lib/command.js'), { command: commandMock })
+//     await mockModule(path.resolve(__dirname, '../lib/gitUtils.js'), { fetchPR: fetchPRMock })
+
+//     // This MUST be a dynamic import because that is the only way to ensure the
+//     // import starts after the mock has been set up.
+//     ;({ main: deploy } = await import('./deploy.js'))
+//   })
+
+//   beforeEach(() => {
+//     commands = mockCommandImplementation(commandMock)
+//   })
+
+//   void it('should deploy root packages', async () => {
+//     await deploy('prod', 'v6', ['root'])
+
+//     assert.deepEqual(getS3Commands(), [
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/datadog-logs-v6.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/datadog-rum-v6.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-v6.js',
+//         env,
+//       },
+//     ])
+
+//     assert.deepEqual(getCloudfrontCommands(), [
+//       {
+//         command:
+//           'aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v6.js,/datadog-rum-v6.js,/datadog-rum-slim-v6.js',
+//         env,
+//       },
+//     ])
+//   })
+
+//   void it('should deploy datacenter packages', async () => {
+//     await deploy('prod', 'v6', ['us1'])
+
+//     assert.deepEqual(getS3Commands(), [
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/us1/v6/datadog-logs.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/us1/v6/datadog-rum.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/us1/v6/datadog-rum-slim.js',
+//         env,
+//       },
+//     ])
+//     assert.deepEqual(getCloudfrontCommands(), [
+//       {
+//         command:
+//           'aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /us1/v6/datadog-logs.js,/us1/v6/datadog-rum.js,/us1/v6/datadog-rum-slim.js',
+//         env,
+//       },
+//     ])
+//   })
+
+//   void it('should deploy staging packages', async () => {
+//     await deploy('staging', 'staging', ['root'])
+
+//     assert.deepEqual(getS3Commands(), [
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-staging/datadog-logs-staging.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-staging/datadog-rum-staging.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/datadog-rum-slim-staging.js',
+//         env,
+//       },
+//     ])
+
+//     assert.deepEqual(getCloudfrontCommands(), [
+//       {
+//         command:
+//           'aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /datadog-logs-staging.js,/datadog-rum-staging.js,/datadog-rum-slim-staging.js',
+//         env,
+//       },
+//     ])
+//   })
+
+//   void it('should deploy PR packages', async () => {
+//     // mack the PR number fetch
+//     fetchPRMock.mock.mockImplementation(() => Promise.resolve({ ['number']: 123 }))
+
+//     await deploy('staging', 'pull-request', ['pull-request'])
+
+//     assert.deepEqual(getS3Commands(), [
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-logs.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-rum.js',
+//         env,
+//       },
+//       {
+//         command:
+//           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-rum-slim.js',
+//         env,
+//       },
+//     ])
+
+//     assert.deepEqual(getCloudfrontCommands(), [
+//       {
+//         command:
+//           'aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /pull-request/123/datadog-logs.js,/pull-request/123/datadog-rum.js,/pull-request/123/datadog-rum-slim.js',
+//         env,
+//       },
+//     ])
+//   })
+// })

--- a/scripts/deploy/lib/testHelpers.js
+++ b/scripts/deploy/lib/testHelpers.js
@@ -1,0 +1,65 @@
+const { mock } = require('node:test')
+
+async function mockModule(modulePath, mockObject) {
+  const { default: defaultExport, ...namedExports } = await import(modulePath)
+
+  mock.module(modulePath, {
+    defaultExport,
+    namedExports: {
+      ...namedExports,
+      ...mockObject,
+    },
+  })
+}
+
+const FAKE_AWS_ENV_CREDENTIALS = {
+  AWS_ACCESS_KEY_ID: 'FAKEACCESSKEYID123456',
+  AWS_SECRET_ACCESS_KEY: 'FAKESECRETACCESSKEY123456',
+  AWS_SESSION_TOKEN: 'FAKESESSIONTOKEN123456',
+}
+
+function mockCommandImplementation(mock) {
+  const commands = []
+
+  mock.mock.mockImplementation((template, ...values) => {
+    const command = rebuildStringTemplate(template, ...values)
+    let commandDetail = { command }
+    const result = {
+      withInput: () => result,
+      withEnvironment: (newEnv) => {
+        commandDetail.env = newEnv
+        return result
+      },
+      withCurrentWorkingDirectory: () => result,
+      withLogs: () => result,
+      run() {
+        commands.push(commandDetail)
+
+        if (command.includes('aws sts assume-role')) {
+          return JSON.stringify({
+            Credentials: {
+              AccessKeyId: FAKE_AWS_ENV_CREDENTIALS.AWS_ACCESS_KEY_ID,
+              SecretAccessKey: FAKE_AWS_ENV_CREDENTIALS.AWS_SECRET_ACCESS_KEY,
+              SessionToken: FAKE_AWS_ENV_CREDENTIALS.AWS_SESSION_TOKEN,
+            },
+          })
+        }
+      },
+    }
+    return result
+  })
+
+  return commands
+}
+
+function rebuildStringTemplate(template, ...values) {
+  const combinedString = template.reduce((acc, part, i) => acc + part + (values[i] || ''), '')
+  const normalizedString = combinedString.replace(/\s+/g, ' ').trim()
+  return normalizedString
+}
+
+module.exports = {
+  mockModule,
+  mockCommandImplementation,
+  FAKE_AWS_ENV_CREDENTIALS,
+}

--- a/scripts/deploy/upload-source-maps.spec.js
+++ b/scripts/deploy/upload-source-maps.spec.js
@@ -1,0 +1,173 @@
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const { beforeEach, before, describe, it, mock } = require('node:test')
+const { siteByDatacenter } = require('../lib/datadogSites')
+const { mockModule, mockCommandImplementation } = require('./lib/testHelpers.js')
+
+const FAKE_API_KEY = 'FAKE_API_KEY'
+const ENV_STAGING = {
+  DATADOG_API_KEY: FAKE_API_KEY,
+  DATADOG_SITE: 'datad0g.com',
+}
+const ENV_PROD = {
+  DATADOG_API_KEY: FAKE_API_KEY,
+  DATADOG_SITE: 'datadoghq.com',
+}
+void describe('upload-source-maps', () => {
+  let commandMock = mock.fn()
+  let commands
+
+  let uploadSourceMaps
+  function getSourceMapCommands() {
+    return commands.filter(({ command }) => command.includes('datadog-ci sourcemaps'))
+  }
+
+  before(async () => {
+    await mockModule(path.resolve(__dirname, '../lib/command.js'), { command: commandMock })
+    await mockModule(path.resolve(__dirname, '../lib/secrets.js'), { getTelemetryOrgApiKey: () => FAKE_API_KEY })
+
+    // This MUST be a dynamic import because that is the only way to ensure the
+    // import starts after the mock has been set up.
+    ;({ main: uploadSourceMaps } = await import('./upload-source-maps.js'))
+  })
+
+  beforeEach(() => {
+    commands = mockCommandImplementation(commandMock)
+  })
+
+  function forEachDatacenter(callback) {
+    for (const site of Object.values(siteByDatacenter)) {
+      callback(site)
+    }
+  }
+
+  void it('should upload root packages source maps', async () => {
+    await uploadSourceMaps('v6', ['root'])
+
+    forEachDatacenter((site) => {
+      const commandsByDatacenter = commands.filter(({ env }) => env?.DATADOG_SITE === site)
+      const env = { DATADOG_API_KEY: FAKE_API_KEY, DATADOG_SITE: site }
+
+      assert.deepEqual(commandsByDatacenter, [
+        {
+          command:
+            'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+          env,
+        },
+        {
+          command:
+            'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+          env,
+        },
+        {
+          command:
+            'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+          env,
+        },
+      ])
+    })
+  })
+
+  void it('should upload datacenter packages source maps', async () => {
+    await uploadSourceMaps('v6', ['us1'])
+
+    assert.deepEqual(commands, [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix /us1/v6 --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix /us1/v6 --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix /us1/v6 --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+    ])
+  })
+
+  void it('should upload staging packages source maps', async () => {
+    await uploadSourceMaps('staging', ['root'])
+
+    assert.deepEqual(getSourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_STAGING,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_STAGING,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_STAGING,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+    ])
+  })
+
+  void it('should upload canary packages source maps', async () => {
+    await uploadSourceMaps('canary', ['root'])
+
+    assert.deepEqual(getSourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+    ])
+  })
+
+  void it('should upload canary packages source maps', async () => {
+    await uploadSourceMaps('canary', ['root'])
+
+    assert.deepEqual(getSourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+    ])
+  })
+})

--- a/scripts/lib/gitUtils.js
+++ b/scripts/lib/gitUtils.js
@@ -5,15 +5,13 @@ const { command } = require('../lib/command')
 const { getGithubDeployKey, getGithubAccessToken } = require('./secrets')
 const { fetchHandlingError } = require('./executionUtils')
 
-const GITHUB_TOKEN = getGithubAccessToken()
-
 async function fetchPR(localBranch) {
   const response = await fetchHandlingError(
     `https://api.github.com/repos/DataDog/browser-sdk/pulls?head=DataDog:${localBranch}`,
     {
       method: 'GET',
       headers: {
-        Authorization: `token ${GITHUB_TOKEN}`,
+        Authorization: `token ${getGithubAccessToken()}`,
       },
     }
   )
@@ -54,6 +52,5 @@ module.exports = {
   initGitConfig,
   fetchPR,
   getLastCommonCommit,
-  LOCAL_BRANCH: process.env.CI_COMMIT_REF_NAME,
-  GITHUB_TOKEN,
+  getLocalBranch: () => process.env.CI_COMMIT_REF_NAME,
 }


### PR DESCRIPTION
## Motivation

Our deployment scripts have become increasingly complex, and the lack of tests makes further changes both challenging and prone to errors. This PR adds test for the CDN deployment script and the source maps upload script.

I’ve chosen to test the scripts by verifying their outputted commands rather than splitting the script and testing each function. I found this approach clearer, as it allows us to easily see the expected commands directly in the tests.

## Changes

- Adds tests deploy.spec.js and upload-source-maps.spec.js
- Adapt eslint rules for script spec files

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
