### PR TITLE
💥 [RUM-7676] default traceContextInjection to sampled

### DIFF
--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -86,20 +86,22 @@ describe('validateAndBuildRumConfiguration', () => {
   })
 
   describe('traceContextInjection', () => {
-    it('defaults to all if no options provided', () => {
-      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.traceContextInjection).toBe('all')
+    it('defaults to sampled if no options provided', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.traceContextInjection).toBe(
+        TraceContextInjection.SAMPLED
+      )
     })
     it('is set to provided value', () => {
       expect(
-        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceContextInjection: 'sampled' })!
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceContextInjection: 'all' })!
           .traceContextInjection
-      ).toBe('sampled')
+      ).toBe(TraceContextInjection.ALL)
     })
     it('ignores incorrect value', () => {
       expect(
         validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, traceContextInjection: 'foo' as any })!
           .traceContextInjection
-      ).toBe(TraceContextInjection.ALL)
+      ).toBe(TraceContextInjection.SAMPLED)
     })
   })
 

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -65,7 +65,7 @@ export interface RumInitConfiguration extends InitConfiguration {
   traceSampleRate?: number | undefined
   /**
    * If you set a `traceSampleRate`, to ensure backend services' sampling decisions are still applied, configure the `traceContextInjection` initialization parameter to sampled.
-   * @default all
+   * @default sampled
    * See [Connect RUM and Traces](https://docs.datadoghq.com/real_user_monitoring/platform/connect_rum_and_traces/?tab=browserrum) for further information.
    */
   traceContextInjection?: TraceContextInjection | undefined
@@ -217,7 +217,7 @@ export function validateAndBuildRumConfiguration(
     customerDataTelemetrySampleRate: 1,
     traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
       ? initConfiguration.traceContextInjection
-      : TraceContextInjection.ALL,
+      : TraceContextInjection.SAMPLED,
     plugins: initConfiguration.plugins || [],
     ...baseConfiguration,
   }

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -87,8 +87,11 @@ describe('tracer', () => {
       expect(xhr.headers).toEqual(tracingHeadersFor(context.traceId!, context.spanId!, '1'))
     })
 
-    it("should trace request with priority '0' when not sampled", () => {
-      const tracer = startTracer({ ...configuration, traceSampleRate: 0 }, sessionManager)
+    it("should trace request with priority '0' when not sampled and config set to all", () => {
+      const tracer = startTracer(
+        { ...configuration, traceSampleRate: 0, traceContextInjection: TraceContextInjection.ALL },
+        sessionManager
+      )
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -98,10 +101,11 @@ describe('tracer', () => {
       expect(xhr.headers).toEqual(tracingHeadersFor(context.traceId!, context.spanId!, '0'))
     })
 
-    it("should trace request with sampled set to '0' in OTel headers when not sampled", () => {
+    it("should trace request with sampled set to '0' in OTel headers when not sampled and config set to all", () => {
       const configurationWithAllOtelHeaders = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
         traceSampleRate: 0,
+        traceContextInjection: TraceContextInjection.ALL,
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext', 'b3multi'] }],
       })!
 
@@ -212,7 +216,6 @@ describe('tracer', () => {
       const configurationWithInjectionParam = {
         ...configuration,
         traceSampleRate: 0,
-        traceContextInjection: TraceContextInjection.SAMPLED,
       }
 
       const tracer = startTracer(configurationWithInjectionParam, sessionManager)
@@ -227,7 +230,6 @@ describe('tracer', () => {
       const configurationWithInjectionParam = {
         ...configuration,
         traceSampleRate: 100,
-        traceContextInjection: TraceContextInjection.SAMPLED,
       }
 
       const tracer = startTracer(configurationWithInjectionParam, sessionManager)
@@ -462,10 +464,13 @@ describe('tracer', () => {
       expect(context.init!.headers).toEqual(tracingHeadersAsArrayFor(context.traceId!, context.spanId!, '1'))
     })
 
-    it("should trace request with priority '0' when not sampled", () => {
+    it("should trace request with priority '0' when not sampled and config set to all", () => {
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
 
-      const tracer = startTracer({ ...configuration, traceSampleRate: 0 }, sessionManager)
+      const tracer = startTracer(
+        { ...configuration, traceSampleRate: 0, traceContextInjection: TraceContextInjection.ALL },
+        sessionManager
+      )
       tracer.traceFetch(context)
 
       expect(context.traceSampled).toBe(false)


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Improve Trace <> RUM correlation with RUM without limits


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

makes `sampled` the new default for traceContextInjection init option

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
