### PR TITLE
🐛 Wrap methods and setters at most once

### DIFF
--- a/packages/core/test/instrumentation.ts
+++ b/packages/core/test/instrumentation.ts
@@ -1,3 +1,5 @@
+import { getObserversForMethod } from '../src/tools/instrumentMethod'
+
 /**
  * @returns a fluent interface for asserting that the given callback adds
  * instrumentation to certain methods. Usage:
@@ -6,19 +8,22 @@
  * > }).toMethod(window, 'foo').whenCalled()
  */
 export function callbackAddsInstrumentation(callback: () => void) {
-  const existingMethods: Array<[any, string, unknown]> = []
+  const existingMethods: Array<[any, string, number]> = []
   const expectation = {
     callback,
     toMethod<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET & string>(
       target: TARGET,
       method: METHOD
     ) {
-      existingMethods.push([target, method, target[method]])
+      const originalCount = getObserversForMethod(target, method).length
+      existingMethods.push([target, method, originalCount])
       return expectation
     },
     whenCalled() {
       callback()
-      return existingMethods.every(([target, method, original]) => target[method] !== original)
+      return existingMethods.every(
+        ([target, method, originalCount]) => getObserversForMethod(target, method).length !== originalCount
+      )
     },
   }
   return expectation

--- a/packages/rum/src/domain/record/trackers/trackInput.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackInput.spec.ts
@@ -1,6 +1,5 @@
 import { DefaultPrivacyLevel } from '@datadog/browser-core'
-import type { Clock } from '@datadog/browser-core/test'
-import { createNewEvent, mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '@datadog/browser-rum-core'
 import { appendElement } from '../../../../../rum-core/test'
@@ -16,7 +15,6 @@ describe('trackInput', () => {
   let inputTracker: Tracker
   let inputCallbackSpy: jasmine.Spy<InputCallback>
   let input: HTMLInputElement
-  let clock: Clock | undefined
   let configuration: RumConfiguration
 
   beforeEach(() => {
@@ -32,7 +30,6 @@ describe('trackInput', () => {
 
     registerCleanupTask(() => {
       inputTracker.stop()
-      clock?.cleanup()
     })
   })
 
@@ -51,12 +48,11 @@ describe('trackInput', () => {
     })
   })
 
-  it('collects input values when a property setter is used', () => {
-    clock = mockClock()
+  it('collects input values when a property setter is used', async () => {
     inputTracker = trackInput(configuration, inputCallbackSpy)
     input.value = 'foo'
 
-    clock.tick(0)
+    await Promise.resolve()
 
     expect(inputCallbackSpy).toHaveBeenCalledOnceWith({
       type: RecordType.IncrementalSnapshot,
@@ -69,11 +65,10 @@ describe('trackInput', () => {
     })
   })
 
-  it('does not invoke callback when the value does not change', () => {
-    clock = mockClock()
+  it('does not invoke callback when the value does not change', async () => {
     inputTracker = trackInput(configuration, inputCallbackSpy)
     input.value = 'foo'
-    clock.tick(0)
+    await Promise.resolve()
 
     dispatchInputEvent('foo')
 


### PR DESCRIPTION
## Motivation

*TLDR*: Today, repeatedly adding and removing instrumentation to the same method or property via `instrumentMethod()` and `instrumentSetter()` can cause wrapper functions to build up, eventually triggering stack overflows. This PR eliminates this problem by reworking these functions to use an observer pattern internally.

In certain situations, we currently use a pattern where we instrument a platform API method via `instrumentMethod()` in response to an event, and remove the instrumentation in response to some other event. An example of this pattern might look like this:

1. When the user clicks, we instrument `HTMLDialogElement#showModal()`.
2. If `showModal()` is called within 100ms, we associate the click with metadata about the dialog that's being opened, and remove the instrumentation.
3. If `showModal()` is not called with 100ms, we remove the instrumentation.

Note that this example isn't something we really do; it's just a simple example of the pattern we're interested in. Here's a visual representation of what happens when the user clicks and a dialog is never opened:

```mermaid
block-beta
columns 4
  api1["showModal()"] api2["showModal()"] api3["showModal()"] api4["showModal()"]
  space space space space
  wrapper1("Instrumentation") wrapper2("Instrumentation") wrapper3("Instrumentation") space
  space space space space
  space space space space
  label1>"Click"] space label3>"Timeout"] space
  wrapper1 --> api1
  wrapper2 --> api2
  wrapper3 --> api3
  label1 --"Add"--> wrapper1
  label3 --"Remove"--> wrapper3
```

In the first column of this diagram, the user clicks. This causes `showModal()` to be wrapped by overwriting it with an instrumentation function that calls the original implementation; this nested relationship is represented by the vertical arrow. In the third column, we reach the 100ms timeout; the instrumentation is removed by restoring the original value of `showModal()`.

Now, consider what happens when the user clicks again before the 100ms timeout is reached:

```mermaid
block-beta
columns 6
  api1["showModal()"] api2["showModal()"] api3["showModal()"]  api4["showModal()"]  api5["showModal()"] space
  space space space space space space
  wrapper1("Instrumentation 1") wrapper2("Instrumentation 1") wrapper3("Disabled<br/>Instrumentation 1") wrapper4("Disabled<br/>Instrumentation 1") wrapper5("Disabled<br/>Instrumentation 1") space
  space space space space space space
  space doubleWrapper2("Instrumentation 2") doubleWrapper3("Instrumentation 2") doubleWrapper4("Instrumentation 2") space space
  space space space space space space
  space space space space space space
  label1>"Click 1"] label2>"Click2"] label3>"Timeout 1"] label4>"Timeout 2"] space space
  wrapper1 --> api1
  wrapper2 --> api2
  wrapper3 --> api3
  wrapper4 --> api4
  wrapper5 --> api5
  doubleWrapper2 --> wrapper2
  doubleWrapper3 --> wrapper3
  doubleWrapper4 --> wrapper4
  label1 --"Add"--> wrapper1
  label2 --"Add"--> doubleWrapper2
  label3 --"Disable"--> wrapper3
  label4 --"Remove"--> doubleWrapper4
```

Here's a play-by-play of the events shown in this diagram:
1. In the first column of this diagram, as before, the user clicks, and we overwrite `showModal()` with a wrapper labeled `Instrumentation 1` that calls the original function.
2. In the second column, the user clicks again; we follow the same procedure and overwrite `showModal()` with a second wrapper labeled `Instrumentation 2` that calls the first. At this point, `showModal()` is doubly wrapped.
3. In the third column, the timeout for the first click occurs. At this point, we'd like to remove the `Instrumentation 1` wrapper by overwriting `showModal()` with its original value, but we notice that its value has changed because it's been wrapped again. Overwriting it would disconnect the new wrapper, so we leave its value as-is and simply set a boolean flag that disables `Instrumentation 1`. `Instrumentation 1` is now a pass-through function that simply calls the original `showModal()`.
4. In the fourth column, the timeout for the second click occurs. At this point, we try to remove the `Instrumentation 2` wrapper by overwriting `showModal()` with the value that was present before that wrapper was added. Because the value of `showModal()` hasn't changed since `Instrumentation 2` was added, this is safe to do, so we restore `showModal()` to its previous value. `showModal()` now points to the disabled `Instrumentation 1`.

There's no other mechanism to remove `Instrumentation 1`, so the end result is that `Instrumentation 1` is now permanently attached to `showModal()`. Every future call to `showModal()` will now create a call stack that's deeper by one function. If this process happens over and over again, more and more wrappers will accumulate on `showModal()`, and eventually the `showModal()` call stack will grow so large that calling `showModal()` causes a stack overflow.

While this is a simplified example, the issue isn't theoretical; we've seen reports of this happening in the wild. So, to ensure that the Datadog browser SDK does not cause unexpected exceptions to be thrown on customer sites, we need to fix this issue.

## Changes

Today, each invocation of `instrumentMethod()` adds a new wrapper function around the target method. Because these wrappers are not always removed when instrumentation is stopped, the total number of wrappers is O(number of times the method has been instrumented).

This PR adds a layer of indirection: the first time a method is instrumented, it's wrapped with a special hook function. This hook function is the only wrapper which is ever added to the target method directly.

The instrumentation code that's actually passed to `instrumentMethod()` no longer wraps the method directly. Instead, this code is registered under the hood as an observer of the hook function. When the hook function is invoked, it calls each of its observers, invokes the underlying method, and then calls any post-call handlers the observers registered. The order of invocations is thus structured just as if the observers functions wrapped each other directly, but no nesting is actually happening on the call stack.

This approach allows us to trivially remove any observer of an instrumented method, in any order, without worrying about breaking other observations or other third party wrappers. Instead of the total number of wrappers on the stack when the method is called being O(number of times the method has been instrumented), it's now O(1), regardless of how many observers are added or removed and how those additions and removals are ordered. The problem described in the Motivation section is thus eliminated at the source.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
