### PR TITLE
Fix unobserve error for non-Element parameter

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.ts
@@ -111,7 +111,7 @@ export function createScrollValuesObservable(
 
       return () => {
         throttledNotify.cancel()
-        resizeObserver.unobserve(observerTarget)
+        resizeObserver.disconnect()
         eventListener.stop()
       }
     }


### PR DESCRIPTION
## Motivation

Fix unobserve error for non-Element parameter. This can legitimately happen in the context of puppeteer injection. cf: [PR](https://github.com/DataDog/browser-sdk/pull/3153/files)

## Changes

Use `resizeObserver.disconnect()` instead of   `resizeObserver.unobserve(observerTarget)`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
