### PR TITLE
✅ Add e2e test for telemetry usage

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export {
   TelemetryErrorEvent,
   TelemetryDebugEvent,
   TelemetryConfigurationEvent,
+  TelemetryUsageEvent,
   TelemetryService,
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -18,19 +18,23 @@ import { createMockServerApp } from './serverApps/mock'
 const DEFAULT_RUM_CONFIGURATION = {
   applicationId: APPLICATION_ID,
   clientToken: CLIENT_TOKEN,
-  sessionReplaySampleRate: 100,
   defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
   trackResources: true,
   trackLongTasks: true,
-  telemetrySampleRate: 100,
-  telemetryConfigurationSampleRate: 100,
   enableExperimentalFeatures: [],
   allowUntrustedEvents: true,
+  // Force All sample rates to 100% to avoid flakiness
+  sessionReplaySampleRate: 100,
+  telemetrySampleRate: 100,
+  telemetryUsageSampleRate: 100,
+  telemetryConfigurationSampleRate: 100,
 }
 
 const DEFAULT_LOGS_CONFIGURATION = {
   clientToken: CLIENT_TOKEN,
+  // Force All sample rates to 100% to avoid flakiness
   telemetrySampleRate: 100,
+  telemetryUsageSampleRate: 100,
   telemetryConfigurationSampleRate: 100,
 }
 

--- a/test/e2e/lib/framework/intakeRegistry.ts
+++ b/test/e2e/lib/framework/intakeRegistry.ts
@@ -7,7 +7,12 @@ import type {
   RumViewEvent,
   RumVitalEvent,
 } from '@datadog/browser-rum'
-import type { TelemetryEvent, TelemetryErrorEvent, TelemetryConfigurationEvent } from '@datadog/browser-core'
+import type {
+  TelemetryEvent,
+  TelemetryErrorEvent,
+  TelemetryConfigurationEvent,
+  TelemetryUsageEvent,
+} from '@datadog/browser-core'
 import type { BrowserSegment } from '@datadog/browser-rum/src/types'
 import type { BrowserSegmentMetadataAndSegmentSizes } from '@datadog/browser-rum/src/domain/segmentCollection'
 
@@ -121,6 +126,10 @@ export class IntakeRegistry {
     return this.telemetryEvents.filter(isTelemetryConfigurationEvent)
   }
 
+  get telemetryUsageEvents() {
+    return this.telemetryEvents.filter(isTelemetryUsageEvent)
+  }
+
   //
   // Replay
   //
@@ -184,4 +193,8 @@ function isTelemetryErrorEvent(event: TelemetryEvent): event is TelemetryErrorEv
 
 function isTelemetryConfigurationEvent(event: TelemetryEvent): event is TelemetryConfigurationEvent {
   return isTelemetryEvent(event) && event.telemetry.type === 'configuration'
+}
+
+function isTelemetryUsageEvent(event: TelemetryEvent): event is TelemetryUsageEvent {
+  return isTelemetryEvent(event) && event.telemetry.type === 'usage'
 }

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -70,4 +70,34 @@ describe('telemetry', () => {
       expect(event.service).toEqual('browser-rum-sdk')
       expect(event.telemetry.configuration.track_user_interactions).toEqual(true)
     })
+
+  createTest('send usage telemetry for RUM')
+    .withSetup(bundleSetup)
+    .withRum()
+    .run(async ({ intakeRegistry }) => {
+      await browser.execute(() => {
+        window.DD_RUM!.addAction('foo')
+      })
+
+      await flushEvents()
+      expect(intakeRegistry.telemetryUsageEvents.length).toBe(2)
+      const event = intakeRegistry.telemetryUsageEvents[1] // first event is 'set-global-context' done in pageSetup.ts
+      expect(event.service).toEqual('browser-rum-sdk')
+      expect(event.telemetry.usage.feature).toEqual('add-action')
+    })
+
+  createTest('send usage telemetry for logs')
+    .withSetup(bundleSetup)
+    .withLogs()
+    .run(async ({ intakeRegistry }) => {
+      await browser.execute(() => {
+        window.DD_LOGS!.setTrackingConsent('granted')
+      })
+
+      await flushEvents()
+      expect(intakeRegistry.telemetryUsageEvents.length).toBe(1)
+      const event = intakeRegistry.telemetryUsageEvents[0]
+      expect(event.service).toEqual('browser-logs-sdk')
+      expect(event.telemetry.usage.feature).toEqual('set-tracking-consent')
+    })
 })


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Telemetry usage e2e test were missing


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

- Add missing e2e test for `telemetryUsage`
- Add comment explaining why we setup `*SampleRate: 100` in the default e2e test config. 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
