### PR TITLE
🐛 AddError should support all instances of type Error

### DIFF
--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -88,7 +88,7 @@ export function getFileFromStackTraceString(stack: string) {
 }
 
 export function isError(error: unknown): error is Error {
-  return Object.prototype.toString.call(error) === '[object Error]'
+  return error instanceof Error || Object.prototype.toString.call(error) === '[object Error]'
 }
 
 export function flattenErrorCauses(error: ErrorWithCause, parentSource: ErrorSource): RawErrorCause[] | undefined {

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -31,8 +31,14 @@ describe('error collection', () => {
 
   // when calling toString on SubErrorViaPrototype, the results will be '[object Object]'
   // but the value of 'error instanceof Error' will still be true.
-  function SubErrorViaPrototype(_message: string) {}
-  SubErrorViaPrototype.prototype = new Error
+  function SubErrorViaPrototype(this: Error, _message: string) {
+    Error.call(this, _message)
+    this.name = 'Error'
+    this.message = _message
+    this.stack = `Error: ${_message}\n    at <anonymous>`
+  }
+  SubErrorViaPrototype.prototype = Object.create(Error.prototype)
+  SubErrorViaPrototype.prototype.constructor = SubErrorViaPrototype
 
   describe('addError', () => {
     ;[
@@ -45,7 +51,7 @@ describe('error collection', () => {
       },
       {
         testCase: 'an error subclass via prototype',
-        error: new (SubErrorViaPrototype as any)('bar'),
+        error: new (SubErrorViaPrototype as unknown as { new (message: string): Error })('bar'),
         message: 'bar',
         type: 'Error',
         stack: jasmine.stringMatching('Error: bar'),

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -29,6 +29,11 @@ describe('error collection', () => {
     rawRumEvents = collectAndValidateRawRumEvents(lifeCycle)
   }
 
+  // when calling toString on SubErrorViaPrototype, the results will be '[object Object]'
+  // but the value of 'error instanceof Error' will still be true.
+  function SubErrorViaPrototype(_message: string) {}
+  SubErrorViaPrototype.prototype = new Error
+
   describe('addError', () => {
     ;[
       {
@@ -37,6 +42,13 @@ describe('error collection', () => {
         message: 'foo',
         type: 'Error',
         stack: jasmine.stringMatching('Error: foo'),
+      },
+      {
+        testCase: 'an error subclass via prototype',
+        error: new (SubErrorViaPrototype as any)('bar'),
+        message: 'bar',
+        type: 'Error',
+        stack: jasmine.stringMatching('Error: bar'),
       },
       {
         testCase: 'a string',


### PR DESCRIPTION
## Motivation

Recently, all errors of type [AxiosError](https://github.com/axios/axios/blob/ce350f1e2163a7c3b7dec874fc9991038f0dc4f9/lib/core/AxiosError.js#L16-L34) stopped logging properly. Instead of the standard log with Error object, it was serializing the error object instead.

After some investigation I tracked down the regression to #3144 - which changes the object type check from `param instanceof Error` to `Object.prototype.toString.call(error) === '[object Error]'`. Unfortunately, the way AxiosError is created, that toString call just produces `[object Object]`. However, the `instanceof` check works just fine.

![Image 12-17-24 at 6 03 PM](https://github.com/user-attachments/assets/d482cac1-97e6-421a-9c51-0ea47435a45e)


## Changes

I've addressed the regression by using both the original `instanceof Error` check as well as the new `toString` check. Supporting both checks cover both the old and the new feature requirements.

## Testing

I spent some time trying to get the tests running - but I was not successful. I don't doubt there might be some tweaks required in the PR, but I think the bulk of it is complete. Please feel free to modify the PR as needed. Hopefully this can get fixed quickly and we can all have AxiosError logging working again.

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
