### PR TITLE
Add setAccount API

### DIFF
--- a/packages/core/src/domain/account/account.spec.ts
+++ b/packages/core/src/domain/account/account.spec.ts
@@ -1,0 +1,18 @@
+import { sanitizeAccount } from './account'
+
+describe('sanitize account function', () => {
+  it('should sanitize a account object', () => {
+    const obj = { id: 42, name: true }
+    const account = sanitizeAccount(obj)
+
+    expect(account).toEqual({ id: '42', name: 'true' })
+  })
+
+  it('should not mutate the original data', () => {
+    const obj = { id: 42, name: 'test' }
+    const account = sanitizeAccount(obj)
+
+    expect(account.id).toEqual('42')
+    expect(obj.id).toEqual(42)
+  })
+})

--- a/packages/core/src/domain/account/account.ts
+++ b/packages/core/src/domain/account/account.ts
@@ -1,0 +1,6 @@
+import type { Context } from '../../tools/serialisation/context'
+import { sanitizeContext } from '../context/contextUtils'
+
+export function sanitizeAccount(newAccount: Context) {
+  return sanitizeContext(newAccount, ['id', 'name'])
+}

--- a/packages/core/src/domain/account/account.types.ts
+++ b/packages/core/src/domain/account/account.types.ts
@@ -1,0 +1,5 @@
+export interface Account {
+  id?: string | undefined
+  name?: string | undefined
+  [key: string]: unknown
+}

--- a/packages/core/src/domain/account/index.ts
+++ b/packages/core/src/domain/account/index.ts
@@ -1,0 +1,2 @@
+export * from './account.types'
+export * from './account'

--- a/packages/core/src/domain/context/contextConstants.ts
+++ b/packages/core/src/domain/context/contextConstants.ts
@@ -3,4 +3,5 @@ export const enum CustomerDataType {
   User,
   GlobalContext,
   View,
+  Account,
 }

--- a/packages/core/src/domain/context/contextUtils.spec.ts
+++ b/packages/core/src/domain/context/contextUtils.spec.ts
@@ -1,0 +1,26 @@
+import { display } from '../../tools/display'
+import type { Context } from '../../tools/serialisation/context'
+import type { Account } from '../account'
+import type { User } from '../user'
+import { checkContext } from './contextUtils'
+
+describe('checkContext function', () => {
+  it('should only accept valid objects', () => {
+    spyOn(display, 'error')
+
+    const obj: any = { id: 42, name: true, email: null } // Valid, even though not sanitized
+    const user: User = { id: '42', name: 'John', email: 'john@doe.com' }
+    const account: Account = { id: '42', name: 'Groupe' }
+    const undefUser: any = undefined
+    const nullUser: any = null
+    const invalidUser: any = 42
+
+    expect(checkContext(obj)).toBe(true)
+    expect(checkContext(user as Context)).toBe(true)
+    expect(checkContext(account as Context)).toBe(true)
+    expect(checkContext(undefUser)).toBe(false)
+    expect(checkContext(nullUser)).toBe(false)
+    expect(checkContext(invalidUser)).toBe(false)
+    expect(display.error).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/core/src/domain/context/contextUtils.ts
+++ b/packages/core/src/domain/context/contextUtils.ts
@@ -1,0 +1,31 @@
+import type { Context } from '../../tools/serialisation/context'
+import { display } from '../../tools/display'
+import { getType } from '../../tools/utils/typeUtils'
+import { assign } from '../../tools/utils/polyfills'
+
+/**
+ * Clone input data and ensure known context properties
+ * are strings, as defined here:
+ * https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
+ */
+export function sanitizeContext(newContext: Context, keys: string[]): Context {
+  // We shallow clone only to prevent mutation of context data.
+  const context = assign({}, newContext)
+  keys.forEach((key) => {
+    if (key in context) {
+      context[key] = String(context[key])
+    }
+  })
+  return context
+}
+
+/**
+ * Simple check to ensure an object is a valid context
+ */
+export function checkContext(newContext: Context): boolean {
+  const isValid = getType(newContext) === 'object'
+  if (!isValid) {
+    display.error('Unsupported context:', newContext)
+  }
+  return isValid
+}

--- a/packages/core/src/domain/user/user.spec.ts
+++ b/packages/core/src/domain/user/user.spec.ts
@@ -1,6 +1,4 @@
-import { display } from '../../tools/display'
-import { checkUser, generateAnonymousId, sanitizeUser } from './user'
-import type { User } from './user.types'
+import { sanitizeUser, generateAnonymousId } from './user'
 
 describe('sanitize user function', () => {
   it('should sanitize a user object', () => {
@@ -16,25 +14,6 @@ describe('sanitize user function', () => {
 
     expect(user.id).toEqual('42')
     expect(obj.id).toEqual(42)
-  })
-})
-
-describe('check user function', () => {
-  it('should only accept valid user objects', () => {
-    spyOn(display, 'error')
-
-    const obj: any = { id: 42, name: true, email: null } // Valid, even though not sanitized
-    const user: User = { id: '42', name: 'John', email: 'john@doe.com' }
-    const undefUser: any = undefined
-    const nullUser: any = null
-    const invalidUser: any = 42
-
-    expect(checkUser(obj)).toBe(true)
-    expect(checkUser(user)).toBe(true)
-    expect(checkUser(undefUser)).toBe(false)
-    expect(checkUser(nullUser)).toBe(false)
-    expect(checkUser(invalidUser)).toBe(false)
-    expect(display.error).toHaveBeenCalledTimes(3)
   })
 })
 

--- a/packages/core/src/domain/user/user.ts
+++ b/packages/core/src/domain/user/user.ts
@@ -1,35 +1,8 @@
 import type { Context } from '../../tools/serialisation/context'
-import { display } from '../../tools/display'
-import { getType } from '../../tools/utils/typeUtils'
-import { assign } from '../../tools/utils/polyfills'
-import type { User } from './user.types'
+import { sanitizeContext } from '../context/contextUtils'
 
-/**
- * Clone input data and ensure known user properties (id, name, email)
- * are strings, as defined here:
- * https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
- */
-export function sanitizeUser(newUser: Context): Context {
-  // We shallow clone only to prevent mutation of user data.
-  const user = assign({}, newUser)
-  const keys = ['id', 'name', 'email']
-  keys.forEach((key) => {
-    if (key in user) {
-      user[key] = String(user[key])
-    }
-  })
-  return user
-}
-
-/**
- * Simple check to ensure user is valid
- */
-export function checkUser(newUser: User): boolean {
-  const isValid = getType(newUser) === 'object'
-  if (!isValid) {
-    display.error('Unsupported user:', newUser)
-  }
-  return isValid
+export function sanitizeUser(newUser: Context) {
+  return sanitizeContext(newUser, ['id', 'name', 'email'])
 }
 
 export function generateAnonymousId() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,7 +139,9 @@ export {
   getSyntheticsTestId,
   getSyntheticsResultId,
 } from './domain/synthetics/syntheticsWorkerValues'
-export { User, checkUser, sanitizeUser } from './domain/user'
+export { User, sanitizeUser } from './domain/user'
+export { Account, sanitizeAccount } from './domain/account'
+export { checkContext } from './domain/context/contextUtils'
 export * from './domain/resourceUtils'
 export * from './tools/utils/polyfills'
 export * from './tools/utils/numberUtils'

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -84,6 +84,7 @@ describe('logs entry', () => {
         },
         context: { foo: 'bar' },
         user: {},
+        account: {},
       })
     })
   })

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -51,6 +51,7 @@ const COMMON_CONTEXT = {
   view: { referrer: 'common_referrer', url: 'common_url' },
   context: {},
   user: {},
+  account: {},
 }
 const DEFAULT_PAYLOAD = {} as Payload
 

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -34,11 +34,13 @@ const COMMON_CONTEXT: CommonContext = {
   },
   context: { common_context_key: 'common_context_value' },
   user: {},
+  account: {},
 }
 
-const COMMON_CONTEXT_WITH_USER: CommonContext = {
+const COMMON_CONTEXT_WITH_USER_AND_ACCOUNT: CommonContext = {
   ...COMMON_CONTEXT,
   user: { id: 'id', name: 'name', email: 'test@test.com' },
+  account: { id: 'id', name: 'name' },
 }
 
 describe('startLogsAssembly', () => {
@@ -195,6 +197,7 @@ describe('startLogsAssembly', () => {
         },
         context: { foo: 'bar' },
         user: { email: 'test@test.com' },
+        account: { id: '123' },
       }
       lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE, savedCommonContext })
 
@@ -320,7 +323,7 @@ describe('startLogsAssembly', () => {
   })
 })
 
-describe('user management', () => {
+describe('user and account management', () => {
   const sessionManager: LogsSessionManager = {
     findTrackedSession: () => (sessionIsTracked ? { id: SESSION_ID } : undefined),
     expireObservable: new Observable<void>(),
@@ -347,15 +350,16 @@ describe('user management', () => {
     serverLogs = []
   })
 
-  it('should not output usr key if user is not set', () => {
+  it('should not output usr/account key if user/account is not set', () => {
     startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT, noop)
 
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
     expect(serverLogs[0].usr).toBeUndefined()
+    expect(serverLogs[0].account).toBeUndefined()
   })
 
-  it('should include user data when user has been set', () => {
-    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT_WITH_USER, noop)
+  it('should include user/account data when user/account has been set', () => {
+    startLogsAssembly(sessionManager, configuration, lifeCycle, () => COMMON_CONTEXT_WITH_USER_AND_ACCOUNT, noop)
 
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, { rawLogsEvent: DEFAULT_MESSAGE })
     expect(serverLogs[0].usr).toEqual({
@@ -363,16 +367,25 @@ describe('user management', () => {
       name: 'name',
       email: 'test@test.com',
     })
+
+    expect(serverLogs[0].account).toEqual({
+      id: 'id',
+      name: 'name',
+    })
   })
 
-  it('should prioritize global context over user context', () => {
+  it('should prioritize global context over user/account context', () => {
     const globalContextWithUser = {
-      ...COMMON_CONTEXT_WITH_USER,
+      ...COMMON_CONTEXT_WITH_USER_AND_ACCOUNT,
       context: {
         ...COMMON_CONTEXT.context,
         usr: {
           id: 4242,
           name: 'solution',
+        },
+        account: {
+          id: 4242,
+          name: 'account',
         },
       },
     }
@@ -383,6 +396,11 @@ describe('user management', () => {
       id: 4242,
       name: 'solution',
       email: 'test@test.com',
+    })
+
+    expect(serverLogs[0].account).toEqual({
+      id: 4242,
+      name: 'account',
     })
   })
 })

--- a/packages/logs/src/domain/assembly.ts
+++ b/packages/logs/src/domain/assembly.ts
@@ -41,8 +41,10 @@ export function startLogsAssembly(
           service: configuration.service,
           session_id: session ? session.id : undefined,
           session: session ? { id: session.id } : undefined,
-          // Insert user first to allow overrides from global context
+          // Insert user and account first to allow overrides from global context
           usr: !isEmptyObject(commonContext.user) ? commonContext.user : undefined,
+          account:
+            !isEmptyObject(commonContext.account) && !!commonContext.account.id ? commonContext.account : undefined,
           view: commonContext.view,
         },
         commonContext.context,

--- a/packages/logs/src/domain/contexts/commonContext.ts
+++ b/packages/logs/src/domain/contexts/commonContext.ts
@@ -3,7 +3,8 @@ import type { CommonContext } from '../../rawLogsEvent.types'
 
 export function buildCommonContext(
   globalContextManager: ContextManager,
-  userContextManager: ContextManager
+  userContextManager: ContextManager,
+  acccountContextManager: ContextManager
 ): CommonContext {
   return {
     view: {
@@ -12,5 +13,6 @@ export function buildCommonContext(
     },
     context: globalContextManager.getContext(),
     user: userContextManager.getContext(),
+    account: acccountContextManager.getContext(),
   }
 }

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -1,4 +1,12 @@
-import type { Context, ErrorSource, RawErrorCause, TimeStamp, User, ErrorHandling } from '@datadog/browser-core'
+import type {
+  Context,
+  ErrorSource,
+  RawErrorCause,
+  TimeStamp,
+  User,
+  Account,
+  ErrorHandling,
+} from '@datadog/browser-core'
 import type { StatusType } from './domain/logger/isAuthorized'
 
 export type RawLogsEvent =
@@ -68,4 +76,5 @@ export interface CommonContext {
   }
   context: Context
   user: User
+  account: Account
 }

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -186,7 +186,7 @@ describe('rum public api', () => {
           type: ActionType.CUSTOM,
           handlingStack: jasmine.any(String),
         },
-        { context: {}, user: {}, hasReplay: undefined },
+        { context: {}, user: {}, account: {}, hasReplay: undefined },
       ])
     })
 
@@ -240,6 +240,19 @@ describe('rum public api', () => {
         })
       })
 
+      it('stores a deep copy of the account', () => {
+        const account = { id: 'foo' }
+        rumPublicApi.setAccount(account)
+        rumPublicApi.addAction('message')
+        account.id = 'bar'
+
+        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+
+        expect(addActionSpy.calls.argsFor(0)[1]!.account).toEqual({
+          id: 'foo',
+        })
+      })
+
       it('stores a deep copy of the action context', () => {
         const context = { foo: 'bar' }
         rumPublicApi.addAction('message', context)
@@ -289,7 +302,7 @@ describe('rum public api', () => {
           handlingStack: jasmine.any(String),
           startClocks: jasmine.any(Object),
         },
-        { context: {}, user: {}, hasReplay: undefined },
+        { context: {}, user: {}, account: {}, hasReplay: undefined },
       ])
     })
 

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -79,6 +79,7 @@ function startRumStub(
     () => ({
       context: {},
       user: {},
+      account: {},
       hasReplay: undefined,
     }),
     reportError
@@ -332,7 +333,7 @@ describe('view events', () => {
       mockRumConfiguration(),
       noopRecorderApi,
       createCustomerDataTrackerManager(),
-      () => ({ user: {}, context: {}, hasReplay: undefined }),
+      () => ({ user: {}, context: {}, account: {}, hasReplay: undefined }),
       undefined,
       createIdentityEncoder,
       createTrackingConsentState(TrackingConsent.GRANTED),

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -471,6 +471,7 @@ describe('rum assembly', () => {
         savedCommonContext: {
           context: { replacedContext: 'a' },
           user: {},
+          account: {},
           hasReplay: undefined,
         },
       })
@@ -510,6 +511,7 @@ describe('rum assembly', () => {
         savedCommonContext: {
           context: {},
           user: { replacedAttribute: 'a' },
+          account: {},
           hasReplay: undefined,
         },
       })
@@ -1010,6 +1012,7 @@ function setupAssemblyTestWithDefaults({
   const commonContext = {
     context: {},
     user: {},
+    account: {},
     hasReplay: undefined,
   } as CommonContext
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -1,4 +1,4 @@
-import type { Context, RawError, EventRateLimiter, User } from '@datadog/browser-core'
+import type { Context, RawError, EventRateLimiter, User, Account } from '@datadog/browser-core'
 import {
   combine,
   isEmptyObject,
@@ -201,6 +201,11 @@ export function startRumAssembly(
         }
         if (!isEmptyObject(commonContext.user)) {
           ;(serverRumEvent.usr as Mutable<RumEvent['usr']>) = commonContext.user as User & Context
+        }
+
+        if (!isEmptyObject(commonContext.account) && !!commonContext.account.id) {
+          ;(serverRumEvent.account as Mutable<RumEvent['account']>) = commonContext.account as Account &
+            Context & { id: string }
         }
 
         if (shouldSend(serverRumEvent, configuration.beforeSend, domainContext, eventRateLimiters)) {

--- a/packages/rum-core/src/domain/contexts/commonContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/commonContext.spec.ts
@@ -15,18 +15,21 @@ describe('commonContext', () => {
     fakeContext = { foo: 'bar' }
     const globalContextManager: ContextManager = createContextManager(createCustomerDataTracker(noop))
     const userContextManager: ContextManager = createContextManager(createCustomerDataTracker(noop))
+    const accountContextManager: ContextManager = createContextManager(createCustomerDataTracker(noop))
     spyOn(globalContextManager, 'getContext').and.callFake(() => fakeContext)
     spyOn(userContextManager, 'getContext').and.callFake(() => fakeContext)
+    spyOn(accountContextManager, 'getContext').and.callFake(() => fakeContext)
 
     const recorderApi: RecorderApi = { ...noopRecorderApi, isRecording: () => isRecording }
     buildCommonContext = (): CommonContext =>
-      buildCommonContextImpl(globalContextManager, userContextManager, recorderApi)
+      buildCommonContextImpl(globalContextManager, userContextManager, accountContextManager, recorderApi)
   })
 
   it('should return common context', () => {
     expect(buildCommonContext()).toEqual({
       context: fakeContext,
       user: fakeContext,
+      account: fakeContext,
       hasReplay: undefined,
     })
   })

--- a/packages/rum-core/src/domain/contexts/commonContext.ts
+++ b/packages/rum-core/src/domain/contexts/commonContext.ts
@@ -1,8 +1,9 @@
-import type { Context, ContextManager, User } from '@datadog/browser-core'
+import type { Account, Context, ContextManager, User } from '@datadog/browser-core'
 import type { RecorderApi } from '../../boot/rumPublicApi'
 
 export interface CommonContext {
   user: User
+  account: Account
   context: Context
   hasReplay: true | undefined
 }
@@ -10,11 +11,13 @@ export interface CommonContext {
 export function buildCommonContext(
   globalContextManager: ContextManager,
   userContextManager: ContextManager,
+  accountContextManager: ContextManager,
   recorderApi: RecorderApi
 ): CommonContext {
   return {
     context: globalContextManager.getContext(),
     user: userContextManager.getContext(),
+    account: accountContextManager.getContext(),
     hasReplay: recorderApi.isRecording() ? true : undefined,
   }
 }


### PR DESCRIPTION
## Motivation

Adding a standard way to set an account.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
