### PR TITLE
✅ fix leak detection issues

### DIFF
--- a/developer-extension/src/panel/hooks/useEvents/eventFilters.ts
+++ b/developer-extension/src/panel/hooks/useEvents/eventFilters.ts
@@ -81,7 +81,7 @@ function filterOutdatedVersions(events: SdkEvent[]): SdkEvent[] {
 
 export function parseQuery(query: string) {
   const queryParts = query
-    .split(new RegExp('(?<!\\\\)\\s', 'g')) // Hack it to escape whitespace with backslashes. Use a regex constructor to avoid syntax errors in older browsers
+    .split(/(?<!\\)\s/g) // Hack it to escape whitespace with backslashes
     .filter((queryPart) => queryPart)
     .map((queryPart) => queryPart.split(':'))
 

--- a/developer-extension/src/panel/hooks/useEvents/eventFilters.ts
+++ b/developer-extension/src/panel/hooks/useEvents/eventFilters.ts
@@ -81,7 +81,7 @@ function filterOutdatedVersions(events: SdkEvent[]): SdkEvent[] {
 
 export function parseQuery(query: string) {
   const queryParts = query
-    .split(/(?<!\\)\s/g) // Hack it to escape whitespace with backslashes
+    .split(new RegExp('(?<!\\\\)\\s', 'g')) // Hack it to escape whitespace with backslashes. Use a regex constructor to avoid syntax errors in older browsers
     .filter((queryPart) => queryPart)
     .map((queryPart) => queryPart.split(':'))
 

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -246,7 +246,7 @@ export function startRumEventCollection(
   const viewHistory = startViewHistory(lifeCycle)
   const urlContexts = startUrlContexts(lifeCycle, locationChangeObservable, location)
 
-  const { addAction, actionContexts } = startActionCollection(
+  const actionCollection = startActionCollection(
     lifeCycle,
     domMutationObservable,
     windowOpenObservable,
@@ -263,7 +263,7 @@ export function startRumEventCollection(
     sessionManager,
     viewHistory,
     urlContexts,
-    actionContexts,
+    actionCollection.actionContexts,
     displayContext,
     ciVisibilityContext,
     getCommonContext,
@@ -274,9 +274,10 @@ export function startRumEventCollection(
     viewHistory,
     pageStateHistory,
     urlContexts,
-    addAction,
-    actionContexts,
+    addAction: actionCollection.addAction,
+    actionContexts: actionCollection.actionContexts,
     stop: () => {
+      actionCollection.stop()
       ciVisibilityContext.stop()
       displayContext.stop()
       urlContexts.stop()

--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -1,6 +1,6 @@
 import type { Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
 import { ExperimentalFeature, Observable } from '@datadog/browser-core'
-import { createNewEvent, mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { createNewEvent, mockExperimentalFeatures, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RawRumActionEvent, RawRumEventCollectedData } from '@datadog/browser-rum-core'
 import { collectAndValidateRawRumEvents, mockPageStateHistory, mockRumConfiguration } from '../../../test'
 import type { RawRumEvent } from '../../rawRumEvent.types'
@@ -19,13 +19,15 @@ describe('actionCollection', () => {
     const domMutationObservable = new Observable<void>()
     const windowOpenObservable = new Observable<void>()
 
-    ;({ addAction } = startActionCollection(
+    const actionCollection = startActionCollection(
       lifeCycle,
       domMutationObservable,
       windowOpenObservable,
       mockRumConfiguration(),
       basePageStateHistory
-    ))
+    )
+    registerCleanupTask(actionCollection.stop)
+    addAction = actionCollection.addAction
 
     rawRumEvents = collectAndValidateRawRumEvents(lifeCycle)
   })

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -46,13 +46,15 @@ export function startActionCollection(
   )
 
   let actionContexts: ActionContexts = { findActionId: noop as () => undefined }
+  let stop: () => void = noop
+
   if (configuration.trackUserInteractions) {
-    actionContexts = trackClickActions(
+    ;({ actionContexts, stop } = trackClickActions(
       lifeCycle,
       domMutationObservable,
       windowOpenObservable,
       configuration
-    ).actionContexts
+    ))
   }
 
   return {
@@ -68,6 +70,7 @@ export function startActionCollection(
       )
     },
     actionContexts,
+    stop,
   }
 }
 

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -18,6 +18,10 @@ if (testReportDirectory) {
 module.exports = {
   basePath: '../..',
   files: [
+    // Make sure 'forEach.spec' is the first file to be loaded, so its `beforeEach` hook is executed
+    // before all other `beforeEach` hooks, and its `afterEach` hook is executed after all other
+    // `afterEach` hooks.
+    'packages/core/test/forEach.spec.ts',
     'packages/*/@(src|test)/**/*.spec.@(ts|tsx)',
     'developer-extension/@(src|test)/**/*.spec.@(ts|tsx)',
     'packages/rum/test/toto.css',

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -60,7 +60,6 @@ module.exports = {
       // with all dependencies shared.  Our test suite does not support sharing dependencies, each
       // spec bundle should include its own copy of dependencies.
       runtimeChunk: false,
-      splitChunks: false,
     },
     ignoreWarnings: [
       // we will see warnings about missing exports in some files

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -60,6 +60,7 @@ module.exports = {
       // with all dependencies shared.  Our test suite does not support sharing dependencies, each
       // spec bundle should include its own copy of dependencies.
       runtimeChunk: false,
+      splitChunks: false,
     },
     ignoreWarnings: [
       // we will see warnings about missing exports in some files


### PR DESCRIPTION
## Motivation

In  the v6 branch, we started seeing a lot of leak detection warnings. We identified that the main issue was brought by https://github.com/DataDog/browser-sdk/pull/3190, switching the default `trackUserInteraction` to `true`: since we are now tracking user interaction every time `startActionCollection` is called, we need to clean it up as well.

Another issue was identified in the leak detection logic: the leak detection cleanup was done too soon, and the `removeEventListener` function was unpatched before some events were removed. [Because leak detection is wrapping the listener function into another "`wrappedListener`" function](https://github.com/DataDog/browser-sdk/blob/8acb3d08836977188a260060709cd7f1609c04f5/packages/core/test/leakDetection.ts#L24), the original function failed to be removed.

## Changes

* properly cleanup action collection in tests
* make sure forEach.spec.ts is run early, so its `afterEach` (and in turn, the leak detection cleanup) is run after every other `afterEach`.
* (bonus) remove `splitChunk: false` again to speed tests again (see https://github.com/DataDog/browser-sdk/pull/3057 an accidental revert https://github.com/DataDog/browser-sdk/commit/56694a12c293e04ced5027aed7240d5f8a9a615d )

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
