### PR TITLE
💚 fix CI PR comment

### DIFF
--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { printLog, runMain } = require('../lib/executionUtils')
-const { fetchPR, getLocalBranch } = require('../lib/gitUtils')
+const { fetchPR, LOCAL_BRANCH } = require('../lib/gitUtils')
 const { command } = require('../lib/command')
 
 const {
@@ -50,7 +50,7 @@ async function main(env, version, uploadPathTypes) {
     for (const uploadPathType of uploadPathTypes) {
       let uploadPath
       if (uploadPathType === 'pull-request') {
-        const pr = await fetchPR(getLocalBranch())
+        const pr = await fetchPR(LOCAL_BRANCH)
         if (!pr) {
           console.log('No pull requests found for the branch')
           return

--- a/scripts/lib/gitUtils.js
+++ b/scripts/lib/gitUtils.js
@@ -52,5 +52,5 @@ module.exports = {
   initGitConfig,
   fetchPR,
   getLastCommonCommit,
-  getLocalBranch: () => process.env.CI_COMMIT_REF_NAME,
+  LOCAL_BRANCH: process.env.CI_COMMIT_REF_NAME,
 }

--- a/scripts/performance/lib/reportAsAPrComment.js
+++ b/scripts/performance/lib/reportAsAPrComment.js
@@ -1,6 +1,7 @@
 const { command } = require('../../lib/command')
 const { fetchHandlingError } = require('../../lib/executionUtils')
-const { LOCAL_BRANCH, GITHUB_TOKEN, getLastCommonCommit, fetchPR } = require('../../lib/gitUtils')
+const { LOCAL_BRANCH, getLastCommonCommit, fetchPR } = require('../../lib/gitUtils')
+const { getGithubAccessToken } = require('../../lib/secrets')
 const { fetchPerformanceMetrics } = require('./fetchPerformanceMetrics')
 const PR_COMMENT_HEADER = 'Bundles Sizes Evolution'
 const PR_COMMENTER_AUTH_TOKEN = command`authanywhere --raw`.run()
@@ -74,7 +75,7 @@ async function retrieveExistingCommentId(prNumber) {
     {
       method: 'GET',
       headers: {
-        Authorization: `token ${GITHUB_TOKEN}`,
+        Authorization: `token ${getGithubAccessToken()}`,
       },
     }
   )


### PR DESCRIPTION
## Motivation

The PR comments are broken since #3211 because `LOCAL_BRANCH` does not exist anymore (it has been replaced by a `getLocalBranch` function).

## Changes

Restore `LOCAL_BRANCH`, remove `getLocalBranch`, as I don't see any reason why it should be a function (but maybe @amortemousque has more context)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
