### PR TITLE
✨ [RUM-6567] Generate new web vitals attribution fields

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -392,9 +392,9 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       is_main_process?: boolean
       /**
-       * The list of events that include feature flags collection
+       * The list of events that include feature flags collection. The tracking is always enabled for views and errors.
        */
-      collect_feature_flags_on?: ('view' | 'error' | 'vital')[]
+      track_feature_flags_for_events?: ('vital' | 'resource' | 'action' | 'long_task')[]
       /**
        * Whether the anonymous users are tracked
        */

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -433,6 +433,7 @@ export type TelemetryCommonFeaturesUsage =
   | AddError
   | SetGlobalContext
   | SetUser
+  | SetAccount
   | AddFeatureFlagEvaluation
 /**
  * Schema of browser specific features usage
@@ -621,6 +622,13 @@ export interface SetUser {
    * setUser, setUserProperty, setUserInfo APIs
    */
   feature: 'set-user'
+  [k: string]: unknown
+}
+export interface SetAccount {
+  /**
+   * setAccount, setAccountProperty APIs
+   */
+  feature: 'set-account'
   [k: string]: unknown
 }
 export interface AddFeatureFlagEvaluation {

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -185,6 +185,30 @@ describe('viewCollection', () => {
           max_scroll_height_time: 4000000000000000 as ServerDuration,
         },
       },
+      performance: {
+        cls: {
+          score: 1,
+          timestamp: (100 * 1e6) as ServerDuration,
+          target_selector: undefined,
+        },
+        fcp: {
+          timestamp: (10 * 1e6) as ServerDuration,
+        },
+        fid: {
+          duration: (12 * 1e6) as ServerDuration,
+          timestamp: (10 * 1e6) as ServerDuration,
+          target_selector: undefined,
+        },
+        inp: {
+          duration: (10 * 1e6) as ServerDuration,
+          timestamp: (100 * 1e6) as ServerDuration,
+          target_selector: undefined,
+        },
+        lcp: {
+          timestamp: (10 * 1e6) as ServerDuration,
+          target_selector: undefined,
+        },
+      },
       privacy: { replay_level: 'mask' },
     })
   })

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -167,6 +167,30 @@ describe('viewCollection', () => {
         long_task: {
           count: 10,
         },
+        performance: {
+          cls: {
+            score: 1,
+            timestamp: (100 * 1e6) as ServerDuration,
+            target_selector: undefined,
+          },
+          fcp: {
+            timestamp: (10 * 1e6) as ServerDuration,
+          },
+          fid: {
+            duration: (12 * 1e6) as ServerDuration,
+            timestamp: (10 * 1e6) as ServerDuration,
+            target_selector: undefined,
+          },
+          inp: {
+            duration: (10 * 1e6) as ServerDuration,
+            timestamp: (100 * 1e6) as ServerDuration,
+            target_selector: undefined,
+          },
+          lcp: {
+            timestamp: (10 * 1e6) as ServerDuration,
+            target_selector: undefined,
+          },
+        },
         resource: {
           count: 10,
         },
@@ -183,30 +207,6 @@ describe('viewCollection', () => {
           max_depth_scroll_top: 1000,
           max_scroll_height: 3000,
           max_scroll_height_time: 4000000000000000 as ServerDuration,
-        },
-      },
-      performance: {
-        cls: {
-          score: 1,
-          timestamp: (100 * 1e6) as ServerDuration,
-          target_selector: undefined,
-        },
-        fcp: {
-          timestamp: (10 * 1e6) as ServerDuration,
-        },
-        fid: {
-          duration: (12 * 1e6) as ServerDuration,
-          timestamp: (10 * 1e6) as ServerDuration,
-          target_selector: undefined,
-        },
-        inp: {
-          duration: (10 * 1e6) as ServerDuration,
-          timestamp: (100 * 1e6) as ServerDuration,
-          target_selector: undefined,
-        },
-        lcp: {
-          timestamp: (10 * 1e6) as ServerDuration,
-          target_selector: undefined,
         },
       },
       privacy: { replay_level: 'mask' },

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -100,6 +100,7 @@ function processViewUpdate(
       long_task: {
         count: view.eventCounts.longTaskCount,
       },
+      performance: computeViewPerformanceData(view.commonViewMetrics, view.initialViewMetrics),
       resource: {
         count: view.eventCounts.resourceCount,
       },
@@ -116,7 +117,6 @@ function processViewUpdate(
           },
         }
       : undefined,
-    performance: computeViewPerformanceData(view.commonViewMetrics, view.initialViewMetrics),
     session: {
       has_replay: replayStats ? true : undefined,
       is_active: view.sessionIsActive ? undefined : false,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -130,6 +130,7 @@ export interface RawRumViewEvent {
   }
   feature_flags?: Context
   display?: ViewDisplay
+  performance?: ViewPerformanceData
   privacy?: {
     replay_level: DefaultPrivacyLevel
   }
@@ -149,6 +150,31 @@ interface ViewDisplay {
     max_depth_scroll_top?: number
     max_scroll_height?: number
     max_scroll_height_time?: ServerDuration
+  }
+}
+
+export interface ViewPerformanceData {
+  cls?: {
+    score: number
+    timestamp?: ServerDuration
+    target_selector?: string
+  }
+  fcp?: {
+    timestamp: number
+  }
+  fid?: {
+    duration: ServerDuration
+    timestamp: ServerDuration
+    target_selector?: string
+  }
+  inp?: {
+    duration: ServerDuration
+    timestamp?: ServerDuration
+    target_selector?: string
+  }
+  lcp?: {
+    timestamp: ServerDuration
+    target_selector?: string
   }
 }
 

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -123,6 +123,7 @@ export interface RawRumViewEvent {
     long_task: Count
     resource: Count
     frustration: Count
+    performance?: ViewPerformanceData
   }
   session: {
     has_replay: true | undefined
@@ -130,7 +131,6 @@ export interface RawRumViewEvent {
   }
   feature_flags?: Context
   display?: ViewDisplay
-  performance?: ViewPerformanceData
   privacy?: {
     replay_level: DefaultPrivacyLevel
   }

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1344,6 +1344,20 @@ export interface CommonProperties {
     [k: string]: unknown
   }
   /**
+   * Account properties
+   */
+  readonly account?: {
+    /**
+     * Identifier of the account
+     */
+    readonly id: string
+    /**
+     * Name of the account
+     */
+    readonly name?: string
+    [k: string]: unknown
+  }
+  /**
    * Device connectivity properties
    */
   connectivity?: {
@@ -1630,6 +1644,14 @@ export interface ViewPerformanceData {
      * CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS
      */
     readonly target_selector?: string
+    /**
+     * Bounding client rect of the element before the layout shift
+     */
+    previous_rect?: RumRect
+    /**
+     * Bounding client rect of the element after the layout shift
+     */
+    current_rect?: RumRect
     [k: string]: unknown
   }
   /**
@@ -1692,5 +1714,27 @@ export interface ViewPerformanceData {
     readonly target_selector?: string
     [k: string]: unknown
   }
+  [k: string]: unknown
+}
+/**
+ * Schema for DOMRect-like rectangles describing an element's bounding client rect
+ */
+export interface RumRect {
+  /**
+   * The x coordinate of the element's origin
+   */
+  readonly x: number
+  /**
+   * The y coordinate of the element's origin
+   */
+  readonly y: number
+  /**
+   * The element's width
+   */
+  readonly width: number
+  /**
+   * The element's height
+   */
+  readonly height: number
   [k: string]: unknown
 }

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1057,6 +1057,10 @@ export type RumViewEvent = CommonProperties &
        * The JavaScript refresh rate for React Native
        */
       js_refresh_rate?: RumPerfMetric
+      /**
+       * Performance data. (Web Vitals, etc.)
+       */
+      performance?: ViewPerformanceData
       [k: string]: unknown
     }
     /**
@@ -1169,10 +1173,6 @@ export type RumViewEvent = CommonProperties &
       }
       [k: string]: unknown
     }
-    /**
-     * Performance data. (Web Vitals, etc.)
-     */
-    performance?: ViewPerformanceData
     [k: string]: unknown
   }
 /**


### PR DESCRIPTION
## Motivation

This PR adds code to generate the new web vitals attribution fields that were added to the event format in [this PR](https://github.com/DataDog/rum-events-format/pull/240).

For now, the old web vitals fields remain. To remove them safely without breaking backwards compatibility, we need backend changes, so we'll hold off until those are done.

## Changes

* The `rum-events-format` submodule has been updated to include the new fields.
* The new fields have been added to the appropriate type definitions.
* The code to populate the new fields has been added to `viewCollection.ts`.
* The tests have been updated appropriately.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
