### PR TITLE
define createReporter API 

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -415,6 +415,7 @@ export type TelemetryCommonFeaturesUsage =
   | StartView
   | AddAction
   | AddError
+  | CreateReporter
   | SetGlobalContext
   | SetUser
   | AddFeatureFlagEvaluation
@@ -587,6 +588,13 @@ export interface AddError {
    * addError API
    */
   feature: 'add-error'
+  [k: string]: unknown
+}
+export interface CreateReporter {
+  /**
+   * createReporter API
+   */
+  feature: 'create-reporter'
   [k: string]: unknown
 }
 export interface SetGlobalContext {


### PR DESCRIPTION
## Motivation

As of today there's no easy way to send RUM errors or actions that share the same tags, this is something that makes a lot of sense if you wish to define scopes for your application that all share the same information.

There's also no way to supply a `handledStack` for specifying which part of the codebase is actually reporting the error or action

## Changes
Introduce a new API that allows to specify a handling stack trace to `addError` (as well as `addAction`?)


```ts
{
  // ... rum public api methods
  createReporter: (component: string, conf?: ReporterConfiguration) => Reporter
  // ...
}
export interface Reporter {
  addAction: RumPublicApi['addAction']
  addError: RumPublicApi['addError']
}
export interface ReporterConfiguration {
  handlingStack?: string
  context?: object
}
```

This new `createReporter` method returns an object that has the `addError` method, but now when that method is called the supplied `handlingStack` will be used as well as all of the `context` passed to the configuration

```ts
const reporter = createReporer('MyComponent', {
  handlingStack: info.componentStack,
  context: { team: 'datadog' }
})
```

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
