### PR TITLE
Use `createReporter` in React plugin to collect errors

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -415,6 +415,7 @@ export type TelemetryCommonFeaturesUsage =
   | StartView
   | AddAction
   | AddError
+  | CreateReporter
   | SetGlobalContext
   | SetUser
   | AddFeatureFlagEvaluation
@@ -587,6 +588,13 @@ export interface AddError {
    * addError API
    */
   feature: 'add-error'
+  [k: string]: unknown
+}
+export interface CreateReporter {
+  /**
+   * createReporter API
+   */
+  feature: 'create-reporter'
   [k: string]: unknown
 }
 export interface SetGlobalContext {

--- a/packages/rum-react/src/domain/error/addReactError.ts
+++ b/packages/rum-react/src/domain/error/addReactError.ts
@@ -1,13 +1,11 @@
 import type { ErrorInfo } from 'react'
-import type { ErrorWithCause } from '@datadog/browser-core'
 import { onReactPluginInit } from '../reactPlugin'
 
 export function addReactError(error: Error, info: ErrorInfo) {
-  const renderingError = new Error(error.message)
-  renderingError.name = 'ReactRenderingError'
-  renderingError.stack = info.componentStack ?? undefined
-  ;(renderingError as ErrorWithCause).cause = error
   onReactPluginInit((_, rumPublicApi) => {
-    rumPublicApi.addError(renderingError, { framework: 'react' })
+    const reporter = rumPublicApi.createReporter('@datadog/browser-rum-react', {
+      handlingStack: info.componentStack ?? undefined,
+    })
+    reporter.addError(error, { framework: 'react' })
   })
 }


### PR DESCRIPTION
## Motivation

Follow up to https://github.com/DataDog/browser-sdk/pull/3254

The ErrorBoundary component will capture whatever error occurs inside of it and send it to datadog, when this happens it renders the fallback component supplied to it. This works similar to a try/catch, where errors that occur within a component tree will not cause the entire application to crash and instead show a fallback.

As of today there’s a big problem with how ErrorBoundary reports these errors to datadog and how that plays into the Error Tracking product.

The original thrown error is not the one being reported, instead a different error is with a different stack trace (the one obtained from react’s error info) and a different error name (or @error.type in datadog). This messes with Error Tracking’s grouping.

This is the anatomy of a react error sent to Datadog today:

![image](https://github.com/user-attachments/assets/bef7e61b-2055-4c19-8ea1-890c613b3611)

It would make more sense to report the original error so it has the original stack and name, drop the cause since it wouldn’t be needed anymore and instead place the component’s stack as the “Handled by” stack.

## Changes

By passing the `info.componentStack` to the SDK through `createReporter` we can make it so the "Handled by" stack trace shows the component stack

```ts
const reporter = rumPublicApi.createReporter('@datadog/browser-rum-react', {
  handlingStack: info.componentStack ?? undefined,
})
reporter.addError(error, { framework: 'react' })
```

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
