### PR TITLE
add the `errorContext` prop to the `ErrorBoundary` component

### DIFF
--- a/packages/rum-react/src/domain/error/addReactError.ts
+++ b/packages/rum-react/src/domain/error/addReactError.ts
@@ -2,12 +2,12 @@ import type { ErrorInfo } from 'react'
 import type { ErrorWithCause } from '@datadog/browser-core'
 import { onReactPluginInit } from '../reactPlugin'
 
-export function addReactError(error: Error, info: ErrorInfo) {
+export function addReactError(error: Error, context: object | undefined, info: ErrorInfo) {
   const renderingError = new Error(error.message)
   renderingError.name = 'ReactRenderingError'
   renderingError.stack = info.componentStack ?? undefined
   ;(renderingError as ErrorWithCause).cause = error
   onReactPluginInit((_, rumPublicApi) => {
-    rumPublicApi.addError(renderingError, { framework: 'react' })
+    rumPublicApi.addError(renderingError, Object.assign({}, { framework: 'react' }, context))
   })
 }

--- a/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
+++ b/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
@@ -86,12 +86,12 @@ describe('ErrorBoundary', () => {
     ;(ComponentSpy as any).displayName = 'ComponentSpy'
 
     appendComponent(
-      <ErrorBoundary fallback={() => null}>
+      <ErrorBoundary fallback={() => null} errorContext={{ id: 1 }}>
         <ComponentSpy />
       </ErrorBoundary>
     )
 
-    expect(addErrorSpy).toHaveBeenCalledOnceWith(jasmine.any(Error), { framework: 'react' })
+    expect(addErrorSpy).toHaveBeenCalledOnceWith(jasmine.any(Error), { id: 1, framework: 'react' })
     const error = addErrorSpy.calls.first().args[0]
     expect(error.message).toBe('error')
     expect(error.name).toBe('ReactRenderingError')

--- a/packages/rum-react/src/domain/error/errorBoundary.ts
+++ b/packages/rum-react/src/domain/error/errorBoundary.ts
@@ -5,6 +5,7 @@ import { addReactError } from './addReactError'
 interface Props {
   fallback: Fallback
   children: React.ReactNode
+  errorContext?: object
 }
 
 export type Fallback = React.ComponentType<{ error: Error; resetError: () => void }>
@@ -37,7 +38,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    addReactError(error, errorInfo)
+    addReactError(error, this.props.errorContext, errorInfo)
   }
 
   render() {


### PR DESCRIPTION
## Motivation

This is a simple, yet useful, change. Giving customers the ability to pass an errorContext prop to the ErrorBoundary component could improve the triaging experiencing of the error. Take this for example:


```tsx
function List() {
  return (
    <div>
      <ErrorBoundary errorContext={{ item: 0 }}>
        <ListItem id={0} />
      </ErrorBoundary>
      <ErrorBoundary errorContext={{ item: 1 }}>
        <ListItem id={1} />
      </ErrorBoundary>
    </div>
  );
}
```
In the component above both ListItem elements are capable of producing an error, and when doing so they would both have the same componentStack reported by react, but since the item prop was added to the error’s context then in Datadog it would be possible to determine which component threw the error.

## Changes

- Take `errorContext` as a prop by the `ErrorBoundary`
- Add the context to the payload sent by the SDK
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
