### PR TITLE
✅ fix session store e2e to account for anonymous id

### DIFF
--- a/test/e2e/scenario/sessionStore.scenario.ts
+++ b/test/e2e/scenario/sessionStore.scenario.ts
@@ -3,6 +3,7 @@ import { createTest } from '../lib/framework'
 
 const DISABLE_LOCAL_STORAGE = '<script>Object.defineProperty(Storage.prototype, "getItem", { get: () => 42});</script>'
 const DISABLE_COOKIES = '<script>Object.defineProperty(Document.prototype, "cookie", { get: () => 42});</script>'
+const SESSION_ID_REGEX = /(?<!a)id=([\w-]+)/ // match `id` but not `aid`
 
 describe('Session Stores', () => {
   describe('Cookies', () => {
@@ -76,10 +77,10 @@ describe('Session Stores', () => {
 
 async function getSessionIdFromLocalStorage(): Promise<string | undefined> {
   const sessionStateString = await browser.execute((key) => window.localStorage.getItem(key), SESSION_STORE_KEY)
-  return sessionStateString?.match(/id=([\w-]+)/)?.[1]
+  return sessionStateString?.match(SESSION_ID_REGEX)?.[1]
 }
 
 async function getSessionIdFromCookie(): Promise<string | undefined> {
   const [cookie] = await browser.getCookies([SESSION_STORE_KEY])
-  return cookie.value.match(/id=([\w-]+)/)?.[1]
+  return cookie.value.match(SESSION_ID_REGEX)?.[1]
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

In v6 we now have both `id` and `aid` in the session cookie / local storage

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

fix e2e to match `id` but not `aid`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
