### PR TITLE
✨ [RUM-7572] Add get api of view specific context

### DIFF
--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -576,7 +576,7 @@ describe('preStartRum', () => {
         createCustomVitalsState(),
         doStartRumSpy
       )
-      expect(strategy.getViewContext()).toBe(undefined)
+      expect(strategy.getViewContext()).toBeUndefined()
     })
   })
 

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -567,6 +567,19 @@ describe('preStartRum', () => {
     })
   })
 
+  describe('getViewContext', () => {
+    it('returns undefined', () => {
+      const strategy = createPreStartStrategy(
+        {},
+        getCommonContextSpy,
+        createTrackingConsentState(),
+        createCustomVitalsState(),
+        doStartRumSpy
+      )
+      expect(strategy.getViewContext()).toBe(undefined)
+    })
+  })
+
   describe('stopSession', () => {
     it('does not buffer the call before starting RUM', () => {
       const strategy = createPreStartStrategy(

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -568,7 +568,7 @@ describe('preStartRum', () => {
   })
 
   describe('getViewContext', () => {
-    it('returns undefined', () => {
+    it('returns empty object', () => {
       const strategy = createPreStartStrategy(
         {},
         getCommonContextSpy,
@@ -576,7 +576,7 @@ describe('preStartRum', () => {
         createCustomVitalsState(),
         doStartRumSpy
       )
-      expect(strategy.getViewContext()).toBeUndefined()
+      expect(strategy.getViewContext()).toEqual({})
     })
   })
 

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -204,7 +204,7 @@ export function createPreStartStrategy(
       bufferApiCalls.add((startRumResult) => startRumResult.setViewContextProperty(key, value))
     },
 
-    getViewContext: noop as () => undefined,
+    getViewContext: noop as () => {},
 
     addAction(action, commonContext = getCommonContext()) {
       bufferApiCalls.add((startRumResult) => startRumResult.addAction(action, commonContext))

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -15,7 +15,7 @@ import {
   addTelemetryConfiguration,
   initFetchObservable,
 } from '@datadog/browser-core'
-import type { TrackingConsentState, DeflateWorker } from '@datadog/browser-core'
+import type { TrackingConsentState, DeflateWorker, Context } from '@datadog/browser-core'
 import {
   validateAndBuildRumConfiguration,
   type RumConfiguration,
@@ -52,6 +52,8 @@ export function createPreStartStrategy(
   let cachedConfiguration: RumConfiguration | undefined
 
   const trackingConsentStateSubscription = trackingConsentState.observable.subscribe(tryStartRum)
+
+  const noopContext: Context = {}
 
   function tryStartRum() {
     if (!cachedInitConfiguration || !cachedConfiguration || !trackingConsentState.isGranted()) {
@@ -204,7 +206,7 @@ export function createPreStartStrategy(
       bufferApiCalls.add((startRumResult) => startRumResult.setViewContextProperty(key, value))
     },
 
-    getViewContext: noop as () => {},
+    getViewContext: () => noopContext,
 
     addAction(action, commonContext = getCommonContext()) {
       bufferApiCalls.add((startRumResult) => startRumResult.addAction(action, commonContext))

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -204,6 +204,8 @@ export function createPreStartStrategy(
       bufferApiCalls.add((startRumResult) => startRumResult.setViewContextProperty(key, value))
     },
 
+    getViewContext: noop as () => undefined,
+
     addAction(action, commonContext = getCommonContext()) {
       bufferApiCalls.add((startRumResult) => startRumResult.addAction(action, commonContext))
     },

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -53,7 +53,7 @@ export function createPreStartStrategy(
 
   const trackingConsentStateSubscription = trackingConsentState.observable.subscribe(tryStartRum)
 
-  const noopContext: Context = {}
+  const emptyContext: Context = {}
 
   function tryStartRum() {
     if (!cachedInitConfiguration || !cachedConfiguration || !trackingConsentState.isGranted()) {
@@ -206,7 +206,7 @@ export function createPreStartStrategy(
       bufferApiCalls.add((startRumResult) => startRumResult.setViewContextProperty(key, value))
     },
 
-    getViewContext: () => noopContext,
+    getViewContext: () => emptyContext,
 
     addAction(action, commonContext = getCommonContext()) {
       bufferApiCalls.add((startRumResult) => startRumResult.addAction(action, commonContext))

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -25,6 +25,7 @@ const noopStartRum = (): ReturnType<StartRum> => ({
   setViewContext: () => undefined,
   setViewContextProperty: () => undefined,
   setViewName: () => undefined,
+  getViewContext: () => undefined,
   getInternalContext: () => undefined,
   lifeCycle: {} as any,
   viewHistory: {} as any,
@@ -889,6 +890,44 @@ describe('rum public api', () => {
       ;(rumPublicApi as any).setViewContextProperty('foo', 'bar')
 
       expect(setViewContextPropertySpy).toHaveBeenCalledWith('foo', 'bar')
+    })
+  })
+
+  describe('getViewContext', () => {
+    let getViewContextSpy: jasmine.Spy<ReturnType<StartRum>['getViewContext']>
+    let rumPublicApi: RumPublicApi
+
+    beforeEach(() => {
+      getViewContextSpy = jasmine.createSpy().and.callFake(() => ({
+        foo: 'bar',
+      }))
+      rumPublicApi = makeRumPublicApi(
+        () => ({
+          ...noopStartRum(),
+          getViewContext: getViewContextSpy,
+        }),
+        noopRecorderApi
+      )
+    })
+
+    it('should return the view context after init', () => {
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+
+      expect(rumPublicApi.getViewContext()).toEqual({ foo: 'bar' })
+      expect(getViewContextSpy).toHaveBeenCalled()
+    })
+
+    it('should return undefined before init', () => {
+      expect(rumPublicApi.getViewContext()).toBeUndefined()
+      expect(getViewContextSpy).not.toHaveBeenCalled()
+    })
+
+    it('should return undefined if getViewContext returns undefined', () => {
+      getViewContextSpy.and.callFake(() => undefined)
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+
+      expect(rumPublicApi.getViewContext()).toBeUndefined()
+      expect(getViewContextSpy).toHaveBeenCalled()
     })
   })
 })

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -25,7 +25,7 @@ const noopStartRum = (): ReturnType<StartRum> => ({
   setViewContext: () => undefined,
   setViewContextProperty: () => undefined,
   setViewName: () => undefined,
-  getViewContext: () => undefined,
+  getViewContext: () => ({}),
   getInternalContext: () => undefined,
   lifeCycle: {} as any,
   viewHistory: {} as any,
@@ -920,14 +920,6 @@ describe('rum public api', () => {
     it('should return undefined before init', () => {
       expect(rumPublicApi.getViewContext()).toBeUndefined()
       expect(getViewContextSpy).not.toHaveBeenCalled()
-    })
-
-    it('should return undefined if getViewContext returns undefined', () => {
-      getViewContextSpy.and.callFake(() => undefined)
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(rumPublicApi.getViewContext()).toBeUndefined()
-      expect(getViewContextSpy).toHaveBeenCalled()
     })
   })
 })

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -917,8 +917,8 @@ describe('rum public api', () => {
       expect(getViewContextSpy).toHaveBeenCalled()
     })
 
-    it('should return undefined before init', () => {
-      expect(rumPublicApi.getViewContext()).toBeUndefined()
+    it('should return an empty object before init', () => {
+      expect(rumPublicApi.getViewContext()).toEqual({})
       expect(getViewContextSpy).not.toHaveBeenCalled()
     })
   })

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -98,6 +98,12 @@ export interface RumPublicApi extends PublicApi {
    * @param value value of the property
    */
   setViewContextProperty: (key: string, value: any) => void
+
+  /**
+   * Get View Context.
+   */
+  getViewContext: () => Context | undefined
+
   /**
    * Set the global context information to all events, stored in `@context`
    *
@@ -352,6 +358,7 @@ export interface Strategy {
   setViewName: StartRumResult['setViewName']
   setViewContext: StartRumResult['setViewContext']
   setViewContextProperty: StartRumResult['setViewContextProperty']
+  getViewContext: StartRumResult['getViewContext']
   addAction: StartRumResult['addAction']
   addError: StartRumResult['addError']
   addFeatureFlagEvaluation: StartRumResult['addFeatureFlagEvaluation']
@@ -452,6 +459,8 @@ export function makeRumPublicApi(
     setViewContextProperty: monitor((key: string, value: any) => {
       strategy.setViewContextProperty(key, value)
     }),
+
+    getViewContext: monitor(() => strategy.getViewContext()),
 
     setGlobalContext: monitor((context) => {
       globalContextManager.setContext(context)

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -102,7 +102,7 @@ export interface RumPublicApi extends PublicApi {
   /**
    * Get View Context.
    */
-  getViewContext: () => Context | undefined
+  getViewContext: () => Context
 
   /**
    * Set the global context information to all events, stored in `@context`

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -159,6 +159,7 @@ export function startRum(
     setViewName,
     setViewContext,
     setViewContextProperty,
+    getViewContext,
     stop: stopViewCollection,
   } = startViewCollection(
     lifeCycle,
@@ -207,6 +208,7 @@ export function startRum(
     startView,
     setViewContext,
     setViewContextProperty,
+    getViewContext,
     setViewName,
     lifeCycle,
     viewHistory,

--- a/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
+++ b/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
@@ -39,21 +39,23 @@ export function setupViewTest({ lifeCycle, initialLocation }: ViewTrackingContex
   } = spyOnViews<ViewEndedEvent>()
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, viewEndHandler)
 
-  const { stop, startView, setViewName, setViewContext, setViewContextProperty, addTiming } = trackViews(
-    location,
-    lifeCycle,
-    domMutationObservable,
-    windowOpenObservable,
-    configuration,
-    locationChangeObservable,
-    !configuration.trackViewsManually,
-    initialViewOptions
-  )
+  const { stop, startView, setViewName, setViewContext, setViewContextProperty, getViewContext, addTiming } =
+    trackViews(
+      location,
+      lifeCycle,
+      domMutationObservable,
+      windowOpenObservable,
+      configuration,
+      locationChangeObservable,
+      !configuration.trackViewsManually,
+      initialViewOptions
+    )
   return {
     stop,
     startView,
     setViewContext,
     setViewContextProperty,
+    getViewContext,
     changeLocation,
     setViewName,
     addTiming,

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -932,6 +932,14 @@ describe('view event count', () => {
       setViewContextProperty('foo', 'bar')
       expect(getViewUpdate(1).context).toEqual({ foo: 'bar' })
     })
+
+    it('should get view context with getViewContext', () => {
+      viewTest = setupViewTest({ lifeCycle })
+      const { getViewContext, setViewContextProperty } = viewTest
+
+      setViewContextProperty('foo', 'bar')
+      expect(getViewContext()).toEqual({ foo: 'bar' })
+    })
   })
 
   describe('set view name', () => {

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -176,6 +176,10 @@ export function trackViews(
     setViewName: (name: string) => {
       currentView.setViewName(name)
     },
+    getViewContext: () => {
+      const context = currentView.contextManager.getContext()
+      return context ? context : undefined
+    },
 
     stop: () => {
       if (locationChangeSubscription) {

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -176,10 +176,7 @@ export function trackViews(
     setViewName: (name: string) => {
       currentView.setViewName(name)
     },
-    getViewContext: () => {
-      const context = currentView.contextManager.getContext()
-      return context ? context : undefined
-    },
+    getViewContext: () => currentView.contextManager.getContext(),
 
     stop: () => {
       if (locationChangeSubscription) {

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -147,7 +147,6 @@ describe('API calls and events around init', () => {
 
       const initialView = intakeRegistry.rumViewEvents[0]
       const nextView = intakeRegistry.rumViewEvents[1]
-
       expect(initialView.context).toEqual(jasmine.objectContaining({ foo: 'bar', bar: 'foo' }))
       expect(nextView.context!.foo).toBeUndefined()
 
@@ -175,6 +174,17 @@ describe('API calls and events around init', () => {
           viewId: nextView.view.id,
         }
       )
+    })
+
+  createTest('get the view context')
+    .withRum()
+    .withRumInit((configuration) => {
+      window.DD_RUM!.init(configuration)
+      window.DD_RUM!.setViewContext({ foo: 'bar' })
+    })
+    .run(async () => {
+      const viewContext = await browser.execute(() => window.DD_RUM?.getViewContext())
+      expect(viewContext).toEqual({ foo: 'bar' })
     })
 })
 


### PR DESCRIPTION
## Motivation

After adding set view context we need to have a get view context api

## Changes

Add a new api

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
