### PR TITLE
👷 do not rename bundle file when name does not change

### DIFF
--- a/scripts/deploy/upload-source-maps.js
+++ b/scripts/deploy/upload-source-maps.js
@@ -68,6 +68,10 @@ async function renameFilesWithVersionSuffix(bundleFolder, version) {
   await forEachFile(bundleFolder, (bundlePath) => {
     const uploadPath = buildRootUploadPath(bundlePath, version)
 
+    if (bundlePath === uploadPath) {
+      return
+    }
+
     console.log(`Renaming ${bundlePath} to ${uploadPath}`)
     command`mv ${bundlePath} ${uploadPath}`.run()
   })

--- a/scripts/deploy/upload-source-maps.spec.js
+++ b/scripts/deploy/upload-source-maps.spec.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict')
 const path = require('node:path')
 const { beforeEach, before, describe, it, mock } = require('node:test')
 const { siteByDatacenter } = require('../lib/datadogSites')
-const { mockModule, mockCommandImplementation, replaceChunkHashes, FAKE_CHUNK_HASH } = require('./lib/testHelpers.js')
+const { mockModule, mockCommandImplementation, replaceChunkHashes } = require('./lib/testHelpers.js')
 
 const FAKE_API_KEY = 'FAKE_API_KEY'
 const ENV_STAGING = {
@@ -59,12 +59,6 @@ void describe('upload-source-maps', () => {
         },
         {
           command: 'mv packages/logs/bundle/datadog-logs.js.map packages/logs/bundle/datadog-logs-v6.js.map',
-        },
-        {
-          command: `mv packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
-        },
-        {
-          command: `mv packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js.map packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js.map`,
         },
         {
           command: 'mv packages/rum/bundle/datadog-rum.js packages/rum/bundle/datadog-rum-v6.js',
@@ -136,12 +130,6 @@ void describe('upload-source-maps', () => {
         command: 'mv packages/logs/bundle/datadog-logs.js.map packages/logs/bundle/datadog-logs-staging.js.map',
       },
       {
-        command: `mv packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
-      },
-      {
-        command: `mv packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js.map packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js.map`,
-      },
-      {
         command: 'mv packages/rum/bundle/datadog-rum.js packages/rum/bundle/datadog-rum-staging.js',
       },
       {
@@ -201,12 +189,6 @@ void describe('upload-source-maps', () => {
       },
       {
         command: 'mv packages/logs/bundle/datadog-logs.js.map packages/logs/bundle/datadog-logs-canary.js.map',
-      },
-      {
-        command: `mv packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
-      },
-      {
-        command: `mv packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js.map packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js.map`,
       },
       {
         command: 'mv packages/rum/bundle/datadog-rum.js packages/rum/bundle/datadog-rum-canary.js',


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

We don't suffix chunks, so we should not try to rename them as this would fail:

```
 Error: Command failed with exit status 1: mv packages/rum/bundle/chunks/recorder-d7628536637b074ddc3b-datadog-rum.js packages/rum/bundle/chunks/recorder-d7628536637b074ddc3b-datadog-rum.js
---- stderr: ----
mv: 'packages/rum/bundle/chunks/recorder-d7628536637b074ddc3b-datadog-rum.js' and 'packages/rum/bundle/chunks/recorder-d7628536637b074ddc3b-datadog-rum.js' are the same file
----
```

We didn't ran into the issue before because `deploy-next-major-canary` don't upload sourcemaps (I guess we should fix that for next time)

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
