### PR TITLE
⚗ [RUM-7213] DOM mutation ignoring

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -20,6 +20,7 @@ export enum ExperimentalFeature {
   ANONYMOUS_USER_TRACKING = 'anonymous_user_tracking',
   ACTION_NAME_MASKING = 'action_name_masking',
   CONSISTENT_TRACE_SAMPLING = 'consistent_trace_sampling',
+  DOM_MUTATION_IGNORING = 'dom_mutation_ignoring'
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()


### PR DESCRIPTION
## Motivation

Ability to exclude certain DOM mutations from affecting the page loading time calculation

## Changes

- `attributes` mutations are ignored if the element has the attribute `dd-ignore-mutations`
- `childList` and `characterData` mutations are ignored if the parent element has the attribute `dd-ignore-mutations`

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
