### PR TITLE
✅ don't rely on segment counts on e2e tests

### DIFF
--- a/packages/rum/test/segments.ts
+++ b/packages/rum/test/segments.ts
@@ -37,10 +37,10 @@ export function findIncrementalSnapshot(
 
 // Returns all the IncrementalSnapshotRecord of a given source in a Segment, if any.
 export function findAllIncrementalSnapshots(
-  segments: BrowserSegment | BrowserSegment[],
+  { records }: { records: BrowserRecord[] },
   source: IncrementalSource
 ): BrowserIncrementalSnapshotRecord[] {
-  return getAllrecords(segments).filter(
+  return records.filter(
     (record) => record.type === RecordType.IncrementalSnapshot && record.data.source === source
   ) as BrowserIncrementalSnapshotRecord[]
 }
@@ -58,8 +58,4 @@ export function findMouseInteractionRecords(
   return findAllIncrementalSnapshots(segment, IncrementalSource.MouseInteraction).filter(
     (record) => 'type' in record.data && record.data.type === source
   )
-}
-
-export function getAllrecords(segments: BrowserSegment | BrowserSegment[]): BrowserRecord[] {
-  return Array.isArray(segments) ? segments.flatMap((segment) => segment.records) : segments.records
 }

--- a/packages/rum/test/segments.ts
+++ b/packages/rum/test/segments.ts
@@ -37,10 +37,10 @@ export function findIncrementalSnapshot(
 
 // Returns all the IncrementalSnapshotRecord of a given source in a Segment, if any.
 export function findAllIncrementalSnapshots(
-  segment: BrowserSegment,
+  segments: BrowserSegment | BrowserSegment[],
   source: IncrementalSource
 ): BrowserIncrementalSnapshotRecord[] {
-  return segment.records.filter(
+  return getAllrecords(segments).filter(
     (record) => record.type === RecordType.IncrementalSnapshot && record.data.source === source
   ) as BrowserIncrementalSnapshotRecord[]
 }
@@ -58,4 +58,8 @@ export function findMouseInteractionRecords(
   return findAllIncrementalSnapshots(segment, IncrementalSource.MouseInteraction).filter(
     (record) => 'type' in record.data && record.data.type === source
   )
+}
+
+export function getAllrecords(segments: BrowserSegment | BrowserSegment[]): BrowserRecord[] {
+  return Array.isArray(segments) ? segments.flatMap((segment) => segment.records) : segments.records
 }

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -1,4 +1,4 @@
-import type { InputData, StyleSheetRuleData, BrowserSegment, ScrollData } from '@datadog/browser-rum/src/types'
+import type { InputData, StyleSheetRuleData, ScrollData } from '@datadog/browser-rum/src/types'
 import { NodeType, IncrementalSource, MouseInteractionType } from '@datadog/browser-rum/src/types'
 
 // Import from src to have properties of const enums
@@ -17,7 +17,6 @@ import {
   findAllFrustrationRecords,
   findMouseInteractionRecords,
   findElementWithTagName,
-  getAllrecords,
 } from '@datadog/browser-rum/test'
 import { SESSION_STORE_KEY } from '@datadog/browser-core'
 import { flushEvents, createTest, bundleSetup, html } from '../../lib/framework'
@@ -484,34 +483,35 @@ describe('recorder', () => {
 
         await flushEvents()
 
-        const segments = intakeRegistry.replaySegments
-
-        const textInputRecords = filterRecordsByIdAttribute(segments, 'text-input')
+        const textInputRecords = filterRecordsByIdAttribute('text-input')
         expect(textInputRecords.length).toBeGreaterThanOrEqual(4)
         expect((textInputRecords[textInputRecords.length - 1].data as { text?: string }).text).toBe('test')
 
-        const radioInputRecords = filterRecordsByIdAttribute(segments, 'radio-input')
+        const radioInputRecords = filterRecordsByIdAttribute('radio-input')
         expect(radioInputRecords.length).toBe(1)
         expect((radioInputRecords[0].data as { text?: string }).text).toBe(undefined)
         expect((radioInputRecords[0].data as { isChecked?: boolean }).isChecked).toBe(true)
 
-        const checkboxInputRecords = filterRecordsByIdAttribute(segments, 'checkbox-input')
+        const checkboxInputRecords = filterRecordsByIdAttribute('checkbox-input')
         expect(checkboxInputRecords.length).toBe(1)
         expect((checkboxInputRecords[0].data as { text?: string }).text).toBe(undefined)
         expect((checkboxInputRecords[0].data as { isChecked?: boolean }).isChecked).toBe(true)
 
-        const textareaRecords = filterRecordsByIdAttribute(segments, 'textarea')
+        const textareaRecords = filterRecordsByIdAttribute('textarea')
         expect(textareaRecords.length).toBeGreaterThanOrEqual(4)
         expect((textareaRecords[textareaRecords.length - 1].data as { text?: string }).text).toBe('textarea test')
 
-        const selectRecords = filterRecordsByIdAttribute(segments, 'select')
+        const selectRecords = filterRecordsByIdAttribute('select')
         expect(selectRecords.length).toBe(1)
         expect((selectRecords[0].data as { text?: string }).text).toBe('2')
 
-        function filterRecordsByIdAttribute(segments: BrowserSegment[], idAttribute: string) {
-          const fullSnapshot = findFullSnapshot({ records: getAllrecords(segments) })!
+        function filterRecordsByIdAttribute(idAttribute: string) {
+          const fullSnapshot = findFullSnapshot({ records: intakeRegistry.replayRecords })!
           const id = findElementWithIdAttribute(fullSnapshot.data.node, idAttribute)!.id
-          const records = findAllIncrementalSnapshots(segments, IncrementalSource.Input) as Array<{ data: InputData }>
+          const records = findAllIncrementalSnapshots(
+            { records: intakeRegistry.replayRecords },
+            IncrementalSource.Input
+          ) as Array<{ data: InputData }>
           return records.filter((record) => record.data.id === id)
         }
       })
@@ -542,7 +542,10 @@ describe('recorder', () => {
 
         await flushEvents()
 
-        const inputRecords = findAllIncrementalSnapshots(intakeRegistry.replaySegments, IncrementalSource.Input)
+        const inputRecords = findAllIncrementalSnapshots(
+          { records: intakeRegistry.replayRecords },
+          IncrementalSource.Input
+        )
 
         expect(inputRecords.length).toBeGreaterThanOrEqual(3) // 4 on Safari, 3 on others
         expect((inputRecords[inputRecords.length - 1].data as { text?: string }).text).toBe('***')


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

`record input interactions` and `don't record ignored input interactions` are the two most flacky e2e tests. This is because they are ensuring they only collect one segment, however, we have _recently_ [reduce the batch time limit](https://github.com/DataDog/browser-sdk/pull/3077) for replay segments to 5 seconds. It seems this test might takes longer sometimes, generating more segments that initially expected.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Stop expecting a fix number of segments and flatmap search for records across all segments when needed.

This only fixes these two tests as they are the only real flaky ones, but we could extend this strategy to all other tests if needed.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
