### PR TITLE
🐛 Prevent collecting the webpack ChunkLoadError

### DIFF
--- a/packages/rum/src/boot/lazyLoadRecorder.ts
+++ b/packages/rum/src/boot/lazyLoadRecorder.ts
@@ -1,3 +1,8 @@
-export function lazyLoadRecorder() {
-  return import(/* webpackChunkName: "recorder" */ './startRecording').then((module) => module.startRecording)
+export async function lazyLoadRecorder() {
+  try {
+    const module = await import(/* webpackChunkName: "recorder" */ './startRecording')
+    return module.startRecording
+  } catch {
+    /* Prevent collecting the webpack ChunkLoadError as it is already collected as a RUM resource. */
+  }
 }

--- a/packages/rum/src/boot/postStartStrategy.ts
+++ b/packages/rum/src/boot/postStartStrategy.ts
@@ -37,7 +37,7 @@ export function createPostStartStrategy(
   lifeCycle: LifeCycle,
   sessionManager: RumSessionManager,
   viewHistory: ViewHistory,
-  loadRecorder: () => Promise<StartRecording>,
+  loadRecorder: () => Promise<StartRecording | undefined>,
   getOrCreateDeflateEncoder: () => DeflateEncoder | undefined
 ): Strategy {
   let status = RecorderStatus.Stopped
@@ -71,7 +71,7 @@ export function createPostStartStrategy(
     }
 
     const deflateEncoder = getOrCreateDeflateEncoder()
-    if (!deflateEncoder) {
+    if (!deflateEncoder || !startRecordingImpl) {
       status = RecorderStatus.Stopped
       return
     }

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -28,7 +28,7 @@ import { createPostStartStrategy } from './postStartStrategy'
 import { createPreStartStrategy } from './preStartStrategy'
 
 export function makeRecorderApi(
-  loadRecorder: () => Promise<StartRecording>,
+  loadRecorder: () => Promise<StartRecording | undefined>,
   createDeflateWorkerImpl?: CreateDeflateWorker
 ): RecorderApi {
   if ((canUseEventBridge() && !bridgeSupports(BridgeCapability.RECORDS)) || !isBrowserSupported()) {


### PR DESCRIPTION
## Motivation

Webpack throws  `ChunkLoadError` if a chunk fail to load. This PR prevents collecting the webpack ChunkLoadError as it is already collected as a RUM resource.

## Changes

Catch ChunkLoadError and do nothing

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
