### PR TITLE
Report original error from `addReactError` instead of fake rendering error

### DIFF
--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -13,6 +13,7 @@ type RawErrorParams = {
   originalError: unknown
 
   handlingStack?: string
+  componentStack?: string
   startClocks: ClocksState
   nonErrorPrefix: NonErrorPrefix
   source: ErrorSource
@@ -23,6 +24,7 @@ export function computeRawError({
   stackTrace,
   originalError,
   handlingStack,
+  componentStack,
   startClocks,
   nonErrorPrefix,
   source,
@@ -43,6 +45,7 @@ export function computeRawError({
     source,
     handling,
     handlingStack,
+    componentStack,
     originalError,
     type,
     message,

--- a/packages/core/src/domain/error/error.types.ts
+++ b/packages/core/src/domain/error/error.types.ts
@@ -33,6 +33,7 @@ export interface RawError {
   originalError?: unknown
   handling?: ErrorHandling
   handlingStack?: string
+  componentStack?: string
   causes?: RawErrorCause[]
   fingerprint?: string
   csp?: Csp

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -137,7 +137,7 @@ export function createPreStartStrategy(
     bufferApiCalls.add((startRumResult) => startRumResult.addDurationVital(vital))
   }
 
-  return {
+  const strategy: Strategy = {
     init(initConfiguration, publicApi) {
       if (!initConfiguration) {
         display.error('Missing configuration')
@@ -229,6 +229,8 @@ export function createPreStartStrategy(
 
     addDurationVital,
   }
+
+  return strategy
 }
 
 function overrideInitConfigurationForBridge(initConfiguration: RumInitConfiguration): RumInitConfiguration {

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -44,6 +44,7 @@ import type { DurationVitalReference } from '../domain/vital/vitalCollection'
 import { createCustomVitalsState } from '../domain/vital/vitalCollection'
 import { createPreStartStrategy } from './preStartRum'
 import type { StartRum, StartRumResult } from './startRum'
+import { callPluginsMethod } from '../domain/plugins'
 
 export interface StartRecordingOptions {
   force: boolean
@@ -420,6 +421,8 @@ export function makeRumPublicApi(
       )
 
       strategy = createPostStartStrategy(strategy, startRumResult)
+
+      callPluginsMethod(configuration.plugins, 'onRumStart', { strategy })
 
       return startRumResult
     }

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -91,6 +91,7 @@ describe('error collection', () => {
               source: ErrorSource.CUSTOM,
               stack,
               handling_stack: 'Error: handling foo',
+              component_stack: undefined,
               type,
               handling: ErrorHandling.HANDLED,
               source_type: 'browser',
@@ -273,6 +274,7 @@ describe('error collection', () => {
           type: 'foo',
           originalError: error,
           handlingStack: 'Error: handling foo',
+          componentStack: 'at div',
         },
       })
 
@@ -285,6 +287,7 @@ describe('error collection', () => {
           source: ErrorSource.CUSTOM,
           stack: 'bar',
           handling_stack: 'Error: handling foo',
+          component_stack: 'at div',
           type: 'foo',
           handling: undefined,
           source_type: 'browser',

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -29,6 +29,7 @@ export interface ProvidedError {
   error: unknown
   context?: Context
   handlingStack: string
+  componentStack?: string
 }
 
 export function startErrorCollection(
@@ -47,7 +48,6 @@ export function startErrorCollection(
 
   return doStartErrorCollection(lifeCycle, pageStateHistory, featureFlagContexts)
 }
-
 export function doStartErrorCollection(
   lifeCycle: LifeCycle,
   pageStateHistory: PageStateHistory,
@@ -63,7 +63,7 @@ export function doStartErrorCollection(
 
   return {
     addError: (
-      { error, handlingStack, startClocks, context: customerContext }: ProvidedError,
+      { error, handlingStack, componentStack, startClocks, context: customerContext }: ProvidedError,
       savedCommonContext?: CommonContext
     ) => {
       const stackTrace = isError(error) ? computeStackTrace(error) : undefined
@@ -71,6 +71,7 @@ export function doStartErrorCollection(
         stackTrace,
         originalError: error,
         handlingStack,
+        componentStack,
         startClocks,
         nonErrorPrefix: NonErrorPrefix.PROVIDED,
         source: ErrorSource.CUSTOM,
@@ -99,6 +100,7 @@ function processError(
       source: error.source,
       stack: error.stack,
       handling_stack: error.handlingStack,
+      component_stack: error.componentStack,
       type: error.type,
       handling: error.handling,
       causes: error.causes,

--- a/packages/rum-core/src/domain/plugins.ts
+++ b/packages/rum-core/src/domain/plugins.ts
@@ -1,19 +1,25 @@
-import type { RumPublicApi } from '../boot/rumPublicApi'
+import type { RumPublicApi, Strategy } from '../boot/rumPublicApi'
 import type { RumInitConfiguration } from './configuration'
 
 export interface RumPlugin {
   name: string
   getConfigurationTelemetry?(): Record<string, unknown>
   onInit?(options: { initConfiguration: RumInitConfiguration; publicApi: RumPublicApi }): void
+  onRumStart?(options: { strategy: Strategy }): void
 }
 
-type MethodNames = 'onInit'
+type MethodNames = 'onInit' | 'onRumStart'
 type MethodParameter<MethodName extends MethodNames> = Parameters<NonNullable<RumPlugin[MethodName]>>[0]
 
 export function callPluginsMethod<MethodName extends MethodNames>(
   plugins: RumPlugin[] | undefined,
   methodName: MethodName,
   parameter: MethodParameter<MethodName>
+): void
+export function callPluginsMethod<MethodName extends MethodNames>(
+  plugins: RumPlugin[] | undefined,
+  methodName: MethodName,
+  parameter: any
 ) {
   if (!plugins) {
     return

--- a/packages/rum-core/src/index.ts
+++ b/packages/rum-core/src/index.ts
@@ -1,4 +1,4 @@
-export { RumPublicApi, makeRumPublicApi, RecorderApi, StartRecordingOptions } from './boot/rumPublicApi'
+export { RumPublicApi, makeRumPublicApi, RecorderApi, StartRecordingOptions, Strategy } from './boot/rumPublicApi'
 export { StartRum } from './boot/startRum'
 export {
   RumEvent,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -74,6 +74,7 @@ export interface RawRumErrorEvent {
     type?: string
     stack?: string
     handling_stack?: string
+    component_stack?: string
     fingerprint?: string
     source: ErrorSource
     message: string

--- a/packages/rum-react/src/domain/error/addReactError.spec.ts
+++ b/packages/rum-react/src/domain/error/addReactError.spec.ts
@@ -5,19 +5,26 @@ describe('addReactError', () => {
   it('reports the error to the SDK', () => {
     const addErrorSpy = jasmine.createSpy()
     initializeReactPlugin({
-      publicApi: {
+      strategy: {
         addError: addErrorSpy,
       },
     })
-    const originalError = new Error('error')
+    const originalError = new Error('error message')
+    originalError.name = 'CustomError'
 
     addReactError(originalError, { componentStack: 'at ComponentSpy toto.js' })
 
-    expect(addErrorSpy).toHaveBeenCalledOnceWith(jasmine.any(Error), { framework: 'react' })
-    const error = addErrorSpy.calls.first().args[0]
-    expect(error.message).toBe('error')
-    expect(error.name).toBe('ReactRenderingError')
-    expect(error.stack).toContain('at ComponentSpy')
-    expect(error.cause).toBe(originalError)
+    expect(addErrorSpy).toHaveBeenCalledOnceWith({
+      error: jasmine.any(Error),
+      handlingStack: jasmine.any(String),
+      componentStack: jasmine.stringContaining('at ComponentSpy'),
+      context: { framework: 'react' },
+      startClocks: jasmine.anything(),
+    })
+    const { error } = addErrorSpy.calls.first().args[0]
+    expect(error.message).toBe(originalError.message)
+    expect(error.name).toBe(originalError.name)
+    expect(error.stack).toBe(originalError.stack)
+    expect(error.cause).toBe(undefined)
   })
 })

--- a/packages/rum-react/src/domain/error/addReactError.ts
+++ b/packages/rum-react/src/domain/error/addReactError.ts
@@ -3,8 +3,8 @@ import { callMonitored, clocksNow, createHandlingStack } from '@datadog/browser-
 import { onRumStart } from '../reactPlugin'
 
 export function addReactError(error: Error, info: ErrorInfo) {
+  const handlingStack = createHandlingStack()
   onRumStart((strategy) => {
-    const handlingStack = createHandlingStack()
     callMonitored(() => {
       strategy.addError({
         error,

--- a/packages/rum-react/src/domain/error/addReactError.ts
+++ b/packages/rum-react/src/domain/error/addReactError.ts
@@ -1,13 +1,18 @@
 import type { ErrorInfo } from 'react'
-import type { ErrorWithCause } from '@datadog/browser-core'
-import { onReactPluginInit } from '../reactPlugin'
+import { callMonitored, clocksNow, createHandlingStack } from '@datadog/browser-core'
+import { onRumStart } from '../reactPlugin'
 
 export function addReactError(error: Error, info: ErrorInfo) {
-  const renderingError = new Error(error.message)
-  renderingError.name = 'ReactRenderingError'
-  renderingError.stack = info.componentStack ?? undefined
-  ;(renderingError as ErrorWithCause).cause = error
-  onReactPluginInit((_, rumPublicApi) => {
-    rumPublicApi.addError(renderingError, { framework: 'react' })
+  onRumStart((strategy) => {
+    const handlingStack = createHandlingStack()
+    callMonitored(() => {
+      strategy.addError({
+        error,
+        handlingStack,
+        componentStack: info.componentStack ?? undefined,
+        context: { framework: 'react' },
+        startClocks: clocksNow(),
+      })
+    })
   })
 }

--- a/packages/rum-react/src/domain/error/addReactError.ts
+++ b/packages/rum-react/src/domain/error/addReactError.ts
@@ -4,6 +4,7 @@ import { onRumStart } from '../reactPlugin'
 
 export function addReactError(error: Error, info: ErrorInfo) {
   const handlingStack = createHandlingStack()
+  const startClocks = clocksNow()
   onRumStart((strategy) => {
     callMonitored(() => {
       strategy.addError({
@@ -11,7 +12,7 @@ export function addReactError(error: Error, info: ErrorInfo) {
         handlingStack,
         componentStack: info.componentStack ?? undefined,
         context: { framework: 'react' },
-        startClocks: clocksNow(),
+        startClocks,
       })
     })
   })

--- a/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
+++ b/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
@@ -77,7 +77,7 @@ describe('ErrorBoundary', () => {
   it('reports the error to the SDK', () => {
     const addErrorSpy = jasmine.createSpy()
     initializeReactPlugin({
-      publicApi: {
+      strategy: {
         addError: addErrorSpy,
       },
     })
@@ -91,11 +91,16 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>
     )
 
-    expect(addErrorSpy).toHaveBeenCalledOnceWith(jasmine.any(Error), { framework: 'react' })
-    const error = addErrorSpy.calls.first().args[0]
-    expect(error.message).toBe('error')
-    expect(error.name).toBe('ReactRenderingError')
-    expect(error.stack).toContain('ComponentSpy')
-    expect(error.cause).toBe(originalError)
+    expect(addErrorSpy).toHaveBeenCalledOnceWith({
+      error: jasmine.any(Error),
+      handlingStack: jasmine.any(String),
+      componentStack: jasmine.stringContaining('ComponentSpy'),
+      context: { framework: 'react' },
+      startClocks: jasmine.anything(),
+    })
+    const { error } = addErrorSpy.calls.first().args[0]
+    expect(error.message).toBe(originalError.message)
+    expect(error.name).toBe(originalError.name)
+    expect(error.cause).toBe(undefined)
   })
 })

--- a/packages/rum-react/src/domain/reactPlugin.spec.ts
+++ b/packages/rum-react/src/domain/reactPlugin.spec.ts
@@ -1,8 +1,9 @@
-import type { RumInitConfiguration, RumPublicApi } from '@datadog/browser-rum-core'
-import { onReactPluginInit, reactPlugin, resetReactPlugin } from './reactPlugin'
+import type { RumInitConfiguration, RumPublicApi, Strategy } from '@datadog/browser-rum-core'
+import { onRumInit, reactPlugin, resetReactPlugin } from './reactPlugin'
 
 const PUBLIC_API = {} as RumPublicApi
 const INIT_CONFIGURATION = {} as RumInitConfiguration
+const STRATEGY = {} as Strategy
 
 describe('reactPlugin', () => {
   afterEach(() => {
@@ -22,11 +23,15 @@ describe('reactPlugin', () => {
   it('calls callbacks registered with onReactPluginInit during onInit', () => {
     const callbackSpy = jasmine.createSpy()
     const pluginConfiguration = {}
-    onReactPluginInit(callbackSpy)
+    onRumInit(callbackSpy)
 
     expect(callbackSpy).not.toHaveBeenCalled()
 
-    reactPlugin(pluginConfiguration).onInit({ publicApi: PUBLIC_API, initConfiguration: INIT_CONFIGURATION })
+    reactPlugin(pluginConfiguration).onInit({
+      publicApi: PUBLIC_API,
+      initConfiguration: INIT_CONFIGURATION,
+      strategy: STRATEGY,
+    })
 
     expect(callbackSpy).toHaveBeenCalledTimes(1)
     expect(callbackSpy.calls.mostRecent().args[0]).toBe(pluginConfiguration)
@@ -36,9 +41,13 @@ describe('reactPlugin', () => {
   it('calls callbacks immediately if onInit was already invoked', () => {
     const callbackSpy = jasmine.createSpy()
     const pluginConfiguration = {}
-    reactPlugin(pluginConfiguration).onInit({ publicApi: PUBLIC_API, initConfiguration: INIT_CONFIGURATION })
+    reactPlugin(pluginConfiguration).onInit({
+      publicApi: PUBLIC_API,
+      initConfiguration: INIT_CONFIGURATION,
+      strategy: STRATEGY,
+    })
 
-    onReactPluginInit(callbackSpy)
+    onRumInit(callbackSpy)
 
     expect(callbackSpy).toHaveBeenCalledTimes(1)
     expect(callbackSpy.calls.mostRecent().args[0]).toBe(pluginConfiguration)
@@ -47,14 +56,14 @@ describe('reactPlugin', () => {
 
   it('enforce manual view tracking when router is enabled', () => {
     const initConfiguration = { ...INIT_CONFIGURATION }
-    reactPlugin({ router: true }).onInit({ publicApi: PUBLIC_API, initConfiguration })
+    reactPlugin({ router: true }).onInit({ publicApi: PUBLIC_API, initConfiguration, strategy: STRATEGY })
 
     expect(initConfiguration.trackViewsManually).toBe(true)
   })
 
   it('does not enforce manual view tracking when router is disabled', () => {
     const initConfiguration = { ...INIT_CONFIGURATION }
-    reactPlugin({ router: false }).onInit({ publicApi: PUBLIC_API, initConfiguration })
+    reactPlugin({ router: false }).onInit({ publicApi: PUBLIC_API, initConfiguration, strategy: STRATEGY })
 
     expect(initConfiguration.trackViewsManually).toBeUndefined()
   })

--- a/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.ts
+++ b/packages/rum-react/src/domain/reactRouterV6/startReactRouterView.ts
@@ -1,9 +1,9 @@
 import type { RouteMatch } from 'react-router-dom'
 import { display } from '@datadog/browser-core'
-import { onReactPluginInit } from '../reactPlugin'
+import { onRumInit } from '../reactPlugin'
 
 export function startReactRouterView(routeMatches: RouteMatch[]) {
-  onReactPluginInit((configuration, rumPublicApi) => {
+  onRumInit((configuration, rumPublicApi) => {
     if (!configuration.router) {
       display.warn('`router: true` is missing from the react plugin configuration, the view will not be tracked.')
       return

--- a/packages/rum-react/test/initializeReactPlugin.ts
+++ b/packages/rum-react/test/initializeReactPlugin.ts
@@ -1,4 +1,4 @@
-import type { RumInitConfiguration, RumPublicApi } from '@datadog/browser-rum-core'
+import type { RumInitConfiguration, RumPublicApi, Strategy } from '@datadog/browser-rum-core'
 import type { ReactPluginConfiguration } from '../src/domain/reactPlugin'
 import { reactPlugin, resetReactPlugin } from '../src/domain/reactPlugin'
 import { registerCleanupTask } from '../../core/test'
@@ -7,15 +7,23 @@ export function initializeReactPlugin({
   configuration = {},
   initConfiguration = {},
   publicApi = {},
+  strategy = {},
 }: {
   configuration?: ReactPluginConfiguration
   initConfiguration?: Partial<RumInitConfiguration>
   publicApi?: Partial<RumPublicApi>
+  strategy?: Partial<Strategy>
 } = {}) {
   resetReactPlugin()
   const plugin = reactPlugin(configuration)
 
-  plugin.onInit({ publicApi: publicApi as RumPublicApi, initConfiguration: initConfiguration as RumInitConfiguration })
+  plugin.onInit({
+    publicApi: publicApi as RumPublicApi,
+    initConfiguration: initConfiguration as RumInitConfiguration,
+  })
+  plugin.onRumStart({
+    strategy: strategy as Strategy,
+  })
 
   registerCleanupTask(() => {
     resetReactPlugin()


### PR DESCRIPTION
## Motivation

The ErrorBoundary component will capture whatever error occurs inside of it and send it to datadog, when this happens it renders the fallback component supplied to it. This works similar to a try/catch, where errors that occur within a component tree will not cause the entire application to crash and instead show a fallback.

As of today there’s a big problem with how ErrorBoundary reports these errors to datadog and how that plays into the Error Tracking product.

The original thrown error is not the one being reported, instead a different error is with a different stack trace (the one obtained from react’s error info) and a different error name (or @error.type in datadog). This messes with Error Tracking’s grouping.

This is the anatomy of a react error sent to Datadog today:

![image](https://github.com/user-attachments/assets/bef7e61b-2055-4c19-8ea1-890c613b3611)

It would make more sense to report the original error so it has the original stack and name, drop the cause since it wouldn’t be needed anymore and add the the component’s stack as an additional `component_stack` property reported to datadog.

## Changes

In order to achieve this it's necessary to expose the `strategy` object through a new hook in plugins named `onRumStart`. Now additional information can be added to the payload outside of the event's `context`

Only after that the `strategy` object is accessed by the react plugin and used in `addReactError` to send the component's stack

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

Unit tests were added
