### PR TITLE
define createLogger API

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -431,6 +431,8 @@ export type TelemetryCommonFeaturesUsage =
   | StartView
   | AddAction
   | AddError
+  | CreateReporter
+  | GetReporter
   | SetGlobalContext
   | SetUser
   | SetAccount
@@ -608,6 +610,20 @@ export interface AddError {
    * addError API
    */
   feature: 'add-error'
+  [k: string]: unknown
+}
+export interface CreateReporter {
+  /**
+   * createReporter API
+   */
+  feature: 'create-reporter'
+  [k: string]: unknown
+}
+export interface GetReporter {
+  /**
+   * getReporter API
+   */
+  feature: 'get-reporter'
   [k: string]: unknown
 }
 export interface SetGlobalContext {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -357,6 +357,35 @@ describe('rum public api', () => {
     })
   })
 
+  describe('createReporter', () => {
+    let addErrorSpy: jasmine.Spy<ReturnType<StartRum>['addError']>
+    let addActionSpy: jasmine.Spy<ReturnType<StartRum>['addAction']>
+    let rumPublicApi: RumPublicApi
+
+    beforeEach(() => {
+      addErrorSpy = jasmine.createSpy()
+      addActionSpy = jasmine.createSpy()
+      rumPublicApi = makeRumPublicApi(
+        () => ({
+          ...noopStartRum(),
+          addError: addErrorSpy,
+          addAction: addActionSpy,
+        }),
+        noopRecorderApi
+      )
+    })
+
+    it('sets the component as part of the context', () => {
+      const reporter = rumPublicApi.createReporter('test-component', { context: { team: 'datadog' } })
+      reporter.addError(new Error('Something went wrong'))
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      expect(addErrorSpy.calls.argsFor(0)[0].context).toEqual({
+        component: 'test-component',
+        team: 'datadog',
+      })
+    })
+  })
+
   describe('setUser', () => {
     let addActionSpy: jasmine.Spy<ReturnType<StartRum>['addAction']>
     let displaySpy: jasmine.Spy<() => void>


### PR DESCRIPTION
## Motivation

As of today there's no easy way to send RUM errors or actions that share the same tags, this is something that makes a lot of sense if you wish to define scopes for your application that all share the same information.

## Changes
Introduce a new API that allows to specify a context to all `addError` and `addAction` calls from it


```ts
{
  // ... rum public api methods
  createReporter: (component: string, conf?: ReporterConfiguration) => Reporter
  // ...
}
export interface Reporter {
  addAction: RumPublicApi['addAction']
  addError: RumPublicApi['addError']
}
export interface ReporterConfiguration {
  context?: object
}
```

This new `createReporter` method returns an object that has the `addError`  and `addAction` methods that will add the `context` supplied to the reporter to any events sent from them

```ts
const reporter = createReporter('MyComponent', {
  context: { team: 'datadog' }
})

reporter.addError(new Error()) // will have context.team:datadog and context.component:MyComponent
```

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

Unit tests were defined