### PR TITLE
♻️ [RUM-8123] Introduce a hook to assemble events

### DIFF
--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -39,12 +39,14 @@ import { startViewCollection } from '../domain/view/viewCollection'
 import type { RumEvent, RumViewEvent } from '../rumEvent.types'
 import type { LocationChange } from '../browser/locationChangeObservable'
 import { startLongAnimationFrameCollection } from '../domain/longAnimationFrame/longAnimationFrameCollection'
-import type { RumSessionManager } from '..'
+import { startViewHistory, type RumSessionManager } from '..'
 import type { RumConfiguration } from '../domain/configuration'
 import { RumEventType } from '../rawRumEvent.types'
 import { startFeatureFlagContexts } from '../domain/contexts/featureFlagContext'
 import type { PageStateHistory } from '../domain/contexts/pageStateHistory'
 import { createCustomVitalsState } from '../domain/vital/vitalCollection'
+import { startHooks } from '../hooks'
+import { startUrlContexts } from '../domain/contexts/urlContexts'
 import { startRum, startRumEventCollection } from './startRum'
 
 function collectServerEvents(lifeCycle: LifeCycle) {
@@ -66,15 +68,19 @@ function startRumStub(
   pageStateHistory: PageStateHistory,
   reportError: (error: RawError) => void
 ) {
+  const hooks = startHooks()
+  const viewHistory = startViewHistory(lifeCycle)
+  const urlContexts = startUrlContexts(lifeCycle, hooks, locationChangeObservable, location)
+
   const { stop: rumEventCollectionStop } = startRumEventCollection(
     lifeCycle,
+    hooks,
     configuration,
-    location,
     sessionManager,
     pageStateHistory,
-    locationChangeObservable,
     domMutationObservable,
     windowOpenObservable,
+    viewHistory,
     () => ({
       context: {},
       user: {},
@@ -84,6 +90,7 @@ function startRumStub(
   )
   const { stop: viewCollectionStop } = startViewCollection(
     lifeCycle,
+    hooks,
     configuration,
     location,
     domMutationObservable,
@@ -91,12 +98,15 @@ function startRumStub(
     locationChangeObservable,
     startFeatureFlagContexts(lifeCycle, createCustomerDataTracker(noop)),
     pageStateHistory,
-    noopRecorderApi
+    noopRecorderApi,
+    viewHistory
   )
 
   startLongAnimationFrameCollection(lifeCycle, configuration)
   return {
     stop: () => {
+      viewHistory.stop()
+      urlContexts.stop()
       rumEventCollectionStop()
       viewCollectionStop()
     },

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -45,7 +45,7 @@ import { RumEventType } from '../rawRumEvent.types'
 import { startFeatureFlagContexts } from '../domain/contexts/featureFlagContext'
 import type { PageStateHistory } from '../domain/contexts/pageStateHistory'
 import { createCustomVitalsState } from '../domain/vital/vitalCollection'
-import { startHooks } from '../hooks'
+import { createHooks } from '../hooks'
 import { startUrlContexts } from '../domain/contexts/urlContexts'
 import { startRum, startRumEventCollection } from './startRum'
 
@@ -68,7 +68,7 @@ function startRumStub(
   pageStateHistory: PageStateHistory,
   reportError: (error: RawError) => void
 ) {
-  const hooks = startHooks()
+  const hooks = createHooks()
   const viewHistory = startViewHistory(lifeCycle)
   const urlContexts = startUrlContexts(lifeCycle, hooks, locationChangeObservable, location)
 

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -51,7 +51,7 @@ import { startLongAnimationFrameCollection } from '../domain/longAnimationFrame/
 import { RumPerformanceEntryType } from '../browser/performanceObservable'
 import { startLongTaskCollection } from '../domain/longTask/longTaskCollection'
 import type { Hooks } from '../hooks'
-import { startHooks } from '../hooks'
+import { createHooks } from '../hooks'
 import type { RecorderApi } from './rumPublicApi'
 
 export type StartRum = typeof startRum
@@ -73,7 +73,7 @@ export function startRum(
 ) {
   const cleanupTasks: Array<() => void> = []
   const lifeCycle = new LifeCycle()
-  const hooks = startHooks()
+  const hooks = createHooks()
 
   lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event) => sendToExtension('rum', event))
 

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -535,18 +535,6 @@ describe('rum assembly', () => {
   describe('service and version', () => {
     const extraConfigurationOptions = { service: 'default service', version: 'default version' }
 
-    it('should come from the init configuration by default', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-        partialConfiguration: extraConfigurationOptions,
-      })
-
-      notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-      })
-      expect(serverRumEvents[0].service).toEqual('default service')
-      expect(serverRumEvents[0].version).toEqual('default version')
-    })
-
     describe('fields service and version', () => {
       it('it should be modifiable', () => {
         const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -15,7 +15,6 @@ import {
   createRumSessionManagerMock,
   createRawRumEvent,
   mockRumConfiguration,
-  mockUrlContexts,
   mockActionContexts,
   mockDisplayContext,
   mockViewHistory,
@@ -24,6 +23,7 @@ import type { RumEventDomainContext } from '../domainContext.types'
 import type { RawRumActionEvent, RawRumEvent } from '../rawRumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
 import type { RumActionEvent, RumErrorEvent, RumEvent, RumResourceEvent } from '../rumEvent.types'
+import { HookNames, startHooks } from '../hooks'
 import { startRumAssembly } from './assembly'
 import type { RawRumEventCollectedData } from './lifeCycle'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
@@ -389,43 +389,6 @@ describe('rum assembly', () => {
     })
   })
 
-  describe('priority of rum context', () => {
-    it('should prioritize view customer context over global context', () => {
-      const { lifeCycle, serverRumEvents, commonContext } = setupAssemblyTestWithDefaults({
-        findView: () => ({
-          id: '7890',
-          name: 'view name',
-          startClocks: {} as ClocksState,
-          context: { foo: 'baz' },
-        }),
-      })
-      commonContext.context = { foo: 'bar' }
-
-      notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.VIEW),
-      })
-
-      expect(serverRumEvents[0].context!.foo).toBe('baz')
-    })
-
-    it('should prioritize child customer context over inherited view context', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-        findView: () => ({
-          id: '7890',
-          name: 'view name',
-          startClocks: {} as ClocksState,
-          context: { foo: 'bar' },
-        }),
-      })
-      notifyRawRumEvent(lifeCycle, {
-        customerContext: { foo: 'baz' },
-        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-      })
-
-      expect(serverRumEvents[0].context!.foo).toBe('baz')
-    })
-  })
-
   describe('rum global context', () => {
     it('should be merged with event attributes', () => {
       const { lifeCycle, serverRumEvents, commonContext } = setupAssemblyTestWithDefaults()
@@ -569,36 +532,6 @@ describe('rum assembly', () => {
     })
   })
 
-  describe('view context', () => {
-    it('should be merged with event attributes', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults()
-      notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-      })
-      expect(serverRumEvents[0].view).toEqual(
-        jasmine.objectContaining({
-          id: '7890',
-          name: 'view name',
-        })
-      )
-    })
-
-    it('child event should have view customer context', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-        findView: () => ({
-          id: '7890',
-          name: 'view name',
-          startClocks: {} as ClocksState,
-          context: { foo: 'bar' },
-        }),
-      })
-      notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-      })
-      expect(serverRumEvents[0].context).toEqual({ foo: 'bar' })
-    })
-  })
-
   describe('service and version', () => {
     const extraConfigurationOptions = { service: 'default service', version: 'default version' }
 
@@ -612,24 +545,6 @@ describe('rum assembly', () => {
       })
       expect(serverRumEvents[0].service).toEqual('default service')
       expect(serverRumEvents[0].version).toEqual('default version')
-    })
-
-    it('should be overridden by the view context', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-        partialConfiguration: extraConfigurationOptions,
-        findView: () => ({
-          service: 'new service',
-          version: 'new version',
-          id: '1234',
-          startClocks: {} as ClocksState,
-        }),
-      })
-
-      notifyRawRumEvent(lifeCycle, {
-        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
-      })
-      expect(serverRumEvents[0].service).toEqual('new service')
-      expect(serverRumEvents[0].version).toEqual('new version')
     })
 
     describe('fields service and version', () => {
@@ -656,14 +571,41 @@ describe('rum assembly', () => {
     })
   })
 
-  describe('url context', () => {
-    it('should be merged with event attributes', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults()
+  describe('assemble hook', () => {
+    it('should add and override common properties', () => {
+      const { lifeCycle, hooks, serverRumEvents, commonContext } = setupAssemblyTestWithDefaults({
+        partialConfiguration: { service: 'default service', version: 'default version' },
+      })
+      commonContext.context = { foo: 'global context' }
+
+      hooks.register(HookNames.Assemble, () => ({
+        service: 'new service',
+        version: 'new version',
+        context: { foo: 'bar' },
+        view: { id: 'new view id', url: '' },
+      }))
+
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })
-      expect(serverRumEvents[0].view.url).toBe(location.href)
-      expect(serverRumEvents[0].view.referrer).toBe(document.referrer)
+      expect(serverRumEvents[0].service).toEqual('new service')
+      expect(serverRumEvents[0].version).toEqual('new version')
+      expect(serverRumEvents[0].context).toEqual({ foo: 'bar' })
+      expect(serverRumEvents[0].view.id).toEqual('new view id')
+    })
+
+    it('should not override customer context', () => {
+      const { lifeCycle, hooks, serverRumEvents } = setupAssemblyTestWithDefaults()
+
+      hooks.register(HookNames.Assemble, () => ({
+        context: { foo: 'bar' },
+      }))
+
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
+        customerContext: { foo: 'customer context' },
+      })
+      expect(serverRumEvents[0].context).toEqual({ foo: 'customer context' })
     })
   })
 
@@ -1015,6 +957,7 @@ function setupAssemblyTestWithDefaults({
   findView = () => ({ id: '7890', name: 'view name', startClocks: {} as ClocksState }),
 }: AssemblyTestParams = {}) {
   const lifeCycle = new LifeCycle()
+  const hooks = startHooks()
   const reportErrorSpy = jasmine.createSpy('reportError')
   const rumSessionManager = sessionManager ?? createRumSessionManagerMock().setId('1234')
   const commonContext = {
@@ -1031,9 +974,9 @@ function setupAssemblyTestWithDefaults({
   startRumAssembly(
     mockRumConfiguration(partialConfiguration),
     lifeCycle,
+    hooks,
     rumSessionManager,
     { ...mockViewHistory(), findView: () => findView() },
-    mockUrlContexts(),
     mockActionContexts(),
     mockDisplayContext(),
     { get: () => ciVisibilityContext } as CiVisibilityContext,
@@ -1045,5 +988,5 @@ function setupAssemblyTestWithDefaults({
     subscription.unsubscribe()
   })
 
-  return { lifeCycle, reportErrorSpy, serverRumEvents, commonContext }
+  return { lifeCycle, hooks, reportErrorSpy, serverRumEvents, commonContext }
 }

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -23,7 +23,7 @@ import type { RumEventDomainContext } from '../domainContext.types'
 import type { RawRumActionEvent, RawRumEvent } from '../rawRumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
 import type { RumActionEvent, RumErrorEvent, RumEvent, RumResourceEvent } from '../rumEvent.types'
-import { HookNames, startHooks } from '../hooks'
+import { HookNames, createHooks } from '../hooks'
 import { startRumAssembly } from './assembly'
 import type { RawRumEventCollectedData } from './lifeCycle'
 import { LifeCycle, LifeCycleEventType } from './lifeCycle'
@@ -959,7 +959,7 @@ function setupAssemblyTestWithDefaults({
   findView = () => ({ id: '7890', name: 'view name', startClocks: {} as ClocksState }),
 }: AssemblyTestParams = {}) {
   const lifeCycle = new LifeCycle()
-  const hooks = startHooks()
+  const hooks = createHooks()
   const reportErrorSpy = jasmine.createSpy('reportError')
   const rumSessionManager = sessionManager ?? createRumSessionManagerMock().setId('1234')
   const commonContext = {

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -578,7 +578,8 @@ describe('rum assembly', () => {
       })
       commonContext.context = { foo: 'global context' }
 
-      hooks.register(HookNames.Assemble, () => ({
+      hooks.register(HookNames.Assemble, ({ eventType }) => ({
+        type: eventType,
         service: 'new service',
         version: 'new version',
         context: { foo: 'bar' },
@@ -597,7 +598,8 @@ describe('rum assembly', () => {
     it('should not override customer context', () => {
       const { lifeCycle, hooks, serverRumEvents } = setupAssemblyTestWithDefaults()
 
-      hooks.register(HookNames.Assemble, () => ({
+      hooks.register(HookNames.Assemble, ({ eventType }) => ({
+        type: eventType,
         context: { foo: 'bar' },
       }))
 

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -181,8 +181,6 @@ export function startRumAssembly(
           rawRumEvent
         ) as RumEvent & Context
 
-        serverRumEvent.context = combine(serverRumEvent.context, customerContext)
-
         if (!('has_replay' in serverRumEvent.session)) {
           ;(serverRumEvent.session as Mutable<RumEvent['session']>).has_replay = commonContext.hasReplay
         }

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -155,8 +155,6 @@ export function startRumAssembly(
             id: configuration.applicationId,
           },
           date: timeStampNow(),
-          service: configuration.service,
-          version: configuration.version,
           source: 'browser',
           session: {
             id: session.id,

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -22,13 +22,14 @@ import type {
 } from '../rawRumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
 import type { RumEvent } from '../rumEvent.types'
+import type { Hooks } from '../hooks'
+import { HookNames } from '../hooks'
 import { getSyntheticsContext } from './contexts/syntheticsContext'
 import type { CiVisibilityContext } from './contexts/ciVisibilityContext'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
 import type { ViewHistory } from './contexts/viewHistory'
 import { SessionReplayState, type RumSessionManager } from './rumSessionManager'
-import type { UrlContexts } from './contexts/urlContexts'
 import type { RumConfiguration } from './configuration'
 import type { ActionContexts } from './action/actionCollection'
 import type { DisplayContext } from './contexts/displayContext'
@@ -67,9 +68,9 @@ type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 export function startRumAssembly(
   configuration: RumConfiguration,
   lifeCycle: LifeCycle,
+  hooks: Hooks,
   sessionManager: RumSessionManager,
   viewHistory: ViewHistory,
-  urlContexts: UrlContexts,
   actionContexts: ActionContexts,
   displayContext: DisplayContext,
   ciVisibilityContext: CiVisibilityContext,
@@ -134,9 +135,9 @@ export function startRumAssembly(
     LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
     ({ startTime, rawRumEvent, domainContext, savedCommonContext, customerContext }) => {
       const viewHistoryEntry = viewHistory.findView(startTime)
-      const urlContext = urlContexts.findUrl(startTime)
       const session = sessionManager.findTrackedSession(startTime)
-      if (session && viewHistoryEntry && urlContext) {
+
+      if (session && viewHistoryEntry) {
         const commonContext = savedCommonContext || getCommonContext()
         const actionId = actionContexts.findActionId(startTime)
 
@@ -154,8 +155,8 @@ export function startRumAssembly(
             id: configuration.applicationId,
           },
           date: timeStampNow(),
-          service: viewHistoryEntry.service || configuration.service,
-          version: viewHistoryEntry.version || configuration.version,
+          service: configuration.service,
+          version: configuration.version,
           source: 'browser',
           session: {
             id: session.id,
@@ -165,21 +166,22 @@ export function startRumAssembly(
                 ? SessionType.CI_TEST
                 : SessionType.USER,
           },
-          view: {
-            id: viewHistoryEntry.id,
-            name: viewHistoryEntry.name,
-            url: urlContext.url,
-            referrer: urlContext.referrer,
-          },
           action: needToAssembleWithAction(rawRumEvent) && actionId ? { id: actionId } : undefined,
           synthetics: syntheticsContext,
           ci_test: ciVisibilityContext.get(),
           display: displayContext.get(),
           connectivity: getConnectivity(),
+          context: commonContext.context,
         }
 
-        const serverRumEvent = combine(rumContext as RumContext & Context, rawRumEvent) as RumEvent & Context
-        serverRumEvent.context = combine(commonContext.context, viewHistoryEntry.context, customerContext)
+        const serverRumEvent = combine(
+          rumContext,
+          hooks.triggerHook(HookNames.Assemble, { eventType: rawRumEvent.type, startTime }) as RumEvent & Context,
+          { context: customerContext },
+          rawRumEvent
+        ) as RumEvent & Context
+
+        serverRumEvent.context = combine(serverRumEvent.context, customerContext)
 
         if (!('has_replay' in serverRumEvent.session)) {
           ;(serverRumEvent.session as Mutable<RumEvent['session']>).has_replay = commonContext.hasReplay
@@ -197,7 +199,7 @@ export function startRumAssembly(
         }
 
         if (shouldSend(serverRumEvent, configuration.beforeSend, domainContext, eventRateLimiters)) {
-          if (isEmptyObject(serverRumEvent.context)) {
+          if (isEmptyObject(serverRumEvent.context!)) {
             delete serverRumEvent.context
           }
           lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, serverRumEvent)

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -4,6 +4,8 @@ import { clocksNow, relativeToClocks } from '@datadog/browser-core'
 import { setupLocationObserver } from '../../../test'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { ViewCreatedEvent, ViewEndedEvent } from '../view/trackViews'
+import type { Hooks } from '../../hooks'
+import { HookNames, startHooks } from '../../hooks'
 import { startUrlContexts, type UrlContexts } from './urlContexts'
 
 describe('urlContexts', () => {
@@ -11,13 +13,15 @@ describe('urlContexts', () => {
   let changeLocation: (to: string) => void
   let urlContexts: UrlContexts
   let clock: Clock
+  let hooks: Hooks
 
   beforeEach(() => {
     clock = mockClock()
+    hooks = startHooks()
     const setupResult = setupLocationObserver('http://fake-url.com')
 
     changeLocation = setupResult.changeLocation
-    urlContexts = startUrlContexts(lifeCycle, setupResult.locationChangeObservable, setupResult.fakeLocation)
+    urlContexts = startUrlContexts(lifeCycle, hooks, setupResult.locationChangeObservable, setupResult.fakeLocation)
 
     registerCleanupTask(() => {
       urlContexts.stop()
@@ -130,5 +134,24 @@ describe('urlContexts', () => {
     } as ViewEndedEvent)
 
     expect(urlContexts.findUrl()).toBeUndefined()
+  })
+
+  describe('assembly hook', () => {
+    it('should add url properties from the history', () => {
+      lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
+        startClocks: relativeToClocks(0 as RelativeTime),
+      } as ViewCreatedEvent)
+
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual(
+        jasmine.objectContaining({
+          view: {
+            url: jasmine.any(String),
+            referrer: jasmine.any(String),
+          },
+        })
+      )
+    })
   })
 })

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -5,7 +5,7 @@ import { setupLocationObserver } from '../../../test'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { ViewCreatedEvent, ViewEndedEvent } from '../view/trackViews'
 import type { Hooks } from '../../hooks'
-import { HookNames, startHooks } from '../../hooks'
+import { HookNames, createHooks } from '../../hooks'
 import { startUrlContexts, type UrlContexts } from './urlContexts'
 
 describe('urlContexts', () => {
@@ -17,7 +17,7 @@ describe('urlContexts', () => {
 
   beforeEach(() => {
     clock = mockClock()
-    hooks = startHooks()
+    hooks = createHooks()
     const setupResult = setupLocationObserver('http://fake-url.com')
 
     changeLocation = setupResult.changeLocation

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -136,7 +136,7 @@ describe('urlContexts', () => {
     expect(urlContexts.findUrl()).toBeUndefined()
   })
 
-  describe('assembly hook', () => {
+  describe('assemble hook', () => {
     it('should add url properties from the history', () => {
       lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, {
         startClocks: relativeToClocks(0 as RelativeTime),

--- a/packages/rum-core/src/domain/contexts/urlContexts.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.ts
@@ -3,6 +3,8 @@ import { SESSION_TIME_OUT_DELAY, relativeNow, createValueHistory } from '@datado
 import type { LocationChange } from '../../browser/locationChangeObservable'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
+import type { PartialRumEvent, Hooks } from '../../hooks'
+import { HookNames } from '../../hooks'
 
 /**
  * We want to attach to an event:
@@ -24,6 +26,7 @@ export interface UrlContexts {
 
 export function startUrlContexts(
   lifeCycle: LifeCycle,
+  hooks: Hooks,
   locationChangeObservable: Observable<LocationChange>,
   location: Location
 ) {
@@ -68,6 +71,18 @@ export function startUrlContexts(
       referrer,
     }
   }
+
+  hooks.register(HookNames.Assemble, ({ startTime, eventType }): PartialRumEvent | undefined => {
+    const { url, referrer } = urlContextHistory.find(startTime)!
+
+    return {
+      type: eventType,
+      view: {
+        url,
+        referrer,
+      },
+    }
+  })
 
   return {
     findUrl: (startTime?: RelativeTime) => urlContextHistory.find(startTime),

--- a/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
+++ b/packages/rum-core/src/domain/view/setupViewTest.specHelper.ts
@@ -2,6 +2,7 @@ import { Observable, deepClone } from '@datadog/browser-core'
 import { mockRumConfiguration, setupLocationObserver } from '../../../test'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
+import type { RumConfiguration } from '../configuration'
 import type { ViewCreatedEvent, ViewEvent, ViewOptions, ViewEndedEvent } from './trackViews'
 import { trackViews } from './trackViews'
 
@@ -10,12 +11,16 @@ export type ViewTest = ReturnType<typeof setupViewTest>
 interface ViewTrackingContext {
   lifeCycle: LifeCycle
   initialLocation?: string
+  partialConfig?: Partial<RumConfiguration>
 }
 
-export function setupViewTest({ lifeCycle, initialLocation }: ViewTrackingContext, initialViewOptions?: ViewOptions) {
+export function setupViewTest(
+  { lifeCycle, initialLocation, partialConfig }: ViewTrackingContext,
+  initialViewOptions?: ViewOptions
+) {
   const domMutationObservable = new Observable<void>()
   const windowOpenObservable = new Observable<void>()
-  const configuration = mockRumConfiguration()
+  const configuration = mockRumConfiguration(partialConfig)
   const { locationChangeObservable, changeLocation } = setupLocationObserver(initialLocation)
 
   const {

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -966,3 +966,43 @@ describe('view event count', () => {
     })
   })
 })
+
+describe('service and version', () => {
+  const lifeCycle = new LifeCycle()
+  let clock: Clock
+  let viewTest: ViewTest
+
+  beforeEach(() => {
+    clock = mockClock()
+
+    registerCleanupTask(() => {
+      viewTest.stop()
+      clock.cleanup()
+      resetExperimentalFeatures()
+    })
+  })
+
+  it('should come from the init configuration by default', () => {
+    viewTest = setupViewTest({ lifeCycle, partialConfig: { service: 'service', version: 'version' } })
+
+    const { getViewUpdate } = viewTest
+
+    expect(getViewUpdate(0).service).toEqual('service')
+    expect(getViewUpdate(0).version).toEqual('version')
+  })
+
+  it('should come from the view option if defined', () => {
+    viewTest = setupViewTest(
+      { lifeCycle, partialConfig: { service: 'service', version: 'version' } },
+      {
+        service: 'view service',
+        version: 'view version',
+      }
+    )
+
+    const { getViewUpdate } = viewTest
+
+    expect(getViewUpdate(0).service).toEqual('view service')
+    expect(getViewUpdate(0).version).toEqual('view version')
+  })
+})

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -208,20 +208,13 @@ function newView(
   const contextManager = createContextManager()
 
   let sessionIsActive = true
-  let name: string | undefined
-  let service: string | undefined
-  let version: string | undefined
-  let context: Context | undefined
+  let name = viewOptions?.name
+  const service = viewOptions?.service || configuration.service
+  const version = viewOptions?.version || configuration.version
+  const context = viewOptions?.context
 
-  if (viewOptions) {
-    name = viewOptions.name
-    service = viewOptions.service || undefined
-    version = viewOptions.version || undefined
-    if (viewOptions.context) {
-      context = viewOptions.context
-      // use ContextManager to update the context so we always sanitize it
-      contextManager.setContext(context)
-    }
+  if (context) {
+    contextManager.setContext(context)
   }
 
   const viewCreatedEvent = {

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -19,7 +19,7 @@ import type { RumConfiguration } from '../configuration'
 import type { FeatureFlagContexts } from '../contexts/featureFlagContext'
 import type { LocationChange } from '../../browser/locationChangeObservable'
 import type { Hooks } from '../../hooks'
-import { HookNames, startHooks } from '../../hooks'
+import { HookNames, createHooks } from '../../hooks'
 
 import type { ViewHistoryEntry } from '../contexts/viewHistory'
 import { startViewCollection } from './viewCollection'
@@ -85,7 +85,7 @@ describe('viewCollection', () => {
     partialFeatureFlagContexts: Partial<FeatureFlagContexts> = {},
     viewHistoryEntry?: ViewHistoryEntry
   ) {
-    hooks = startHooks()
+    hooks = createHooks()
     const viewHistory = mockViewHistory(viewHistoryEntry)
     getReplayStatsSpy = jasmine.createSpy()
     const domMutationObservable = new Observable<void>()

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -1,12 +1,13 @@
 import { Observable } from '@datadog/browser-core'
 import type { Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
-import { registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RecorderApi } from '../../boot/rumPublicApi'
 import {
   collectAndValidateRawRumEvents,
   mockFeatureFlagContexts,
   mockPageStateHistory,
   mockRumConfiguration,
+  mockViewHistory,
   noopRecorderApi,
 } from '../../../test'
 import type { RawRumEvent, RawRumViewEvent } from '../../rawRumEvent.types'
@@ -17,8 +18,12 @@ import { PageState } from '../contexts/pageStateHistory'
 import type { RumConfiguration } from '../configuration'
 import type { FeatureFlagContexts } from '../contexts/featureFlagContext'
 import type { LocationChange } from '../../browser/locationChangeObservable'
-import type { ViewEvent } from './trackViews'
+import type { Hooks } from '../../hooks'
+import { HookNames, startHooks } from '../../hooks'
+
+import type { ViewHistoryEntry } from '../contexts/viewHistory'
 import { startViewCollection } from './viewCollection'
+import type { ViewEvent } from './trackViews'
 
 const VIEW: ViewEvent = {
   customTimings: {
@@ -71,20 +76,26 @@ const VIEW: ViewEvent = {
 
 describe('viewCollection', () => {
   const lifeCycle = new LifeCycle()
+  let hooks: Hooks
   let getReplayStatsSpy: jasmine.Spy<RecorderApi['getReplayStats']>
   let rawRumEvents: Array<RawRumEventCollectedData<RawRumEvent>> = []
 
   function setupViewCollection(
     partialConfiguration: Partial<RumConfiguration> = {},
-    partialFeatureFlagContexts: Partial<FeatureFlagContexts> = {}
+    partialFeatureFlagContexts: Partial<FeatureFlagContexts> = {},
+    viewHistoryEntry?: ViewHistoryEntry
   ) {
+    hooks = startHooks()
+    const viewHistory = mockViewHistory(viewHistoryEntry)
     getReplayStatsSpy = jasmine.createSpy()
     const domMutationObservable = new Observable<void>()
     const windowOpenObservable = new Observable<void>()
     const locationChangeObservable = new Observable<LocationChange>()
+    const clock = mockClock()
 
     const collectionResult = startViewCollection(
       lifeCycle,
+      hooks,
       mockRumConfiguration(partialConfiguration),
       location,
       domMutationObservable,
@@ -100,14 +111,18 @@ describe('viewCollection', () => {
       {
         ...noopRecorderApi,
         getReplayStats: getReplayStatsSpy,
-      }
+      },
+      viewHistory
     )
 
     rawRumEvents = collectAndValidateRawRumEvents(lifeCycle)
 
     registerCleanupTask(() => {
       collectionResult.stop()
+      viewHistory.stop()
+      clock.cleanup()
     })
+    return collectionResult
   }
 
   it('should create view from view update', () => {
@@ -287,6 +302,35 @@ describe('viewCollection', () => {
         (rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent)._dd.configuration
           .start_session_replay_recording_manually
       ).toBe(true)
+    })
+  })
+
+  describe('assembly hook', () => {
+    it('should add view properties from the history', () => {
+      const viewHistoryEntry: ViewHistoryEntry = {
+        service: 'service',
+        version: 'version',
+        context: { myContext: 'foo' },
+        id: 'id',
+        name: 'name',
+        startClocks: { relative: 0 as RelativeTime, timeStamp: 0 as TimeStamp },
+      }
+
+      setupViewCollection({ trackViewsManually: true }, {}, viewHistoryEntry)
+
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual(
+        jasmine.objectContaining({
+          service: 'service',
+          version: 'version',
+          context: { myContext: 'foo' },
+          view: {
+            id: 'id',
+            name: 'name',
+          },
+        })
+      )
     })
   })
 })

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -43,8 +43,6 @@ export function startViewCollection(
     const { service, version, id, name, context } = viewHistory.findView(startTime)!
 
     return {
-      // Explicitly set the event type to enhance type checking, especially for cases
-      // where conditional logic depends on the `type` field (e.g., `if (eventType === 'VIEW')`).
       type: eventType,
       service,
       version,

--- a/packages/rum-core/src/hooks.spec.ts
+++ b/packages/rum-core/src/hooks.spec.ts
@@ -22,21 +22,21 @@ describe('startHooks', () => {
 
   describe('assemble hook', () => {
     it('combines results from multiple callbacks', () => {
-      const callback1 = jasmine.createSpy().and.returnValue({ service: 'foo' })
-      const callback2 = jasmine.createSpy().and.returnValue({ version: 'bar' })
+      const callback1 = jasmine.createSpy().and.returnValue({ type: 'action', service: 'foo' })
+      const callback2 = jasmine.createSpy().and.returnValue({ type: 'action', version: 'bar' })
 
       hooks.register(HookNames.Assemble, callback1)
       hooks.register(HookNames.Assemble, callback2)
 
       const result = hooks.triggerHook(HookNames.Assemble, hookParams)
 
-      expect(result).toEqual({ service: 'foo', version: 'bar' })
+      expect(result).toEqual({ type: 'action', service: 'foo', version: 'bar' })
       expect(callback1).toHaveBeenCalled()
       expect(callback2).toHaveBeenCalled()
     })
 
     it('does not combine undefined results from callbacks', () => {
-      const callback1 = jasmine.createSpy().and.returnValue({ service: 'foo' })
+      const callback1 = jasmine.createSpy().and.returnValue({ type: 'action', service: 'foo' })
       const callback2 = jasmine.createSpy().and.returnValue(undefined)
 
       hooks.register(HookNames.Assemble, callback1)
@@ -44,7 +44,7 @@ describe('startHooks', () => {
 
       const result = hooks.triggerHook(HookNames.Assemble, hookParams)
 
-      expect(result).toEqual({ service: 'foo' })
+      expect(result).toEqual({ type: 'action', service: 'foo' })
       expect(callback1).toHaveBeenCalled()
       expect(callback2).toHaveBeenCalled()
     })

--- a/packages/rum-core/src/hooks.spec.ts
+++ b/packages/rum-core/src/hooks.spec.ts
@@ -1,11 +1,11 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import { HookNames, startHooks } from './hooks'
+import { HookNames, createHooks } from './hooks'
 
 describe('startHooks', () => {
-  let hooks: ReturnType<typeof startHooks>
+  let hooks: ReturnType<typeof createHooks>
   const hookParams = { eventType: 'error', startTime: 1011 as RelativeTime } as any
   beforeEach(() => {
-    hooks = startHooks()
+    hooks = createHooks()
   })
 
   it('unregister a hook callback', () => {

--- a/packages/rum-core/src/hooks.spec.ts
+++ b/packages/rum-core/src/hooks.spec.ts
@@ -1,0 +1,52 @@
+import type { RelativeTime } from '@datadog/browser-core'
+import { HookNames, startHooks } from './hooks'
+
+describe('startHooks', () => {
+  let hooks: ReturnType<typeof startHooks>
+  const hookParams = { eventType: 'error', startTime: 1011 as RelativeTime } as any
+  beforeEach(() => {
+    hooks = startHooks()
+  })
+
+  it('unregister a hook callback', () => {
+    const callback = jasmine.createSpy().and.returnValue({ service: 'foo' })
+
+    const { unregister } = hooks.register(HookNames.Assemble, callback)
+    unregister()
+
+    const result = hooks.triggerHook(HookNames.Assemble, hookParams)
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(result).toEqual(undefined)
+  })
+
+  describe('assemble hook', () => {
+    it('combines results from multiple callbacks', () => {
+      const callback1 = jasmine.createSpy().and.returnValue({ service: 'foo' })
+      const callback2 = jasmine.createSpy().and.returnValue({ version: 'bar' })
+
+      hooks.register(HookNames.Assemble, callback1)
+      hooks.register(HookNames.Assemble, callback2)
+
+      const result = hooks.triggerHook(HookNames.Assemble, hookParams)
+
+      expect(result).toEqual({ service: 'foo', version: 'bar' })
+      expect(callback1).toHaveBeenCalled()
+      expect(callback2).toHaveBeenCalled()
+    })
+
+    it('does not combine undefined results from callbacks', () => {
+      const callback1 = jasmine.createSpy().and.returnValue({ service: 'foo' })
+      const callback2 = jasmine.createSpy().and.returnValue(undefined)
+
+      hooks.register(HookNames.Assemble, callback1)
+      hooks.register(HookNames.Assemble, callback2)
+
+      const result = hooks.triggerHook(HookNames.Assemble, hookParams)
+
+      expect(result).toEqual({ service: 'foo' })
+      expect(callback1).toHaveBeenCalled()
+      expect(callback2).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/rum-core/src/hooks.ts
+++ b/packages/rum-core/src/hooks.ts
@@ -7,15 +7,27 @@ export const enum HookNames {
 }
 
 type RecursivePartialExcept<T, K extends keyof T> = {
-  [P in keyof T as P extends K ? never : P]?: T[P] extends object ? RecursivePartialExcept<T[P], never> : T[P]
+  [P in keyof T]?: T[P] extends object ? RecursivePartialExcept<T[P], never> : T[P]
 } & {
-  [P in keyof T as P extends K ? P : never]-?: T[P]
+  [P in K]: T[P]
 }
 
+// Define a partially recursive type for RUM events, ensuring the `type` field is always present.
+// This improves type checking, especially in conditional logic in hooks (e.g., `if (eventType === 'VIEW')`).
 export type PartialRumEvent = RecursivePartialExcept<RumEvent, 'type'>
 
+// This is a workaround for an issue occurring when the Browser SDK is included in a TypeScript
+// project configured with `isolatedModules: true`. Even if the const enum is declared in this
+// module, we cannot use it directly to define the EventMap interface keys (TS error: "Cannot access
+// ambient const enums when the '--isolatedModules' flag is provided.").
+declare const HookNamesAsConst: {
+  ASSEMBLE: HookNames.Assemble
+}
 export type HookCallbackMap = {
-  [HookNames.Assemble]: (param: { eventType: RumEvent['type']; startTime: RelativeTime }) => PartialRumEvent | undefined
+  [HookNamesAsConst.ASSEMBLE]: (param: {
+    eventType: RumEvent['type']
+    startTime: RelativeTime
+  }) => PartialRumEvent | undefined
 }
 
 export type Hooks = ReturnType<typeof startHooks>

--- a/packages/rum-core/src/hooks.ts
+++ b/packages/rum-core/src/hooks.ts
@@ -6,15 +6,13 @@ export const enum HookNames {
   Assemble,
 }
 
-type RemoveIndexSignature<T> = {
-  [K in keyof T as K extends string ? (string extends K ? never : K) : never]: T[K]
+type RecursivePartialExcept<T, K extends keyof T> = {
+  [P in keyof T as P extends K ? never : P]?: T[P] extends object ? RecursivePartialExcept<T[P], never> : T[P]
+} & {
+  [P in keyof T as P extends K ? P : never]-?: T[P]
 }
 
-type RecursivePartial<T> = {
-  [P in keyof T]?: T[P] extends object ? RecursivePartial<T[P]> : T[P]
-}
-
-export type PartialRumEvent = RecursivePartial<RemoveIndexSignature<RumEvent>>
+export type PartialRumEvent = RecursivePartialExcept<RumEvent, 'type'>
 
 export type HookCallbackMap = {
   [HookNames.Assemble]: (param: { eventType: RumEvent['type']; startTime: RelativeTime }) => PartialRumEvent | undefined

--- a/packages/rum-core/src/hooks.ts
+++ b/packages/rum-core/src/hooks.ts
@@ -30,9 +30,9 @@ export type HookCallbackMap = {
   }) => PartialRumEvent | undefined
 }
 
-export type Hooks = ReturnType<typeof startHooks>
+export type Hooks = ReturnType<typeof createHooks>
 
-export function startHooks() {
+export function createHooks() {
   const callbacks: { [K in HookNames]?: Array<HookCallbackMap[K]> } = {}
 
   return {

--- a/packages/rum-core/src/hooks.ts
+++ b/packages/rum-core/src/hooks.ts
@@ -12,8 +12,8 @@ type RecursivePartialExcept<T, K extends keyof T> = {
   [P in K]: T[P]
 }
 
-// Define a partially recursive type for RUM events, ensuring the `type` field is always present.
-// This improves type checking, especially in conditional logic in hooks (e.g., `if (eventType === 'VIEW')`).
+// Define a partial RUM event type.
+// Ensuring the `type` field is always present improves type checking, especially in conditional logic in hooks (e.g., `if (eventType === 'view')`).
 export type PartialRumEvent = RecursivePartialExcept<RumEvent, 'type'>
 
 // This is a workaround for an issue occurring when the Browser SDK is included in a TypeScript

--- a/packages/rum-core/src/hooks.ts
+++ b/packages/rum-core/src/hooks.ts
@@ -1,0 +1,49 @@
+import { combine } from '@datadog/browser-core'
+import type { RelativeTime } from '@datadog/browser-core'
+import type { RumEvent } from './rumEvent.types'
+
+export const enum HookNames {
+  Assemble,
+}
+
+type RemoveIndexSignature<T> = {
+  [K in keyof T as K extends string ? (string extends K ? never : K) : never]: T[K]
+}
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends object ? RecursivePartial<T[P]> : T[P]
+}
+
+export type PartialRumEvent = RecursivePartial<RemoveIndexSignature<RumEvent>>
+
+export type HookCallbackMap = {
+  [HookNames.Assemble]: (param: { eventType: RumEvent['type']; startTime: RelativeTime }) => PartialRumEvent | undefined
+}
+
+export type Hooks = ReturnType<typeof startHooks>
+
+export function startHooks() {
+  const callbacks: { [K in HookNames]?: Array<HookCallbackMap[K]> } = {}
+
+  return {
+    register<K extends HookNames>(hookName: K, callback: HookCallbackMap[K]) {
+      if (!callbacks[hookName]) {
+        callbacks[hookName] = []
+      }
+      callbacks[hookName]!.push(callback)
+      return {
+        unregister: () => {
+          callbacks[hookName] = callbacks[hookName]!.filter((cb) => cb !== callback)
+        },
+      }
+    },
+    triggerHook<K extends keyof HookCallbackMap>(
+      hookName: K,
+      param: Parameters<HookCallbackMap[K]>[0]
+    ): ReturnType<HookCallbackMap[K]> {
+      const hookCallbacks = callbacks[hookName] || []
+      const results = hookCallbacks.map((callback) => callback(param))
+      return combine(...(results as [object, object])) as ReturnType<HookCallbackMap[K]>
+    },
+  }
+}

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -359,12 +359,6 @@ export interface RumContext {
       height: number
     }
   }
-  view: {
-    id: string
-    referrer?: string
-    url: string
-    name?: string
-  }
   connectivity: Connectivity
   action?: {
     id: string | string[]
@@ -376,6 +370,7 @@ export interface RumContext {
   ci_test?: {
     test_execution_id: string
   }
+  context: Context
   _dd: {
     format_version: 2
     drift: number

--- a/packages/rum-core/test/formatValidation.ts
+++ b/packages/rum-core/test/formatValidation.ts
@@ -2,6 +2,7 @@ import ajv from 'ajv'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 import type { TimeStamp, Context } from '@datadog/browser-core'
 import { combine } from '@datadog/browser-core'
+import type { CommonProperties } from '@datadog/browser-rum-core'
 import type { LifeCycle, RawRumEventCollectedData } from '../src/domain/lifeCycle'
 import { LifeCycleEventType } from '../src/domain/lifeCycle'
 import type { RawRumEvent, RumContext } from '../src/rawRumEvent.types'
@@ -22,7 +23,7 @@ export function collectAndValidateRawRumEvents(lifeCycle: LifeCycle) {
 
 function validateRumEventFormat(rawRumEvent: RawRumEvent) {
   const fakeId = '00000000-aaaa-0000-aaaa-000000000000'
-  const fakeContext: RumContext = {
+  const fakeContext: Partial<CommonProperties> = {
     _dd: {
       format_version: 2,
       drift: 0,
@@ -50,6 +51,7 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
       interfaces: ['wifi'],
       effective_type: '4g',
     },
+    context: {},
   }
   validateRumFormat(combine(fakeContext as RumContext & Context, rawRumEvent))
 }

--- a/packages/rum-core/test/mockContexts.ts
+++ b/packages/rum-core/test/mockContexts.ts
@@ -2,7 +2,7 @@ import { noop } from '@datadog/browser-core'
 import type { ActionContexts } from '../src/domain/action/trackClickActions'
 import type { DisplayContext } from '../src/domain/contexts/displayContext'
 import type { UrlContexts } from '../src/domain/contexts/urlContexts'
-import type { ViewHistory } from '../src/domain/contexts/viewHistory'
+import type { ViewHistory, ViewHistoryEntry } from '../src/domain/contexts/viewHistory'
 import type { FeatureFlagContexts } from '../src/domain/contexts/featureFlagContext'
 
 export function mockUrlContexts(fakeLocation: Location = location): UrlContexts {
@@ -15,9 +15,9 @@ export function mockUrlContexts(fakeLocation: Location = location): UrlContexts 
   }
 }
 
-export function mockViewHistory(): ViewHistory {
+export function mockViewHistory(view?: Partial<ViewHistoryEntry>): ViewHistory {
   return {
-    findView: () => undefined,
+    findView: () => view as ViewHistoryEntry,
     stop: noop,
   }
 }


### PR DESCRIPTION
## Motivation

The overall goal is to create a Modular SDK to simplify contributions and enhance extensibility.

This PR introduces a **hook system**, initially used to `decouple event assembly`. Each collection module can now independently handle the assembly of its own properties.

## Changes

- Introduce a Hooks system
- Use the Assemble hook in viewCollection to manage the assembly of view properties
- Use the Assemble hook in urlContext to manage the assembly of url properties


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
