### PR TITLE
👷 various tiny fixes

### DIFF
--- a/packages/core/src/domain/report/reportObservable.spec.ts
+++ b/packages/core/src/domain/report/reportObservable.spec.ts
@@ -24,7 +24,7 @@ describe('report observable', () => {
   })
 
   afterEach(() => {
-    consoleSubscription.unsubscribe()
+    consoleSubscription?.unsubscribe()
   })
   ;[RawReportType.deprecation, RawReportType.intervention].forEach((type) => {
     it(`should notify ${type} reports`, () => {

--- a/scripts/test/export-test-result.js
+++ b/scripts/test/export-test-result.js
@@ -18,6 +18,7 @@ runMain(() => {
     .withEnvironment({
       DATADOG_API_KEY: getOrg2ApiKey(),
     })
+    .withLogs()
     .run()
 
   printLog(`Export ${testType} tests done.`)

--- a/test/e2e/scenario/recorder/recorder.scenario.ts
+++ b/test/e2e/scenario/recorder/recorder.scenario.ts
@@ -683,7 +683,7 @@ describe('recorder', () => {
       })
 
     createTest('should detect a rage click and match it to mouse interaction records')
-      .withRum({ trackUserInteractions: true, allowUntrustedEvents: true })
+      .withRum({ trackUserInteractions: true })
       .withSetup(bundleSetup)
       .withBody(html`
         <div id="main-div" />

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -355,7 +355,7 @@ describe('action collection', () => {
     })
 
   createTest('collect a "rage click"')
-    .withRum({ trackUserInteractions: true, allowUntrustedEvents: true })
+    .withRum({ trackUserInteractions: true })
     .withBody(html`
       <button>click me</button>
       <script>


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Three tiny fixes:
- fix a some test that show as failed in test visibility because they are skipped but the `afterEach` throws an error. (but Gitlab still mark the job as passed)
- remove unnecessary allowUntrustedEvents options in some e2e test setup
- add logs in export test report script 

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
