### PR TITLE
👷 fix eslint error on UNSTABLE_ReactComponentTracker case

### DIFF
--- a/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
+++ b/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
@@ -4,8 +4,7 @@ import { appendComponent } from '../../../test/appendComponent'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'
 import type { Clock } from '../../../../core/test'
 import { mockClock, registerCleanupTask } from '../../../../core/test'
-// eslint-disable-next-line camelcase
-import { UNSTABLE_ReactComponentTracker } from './reactComponentTracker'
+import { UNSTABLE_ReactComponentTracker as ReactComponentTracker } from './reactComponentTracker'
 
 const RENDER_DURATION = 100
 const EFFECT_DURATION = 101
@@ -36,10 +35,9 @@ describe('UNSTABLE_ReactComponentTracker', () => {
     })
 
     appendComponent(
-      // eslint-disable-next-line camelcase
-      <UNSTABLE_ReactComponentTracker name="ChildComponent">
+      <ReactComponentTracker name="ChildComponent">
         <ChildComponent clock={clock} />
-      </UNSTABLE_ReactComponentTracker>
+      </ReactComponentTracker>
     )
 
     expect(addDurationVitalSpy).toHaveBeenCalledTimes(1)
@@ -74,10 +72,9 @@ describe('UNSTABLE_ReactComponentTracker', () => {
       forceUpdate = () => setState((prev) => prev + 1)
       return (
         <>
-          {/* eslint-disable-next-line camelcase */}
-          <UNSTABLE_ReactComponentTracker name="ChildComponent">
+          <ReactComponentTracker name="ChildComponent">
             <ChildComponent clock={clock} />
-          </UNSTABLE_ReactComponentTracker>
+          </ReactComponentTracker>
         </>
       )
     }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

fix the following error:
```
/go/src/github.com/DataDog/browser-sdk/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
  42:9   error  Identifier 'UNSTABLE_ReactComponentTracker' is not in camel case  camelcase
  80:13  error  Identifier 'UNSTABLE_ReactComponentTracker' is not in camel case  camelcase
```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

use `as` to import `ReactComponentTracker` without the `UNSTABLE` prefix in spec file. This avoid multiple `eslint-disable-next-line` comments and will generate smaller diff when making the component stable.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
