### PR TITLE
🔊 Add telemetry hook

### DIFF
--- a/packages/core/src/tools/valueHistory.ts
+++ b/packages/core/src/tools/valueHistory.ts
@@ -1,3 +1,4 @@
+import type { Context } from './serialisation/context'
 import { setInterval, clearInterval } from './timer'
 import type { TimeoutId } from './timer'
 import { removeItem } from './utils/arrayUtils'
@@ -28,6 +29,8 @@ export interface ValueHistory<Value> {
   findAll: (startTime?: RelativeTime, duration?: Duration) => Value[]
   reset: () => void
   stop: () => void
+
+  getAllEntries: () => Context[]
 }
 
 export function createValueHistory<Value>({
@@ -116,6 +119,14 @@ export function createValueHistory<Value>({
       .map((entry) => entry.value)
   }
 
+  function getAllEntries() {
+    return entries.map(({ startTime, endTime, value }) => ({
+      startTime,
+      endTime,
+      value,
+    })) as Context[]
+  }
+
   /**
    * Remove all entries from this collection.
    */
@@ -130,5 +141,5 @@ export function createValueHistory<Value>({
     clearInterval(clearOldValuesInterval)
   }
 
-  return { add, find, closeActive, findAll, reset, stop }
+  return { add, find, closeActive, findAll, reset, stop, getAllEntries }
 }

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -70,7 +70,7 @@ function startRumStub(
 ) {
   const hooks = createHooks()
   const viewHistory = startViewHistory(lifeCycle)
-  const urlContexts = startUrlContexts(lifeCycle, hooks, locationChangeObservable, location)
+  const urlContexts = startUrlContexts(lifeCycle, hooks, locationChangeObservable, location, viewHistory)
 
   const { stop: rumEventCollectionStop } = startRumEventCollection(
     lifeCycle,

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -132,7 +132,7 @@ export function startRum(
   const locationChangeObservable = createLocationChangeObservable(configuration, location)
   const pageStateHistory = startPageStateHistory(configuration)
   const viewHistory = startViewHistory(lifeCycle)
-  const urlContexts = startUrlContexts(lifeCycle, hooks, locationChangeObservable, location)
+  const urlContexts = startUrlContexts(lifeCycle, hooks, locationChangeObservable, location, viewHistory)
 
   const { observable: windowOpenObservable, stop: stopWindowOpen } = createWindowOpenObservable()
   cleanupTasks.push(stopWindowOpen)

--- a/packages/rum-core/src/domain/contexts/internalContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/internalContext.spec.ts
@@ -20,6 +20,7 @@ describe('internal context', () => {
         id: 'abcde',
         name: 'foo',
       }),
+      getAllEntries: () => [],
       stop: noop,
     }
 

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -1,7 +1,7 @@
 import { mockClock, registerCleanupTask, type Clock } from '@datadog/browser-core/test'
 import type { RelativeTime } from '@datadog/browser-core'
 import { clocksNow, relativeToClocks } from '@datadog/browser-core'
-import { setupLocationObserver } from '../../../test'
+import { mockViewHistory, setupLocationObserver } from '../../../test'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { ViewCreatedEvent, ViewEndedEvent } from '../view/trackViews'
 import type { Hooks } from '../../hooks'
@@ -21,7 +21,13 @@ describe('urlContexts', () => {
     const setupResult = setupLocationObserver('http://fake-url.com')
 
     changeLocation = setupResult.changeLocation
-    urlContexts = startUrlContexts(lifeCycle, hooks, setupResult.locationChangeObservable, setupResult.fakeLocation)
+    urlContexts = startUrlContexts(
+      lifeCycle,
+      hooks,
+      setupResult.locationChangeObservable,
+      setupResult.fakeLocation,
+      mockViewHistory()
+    )
 
     registerCleanupTask(() => {
       urlContexts.stop()

--- a/packages/rum-core/src/domain/contexts/urlContexts.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.ts
@@ -1,10 +1,11 @@
 import type { RelativeTime, Observable } from '@datadog/browser-core'
-import { SESSION_TIME_OUT_DELAY, relativeNow, createValueHistory } from '@datadog/browser-core'
+import { SESSION_TIME_OUT_DELAY, relativeNow, createValueHistory, addTelemetryDebug } from '@datadog/browser-core'
 import type { LocationChange } from '../../browser/locationChangeObservable'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 import type { PartialRumEvent, Hooks } from '../../hooks'
 import { HookNames } from '../../hooks'
+import type { ViewHistory } from './viewHistory'
 
 /**
  * We want to attach to an event:
@@ -28,7 +29,8 @@ export function startUrlContexts(
   lifeCycle: LifeCycle,
   hooks: Hooks,
   locationChangeObservable: Observable<LocationChange>,
-  location: Location
+  location: Location,
+  viewContexts: ViewHistory
 ) {
   const urlContextHistory = createValueHistory<UrlContext>({ expireDelay: URL_CONTEXT_TIME_OUT_DELAY })
 
@@ -73,13 +75,21 @@ export function startUrlContexts(
   }
 
   hooks.register(HookNames.Assemble, ({ startTime, eventType }): PartialRumEvent | undefined => {
-    const { url, referrer } = urlContextHistory.find(startTime)!
+    const entry = urlContextHistory.find(startTime)!
+
+    if (!entry) {
+      addTelemetryDebug('Missing URL entry', {
+        startTime,
+        urlContextEntries: urlContextHistory.getAllEntries(),
+        viewContextEntries: viewContexts.getAllEntries(),
+      })
+    }
 
     return {
       type: eventType,
       view: {
-        url,
-        referrer,
+        url: entry.url,
+        referrer: entry.referrer,
       },
     }
   })

--- a/packages/rum-core/src/domain/contexts/urlContexts.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.ts
@@ -79,9 +79,12 @@ export function startUrlContexts(
 
     if (!entry) {
       addTelemetryDebug('Missing URL entry', {
-        startTime,
-        urlContextEntries: urlContextHistory.getAllEntries(),
-        viewContextEntries: viewContexts.getAllEntries(),
+        debug: {
+          eventType,
+          startTime,
+          urlContextEntries: urlContextHistory.getAllEntries(),
+          viewContextEntries: viewContexts.getAllEntries(),
+        },
       })
     }
 

--- a/packages/rum-core/src/domain/contexts/viewHistory.ts
+++ b/packages/rum-core/src/domain/contexts/viewHistory.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime, ClocksState, Context } from '@datadog/browser-core'
+import type { RelativeTime, ClocksState, Context, ValueHistoryEntry } from '@datadog/browser-core'
 import { SESSION_TIME_OUT_DELAY, createValueHistory } from '@datadog/browser-core'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
@@ -18,6 +18,7 @@ export interface ViewHistoryEntry {
 export interface ViewHistory {
   findView: (startTime?: RelativeTime) => ViewHistoryEntry | undefined
   stop: () => void
+  getAllEntries: () => Context[]
 }
 
 export function startViewHistory(lifeCycle: LifeCycle): ViewHistory {
@@ -58,6 +59,7 @@ export function startViewHistory(lifeCycle: LifeCycle): ViewHistory {
 
   return {
     findView: (startTime) => viewValueHistory.find(startTime),
+    getAllEntries: () => viewValueHistory.getAllEntries(),
     stop: () => {
       viewValueHistory.stop()
     },

--- a/packages/rum-core/src/domain/contexts/viewHistory.ts
+++ b/packages/rum-core/src/domain/contexts/viewHistory.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime, ClocksState, Context, ValueHistoryEntry } from '@datadog/browser-core'
+import type { RelativeTime, ClocksState, Context } from '@datadog/browser-core'
 import { SESSION_TIME_OUT_DELAY, createValueHistory } from '@datadog/browser-core'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'

--- a/packages/rum-core/test/mockContexts.ts
+++ b/packages/rum-core/test/mockContexts.ts
@@ -19,6 +19,7 @@ export function mockViewHistory(view?: Partial<ViewHistoryEntry>): ViewHistory {
   return {
     findView: () => view as ViewHistoryEntry,
     stop: noop,
+    getAllEntries: () => [],
   }
 }
 


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/browser-sdk/pull/3289, we start seeing a telemetry error:
`Cannot destructure property 'url' of 'o.find(...)' as it is undefined`

This PR adds telemetry to help diagnose the root cause.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
