### PR TITLE
🐛 fix document resource duration

### DIFF
--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -71,6 +71,7 @@ export interface RumPerformancePaintTiming {
   entryType: RumPerformanceEntryType.PAINT
   name: 'first-paint' | 'first-contentful-paint'
   startTime: RelativeTime
+  toJSON(): Omit<RumPerformancePaintTiming, 'toJSON'>
 }
 
 export interface RumPerformanceNavigationTiming extends Omit<RumPerformanceResourceTiming, 'entryType'> {
@@ -103,7 +104,7 @@ export interface RumFirstInputTiming {
   duration: Duration
   target?: Node
   interactionId?: number
-  name: string
+  toJSON(): Omit<RumFirstInputTiming, 'toJSON'>
 }
 
 export interface RumPerformanceEventTiming {
@@ -115,6 +116,7 @@ export interface RumPerformanceEventTiming {
   interactionId?: number
   target?: Node
   name: string
+  toJSON(): Omit<RumPerformanceEventTiming, 'toJSON'>
 }
 
 export interface RumLayoutShiftAttribution {
@@ -129,6 +131,7 @@ export interface RumLayoutShiftTiming {
   value: number
   hadRecentInput: boolean
   sources: RumLayoutShiftAttribution[]
+  toJSON(): Omit<RumLayoutShiftTiming, 'toJSON'>
 }
 
 // Documentation https://developer.chrome.com/docs/web-platform/long-animation-frames#better-attribution
@@ -165,6 +168,7 @@ export interface RumPerformanceLongAnimationFrameTiming {
   scripts: RumPerformanceScriptTiming[]
   startTime: RelativeTime
   styleAndLayoutStart: RelativeTime
+  toJSON(): Omit<RumPerformanceLongAnimationFrameTiming, 'toJSON'>
 }
 
 export type RumPerformanceEntry =

--- a/packages/rum-core/src/browser/performanceUtils.ts
+++ b/packages/rum-core/src/browser/performanceUtils.ts
@@ -22,7 +22,7 @@ export function getNavigationEntry(): RumPerformanceNavigationTiming {
     initiatorType: 'navigation' as const,
     name: window.location.href,
     startTime: 0 as RelativeTime,
-    duration: timings.responseEnd,
+    duration: timings.loadEventEnd,
     decodedBodySize: 0,
     encodedBodySize: 0,
     transferSize: 0,

--- a/packages/rum-core/src/domain/longAnimationFrame/longAnimationFrameCollection.spec.ts
+++ b/packages/rum-core/src/domain/longAnimationFrame/longAnimationFrameCollection.spec.ts
@@ -14,9 +14,9 @@ import { startLongAnimationFrameCollection } from './longAnimationFrameCollectio
 describe('long animation frames collection', () => {
   it('should create raw rum event from long animation frame performance entry', () => {
     const { notifyPerformanceEntries, rawRumEvents } = setupLongAnimationFrameCollection()
-    const PerformanceLongAnimationFrameTiming = createPerformanceEntry(RumPerformanceEntryType.LONG_ANIMATION_FRAME)
+    const performanceLongAnimationFrameTiming = createPerformanceEntry(RumPerformanceEntryType.LONG_ANIMATION_FRAME)
 
-    notifyPerformanceEntries([PerformanceLongAnimationFrameTiming])
+    notifyPerformanceEntries([performanceLongAnimationFrameTiming])
 
     expect(rawRumEvents[0].startTime).toBe(1234 as RelativeTime)
     expect(rawRumEvents[0].rawRumEvent).toEqual({
@@ -52,34 +52,7 @@ describe('long animation frames collection', () => {
       },
     })
     expect(rawRumEvents[0].domainContext).toEqual({
-      performanceEntry: {
-        name: 'long-animation-frame',
-        duration: 82,
-        entryType: 'long-animation-frame',
-        startTime: 1234,
-        renderStart: 1421.5,
-        styleAndLayoutStart: 1428,
-        firstUIEventTimestamp: 0,
-        blockingDuration: 0,
-        scripts: [
-          {
-            name: 'script',
-            entryType: 'script',
-            startTime: 1348,
-            duration: 6,
-            invoker: 'http://example.com/script.js',
-            invokerType: 'classic-script',
-            windowAttribution: 'self',
-            executionStart: 1348.7,
-            forcedStyleAndLayoutDuration: 0,
-            pauseDuration: 0,
-            sourceURL: 'http://example.com/script.js',
-            sourceFunctionName: '',
-            sourceCharPosition: 9876,
-          },
-        ],
-        toJSON: jasmine.any(Function),
-      },
+      performanceEntry: performanceLongAnimationFrameTiming,
     })
   })
 })

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -80,7 +80,7 @@ describe('resourceCollection', () => {
         encoded_body_size: 42,
         decoded_body_size: 51,
         transfer_size: 63,
-        type: ResourceType.OTHER,
+        type: ResourceType.IMAGE,
         url: 'https://resource.com/valid',
         download: jasmine.any(Object),
         first_byte: jasmine.any(Object),

--- a/packages/rum-core/src/domain/resource/retrieveInitialDocumentResourceTiming.spec.ts
+++ b/packages/rum-core/src/domain/resource/retrieveInitialDocumentResourceTiming.spec.ts
@@ -1,10 +1,12 @@
-import { mockRumConfiguration } from '../../../test'
+import { mockDocumentReadyState, mockRumConfiguration } from '../../../test'
+import { FAKE_INITIAL_DOCUMENT } from './resourceUtils'
 import { retrieveInitialDocumentResourceTiming } from './retrieveInitialDocumentResourceTiming'
 
 describe('rum initial document resource', () => {
   it('creates a resource timing for the initial document', (done) => {
     retrieveInitialDocumentResourceTiming(mockRumConfiguration(), (timing) => {
       expect(timing.entryType).toBe('resource')
+      expect(timing.initiatorType).toBe(FAKE_INITIAL_DOCUMENT)
       expect(timing.duration).toBeGreaterThan(0)
 
       // generate a performance entry like structure
@@ -14,5 +16,14 @@ describe('rum initial document resource', () => {
       expect((toJsonTiming as any).toJSON).toBeUndefined()
       done()
     })
+  })
+
+  it('waits until the document is interactive to notify the resource', () => {
+    const { triggerOnDomLoaded } = mockDocumentReadyState()
+    const spy = jasmine.createSpy()
+    retrieveInitialDocumentResourceTiming(mockRumConfiguration(), spy)
+    expect(spy).not.toHaveBeenCalled()
+    triggerOnDomLoaded()
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/src/domain/resource/retrieveInitialDocumentResourceTiming.spec.ts
+++ b/packages/rum-core/src/domain/resource/retrieveInitialDocumentResourceTiming.spec.ts
@@ -1,4 +1,6 @@
-import { mockDocumentReadyState, mockRumConfiguration } from '../../../test'
+import type { RelativeTime } from '@datadog/browser-core'
+import { createPerformanceEntry, mockDocumentReadyState, mockRumConfiguration } from '../../../test'
+import { RumPerformanceEntryType } from '../../browser/performanceObservable'
 import { FAKE_INITIAL_DOCUMENT } from './resourceUtils'
 import { retrieveInitialDocumentResourceTiming } from './retrieveInitialDocumentResourceTiming'
 
@@ -25,5 +27,20 @@ describe('rum initial document resource', () => {
     expect(spy).not.toHaveBeenCalled()
     triggerOnDomLoaded()
     expect(spy).toHaveBeenCalled()
+  })
+
+  it('uses the responseEnd to define the resource duration', (done) => {
+    retrieveInitialDocumentResourceTiming(
+      mockRumConfiguration(),
+      (timing) => {
+        expect(timing.duration).toBe(100 as RelativeTime)
+        done()
+      },
+      () =>
+        createPerformanceEntry(RumPerformanceEntryType.NAVIGATION, {
+          responseEnd: 100 as RelativeTime,
+          duration: 200 as RelativeTime,
+        })
+    )
   })
 })

--- a/packages/rum-core/src/domain/resource/retrieveInitialDocumentResourceTiming.ts
+++ b/packages/rum-core/src/domain/resource/retrieveInitialDocumentResourceTiming.ts
@@ -8,12 +8,17 @@ import { FAKE_INITIAL_DOCUMENT } from './resourceUtils'
 
 export function retrieveInitialDocumentResourceTiming(
   configuration: RumConfiguration,
-  callback: (timing: RumPerformanceResourceTiming) => void
+  callback: (timing: RumPerformanceResourceTiming) => void,
+  getNavigationEntryImpl = getNavigationEntry
 ) {
   runOnReadyState(configuration, 'interactive', () => {
-    const entry: RumPerformanceResourceTiming = Object.assign(getNavigationEntry().toJSON(), {
+    const navigationEntry = getNavigationEntryImpl()
+    const entry: RumPerformanceResourceTiming = Object.assign(navigationEntry.toJSON(), {
       entryType: RumPerformanceEntryType.RESOURCE as const,
       initiatorType: FAKE_INITIAL_DOCUMENT,
+      // The ResourceTiming duration entry should be `responseEnd - startTime`. With
+      // NavigationTiming entries, `startTime` is always 0, so set it to `responseEnd`.
+      duration: navigationEntry.responseEnd,
       traceId: getDocumentTraceId(document),
       toJSON: () => ({ ...entry, toJSON: undefined }),
     })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.spec.ts
@@ -153,6 +153,7 @@ describe('trackInteractionToNextPaint', () => {
       interactionId: 1,
       entryType: RumPerformanceEntryType.FIRST_INPUT,
       startTime: 1 as RelativeTime,
+      duration: 40 as Duration,
     })
     expect(getInteractionToNextPaint()).toEqual({
       value: 40 as Duration,

--- a/packages/rum-core/test/fixtures.ts
+++ b/packages/rum-core/test/fixtures.ts
@@ -1,9 +1,10 @@
 import type { Context, Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
 import { combine, ErrorHandling, ErrorSource, generateUUID, relativeNow, ResourceType } from '@datadog/browser-core'
 import {
+  type RumPerformanceEntry,
   type RumLayoutShiftAttribution,
-  RumPerformanceEntryType,
   type EntryTypeToReturnType,
+  RumPerformanceEntryType,
 } from '../src/browser/performanceObservable'
 import type { RawRumEvent } from '../src/rawRumEvent.types'
 import { VitalType, ActionType, RumEventType, ViewLoadingType, RumLongTaskEntryType } from '../src/rawRumEvent.types'
@@ -124,72 +125,68 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
   entryType: T,
   overrides?: Partial<EntryTypeToReturnType[T]>
 ): EntryTypeToReturnType[T] {
+  type OmitToJSON<T> = T extends any ? Omit<T, 'toJSON'> : never
+  let entry: OmitToJSON<RumPerformanceEntry>
+
   switch (entryType) {
     case RumPerformanceEntryType.EVENT:
-      return {
+      entry = {
         entryType: RumPerformanceEntryType.EVENT,
-        processingStart: relativeNow(),
-        startTime: relativeNow(),
-        duration: 40 as Duration,
-        ...overrides,
-      } as EntryTypeToReturnType[T]
-    case RumPerformanceEntryType.FIRST_INPUT:
-      return {
-        entryType: RumPerformanceEntryType.FIRST_INPUT,
-        processingStart: 1100 as RelativeTime,
         startTime: 1000 as RelativeTime,
-        duration: 40 as Duration,
-        ...overrides,
-      } as EntryTypeToReturnType[T]
-    case RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT: {
-      const entry = {
+        processingStart: 1100 as RelativeTime,
+        processingEnd: 1200 as RelativeTime,
+        duration: 200 as Duration,
+        name: 'click',
+      }
+      break
+
+    case RumPerformanceEntryType.FIRST_INPUT:
+      entry = {
+        entryType: RumPerformanceEntryType.FIRST_INPUT,
+        startTime: 1000 as RelativeTime,
+        processingStart: 1100 as RelativeTime,
+        processingEnd: 1200 as RelativeTime,
+        duration: 200 as Duration,
+      }
+      break
+
+    case RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT:
+      entry = {
         entryType: RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
         startTime: 789 as RelativeTime,
         size: 10,
-        ...overrides,
-      } as EntryTypeToReturnType[T]
-      return { ...entry, toJSON: () => entry }
-    }
+      }
+      break
+
     case RumPerformanceEntryType.LAYOUT_SHIFT:
-      return {
+      entry = {
         entryType: RumPerformanceEntryType.LAYOUT_SHIFT,
         startTime: relativeNow(),
         hadRecentInput: false,
         value: 0.1,
         sources: [] as RumLayoutShiftAttribution[],
-        ...overrides,
-      } as EntryTypeToReturnType[T]
+      }
+      break
+
     case RumPerformanceEntryType.PAINT:
-      return {
+      entry = {
         entryType: RumPerformanceEntryType.PAINT,
         name: 'first-contentful-paint',
         startTime: 123 as RelativeTime,
-        ...overrides,
-      } as EntryTypeToReturnType[T]
-    case RumPerformanceEntryType.NAVIGATION:
-      return {
-        entryType: RumPerformanceEntryType.NAVIGATION,
-        responseStart: 123 as RelativeTime,
-        domComplete: 456 as RelativeTime,
-        domContentLoadedEventEnd: 345 as RelativeTime,
-        domInteractive: 234 as RelativeTime,
-        loadEventEnd: 567 as RelativeTime,
-        ...overrides,
-      } as EntryTypeToReturnType[T]
+      }
+      break
 
-    case RumPerformanceEntryType.LONG_TASK: {
-      const entry = {
+    case RumPerformanceEntryType.LONG_TASK:
+      entry = {
         name: 'self',
         duration: 100 as Duration,
         entryType: RumPerformanceEntryType.LONG_TASK,
         startTime: 1234 as RelativeTime,
-        ...overrides,
-      } as EntryTypeToReturnType[T]
+      }
+      break
 
-      return { ...entry, toJSON: () => entry }
-    }
-    case RumPerformanceEntryType.LONG_ANIMATION_FRAME: {
-      const entry = {
+    case RumPerformanceEntryType.LONG_ANIMATION_FRAME:
+      entry = {
         name: 'long-animation-frame',
         entryType: RumPerformanceEntryType.LONG_ANIMATION_FRAME,
         startTime: 1234 as RelativeTime,
@@ -213,41 +210,71 @@ export function createPerformanceEntry<T extends RumPerformanceEntryType>(
             sourceURL: 'http://example.com/script.js',
             sourceFunctionName: '',
             sourceCharPosition: 9876,
+            window,
           },
         ],
-        ...overrides,
-      } as EntryTypeToReturnType[T]
+      }
+      break
 
-      return { ...entry, toJSON: () => entry }
-    }
-    case RumPerformanceEntryType.RESOURCE: {
-      const entry = {
-        connectEnd: 200 as RelativeTime,
-        connectStart: 200 as RelativeTime,
-        renderBlockingStatus: 'non-blocking',
-        deliveryType: 'cache',
-        domainLookupEnd: 200 as RelativeTime,
-        domainLookupStart: 200 as RelativeTime,
-        duration: 100 as Duration,
-        entryType: RumPerformanceEntryType.RESOURCE,
-        workerStart: 200 as RelativeTime,
-        fetchStart: 200 as RelativeTime,
-        name: 'https://resource.com/valid',
-        redirectEnd: 200 as RelativeTime,
-        redirectStart: 200 as RelativeTime,
-        requestStart: 200 as RelativeTime,
-        responseEnd: 300 as RelativeTime,
-        responseStart: 200 as RelativeTime,
-        secureConnectionStart: 200 as RelativeTime,
-        startTime: 200 as RelativeTime,
-        responseStatus: 200,
-        nextHopProtocol: 'HTTP/1.0',
-        ...overrides,
-      } as EntryTypeToReturnType[T]
+    case RumPerformanceEntryType.NAVIGATION:
+    case RumPerformanceEntryType.RESOURCE:
+      {
+        const baseEntry = {
+          connectEnd: 200 as RelativeTime,
+          connectStart: 200 as RelativeTime,
+          renderBlockingStatus: 'non-blocking',
+          deliveryType: 'cache' as const,
+          domainLookupEnd: 200 as RelativeTime,
+          domainLookupStart: 200 as RelativeTime,
+          workerStart: 200 as RelativeTime,
+          fetchStart: 200 as RelativeTime,
+          name: 'https://resource.com/valid',
+          redirectEnd: 200 as RelativeTime,
+          redirectStart: 200 as RelativeTime,
+          requestStart: 200 as RelativeTime,
+          responseEnd: 300 as RelativeTime,
+          responseStart: 200 as RelativeTime,
+          secureConnectionStart: 200 as RelativeTime,
+          responseStatus: 200,
+          nextHopProtocol: 'HTTP/1.0',
+          decodedBodySize: 1000,
+          encodedBodySize: 500,
+          transferSize: 500,
+        }
+        if (entryType === RumPerformanceEntryType.NAVIGATION) {
+          entry = {
+            ...baseEntry,
+            entryType: RumPerformanceEntryType.NAVIGATION,
+            initiatorType: 'navigation' as const,
+            startTime: 0 as RelativeTime,
+            responseStart: 123 as RelativeTime,
+            domComplete: 456 as RelativeTime,
+            domContentLoadedEventEnd: 345 as RelativeTime,
+            domInteractive: 234 as RelativeTime,
+            loadEventEnd: 567 as RelativeTime,
+            duration: 567 as Duration,
+          }
+        } else {
+          entry = {
+            ...baseEntry,
+            entryType: RumPerformanceEntryType.RESOURCE,
+            initiatorType: 'img' as const,
+            startTime: 200 as RelativeTime,
+            duration: 100 as Duration,
+          }
+        }
+      }
+      break
 
-      return { ...entry, toJSON: () => entry }
-    }
     default:
       throw new Error(`Unsupported entryType fixture: ${entryType}`)
   }
+
+  Object.assign(entry, overrides)
+
+  const fullEntry = {
+    ...entry,
+    toJSON: () => entry,
+  }
+  return fullEntry as EntryTypeToReturnType[T]
 }


### PR DESCRIPTION
## Motivation

Before this PR, we used the navigation entry duration as the duration for the document resource. However, that duration includes the time it takes to load the page until the `load` event (including the load of assets declared in the HTML like JS, CSS, images...).

## Changes

This PR fixes this by adjusting the duration to `responseEnd`, which conforms with the duration of other resource entries.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
