### PR TITLE
✅ fix failing skipped test

### DIFF
--- a/packages/rum/src/domain/record/trackers/trackStyleSheet.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackStyleSheet.spec.ts
@@ -26,7 +26,7 @@ describe('trackStyleSheet', () => {
       elementsScrollPositions: createElementsScrollPositions(),
     })
     registerCleanupTask(() => {
-      styleSheetTracker.stop()
+      styleSheetTracker?.stop()
       styleElement.remove()
     })
   })


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

registerCleanupTask fail when the test is [skipped](https://github.com/DataDog/browser-sdk/blob/61fda307c02d80acbe694a9d2cab5646348401e8/packages/rum/src/domain/record/trackers/trackStyleSheet.spec.ts). The job will pass but CI visibility will mark the test as failed.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
