### PR TITLE
🔊 Add missing URL context extra telemetry

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -18,6 +18,7 @@ export enum ExperimentalFeature {
   REMOTE_CONFIGURATION = 'remote_configuration',
   ACTION_NAME_MASKING = 'action_name_masking',
   CONSISTENT_TRACE_SAMPLING = 'consistent_trace_sampling',
+  MISSING_URL_CONTEXT_TELEMETRY = 'missing_url_context_telemetry',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/domain/contexts/internalContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/internalContext.spec.ts
@@ -21,6 +21,7 @@ describe('internal context', () => {
         name: 'foo',
       }),
       getAllEntries: () => [],
+      getDeletedEntries: () => [],
       stop: noop,
     }
 

--- a/packages/rum-core/src/domain/contexts/urlContexts.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.ts
@@ -82,8 +82,10 @@ export function startUrlContexts(
         debug: {
           eventType,
           startTime,
-          urlContextEntries: urlContextHistory.getAllEntries(),
-          viewContextEntries: viewContexts.getAllEntries(),
+          urlEntries: urlContextHistory.getAllEntries(),
+          urlDeletedEntries: urlContextHistory.getDeletedEntries(),
+          viewEntries: viewContexts.getAllEntries(),
+          viewDeletedEntries: viewContexts.getDeletedEntries(),
         },
       })
     }

--- a/packages/rum-core/src/domain/contexts/urlContexts.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.ts
@@ -1,5 +1,12 @@
 import type { RelativeTime, Observable } from '@datadog/browser-core'
-import { SESSION_TIME_OUT_DELAY, relativeNow, createValueHistory, addTelemetryDebug } from '@datadog/browser-core'
+import {
+  SESSION_TIME_OUT_DELAY,
+  relativeNow,
+  createValueHistory,
+  addTelemetryDebug,
+  isExperimentalFeatureEnabled,
+  ExperimentalFeature,
+} from '@datadog/browser-core'
 import type { LocationChange } from '../../browser/locationChangeObservable'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
@@ -78,16 +85,19 @@ export function startUrlContexts(
     const entry = urlContextHistory.find(startTime)!
 
     if (!entry) {
-      addTelemetryDebug('Missing URL entry', {
-        debug: {
-          eventType,
-          startTime,
-          urlEntries: urlContextHistory.getAllEntries(),
-          urlDeletedEntries: urlContextHistory.getDeletedEntries(),
-          viewEntries: viewContexts.getAllEntries(),
-          viewDeletedEntries: viewContexts.getDeletedEntries(),
-        },
-      })
+      if (isExperimentalFeatureEnabled(ExperimentalFeature.MISSING_URL_CONTEXT_TELEMETRY)) {
+        addTelemetryDebug('Missing URL entry', {
+          debug: {
+            eventType,
+            startTime,
+            urlEntries: urlContextHistory.getAllEntries(),
+            urlDeletedEntries: urlContextHistory.getDeletedEntries(),
+            viewEntries: viewContexts.getAllEntries(),
+            viewDeletedEntries: viewContexts.getDeletedEntries(),
+          },
+        })
+      }
+      return
     }
 
     return {

--- a/packages/rum-core/src/domain/contexts/viewHistory.ts
+++ b/packages/rum-core/src/domain/contexts/viewHistory.ts
@@ -19,6 +19,7 @@ export interface ViewHistory {
   findView: (startTime?: RelativeTime) => ViewHistoryEntry | undefined
   stop: () => void
   getAllEntries: () => Context[]
+  getDeletedEntries: () => RelativeTime[]
 }
 
 export function startViewHistory(lifeCycle: LifeCycle): ViewHistory {
@@ -60,6 +61,7 @@ export function startViewHistory(lifeCycle: LifeCycle): ViewHistory {
   return {
     findView: (startTime) => viewValueHistory.find(startTime),
     getAllEntries: () => viewValueHistory.getAllEntries(),
+    getDeletedEntries: () => viewValueHistory.getDeletedEntries(),
     stop: () => {
       viewValueHistory.stop()
     },

--- a/packages/rum-core/test/mockContexts.ts
+++ b/packages/rum-core/test/mockContexts.ts
@@ -20,6 +20,7 @@ export function mockViewHistory(view?: Partial<ViewHistoryEntry>): ViewHistory {
     findView: () => view as ViewHistoryEntry,
     stop: noop,
     getAllEntries: () => [],
+    getDeletedEntries: () => [],
   }
 }
 


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/browser-sdk/pull/3304

## Changes

- Add telemetry to collect deleted context history entries
- Add a feature flag to collect the telemetry only on org2

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
