### PR TITLE
🔥 Remove RumContext type

### DIFF
--- a/packages/rum-core/src/browser/viewportObservable.ts
+++ b/packages/rum-core/src/browser/viewportObservable.ts
@@ -4,6 +4,7 @@ import type { RumConfiguration } from '../domain/configuration'
 export interface ViewportDimension {
   height: number
   width: number
+  [k: string]: unknown
 }
 
 let viewportObservable: Observable<ViewportDimension> | undefined

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -14,15 +14,9 @@ import {
   addTelemetryDebug,
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
-import type {
-  RawRumErrorEvent,
-  RawRumEvent,
-  RawRumLongTaskEvent,
-  RawRumResourceEvent,
-  RumContext,
-} from '../rawRumEvent.types'
+import type { RawRumErrorEvent, RawRumEvent, RawRumLongTaskEvent, RawRumResourceEvent } from '../rawRumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
-import type { RumEvent } from '../rumEvent.types'
+import type { CommonProperties, RumEvent } from '../rumEvent.types'
 import type { FeatureFlagContexts } from './contexts/featureFlagContext'
 import { getSyntheticsContext } from './contexts/syntheticsContext'
 import type { CiVisibilityContext } from './contexts/ciVisibilityContext'
@@ -162,7 +156,7 @@ export function startRumAssembly(
         const commonContext = savedCommonContext || getCommonContext()
         const actionId = actionContexts.findActionId(startTime)
 
-        const rumContext: RumContext = {
+        const rumContext: CommonProperties = {
           _dd: {
             format_version: 2,
             drift: currentDrift(),
@@ -206,7 +200,7 @@ export function startRumAssembly(
           connectivity: getConnectivity(),
         }
 
-        const serverRumEvent = combine(rumContext as RumContext & Context, rawRumEvent) as RumEvent & Context
+        const serverRumEvent = combine(rumContext, rawRumEvent) as RumEvent & Context
         serverRumEvent.context = combine(commonContext.context, viewHistoryEntry.context, customerContext)
 
         if (!('has_replay' in serverRumEvent.session)) {

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -1,5 +1,4 @@
 import type {
-  Context,
   Duration,
   ErrorSource,
   ErrorHandling,
@@ -8,7 +7,6 @@ import type {
   TimeStamp,
   RawErrorCause,
   DefaultPrivacyLevel,
-  Connectivity,
   Csp,
 } from '@datadog/browser-core'
 import type { PageState } from './domain/contexts/pageStateHistory'
@@ -338,51 +336,3 @@ export type RawRumEvent =
   | RawRumLongAnimationFrameEvent
   | RawRumActionEvent
   | RawRumVitalEvent
-
-export interface RumContext {
-  date: TimeStamp
-  application: {
-    id: string
-  }
-  service?: string
-  version?: string
-  source: 'browser'
-  session: {
-    id: string
-    type: string
-    has_replay?: boolean
-  }
-  display?: {
-    viewport: {
-      width: number
-      height: number
-    }
-  }
-  view: {
-    id: string
-    referrer?: string
-    url: string
-    name?: string
-  }
-  connectivity: Connectivity
-  action?: {
-    id: string | string[]
-  }
-  feature_flags?: Context
-  synthetics?: {
-    test_id: string
-    result_id: string
-  }
-  ci_test?: {
-    test_execution_id: string
-  }
-  _dd: {
-    format_version: 2
-    drift: number
-    configuration: {
-      session_sample_rate: number
-      session_replay_sample_rate: number
-    }
-    browser_sdk_version?: string
-  }
-}

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1382,7 +1382,7 @@ export interface CommonProperties {
     /**
      * Cellular connection type reflecting the measured network performance
      */
-    readonly effective_type?: 'slow_2g' | '2g' | '3g' | '4g'
+    readonly effective_type?: 'slow-2g' | '2g' | '3g' | '4g'
     /**
      * Cellular connectivity properties
      */

--- a/packages/rum-core/test/formatValidation.ts
+++ b/packages/rum-core/test/formatValidation.ts
@@ -2,9 +2,10 @@ import ajv from 'ajv'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 import type { TimeStamp, Context } from '@datadog/browser-core'
 import { combine } from '@datadog/browser-core'
+import type { CommonProperties } from '@datadog/browser-rum-core'
 import type { LifeCycle, RawRumEventCollectedData } from '../src/domain/lifeCycle'
 import { LifeCycleEventType } from '../src/domain/lifeCycle'
-import type { RawRumEvent, RumContext } from '../src/rawRumEvent.types'
+import type { RawRumEvent } from '../src/rawRumEvent.types'
 import { allJsonSchemas } from './allJsonSchemas'
 
 export function collectAndValidateRawRumEvents(lifeCycle: LifeCycle) {
@@ -22,7 +23,7 @@ export function collectAndValidateRawRumEvents(lifeCycle: LifeCycle) {
 
 function validateRumEventFormat(rawRumEvent: RawRumEvent) {
   const fakeId = '00000000-aaaa-0000-aaaa-000000000000'
-  const fakeContext: RumContext = {
+  const fakeContext: CommonProperties = {
     _dd: {
       format_version: 2,
       drift: 0,
@@ -51,7 +52,7 @@ function validateRumEventFormat(rawRumEvent: RawRumEvent) {
       effective_type: '4g',
     },
   }
-  validateRumFormat(combine(fakeContext as RumContext & Context, rawRumEvent))
+  validateRumFormat(combine(fakeContext as CommonProperties & Context, rawRumEvent))
 }
 
 function validateRumFormat(rumEvent: Context) {


### PR DESCRIPTION
## Motivation

Remove `RumContext` type in favor of  `CommonProperties` type which is auto generated by the rum event format. 

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
