### PR TITLE
✨ [RUM-7459] Collect error context from a custom Error field

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.spec.ts
+++ b/packages/core/src/domain/console/consoleObservable.spec.ts
@@ -128,4 +128,15 @@ describe('console error observable', () => {
     const consoleLog = notifyLog.calls.mostRecent().args[0]
     expect(consoleLog.error.fingerprint).toBe('2')
   })
+
+  it('should retrieve context from error', () => {
+    interface DatadogError extends Error {
+      dd_context?: Record<string, unknown>
+    }
+    const error = new Error('foo')
+    ;(error as DatadogError).dd_context = { foo: 'bar' }
+    console.error(error)
+    const consoleLog = notifyLog.calls.mostRecent().args[0]
+    expect(consoleLog.error.context).toEqual({ foo: 'bar' })
+  })
 })

--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -1,4 +1,4 @@
-import { flattenErrorCauses, isError, tryToGetFingerprint } from '../error/error'
+import { flattenErrorCauses, isError, tryToGetFingerprint, tryToGetErrorContext } from '../error/error'
 import { mergeObservables, Observable } from '../../tools/observable'
 import { ConsoleApiName, globalConsole } from '../../tools/display'
 import { callMonitored } from '../../tools/monitor'
@@ -84,6 +84,7 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
       source: ErrorSource.CONSOLE,
       handling: ErrorHandling.HANDLED,
       handlingStack,
+      context: tryToGetErrorContext(firstErrorParam),
     }
   }
 

--- a/packages/core/src/domain/error/error.spec.ts
+++ b/packages/core/src/domain/error/error.spec.ts
@@ -313,3 +313,24 @@ describe('isError', () => {
     expect(isError(new iframeWindow.Error())).toBe(true)
   })
 })
+
+describe('tryToGetContext', () => {
+  it('should extract dd_context from an error object', () => {
+    const context = { key: 'value' }
+    const error = new Error('Test error') as any
+    error.dd_context = context
+
+    const rawError = computeRawError({
+      stackTrace: undefined,
+      originalError: error,
+      handlingStack: undefined,
+      componentStack: undefined,
+      startClocks: clocksNow(),
+      nonErrorPrefix: NonErrorPrefix.UNCAUGHT,
+      source: ErrorSource.CUSTOM,
+      handling: ErrorHandling.HANDLED,
+    })
+
+    expect(rawError.context).toEqual(context)
+  })
+})

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -92,7 +92,6 @@ export function tryToGetErrorContext(originalError: unknown) {
   if (originalError !== null && typeof originalError === 'object' && 'dd_context' in originalError) {
     return originalError.dd_context as Context
   }
-  return undefined
 }
 
 export function getFileFromStackTraceString(stack: string) {

--- a/packages/core/src/domain/error/error.types.ts
+++ b/packages/core/src/domain/error/error.types.ts
@@ -1,3 +1,4 @@
+import type { Context } from '../../tools/serialisation/context'
 import type { ClocksState } from '../../tools/utils/timeUtils'
 
 // TS v4.6 introduced Error.cause[1] typed as `Error`. TS v4.8 changed Error.cause to be
@@ -37,6 +38,7 @@ export interface RawError {
   causes?: RawErrorCause[]
   fingerprint?: string
   csp?: Csp
+  context?: Context
 }
 
 export const ErrorSource = {

--- a/packages/logs/src/domain/console/consoleCollection.ts
+++ b/packages/logs/src/domain/console/consoleCollection.ts
@@ -31,6 +31,7 @@ export function startConsoleCollection(configuration: LogsConfiguration, lifeCyc
         error: log.error && createErrorFieldFromRawError(log.error),
         status: LogStatusForApi[log.api],
       },
+      messageContext: log.error?.context,
       domainContext: {
         handlingStack: log.handlingStack,
       },

--- a/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
+++ b/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
@@ -20,6 +20,9 @@ describe('createErrorFieldFromRawError', () => {
     csp: {
       disposition: 'enforce',
     },
+    context: {
+      foo: 'bar',
+    },
   }
 
   it('creates an error field from a raw error', () => {

--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -158,7 +158,12 @@ describe('Logger', () => {
               message: 'High level error',
               handling: ErrorHandling.HANDLED,
               causes: [
-                { message: 'Mid level error', source: 'logger', type: 'Error', stack: 'Error: Mid level error' },
+                {
+                  message: 'Mid level error',
+                  source: 'logger',
+                  type: 'Error',
+                  stack: 'Error: Mid level error',
+                },
                 {
                   message: 'Low level error',
                   source: 'logger',

--- a/packages/logs/src/domain/report/reportCollection.ts
+++ b/packages/logs/src/domain/report/reportCollection.ts
@@ -33,7 +33,6 @@ export function startReportCollection(configuration: LogsConfiguration, lifeCycl
         error,
         status,
       },
-      messageContext: rawError.context,
     })
   })
 

--- a/packages/logs/src/domain/report/reportCollection.ts
+++ b/packages/logs/src/domain/report/reportCollection.ts
@@ -33,6 +33,7 @@ export function startReportCollection(configuration: LogsConfiguration, lifeCycl
         error,
         status,
       },
+      messageContext: rawError.context,
     })
   })
 

--- a/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
+++ b/packages/logs/src/domain/runtimeError/runtimeErrorCollection.spec.ts
@@ -121,4 +121,22 @@ describe('runtime error collection', () => {
       done()
     }, 10)
   })
+
+  it('should retrieve dd_context from runtime errors', (done) => {
+    interface DatadogError extends Error {
+      dd_context?: Record<string, unknown>
+    }
+
+    const error = new Error('Error with dd_context') as DatadogError
+    error.dd_context = { foo: 'barr' }
+    ;({ stop: stopRuntimeErrorCollection } = startRuntimeErrorCollection(configuration, lifeCycle))
+    setTimeout(() => {
+      throw error
+    })
+
+    setTimeout(() => {
+      expect(rawLogsEvents[0].messageContext).toEqual({ foo: 'barr' })
+      done()
+    }, 10)
+  })
 })

--- a/packages/logs/src/domain/runtimeError/runtimeErrorCollection.ts
+++ b/packages/logs/src/domain/runtimeError/runtimeErrorCollection.ts
@@ -31,6 +31,7 @@ export function startRuntimeErrorCollection(configuration: LogsConfiguration, li
         origin: ErrorSource.SOURCE,
         status: StatusType.error,
       },
+      messageContext: rawError.context,
     })
   })
 

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -301,5 +301,23 @@ describe('error collection', () => {
 
       expect((rawRumEvents[0].rawRumEvent as RawRumErrorEvent).error.csp?.disposition).toEqual('enforce')
     })
+
+    it('should merge dd_context from the original error with addError context', () => {
+      setupErrorCollection()
+      const error = new Error('foo')
+      ;(error as any).dd_context = { component: 'Menu', param: 123 }
+
+      addError({
+        error,
+        context: { user: 'john' },
+        handlingStack: 'Error: handling dd_context',
+        startClocks: { relative: 500 as RelativeTime, timeStamp: 500000 as TimeStamp },
+      })
+      expect(rawRumEvents[0].customerContext).toEqual({
+        component: 'Menu',
+        param: 123,
+        user: 'john',
+      })
+    })
   })
 })

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -49,7 +49,7 @@ export function startErrorCollection(
 
 export function doStartErrorCollection(lifeCycle: LifeCycle, pageStateHistory: PageStateHistory) {
   lifeCycle.subscribe(LifeCycleEventType.RAW_ERROR_COLLECTED, ({ error, customerContext, savedCommonContext }) => {
-    customerContext = combine(tryToGetErrorContext(error.originalError), customerContext) as Context
+    customerContext = combine(error.context, customerContext)
     lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
       customerContext,
       savedCommonContext,
@@ -114,11 +114,4 @@ function processError(error: RawError, pageStateHistory: PageStateHistory): RawR
     startTime: error.startClocks.relative,
     domainContext,
   }
-}
-
-function tryToGetErrorContext(originalError: unknown) {
-  if (originalError !== null && typeof originalError === 'object' && 'dd_context' in originalError) {
-    return originalError.dd_context as Context
-  }
-  return undefined
 }

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -117,7 +117,7 @@ function processError(error: RawError, pageStateHistory: PageStateHistory): RawR
 }
 
 function tryToGetErrorContext(originalError: unknown) {
-  if (isError(originalError) && 'dd_context' in originalError) {
+  if (originalError !== null && typeof originalError === 'object' && 'dd_context' in originalError) {
     return originalError.dd_context as Context
   }
   return undefined

--- a/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
@@ -33,11 +33,12 @@ describe('trackConsoleError', () => {
       startClocks: clocksNow(),
       message: jasmine.any(String),
       stack: jasmine.any(String),
-      fingerprint: undefined,
       source: ErrorSource.CONSOLE,
       handling: ErrorHandling.HANDLED,
       handlingStack: jasmine.any(String),
+      fingerprint: undefined,
       causes: undefined,
+      context: undefined,
     })
   })
 
@@ -60,6 +61,7 @@ describe('trackConsoleError', () => {
       handlingStack: jasmine.any(String),
       fingerprint: 'my-fingerprint',
       causes: undefined,
+      context: undefined,
     })
   })
 })


### PR DESCRIPTION
## Motivation

When throwing an exception in an App, Browser SDK users sometimes want to provide more context that is only accessible locally when the error is constructed.

## Changes

support error.dd_context as a custom error property

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
