### PR TITLE
✨ Allow to modify source_url property in Loaf script attributions

### DIFF
--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -100,6 +100,7 @@ export function startRumAssembly(
       ...ROOT_MODIFIABLE_FIELD_PATHS,
     },
     [RumEventType.LONG_TASK]: {
+      'long_task.scripts[].source_url': 'string',
       ...USER_CUSTOMIZABLE_FIELD_PATHS,
       ...VIEW_MODIFIABLE_FIELD_PATHS,
     },

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -101,6 +101,7 @@ export function startRumAssembly(
     },
     [RumEventType.LONG_TASK]: {
       'long_task.scripts[].source_url': 'string',
+      'long_task.scripts[].invoker': 'string',
       ...USER_CUSTOMIZABLE_FIELD_PATHS,
       ...VIEW_MODIFIABLE_FIELD_PATHS,
     },

--- a/packages/rum-core/src/domain/limitModification.ts
+++ b/packages/rum-core/src/domain/limitModification.ts
@@ -4,8 +4,9 @@ import type { Context } from '@datadog/browser-core'
 export type ModifiableFieldPaths = Record<string, 'string' | 'object'>
 
 /**
- * Current limitation:
- * - field path do not support array, 'a.b.c' only
+ * Allows declaring and enforcing modifications to specific fields of an object.
+ * Only supports modifying properties of an object (even if nested in an array).
+ * Does not support array manipulation (adding/removing items).
  */
 export function limitModification<T extends Context, Result>(
   object: T,
@@ -14,43 +15,85 @@ export function limitModification<T extends Context, Result>(
 ): Result | undefined {
   const clone = deepClone(object)
   const result = modifier(clone)
+
+  // Validate the modified fields and assign them back to 'original' if they match the expected type.
   objectEntries(modifiableFieldPaths).forEach(([fieldPath, fieldType]) => {
-    const newValue = get(clone, fieldPath)
-    const newType = getType(newValue)
-    if (newType === fieldType) {
-      set(object, fieldPath, sanitize(newValue))
+    const pathSegments = fieldPath.split('.')
+    const newValue = getValueFromPath(clone, pathSegments)
+    const newType = getTypes(newValue)
+
+    if (isValidType(newType, fieldType)) {
+      setValueAtPath(object, pathSegments, sanitizeValues(newValue))
     } else if (fieldType === 'object' && (newType === 'undefined' || newType === 'null')) {
-      set(object, fieldPath, {})
+      setValueAtPath(object, pathSegments, {})
     }
   })
+
   return result
 }
 
-function get(object: unknown, path: string) {
-  let current = object
-  for (const field of path.split('.')) {
-    if (!isValidObjectContaining(current, field)) {
+function getValueFromPath(object: unknown, pathSegments: string[]): unknown {
+  let [field, ...restPathSegments] = pathSegments // eslint-disable-line prefer-const
+
+  // Handle array-access notation "something[]"
+  if (field.endsWith('[]')) {
+    field = field.slice(0, -2)
+
+    if (!isValidObjectContaining(object, field) || !Array.isArray(object[field])) {
       return
     }
-    current = current[field]
+
+    return (object[field] as unknown[]).map((item) => getValueFromPath(item, restPathSegments))
   }
-  return current
+
+  return getNestedValue(object, pathSegments)
 }
 
-function set(object: unknown, path: string, value: unknown) {
-  let current = object
-  const fields = path.split('.')
-  for (let i = 0; i < fields.length; i += 1) {
-    const field = fields[i]
-    if (!isValidObject(current)) {
+function getNestedValue(object: unknown, pathSegments: string[]): unknown {
+  const [field, ...restPathSegments] = pathSegments
+
+  if (!isValidObjectContaining(object, field)) {
+    return
+  }
+
+  if (restPathSegments.length === 0) {
+    return object[field]
+  }
+
+  return getValueFromPath(object[field], restPathSegments)
+}
+
+function setValueAtPath(object: unknown, pathSegments: string[], value: unknown) {
+  let [field, ...restPathSegments] = pathSegments // eslint-disable-line prefer-const
+
+  // Handle array-access notation "something[]"
+  if (field.endsWith('[]')) {
+    field = field.slice(0, -2)
+
+    if (!isValidObjectContaining(object, field) || !Array.isArray(object[field]) || !Array.isArray(value)) {
       return
     }
-    if (i !== fields.length - 1) {
-      current = current[field]
-    } else {
-      current[field] = value
-    }
+
+    ;(object[field] as unknown[]).forEach((item, i) => setValueAtPath(item, restPathSegments, value[i]))
+    return
   }
+
+  setNestedValue(object, pathSegments, value)
+}
+
+function setNestedValue(object: unknown, pathSegments: string[], value: unknown) {
+  const [field, ...restPathSegments] = pathSegments
+
+  if (!isValidObject(object)) {
+    return
+  }
+
+  if (restPathSegments.length === 0) {
+    object[field] = value
+    return
+  }
+
+  setValueAtPath(object[field], restPathSegments, value)
 }
 
 function isValidObject(object: unknown): object is Record<string, unknown> {
@@ -59,4 +102,28 @@ function isValidObject(object: unknown): object is Record<string, unknown> {
 
 function isValidObjectContaining(object: unknown, field: string): object is Record<string, unknown> {
   return isValidObject(object) && Object.prototype.hasOwnProperty.call(object, field)
+}
+
+function isValidType(actualType: string | string[], expectedType: 'string' | 'object'): boolean {
+  if (Array.isArray(actualType)) {
+    return actualType.length > 0 && actualType.every((type) => type === expectedType)
+  }
+
+  return actualType === expectedType
+}
+
+function sanitizeValues(thing: unknown) {
+  if (Array.isArray(thing)) {
+    return thing.map((item) => sanitize(item))
+  }
+
+  return sanitize(thing)
+}
+
+function getTypes(thing: unknown) {
+  if (Array.isArray(thing)) {
+    return thing.map((item) => getType(item))
+  }
+
+  return getType(thing)
 }

--- a/packages/rum-core/src/domain/limitModification.ts
+++ b/packages/rum-core/src/domain/limitModification.ts
@@ -28,11 +28,10 @@ function setValueAtPath(object: unknown, clone: unknown, pathSegments: string[],
   const [field, ...restPathSegments] = pathSegments
 
   if (field === '[]') {
-    if (!Array.isArray(object) || !Array.isArray(clone)) {
-      return
+    if (Array.isArray(object) && Array.isArray(clone)) {
+      object.forEach((item, i) => setValueAtPath(item, clone[i], restPathSegments, fieldType))
     }
 
-    object.forEach((item, i) => setValueAtPath(item, clone[i], restPathSegments, fieldType))
     return
   }
 

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -516,7 +516,7 @@ export type RumLongTaskEvent = CommonProperties &
         /**
          * The script resource name where available (or empty if not found)
          */
-        readonly source_url?: string
+        source_url?: string
         /**
          * The script function name where available (or empty if not found)
          */
@@ -528,7 +528,7 @@ export type RumLongTaskEvent = CommonProperties &
         /**
          * Information about the invoker of the script
          */
-        readonly invoker?: string
+        invoker?: string
         /**
          * Type of the invoker of the script
          */


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

We want to be able to modify `source_url` and `invoker` properties of Loaf script attributions from the `beforeSend` function. This allow customer to scrub urls for potential PII.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

Refactor `limitModification` to allow arrays to be present in the path. (e.g. `long_task.scripts[].source_url` will allow to modify `source_url` in long tasks (LoaF) events

Allow modification on `long_task.scripts[].source_url` and `long_task.scripts[].invoker`


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
