### PR TITLE
🐛 [RUM-8429] Report an error when lazy loading the recorder module fails

### DIFF
--- a/packages/rum/src/boot/lazyLoadRecorder.spec.ts
+++ b/packages/rum/src/boot/lazyLoadRecorder.spec.ts
@@ -1,0 +1,106 @@
+import type { DeflateWorker, RawTelemetryEvent } from '@datadog/browser-core'
+import { display, resetTelemetry, startFakeTelemetry } from '@datadog/browser-core'
+import type { RecorderApi, RumSessionManager } from '@datadog/browser-rum-core'
+import { LifeCycle } from '@datadog/browser-rum-core'
+import { registerCleanupTask, wait } from '@datadog/browser-core/test'
+import { createRumSessionManagerMock, mockRumConfiguration, mockViewHistory } from '../../../rum-core/test'
+import type { CreateDeflateWorker } from '../domain/deflate'
+import { MockWorker } from '../../test'
+import { resetDeflateWorkerState } from '../domain/deflate'
+import * as replayStats from '../domain/replayStats'
+import { makeRecorderApi } from './recorderApi'
+import type { StartRecording } from './postStartStrategy'
+import { lazyLoadRecorder } from './lazyLoadRecorder'
+
+describe('lazyLoadRecorder', () => {
+  let displaySpy: jasmine.Spy
+  let telemetryEvents: RawTelemetryEvent[]
+  let lifeCycle: LifeCycle
+  let recorderApi: RecorderApi
+  let startRecordingSpy: jasmine.Spy
+  let loadRecorderSpy: jasmine.Spy<() => Promise<StartRecording>>
+  let stopRecordingSpy: jasmine.Spy<() => void>
+  let mockWorker: MockWorker
+  let createDeflateWorkerSpy: jasmine.Spy<CreateDeflateWorker>
+  let rumInit: (options?: { worker?: DeflateWorker }) => void
+
+  function setupRecorderApi({
+    loadRecorderError,
+    sessionManager,
+    startSessionReplayRecordingManually,
+  }: {
+    loadRecorderError?: Error
+    sessionManager?: RumSessionManager
+    startSessionReplayRecordingManually?: boolean
+  } = {}) {
+    telemetryEvents = startFakeTelemetry()
+    mockWorker = new MockWorker()
+    createDeflateWorkerSpy = jasmine.createSpy('createDeflateWorkerSpy').and.callFake(() => mockWorker)
+    displaySpy = spyOn(display, 'error')
+
+    lifeCycle = new LifeCycle()
+    stopRecordingSpy = jasmine.createSpy('stopRecording')
+    startRecordingSpy = jasmine.createSpy('startRecording')
+
+    // Workaround because using resolveTo(startRecordingSpy) was not working
+    loadRecorderSpy = jasmine.createSpy('loadRecorder').and.resolveTo((...args: any) => {
+      if (loadRecorderError) {
+        return lazyLoadRecorder(() => Promise.reject(loadRecorderError))
+      }
+      startRecordingSpy(...args)
+      return {
+        stop: stopRecordingSpy,
+      }
+    })
+
+    recorderApi = makeRecorderApi(loadRecorderSpy, createDeflateWorkerSpy)
+    rumInit = ({ worker } = {}) => {
+      recorderApi.onRumStart(
+        lifeCycle,
+        mockRumConfiguration({ startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false }),
+        sessionManager ?? createRumSessionManagerMock().setId('1234'),
+        mockViewHistory(),
+        worker
+      )
+    }
+
+    registerCleanupTask(() => {
+      resetDeflateWorkerState()
+      replayStats.resetReplayStats()
+      resetTelemetry()
+    })
+  }
+
+  it('should report an error but no telemetry if CSP blocks the module', async () => {
+    const loadRecorderError = new Error('Dynamic import was blocked due to Content Security Policy')
+    setupRecorderApi({
+      loadRecorderError,
+      startSessionReplayRecordingManually: true,
+    })
+    rumInit()
+    recorderApi.start()
+    expect(loadRecorderSpy).toHaveBeenCalled()
+
+    await wait(0)
+
+    expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Recorder failed to start'), loadRecorderError)
+    expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Please make sure CSP is correctly configured'))
+    expect(telemetryEvents.length).toBe(0)
+  })
+
+  it('should report an error but no telemetry if importing fails for non-CSP reasons', async () => {
+    const loadRecorderError = new Error('Dynamic import failed')
+    setupRecorderApi({
+      loadRecorderError,
+      startSessionReplayRecordingManually: true,
+    })
+    rumInit()
+    recorderApi.start()
+    expect(loadRecorderSpy).toHaveBeenCalled()
+
+    await wait(0)
+
+    expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Recorder failed to start'), loadRecorderError)
+    expect(telemetryEvents.length).toBe(0)
+  })
+})

--- a/packages/rum/src/boot/lazyLoadRecorder.ts
+++ b/packages/rum/src/boot/lazyLoadRecorder.ts
@@ -1,18 +1,11 @@
 import { reportScriptLoadingError } from '../domain/scriptLoadingError'
 import type { startRecording } from './startRecording'
 
-export function lazyLoadRecorder() {
-  return lazyLoadRecorderFrom(async () => {
-    const module = await import(/* webpackChunkName: "recorder" */ './startRecording')
-    return module.startRecording
-  })
-}
-
-export async function lazyLoadRecorderFrom(
-  importer: () => Promise<typeof startRecording>
+export async function lazyLoadRecorder(
+  importRecorderImpl = importRecorder
 ): Promise<typeof startRecording | undefined> {
   try {
-    return await importer()
+    return await importRecorderImpl()
   } catch (error: unknown) {
     reportScriptLoadingError({
       error,
@@ -20,4 +13,9 @@ export async function lazyLoadRecorderFrom(
       scriptType: 'module',
     })
   }
+}
+
+async function importRecorder() {
+  const module = await import(/* webpackChunkName: "recorder" */ './startRecording')
+  return module.startRecording
 }

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -1,8 +1,8 @@
-import type { DeflateEncoder, DeflateWorker, DeflateWorkerAction } from '@datadog/browser-core'
-import { BridgeCapability, PageExitReason, display } from '@datadog/browser-core'
+import type { DeflateEncoder, DeflateWorker, DeflateWorkerAction, RawTelemetryEvent } from '@datadog/browser-core'
+import { BridgeCapability, PageExitReason, display, resetTelemetry, startFakeTelemetry } from '@datadog/browser-core'
 import type { RecorderApi, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
-import { collectAsyncCalls, mockEventBridge, registerCleanupTask } from '@datadog/browser-core/test'
+import { collectAsyncCalls, mockEventBridge, registerCleanupTask, wait } from '@datadog/browser-core/test'
 import type { RumSessionManagerMock } from '../../../rum-core/test'
 import {
   createRumSessionManagerMock,
@@ -16,8 +16,11 @@ import { resetDeflateWorkerState } from '../domain/deflate'
 import * as replayStats from '../domain/replayStats'
 import { makeRecorderApi } from './recorderApi'
 import type { StartRecording } from './postStartStrategy'
+import { lazyLoadRecorderFrom } from './lazyLoadRecorder'
 
 describe('makeRecorderApi', () => {
+  let displaySpy: jasmine.Spy
+  let telemetryEvents: RawTelemetryEvent[]
   let lifeCycle: LifeCycle
   let recorderApi: RecorderApi
   let startRecordingSpy: jasmine.Spy
@@ -28,12 +31,18 @@ describe('makeRecorderApi', () => {
   let rumInit: (options?: { worker?: DeflateWorker }) => void
 
   function setupRecorderApi({
+    loadRecorderError,
     sessionManager,
     startSessionReplayRecordingManually,
-  }: { sessionManager?: RumSessionManager; startSessionReplayRecordingManually?: boolean } = {}) {
+  }: {
+    loadRecorderError?: Error
+    sessionManager?: RumSessionManager
+    startSessionReplayRecordingManually?: boolean
+  } = {}) {
+    telemetryEvents = startFakeTelemetry()
     mockWorker = new MockWorker()
     createDeflateWorkerSpy = jasmine.createSpy('createDeflateWorkerSpy').and.callFake(() => mockWorker)
-    spyOn(display, 'error')
+    displaySpy = spyOn(display, 'error')
 
     lifeCycle = new LifeCycle()
     stopRecordingSpy = jasmine.createSpy('stopRecording')
@@ -41,6 +50,9 @@ describe('makeRecorderApi', () => {
 
     // Workaround because using resolveTo(startRecordingSpy) was not working
     loadRecorderSpy = jasmine.createSpy('loadRecorder').and.resolveTo((...args: any) => {
+      if (loadRecorderError) {
+        return lazyLoadRecorderFrom(() => Promise.reject(loadRecorderError))
+      }
       startRecordingSpy(...args)
       return {
         stop: stopRecordingSpy,
@@ -61,6 +73,7 @@ describe('makeRecorderApi', () => {
     registerCleanupTask(() => {
       resetDeflateWorkerState()
       replayStats.resetReplayStats()
+      resetTelemetry()
     })
   }
 
@@ -258,6 +271,43 @@ describe('makeRecorderApi', () => {
 
         expect(loadRecorderSpy).not.toHaveBeenCalled()
         expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('while lazy loading the recorder module', () => {
+      it('should report an error but no telemetry if CSP blocks the module', async () => {
+        const loadRecorderError = new Error('Dynamic import was blocked due to Content Security Policy')
+        setupRecorderApi({
+          loadRecorderError,
+          startSessionReplayRecordingManually: true,
+        })
+        rumInit()
+        recorderApi.start()
+        expect(loadRecorderSpy).toHaveBeenCalled()
+
+        await wait(0)
+
+        expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Recorder failed to start'), loadRecorderError)
+        expect(displaySpy).toHaveBeenCalledWith(
+          jasmine.stringContaining('Please make sure CSP is correctly configured')
+        )
+        expect(telemetryEvents.length).toBe(0)
+      })
+
+      it('should report an error and send telemetry if importing fails for non-CSP reasons', async () => {
+        const loadRecorderError = new Error('Dynamic import failed')
+        setupRecorderApi({
+          loadRecorderError,
+          startSessionReplayRecordingManually: true,
+        })
+        rumInit()
+        recorderApi.start()
+        expect(loadRecorderSpy).toHaveBeenCalled()
+
+        await wait(0)
+
+        expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Recorder failed to start'), loadRecorderError)
+        expect(telemetryEvents.length).toBeGreaterThan(0)
       })
     })
 

--- a/packages/rum/src/domain/deflate/deflateWorker.spec.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.spec.ts
@@ -151,7 +151,7 @@ describe('startDeflateWorker', () => {
         mockWorker.dispatchErrorEvent()
         expect(displaySpy).toHaveBeenCalledWith(
           jasmine.stringContaining(
-            'Please make sure the Worker URL /worker.js is correct and CSP is correctly configured.'
+            'Please make sure the worker URL /worker.js is correct and CSP is correctly configured.'
           )
         )
       })
@@ -218,7 +218,7 @@ describe('startDeflateWorker', () => {
       createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
       startDeflateWorkerWithDefaults()
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Session Replay failed to start: an error occurred while creating the Worker:',
+        'Session Replay failed to start: an error occurred while initializing the worker:',
         UNKNOWN_ERROR
       )
     })
@@ -227,7 +227,7 @@ describe('startDeflateWorker', () => {
       createDeflateWorkerSpy.and.throwError(UNKNOWN_ERROR)
       startDeflateWorkerWithDefaults({ source: 'Foo' })
       expect(displaySpy).toHaveBeenCalledOnceWith(
-        'Foo failed to start: an error occurred while creating the Worker:',
+        'Foo failed to start: an error occurred while initializing the worker:',
         UNKNOWN_ERROR
       )
     })

--- a/packages/rum/src/domain/deflate/deflateWorker.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.ts
@@ -142,7 +142,7 @@ function onError(configuration: RumConfiguration, source: string, error: unknown
       configuredUrl: configuration.workerUrl,
       error,
       source,
-      scriptType: 'Worker',
+      scriptType: 'worker',
     })
     if (state.status === DeflateWorkerStatus.Loading) {
       state.initializationFailureCallbacks.forEach((callback) => callback())

--- a/packages/rum/src/domain/deflate/deflateWorker.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.ts
@@ -1,13 +1,7 @@
 import type { DeflateWorker, DeflateWorkerResponse } from '@datadog/browser-core'
-import {
-  addTelemetryError,
-  display,
-  addEventListener,
-  setTimeout,
-  ONE_SECOND,
-  DOCS_ORIGIN,
-} from '@datadog/browser-core'
+import { addTelemetryError, display, addEventListener, setTimeout, ONE_SECOND } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
+import { reportScriptLoadingError } from '../scriptLoadingError'
 
 export const INITIALIZATION_TIME_OUT_DELAY = 30 * ONE_SECOND
 
@@ -144,20 +138,12 @@ function onInitialized(version: string) {
 
 function onError(configuration: RumConfiguration, source: string, error: unknown, streamId?: number) {
   if (state.status === DeflateWorkerStatus.Loading || state.status === DeflateWorkerStatus.Nil) {
-    display.error(`${source} failed to start: an error occurred while creating the Worker:`, error)
-    if (error instanceof Event || (error instanceof Error && isMessageCspRelated(error.message))) {
-      let baseMessage
-      if (configuration.workerUrl) {
-        baseMessage = `Please make sure the Worker URL ${configuration.workerUrl} is correct and CSP is correctly configured.`
-      } else {
-        baseMessage = 'Please make sure CSP is correctly configured.'
-      }
-      display.error(
-        `${baseMessage} See documentation at ${DOCS_ORIGIN}/integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay`
-      )
-    } else {
-      addTelemetryError(error)
-    }
+    reportScriptLoadingError({
+      configuredUrl: configuration.workerUrl,
+      error,
+      source,
+      scriptType: 'Worker',
+    })
     if (state.status === DeflateWorkerStatus.Loading) {
       state.initializationFailureCallbacks.forEach((callback) => callback())
     }
@@ -168,12 +154,4 @@ function onError(configuration: RumConfiguration, source: string, error: unknown
       stream_id: streamId,
     })
   }
-}
-
-function isMessageCspRelated(message: string) {
-  return (
-    message.includes('Content Security Policy') ||
-    // Related to `require-trusted-types-for` CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for
-    message.includes("requires 'TrustedScriptURL'")
-  )
 }

--- a/packages/rum/src/domain/scriptLoadingError.ts
+++ b/packages/rum/src/domain/scriptLoadingError.ts
@@ -9,10 +9,9 @@ export function reportScriptLoadingError({
   configuredUrl?: string | undefined
   error: unknown
   source: string
-  scriptType: 'module' | 'Worker'
+  scriptType: 'module' | 'worker'
 }) {
-  const verb = scriptType === 'Worker' ? 'creating' : 'importing'
-  display.error(`${source} failed to start: an error occurred while ${verb} the ${scriptType}:`, error)
+  display.error(`${source} failed to start: an error occurred while initializing the ${scriptType}:`, error)
   if (error instanceof Event || (error instanceof Error && isMessageCspRelated(error.message))) {
     let baseMessage
     if (configuredUrl) {
@@ -23,7 +22,7 @@ export function reportScriptLoadingError({
     display.error(
       `${baseMessage} See documentation at ${DOCS_ORIGIN}/integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay`
     )
-  } else {
+  } else if (scriptType === 'worker') {
     addTelemetryError(error)
   }
 }

--- a/packages/rum/src/domain/scriptLoadingError.ts
+++ b/packages/rum/src/domain/scriptLoadingError.ts
@@ -1,0 +1,37 @@
+import { addTelemetryError, display, DOCS_ORIGIN } from '@datadog/browser-core'
+
+export function reportScriptLoadingError({
+  configuredUrl,
+  error,
+  source,
+  scriptType,
+}: {
+  configuredUrl?: string | undefined
+  error: unknown
+  source: string
+  scriptType: 'module' | 'Worker'
+}) {
+  const verb = scriptType === 'Worker' ? 'creating' : 'importing'
+  display.error(`${source} failed to start: an error occurred while ${verb} the ${scriptType}:`, error)
+  if (error instanceof Event || (error instanceof Error && isMessageCspRelated(error.message))) {
+    let baseMessage
+    if (configuredUrl) {
+      baseMessage = `Please make sure the ${scriptType} URL ${configuredUrl} is correct and CSP is correctly configured.`
+    } else {
+      baseMessage = 'Please make sure CSP is correctly configured.'
+    }
+    display.error(
+      `${baseMessage} See documentation at ${DOCS_ORIGIN}/integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay`
+    )
+  } else {
+    addTelemetryError(error)
+  }
+}
+
+function isMessageCspRelated(message: string) {
+  return (
+    message.includes('Content Security Policy') ||
+    // Related to `require-trusted-types-for` CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for
+    message.includes("requires 'TrustedScriptURL'")
+  )
+}


### PR DESCRIPTION
## Motivation

Lazy loading the recorder module can fail, either due to a customer-side issue (like a CSP misconfiguration) or due to an issue on our end (like failing to upload the chunk to the CDN). We should report an error when this happens and add telemetry.

The current situation is a bummer since the failure is totally silent; no error is reported anywhere. I spent quite a bit of time over the past couple of days trying to understand why one of my local changes wasn't working. The root cause turned out to be #3324; the problem would've been instantly obvious with the changes in this PR.

## Changes

This PR adapts the current error reporting we do when the compression worker fails to load so that it can be used for both the compression worker and the lazy loaded recorder module. We now use the same code in both places, so our existing infrastructure for detecting CSP-related errors can be reused.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
