### PR TITLE
🎨 Use a more specific chunk name for recorder

### DIFF
--- a/packages/rum/src/boot/lazyLoadRecorder.ts
+++ b/packages/rum/src/boot/lazyLoadRecorder.ts
@@ -1,6 +1,6 @@
 export async function lazyLoadRecorder() {
   try {
-    const module = await import(/* webpackChunkName: "recorder" */ './startRecording')
+    const module = await import(/* webpackChunkName: "datadog-recorder" */ './startRecording')
     return module.startRecording
   } catch {
     /* Prevent collecting the webpack ChunkLoadError as it is already collected as a RUM resource. */


### PR DESCRIPTION
## Motivation

When RUM SDK async loads recorder, it instructs webpack to use the name `recorder` for the chunk. Declarin a name is nice, as it keep awareness of the purpose of the file, but the name `recorder` might conflict with other people's chunk names.

## Changes

Simply rename recorder chunk name to `datadog-recorder`, making clear its origin and purpose, while avoiding possible conflicts.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

Build and check the chunk name in build output directory.

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.