### PR TITLE
[RUM-8526] Remove ff for action name masking

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -15,7 +15,6 @@ import { objectHasValue } from './utils/objectUtils'
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  ACTION_NAME_MASKING = 'action_name_masking',
   CONSISTENT_TRACE_SAMPLING = 'consistent_trace_sampling',
   MISSING_URL_CONTEXT_TELEMETRY = 'missing_url_context_telemetry',
 }

--- a/packages/rum-core/src/domain/action/actionCollection.spec.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.spec.ts
@@ -1,6 +1,6 @@
 import type { Duration, RelativeTime, ServerDuration, TimeStamp } from '@datadog/browser-core'
-import { ExperimentalFeature, Observable } from '@datadog/browser-core'
-import { createNewEvent, mockExperimentalFeatures, registerCleanupTask } from '@datadog/browser-core/test'
+import { Observable } from '@datadog/browser-core'
+import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RawRumActionEvent, RawRumEventCollectedData } from '@datadog/browser-rum-core'
 import { collectAndValidateRawRumEvents, mockPageStateHistory, mockRumConfiguration } from '../../../test'
 import type { RawRumEvent } from '../../rawRumEvent.types'
@@ -33,7 +33,6 @@ describe('actionCollection', () => {
   })
 
   it('should create action from auto action with name source', () => {
-    mockExperimentalFeatures([ExperimentalFeature.ACTION_NAME_MASKING])
     const event = createNewEvent('pointerup', { target: document.createElement('button') })
     lifeCycle.notify(LifeCycleEventType.AUTO_ACTION_COMPLETED, {
       counts: {

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -1,12 +1,5 @@
 import type { ClocksState, Context, Observable } from '@datadog/browser-core'
-import {
-  noop,
-  combine,
-  toServerDuration,
-  generateUUID,
-  ExperimentalFeature,
-  isExperimentalFeatureEnabled,
-} from '@datadog/browser-core'
+import { noop, combine, toServerDuration, generateUUID } from '@datadog/browser-core'
 import { discardNegativeDuration } from '../discardNegativeDuration'
 import type { RawRumActionEvent } from '../../rawRumEvent.types'
 import { ActionType, RumEventType } from '../../rawRumEvent.types'
@@ -93,9 +86,7 @@ function processAction(
           action: {
             target: action.target,
             position: action.position,
-            name_source: isExperimentalFeatureEnabled(ExperimentalFeature.ACTION_NAME_MASKING)
-              ? action.nameSource
-              : undefined,
+            name_source: action.nameSource,
           },
         },
       }

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -3,7 +3,7 @@ import { createTest, flushEvents, html, waitForServersIdle } from '../../lib/fra
 
 describe('action collection', () => {
   createTest('track a click action')
-    .withRum({ trackUserInteractions: true, enableExperimentalFeatures: ['action_name_masking'] })
+    .withRum({ trackUserInteractions: true })
     .withBody(html`
       <button>click me</button>
       <script>


### PR DESCRIPTION
## Motivation
Masquerade apps, login apps, etc. apps without authentication are not handled by current feature flag roll out workflows. This could cause different subdomains not covered with `dd-action-name` have arbitrary data in action names.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Remove feature flag of `action_name_masking`, so we have name_source everywhere with latest version.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
