### PR TITLE
🔥 remove some workarounds related to unsupported browsers

### DIFF
--- a/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
@@ -1,5 +1,5 @@
 import { appendElement } from '../../test'
-import { getSelectorFromElement, isSelectorUniqueAmongSiblings, supportScopeSelector } from './getSelectorFromElement'
+import { getSelectorFromElement, isSelectorUniqueAmongSiblings } from './getSelectorFromElement'
 
 describe('getSelectorFromElement', () => {
   afterEach(() => {
@@ -83,15 +83,7 @@ describe('getSelectorFromElement', () => {
             <div><button target></button></div>
           </main>
         `)
-      ).toBe(
-        supportScopeSelector()
-          ? 'BODY>MAIN>DIV>BUTTON'
-          : // Degraded support for browsers not supporting scoped selector: the selector is still
-            // correct, but its quality is a bit worse, as using a `nth-of-type` selector is a bit
-            // too specific and might not match if an element is conditionally inserted before the
-            // target.
-            'BODY>MAIN>DIV:nth-of-type(2)>BUTTON'
-      )
+      ).toBe('BODY>MAIN>DIV>BUTTON')
     })
   })
 
@@ -215,10 +207,6 @@ describe('isSelectorUniqueAmongSiblings', () => {
   })
 
   it('the selector should not consider elements deep in the tree', () => {
-    if (!supportScopeSelector()) {
-      pending('This test is only relevant for browsers supporting scoped selectors')
-    }
-
     const element = appendElement(`
       <div target>
         <hr>

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -41,7 +41,7 @@ export function getSelectorFromElement(
   targetElement: Element,
   actionNameAttribute: string | undefined
 ): string | undefined {
-  if (!isConnected(targetElement)) {
+  if (!targetElement.isConnected) {
     // We cannot compute a selector for a detached element, as we don't have access to all of its
     // parents, and we cannot determine if it's unique in the document.
     return
@@ -265,19 +265,4 @@ export function isSelectorUniqueAmongSiblings(
 
 function combineSelector(parent: string, child: string | undefined): string {
   return child ? `${parent}>${child}` : parent
-}
-
-/**
- * Polyfill-utility for the `isConnected` property not supported in Edge <=18
- */
-function isConnected(element: Element): boolean {
-  if (
-    'isConnected' in
-    // cast is to make sure `element` is not inferred as `never` after the check
-    (element as { isConnected?: boolean })
-  ) {
-    return element.isConnected
-  }
-
-  return element.ownerDocument.documentElement.contains(element)
 }

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -218,12 +218,6 @@ function isSelectorUniqueGlobally(
  * To avoid this, we can use the `:scope` selector to make sure the selector starts from the current
  * sibling (i.e. `sibling.querySelector('DIV:scope > SPAN')` will only match the first span).
  *
- * The result will be less accurate on browsers that don't support :scope (i. e. IE): it will check
- * for any element matching the selector contained in the parent (in other words,
- * "ELEMENT_PARENT CHILD_SELECTOR" returns a single element), regardless of whether the selector is
- * a direct descendant of the element parent. This should not impact results too much: if it
- * inaccurately returns false, we'll just fall back to another strategy.
- *
  * [1]: https://developer.mozilla.org/fr/docs/Web/CSS/:scope
  *
  * # Performance considerations
@@ -253,9 +247,7 @@ export function isSelectorUniqueAmongSiblings(
     // as `querySelector` only returns a descendant of the element.
     isSiblingMatching = (sibling) => sibling.matches(currentElementSelector)
   } else {
-    const scopedSelector = supportScopeSelector()
-      ? combineSelector(`${currentElementSelector}:scope`, childSelector)
-      : combineSelector(currentElementSelector, childSelector)
+    const scopedSelector = combineSelector(`${currentElementSelector}:scope`, childSelector)
     isSiblingMatching = (sibling) => sibling.querySelector(scopedSelector) !== null
   }
 
@@ -273,19 +265,6 @@ export function isSelectorUniqueAmongSiblings(
 
 function combineSelector(parent: string, child: string | undefined): string {
   return child ? `${parent}>${child}` : parent
-}
-
-let supportScopeSelectorCache: boolean | undefined
-export function supportScopeSelector() {
-  if (supportScopeSelectorCache === undefined) {
-    try {
-      document.querySelector(':scope')
-      supportScopeSelectorCache = true
-    } catch {
-      supportScopeSelectorCache = false
-    }
-  }
-  return supportScopeSelectorCache
 }
 
 /**


### PR DESCRIPTION
## Motivation

In v6, we dropped support for browsers not supporting ES2015. I found a couple of "old browser mitigations" that are not relevant anymore.

## Changes

* Assume the browser supports CSS `:scope` ([caniuse](https://caniuse.com/mdn-css_selectors_scope))
* Assume the browser supports `element.isConnected` ([caniuse](https://caniuse.com/mdn-api_node_isconnected)) (also we already [assume this for session replay](https://github.com/DataDog/browser-sdk/blob/a1ba24165e3d424d1894870242ad0c73b191f102/packages/rum/src/domain/record/trackers/trackMutation.ts#L135))

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
