### PR TITLE
⚡ [RUM-8353] throttle view update in set view context

### DIFF
--- a/packages/rum-core/src/domain/contexts/viewHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/viewHistory.spec.ts
@@ -3,7 +3,7 @@ import { relativeToClocks, CLEAR_OLD_VALUES_INTERVAL } from '@datadog/browser-co
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
-import type { ViewCreatedEvent, ViewEvent } from '../view/trackViews'
+import type { BeforeViewUpdateEvent, ViewCreatedEvent } from '../view/trackViews'
 import type { ViewHistory } from './viewHistory'
 import { startViewHistory, VIEW_CONTEXT_TIME_OUT_DELAY } from './viewHistory'
 
@@ -98,19 +98,19 @@ describe('ViewHistory', () => {
 
     it('should update the view name for the current context', () => {
       lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, buildViewCreatedEvent({ name: 'foo' }))
-      lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, {
+      lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_UPDATED, {
         startClocks,
         name: 'Fake Name',
-      } as ViewEvent)
+      } as BeforeViewUpdateEvent)
       expect(viewHistory.findView()!.name).toBe('Fake Name')
     })
 
     it('should update the view context for the current context', () => {
       lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_CREATED, buildViewCreatedEvent({ context: { foo: 'bar' } }))
-      lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, {
+      lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_UPDATED, {
         startClocks,
         context: { bar: 'foo' } as Context,
-      } as ViewEvent)
+      } as BeforeViewUpdateEvent)
       expect(viewHistory.findView()!.context).toEqual({ bar: 'foo' })
     })
   })

--- a/packages/rum-core/src/domain/contexts/viewHistory.ts
+++ b/packages/rum-core/src/domain/contexts/viewHistory.ts
@@ -2,7 +2,7 @@ import type { RelativeTime, ClocksState, Context } from '@datadog/browser-core'
 import { SESSION_TIME_OUT_DELAY, createValueHistory } from '@datadog/browser-core'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
-import type { ViewCreatedEvent, ViewEvent } from '../view/trackViews'
+import type { BeforeViewUpdateEvent, ViewCreatedEvent } from '../view/trackViews'
 
 export const VIEW_CONTEXT_TIME_OUT_DELAY = SESSION_TIME_OUT_DELAY
 
@@ -31,7 +31,7 @@ export function startViewHistory(lifeCycle: LifeCycle): ViewHistory {
     viewValueHistory.closeActive(endClocks.relative)
   })
 
-  lifeCycle.subscribe(LifeCycleEventType.VIEW_UPDATED, (viewUpdate: ViewEvent) => {
+  lifeCycle.subscribe(LifeCycleEventType.BEFORE_VIEW_UPDATED, (viewUpdate: BeforeViewUpdateEvent) => {
     const currentView = viewValueHistory.find(viewUpdate.startClocks.relative)
     if (currentView && viewUpdate.name) {
       currentView.name = viewUpdate.name

--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -6,7 +6,7 @@ import type { RumEvent } from '../rumEvent.types'
 import type { CommonContext } from './contexts/commonContext'
 import type { RequestCompleteEvent, RequestStartEvent } from './requestCollection'
 import type { AutoAction } from './action/actionCollection'
-import type { ViewEvent, ViewCreatedEvent, ViewEndedEvent } from './view/trackViews'
+import type { ViewEvent, ViewCreatedEvent, ViewEndedEvent, BeforeViewUpdateEvent } from './view/trackViews'
 
 export const enum LifeCycleEventType {
   // Contexts (like viewHistory) should be opened using prefixed BEFORE_XXX events and closed using prefixed AFTER_XXX events
@@ -14,6 +14,7 @@ export const enum LifeCycleEventType {
   AUTO_ACTION_COMPLETED,
   BEFORE_VIEW_CREATED,
   VIEW_CREATED,
+  BEFORE_VIEW_UPDATED,
   VIEW_UPDATED,
   VIEW_ENDED,
   AFTER_VIEW_ENDED,
@@ -55,6 +56,7 @@ declare const LifeCycleEventTypeAsConst: {
   AUTO_ACTION_COMPLETED: LifeCycleEventType.AUTO_ACTION_COMPLETED
   BEFORE_VIEW_CREATED: LifeCycleEventType.BEFORE_VIEW_CREATED
   VIEW_CREATED: LifeCycleEventType.VIEW_CREATED
+  BEFORE_VIEW_UPDATED: LifeCycleEventType.BEFORE_VIEW_UPDATED
   VIEW_UPDATED: LifeCycleEventType.VIEW_UPDATED
   VIEW_ENDED: LifeCycleEventType.VIEW_ENDED
   AFTER_VIEW_ENDED: LifeCycleEventType.AFTER_VIEW_ENDED
@@ -74,6 +76,7 @@ export interface LifeCycleEventMap {
   [LifeCycleEventTypeAsConst.AUTO_ACTION_COMPLETED]: AutoAction
   [LifeCycleEventTypeAsConst.BEFORE_VIEW_CREATED]: ViewCreatedEvent
   [LifeCycleEventTypeAsConst.VIEW_CREATED]: ViewCreatedEvent
+  [LifeCycleEventTypeAsConst.BEFORE_VIEW_UPDATED]: BeforeViewUpdateEvent
   [LifeCycleEventTypeAsConst.VIEW_UPDATED]: ViewEvent
   [LifeCycleEventTypeAsConst.VIEW_ENDED]: ViewEndedEvent
   [LifeCycleEventTypeAsConst.AFTER_VIEW_ENDED]: ViewEndedEvent

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -922,6 +922,8 @@ describe('view event count', () => {
       const { getViewUpdate, setViewContext } = viewTest
 
       setViewContext({ foo: 'bar' })
+      clock.tick(3000)
+
       expect(getViewUpdate(1).context).toEqual({ foo: 'bar' })
     })
 
@@ -930,6 +932,8 @@ describe('view event count', () => {
       const { getViewUpdate, setViewContextProperty } = viewTest
 
       setViewContextProperty('foo', 'bar')
+      clock.tick(3000)
+
       expect(getViewUpdate(1).context).toEqual({ foo: 'bar' })
     })
   })

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -922,7 +922,7 @@ describe('view event count', () => {
       const { getViewUpdate, setViewContext } = viewTest
 
       setViewContext({ foo: 'bar' })
-      clock.tick(3000)
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       expect(getViewUpdate(1).context).toEqual({ foo: 'bar' })
     })
@@ -932,7 +932,7 @@ describe('view event count', () => {
       const { getViewUpdate, setViewContextProperty } = viewTest
 
       setViewContextProperty('foo', 'bar')
-      clock.tick(3000)
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
 
       expect(getViewUpdate(1).context).toEqual({ foo: 'bar' })
     })

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -67,6 +67,13 @@ export interface ViewCreatedEvent {
   startClocks: ClocksState
 }
 
+export interface BeforeViewUpdateEvent {
+  id: string
+  name?: string
+  context?: Context
+  startClocks: ClocksState
+}
+
 export interface ViewEndedEvent {
   endClocks: ClocksState
 }
@@ -271,7 +278,17 @@ function newView(
 
   // Initial view update
   triggerViewUpdate()
-  contextManager.changeObservable.subscribe(triggerViewUpdate)
+
+  // View context update should always be throttled
+  contextManager.changeObservable.subscribe(() => {
+    lifeCycle.notify(LifeCycleEventType.BEFORE_VIEW_UPDATED, {
+      id,
+      name,
+      context: contextManager.getContext(),
+      startClocks,
+    })
+    scheduleViewUpdate()
+  })
 
   function triggerViewUpdate() {
     cancelScheduleViewUpdate()

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -122,7 +122,7 @@ describe('API calls and events around init', () => {
     })
 
   createTest('should be able to set view context')
-    .withRum({ enableExperimentalFeatures: ['view_specific_context'] })
+    .withRum()
     .withRumSlim()
     .withRumInit((configuration) => {
       window.DD_RUM!.init(configuration)


### PR DESCRIPTION
Excessive requests could be triggered when sending too much data, so every view update triggers requests. Related PR https://github.com/DataDog/browser-sdk/pull/3314 is on v6. Backporting this fix to v5 to mitigate the situation.

Note: the issue will still persist while triggering view updates through other APIs.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
