### PR TITLE
👷‍♀️ always publish all packages with lerna

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -62,7 +62,10 @@ cmd_build_json2type () {
 
 cmd_release () {
   [[ `git branch --show-current` != "main" ]] || fail 'please do not release from `main` branch'
-  yarn lerna version --exact
+  # We should publish all packages regardless of if there are changes in each.
+  # --force-publish will skip the `lerna changed` check for changed packages
+  # https://github.com/lerna/lerna/tree/main/libs/commands/version#--force-publish
+  yarn lerna version --exact --force-publish
 }
 
 cmd_version () {


### PR DESCRIPTION
## Motivation
When there are no changes in `core`, current approach will skip `logs` and `core` because lerna version run `changed` command to version packages with `diff` only.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Add `--force-publish` flag to always publish all packages (including `performances` and `developer-extension`)
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
