### PR TITLE
♻️ [RUM-59] refactor npm scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,10 +223,7 @@ e2e:
       junit: test-report/e2e/*.xml
   script:
     - yarn
-    - yarn build
-    - yarn build:app
-    - yarn playwright install chromium --with-deps
-    - FORCE_COLOR=1 yarn test:e2e
+    - FORCE_COLOR=1 yarn test:e2e:ci
   after_script:
     - node ./scripts/test/export-test-result.js e2e
 
@@ -291,9 +288,7 @@ e2e-bs:
       junit: test-report/e2e-bs/*.xml
   script:
     - yarn
-    - yarn build
-    - yarn build:app
-    - FORCE_COLOR=1 ./scripts/test/ci-bs.sh test:e2e
+    - FORCE_COLOR=1 ./scripts/test/ci-bs.sh test:e2e:ci
   after_script:
     - node ./scripts/test/export-test-result.js e2e-bs
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:unit:bs": "node ./scripts/test/bs-wrapper.js karma start test/unit/karma.bs.conf.js",
     "test:e2e": "playwright test --config test/e2e/playwright.local.config.ts --project chromium",
     "test:e2e:bs": "node ./scripts/test/bs-wrapper.js playwright test --config test/e2e/playwright.bs.config.ts",
+    "test:e2e:ci": "yarn build && yarn build:app && yarn playwright install chromium --with-deps && yarn test:e2e",
+    "test:e2e:ci:bs": "yarn build && yarn build:app && yarn test:e2e:bs",
     "test:compat:tsc": "scripts/cli check_typescript_compatibility",
     "test:compat:ssr": "scripts/cli check_server_side_rendering_compatibility",
     "rum-events-format:sync": "scripts/cli update_submodule && scripts/cli build_json2type && node scripts/generate-schema-types.js",

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -22,7 +22,7 @@ export interface SetupOptions {
 export type SetupFactory = (options: SetupOptions, servers: Servers) => string
 
 const isBrowserStack = process.env.BROWSER_STACK
-const isContinuousIntegration = Boolean(process.env.CI_JOB_ID)
+const isContinuousIntegration = Boolean(process.env.CI)
 
 // By default, run tests only with the 'bundle' setup outside of the CI (to run faster on the
 // developer laptop) or with Browser Stack (to limit flakiness).


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Refactor, so that the e2e test can be run in https://github.com/DataDog/rum-events-format/pull/253

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->
 
- Move build from gitlab config to npm script
- use `process.env.CI` instead of `process.env.CI_JOB_ID` because it is available both in github and gitlab


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
