### PR TITLE
🐛 do not calculate resource duration if page was in frozen state during resource duration

### DIFF
--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -2,9 +2,11 @@ import type { Duration, RelativeTime, ServerDuration, TaskQueue, TimeStamp } fro
 import { createTaskQueue, noop, RequestType, ResourceType } from '@datadog/browser-core'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumFetchResourceEventDomainContext, RumXhrResourceEventDomainContext } from '../../domainContext.types'
+import type { GlobalPerformanceBufferMock } from '../../../test'
 import {
   collectAndValidateRawRumEvents,
   createPerformanceEntry,
+  mockGlobalPerformanceBuffer,
   mockPageStateHistory,
   mockPerformanceObserver,
   mockRumConfiguration,
@@ -29,6 +31,7 @@ describe('resourceCollection', () => {
   let lifeCycle: LifeCycle
   let wasInPageStateDuringPeriodSpy: jasmine.Spy<jasmine.Func>
   let notifyPerformanceEntries: (entries: RumPerformanceEntry[]) => void
+  let globalPerformanceObjectMock: GlobalPerformanceBufferMock
   let rawRumEvents: Array<RawRumEventCollectedData<RawRumEvent>> = []
   let taskQueuePushSpy: jasmine.Spy<TaskQueue['push']>
 
@@ -54,6 +57,8 @@ describe('resourceCollection', () => {
 
   beforeEach(() => {
     ;({ notifyPerformanceEntries } = mockPerformanceObserver())
+    globalPerformanceObjectMock = mockGlobalPerformanceBuffer()
+    globalPerformanceObjectMock.addPerformanceEntry(createPerformanceEntry(RumPerformanceEntryType.RESOURCE))
     wasInPageStateDuringPeriodSpy = spyOn(pageStateHistory, 'wasInPageStateDuringPeriod')
   })
 
@@ -439,7 +444,7 @@ function createCompletedRequest(details?: Partial<RequestCompleteEvent>): Reques
   const request: Partial<RequestCompleteEvent> = {
     duration: 100 as Duration,
     method: 'GET',
-    startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
+    startClocks: { relative: 200 as RelativeTime, timeStamp: 123456789 as TimeStamp },
     status: 200,
     type: RequestType.XHR,
     url: 'https://resource.com/valid',


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Fixes Bug with resource duration where incorrect due to page being in a frozen state sometime during the request.

The intention was to set duration to `undefined` when the page was in a frozen state during the request duration (`computeRequestDuration`), however this was overridden by `computeResourceEntryMetrics`.

The unit tests where not catching the issue because no matching PerformanceResourceTiming was mocked.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

- Mock a matching PerformanceResourceTiming, making the unit test fail.
- Make `computeResourceEntryMetrics` aware of frozen states and prevent calculating any durations when needed.
- Improve fetch and XHR request collection unit test to take into account a matching PerformanceResourceTiming.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
