### PR TITLE
👷 only connect to background script when the extension is actually loaded

### DIFF
--- a/developer-extension/src/panel/backgroundScriptConnection.ts
+++ b/developer-extension/src/panel/backgroundScriptConnection.ts
@@ -10,9 +10,7 @@ export const onBackgroundDisconnection = new EventListeners<void>()
 
 let backgroundScriptConnection: chrome.runtime.Port | undefined
 
-connectToBackgroundScript()
-
-function connectToBackgroundScript() {
+export function connectToBackgroundScript() {
   try {
     backgroundScriptConnection = chrome.runtime.connect({
       name: `devtools-panel-for-tab-${chrome.devtools.inspectedWindow.tabId}`,

--- a/developer-extension/src/panel/components/app.tsx
+++ b/developer-extension/src/panel/components/app.tsx
@@ -2,7 +2,7 @@ import { Button, MantineProvider } from '@mantine/core'
 import type { ReactNode } from 'react'
 import React, { Suspense, useEffect, useState } from 'react'
 import { isDisconnectError } from '../../common/isDisconnectError'
-import { onBackgroundDisconnection } from '../backgroundScriptConnection'
+import { onBackgroundDisconnection, connectToBackgroundScript } from '../backgroundScriptConnection'
 import { Alert } from './alert'
 import { Panel } from './panel'
 
@@ -10,6 +10,8 @@ export function App() {
   const [isDisconnected, setIsDisconnected] = useState(false)
 
   useEffect(() => {
+    connectToBackgroundScript()
+
     const subscription = onBackgroundDisconnection.subscribe(() => setIsDisconnected(true))
     return () => subscription.unsubscribe()
   }, [])


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Connect background script when the developer extension loads. This prevent error message in [unit test console](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/811453829):

```
Chrome Headless 133.0.0.0 (Linux x86_64) ERROR LOG: 'Datadog Browser SDK extension:', '[backgroundScriptConnection]', 'While creating connection:', TypeError: Cannot read properties of undefined (reading 'connect')
TypeError: Cannot read properties of undefined (reading 'connect')
    at connectToBackgroundScript (http://localhost:9876/absolute/tmp/_karma_webpack_607690/commons.js?7e5dad90306c0398a735c523345dcf0765954e1f:1193:49)
    at ./developer-extension/src/panel/backgroundScriptConnection.ts (http://localhost:9876/absolute/tmp/_karma_webpack_607690/commons.js?7e5dad90306c0398a735c523345dcf0765954e1f:1185:1)
    at __webpack_require__ (http://localhost:9876/absolutecomputeFacetState.spec.726096698.js?699e3caaeb3a37511ddf3700830e5c3c442b4d94:23:42)
    at ./developer-extension/src/panel/hooks/useEvents/eventCollection.ts (http://localhost:9876/absolute/tmp/_karma_webpack_607690/commons.js?7e5dad90306c0398a735c523345dcf0765954e1f:4184:85)
    at __webpack_require__ (http://localhost:9876/absolutecomputeFacetState.spec.726096698.js?699e3caaeb3a37511ddf3700830e5c3c442b4d94:23:42)
    at ./developer-extension/src/panel/hooks/useEvents/useEvents.ts (http://localhost:9876/absolute/tmp/_karma_webpack_607690/commons.js?7e5dad90306c0398a735c523345dcf0765954e1f:9659:74)
    at __webpack_require__ (http://localhost:9876/absolutecomputeFacetState.spec.726096698.js?699e3caaeb3a37511ddf3700830e5c3c442b4d94:23:42)
    at ./developer-extension/src/panel/hooks/useEvents/index.ts (http://localhost:9876/absolute/tmp/_karma_webpack_607690/commons.js?7e5dad90306c0398a735c523345dcf0765954e1f:9596:68)
    at __webpack_require__ (http://localhost:9876/absolutecomputeFacetState.spec.726096698.js?699e3caaeb3a37511ddf3700830e5c3c442b4d94:23:42)
    at ./developer-extension/src/panel/components/tabs/eventsTab/computeFacetState.spec.ts (http://localhost:9876/absolute/tmp/_karma_webpack_607690/commons.js?7e5dad90306c0398a735c523345dcf0765954e1f:1260:74)
```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
