### PR TITLE
♻️ Use `window.crypto` instead of `getCrypto` wrapper

### DIFF
--- a/packages/rum-core/src/browser/crypto.ts
+++ b/packages/rum-core/src/browser/crypto.ts
@@ -1,4 +1,0 @@
-export function getCrypto() {
-  // TODO: remove msCrypto when IE11 support is dropped
-  return window.crypto || (window as any).msCrypto
-}

--- a/packages/rum-core/src/domain/tracing/identifier.spec.ts
+++ b/packages/rum-core/src/domain/tracing/identifier.spec.ts
@@ -1,6 +1,5 @@
 import { ExperimentalFeature } from '@datadog/browser-core'
 import { mockExperimentalFeatures } from '../../../../core/test'
-import { getCrypto } from '../../browser/crypto'
 import {
   createSpanIdentifier,
   createTraceIdentifier,
@@ -85,7 +84,7 @@ describe('toPaddedHexadecimalString', () => {
 })
 
 function mockRandomValues(cb: (buffer: Uint8Array) => void) {
-  spyOn(getCrypto(), 'getRandomValues').and.callFake((bufferView) => {
+  spyOn(window.crypto, 'getRandomValues').and.callFake((bufferView) => {
     cb(new Uint8Array(bufferView!.buffer))
     return bufferView
   })

--- a/packages/rum-core/src/domain/tracing/identifier.ts
+++ b/packages/rum-core/src/domain/tracing/identifier.ts
@@ -1,5 +1,4 @@
 import { ExperimentalFeature, isExperimentalFeatureEnabled } from '@datadog/browser-core'
-import { getCrypto } from '../../browser/crypto'
 
 interface BaseIdentifier {
   toString(radix?: number): string
@@ -59,7 +58,7 @@ function createIdentifierUsingBigInt(bits: 63 | 64): BaseIdentifier {
 
 // TODO: remove this when all browser we support have BigInt support
 function createIdentifierUsingUint32Array(bits: 63 | 64): BaseIdentifier {
-  const buffer = getCrypto().getRandomValues(new Uint32Array(2))
+  const buffer = window.crypto.getRandomValues(new Uint32Array(2))
   if (bits === 63) {
     // eslint-disable-next-line no-bitwise
     buffer[buffer.length - 1] >>>= 1 // force 63-bit

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -14,7 +14,6 @@ import type {
   RumXhrStartContext,
 } from '../requestCollection'
 import type { RumSessionManager } from '../rumSessionManager'
-import { getCrypto } from '../../browser/crypto'
 import type { PropagatorType, TracingOption } from './tracer.types'
 import type { SpanIdentifier, TraceIdentifier } from './identifier'
 import { createSpanIdentifier, createTraceIdentifier, toPaddedHexadecimalString } from './identifier'
@@ -108,7 +107,7 @@ function injectHeadersIfTracingAllowed(
   sessionManager: RumSessionManager,
   inject: (tracingHeaders: TracingHeaders) => void
 ) {
-  if (!isTracingSupported() || !sessionManager.findTrackedSession()) {
+  if (!sessionManager.findTrackedSession()) {
     return
   }
 
@@ -131,10 +130,6 @@ function injectHeadersIfTracingAllowed(
   context.spanId = createSpanIdentifier()
 
   inject(makeTracingHeaders(context.traceId, context.spanId, context.traceSampled, tracingOption.propagatorTypes))
-}
-
-export function isTracingSupported() {
-  return getCrypto() !== undefined
 }
 
 /**


### PR DESCRIPTION
## Motivation

`getCrypto` was used to retrieve the correct API depending on the browser. Now that we dropped IE11 we can directly use `window.crypto`.

## Changes

Remove getCrypto and use `window.crypto`.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
