### PR TITLE
 ⚗️✨ [RUM-8622] session consistent trace sampling 

### DIFF
--- a/packages/rum-core/src/domain/tracing/identifier.spec.ts
+++ b/packages/rum-core/src/domain/tracing/identifier.spec.ts
@@ -15,7 +15,7 @@ describe('identifier', () => {
     })
 
     it('should generate a max value of 64 bits', () => {
-      mockRandomValues((buffer) => fill(buffer, 0xff))
+      mockRandomValues((buffer) => buffer.fill(0xff))
       const identifier = createTraceIdentifier()
       expect(identifier.toString(16)).toEqual('ffffffffffffffff')
     })
@@ -23,7 +23,7 @@ describe('identifier', () => {
 
   describe('SpanIdentifier', () => {
     it('generates a max value of 63 bits', () => {
-      mockRandomValues((buffer) => fill(buffer, 0xff))
+      mockRandomValues((buffer) => buffer.fill(0xff))
       const identifier = createSpanIdentifier()
       expect(identifier.toString(16)).toEqual('7fffffffffffffff')
     })
@@ -43,11 +43,4 @@ function mockRandomValues(cb: (buffer: Uint8Array) => void) {
     cb(new Uint8Array(bufferView!.buffer))
     return bufferView
   })
-}
-
-// TODO: replace with `buffer.fill(value)` when we drop support for IE11
-function fill(buffer: Uint8Array, value: number) {
-  for (let i = 0; i < buffer.length; i++) {
-    buffer[i] = value
-  }
 }

--- a/packages/rum-core/src/domain/tracing/identifier.spec.ts
+++ b/packages/rum-core/src/domain/tracing/identifier.spec.ts
@@ -1,18 +1,7 @@
-import { ExperimentalFeature } from '@datadog/browser-core'
-import { mockExperimentalFeatures } from '../../../../core/test'
 import { getCrypto } from '../../browser/crypto'
-import {
-  createSpanIdentifier,
-  createTraceIdentifier,
-  toPaddedHexadecimalString,
-  clearIdentifierImplementationCache,
-} from './identifier'
+import { createSpanIdentifier, createTraceIdentifier, toPaddedHexadecimalString } from './identifier'
 
 describe('identifier', () => {
-  beforeEach(() => {
-    clearIdentifierImplementationCache()
-  })
-
   describe('TraceIdentifier', () => {
     it('generates a random id', () => {
       const identifier = createTraceIdentifier()
@@ -37,41 +26,6 @@ describe('identifier', () => {
       mockRandomValues((buffer) => fill(buffer, 0xff))
       const identifier = createSpanIdentifier()
       expect(identifier.toString(16)).toEqual('7fffffffffffffff')
-    })
-  })
-
-  // Run the same tests again with consistent trace sampling enabled, which uses the BigInt
-  // implementation
-  describe('with CONSISTENT_TRACE_SAMPLING enabled', () => {
-    beforeEach(() => {
-      mockExperimentalFeatures([ExperimentalFeature.CONSISTENT_TRACE_SAMPLING])
-    })
-
-    describe('TraceIdentifier', () => {
-      it('generates a random id', () => {
-        const identifier = createTraceIdentifier()
-        expect(identifier.toString()).toMatch(/^\d+$/)
-      })
-
-      it('formats using base 16', () => {
-        mockRandomValues((buffer) => (buffer[0] = 0xff))
-        const identifier = createTraceIdentifier()
-        expect(identifier.toString(16)).toEqual('ff')
-      })
-
-      it('should generate a max value of 64 bits', () => {
-        mockRandomValues((buffer) => fill(buffer, 0xff))
-        const identifier = createTraceIdentifier()
-        expect(identifier.toString(16)).toEqual('ffffffffffffffff')
-      })
-    })
-
-    describe('SpanIdentifier', () => {
-      it('generates a max value of 63 bits', () => {
-        mockRandomValues((buffer) => fill(buffer, 0xff))
-        const identifier = createSpanIdentifier()
-        expect(identifier.toString(16)).toEqual('7fffffffffffffff')
-      })
     })
   })
 })

--- a/packages/rum-core/src/domain/tracing/identifier.ts
+++ b/packages/rum-core/src/domain/tracing/identifier.ts
@@ -1,4 +1,3 @@
-import { ExperimentalFeature, isExperimentalFeatureEnabled } from '@datadog/browser-core'
 import { getCrypto } from '../../browser/crypto'
 
 interface BaseIdentifier {
@@ -23,48 +22,32 @@ export function createSpanIdentifier() {
   return createIdentifier(63) as SpanIdentifier
 }
 
-let createIdentifierImplementationCache: ((bits: 63 | 64) => BaseIdentifier) | undefined
-
-export function clearIdentifierImplementationCache() {
-  createIdentifierImplementationCache = undefined
-}
-
 function createIdentifier(bits: 63 | 64): BaseIdentifier {
-  if (!createIdentifierImplementationCache) {
-    createIdentifierImplementationCache =
-      isExperimentalFeatureEnabled(ExperimentalFeature.CONSISTENT_TRACE_SAMPLING) && areBigIntIdentifiersSupported()
-        ? createIdentifierUsingBigInt
-        : createIdentifierUsingUint32Array
-  }
-  return createIdentifierImplementationCache(bits)
-}
-
-export function areBigIntIdentifiersSupported() {
-  try {
-    crypto.getRandomValues(new BigUint64Array(1))
-    return true
-  } catch {
-    return false
-  }
-}
-
-function createIdentifierUsingBigInt(bits: 63 | 64): BaseIdentifier {
-  let id = crypto.getRandomValues(new BigUint64Array(1))[0]
-  if (bits === 63) {
-    // eslint-disable-next-line no-bitwise
-    id >>= BigInt('1')
-  }
-  return id
-}
-
-// TODO: remove this when all browser we support have BigInt support
-function createIdentifierUsingUint32Array(bits: 63 | 64): BaseIdentifier {
   const buffer = getCrypto().getRandomValues(new Uint32Array(2))
   if (bits === 63) {
     // eslint-disable-next-line no-bitwise
     buffer[buffer.length - 1] >>>= 1 // force 63-bit
   }
 
+  // The `.toString` function is intentionally similar to Number and BigInt `.toString` method.
+  //
+  // JavaScript numbers can represent integers up to 48 bits, this is why we need two of them to
+  // represent a 64 bits identifier. But BigInts don't have this limitation and can represent larger
+  // integer values.
+  //
+  // In the future, when we drop browsers without BigInts support, we could use BigInts to directly
+  // represent identifiers by simply returning a BigInt from this function (as all we need is a
+  // value with a `.toString` method).
+  //
+  // Examples:
+  //   const buffer = getCrypto().getRandomValues(new Uint32Array(2))
+  //   return BigInt(buffer[0]) + BigInt(buffer[1]) << 32n
+  //
+  //   // Alternative with BigUint64Array (different Browser support than plain bigints!):
+  //   return crypto.getRandomValues(new BigUint64Array(1))[0]
+  //
+  // For now, let's keep using two plain numbers as having two different implementations (one for
+  // browsers with BigInt support and one for older browsers) don't bring much value.
   return {
     toString(radix = 10) {
       let high = buffer[1]

--- a/packages/rum-core/src/domain/tracing/identifier.ts
+++ b/packages/rum-core/src/domain/tracing/identifier.ts
@@ -67,7 +67,5 @@ function createIdentifier(bits: 63 | 64): BaseIdentifier {
 }
 
 export function toPaddedHexadecimalString(id: BaseIdentifier) {
-  const traceId = id.toString(16)
-  // TODO: replace with String.prototype.padStart when we drop IE11 support
-  return Array(17 - traceId.length).join('0') + traceId
+  return id.toString(16).padStart(16, '0')
 }

--- a/packages/rum-core/src/domain/tracing/sampler.spec.ts
+++ b/packages/rum-core/src/domain/tracing/sampler.spec.ts
@@ -1,62 +1,118 @@
-import type { TraceIdentifier } from './identifier'
-import { isTraceSampled } from './sampler'
+import { ExperimentalFeature } from '@datadog/browser-core'
+import { mockExperimentalFeatures } from '../../../../core/test'
+import { isTraceSampled, resetSampleDecisionCache, sampleUsingKnuthFactor } from './sampler'
+
+// UUID known to yield a low hash value using the Knuth formula, making it more likely to be sampled
+const LOW_HASH_UUID = '29a4b5e3-9859-4290-99fa-4bc4a1a348b9'
+// UUID known to yield a high hash value using the Knuth formula, making it less likely to be
+// sampled
+const HIGH_HASH_UUID = '5321b54a-d6ec-4b24-996d-dd70c617e09a'
+
+// UUID chosen arbitrarily, to be used when the test doesn't actually depend on it.
+const ARBITRARY_UUID = '1ff81c8c-6e32-473b-869b-55af08048323'
 
 describe('isTraceSampled', () => {
-  describe('with bigint support', () => {
+  beforeEach(() => {
+    resetSampleDecisionCache()
+  })
+
+  describe('with CONSISTENT_TRACE_SAMPLING enabled', () => {
     beforeEach(() => {
-      if (!window.BigInt) {
-        pending('BigInt is not supported')
-      }
+      mockExperimentalFeatures([ExperimentalFeature.CONSISTENT_TRACE_SAMPLING])
     })
 
     it('returns true when sampleRate is 100', () => {
-      expect(isTraceSampled(BigInt('1234') as unknown as TraceIdentifier, 100)).toBeTrue()
+      expect(isTraceSampled(ARBITRARY_UUID, 100)).toBeTrue()
     })
 
     it('returns false when sampleRate is 0', () => {
-      expect(isTraceSampled(BigInt('1234') as unknown as TraceIdentifier, 0)).toBeFalse()
+      expect(isTraceSampled(ARBITRARY_UUID, 0)).toBeFalse()
     })
 
-    it('sampling should be based on the trace id', () => {
-      // Generated using the dd-trace-go implementation with the following program: https://go.dev/play/p/CUrDJtze8E_e
-      const inputs: Array<[bigint, number, boolean]> = [
-        [BigInt('5577006791947779410'), 94.0509, true],
-        [BigInt('15352856648520921629'), 43.7714, true],
-        [BigInt('3916589616287113937'), 68.6823, true],
-        [BigInt('894385949183117216'), 30.0912, true],
-        [BigInt('12156940908066221323'), 46.889, true],
+    describe('with bigint support', () => {
+      beforeEach(() => {
+        if (!window.BigInt) {
+          pending('BigInt is not supported')
+        }
+      })
 
-        [BigInt('9828766684487745566'), 15.6519, false],
-        [BigInt('4751997750760398084'), 81.364, false],
-        [BigInt('11199607447739267382'), 38.0657, false],
-        [BigInt('6263450610539110790'), 21.8553, false],
-        [BigInt('1874068156324778273'), 36.0871, false],
-      ]
+      it('a session id with a low hash value should be sampled with a rate close to 0%', () => {
+        expect(isTraceSampled(LOW_HASH_UUID, 0.1)).toBeTrue()
+        expect(isTraceSampled(LOW_HASH_UUID, 0.01)).toBeTrue()
+        expect(isTraceSampled(LOW_HASH_UUID, 0.001)).toBeTrue()
+        expect(isTraceSampled(LOW_HASH_UUID, 0.0001)).toBeTrue()
+        // At some point the sample rate is so low that the session is not sampled even if the hash
+        // is low. This is not an error: we can probably find a UUID with an even lower hash.
+        expect(isTraceSampled(LOW_HASH_UUID, 0.0000000001)).toBeFalse()
+      })
 
-      for (const [identifier, sampleRate, expected] of inputs) {
-        expect(isTraceSampled(identifier as unknown as TraceIdentifier, sampleRate))
-          .withContext(`identifier=${identifier}, sampleRate=${sampleRate}`)
-          .toBe(expected)
-      }
+      it('a session id with a high hash value should not be sampled even if the rate is close to 100%', () => {
+        expect(isTraceSampled(HIGH_HASH_UUID, 99.9)).toBeFalse()
+        expect(isTraceSampled(HIGH_HASH_UUID, 99.99)).toBeFalse()
+        expect(isTraceSampled(HIGH_HASH_UUID, 99.999)).toBeFalse()
+        expect(isTraceSampled(HIGH_HASH_UUID, 99.9999)).toBeFalse()
+        // At some point the sample rate is so high that the session is sampled even if the hash is
+        // high. This is not an error: we can probably find a UUID with an even higher hash.
+        expect(isTraceSampled(HIGH_HASH_UUID, 99.9999999999)).toBeTrue()
+      })
+    })
+
+    describe('without bigint support', () => {
+      beforeEach(() => {
+        // @ts-expect-error BigInt might not be defined depending on the browser where we execute
+        // the tests
+        if (window.BigInt) {
+          pending('BigInt is supported')
+        }
+      })
+
+      it('sampling decision should be cached', () => {
+        spyOn(Math, 'random').and.returnValues(0.2, 0.8)
+        expect(isTraceSampled(ARBITRARY_UUID, 50)).toBeTrue()
+        expect(isTraceSampled(ARBITRARY_UUID, 50)).toBeTrue()
+      })
     })
   })
 
-  describe('without bigint support', () => {
-    it('returns true when sampleRate is 100', () => {
-      expect(isTraceSampled({} as TraceIdentifier, 100)).toBeTrue()
-    })
-
-    it('returns false when sampleRate is 0', () => {
-      expect(isTraceSampled({} as TraceIdentifier, 0)).toBeFalse()
-    })
-
+  describe('without CONSISTENT_TRACE_SAMPLING enabled', () => {
     it('sampling should be random', () => {
       spyOn(Math, 'random').and.returnValues(0.2, 0.8, 0.2, 0.8, 0.2)
-      expect(isTraceSampled({} as TraceIdentifier, 50)).toBeTrue()
-      expect(isTraceSampled({} as TraceIdentifier, 50)).toBeFalse()
-      expect(isTraceSampled({} as TraceIdentifier, 50)).toBeTrue()
-      expect(isTraceSampled({} as TraceIdentifier, 50)).toBeFalse()
-      expect(isTraceSampled({} as TraceIdentifier, 50)).toBeTrue()
+      expect(isTraceSampled(ARBITRARY_UUID, 50)).toBeTrue()
+      expect(isTraceSampled(ARBITRARY_UUID, 50)).toBeFalse()
+      expect(isTraceSampled(ARBITRARY_UUID, 50)).toBeTrue()
+      expect(isTraceSampled(ARBITRARY_UUID, 50)).toBeFalse()
+      expect(isTraceSampled(ARBITRARY_UUID, 50)).toBeTrue()
     })
+  })
+})
+
+describe('sampleUsingKnuthFactor', () => {
+  beforeEach(() => {
+    if (!window.BigInt) {
+      pending('BigInt is not supported')
+    }
+  })
+
+  it('sampling should be based on the trace id', () => {
+    // Generated using the dd-trace-go implementation with the following program: https://go.dev/play/p/CUrDJtze8E_e
+    const inputs: Array<[bigint, number, boolean]> = [
+      [BigInt('5577006791947779410'), 94.0509, true],
+      [BigInt('15352856648520921629'), 43.7714, true],
+      [BigInt('3916589616287113937'), 68.6823, true],
+      [BigInt('894385949183117216'), 30.0912, true],
+      [BigInt('12156940908066221323'), 46.889, true],
+
+      [BigInt('9828766684487745566'), 15.6519, false],
+      [BigInt('4751997750760398084'), 81.364, false],
+      [BigInt('11199607447739267382'), 38.0657, false],
+      [BigInt('6263450610539110790'), 21.8553, false],
+      [BigInt('1874068156324778273'), 36.0871, false],
+    ]
+
+    for (const [identifier, sampleRate, expected] of inputs) {
+      expect(sampleUsingKnuthFactor(identifier, sampleRate))
+        .withContext(`identifier=${identifier}, sampleRate=${sampleRate}`)
+        .toBe(expected)
+    }
   })
 })

--- a/packages/rum-core/src/domain/tracing/sampler.ts
+++ b/packages/rum-core/src/domain/tracing/sampler.ts
@@ -1,7 +1,8 @@
-import { performDraw } from '@datadog/browser-core'
-import type { TraceIdentifier } from './identifier'
+import { ExperimentalFeature, isExperimentalFeatureEnabled, performDraw } from '@datadog/browser-core'
 
-export function isTraceSampled(identifier: TraceIdentifier, sampleRate: number) {
+let sampleDecisionCache: { sessionId: string; sampleRate: number; decision: boolean } | undefined
+
+export function isTraceSampled(sessionId: string, sampleRate: number) {
   // Shortcuts for common cases. This is not strictly necessary, but it makes the code faster for
   // customers willing to ingest all traces.
   if (sampleRate === 100) {
@@ -12,13 +13,45 @@ export function isTraceSampled(identifier: TraceIdentifier, sampleRate: number) 
     return false
   }
 
-  // For simplicity, we don't use consistent sampling for browser that don't support BigInt
-  // TODO: remove this when all browser we support have BigInt support
-  if (typeof identifier !== 'bigint') {
+  if (!isExperimentalFeatureEnabled(ExperimentalFeature.CONSISTENT_TRACE_SAMPLING)) {
     return performDraw(sampleRate)
   }
 
-  // Offer consistent sampling for the same trace id across different environments. The rule is:
+  if (
+    sampleDecisionCache &&
+    sessionId === sampleDecisionCache.sessionId &&
+    sampleRate === sampleDecisionCache.sampleRate
+  ) {
+    return sampleDecisionCache.decision
+  }
+
+  let decision: boolean
+  // @ts-expect-error BigInt might not be defined in every browser we support
+  if (window.BigInt) {
+    decision = sampleUsingKnuthFactor(BigInt(`0x${sessionId.split('-')[4]}`), sampleRate)
+  } else {
+    // For simplicity, we don't use consistent sampling for browser without BigInt support
+    // TODO: remove this when all browser we support have BigInt support
+    decision = performDraw(sampleRate)
+  }
+  sampleDecisionCache = { sessionId, sampleRate, decision }
+  return decision
+}
+
+// Exported for tests
+export function resetSampleDecisionCache() {
+  sampleDecisionCache = undefined
+}
+
+/**
+ * Perform sampling using the Knuth factor method. This method offer consistent sampling result
+ * based on the provided identifier.
+ *
+ * @param identifier The identifier to use for sampling.
+ * @param sampleRate The sample rate in percentage between 0 and 100.
+ */
+export function sampleUsingKnuthFactor(identifier: bigint, sampleRate: number) {
+  // The formula is:
   //
   //   (identifier * knuthFactor) % 2^64 < sampleRate * 2^64
   //


### PR DESCRIPTION
## Motivation

Make sure all requests are sampled for a given session. This replaces #3186 where trace sampling was based on the trace id.

## Changes

* Do some cleanup, as #3186 is droped
* Implement session-consistent trace sampling

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
