### PR TITLE
[RUM-260] Support bfcache restore for web vitals

### DIFF
--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -208,6 +208,7 @@ describe('viewCollection', () => {
         resource: {
           count: 10,
         },
+        bf_cache: undefined,
         time_spent: (100 * 1e6) as ServerDuration,
       },
       session: {
@@ -231,6 +232,17 @@ describe('viewCollection', () => {
     lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, { ...VIEW, sessionIsActive: false })
 
     expect((rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent).session.is_active).toBe(false)
+  })
+
+  it('should include bf_cache when bfcache is set to true', () => {
+    setupViewCollection()
+    const viewWithBfcache = {
+      ...VIEW,
+      initialViewMetrics: { ...VIEW.initialViewMetrics, bfCache: true },
+    }
+    lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, viewWithBfcache)
+    const rawRumViewEvent = rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent
+    expect(rawRumViewEvent.view.bf_cache).toBe(true)
   })
 
   it('should include replay information if available', () => {

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -122,6 +122,7 @@ function processViewUpdate(
         count: view.eventCounts.resourceCount,
       },
       time_spent: toServerDuration(view.duration),
+      bf_cache: view.initialViewMetrics.bfCache,
     },
     display: view.commonViewMetrics.scroll
       ? {

--- a/packages/rum-core/src/domain/view/viewMetrics/bfCacheSupport.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/bfCacheSupport.ts
@@ -1,0 +1,15 @@
+import { monitor, addEventListener, DOM_EVENT } from '@datadog/browser-core'
+
+export function onBFCacheRestore(callback: (event: PageTransitionEvent) => void) {
+  addEventListener(
+    { allowUntrustedEvents: false },
+    window,
+    DOM_EVENT.PAGE_SHOW,
+    monitor((event: PageTransitionEvent) => {
+      if (event.persisted) {
+        callback(event)
+      }
+    }),
+    { capture: true }
+  )
+}

--- a/packages/rum-core/src/domain/view/viewMetrics/bfCacheSupport.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/bfCacheSupport.ts
@@ -1,15 +1,15 @@
-import { monitor, addEventListener, DOM_EVENT } from '@datadog/browser-core'
+import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 
 export function onBFCacheRestore(callback: (event: PageTransitionEvent) => void) {
   addEventListener(
-    { allowUntrustedEvents: false },
+    { allowUntrustedEvents: true },
     window,
     DOM_EVENT.PAGE_SHOW,
-    monitor((event: PageTransitionEvent) => {
+    (event: PageTransitionEvent) => {
       if (event.persisted) {
         callback(event)
       }
-    }),
+    },
     { capture: true }
   )
 }

--- a/packages/rum-core/src/domain/view/viewMetrics/cwvPolyfill.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/cwvPolyfill.spec.ts
@@ -1,0 +1,50 @@
+import type { Duration } from '@datadog/browser-core'
+import { measureRestoredFCP, measureRestoredLCP, measureRestoredFID } from './cwvPolyfill'
+
+describe('cwvPolyfill', () => {
+  let originalRAF: typeof requestAnimationFrame
+  let originalPerformanceNow: () => number
+
+  beforeEach(() => {
+    originalRAF = window.requestAnimationFrame
+    originalPerformanceNow = performance.now
+
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      cb(performance.now())
+      return 0
+    }
+  })
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRAF
+    performance.now = originalPerformanceNow
+  })
+
+  it('should measure restored FCP correctly', (done) => {
+    const fakePageshowEvent = { timeStamp: 100 } as PageTransitionEvent
+    performance.now = () => 150
+    measureRestoredFCP(fakePageshowEvent, (fcp: Duration) => {
+      expect(fcp).toEqual(50 as Duration)
+      done()
+    })
+  })
+
+  it('should measure restored LCP correctly', (done) => {
+    const fakePageshowEvent = { timeStamp: 100 } as PageTransitionEvent
+    performance.now = () => 150
+    measureRestoredLCP(fakePageshowEvent, (lcp: Duration) => {
+      expect(lcp).toEqual(50 as Duration)
+      done()
+    })
+  })
+
+  it('should measure restored FID correctly', (done) => {
+    const fakePageshowEvent = { timeStamp: 100 } as PageTransitionEvent
+    performance.now = () => 150
+    measureRestoredFID(fakePageshowEvent, (fid) => {
+      expect(fid.delay).toEqual(0 as Duration)
+      expect(fid.time).toEqual(50 as Duration)
+      done()
+    })
+  })
+})

--- a/packages/rum-core/src/domain/view/viewMetrics/cwvPolyfill.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/cwvPolyfill.spec.ts
@@ -7,7 +7,7 @@ describe('cwvPolyfill', () => {
 
   beforeEach(() => {
     originalRAF = window.requestAnimationFrame
-    originalPerformanceNow = performance.now
+    originalPerformanceNow = performance.now.bind(performance)
 
     window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
       cb(performance.now())

--- a/packages/rum-core/src/domain/view/viewMetrics/cwvPolyfill.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/cwvPolyfill.ts
@@ -1,0 +1,31 @@
+import type { Duration } from '@datadog/browser-core'
+
+export function measureRestoredFCP(pageshowEvent: PageTransitionEvent, callback: (fcp: Duration) => void): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const fcp = performance.now() - pageshowEvent.timeStamp
+      callback(fcp as Duration)
+    })
+  })
+}
+
+export function measureRestoredLCP(pageshowEvent: PageTransitionEvent, callback: (lcp: Duration) => void): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const lcp = performance.now() - pageshowEvent.timeStamp
+      callback(lcp as Duration)
+    })
+  })
+}
+export function measureRestoredFID(
+  pageshowEvent: PageTransitionEvent,
+  callback: (fid: { delay: Duration; time: Duration }) => void
+): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const fidDelay = 0 as Duration
+      const fidTime = performance.now() - pageshowEvent.timeStamp
+      callback({ delay: fidDelay, time: fidTime as Duration })
+    })
+  })
+}

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
@@ -23,7 +23,6 @@ describe('trackInitialViewMetrics', () => {
     registerCleanupTask(clock.cleanup)
 
     trackInitialViewMetricsResult = trackInitialViewMetrics(configuration, setLoadEventSpy, scheduleViewUpdateSpy)
-
     registerCleanupTask(trackInitialViewMetricsResult.stop)
   })
 
@@ -57,5 +56,32 @@ describe('trackInitialViewMetrics', () => {
     clock.tick(0)
 
     expect(setLoadEventSpy).toHaveBeenCalledOnceWith(jasmine.any(Number))
+  })
+})
+
+describe('trackInitialViewMetrics - bfCache restore', () => {
+  let clock: ReturnType<typeof mockClock>
+  let scheduleViewUpdateSpy: jasmine.Spy<() => void>
+  let setLoadEventSpy: jasmine.Spy<(loadEvent: Duration) => void>
+  let trackResult: ReturnType<typeof trackInitialViewMetrics>
+
+  beforeEach(() => {
+    scheduleViewUpdateSpy = jasmine.createSpy()
+    setLoadEventSpy = jasmine.createSpy()
+    const configuration = mockRumConfiguration()
+    clock = mockClock()
+    registerCleanupTask(clock.cleanup)
+
+    trackResult = trackInitialViewMetrics(configuration, setLoadEventSpy, scheduleViewUpdateSpy)
+    registerCleanupTask(trackResult.stop)
+  })
+
+  it('should update metrics with bfCache restore values', () => {
+    const fakePageshowEvent = new PageTransitionEvent('pageshow', {
+      persisted: true,
+    })
+    window.dispatchEvent(fakePageshowEvent)
+    const { initialViewMetrics } = trackResult
+    expect(initialViewMetrics.bfCache).toBe(true)
   })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -16,6 +16,7 @@ export interface InitialViewMetrics {
   navigationTimings?: NavigationTimings
   largestContentfulPaint?: LargestContentfulPaint
   firstInput?: FirstInput
+  bfCache?: boolean
 }
 
 export function trackInitialViewMetrics(
@@ -53,6 +54,7 @@ export function trackInitialViewMetrics(
   })
 
   onBFCacheRestore((pageshowEvent) => {
+    initialViewMetrics.bfCache = true
     measureRestoredFCP(pageshowEvent, (restoredFCP) => {
       initialViewMetrics.firstContentfulPaint = restoredFCP
       measureRestoredLCP(pageshowEvent, (restoredLCP) => {

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -121,6 +121,7 @@ export interface RawRumViewEvent {
     resource: Count
     frustration: Count
     performance?: ViewPerformanceData
+    bf_cache?: boolean
   }
   session: {
     has_replay: true | undefined


### PR DESCRIPTION
## Motivation

Users navigating back to a page via the browser’s back-forward cache do not experience a full page reload. Therefore, initial performance metrics may no longer accurately represent what the user sees upon restoration. By capturing metrics specifically for bfCache restores, we gain a more precise understanding of user-perceived performance.



## Changes

This PR introduces support for detecting and handling the Back-Forward Cache (bfCache). When a page is restored from bfCache (i.e., a pageshow event with persisted = true)

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
