### PR TITLE
👷 format rum event format validation errors

### DIFF
--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -274,7 +274,7 @@ async function setUpTest(browserLogsManager: BrowserLogsManager, { baseUrl, page
 
 function tearDownPassedTest({ intakeRegistry, withBrowserLogs }: TestContext) {
   expect(intakeRegistry.telemetryErrorEvents).toHaveLength(0)
-  validateRumFormat(intakeRegistry.rumEvents)
+  expect(() => validateRumFormat(intakeRegistry.rumEvents)).not.toThrow()
   withBrowserLogs((logs) => {
     expect(logs.filter((log) => log.level === 'error')).toHaveLength(0)
   })

--- a/test/e2e/lib/helpers/validation.ts
+++ b/test/e2e/lib/helpers/validation.ts
@@ -2,7 +2,6 @@ import fs from 'fs'
 import type { RumEvent } from '@datadog/browser-rum'
 import ajv from 'ajv'
 import { globSync } from 'glob'
-import { expect } from '@playwright/test'
 
 export function validateRumFormat(events: RumEvent[]) {
   const instance = new ajv({
@@ -15,6 +14,38 @@ export function validateRumFormat(events: RumEvent[]) {
 
   events.forEach((rumEvent) => {
     void instance.validate('rum-events-schema.json', rumEvent)
-    expect(instance.errors).toBe(null)
+
+    if (instance.errors) {
+      const formattedError = instance.errors.map((error) => {
+        let allowedValues: string[] | string | undefined
+        switch (error.keyword) {
+          case 'enum':
+            allowedValues = error.params?.allowedValues as string[]
+            break
+          case 'const':
+            allowedValues = error.params?.allowedValue as string
+            break
+        }
+
+        return `event/${error.instancePath || ''} ${error.message!} ${allowedValues ? formatAllowedValues(allowedValues) : ''}`
+      })
+
+      throw new InvalidRumEventError(formattedError.join('\n'))
+    }
   })
+}
+
+class InvalidRumEventError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidRumEventError'
+  }
+}
+
+function formatAllowedValues(allowedValues: string[] | string) {
+  if (!Array.isArray(allowedValues)) {
+    return `'${allowedValues}'`
+  }
+
+  return `('${allowedValues.join("', '")}')`
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Format error when validating events:

![Screenshot 2025-02-21 at 15 51 33](https://github.com/user-attachments/assets/6940bae9-c05b-49c6-9260-c9106b1d3a5d)


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
