### PR TITLE
✅ Change flush sync into act

### DIFF
--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -6,6 +6,7 @@ beforeEach(() => {
   // reset globals
   ;(window as any).DD_LOGS = {}
   ;(window as any).DD_RUM = {}
+  ;(window as any).IS_REACT_ACT_ENVIRONMENT = true
   // prevent 'Some of your tests did a full page reload!' issue
   window.onbeforeunload = () => 'stop'
   startLeakDetection()

--- a/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
+++ b/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
@@ -1,5 +1,4 @@
-import React, {act} from 'react'
-
+import React, { act } from 'react'
 
 import { disableJasmineUncaughtExceptionTracking } from '../../../../core/test'
 import { appendComponent } from '../../../test/appendComponent'

--- a/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
+++ b/packages/rum-react/src/domain/error/errorBoundary.spec.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { flushSync } from 'react-dom'
+import React, {act} from 'react'
+
 
 import { disableJasmineUncaughtExceptionTracking } from '../../../../core/test'
 import { appendComponent } from '../../../test/appendComponent'
@@ -74,7 +74,7 @@ describe('ErrorBoundary', () => {
     ComponentSpy.and.returnValue('bar')
 
     const { resetError } = fallbackSpy.calls.mostRecent().args[0]
-    flushSync(() => {
+    act(() => {
       resetError()
     })
 

--- a/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
+++ b/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect,act } from 'react'
+import React, { useEffect, useLayoutEffect, act } from 'react'
 import { appendComponent } from '../../../test/appendComponent'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'
 import type { Clock } from '../../../../core/test'

--- a/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
+++ b/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useLayoutEffect } from 'react'
-import { flushSync } from 'react-dom'
+import React, { useEffect, useLayoutEffect,act } from 'react'
 import { appendComponent } from '../../../test/appendComponent'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'
 import type { Clock } from '../../../../core/test'
@@ -83,7 +82,7 @@ describe('UNSTABLE_ReactComponentTracker', () => {
 
     clock.tick(1)
 
-    flushSync(() => {
+    act(() => {
       forceUpdate!()
     })
 

--- a/packages/rum-react/src/domain/reactRouterV6/routesComponent.spec.tsx
+++ b/packages/rum-react/src/domain/reactRouterV6/routesComponent.spec.tsx
@@ -1,4 +1,4 @@
-import React,{ act }  from 'react'
+import React, { act } from 'react'
 
 import { MemoryRouter, Route, useNavigate } from 'react-router-dom'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'

--- a/packages/rum-react/src/domain/reactRouterV6/routesComponent.spec.tsx
+++ b/packages/rum-react/src/domain/reactRouterV6/routesComponent.spec.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { flushSync } from 'react-dom'
+import React,{ act }  from 'react'
 
 import { MemoryRouter, Route, useNavigate } from 'react-router-dom'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'
@@ -64,7 +63,7 @@ describe('Routes component', () => {
 
     expect(startViewSpy).toHaveBeenCalledTimes(1)
 
-    flushSync(() => {
+    act(() => {
       forceUpdate!()
     })
 
@@ -91,7 +90,7 @@ describe('Routes component', () => {
     )
 
     startViewSpy.calls.reset()
-    flushSync(() => {
+    act(() => {
       navigate!('/bar')
     })
 
@@ -117,7 +116,7 @@ describe('Routes component', () => {
     )
 
     startViewSpy.calls.reset()
-    flushSync(() => {
+    act(() => {
       navigate!('/foo')
     })
 
@@ -143,7 +142,7 @@ describe('Routes component', () => {
     )
 
     startViewSpy.calls.reset()
-    flushSync(() => {
+    act(() => {
       navigate!('/foo?bar=baz')
     })
 

--- a/packages/rum-react/src/domain/reactRouterV6/useRoutes.spec.tsx
+++ b/packages/rum-react/src/domain/reactRouterV6/useRoutes.spec.tsx
@@ -1,4 +1,4 @@
-import React, {act} from 'react'
+import React, { act } from 'react'
 
 import type { RouteObject } from 'react-router-dom'
 import { MemoryRouter, useNavigate } from 'react-router-dom'

--- a/packages/rum-react/src/domain/reactRouterV6/useRoutes.spec.tsx
+++ b/packages/rum-react/src/domain/reactRouterV6/useRoutes.spec.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { flushSync } from 'react-dom'
+import React, {act} from 'react'
 
 import type { RouteObject } from 'react-router-dom'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
@@ -80,7 +79,7 @@ describe('useRoutes', () => {
 
     expect(startViewSpy).toHaveBeenCalledTimes(1)
 
-    flushSync(() => {
+    act(() => {
       forceUpdate!()
     })
 
@@ -115,7 +114,7 @@ describe('useRoutes', () => {
     )
 
     startViewSpy.calls.reset()
-    flushSync(() => {
+    act(() => {
       navigate!('/bar')
     })
 
@@ -146,7 +145,7 @@ describe('useRoutes', () => {
     )
 
     startViewSpy.calls.reset()
-    flushSync(() => {
+    act(() => {
       navigate!('/foo')
     })
 
@@ -177,7 +176,7 @@ describe('useRoutes', () => {
     )
 
     startViewSpy.calls.reset()
-    flushSync(() => {
+    act(() => {
       navigate!('/foo?bar=baz')
     })
 

--- a/packages/rum-react/test/appendComponent.ts
+++ b/packages/rum-react/test/appendComponent.ts
@@ -1,5 +1,5 @@
 import { createRoot } from 'react-dom/client'
-import { flushSync } from 'react-dom'
+import { act } from 'react'
 import { noop } from '@datadog/browser-core'
 import { appendElement } from '../../rum-core/test'
 import { registerCleanupTask } from '../../core/test'
@@ -10,11 +10,13 @@ export function appendComponent(component: React.ReactNode) {
     // Do nothing by default when an error occurs
     onRecoverableError: noop,
   })
-  flushSync(() => {
+  act(() => {
     root.render(component)
   })
   registerCleanupTask(() => {
-    root.unmount()
+    act(() => {
+      root.unmount()
+    })
   })
   return container
 }


### PR DESCRIPTION
## Motivation

Following the use of act in react-router test, change all flushsync to avoid error log in test. 

## Changes

Update flushsync, set isReactEnvironment to true to avoid this error : 'The current testing environment is not configured to support act(...)'

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
