### PR TITLE
CLS tracking: change source attribution logic and include `devicePixelRatio` inside `performance.cls` namespace

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -405,7 +405,7 @@ describe('view metrics', () => {
         time: clock.relative(0),
         previousRect: undefined,
         currentRect: undefined,
-        devicePixelRatio: 2,
+        devicePixelRatio: jasmine.any(Number),
       })
     })
 

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -405,6 +405,7 @@ describe('view metrics', () => {
         time: clock.relative(0),
         previousRect: undefined,
         currentRect: undefined,
+        devicePixelRatio: 2
       })
     })
 

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -405,7 +405,7 @@ describe('view metrics', () => {
         time: clock.relative(0),
         previousRect: undefined,
         currentRect: undefined,
-        devicePixelRatio: 2
+        devicePixelRatio: 2,
       })
     })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -27,7 +27,7 @@ describe('trackCumulativeLayoutShift', () => {
     viewStart = 0 as RelativeTime,
     isLayoutShiftSupported = true,
   }: Partial<StartCLSTrackingArgs> = {}) {
-    ;({ notifyPerformanceEntries } = mockPerformanceObserver())
+    ; ({ notifyPerformanceEntries } = mockPerformanceObserver())
 
     clsCallback = jasmine.createSpy()
     originalSupportedEntryTypes = Object.getOwnPropertyDescriptor(PerformanceObserver, 'supportedEntryTypes')
@@ -306,6 +306,7 @@ describe('trackCumulativeLayoutShift', () => {
     it('should get the target element, time, and rects of the largest layout shift', () => {
       startCLSTracking()
       const divElement = appendElement('<div id="div-element"></div>')
+      const spanElement = appendElement('<span id="span-element"></span>')
 
       // first session window:  { value: 0.5, time: 1, targetSelector: '#div-element' }
       notifyPerformanceEntries([
@@ -320,6 +321,11 @@ describe('trackCumulativeLayoutShift', () => {
               node: divElement,
               previousRect: DOMRectReadOnly.fromRect({ x: 0, y: 0, width: 10, height: 10 }),
               currentRect: DOMRectReadOnly.fromRect({ x: 50, y: 50, width: 10, height: 10 }),
+            },
+            {
+              node: spanElement,
+              previousRect: DOMRectReadOnly.fromRect({ x: 0, y: 0, width: 40, height: 40 }),
+              currentRect: DOMRectReadOnly.fromRect({ x: 50, y: 50, width: 40, height: 40 }),
             },
           ],
         }),
@@ -346,9 +352,9 @@ describe('trackCumulativeLayoutShift', () => {
       expect(clsCallback.calls.mostRecent().args[0]).toEqual({
         value: 0.5,
         time: 1 as RelativeTime,
-        targetSelector: '#div-element',
-        previousRect: { x: 0, y: 0, width: 10, height: 10 },
-        currentRect: { x: 50, y: 50, width: 10, height: 10 },
+        targetSelector: '#span-element',
+        previousRect: { x: 0, y: 0, width: 40, height: 40 },
+        currentRect: { x: 50, y: 50, width: 40, height: 40 },
       })
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -79,6 +79,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: 2,
     })
   })
 
@@ -143,6 +144,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: 2,
     })
   })
 
@@ -164,6 +166,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: 2,
     })
   })
 
@@ -218,6 +221,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: 2,
     })
   })
 
@@ -355,6 +359,7 @@ describe('trackCumulativeLayoutShift', () => {
         targetSelector: '#span-element',
         previousRect: { x: 0, y: 0, width: 40, height: 40 },
         currentRect: { x: 50, y: 50, width: 40, height: 40 },
+        devicePixelRatio: 2,
       })
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -27,7 +27,7 @@ describe('trackCumulativeLayoutShift', () => {
     viewStart = 0 as RelativeTime,
     isLayoutShiftSupported = true,
   }: Partial<StartCLSTrackingArgs> = {}) {
-    ; ({ notifyPerformanceEntries } = mockPerformanceObserver())
+    ;({ notifyPerformanceEntries } = mockPerformanceObserver())
 
     clsCallback = jasmine.createSpy()
     originalSupportedEntryTypes = Object.getOwnPropertyDescriptor(PerformanceObserver, 'supportedEntryTypes')

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -79,7 +79,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
-      devicePixelRatio: 2,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -144,7 +144,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
-      devicePixelRatio: 2,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -166,7 +166,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
-      devicePixelRatio: 2,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -221,7 +221,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
-      devicePixelRatio: 2,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -359,7 +359,7 @@ describe('trackCumulativeLayoutShift', () => {
         targetSelector: '#span-element',
         previousRect: { x: 0, y: 0, width: 40, height: 40 },
         currentRect: { x: 50, y: 50, width: 40, height: 40 },
-        devicePixelRatio: 2,
+        devicePixelRatio: jasmine.any(Number),
       })
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -117,7 +117,7 @@ function getBiggestElementAttribution(
     (source): source is RumLayoutShiftAttribution & { node: Element } => !!source.node && isElementNode(source.node)
   )
   if (elementNodeSources.length > 0) {
-    return elementNodeSources.reduce((a, b) => {
+    return elementNodeSources.reduce(function (a, b) {
       return a.node && a.previousRect?.width * a.previousRect?.height > b.previousRect?.width * b.previousRect?.height
         ? a
         : b

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -97,7 +97,7 @@ export function trackCumulativeLayoutShift(
           time: biggestShift?.time,
           previousRect: biggestShift?.previousRect ? asRumRect(biggestShift.previousRect) : undefined,
           currentRect: biggestShift?.currentRect ? asRumRect(biggestShift.currentRect) : undefined,
-          devicePixelRatio
+          devicePixelRatio,
         })
       }
     }
@@ -118,9 +118,10 @@ function getBiggestElementAttribution(
   )
   if (elementNodeSources.length > 0) {
     return elementNodeSources.reduce((a, b) => {
-      return a.node && a.previousRect?.width * a.previousRect?.height >
-        b.previousRect?.width * b.previousRect?.height ? a : b;
-    });
+      return a.node && a.previousRect?.width * a.previousRect?.height > b.previousRect?.width * b.previousRect?.height
+        ? a
+        : b
+    })
   }
   return undefined
 }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -77,7 +77,7 @@ export function trackCumulativeLayoutShift(
       const { cumulatedValue, isMaxValue } = window.update(entry)
 
       if (isMaxValue) {
-        const attribution = getFirstElementAttribution(entry.sources)
+        const attribution = getBiggestElementAttribution(entry.sources)
         biggestShift = {
           target: attribution?.node ? new WeakRef(attribution.node) : undefined,
           time: elapsed(viewStart, entry.startTime),
@@ -108,12 +108,19 @@ export function trackCumulativeLayoutShift(
   }
 }
 
-function getFirstElementAttribution(
+function getBiggestElementAttribution(
   sources: RumLayoutShiftAttribution[]
 ): (RumLayoutShiftAttribution & { node: Element }) | undefined {
-  return sources.find(
+  const elementNodeSources = sources.filter(
     (source): source is RumLayoutShiftAttribution & { node: Element } => !!source.node && isElementNode(source.node)
   )
+  if (elementNodeSources.length > 0) {
+    return elementNodeSources.reduce((a, b) => {
+      return a.node && a.previousRect?.width * a.previousRect?.height >
+        b.previousRect?.width * b.previousRect?.height ? a : b;
+    });
+  }
+  return undefined
 }
 
 function asRumRect({ x, y, width, height }: DOMRectReadOnly): RumRect {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -19,6 +19,7 @@ export interface CumulativeLayoutShift {
   time?: Duration
   previousRect?: RumRect
   currentRect?: RumRect
+  devicePixelRatio?: number
 }
 
 interface LayoutShiftInstance {
@@ -74,7 +75,7 @@ export function trackCumulativeLayoutShift(
         continue
       }
 
-      const { cumulatedValue, isMaxValue } = window.update(entry)
+      const { cumulatedValue, isMaxValue, devicePixelRatio } = window.update(entry)
 
       if (isMaxValue) {
         const attribution = getBiggestElementAttribution(entry.sources)
@@ -96,6 +97,7 @@ export function trackCumulativeLayoutShift(
           time: biggestShift?.time,
           previousRect: biggestShift?.previousRect ? asRumRect(biggestShift.previousRect) : undefined,
           currentRect: biggestShift?.currentRect ? asRumRect(biggestShift.currentRect) : undefined,
+          devicePixelRatio
         })
       }
     }
@@ -162,6 +164,7 @@ function slidingSessionWindow() {
       return {
         cumulatedValue,
         isMaxValue,
+        devicePixelRatio: window.devicePixelRatio,
       }
     },
   }


### PR DESCRIPTION
## Motivation
https://datadoghq.atlassian.net/browse/RUM-8744

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
- Adapt cls tracking logic to:
   - Pick the source having the biggest area among those attributed to the biggest CLS score (instead of the first one)
   - See inspiration [here](https://github.com/GoogleChromeLabs/web-vitals-report/blob/71b0879334798c732f460945ded5267cab5a36bf/src/js/analytics.js#L104) 

- Include new attribute `devicePixelRatio` in `performance.cls` namespace:
   - See [this document](https://datadoghq.atlassian.net/wiki/spaces/~614b8bf2071141006ad0cebd/pages/4757587959/Bug+discovered+on+Google+Layout+Instability+API) that explains why we need it

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
