### PR TITLE
CLS tracking: change source attribution logic and include `devicePixelRatio` inside `performance.cls` namespace

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -405,6 +405,7 @@ describe('view metrics', () => {
         time: clock.relative(0),
         previousRect: undefined,
         currentRect: undefined,
+        devicePixelRatio: jasmine.any(Number),
       })
     })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -79,6 +79,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -143,6 +144,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -164,6 +166,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -218,6 +221,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -355,6 +359,7 @@ describe('trackCumulativeLayoutShift', () => {
         targetSelector: '#span-element',
         previousRect: { x: 0, y: 0, width: 40, height: 40 },
         currentRect: { x: 50, y: 50, width: 40, height: 40 },
+        devicePixelRatio: jasmine.any(Number),
       })
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -310,9 +310,8 @@ describe('trackCumulativeLayoutShift', () => {
     it('should get the target element, time, and rects of the largest layout shift', () => {
       startCLSTracking()
       const divElement = appendElement('<div id="div-element"></div>')
-      const spanElement = appendElement('<span id="span-element"></span>')
+      const largerElement = appendElement('<span id="larger-element"></span>')
 
-      // first session window:  { value: 0.5, time: 1, targetSelector: '#div-element' }
       notifyPerformanceEntries([
         createPerformanceEntry(RumPerformanceEntryType.LAYOUT_SHIFT, { value: 0.1, startTime: 0 as RelativeTime }),
       ])
@@ -327,7 +326,7 @@ describe('trackCumulativeLayoutShift', () => {
               currentRect: DOMRectReadOnly.fromRect({ x: 50, y: 50, width: 10, height: 10 }),
             },
             {
-              node: spanElement,
+              node: largerElement,
               previousRect: DOMRectReadOnly.fromRect({ x: 0, y: 0, width: 40, height: 40 }),
               currentRect: DOMRectReadOnly.fromRect({ x: 50, y: 50, width: 40, height: 40 }),
             },
@@ -356,7 +355,7 @@ describe('trackCumulativeLayoutShift', () => {
       expect(clsCallback.calls.mostRecent().args[0]).toEqual({
         value: 0.5,
         time: 1 as RelativeTime,
-        targetSelector: '#span-element',
+        targetSelector: '#larger-element',
         previousRect: { x: 0, y: 0, width: 40, height: 40 },
         currentRect: { x: 50, y: 50, width: 40, height: 40 },
         devicePixelRatio: jasmine.any(Number),

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -306,6 +306,7 @@ describe('trackCumulativeLayoutShift', () => {
     it('should get the target element, time, and rects of the largest layout shift', () => {
       startCLSTracking()
       const divElement = appendElement('<div id="div-element"></div>')
+      const spanElement = appendElement('<span id="span-element"></span>')
 
       // first session window:  { value: 0.5, time: 1, targetSelector: '#div-element' }
       notifyPerformanceEntries([
@@ -320,6 +321,11 @@ describe('trackCumulativeLayoutShift', () => {
               node: divElement,
               previousRect: DOMRectReadOnly.fromRect({ x: 0, y: 0, width: 10, height: 10 }),
               currentRect: DOMRectReadOnly.fromRect({ x: 50, y: 50, width: 10, height: 10 }),
+            },
+            {
+              node: spanElement,
+              previousRect: DOMRectReadOnly.fromRect({ x: 0, y: 0, width: 40, height: 40 }),
+              currentRect: DOMRectReadOnly.fromRect({ x: 50, y: 50, width: 40, height: 40 }),
             },
           ],
         }),
@@ -346,9 +352,9 @@ describe('trackCumulativeLayoutShift', () => {
       expect(clsCallback.calls.mostRecent().args[0]).toEqual({
         value: 0.5,
         time: 1 as RelativeTime,
-        targetSelector: '#div-element',
-        previousRect: { x: 0, y: 0, width: 10, height: 10 },
-        currentRect: { x: 50, y: 50, width: 10, height: 10 },
+        targetSelector: '#span-element',
+        previousRect: { x: 0, y: 0, width: 40, height: 40 },
+        currentRect: { x: 50, y: 50, width: 40, height: 40 },
       })
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -19,6 +19,7 @@ export interface CumulativeLayoutShift {
   time?: Duration
   previousRect?: RumRect
   currentRect?: RumRect
+  devicePixelRatio?: number
 }
 
 interface LayoutShiftInstance {
@@ -74,7 +75,7 @@ export function trackCumulativeLayoutShift(
         continue
       }
 
-      const { cumulatedValue, isMaxValue } = window.update(entry)
+      const { cumulatedValue, isMaxValue, devicePixelRatio } = window.update(entry)
 
       if (isMaxValue) {
         const attribution = getBiggestElementAttribution(entry.sources)
@@ -96,6 +97,7 @@ export function trackCumulativeLayoutShift(
           time: biggestShift?.time,
           previousRect: biggestShift?.previousRect ? asRumRect(biggestShift.previousRect) : undefined,
           currentRect: biggestShift?.currentRect ? asRumRect(biggestShift.currentRect) : undefined,
+          devicePixelRatio,
         })
       }
     }
@@ -163,6 +165,7 @@ function slidingSessionWindow() {
       return {
         cumulatedValue,
         isMaxValue,
+        devicePixelRatio: window.devicePixelRatio,
       }
     },
   }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -116,14 +116,12 @@ function getBiggestElementAttribution(
   const elementNodeSources = sources.filter(
     (source): source is RumLayoutShiftAttribution & { node: Element } => !!source.node && isElementNode(source.node)
   )
-  if (elementNodeSources.length > 0) {
-    return elementNodeSources.reduce(function (a, b) {
-      return a.node && a.previousRect?.width * a.previousRect?.height > b.previousRect?.width * b.previousRect?.height
-        ? a
-        : b
-    })
+  if (elementNodeSources.length <= 0) {
+    return
   }
-  return undefined
+  return elementNodeSources.reduce(function (a, b) {
+    return a.previousRect?.width * a.previousRect?.height > b.previousRect?.width * b.previousRect?.height ? a : b
+  })
 }
 
 function asRumRect({ x, y, width, height }: DOMRectReadOnly): RumRect {


### PR DESCRIPTION
## Motivation
Implementation of small adjustments in Browser SDK for CLS attribution:
- Include `devicePixelRatio` attribute: 
   - Recent discoveries showed that Layout Instability API does not report viewPort coordinates for `prevRect` and `currentRect`.
   - We'd need to include this data in the CLS attribution object. See [this document](https://datadoghq.atlassian.net/wiki/spaces/~614b8bf2071141006ad0cebd/pages/4757587959/Bug+discovered+on+Google+Layout+Instability+API) for more context

- Adapt fix “most shifted“ element calculation: 
   - The current calculation does not take into account the sources size attached to a CLS entry, it returns always the first one
   - It’d be more relevant returning the biggest element (among those having the same shift), since it could be more impactful than a smaller element with the same shift
   - Change inspired on [this snippet](https://github.com/GoogleChromeLabs/web-vitals-report/blob/71b0879334798c732f460945ded5267cab5a36bf/src/js/analytics.js#L104)

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
- Include new attribute `devicePixelRatio` in the CLS attribution
- Adapt cls tracking logic to pick the source having the biggest area among those attributed to the CLS entry

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
