### PR TITLE
🐛 Fix empty string for resource url in LCP 

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -149,4 +149,19 @@ describe('trackLargestContentfulPaint', () => {
     expect(lcpCallback.calls.first().args[0]).toEqual(jasmine.objectContaining({ value: 1 }))
     expect(lcpCallback.calls.mostRecent().args[0]).toEqual(jasmine.objectContaining({ value: 2 }))
   })
+
+  it('should return undefined when LCP entry has an empty string as url', () => {
+    startLCPTracking()
+    notifyPerformanceEntries([
+      createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT, {
+        url: '',
+      }),
+    ])
+
+    expect(lcpCallback).toHaveBeenCalledOnceWith({
+      value: 789 as RelativeTime,
+      targetSelector: undefined,
+      resourceUrl: undefined,
+    })
+  })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
@@ -67,7 +67,7 @@ export function trackLargestContentfulPaint(
       callback({
         value: lcpEntry.startTime,
         targetSelector: lcpTargetSelector,
-        resourceUrl: lcpEntry.url,
+        resourceUrl: computeLcpEntryUrl(lcpEntry),
       })
       biggestLcpSize = lcpEntry.size
     }
@@ -79,4 +79,9 @@ export function trackLargestContentfulPaint(
       performanceLcpSubscription.unsubscribe()
     },
   }
+}
+
+// The property url report an empty string if the value is not available, we shouldn't report it in this case.
+function computeLcpEntryUrl(entry: RumLargestContentfulPaintTiming) {
+  return entry.url === '' ? undefined : entry.url
 }


### PR DESCRIPTION
## Motivation

The property url report an empty string if the value is not available, we shouldn't report it in this case.

## Changes

Add a check  function to discard empty string value

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
