### PR TITLE
✨ [RUM-8622] introduce session-consistent trace sample rate

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -15,7 +15,6 @@ import { objectHasValue } from './utils/objectUtils'
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  CONSISTENT_TRACE_SAMPLING = 'consistent_trace_sampling',
   MISSING_URL_CONTEXT_TELEMETRY = 'missing_url_context_telemetry',
 }
 

--- a/packages/rum-core/src/domain/tracing/sampler.ts
+++ b/packages/rum-core/src/domain/tracing/sampler.ts
@@ -1,4 +1,4 @@
-import { ExperimentalFeature, isExperimentalFeatureEnabled, performDraw } from '@datadog/browser-core'
+import { performDraw } from '@datadog/browser-core'
 
 let sampleDecisionCache: { sessionId: string; decision: boolean } | undefined
 
@@ -11,10 +11,6 @@ export function isTraceSampled(sessionId: string, sampleRate: number) {
 
   if (sampleRate === 0) {
     return false
-  }
-
-  if (!isExperimentalFeatureEnabled(ExperimentalFeature.CONSISTENT_TRACE_SAMPLING)) {
-    return performDraw(sampleRate)
   }
 
   if (sampleDecisionCache && sessionId === sampleDecisionCache.sessionId) {


### PR DESCRIPTION
## Motivation

Before, the `traceSampleRate` was re-evaluated randomly for each request.

With this PR, the `traceSampleRate` is computed based on the session id, ensuring all request of a given session are either traced or not.

## Changes

* Remove the flag introduced by #3352 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
