### PR TITLE
🐛 [RUM-8744] CLS tracking: provide cls `devicePixelRatio` to adjust cls rect scale

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -405,6 +405,7 @@ describe('view metrics', () => {
         time: clock.relative(0),
         previousRect: undefined,
         currentRect: undefined,
+        devicePixelRatio: jasmine.any(Number),
       })
     })
 

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -120,6 +120,7 @@ describe('viewCollection', () => {
         configuration: {
           start_session_replay_recording_manually: jasmine.any(Boolean),
         },
+        cls: undefined,
       },
       date: jasmine.any(Number),
       type: RumEventType.VIEW,

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -65,10 +65,19 @@ function processViewUpdate(
   recorderApi: RecorderApi
 ): RawRumEventCollectedData<RawRumViewEvent> {
   const replayStats = recorderApi.getReplayStats(view.id)
+  const { cls_device_pixel_ratio: clsDevicePixelRatio, ...viewPerformanceData } = computeViewPerformanceData(
+    view.commonViewMetrics,
+    view.initialViewMetrics
+  )
   const viewEvent: RawRumViewEvent = {
     _dd: {
       document_version: view.documentVersion,
       replay_stats: replayStats,
+      cls: clsDevicePixelRatio
+        ? {
+            device_pixel_ratio: clsDevicePixelRatio,
+          }
+        : undefined,
       configuration: {
         start_session_replay_recording_manually: configuration.startSessionReplayRecordingManually,
       },
@@ -109,7 +118,7 @@ function processViewUpdate(
       long_task: {
         count: view.eventCounts.longTaskCount,
       },
-      performance: computeViewPerformanceData(view.commonViewMetrics, view.initialViewMetrics),
+      performance: viewPerformanceData,
       resource: {
         count: view.eventCounts.resourceCount,
       },
@@ -178,5 +187,6 @@ function computeViewPerformanceData(
       target_selector: largestContentfulPaint.targetSelector,
       resource_url: largestContentfulPaint.resourceUrl,
     },
+    cls_device_pixel_ratio: cumulativeLayoutShift && cumulativeLayoutShift.devicePixelRatio,
   }
 }

--- a/packages/rum-core/src/domain/view/viewCollection.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.ts
@@ -65,10 +65,7 @@ function processViewUpdate(
   recorderApi: RecorderApi
 ): RawRumEventCollectedData<RawRumViewEvent> {
   const replayStats = recorderApi.getReplayStats(view.id)
-  const { cls_device_pixel_ratio: clsDevicePixelRatio, ...viewPerformanceData } = computeViewPerformanceData(
-    view.commonViewMetrics,
-    view.initialViewMetrics
-  )
+  const clsDevicePixelRatio = view.commonViewMetrics?.cumulativeLayoutShift?.devicePixelRatio
   const viewEvent: RawRumViewEvent = {
     _dd: {
       document_version: view.documentVersion,
@@ -118,7 +115,7 @@ function processViewUpdate(
       long_task: {
         count: view.eventCounts.longTaskCount,
       },
-      performance: viewPerformanceData,
+      performance: computeViewPerformanceData(view.commonViewMetrics, view.initialViewMetrics),
       resource: {
         count: view.eventCounts.resourceCount,
       },
@@ -187,6 +184,5 @@ function computeViewPerformanceData(
       target_selector: largestContentfulPaint.targetSelector,
       resource_url: largestContentfulPaint.resourceUrl,
     },
-    cls_device_pixel_ratio: cumulativeLayoutShift && cumulativeLayoutShift.devicePixelRatio,
   }
 }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.spec.ts
@@ -79,6 +79,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -143,6 +144,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -164,6 +166,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -218,6 +221,7 @@ describe('trackCumulativeLayoutShift', () => {
       targetSelector: undefined,
       previousRect: undefined,
       currentRect: undefined,
+      devicePixelRatio: jasmine.any(Number),
     })
   })
 
@@ -349,6 +353,7 @@ describe('trackCumulativeLayoutShift', () => {
         targetSelector: '#div-element',
         previousRect: { x: 0, y: 0, width: 10, height: 10 },
         currentRect: { x: 50, y: 50, width: 10, height: 10 },
+        devicePixelRatio: jasmine.any(Number),
       })
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -19,6 +19,7 @@ export interface CumulativeLayoutShift {
   time?: Duration
   previousRect?: RumRect
   currentRect?: RumRect
+  devicePixelRatio?: number
 }
 
 interface LayoutShiftInstance {
@@ -26,6 +27,7 @@ interface LayoutShiftInstance {
   time: Duration
   previousRect: DOMRectReadOnly | undefined
   currentRect: DOMRectReadOnly | undefined
+  devicePixelRatio: number
 }
 
 /**
@@ -64,7 +66,7 @@ export function trackCumulativeLayoutShift(
     value: 0,
   })
 
-  const window = slidingSessionWindow()
+  const slidingWindow = slidingSessionWindow()
   const performanceSubscription = createPerformanceObservable(configuration, {
     type: RumPerformanceEntryType.LAYOUT_SHIFT,
     buffered: true,
@@ -74,7 +76,7 @@ export function trackCumulativeLayoutShift(
         continue
       }
 
-      const { cumulatedValue, isMaxValue } = window.update(entry)
+      const { cumulatedValue, isMaxValue } = slidingWindow.update(entry)
 
       if (isMaxValue) {
         const attribution = getFirstElementAttribution(entry.sources)
@@ -83,6 +85,7 @@ export function trackCumulativeLayoutShift(
           time: elapsed(viewStart, entry.startTime),
           previousRect: attribution?.previousRect,
           currentRect: attribution?.currentRect,
+          devicePixelRatio: window.devicePixelRatio,
         }
       }
 
@@ -96,6 +99,7 @@ export function trackCumulativeLayoutShift(
           time: biggestShift?.time,
           previousRect: biggestShift?.previousRect ? asRumRect(biggestShift.previousRect) : undefined,
           currentRect: biggestShift?.currentRect ? asRumRect(biggestShift.currentRect) : undefined,
+          devicePixelRatio: biggestShift?.devicePixelRatio,
         })
       }
     }

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -178,7 +178,6 @@ export interface ViewPerformanceData {
     target_selector?: string
     resource_url?: string
   }
-  cls_device_pixel_ratio?: number
 }
 
 export interface RumRect {

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -134,6 +134,9 @@ export interface RawRumViewEvent {
     document_version: number
     replay_stats?: ReplayStats
     page_states?: PageStateServerEntry[]
+    cls?: {
+      device_pixel_ratio: number
+    }
     configuration: {
       start_session_replay_recording_manually: boolean
     }
@@ -175,6 +178,7 @@ export interface ViewPerformanceData {
     target_selector?: string
     resource_url?: string
   }
+  cls_device_pixel_ratio?: number
 }
 
 export interface RumRect {

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1132,6 +1132,12 @@ export type RumViewEvent = CommonProperties &
          */
         segments_total_raw_size?: number
         [k: string]: unknown
+        /**
+         * Device pixel ratio of the device when the cumulative layout shift was reported
+         */
+        cls?: {
+          device_pixel_ratio: number
+        }
       }
       /**
        * Subset of the SDK configuration options in use during its execution

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1132,12 +1132,16 @@ export type RumViewEvent = CommonProperties &
          */
         segments_total_raw_size?: number
         [k: string]: unknown
+      }
+      /**
+       * Additional information of the reported Cumulative Layout Shift
+       */
+      readonly cls?: {
         /**
-         * Device pixel ratio of the device when the cumulative layout shift was reported
+         * Pixel ratio of the device where the layout shift was reported
          */
-        cls?: {
-          device_pixel_ratio: number
-        }
+        readonly device_pixel_ratio?: number
+        [k: string]: unknown
       }
       /**
        * Subset of the SDK configuration options in use during its execution


### PR DESCRIPTION
## Motivation
https://datadoghq.atlassian.net/browse/RUM-8744

Implementation of small adjustments in Browser SDK for CLS attribution:
- Include `devicePixelRatio` attribute: 
   - Recent discoveries showed that Layout Instability API does not report viewPort coordinates for `prevRect` and `currentRect`.
   - We'd need to include this data in `_dd.cls.device_pixel_ratio`. See [this document](https://datadoghq.atlassian.net/wiki/spaces/~614b8bf2071141006ad0cebd/pages/4757587959/Bug+discovered+on+Google+Layout+Instability+API) for more context

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/914ef8ec-5241-4530-8f10-3cc0c10cc3b2" />

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
- Include new attribute `devicePixelRatio` in the CLS attribution

Tested in local:
![image](https://github.com/user-attachments/assets/05d16211-3d3c-4b61-93fd-5abf71fa95e9)


<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
