### PR TITLE
🐛 [RUM-8606] Track First Hidden before init

### DIFF
--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -28,6 +28,7 @@ export enum RumPerformanceEntryType {
   NAVIGATION = 'navigation',
   PAINT = 'paint',
   RESOURCE = 'resource',
+  VISIBILITY_STATE = 'visibility-state',
 }
 
 export interface RumPerformanceLongTaskTiming {
@@ -171,6 +172,13 @@ export interface RumPerformanceLongAnimationFrameTiming {
   toJSON(): Omit<RumPerformanceLongAnimationFrameTiming, 'toJSON'>
 }
 
+export interface RumFirstHiddenTiming {
+  entryType: RumPerformanceEntryType.VISIBILITY_STATE
+  name: 'hidden'
+  startTime: RelativeTime
+  toJSON(): Omit<RumFirstHiddenTiming, 'toJSON'>
+}
+
 export type RumPerformanceEntry =
   | RumPerformanceResourceTiming
   | RumPerformanceLongTaskTiming
@@ -181,6 +189,7 @@ export type RumPerformanceEntry =
   | RumFirstInputTiming
   | RumPerformanceEventTiming
   | RumLayoutShiftTiming
+  | RumFirstHiddenTiming
 
 export type EntryTypeToReturnType = {
   [RumPerformanceEntryType.EVENT]: RumPerformanceEventTiming
@@ -192,6 +201,7 @@ export type EntryTypeToReturnType = {
   [RumPerformanceEntryType.LONG_ANIMATION_FRAME]: RumPerformanceLongAnimationFrameTiming
   [RumPerformanceEntryType.NAVIGATION]: RumPerformanceNavigationTiming
   [RumPerformanceEntryType.RESOURCE]: RumPerformanceResourceTiming
+  [RumPerformanceEntryType.VISIBILITY_STATE]: RumFirstHiddenTiming
 }
 
 export function createPerformanceObservable<T extends RumPerformanceEntryType>(

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -174,7 +174,7 @@ export interface RumPerformanceLongAnimationFrameTiming {
 
 export interface RumFirstHiddenTiming {
   entryType: RumPerformanceEntryType.VISIBILITY_STATE
-  name: 'hidden'
+  name: 'hidden' | 'visible'
   startTime: RelativeTime
   toJSON(): Omit<RumFirstHiddenTiming, 'toJSON'>
 }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -85,8 +85,16 @@ describe('trackFirstHidden', () => {
   })
 
   describe('using visibilityState entries', () => {
+    let originalSupportedEntryTypes: string[] | undefined
     beforeEach(() => {
       performanceBufferMock = mockGlobalPerformanceBuffer()
+      if (typeof PerformanceObserver !== 'undefined') {
+        originalSupportedEntryTypes = PerformanceObserver.supportedEntryTypes as string[]
+        Object.defineProperty(PerformanceObserver, 'supportedEntryTypes', {
+          get: () => [...(originalSupportedEntryTypes || []), 'visibility-state'],
+          configurable: true,
+        })
+      }
     })
     it('should set timestamp to earliest hidden event from performance entries', () => {
       setPageVisibility('visible')

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -102,12 +102,13 @@ describe('trackFirstHidden', () => {
       performanceBufferMock.addPerformanceEntry({
         entryType: 'visibility-state',
         name: 'hidden',
-        startTime: 23219031,
+        startTime: 23,
       } as PerformanceEntry)
+
       performanceBufferMock.addPerformanceEntry({
         entryType: 'visibility-state',
         name: 'hidden',
-        startTime: 23,
+        startTime: 23219031,
       } as PerformanceEntry)
 
       firstHidden = trackFirstHidden(configuration)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -1,12 +1,14 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { DOM_EVENT } from '@datadog/browser-core'
 import { createNewEvent, restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../../../test'
+import { mockRumConfiguration, mockGlobalPerformanceBuffer } from '../../../../test'
+import type { GlobalPerformanceBufferMock } from '../../../../test'
 import { trackFirstHidden } from './trackFirstHidden'
 
 describe('trackFirstHidden', () => {
   const configuration = mockRumConfiguration()
   let firstHidden: { timeStamp: RelativeTime; stop: () => void }
+  let performanceBufferMock: GlobalPerformanceBufferMock
 
   afterEach(() => {
     restorePageVisibility()
@@ -79,6 +81,29 @@ describe('trackFirstHidden', () => {
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.VISIBILITY_CHANGE, { timeStamp: 200 }))
 
       expect(firstHidden.timeStamp).toBe(100 as RelativeTime)
+    })
+  })
+
+  describe('using visibilityState entries', () => {
+    beforeEach(() => {
+      performanceBufferMock = mockGlobalPerformanceBuffer()
+    })
+    it('should set timestamp to earliest hidden event from performance entries', () => {
+      setPageVisibility('visible')
+
+      performanceBufferMock.addPerformanceEntry({
+        entryType: 'visibility-state',
+        name: 'hidden',
+        startTime: 23219031,
+      } as PerformanceEntry)
+      performanceBufferMock.addPerformanceEntry({
+        entryType: 'visibility-state',
+        name: 'hidden',
+        startTime: 23,
+      } as PerformanceEntry)
+
+      firstHidden = trackFirstHidden(configuration)
+      expect(firstHidden.timeStamp).toBe(23 as RelativeTime)
     })
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -11,7 +11,9 @@ export function trackFirstHidden(configuration: RumConfiguration, eventTarget: W
   }
 
   if (supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
-    const firstHiddenEntry = performance.getEntriesByType('visibility-state').find((entry) => entry.name === 'hidden')
+    const firstHiddenEntry = performance
+      .getEntriesByType(RumPerformanceEntryType.VISIBILITY_STATE)
+      .find((entry) => entry.name === 'hidden')
     if (firstHiddenEntry) {
       return { timeStamp: firstHiddenEntry.startTime as RelativeTime, stop: noop }
     }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -8,7 +8,8 @@ export function trackFirstHidden(configuration: RumConfiguration, eventTarget: W
   let timeStamp: RelativeTime = Infinity as RelativeTime
   let stopListeners: () => void | undefined
   let earliestHidden = Infinity
-  if (typeof performance !== 'undefined' && 'getEntriesByType' in performance) {
+
+  if (typeof performance !== 'undefined' && 'getEntriesByType' in performance && supportsVisibilityStateEntries()) {
     const visibilityEntries = performance.getEntriesByType('visibility-state')
     if (visibilityEntries && visibilityEntries.length > 0) {
       for (const entry of visibilityEntries) {
@@ -45,5 +46,13 @@ export function trackFirstHidden(configuration: RumConfiguration, eventTarget: W
     stop() {
       stopListeners?.()
     },
+  }
+
+  function supportsVisibilityStateEntries() {
+    return (
+      typeof PerformanceObserver !== 'undefined' &&
+      PerformanceObserver.supportedEntryTypes &&
+      PerformanceObserver.supportedEntryTypes.includes('visibility-state')
+    )
   }
 }


### PR DESCRIPTION
## Motivation

When a page is in background, the browser can pause or slow down its execution to preserve resources. This is known to skew page-load related metrics (ex: vitals like FCP/FID and other like `@view.loading_time`): when the user opens a page in background (ex: middle click), those timings can be arbitrary long (as long as the tab stays in background). This is why we try to detect that a page was hidden/in background and discard those timings in this case.

But we only do so once init is called: we don’t know whether a page was in background before init is called, or even before the SDK was loaded.

## Changes

Chrome is providing Performance entries called visibility-state that are notified whenever a page gets hidden/visible: [VisibilityStateEntry - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/VisibilityStateEntry) . It is possible to query past entries using performange.getEntriesByType('visibility-state'). When the browser support this, it could be used as initial state in trackFirstHidden .

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
