### PR TITLE
👷 filter out "Layout was forced..." console warning in e2e tests on Firefox

### DIFF
--- a/test/e2e/lib/helpers/browser.ts
+++ b/test/e2e/lib/helpers/browser.ts
@@ -26,6 +26,8 @@ export interface BrowserLog {
   timestamp: number
 }
 
+const IGNORE_LOG_MESSAGES = ['Ignoring unsupported entryTypes:', 'Layout was forced before the page was fully loaded.']
+
 export class BrowserLogsManager {
   private logs: BrowserLog[] = []
 
@@ -34,15 +36,14 @@ export class BrowserLogsManager {
   }
 
   get() {
-    const filteredLogs = this.logs.filter((log) => !log.message.includes('Ignoring unsupported entryTypes: '))
+    return this.logs.filter((log) => {
+      if (IGNORE_LOG_MESSAGES.some((message) => log.message.includes(message))) {
+        addTag('test.fixme', `Unnexpected Console log message: "${log.message}"`)
+        return false
+      }
 
-    if (this.logs.some((log) => log.message.includes('Ignoring unsupported entryTypes: '))) {
-      // FIXME: fix this at the perfomance observer level as it is visible to customers
-      // It used to pass before because it was only happening in Firefox but wdio io did not support console logs for FF
-      addTag('test.fixme', 'Unnexpected Console log message: "Ignoring unsupported entryTypes: *"')
-    }
-
-    return filteredLogs
+      return true
+    })
   }
 
   clear() {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Firefox is sometimes showing a console warning about `Layout was forced before the page was fully loaded.` in our e2e tests. It's not consistent but makes test to fails unexpectedly from time to time. 

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
