### PR TITLE
⚡️ use `import()` for lazy loading chunks

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -18,6 +18,8 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
           `chunks/[name]-${filename}`
         : // Include a content hash in chunk names in production.
           `chunks/[name]-[contenthash]-${filename}`,
+    chunkLoading: 'import',
+    chunkFormat: 'module',
     path: path.resolve('./bundle'),
   },
   target: ['web', 'es2018'],


### PR DESCRIPTION
## Motivation

The default webpack strategy to lazy load chunks is "jsonp" which adds around 4kb to bundles

## Changes

Using "import" should reduce the webpack boilerplate for lazy-loading bundles.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
