### PR TITLE
[RUM-8912] Add documentation to the beforeSend function in configuration

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -33,6 +33,9 @@ export interface InitConfiguration {
    * The client token for Datadog. Required for authenticating your application with Datadog.
    */
   clientToken: string
+  /**
+   * A callback function that can be used to modify events before they are sent to Datadog.
+   */
   beforeSend?: GenericBeforeSendCallback | undefined
   /**
    * The percentage of sessions tracked. A value between 0 and 100.


### PR DESCRIPTION
## Motivation

Added missing JSDoc comment for the beforeSend configuration option to maintain documentation consistency.

## Changes

Added documentation comment for the beforeSend callback function in InitConfiguration.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [X] Local- Verified that the comment appears correctly in the source code
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
