### PR TITLE
🐛  Add missing original error for beforeSend context

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -85,6 +85,7 @@ function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: 
       handling: ErrorHandling.HANDLED,
       handlingStack,
       context: tryToGetErrorContext(firstErrorParam),
+      originalError: firstErrorParam,
     }
   }
 


### PR DESCRIPTION
Closes #3402 

## Motivation

Fix `error: undefined` in `context` of `beforeSend`.

## Changes

Add missing original error to `context` of `beforeSend` for React (SSR) production mode.

_Before:_

<img width="468" alt="before" src="https://github.com/user-attachments/assets/d00d9da7-ebfe-4c09-9cd5-ac43d280ca86" />

_After:_

<img width="468" alt="after" src="https://github.com/user-attachments/assets/8c2bc6bd-e0a6-4933-b08f-20bae8ae4107" />

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [x] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
