### PR TITLE
📝 [RUM-7705] Add js doc about option that need to be aligned

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -28,18 +28,6 @@ export const TraceContextInjection = {
 
 export type TraceContextInjection = (typeof TraceContextInjection)[keyof typeof TraceContextInjection]
 
-/**
- * Important, if you are using the RUM and Logs Browser SDKs, the following options
- * must be configured with identical values :
- *
- * - sessionPersistence
- * - trackSessionAcrossSubdomains
- * - useSecureSessionCookie
- * - usePartitionedCrossSiteSessionCookie
- * - allowFallbackToLocalStorage (deprecated)
- *
- * Mismatching these options between RUM and Logs can cause inconsistent session behavior.
- */
 export interface InitConfiguration {
   /**
    * The client token for Datadog. Required for authenticating your application with Datadog.
@@ -67,12 +55,14 @@ export interface InitConfiguration {
 
   /**
    * Which storage strategy to use for persisting sessions. Can be either 'cookie' or 'local-storage'.
+   * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default "cookie"
    */
   sessionPersistence?: SessionPersistence | undefined
 
   /**
    * Allows the use of localStorage when cookies cannot be set. This enables the RUM Browser SDK to run in environments that do not provide cookie support.
+   * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * See [Monitor Electron Applications Using the Browser SDK](https://docs.datadoghq.com/real_user_monitoring/guide/monitor-electron-applications-using-browser-sdk) for further information.
    * @deprecated use `sessionPersistence: local-storage` where you want to use localStorage instead
    */
@@ -125,16 +115,19 @@ export interface InitConfiguration {
   // cookie options
   /**
    * Use a partitioned secure cross-site session cookie. This allows the RUM Browser SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`.
+   * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default false
    */
   usePartitionedCrossSiteSessionCookie?: boolean | undefined
   /**
    * Use a secure session cookie. This disables RUM events sent on insecure (non-HTTPS) connections.
+   * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default false
    */
   useSecureSessionCookie?: boolean | undefined
   /**
    * Preserve the session across subdomains for the same site.
+   * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default false
    */
   trackSessionAcrossSubdomains?: boolean | undefined

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -55,6 +55,7 @@ export interface InitConfiguration {
 
   /**
    * Which storage strategy to use for persisting sessions. Can be either 'cookie' or 'local-storage'.
+   *
    * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default "cookie"
    */
@@ -62,6 +63,7 @@ export interface InitConfiguration {
 
   /**
    * Allows the use of localStorage when cookies cannot be set. This enables the RUM Browser SDK to run in environments that do not provide cookie support.
+   *
    * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * See [Monitor Electron Applications Using the Browser SDK](https://docs.datadoghq.com/real_user_monitoring/guide/monitor-electron-applications-using-browser-sdk) for further information.
    * @deprecated use `sessionPersistence: local-storage` where you want to use localStorage instead
@@ -115,18 +117,21 @@ export interface InitConfiguration {
   // cookie options
   /**
    * Use a partitioned secure cross-site session cookie. This allows the RUM Browser SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`.
+   *
    * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default false
    */
   usePartitionedCrossSiteSessionCookie?: boolean | undefined
   /**
    * Use a secure session cookie. This disables RUM events sent on insecure (non-HTTPS) connections.
+   *
    * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default false
    */
   useSecureSessionCookie?: boolean | undefined
   /**
    * Preserve the session across subdomains for the same site.
+   *
    * Important: If you are using the RUM and Logs Browser SDKs, this option must be configured with identical values
    * @default false
    */

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -28,6 +28,18 @@ export const TraceContextInjection = {
 
 export type TraceContextInjection = (typeof TraceContextInjection)[keyof typeof TraceContextInjection]
 
+/**
+ * Important, if you are using the RUM and Logs Browser SDKs, the following options
+ * must be configured with identical values :
+ *
+ * - sessionPersistence
+ * - trackSessionAcrossSubdomains
+ * - useSecureSessionCookie
+ * - usePartitionedCrossSiteSessionCookie
+ * - allowFallbackToLocalStorage (deprecated)
+ *
+ * Mismatching these options between RUM and Logs can cause inconsistent session behavior.
+ */
 export interface InitConfiguration {
   /**
    * The client token for Datadog. Required for authenticating your application with Datadog.


### PR DESCRIPTION
## Motivation

If options are not aligned between RUM and LOGS the SDK could not initialised correctly.

## Changes

Add Js doc to highlight this better

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
