### PR TITLE
👷 Use four Terser passes

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -57,6 +57,11 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
     minimizer: [
       new TerserPlugin({
         extractComments: false,
+        terserOptions: {
+          compress: {
+            passes: 4,
+          },
+        },
       }),
     ],
   },


### PR DESCRIPTION
## Motivation

This is one of a series of PRs experimenting with enabling more aggressive options for Terser, with the goal of reducing the size of the browser SDK bundles.

## Changes

This PR enables the following options:
* `passes: 4`

The default is `passes: 2`. I tried `passes: 3` as well in [this draft PR](https://github.com/DataDog/browser-sdk/pull/3415), but `passes: 4` seems to be enough of an improvement to be worth it.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
