### PR TITLE
👷 Use three Terser passes

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -55,6 +55,11 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
     minimizer: [
       new TerserPlugin({
         extractComments: false,
+        terserOptions: {
+          compress: {
+            passes: 3,
+          },
+        },
       }),
     ],
   },


### PR DESCRIPTION
## Motivation

This is one of a series of PRs experimenting with enabling more aggressive options for Terser, with the goal of reducing the size of the browser SDK bundles.

## Changes

This PR enables the following options:
* `passes: 3`

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
