### PR TITLE
👷 Enable the Terser unsafe_methods option

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -58,8 +58,11 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
       new TerserPlugin({
         extractComments: false,
         terserOptions: {
+          ecma: 2018,
+          module: true,
           compress: {
             passes: 4,
+            unsafe_methods: true,
           },
         },
       }),


### PR DESCRIPTION
## Motivation

This is one of a series of PRs experimenting with enabling more aggressive options for Terser, with the goal of reducing the size of the browser SDK bundles.

## Changes

This PR enables the following options:
* `unsafe_methods: true`
* `ecma: 2018` (Using `ecma: 6` or greater is required for `unsafe_methods`; I matched the target we're using for webpack.)
* `module: true` (This specifies that we're bundling ES modules, again matching the webpack configuration.)

The focus here is `unsafe_methods: true`. Here's what the Terser docs have to say about it:

> unsafe_methods (default: false) -- Converts { m: function(){} } to { m(){} }. ecma must be set to 6 or greater to enable this transform. If unsafe_methods is a RegExp then key/value pairs with keys matching the RegExp will be converted to concise methods. Note: if enabled there is a risk of getting a "<method name> is not a constructor" TypeError should any code try to new the former function.

I don't think we use any patterns in our code base that would lead us to `new` object properties in this way. (And if we do, I'd expect there to be test coverage, so we should see a test failure.) So, while this Terser option has `unsafe` in the name, I expect it to be safe in our case.

In case anyone is curious, I did test the effect of changing `ecma` and `module` by themselves in [this draft PR](https://github.com/DataDog/browser-sdk/pull/3413); they have very, very little effect. So the improvements we see here are almost entirely due to `unsafe_methods: true`.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
