### PR TITLE
♻️ [RUM-8795] Replace XHR with Fetch for HTTP requests

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -16,35 +16,35 @@ describe('endpointBuilder', () => {
 
   describe('query parameters', () => {
     it('should add intake query parameters', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toMatch(
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('fetch', DEFAULT_PAYLOAD)).toMatch(
         `&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)`
       )
     })
 
     it('should add batch_time for rum endpoint', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toContain(
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('fetch', DEFAULT_PAYLOAD)).toContain(
         '&batch_time='
       )
     })
 
     it('should not add batch_time for logs and replay endpoints', () => {
-      expect(createEndpointBuilder(initConfiguration, 'logs', []).build('xhr', DEFAULT_PAYLOAD)).not.toContain(
+      expect(createEndpointBuilder(initConfiguration, 'logs', []).build('fetch', DEFAULT_PAYLOAD)).not.toContain(
         '&batch_time='
       )
-      expect(createEndpointBuilder(initConfiguration, 'replay', []).build('xhr', DEFAULT_PAYLOAD)).not.toContain(
+      expect(createEndpointBuilder(initConfiguration, 'replay', []).build('fetch', DEFAULT_PAYLOAD)).not.toContain(
         '&batch_time='
       )
     })
 
     it('should add the provided encoding', () => {
       expect(
-        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', { ...DEFAULT_PAYLOAD, encoding: 'deflate' })
+        createEndpointBuilder(initConfiguration, 'rum', []).build('fetch', { ...DEFAULT_PAYLOAD, encoding: 'deflate' })
       ).toContain('&dd-evp-encoding=deflate')
     })
 
     it('should not start with ddsource for internal analytics mode', () => {
       const url = createEndpointBuilder({ ...initConfiguration, internalAnalyticsSubdomain: 'foo' }, 'rum', []).build(
-        'xhr',
+        'fetch',
         DEFAULT_PAYLOAD
       )
       expect(url).not.toContain('/rum?ddsource')
@@ -56,7 +56,7 @@ describe('endpointBuilder', () => {
     it('should replace the intake endpoint by the proxy and set the intake path and parameters in the attribute ddforward', () => {
       expect(
         createEndpointBuilder({ ...initConfiguration, proxy: 'https://proxy.io/path' }, 'rum', []).build(
-          'xhr',
+          'fetch',
           DEFAULT_PAYLOAD
         )
       ).toMatch(
@@ -69,7 +69,7 @@ describe('endpointBuilder', () => {
 
     it('normalizes the proxy url', () => {
       const endpoint = createEndpointBuilder({ ...initConfiguration, proxy: '/path' }, 'rum', []).build(
-        'xhr',
+        'fetch',
         DEFAULT_PAYLOAD
       )
       expect(endpoint.startsWith(`${location.origin}/path?ddforward`)).toBeTrue()
@@ -79,7 +79,7 @@ describe('endpointBuilder', () => {
       const proxyFn = (options: { path: string; parameters: string }) =>
         `https://proxy.io/prefix${options.path}/suffix?${options.parameters}`
       expect(
-        createEndpointBuilder({ ...initConfiguration, proxy: proxyFn }, 'rum', []).build('xhr', DEFAULT_PAYLOAD)
+        createEndpointBuilder({ ...initConfiguration, proxy: proxyFn }, 'rum', []).build('fetch', DEFAULT_PAYLOAD)
       ).toMatch(
         `https://proxy.io/prefix/api/v2/rum/suffix\\?ddsource=(.*)&ddtags=(.*)&dd-api-key=${clientToken}&dd-evp-origin-version=(.*)&dd-evp-origin=browser&dd-request-id=(.*)&batch_time=(.*)`
       )
@@ -88,19 +88,21 @@ describe('endpointBuilder', () => {
 
   describe('tags', () => {
     it('should contain sdk version', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toContain(
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('fetch', DEFAULT_PAYLOAD)).toContain(
         'sdk_version%3Asome_version'
       )
     })
 
     it('should contain api', () => {
-      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).toContain('api%3Axhr')
+      expect(createEndpointBuilder(initConfiguration, 'rum', []).build('fetch', DEFAULT_PAYLOAD)).toContain(
+        'api%3Afetch'
+      )
     })
 
     it('should be encoded', () => {
       expect(
         createEndpointBuilder(initConfiguration, 'rum', ['service:bar:foo', 'datacenter:us1.prod.dog']).build(
-          'xhr',
+          'fetch',
           DEFAULT_PAYLOAD
         )
       ).toContain('service%3Abar%3Afoo%2Cdatacenter%3Aus1.prod.dog')
@@ -108,7 +110,7 @@ describe('endpointBuilder', () => {
 
     it('should contain retry infos', () => {
       expect(
-        createEndpointBuilder(initConfiguration, 'rum', []).build('xhr', {
+        createEndpointBuilder(initConfiguration, 'rum', []).build('fetch', {
           ...DEFAULT_PAYLOAD,
           retry: {
             count: 5,
@@ -130,7 +132,7 @@ describe('endpointBuilder', () => {
         usePciIntake: true,
         site: 'datadoghq.com',
       }
-      expect(createEndpointBuilder(config, 'logs', []).build('xhr', DEFAULT_PAYLOAD)).toContain(
+      expect(createEndpointBuilder(config, 'logs', []).build('fetch', DEFAULT_PAYLOAD)).toContain(
         'https://pci.browser-intake-datadoghq.com'
       )
     })
@@ -140,7 +142,7 @@ describe('endpointBuilder', () => {
         usePciIntake: true,
         site: 'ap1.datadoghq.com',
       }
-      expect(createEndpointBuilder(config, 'logs', []).build('xhr', DEFAULT_PAYLOAD)).not.toContain(
+      expect(createEndpointBuilder(config, 'logs', []).build('fetch', DEFAULT_PAYLOAD)).not.toContain(
         'https://pci.browser-intake-datadoghq.com'
       )
     })
@@ -150,7 +152,7 @@ describe('endpointBuilder', () => {
         usePciIntake: true,
         site: 'datadoghq.com',
       }
-      expect(createEndpointBuilder(config, 'rum', []).build('xhr', DEFAULT_PAYLOAD)).not.toContain(
+      expect(createEndpointBuilder(config, 'rum', []).build('fetch', DEFAULT_PAYLOAD)).not.toContain(
         'https://pci.browser-intake-datadoghq.com'
       )
     })

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -10,7 +10,7 @@ declare const __BUILD_ENV__SDK_VERSION__: string
 
 export type TrackType = 'logs' | 'rum' | 'replay'
 export type ApiType =
-  | 'xhr'
+  | 'fetch-keepalive'
   | 'fetch'
   | 'beacon'
   // 'manual' reflects that the request have been sent manually, outside of the SDK (ex: via curl or

--- a/packages/core/src/domain/configuration/transportConfiguration.spec.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.spec.ts
@@ -12,19 +12,21 @@ describe('transportConfiguration', () => {
   describe('site', () => {
     it('should use US site by default', () => {
       const configuration = computeTransportConfiguration({ clientToken })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('datadoghq.com')
+      expect(configuration.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD)).toContain('datadoghq.com')
       expect(configuration.site).toBe('datadoghq.com')
     })
 
     it('should use logs intake domain for fed staging', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: INTAKE_SITE_FED_STAGING })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('http-intake.logs.dd0g-gov.com')
+      expect(configuration.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD)).toContain(
+        'http-intake.logs.dd0g-gov.com'
+      )
       expect(configuration.site).toBe(INTAKE_SITE_FED_STAGING)
     })
 
     it('should use site value when set', () => {
       const configuration = computeTransportConfiguration({ clientToken, site: 'datadoghq.com' })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain('datadoghq.com')
+      expect(configuration.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD)).toContain('datadoghq.com')
       expect(configuration.site).toBe('datadoghq.com')
     })
   })
@@ -35,7 +37,7 @@ describe('transportConfiguration', () => {
         clientToken,
         internalAnalyticsSubdomain,
       })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).toContain(internalAnalyticsSubdomain)
+      expect(configuration.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD)).toContain(internalAnalyticsSubdomain)
     })
 
     it('should not use internal analytics subdomain value when set for other sites', () => {
@@ -44,42 +46,32 @@ describe('transportConfiguration', () => {
         site: 'us3.datadoghq.com',
         internalAnalyticsSubdomain,
       })
-      expect(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).not.toContain(internalAnalyticsSubdomain)
+      expect(configuration.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD)).not.toContain(internalAnalyticsSubdomain)
     })
   })
 
   describe('sdk_version, env, version and service', () => {
     it('should not modify the logs and rum endpoints tags when not defined', () => {
       const configuration = computeTransportConfiguration({ clientToken })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(',env:')
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
-        ',service:'
-      )
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
-        ',version:'
-      )
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
-        ',datacenter:'
-      )
+      const rumEndpoint = decodeURIComponent(configuration.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD))
+      expect(rumEndpoint).not.toContain(',env:')
+      expect(rumEndpoint).not.toContain(',service:')
+      expect(rumEndpoint).not.toContain(',version:')
+      expect(rumEndpoint).not.toContain(',datacenter:')
 
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(',env:')
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
-        ',service:'
-      )
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
-        ',version:'
-      )
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).not.toContain(
-        ',datacenter:'
-      )
+      const logsEndpoint = decodeURIComponent(configuration.logsEndpointBuilder.build('fetch', DEFAULT_PAYLOAD))
+      expect(logsEndpoint).not.toContain(',env:')
+      expect(logsEndpoint).not.toContain(',service:')
+      expect(logsEndpoint).not.toContain(',version:')
+      expect(logsEndpoint).not.toContain(',datacenter:')
     })
 
     it('should be set as tags in the logs and rum endpoints', () => {
       const configuration = computeTransportConfiguration({ clientToken, env: 'foo', service: 'bar', version: 'baz' })
-      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).toContain(
+      expect(decodeURIComponent(configuration.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD))).toContain(
         'env:foo,service:bar,version:baz'
       )
-      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))).toContain(
+      expect(decodeURIComponent(configuration.logsEndpointBuilder.build('fetch', DEFAULT_PAYLOAD))).toContain(
         'env:foo,service:bar,version:baz'
       )
     })

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -10,7 +10,7 @@ import type { Request } from '../../test'
 import type { EndpointBuilder } from '../domain/configuration'
 import { createEndpointBuilder } from '../domain/configuration'
 import { noop } from '../tools/utils/functionUtils'
-import { createHttpRequest, fetchKeepAliveStrategy } from './httpRequest'
+import { createHttpRequest, fetchKeepAliveStrategy, fetchStrategy } from './httpRequest'
 import type { HttpRequest } from './httpRequest'
 
 describe('httpRequest', () => {
@@ -139,6 +139,26 @@ describe('httpRequest', () => {
           done()
         }
       )
+    })
+  })
+
+  describe('fetchStrategy onResponse', () => {
+    it('should be called with intake response', (done) => {
+      interceptor.withFetch(DEFAULT_FETCH_MOCK)
+
+      fetchStrategy(endpointBuilder, { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 }, (response) => {
+        expect(response).toEqual({ status: 200, type: 'cors' })
+        done()
+      })
+    })
+
+    it('should be called with status 0 when fetch fails', (done) => {
+      interceptor.withFetch(NETWORK_ERROR_FETCH_MOCK)
+
+      fetchStrategy(endpointBuilder, { data: '{"foo":"bar1"}\n{"foo":"bar2"}', bytesCount: 10 }, (response) => {
+        expect(response).toEqual({ status: 0 })
+        done()
+      })
     })
   })
 

--- a/packages/core/src/transport/httpRequest.spec.ts
+++ b/packages/core/src/transport/httpRequest.spec.ts
@@ -72,8 +72,9 @@ describe('httpRequest', () => {
 
       await interceptor.waitForAllFetchCalls()
       await collectAsyncCalls(fetchSpy, 2)
-      expect(requests.length).toEqual(1)
-      expect(requests[0].type).toBe('fetch')
+      expect(requests.length).toEqual(2)
+      expect(requests[0].type).toBe('fetch-keepalive')
+      expect(requests[1].type).toBe('fetch')
     })
 
     it('should use retry strategy', async () => {

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -1,8 +1,6 @@
 import type { EndpointBuilder } from '../domain/configuration'
-import { addTelemetryError } from '../domain/telemetry'
 import type { Context } from '../tools/serialisation/context'
-import { monitor } from '../tools/monitor'
-import { addEventListener } from '../browser/addEventListener'
+import { monitor, monitorError } from '../tools/monitor'
 import type { RawError } from '../domain/error/error.types'
 import { newRetryState, sendWithRetryStrategy } from './sendWithRetryStrategy'
 
@@ -72,8 +70,7 @@ function sendBeaconStrategy(endpointBuilder: EndpointBuilder, bytesLimit: number
     }
   }
 
-  const xhrUrl = endpointBuilder.build('xhr', payload)
-  sendXHR(xhrUrl, payload.data)
+  fetchStrategy(endpointBuilder, payload)
 }
 
 let hasReportedBeaconError = false
@@ -81,7 +78,7 @@ let hasReportedBeaconError = false
 function reportBeaconError(e: unknown) {
   if (!hasReportedBeaconError) {
     hasReportedBeaconError = true
-    addTelemetryError(e)
+    monitorError(e)
   }
 }
 
@@ -92,20 +89,28 @@ export function fetchKeepAliveStrategy(
   onResponse?: (r: HttpResponse) => void
 ) {
   const canUseKeepAlive = isKeepAliveSupported() && payload.bytesCount < bytesLimit
+
   if (canUseKeepAlive) {
-    const fetchUrl = endpointBuilder.build('fetch', payload)
-    fetch(fetchUrl, { method: 'POST', body: payload.data, keepalive: true, mode: 'cors' }).then(
-      monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })),
-      monitor(() => {
-        const xhrUrl = endpointBuilder.build('xhr', payload)
-        // failed to queue the request
-        sendXHR(xhrUrl, payload.data, onResponse)
-      })
-    )
+    const fetchUrl = endpointBuilder.build('fetch-keepalive', payload)
+
+    fetch(fetchUrl, { method: 'POST', body: payload.data, keepalive: true, mode: 'cors' })
+      .then(monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })))
+      .catch(monitor(() => fetchStrategy(endpointBuilder, payload, onResponse)))
   } else {
-    const xhrUrl = endpointBuilder.build('xhr', payload)
-    sendXHR(xhrUrl, payload.data, onResponse)
+    fetchStrategy(endpointBuilder, payload, onResponse)
   }
+}
+
+export function fetchStrategy(
+  endpointBuilder: EndpointBuilder,
+  payload: Payload,
+  onResponse?: (r: HttpResponse) => void
+) {
+  const fetchUrl = endpointBuilder.build('fetch', payload)
+
+  fetch(fetchUrl, { method: 'POST', body: payload.data, mode: 'cors' })
+    .then(monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })))
+    .catch((error) => monitorError(error))
 }
 
 function isKeepAliveSupported() {
@@ -115,30 +120,4 @@ function isKeepAliveSupported() {
   } catch {
     return false
   }
-}
-
-export function sendXHR(url: string, data: Payload['data'], onResponse?: (r: HttpResponse) => void) {
-  const request = new XMLHttpRequest()
-  request.open('POST', url, true)
-  if (data instanceof Blob) {
-    // When using a Blob instance, IE does not use its 'type' to define the 'Content-Type' header
-    // automatically, so the intake request ends up being rejected with an HTTP status 415
-    // Defining the header manually fixes this issue.
-    request.setRequestHeader('Content-Type', data.type)
-  }
-  addEventListener(
-    // allow untrusted event to acount for synthetic event dispatched by third party xhr wrapper
-    { allowUntrustedEvents: true },
-    request,
-    'loadend',
-    () => {
-      onResponse?.({ status: request.status })
-    },
-    {
-      // prevent multiple onResponse callbacks
-      // if the xhr instance is reused by a third party
-      once: true,
-    }
-  )
-  request.send(data)
 }

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -110,10 +110,7 @@ export function fetchStrategy(
 
   fetch(fetchUrl, { method: 'POST', body: payload.data, mode: 'cors' })
     .then(monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })))
-    .catch((error) => {
-      monitorError(error)
-      onResponse?.({ status: 0 })
-    })
+    .catch(() => onResponse?.({ status: 0 }))
 }
 
 function isKeepAliveSupported() {

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -110,7 +110,10 @@ export function fetchStrategy(
 
   fetch(fetchUrl, { method: 'POST', body: payload.data, mode: 'cors' })
     .then(monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })))
-    .catch((error) => monitorError(error))
+    .catch((error) => {
+      monitorError(error)
+      onResponse?.({ status: 0 })
+    })
 }
 
 function isKeepAliveSupported() {

--- a/packages/core/src/transport/httpRequest.ts
+++ b/packages/core/src/transport/httpRequest.ts
@@ -110,7 +110,7 @@ export function fetchStrategy(
 
   fetch(fetchUrl, { method: 'POST', body: payload.data, mode: 'cors' })
     .then(monitor((response: Response) => onResponse?.({ status: response.status, type: response.type })))
-    .catch(() => onResponse?.({ status: 0 }))
+    .catch(monitor(() => onResponse?.({ status: 0 })))
 }
 
 function isKeepAliveSupported() {

--- a/packages/core/test/interceptRequests.ts
+++ b/packages/core/test/interceptRequests.ts
@@ -5,6 +5,10 @@ import { registerCleanupTask } from './registerCleanupTask'
 
 const INTAKE_PARAMS = INTAKE_URL_PARAMETERS.join('&')
 
+export const DEFAULT_FETCH_MOCK = () => Promise.resolve({ status: 200, type: 'cors' })
+export const TOO_MANY_REQUESTS_FETCH_MOCK = () => Promise.resolve({ status: 429, type: 'cors' })
+export const NETWORK_ERROR_FETCH_MOCK = () => Promise.reject(new Error('Network request failed'))
+
 export const SPEC_ENDPOINTS = {
   logsEndpointBuilder: mockEndpointBuilder(`https://mock.com/abcde?${INTAKE_PARAMS}`),
   rumEndpointBuilder: mockEndpointBuilder(`https://mock.com/abcde?${INTAKE_PARAMS}`),
@@ -15,7 +19,7 @@ export function mockEndpointBuilder(url: string) {
 }
 
 export interface Request {
-  type: 'xhr' | 'sendBeacon' | 'fetch'
+  type: 'sendBeacon' | 'fetch' | 'fetch-keepalive' // TODO remove xhr
   url: string
   body: string
 }
@@ -26,27 +30,50 @@ export function interceptRequests() {
   const originalRequest = window.Request
   const originalFetch = window.fetch
 
-  spyOn(XMLHttpRequest.prototype, 'open').and.callFake((_, url) => requests.push({ type: 'xhr', url } as Request))
-  spyOn(XMLHttpRequest.prototype, 'send').and.callFake((body) => (requests[requests.length - 1].body = body as string))
   if (isSendBeaconSupported()) {
     spyOn(navigator, 'sendBeacon').and.callFake((url, body) => {
       requests.push({ type: 'sendBeacon', url: url as string, body: body as string })
       return true
     })
   }
-  if (isFetchKeepAliveSupported()) {
-    spyOn(window, 'fetch').and.callFake((url, config) => {
-      requests.push({ type: 'fetch', url: url as string, body: config!.body as string })
-      return new Promise<Response>(() => undefined)
-    })
-  }
+
+  let fetchMocks: Array<() => Promise<unknown>> = [DEFAULT_FETCH_MOCK]
+
+  let resolveFetchCallReturns: (() => void) | undefined
+  const endAllPromises = new Promise<void>((resolve) => {
+    resolveFetchCallReturns = resolve
+  })
+
+  const fetchSpy = spyOn(window, 'fetch').and.callFake((url, config) => {
+    const fetchPromise = fetchMocks.shift()
+
+    if (!fetchPromise) {
+      throw new Error('No fetch mock provided')
+    }
+
+    return fetchPromise()
+      .then((response) => {
+        requests.push({
+          type: config?.keepalive ? 'fetch-keepalive' : 'fetch',
+          url: url as string,
+          body: config!.body as string,
+        })
+
+        return response as Response
+      })
+      .finally(() => {
+        if (fetchMocks.length === 0) {
+          resolveFetchCallReturns?.()
+        }
+      })
+  })
 
   function isSendBeaconSupported() {
     return !!navigator.sendBeacon
   }
 
   function isFetchKeepAliveSupported() {
-    return 'fetch' in window && 'keepalive' in new window.Request('')
+    return window.Request && 'keepalive' in new window.Request('')
   }
 
   registerCleanupTask(() => {
@@ -66,14 +93,16 @@ export function interceptRequests() {
     requests,
     isSendBeaconSupported,
     isFetchKeepAliveSupported,
+    waitForAllFetchCalls: () => endAllPromises,
     withSendBeacon(newSendBeacon: any) {
       navigator.sendBeacon = newSendBeacon
     },
     withRequest(newRequest: any) {
       window.Request = newRequest
     },
-    withFetch(newFetch: any) {
-      window.fetch = newFetch
+    withFetch(...responses: Array<() => Promise<unknown>>) {
+      fetchMocks = responses
+      return fetchSpy
     },
     withMockXhr(onSend: (xhr: MockXhr) => void) {
       mockXhr()

--- a/packages/core/test/interceptRequests.ts
+++ b/packages/core/test/interceptRequests.ts
@@ -19,7 +19,7 @@ export function mockEndpointBuilder(url: string) {
 }
 
 export interface Request {
-  type: 'sendBeacon' | 'fetch' | 'fetch-keepalive' // TODO remove xhr
+  type: 'sendBeacon' | 'fetch' | 'fetch-keepalive'
   url: string
   body: string
 }
@@ -51,16 +51,13 @@ export function interceptRequests() {
       throw new Error('No fetch mock provided')
     }
 
+    requests.push({
+      type: config?.keepalive ? 'fetch-keepalive' : 'fetch',
+      url: url as string,
+      body: config!.body as string,
+    })
     return fetchPromise()
-      .then((response) => {
-        requests.push({
-          type: config?.keepalive ? 'fetch-keepalive' : 'fetch',
-          url: url as string,
-          body: config!.body as string,
-        })
-
-        return response as Response
-      })
+      .then((response) => response as Response)
       .finally(() => {
         if (fetchMocks.length === 0) {
           resolveFetchCallReturns?.()

--- a/packages/rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/rum-core/src/domain/requestCollection.spec.ts
@@ -126,7 +126,7 @@ describe('collect fetch', () => {
   })
 
   it('should ignore intake requests', (done) => {
-    fetch(SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD)).resolveWith({
+    fetch(SPEC_ENDPOINTS.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD)).resolveWith({
       status: 200,
       responseText: 'foo',
     })
@@ -259,7 +259,7 @@ describe('collect xhr', () => {
   it('should ignore intake requests', (done) => {
     withXhr({
       setup(xhr) {
-        xhr.open('GET', SPEC_ENDPOINTS.rumEndpointBuilder.build('xhr', DEFAULT_PAYLOAD))
+        xhr.open('GET', SPEC_ENDPOINTS.rumEndpointBuilder.build('fetch', DEFAULT_PAYLOAD))
         xhr.send()
         xhr.complete(200)
       },


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Over time we've added a fixes to our xhr strategy to account for bad implementations/overrides (IE content type header, multiple onResponse callbacks, untrusted events...)

Instead of yet another fix to account for the combination of dynatrace + zonejs making xhr request to fail, and as we don't support IE anymore, we can use plain fetch instead of xhr.

closes #3394 


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
