### PR TITLE
👷 Enable the Terser unsafe option

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -62,6 +62,7 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
           module: true,
           compress: {
             passes: 4,
+            unsafe: true,
             unsafe_methods: true,
           },
         },


### PR DESCRIPTION
## Motivation

This is one of a series of PRs experimenting with enabling more aggressive options for Terser, with the goal of reducing the size of the browser SDK bundles.

## Changes

This PR enables the following options:
* `unsafe: true`

Here's what the Terser docs have to say about `unsafe: true`:

> It enables some transformations that might break code logic in certain contrived cases, but should be fine for most code. It assumes that standard built-in ECMAScript functions and classes have not been altered or replaced. You might want to try it on your own code; it should reduce the minified size. Some examples of the optimizations made when this option is enabled:
> * new Array(1, 2, 3) or Array(1, 2, 3) → [ 1, 2, 3 ]
> * Array.from([1, 2, 3]) → [1, 2, 3]
> * new Object() → {}
> * String(exp) or exp.toString() → "" + exp
> * new Object/RegExp/Function/Error/Array (...) → we discard the new
> * "foo bar".substr(4) → "bar"

It's a bit unfortunate that these transformations don't seem to have been split out into their own, isolated `unsafe_*` options, which would make it a bit easier to evaluate them one by one. (There are other `unsafe_*` options, but there don't seem to be any that control the transformations controlled by `unsafe: true`.)

In general, these transformations strike me as reasonable, in that they seem semantically correct unless someone has been replacing built-in functions/prototypes/etc with the goal of giving them behavior contrary to the originals, and in such a situation, I suspect a general purpose library like this one would have problems with or without these transformations. That said, great caution is certainly warranted here; I'll test extensively on staging before merging.

## Testing

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
