### PR TITLE
🔧 Update GitLab CI to exclude staging branch from performance tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,6 @@ stages:
 ###########################################################################################################################
 # Resource allocation
 ###########################################################################################################################
-
 .resource-allocation-4-cpus:
   variables:
     WORKERS: 2
@@ -170,6 +169,9 @@ test-performance:
   extends:
     - .base-configuration
     - .test-allowed-branches
+  except:
+    variables:
+      - $CI_COMMIT_REF_NAME == $CURRENT_STAGING
   interruptible: true
   allow_failure: true
   script:


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

when integrating a branch to staging, the test-performance job does not add much value. Skipping it will make deployment of staging branch almost 2 times faster.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
