### PR TITLE
[devext] 🐛 fix non-string log message

### DIFF
--- a/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
+++ b/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
@@ -305,7 +305,11 @@ export const EventDescription = React.memo(({ event }: { event: SdkEvent }) => {
 })
 
 function LogDescription({ event }: { event: LogsEvent }) {
-  return <>{event.message}</>
+  if (typeof event.message === 'string') {
+    return <>{event.message}</>
+  }
+
+  return <Json value={event.message} defaultCollapseLevel={0} />
 }
 
 function TelemetryDescription({ event }: { event: TelemetryEvent }) {


### PR DESCRIPTION
## Motivation

`DD_LOGS.logger.log({})` crashes the extension

## Changes

Use the Json component to display the value in this case.

![Screenshot 2025-03-13 at 15 57 15](https://github.com/user-attachments/assets/20eb1856-0c20-44fe-a802-49b3c9da203d)


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
