### PR TITLE
⚗️ ✨  [RUM-8365] Propagate session id in `baggage` header

### DIFF
--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -281,13 +281,13 @@ describe('tracer', () => {
         return xhr.headers.baggage
       }
 
-      it('should add usr.id and account.id to baggage header when feature is enabled and propagateTraceBaggage is true', () => {
+      it('should add usr.id, account.id and session.id to baggage header when feature is enabled and propagateTraceBaggage is true', () => {
         const baggage = traceRequestAndGetBaggageHeader({
           initConfiguration: {
             propagateTraceBaggage: true,
           },
         })
-        expect(baggage).toEqual('usr.id=1234,account.id=5678')
+        expect(baggage).toEqual('session.id=session-id,usr.id=1234,account.id=5678')
       })
 
       it('should not add baggage header when propagateTraceBaggage is false', () => {
@@ -306,7 +306,7 @@ describe('tracer', () => {
           },
           userId: '1234, 😀',
         })
-        expect(baggage).toBe('usr.id=1234%2C%20%F0%9F%98%80,account.id=5678')
+        expect(baggage).toBe('session.id=session-id,usr.id=1234%2C%20%F0%9F%98%80,account.id=5678')
       })
 
       it('skips non-string context values', () => {
@@ -316,7 +316,7 @@ describe('tracer', () => {
           },
           userId: 1234,
         })
-        expect(baggage).toBe('account.id=5678')
+        expect(baggage).toBe('session.id=session-id,account.id=5678')
       })
     })
 

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -159,6 +159,7 @@ function injectHeadersIfTracingAllowed(
       context.traceId,
       context.spanId,
       context.traceSampled,
+      session.id,
       tracingOption.propagatorTypes,
       userContext,
       accountContext,
@@ -175,6 +176,7 @@ function makeTracingHeaders(
   traceId: TraceIdentifier,
   spanId: SpanIdentifier,
   traceSampled: boolean,
+  sessionId: string,
   propagatorTypes: PropagatorType[],
   userContext: ContextManager,
   accountContext: ContextManager,
@@ -225,7 +227,9 @@ function makeTracingHeaders(
     isExperimentalFeatureEnabled(ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER) &&
     configuration.propagateTraceBaggage
   ) {
-    const baggageItems: Record<string, string> = {}
+    const baggageItems: Record<string, string> = {
+      'session.id': sessionId,
+    }
 
     const userId = userContext.getContext().id
     if (typeof userId === 'string') {

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -225,19 +225,23 @@ function makeTracingHeaders(
     isExperimentalFeatureEnabled(ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER) &&
     configuration.propagateTraceBaggage
   ) {
+    const baggageItems: Record<string, string> = {}
+
     const userId = userContext.getContext().id
-    const accountId = accountContext.getContext().id
-    const baggageItems: string[] = []
-
     if (typeof userId === 'string') {
-      baggageItems.push(`usr.id=${encodeURIComponent(userId)}`)
-    }
-    if (typeof accountId === 'string') {
-      baggageItems.push(`account.id=${encodeURIComponent(accountId)}`)
+      baggageItems['usr.id'] = userId
     }
 
-    if (baggageItems.length > 0) {
-      tracingHeaders['baggage'] = baggageItems.join(',')
+    const accountId = accountContext.getContext().id
+    if (typeof accountId === 'string') {
+      baggageItems['account.id'] = accountId
+    }
+
+    const baggageHeader = Object.entries(baggageItems)
+      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+      .join(',')
+    if (baggageHeader) {
+      tracingHeaders['baggage'] = baggageHeader
     }
   }
 


### PR DESCRIPTION
## Motivation

This lets the APM backend know about the Session which started a trace, useful for Joint Sampling, and also for ad-blocker metrics


## Changes

* Refactor tracer test setups a bit
* Refactor baggage header formatting
* Add some unit tests on baggage header
* ... and finally, propagate `session.id``


## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end
