### PR TITLE
[RUM-9126] Decouple common contexts from rumPublicApi

### DIFF
--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -20,7 +20,6 @@ import {
   mockSyntheticsWorkerValues,
 } from '@datadog/browser-core/test'
 import type { HybridInitConfiguration, RumConfiguration, RumInitConfiguration } from '../domain/configuration'
-import type { CommonContext } from '../domain/contexts/commonContext'
 import type { ViewOptions } from '../domain/view/trackViews'
 import { ActionType, VitalType } from '../rawRumEvent.types'
 import type { CustomAction } from '../domain/action/actionCollection'
@@ -45,11 +44,9 @@ describe('preStartRum', () => {
       initialViewOptions?: ViewOptions
     ) => StartRumResult
   >
-  let getCommonContextSpy: jasmine.Spy<() => CommonContext>
 
   beforeEach(() => {
     doStartRumSpy = jasmine.createSpy()
-    getCommonContextSpy = jasmine.createSpy()
   })
 
   afterEach(() => {
@@ -62,13 +59,7 @@ describe('preStartRum', () => {
 
     beforeEach(() => {
       displaySpy = spyOn(display, 'error')
-      strategy = createPreStartStrategy(
-        {},
-        getCommonContextSpy,
-        createTrackingConsentState(),
-        createCustomVitalsState(),
-        doStartRumSpy
-      )
+      strategy = createPreStartStrategy({}, createTrackingConsentState(), createCustomVitalsState(), doStartRumSpy)
     })
 
     it('should start when the configuration is valid', () => {
@@ -176,7 +167,6 @@ describe('preStartRum', () => {
       const displaySpy = spyOn(display, 'warn')
       const strategy = createPreStartStrategy(
         {},
-        getCommonContextSpy,
         createTrackingConsentState(),
         createCustomVitalsState(),
         doStartRumSpy
@@ -194,7 +184,6 @@ describe('preStartRum', () => {
           {
             ignoreInitIfSyntheticsWillInjectRum: true,
           },
-          getCommonContextSpy,
           createTrackingConsentState(),
           createCustomVitalsState(),
           doStartRumSpy
@@ -211,7 +200,6 @@ describe('preStartRum', () => {
           {
             ignoreInitIfSyntheticsWillInjectRum: false,
           },
-          getCommonContextSpy,
           createTrackingConsentState(),
           createCustomVitalsState(),
           doStartRumSpy
@@ -234,7 +222,6 @@ describe('preStartRum', () => {
             startDeflateWorker: startDeflateWorkerSpy,
             createDeflateEncoder: noop as any,
           },
-          getCommonContextSpy,
           createTrackingConsentState(),
           createCustomVitalsState(),
           doStartRumSpy
@@ -313,13 +300,7 @@ describe('preStartRum', () => {
           addTiming: addTimingSpy,
           setViewName: setViewNameSpy,
         } as unknown as StartRumResult)
-        strategy = createPreStartStrategy(
-          {},
-          getCommonContextSpy,
-          createTrackingConsentState(),
-          createCustomVitalsState(),
-          doStartRumSpy
-        )
+        strategy = createPreStartStrategy({}, createTrackingConsentState(), createCustomVitalsState(), doStartRumSpy)
       })
 
       afterEach(() => {
@@ -377,7 +358,6 @@ describe('preStartRum', () => {
         it('calling startView then init does not start rum if tracking consent is not granted', () => {
           const strategy = createPreStartStrategy(
             {},
-            getCommonContextSpy,
             createTrackingConsentState(),
             createCustomVitalsState(),
             doStartRumSpy
@@ -465,7 +445,6 @@ describe('preStartRum', () => {
 
         const strategy = createPreStartStrategy(
           {},
-          getCommonContextSpy,
           createTrackingConsentState(),
           createCustomVitalsState(),
           doStartRumSpy
@@ -485,7 +464,6 @@ describe('preStartRum', () => {
         const plugin = { name: 'a', onInit: jasmine.createSpy() }
         const strategy = createPreStartStrategy(
           {},
-          getCommonContextSpy,
           createTrackingConsentState(),
           createCustomVitalsState(),
           doStartRumSpy
@@ -509,7 +487,6 @@ describe('preStartRum', () => {
         }
         const strategy = createPreStartStrategy(
           {},
-          getCommonContextSpy,
           createTrackingConsentState(),
           createCustomVitalsState(),
           doStartRumSpy
@@ -531,7 +508,6 @@ describe('preStartRum', () => {
     it('returns undefined', () => {
       const strategy = createPreStartStrategy(
         {},
-        getCommonContextSpy,
         createTrackingConsentState(),
         createCustomVitalsState(),
         doStartRumSpy
@@ -544,7 +520,6 @@ describe('preStartRum', () => {
     it('returns empty object', () => {
       const strategy = createPreStartStrategy(
         {},
-        getCommonContextSpy,
         createTrackingConsentState(),
         createCustomVitalsState(),
         doStartRumSpy
@@ -557,7 +532,6 @@ describe('preStartRum', () => {
     it('does not buffer the call before starting RUM', () => {
       const strategy = createPreStartStrategy(
         {},
-        getCommonContextSpy,
         createTrackingConsentState(),
         createCustomVitalsState(),
         doStartRumSpy
@@ -578,13 +552,7 @@ describe('preStartRum', () => {
 
     beforeEach(() => {
       interceptor = interceptRequests()
-      strategy = createPreStartStrategy(
-        {},
-        getCommonContextSpy,
-        createTrackingConsentState(),
-        createCustomVitalsState(),
-        doStartRumSpy
-      )
+      strategy = createPreStartStrategy({}, createTrackingConsentState(), createCustomVitalsState(), doStartRumSpy)
       initConfiguration = { ...DEFAULT_INIT_CONFIGURATION, service: 'my-service', version: '1.4.2', env: 'dev' }
     })
 
@@ -609,7 +577,6 @@ describe('preStartRum', () => {
         {
           ignoreInitIfSyntheticsWillInjectRum: true,
         },
-        getCommonContextSpy,
         createTrackingConsentState(),
         createCustomVitalsState(),
         doStartRumSpy
@@ -629,7 +596,6 @@ describe('preStartRum', () => {
 
       const strategy = createPreStartStrategy(
         {},
-        getCommonContextSpy,
         createTrackingConsentState(),
         createCustomVitalsState(),
         doStartRumSpy
@@ -648,13 +614,7 @@ describe('preStartRum', () => {
     let strategy: Strategy
 
     beforeEach(() => {
-      strategy = createPreStartStrategy(
-        {},
-        getCommonContextSpy,
-        createTrackingConsentState(),
-        createCustomVitalsState(),
-        doStartRumSpy
-      )
+      strategy = createPreStartStrategy({}, createTrackingConsentState(), createCustomVitalsState(), doStartRumSpy)
     })
 
     it('addAction', () => {
@@ -668,7 +628,7 @@ describe('preStartRum', () => {
       }
       strategy.addAction(customAction)
       strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
-      expect(addActionSpy).toHaveBeenCalledOnceWith(customAction, undefined)
+      expect(addActionSpy).toHaveBeenCalledOnceWith(customAction)
     })
 
     it('addError', () => {
@@ -683,7 +643,7 @@ describe('preStartRum', () => {
       }
       strategy.addError(error)
       strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
-      expect(addErrorSpy).toHaveBeenCalledOnceWith(error, undefined)
+      expect(addErrorSpy).toHaveBeenCalledOnceWith(error)
     })
 
     it('startView', () => {
@@ -781,13 +741,7 @@ describe('preStartRum', () => {
 
     beforeEach(() => {
       trackingConsentState = createTrackingConsentState()
-      strategy = createPreStartStrategy(
-        {},
-        getCommonContextSpy,
-        trackingConsentState,
-        createCustomVitalsState(),
-        doStartRumSpy
-      )
+      strategy = createPreStartStrategy({}, trackingConsentState, createCustomVitalsState(), doStartRumSpy)
     })
 
     describe('basic methods instrumentation', () => {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -3,7 +3,6 @@ import {
   ONE_SECOND,
   display,
   DefaultPrivacyLevel,
-  removeStorageListeners,
   CustomerDataCompressionStatus,
   timeStampToClocks,
 } from '@datadog/browser-core'
@@ -35,6 +34,24 @@ const noopStartRum = (): ReturnType<StartRum> => ({
   stopDurationVital: () => undefined,
   addDurationVital: () => undefined,
   stop: () => undefined,
+
+  setAccount: () => undefined,
+  setAccountProperty: () => undefined,
+  getAccount: () => ({}),
+  clearAccount: () => undefined,
+  removeAccountProperty: () => undefined,
+
+  setGlobalContext: () => undefined,
+  setGlobalContextProperty: () => undefined,
+  getGlobalContext: () => ({}),
+  clearGlobalContext: () => undefined,
+  removeGlobalContextProperty: () => undefined,
+
+  setUser: () => undefined,
+  setUserProperty: () => undefined,
+  getUser: () => ({}),
+  clearUser: () => undefined,
+  removeUserProperty: () => undefined,
 })
 const DEFAULT_INIT_CONFIGURATION = { applicationId: 'xxx', clientToken: 'xxx' }
 const FAKE_WORKER = {} as DeflateWorker
@@ -187,7 +204,6 @@ describe('rum public api', () => {
           type: ActionType.CUSTOM,
           handlingStack: jasmine.any(String),
         },
-        { context: {}, user: {}, account: {}, hasReplay: undefined },
       ])
     })
 
@@ -203,68 +219,6 @@ describe('rum public api', () => {
       expect(addActionSpy).toHaveBeenCalledTimes(1)
       const stacktrace = addActionSpy.calls.argsFor(0)[0].handlingStack
       expect(stacktrace).toMatch(/^HandlingStack: action\s+at triggerAction @/)
-    })
-
-    describe('save context when sending an action', () => {
-      it('saves the date', () => {
-        clock.tick(ONE_SECOND)
-        rumPublicApi.addAction('foo')
-
-        clock.tick(ONE_SECOND)
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addActionSpy.calls.argsFor(0)[0].startClocks.relative as number).toEqual(clock.relative(ONE_SECOND))
-      })
-
-      it('stores a deep copy of the global context', () => {
-        rumPublicApi.setGlobalContextProperty('foo', 'bar')
-        rumPublicApi.addAction('message')
-        rumPublicApi.setGlobalContextProperty('foo', 'baz')
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addActionSpy.calls.argsFor(0)[1]!.context).toEqual({
-          foo: 'bar',
-        })
-      })
-
-      it('stores a deep copy of the user', () => {
-        const user = { id: 'foo' }
-        rumPublicApi.setUser(user)
-        rumPublicApi.addAction('message')
-        user.id = 'bar'
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addActionSpy.calls.argsFor(0)[1]!.user).toEqual({
-          id: 'foo',
-        })
-      })
-
-      it('stores a deep copy of the account', () => {
-        const account = { id: 'foo' }
-        rumPublicApi.setAccount(account)
-        rumPublicApi.addAction('message')
-        account.id = 'bar'
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addActionSpy.calls.argsFor(0)[1]!.account).toEqual({
-          id: 'foo',
-        })
-      })
-
-      it('stores a deep copy of the action context', () => {
-        const context = { foo: 'bar' }
-        rumPublicApi.addAction('message', context)
-        context.foo = 'baz'
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addActionSpy.calls.argsFor(0)[0].context).toEqual({
-          foo: 'bar',
-        })
-      })
     })
   })
 
@@ -303,7 +257,6 @@ describe('rum public api', () => {
           handlingStack: jasmine.any(String),
           startClocks: jasmine.any(Object),
         },
-        { context: {}, user: {}, account: {}, hasReplay: undefined },
       ])
     })
 
@@ -330,362 +283,6 @@ describe('rum public api', () => {
 
         expect(addErrorSpy.calls.argsFor(0)[0].startClocks.relative as number).toEqual(clock.relative(ONE_SECOND))
       })
-
-      it('stores a deep copy of the global context', () => {
-        rumPublicApi.setGlobalContextProperty('foo', 'bar')
-        rumPublicApi.addError(new Error('message'))
-        rumPublicApi.setGlobalContextProperty('foo', 'baz')
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addErrorSpy.calls.argsFor(0)[1]!.context).toEqual({
-          foo: 'bar',
-        })
-      })
-
-      it('stores a deep copy of the user', () => {
-        const user = { id: 'foo' }
-        rumPublicApi.setUser(user)
-        rumPublicApi.addError(new Error('message'))
-        user.id = 'bar'
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addErrorSpy.calls.argsFor(0)[1]!.user).toEqual({
-          id: 'foo',
-        })
-      })
-
-      it('stores a deep copy of the account', () => {
-        const account = { id: 'foo' }
-        rumPublicApi.setAccount(account)
-        rumPublicApi.addError(new Error('message'))
-        account.id = 'bar'
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addErrorSpy.calls.argsFor(0)[1]!.account).toEqual({
-          id: 'foo',
-        })
-      })
-
-      it('stores a deep copy of the error context', () => {
-        const context = { foo: 'bar' }
-        rumPublicApi.addError(new Error('message'), context)
-        context.foo = 'baz'
-
-        rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-        expect(addErrorSpy.calls.argsFor(0)[0].context).toEqual({
-          foo: 'bar',
-        })
-      })
-    })
-  })
-
-  describe('setUser', () => {
-    let addActionSpy: jasmine.Spy<ReturnType<StartRum>['addAction']>
-    let displaySpy: jasmine.Spy<() => void>
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      addActionSpy = jasmine.createSpy()
-      displaySpy = spyOn(display, 'error')
-      rumPublicApi = makeRumPublicApi(
-        () => ({
-          ...noopStartRum(),
-          addAction: addActionSpy,
-        }),
-        noopRecorderApi
-      )
-    })
-
-    it('should attach valid objects', () => {
-      const user = { id: 'foo', name: 'bar', email: 'qux', foo: { bar: 'qux' } }
-      rumPublicApi.setUser(user)
-      rumPublicApi.addAction('message')
-
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(addActionSpy.calls.argsFor(0)[1]!.user).toEqual({
-        email: 'qux',
-        foo: { bar: 'qux' },
-        id: 'foo',
-        name: 'bar',
-      })
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('should sanitize predefined properties', () => {
-      const user = { id: null, name: 2, email: { bar: 'qux' } }
-      rumPublicApi.setUser(user as any)
-      rumPublicApi.addAction('message')
-
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(addActionSpy.calls.argsFor(0)[1]!.user).toEqual({
-        email: '[object Object]',
-        id: 'null',
-        name: '2',
-      })
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('should remove the user', () => {
-      const user = { id: 'foo', name: 'bar', email: 'qux' }
-      rumPublicApi.setUser(user)
-      rumPublicApi.clearUser()
-      rumPublicApi.addAction('message')
-
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(addActionSpy.calls.argsFor(0)[1]!.user).toEqual({})
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('should reject non object input', () => {
-      rumPublicApi.setUser(2 as any)
-      rumPublicApi.setUser(null as any)
-      rumPublicApi.setUser(undefined as any)
-      expect(displaySpy).toHaveBeenCalledTimes(3)
-    })
-  })
-
-  describe('getUser', () => {
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-    })
-
-    it('should return empty object if no user has been set', () => {
-      const userClone = rumPublicApi.getUser()
-      expect(userClone).toEqual({})
-    })
-
-    it('should return a clone of the original object if set', () => {
-      const user = { id: 'foo', name: 'bar', email: 'qux', foo: { bar: 'qux' } }
-      rumPublicApi.setUser(user)
-      const userClone = rumPublicApi.getUser()
-      const userClone2 = rumPublicApi.getUser()
-
-      expect(userClone).not.toBe(user)
-      expect(userClone).not.toBe(userClone2)
-      expect(userClone).toEqual(user)
-    })
-  })
-
-  describe('setUserProperty', () => {
-    const user = { id: 'foo', name: 'bar', email: 'qux', foo: { bar: 'qux' } }
-    const addressAttribute = { city: 'Paris' }
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-    })
-
-    it('should add attribute', () => {
-      rumPublicApi.setUser(user)
-      rumPublicApi.setUserProperty('address', addressAttribute)
-      const userClone = rumPublicApi.getUser()
-
-      expect(userClone.address).toEqual(addressAttribute)
-    })
-
-    it('should not contain original reference to object', () => {
-      const userDetails: { [key: string]: any } = { name: 'john' }
-      rumPublicApi.setUser(user)
-      rumPublicApi.setUserProperty('userDetails', userDetails)
-      userDetails.DOB = '11/11/1999'
-      const userClone = rumPublicApi.getUser()
-
-      expect(userClone.userDetails).not.toBe(userDetails)
-    })
-
-    it('should override attribute', () => {
-      rumPublicApi.setUser(user)
-      rumPublicApi.setUserProperty('foo', addressAttribute)
-      const userClone = rumPublicApi.getUser()
-
-      expect(userClone).toEqual({ ...user, foo: addressAttribute })
-    })
-
-    it('should sanitize properties', () => {
-      rumPublicApi.setUserProperty('id', 123)
-      rumPublicApi.setUserProperty('name', ['Adam', 'Smith'])
-      rumPublicApi.setUserProperty('email', { foo: 'bar' })
-      const userClone = rumPublicApi.getUser()
-
-      expect(userClone.id).toEqual('123')
-      expect(userClone.name).toEqual('Adam,Smith')
-      expect(userClone.email).toEqual('[object Object]')
-    })
-  })
-
-  describe('removeUserProperty', () => {
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-    })
-
-    it('should remove property', () => {
-      const user = { id: 'foo', name: 'bar', email: 'qux', foo: { bar: 'qux' } }
-
-      rumPublicApi.setUser(user)
-      rumPublicApi.removeUserProperty('foo')
-      const userClone = rumPublicApi.getUser()
-      expect(userClone.foo).toBeUndefined()
-    })
-  })
-
-  describe('setAccount', () => {
-    let addActionSpy: jasmine.Spy<ReturnType<StartRum>['addAction']>
-    let displaySpy: jasmine.Spy<() => void>
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      addActionSpy = jasmine.createSpy()
-      displaySpy = spyOn(display, 'error')
-      rumPublicApi = makeRumPublicApi(
-        () => ({
-          ...noopStartRum(),
-          addAction: addActionSpy,
-        }),
-        noopRecorderApi
-      )
-    })
-
-    it('should attach valid objects', () => {
-      const account = { id: 'foo', name: 'bar', foo: { bar: 'qux' } }
-      rumPublicApi.setAccount(account)
-      rumPublicApi.addAction('message')
-
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(addActionSpy.calls.argsFor(0)[1]!.account).toEqual({
-        foo: { bar: 'qux' },
-        id: 'foo',
-        name: 'bar',
-      })
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('should sanitize predefined properties', () => {
-      const account = { id: null, name: 2 }
-      rumPublicApi.setAccount(account as any)
-      rumPublicApi.addAction('message')
-
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(addActionSpy.calls.argsFor(0)[1]!.account).toEqual({
-        id: 'null',
-        name: '2',
-      })
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('should remove the account', () => {
-      const account = { id: 'foo', name: 'bar' }
-      rumPublicApi.setAccount(account)
-      rumPublicApi.clearAccount()
-      rumPublicApi.addAction('message')
-
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-
-      expect(addActionSpy.calls.argsFor(0)[1]!.account).toEqual({})
-      expect(displaySpy).not.toHaveBeenCalled()
-    })
-
-    it('should reject non object input', () => {
-      rumPublicApi.setAccount(2 as any)
-      rumPublicApi.setAccount(null as any)
-      rumPublicApi.setAccount(undefined as any)
-      expect(displaySpy).toHaveBeenCalledTimes(3)
-    })
-  })
-
-  describe('getAccount', () => {
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-    })
-
-    it('should return empty object if no account has been set', () => {
-      const accountClone = rumPublicApi.getAccount()
-      expect(accountClone).toEqual({})
-    })
-
-    it('should return a clone of the original object if set', () => {
-      const account = { id: 'foo', name: 'bar', foo: { bar: 'qux' } }
-      rumPublicApi.setAccount(account)
-      const accountClone = rumPublicApi.getAccount()
-      const accountClone2 = rumPublicApi.getAccount()
-
-      expect(accountClone).not.toBe(account)
-      expect(accountClone).not.toBe(accountClone2)
-      expect(accountClone).toEqual(account)
-    })
-  })
-
-  describe('setAccountProperty', () => {
-    const account = { id: 'foo', name: 'bar', foo: { bar: 'qux' } }
-    const addressAttribute = { city: 'Paris' }
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-    })
-
-    it('should add attribute', () => {
-      rumPublicApi.setAccount(account)
-      rumPublicApi.setAccountProperty('address', addressAttribute)
-      const accountClone = rumPublicApi.getAccount()
-
-      expect(accountClone.address).toEqual(addressAttribute)
-    })
-
-    it('should not contain original reference to object', () => {
-      const accountDetails: { [key: string]: any } = { name: 'company' }
-      rumPublicApi.setAccount(account)
-      rumPublicApi.setAccountProperty('accountDetails', accountDetails)
-      const accountClone = rumPublicApi.getAccount()
-
-      expect(accountClone.accountDetails).not.toBe(accountDetails)
-    })
-
-    it('should override attribute', () => {
-      rumPublicApi.setAccount(account)
-      rumPublicApi.setAccountProperty('foo', addressAttribute)
-      const accountClone = rumPublicApi.getAccount()
-
-      expect(accountClone).toEqual({ ...account, foo: addressAttribute })
-    })
-
-    it('should sanitize properties', () => {
-      rumPublicApi.setAccountProperty('id', 123)
-      rumPublicApi.setAccountProperty('name', ['My', 'Company'])
-      const accountClone = rumPublicApi.getAccount()
-
-      expect(accountClone.id).toEqual('123')
-      expect(accountClone.name).toEqual('My,Company')
-    })
-  })
-
-  describe('removeAccountProperty', () => {
-    let rumPublicApi: RumPublicApi
-
-    beforeEach(() => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
-    })
-    it('should remove property', () => {
-      const account = { id: 'foo', name: 'bar', email: 'qux', foo: { bar: 'qux' } }
-
-      rumPublicApi.setAccount(account)
-      rumPublicApi.removeAccountProperty('foo')
-      const accountClone = rumPublicApi.getAccount()
-      expect(accountClone.foo).toBeUndefined()
     })
   })
 
@@ -841,85 +438,85 @@ describe('rum public api', () => {
     })
   })
 
-  describe('storeContextsAcrossPages', () => {
-    let rumPublicApi: RumPublicApi
+  // fdescribe('storeContextsAcrossPages', () => {
+  //   let rumPublicApi: RumPublicApi
 
-    beforeEach(() => {
-      rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
+  //   beforeEach(() => {
+  //     rumPublicApi = makeRumPublicApi(noopStartRum, noopRecorderApi)
 
-      registerCleanupTask(() => {
-        localStorage.clear()
-        removeStorageListeners()
-      })
-    })
+  //     registerCleanupTask(() => {
+  //       localStorage.clear()
+  //       removeStorageListeners()
+  //     })
+  //   })
 
-    it('when disabled, should store contexts only in memory', () => {
-      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+  //   it('when disabled, should store contexts only in memory', () => {
+  //     rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
 
-      rumPublicApi.setGlobalContext({ foo: 'bar' })
-      expect(rumPublicApi.getGlobalContext()).toEqual({ foo: 'bar' })
-      expect(localStorage.getItem('_dd_c_rum_2')).toBeNull()
+  //     rumPublicApi.setGlobalContext({ foo: 'bar' })
+  //     expect(rumPublicApi.getGlobalContext()).toEqual({ foo: 'bar' })
+  //     expect(localStorage.getItem('_dd_c_rum_2')).toBeNull()
 
-      rumPublicApi.setUser({ id: 'foo', qux: 'qix' })
-      expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix' })
-      expect(localStorage.getItem('_dd_c_rum_1')).toBeNull()
-    })
+  //     rumPublicApi.setUser({ id: 'foo', qux: 'qix' })
+  //     expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix' })
+  //     expect(localStorage.getItem('_dd_c_rum_1')).toBeNull()
+  //   })
 
-    it('when enabled, should maintain user context in local storage', () => {
-      rumPublicApi.init({ ...DEFAULT_INIT_CONFIGURATION, storeContextsAcrossPages: true })
+  //   it('when enabled, should maintain user context in local storage', () => {
+  //     rumPublicApi.init({ ...DEFAULT_INIT_CONFIGURATION, storeContextsAcrossPages: true })
 
-      rumPublicApi.setUser({ id: 'foo', qux: 'qix' })
-      expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix' })
-      expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix"}')
+  //     rumPublicApi.setUser({ id: 'foo', qux: 'qix' })
+  //     expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix' })
+  //     expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix"}')
 
-      rumPublicApi.setUserProperty('foo', 'bar')
-      expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix', foo: 'bar' })
-      expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix","foo":"bar"}')
+  //     rumPublicApi.setUserProperty('foo', 'bar')
+  //     expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix', foo: 'bar' })
+  //     expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix","foo":"bar"}')
 
-      rumPublicApi.removeUserProperty('foo')
-      expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix' })
-      expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix"}')
+  //     rumPublicApi.removeUserProperty('foo')
+  //     expect(rumPublicApi.getUser()).toEqual({ id: 'foo', qux: 'qix' })
+  //     expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix"}')
 
-      rumPublicApi.clearUser()
-      expect(rumPublicApi.getUser()).toEqual({})
-      expect(localStorage.getItem('_dd_c_rum_1')).toBe('{}')
-    })
+  //     rumPublicApi.clearUser()
+  //     expect(rumPublicApi.getUser()).toEqual({})
+  //     expect(localStorage.getItem('_dd_c_rum_1')).toBe('{}')
+  //   })
 
-    it('when enabled, should maintain global context in local storage', () => {
-      rumPublicApi.init({ ...DEFAULT_INIT_CONFIGURATION, storeContextsAcrossPages: true })
+  //   it('when enabled, should maintain global context in local storage', () => {
+  //     rumPublicApi.init({ ...DEFAULT_INIT_CONFIGURATION, storeContextsAcrossPages: true })
 
-      rumPublicApi.setGlobalContext({ qux: 'qix' })
-      expect(rumPublicApi.getGlobalContext()).toEqual({ qux: 'qix' })
-      expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"qux":"qix"}')
+  //     rumPublicApi.setGlobalContext({ qux: 'qix' })
+  //     expect(rumPublicApi.getGlobalContext()).toEqual({ qux: 'qix' })
+  //     expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"qux":"qix"}')
 
-      rumPublicApi.setGlobalContextProperty('foo', 'bar')
-      expect(rumPublicApi.getGlobalContext()).toEqual({ qux: 'qix', foo: 'bar' })
-      expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"qux":"qix","foo":"bar"}')
+  //     rumPublicApi.setGlobalContextProperty('foo', 'bar')
+  //     expect(rumPublicApi.getGlobalContext()).toEqual({ qux: 'qix', foo: 'bar' })
+  //     expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"qux":"qix","foo":"bar"}')
 
-      rumPublicApi.removeGlobalContextProperty('foo')
-      expect(rumPublicApi.getGlobalContext()).toEqual({ qux: 'qix' })
-      expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"qux":"qix"}')
+  //     rumPublicApi.removeGlobalContextProperty('foo')
+  //     expect(rumPublicApi.getGlobalContext()).toEqual({ qux: 'qix' })
+  //     expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"qux":"qix"}')
 
-      rumPublicApi.clearGlobalContext()
-      expect(rumPublicApi.getGlobalContext()).toEqual({})
-      expect(localStorage.getItem('_dd_c_rum_2')).toBe('{}')
-    })
+  //     rumPublicApi.clearGlobalContext()
+  //     expect(rumPublicApi.getGlobalContext()).toEqual({})
+  //     expect(localStorage.getItem('_dd_c_rum_2')).toBe('{}')
+  //   })
 
-    // TODO in next major, buffer context calls to correctly apply before init set/remove/clear
-    it('when enabled, before init context values should override local storage values', () => {
-      localStorage.setItem('_dd_c_rum_1', '{"foo":"bar","qux":"qix"}')
-      localStorage.setItem('_dd_c_rum_2', '{"foo":"bar","qux":"qix"}')
-      rumPublicApi.setUserProperty('foo', 'user')
-      rumPublicApi.setGlobalContextProperty('foo', 'global')
+  //   // TODO in next major, buffer context calls to correctly apply before init set/remove/clear
+  //   it('when enabled, before init context values should override local storage values', () => {
+  //     localStorage.setItem('_dd_c_rum_1', '{"foo":"bar","qux":"qix"}')
+  //     localStorage.setItem('_dd_c_rum_2', '{"foo":"bar","qux":"qix"}')
+  //     rumPublicApi.setUserProperty('foo', 'user')
+  //     rumPublicApi.setGlobalContextProperty('foo', 'global')
 
-      rumPublicApi.init({ ...DEFAULT_INIT_CONFIGURATION, storeContextsAcrossPages: true })
+  //     rumPublicApi.init({ ...DEFAULT_INIT_CONFIGURATION, storeContextsAcrossPages: true })
 
-      expect(rumPublicApi.getUser()).toEqual({ foo: 'user', qux: 'qix' })
-      expect(rumPublicApi.getGlobalContext()).toEqual({ foo: 'global', qux: 'qix' })
-      expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"foo":"user","qux":"qix"}')
-      expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"foo":"global","qux":"qix"}')
-    })
-  })
+  //     expect(rumPublicApi.getUser()).toEqual({ foo: 'user', qux: 'qix' })
+  //     expect(rumPublicApi.getGlobalContext()).toEqual({ foo: 'global', qux: 'qix' })
+  //     expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"foo":"user","qux":"qix"}')
+  //     expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"foo":"global","qux":"qix"}')
+  //   })
+  // })
 
   describe('startDurationVital', () => {
     it('should call startDurationVital on the startRum result', () => {

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -80,12 +80,7 @@ function startRumStub(
     windowOpenObservable,
     urlContexts,
     viewHistory,
-    () => ({
-      context: {},
-      user: {},
-      account: {},
-      hasReplay: undefined,
-    }),
+    noopRecorderApi,
     reportError
   )
   const { stop: viewCollectionStop } = startViewCollection(
@@ -332,7 +327,6 @@ describe('view events', () => {
       mockRumConfiguration(),
       noopRecorderApi,
       createCustomerDataTrackerManager(),
-      () => ({ user: {}, context: {}, account: {}, hasReplay: undefined }),
       undefined,
       createIdentityEncoder,
       createTrackingConsentState(TrackingConsent.GRANTED),

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -4,8 +4,8 @@ import type {
   RawError,
   DeflateEncoderStreamId,
   Encoder,
-  CustomerDataTrackerManager,
   TrackingConsentState,
+  CustomerDataTrackerManager,
 } from '@datadog/browser-core'
 import {
   sendToExtension,
@@ -20,7 +20,6 @@ import {
 } from '@datadog/browser-core'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { createWindowOpenObservable } from '../browser/windowOpenObservable'
-import { startRumAssembly } from '../domain/assembly'
 import { startInternalContext } from '../domain/contexts/internalContext'
 import { LifeCycle, LifeCycleEventType } from '../domain/lifeCycle'
 import type { ViewHistory } from '../domain/contexts/viewHistory'
@@ -43,7 +42,6 @@ import { startFeatureFlagContexts } from '../domain/contexts/featureFlagContext'
 import { startCustomerDataTelemetry } from '../domain/startCustomerDataTelemetry'
 import type { PageStateHistory } from '../domain/contexts/pageStateHistory'
 import { startPageStateHistory } from '../domain/contexts/pageStateHistory'
-import type { CommonContext } from '../domain/contexts/commonContext'
 import { startDisplayContext } from '../domain/contexts/displayContext'
 import type { CustomVitalsState } from '../domain/vital/vitalCollection'
 import { startVitalCollection } from '../domain/vital/vitalCollection'
@@ -54,6 +52,10 @@ import { startLongTaskCollection } from '../domain/longTask/longTaskCollection'
 import type { Hooks } from '../hooks'
 import { createHooks } from '../hooks'
 import { startSyntheticsContext } from '../domain/contexts/syntheticsContext'
+import { startGlobalContext } from '../domain/contexts/globalContext'
+import { startUserContext } from '../domain/contexts/userContext'
+import { startAccountContext } from '../domain/contexts/accountContext'
+import { startRumAssembly } from '../domain/assembly'
 import type { RecorderApi } from './rumPublicApi'
 
 export type StartRum = typeof startRum
@@ -63,7 +65,7 @@ export function startRum(
   configuration: RumConfiguration,
   recorderApi: RecorderApi,
   customerDataTrackerManager: CustomerDataTrackerManager,
-  getCommonContext: () => CommonContext,
+
   initialViewOptions: ViewOptions | undefined,
   createEncoder: (streamId: DeflateEncoderStreamId) => Encoder,
 
@@ -140,6 +142,10 @@ export function startRum(
   const { observable: windowOpenObservable, stop: stopWindowOpen } = createWindowOpenObservable()
   cleanupTasks.push(stopWindowOpen)
 
+  const globalContext = startGlobalContext(customerDataTrackerManager, hooks, configuration)
+  const userContext = startUserContext(customerDataTrackerManager, hooks, session, configuration)
+  const accountContext = startAccountContext(customerDataTrackerManager, hooks, configuration)
+
   const {
     actionContexts,
     addAction,
@@ -154,7 +160,7 @@ export function startRum(
     windowOpenObservable,
     urlContexts,
     viewHistory,
-    getCommonContext,
+    recorderApi,
     reportError
   )
   cleanupTasks.push(stopRumEventCollection)
@@ -198,7 +204,7 @@ export function startRum(
 
   const { addError } = startErrorCollection(lifeCycle, configuration)
 
-  startRequestCollection(lifeCycle, configuration, session, getCommonContext)
+  startRequestCollection(lifeCycle, configuration, session, userContext, accountContext)
 
   const vitalCollection = startVitalCollection(lifeCycle, pageStateHistory, customVitalsState)
   const internalContext = startInternalContext(
@@ -227,6 +233,9 @@ export function startRum(
     startDurationVital: vitalCollection.startDurationVital,
     stopDurationVital: vitalCollection.stopDurationVital,
     addDurationVital: vitalCollection.addDurationVital,
+    ...globalContext,
+    ...userContext,
+    ...accountContext,
     stop: () => {
       cleanupTasks.forEach((task) => task())
     },
@@ -252,7 +261,7 @@ export function startRumEventCollection(
   windowOpenObservable: Observable<void>,
   urlContexts: UrlContexts,
   viewHistory: ViewHistory,
-  getCommonContext: () => CommonContext,
+  recorderApi: RecorderApi,
   reportError: (error: RawError) => void
 ) {
   const actionCollection = startActionCollection(
@@ -265,6 +274,7 @@ export function startRumEventCollection(
 
   const displayContext = startDisplayContext(configuration)
   const ciVisibilityContext = startCiVisibilityContext(configuration, hooks)
+
   startSyntheticsContext(hooks)
 
   startRumAssembly(
@@ -275,7 +285,7 @@ export function startRumEventCollection(
     viewHistory,
     urlContexts,
     displayContext,
-    getCommonContext,
+    recorderApi,
     reportError
   )
 

--- a/packages/rum-core/src/domain/action/actionCollection.ts
+++ b/packages/rum-core/src/domain/action/actionCollection.ts
@@ -6,7 +6,6 @@ import { ActionType, RumEventType } from '../../rawRumEvent.types'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
 import type { RumConfiguration } from '../configuration'
-import type { CommonContext } from '../contexts/commonContext'
 import type { RumActionEventDomainContext } from '../../domainContext.types'
 import type { PartialRumEvent, Hooks } from '../../hooks'
 import { HookNames } from '../../hooks'
@@ -69,11 +68,8 @@ export function startActionCollection(
   }
 
   return {
-    addAction: (action: CustomAction, savedCommonContext?: CommonContext) => {
-      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
-        savedCommonContext,
-        ...processAction(action),
-      })
+    addAction: (action: CustomAction) => {
+      lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, processAction(action))
     },
     actionContexts,
     stop,

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -18,13 +18,13 @@ import { RumEventType } from '../rawRumEvent.types'
 import type { CommonProperties, RumEvent } from '../rumEvent.types'
 import type { Hooks } from '../hooks'
 import { HookNames } from '../hooks'
+import type { RecorderApi } from '../boot/rumPublicApi'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
 import type { ViewHistory } from './contexts/viewHistory'
 import { SessionReplayState, SessionType, type RumSessionManager } from './rumSessionManager'
 import type { RumConfiguration } from './configuration'
 import type { DisplayContext } from './contexts/displayContext'
-import type { CommonContext } from './contexts/commonContext'
 import type { ModifiableFieldPaths } from './limitModification'
 import { limitModification } from './limitModification'
 import type { UrlContexts } from './contexts/urlContexts'
@@ -59,7 +59,7 @@ export function startRumAssembly(
   viewHistory: ViewHistory,
   urlContexts: UrlContexts,
   displayContext: DisplayContext,
-  getCommonContext: () => CommonContext,
+  recorderApi: RecorderApi,
   reportError: (error: RawError) => void
 ) {
   modifiableFieldPathsByEvent = {
@@ -123,7 +123,7 @@ export function startRumAssembly(
 
   lifeCycle.subscribe(
     LifeCycleEventType.RAW_RUM_EVENT_COLLECTED,
-    ({ startTime, duration, rawRumEvent, domainContext, savedCommonContext, customerContext }) => {
+    ({ startTime, duration, rawRumEvent, domainContext, customerContext }) => {
       const viewHistoryEntry = viewHistory.findView(startTime)
       const urlContext = urlContexts.findUrl(startTime)
       const session = sessionManager.findTrackedSession(startTime)
@@ -147,8 +147,6 @@ export function startRumAssembly(
       }
 
       if (session && viewHistoryEntry && urlContext) {
-        const commonContext = savedCommonContext || getCommonContext()
-
         const rumContext: Partial<CommonProperties> = {
           _dd: {
             format_version: 2,
@@ -170,7 +168,6 @@ export function startRumAssembly(
           },
           display: displayContext.get(),
           connectivity: getConnectivity(),
-          context: commonContext.context,
         }
 
         const serverRumEvent = combine(
@@ -185,22 +182,14 @@ export function startRumAssembly(
         ) as RumEvent & Context
 
         if (!('has_replay' in serverRumEvent.session)) {
-          ;(serverRumEvent.session as Mutable<RumEvent['session']>).has_replay = commonContext.hasReplay
+          ;(serverRumEvent.session as Mutable<RumEvent['session']>).has_replay = recorderApi.isRecording()
+            ? true
+            : undefined
         }
+
         if (serverRumEvent.type === 'view') {
           ;(serverRumEvent.session as Mutable<RumEvent['session']>).sampled_for_replay =
             session.sessionReplay === SessionReplayState.SAMPLED
-        }
-
-        if (session.anonymousId && !commonContext.user.anonymous_id && !!configuration.trackAnonymousUser) {
-          commonContext.user.anonymous_id = session.anonymousId
-        }
-        if (!isEmptyObject(commonContext.user)) {
-          ;(serverRumEvent.usr as Mutable<RumEvent['usr']>) = commonContext.user as User & Context
-        }
-
-        if (!isEmptyObject(commonContext.account) && commonContext.account.id) {
-          ;(serverRumEvent.account as Mutable<RumEvent['account']>) = commonContext.account as Account
         }
 
         if (shouldSend(serverRumEvent, configuration.beforeSend, domainContext, eventRateLimiters)) {

--- a/packages/rum-core/src/domain/contexts/accountContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/accountContext.spec.ts
@@ -1,0 +1,137 @@
+import type { CustomerDataTrackerManager, RelativeTime } from '@datadog/browser-core'
+import {
+  createCustomerDataTrackerManager,
+  CustomerDataCompressionStatus,
+  display,
+  removeStorageListeners,
+} from '@datadog/browser-core'
+import { registerCleanupTask } from 'packages/core/test'
+import { mockRumConfiguration } from '../../../test'
+import type { Hooks } from '../../hooks'
+import { createHooks, HookNames } from '../../hooks'
+import type { AccountContext } from './accountContext'
+import { startAccountContext } from './accountContext'
+
+describe('account context', () => {
+  let hooks: Hooks
+  let accountContext: AccountContext
+  let displaySpy: jasmine.Spy
+
+  beforeEach(() => {
+    const customerDataTrackerManager = createCustomerDataTrackerManager(CustomerDataCompressionStatus.Disabled)
+    hooks = createHooks()
+    displaySpy = spyOn(display, 'warn')
+
+    accountContext = startAccountContext(customerDataTrackerManager, hooks, mockRumConfiguration())
+  })
+
+  it('should get account', () => {
+    accountContext.setAccount({ id: '123' })
+    expect(accountContext.getAccount()).toEqual({ id: '123' })
+  })
+
+  it('should set account property', () => {
+    accountContext.setAccountProperty('foo', 'bar')
+    expect(accountContext.getAccount()).toEqual({ foo: 'bar' })
+  })
+
+  it('should remove account property', () => {
+    accountContext.setAccount({ id: '123', foo: 'bar' })
+    accountContext.removeAccountProperty('foo')
+    expect(accountContext.getAccount()).toEqual({ id: '123' })
+  })
+
+  it('should clear account', () => {
+    accountContext.setAccount({ id: '123' })
+    accountContext.clearAccount()
+    expect(accountContext.getAccount()).toEqual({})
+  })
+
+  it('should warn when the account.id is missing', () => {
+    accountContext.setAccount({ foo: 'bar' })
+    expect(displaySpy).toHaveBeenCalled()
+  })
+
+  it('should sanitize predefined properties', () => {
+    accountContext.setAccount({ id: null, name: 2 })
+    expect(accountContext.getAccount()).toEqual({
+      id: 'null',
+      name: '2',
+    })
+  })
+
+  describe('assemble hook', () => {
+    it('should set the account', () => {
+      accountContext.setAccount({ id: '123', foo: 'bar' })
+
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual({
+        type: 'view',
+        account: {
+          id: '123',
+          foo: 'bar',
+        },
+      })
+    })
+
+    it('should not set the account when account.id is undefined', () => {
+      accountContext.setAccount({ foo: 'bar' })
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual(undefined)
+    })
+  })
+})
+
+describe('account context across pages', () => {
+  let hooks: Hooks
+  let accountContext: AccountContext
+  let customerDataTrackerManager: CustomerDataTrackerManager
+
+  beforeEach(() => {
+    customerDataTrackerManager = createCustomerDataTrackerManager(CustomerDataCompressionStatus.Disabled)
+    hooks = createHooks()
+
+    registerCleanupTask(() => {
+      localStorage.clear()
+      removeStorageListeners()
+    })
+  })
+
+  it('when disabled, should store contexts only in memory', () => {
+    accountContext = startAccountContext(
+      customerDataTrackerManager,
+      hooks,
+      mockRumConfiguration({ storeContextsAcrossPages: false })
+    )
+    accountContext.setAccount({ id: '123' })
+
+    expect(accountContext.getAccount()).toEqual({ id: '123' })
+    expect(localStorage.getItem('_dd_c_rum_4')).toBeNull()
+  })
+
+  it('when enabled, should maintain the account in local storage', () => {
+    accountContext = startAccountContext(
+      customerDataTrackerManager,
+      hooks,
+      mockRumConfiguration({ storeContextsAcrossPages: true })
+    )
+
+    accountContext.setAccount({ id: 'foo', qux: 'qix' })
+    expect(accountContext.getAccount()).toEqual({ id: 'foo', qux: 'qix' })
+    expect(localStorage.getItem('_dd_c_rum_4')).toBe('{"id":"foo","qux":"qix"}')
+
+    accountContext.setAccountProperty('foo', 'bar')
+    expect(accountContext.getAccount()).toEqual({ id: 'foo', qux: 'qix', foo: 'bar' })
+    expect(localStorage.getItem('_dd_c_rum_4')).toBe('{"id":"foo","qux":"qix","foo":"bar"}')
+
+    accountContext.removeAccountProperty('foo')
+    expect(accountContext.getAccount()).toEqual({ id: 'foo', qux: 'qix' })
+    expect(localStorage.getItem('_dd_c_rum_4')).toBe('{"id":"foo","qux":"qix"}')
+
+    accountContext.clearAccount()
+    expect(accountContext.getAccount()).toEqual({})
+    expect(localStorage.getItem('_dd_c_rum_4')).toBe('{}')
+  })
+})

--- a/packages/rum-core/src/domain/contexts/accountContext.ts
+++ b/packages/rum-core/src/domain/contexts/accountContext.ts
@@ -1,0 +1,50 @@
+import type { Account, CustomerDataTrackerManager } from '@datadog/browser-core'
+import { createContextManager, CustomerDataType, display, storeContextManager } from '@datadog/browser-core'
+import { HookNames } from '../../hooks'
+import type { Hooks, PartialRumEvent } from '../../hooks'
+import type { RumConfiguration } from '../configuration'
+
+export type AccountContext = ReturnType<typeof startAccountContext>
+
+export function startAccountContext(
+  customerDataTrackerManager: CustomerDataTrackerManager,
+  hooks: Hooks,
+  configuration: RumConfiguration
+) {
+  const accountContextManager = buildAccountContextManager(customerDataTrackerManager)
+
+  if (configuration.storeContextsAcrossPages) {
+    storeContextManager(configuration, accountContextManager, 'rum', CustomerDataType.Account)
+  }
+
+  hooks.register(HookNames.Assemble, ({ eventType }): PartialRumEvent | undefined => {
+    const account = accountContextManager.getContext() as Account
+
+    if (!account.id) {
+      return
+    }
+
+    return {
+      type: eventType,
+      account,
+    }
+  })
+
+  return {
+    getAccount: accountContextManager.getContext,
+    setAccount: accountContextManager.setContext,
+    setAccountProperty: accountContextManager.setContextProperty,
+    removeAccountProperty: accountContextManager.removeContextProperty,
+    clearAccount: accountContextManager.clearContext,
+  }
+}
+
+export function buildAccountContextManager(customerDataTrackerManager: CustomerDataTrackerManager) {
+  return createContextManager('account', {
+    customerDataTracker: customerDataTrackerManager.getOrCreateTracker(CustomerDataType.Account),
+    propertiesConfig: {
+      id: { type: 'string', required: true },
+      name: { type: 'string' },
+    },
+  })
+}

--- a/packages/rum-core/src/domain/contexts/globalContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/globalContext.spec.ts
@@ -1,0 +1,112 @@
+import type { CustomerDataTrackerManager, RelativeTime } from '@datadog/browser-core'
+import {
+  createCustomerDataTrackerManager,
+  CustomerDataCompressionStatus,
+  removeStorageListeners,
+} from '@datadog/browser-core'
+import { registerCleanupTask } from '@datadog/browser-core/test'
+import { mockRumConfiguration } from '../../../test'
+import type { Hooks } from '../../hooks'
+import { createHooks, HookNames } from '../../hooks'
+import type { GlobalContext } from './globalContext'
+import { startGlobalContext } from './globalContext'
+
+describe('global context', () => {
+  let hooks: Hooks
+  let globalContext: GlobalContext
+
+  beforeEach(() => {
+    const customerDataTrackerManager = createCustomerDataTrackerManager(CustomerDataCompressionStatus.Disabled)
+    hooks = createHooks()
+    globalContext = startGlobalContext(customerDataTrackerManager, hooks, mockRumConfiguration())
+  })
+
+  it('should get context', () => {
+    globalContext.setGlobalContext({ id: '123' })
+    expect(globalContext.getGlobalContext()).toEqual({ id: '123' })
+  })
+
+  it('should set context property', () => {
+    globalContext.setGlobalContextProperty('foo', 'bar')
+    expect(globalContext.getGlobalContext()).toEqual({ foo: 'bar' })
+  })
+
+  it('should remove context property', () => {
+    globalContext.setGlobalContext({ id: '123', foo: 'bar' })
+    globalContext.removeGlobalContextProperty('foo')
+    expect(globalContext.getGlobalContext()).toEqual({ id: '123' })
+  })
+
+  it('should clear context', () => {
+    globalContext.setGlobalContext({ id: '123' })
+    globalContext.clearGlobalContext()
+    expect(globalContext.getGlobalContext()).toEqual({})
+  })
+
+  describe('assemble hook', () => {
+    it('should set the context', () => {
+      globalContext.setGlobalContext({ id: '123', foo: 'bar' })
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual({
+        type: 'view',
+        context: {
+          id: '123',
+          foo: 'bar',
+        },
+      })
+    })
+  })
+})
+
+describe('global context across pages', () => {
+  let hooks: Hooks
+  let globalContext: GlobalContext
+  let customerDataTrackerManager: CustomerDataTrackerManager
+
+  beforeEach(() => {
+    customerDataTrackerManager = createCustomerDataTrackerManager(CustomerDataCompressionStatus.Disabled)
+    hooks = createHooks()
+
+    registerCleanupTask(() => {
+      localStorage.clear()
+      removeStorageListeners()
+    })
+  })
+
+  it('when disabled, should store contexts only in memory', () => {
+    globalContext = startGlobalContext(
+      customerDataTrackerManager,
+      hooks,
+      mockRumConfiguration({ storeContextsAcrossPages: false })
+    )
+    globalContext.setGlobalContext({ id: '123' })
+
+    expect(globalContext.getGlobalContext()).toEqual({ id: '123' })
+    expect(localStorage.getItem('_dd_c_rum_2')).toBeNull()
+  })
+
+  it('when enabled, should maintain the global context in local storage', () => {
+    globalContext = startGlobalContext(
+      customerDataTrackerManager,
+      hooks,
+      mockRumConfiguration({ storeContextsAcrossPages: true })
+    )
+
+    globalContext.setGlobalContext({ id: 'foo', qux: 'qix' })
+    expect(globalContext.getGlobalContext()).toEqual({ id: 'foo', qux: 'qix' })
+    expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"id":"foo","qux":"qix"}')
+
+    globalContext.setGlobalContextProperty('foo', 'bar')
+    expect(globalContext.getGlobalContext()).toEqual({ id: 'foo', qux: 'qix', foo: 'bar' })
+    expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"id":"foo","qux":"qix","foo":"bar"}')
+
+    globalContext.removeGlobalContextProperty('foo')
+    expect(globalContext.getGlobalContext()).toEqual({ id: 'foo', qux: 'qix' })
+    expect(localStorage.getItem('_dd_c_rum_2')).toBe('{"id":"foo","qux":"qix"}')
+
+    globalContext.clearGlobalContext()
+    expect(globalContext.getGlobalContext()).toEqual({})
+    expect(localStorage.getItem('_dd_c_rum_2')).toBe('{}')
+  })
+})

--- a/packages/rum-core/src/domain/contexts/globalContext.ts
+++ b/packages/rum-core/src/domain/contexts/globalContext.ts
@@ -1,0 +1,38 @@
+import type { CustomerDataTrackerManager } from '@datadog/browser-core'
+import { createContextManager, CustomerDataType, storeContextManager } from '@datadog/browser-core'
+import { HookNames } from '../../hooks'
+import type { Hooks, PartialRumEvent } from '../../hooks'
+import type { RumConfiguration } from '../configuration'
+
+export type GlobalContext = ReturnType<typeof startGlobalContext>
+
+export function startGlobalContext(
+  customerDataTrackerManager: CustomerDataTrackerManager,
+  hooks: Hooks,
+  configuration: RumConfiguration
+) {
+  const globalContextManager = buildGlobalContextManager(customerDataTrackerManager)
+
+  if (configuration.storeContextsAcrossPages) {
+    storeContextManager(configuration, globalContextManager, 'rum', CustomerDataType.GlobalContext)
+  }
+
+  hooks.register(HookNames.Assemble, ({ eventType }): PartialRumEvent | undefined => ({
+    type: eventType,
+    context: globalContextManager.getContext(),
+  }))
+
+  return {
+    getGlobalContext: globalContextManager.getContext,
+    setGlobalContext: globalContextManager.setContext,
+    setGlobalContextProperty: globalContextManager.setContextProperty,
+    removeGlobalContextProperty: globalContextManager.removeContextProperty,
+    clearGlobalContext: globalContextManager.clearContext,
+  }
+}
+
+export function buildGlobalContextManager(customerDataTrackerManager: CustomerDataTrackerManager) {
+  return createContextManager('global context', {
+    customerDataTracker: customerDataTrackerManager.getOrCreateTracker(CustomerDataType.GlobalContext),
+  })
+}

--- a/packages/rum-core/src/domain/contexts/userContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/userContext.spec.ts
@@ -1,0 +1,169 @@
+import type { CustomerDataTrackerManager, RelativeTime } from '@datadog/browser-core'
+import {
+  createCustomerDataTrackerManager,
+  CustomerDataCompressionStatus,
+  removeStorageListeners,
+} from '@datadog/browser-core'
+import { registerCleanupTask } from '@datadog/browser-core/test'
+import { createRumSessionManagerMock, mockRumConfiguration } from '../../../test'
+import type { Hooks } from '../../hooks'
+import { createHooks, HookNames } from '../../hooks'
+import type { UserContext } from './userContext'
+import { startUserContext } from './userContext'
+
+describe('user context', () => {
+  let hooks: Hooks
+  let userContext: UserContext
+  let customerDataTrackerManager: CustomerDataTrackerManager
+
+  beforeEach(() => {
+    customerDataTrackerManager = createCustomerDataTrackerManager(CustomerDataCompressionStatus.Disabled)
+    hooks = createHooks()
+
+    userContext = startUserContext(
+      customerDataTrackerManager,
+      hooks,
+      createRumSessionManagerMock(),
+      mockRumConfiguration({ trackAnonymousUser: false })
+    )
+  })
+
+  it('should get user', () => {
+    userContext.setUser({ id: '123' })
+    expect(userContext.getUser()).toEqual({ id: '123' })
+  })
+
+  it('should set user property', () => {
+    userContext.setUserProperty('foo', 'bar')
+    expect(userContext.getUser()).toEqual({ foo: 'bar' })
+  })
+
+  it('should remove user property', () => {
+    userContext.setUser({ id: '123', foo: 'bar' })
+    userContext.removeUserProperty('foo')
+    expect(userContext.getUser()).toEqual({ id: '123' })
+  })
+
+  it('should clear user', () => {
+    userContext.setUser({ id: '123' })
+    userContext.clearUser()
+    expect(userContext.getUser()).toEqual({})
+  })
+
+  it('should sanitize predefined properties', () => {
+    userContext.setUser({ id: null, name: 2, email: { bar: 'qux' } })
+
+    expect(userContext.getUser()).toEqual({
+      email: '[object Object]',
+      id: 'null',
+      name: '2',
+    })
+  })
+
+  describe('assemble hook', () => {
+    it('should set the user', () => {
+      userContext.setUser({ id: '123', foo: 'bar' })
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual({
+        type: 'view',
+        usr: {
+          id: '123',
+          foo: 'bar',
+        },
+      })
+    })
+
+    it('should set the user.anonymous_id when trackAnonymousUser is true', () => {
+      userContext = startUserContext(
+        customerDataTrackerManager,
+        hooks,
+        createRumSessionManagerMock(),
+        mockRumConfiguration({ trackAnonymousUser: true })
+      )
+      userContext.setUser({ id: '123' })
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual({
+        type: 'view',
+        usr: {
+          id: '123',
+          anonymous_id: 'device-123',
+        },
+      })
+    })
+
+    it('should not override customer provided anonymous_id when trackAnonymousUser is true', () => {
+      userContext = startUserContext(
+        customerDataTrackerManager,
+        hooks,
+        createRumSessionManagerMock(),
+        mockRumConfiguration({ trackAnonymousUser: true })
+      )
+      userContext.setUser({ id: '123', anonymous_id: 'foo' })
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual({
+        type: 'view',
+        usr: {
+          id: '123',
+          anonymous_id: 'foo',
+        },
+      })
+    })
+  })
+})
+
+describe('user context across pages', () => {
+  let hooks: Hooks
+  let userContext: UserContext
+  let customerDataTrackerManager: CustomerDataTrackerManager
+
+  beforeEach(() => {
+    customerDataTrackerManager = createCustomerDataTrackerManager(CustomerDataCompressionStatus.Disabled)
+    hooks = createHooks()
+
+    registerCleanupTask(() => {
+      localStorage.clear()
+      removeStorageListeners()
+    })
+  })
+
+  it('when disabled, should store contexts only in memory', () => {
+    userContext = startUserContext(
+      customerDataTrackerManager,
+      hooks,
+      createRumSessionManagerMock(),
+      mockRumConfiguration({ storeContextsAcrossPages: false })
+    )
+    userContext.setUser({ id: '123' })
+
+    expect(userContext.getUser()).toEqual({ id: '123' })
+    expect(localStorage.getItem('_dd_c_rum_1')).toBeNull()
+  })
+
+  it('when enabled, should maintain the user in local storage', () => {
+    userContext = startUserContext(
+      customerDataTrackerManager,
+      hooks,
+      createRumSessionManagerMock(),
+      mockRumConfiguration({ storeContextsAcrossPages: true })
+    )
+
+    userContext.setUser({ id: 'foo', qux: 'qix' })
+    expect(userContext.getUser()).toEqual({ id: 'foo', qux: 'qix' })
+    expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix"}')
+
+    userContext.setUserProperty('foo', 'bar')
+    expect(userContext.getUser()).toEqual({ id: 'foo', qux: 'qix', foo: 'bar' })
+    expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix","foo":"bar"}')
+
+    userContext.removeUserProperty('foo')
+    expect(userContext.getUser()).toEqual({ id: 'foo', qux: 'qix' })
+    expect(localStorage.getItem('_dd_c_rum_1')).toBe('{"id":"foo","qux":"qix"}')
+
+    userContext.clearUser()
+    expect(userContext.getUser()).toEqual({})
+    expect(localStorage.getItem('_dd_c_rum_1')).toBe('{}')
+  })
+})

--- a/packages/rum-core/src/domain/contexts/userContext.ts
+++ b/packages/rum-core/src/domain/contexts/userContext.ts
@@ -1,0 +1,58 @@
+import type { CustomerDataTrackerManager } from '@datadog/browser-core'
+import { createContextManager, CustomerDataType, isEmptyObject, storeContextManager } from '@datadog/browser-core'
+import { HookNames } from '../../hooks'
+import type { Hooks, PartialRumEvent } from '../../hooks'
+import type { RumSessionManager } from '../rumSessionManager'
+import type { RumConfiguration } from '../configuration'
+
+export type UserContext = ReturnType<typeof startUserContext>
+
+export function startUserContext(
+  customerDataTrackerManager: CustomerDataTrackerManager,
+  hooks: Hooks,
+  sessionManager: RumSessionManager,
+  configuration: RumConfiguration
+) {
+  const userContextManager = buildUserContextManager(customerDataTrackerManager)
+
+  if (configuration.storeContextsAcrossPages) {
+    storeContextManager(configuration, userContextManager, 'rum', CustomerDataType.User)
+  }
+
+  hooks.register(HookNames.Assemble, ({ startTime, eventType }): PartialRumEvent | undefined => {
+    const user = userContextManager.getContext()
+    const session = sessionManager.findTrackedSession(startTime)
+
+    if (isEmptyObject(user)) {
+      return
+    }
+
+    if (session && session.anonymousId && !user.anonymous_id && !!configuration.trackAnonymousUser) {
+      user.anonymous_id = session.anonymousId
+    }
+
+    return {
+      type: eventType,
+      usr: user,
+    }
+  })
+
+  return {
+    getUser: userContextManager.getContext,
+    setUser: userContextManager.setContext,
+    setUserProperty: userContextManager.setContextProperty,
+    removeUserProperty: userContextManager.removeContextProperty,
+    clearUser: userContextManager.clearContext,
+  }
+}
+
+export function buildUserContextManager(customerDataTrackerManager: CustomerDataTrackerManager) {
+  return createContextManager('user', {
+    customerDataTracker: customerDataTrackerManager.getOrCreateTracker(CustomerDataType.User),
+    propertiesConfig: {
+      id: { type: 'string' },
+      name: { type: 'string' },
+      email: { type: 'string' },
+    },
+  })
+}

--- a/packages/rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.spec.ts
@@ -92,7 +92,6 @@ describe('error collection', () => {
             },
             type: RumEventType.ERROR,
           },
-          savedCommonContext: undefined,
           startTime: 1234 as RelativeTime,
           domainContext: {
             error,
@@ -170,36 +169,6 @@ describe('error collection', () => {
       })
       expect(rawRumEvents[0].customerContext).toEqual({
         foo: 'bar',
-      })
-    })
-
-    it('should save the global context', () => {
-      setupErrorCollection()
-      addError(
-        {
-          error: new Error('foo'),
-          handlingStack: 'Error: handling foo',
-          startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
-        },
-        { context: { foo: 'bar' }, user: {}, account: {}, hasReplay: undefined }
-      )
-      expect(rawRumEvents[0].savedCommonContext!.context).toEqual({
-        foo: 'bar',
-      })
-    })
-
-    it('should save the user', () => {
-      setupErrorCollection()
-      addError(
-        {
-          error: new Error('foo'),
-          handlingStack: 'Error: handling foo',
-          startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
-        },
-        { context: {}, user: { id: 'foo' }, account: {}, hasReplay: undefined }
-      )
-      expect(rawRumEvents[0].savedCommonContext!.user).toEqual({
-        id: 'foo',
       })
     })
 

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -16,7 +16,6 @@ import type { RawRumErrorEvent } from '../../rawRumEvent.types'
 import { RumEventType } from '../../rawRumEvent.types'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
-import type { CommonContext } from '../contexts/commonContext'
 import type { RumErrorEventDomainContext } from '../../domainContext.types'
 import { trackConsoleError } from './trackConsoleError'
 import { trackReportError } from './trackReportError'
@@ -42,20 +41,16 @@ export function startErrorCollection(lifeCycle: LifeCycle, configuration: RumCon
 }
 
 export function doStartErrorCollection(lifeCycle: LifeCycle) {
-  lifeCycle.subscribe(LifeCycleEventType.RAW_ERROR_COLLECTED, ({ error, customerContext, savedCommonContext }) => {
+  lifeCycle.subscribe(LifeCycleEventType.RAW_ERROR_COLLECTED, ({ error, customerContext }) => {
     customerContext = combine(error.context, customerContext)
     lifeCycle.notify(LifeCycleEventType.RAW_RUM_EVENT_COLLECTED, {
       customerContext,
-      savedCommonContext,
       ...processError(error),
     })
   })
 
   return {
-    addError: (
-      { error, handlingStack, componentStack, startClocks, context: customerContext }: ProvidedError,
-      savedCommonContext?: CommonContext
-    ) => {
+    addError: ({ error, handlingStack, componentStack, startClocks, context: customerContext }: ProvidedError) => {
       const stackTrace = isError(error) ? computeStackTrace(error) : undefined
       const rawError = computeRawError({
         stackTrace,
@@ -70,7 +65,6 @@ export function doStartErrorCollection(lifeCycle: LifeCycle) {
 
       lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, {
         customerContext,
-        savedCommonContext,
         error: rawError,
       })
     },

--- a/packages/rum-core/src/domain/requestCollection.ts
+++ b/packages/rum-core/src/domain/requestCollection.ts
@@ -23,7 +23,8 @@ import { isAllowedRequestUrl } from './resource/resourceUtils'
 import type { Tracer } from './tracing/tracer'
 import { startTracer } from './tracing/tracer'
 import type { SpanIdentifier, TraceIdentifier } from './tracing/identifier'
-import type { CommonContext } from './contexts/commonContext'
+import type { UserContext } from './contexts/userContext'
+import type { AccountContext } from './contexts/accountContext'
 
 export interface CustomContext {
   requestIndex: number
@@ -67,9 +68,10 @@ export function startRequestCollection(
   lifeCycle: LifeCycle,
   configuration: RumConfiguration,
   sessionManager: RumSessionManager,
-  getCommonContext: () => CommonContext
+  userContext: UserContext,
+  accountContext: AccountContext
 ) {
-  const tracer = startTracer(configuration, sessionManager, getCommonContext)
+  const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
   trackXhr(lifeCycle, configuration, tracer)
   trackFetch(lifeCycle, tracer)
 }

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -5,20 +5,16 @@ import { createRumSessionManagerMock } from '../../../test'
 import type { RumFetchResolveContext, RumFetchStartContext, RumXhrStartContext } from '../requestCollection'
 import type { RumConfiguration, RumInitConfiguration } from '../configuration'
 import { validateAndBuildRumConfiguration } from '../configuration'
-import type { CommonContext } from '../contexts/commonContext'
+import type { UserContext } from '../contexts/userContext'
+import type { AccountContext } from '../contexts/accountContext'
 import { startTracer } from './tracer'
 import type { SpanIdentifier, TraceIdentifier } from './identifier'
 import { createSpanIdentifier, createTraceIdentifier } from './identifier'
 
-const mockGetCommonContext = jasmine.createSpy().and.returnValue({
-  user: {
-    id: '1234',
-  },
-  account: { id: '5678' },
-} as unknown as CommonContext)
-
 describe('tracer', () => {
   let configuration: RumConfiguration
+  const userContext = { getUser: () => ({ id: '1234' }) } as unknown as UserContext
+  const accountContext = { getAccount: () => ({ id: '5678' }) } as unknown as AccountContext
   const ALLOWED_DOMAIN_CONTEXT: Partial<RumXhrStartContext | RumFetchStartContext> = {
     url: window.location.origin,
   }
@@ -56,7 +52,7 @@ describe('tracer', () => {
     })
 
     it('should add traceId and spanId to context and add tracing headers', () => {
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -66,7 +62,7 @@ describe('tracer', () => {
     })
 
     it('should not trace request on disallowed domain', () => {
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       const context = { ...DISALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -76,7 +72,7 @@ describe('tracer', () => {
     })
 
     it('should not trace request during untracked session', () => {
-      const tracer = startTracer(configuration, sessionManager.setNotTracked(), mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager.setNotTracked(), userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -86,7 +82,12 @@ describe('tracer', () => {
     })
 
     it("should trace request with priority '1' when sampled", () => {
-      const tracer = startTracer({ ...configuration, traceSampleRate: 100 }, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(
+        { ...configuration, traceSampleRate: 100 },
+        sessionManager,
+        userContext,
+        accountContext
+      )
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -100,7 +101,8 @@ describe('tracer', () => {
       const tracer = startTracer(
         { ...configuration, traceSampleRate: 0, traceContextInjection: TraceContextInjection.ALL },
         sessionManager,
-        mockGetCommonContext
+        userContext,
+        accountContext
       )
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
@@ -119,7 +121,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext', 'b3multi'] }],
       })!
 
-      const tracer = startTracer(configurationWithAllOtelHeaders, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithAllOtelHeaders, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -144,7 +146,7 @@ describe('tracer', () => {
       })!
       const stub = xhr as unknown as XMLHttpRequest
 
-      const tracer = startTracer(configurationWithTracingUrls, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithTracingUrls, sessionManager, userContext, accountContext)
 
       let context: Partial<RumXhrStartContext> = { url: 'http://qux.com' }
       tracer.traceXhr(context, stub)
@@ -168,7 +170,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3multi'] }],
       })!
 
-      const tracer = startTracer(configurationWithb3multi, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithb3multi, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -192,7 +194,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext'] }],
       })!
 
-      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -211,7 +213,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: [] }],
       })!
 
-      const tracer = startTracer(configurationWithoutHeaders, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithoutHeaders, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -228,7 +230,7 @@ describe('tracer', () => {
         traceSampleRate: 0,
       }
 
-      const tracer = startTracer(configurationWithInjectionParam, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithInjectionParam, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -242,7 +244,7 @@ describe('tracer', () => {
         traceSampleRate: 100,
       }
 
-      const tracer = startTracer(configurationWithInjectionParam, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithInjectionParam, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -257,7 +259,7 @@ describe('tracer', () => {
         traceContextInjection: TraceContextInjection.ALL,
       }
 
-      const tracer = startTracer(configurationWithInjectionParam, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithInjectionParam, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -272,7 +274,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['tracecontext'] }],
       })!
 
-      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
       expect(xhr.headers).toEqual(
@@ -289,7 +291,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['foo', 32, () => true] as any }],
       })!
 
-      const tracer = startTracer(configurationWithBadParams, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithBadParams, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -311,7 +313,7 @@ describe('tracer', () => {
         ],
       })!
 
-      const tracer = startTracer(configurationWithBadParams, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithBadParams, sessionManager, userContext, accountContext)
       const context = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
 
@@ -322,7 +324,7 @@ describe('tracer', () => {
   describe('traceFetch', () => {
     it('should add traceId and spanId to context, and add tracing headers', () => {
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.traceId).toBeDefined()
@@ -337,7 +339,7 @@ describe('tracer', () => {
         init,
       }
 
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.init).not.toBe(init)
@@ -354,7 +356,7 @@ describe('tracer', () => {
         init: { headers, method: 'POST' },
       }
 
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.init!.headers).not.toBe(headers)
@@ -375,7 +377,7 @@ describe('tracer', () => {
         init: { headers, method: 'POST' },
       }
 
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.init!.headers).not.toBe(headers)
@@ -400,7 +402,7 @@ describe('tracer', () => {
         init: { headers, method: 'POST' },
       }
 
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.init!.headers).not.toBe(headers)
@@ -428,7 +430,7 @@ describe('tracer', () => {
         input: request,
       }
 
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.init).toBe(undefined)
@@ -449,7 +451,7 @@ describe('tracer', () => {
         }),
       }
 
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.init!.headers).toEqual([
@@ -461,7 +463,7 @@ describe('tracer', () => {
     it('should not trace request on disallowed domain', () => {
       const context: Partial<RumFetchStartContext> = { ...DISALLOWED_DOMAIN_CONTEXT }
 
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.traceId).toBeUndefined()
@@ -472,7 +474,7 @@ describe('tracer', () => {
     it('should not trace request during untracked session', () => {
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
 
-      const tracer = startTracer(configuration, sessionManager.setNotTracked(), mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager.setNotTracked(), userContext, accountContext)
       tracer.traceFetch(context)
 
       expect(context.traceId).toBeUndefined()
@@ -483,7 +485,12 @@ describe('tracer', () => {
     it("should trace request with priority '1' when sampled", () => {
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
 
-      const tracer = startTracer({ ...configuration, traceSampleRate: 100 }, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(
+        { ...configuration, traceSampleRate: 100 },
+        sessionManager,
+        userContext,
+        accountContext
+      )
       tracer.traceFetch(context)
 
       expect(context.traceSampled).toBe(true)
@@ -498,7 +505,8 @@ describe('tracer', () => {
       const tracer = startTracer(
         { ...configuration, traceSampleRate: 0, traceContextInjection: TraceContextInjection.ALL },
         sessionManager,
-        mockGetCommonContext
+        userContext,
+        accountContext
       )
       tracer.traceFetch(context)
 
@@ -521,7 +529,7 @@ describe('tracer', () => {
       const barDomainContext: Partial<RumFetchStartContext> = { url: 'http://bar.com' }
       const dynamicDomainContext: Partial<RumFetchStartContext> = { url: 'http://dynamic.com' }
 
-      const tracer = startTracer(configurationWithTracingUrls, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithTracingUrls, sessionManager, userContext, accountContext)
 
       tracer.traceFetch(quxDomainContext)
       tracer.traceFetch(barDomainContext)
@@ -540,7 +548,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3multi'] }],
       })!
 
-      const tracer = startTracer(configurationWithb3multi, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithb3multi, sessionManager, userContext, accountContext)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -568,7 +576,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['b3', 'tracecontext'] }],
       })!
 
-      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, userContext, accountContext)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -587,7 +595,7 @@ describe('tracer', () => {
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: [] }],
       })!
 
-      const tracer = startTracer(configurationWithoutHeaders, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithoutHeaders, sessionManager, userContext, accountContext)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -604,7 +612,7 @@ describe('tracer', () => {
         traceContextInjection: TraceContextInjection.SAMPLED,
       })!
 
-      const tracer = startTracer(configurationWithHeaders, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithHeaders, sessionManager, userContext, accountContext)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -618,7 +626,7 @@ describe('tracer', () => {
         traceContextInjection: TraceContextInjection.SAMPLED,
       })!
 
-      const tracer = startTracer(configurationWithHeaders, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithHeaders, sessionManager, userContext, accountContext)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -635,7 +643,7 @@ describe('tracer', () => {
         traceContextInjection: TraceContextInjection.ALL,
       })!
 
-      const tracer = startTracer(configurationWithHeaders, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configurationWithHeaders, sessionManager, userContext, accountContext)
       const context: Partial<RumFetchStartContext> = { ...ALLOWED_DOMAIN_CONTEXT }
       tracer.traceFetch(context)
 
@@ -648,7 +656,7 @@ describe('tracer', () => {
 
   describe('clearTracingIfCancelled', () => {
     it('should clear tracing if status is 0', () => {
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       const context: RumFetchResolveContext = {
         status: 0,
 
@@ -662,7 +670,7 @@ describe('tracer', () => {
     })
 
     it('should not clear tracing if status is not 0', () => {
-      const tracer = startTracer(configuration, sessionManager, mockGetCommonContext)
+      const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
       const context: RumFetchResolveContext = {
         status: 200,
 


### PR DESCRIPTION
## Motivation

Decouple common context from rumPublicApi

## Changes

- Create dedicated module for account, user and global context. 
- Replace common context in rumPublicApi. 
- Remove savedCommonContext in collections and assembly 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
