### PR TITLE
👷‍♀️ [Devx] Make developer extension queries compatible with exclusion

### DIFF
--- a/developer-extension/src/panel/components/tabs/eventsTab/eventsTabSide.tsx
+++ b/developer-extension/src/panel/components/tabs/eventsTab/eventsTabSide.tsx
@@ -21,15 +21,7 @@ export function EventsTabSide({
         mb="sm"
       />
 
-      {facetRegistry && (
-        <FacetList
-          facetRegistry={facetRegistry}
-          facetValuesFilter={filters.facetValuesFilter}
-          onExcludedFacetValuesChange={(newExcludedFacetValues) =>
-            onFiltersChange({ ...filters, facetValuesFilter: newExcludedFacetValues })
-          }
-        />
-      )}
+      {facetRegistry && <FacetList facetRegistry={facetRegistry} filters={filters} onFiltersChange={onFiltersChange} />}
     </Box>
   )
 }

--- a/developer-extension/src/panel/hooks/useEvents/eventFilters.spec.ts
+++ b/developer-extension/src/panel/hooks/useEvents/eventFilters.spec.ts
@@ -1,13 +1,21 @@
-import type { RumEvent } from '../../../../../packages/rum-core/src/rumEvent.types'
-import type { LogsEvent } from '../../../../../packages/logs/src/logsEvent.types'
 import { isSafari } from '../../../../../packages/core/src/tools/utils/browserDetection'
-import { parseQuery, matchWithWildcard, filterFacets } from './eventFilters'
+import {
+  RUM_ACTION_EVENT,
+  RUM_ERROR_EVENT,
+  RUM_XHR_RESOURCE_EVENT,
+  LOGS_EVENT,
+  RUM_BEACON_EVENT,
+} from '../../test/events'
+import {
+  parseQuery,
+  matchWithWildcard,
+  filterFacets,
+  generateQueryFromFacetValues,
+  applyEventFilters,
+  DEFAULT_FILTERS,
+} from './eventFilters'
 import type { FacetValuesFilter } from './eventFilters'
 import { FacetRegistry } from './facetRegistry'
-const RUM_ERROR_EVENT = { type: 'error' } as RumEvent
-const RUM_ACTION_EVENT = { type: 'action' } as RumEvent
-const LOGS_EVENT = { status: 'info', origin: 'logger' } as LogsEvent
-const RUM_XHR_RESOURCE_EVENT = { type: 'resource', resource: { type: 'xhr' } } as RumEvent
 
 if (!isSafari()) {
   describe('filterFacets', () => {
@@ -67,29 +75,51 @@ if (!isSafari()) {
 
   describe('parseQuery', () => {
     it('return a simple field', () => {
-      expect(parseQuery('foo:bar')).toEqual([['foo', 'bar']])
+      expect(parseQuery('foo:bar')).toEqual([['include', 'foo', 'bar']])
     })
     it('return intermediary fields', () => {
-      expect(parseQuery('foo.bar:baz')).toEqual([['foo.bar', 'baz']])
+      expect(parseQuery('foo.bar:baz')).toEqual([['include', 'foo.bar', 'baz']])
     })
     it('return multiple fields', () => {
       expect(parseQuery('foo:bar baz:qux')).toEqual([
-        ['foo', 'bar'],
-        ['baz', 'qux'],
+        ['include', 'foo', 'bar'],
+        ['include', 'baz', 'qux'],
       ])
     })
     it('parse escaped whitespace with backslashes in search terms', () => {
-      expect(parseQuery('foo:bar\\ baz')).toEqual([['foo', 'bar\\ baz']])
+      expect(parseQuery('foo:bar\\ baz')).toEqual([['include', 'foo', 'bar\\ baz']])
     })
     it('parse escaped whitespace with backslashes in keys', () => {
-      expect(parseQuery('foo\\ bar:baz')).toEqual([['foo\\ bar', 'baz']])
+      expect(parseQuery('foo\\ bar:baz')).toEqual([['include', 'foo\\ bar', 'baz']])
     })
     it('return multiple fields with escaped whitespace', () => {
-      expect(parseQuery('foo\\ bar:baz\\ qux')).toEqual([['foo\\ bar', 'baz\\ qux']])
+      expect(parseQuery('foo\\ bar:baz\\ qux')).toEqual([['include', 'foo\\ bar', 'baz\\ qux']])
       expect(parseQuery('foo:bar\\ baz qux:quux\\ corge')).toEqual([
-        ['foo', 'bar\\ baz'],
-        ['qux', 'quux\\ corge'],
+        ['include', 'foo', 'bar\\ baz'],
+        ['include', 'qux', 'quux\\ corge'],
       ])
+    })
+    it('should parse simple queries', () => {
+      expect(parseQuery('resource.type:beacon')).toEqual([['include', 'resource.type', 'beacon']])
+    })
+    it('should parse queries with multiple values for the same field', () => {
+      expect(parseQuery('resource.type:beacon resource.type:xhr resource.type:image')).toEqual([
+        ['include', 'resource.type', 'beacon'],
+        ['include', 'resource.type', 'xhr'],
+        ['include', 'resource.type', 'image'],
+      ])
+    })
+    it('should parse queries with exclude prefix', () => {
+      expect(parseQuery('-resource.type:beacon')).toEqual([['exclude', 'resource.type', 'beacon']])
+    })
+    it('should parse mixed include and exclude queries', () => {
+      expect(parseQuery('resource.type:beacon -resource.type:xhr')).toEqual([
+        ['include', 'resource.type', 'beacon'],
+        ['exclude', 'resource.type', 'xhr'],
+      ])
+    })
+    it('should handle values with colons', () => {
+      expect(parseQuery('url:https://example.com:8080')).toEqual([['include', 'url', 'https://example.com:8080']])
     })
   })
 
@@ -135,6 +165,121 @@ if (!isSafari()) {
     })
     it('does not match missing substrings with wildcard at the beginning and the end case-insensitively', () => {
       expect(matchWithWildcard('foo', '*BAR*')).toBe(false)
+    })
+  })
+
+  describe('applyEventFilters with query', () => {
+    const facetRegistry = new FacetRegistry()
+    facetRegistry.addEvent(RUM_ACTION_EVENT)
+    facetRegistry.addEvent(RUM_ERROR_EVENT)
+    facetRegistry.addEvent(RUM_XHR_RESOURCE_EVENT)
+    facetRegistry.addEvent(LOGS_EVENT)
+
+    it('should filter events by resource type', () => {
+      const filters = {
+        ...DEFAULT_FILTERS,
+        query: 'resource.type:beacon',
+      }
+      const result = applyEventFilters(
+        filters,
+        [RUM_BEACON_EVENT, RUM_ERROR_EVENT, RUM_XHR_RESOURCE_EVENT, LOGS_EVENT],
+        facetRegistry
+      )
+      expect(result).toEqual([RUM_BEACON_EVENT])
+    })
+
+    it('should filter events by multiple quries', () => {
+      const filters = {
+        ...DEFAULT_FILTERS,
+        query: 'action.type:click resource.type:xhr',
+      }
+      const result = applyEventFilters(
+        filters,
+        [RUM_ACTION_EVENT, RUM_ERROR_EVENT, RUM_XHR_RESOURCE_EVENT, LOGS_EVENT],
+        facetRegistry
+      )
+      expect(result).toEqual([RUM_ACTION_EVENT, RUM_XHR_RESOURCE_EVENT])
+    })
+
+    it('should handle exclude queries', () => {
+      const filters = {
+        ...DEFAULT_FILTERS,
+        query: '-resource.type:beacon',
+      }
+      const result = applyEventFilters(
+        filters,
+        [RUM_BEACON_EVENT, RUM_ERROR_EVENT, RUM_XHR_RESOURCE_EVENT, LOGS_EVENT],
+        facetRegistry
+      )
+      expect(result).toEqual([RUM_ERROR_EVENT, RUM_XHR_RESOURCE_EVENT, LOGS_EVENT])
+    })
+
+    it('should handle mixed include and exclude queries', () => {
+      const filters = {
+        ...DEFAULT_FILTERS,
+        query: 'type:resource -resource.type:xhr',
+      }
+      const result = applyEventFilters(
+        filters,
+        [RUM_BEACON_EVENT, RUM_ERROR_EVENT, RUM_XHR_RESOURCE_EVENT, LOGS_EVENT],
+        facetRegistry
+      )
+      expect(result).toEqual([RUM_BEACON_EVENT])
+    })
+
+    it('should filter events by event source', () => {
+      const filters = {
+        ...DEFAULT_FILTERS,
+        query: '$eventSource:rum',
+      }
+      const result = applyEventFilters(
+        filters,
+        [RUM_BEACON_EVENT, RUM_ERROR_EVENT, RUM_XHR_RESOURCE_EVENT, LOGS_EVENT],
+        facetRegistry
+      )
+      expect(result).toEqual([RUM_BEACON_EVENT, RUM_ERROR_EVENT, RUM_XHR_RESOURCE_EVENT])
+    })
+  })
+
+  describe('generateQueryFromFacetValues', () => {
+    it('should generate query for single facet value', () => {
+      const facetValuesFilter: FacetValuesFilter = {
+        type: 'include' as const,
+        facetValues: {
+          'resource.type': ['beacon'],
+        },
+      }
+      expect(generateQueryFromFacetValues(facetValuesFilter)).toBe('resource.type:beacon')
+    })
+
+    it('should generate query for multiple facet values', () => {
+      const facetValuesFilter: FacetValuesFilter = {
+        type: 'include' as const,
+        facetValues: {
+          'resource.type': ['beacon', 'xhr', 'image'],
+        },
+      }
+      expect(generateQueryFromFacetValues(facetValuesFilter)).toBe(
+        'resource.type:beacon resource.type:xhr resource.type:image'
+      )
+    })
+
+    it('should generate query with exclude prefix', () => {
+      const facetValuesFilter: FacetValuesFilter = {
+        type: 'exclude' as const,
+        facetValues: {
+          'resource.type': ['beacon'],
+        },
+      }
+      expect(generateQueryFromFacetValues(facetValuesFilter)).toBe('-resource.type:beacon')
+    })
+
+    it('should handle empty facet values', () => {
+      const facetValuesFilter: FacetValuesFilter = {
+        type: 'include' as const,
+        facetValues: {},
+      }
+      expect(generateQueryFromFacetValues(facetValuesFilter)).toBe('')
     })
   })
 }

--- a/developer-extension/src/panel/hooks/useEvents/index.ts
+++ b/developer-extension/src/panel/hooks/useEvents/index.ts
@@ -1,3 +1,4 @@
 export { useEvents } from './useEvents'
 export type { EventFilters, FacetValuesFilter } from './eventFilters'
+export { DEFAULT_FILTERS, generateQueryFromFacetValues } from './eventFilters'
 export { FacetRegistry } from './facetRegistry'

--- a/developer-extension/src/panel/test/events.ts
+++ b/developer-extension/src/panel/test/events.ts
@@ -1,0 +1,46 @@
+import type { LogsEvent } from '@datadog/browser-logs'
+import type { RumEvent } from '../../../../packages/rum-core/src/rumEvent.types'
+
+export const RUM_BEACON_EVENT = {
+  type: 'resource',
+  resource: {
+    type: 'beacon',
+    status: 200,
+  },
+  date: Date.now(),
+  application: { id: 'test-app' },
+} as unknown as RumEvent
+
+export const RUM_ACTION_EVENT = {
+  type: 'action',
+  action: {
+    name: 'Test action',
+    type: 'click',
+  },
+} as unknown as RumEvent
+
+export const RUM_ERROR_EVENT = {
+  type: 'error',
+  error: {
+    message: 'Test error',
+    source: 'console',
+  },
+  date: Date.now(),
+  application: { id: 'test-app' },
+} as unknown as RumEvent
+
+export const RUM_XHR_RESOURCE_EVENT = {
+  type: 'resource',
+  resource: {
+    type: 'xhr',
+    status: 200,
+    url: 'http://test.com/api',
+  },
+  date: Date.now(),
+  application: { id: 'test-app' },
+} as unknown as RumEvent
+
+export const LOGS_EVENT = {
+  status: 'info',
+  origin: 'logger',
+} as unknown as LogsEvent


### PR DESCRIPTION
## Motivation
Current filter queries do not support exclusion, despite that we support this mode in the filters. It would also be nice to update the query while selecting with facets.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
1. Added exclusion mode support in query parsing
2. Added more tests for events filter
3. Made selections in facets update the search queries (but not vice versa yet)
<img width="851" alt="Screenshot 2025-03-18 at 18 18 34" src="https://github.com/user-attachments/assets/cad332a6-6dac-419d-9fc8-36e41011edb6" />
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
