### PR TITLE
Expose Site type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export {
   INTAKE_SITE_EU1,
   INTAKE_URL_PARAMETERS,
   isIntakeUrl,
+  Site
 } from './domain/configuration'
 export type { TrackingConsentState } from './domain/trackingConsent'
 export { TrackingConsent, createTrackingConsentState } from './domain/trackingConsent'


### PR DESCRIPTION
## Motivation

Without this type it's not possible to create intermediary types for Datadog configuration in my application.

## Changes

It exposes the Site type from the core package.


I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
