### PR TITLE
Revert "⚡️ use `import()` for lazy loading chunks (#3399)"

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -18,8 +18,6 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
           `chunks/[name]-${filename}`
         : // Include a content hash in chunk names in production.
           `chunks/[name]-[contenthash]-${filename}`,
-    chunkLoading: 'import',
-    chunkFormat: 'module',
     path: path.resolve('./bundle'),
   },
   target: ['web', 'es2018'],


### PR DESCRIPTION
This reverts commit b8f902ec1dec9eaa9ceb3bb31ef97739e7e61b27.

## Motivation

```
Datadog Browser SDK: Recorder failed to start: an error occurred while initializing the module: TypeError: Failed to resolve module specifier './chunks/recorder-94a4290a03c458bec36d-datadog-rum.js'. The base URL is about:blank because import() is called from a CORS-cross-origin script.

```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
