### PR TITLE
Use baggage to forward user / account id

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -204,7 +204,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
       /**
        * A list of selected tracing propagators
        */
-      selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[]
+      selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext' | 'baggage')[]
       /**
        * Session replay default privacy level
        */

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -21,7 +21,6 @@ import type { PropagatorType, TracingOption } from './tracer.types'
 import type { SpanIdentifier, TraceIdentifier } from './identifier'
 import { createSpanIdentifier, createTraceIdentifier, toPaddedHexadecimalString } from './identifier'
 import { isTraceSampled } from './sampler'
-import { getEncodedContext } from './encodedContext'
 
 export interface Tracer {
   traceFetch: (context: Partial<RumFetchStartContext>) => void
@@ -192,7 +191,7 @@ function makeTracingHeaders(
           traceparent: `00-0000000000000000${toPaddedHexadecimalString(traceId)}-${toPaddedHexadecimalString(spanId)}-0${
             traceSampled ? '1' : '0'
           }`,
-          tracestate: `dd=${getTraceStateDatadogItems(traceSampled, getCommonContext).join(';')}`,
+          tracestate: `dd=s:${traceSampled ? '1' : '0'};o:rum`,
         })
         break
       }
@@ -211,25 +210,26 @@ function makeTracingHeaders(
         })
         break
       }
+      case 'baggage': {
+        if (isExperimentalFeatureEnabled(ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER)) {
+          const userId = getCommonContext().user.id
+          const accountId = getCommonContext().account.id
+          const baggageItems: string[] = []
+
+          if (typeof userId === 'string') {
+            baggageItems.push(`user.id=${encodeURIComponent(userId)}`)
+          }
+          if (typeof accountId === 'string') {
+            baggageItems.push(`account.id=${encodeURIComponent(accountId)}`)
+          }
+
+          if (baggageItems.length > 0) {
+            tracingHeaders['baggage'] = baggageItems.join(',')
+          }
+        }
+        break
+      }
     }
   })
   return tracingHeaders
-}
-
-function getTraceStateDatadogItems(traceSampled: boolean, getCommonContext: () => CommonContext): string[] {
-  const traceStateDatadogItems: string[] = [`s:${traceSampled ? '1' : '0'}`, 'o:rum']
-  if (isExperimentalFeatureEnabled(ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER)) {
-    /**
-     * We should only enable this feature after the decoding service is available
-     */
-    const userIdEncoded = getEncodedContext(getCommonContext().user.id)
-    const accountIdEncoded = getEncodedContext(getCommonContext().account.id)
-    if (userIdEncoded) {
-      traceStateDatadogItems.push(`t.usr.id:${userIdEncoded}`)
-    }
-    if (accountIdEncoded) {
-      traceStateDatadogItems.push(`t.account.id:${accountIdEncoded}`)
-    }
-  }
-  return traceStateDatadogItems
 }

--- a/packages/rum-core/src/domain/tracing/tracer.types.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.types.ts
@@ -5,6 +5,7 @@ import type { MatchOption } from '@datadog/browser-core'
  * tracecontext: W3C Trace Context (traceparent, tracestate)
  * b3: B3 Single Header (b3)
  * b3multi: B3 Multiple Headers (X-B3-*)
+ * baggage: OpenTelemetry Baggage
  */
-export type PropagatorType = 'datadog' | 'b3' | 'b3multi' | 'tracecontext'
+export type PropagatorType = 'datadog' | 'b3' | 'b3multi' | 'tracecontext' | 'baggage'
 export type TracingOption = { match: MatchOption; propagatorTypes: PropagatorType[] }


### PR DESCRIPTION
## Motivation

Switch usr.id / account.id context forwarding to baggage instead of tracestate

## Changes

Users can now enable baggage propagation by adding 'baggage' to the propagator types in their configuration:

```
DD_RUM.init({
  // ... other config options ...
  allowedTracingUrls: [{
    match: 'https://api.example.com',
    propagatorTypes: ['baggage', 'tracecontext']
  }]
})

```

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
