### PR TITLE
support declaration maps

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "declarationMap": true,
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "importHelpers": false,


### PR DESCRIPTION
## Motivation

When I Ctrl-Click into the Datadog SDK from VS Code,
I see the TypeScript definition file.
However, I expect to see the source code.

## Changes

I enabled declaration maps in the base TSConfig file. This should generate a `.d.ts.map` file in addition to `.d.ts`, which will allow tools to map the declaration file to the source code, which is already included in the package (I only checked the `core` and `logs` packages).

## Testing

YOLO

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
