### PR TITLE
use baggage for user.id / account.id forwarding

### DIFF
--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -539,6 +539,7 @@ describe('serializeRumConfiguration', () => {
       plugins: [{ name: 'foo', getConfigurationTelemetry: () => ({ bar: true }) }],
       trackFeatureFlagsForEvents: ['vital'],
       profilingSampleRate: 0,
+      propagateTraceBaggage: true,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -547,7 +548,12 @@ describe('serializeRumConfiguration', () => {
         ? `use_${CamelToSnakeCase<Key>}`
         : Key extends 'trackLongTasks'
           ? 'track_long_task' // oops
-          : Key extends 'applicationId' | 'subdomain' | 'remoteConfigurationId' | 'profilingSampleRate'
+          : Key extends
+                | 'applicationId'
+                | 'subdomain'
+                | 'remoteConfigurationId'
+                | 'profilingSampleRate'
+                | 'propagateTraceBaggage'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -28,6 +28,11 @@ export interface RumInitConfiguration extends InitConfiguration {
    */
   applicationId: string
   /**
+   * Whether to propagate user and account IDs in the baggage header of trace requests.
+   * @default false
+   */
+  propagateTraceBaggage?: boolean | undefined
+  /**
    * Access to every event collected by the RUM SDK before they are sent to Datadog.
    * It allows:
    * - Enrich your RUM events with additional context attributes
@@ -177,6 +182,7 @@ export interface RumConfiguration extends Configuration {
   plugins: RumPlugin[]
   trackFeatureFlagsForEvents: FeatureFlagsForEvents[]
   profilingSampleRate: number
+  propagateTraceBaggage: boolean
 }
 
 export function validateAndBuildRumConfiguration(
@@ -251,6 +257,7 @@ export function validateAndBuildRumConfiguration(
     plugins: initConfiguration.plugins || [],
     trackFeatureFlagsForEvents: initConfiguration.trackFeatureFlagsForEvents || [],
     profilingSampleRate: profilingEnabled ? (initConfiguration.profilingSampleRate ?? 0) : 0, // Enforce 0 if profiling is not enabled, and set 0 as default when not set.
+    propagateTraceBaggage: !!initConfiguration.propagateTraceBaggage,
     ...baseConfiguration,
   }
 }

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -265,11 +265,12 @@ describe('tracer', () => {
       expect(xhr.headers['x-datadog-sampling-priority']).toBeDefined()
     })
 
-    it('should add usr.id and account.id to tracestate when feature is disabled', () => {
+    it('should add usr.id and account.id to baggage header when feature is enabled and propagateTraceBaggage is true', () => {
       mockExperimentalFeatures([ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER])
       const configurationWithB3andTracecontext = validateAndBuildRumConfiguration({
         ...INIT_CONFIGURATION,
         allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['tracecontext'] }],
+        propagateTraceBaggage: true,
       })!
 
       const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, mockGetCommonContext)
@@ -278,9 +279,25 @@ describe('tracer', () => {
       expect(xhr.headers).toEqual(
         jasmine.objectContaining({
           traceparent: jasmine.stringMatching(/^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-01$/),
-          tracestate: 'dd=s:1;o:rum;t.usr.id:MTIzNA==;t.account.id:NTY3OA==',
+          tracestate: 'dd=s:1;o:rum',
+          baggage: 'usr.id=1234,account.id=5678',
         })
       )
+    })
+
+    it('should not add baggage header when propagateTraceBaggage is false', () => {
+      mockExperimentalFeatures([ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER])
+      const configurationWithB3andTracecontext = validateAndBuildRumConfiguration({
+        ...INIT_CONFIGURATION,
+        allowedTracingUrls: [{ match: window.location.origin, propagatorTypes: ['tracecontext'] }],
+        propagateTraceBaggage: false,
+      })!
+
+      const tracer = startTracer(configurationWithB3andTracecontext, sessionManager, mockGetCommonContext)
+      const context = { ...ALLOWED_DOMAIN_CONTEXT }
+      tracer.traceXhr(context, xhr as unknown as XMLHttpRequest)
+
+      expect(xhr.headers['baggage']).toBeUndefined()
     })
 
     it('should ignore wrong propagator types', () => {


### PR DESCRIPTION
## Motivation

Switch usr.id / account.id context forwarding to `baggage` instead of `tracestate`. 

## Changes

Adds a flag `propagateTraceBaggage` to activate the baggage forwarding.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
