### PR TITLE
👌 [RUM-99] don't set views as inactive when the page is exiting

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -307,14 +307,14 @@ describe('view lifecycle', () => {
       })
     })
 
-    it('should set the view inactive when the page is exiting', () => {
-      const { getViewUpdate, getViewUpdateCount } = viewTest
+    it('should trigger a view update on page exit', () => {
+      const { getViewUpdateCount } = viewTest
 
-      expect(getViewUpdate(getViewUpdateCount() - 1).isActive).toBe(true)
+      expect(getViewUpdateCount()).toEqual(1)
 
       lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
 
-      expect(getViewUpdate(getViewUpdateCount() - 1).isActive).toBe(false)
+      expect(getViewUpdateCount()).toEqual(2)
     })
 
     it('should not create a new view when ending the view on page exit', () => {

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -307,7 +307,7 @@ describe('view lifecycle', () => {
       })
     })
 
-    it('should trigger a view update on page exit', () => {
+    it('should trigger a view update on unloading', () => {
       const { getViewUpdateCount } = viewTest
 
       expect(getViewUpdateCount()).toEqual(1)
@@ -317,7 +317,7 @@ describe('view lifecycle', () => {
       expect(getViewUpdateCount()).toEqual(2)
     })
 
-    it('should not create a new view when ending the view on page exit', () => {
+    it('should not create a new view when ending the view on unloading', () => {
       const { getViewCreateCount } = viewTest
 
       expect(getViewCreateCount()).toEqual(1)
@@ -325,6 +325,14 @@ describe('view lifecycle', () => {
       lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
 
       expect(getViewCreateCount()).toEqual(1)
+    })
+
+    it('should not set the view as inactive on unloading', () => {
+      const { getViewUpdate, getViewUpdateCount } = viewTest
+
+      lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
+
+      expect(getViewUpdate(getViewUpdateCount() - 1).isActive).toBe(true)
     })
   })
 


### PR DESCRIPTION

## Motivation

Follow-up on #3406. After discussion with the backend, we figured that setting the view as inactive on potential page exit was not worth it:

* The backend already "closes" (set is_active to false) the view for us after 20 minutes of inactivity

* Setting the view as inactive too soon could have an impact on rum2metrics if the page stays active

* Sending View updates on inactive views is unexpected from a backend perspective, so we would need to add extra logic so reset `is_active:true` for future updates.

* The "active" view concept is already used within the SDK to designate the current view. Diverging from this would be confusing

## Changes

Don't set view as inactive on page exit, just trigger an update.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
