### PR TITLE
[RUM Profiler] Improvements around Views and Long Tasks

### DIFF
--- a/packages/rum/src/boot/profilerApi.ts
+++ b/packages/rum/src/boot/profilerApi.ts
@@ -49,7 +49,7 @@ export function makeProfilerApi(): ProfilerApi {
 
         profiler = createRumProfiler(configuration, lifeCycle, sessionManager)
 
-        profiler.start(viewHistory.findView()?.id)
+        profiler.start(viewHistory.findView())
 
         cleanupTasks.push(() => {
           profiler.stop().catch(monitorError)

--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -1,4 +1,5 @@
 import { LifeCycle } from '@datadog/browser-rum-core'
+import { relativeNow, timeStampNow } from '@datadog/browser-core'
 import { createRumSessionManagerMock, mockPerformanceObserver, mockRumConfiguration } from '../../../../rum-core/test'
 import { mockProfiler } from '../../../test'
 import { mockedTrace } from './test-utils/mockedTrace'
@@ -42,7 +43,14 @@ describe('profiler', () => {
   it('should start profiling collection and collect data on stop', async () => {
     const profiler = setupProfiler()
 
-    profiler.start('view-id-1')
+    profiler.start({
+      id: 'view-id-1',
+      name: 'view-name-1',
+      startClocks: {
+        relative: relativeNow(),
+        timeStamp: timeStampNow(),
+      },
+    })
 
     // Wait for start of collection.
     await waitForBoolean(() => profiler.isStarted())

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -53,8 +53,9 @@ export function createRumProfiler(
     }
 
     // Add initial view
+    // Note: `viewEntry.name` is only filled when users use manual view creation via `startView` method.
     lastViewEntry = viewEntry
-      ? { startTime: performance.now(), viewId: viewEntry.id, viewName: viewEntry.name }
+      ? { startTime: viewEntry.startClocks.relative, viewId: viewEntry.id, viewName: viewEntry.name }
       : undefined
 
     // Start profiler instance
@@ -113,7 +114,8 @@ export function createRumProfiler(
 
     // Whenever the View is updated, we add a views entry to the profiler instance.
     const viewUpdatedSubscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
-      collectViewEntry({ viewId: view.id, viewName: view.name, startTime: performance.now() })
+      // Note: `view.name` is only filled when users use manual view creation via `startView` method.
+      collectViewEntry({ viewId: view.id, viewName: view.name, startTime: view.startClocks.relative })
     })
     cleanupTasks.push(viewUpdatedSubscription.unsubscribe)
 

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -19,7 +19,7 @@ import type {
   RumViewEntry,
 } from './types'
 import { getNumberOfSamples } from './utils/getNumberOfSamples'
-import { disableLongTaskRegistry, enableLongTaskRegistry, deleteLongTaskIdsBefore } from './utils/longTaskRegistry'
+import { disableLongTaskRegistry, enableLongTaskRegistry, deleteLongTaskIdsBefore, getLongTaskId } from './utils/longTaskRegistry'
 import { mayStoreLongTaskIdForProfilerCorrelation } from './profilingCorrelation'
 import { transport } from './transport/transport'
 
@@ -271,7 +271,7 @@ export function createRumProfiler(
         continue
       }
 
-      instance.longTasks.push(entry)
+      instance.longTasks.push({...entry, id: getLongTaskId(entry)})
     }
   }
 

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -10,7 +10,14 @@ import {
 
 import type { LifeCycle, RumConfiguration, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycleEventType, RumPerformanceEntryType, supportPerformanceTimingEvent } from '@datadog/browser-rum-core'
-import type { RumProfilerTrace, RumProfilerInstance, Profiler, RUMProfiler, RUMProfilerConfiguration } from './types'
+import type {
+  RumProfilerTrace,
+  RumProfilerInstance,
+  Profiler,
+  RUMProfiler,
+  RUMProfilerConfiguration,
+  RumViewEntry,
+} from './types'
 import { getNumberOfSamples } from './utils/getNumberOfSamples'
 import { disableLongTaskRegistry, enableLongTaskRegistry, deleteLongTaskIdsBefore } from './utils/longTaskRegistry'
 import { mayStoreLongTaskIdForProfilerCorrelation } from './profilingCorrelation'
@@ -31,6 +38,8 @@ export function createRumProfiler(
 ): RUMProfiler {
   const isLongAnimationFrameEnabled = supportPerformanceTimingEvent(RumPerformanceEntryType.LONG_ANIMATION_FRAME)
 
+  let lastViewEntry: RumViewEntry | undefined
+
   let instance: RumProfilerInstance = { state: 'stopped' }
 
   function start(viewId: string | undefined): void {
@@ -39,7 +48,7 @@ export function createRumProfiler(
     }
 
     // Add initial view
-    collectViewEntry(viewId)
+    lastViewEntry = viewId ? { startTime: performance.now(), viewId } : undefined
 
     // Start profiler instance
     startNextProfilerInstance()
@@ -97,7 +106,7 @@ export function createRumProfiler(
 
     // Whenever the View is updated, we add a views entry to the profiler instance.
     const viewUpdatedSubscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
-      collectViewEntry(view.id)
+      collectViewEntry({ viewId: view.id, startTime: performance.now() })
     })
     cleanupTasks.push(viewUpdatedSubscription.unsubscribe)
 
@@ -116,7 +125,7 @@ export function createRumProfiler(
     }
 
     // Don't wait for data collection to start next instance
-    collectProfilerInstance().catch(monitorError)
+    collectProfilerInstance(instance).catch(monitorError)
 
     const { cleanupTasks, observer } = addEventListeners(instance)
 
@@ -152,30 +161,33 @@ export function createRumProfiler(
       observer,
     }
 
+    // Add last view entry
+    collectViewEntry(lastViewEntry)
+
     // Add event handler case we overflow the buffer
     profiler.addEventListener('samplebufferfull', handleSampleBufferFull)
   }
 
-  async function collectProfilerInstance() {
-    if (instance.state !== 'running') {
+  async function collectProfilerInstance(lastInstance: RumProfilerInstance) {
+    if (lastInstance.state !== 'running') {
       return
     }
 
     // Empty the performance observer buffer
-    handleLongTaskEntries(instance.observer?.takeRecords() ?? [])
+    handleLongTaskEntries(lastInstance.observer?.takeRecords() ?? [])
 
     // Cleanup instance
-    clearTimeout(instance.timeoutId)
-    instance.profiler.removeEventListener('samplebufferfull', handleSampleBufferFull)
+    clearTimeout(lastInstance.timeoutId)
+    lastInstance.profiler.removeEventListener('samplebufferfull', handleSampleBufferFull)
 
     // Store instance data snapshot in local variables to use in async callback
-    const { startTime, longTasks, views } = instance
+    const { startTime, longTasks, views } = lastInstance
 
     // Capturing when we stop the profiler so we use this time as a reference to clean-up long task registry, eg. remove the long tasks that we collected already
     const collectTime = performance.now()
 
     // Stop current profiler to get trace
-    await instance.profiler
+    await lastInstance.profiler
       .stop()
       .then((trace) => {
         const endTime = performance.now()
@@ -216,21 +228,18 @@ export function createRumProfiler(
     // Cleanup tasks
     instance.cleanupTasks.forEach((cleanupTask) => cleanupTask())
 
-    await collectProfilerInstance()
+    await collectProfilerInstance(instance)
 
     instance = { state: nextState }
   }
 
-  function collectViewEntry(viewId: string | undefined): void {
-    if (instance.state !== 'running') {
+  function collectViewEntry(viewEntry: RumViewEntry | undefined): void {
+    if (instance.state !== 'running' || !viewEntry) {
       return
     }
 
     // Add entry to views
-    instance.views.push({
-      startTime: performance.now(),
-      viewId: viewId || '',
-    })
+    instance.views.push(viewEntry)
   }
 
   function handleProfilerTrace(trace: RumProfilerTrace): void {

--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -5,7 +5,7 @@ import { getLongTaskId } from '../utils/longTaskRegistry'
 interface ProfileEventAttributes {
   application: { id: string }
   session?: { id: string }
-  view?: { ids: string[] }
+  view?: { id: string[] }
   long_task?: { id: string[] }
 }
 interface ProfileEvent extends ProfileEventAttributes {
@@ -128,7 +128,7 @@ function buildProfileEventAttributes(
   const viewIds = Array.from(new Set(profilerTrace.views.map((viewEntry) => viewEntry.viewId)))
   if (viewIds.length) {
     attributes.view = {
-      ids: viewIds,
+      id: viewIds,
     }
   }
   const longTaskIds: string[] = profilerTrace.longTasks

--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -13,6 +13,8 @@ interface ProfileEvent extends ProfileEventAttributes {
   start: string // ISO date
   end: string // ISO date
   family: 'chrome'
+  runtime: 'chrome'
+  format: 'json'
   tags_profiler: string
 }
 
@@ -61,6 +63,8 @@ function buildProfileEvent(
     start: start.toISOString(),
     end: end.toISOString(),
     family: 'chrome',
+    runtime: 'chrome',
+    format: 'json',
     tags_profiler: profileEventTags.join(','),
   }
 
@@ -75,13 +79,7 @@ function buildProfileEvent(
 function buildProfileEventTags(tags: string[]): string[] {
   // Tags already contains the common tags for all events. (service, env, version, etc.)
   // Here we are adding some specific-to-profiling tags.
-  const profileEventTags = tags.concat([
-    'language:javascript',
-    'runtime:chrome',
-    'family:chrome',
-    'format:json',
-    'host:browser',
-  ])
+  const profileEventTags = tags.concat(['language:javascript', 'runtime:chrome', 'family:chrome', 'host:browser'])
 
   return profileEventTags
 }

--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -15,6 +15,7 @@ interface ProfileEvent extends ProfileEventAttributes {
   family: 'chrome'
   runtime: 'chrome'
   format: 'json'
+  version: 4
   tags_profiler: string
 }
 
@@ -65,6 +66,7 @@ function buildProfileEvent(
     family: 'chrome',
     runtime: 'chrome',
     format: 'json',
+    version: 4, // Ingestion event version (not the version application tag)
     tags_profiler: profileEventTags.join(','),
   }
 

--- a/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
+++ b/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
@@ -8,12 +8,17 @@ export interface RumViewEntry {
   readonly viewId: string
 }
 
+export interface RUMProfilerPerformanceEntry extends PerformanceEntry {
+  /** RUM Long Task id */
+  readonly id: string | undefined;
+}
+
 /**
  * Additional data recorded during profiling session
  */
 export interface RumProfilerEnrichmentData {
   /** List of detected long tasks */
-  readonly longTasks: PerformanceEntry[]
+  readonly longTasks: RUMProfilerPerformanceEntry[]
   /** List of detected navigation entries */
   readonly views: RumViewEntry[]
 }

--- a/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
+++ b/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
@@ -1,4 +1,5 @@
 import type { TimeoutId } from '@datadog/browser-core'
+import type { ViewHistoryEntry } from '@datadog/browser-rum-core'
 import type { ProfilerTrace, Profiler } from './profilerApi.types'
 
 export interface RumViewEntry {
@@ -6,11 +7,19 @@ export interface RumViewEntry {
   readonly startTime: DOMHighResTimeStamp
   /** RUM view id */
   readonly viewId: string
+  /** RUM view name */
+  readonly viewName: string | undefined
 }
 
-export interface RUMProfilerPerformanceEntry extends PerformanceEntry {
+export interface RUMProfilerLongTaskEntry {
   /** RUM Long Task id */
-  readonly id: string | undefined;
+  readonly id: string | undefined
+  /** RUM Long Task duration */
+  readonly duration: number
+  /** RUM Long Task entry type */
+  readonly entryType: string
+  /** RUM Long Task start time */
+  readonly startTime: DOMHighResTimeStamp
 }
 
 /**
@@ -18,7 +27,7 @@ export interface RUMProfilerPerformanceEntry extends PerformanceEntry {
  */
 export interface RumProfilerEnrichmentData {
   /** List of detected long tasks */
-  readonly longTasks: RUMProfilerPerformanceEntry[]
+  readonly longTasks: RUMProfilerLongTaskEntry[]
   /** List of detected navigation entries */
   readonly views: RumViewEntry[]
 }
@@ -69,7 +78,7 @@ export interface RumProfilerRunningInstance extends RumProfilerEnrichmentData {
 export type RumProfilerInstance = RumProfilerStoppedInstance | RumProfilerPausedInstance | RumProfilerRunningInstance
 
 export interface RUMProfiler {
-  start: (viewId: string | undefined) => void
+  start: (viewEntry: ViewHistoryEntry | undefined) => void
   stop: () => Promise<void>
   isStopped: () => boolean
   isStarted: () => boolean

--- a/packages/rum/src/domain/profiling/utils/longTaskRegistry.ts
+++ b/packages/rum/src/domain/profiling/utils/longTaskRegistry.ts
@@ -24,7 +24,7 @@ export function setLongTaskId(longTaskId: string, performanceEntryStartTime: num
   registry.set(performanceEntryStartTime, longTaskId)
 }
 
-export function getLongTaskId(longTaskEntry: PerformanceEntry): string | undefined {
+export function getLongTaskId(longTaskEntry: { startTime: DOMHighResTimeStamp }): string | undefined {
   // Don't return if it's not enabled or the long task has been reported before the activation
   if (enabledTime === false || longTaskEntry.startTime < enabledTime) {
     return undefined


### PR DESCRIPTION
## Motivation

- Attribute `view.ids` had a `s` that was not coherent with other attributes.
- Views are missing from the exported JSON.
- Long Tasks are missing the  RUM Long Task `id` (when available)
- Long Tasks are full `PerformanceEntry` objects, and we don't need most of it.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
- Fix how we capture views so that we now report them properly. 
- Add name to view entry so that Profiling BE can do aggregation using that name. In the UI it would ultimately use the `viewId` to get the latest name.
- Make sure attribute fields are coherent.
- Add `id` to the Long Task entry, and make it a lighter object than the full performance entry.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing
- Tested locally and in staging that everything is now reported. 
- In staging, you can : 
   - Open any page, 
   - Stay on a single page from the initial page load
   - Assert that the profile sent has a unique view. 
   - Assert Long tasks now have `id` when applicable.
   - 
- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end


---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
