### PR TITLE
✨ [RUM-9302] Page state consolidation

### DIFF
--- a/packages/rum-core/src/domain/contexts/pageStateHistory.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.ts
@@ -54,8 +54,6 @@ export function startPageStateHistory(
       RumPerformanceEntryType.VISIBILITY_STATE
     ) as PerformanceEntry[]
 
-    visibilityEntries.sort((a, b) => a.startTime - b.startTime)
-
     visibilityEntries.forEach((entry) => {
       const state = entry.name === 'hidden' ? PageState.HIDDEN : PageState.ACTIVE
       addPageState(state, entry.startTime as RelativeTime)

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.ts
@@ -9,6 +9,7 @@ import {
   DOM_EVENT,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
+import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../browser/performanceObservable'
 import { RumEventType, type PageStateServerEntry } from '../../rawRumEvent.types'
 import { HookNames } from '../../hooks'
 import type { Hooks, PartialRumEvent } from '../../hooks'
@@ -47,6 +48,20 @@ export function startPageStateHistory(
   })
 
   let currentPageState: PageState
+
+  if (supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
+    const visibilityEntries = performance.getEntriesByType(
+      RumPerformanceEntryType.VISIBILITY_STATE
+    ) as PerformanceEntry[]
+
+    visibilityEntries.sort((a, b) => a.startTime - b.startTime)
+
+    visibilityEntries.forEach((entry) => {
+      const state = entry.name === 'hidden' ? PageState.HIDDEN : PageState.ACTIVE
+      addPageState(state, entry.startTime as RelativeTime)
+    })
+  }
+
   addPageState(getPageState(), relativeNow())
 
   const { stop: stopEventListeners } = addEventListeners(

--- a/packages/rum-core/test/emulate/mockPerformanceObserver.ts
+++ b/packages/rum-core/test/emulate/mockPerformanceObserver.ts
@@ -2,13 +2,17 @@ import { registerCleanupTask } from '@datadog/browser-core/test'
 import { objectValues } from '@datadog/browser-core'
 import { RumPerformanceEntryType, type RumPerformanceEntry } from '../../src/browser/performanceObservable'
 
-export function mockPerformanceObserver({ typeSupported = true, emulateAllEntryTypesUnsupported = false } = {}) {
+export function mockPerformanceObserver({
+  typeSupported = true,
+  emulateAllEntryTypesUnsupported = false,
+  supportedEntryTypes = objectValues(RumPerformanceEntryType),
+} = {}) {
   const originalPerformanceObserver = window.PerformanceObserver
   const instances = new Set<MockPerformanceObserver>()
   let bufferedEntries: RumPerformanceEntry[] = []
 
   class MockPerformanceObserver {
-    static supportedEntryTypes = objectValues(RumPerformanceEntryType)
+    static supportedEntryTypes = supportedEntryTypes
 
     public entryTypes: string[] = []
 


### PR DESCRIPTION
## Motivation


When a page is in background, the browser can pause or slow down its execution to preserve resources. Our SDK currently tracks page state changes (active, passive, hidden, frozen, terminated) to understand user engagement and to properly interpret performance metrics. However, we only start tracking these states after the SDK is initialized, which can create a gap in our understanding of the page's history.

Currently, our page state tracking begins only after the SDK is initialized. This means we have no visibility into the page's state history before initialization.

## Changes

Chrome provides Performance entries called 'visibility-state' that are recorded whenever a page changes visibility state. We can use performance.getEntriesByType('visibility-state') to retrieve these entries and backfill our page state history for the period before SDK initialization.

Modify the startPageStateHistory() function to check for visibility-state performance entries at initialization and use them to backfill the page state history.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
