### PR TITLE
♻️ Refactor cookieObservable to not rely on cookieStore

### DIFF
--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -268,7 +268,7 @@ export function startRumEventCollection(
   )
 
   const displayContext = startDisplayContext(configuration)
-  const ciVisibilityContext = startCiVisibilityContext(configuration, hooks)
+  const ciVisibilityContext = startCiVisibilityContext(hooks)
   startSyntheticsContext(hooks)
 
   startRumAssembly(

--- a/packages/rum-core/src/browser/cookieObservable.spec.ts
+++ b/packages/rum-core/src/browser/cookieObservable.spec.ts
@@ -37,7 +37,7 @@ describe('cookieObservable', () => {
     clock.tick(WATCH_COOKIE_INTERVAL_DELAY)
   })
 
-  it('should not notify observers on cookie change when the cookie value as not changed', () => {
+  it('should not notify observers on cookie change when the cookie value has not changed', () => {
     const observable = createCookieObservable(COOKIE_NAME)
 
     setCookie(COOKIE_NAME, 'foo', COOKIE_DURATION)

--- a/packages/rum-core/src/browser/cookieObservable.spec.ts
+++ b/packages/rum-core/src/browser/cookieObservable.spec.ts
@@ -2,7 +2,6 @@ import type { Subscription } from '@datadog/browser-core'
 import { ONE_MINUTE, deleteCookie, setCookie } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../test'
 import { WATCH_COOKIE_INTERVAL_DELAY, createCookieObservable } from './cookieObservable'
 
 const COOKIE_NAME = 'cookie_name'
@@ -27,7 +26,7 @@ describe('cookieObservable', () => {
   })
 
   it('should notify observers on cookie change', (done) => {
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+    const observable = createCookieObservable(COOKIE_NAME)
 
     subscription = observable.subscribe((cookieChange) => {
       expect(cookieChange).toEqual('foo')
@@ -38,22 +37,8 @@ describe('cookieObservable', () => {
     clock.tick(WATCH_COOKIE_INTERVAL_DELAY)
   })
 
-  it('should notify observers on cookie change when cookieStore is not supported', () => {
-    Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
-
-    let cookieChange: string | undefined
-    subscription = observable.subscribe((change) => (cookieChange = change))
-
-    setCookie(COOKIE_NAME, 'foo', COOKIE_DURATION)
-    clock.tick(WATCH_COOKIE_INTERVAL_DELAY)
-
-    expect(cookieChange).toEqual('foo')
-  })
-
-  it('should not notify observers on cookie change when the cookie value as not changed when cookieStore is not supported', () => {
-    Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+  it('should not notify observers on cookie change when the cookie value as not changed', () => {
+    const observable = createCookieObservable(COOKIE_NAME)
 
     setCookie(COOKIE_NAME, 'foo', COOKIE_DURATION)
 

--- a/packages/rum-core/src/browser/cookieObservable.ts
+++ b/packages/rum-core/src/browser/cookieObservable.ts
@@ -7,17 +7,15 @@ export interface CookieStoreWindow extends Window {
 
 export type CookieObservable = ReturnType<typeof createCookieObservable>
 
-export function createCookieObservable(cookieName: string) {
-  // NOTE: we don't use cookiestore.addEventListner('change', handler) as it seems to me more prone to bugs
-  // and cause our tests to be flaky (and probably in production as well)
-  const detectCookieChangeStrategy = watchCookieStrategy
+export const WATCH_COOKIE_INTERVAL_DELAY = ONE_SECOND
 
+export function createCookieObservable(cookieName: string) {
   return new Observable<string | undefined>((observable) =>
-    detectCookieChangeStrategy(cookieName, (event) => observable.notify(event))
+    // NOTE: we don't use cookiestore.addEventListner('change', handler) as it seems to me more prone to bugs
+    // and cause our tests to be flaky (and probably in production as well)
+    watchCookieStrategy(cookieName, (event) => observable.notify(event))
   )
 }
-
-export const WATCH_COOKIE_INTERVAL_DELAY = ONE_SECOND
 
 function watchCookieStrategy(cookieName: string, callback: (event: string | undefined) => void) {
   const previousCookieValue = findCommaSeparatedValue(document.cookie, cookieName)
@@ -28,7 +26,5 @@ function watchCookieStrategy(cookieName: string, callback: (event: string | unde
     }
   }, WATCH_COOKIE_INTERVAL_DELAY)
 
-  return () => {
-    clearInterval(watchCookieIntervalId)
-  }
+  return () => clearInterval(watchCookieIntervalId)
 }

--- a/packages/rum-core/src/browser/cookieObservable.ts
+++ b/packages/rum-core/src/browser/cookieObservable.ts
@@ -1,13 +1,5 @@
-import type { Configuration, CookieStore } from '@datadog/browser-core'
-import {
-  setInterval,
-  clearInterval,
-  Observable,
-  addEventListener,
-  ONE_SECOND,
-  findCommaSeparatedValue,
-  DOM_EVENT,
-} from '@datadog/browser-core'
+import type { CookieStore } from '@datadog/browser-core'
+import { setInterval, clearInterval, Observable, ONE_SECOND, findCommaSeparatedValue } from '@datadog/browser-core'
 
 export interface CookieStoreWindow extends Window {
   cookieStore?: CookieStore
@@ -15,40 +7,19 @@ export interface CookieStoreWindow extends Window {
 
 export type CookieObservable = ReturnType<typeof createCookieObservable>
 
-export function createCookieObservable(configuration: Configuration, cookieName: string) {
-  const detectCookieChangeStrategy = (window as CookieStoreWindow).cookieStore
-    ? listenToCookieStoreChange(configuration)
-    : watchCookieFallback
+export function createCookieObservable(cookieName: string) {
+  // NOTE: we don't use cookiestore.addEventListner('change', handler) as it seems to me more prone to bugs
+  // and cause our tests to be flaky (and probably in production as well)
+  const detectCookieChangeStrategy = watchCookieStrategy
 
   return new Observable<string | undefined>((observable) =>
     detectCookieChangeStrategy(cookieName, (event) => observable.notify(event))
   )
 }
 
-function listenToCookieStoreChange(configuration: Configuration) {
-  return (cookieName: string, callback: (event: string | undefined) => void) => {
-    const listener = addEventListener(
-      configuration,
-      (window as CookieStoreWindow).cookieStore!,
-      DOM_EVENT.CHANGE,
-      (event) => {
-        // Based on our experimentation, we're assuming that entries for the same cookie cannot be in both the 'changed' and 'deleted' arrays.
-        // However, due to ambiguity in the specification, we asked for clarification: https://github.com/WICG/cookie-store/issues/226
-        const changeEvent =
-          event.changed.find((event) => event.name === cookieName) ||
-          event.deleted.find((event) => event.name === cookieName)
-        if (changeEvent) {
-          callback(changeEvent.value)
-        }
-      }
-    )
-    return listener.stop
-  }
-}
-
 export const WATCH_COOKIE_INTERVAL_DELAY = ONE_SECOND
 
-function watchCookieFallback(cookieName: string, callback: (event: string | undefined) => void) {
+function watchCookieStrategy(cookieName: string, callback: (event: string | undefined) => void) {
   const previousCookieValue = findCommaSeparatedValue(document.cookie, cookieName)
   const watchCookieIntervalId = setInterval(() => {
     const cookieValue = findCommaSeparatedValue(document.cookie, cookieName)

--- a/packages/rum-core/src/domain/contexts/ciVisibilityContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/ciVisibilityContext.spec.ts
@@ -1,4 +1,4 @@
-import type { Configuration, RelativeTime } from '@datadog/browser-core'
+import type { RelativeTime } from '@datadog/browser-core'
 import { Observable } from '@datadog/browser-core'
 import { mockCiVisibilityValues } from '../../../test'
 import type { CookieObservable } from '../../browser/cookieObservable'
@@ -24,7 +24,7 @@ describe('startCiVisibilityContext', () => {
   describe('assemble hook', () => {
     it('should set ci visibility context defined by Cypress global variables', () => {
       mockCiVisibilityValues('trace_id_value')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hooks, cookieObservable))
 
       const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
 
@@ -41,7 +41,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should add the ci visibility context defined by global cookie', () => {
       mockCiVisibilityValues('trace_id_value', 'cookies')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hooks, cookieObservable))
 
       const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
 
@@ -58,7 +58,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should update the ci visibility context when global cookie is updated', () => {
       mockCiVisibilityValues('trace_id_value', 'cookies')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hooks, cookieObservable))
       cookieObservable.notify('trace_id_value_updated')
 
       const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
@@ -76,7 +76,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should not set ci visibility context if the Cypress global variable is undefined', () => {
       mockCiVisibilityValues(undefined)
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hooks, cookieObservable))
 
       const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
 
@@ -85,7 +85,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should not set ci visibility context if it is not a string', () => {
       mockCiVisibilityValues({ key: 'value' })
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hooks, cookieObservable))
 
       const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
 

--- a/packages/rum-core/src/domain/contexts/ciVisibilityContext.ts
+++ b/packages/rum-core/src/domain/contexts/ciVisibilityContext.ts
@@ -1,5 +1,4 @@
 import { getInitCookie } from '@datadog/browser-core'
-import type { Configuration } from '@datadog/browser-core'
 import { createCookieObservable } from '../../browser/cookieObservable'
 import type { Hooks, PartialRumEvent } from '../../hooks'
 import { HookNames } from '../../hooks'
@@ -16,9 +15,8 @@ export interface CiTestWindow extends Window {
 export type CiVisibilityContext = ReturnType<typeof startCiVisibilityContext>
 
 export function startCiVisibilityContext(
-  configuration: Configuration,
   hooks: Hooks,
-  cookieObservable = createCookieObservable(configuration, CI_VISIBILITY_TEST_ID_COOKIE_NAME)
+  cookieObservable = createCookieObservable(CI_VISIBILITY_TEST_ID_COOKIE_NAME)
 ) {
   let testExecutionId =
     getInitCookie(CI_VISIBILITY_TEST_ID_COOKIE_NAME) || (window as CiTestWindow).Cypress?.env('traceId')


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

The test `should notify observers on cookie change` is very flaky and it does not seems to be cause by the test setup or mocks.
In the other hand the fallback does not seems to suffer the same problems, so let's only use the fallback

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
