### PR TITLE
[RUM Profiler] Fix collection of profiles after visibility change

### DIFF
--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -1,5 +1,6 @@
 import { LifeCycle } from '@datadog/browser-rum-core'
 import { relativeNow, timeStampNow } from '@datadog/browser-core'
+import { setPageVisibility, restorePageVisibility, createNewEvent } from '@datadog/browser-core/test'
 import { createRumSessionManagerMock, mockPerformanceObserver, mockRumConfiguration } from '../../../../rum-core/test'
 import { mockProfiler } from '../../../test'
 import { mockedTrace } from './test-utils/mockedTrace'
@@ -14,9 +15,8 @@ describe('profiler', () => {
     sendProfileSpy = spyOn(transport, 'sendProfile')
   })
 
-  afterAll(() => {
-    // Restore original visibility state
-    setVisibilityState('visible')
+  afterEach(() => {
+    restorePageVisibility()
   })
 
   let lifeCycle = new LifeCycle()
@@ -131,9 +131,6 @@ function waitForBoolean(booleanCallback: () => boolean) {
 }
 
 function setVisibilityState(state: 'hidden' | 'visible') {
-  Object.defineProperty(window, 'visibilityState', {
-    configurable: true,
-    get: () => state,
-  })
-  window.dispatchEvent(new Event('visibilitychange'))
+  setPageVisibility(state)
+  window.dispatchEvent(createNewEvent('visibilitychange'))
 }

--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -8,9 +8,15 @@ import { createRumProfiler } from './profiler'
 
 describe('profiler', () => {
   let sendProfileSpy: jasmine.Spy
+
   beforeEach(() => {
     // Spy on transport.sendProfile to avoid sending data to the server, and check what's sent.
     sendProfileSpy = spyOn(transport, 'sendProfile')
+  })
+
+  afterAll(() => {
+    // Restore original visibility state
+    setVisibilityState('visible')
   })
 
   let lifeCycle = new LifeCycle()
@@ -53,7 +59,7 @@ describe('profiler', () => {
     })
 
     // Wait for start of collection.
-    await waitForBoolean(() => profiler.isStarted())
+    await waitForBoolean(() => profiler.isRunning())
 
     // Stop collection of profile.
     await profiler.stop()
@@ -62,6 +68,49 @@ describe('profiler', () => {
     await waitForBoolean(() => profiler.isStopped())
 
     expect(sendProfileSpy).toHaveBeenCalledTimes(1)
+
+    // Check the the sendProfilesSpy was called with the mocked trace
+    expect(sendProfileSpy).toHaveBeenCalledWith(mockedTrace, jasmine.any(Object), jasmine.any(String), 'session-id-1')
+  })
+
+  it('should pause profiling collection on hidden visibility and restart on visible visibility', async () => {
+    const profiler = setupProfiler()
+
+    profiler.start({
+      id: 'view-id-1',
+      name: 'view-name-1',
+      startClocks: {
+        relative: relativeNow(),
+        timeStamp: timeStampNow(),
+      },
+    })
+
+    // Wait for start of collection.
+    await waitForBoolean(() => profiler.isRunning())
+
+    // Emulate visibility change to `hidden` state
+    setVisibilityState('hidden')
+
+    // Wait for profiler to pause
+    await waitForBoolean(() => profiler.isPaused())
+
+    // Assert that the profiler has collected data on pause.
+    expect(sendProfileSpy).toHaveBeenCalledTimes(1)
+
+    // Change back to visible
+    setVisibilityState('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    // Wait for profiler to restart
+    await waitForBoolean(() => profiler.isRunning())
+
+    // Stop collection of profile.
+    await profiler.stop()
+
+    // Wait for stop of collection.
+    await waitForBoolean(() => profiler.isStopped())
+
+    expect(sendProfileSpy).toHaveBeenCalledTimes(2)
 
     // Check the the sendProfilesSpy was called with the mocked trace
     expect(sendProfileSpy).toHaveBeenCalledWith(mockedTrace, jasmine.any(Object), jasmine.any(String), 'session-id-1')
@@ -79,4 +128,12 @@ function waitForBoolean(booleanCallback: () => boolean) {
     }
     poll()
   })
+}
+
+function setVisibilityState(state: 'hidden' | 'visible') {
+  Object.defineProperty(window, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  })
+  window.dispatchEvent(new Event('visibilitychange'))
 }

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -208,13 +208,12 @@ export function createRumProfiler(
       .then((trace) => {
         const endTime = performance.now()
 
-        if (endTime - startTime < profilerConfiguration.minProfileDurationMs) {
-          // Skip very short profiles to reduce noise and cost
-          return
-        }
+        const hasLongTasks = longTasks.length > 0
+        const isBelowDurationThreshold = endTime - startTime < profilerConfiguration.minProfileDurationMs
+        const isBelowSampleThreshold = getNumberOfSamples(trace.samples) < profilerConfiguration.minNumberOfSamples
 
-        if (getNumberOfSamples(trace.samples) < profilerConfiguration.minNumberOfSamples) {
-          // Skip idle profiles to reduce noise and cost
+        if (!hasLongTasks && (isBelowDurationThreshold || isBelowSampleThreshold)) {
+          // Skip very short profiles to reduce noise and cost, but keep them if they contain long tasks.
           return
         }
 

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -30,7 +30,7 @@ import { transport } from './transport/transport'
 
 export const DEFAULT_RUM_PROFILER_CONFIGURATION: RUMProfilerConfiguration = {
   sampleIntervalMs: 10, // Sample stack trace every 10ms
-  collectIntervalMs: 10000, // Collect data every minute
+  collectIntervalMs: 60000, // Collect data every minute
   minProfileDurationMs: 5000, // Require at least 5 seconds of profile data to reduce noise and cost
   minNumberOfSamples: 50, // Require at least 50 samples (~500 ms) to report a profile to reduce noise and cost
 }

--- a/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
+++ b/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
@@ -81,7 +81,8 @@ export interface RUMProfiler {
   start: (viewEntry: ViewHistoryEntry | undefined) => void
   stop: () => Promise<void>
   isStopped: () => boolean
-  isStarted: () => boolean
+  isRunning: () => boolean
+  isPaused: () => boolean
 }
 
 export interface RUMProfilerConfiguration {


### PR DESCRIPTION
## Motivation

- Whenever the visibility change to `hidden` (eg. user switch away to another tab), the profiler is paused. 
- Whenever users come back, the profiler is not re-started properly and does not collect profiles anymore.


## Problem

- On pause, we are cleaning-up tasks including the listeners to `DOM_EVENT.VISIBILITY_CHANGE`. 
- When user comes back, nothing is listening to `DOM_EVENT.VISIBILITY_CHANGE` value and thus the profiler is never restarted.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
- Move "global" listeners outside of the instance (eg. visibility change and unload handlers). Global listeners are not associated to a single instance and now live outside.
- Add unit test.


<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [x] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
