### PR TITLE
👷 Enable timestamps for GitLab CI logs in configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ variables:
   MAIN_BRANCH: 'main'
   NEXT_MAJOR_BRANCH: ''
   CHROME_PACKAGE_VERSION: 135.0.7049.52-1
+  FF_TIMESTAMPS: 'true' # Enable timestamps for gitlab-ci logs
 
 cache:
   key:


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Some time to time I'm frustrated that there is no timestamps in gitlab logs, this fixes it.
Note that this is a feature-flag, but it was also [enabled in web-ui](https://github.com/DataDog/web-ui/pull/193581) so it's probably safe to use in our repo too.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
