### PR TITLE
🐛 Update .npmignore to include react-router 7

### DIFF
--- a/packages/rum-react/.npmignore
+++ b/packages/rum-react/.npmignore
@@ -4,4 +4,4 @@
 !/src/**/*
 /src/**/*.spec.ts
 /src/**/*.specHelper.ts
-!/react-router-v6/*
+!/react-router-v[6-7]/*


### PR DESCRIPTION
## Motivation

Currently the entry point to react router v7 is not accessible via NPM

## Changes

Update .npmignore to fix that

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
