### PR TITLE
👷 Filter out package.json files for check release script

### DIFF
--- a/scripts/release/check-release.js
+++ b/scripts/release/check-release.js
@@ -65,8 +65,8 @@ function checkPackageDependencyVersions(packageJsonFile) {
     for (const [dependencyName, dependencyVersion] of Object.entries(dependencies)) {
       if (
         isBrowserSdkPublicPackageName(dependencyName) &&
-        !dependencyVersion.startsWith('portal:') &&
         !dependencyVersion.startsWith('workspace:') &&
+        !dependencyVersion.startsWith('file:') &&
         dependencyVersion !== releaseVersion
       ) {
         throw new Error(


### PR DESCRIPTION
## Motivation

We recently released a pr to use local tarballs for e2e test (instead of portals)
The check-release script was failing for release due to not filtering the new type of dependencies used in test apps. 

## Changes

Filter "file : "

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
