### PR TITLE
🐛 Improve context properties sanitization

### DIFF
--- a/packages/core/src/domain/context/contextManager.ts
+++ b/packages/core/src/domain/context/contextManager.ts
@@ -23,12 +23,12 @@ function ensureProperties(context: Context, propertiesConfig: PropertiesConfig, 
      * https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
      */
 
-    if (type === 'string' && !isNullish(newContext[key])) {
+    if (type === 'string' && !isDefined(newContext[key])) {
       /* eslint-disable @typescript-eslint/no-base-to-string */
       newContext[key] = String(newContext[key])
     }
 
-    if (required && isNullish(newContext[key])) {
+    if (required && isDefined(newContext[key])) {
       display.warn(`The property ${key} of ${name} is required; context will not be sent to the intake.`)
     }
   }
@@ -36,7 +36,7 @@ function ensureProperties(context: Context, propertiesConfig: PropertiesConfig, 
   return newContext
 }
 
-function isNullish(value: unknown) {
+function isDefined(value: unknown) {
   return value === undefined || value === null || value === ''
 }
 

--- a/packages/core/src/domain/context/contextManager.ts
+++ b/packages/core/src/domain/context/contextManager.ts
@@ -22,17 +22,22 @@ function ensureProperties(context: Context, propertiesConfig: PropertiesConfig, 
      * Ensure specified properties are strings as defined here:
      * https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
      */
-    if (type === 'string' && key in newContext) {
+
+    if (type === 'string' && !isNullish(newContext[key])) {
       /* eslint-disable @typescript-eslint/no-base-to-string */
       newContext[key] = String(newContext[key])
     }
 
-    if (required && !(key in context)) {
+    if (required && isNullish(newContext[key])) {
       display.warn(`The property ${key} of ${name} is required; context will not be sent to the intake.`)
     }
   }
 
   return newContext
+}
+
+function isNullish(value: unknown) {
+  return value === undefined || value === null || value === ''
 }
 
 export function createContextManager(

--- a/packages/logs/src/boot/logsPublicApi.spec.ts
+++ b/packages/logs/src/boot/logsPublicApi.spec.ts
@@ -202,12 +202,12 @@ describe('logs entry', () => {
       })
 
       it('should sanitize predefined properties', () => {
-        const user = { id: null, name: 2, email: { bar: 'qux' } }
+        const user = { id: false, name: 2, email: { bar: 'qux' } }
         logsPublicApi.setUser(user as any)
         const getCommonContext = startLogs.calls.mostRecent().args[2]
         expect(getCommonContext().user).toEqual({
           email: '[object Object]',
-          id: 'null',
+          id: 'false',
           name: '2',
         })
       })
@@ -343,11 +343,11 @@ describe('logs entry', () => {
       })
 
       it('should sanitize predefined properties', () => {
-        const account = { id: null, name: 2 }
+        const account = { id: false, name: 2 }
         logsPublicApi.setAccount(account as any)
         const getCommonContext = startLogs.calls.mostRecent().args[2]
         expect(getCommonContext().account).toEqual({
-          id: 'null',
+          id: 'false',
           name: '2',
         })
       })

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -271,13 +271,13 @@ describe('rum public api', () => {
     })
 
     it('should sanitize predefined properties', () => {
-      const user = { id: null, name: 2, email: { bar: 'qux' } }
+      const user = { id: false, name: 2, email: { bar: 'qux' } }
       rumPublicApi.setUser(user as any)
       rumPublicApi.addAction('message')
 
       expect(rumPublicApi.getUser()).toEqual({
         email: '[object Object]',
-        id: 'null',
+        id: 'false',
         name: '2',
       })
       expect(displaySpy).not.toHaveBeenCalled()
@@ -421,12 +421,12 @@ describe('rum public api', () => {
     })
 
     it('should sanitize predefined properties', () => {
-      const account = { id: null, name: 2 }
+      const account = { id: false, name: 2 }
       rumPublicApi.setAccount(account as any)
       rumPublicApi.addAction('message')
 
       expect(rumPublicApi.getAccount()).toEqual({
-        id: 'null',
+        id: 'false',
         name: '2',
       })
       expect(displaySpy).not.toHaveBeenCalled()

--- a/packages/rum-core/src/domain/contexts/accountContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/accountContext.spec.ts
@@ -42,9 +42,9 @@ describe('account context', () => {
   })
 
   it('should sanitize predefined properties', () => {
-    accountContext.setContext({ id: null, name: 2 })
+    accountContext.setContext({ id: false, name: 2 })
     expect(accountContext.getContext()).toEqual({
-      id: 'null',
+      id: 'false',
       name: '2',
     })
   })

--- a/packages/rum-core/src/domain/contexts/userContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/userContext.spec.ts
@@ -34,11 +34,11 @@ describe('user context', () => {
   })
 
   it('should sanitize predefined properties', () => {
-    userContext.setContext({ id: null, name: 2, email: { bar: 'qux' } })
+    userContext.setContext({ id: false, name: 2, email: { bar: 'qux' } })
 
     expect(userContext.getContext()).toEqual({
       email: '[object Object]',
-      id: 'null',
+      id: 'false',
       name: '2',
     })
   })


### PR DESCRIPTION
## Motivation

Certain context properties like `usr.id` and `usr.name` are converted to strings. This PR stops converting `undefined` and `null` values to strings, aligning the behavior with other context properties.

ex: 
```ts
DD_RUM.setUser({ id: null, name: undefined })
````
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

```json
{ 
  "id": "null", 
  "name": "undefined", 
}
```
</td><td>

```json
{ 
}
```
</td></tr>

</table>

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
