### PR TITLE
🐛 [RUM-9465] Add support for parsing Safari Wasm stack trace

### DIFF
--- a/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
@@ -90,11 +90,7 @@ Error: foo
   })
 
   it('should handle a native error object stack from Chrome', () => {
-    const mockErr = {
-      message: 'foo',
-      name: 'Error',
-      stack: stackStr,
-    }
+    const mockErr = { message: 'foo', name: 'Error', stack: stackStr }
     const stackFrames = computeStackTrace(mockErr)
 
     expect(stackFrames.stack[0].url).toEqual('<anonymous>')
@@ -173,20 +169,8 @@ Error: foo
     const stackFrames = computeStackTrace(CapturedExceptions.SAFARI_7)
 
     expect(stackFrames.stack.length).toEqual(3)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 22,
-      func: '?',
-      line: 48,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 15,
-      func: 'foo',
-      line: 52,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[0]).toEqual({ args: [], column: 22, func: '?', line: 48, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 15, func: 'foo', line: 52, url: 'http://path/to/file.js' })
     expect(stackFrames.stack[2]).toEqual({
       args: [],
       column: 107,
@@ -200,20 +184,8 @@ Error: foo
     const stackFrames = computeStackTrace(CapturedExceptions.SAFARI_8)
 
     expect(stackFrames.stack.length).toEqual(3)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 22,
-      func: '?',
-      line: 47,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 15,
-      func: 'foo',
-      line: 52,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[0]).toEqual({ args: [], column: 22, func: '?', line: 47, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 15, func: 'foo', line: 52, url: 'http://path/to/file.js' })
     expect(stackFrames.stack[2]).toEqual({
       args: [],
       column: 23,
@@ -236,13 +208,7 @@ Error: foo
       line: undefined,
       url: '[native code]',
     })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 21,
-      func: 'foo',
-      line: 58,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 21, func: 'foo', line: 58, url: 'http://path/to/file.js' })
     expect(stackFrames.stack[2]).toEqual({
       args: [],
       column: 91,
@@ -393,20 +359,8 @@ Error: foo
     const stackFrames = computeStackTrace(CapturedExceptions.FIREFOX_31)
 
     expect(stackFrames.stack.length).toEqual(3)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 13,
-      func: 'foo',
-      line: 41,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 1,
-      func: 'bar',
-      line: 1,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[0]).toEqual({ args: [], column: 13, func: 'foo', line: 41, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 1, func: 'bar', line: 1, url: 'http://path/to/file.js' })
     expect(stackFrames.stack[2]).toEqual({
       args: [],
       column: 1,
@@ -434,13 +388,7 @@ Error: foo
       line: 15,
       url: 'file:///path/to/file.js',
     })
-    expect(stackFrames.stack[2]).toEqual({
-      args: [],
-      column: 3,
-      func: 'bar',
-      line: 20,
-      url: 'file:///path/to/file.js',
-    })
+    expect(stackFrames.stack[2]).toEqual({ args: [], column: 3, func: 'bar', line: 20, url: 'file:///path/to/file.js' })
     expect(stackFrames.stack[3]).toEqual({
       args: [],
       column: 1,
@@ -485,13 +433,7 @@ Error: foo
       line: 128,
       url: 'std_interceptors.js',
     })
-    expect(stackFrames.stack[2]).toEqual({
-      args: [],
-      column: 29,
-      func: 'eval',
-      line: 132,
-      url: 'std_interceptors.jsx',
-    })
+    expect(stackFrames.stack[2]).toEqual({ args: [], column: 29, func: 'eval', line: 132, url: 'std_interceptors.jsx' })
   })
 
   it('should not include error message into stacktrace ', () => {
@@ -527,34 +469,10 @@ Error: foo
     const stackFrames = computeStackTrace(CapturedExceptions.CHROME_15 as any)
 
     expect(stackFrames.stack.length).toEqual(4)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 17,
-      func: 'bar',
-      line: 13,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 5,
-      func: 'bar',
-      line: 16,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[2]).toEqual({
-      args: [],
-      column: 5,
-      func: 'foo',
-      line: 20,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[3]).toEqual({
-      args: [],
-      column: 4,
-      func: '?',
-      line: 24,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[0]).toEqual({ args: [], column: 17, func: 'bar', line: 13, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 5, func: 'bar', line: 16, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[2]).toEqual({ args: [], column: 5, func: 'foo', line: 20, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[3]).toEqual({ args: [], column: 4, func: '?', line: 24, url: 'http://path/to/file.js' })
   })
 
   it('should parse Chrome 36 error with port numbers', () => {
@@ -738,13 +656,7 @@ Error: foo
     const stackFrames = computeStackTrace(CapturedExceptions.CHROME_111_SNIPPET)
 
     expect(stackFrames.stack.length).toEqual(1)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 13,
-      func: '?',
-      line: 1,
-      url: 'snippet:///snippet_file',
-    })
+    expect(stackFrames.stack[0]).toEqual({ args: [], column: 13, func: '?', line: 1, url: 'snippet:///snippet_file' })
   })
 
   it('should parse empty IE 9 error', () => {
@@ -767,20 +679,8 @@ Error: foo
       line: 48,
       url: 'http://path/to/file.js',
     })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 9,
-      func: 'foo',
-      line: 46,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[2]).toEqual({
-      args: [],
-      column: 1,
-      func: 'bar',
-      line: 82,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 9, func: 'foo', line: 46, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[2]).toEqual({ args: [], column: 1, func: 'bar', line: 82, url: 'http://path/to/file.js' })
   })
 
   it('should parse IE 11 error', () => {
@@ -795,67 +695,25 @@ Error: foo
       line: 47,
       url: 'http://path/to/file.js',
     })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 13,
-      func: 'foo',
-      line: 45,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[2]).toEqual({
-      args: [],
-      column: 1,
-      func: 'bar',
-      line: 108,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 13, func: 'foo', line: 45, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[2]).toEqual({ args: [], column: 1, func: 'bar', line: 108, url: 'http://path/to/file.js' })
   })
 
   it('should parse IE 11 eval error', () => {
     const stackFrames = computeStackTrace(CapturedExceptions.IE_11_EVAL)
 
     expect(stackFrames.stack.length).toEqual(3)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 1,
-      func: 'eval code',
-      line: 1,
-      url: 'eval code',
-    })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 17,
-      func: 'foo',
-      line: 58,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[2]).toEqual({
-      args: [],
-      column: 1,
-      func: 'bar',
-      line: 109,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[0]).toEqual({ args: [], column: 1, func: 'eval code', line: 1, url: 'eval code' })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 17, func: 'foo', line: 58, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[2]).toEqual({ args: [], column: 1, func: 'bar', line: 109, url: 'http://path/to/file.js' })
   })
 
   it('should parse Opera 25 error', () => {
     const stackFrames = computeStackTrace(CapturedExceptions.OPERA_25)
 
     expect(stackFrames.stack.length).toEqual(3)
-    expect(stackFrames.stack[0]).toEqual({
-      args: [],
-      column: 22,
-      func: '?',
-      line: 47,
-      url: 'http://path/to/file.js',
-    })
-    expect(stackFrames.stack[1]).toEqual({
-      args: [],
-      column: 15,
-      func: 'foo',
-      line: 52,
-      url: 'http://path/to/file.js',
-    })
+    expect(stackFrames.stack[0]).toEqual({ args: [], column: 22, func: '?', line: 47, url: 'http://path/to/file.js' })
+    expect(stackFrames.stack[1]).toEqual({ args: [], column: 15, func: 'foo', line: 52, url: 'http://path/to/file.js' })
     expect(stackFrames.stack[2]).toEqual({
       args: [],
       column: 168,
@@ -1010,6 +868,38 @@ Error: foo
       func: 'r',
       line: 34,
       url: 'capacitor://localhost/media/dist/bundle.js',
+    })
+  })
+
+  it('should parse Safari WebAssembly stack frames', () => {
+    const wasmStack = `
+  RuntimeError: Out of bounds memory access
+      myModule.wasm-function[crashHandler]@[wasm code]
+      handleError@https://example.com/app.js:123:45
+      @https://example.com/app.js:150:30
+    `
+    const mockErr = { message: 'Out of bounds memory access', name: 'RuntimeError', stack: wasmStack }
+
+    const stackFrames = computeStackTrace(mockErr)
+
+    expect(stackFrames.stack.length).toBe(3)
+
+    expect(stackFrames.stack[0]).toEqual({ func: 'myModule.wasm-function.crashHandler', url: '[wasm code]', args: [] })
+
+    expect(stackFrames.stack[1]).toEqual({
+      func: 'handleError',
+      url: 'https://example.com/app.js',
+      line: 123,
+      column: 45,
+      args: [],
+    })
+
+    expect(stackFrames.stack[2]).toEqual({
+      func: '?',
+      url: 'https://example.com/app.js',
+      line: 150,
+      column: 30,
+      args: [],
     })
   })
 })

--- a/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
@@ -875,21 +875,29 @@ Error: foo
     const wasmStack = `
   RuntimeError: Out of bounds memory access
       myModule.wasm-function[crashHandler]@[wasm code]
-      handleError@https://example.com/app.js:123:45
-      @https://example.com/app.js:150:30
+      myModule.wasm-function[42]@[wasm code]
+      handleError@http://192.168.1.113:3000/:98:25
+      @http://192.168.1.113:3000/:113:32
     `
     const mockErr = { message: 'Out of bounds memory access', name: 'RuntimeError', stack: wasmStack }
-
     const stackFrames = computeStackTrace(mockErr)
 
-    expect(stackFrames.stack.length).toBe(3)
+    expect(stackFrames.stack.length).toBe(4)
 
     expect(stackFrames.stack[0]).toEqual({
+      args: [],
       func: 'myModule.wasm-function[crashHandler]',
       url: '[wasm code]',
       column: undefined,
       line: undefined,
+    })
+
+    expect(stackFrames.stack[1]).toEqual({
       args: [],
+      func: 'myModule.wasm-function[42]', // test case if have numeric index instead of the name
+      url: '[wasm code]',
+      column: undefined,
+      line: undefined,
     })
   })
 

--- a/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
@@ -901,6 +901,25 @@ Error: foo
     })
   })
 
+  it('should parse Safari Wasm stack frames from file URL', () => {
+    const wasmStack = `
+  RuntimeError: Some Wasm Error
+      myModule.wasm-function[crashFunc]@http://example.com/myModule.wasm
+      regularJsFunc@http://example.com/script.js:10:5
+    `
+    const mockErr = { message: 'Some Wasm Error', name: 'RuntimeError', stack: wasmStack }
+    const stackFrames = computeStackTrace(mockErr)
+
+    expect(stackFrames.stack.length).toBe(2)
+    expect(stackFrames.stack[0]).toEqual({
+      args: [],
+      func: 'myModule.wasm-function[crashFunc]',
+      url: 'http://example.com/myModule.wasm',
+      line: undefined,
+      column: undefined,
+    })
+  })
+
   it('should parse Chrome WebAssembly stack frames', () => {
     const wasmStack = `
   Error: Wasm Error
@@ -914,7 +933,7 @@ Error: foo
     expect(stackFrames.stack[0]).toEqual({
       args: [],
       func: 'foo',
-      url: '<anonymous>:wasm-function[42]:0x1a3b',
+      url: '<anonymous>',
       line: undefined,
       column: undefined,
     })
@@ -934,7 +953,7 @@ Error: foo
     expect(stackFrames.stack[0]).toEqual({
       args: [],
       func: 'wasm-function[42]',
-      url: 'http://example.com/my-module.wasm:wasm-function[42]:0x1a3b',
+      url: 'http://example.com/my-module.wasm',
       line: undefined,
       column: undefined,
     })

--- a/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.spec.ts
@@ -875,7 +875,7 @@ Error: foo
     const wasmStack = `
   RuntimeError: Out of bounds memory access
       myModule.wasm-function[crashHandler]@[wasm code]
-      myModule.wasm-function[42]@[wasm code]
+      <?>.wasm-function[42]@[wasm code]
       handleError@http://192.168.1.113:3000/:98:25
       @http://192.168.1.113:3000/:113:32
     `
@@ -894,7 +894,7 @@ Error: foo
 
     expect(stackFrames.stack[1]).toEqual({
       args: [],
-      func: 'myModule.wasm-function[42]', // test case if have numeric index instead of the name
+      func: '<?>.wasm-function[42]',
       url: '[wasm code]',
       column: undefined,
       line: undefined,
@@ -904,7 +904,7 @@ Error: foo
   it('should parse Safari Wasm stack frames from file URL', () => {
     const wasmStack = `
   RuntimeError: Some Wasm Error
-      myModule.wasm-function[crashFunc]@http://example.com/myModule.wasm
+      myModule.wasm-function[crashFunc]@[wasm code]
       regularJsFunc@http://example.com/script.js:10:5
     `
     const mockErr = { message: 'Some Wasm Error', name: 'RuntimeError', stack: wasmStack }
@@ -914,7 +914,7 @@ Error: foo
     expect(stackFrames.stack[0]).toEqual({
       args: [],
       func: 'myModule.wasm-function[crashFunc]',
-      url: 'http://example.com/myModule.wasm',
+      url: '[wasm code]',
       line: undefined,
       column: undefined,
     })
@@ -923,7 +923,7 @@ Error: foo
   it('should parse Chrome WebAssembly stack frames', () => {
     const wasmStack = `
   Error: Wasm Error
-    at foo (<anonymous>:wasm-function[42]:0x1a3b)
+    at myModule.foo (http://example.com/myModule.wasm:wasm-function[42]:0x1a3b)
     at bar (http://example.com/script.js:10:5)
     `
     const mockErr = { message: 'Wasm Error', name: 'Error', stack: wasmStack }
@@ -932,8 +932,8 @@ Error: foo
     expect(stackFrames.stack.length).toBe(2)
     expect(stackFrames.stack[0]).toEqual({
       args: [],
-      func: 'foo',
-      url: '<anonymous>',
+      func: 'myModule.foo',
+      url: 'http://example.com/myModule.wasm:wasm-function[42]:0x1a3b',
       line: undefined,
       column: undefined,
     })
@@ -942,7 +942,7 @@ Error: foo
   it('should parse Firefox WebAssembly stack frames', () => {
     const wasmStack = `
   Error: Wasm Error
-    wasm-function[42]@http://example.com/my-module.wasm:wasm-function[42]:0x1a3b
+    myModule.foo@http://example.com/my-module.wasm:wasm-function[42]:0x1a3b
     bar@http://example.com/script.js:10:5
     `
     const mockErr = { message: 'Wasm Error', name: 'Error', stack: wasmStack }
@@ -952,8 +952,8 @@ Error: foo
 
     expect(stackFrames.stack[0]).toEqual({
       args: [],
-      func: 'wasm-function[42]',
-      url: 'http://example.com/my-module.wasm',
+      func: 'myModule.foo',
+      url: 'http://example.com/my-module.wasm:wasm-function[42]:0x1a3b',
       line: undefined,
       column: undefined,
     })

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -83,7 +83,6 @@ function parseChromeLine(line: string): StackFrame | undefined {
     url: !isNative ? parts[2] : undefined,
   }
 
-  tryToParseWasmUrl(frame)
   return frame
 }
 
@@ -151,7 +150,6 @@ function parseGeckoLine(line: string): StackFrame | undefined {
     url: parts[3],
   }
 
-  tryToParseWasmUrl(frame)
   return frame
 }
 
@@ -180,17 +178,4 @@ function tryToParseMessage(messageObj: unknown) {
     ;[, name, message] = ERROR_TYPES_RE.exec(messageObj as string)!
   }
   return { name, message }
-}
-
-const WASM_STANDARD_URL_RE = /^(.+?):wasm-function\[.+?\]:0x[a-fA-F0-9]+$/
-
-function tryToParseWasmUrl(frame: StackFrame): void {
-  if (frame.url) {
-    const wasmUrlMatch = WASM_STANDARD_URL_RE.exec(frame.url)
-    if (wasmUrlMatch) {
-      frame.url = wasmUrlMatch[1]
-      frame.line = undefined
-      frame.column = undefined
-    }
-  }
 }

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -84,7 +84,6 @@ function parseChromeLine(line: string): StackFrame | undefined {
   }
 
   tryToParseWasmUrl(frame)
-
   return frame
 }
 

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -48,7 +48,11 @@ export function computeStackTrace(ex: unknown): StackTrace {
     })
   }
 
-  return { message: tryToGetString(ex, 'message'), name: tryToGetString(ex, 'name'), stack }
+  return {
+    message: tryToGetString(ex, 'message'),
+    name: tryToGetString(ex, 'name'),
+    stack,
+  }
 }
 const fileUrl =
   '((?:file|https?|blob|chrome-extension|electron|native|eval|webpack|snippet|<anonymous>|\\w+\\.|\\/).*?)'
@@ -75,15 +79,13 @@ function parseChromeLine(line: string): StackFrame | undefined {
     parts[4] = submatch[3] // column
   }
 
-  const frame = {
+  return {
     args: isNative ? [parts[2]] : [],
     column: parts[4] ? +parts[4] : undefined,
     func: parts[1] || UNKNOWN_FUNCTION,
     line: parts[3] ? +parts[3] : undefined,
     url: !isNative ? parts[2] : undefined,
   }
-
-  return frame
 }
 
 const CHROME_ANONYMOUS_FUNCTION_RE = new RegExp(`^\\s*at ?${fileUrl}${filePosition}?${filePosition}??\\s*$`, 'i')
@@ -142,15 +144,13 @@ function parseGeckoLine(line: string): StackFrame | undefined {
     parts[5] = undefined! // no column when eval
   }
 
-  const frame = {
+  return {
     args: parts[2] ? parts[2].split(',') : [],
     column: parts[5] ? +parts[5] : undefined,
     func: parts[1] || UNKNOWN_FUNCTION,
     line: parts[4] ? +parts[4] : undefined,
     url: parts[3],
   }
-
-  return frame
 }
 
 function tryToGetString(candidate: unknown, property: string) {
@@ -164,7 +164,11 @@ function tryToGetString(candidate: unknown, property: string) {
 export function computeStackTraceFromOnErrorMessage(messageObj: unknown, url?: string, line?: number, column?: number) {
   const stack = [{ url, column, line }]
   const { name, message } = tryToParseMessage(messageObj)
-  return { name, message, stack }
+  return {
+    name,
+    message,
+    stack,
+  }
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Error_types

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -37,11 +37,7 @@ export function computeStackTrace(ex: unknown): StackTrace {
   if (stackProperty) {
     stackProperty.split('\n').forEach((line) => {
       const stackFrame =
-        parseChromeLine(line) ||
-        parseChromeAnonymousLine(line) ||
-        parseWinLine(line) ||
-        parseGeckoLine(line) ||
-        parseSafariWasmLine(line)
+        parseChromeLine(line) || parseChromeAnonymousLine(line) || parseWinLine(line) || parseGeckoLine(line)
       if (stackFrame) {
         if (!stackFrame.func && stackFrame.line) {
           stackFrame.func = UNKNOWN_FUNCTION
@@ -125,7 +121,7 @@ function parseWinLine(line: string): StackFrame | undefined {
 }
 
 const GECKO_LINE_RE =
-  /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|capacitor|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i
+  /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|capacitor|\[native).*?|[^@]*bundle|\[wasm code\])(?::(\d+))?(?::(\d+))?\s*$/i
 const GECKO_EVAL_RE = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i
 
 function parseGeckoLine(line: string): StackFrame | undefined {
@@ -151,16 +147,6 @@ function parseGeckoLine(line: string): StackFrame | undefined {
     line: parts[4] ? +parts[4] : undefined,
     url: parts[3],
   }
-}
-
-const SAFARI_WASM_RE = /^(\S+)\[(\S+)\]@\[wasm code\]$/i
-
-function parseSafariWasmLine(line: string): StackFrame | undefined {
-  const match = SAFARI_WASM_RE.exec(line.trim())
-  if (!match) {
-    return
-  }
-  return { func: `${match[1]}.${match[2]}`, url: '[wasm code]', args: [] }
 }
 
 function tryToGetString(candidate: unknown, property: string) {

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -157,8 +157,9 @@ const SAFARI_WASM_RE = /^(\S+)\[(\S+)\]@\[wasm code\]$/i
 
 function parseSafariWasmLine(line: string): StackFrame | undefined {
   const match = SAFARI_WASM_RE.exec(line.trim())
-  if (!match) return
-
+  if (!match) {
+    return
+  }
   return { func: `${match[1]}.${match[2]}`, url: '[wasm code]', args: [] }
 }
 


### PR DESCRIPTION
## Motivation

Add support for parsing correctly stack trace in a safari wasm context. Cf https://github.com/DataDog/browser-sdk/issues/3479

## Changes

Modify computeStackTrace function / add unit test

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
