### PR TITLE
👷 Update chunk name formatting to use underscore instead of dash

### DIFF
--- a/scripts/lib/computeBundleSize.js
+++ b/scripts/lib/computeBundleSize.js
@@ -9,7 +9,7 @@ function getPackageName(file) {
   if (file.includes('chunk')) {
     const { chunkName, packageName } =
       file.match(/chunks\/(?<chunkName>[a-z0-9]*)-[a-z0-9]*-datadog-(?<packageName>[a-z-]*)\.js/)?.groups ?? {}
-    return `${packageName}-${chunkName}`
+    return `${packageName}_${chunkName}`
   }
 
   return file


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Metrics can't have `-` in their name, renaming packages name using `_` instead of `-` to keep all names in sync and avoid converting them before fetching the metrics in `fetchPerformanceMetrics`

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
