### PR TITLE
✅ hide unexpected unit test logs

### DIFF
--- a/packages/core/src/domain/context/contextManager.spec.ts
+++ b/packages/core/src/domain/context/contextManager.spec.ts
@@ -75,6 +75,7 @@ describe('createContextManager', () => {
   })
 
   it('should prevent setting non object values', () => {
+    spyOn(display, 'error')
     const manager = createContextManagerWithDefaults()
     manager.setContext(null as any)
     expect(manager.getContext()).toEqual({})


### PR DESCRIPTION
## Motivation

Some logs are shown when running unit tests.

## Changes

Mock display.error so they aren't showing up.

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [ ] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
