### PR TITLE
✨ Add publicPath configuration to webpack setups

### DIFF
--- a/packages/logs/webpack.config.js
+++ b/packages/logs/webpack.config.js
@@ -5,6 +5,7 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
+    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'datadog-logs.js',
   })

--- a/packages/rum-slim/webpack.config.js
+++ b/packages/rum-slim/webpack.config.js
@@ -5,6 +5,7 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
+    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'datadog-rum-slim.js',
   })

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -5,6 +5,7 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
+    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'datadog-rum.js',
   })

--- a/packages/worker/webpack.config.js
+++ b/packages/worker/webpack.config.js
@@ -5,6 +5,7 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
+    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'worker.js',
   })

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -30,8 +30,8 @@ function createStaticSandboxApp() {
   app.use(express.static(sandboxPath))
   for (const config of [rumConfig, logsConfig, rumSlimConfig, workerConfig]) {
     app.use(
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       middleware(
+        // Set publicPath for development mode. Fixes issue when using the developer extension with NPM package override.
         webpack(config(null, { mode: 'development', publicPath: `http://localhost:${DEFAULT_DEVELOPMENT_PORT}/` }))
       )
     )

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -13,13 +13,15 @@ const webpackBase = require('../webpack.base')
 const { printLog, runMain } = require('./lib/executionUtils')
 
 const sandboxPath = path.join(__dirname, '../sandbox')
-const port = 8080
+
+// Development server configuration
+const DEFAULT_DEVELOPMENT_PORT = 8080
 
 runMain(() => {
   const app = express()
   app.use(createStaticSandboxApp())
   app.use('/react-app', createReactApp())
-  app.listen(port, () => printLog(`Server listening on port ${port}.`))
+  app.listen(DEFAULT_DEVELOPMENT_PORT, () => printLog(`Server listening on port ${DEFAULT_DEVELOPMENT_PORT}.`))
 })
 
 function createStaticSandboxApp() {
@@ -27,7 +29,12 @@ function createStaticSandboxApp() {
   app.use(cors())
   app.use(express.static(sandboxPath))
   for (const config of [rumConfig, logsConfig, rumSlimConfig, workerConfig]) {
-    app.use(middleware(webpack(config(null, { mode: 'development' }))))
+    app.use(
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      middleware(
+        webpack(config(null, { mode: 'development', publicPath: `http://localhost:${DEFAULT_DEVELOPMENT_PORT}/` }))
+      )
+    )
   }
 
   // Redirect suffixed files
@@ -61,6 +68,7 @@ function createReactApp() {
           entry: `${sandboxPath}/react-app/main.tsx`,
           plugins: [new HtmlWebpackPlugin({ publicPath: '/react-app/' })],
           mode: 'development',
+          publicPath: `http://localhost:${DEFAULT_DEVELOPMENT_PORT}/`,
         })
       )
     )

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -5,8 +5,7 @@ const TerserPlugin = require('terser-webpack-plugin')
 const { buildEnvKeys, getBuildEnvValue } = require('./scripts/lib/buildEnv')
 
 const tsconfigPath = path.join(__dirname, 'tsconfig.webpack.json')
-
-module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins }) => ({
+module.exports = ({ entry, mode, publicPath, filename, types, keepBuildEnvVariables, plugins }) => ({
   entry,
   mode,
   output: {
@@ -19,6 +18,8 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
         : // Include a content hash in chunk names in production.
           `chunks/[name]-[contenthash]-${filename}`,
     path: path.resolve('./bundle'),
+    // Set explicit publicPath for development mode when using the developer extension with NPM package override
+    publicPath: mode === 'development' ? publicPath : 'auto',
   },
   target: ['web', 'es2018'],
   devtool: false,

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -18,8 +18,7 @@ module.exports = ({ entry, mode, publicPath, filename, types, keepBuildEnvVariab
         : // Include a content hash in chunk names in production.
           `chunks/[name]-[contenthash]-${filename}`,
     path: path.resolve('./bundle'),
-    // Set explicit publicPath for development mode when using the developer extension with NPM package override
-    publicPath: mode === 'development' ? publicPath : 'auto',
+    publicPath,
   },
   target: ['web', 'es2018'],
   devtool: false,


### PR DESCRIPTION
## Motivation

When using the `Use development bundles` feature of the developer extension, with the `On NPM setup` experimental option, I would receive the following message from the application (Chrome 135):
![Pasted Graphic](https://github.com/user-attachments/assets/94e21caf-5294-440e-bbc1-cafdf2ea6d24)

## Changes

- Force the publicPath in webpack config to be `http://localhost:8080` when in development mode. 
The browser SDK extension now shows the version as `dev` as expected, however, the following warning is issued:
![Pasted Graphic 1](https://github.com/user-attachments/assets/ab52ba9c-8d83-4722-9624-f12962b9c4d5)
Functions updated in the development SDK seems to be called properly.

## Testing

Take the PR locally, run `yarn dev` and find a website using NPM to bundle the SDK. Try to override with your local bundles using: 
![image](https://github.com/user-attachments/assets/fb8d1cd6-dd3c-4909-ae9f-bed328baf17a)


- [x] Local
- [ ] Staging
- [ ] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
