### PR TITLE
♻️ Decouple the display context from assembly using hooks

### DIFF
--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -266,21 +266,11 @@ export function startRumEventCollection(
     configuration
   )
 
-  const displayContext = startDisplayContext(configuration)
+  const displayContext = startDisplayContext(hooks, configuration)
   const ciVisibilityContext = startCiVisibilityContext(hooks)
   startSyntheticsContext(hooks)
 
-  startRumAssembly(
-    configuration,
-    lifeCycle,
-    hooks,
-    sessionManager,
-    viewHistory,
-    urlContexts,
-    displayContext,
-    recorderApi,
-    reportError
-  )
+  startRumAssembly(configuration, lifeCycle, hooks, sessionManager, viewHistory, urlContexts, recorderApi, reportError)
 
   return {
     pageStateHistory,

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -13,7 +13,6 @@ import {
   createRumSessionManagerMock,
   createRawRumEvent,
   mockRumConfiguration,
-  mockDisplayContext,
   mockViewHistory,
   mockUrlContexts,
   noopRecorderApi,
@@ -784,7 +783,6 @@ function setupAssemblyTestWithDefaults({
     rumSessionManager,
     { ...mockViewHistory(), findView: () => findView() },
     mockUrlContexts(),
-    mockDisplayContext(),
     recorderApi,
     reportErrorSpy
   )

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -25,7 +25,6 @@ import type { ViewHistory } from './contexts/viewHistory'
 import { SessionReplayState, SessionType } from './rumSessionManager'
 import type { RumSessionManager } from './rumSessionManager'
 import type { RumConfiguration } from './configuration'
-import type { DisplayContext } from './contexts/displayContext'
 import type { ModifiableFieldPaths } from './limitModification'
 import { limitModification } from './limitModification'
 import type { UrlContexts } from './contexts/urlContexts'
@@ -59,7 +58,6 @@ export function startRumAssembly(
   sessionManager: RumSessionManager,
   viewHistory: ViewHistory,
   urlContexts: UrlContexts,
-  displayContext: DisplayContext,
   recorderApi: RecorderApi,
   reportError: (error: RawError) => void
 ) {
@@ -167,7 +165,6 @@ export function startRumAssembly(
             id: session.id,
             type: SessionType.USER,
           },
-          display: displayContext.get(),
           connectivity: getConnectivity(),
         }
 

--- a/packages/rum-core/src/domain/contexts/displayContext.ts
+++ b/packages/rum-core/src/domain/contexts/displayContext.ts
@@ -2,10 +2,12 @@ import { monitor } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type { ViewportDimension } from '../../browser/viewportObservable'
 import { getViewportDimension, initViewportObservable } from '../../browser/viewportObservable'
+import type { Hooks, PartialRumEvent } from '../../hooks'
+import { HookNames } from '../../hooks'
 
 export type DisplayContext = ReturnType<typeof startDisplayContext>
 
-export function startDisplayContext(configuration: RumConfiguration) {
+export function startDisplayContext(hooks: Hooks, configuration: RumConfiguration) {
   let viewport: ViewportDimension | undefined
   // Use requestAnimationFrame to delay the calculation of viewport dimensions until after SDK initialization, preventing long tasks.
   const animationFrameId = requestAnimationFrame(
@@ -18,8 +20,12 @@ export function startDisplayContext(configuration: RumConfiguration) {
     viewport = viewportDimension
   }).unsubscribe
 
+  hooks.register(HookNames.Assemble, ({ eventType }): PartialRumEvent | undefined => ({
+    type: eventType,
+    display: viewport ? { viewport } : undefined,
+  }))
+
   return {
-    get: () => (viewport ? { viewport } : undefined),
     stop: () => {
       unsubscribeViewport()
       if (animationFrameId) {

--- a/packages/rum-core/test/mockContexts.ts
+++ b/packages/rum-core/test/mockContexts.ts
@@ -1,9 +1,6 @@
 import { noop } from '@datadog/browser-core'
-import type { ActionContexts } from '../src/domain/action/trackClickActions'
-import type { DisplayContext } from '../src/domain/contexts/displayContext'
 import type { UrlContexts } from '../src/domain/contexts/urlContexts'
 import type { ViewHistory, ViewHistoryEntry } from '../src/domain/contexts/viewHistory'
-import type { FeatureFlagContexts } from '../src/domain/contexts/featureFlagContext'
 
 export function mockUrlContexts(fakeLocation: Location = location): UrlContexts {
   return {
@@ -23,25 +20,5 @@ export function mockViewHistory(view?: Partial<ViewHistoryEntry>): ViewHistory {
     stop: noop,
     getAllEntries: () => [],
     getDeletedEntries: () => [],
-  }
-}
-
-export function mockActionContexts(): ActionContexts {
-  return {
-    findActionId: () => '7890',
-  }
-}
-
-export function mockDisplayContext(): DisplayContext {
-  return {
-    get: () => ({ viewport: { height: 0, width: 0 } }),
-    stop: noop,
-  }
-}
-
-export function mockFeatureFlagContexts(partialContext: Partial<FeatureFlagContexts> = {}): FeatureFlagContexts {
-  return {
-    addFeatureFlagEvaluation: noop,
-    ...partialContext,
   }
 }


### PR DESCRIPTION
## Motivation

Decouple the display context from assembly using hooks

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
