### PR TITLE
♻️ Decouple the connectivity context from assembly using hooks

### DIFF
--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -54,6 +54,7 @@ import { startGlobalContext } from '../domain/contexts/globalContext'
 import { startUserContext } from '../domain/contexts/userContext'
 import { startAccountContext } from '../domain/contexts/accountContext'
 import { startRumAssembly } from '../domain/assembly'
+import { startConnectivityContext } from '../domain/contexts/connectivityContext'
 import type { RecorderApi, ProfilerApi } from './rumPublicApi'
 
 export type StartRum = typeof startRum
@@ -126,13 +127,13 @@ export function startRum(
 
   const domMutationObservable = createDOMMutationObservable()
   const locationChangeObservable = createLocationChangeObservable(configuration, location)
+  const { observable: windowOpenObservable, stop: stopWindowOpen } = createWindowOpenObservable()
+  cleanupTasks.push(stopWindowOpen)
   const pageStateHistory = startPageStateHistory(hooks, configuration)
   const viewHistory = startViewHistory(lifeCycle)
   const urlContexts = startUrlContexts(lifeCycle, hooks, locationChangeObservable, location)
   const featureFlagContexts = startFeatureFlagContexts(lifeCycle, hooks, configuration)
-  const { observable: windowOpenObservable, stop: stopWindowOpen } = createWindowOpenObservable()
-  cleanupTasks.push(stopWindowOpen)
-
+  startConnectivityContext(hooks)
   const globalContext = startGlobalContext(hooks, configuration)
   const userContext = startUserContext(hooks, configuration, session)
   const accountContext = startAccountContext(hooks, configuration)

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,14 +1,7 @@
 import type { ClocksState, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import { ErrorSource, ExperimentalFeature, ONE_MINUTE, display } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import {
-  mockEventBridge,
-  mockExperimentalFeatures,
-  setNavigatorOnLine,
-  setNavigatorConnection,
-  registerCleanupTask,
-  mockClock,
-} from '@datadog/browser-core/test'
+import { mockEventBridge, mockExperimentalFeatures, registerCleanupTask, mockClock } from '@datadog/browser-core/test'
 import {
   createRumSessionManagerMock,
   createRawRumEvent,
@@ -623,23 +616,6 @@ describe('rum assembly', () => {
 
       expect(serverRumEvents[0]._dd.browser_sdk_version).not.toBeDefined()
       expect(serverRumEvents[1]._dd.browser_sdk_version).toBeDefined()
-    })
-  })
-
-  describe('connectivity', () => {
-    it('should include the connectivity information', () => {
-      setNavigatorOnLine(true)
-      setNavigatorConnection({ effectiveType: '2g' })
-
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults()
-      const rawRumEvent = createRawRumEvent(RumEventType.VIEW)
-      notifyRawRumEvent(lifeCycle, { rawRumEvent })
-
-      expect(serverRumEvents[0].connectivity).toEqual({
-        status: 'connected',
-        effective_type: '2g',
-        interfaces: undefined,
-      })
     })
   })
   ;[

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -10,7 +10,6 @@ import {
   round,
   isExperimentalFeatureEnabled,
   ExperimentalFeature,
-  getConnectivity,
   addTelemetryDebug,
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
@@ -168,7 +167,6 @@ export function startRumAssembly(
             type: SessionType.USER,
           },
           display: displayContext.get(),
-          connectivity: getConnectivity(),
         }
 
         const serverRumEvent = combine(

--- a/packages/rum-core/src/domain/contexts/connectivityContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/connectivityContext.spec.ts
@@ -1,0 +1,31 @@
+import { setNavigatorOnLine, setNavigatorConnection } from '@datadog/browser-core/test'
+import type { RelativeTime } from '@datadog/browser-core'
+import type { Hooks } from '../../hooks'
+import { createHooks, HookNames } from '../../hooks'
+import { startConnectivityContext } from './connectivityContext'
+
+describe('startConnectivityContext', () => {
+  describe('assemble hook', () => {
+    let hooks: Hooks
+
+    beforeEach(() => {
+      hooks = createHooks()
+    })
+
+    it('should set ci visibility context defined by Cypress global variables', () => {
+      startConnectivityContext(hooks)
+      setNavigatorOnLine(true)
+      setNavigatorConnection({ effectiveType: '2g' })
+      const event = hooks.triggerHook(HookNames.Assemble, { eventType: 'view', startTime: 0 as RelativeTime })
+
+      expect(event).toEqual({
+        type: 'view',
+        connectivity: {
+          status: 'connected',
+          effective_type: '2g',
+          interfaces: undefined,
+        },
+      })
+    })
+  })
+})

--- a/packages/rum-core/src/domain/contexts/connectivityContext.ts
+++ b/packages/rum-core/src/domain/contexts/connectivityContext.ts
@@ -1,0 +1,10 @@
+import { getConnectivity } from '@datadog/browser-core'
+import type { Hooks, PartialRumEvent } from '../../hooks'
+import { HookNames } from '../../hooks'
+
+export function startConnectivityContext(hooks: Hooks) {
+  hooks.register(HookNames.Assemble, ({ eventType }): PartialRumEvent | undefined => ({
+    type: eventType,
+    connectivity: getConnectivity(),
+  }))
+}


### PR DESCRIPTION
## Motivation

Decouple the connectivity context from assembly using hooks

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. -->

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [x] Local
- [x] Staging
- [x] Unit
- [ ] End to end

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
