### PR TITLE
♻️ [RUM-9667] refactor stack trace computation

### DIFF
--- a/packages/core/src/domain/console/consoleObservable.ts
+++ b/packages/core/src/domain/console/consoleObservable.ts
@@ -1,13 +1,13 @@
-import { flattenErrorCauses, isError, tryToGetFingerprint, tryToGetErrorContext } from '../error/error'
+import { isError, computeRawError } from '../error/error'
 import { mergeObservables, Observable } from '../../tools/observable'
 import { ConsoleApiName, globalConsole } from '../../tools/display'
 import { callMonitored } from '../../tools/monitor'
 import { sanitize } from '../../tools/serialisation/sanitize'
 import { jsonStringify } from '../../tools/serialisation/jsonStringify'
 import type { RawError } from '../error/error.types'
-import { ErrorHandling, ErrorSource } from '../error/error.types'
+import { ErrorHandling, ErrorSource, NonErrorPrefix } from '../error/error.types'
 import { computeStackTrace } from '../../tools/stackTrace/computeStackTrace'
-import { createHandlingStack, toStackTraceString, formatErrorMessage } from '../../tools/stackTrace/handlingStack'
+import { createHandlingStack, formatErrorMessage } from '../../tools/stackTrace/handlingStack'
 import { clocksNow } from '../../tools/utils/timeUtils'
 
 export type ConsoleLog = NonErrorConsoleLog | ErrorConsoleLog
@@ -70,31 +70,41 @@ function createConsoleObservable(api: ConsoleApiName) {
 
 function buildConsoleLog(params: unknown[], api: ConsoleApiName, handlingStack: string): ConsoleLog {
   const message = params.map((param) => formatConsoleParameters(param)).join(' ')
-  let error: RawError | undefined
 
   if (api === ConsoleApiName.error) {
     const firstErrorParam = params.find(isError)
 
-    error = {
-      stack: firstErrorParam ? toStackTraceString(computeStackTrace(firstErrorParam)) : undefined,
-      fingerprint: tryToGetFingerprint(firstErrorParam),
-      causes: firstErrorParam ? flattenErrorCauses(firstErrorParam, 'console') : undefined,
+    const rawError = computeRawError({
+      originalError: firstErrorParam,
+      handlingStack,
       startClocks: clocksNow(),
-      message,
       source: ErrorSource.CONSOLE,
       handling: ErrorHandling.HANDLED,
+      nonErrorPrefix: NonErrorPrefix.PROVIDED,
+
+      // if no good stack is computed from the error, let's not use the fallback stack message
+      // advising the user to use an instance of Error, as console.error is commonly used without an
+      // Error instance.
+      useFallbackStack: false,
+    })
+
+    // Use the full log message as the error message instead of just the error instance message.
+    rawError.message = message
+
+    return {
+      api,
+      message,
       handlingStack,
-      context: tryToGetErrorContext(firstErrorParam),
-      originalError: firstErrorParam,
+      error: rawError,
     }
   }
 
   return {
     api,
     message,
-    error,
+    error: undefined,
     handlingStack,
-  } as ConsoleLog
+  }
 }
 
 function formatConsoleParameters(param: unknown) {

--- a/packages/core/src/domain/error/error.spec.ts
+++ b/packages/core/src/domain/error/error.spec.ts
@@ -134,21 +134,6 @@ describe('computeRawError', () => {
     expect(formatted.type).toEqual('TypeError')
   })
 
-  it('discards unusable stack traces', () => {
-    const stackTrace: StackTrace = { name: undefined, message: undefined, stack: [] } as any
-
-    const formatted = computeRawError({
-      ...DEFAULT_RAW_ERROR_PARAMS,
-      originalError: 'toto',
-      handling: ErrorHandling.HANDLED,
-      stackTrace,
-    })
-
-    expect(formatted.message).toEqual('Uncaught "toto"')
-    expect(formatted.stack).toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
-    expect(formatted.type).toEqual(undefined)
-  })
-
   it('should set handling according to given parameter', () => {
     const error = { foo: 'bar' }
 

--- a/packages/core/src/domain/error/error.spec.ts
+++ b/packages/core/src/domain/error/error.spec.ts
@@ -77,6 +77,19 @@ describe('computeRawError', () => {
     expect(formatted.stack).toEqual(NO_ERROR_STACK_PRESENT_MESSAGE)
   })
 
+  it('does not define the stack if useFallbackStack is false', () => {
+    const error = 'foo is undefined'
+
+    const formatted = computeRawError({
+      ...DEFAULT_RAW_ERROR_PARAMS,
+      originalError: error,
+      handling: ErrorHandling.HANDLED,
+      useFallbackStack: false,
+    })
+
+    expect(formatted.stack).toEqual(undefined)
+  })
+
   it('uses the provided stack trace object', () => {
     const stackTrace: StackTrace = {
       message: 'oh snap!',

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -38,12 +38,12 @@ export function computeRawError({
   }
 
   const message = computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError)
-  const stack = hasUsableStack(isErrorInstance, stackTrace)
+  const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
+  const stack = stackTrace
     ? toStackTraceString(stackTrace)
     : useFallbackStack
       ? NO_ERROR_STACK_PRESENT_MESSAGE
       : undefined
-  const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
   const type = stackTrace ? stackTrace.name : undefined
   const fingerprint = tryToGetFingerprint(originalError)
   const context = tryToGetErrorContext(originalError)
@@ -77,18 +77,6 @@ function computeMessage(
     : !isErrorInstance
       ? `${nonErrorPrefix} ${jsonStringify(sanitize(originalError))!}`
       : 'Empty message'
-}
-
-function hasUsableStack(isErrorInstance: boolean, stackTrace?: StackTrace): stackTrace is StackTrace {
-  if (stackTrace === undefined) {
-    return false
-  }
-  if (isErrorInstance) {
-    return true
-  }
-  // handle cases where tracekit return stack = [] or stack = [{url: undefined, line: undefined, column: undefined}]
-  // TODO rework tracekit integration to avoid generating those unusable stack
-  return stackTrace.stack.length > 0 && (stackTrace.stack.length > 1 || stackTrace.stack[0].url !== undefined)
 }
 
 export function tryToGetFingerprint(originalError: unknown) {

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -37,17 +37,6 @@ export function computeRawError({
     stackTrace = computeStackTrace(originalError)
   }
 
-  const message = computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError)
-  const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
-  const stack = stackTrace
-    ? toStackTraceString(stackTrace)
-    : useFallbackStack
-      ? NO_ERROR_STACK_PRESENT_MESSAGE
-      : undefined
-  const type = stackTrace ? stackTrace.name : undefined
-  const fingerprint = tryToGetFingerprint(originalError)
-  const context = tryToGetErrorContext(originalError)
-
   return {
     startClocks,
     source,
@@ -55,12 +44,12 @@ export function computeRawError({
     handlingStack,
     componentStack,
     originalError,
-    type,
-    message,
-    stack,
-    causes,
-    fingerprint,
-    context,
+    type: stackTrace ? stackTrace.name : undefined,
+    message: computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError),
+    stack: stackTrace ? toStackTraceString(stackTrace) : useFallbackStack ? NO_ERROR_STACK_PRESENT_MESSAGE : undefined,
+    causes: isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined,
+    fingerprint: tryToGetFingerprint(originalError),
+    context: tryToGetErrorContext(originalError),
   }
 }
 

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -16,6 +16,7 @@ type RawErrorParams = {
   componentStack?: string
   startClocks: ClocksState
   nonErrorPrefix: NonErrorPrefix
+  useFallbackStack?: boolean
   source: ErrorSource
   handling: ErrorHandling
 }
@@ -27,6 +28,7 @@ export function computeRawError({
   componentStack,
   startClocks,
   nonErrorPrefix,
+  useFallbackStack = true,
   source,
   handling,
 }: RawErrorParams): RawError {
@@ -38,7 +40,9 @@ export function computeRawError({
   const message = computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError)
   const stack = hasUsableStack(isErrorInstance, stackTrace)
     ? toStackTraceString(stackTrace)
-    : NO_ERROR_STACK_PRESENT_MESSAGE
+    : useFallbackStack
+      ? NO_ERROR_STACK_PRESENT_MESSAGE
+      : undefined
   const causes = isErrorInstance ? flattenErrorCauses(originalError as ErrorWithCause, source) : undefined
   const type = stackTrace ? stackTrace.name : undefined
   const fingerprint = tryToGetFingerprint(originalError)

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -31,6 +31,9 @@ export function computeRawError({
   handling,
 }: RawErrorParams): RawError {
   const isErrorInstance = isError(originalError)
+  if (!stackTrace && isErrorInstance) {
+    stackTrace = computeStackTrace(originalError)
+  }
 
   const message = computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError)
   const stack = hasUsableStack(isErrorInstance, stackTrace)

--- a/packages/core/src/domain/error/trackRuntimeError.spec.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.spec.ts
@@ -1,5 +1,6 @@
 import { disableJasmineUncaughtExceptionTracking, wait } from '../../../test'
 import { Observable } from '../../tools/observable'
+import type { UnhandledErrorCallback } from './trackRuntimeError'
 import { instrumentOnError, instrumentUnhandledRejection, trackRuntimeError } from './trackRuntimeError'
 import type { RawError } from './error.types'
 
@@ -54,9 +55,9 @@ describe('instrumentOnError', () => {
   const testColNo = 42
   const ERROR_MESSAGE = 'foo'
 
-  const spyViaInstrumentOnError = async (callback: () => void): Promise<jasmine.Spy> => {
+  const spyViaInstrumentOnError = async (callback: () => void) => {
     const onErrorSpy = spyOn(window as any, 'onerror')
-    const callbackSpy = jasmine.createSpy()
+    const callbackSpy = jasmine.createSpy<UnhandledErrorCallback>()
     const { stop } = instrumentOnError(callbackSpy)
 
     try {
@@ -82,9 +83,9 @@ describe('instrumentOnError', () => {
       throw error
     })
 
-    const [stack, originalError] = spy.calls.mostRecent().args
+    const [originalError, stack] = spy.calls.mostRecent().args
     expect(originalError).toBe(error)
-    expect(stack).toBeDefined()
+    expect(stack).toBeUndefined()
   })
 
   it('should notify unhandled string', async () => {
@@ -93,7 +94,7 @@ describe('instrumentOnError', () => {
       throw error
     })
 
-    const [stack, originalError] = spy.calls.mostRecent().args
+    const [originalError, stack] = spy.calls.mostRecent().args
     expect(originalError).toBe(error)
     expect(stack).toBeDefined()
   })
@@ -104,7 +105,7 @@ describe('instrumentOnError', () => {
       throw error
     })
 
-    const [stack, originalError] = spy.calls.mostRecent().args
+    const [originalError, stack] = spy.calls.mostRecent().args
     expect(originalError).toBe(error)
     expect(stack).toBeDefined()
   })
@@ -129,7 +130,7 @@ describe('instrumentOnError', () => {
       expect(spy).toHaveBeenCalledTimes(1)
       await wait(1000)
       expect(spy).toHaveBeenCalledTimes(1)
-      const [, reportedError] = spy.calls.mostRecent().args
+      const [reportedError] = spy.calls.mostRecent().args
       expect(reportedError).toEqual(exception)
     })
   })
@@ -141,7 +142,7 @@ describe('instrumentOnError', () => {
         window.onerror!(error)
       })
 
-      const [stack, originalError] = spy.calls.mostRecent().args
+      const [originalError, stack] = spy.calls.mostRecent().args
       expect(originalError).toBe(error)
       expect(stack).toBeDefined()
     })
@@ -154,9 +155,9 @@ describe('instrumentOnError', () => {
           window.onerror!(undefined!, undefined, testLineNo)
         })
 
-        const [stack] = spy.calls.mostRecent().args
-        expect(stack.name).toBeUndefined()
-        expect(stack.message).toBeUndefined()
+        const [, stack] = spy.calls.mostRecent().args
+        expect(stack!.name).toBeUndefined()
+        expect(stack!.message).toBeUndefined()
       })
     })
 
@@ -166,9 +167,9 @@ describe('instrumentOnError', () => {
           window.onerror!('ReferenceError: foo is undefined', 'http://example.com', testLineNo)
         })
 
-        const [stack] = spy.calls.mostRecent().args
-        expect(stack.name).toEqual('ReferenceError')
-        expect(stack.message).toEqual('foo is undefined')
+        const [, stack] = spy.calls.mostRecent().args
+        expect(stack!.name).toEqual('ReferenceError')
+        expect(stack!.message).toEqual('foo is undefined')
       })
 
       it('should separate name, message for default error types (e.g. Uncaught ReferenceError)', async () => {
@@ -177,9 +178,9 @@ describe('instrumentOnError', () => {
           window.onerror!('Uncaught ReferenceError: foo is undefined', 'http://example.com', testLineNo)
         })
 
-        const [stack] = spy.calls.mostRecent().args
-        expect(stack.name).toEqual('ReferenceError')
-        expect(stack.message).toEqual('foo is undefined')
+        const [, stack] = spy.calls.mostRecent().args
+        expect(stack!.name).toEqual('ReferenceError')
+        expect(stack!.message).toEqual('foo is undefined')
       })
 
       it('should separate name, message for default error types on Opera Mini', async () => {
@@ -191,9 +192,9 @@ describe('instrumentOnError', () => {
           )
         })
 
-        const [stack] = spy.calls.mostRecent().args
-        expect(stack.name).toEqual('ReferenceError')
-        expect(stack.message).toEqual('Undefined variable: foo')
+        const [, stack] = spy.calls.mostRecent().args
+        expect(stack!.name).toEqual('ReferenceError')
+        expect(stack!.message).toEqual('Undefined variable: foo')
       })
 
       it('should separate name, message for error with multiline message', async () => {
@@ -201,9 +202,9 @@ describe('instrumentOnError', () => {
           window.onerror!("TypeError: foo is not a function. (In 'my.function(\n foo)")
         })
 
-        const [stack] = spy.calls.mostRecent().args
-        expect(stack.message).toEqual("foo is not a function. (In 'my.function(\n foo)")
-        expect(stack.name).toEqual('TypeError')
+        const [, stack] = spy.calls.mostRecent().args
+        expect(stack!.message).toEqual("foo is not a function. (In 'my.function(\n foo)")
+        expect(stack!.name).toEqual('TypeError')
       })
 
       it('should ignore unknown error types', async () => {
@@ -212,9 +213,9 @@ describe('instrumentOnError', () => {
         })
 
         // TODO: should we attempt to parse this?
-        const [stack] = spy.calls.mostRecent().args
-        expect(stack.name).toEqual(undefined)
-        expect(stack.message).toEqual('CustomError: woo scary')
+        const [, stack] = spy.calls.mostRecent().args
+        expect(stack!.name).toEqual(undefined)
+        expect(stack!.message).toEqual('CustomError: woo scary')
       })
 
       it('should ignore arbitrary messages passed through onerror', async () => {
@@ -222,9 +223,9 @@ describe('instrumentOnError', () => {
           window.onerror!('all work and no play makes homer: something something', 'http://example.com', testLineNo)
         })
 
-        const [stack] = spy.calls.mostRecent().args
-        expect(stack.name).toEqual(undefined)
-        expect(stack.message).toEqual('all work and no play makes homer: something something')
+        const [, stack] = spy.calls.mostRecent().args
+        expect(stack!.name).toEqual(undefined)
+        expect(stack!.message).toEqual('all work and no play makes homer: something something')
       })
 
       it('should handle object message passed through onerror', async () => {
@@ -232,8 +233,8 @@ describe('instrumentOnError', () => {
           window.onerror!({ foo: 'bar' } as any)
         })
 
-        const [stack, error] = spy.calls.mostRecent().args
-        expect(stack.message).toBeUndefined()
+        const [error, stack] = spy.calls.mostRecent().args
+        expect(stack!.message).toBeUndefined()
         expect(error).toEqual({ foo: 'bar' }) // consider the message as initial error
       })
     })
@@ -250,9 +251,9 @@ describe('instrumentOnError', () => {
           )
         })
 
-        const [stack, error] = spy.calls.mostRecent().args
-        expect(stack.message).toBe('Any error message')
-        expect(stack.stack).toEqual([{ url: 'https://example.com', column: testColNo, line: testLineNo }])
+        const [error, stack] = spy.calls.mostRecent().args
+        expect(stack!.message).toBe('Any error message')
+        expect(stack!.stack).toEqual([{ url: 'https://example.com', column: testColNo, line: testLineNo }])
         expect(error).toEqual('Actual Error Message')
       })
 
@@ -264,9 +265,9 @@ describe('instrumentOnError', () => {
           } as any)
         })
 
-        const [stack, error] = spy.calls.mostRecent().args
-        expect(stack.message).toBe('Any error message')
-        expect(stack.stack).toEqual([{ url: 'https://example.com', column: testColNo, line: testLineNo }])
+        const [error, stack] = spy.calls.mostRecent().args
+        expect(stack!.message).toBe('Any error message')
+        expect(stack!.stack).toEqual([{ url: 'https://example.com', column: testColNo, line: testLineNo }])
         expect(error).toEqual({ message: 'SyntaxError', data: 'foo' })
       })
     })
@@ -282,7 +283,7 @@ describe('instrumentUnhandledRejection', () => {
     }
 
     const onUnhandledRejectionSpy = spyOn(window as any, 'onunhandledrejection')
-    const callbackSpy = jasmine.createSpy()
+    const callbackSpy = jasmine.createSpy<UnhandledErrorCallback>()
     const { stop } = instrumentUnhandledRejection(callbackSpy)
 
     try {
@@ -311,9 +312,9 @@ describe('instrumentUnhandledRejection', () => {
       window.onunhandledrejection!({ reason } as PromiseRejectionEvent)
     })
 
-    const [stack, originalError] = spy.calls.mostRecent().args
+    const [originalError, stack] = spy.calls.mostRecent().args
     expect(originalError).toBe(reason)
-    expect(stack).toBeDefined()
+    expect(stack).toBeUndefined()
   })
 })
 

--- a/packages/core/src/domain/error/trackRuntimeError.spec.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.spec.ts
@@ -139,7 +139,7 @@ describe('instrumentOnError', () => {
     it('with objects', async () => {
       const error = { foo: 'bar' } as any
       const spy = await spyViaInstrumentOnError(() => {
-        window.onerror!(error)
+        window.onerror!(error, 'http://example.com', testLineNo, testColNo)
       })
 
       const [originalError, stack] = spy.calls.mostRecent().args
@@ -148,7 +148,7 @@ describe('instrumentOnError', () => {
     })
 
     describe('with undefined arguments', () => {
-      it('should pass undefined:undefined', async () => {
+      it('discards the stack', async () => {
         // this is probably not good behavior;  just writing this test to verify
         // that it doesn't change unintentionally
         const spy = await spyViaInstrumentOnError(() => {
@@ -156,8 +156,7 @@ describe('instrumentOnError', () => {
         })
 
         const [, stack] = spy.calls.mostRecent().args
-        expect(stack!.name).toBeUndefined()
-        expect(stack!.message).toBeUndefined()
+        expect(stack).toBeUndefined()
       })
     })
 
@@ -199,7 +198,11 @@ describe('instrumentOnError', () => {
 
       it('should separate name, message for error with multiline message', async () => {
         const spy = await spyViaInstrumentOnError(() => {
-          window.onerror!("TypeError: foo is not a function. (In 'my.function(\n foo)")
+          window.onerror!(
+            "TypeError: foo is not a function. (In 'my.function(\n foo)",
+            'http://example.com',
+            testLineNo
+          )
         })
 
         const [, stack] = spy.calls.mostRecent().args
@@ -230,7 +233,7 @@ describe('instrumentOnError', () => {
 
       it('should handle object message passed through onerror', async () => {
         const spy = await spyViaInstrumentOnError(() => {
-          window.onerror!({ foo: 'bar' } as any)
+          window.onerror!({ foo: 'bar' } as any, 'http://example.com', testLineNo, testColNo)
         })
 
         const [error, stack] = spy.calls.mostRecent().args

--- a/packages/core/src/domain/error/trackRuntimeError.ts
+++ b/packages/core/src/domain/error/trackRuntimeError.ts
@@ -2,15 +2,15 @@ import { instrumentMethod } from '../../tools/instrumentMethod'
 import type { Observable } from '../../tools/observable'
 import { clocksNow } from '../../tools/utils/timeUtils'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
-import { computeStackTrace, computeStackTraceFromOnErrorMessage } from '../../tools/stackTrace/computeStackTrace'
+import { computeStackTraceFromOnErrorMessage } from '../../tools/stackTrace/computeStackTrace'
 import { computeRawError, isError } from './error'
 import type { RawError } from './error.types'
 import { ErrorHandling, ErrorSource, NonErrorPrefix } from './error.types'
 
-export type UnhandledErrorCallback = (stackTrace: StackTrace, originalError?: any) => any
+export type UnhandledErrorCallback = (originalError: unknown, stackTrace?: StackTrace) => any
 
 export function trackRuntimeError(errorObservable: Observable<RawError>) {
-  const handleRuntimeError = (stackTrace: StackTrace, originalError?: any) => {
+  const handleRuntimeError = (originalError: unknown, stackTrace?: StackTrace) => {
     const rawError = computeRawError({
       stackTrace,
       originalError,
@@ -35,19 +35,15 @@ export function trackRuntimeError(errorObservable: Observable<RawError>) {
 export function instrumentOnError(callback: UnhandledErrorCallback) {
   return instrumentMethod(window, 'onerror', ({ parameters: [messageObj, url, line, column, errorObj] }) => {
     let stackTrace
-    if (isError(errorObj)) {
-      stackTrace = computeStackTrace(errorObj)
-    } else {
+    if (!isError(errorObj)) {
       stackTrace = computeStackTraceFromOnErrorMessage(messageObj, url, line, column)
     }
-    callback(stackTrace, errorObj ?? messageObj)
+    callback(errorObj ?? messageObj, stackTrace)
   })
 }
 
 export function instrumentUnhandledRejection(callback: UnhandledErrorCallback) {
   return instrumentMethod(window, 'onunhandledrejection', ({ parameters: [e] }) => {
-    const reason = e.reason || 'Empty reason'
-    const stack = computeStackTrace(reason)
-    callback(stack, reason)
+    callback(e.reason || 'Empty reason')
   })
 }

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -161,13 +161,20 @@ function tryToGetString(candidate: unknown, property: string) {
   return typeof value === 'string' ? value : undefined
 }
 
-export function computeStackTraceFromOnErrorMessage(messageObj: unknown, url?: string, line?: number, column?: number) {
-  const stack = [{ url, column, line }]
+export function computeStackTraceFromOnErrorMessage(
+  messageObj: unknown,
+  url?: string,
+  line?: number,
+  column?: number
+): StackTrace | undefined {
+  if (url === undefined) {
+    return
+  }
   const { name, message } = tryToParseMessage(messageObj)
   return {
     name,
     message,
-    stack,
+    stack: [{ url, column, line }],
   }
 }
 

--- a/packages/logs/src/domain/console/consoleCollection.spec.ts
+++ b/packages/logs/src/domain/console/consoleCollection.spec.ts
@@ -97,7 +97,7 @@ describe('console collection', () => {
       fingerprint: 'my-fingerprint',
       causes: undefined,
       handling: ErrorHandling.HANDLED,
-      kind: undefined,
+      kind: 'Error',
       message: undefined,
     })
   })
@@ -157,7 +157,7 @@ describe('console collection', () => {
         },
       ],
       fingerprint: undefined,
-      kind: undefined,
+      kind: 'Error',
       message: undefined,
     })
   })

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -3,7 +3,6 @@ import {
   clocksNow,
   computeRawError,
   ErrorHandling,
-  computeStackTrace,
   combine,
   createContextManager,
   ErrorSource,
@@ -11,7 +10,6 @@ import {
   sanitize,
   NonErrorPrefix,
   createHandlingStack,
-  isError,
 } from '@datadog/browser-core'
 
 import { isAuthorized, StatusType } from './logger/isAuthorized'
@@ -64,7 +62,6 @@ export class Logger {
 
     if (error !== undefined && error !== null) {
       const rawError = computeRawError({
-        stackTrace: isError(error) ? computeStackTrace(error) : undefined,
         originalError: error,
         nonErrorPrefix: NonErrorPrefix.PROVIDED,
         source: ErrorSource.LOGGER,

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -4,11 +4,9 @@ import {
   generateUUID,
   computeRawError,
   ErrorHandling,
-  computeStackTrace,
   Observable,
   trackRuntimeError,
   NonErrorPrefix,
-  isError,
   combine,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
@@ -51,9 +49,7 @@ export function doStartErrorCollection(lifeCycle: LifeCycle) {
 
   return {
     addError: ({ error, handlingStack, componentStack, startClocks, context: customerContext }: ProvidedError) => {
-      const stackTrace = isError(error) ? computeStackTrace(error) : undefined
       const rawError = computeRawError({
-        stackTrace,
         originalError: error,
         handlingStack,
         componentStack,

--- a/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
@@ -42,6 +42,8 @@ describe('trackConsoleError', () => {
       causes: undefined,
       context: undefined,
       originalError: error,
+      type: 'TypeError',
+      componentStack: undefined,
     })
   })
 
@@ -66,6 +68,8 @@ describe('trackConsoleError', () => {
       causes: undefined,
       context: undefined,
       originalError: error,
+      type: 'Error',
+      componentStack: undefined,
     })
   })
 })


### PR DESCRIPTION
## Motivation

Small refactors around errors to reduce maintenance, reduce bundle size, and potentially simplify generating error events from the `rum-react` plugin (cf "Enable web targets of mobile platforms" project)

## Changes

* compute the error stack trace in `computeRawError`, so we don’t have to compute it in most places
* use `computeRawError` everywhere (the only place missing was in `consoleObservable`)
* make sure we don’t generate unusable stack traces (from onerror)

## Test instructions

As this is mostly a refactor, the functional changes are limited, although we should have the error type for errors collected from console.error now.

Using `yarn dev` sandbox:

```js
DD_RUM.init({
  clientToken: 'xxx',
  applicationId: 'xxx',
})
DD_LOGS.init({
  clientToken: 'xxx',
  forwardErrorsToLogs: true,
})

console.error('This is an error message')
// should generate a RUM error with:
// * error.message "This is an error message"
// * no error.stack or error.type
// should generate a Logs error with:
// * message "This is an error message"
// * no error.stack or error.kind

console.error('foo', new Error('Error message'))
// should generate a RUM error with:
// * error.message "foo Error: Error message"
// * a error.stack
// * error.type "Error"
// should generate a Logs error with:
// * message "foo Error: Error message"
// * a error.stack
// * error.kind "Error"

setTimeout(() => {
  throw 'toto'
})
// should generate a RUM error with:
// * error.message 'Uncaught "toto"'
// * a error.stack
// * no error.type
// should generate a Logs error with:
// * message 'Uncaught "toto"'
// * a error.stack
// * no error.kind

```

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
