### PR TITLE
🐛️local e2e: allow to execute script from dev server

### DIFF
--- a/test/e2e/lib/framework/serverApps/mock.ts
+++ b/test/e2e/lib/framework/serverApps/mock.ts
@@ -97,7 +97,7 @@ export function createMockServerApp(servers: Servers, setup: string): MockServer
       'Content-Security-Policy',
       [
         `connect-src ${servers.intake.url} ${servers.base.url} ${servers.crossOrigin.url}`,
-        "script-src 'self' 'unsafe-inline'",
+        `script-src 'self' 'unsafe-inline'  ${DEV_SERVER_BASE_URL}`,
         'worker-src blob:',
       ].join(';')
     )
@@ -110,7 +110,7 @@ export function createMockServerApp(servers: Servers, setup: string): MockServer
       'Content-Security-Policy',
       [
         `connect-src ${servers.intake.url} ${servers.base.url} ${servers.crossOrigin.url}`,
-        "script-src 'self' 'unsafe-inline'",
+        `script-src 'self' 'unsafe-inline' ${DEV_SERVER_BASE_URL}`,
       ].join(';')
     )
     res.send(setup)


### PR DESCRIPTION
## Motivation

Fix local e2e execution.

Most of the scenarios are failing due to this error:

```
Refused to load the script 'http://localhost:8080/chunks/recorder-datadog-rum.js' 
because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". 
```

Regression introduced by https://github.com/DataDog/browser-sdk/pull/3488.

## Changes

Tweak CSPs to allow to execute script from dev server 

## Test instructions

Run e2e tests on your laptop

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
