### PR TITLE
🐛 [devext] fix "Use development bundle on NPM setup"

### DIFF
--- a/packages/logs/webpack.config.js
+++ b/packages/logs/webpack.config.js
@@ -5,7 +5,6 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
-    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'datadog-logs.js',
   })

--- a/packages/rum-slim/webpack.config.js
+++ b/packages/rum-slim/webpack.config.js
@@ -5,7 +5,6 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
-    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'datadog-rum-slim.js',
   })

--- a/packages/rum/webpack.config.js
+++ b/packages/rum/webpack.config.js
@@ -5,7 +5,6 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
-    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'datadog-rum.js',
   })

--- a/packages/worker/webpack.config.js
+++ b/packages/worker/webpack.config.js
@@ -5,7 +5,6 @@ const webpackBase = require('../../webpack.base')
 module.exports = (_env, argv) =>
   webpackBase({
     mode: argv.mode,
-    publicPath: argv.publicPath,
     entry: path.resolve(__dirname, 'src/entries/main.ts'),
     filename: 'worker.js',
   })

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -13,15 +13,13 @@ const webpackBase = require('../webpack.base')
 const { printLog, runMain } = require('./lib/executionUtils')
 
 const sandboxPath = path.join(__dirname, '../sandbox')
-
-// Development server configuration
-const DEFAULT_DEVELOPMENT_PORT = 8080
+const port = 8080
 
 runMain(() => {
   const app = express()
   app.use(createStaticSandboxApp())
   app.use('/react-app', createReactApp())
-  app.listen(DEFAULT_DEVELOPMENT_PORT, () => printLog(`Server listening on port ${DEFAULT_DEVELOPMENT_PORT}.`))
+  app.listen(port, () => printLog(`Server listening on port ${port}.`))
 })
 
 function createStaticSandboxApp() {
@@ -29,12 +27,7 @@ function createStaticSandboxApp() {
   app.use(cors())
   app.use(express.static(sandboxPath))
   for (const config of [rumConfig, logsConfig, rumSlimConfig, workerConfig]) {
-    app.use(
-      middleware(
-        // Set publicPath for development mode. Fixes issue when using the developer extension with NPM package override.
-        webpack(config(null, { mode: 'development', publicPath: `http://localhost:${DEFAULT_DEVELOPMENT_PORT}/` }))
-      )
-    )
+    app.use(middleware(webpack(config(null, { mode: 'development' }))))
   }
 
   // Redirect suffixed files
@@ -68,7 +61,6 @@ function createReactApp() {
           entry: `${sandboxPath}/react-app/main.tsx`,
           plugins: [new HtmlWebpackPlugin({ publicPath: '/react-app/' })],
           mode: 'development',
-          publicPath: `http://localhost:${DEFAULT_DEVELOPMENT_PORT}/`,
         })
       )
     )

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -5,7 +5,8 @@ const TerserPlugin = require('terser-webpack-plugin')
 const { buildEnvKeys, getBuildEnvValue } = require('./scripts/lib/buildEnv')
 
 const tsconfigPath = path.join(__dirname, 'tsconfig.webpack.json')
-module.exports = ({ entry, mode, publicPath, filename, types, keepBuildEnvVariables, plugins }) => ({
+
+module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins }) => ({
   entry,
   mode,
   output: {
@@ -18,7 +19,6 @@ module.exports = ({ entry, mode, publicPath, filename, types, keepBuildEnvVariab
         : // Include a content hash in chunk names in production.
           `chunks/[name]-[contenthash]-${filename}`,
     path: path.resolve('./bundle'),
-    publicPath,
   },
   target: ['web', 'es2018'],
   devtool: false,


### PR DESCRIPTION
## Motivation

Since v6, we lazy load some chunks (session replay, profiler) from the main SDK bundle. This broke the developer extension "Use development bundle on NPM setup" feature as we are loading the SDK code in an inline `<script>` tag and the Webpack runtime does not know from which URL it should load the chunks.

https://github.com/DataDog/browser-sdk/pull/3488 fixed this issue by configuring Webpack to hardcode the dev server URL (`http://localhost:8080`) in the development bundle.

Unfortunately, it turns out doing this broke local e2e test execution as (since #3420) the SDK code is loaded through [a "proxy"](https://github.com/DataDog/browser-sdk/blob/8f0b943a179d2b3e5c3a4230b3264074bac54c65/test/e2e/lib/framework/serverApps/mock.ts#L126) and the dev server (`http://localhost:8080`) isn't allowed by [our default CSP policy](https://github.com/DataDog/browser-sdk/blob/8f0b943a179d2b3e5c3a4230b3264074bac54c65/test/e2e/lib/framework/serverApps/mock.ts#L98-L102), so the chunk fails to load.

To workaround this issue, we could [adjust our CSP policy](https://github.com/DataDog/browser-sdk/pull/3500). But it might be better to keep the dirt contained and fix the original issue in the extension instead of doing things that forces us to adjust our setup in unexpected places.

## Changes

* Revert https://github.com/DataDog/browser-sdk/pull/3488
* In the extension, rewrite the loaded SDK code to let Webpack know about the script url.

## Test instructions

Using the extension, enable "Use development bundle on NPM setup". No error should be shown in the console (specifically, no "Automatic publicPath is not supported in this browser"). The SDK should be replaced with the dev bundle.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
