### PR TITLE
⚗️️[RUM-9672] trace baggage: rename `usr` to `user`

### DIFF
--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -281,13 +281,13 @@ describe('tracer', () => {
         return xhr.headers.baggage
       }
 
-      it('should add usr.id, account.id and session.id to baggage header when feature is enabled and propagateTraceBaggage is true', () => {
+      it('should add user.id, account.id and session.id to baggage header when feature is enabled and propagateTraceBaggage is true', () => {
         const baggage = traceRequestAndGetBaggageHeader({
           initConfiguration: {
             propagateTraceBaggage: true,
           },
         })
-        expect(baggage).toEqual('session.id=session-id,usr.id=1234,account.id=5678')
+        expect(baggage).toEqual('session.id=session-id,user.id=1234,account.id=5678')
       })
 
       it('should not add baggage header when propagateTraceBaggage is false', () => {
@@ -306,7 +306,7 @@ describe('tracer', () => {
           },
           userId: '1234, 😀',
         })
-        expect(baggage).toBe('session.id=session-id,usr.id=1234%2C%20%F0%9F%98%80,account.id=5678')
+        expect(baggage).toBe('session.id=session-id,user.id=1234%2C%20%F0%9F%98%80,account.id=5678')
       })
 
       it('skips non-string context values', () => {

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -233,7 +233,7 @@ function makeTracingHeaders(
 
     const userId = userContext.getContext().id
     if (typeof userId === 'string') {
-      baggageItems['usr.id'] = userId
+      baggageItems['user.id'] = userId
     }
 
     const accountId = accountContext.getContext().id

--- a/test/e2e/scenario/rum/tracing.scenario.ts
+++ b/test/e2e/scenario/rum/tracing.scenario.ts
@@ -116,7 +116,7 @@ test.describe('tracing', () => {
     expect(headers['x-datadog-origin']).toBe('rum')
     expect(headers['traceparent']).toMatch(/^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-01$/)
     if (withBaggage) {
-      expect(headers['baggage']).toMatch(/^session.id=.*,usr.id=.*,account.id=.*$/)
+      expect(headers['baggage']).toMatch(/^session.id=.*,user.id=.*,account.id=.*$/)
     } else {
       expect(headers['baggage']).not.toBeDefined()
     }


### PR DESCRIPTION
## Motivation

Reflect latest spec changes.

## Changes

- add a scenario for baggage header propagation
- rename usr to user

## Test instructions

Enable trace baggage propagation:

```
propagateTraceBaggage: true,
enableExperimentalFeatures: ['user_account_trace_header']
```

Looking at a traced request headers:

```diff
- Baggage: session.id=XXX,usr.id=YYY,account.id=ZZZ
+ Baggage: session.id=XXX,user.id=YYY,account.id=ZZZ
```

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
