### PR TITLE
:package: [PANA 2591] Bump replay sandbox to 0.119.0 in developer extension

### DIFF
--- a/developer-extension/src/panel/sessionReplayPlayer/startSessionReplayPlayer.ts
+++ b/developer-extension/src/panel/sessionReplayPlayer/startSessionReplayPlayer.ts
@@ -17,7 +17,7 @@ export type SessionReplayPlayerState = {
 const sandboxOrigin = 'https://session-replay-datadoghq.com'
 // To follow web-ui development, this version will need to be manually updated from time to time.
 // When doing that, be sure to update types and implement any protocol changes.
-const sandboxVersion = '0.116.0'
+const sandboxVersion = '0.119.0'
 const sandboxParams = new URLSearchParams({
   staticContext: JSON.stringify({
     tabId: 'xxx',


### PR DESCRIPTION
## Motivation

https://datadoghq.atlassian.net/browse/PANA-2591
Update the Session Replay Sandbox to 0.119.0

## Changes

Sandbox 0.119.0 improves rendering of components using ShadowDOM.

## Test instructions

Install the developer extension locally.
Inspect the replay tab, you should see version `0.119.0` in the sandbox URL: 
![image](https://github.com/user-attachments/assets/2744f056-161a-4045-8553-6eb621cd2bff)


## Checklist
- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
