### PR TITLE
Add experimental feature flag to enable intake request tracking

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -14,9 +14,10 @@ import { objectHasValue } from './utils/objectUtils'
 
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
-  WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  USER_ACCOUNT_TRACE_HEADER = 'user_account_trace_header',
   PROFILING = 'profiling',
+  TRACK_INTAKE_REQUESTS = 'track_intake_requests',
+  USER_ACCOUNT_TRACE_HEADER = 'user_account_trace_header',
+  WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
@@ -1,4 +1,5 @@
 import { type Duration, type RelativeTime, type ServerDuration } from '@datadog/browser-core'
+import { addExperimentalFeatures, ExperimentalFeature, resetExperimentalFeatures } from '@datadog/browser-core'
 import { RumPerformanceEntryType, type RumPerformanceResourceTiming } from '../../browser/performanceObservable'
 import {
   MAX_ATTRIBUTE_VALUE_CHAR_LENGTH,
@@ -292,6 +293,15 @@ describe('shouldTrackResource', () => {
   const intakeParameters = 'ddsource=browser&ddtags=sdk_version'
   it('should exclude requests on intakes endpoints', () => {
     expect(isAllowedRequestUrl(`https://rum-intake.com/v1/input/abcde?${intakeParameters}`)).toBe(false)
+  })
+
+  it('should allow requests on intake endpoints when TRACK_INTAKE_REQUESTS is enabled', () => {
+    try {
+      addExperimentalFeatures([ExperimentalFeature.TRACK_INTAKE_REQUESTS])
+      expect(isAllowedRequestUrl(`https://rum-intake.com/v1/input/abcde?${intakeParameters}`)).toBe(true)
+    } finally {
+      resetExperimentalFeatures()
+    }
   })
 
   it('should exclude requests on intakes endpoints with different client parameters', () => {

--- a/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.spec.ts
@@ -1,5 +1,6 @@
 import { type Duration, type RelativeTime, type ServerDuration } from '@datadog/browser-core'
-import { addExperimentalFeatures, ExperimentalFeature, resetExperimentalFeatures } from '@datadog/browser-core'
+import { ExperimentalFeature } from '@datadog/browser-core'
+import { mockExperimentalFeatures } from '@datadog/browser-core/test'
 import { RumPerformanceEntryType, type RumPerformanceResourceTiming } from '../../browser/performanceObservable'
 import {
   MAX_ATTRIBUTE_VALUE_CHAR_LENGTH,
@@ -296,12 +297,8 @@ describe('shouldTrackResource', () => {
   })
 
   it('should allow requests on intake endpoints when TRACK_INTAKE_REQUESTS is enabled', () => {
-    try {
-      addExperimentalFeatures([ExperimentalFeature.TRACK_INTAKE_REQUESTS])
-      expect(isAllowedRequestUrl(`https://rum-intake.com/v1/input/abcde?${intakeParameters}`)).toBe(true)
-    } finally {
-      resetExperimentalFeatures()
-    }
+    mockExperimentalFeatures([ExperimentalFeature.TRACK_INTAKE_REQUESTS])
+    expect(isAllowedRequestUrl(`https://rum-intake.com/v1/input/abcde?${intakeParameters}`)).toBe(true)
   })
 
   it('should exclude requests on intakes endpoints with different client parameters', () => {

--- a/packages/rum-core/src/domain/resource/resourceUtils.ts
+++ b/packages/rum-core/src/domain/resource/resourceUtils.ts
@@ -7,6 +7,8 @@ import {
   ResourceType,
   toServerDuration,
   isIntakeUrl,
+  isExperimentalFeatureEnabled,
+  ExperimentalFeature,
 } from '@datadog/browser-core'
 
 import type { RumPerformanceResourceTiming } from '../../browser/performanceObservable'
@@ -221,7 +223,7 @@ export function computeResourceEntrySize(entry: RumPerformanceResourceTiming) {
 }
 
 export function isAllowedRequestUrl(url: string) {
-  return url && !isIntakeUrl(url)
+  return url && (!isIntakeUrl(url) || isExperimentalFeatureEnabled(ExperimentalFeature.TRACK_INTAKE_REQUESTS))
 }
 
 const DATA_URL_REGEX = /data:(.+)?(;base64)?,/g


### PR DESCRIPTION
## Motivation

To debug network-level issues with sending data to the intake, it would be useful to optionally record the network requests, instead of filtering them out as we do now.

## Changes

This PR adds an experimental feature flag that enables recording of network requests to the intake.

## Test instructions

It's straightforward to test this feature locally by enabling the new experimental feature flag using the developer extension.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
