### PR TITLE
[RUM Profiler] Use clocks for start/end time

### DIFF
--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -296,7 +296,7 @@ export function createRumProfiler(
 
       // Store Long Task entry, which is a lightweight version of the PerformanceEntry
       instance.longTasks.push({
-        id: getLongTaskId({ startClocks }),
+        id: getLongTaskId(startClocks.relative),
         duration: entry.duration as Duration,
         entryType: entry.entryType,
         startClocks,

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -1,3 +1,4 @@
+import type { RelativeTime } from '@datadog/browser-core'
 import {
   addEventListener,
   clearTimeout,
@@ -6,6 +7,8 @@ import {
   monitorError,
   display,
   getGlobalObject,
+  relativeNow,
+  relativeToClocks,
 } from '@datadog/browser-core'
 
 import type { LifeCycle, RumConfiguration, RumSessionManager, ViewHistoryEntry } from '@datadog/browser-rum-core'
@@ -168,7 +171,7 @@ export function createRumProfiler(
     // Kick-off the new instance
     instance = {
       state: 'running',
-      startTime: performance.now(),
+      startTime: relativeNow(),
       profiler,
       timeoutId: setTimeout(startNextProfilerInstance, profilerConfiguration.collectIntervalMs),
       longTasks: [],
@@ -206,7 +209,7 @@ export function createRumProfiler(
     await lastInstance.profiler
       .stop()
       .then((trace) => {
-        const endTime = performance.now()
+        const endTime = relativeNow()
 
         const hasLongTasks = longTasks.length > 0
         const isBelowDurationThreshold = endTime - startTime < profilerConfiguration.minProfileDurationMs
@@ -291,7 +294,7 @@ export function createRumProfiler(
         id: getLongTaskId(entry),
         duration: entry.duration,
         entryType: entry.entryType,
-        startTime: entry.startTime,
+        startTime: relativeToClocks(entry.startTime as RelativeTime).relative,
       })
     }
   }

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -214,7 +214,8 @@ export function createRumProfiler(
         const endClocks = clocksNow()
 
         const hasLongTasks = longTasks.length > 0
-        const isBelowDurationThreshold = elapsed(startClocks.timeStamp, endClocks.timeStamp) < profilerConfiguration.minProfileDurationMs
+        const isBelowDurationThreshold =
+          elapsed(startClocks.timeStamp, endClocks.timeStamp) < profilerConfiguration.minProfileDurationMs
         const isBelowSampleThreshold = getNumberOfSamples(trace.samples) < profilerConfiguration.minNumberOfSamples
 
         if (!hasLongTasks && (isBelowDurationThreshold || isBelowSampleThreshold)) {

--- a/packages/rum/src/domain/profiling/profilingCorrelation.ts
+++ b/packages/rum/src/domain/profiling/profilingCorrelation.ts
@@ -1,6 +1,6 @@
 import type { RawRumEvent } from '@datadog/browser-rum-core'
 import { RumEventType } from '@datadog/browser-rum-core'
-
+import type { RelativeTime } from '@datadog/browser-core'
 import { setLongTaskId } from './utils/longTaskRegistry'
 
 /**
@@ -14,7 +14,7 @@ export function mayStoreLongTaskIdForProfilerCorrelation({
   startTime,
 }: {
   rawRumEvent: RawRumEvent
-  startTime: number
+  startTime: RelativeTime
 }) {
   if (rawRumEvent.type !== RumEventType.LONG_TASK) {
     return

--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -1,9 +1,4 @@
-import {
-  addTelemetryDebug,
-  currentDrift,
-  type EndpointBuilder,
-  type Payload,
-} from '@datadog/browser-core'
+import { addTelemetryDebug, currentDrift, type EndpointBuilder, type Payload } from '@datadog/browser-core'
 import type { RumProfilerTrace } from '../types'
 import { getLongTaskId } from '../utils/longTaskRegistry'
 

--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -1,7 +1,6 @@
 import {
   addTelemetryDebug,
   currentDrift,
-  relativeToClocks,
   type EndpointBuilder,
   type Payload,
 } from '@datadog/browser-core'

--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -135,7 +135,7 @@ function buildProfileEventAttributes(
     }
   }
   const longTaskIds: string[] = profilerTrace.longTasks
-    .map((longTask) => getLongTaskId(longTask))
+    .map((longTask) => getLongTaskId(longTask.startClocks.relative))
     .filter((id) => id !== undefined)
 
   if (longTaskIds.length) {

--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -64,14 +64,11 @@ function buildProfileEvent(
   const profileAttributes = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
   const profileEventTags = buildProfileEventTags(tags)
 
-  const profilerStartClocks = relativeToClocks(profilerTrace.startTime)
-  const profilerEndClocks = relativeToClocks(profilerTrace.endTime)
-
   const profileEvent: ProfileEvent = {
     ...profileAttributes,
     attachments: ['wall-time.json'],
-    start: new Date(profilerStartClocks.timeStamp).toISOString(),
-    end: new Date(profilerEndClocks.timeStamp).toISOString(),
+    start: new Date(profilerTrace.startClocks.timeStamp).toISOString(),
+    end: new Date(profilerTrace.endClocks.timeStamp).toISOString(),
     family: 'chrome',
     runtime: 'chrome',
     format: 'json',

--- a/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
+++ b/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
@@ -1,10 +1,10 @@
-import type { TimeoutId, RelativeTime } from '@datadog/browser-core'
+import type { TimeoutId, RelativeTime, ClocksState, Duration } from '@datadog/browser-core'
 import type { ViewHistoryEntry } from '@datadog/browser-rum-core'
 import type { ProfilerTrace, Profiler } from './profilerApi.types'
 
 export interface RumViewEntry {
   /** Detected start time of view */
-  readonly startTime: RelativeTime
+  readonly startClocks: ClocksState
   /** RUM view id */
   readonly viewId: string
   /** RUM view name */
@@ -15,11 +15,11 @@ export interface RUMProfilerLongTaskEntry {
   /** RUM Long Task id */
   readonly id: string | undefined
   /** RUM Long Task duration */
-  readonly duration: number
+  readonly duration: Duration
   /** RUM Long Task entry type */
   readonly entryType: string
   /** RUM Long Task start time */
-  readonly startTime: RelativeTime
+  readonly startClocks: ClocksState
 }
 
 /**
@@ -34,11 +34,11 @@ export interface RumProfilerEnrichmentData {
 
 export interface RumProfilerTrace extends ProfilerTrace, RumProfilerEnrichmentData {
   /** High resolution time when profiler trace started, relative to the profiling session's time origin */
-  readonly startTime: RelativeTime
+  readonly startClocks: ClocksState
   /** High resolution time when profiler trace ended, relative to the profiling session's time origin */
-  readonly endTime: RelativeTime
+  readonly endClocks: ClocksState
   /** Time origin of the profiling session */
-  readonly timeOrigin: number
+  readonly clocksOrigin: ClocksState
   /** Sample interval in milliseconds */
   readonly sampleInterval: number
 }
@@ -66,7 +66,7 @@ export interface RumProfilerRunningInstance extends RumProfilerEnrichmentData {
   /** Current profiler instance */
   readonly profiler: Profiler
   /** High resolution time when profiler session started */
-  readonly startTime: RelativeTime
+  readonly startClocks: ClocksState
   /** Timeout id to stop current session */
   readonly timeoutId: TimeoutId
   /** Clean-up tasks to execute after running the Profiler */

--- a/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
+++ b/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
@@ -1,4 +1,4 @@
-import type { TimeoutId, RelativeTime, ClocksState, Duration } from '@datadog/browser-core'
+import type { TimeoutId, ClocksState, Duration } from '@datadog/browser-core'
 import type { ViewHistoryEntry } from '@datadog/browser-rum-core'
 import type { ProfilerTrace, Profiler } from './profilerApi.types'
 

--- a/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
+++ b/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
@@ -1,10 +1,10 @@
-import type { TimeoutId } from '@datadog/browser-core'
+import type { TimeoutId, RelativeTime } from '@datadog/browser-core'
 import type { ViewHistoryEntry } from '@datadog/browser-rum-core'
 import type { ProfilerTrace, Profiler } from './profilerApi.types'
 
 export interface RumViewEntry {
   /** Detected start time of view */
-  readonly startTime: DOMHighResTimeStamp
+  readonly startTime: RelativeTime
   /** RUM view id */
   readonly viewId: string
   /** RUM view name */
@@ -19,7 +19,7 @@ export interface RUMProfilerLongTaskEntry {
   /** RUM Long Task entry type */
   readonly entryType: string
   /** RUM Long Task start time */
-  readonly startTime: DOMHighResTimeStamp
+  readonly startTime: RelativeTime
 }
 
 /**
@@ -34,9 +34,9 @@ export interface RumProfilerEnrichmentData {
 
 export interface RumProfilerTrace extends ProfilerTrace, RumProfilerEnrichmentData {
   /** High resolution time when profiler trace started, relative to the profiling session's time origin */
-  readonly startTime: DOMHighResTimeStamp
+  readonly startTime: RelativeTime
   /** High resolution time when profiler trace ended, relative to the profiling session's time origin */
-  readonly endTime: DOMHighResTimeStamp
+  readonly endTime: RelativeTime
   /** Time origin of the profiling session */
   readonly timeOrigin: number
   /** Sample interval in milliseconds */
@@ -66,7 +66,7 @@ export interface RumProfilerRunningInstance extends RumProfilerEnrichmentData {
   /** Current profiler instance */
   readonly profiler: Profiler
   /** High resolution time when profiler session started */
-  readonly startTime: DOMHighResTimeStamp
+  readonly startTime: RelativeTime
   /** Timeout id to stop current session */
   readonly timeoutId: TimeoutId
   /** Clean-up tasks to execute after running the Profiler */


### PR DESCRIPTION
## Motivation

We are not using the exact same clocks when collecting long tasks (& LoAF) in both the Browser SDK and the RUM Profiler. 
Let's have the RUM Profiler use the same clocks.

## Changes

- Relative time should now use `RelativeTime` types.
- Make use of clocks helpers to get corrected relative and absolute time.
- Save the drift for debugging purposes.

## Test instructions

- No behavior change expected. Only start/end time should be slightly updated, as they now take the drift into account.


## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
