### PR TITLE
✨ Add developer extension support for replay sandbox local development

### DIFF
--- a/developer-extension/src/common/extension.types.ts
+++ b/developer-extension/src/common/extension.types.ts
@@ -47,6 +47,7 @@ export type EventCollectionStrategy = 'sdk' | 'requests'
 
 export interface Settings {
   useDevBundles: DevBundlesOverride
+  useDevReplaySandbox: boolean
   useRumSlim: boolean
   blockIntakeRequests: boolean
   autoFlush: boolean

--- a/developer-extension/src/common/packagesUrlConstants.ts
+++ b/developer-extension/src/common/packagesUrlConstants.ts
@@ -2,3 +2,12 @@ export const DEV_SERVER_ORIGIN = 'http://localhost:8080'
 export const DEV_LOGS_URL = `${DEV_SERVER_ORIGIN}/datadog-logs.js`
 export const DEV_RUM_SLIM_URL = `${DEV_SERVER_ORIGIN}/datadog-rum-slim.js`
 export const DEV_RUM_URL = `${DEV_SERVER_ORIGIN}/datadog-rum.js`
+
+// To follow web-ui development, this version will need to be manually updated from time to time.
+// When doing that, be sure to update types and implement any protocol changes.
+export const PROD_REPLAY_SANDBOX_VERSION = '0.119.0'
+export const PROD_REPLAY_SANDBOX_ORIGIN = 'https://session-replay-datadoghq.com'
+export const PROD_REPLAY_SANDBOX_URL = `${PROD_REPLAY_SANDBOX_ORIGIN}/${PROD_REPLAY_SANDBOX_VERSION}/index.html`
+
+export const DEV_REPLAY_SANDBOX_ORIGIN = 'https://localhost:8443'
+export const DEV_REPLAY_SANDBOX_URL = `${DEV_REPLAY_SANDBOX_ORIGIN}/static-apps/replay-sandbox/public/index.html`

--- a/developer-extension/src/content-scripts/main.ts
+++ b/developer-extension/src/content-scripts/main.ts
@@ -1,6 +1,6 @@
 import type { Settings } from '../common/extension.types'
 import { EventListeners } from '../common/eventListeners'
-import { DEV_LOGS_URL, DEV_RUM_URL } from '../common/packagesUrlConstants'
+import { DEV_LOGS_URL, DEV_RUM_SLIM_URL, DEV_RUM_URL } from '../common/packagesUrlConstants'
 import { SESSION_STORAGE_SETTINGS_KEY } from '../common/sessionKeyConstant'
 
 declare global {
@@ -46,7 +46,7 @@ function main() {
     }
 
     if (settings.useDevBundles === 'npm') {
-      injectDevBundle(DEV_RUM_URL, ddRumGlobal)
+      injectDevBundle(settings.useRumSlim ? DEV_RUM_SLIM_URL : DEV_RUM_URL, ddRumGlobal)
       injectDevBundle(DEV_LOGS_URL, ddLogsGlobal)
     }
   }

--- a/developer-extension/src/panel/components/tabs/replayTab.tsx
+++ b/developer-extension/src/panel/components/tabs/replayTab.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Checkbox } from '@mantine/core'
+import { Button, Flex, Checkbox, Badge } from '@mantine/core'
 import React, { useEffect, useRef, useState } from 'react'
 import { TabBase } from '../tabBase'
 import type { SessionReplayPlayerState } from '../../sessionReplayPlayer/startSessionReplayPlayer'
@@ -7,6 +7,7 @@ import { evalInWindow } from '../../evalInWindow'
 import { createLogger } from '../../../common/logger'
 import { Alert } from '../alert'
 import { useSdkInfos } from '../../hooks/useSdkInfos'
+import { useSettings } from '../../hooks/useSettings'
 import * as classes from './replayTab.module.css'
 
 const logger = createLogger('replayTab')
@@ -33,6 +34,7 @@ export function ReplayTab() {
 }
 
 function Player() {
+  const [{ useDevReplaySandbox }] = useSettings()
   const frameRef = useRef<HTMLIFrameElement | null>(null)
   const [playerState, setPlayerState] = useState<SessionReplayPlayerState>({
     status: 'loading',
@@ -42,8 +44,8 @@ function Player() {
   const playerRef = useRef<ReturnType<typeof startSessionReplayPlayer>>(null)
 
   useEffect(() => {
-    playerRef.current = startSessionReplayPlayer(frameRef.current!, setPlayerState)
-  }, [])
+    playerRef.current = startSessionReplayPlayer(frameRef.current!, setPlayerState, useDevReplaySandbox)
+  }, [useDevReplaySandbox])
 
   const downloadRecords = () => {
     if (!playerRef.current?.getRecords) {
@@ -67,29 +69,32 @@ function Player() {
   return (
     <TabBase
       top={
-        <Flex justify="space-between" align="center" w="100%">
-          <Flex align="center" gap="md">
-            <Button onClick={generateFullSnapshot} color="orange">
-              Force Full Snapshot
-            </Button>
-            <Checkbox
-              label="Exclude mouse movements"
-              checked={playerState.excludeMouseMovements}
-              onChange={(event) => playerRef.current?.setExcludeMouseMovements(event.currentTarget.checked)}
-            />
+        <Flex>
+          <Flex justify="space-between" align="center" flex="1">
+            <Flex align="center" gap="md">
+              <Button onClick={generateFullSnapshot} color="orange">
+                Force Full Snapshot
+              </Button>
+              <Checkbox
+                label="Exclude mouse movements"
+                checked={playerState.excludeMouseMovements}
+                onChange={(event) => playerRef.current?.setExcludeMouseMovements(event.currentTarget.checked)}
+              />
+            </Flex>
+            <Flex align="center" gap="xs">
+              <div>Records applied: {playerState.recordCount}</div>
+              <Button
+                onClick={downloadRecords}
+                variant="subtle"
+                disabled={playerState.recordCount === 0}
+                title="Download records as JSON"
+                p="xs"
+              >
+                📥
+              </Button>
+            </Flex>
           </Flex>
-          <Flex align="center" gap="xs">
-            <div>Records applied: {playerState.recordCount}</div>
-            <Button
-              onClick={downloadRecords}
-              variant="subtle"
-              disabled={playerState.recordCount === 0}
-              title="Download records as JSON"
-              p="xs"
-            >
-              📥
-            </Button>
-          </Flex>
+          <Flex align="center">{useDevReplaySandbox ? <Badge color="blue">Dev</Badge> : <></>}</Flex>
         </Flex>
       }
     >

--- a/developer-extension/src/panel/components/tabs/settingsTab.tsx
+++ b/developer-extension/src/panel/components/tabs/settingsTab.tsx
@@ -1,5 +1,6 @@
-import { Badge, Box, Checkbox, Code, Group, Space, Text, SegmentedControl } from '@mantine/core'
+import { Badge, Box, Checkbox, Code, Group, Space, Switch, Text, SegmentedControl, Accordion } from '@mantine/core'
 import React from 'react'
+import { DEV_LOGS_URL, DEV_REPLAY_SANDBOX_URL } from '../../../common/packagesUrlConstants'
 import { DevServerStatus, useDevServerStatus } from '../../hooks/useDevServerStatus'
 import { useSettings } from '../../hooks/useSettings'
 import { Columns } from '../columns'
@@ -7,10 +8,12 @@ import { TabBase } from '../tabBase'
 import type { DevBundlesOverride, EventCollectionStrategy } from '../../../common/extension.types'
 
 export function SettingsTab() {
-  const devServerStatus = useDevServerStatus()
+  const sdkDevServerStatus = useDevServerStatus(DEV_LOGS_URL)
+  const replayDevServerStatus = useDevServerStatus(DEV_REPLAY_SANDBOX_URL)
   const [
     {
       useDevBundles,
+      useDevReplaySandbox,
       useRumSlim,
       blockIntakeRequests,
       preserveEvents,
@@ -25,66 +28,150 @@ export function SettingsTab() {
     <TabBase>
       <div className="dd-privacy-allow">
         <Columns>
-          <Columns.Column title="Request interception">
-            <SettingItem
-              input={
-                <Group>
-                  <Text>Use development bundles:</Text>
-                  <SegmentedControl
-                    color="violet"
-                    value={useDevBundles || 'No'}
-                    size="xs"
-                    data={[
-                      'No',
-                      { value: 'cdn', label: 'On CDN setup' },
-                      { value: 'npm', label: 'On NPM setup (experimental)' },
-                    ]}
-                    onChange={(value) =>
-                      setSetting('useDevBundles', value === 'No' ? false : (value as DevBundlesOverride))
+          <Columns.Column title="Overrides">
+            <Accordion defaultValue="browser-sdk">
+              <Accordion.Item key="browser-sdk" value="browser-sdk">
+                <Accordion.Control>
+                  <Group>
+                    <Text>Browser SDK</Text>
+                    <Box style={{ marginLeft: 'auto' }}>
+                      {sdkDevServerStatus === DevServerStatus.AVAILABLE && useDevBundles ? (
+                        <Badge color="blue">Overridden</Badge>
+                      ) : sdkDevServerStatus === DevServerStatus.AVAILABLE ? (
+                        <Badge color="green">Available</Badge>
+                      ) : sdkDevServerStatus === DevServerStatus.CHECKING ? (
+                        <Badge color="yellow">Checking...</Badge>
+                      ) : (
+                        <Badge color="red">Unavailable</Badge>
+                      )}
+                    </Box>
+                  </Group>
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <Box>
+                    Use the local development version of the browser SDK. The development server must be running; to
+                    start it, run <Code>yarn dev</Code>.
+                  </Box>
+
+                  <Space h="md" />
+
+                  <SettingItem
+                    input={
+                      <Group>
+                        <Text>Override strategy:</Text>
+                        <SegmentedControl
+                          color="violet"
+                          value={useDevBundles || 'off'}
+                          size="xs"
+                          data={[
+                            { value: 'off', label: 'Off' },
+                            { value: 'cdn', label: 'Redirect' },
+                            { value: 'npm', label: 'Inject' },
+                          ]}
+                          onChange={(value) =>
+                            setSetting('useDevBundles', value === 'off' ? false : (value as DevBundlesOverride))
+                          }
+                        />
+                      </Group>
+                    }
+                    description={
+                      <>
+                        Choose an override strategy. Network request redirection is reliable, but only works for CDN
+                        setups. Injecting the bundle into the page can work for both CDN and NPM setups, but it's not
+                        always reliable.
+                      </>
                     }
                   />
-                  {devServerStatus === DevServerStatus.AVAILABLE ? (
-                    <Badge color="green">Available</Badge>
-                  ) : devServerStatus === DevServerStatus.CHECKING ? (
-                    <Badge color="yellow">Checking...</Badge>
-                  ) : (
-                    <Badge color="red">Unavailable</Badge>
-                  )}
-                </Group>
-              }
-              description={
-                <>
-                  Overrides bundles with local development bundles served by the Browser SDK development server. To
-                  start the development server, run <Code>yarn dev</Code> in the Browser SDK root folder.
-                </>
-              }
-            />
 
-            <SettingItem
-              input={
-                <Checkbox
-                  label="Use RUM Slim"
-                  checked={useRumSlim}
-                  onChange={(e) => setSetting('useRumSlim', isChecked(e.target))}
-                  color="violet"
-                />
-              }
-              description={
-                <>If the page is using the RUM CDN bundle, this bundle will be replaced by the RUM Slim CDN bundle.</>
-              }
-            />
+                  <SettingItem
+                    input={
+                      <Group>
+                        <Text>SDK variant:</Text>
+                        <SegmentedControl
+                          color="violet"
+                          value={useRumSlim ? 'rum-slim' : 'rum'}
+                          size="xs"
+                          data={[
+                            { value: 'rum', label: 'RUM' },
+                            { value: 'rum-slim', label: 'RUM Slim' },
+                          ]}
+                          onChange={(value) => {
+                            setSetting('useRumSlim', value === 'rum-slim')
+                          }}
+                        />
+                      </Group>
+                    }
+                    description={<>Choose an SDK variant. Session replay features won't work with the slim version.</>}
+                  />
+                </Accordion.Panel>
+              </Accordion.Item>
 
-            <SettingItem
-              input={
-                <Checkbox
-                  label="Block intake requests"
-                  checked={blockIntakeRequests}
-                  onChange={(e) => setSetting('blockIntakeRequests', isChecked(e.target))}
-                  color="violet"
-                />
-              }
-              description={<>Block requests made to the intake, preventing any data to be sent to Datadog.</>}
-            />
+              <Accordion.Item key="replay-sandbox" value="replay-sandbox">
+                <Accordion.Control>
+                  <Group>
+                    <Text>Live replay</Text>
+                    <Box style={{ marginLeft: 'auto' }}>
+                      {replayDevServerStatus === DevServerStatus.AVAILABLE && useDevReplaySandbox ? (
+                        <Badge color="blue">Overridden</Badge>
+                      ) : replayDevServerStatus === DevServerStatus.AVAILABLE ? (
+                        <Badge color="green">Available</Badge>
+                      ) : replayDevServerStatus === DevServerStatus.CHECKING ? (
+                        <Badge color="yellow">Checking...</Badge>
+                      ) : (
+                        <Badge color="red">Unavailable</Badge>
+                      )}
+                    </Box>
+                  </Group>
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <Box>
+                    Use the Datadog-internal local development version of the live replay sandbox. The development
+                    server must be running; to start it, run
+                    <Code>yarn dev</Code>.
+                  </Box>
+
+                  <Space h="md" />
+
+                  <SettingItem
+                    input={
+                      <Switch
+                        label="Override the live replay sandbox"
+                        checked={!!useDevReplaySandbox}
+                        onChange={(event) => setSetting('useDevReplaySandbox', event.currentTarget.checked)}
+                        color="violet"
+                      />
+                    }
+                    description={<>Activate to use the local development version of the live replay sandbox.</>}
+                  />
+                </Accordion.Panel>
+              </Accordion.Item>
+
+              <Accordion.Item key="intake-requests" value="intake-requests">
+                <Accordion.Control>
+                  <Group>
+                    <Text>Intake requests</Text>
+                    <Box style={{ marginLeft: 'auto' }}>
+                      {blockIntakeRequests ? <Badge color="blue">Blocked</Badge> : <Badge color="green">Allowed</Badge>}
+                    </Box>
+                  </Group>
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <SettingItem
+                    input={
+                      <Switch
+                        label="Block intake requests"
+                        checked={blockIntakeRequests}
+                        onChange={(event) => setSetting('blockIntakeRequests', event.currentTarget.checked)}
+                        color="violet"
+                      />
+                    }
+                    description={
+                      <>Block requests made to the intake, preventing any data from being sent to Datadog.</>
+                    }
+                  />
+                </Accordion.Panel>
+              </Accordion.Item>
+            </Accordion>
           </Columns.Column>
 
           <Columns.Column title="Events list">

--- a/developer-extension/src/panel/hooks/useSettings.ts
+++ b/developer-extension/src/panel/hooks/useSettings.ts
@@ -9,6 +9,7 @@ const logger = createLogger('useSettings')
 
 const DEFAULT_SETTINGS: Readonly<Settings> = {
   useDevBundles: false,
+  useDevReplaySandbox: false,
   useRumSlim: false,
   blockIntakeRequests: false,
   autoFlush: false,


### PR DESCRIPTION
## Motivation

The development experience for session replay is less than ideal right now. When you're working on a session replay feature that involves changes to both the browser SDK and the session replay sandbox, there's no easy way to preview the effect of those changes on a live web page. This limits the pace at which we can make progress.

## Changes

This PR adds the ability to use the local development version of the session replay sandbox in the Live Replay tab of the developer extension, using an interface similar to the one we use now for overriding the browser SDK bundle. By overriding both the browser SDK bundle and the session replay sandbox simultaneously, you can preview the end-to-end behavior of new session replay features on a live web page.

To support this functional change, I've reworked the UI of the Settings tab of the developer extension a bit. The left column is now called "Overrides", and it contains an accordion UI with three sections: one for the browser SDK, one for the live replay feature, and one for requests to the intake. Here's what the new version of the Settings tab looks like when you first open it:

<img width="954" alt="Screenshot 2025-04-30 at 17 41 22" src="https://github.com/user-attachments/assets/22d980d0-716d-4a9b-a6a1-8a2d116bf4fc" />

Here's what the live replay section of the accordion looks like when you expand it:

<img width="338" alt="Screenshot 2025-04-30 at 17 41 42" src="https://github.com/user-attachments/assets/a25d0825-86a9-4dea-907b-f64d1d4fd121" />

Here's the intake requests section:

<img width="339" alt="Screenshot 2025-04-30 at 17 57 43" src="https://github.com/user-attachments/assets/17a05653-e056-4d09-9b75-c2da55c6f96d" />

Note that both the browser SDK and live replay sections have an enhanced version of the badge we use to report the presence of the development server. In addition to reporting when the development server is unavailable or available, there's now a new state that clearly indicates when overriding is active. The intake requests section also now has a badge that reports whether requests to the intake are blocked.

When the live replay sandbox is overridden, a small "dev" indicator is also displayed in the upper right corner of the Live Replay tab, as you can see in this screenshot:

<img width="1017" alt="Screenshot 2025-04-30 at 17 40 55" src="https://github.com/user-attachments/assets/5f459786-eea7-4fb4-a556-c41f106cc305" />

I made one other small functional change: instead of explaining in the settings tab that using the RUM Slim bundle is only possible with the network request redirection strategy (i.e., the old "CDN" strategy), I made it work with the other strategy too. The change was trivial, and I think it simplifies the UI slightly to make the choice of how to override the browser SDK bundle separate from the choice of which bundle to replace it with.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
