### PR TITLE
🔧 [RUM-9766] include bundle chunks in NPM packages

### DIFF
--- a/packages/logs/.npmignore
+++ b/packages/logs/.npmignore
@@ -1,5 +1,5 @@
 *
-!/bundle/datadog-logs.js
+!/bundle/**/*.js
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*

--- a/packages/rum-slim/.npmignore
+++ b/packages/rum-slim/.npmignore
@@ -1,5 +1,5 @@
 *
-!/bundle/datadog-rum-slim.js
+!/bundle/**/*.js
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*

--- a/packages/rum/.npmignore
+++ b/packages/rum/.npmignore
@@ -1,5 +1,5 @@
 *
-!/bundle/datadog-rum.js
+!/bundle/**/*.js
 !/cjs/**/*
 !/esm/**/*
 !/src/**/*

--- a/packages/worker/.npmignore
+++ b/packages/worker/.npmignore
@@ -1,5 +1,5 @@
 *
-!/bundle/worker.js
+!/bundle/**/*.js
 !/src/**/*
 /src/**/*.spec.ts
 /src/**/*.specHelper.ts


### PR DESCRIPTION


## Motivation

Fixes #3512

## Changes

Un-ignore all .js files from the bundles directory, not just the main bundle.

## Test instructions

Check that the RUM package includes the chunks:

```bash
$ yarn build
$ npx lerna run pack
$ tar -tf packages/rum/package.tgz '*/bundle/*' 
package/bundle/chunks/profiler-2eb0077dd11567238403-datadog-rum.js
package/bundle/chunks/recorder-f24e5f2f7ba365163d90-datadog-rum.js
package/bundle/datadog-rum.js
```

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
