### PR TITLE
✨ [RUM-139] use trusted types policy

### DIFF
--- a/test/e2e/scenario/transport.scenario.ts
+++ b/test/e2e/scenario/transport.scenario.ts
@@ -51,5 +51,31 @@ test.describe('transport', () => {
           expect(cspDocLog, "'CSP doc' log").toBeTruthy()
         })
       })
+
+    createTest('workerUrl initialization parameter')
+      .withRum({ compressIntakeRequests: true, workerUrl: '/worker.js' })
+      .withBasePath('/no-blob-worker-csp')
+      .run(async ({ intakeRegistry, flushEvents }) => {
+        await flushEvents()
+        expect(intakeRegistry.rumRequests.length).toBeGreaterThan(0)
+      })
+
+    test.describe('Trusted Types CSP', () => {
+      createTest('supports Trusted Types CSP')
+        .withRum({ compressIntakeRequests: true })
+        .withBasePath('/trusted-types-csp')
+        .run(async ({ flushEvents, intakeRegistry }) => {
+          await flushEvents()
+          expect(intakeRegistry.rumRequests.length).toBeGreaterThan(0)
+        })
+
+      createTest('supports Trusted Types CSP with workerUrl')
+        .withRum({ compressIntakeRequests: true, workerUrl: '/worker.js' })
+        .withBasePath('/trusted-types-csp')
+        .run(async ({ intakeRegistry, flushEvents }) => {
+          await flushEvents()
+          expect(intakeRegistry.rumRequests.length).toBeGreaterThan(0)
+        })
+    })
   })
 })

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -19,6 +19,9 @@ module.exports = ({ entry, mode, filename, types, keepBuildEnvVariables, plugins
         : // Include a content hash in chunk names in production.
           `chunks/[name]-[contenthash]-${filename}`,
     path: path.resolve('./bundle'),
+    trustedTypes: {
+      policyName: 'datadog-chunks',
+    },
   },
   target: ['web', 'es2018'],
   devtool: false,


### PR DESCRIPTION
## Motivation

#3506 

## Changes

* Configure Webpack to use the `datadog-chunk` Trusted Type policy to load chunks
* Use the `datadog-worker` Trusted Type policy to load the compression worker

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
