### PR TITLE
👷️enable renovate `lockFileMaintenance`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "prHourlyLimit": 1,
   "schedule": ["every weekend"],
   "postUpdateOptions": ["yarnDedupeHighest"],
+  "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
## Motivation

Automatically update transitive dependencies, it should prevent some security issues to be opened

## Changes

Enable [`lockFileMaintenance`](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance):

```
You can use lockFileMaintenance to refresh lock files to keep them up-to-date.

When Renovate performs lockFileMaintenance it deletes the lock file and runs the relevant package manager. 
That package manager creates a new lock file, where all dependency versions are updated to the latest version. 
Renovate then commits that lock file to the update branch and creates the lock file update PR.
```

## Test instructions

Conf validated with `npx --yes --package renovate -- renovate-config-validator`

Let's see how it will behave when merged

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
