### PR TITLE
✨ Allow overriding service and version for views events in beforeSend

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -70,7 +70,7 @@ describe('rum assembly', () => {
 
           expect((serverRumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
         })
-        
+
         describe('view type modifyable fields', () => {
           it('service and version should be modifiable', () => {
             const extraConfigurationOptions = { service: 'default service', version: 'default version' }
@@ -80,16 +80,16 @@ describe('rum assembly', () => {
                 beforeSend: (event) => {
                   event.service = 'bar'
                   event.version = '0.2.0'
-    
+
                   return true
                 },
               },
             })
-    
+
             notifyRawRumEvent(lifeCycle, {
               rawRumEvent: createRawRumEvent(RumEventType.VIEW, { view: { name: 'raboof', url: '/path?foo=bar' } }),
             })
-    
+
             expect((serverRumEvents[0] as RumResourceEvent).service).toBe('bar')
             expect((serverRumEvents[0] as RumResourceEvent).version).toBe('0.2.0')
           })

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -70,6 +70,30 @@ describe('rum assembly', () => {
 
           expect((serverRumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
         })
+        
+        describe('view type modifyable fields', () => {
+          it('service and version should be modifiable', () => {
+          const extraConfigurationOptions = { service: 'default service', version: 'default version' }
+            const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+              partialConfiguration: {
+                ...extraConfigurationOptions,
+                beforeSend: (event) => {
+                  event.service = 'bar'
+                  event.version = '0.2.0'
+    
+                  return true
+                },
+              },
+            })
+    
+            notifyRawRumEvent(lifeCycle, {
+              rawRumEvent: createRawRumEvent(RumEventType.VIEW, { view: { name: 'raboof', url: '/path?foo=bar' } }),
+            })
+    
+            expect((serverRumEvents[0] as RumResourceEvent).service).toBe('bar')
+            expect((serverRumEvents[0] as RumResourceEvent).version).toBe('0.2.0')
+          })
+        })
 
         describe('field resource.graphql on Resource events', () => {
           it('by default, it should not be modifiable', () => {

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -73,7 +73,7 @@ describe('rum assembly', () => {
         
         describe('view type modifyable fields', () => {
           it('service and version should be modifiable', () => {
-          const extraConfigurationOptions = { service: 'default service', version: 'default version' }
+            const extraConfigurationOptions = { service: 'default service', version: 'default version' }
             const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
               partialConfiguration: {
                 ...extraConfigurationOptions,

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -12,7 +12,7 @@ import {
 import type { RumEventDomainContext } from '../domainContext.types'
 import type { RawRumEvent } from '../rawRumEvent.types'
 import { RumEventType } from '../rawRumEvent.types'
-import type { RumErrorEvent, RumEvent, RumResourceEvent } from '../rumEvent.types'
+import type { RumErrorEvent, RumEvent, RumResourceEvent, RumViewEvent } from '../rumEvent.types'
 import { HookNames, createHooks } from '../hooks'
 import { startRumAssembly } from './assembly'
 import type { RawRumEventCollectedData } from './lifeCycle'
@@ -69,30 +69,6 @@ describe('rum assembly', () => {
           })
 
           expect((serverRumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
-        })
-
-        describe('view type modifyable fields', () => {
-          it('service and version should be modifiable', () => {
-            const extraConfigurationOptions = { service: 'default service', version: 'default version' }
-            const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-              partialConfiguration: {
-                ...extraConfigurationOptions,
-                beforeSend: (event) => {
-                  event.service = 'bar'
-                  event.version = '0.2.0'
-
-                  return true
-                },
-              },
-            })
-
-            notifyRawRumEvent(lifeCycle, {
-              rawRumEvent: createRawRumEvent(RumEventType.VIEW, { view: { name: 'raboof', url: '/path?foo=bar' } }),
-            })
-
-            expect((serverRumEvents[0] as RumResourceEvent).service).toBe('bar')
-            expect((serverRumEvents[0] as RumResourceEvent).version).toBe('0.2.0')
-          })
         })
 
         describe('field resource.graphql on Resource events', () => {
@@ -426,11 +402,16 @@ describe('rum assembly', () => {
         })
 
         notifyRawRumEvent(lifeCycle, {
-          rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, { resource: { url: '/path?foo=bar' } }),
+          rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
         })
-
         expect((serverRumEvents[0] as RumResourceEvent).service).toBe('bar')
         expect((serverRumEvents[0] as RumResourceEvent).version).toBe('0.2.0')
+
+        notifyRawRumEvent(lifeCycle, {
+          rawRumEvent: createRawRumEvent(RumEventType.VIEW),
+        })
+        expect((serverRumEvents[1] as RumViewEvent).service).toBe('bar')
+        expect((serverRumEvents[1] as RumViewEvent).version).toBe('0.2.0')
       })
     })
   })

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -46,6 +46,7 @@ export function startRumAssembly(
       'view.performance.lcp.resource_url': 'string',
       ...USER_CUSTOMIZABLE_FIELD_PATHS,
       ...VIEW_MODIFIABLE_FIELD_PATHS,
+      ...ROOT_MODIFIABLE_FIELD_PATHS,
     },
     [RumEventType.ERROR]: {
       'error.message': 'string',

--- a/test/e2e/scenario/microfrontend.scenario.ts
+++ b/test/e2e/scenario/microfrontend.scenario.ts
@@ -190,7 +190,7 @@ test.describe('microfrontend', () => {
       })
   })
 
-  createTest('allow to modify service and version')
+  createTest('resource: allow to modify service and version')
     .withRum(RUM_CONFIG)
     .withRumInit((configuration) => {
       window.DD_RUM!.init({
@@ -218,5 +218,30 @@ test.describe('microfrontend', () => {
       expect(resourceEvent).toBeTruthy()
       expect(resourceEvent.service).toBe('mf-service')
       expect(resourceEvent.version).toBe('0.1.0')
+    })
+
+  createTest('view: allowed to modify service and version')
+    .withRum(RUM_CONFIG)
+    .withRumInit((configuration) => {
+      window.DD_RUM!.init({
+        ...configuration,
+        beforeSend: (event: RumEvent) => {
+          if (event.type === 'view') {
+            event.service = 'mf-service'
+            event.version = '0.1.0'
+          }
+
+          return true
+        },
+      })
+    })
+    .run(async ({ intakeRegistry, flushEvents }) => {
+      await flushEvents()
+
+      const viewEvent = intakeRegistry.rumViewEvents[0]
+
+      expect(viewEvent).toBeTruthy()
+      expect(viewEvent.service).toBe('mf-service')
+      expect(viewEvent.version).toBe('0.1.0')
     })
 })


### PR DESCRIPTION
## Motivation

* This change allows you to override the `service` and `version` on`view` events in the `beforeSend` callback.
* This feature exists for errors, resources and actions as part of the original microfrontend support.
* This provides further microfrontend support for changing the view when using custom view tracking is not feasible.

## Changes

* Includes `ROOT_MODIFIABLE_FIELD_PATHS` (`service`/`version`) for `RumEventType.VIEW`.
* Add unit test reassigning `service` and `version` with a `view` event.
* Add e2e test reassigning `service` and `version` with a `view` event.
* I did not yet, but can add this as an experimental feature if desired.
* I am unaware of any other implications this could create but will make updates as the discussion advances.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

* Configure a `beforeSend` hook to update service/version for a view event.
* Unit and e2e tests were added.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
