### PR TITLE
📝 mention missing `compressIntakeRequests` support in rum-slim readme

### DIFF
--- a/packages/rum-slim/README.md
+++ b/packages/rum-slim/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This package is equivalent to the [RUM package](../rum), but without support for Session Replay
-recording and [`compressIntakeRequests`][1] initialization parameter.
+recording and the [`compressIntakeRequests`][1] initialization parameter.
 
 ## Setup
 

--- a/packages/rum-slim/README.md
+++ b/packages/rum-slim/README.md
@@ -3,8 +3,10 @@
 ## Overview
 
 This package is equivalent to the [RUM package](../rum), but without support for Session Replay
-recording.
+recording and [`compressIntakeRequests`][1] initialization parameter.
 
 ## Setup
 
 See the [RUM package](../rum/README.md) documentation.
+
+[1]: https://docs.datadoghq.com/real_user_monitoring/browser/setup/client/?tab=rum#initialization-parameters:~:text=compressIntakeRequests


### PR DESCRIPTION
## Motivation

Clarify the difference between rum and rum-slim

## Changes

mention missing `compressIntakeRequests` support in rum-slim readme

## Test instructions

Check the [rendered readme](https://github.com/DataDog/browser-sdk/blob/benoit/mention-request-compression-in-rum-slim-readme/packages/rum-slim/README.md)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
