### PR TITLE
🐛 [devx] Enable flush manually in developer extension

### DIFF
--- a/developer-extension/src/panel/flushEvents.spec.ts
+++ b/developer-extension/src/panel/flushEvents.spec.ts
@@ -1,0 +1,23 @@
+import type { Configuration } from '@datadog/browser-core'
+import { registerCleanupTask } from '../../../packages/core/test'
+import type { PageMayExitEvent } from '../../../packages/core/src/browser/pageMayExitObservable'
+import { createPageMayExitObservable } from '../../../packages/core/src/browser/pageMayExitObservable'
+import { flushScript } from './flushEvents'
+
+describe('flushEvents', () => {
+  let onExitSpy: jasmine.Spy<(event: PageMayExitEvent) => void>
+  let configuration: Configuration
+
+  beforeEach(() => {
+    onExitSpy = jasmine.createSpy()
+    configuration = {} as Configuration
+    registerCleanupTask(createPageMayExitObservable(configuration).subscribe(onExitSpy).unsubscribe)
+  })
+
+  it('flushes when the flush scripts evaluated', () => {
+    // evalInWindow() uses extension APIs that are not available in the test environment
+    // eslint-disable-next-line no-eval
+    eval(flushScript)
+    expect(onExitSpy).toHaveBeenCalled()
+  })
+})

--- a/developer-extension/src/panel/flushEvents.ts
+++ b/developer-extension/src/panel/flushEvents.ts
@@ -2,15 +2,17 @@ import { createLogger } from '../common/logger'
 import { evalInWindow } from './evalInWindow'
 
 const logger = createLogger('flushEvents')
-
+export const flushScript = `
+const descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState');
+Object.defineProperty(Document.prototype, 'visibilityState', { value: 'hidden' });
+const hiddenEvent = new Event('visibilitychange', { bubbles: true});
+hiddenEvent.__ddIsTrusted = true;
+document.dispatchEvent(hiddenEvent);
+Object.defineProperty(Document.prototype, 'visibilityState', descriptor);
+document.dispatchEvent(new Event('visibilitychange', { bubbles: true }));
+`
 export function flushEvents() {
-  evalInWindow(
-    `
-      const descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
-      Object.defineProperty(Document.prototype, 'visibilityState', { value: 'hidden' })
-      document.dispatchEvent(new Event('visibilitychange', { bubbles: true }))
-      Object.defineProperty(Document.prototype, 'visibilityState', descriptor)
-      document.dispatchEvent(new Event('visibilitychange', { bubbles: true }))
-    `
-  ).catch((error) => logger.error('Error while flushing events:', error))
+  evalInWindow(flushScript).catch((error) => {
+    logger.error('Error while flushing events:', error)
+  })
 }


### PR DESCRIPTION
## Motivation
The flush button in developer extension does not work because SDK now only flush on trusted events.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Set `__ddIsTrusted` for the events to trigger flushing.
Added a unit test for flush events script.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions
Should pass added test case
<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
