### PR TITLE
👷️[RUM-9996] Support deployment for ap2 datacenter

### DIFF
--- a/.gitlab/deploy-auto.yml
+++ b/.gitlab/deploy-auto.yml
@@ -25,6 +25,15 @@ step-1_deploy-prod-minor-dcs:
   variables:
     UPLOAD_PATH: us3,us5,ap1
 
+step-1bis_deploy-wip-dcs:
+  when: manual
+  allow_failure: true
+  extends:
+    - .base-configuration
+    - .deploy-prod
+  variables:
+    UPLOAD_PATH: ap2
+
 step-2_deploy-prod-eu1:
   needs:
     - step-1_deploy-prod-minor-dcs

--- a/.gitlab/deploy-manual.yml
+++ b/.gitlab/deploy-manual.yml
@@ -25,6 +25,14 @@ step-1_deploy-prod-minor-dcs:
   variables:
     UPLOAD_PATH: us3,us5,ap1
 
+step-1bis_deploy-wip-dc:
+  extends:
+    - .base-configuration
+    - .deploy-prod
+  allow_failure: true
+  variables:
+    UPLOAD_PATH: ap2
+
 step-2_deploy-prod-eu1:
   extends:
     - .base-configuration

--- a/scripts/deploy/check-monitors.js
+++ b/scripts/deploy/check-monitors.js
@@ -13,6 +13,7 @@ const monitorIdsByDatacenter = {
   us3: [164368, 160677, 329066],
   us5: [22388, 20646, 96049],
   ap1: [858, 859, 2757030],
+  ap2: false, // no telemetry org yet
 }
 
 const datacenters = process.argv[2].split(',')

--- a/scripts/deploy/upload-source-maps.js
+++ b/scripts/deploy/upload-source-maps.js
@@ -53,7 +53,12 @@ async function uploadSourceMaps(packageName, service, version, uploadPathTypes) 
       uploadPath = buildRootUploadPath(packageName, version)
       await renameFilesWithVersionSuffix(bundleFolder, version)
     } else {
-      sites = [siteByDatacenter[uploadPathType]]
+      const site = siteByDatacenter[uploadPathType]
+      if (!site) {
+        printLog(`No source maps upload configured for datacenter ${uploadPathType}`)
+        continue
+      }
+      sites = [site]
       uploadPath = buildDatacenterUploadPath(uploadPathType, packageName, version)
     }
     const prefix = path.dirname(`/${uploadPath}`)

--- a/scripts/lib/datadogSites.js
+++ b/scripts/lib/datadogSites.js
@@ -4,6 +4,7 @@ const siteByDatacenter = {
   us3: 'us3.datadoghq.com',
   us5: 'us5.datadoghq.com',
   ap1: 'ap1.datadoghq.com',
+  ap2: false, // no telemetry org yet
 }
 
 module.exports = {


### PR DESCRIPTION
## Motivation

Start adding support for ap2 datacenter

## Changes

- Only upload sdk files to `/ap2/` route for now
- Isolate ap2 deployment to dedicated jobs to avoid impacting deployment on other DCs for now

next PR with source map upload and monitors check when telemetry org available
 
## Test instructions

After next release, we should be able to access https://www.datadoghq-browser-agent.com/ap2/v6/datadog-rum.js

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
