### PR TITLE
👷️ [RUM-9996] fix internal source maps upload for root upload type

### DIFF
--- a/scripts/deploy/upload-source-maps.js
+++ b/scripts/deploy/upload-source-maps.js
@@ -15,9 +15,6 @@ const { buildRootUploadPath, buildDatacenterUploadPath, buildBundleFolder, packa
  * BUILD_MODE=canary|release node upload-source-maps.js staging|canary|vXXX root,us1,eu1,...
  */
 
-// To use when the telemetry is not yet configured on a DC
-const DCS_WITHOUT_SOURCE_MAPS_UPLOAD = [siteByDatacenter['ap2']]
-
 function getSitesByVersion(version) {
   switch (version) {
     case 'staging':
@@ -82,7 +79,7 @@ async function renameFilesWithVersionSuffix(bundleFolder, version) {
 
 function uploadToDatadog(packageName, service, prefix, bundleFolder, sites) {
   for (const site of sites) {
-    if (DCS_WITHOUT_SOURCE_MAPS_UPLOAD.includes(site)) {
+    if (!site) {
       printLog(`No source maps upload configured for ${site}, skipping...`)
       continue
     }

--- a/scripts/deploy/upload-source-maps.spec.js
+++ b/scripts/deploy/upload-source-maps.spec.js
@@ -75,6 +75,12 @@ void describe('upload-source-maps', () => {
         },
       ])
 
+      // no telemetry org yet
+      if (site === siteByDatacenter['ap2']) {
+        assert.deepEqual(commandsByDatacenter, [])
+        return
+      }
+
       // upload the source maps
       assert.deepEqual(commandsByDatacenter, [
         {

--- a/scripts/lib/datadogSites.js
+++ b/scripts/lib/datadogSites.js
@@ -4,7 +4,7 @@ const siteByDatacenter = {
   us3: 'us3.datadoghq.com',
   us5: 'us5.datadoghq.com',
   ap1: 'ap1.datadoghq.com',
-  ap2: 'ap2.datadoghq.com',
+  ap2: false, // no telemetry org yet
 }
 
 module.exports = {

--- a/scripts/lib/datadogSites.js
+++ b/scripts/lib/datadogSites.js
@@ -4,7 +4,7 @@ const siteByDatacenter = {
   us3: 'us3.datadoghq.com',
   us5: 'us5.datadoghq.com',
   ap1: 'ap1.datadoghq.com',
-  ap2: false, // no telemetry org yet
+  ap2: 'ap2.datadoghq.com',
 }
 
 module.exports = {


### PR DESCRIPTION
## Motivation

source map upload for the root upload type failed while handling the new DC:

```
...
 Uploading logs source maps with prefix / for ap1.datadoghq.com... 
 Uploading logs source maps with prefix / for false... 
 
Script exited with error: TypeError: site.replaceAll is not a function
    at getTelemetryOrgApiKey (/go/src/github.com/DataDog/browser-sdk/scripts/lib/secrets.js:20:31)
    at uploadToDatadog (/go/src/github.com/DataDog/browser-sdk/scripts/deploy/upload-source-maps.js:98:26)
    at uploadSourceMaps (/go/src/github.com/DataDog/browser-sdk/scripts/deploy/upload-source-maps.js:65:5)
    at async main (/go/src/github.com/DataDog/browser-sdk/scripts/deploy/upload-source-maps.js:40:5)
    at async /go/src/github.com/DataDog/browser-sdk/scripts/deploy/upload-source-maps.js:34:5 
```

Regression caused by https://github.com/DataDog/browser-sdk/pull/3538

## Changes

- check for site being false at upload time
- Updated unit test to handle ap2 case
 
## Test instructions

Run script locally while commenting the upload command:

```
> node ./scripts/deploy/upload-source-maps.js v6.7.0 root

...

 Uploading rum-slim source maps with prefix / for ap1.datadoghq.com...
 No source maps upload configured for ap2.datadoghq.com, skipping...

 Source maps upload done.
```



## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
