### PR TITLE
🔧 apply sourcemaps to unit tests common chunk

### DIFF
--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -36,6 +36,8 @@ module.exports = {
   },
   preprocessors: {
     '**/*.+(ts|tsx)': ['webpack', 'sourcemap'],
+    // Apply sourcemaps to webpack common chunk
+    '/**/*.js': ['sourcemap'],
   },
   reporters,
   specReporter: {


### PR DESCRIPTION
## Motivation

Since #3308, error reported by karma in the terminal were suboptimal as it pointed to the common JS chunk instead of the source file.

## Changes

* Apply source maps to the common chunk

Before:

```
 rum session keep alive
    ✗ should send a view update regularly [Chrome Headless 136.0.0.0 (Mac OS 10.15.7)]
	Error: test error
	    at UserContext.<anonymous> (/var/folders/n3/mnsy_yb16416d6hb4sn2w7fc0000gq/T/_karma_webpack_626493/commons.js:178805:15)
	    at <Jasmine>
```

After:

```
 rum session keep alive
    ✗ should send a view update regularly [Chrome Headless 136.0.0.0 (Mac OS 10.15.7)]
	Error: test error
	    at UserContext.<anonymous> (/Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/packages/rum-core/src/boot/startRum.spec.ts:193:11 <- /var/folders/n3/mnsy_yb16416d6hb4sn2w7fc0000gq/T/_karma_webpack_866647/commons.js:178805:15)
	    at <Jasmine>
```

## Test instructions

Run `yarn test` with an error, the stack trace should show source files

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
