### PR TITLE
👷‍♀️ [RUM-10010] Send the user, account and session using the trace baggage header

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -16,7 +16,6 @@ import { objectHasValue } from './utils/objectUtils'
 export enum ExperimentalFeature {
   PROFILING = 'profiling',
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
-  USER_ACCOUNT_TRACE_HEADER = 'user_account_trace_header',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
 }
 

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -1,6 +1,5 @@
 import type { ContextManager, ContextValue } from '@datadog/browser-core'
-import { display, ExperimentalFeature, objectEntries, TraceContextInjection } from '@datadog/browser-core'
-import { mockExperimentalFeatures } from '../../../../core/test'
+import { display, objectEntries, TraceContextInjection } from '@datadog/browser-core'
 import type { RumSessionManagerMock } from '../../../test'
 import { createRumSessionManagerMock } from '../../../test'
 import type { RumFetchResolveContext, RumFetchStartContext, RumXhrStartContext } from '../requestCollection'
@@ -261,10 +260,6 @@ describe('tracer', () => {
     })
 
     describe('baggage propagation header', () => {
-      beforeEach(() => {
-        mockExperimentalFeatures([ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER])
-      })
-
       function traceRequestAndGetBaggageHeader({
         initConfiguration,
         userId,

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -6,8 +6,6 @@ import {
   isMatchOption,
   matchList,
   TraceContextInjection,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type {
@@ -223,10 +221,7 @@ function makeTracingHeaders(
     }
   })
 
-  if (
-    isExperimentalFeatureEnabled(ExperimentalFeature.USER_ACCOUNT_TRACE_HEADER) &&
-    configuration.propagateTraceBaggage
-  ) {
+  if (configuration.propagateTraceBaggage) {
     const baggageItems: Record<string, string> = {
       'session.id': sessionId,
     }


### PR DESCRIPTION
## Motivation
ddtracer-py 3.7.0 is actively using baggage header, we want to remove the feature flag and release from SDK side. 
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Remove Feature Flag USER_ACCOUNT_TRACE_HEADER
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions
Pass CI and behaviours on staging should stay same.
<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
