### PR TITLE
🐛 [RUM-10002] Verify the document was not hidden while loading

### DIFF
--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -85,7 +85,7 @@ describe('trackFirstHidden', () => {
     })
   })
 
-  describe('using visibilityState entries', () => {
+  xdescribe('using visibilityState entries', () => {
     let originalSupportedEntryTypes: string[] | undefined
     beforeEach(() => {
       performanceBufferMock = mockGlobalPerformanceBuffer()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -1,12 +1,31 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { addEventListeners, DOM_EVENT, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
+import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../../browser/performanceObservable'
 
 export type FirstHidden = ReturnType<typeof trackFirstHidden>
+export type Options = {
+  initialView?: boolean
+}
 
-export function trackFirstHidden(configuration: RumConfiguration, eventTarget: Window = window) {
+export function trackFirstHidden(
+  configuration: RumConfiguration,
+  eventTarget: Window = window,
+  { initialView = false }: Options = {}
+) {
   if (document.visibilityState === 'hidden') {
     return { timeStamp: 0 as RelativeTime, stop: noop }
+  }
+
+  // We only want to check the previous visibility state changes on the initial view where the
+  // SDK was still loading.
+  if (initialView && supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
+    const firstHiddenEntry = performance
+      .getEntriesByType(RumPerformanceEntryType.VISIBILITY_STATE)
+      .find((entry) => entry.name === 'hidden')
+    if (firstHiddenEntry) {
+      return { timeStamp: firstHiddenEntry.startTime as RelativeTime, stop: noop }
+    }
   }
 
   let timeStamp: RelativeTime = Infinity as RelativeTime

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -1,22 +1,12 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { addEventListeners, DOM_EVENT, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
-import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../../browser/performanceObservable'
 
 export type FirstHidden = ReturnType<typeof trackFirstHidden>
 
 export function trackFirstHidden(configuration: RumConfiguration, eventTarget: Window = window) {
   if (document.visibilityState === 'hidden') {
     return { timeStamp: 0 as RelativeTime, stop: noop }
-  }
-
-  if (supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
-    const firstHiddenEntry = performance
-      .getEntriesByType(RumPerformanceEntryType.VISIBILITY_STATE)
-      .find((entry) => entry.name === 'hidden')
-    if (firstHiddenEntry) {
-      return { timeStamp: firstHiddenEntry.startTime as RelativeTime, stop: noop }
-    }
   }
 
   let timeStamp: RelativeTime = Infinity as RelativeTime

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -1,6 +1,4 @@
-import type { Duration, RelativeTime } from '@datadog/browser-core'
-import { noop } from '@datadog/browser-core'
-import { RumPerformanceEntryType, supportPerformanceTimingEvent } from '@datadog/browser-rum-core'
+import type { Duration } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
 import { trackFirstContentfulPaint } from './trackFirstContentfulPaint'
 import type { FirstInput } from './trackFirstInput'
@@ -18,26 +16,6 @@ export interface InitialViewMetrics {
   firstInput?: FirstInput
 }
 
-function trackInitialFirstHidden(configuration: RumConfiguration, eventTarget: Window = window) {
-  const firstHidden = trackFirstHidden(configuration, eventTarget)
-
-  if (supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
-    const firstHiddenEntry = performance
-      .getEntriesByType(RumPerformanceEntryType.VISIBILITY_STATE)
-      .find((entry) => entry.name === 'hidden')
-    if (firstHiddenEntry) {
-      return {
-        timeStamp: (firstHidden.timeStamp > firstHiddenEntry.startTime
-          ? firstHiddenEntry.startTime
-          : firstHidden.timeStamp) as RelativeTime,
-        stop: noop,
-      }
-    }
-  }
-
-  return firstHidden
-}
-
 export function trackInitialViewMetrics(
   configuration: RumConfiguration,
   setLoadEvent: (loadEnd: Duration) => void,
@@ -51,7 +29,7 @@ export function trackInitialViewMetrics(
     scheduleViewUpdate()
   })
 
-  const firstHidden = trackInitialFirstHidden(configuration)
+  const firstHidden = trackFirstHidden(configuration, window, { initialView: true })
   const { stop: stopFCPTracking } = trackFirstContentfulPaint(configuration, firstHidden, (firstContentfulPaint) => {
     initialViewMetrics.firstContentfulPaint = firstContentfulPaint
     scheduleViewUpdate()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -136,6 +136,10 @@ describe('trackLoadingTime', () => {
     setPageVisibility('hidden')
     startLoadingTimeTracking()
 
+    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
+    domMutationObservable.notify([createMutationRecord()])
+    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
+
     expect(loadingTimeCallback).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -144,15 +144,14 @@ describe('trackLoadingTime', () => {
   })
 
   it('should discard loading time if page is hidden before activity when changing routes', () => {
-    startLoadingTimeTracking(ViewLoadingType.INITIAL_LOAD)
+    // Set some time before triggering the route change to test that the visibility change was captured
+    // with a timer higher than the loading time validation delay
+    clock.tick(300)
 
-    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
-
-    expect(loadingTimeCallback).not.toHaveBeenCalled()
-    stopLoadingTimeTracking()
+    startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE)
+    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
 
     setPageVisibility('hidden')
-    startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE)
 
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -149,12 +149,13 @@ describe('trackLoadingTime', () => {
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
     expect(loadingTimeCallback).not.toHaveBeenCalled()
+    stopLoadingTimeTracking()
 
     setPageVisibility('hidden')
     startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE)
 
     clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
 
-    expect(loadingTimeCallback).toHaveBeenCalled()
+    expect(loadingTimeCallback).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -142,4 +142,19 @@ describe('trackLoadingTime', () => {
 
     expect(loadingTimeCallback).not.toHaveBeenCalled()
   })
+
+  it('should discard loading time if page is hidden before activity when changing routes', () => {
+    startLoadingTimeTracking(ViewLoadingType.INITIAL_LOAD)
+
+    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
+
+    expect(loadingTimeCallback).not.toHaveBeenCalled()
+
+    setPageVisibility('hidden')
+    startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE)
+
+    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
+
+    expect(loadingTimeCallback).toHaveBeenCalled()
+  })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -24,7 +24,12 @@ export function trackLoadingTime(
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
       const loadingTime = Math.max(...loadingTimeCandidates)
-      if (loadingTime < firstHidden.timeStamp) {
+      // Beware, Date.now() at time origin could differ from performance.timeOrigin by a few ms
+      // @see https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin
+      const viewStartRelativeTime = viewStart.timeStamp - performance.timeOrigin
+      const isVisibleDuringLoading = loadingTime < firstHidden.timeStamp - viewStartRelativeTime
+
+      if (isVisibleDuringLoading) {
         callback(loadingTime as Duration)
       }
     }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -22,9 +22,15 @@ export function trackLoadingTime(
   const firstHidden = trackFirstHidden(configuration)
 
   function invokeCallbackIfAllCandidatesAreReceived() {
-    if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
+    const isWaitingForActivity = isWaitingForActivityLoadingTime || isWaitingForLoadEvent
+    const hasCompletedCandidates = loadingTimeCandidates.length > 0
+
+    if (!isWaitingForActivity && hasCompletedCandidates) {
+      // Be aware that Math.max(...[]) results in -Infinity
       const loadingTime = Math.max(...loadingTimeCandidates)
-      if (loadingTime < firstHidden.timeStamp) {
+      const hasBeenHidden = firstHidden.timeStamp > viewStart.timeStamp
+
+      if (hasBeenHidden && loadingTime < firstHidden.timeStamp) {
         callback(loadingTime as Duration)
       }
     }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -19,18 +19,12 @@ export function trackLoadingTime(
   let isWaitingForLoadEvent = loadType === ViewLoadingType.INITIAL_LOAD
   let isWaitingForActivityLoadingTime = true
   const loadingTimeCandidates: Duration[] = []
-  const firstHidden = trackFirstHidden(configuration)
+  const firstHidden = trackFirstHidden(configuration, window, { initialView: isWaitingForLoadEvent })
 
   function invokeCallbackIfAllCandidatesAreReceived() {
-    const isWaitingForActivity = isWaitingForActivityLoadingTime || isWaitingForLoadEvent
-    const hasCompletedCandidates = loadingTimeCandidates.length > 0
-
-    if (!isWaitingForActivity && hasCompletedCandidates) {
-      // Be aware that Math.max(...[]) results in -Infinity
+    if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
       const loadingTime = Math.max(...loadingTimeCandidates)
-      const hasBeenHidden = firstHidden.timeStamp > viewStart.timeStamp
-
-      if (hasBeenHidden && loadingTime < firstHidden.timeStamp) {
+      if (loadingTime < firstHidden.timeStamp) {
         callback(loadingTime as Duration)
       }
     }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -24,10 +24,7 @@ export function trackLoadingTime(
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
       const loadingTime = Math.max(...loadingTimeCandidates)
-      // Beware, Date.now() at time origin could differ from performance.timeOrigin by a few ms
-      // @see https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin
-      const viewStartRelativeTime = viewStart.timeStamp - performance.timeOrigin
-      const isVisibleDuringLoading = loadingTime < firstHidden.timeStamp - viewStartRelativeTime
+      const isVisibleDuringLoading = loadingTime < firstHidden.timeStamp - viewStart.relative
 
       if (isVisibleDuringLoading) {
         callback(loadingTime as Duration)


### PR DESCRIPTION
## Motivation

This PR addresses two issues with the current implementation of loading time when the page is hidden during loading.

**Issue 1**  
During the initial load, we check the `PerformanceObserver` to determine if the page was hidden or visible while loading. We do this because the SDK loads asynchronously, so we only have access to future events from that point onward.

The previous implementation had a problem: the performance observer was accessed even during client-side navigation. 

This condition will always be true, potentially leading to an entry in the observer that is lower than the loading time.

**Issue 2**  
This issue is related to Issue 1. The time compared during client-side navigation was always based on the time origin instead of the loading view. 

This means that if the page undergoes client-side navigation while hidden, the timestamp used in the visibility-change event is based on the time origin rather than the view start reference. As a result, it is almost always higher than expected.

## Changes

This PR changes the `trackFirstHidden` function adding options to only check the performance observer when needed. Additionally, it modifies the condition to check if the page was hidden while loading by replacing the reference point to view start.

| Before | Header |
|--------|--------|
| https://github.com/user-attachments/assets/dbbadff0-422d-49c6-a66a-745e327f4037 | https://github.com/user-attachments/assets/0cad4558-3c9e-415f-9adb-73a02999b0ba | 

## Test instructions

**Case 1**

Using the sandbox, modify the home page to extend the loading time. Like adding a fetch to the home page:

```
fetch('https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Fronalpstock_big.jpg/1599px-Fronalpstock_big.jpg')
```

1. Go to http://localhost:8080/react-app/user/42
2. Open dev tools
3. Throttle the network for easy testing
4. Reload the page and quickly change the active tab
5. Go back to the sandbox tab
6. _Check there is no loading time for the current view_
7. Click the home link
8. _Check there is loading time for the home view_

> [!NOTE]
> Previously, this fails as it finds a performance observer entry with a lower time than the loading time.

**Case 2**

Following the same approach as the case above:

1. Go to http://localhost:8080/react-app/user/42
2. Open dev tools
3. Throttle the network for easy testing
7. Click the home link
8. Quickly change the active tab and go back
9. _Check there is **no** loading time for the home view_

> [!NOTE]
> Previously, it reported a wrongful time. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
