### PR TITLE
fix: skip unwanted stackframe on custom errors for faulty browsers

### DIFF
--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -48,10 +48,10 @@ export function computeStackTrace(ex: unknown): StackTrace {
     })
   }
 
-  if (stack.length > 0 && BADLY_REPORTING_CUSTOM_ERRORS) { // if we are wrongly reporting custom errors
+  if (stack.length > 0 && WRONGLY_REPORTING_CUSTOM_ERRORS) { // if we are wrongly reporting custom errors
     if (ex instanceof Error && isErrorCustomError(ex)) { // if the element is a custom error
       const firstStackFrame = stack[0];
-      const errorConstructorName = Object.getPrototypeOf(ex).constructor?.name;
+      const errorConstructorName = Object.getPrototypeOf(ex)?.constructor?.name;
       if (firstStackFrame?.func === errorConstructorName) { // if the first stack frame is the custom error constructor
         stack.shift(); // remove it
       }
@@ -207,10 +207,10 @@ function tryToParseMessage(messageObj: unknown) {
 
 function isErrorCustomError(error: Error) {
   let errorProto = Object.getPrototypeOf(error);
-  return errorProto.constructor?.toString().startsWith('class ');
+  return errorProto?.constructor?.toString().startsWith('class ');
 }
 
-function isBadlyReportingCustomErrors() {
+function isWronglyReportingCustomErrors() {
   // Should not be minified during compilation.
   class _DatadogTestCustomError extends Error {
       constructor() {
@@ -226,4 +226,4 @@ function isBadlyReportingCustomErrors() {
   return customErrorStack.includes('_DatadogTestCustomError');
 }
 
-const BADLY_REPORTING_CUSTOM_ERRORS = isBadlyReportingCustomErrors();
+const WRONGLY_REPORTING_CUSTOM_ERRORS = isWronglyReportingCustomErrors();

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -48,11 +48,10 @@ export function computeStackTrace(ex: unknown): StackTrace {
     })
   }
 
-  if (stack.length > 0 && BADLY_REPORTING_CUSTOM_ERRORS) { // if we are badly reporting custom errors
+  if (stack.length > 0 && BADLY_REPORTING_CUSTOM_ERRORS) { // if we are wrongly reporting custom errors
     if (ex instanceof Error && isErrorCustomError(ex)) { // if the element is a custom error
       const firstStackFrame = stack[0];
       const errorConstructorName = Object.getPrototypeOf(ex).constructor?.name;
-      console.log("custom error", firstStackFrame?.func, errorConstructorName, firstStackFrame)
       if (firstStackFrame?.func === errorConstructorName) { // if the first stack frame is the custom error constructor
         stack.shift(); // remove it
       }

--- a/packages/core/src/tools/stackTrace/computeStackTrace.ts
+++ b/packages/core/src/tools/stackTrace/computeStackTrace.ts
@@ -226,4 +226,8 @@ function isWronglyReportingCustomErrors() {
   return customErrorStack.includes('_DatadogTestCustomError');
 }
 
-const WRONGLY_REPORTING_CUSTOM_ERRORS = isWronglyReportingCustomErrors();
+let WRONGLY_REPORTING_CUSTOM_ERRORS = isWronglyReportingCustomErrors();
+
+export function _setWRONGLY_REPORTING_CUSTOM_ERRORS(value: boolean) {
+  WRONGLY_REPORTING_CUSTOM_ERRORS = value;
+}


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
