### PR TITLE
🐛 [RUM-10101] Persist session cookie to one year when opt-in anonymous user tracking

### DIFF
--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -1,9 +1,8 @@
-import { resetExperimentalFeatures } from '../../../tools/experimentalFeatures'
 import { mockClock, getSessionState } from '../../../../test'
 import { setCookie, deleteCookie, getCookie, getCurrentSite } from '../../../browser/cookie'
 import type { SessionState } from '../sessionState'
 import type { Configuration } from '../../configuration'
-import { SESSION_TIME_OUT_DELAY } from '../sessionConstants'
+import { SESSION_COOKIE_EXPIRATION_DELAY, SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from '../sessionConstants'
 import { buildCookieOptions, selectCookieStrategy, initCookieStrategy } from './sessionInCookie'
 import type { SessionStoreStrategy } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './sessionStoreStrategy'
@@ -103,6 +102,56 @@ describe('session in cookie strategy', () => {
     })
   })
 })
+
+describe('session cookie expire in one year when opt-in anonymous user tracking', () => {
+  const anonymousId = 'device-123'
+  const sessionState: SessionState = { id: '123', created: '0' }
+  let cookieStorageStrategy: SessionStoreStrategy
+  beforeEach(() => {
+    cookieStorageStrategy = initCookieStrategy(
+      { ...DEFAULT_INIT_CONFIGURATION, trackAnonymousUser: true } as Configuration,
+      {}
+    )
+  })
+
+  afterEach(() => {
+    deleteCookie(SESSION_STORE_KEY)
+  })
+  it('should persist with anonymous id', () => {
+    cookieStorageStrategy.persistSession({ ...sessionState, anonymousId })
+    const session = cookieStorageStrategy.retrieveSession()
+    expect(session).toEqual({ ...sessionState, anonymousId })
+    expect(getCookie(SESSION_STORE_KEY)).toBe('id=123&created=0&aid=device-123')
+  })
+
+  it('should expire with anonymous id', () => {
+    cookieStorageStrategy.expireSession({ ...sessionState, anonymousId })
+    const session = cookieStorageStrategy.retrieveSession()
+    expect(session).toEqual({ isExpired: '1', anonymousId })
+    expect(getCookie(SESSION_STORE_KEY)).toBe('isExpired=1&aid=device-123')
+  })
+
+  it('should persist for one year when opt-in', () => {
+    const cookieSetSpy = spyOnProperty(document, 'cookie', 'set')
+    const clock = mockClock()
+    cookieStorageStrategy.persistSession({ ...sessionState, anonymousId })
+    expect(cookieSetSpy.calls.argsFor(0)[0]).toContain(
+      new Date(clock.timeStamp(SESSION_COOKIE_EXPIRATION_DELAY)).toUTCString()
+    )
+    clock.cleanup()
+  })
+
+  it('should expire in one year when opt-in', () => {
+    const cookieSetSpy = spyOnProperty(document, 'cookie', 'set')
+    const clock = mockClock()
+    cookieStorageStrategy.expireSession({ ...sessionState, anonymousId })
+    expect(cookieSetSpy.calls.argsFor(0)[0]).toContain(
+      new Date(clock.timeStamp(SESSION_COOKIE_EXPIRATION_DELAY)).toUTCString()
+    )
+    clock.cleanup()
+  })
+})
+
 describe('session in cookie strategy when opt-out anonymous user tracking', () => {
   const anonymousId = 'device-123'
   const sessionState: SessionState = { id: '123', created: '0' }
@@ -113,7 +162,6 @@ describe('session in cookie strategy when opt-out anonymous user tracking', () =
   })
 
   afterEach(() => {
-    resetExperimentalFeatures()
     deleteCookie(SESSION_STORE_KEY)
   })
 
@@ -123,6 +171,12 @@ describe('session in cookie strategy when opt-out anonymous user tracking', () =
     cookieStorageStrategy.expireSession({ ...sessionState, anonymousId })
     expect(cookieSetSpy.calls.argsFor(0)[0]).toContain(new Date(clock.timeStamp(SESSION_TIME_OUT_DELAY)).toUTCString())
     clock.cleanup()
+  })
+
+  it('should not persist with one year when opt-out', () => {
+    const cookieSetSpy = spyOnProperty(document, 'cookie', 'set')
+    cookieStorageStrategy.persistSession({ ...sessionState, anonymousId })
+    expect(cookieSetSpy.calls.argsFor(0)[0]).toContain(new Date(Date.now() + SESSION_EXPIRATION_DELAY).toUTCString())
   })
 
   it('should not persist or expire a session with anonymous id when opt-out', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -26,7 +26,7 @@ export function initCookieStrategy(configuration: Configuration, cookieOptions: 
      * This issue concerns only chromium browsers and enabling this on firefox increases cookie write failures.
      */
     isLockEnabled: isChromium(),
-    persistSession: persistSessionCookie(cookieOptions),
+    persistSession: persistSessionCookie(cookieOptions, configuration),
     retrieveSession: retrieveSessionCookie,
     expireSession: (sessionState: SessionState) => expireSessionCookie(cookieOptions, sessionState, configuration),
   }
@@ -36,9 +36,14 @@ export function initCookieStrategy(configuration: Configuration, cookieOptions: 
   return cookieStore
 }
 
-function persistSessionCookie(options: CookieOptions) {
+function persistSessionCookie(options: CookieOptions, configuration: Configuration) {
   return (session: SessionState) => {
-    setCookie(SESSION_STORE_KEY, toSessionString(session), SESSION_EXPIRATION_DELAY, options)
+    setCookie(
+      SESSION_STORE_KEY,
+      toSessionString(session),
+      configuration.trackAnonymousUser ? SESSION_COOKIE_EXPIRATION_DELAY : SESSION_EXPIRATION_DELAY,
+      options
+    )
   }
 }
 


### PR DESCRIPTION
## Motivation
https://github.com/DataDog/browser-sdk/issues/3556
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Persist session cookie to one year in session cookie strategy
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions
Exit tab before expire
Come back after 4 hours
Anonymous ID should persist
<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
