### PR TITLE
✨ use error.dd_context when logging an error

### DIFF
--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -122,6 +122,14 @@ describe('Logger', () => {
       })
     })
 
+    it('uses the error dd_context property as context', () => {
+      const error = new TypeError('My Error')
+      ;(error as any).dd_context = { foo: 'bar' }
+      logger.log('message', {}, StatusType.error, error)
+
+      expect(getLoggedMessage(0).context!.foo).toBe('bar')
+    })
+
     describe('when using logger.error', () => {
       it("'logger.error' should have an empty context if no Error object is provided", () => {
         logger.error('message')

--- a/packages/logs/src/domain/logger.ts
+++ b/packages/logs/src/domain/logger.ts
@@ -73,6 +73,7 @@ export class Logger {
         {
           error: createErrorFieldFromRawError(rawError, { includeMessage: true }),
         },
+        rawError.context,
         sanitizedMessageContext
       )
     } else {


### PR DESCRIPTION
## Motivation

We take `error.dd_context` into account when collecting errors via `console.error(error)` and uncaught exceptions, but not when using `logger.log('message', {}, error)`. This is probably an omission from our side.

Related ticket: https://github.com/DataDog/browser-sdk/issues/3557

## Changes

Apply the context from `error.dd_context` when passing an error to logger methods

## Test instructions

Go to the sandbox, open the devtools, run the following:

```
const error = new Error('message')
error.dd_context = { foo: 'bar' }
DD_LOGS.logger.error('toto', {}, error)
```

Look at the logs in the devtools extension. It should have the `foo: 'bar'` property.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
