### PR TITLE
🔧 add flagging path to tsconfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,7 +21,8 @@
       "@datadog/browser-rum-core": ["./packages/rum-core/src"],
       "@datadog/browser-rum-react": ["./packages/rum-react/src/entries/main"],
       "@datadog/browser-rum-react/react-router-v6": ["./packages/rum-react/src/entries/reactRouter"],
-      "@datadog/browser-rum-react/react-router-v7": ["./packages/rum-react/src/entries/reactRouter"]
+      "@datadog/browser-rum-react/react-router-v7": ["./packages/rum-react/src/entries/reactRouter"],
+      "@datadog/browser-flagging": ["./packages/flagging/src/entries/main"]
     }
   }
 }


### PR DESCRIPTION
## Motivation

`yarn dev` fails with the error:

```
Module not found: Error: Can't resolve '@datadog/browser-flagging' in '/Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/sandbox/react-app'
```

## Changes

Add the flagging package to `tsconfig` so the react app knows where to look for it.

## Test instructions

`yarn dev` should work.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
