### PR TITLE
🐛 [RUM-10002] Verify the document was not hidden while loading

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -267,7 +267,7 @@ function newView(
 
   const { stop: stopInitialViewMetricsTracking, initialViewMetrics } =
     loadingType === ViewLoadingType.INITIAL_LOAD
-      ? trackInitialViewMetrics(configuration, setLoadEvent, scheduleViewUpdate, startClocks)
+      ? trackInitialViewMetrics(configuration, startClocks, setLoadEvent, scheduleViewUpdate)
       : { stop: noop, initialViewMetrics: {} as InitialViewMetrics }
 
   // Start BFCache-specific metrics when restoring from BFCache

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -267,7 +267,7 @@ function newView(
 
   const { stop: stopInitialViewMetricsTracking, initialViewMetrics } =
     loadingType === ViewLoadingType.INITIAL_LOAD
-      ? trackInitialViewMetrics(configuration, setLoadEvent, scheduleViewUpdate)
+      ? trackInitialViewMetrics(configuration, setLoadEvent, scheduleViewUpdate, startClocks)
       : { stop: noop, initialViewMetrics: {} as InitialViewMetrics }
 
   // Start BFCache-specific metrics when restoring from BFCache

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
@@ -1,4 +1,5 @@
 import type { RelativeTime } from '@datadog/browser-core'
+import { clocksOrigin } from '@datadog/browser-core'
 import { registerCleanupTask, restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { RumPerformanceEntry } from '../../../browser/performanceObservable'
 import { RumPerformanceEntryType } from '../../../browser/performanceObservable'
@@ -14,7 +15,7 @@ describe('trackFirstContentfulPaint', () => {
     ;({ notifyPerformanceEntries } = mockPerformanceObserver())
 
     fcpCallback = jasmine.createSpy()
-    const firstHidden = trackFirstHidden(mockRumConfiguration())
+    const firstHidden = trackFirstHidden(mockRumConfiguration(), clocksOrigin())
     const firstContentfulPaint = trackFirstContentfulPaint(mockRumConfiguration(), firstHidden, fcpCallback)
 
     registerCleanupTask(() => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime } from '@datadog/browser-core'
+import type { RelativeTime, TimeStamp } from '@datadog/browser-core'
 import { DOM_EVENT } from '@datadog/browser-core'
 import { createNewEvent, restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import { mockRumConfiguration, mockGlobalPerformanceBuffer } from '../../../../test'
@@ -114,6 +114,21 @@ describe('trackFirstHidden', () => {
 
       firstHidden = trackFirstHidden(configuration)
       expect(firstHidden.timeStamp).toBe(23 as RelativeTime)
+    })
+
+    it('should ignore entries before view start', () => {
+      setPageVisibility('visible')
+
+      performanceBufferMock.addPerformanceEntry({
+        entryType: 'visibility-state',
+        name: 'hidden',
+        startTime: 23,
+      } as PerformanceEntry)
+
+      firstHidden = trackFirstHidden(configuration, createWindowEventTarget(), {
+        viewStart: { relative: 100 as RelativeTime, timeStamp: 100 as TimeStamp },
+      })
+      expect(firstHidden.timeStamp).toBe(Infinity as RelativeTime)
     })
   })
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -140,6 +140,19 @@ describe('trackFirstHidden', () => {
       })
       expect(firstHidden.timeStamp).toBe(Infinity as RelativeTime)
     })
+
+    it('should return 0 when the page was loaded hidden', () => {
+      setPageVisibility('visible')
+
+      performanceBufferMock.addPerformanceEntry({
+        entryType: 'visibility-state',
+        name: 'hidden',
+        startTime: 0,
+      } as PerformanceEntry)
+
+      firstHidden = trackFirstHiddenWithDefaults({ configuration })
+      expect(firstHidden.timeStamp).toBe(0 as RelativeTime)
+    })
   })
 
   function createWindowEventTarget() {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -1,5 +1,5 @@
 import type { ClocksState, RelativeTime } from '@datadog/browser-core'
-import { clocksOrigin, addEventListeners, DOM_EVENT, noop } from '@datadog/browser-core'
+import { addEventListeners, DOM_EVENT, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
 import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../../browser/performanceObservable'
 
@@ -11,8 +11,8 @@ export type Options = {
 
 export function trackFirstHidden(
   configuration: RumConfiguration,
-  eventTarget: Window = window,
-  { viewStart = clocksOrigin() }: Partial<Options> = {}
+  viewStart: ClocksState,
+  eventTarget: Window = window
 ) {
   if (document.visibilityState === 'hidden') {
     return { timeStamp: 0 as RelativeTime, stop: noop }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -22,7 +22,7 @@ export function trackFirstHidden(
     const firstHiddenEntry = performance
       .getEntriesByType(RumPerformanceEntryType.VISIBILITY_STATE)
       .filter((entry) => entry.name === 'hidden')
-      .find((entry) => entry.startTime > viewStart.relative)
+      .find((entry) => entry.startTime >= viewStart.relative)
 
     if (firstHiddenEntry) {
       return { timeStamp: firstHiddenEntry.startTime as RelativeTime, stop: noop }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -1,11 +1,19 @@
-import type { RelativeTime } from '@datadog/browser-core'
-import { addEventListeners, DOM_EVENT, noop } from '@datadog/browser-core'
+import type { ClocksState, RelativeTime } from '@datadog/browser-core'
+import { clocksOrigin, addEventListeners, DOM_EVENT, noop } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
 import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../../browser/performanceObservable'
 
 export type FirstHidden = ReturnType<typeof trackFirstHidden>
 
-export function trackFirstHidden(configuration: RumConfiguration, eventTarget: Window = window) {
+export type Options = {
+  viewStart: ClocksState
+}
+
+export function trackFirstHidden(
+  configuration: RumConfiguration,
+  eventTarget: Window = window,
+  { viewStart = clocksOrigin() }: Partial<Options> = {}
+) {
   if (document.visibilityState === 'hidden') {
     return { timeStamp: 0 as RelativeTime, stop: noop }
   }
@@ -13,7 +21,9 @@ export function trackFirstHidden(configuration: RumConfiguration, eventTarget: W
   if (supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
     const firstHiddenEntry = performance
       .getEntriesByType(RumPerformanceEntryType.VISIBILITY_STATE)
-      .find((entry) => entry.name === 'hidden')
+      .filter((entry) => entry.name === 'hidden')
+      .find((entry) => entry.startTime > viewStart.relative)
+
     if (firstHiddenEntry) {
       return { timeStamp: firstHiddenEntry.startTime as RelativeTime, stop: noop }
     }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstInput.spec.ts
@@ -1,4 +1,4 @@
-import { type Duration, type RelativeTime } from '@datadog/browser-core'
+import { clocksOrigin, type Duration, type RelativeTime } from '@datadog/browser-core'
 import { registerCleanupTask, restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import {
   appendElement,
@@ -23,7 +23,7 @@ describe('firstInputTimings', () => {
     const configuration = mockRumConfiguration()
     fitCallback = jasmine.createSpy()
 
-    const firstHidden = trackFirstHidden(configuration)
+    const firstHidden = trackFirstHidden(configuration, clocksOrigin())
     const firstInputTimings = trackFirstInput(configuration, firstHidden, fitCallback)
 
     registerCleanupTask(() => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
@@ -32,6 +32,10 @@ describe('trackInitialViewMetrics', () => {
     registerCleanupTask(trackInitialViewMetricsResult.stop)
   })
 
+  afterEach(() => {
+    clock.cleanup()
+  })
+
   it('should merge metrics from various sources', () => {
     notifyPerformanceEntries([
       createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
@@ -32,10 +32,6 @@ describe('trackInitialViewMetrics', () => {
     registerCleanupTask(trackInitialViewMetricsResult.stop)
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   it('should merge metrics from various sources', () => {
     notifyPerformanceEntries([
       createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
@@ -1,4 +1,5 @@
 import type { Duration, RelativeTime } from '@datadog/browser-core'
+import { clocksOrigin } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumPerformanceEntry } from '../../../browser/performanceObservable'
@@ -21,7 +22,12 @@ describe('trackInitialViewMetrics', () => {
     setLoadEventSpy = jasmine.createSpy()
     clock = mockClock()
 
-    trackInitialViewMetricsResult = trackInitialViewMetrics(configuration, setLoadEventSpy, scheduleViewUpdateSpy)
+    trackInitialViewMetricsResult = trackInitialViewMetrics(
+      configuration,
+      clocksOrigin(),
+      setLoadEventSpy,
+      scheduleViewUpdateSpy
+    )
 
     registerCleanupTask(trackInitialViewMetricsResult.stop)
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -30,7 +30,7 @@ export function trackInitialViewMetrics(
     scheduleViewUpdate()
   })
 
-  const firstHidden = trackFirstHidden(configuration, viewStart, window)
+  const firstHidden = trackFirstHidden(configuration, viewStart)
   const { stop: stopFCPTracking } = trackFirstContentfulPaint(configuration, firstHidden, (firstContentfulPaint) => {
     initialViewMetrics.firstContentfulPaint = firstContentfulPaint
     scheduleViewUpdate()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -1,4 +1,5 @@
-import type { Duration } from '@datadog/browser-core'
+import type { ClocksState, Duration } from '@datadog/browser-core'
+import { clocksOrigin } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
 import { trackFirstContentfulPaint } from './trackFirstContentfulPaint'
 import type { FirstInput } from './trackFirstInput'
@@ -19,7 +20,8 @@ export interface InitialViewMetrics {
 export function trackInitialViewMetrics(
   configuration: RumConfiguration,
   setLoadEvent: (loadEnd: Duration) => void,
-  scheduleViewUpdate: () => void
+  scheduleViewUpdate: () => void,
+  viewStart: ClocksState = clocksOrigin()
 ) {
   const initialViewMetrics: InitialViewMetrics = {}
 
@@ -29,7 +31,7 @@ export function trackInitialViewMetrics(
     scheduleViewUpdate()
   })
 
-  const firstHidden = trackFirstHidden(configuration)
+  const firstHidden = trackFirstHidden(configuration, window, { viewStart })
   const { stop: stopFCPTracking } = trackFirstContentfulPaint(configuration, firstHidden, (firstContentfulPaint) => {
     initialViewMetrics.firstContentfulPaint = firstContentfulPaint
     scheduleViewUpdate()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -31,7 +31,7 @@ export function trackInitialViewMetrics(
     scheduleViewUpdate()
   })
 
-  const firstHidden = trackFirstHidden(configuration, window, { viewStart })
+  const firstHidden = trackFirstHidden(configuration, viewStart, window)
   const { stop: stopFCPTracking } = trackFirstContentfulPaint(configuration, firstHidden, (firstContentfulPaint) => {
     initialViewMetrics.firstContentfulPaint = firstContentfulPaint
     scheduleViewUpdate()

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -1,5 +1,4 @@
 import type { ClocksState, Duration } from '@datadog/browser-core'
-import { clocksOrigin } from '@datadog/browser-core'
 import type { RumConfiguration } from '../../configuration'
 import { trackFirstContentfulPaint } from './trackFirstContentfulPaint'
 import type { FirstInput } from './trackFirstInput'

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -19,9 +19,9 @@ export interface InitialViewMetrics {
 
 export function trackInitialViewMetrics(
   configuration: RumConfiguration,
+  viewStart: ClocksState,
   setLoadEvent: (loadEnd: Duration) => void,
-  scheduleViewUpdate: () => void,
-  viewStart: ClocksState = clocksOrigin()
+  scheduleViewUpdate: () => void
 ) {
   const initialViewMetrics: InitialViewMetrics = {}
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -1,5 +1,5 @@
 import type { RelativeTime } from '@datadog/browser-core'
-import { DOM_EVENT } from '@datadog/browser-core'
+import { clocksOrigin, DOM_EVENT } from '@datadog/browser-core'
 import {
   setPageVisibility,
   createNewEvent,
@@ -21,7 +21,7 @@ describe('trackLargestContentfulPaint', () => {
   function startLCPTracking() {
     ;({ notifyPerformanceEntries } = mockPerformanceObserver())
 
-    const firstHidden = trackFirstHidden(mockRumConfiguration())
+    const firstHidden = trackFirstHidden(mockRumConfiguration(), clocksOrigin())
     const largestContentfulPaint = trackLargestContentfulPaint(
       mockRumConfiguration(),
       firstHidden,

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -165,13 +165,13 @@ describe('trackLoadingTime', () => {
       pending('Performance Timing Event is not supported')
     }
 
-    clock.tick(RANDOM_VIEW_START)
-
     performanceBufferMock.addPerformanceEntry({
       entryType: 'visibility-state',
       name: 'hidden',
-      startTime: clock.relative(RANDOM_VIEW_START - 3000) as number,
+      startTime: performance.now(),
     } as PerformanceEntry)
+
+    clock.tick(RANDOM_VIEW_START)
 
     startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE, clocksNow())
 
@@ -187,13 +187,17 @@ describe('trackLoadingTime', () => {
 
     clock.tick(RANDOM_VIEW_START)
 
+    const viewStart = clocksNow()
+
+    clock.tick(10)
+
     performanceBufferMock.addPerformanceEntry({
       entryType: 'visibility-state',
       name: 'hidden',
-      startTime: clock.relative(RANDOM_VIEW_START + 10) as number,
+      startTime: performance.now(),
     } as PerformanceEntry)
 
-    startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE, clocksNow())
+    startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE, viewStart)
 
     emulatePageActivityDuringViewLoading()
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -37,6 +37,10 @@ describe('trackLoadingTime', () => {
   let originalSupportedEntryTypes: string[] | undefined
   let performanceBufferMock: GlobalPerformanceBufferMock
 
+  function emulatePageActivityDuringViewLoading() {
+    emulatePageActivityDuringViewLoading()
+  }
+
   beforeEach(() => {
     performanceBufferMock = mockGlobalPerformanceBuffer()
     if (typeof PerformanceObserver !== 'undefined') {
@@ -85,9 +89,7 @@ describe('trackLoadingTime', () => {
   it('should have a loading time equal to the activity time if there is a unique activity on a route change', () => {
     startLoadingTimeTracking()
 
-    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
-    domMutationObservable.notify([createMutationRecord()])
-    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
+    emulatePageActivityDuringViewLoading()
 
     expect(loadingTimeCallback).toHaveBeenCalledOnceWith(clock.relative(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY))
   })
@@ -159,9 +161,7 @@ describe('trackLoadingTime', () => {
     setPageVisibility('hidden')
     startLoadingTimeTracking()
 
-    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
-    domMutationObservable.notify([createMutationRecord()])
-    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
+    emulatePageActivityDuringViewLoading()
 
     expect(loadingTimeCallback).not.toHaveBeenCalled()
   })
@@ -177,9 +177,7 @@ describe('trackLoadingTime', () => {
 
     startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE, clocksNow())
 
-    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
-    domMutationObservable.notify([createMutationRecord()])
-    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
+    emulatePageActivityDuringViewLoading()
 
     expect(loadingTimeCallback).toHaveBeenCalled()
   })
@@ -195,16 +193,7 @@ describe('trackLoadingTime', () => {
 
     startLoadingTimeTracking(ViewLoadingType.ROUTE_CHANGE, clocksNow())
 
-    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
-    domMutationObservable.notify([createMutationRecord()])
-    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
-
-    expect(loadingTimeCallback).not.toHaveBeenCalled()
-  })
-
-  it('should NOT discard loading time if page is hidden before a new view start happened', () => {
-    setPageVisibility('hidden')
-    startLoadingTimeTracking()
+    emulatePageActivityDuringViewLoading()
 
     expect(loadingTimeCallback).not.toHaveBeenCalled()
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -38,7 +38,9 @@ describe('trackLoadingTime', () => {
   let performanceBufferMock: GlobalPerformanceBufferMock
 
   function emulatePageActivityDuringViewLoading() {
-    emulatePageActivityDuringViewLoading()
+    clock.tick(BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY)
+    domMutationObservable.notify([createMutationRecord()])
+    clock.tick(AFTER_PAGE_ACTIVITY_END_DELAY)
   }
 
   beforeEach(() => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -1,5 +1,5 @@
 import type { RelativeTime, Duration } from '@datadog/browser-core'
-import { dateNow, relativeToClocks, clocksNow, clocksOrigin, Observable } from '@datadog/browser-core'
+import { clocksNow, clocksOrigin, Observable } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, setPageVisibility, restorePageVisibility } from '@datadog/browser-core/test'
 import { ViewLoadingType } from '../../../rawRumEvent.types'

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -161,7 +161,7 @@ describe('trackLoadingTime', () => {
   })
 
   it('should not discard loading time if page was hidden before the view start', () => {
-    clock.tick(clock.relative(RANDOM_VIEW_START))
+    clock.tick(RANDOM_VIEW_START)
 
     performanceBufferMock.addPerformanceEntry({
       entryType: 'visibility-state',

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -11,7 +11,7 @@ import {
   mockRumConfiguration,
 } from '../../../../test'
 import { PAGE_ACTIVITY_END_DELAY, PAGE_ACTIVITY_VALIDATION_DELAY } from '../../waitPageActivityEnd'
-import { RumPerformanceEntryType } from '../../../browser/performanceObservable'
+import { RumPerformanceEntryType, supportPerformanceTimingEvent } from '../../../browser/performanceObservable'
 import { LifeCycle } from '../../lifeCycle'
 import type { RumMutationRecord } from '../../../browser/domMutationObservable'
 import { trackLoadingTime } from './trackLoadingTime'
@@ -161,6 +161,10 @@ describe('trackLoadingTime', () => {
   })
 
   it('should not discard loading time if page was hidden before the view start', () => {
+    if (!supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
+      pending('Performance Timing Event is not supported')
+    }
+
     clock.tick(RANDOM_VIEW_START)
 
     performanceBufferMock.addPerformanceEntry({
@@ -177,6 +181,10 @@ describe('trackLoadingTime', () => {
   })
 
   it('should discard loading time if page was hidden during the loading time', () => {
+    if (!supportPerformanceTimingEvent(RumPerformanceEntryType.VISIBILITY_STATE)) {
+      pending('Performance Timing Event is not supported')
+    }
+
     clock.tick(RANDOM_VIEW_START)
 
     performanceBufferMock.addPerformanceEntry({

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -137,4 +137,11 @@ describe('trackLoadingTime', () => {
 
     expect(loadingTimeCallback).not.toHaveBeenCalled()
   })
+
+  it('should NOT discard loading time if page is hidden before a new view start happened', () => {
+    setPageVisibility('hidden')
+    startLoadingTimeTracking()
+
+    expect(loadingTimeCallback).not.toHaveBeenCalled()
+  })
 })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -34,7 +34,6 @@ describe('trackLoadingTime', () => {
   let loadingTimeCallback: jasmine.Spy<(loadingTime: Duration) => void>
   let setLoadEvent: (loadEvent: Duration) => void
   let stopLoadingTimeTracking: () => void
-  let originalSupportedEntryTypes: string[] | undefined
   let performanceBufferMock: GlobalPerformanceBufferMock
 
   function emulatePageActivityDuringViewLoading() {
@@ -45,13 +44,6 @@ describe('trackLoadingTime', () => {
 
   beforeEach(() => {
     performanceBufferMock = mockGlobalPerformanceBuffer()
-    if (typeof PerformanceObserver !== 'undefined') {
-      originalSupportedEntryTypes = PerformanceObserver.supportedEntryTypes as string[]
-      Object.defineProperty(PerformanceObserver, 'supportedEntryTypes', {
-        get: () => [...(originalSupportedEntryTypes || []), 'visibility-state'],
-        configurable: true,
-      })
-    }
   })
 
   function startLoadingTimeTracking(

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -30,6 +30,7 @@ export function trackLoadingTime(
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
       const loadingTime = Math.max(...loadingTimeCandidates)
+      // firstHidden is a relative time from time origin, so we use the relative start time of the view to compare with the loading time
       if (loadingTime < firstHidden.timeStamp - viewStart.relative) {
         callback(loadingTime as Duration)
       }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -25,7 +25,7 @@ export function trackLoadingTime(
   let isWaitingForLoadEvent = loadType === ViewLoadingType.INITIAL_LOAD
   let isWaitingForActivityLoadingTime = true
   const loadingTimeCandidates: Duration[] = []
-  const firstHidden = trackFirstHidden(configuration)
+  const firstHidden = trackFirstHidden(configuration, window, { viewStart })
 
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -30,7 +30,7 @@ export function trackLoadingTime(
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
       const loadingTime = Math.max(...loadingTimeCandidates)
-      if (loadingTime < firstHidden.timeStamp) {
+      if (loadingTime < firstHidden.timeStamp - viewStart.relative) {
         callback(loadingTime as Duration)
       }
     }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -30,7 +30,6 @@ export function trackLoadingTime(
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
       const loadingTime = Math.max(...loadingTimeCandidates)
-      console.log(loadingTime, firstHidden.timeStamp, viewStart.relative)
       // firstHidden is a relative time from time origin, so we use the relative start time of the view to compare with the loading time
       if (loadingTime < firstHidden.timeStamp - viewStart.relative) {
         callback(loadingTime as Duration)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -30,6 +30,7 @@ export function trackLoadingTime(
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {
       const loadingTime = Math.max(...loadingTimeCandidates)
+      console.log(loadingTime, firstHidden.timeStamp, viewStart.relative)
       // firstHidden is a relative time from time origin, so we use the relative start time of the view to compare with the loading time
       if (loadingTime < firstHidden.timeStamp - viewStart.relative) {
         callback(loadingTime as Duration)

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -25,7 +25,7 @@ export function trackLoadingTime(
   let isWaitingForLoadEvent = loadType === ViewLoadingType.INITIAL_LOAD
   let isWaitingForActivityLoadingTime = true
   const loadingTimeCandidates: Duration[] = []
-  const firstHidden = trackFirstHidden(configuration, viewStart, window)
+  const firstHidden = trackFirstHidden(configuration, viewStart)
 
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -25,7 +25,7 @@ export function trackLoadingTime(
   let isWaitingForLoadEvent = loadType === ViewLoadingType.INITIAL_LOAD
   let isWaitingForActivityLoadingTime = true
   const loadingTimeCandidates: Duration[] = []
-  const firstHidden = trackFirstHidden(configuration, window, { viewStart })
+  const firstHidden = trackFirstHidden(configuration, viewStart, window)
 
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {

--- a/sandbox/react-app/main.tsx
+++ b/sandbox/react-app/main.tsx
@@ -64,6 +64,8 @@ function Layout() {
 }
 
 function HomePage() {
+  fetch('https://jsonplaceholder.typicode.com/posts/1')
+
   return <h1>Home</h1>
 }
 

--- a/sandbox/react-app/main.tsx
+++ b/sandbox/react-app/main.tsx
@@ -64,8 +64,6 @@ function Layout() {
 }
 
 function HomePage() {
-  fetch('https://jsonplaceholder.typicode.com/posts/1')
-
   return <h1>Home</h1>
 }
 


### PR DESCRIPTION
## Motivation

This PR addresses two issues with the current implementation of loading time when the page is hidden during loading.

**Issue 1**  
During the initial load, we check the `PerformanceObserver` to determine if the page was hidden or visible while loading. We do this because the SDK loads asynchronously, so we only have access to future events from that point onward.

The previous implementation had a problem: the performance observer was accessed even during client-side navigation. 

This condition will always be true, potentially leading to an entry in the observer that is lower than the loading time.

**Issue 2**  
This issue is related to Issue 1. The time compared during client-side navigation was always based on the time origin instead of the loading view. 

This means that if the page undergoes client-side navigation while hidden, the timestamp used in the visibility-change event is based on the time origin rather than the view start reference. As a result, it is almost always higher than expected.

## Changes

This PR changes the `trackFirstHidden` function adding options to only check the performance observer when needed. Additionally, it modifies the condition to check if the page was hidden while loading by replacing the reference point to view start.

| Before | Header |
|--------|--------|
| https://github.com/user-attachments/assets/dbbadff0-422d-49c6-a66a-745e327f4037 | https://github.com/user-attachments/assets/0cad4558-3c9e-415f-9adb-73a02999b0ba | 

## Test instructions

**Case 1**

Using the sandbox, modify the home page to extend the loading time. Like adding a fetch to the home page:

```
fetch('https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Fronalpstock_big.jpg/1599px-Fronalpstock_big.jpg')
```

1. Go to http://localhost:8080/react-app/user/42
2. Open dev tools
3. Throttle the network for easy testing
4. Reload the page and quickly change the active tab
5. Go back to the sandbox tab
6. _Check there is no loading time for the current view_
7. Click the home link
8. _Check there is loading time for the home view_

> [!NOTE]
> Previously, this fails as it finds a performance observer entry with a lower time than the loading time.

**Case 2**

Following the same approach as the case above:

1. Go to http://localhost:8080/react-app/user/42
2. Open dev tools
3. Throttle the network for easy testing
7. Click the home link
8. Quickly change the active tab and go back
9. _Check there is **no** loading time for the home view_

> [!NOTE]
> Previously, it reported a wrongful time. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
