### PR TITLE
✅ Fix usage of non-existent configuration options in remoteConfiguration.spec.ts

### DIFF
--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -3,13 +3,12 @@ import { interceptRequests } from '@datadog/browser-core/test'
 import type { RumInitConfiguration } from './configuration'
 import { applyRemoteConfiguration, buildEndpoint, fetchRemoteConfiguration } from './remoteConfiguration'
 
-const DEFAULT_INIT_CONFIGURATION = {
+const DEFAULT_INIT_CONFIGURATION: RumInitConfiguration = {
   clientToken: 'xxx',
   applicationId: 'xxx',
-  samplingRate: 100,
-  sessionReplaySamplingRate: 100,
+  sessionReplaySampleRate: 100,
   defaultPrivacyLevel: DefaultPrivacyLevel.MASK,
-} as RumInitConfiguration
+}
 
 describe('remoteConfiguration', () => {
   let displayErrorSpy: jasmine.Spy<typeof display.error>
@@ -55,10 +54,10 @@ describe('remoteConfiguration', () => {
   })
 
   describe('applyRemoteConfiguration', () => {
-    it('should override the iniConfiguration options with the ones from the remote configuration', () => {
-      const remoteConfiguration = {
-        samplingRate: 1,
-        sessionReplaySamplingRate: 1,
+    it('should override the initConfiguration options with the ones from the remote configuration', () => {
+      const remoteConfiguration: Partial<RumInitConfiguration> = {
+        sessionSampleRate: 1,
+        sessionReplaySampleRate: 1,
         defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
       }
       expect(applyRemoteConfiguration(DEFAULT_INIT_CONFIGURATION, remoteConfiguration)).toEqual(


### PR DESCRIPTION
## Changes

This PR fixes some usage of non-existent configuration options in `remoteConfiguration.spec.ts`, and tweaks things such that the compiler will catch the issue in the future. This probably doesn't matter too much in terms of correctness of the tests, but it avoids potentially confusing people who (like myself today) are searching around in the codebase to find places where these options are referenced.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.