### PR TITLE
🔥 🐛 fix Next.js 12 + swcMinify compatibility

### DIFF
--- a/packages/core/src/domain/session/sessionConstants.ts
+++ b/packages/core/src/domain/session/sessionConstants.ts
@@ -3,6 +3,7 @@ import { ONE_HOUR, ONE_MINUTE, ONE_YEAR } from '../../tools/utils/timeUtils'
 export const SESSION_TIME_OUT_DELAY = 4 * ONE_HOUR
 export const SESSION_EXPIRATION_DELAY = 15 * ONE_MINUTE
 export const SESSION_COOKIE_EXPIRATION_DELAY = ONE_YEAR
+export const SESSION_NOT_TRACKED = '0'
 
 export const SessionPersistence = {
   COOKIE: 'cookie',

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -16,24 +16,19 @@ import type { TrackingConsentState } from '../trackingConsent'
 import { TrackingConsent, createTrackingConsentState } from '../trackingConsent'
 import type { SessionManager } from './sessionManager'
 import { startSessionManager, stopSessionManager, VISIBILITY_CHECK_DELAY } from './sessionManager'
-import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY, SessionPersistence } from './sessionConstants'
+import {
+  SESSION_EXPIRATION_DELAY,
+  SESSION_NOT_TRACKED,
+  SESSION_TIME_OUT_DELAY,
+  SessionPersistence,
+} from './sessionConstants'
 import type { SessionStoreStrategyType } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 import { STORAGE_POLL_DELAY } from './sessionStore'
 
 const enum FakeTrackingType {
-  NOT_TRACKED = 'not-tracked',
+  NOT_TRACKED = SESSION_NOT_TRACKED,
   TRACKED = 'tracked',
-}
-
-const TRACKED_SESSION_STATE = {
-  isTracked: true,
-  trackingType: FakeTrackingType.TRACKED,
-}
-
-const NOT_TRACKED_SESSION_STATE = {
-  isTracked: false,
-  trackingType: FakeTrackingType.NOT_TRACKED,
 }
 
 describe('startSessionManager', () => {
@@ -136,7 +131,9 @@ describe('startSessionManager', () => {
     })
 
     it('when not tracked should store tracking type', () => {
-      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
+      const sessionManager = startSessionManagerWithDefaults({
+        computeTrackingType: () => FakeTrackingType.NOT_TRACKED,
+      })
 
       expectSessionIdToNotBeDefined(sessionManager)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
@@ -152,42 +149,44 @@ describe('startSessionManager', () => {
     })
 
     it('when not tracked should keep existing tracking type', () => {
-      setCookie(SESSION_STORE_KEY, 'first=not-tracked', DURATION)
+      setCookie(SESSION_STORE_KEY, `first=${SESSION_NOT_TRACKED}`, DURATION)
 
-      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
+      const sessionManager = startSessionManagerWithDefaults({
+        computeTrackingType: () => FakeTrackingType.NOT_TRACKED,
+      })
 
       expectSessionIdToNotBeDefined(sessionManager)
       expectTrackingTypeToBe(sessionManager, FIRST_PRODUCT_KEY, FakeTrackingType.NOT_TRACKED)
     })
   })
 
-  describe('computeSessionState', () => {
-    let spy: (rawTrackingType?: string) => { trackingType: FakeTrackingType; isTracked: boolean }
+  describe('computeTrackingType', () => {
+    let spy: (rawTrackingType?: string) => FakeTrackingType
 
     beforeEach(() => {
-      spy = jasmine.createSpy().and.returnValue(TRACKED_SESSION_STATE)
+      spy = jasmine.createSpy().and.returnValue(FakeTrackingType.TRACKED)
     })
 
     it('should be called with an empty value if the cookie is not defined', () => {
-      startSessionManagerWithDefaults({ computeSessionState: spy })
+      startSessionManagerWithDefaults({ computeTrackingType: spy })
       expect(spy).toHaveBeenCalledWith(undefined)
     })
 
     it('should be called with an invalid value if the cookie has an invalid value', () => {
       setCookie(SESSION_STORE_KEY, 'first=invalid', DURATION)
-      startSessionManagerWithDefaults({ computeSessionState: spy })
+      startSessionManagerWithDefaults({ computeTrackingType: spy })
       expect(spy).toHaveBeenCalledWith('invalid')
     })
 
     it('should be called with TRACKED', () => {
       setCookie(SESSION_STORE_KEY, 'first=tracked', DURATION)
-      startSessionManagerWithDefaults({ computeSessionState: spy })
+      startSessionManagerWithDefaults({ computeTrackingType: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.TRACKED)
     })
 
     it('should be called with NOT_TRACKED', () => {
-      setCookie(SESSION_STORE_KEY, 'first=not-tracked', DURATION)
-      startSessionManagerWithDefaults({ computeSessionState: spy })
+      setCookie(SESSION_STORE_KEY, `first=${SESSION_NOT_TRACKED}`, DURATION)
+      startSessionManagerWithDefaults({ computeTrackingType: spy })
       expect(spy).toHaveBeenCalledWith(FakeTrackingType.NOT_TRACKED)
     })
   })
@@ -283,11 +282,11 @@ describe('startSessionManager', () => {
     it('should have independent tracking types', () => {
       const firstSessionManager = startSessionManagerWithDefaults({
         productKey: FIRST_PRODUCT_KEY,
-        computeSessionState: () => TRACKED_SESSION_STATE,
+        computeTrackingType: () => FakeTrackingType.TRACKED,
       })
       const secondSessionManager = startSessionManagerWithDefaults({
         productKey: SECOND_PRODUCT_KEY,
-        computeSessionState: () => NOT_TRACKED_SESSION_STATE,
+        computeTrackingType: () => FakeTrackingType.NOT_TRACKED,
       })
 
       expect(firstSessionManager.findSession()!.trackingType).toEqual(FakeTrackingType.TRACKED)
@@ -398,7 +397,9 @@ describe('startSessionManager', () => {
     })
 
     it('should expand not tracked session duration on activity', () => {
-      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
+      const sessionManager = startSessionManagerWithDefaults({
+        computeTrackingType: () => FakeTrackingType.NOT_TRACKED,
+      })
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -440,7 +441,9 @@ describe('startSessionManager', () => {
     it('should expand not tracked session on visibility', () => {
       setPageVisibility('visible')
 
-      const sessionManager = startSessionManagerWithDefaults({ computeSessionState: () => NOT_TRACKED_SESSION_STATE })
+      const sessionManager = startSessionManagerWithDefaults({
+        computeTrackingType: () => FakeTrackingType.NOT_TRACKED,
+      })
       const expireSessionSpy = jasmine.createSpy()
       sessionManager.expireObservable.subscribe(expireSessionSpy)
 
@@ -651,12 +654,12 @@ describe('startSessionManager', () => {
   function startSessionManagerWithDefaults({
     configuration,
     productKey = FIRST_PRODUCT_KEY,
-    computeSessionState = () => TRACKED_SESSION_STATE,
+    computeTrackingType = () => FakeTrackingType.TRACKED,
     trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED),
   }: {
     configuration?: Partial<Configuration>
     productKey?: string
-    computeSessionState?: () => { trackingType: FakeTrackingType; isTracked: boolean }
+    computeTrackingType?: () => FakeTrackingType
     trackingConsentState?: TrackingConsentState
   } = {}) {
     return startSessionManager(
@@ -665,7 +668,7 @@ describe('startSessionManager', () => {
         ...configuration,
       } as Configuration,
       productKey,
-      computeSessionState,
+      computeTrackingType,
       trackingConsentState
     )
   }

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -37,7 +37,7 @@ let stopCallbacks: Array<() => void> = []
 export function startSessionManager<TrackingType extends string>(
   configuration: Configuration,
   productKey: string,
-  computeSessionState: (rawTrackingType?: string) => { trackingType: TrackingType; isTracked: boolean },
+  computeTrackingType: (rawTrackingType?: string) => TrackingType,
   trackingConsentState: TrackingConsentState
 ): SessionManager<TrackingType> {
   const renewObservable = new Observable<void>()
@@ -48,7 +48,7 @@ export function startSessionManager<TrackingType extends string>(
     configuration.sessionStoreStrategyType!,
     configuration,
     productKey,
-    computeSessionState
+    computeTrackingType
   )
   stopCallbacks.push(() => sessionStore.stop())
 

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -1,5 +1,5 @@
 import { dateNow } from '../../tools/utils/timeUtils'
-import { SESSION_EXPIRATION_DELAY } from './sessionConstants'
+import { SESSION_EXPIRATION_DELAY, SESSION_NOT_TRACKED } from './sessionConstants'
 import type { SessionState } from './sessionState'
 import {
   expandSessionState,
@@ -43,7 +43,7 @@ describe('session state utilities', () => {
       expect(isSessionInExpiredState({ created: dateNowWithOffset(-1000), expire: dateNowWithOffset(1000) })).toBe(
         false
       )
-      expect(isSessionInExpiredState({ first: 'not-tracked' })).toBe(false)
+      expect(isSessionInExpiredState({ first: SESSION_NOT_TRACKED })).toBe(false)
       expect(isSessionInExpiredState({ first: 'tracked' })).toBe(false)
     })
   })

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -5,12 +5,17 @@ import type { InitConfiguration, Configuration } from '../configuration'
 import { display } from '../../tools/display'
 import type { SessionStore } from './sessionStore'
 import { STORAGE_POLL_DELAY, startSessionStore, selectSessionStoreStrategyType } from './sessionStore'
-import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY, SessionPersistence } from './sessionConstants'
+import {
+  SESSION_EXPIRATION_DELAY,
+  SESSION_NOT_TRACKED,
+  SESSION_TIME_OUT_DELAY,
+  SessionPersistence,
+} from './sessionConstants'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 
 const enum FakeTrackingType {
   TRACKED = 'tracked',
-  NOT_TRACKED = 'not-tracked',
+  NOT_TRACKED = SESSION_NOT_TRACKED,
 }
 
 const DURATION = 123456
@@ -173,13 +178,7 @@ describe('session store', () => {
     let clock: Clock
 
     function setupSessionStore(
-      computeSessionState: (rawTrackingType?: string) => {
-        trackingType: FakeTrackingType
-        isTracked: boolean
-      } = () => ({
-        isTracked: true,
-        trackingType: FakeTrackingType.TRACKED,
-      })
+      computeTrackingType: (rawTrackingType?: string) => FakeTrackingType = () => FakeTrackingType.TRACKED
     ) {
       const sessionStoreStrategyType = selectSessionStoreStrategyType(DEFAULT_INIT_CONFIGURATION)
       if (sessionStoreStrategyType?.type !== SessionPersistence.COOKIE) {
@@ -190,7 +189,7 @@ describe('session store', () => {
         sessionStoreStrategyType,
         DEFAULT_CONFIGURATION,
         PRODUCT_KEY,
-        computeSessionState
+        computeTrackingType
       )
       sessionStoreManager.expireObservable.subscribe(expireSpy)
       sessionStoreManager.renewObservable.subscribe(renewSpy)
@@ -254,7 +253,7 @@ describe('session store', () => {
         'when session not in cache, session not in store and new session not tracked, ' +
           'should store not tracked session and trigger renew session',
         () => {
-          setupSessionStore(() => ({ isTracked: false, trackingType: FakeTrackingType.NOT_TRACKED }))
+          setupSessionStore(() => FakeTrackingType.NOT_TRACKED)
 
           sessionStoreManager.expandOrRenewSession()
 
@@ -301,7 +300,7 @@ describe('session store', () => {
           'should expire session, store not tracked session and trigger renew session',
         () => {
           setSessionInStore(FakeTrackingType.TRACKED, FIRST_ID)
-          setupSessionStore(() => ({ isTracked: false, trackingType: FakeTrackingType.NOT_TRACKED }))
+          setupSessionStore(() => FakeTrackingType.NOT_TRACKED)
           resetSessionInStore()
 
           sessionStoreManager.expandOrRenewSession()
@@ -319,7 +318,7 @@ describe('session store', () => {
           'should expire session, store not tracked session and trigger renew session',
         () => {
           setSessionInStore(FakeTrackingType.NOT_TRACKED)
-          setupSessionStore(() => ({ isTracked: false, trackingType: FakeTrackingType.NOT_TRACKED }))
+          setupSessionStore(() => FakeTrackingType.NOT_TRACKED)
           resetSessionInStore()
 
           sessionStoreManager.expandOrRenewSession()
@@ -368,10 +367,9 @@ describe('session store', () => {
           'should expire session, store not tracked session and trigger renew',
         () => {
           setSessionInStore(FakeTrackingType.TRACKED, FIRST_ID)
-          setupSessionStore((rawTrackingType) => ({
-            isTracked: rawTrackingType === FakeTrackingType.TRACKED,
-            trackingType: rawTrackingType as FakeTrackingType,
-          }))
+          setupSessionStore((rawTrackingType) =>
+            rawTrackingType === FakeTrackingType.TRACKED ? FakeTrackingType.TRACKED : FakeTrackingType.NOT_TRACKED
+          )
           setSessionInStore(FakeTrackingType.NOT_TRACKED, '')
 
           sessionStoreManager.expandOrRenewSession()
@@ -554,20 +552,14 @@ describe('session store', () => {
     let clock: Clock
 
     function setupSessionStore(updateSpy: () => void) {
-      const computeSessionState: (rawTrackingType?: string) => {
-        trackingType: FakeTrackingType
-        isTracked: boolean
-      } = () => ({
-        isTracked: true,
-        trackingType: FakeTrackingType.TRACKED,
-      })
+      const computeTrackingType: (rawTrackingType?: string) => FakeTrackingType = () => FakeTrackingType.TRACKED
       const sessionStoreStrategyType = selectSessionStoreStrategyType(DEFAULT_INIT_CONFIGURATION)
 
       const sessionStoreManager = startSessionStore(
         sessionStoreStrategyType!,
         DEFAULT_CONFIGURATION,
         PRODUCT_KEY,
-        computeSessionState
+        computeTrackingType
       )
       sessionStoreManager.sessionStateUpdateObservable.subscribe(updateSpy)
 

--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -16,7 +16,7 @@ import {
 import type { SessionState } from './sessionState'
 import { initLocalStorageStrategy, selectLocalStorageStrategy } from './storeStrategies/sessionInLocalStorage'
 import { processSessionStoreOperations } from './sessionStoreOperations'
-import { SessionPersistence } from './sessionConstants'
+import { SESSION_NOT_TRACKED, SessionPersistence } from './sessionConstants'
 
 export interface SessionStore {
   expandOrRenewSession: () => void
@@ -75,7 +75,7 @@ export function startSessionStore<TrackingType extends string>(
   sessionStoreStrategyType: SessionStoreStrategyType,
   configuration: Configuration,
   productKey: string,
-  computeSessionState: (rawTrackingType?: string) => { trackingType: TrackingType; isTracked: boolean }
+  computeTrackingType: (rawTrackingType?: string) => TrackingType
 ): SessionStore {
   const renewObservable = new Observable<void>()
   const expireObservable = new Observable<void>()
@@ -176,10 +176,10 @@ export function startSessionStore<TrackingType extends string>(
       return false
     }
 
-    const { trackingType, isTracked } = computeSessionState(sessionState[productKey])
+    const trackingType = computeTrackingType(sessionState[productKey])
     sessionState[productKey] = trackingType
     delete sessionState.isExpired
-    if (isTracked && !sessionState.id) {
+    if (trackingType !== SESSION_NOT_TRACKED && !sessionState.id) {
       sessionState.id = generateUUID()
       sessionState.created = String(dateNow())
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,7 @@ export type { SessionManager } from './domain/session/sessionManager'
 export { startSessionManager, stopSessionManager } from './domain/session/sessionManager'
 export {
   SESSION_TIME_OUT_DELAY, // Exposed for tests
+  SESSION_NOT_TRACKED,
   SessionPersistence,
 } from './domain/session/sessionConstants'
 export type { HttpRequest, Payload, FlushEvent, FlushReason } from './transport'


### PR DESCRIPTION
## Motivation

Next.js 12 introduced the `swcMinify` to opt-in using SWC to minify JS. The SWC version used at the time was very early and suffered from major issues. In particular, it was observed that the `computeSessionState` function in `rumSessionManager.ts` was minified incorrectly in such a way that it returned `undefined` every time.

## Changes

This commit fixes this issue by adjusting the faulty function implementation.

Instead of returning a "session state", it only returns the "session tracking type" and consider that all sessions with tracking type '0' are not tracked.

This reduces the bundle size a tiny bit, and prevents the concept of "session state" to leak outside of `sessionStore`.

## Test instructions

* Create a Next.js v12 app 
* Enable `swcMinify` using the following `next.config.js`:
```
module.exports = {
  swcMinify: true,
};
```
* Add the browser SDK (using local builds generated by `npm pack` for example) and configure it
* Build the app with `next build`
* Serve the app with `next start`
* Open the app in a browser

-> RUM data should be sent to datadog

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
