### PR TITLE
🐛 Automatic mock clock cleanup

### DIFF
--- a/packages/core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
+++ b/packages/core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
@@ -14,10 +14,6 @@ describe('createEventRateLimiter', () => {
     clock = mockClock()
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   it('returns false if the limit is not reached', () => {
     eventLimiter = createEventRateLimiter('error', limit, noop)
 

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -93,7 +93,6 @@ describe('startSessionManager', () => {
       stopSessionManager()
       // flush pending callbacks to avoid random failures
       clock.tick(ONE_HOUR)
-      clock.cleanup()
     })
   })
 

--- a/packages/core/src/domain/session/sessionStore.spec.ts
+++ b/packages/core/src/domain/session/sessionStore.spec.ts
@@ -203,7 +203,6 @@ describe('session store', () => {
 
     afterEach(() => {
       resetSessionInStore()
-      clock.cleanup()
       sessionStoreManager.stop()
     })
 
@@ -577,7 +576,6 @@ describe('session store', () => {
 
     afterEach(() => {
       resetSessionInStore()
-      clock.cleanup()
       sessionStoreManager.stop()
       otherSessionStoreManager.stop()
     })

--- a/packages/core/src/domain/session/sessionStoreOperations.spec.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.spec.ts
@@ -244,8 +244,6 @@ const DEFAULT_INIT_CONFIGURATION = { trackAnonymousUser: true } as Configuration
         expect(processSpy).not.toHaveBeenCalled()
         expect(afterSpy).not.toHaveBeenCalled()
         expect(storage.setSpy).not.toHaveBeenCalled()
-
-        clock.cleanup()
       })
 
       it('should execute cookie accesses in order', (done) => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -138,7 +138,6 @@ describe('session in cookie strategy when opt-in anonymous user tracking', () =>
     expect(cookieSetSpy.calls.argsFor(0)[0]).toContain(
       new Date(clock.timeStamp(SESSION_COOKIE_EXPIRATION_DELAY)).toUTCString()
     )
-    clock.cleanup()
   })
 
   it('should expire in one year when opt-in', () => {
@@ -148,7 +147,6 @@ describe('session in cookie strategy when opt-in anonymous user tracking', () =>
     expect(cookieSetSpy.calls.argsFor(0)[0]).toContain(
       new Date(clock.timeStamp(SESSION_COOKIE_EXPIRATION_DELAY)).toUTCString()
     )
-    clock.cleanup()
   })
 })
 
@@ -170,7 +168,6 @@ describe('session in cookie strategy when opt-out anonymous user tracking', () =
     const clock = mockClock()
     cookieStorageStrategy.expireSession({ ...sessionState, anonymousId })
     expect(cookieSetSpy.calls.argsFor(0)[0]).toContain(new Date(clock.timeStamp(SESSION_TIME_OUT_DELAY)).toUTCString())
-    clock.cleanup()
   })
 
   it('should not persist with one year when opt-out', () => {

--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -1,4 +1,4 @@
-import { mockClock, mockZoneJs, registerCleanupTask } from '../../test'
+import { mockClock, mockZoneJs } from '../../test'
 import type { Clock, MockZoneJs } from '../../test'
 import type { InstrumentedMethodCall } from './instrumentMethod'
 import { instrumentMethod, instrumentSetter } from './instrumentMethod'

--- a/packages/core/src/tools/instrumentMethod.spec.ts
+++ b/packages/core/src/tools/instrumentMethod.spec.ts
@@ -204,9 +204,6 @@ describe('instrumentSetter', () => {
 
   beforeEach(() => {
     clock = mockClock()
-    registerCleanupTask(() => {
-      clock.cleanup()
-    })
     zoneJs = mockZoneJs()
   })
 

--- a/packages/core/src/tools/requestIdleCallback.spec.ts
+++ b/packages/core/src/tools/requestIdleCallback.spec.ts
@@ -4,7 +4,6 @@ import { MAX_TASK_TIME, requestIdleCallbackShim, requestIdleCallback } from './r
 describe('requestIdleCallback', () => {
   it('fallbacks to the shim when requestIdleCallback is not available', () => {
     const clock = mockClock()
-    registerCleanupTask(clock.cleanup)
     removeGlobalRequestIdleCallback()
 
     const spy = jasmine.createSpy<(deadline: IdleDeadline) => void>()
@@ -22,9 +21,6 @@ describe('requestIdleCallbackShim', () => {
 
   beforeEach(() => {
     clock = mockClock()
-    registerCleanupTask(() => {
-      clock.cleanup()
-    })
   })
 
   it('calls the callback asynchronously', () => {

--- a/packages/core/src/tools/taskQueue.spec.ts
+++ b/packages/core/src/tools/taskQueue.spec.ts
@@ -16,7 +16,6 @@ describe('createTaskQueue', () => {
 
   it('runs as many tasks as possible in a single idle callback', () => {
     const clock = mockClock()
-    registerCleanupTask(clock.cleanup)
     const requestIdleCallbackMock = mockRequestIdleCallback()
 
     // Each task takes 10ms to run
@@ -41,7 +40,6 @@ describe('createTaskQueue', () => {
 
   it('runs some tasks in case of timeout', () => {
     const clock = mockClock()
-    registerCleanupTask(clock.cleanup)
     const requestIdleCallbackMock = mockRequestIdleCallback()
 
     const task1 = jasmine.createSpy().and.callFake(() => clock.tick(MAX_EXECUTION_TIME_ON_TIMEOUT - 10))

--- a/packages/core/src/tools/taskQueue.spec.ts
+++ b/packages/core/src/tools/taskQueue.spec.ts
@@ -1,4 +1,4 @@
-import { mockClock, mockRequestIdleCallback, registerCleanupTask } from '../../test'
+import { mockClock, mockRequestIdleCallback } from '../../test'
 import { createTaskQueue, MAX_EXECUTION_TIME_ON_TIMEOUT } from './taskQueue'
 
 describe('createTaskQueue', () => {

--- a/packages/core/src/tools/timer.spec.ts
+++ b/packages/core/src/tools/timer.spec.ts
@@ -22,7 +22,6 @@ import { noop } from './utils/functionUtils'
     beforeEach(() => {
       clock = mockClock()
       registerCleanupTask(() => {
-        clock.cleanup()
         resetMonitor()
       })
       zoneJs = mockZoneJs()

--- a/packages/core/src/tools/utils/functionUtils.spec.ts
+++ b/packages/core/src/tools/utils/functionUtils.spec.ts
@@ -14,10 +14,6 @@ describe('functionUtils', () => {
       spy = jasmine.createSpy()
     })
 
-    afterEach(() => {
-      clock.cleanup()
-    })
-
     describe('when {leading: false, trailing:false}', () => {
       beforeEach(() => {
         throttled = throttle(spy, 2, { leading: false, trailing: false }).throttled

--- a/packages/core/src/tools/valueHistory.spec.ts
+++ b/packages/core/src/tools/valueHistory.spec.ts
@@ -18,7 +18,6 @@ describe('valueHistory', () => {
 
   afterEach(() => {
     valueHistory.stop()
-    clock.cleanup()
   })
 
   describe('find', () => {

--- a/packages/core/src/transport/flushController.spec.ts
+++ b/packages/core/src/transport/flushController.spec.ts
@@ -34,10 +34,6 @@ describe('flushController', () => {
     flushController.flushObservable.subscribe(flushSpy)
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   it('when flushing, the event contains a reason, the bytes count and the messages count', () => {
     const messagesCount = 3
     for (let i = 0; i < messagesCount; i += 1) {

--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -49,10 +49,6 @@ describe('sendWithRetryStrategy', () => {
     }
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   describe('nominal cases:', () => {
     it('should send request when no bandwidth limit reached', () => {
       sendRequest()

--- a/packages/core/test/emulate/mockClock.ts
+++ b/packages/core/test/emulate/mockClock.ts
@@ -1,4 +1,5 @@
 import type { RelativeTime, TimeStamp } from '../../src/tools/utils/timeUtils'
+import { registerCleanupTask } from '../registerCleanupTask'
 
 export type Clock = ReturnType<typeof mockClock>
 
@@ -11,6 +12,8 @@ export function mockClock() {
   const relativeStart = timeStampStart - timeOrigin
 
   spyOn(performance, 'now').and.callFake(() => Date.now() - timeOrigin)
+
+  registerCleanupTask(() => jasmine.clock().uninstall())
 
   return {
     /**

--- a/packages/core/test/emulate/mockClock.ts
+++ b/packages/core/test/emulate/mockClock.ts
@@ -28,8 +28,5 @@ export function mockClock() {
     timeStamp: (duration: number) => (timeStampStart + duration) as TimeStamp,
     tick: (ms: number) => jasmine.clock().tick(ms),
     setDate: (date: Date) => jasmine.clock().mockDate(date),
-    cleanup: () => {
-      jasmine.clock().uninstall()
-    },
   }
 }

--- a/packages/logs/src/boot/preStartLogs.spec.ts
+++ b/packages/logs/src/boot/preStartLogs.spec.ts
@@ -44,7 +44,6 @@ describe('preStartLogs', () => {
 
   afterEach(() => {
     resetFetchObservable()
-    clock.cleanup()
   })
 
   describe('configuration validation', () => {

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -257,9 +257,6 @@ describe('logs', () => {
     beforeEach(() => {
       clock = mockClock()
     })
-    afterEach(() => {
-      clock.cleanup()
-    })
 
     it('sends logs without session id when the session expires ', async () => {
       setCookie(SESSION_STORE_KEY, 'id=foo&logs=1', ONE_MINUTE)

--- a/packages/logs/src/domain/assembly.spec.ts
+++ b/packages/logs/src/domain/assembly.spec.ts
@@ -448,7 +448,6 @@ describe('logs limitation', () => {
   })
 
   afterEach(() => {
-    clock.cleanup()
     serverLogs = []
   })
 

--- a/packages/logs/src/domain/logger/loggerCollection.spec.ts
+++ b/packages/logs/src/domain/logger/loggerCollection.spec.ts
@@ -32,10 +32,6 @@ describe('logger collection', () => {
     clock = mockClock()
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   describe('when handle type is set to "console"', () => {
     beforeEach(() => {
       logger.setHandler(HandlerType.console)

--- a/packages/logs/src/domain/logger/loggerCollection.spec.ts
+++ b/packages/logs/src/domain/logger/loggerCollection.spec.ts
@@ -1,6 +1,5 @@
 import type { TimeStamp } from '@datadog/browser-core'
 import { ConsoleApiName, timeStampNow, ErrorSource, originalConsoleMethods } from '@datadog/browser-core'
-import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
 import type { CommonContext, RawLoggerLogsEvent } from '../../rawLogsEvent.types'
 import type { RawLogsEventCollectedData } from '../lifeCycle'
@@ -18,7 +17,6 @@ describe('logger collection', () => {
   let handleLog: ReturnType<typeof startLoggerCollection>['handleLog']
   let logger: Logger
   let rawLogsEvents: Array<RawLogsEventCollectedData<RawLoggerLogsEvent>>
-  let clock: Clock
 
   beforeEach(() => {
     rawLogsEvents = []
@@ -29,7 +27,7 @@ describe('logger collection', () => {
     spyOn(console, 'error').and.callFake(() => true)
     logger = new Logger((...params) => handleLog(...params))
     ;({ handleLog: handleLog } = startLoggerCollection(lifeCycle))
-    clock = mockClock()
+    mockClock()
   })
 
   describe('when handle type is set to "console"', () => {

--- a/packages/logs/src/domain/logsSessionManager.spec.ts
+++ b/packages/logs/src/domain/logsSessionManager.spec.ts
@@ -35,7 +35,6 @@ describe('logs session manager', () => {
     stopSessionManager()
     // flush pending callbacks to avoid random failures
     clock.tick(new Date().getTime())
-    clock.cleanup()
   })
 
   it('when tracked should store tracking type and session id', () => {

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -303,12 +303,6 @@ describe('preStartRum', () => {
         strategy = createPreStartStrategy({}, createTrackingConsentState(), createCustomVitalsState(), doStartRumSpy)
       })
 
-      afterEach(() => {
-        if (clock) {
-          clock.cleanup()
-        }
-      })
-
       describe('when auto', () => {
         it('should start rum at init', () => {
           strategy.init(AUTO_CONFIGURATION, PUBLIC_API)

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -1,7 +1,7 @@
 import type { RelativeTime, DeflateWorker, TimeStamp } from '@datadog/browser-core'
 import { ONE_SECOND, display, DefaultPrivacyLevel, timeStampToClocks } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock } from '@datadog/browser-core/test'
 import { noopRecorderApi, noopProfilerApi } from '../../test'
 import { ActionType, VitalType } from '../rawRumEvent.types'
 import type { DurationVitalReference } from '../domain/vital/vitalCollection'
@@ -122,7 +122,6 @@ describe('rum public api', () => {
   describe('addAction', () => {
     let addActionSpy: jasmine.Spy<ReturnType<StartRum>['addAction']>
     let rumPublicApi: RumPublicApi
-    let clock: Clock
 
     beforeEach(() => {
       addActionSpy = jasmine.createSpy()
@@ -134,7 +133,7 @@ describe('rum public api', () => {
         noopRecorderApi,
         noopProfilerApi
       )
-      clock = mockClock()
+      mockClock()
     })
 
     it('allows sending actions before init', () => {

--- a/packages/rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.spec.ts
@@ -135,10 +135,6 @@ describe('rum public api', () => {
         noopProfilerApi
       )
       clock = mockClock()
-
-      registerCleanupTask(() => {
-        clock.cleanup()
-      })
     })
 
     it('allows sending actions before init', () => {
@@ -190,10 +186,6 @@ describe('rum public api', () => {
         noopProfilerApi
       )
       clock = mockClock()
-
-      registerCleanupTask(() => {
-        clock.cleanup()
-      })
     })
 
     it('allows capturing an error before init', () => {

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -183,7 +183,6 @@ describe('rum session keep alive', () => {
 
     registerCleanupTask(() => {
       stop()
-      clock.cleanup()
     })
   })
 
@@ -255,7 +254,6 @@ describe('rum events url', () => {
     serverRumEvents = collectServerEvents(lifeCycle)
 
     registerCleanupTask(() => {
-      clock?.cleanup()
       stop()
     })
   })
@@ -343,7 +341,6 @@ describe('view events', () => {
     registerCleanupTask(() => {
       stop()
       stopSessionManager()
-      clock.cleanup()
     })
   })
 

--- a/packages/rum-core/src/browser/cookieObservable.spec.ts
+++ b/packages/rum-core/src/browser/cookieObservable.spec.ts
@@ -24,7 +24,6 @@ describe('cookieObservable', () => {
     if (originalSupportedEntryTypes) {
       Object.defineProperty(window, 'cookieStore', originalSupportedEntryTypes)
     }
-    clock.cleanup()
   })
 
   it('should notify observers on cookie change', async () => {

--- a/packages/rum-core/src/browser/performanceObservable.spec.ts
+++ b/packages/rum-core/src/browser/performanceObservable.spec.ts
@@ -28,7 +28,6 @@ describe('performanceObservable', () => {
 
   afterEach(() => {
     performanceSubscription?.unsubscribe()
-    clock?.cleanup()
   })
 
   describe('primary strategy when type supported', () => {

--- a/packages/rum-core/src/browser/viewportObservable.spec.ts
+++ b/packages/rum-core/src/browser/viewportObservable.spec.ts
@@ -20,7 +20,6 @@ describe('viewportObservable', () => {
 
   afterEach(() => {
     viewportSubscription.unsubscribe()
-    clock.cleanup()
   })
 
   const addVerticalScrollBar = () => {

--- a/packages/rum-core/src/domain/action/clickChain.spec.ts
+++ b/packages/rum-core/src/domain/action/clickChain.spec.ts
@@ -16,7 +16,6 @@ describe('createClickChain', () => {
 
   afterEach(() => {
     clickChain?.stop()
-    clock.cleanup()
   })
 
   it('creates a click chain', () => {

--- a/packages/rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/action/computeFrustration.spec.ts
@@ -87,10 +87,6 @@ describe('isRage', () => {
     clock = mockClock()
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   it('considers as rage three clicks happening at the same time', () => {
     expect(isRage([createFakeClick(), createFakeClick(), createFakeClick()])).toBe(true)
   })

--- a/packages/rum-core/src/domain/action/interactionSelectorCache.spec.ts
+++ b/packages/rum-core/src/domain/action/interactionSelectorCache.spec.ts
@@ -14,10 +14,6 @@ describe('interactionSelectorCache', () => {
     clock = mockClock()
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   it('should delete the selector after getting it', () => {
     const timestamp = relativeNow()
     updateInteractionSelector(timestamp, 'selector')

--- a/packages/rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.spec.ts
@@ -95,7 +95,6 @@ describe('trackClickActions', () => {
 
   afterEach(() => {
     stopClickActionsTracking()
-    clock.cleanup()
     button.parentNode!.removeChild(button)
     emptyElement.parentNode!.removeChild(emptyElement)
     input.parentNode!.removeChild(input)

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -556,7 +556,6 @@ describe('rum assembly', () => {
         let clock: Clock
         beforeEach(() => {
           clock = mockClock()
-          registerCleanupTask(() => clock.cleanup())
         })
 
         it(`allows to send new ${eventType} events after a minute`, () => {

--- a/packages/rum-core/src/domain/contexts/defaultContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/defaultContext.spec.ts
@@ -15,7 +15,6 @@ describe('startDefaultContext', () => {
     beforeEach(() => {
       clock = mockClock()
       hooks = createHooks()
-      registerCleanupTask(() => clock.cleanup())
     })
 
     it('should set the rum default context', () => {

--- a/packages/rum-core/src/domain/contexts/defaultContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/defaultContext.spec.ts
@@ -1,5 +1,4 @@
-import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, registerCleanupTask, mockEventBridge } from '@datadog/browser-core/test'
+import { mockClock, mockEventBridge } from '@datadog/browser-core/test'
 import { HookNames, timeStampNow } from '@datadog/browser-core'
 import type { RelativeTime } from '@datadog/browser-core'
 import { mockRumConfiguration } from '../../../test'
@@ -10,10 +9,9 @@ import { startDefaultContext } from './defaultContext'
 describe('startDefaultContext', () => {
   describe('assemble hook', () => {
     let hooks: Hooks
-    let clock: Clock
 
     beforeEach(() => {
-      clock = mockClock()
+      mockClock()
       hooks = createHooks()
     })
 

--- a/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
@@ -25,10 +25,6 @@ describe('featureFlagContexts', () => {
     featureFlagContexts = startFeatureFlagContexts(lifeCycle, hooks, {
       trackFeatureFlagsForEvents,
     } as unknown as RumConfiguration)
-
-    registerCleanupTask(() => {
-      clock.cleanup()
-    })
   })
 
   describe('assemble hook', () => {

--- a/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/featureFlagContext.spec.ts
@@ -1,7 +1,7 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { HookNames, relativeToClocks } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock } from '@datadog/browser-core/test'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { ViewCreatedEvent, ViewEndedEvent } from '../view/trackViews'
 import type { RumConfiguration } from '../configuration'

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.spec.ts
@@ -22,10 +22,6 @@ describe('pageStateHistory', () => {
     getEntriesByTypeSpy = spyOn(performance, 'getEntriesByType').and.returnValue([])
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   describe('wasInPageStateDuringPeriod', () => {
     let pageStateHistory: PageStateHistory
 

--- a/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.spec.ts
@@ -26,7 +26,6 @@ describe('urlContexts', () => {
 
     registerCleanupTask(() => {
       urlContexts.stop()
-      clock.cleanup()
     })
   })
 

--- a/packages/rum-core/src/domain/contexts/viewHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/viewHistory.spec.ts
@@ -29,7 +29,6 @@ describe('ViewHistory', () => {
 
     registerCleanupTask(() => {
       viewHistory.stop()
-      clock.cleanup()
     })
   })
 

--- a/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
@@ -22,7 +22,6 @@ describe('trackConsoleError', () => {
   afterEach(() => {
     resetConsoleObservable()
     subscription.unsubscribe()
-    clock.cleanup()
   })
 
   it('should track console error', () => {

--- a/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackConsoleError.spec.ts
@@ -1,6 +1,5 @@
 import type { RawError, Subscription } from '@datadog/browser-core'
 import { ErrorHandling, ErrorSource, Observable, clocksNow, resetConsoleObservable } from '@datadog/browser-core'
-import type { Clock } from '@datadog/browser-core/test'
 import { ignoreConsoleLogs, mockClock } from '@datadog/browser-core/test'
 import { trackConsoleError } from './trackConsoleError'
 
@@ -8,7 +7,6 @@ describe('trackConsoleError', () => {
   let errorObservable: Observable<RawError>
   let subscription: Subscription
   let notifyLog: jasmine.Spy
-  let clock: Clock
 
   beforeEach(() => {
     ignoreConsoleLogs('error', 'Error: foo')
@@ -16,7 +14,7 @@ describe('trackConsoleError', () => {
     notifyLog = jasmine.createSpy('notifyLog')
     trackConsoleError(errorObservable)
     subscription = errorObservable.subscribe(notifyLog)
-    clock = mockClock()
+    mockClock()
   })
 
   afterEach(() => {

--- a/packages/rum-core/src/domain/error/trackReportError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackReportError.spec.ts
@@ -1,6 +1,6 @@
 import type { RawError, Subscription } from '@datadog/browser-core'
 import { ErrorHandling, ErrorSource, Observable, clocksNow } from '@datadog/browser-core'
-import type { Clock, MockCspEventListener, MockReportingObserver } from '@datadog/browser-core/test'
+import type { MockCspEventListener, MockReportingObserver } from '@datadog/browser-core/test'
 import {
   FAKE_CSP_VIOLATION_EVENT,
   FAKE_REPORT,
@@ -17,7 +17,6 @@ describe('trackReportError', () => {
   let errorObservable: Observable<RawError>
   let subscription: Subscription
   let notifyLog: jasmine.Spy
-  let clock: Clock
   let reportingObserver: MockReportingObserver
   let cspEventListener: MockCspEventListener
   let configuration: RumConfiguration
@@ -31,7 +30,7 @@ describe('trackReportError', () => {
     notifyLog = jasmine.createSpy('notifyLog')
     reportingObserver = mockReportingObserver()
     subscription = errorObservable.subscribe(notifyLog)
-    clock = mockClock()
+    mockClock()
     registerCleanupTask(() => {
       subscription.unsubscribe()
     })

--- a/packages/rum-core/src/domain/error/trackReportError.spec.ts
+++ b/packages/rum-core/src/domain/error/trackReportError.spec.ts
@@ -34,7 +34,6 @@ describe('trackReportError', () => {
     clock = mockClock()
     registerCleanupTask(() => {
       subscription.unsubscribe()
-      clock.cleanup()
     })
     cspEventListener = mockCspEventListener()
   })

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -51,7 +51,6 @@ describe('rum session manager', () => {
       stopSessionManager()
       // flush pending callbacks to avoid random failures
       clock.tick(new Date().getTime())
-      clock.cleanup()
     })
   })
 

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.spec.ts
@@ -65,7 +65,6 @@ describe('customerDataTelemetry', () => {
 
   afterEach(() => {
     resetExperimentalFeatures()
-    clock.cleanup()
   })
 
   it('should collect customer data telemetry', () => {

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -122,7 +122,6 @@ describe('view lifecycle', () => {
 
     registerCleanupTask(() => {
       viewTest.stop()
-      clock.cleanup()
     })
   })
 
@@ -363,7 +362,6 @@ describe('view loading type', () => {
 
     registerCleanupTask(() => {
       viewTest.stop()
-      clock.cleanup()
     })
   })
 
@@ -396,7 +394,6 @@ describe('view metrics', () => {
 
     registerCleanupTask(() => {
       viewTest.stop()
-      clock.cleanup()
     })
   })
 
@@ -606,7 +603,6 @@ describe('view custom timings', () => {
 
     registerCleanupTask(() => {
       viewTest.stop()
-      clock.cleanup()
     })
   })
 
@@ -743,7 +739,6 @@ describe('start view', () => {
 
     registerCleanupTask(() => {
       viewTest.stop()
-      clock.cleanup()
     })
   })
 
@@ -840,7 +835,6 @@ describe('view event count', () => {
 
     registerCleanupTask(() => {
       viewTest.stop()
-      clock.cleanup()
       resetExperimentalFeatures()
     })
   })
@@ -1000,7 +994,6 @@ describe('service and version', () => {
 
     registerCleanupTask(() => {
       viewTest.stop()
-      clock.cleanup()
       resetExperimentalFeatures()
     })
   })

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -352,11 +352,10 @@ describe('view lifecycle', () => {
 
 describe('view loading type', () => {
   const lifeCycle = new LifeCycle()
-  let clock: Clock
   let viewTest: ViewTest
 
   beforeEach(() => {
-    clock = mockClock()
+    mockClock()
 
     viewTest = setupViewTest({ lifeCycle })
 
@@ -986,11 +985,10 @@ describe('view event count', () => {
 
 describe('service and version', () => {
   const lifeCycle = new LifeCycle()
-  let clock: Clock
   let viewTest: ViewTest
 
   beforeEach(() => {
-    clock = mockClock()
+    mockClock()
 
     registerCleanupTask(() => {
       viewTest.stop()

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -80,7 +80,7 @@ describe('viewCollection', () => {
     const domMutationObservable = new Observable<RumMutationRecord[]>()
     const windowOpenObservable = new Observable<void>()
     const locationChangeObservable = new Observable<LocationChange>()
-    const clock = mockClock()
+    mockClock()
 
     const collectionResult = startViewCollection(
       lifeCycle,

--- a/packages/rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/rum-core/src/domain/view/viewCollection.spec.ts
@@ -102,7 +102,6 @@ describe('viewCollection', () => {
     registerCleanupTask(() => {
       collectionResult.stop()
       viewHistory.stop()
-      clock.cleanup()
     })
     return collectionResult
   }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackBfcacheMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackBfcacheMetrics.spec.ts
@@ -9,7 +9,6 @@ describe('trackBfcacheMetrics', () => {
 
   beforeEach(() => {
     clock = mockClock()
-    registerCleanupTask(clock.cleanup)
 
     spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback): number => {
       cb(performance.now())

--- a/packages/rum-core/src/domain/view/viewMetrics/trackBfcacheMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackBfcacheMetrics.spec.ts
@@ -1,6 +1,6 @@
 import type { Duration, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { createNewEvent, mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { createNewEvent, mockClock } from '@datadog/browser-core/test'
 import { trackBfcacheMetrics } from './trackBfcacheMetrics'
 import type { InitialViewMetrics } from './trackInitialViewMetrics'
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.spec.ts
@@ -20,7 +20,6 @@ describe('trackInitialViewMetrics', () => {
     scheduleViewUpdateSpy = jasmine.createSpy()
     setLoadEventSpy = jasmine.createSpy()
     clock = mockClock()
-    registerCleanupTask(clock.cleanup)
 
     trackInitialViewMetricsResult = trackInitialViewMetrics(configuration, setLoadEventSpy, scheduleViewUpdateSpy)
 

--- a/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackLoadingTime.spec.ts
@@ -51,7 +51,6 @@ describe('trackLoadingTime', () => {
   afterEach(() => {
     stopLoadingTimeTracking()
     restorePageVisibility()
-    clock.cleanup()
   })
 
   it('should have an undefined loading time if there is no activity on a route change', () => {

--- a/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
@@ -31,7 +31,6 @@ describe('trackNavigationTimings', () => {
     clock = mockClock()
 
     registerCleanupTask(() => {
-      clock.cleanup()
       stop()
     })
   })

--- a/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
@@ -62,7 +62,6 @@ describe('trackScrollMetrics', () => {
 
   afterEach(() => {
     document.body.innerHTML = ''
-    clock.cleanup()
   })
 
   const updateScrollValues = (scrollValues: ScrollValues) => {

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -25,10 +25,6 @@ describe('vitalCollection', () => {
     vitalCollection = startVitalCollection(lifeCycle, pageStateHistory, vitalsState)
 
     rawRumEvents = collectAndValidateRawRumEvents(lifeCycle)
-
-    registerCleanupTask(() => {
-      clock.cleanup()
-    })
   })
 
   describe('custom duration', () => {

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -1,5 +1,5 @@
 import type { Duration } from '@datadog/browser-core'
-import { mockClock, registerCleanupTask, type Clock } from '@datadog/browser-core/test'
+import { mockClock, type Clock } from '@datadog/browser-core/test'
 import { clocksNow } from '@datadog/browser-core'
 import { collectAndValidateRawRumEvents, mockPageStateHistory } from '../../../test'
 import type { RawRumEvent, RawRumVitalEvent } from '../../rawRumEvent.types'

--- a/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
@@ -249,10 +249,6 @@ describe('doWaitPageActivityEnd', () => {
     clock = mockClock()
   })
 
-  afterEach(() => {
-    clock.cleanup()
-  })
-
   it('should notify the callback after `EXPIRE_DELAY` when there is no activity', () => {
     doWaitPageActivityEnd(new Observable(), idlPageActivityCallbackSpy)
 

--- a/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
+++ b/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, act } from 'react'
 import { appendComponent } from '../../../test/appendComponent'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'
 import type { Clock } from '../../../../core/test'
-import { mockClock, registerCleanupTask } from '../../../../core/test'
+import { mockClock } from '../../../../core/test'
 import { UNSTABLE_ReactComponentTracker as ReactComponentTracker } from './reactComponentTracker'
 
 const RENDER_DURATION = 100

--- a/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
+++ b/packages/rum-react/src/domain/performance/reactComponentTracker.spec.tsx
@@ -22,7 +22,6 @@ describe('UNSTABLE_ReactComponentTracker', () => {
 
   beforeEach(() => {
     clock = mockClock()
-    registerCleanupTask(() => clock.cleanup())
   })
 
   it('should call addDurationVital after the component rendering', () => {

--- a/packages/rum-react/src/domain/performance/timer.spec.ts
+++ b/packages/rum-react/src/domain/performance/timer.spec.ts
@@ -1,4 +1,4 @@
-import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
+import { mockClock } from '@datadog/browser-core/test'
 import type { Duration } from '@datadog/browser-core'
 import { createTimer } from './timer'
 

--- a/packages/rum-react/src/domain/performance/timer.spec.ts
+++ b/packages/rum-react/src/domain/performance/timer.spec.ts
@@ -5,7 +5,6 @@ import { createTimer } from './timer'
 describe('createTimer', () => {
   it('is able to measure time', () => {
     const clock = mockClock()
-    registerCleanupTask(clock.cleanup)
 
     const timer = createTimer()
     timer.startTimer()

--- a/packages/rum/src/domain/deflate/deflateWorker.spec.ts
+++ b/packages/rum/src/domain/deflate/deflateWorker.spec.ts
@@ -179,10 +179,6 @@ describe('startDeflateWorker', () => {
       clock = mockClock()
     })
 
-    afterEach(() => {
-      clock.cleanup()
-    })
-
     it('displays an error message when the worker does not respond to the init action', () => {
       startDeflateWorkerWithDefaults()
       clock.tick(INITIALIZATION_TIME_OUT_DELAY)

--- a/packages/rum/src/domain/record/mutationBatch.spec.ts
+++ b/packages/rum/src/domain/record/mutationBatch.spec.ts
@@ -18,7 +18,6 @@ describe('createMutationBatch', () => {
 
   afterEach(() => {
     mutationBatch.stop()
-    clock.cleanup()
   })
 
   it('calls the callback asynchronously after MUTATION_PROCESS_MIN_DELAY', () => {

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -1,7 +1,6 @@
 import { DefaultPrivacyLevel, findLast } from '@datadog/browser-core'
 import type { RumConfiguration, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
-import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, collectAsyncCalls, registerCleanupTask } from '@datadog/browser-core/test'
 import {
   findElement,
@@ -28,7 +27,6 @@ describe('record', () => {
   let recordApi: RecordAPI
   let lifeCycle: LifeCycle
   let emitSpy: jasmine.Spy<(record: BrowserRecord) => void>
-  let clock: Clock | undefined
   const FAKE_VIEW_ID = '123'
 
   beforeEach(() => {

--- a/packages/rum/src/domain/record/record.spec.ts
+++ b/packages/rum/src/domain/record/record.spec.ts
@@ -35,7 +35,6 @@ describe('record', () => {
     emitSpy = jasmine.createSpy()
 
     registerCleanupTask(() => {
-      clock?.cleanup()
       recordApi?.stop()
     })
   })

--- a/packages/rum/src/domain/record/trackers/trackInput.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackInput.spec.ts
@@ -32,7 +32,6 @@ describe('trackInput', () => {
 
     registerCleanupTask(() => {
       inputTracker.stop()
-      clock?.cleanup()
     })
   })
 

--- a/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -74,7 +74,6 @@ describe('startSegmentCollection', () => {
     ))
 
     registerCleanupTask(() => {
-      clock?.cleanup()
       stopSegmentCollection()
     })
   })


### PR DESCRIPTION
## Motivation

While working on #3573, I had issues with unit tests running in BrowserStack. The issue comes from the clock not being cleanup properly and it's more evident when you access the clocks during the tests.

## Changes

This PR applies an automatic cleanup callback when the clock is mocked in a test.

## Test instructions

All tests passed

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
