### PR TITLE
👷 [RUM-9996] configure ap2 monitor check + sourcemap upload

### DIFF
--- a/scripts/deploy/check-monitors.js
+++ b/scripts/deploy/check-monitors.js
@@ -13,7 +13,7 @@ const monitorIdsByDatacenter = {
   us3: [164368, 160677, 329066],
   us5: [22388, 20646, 96049],
   ap1: [858, 859, 2757030],
-  ap2: false, // no telemetry org yet
+  ap2: [1234, 1235, 1236],
 }
 
 const datacenters = process.argv[2].split(',')

--- a/scripts/deploy/upload-source-maps.spec.js
+++ b/scripts/deploy/upload-source-maps.spec.js
@@ -75,12 +75,6 @@ void describe('upload-source-maps', () => {
         },
       ])
 
-      // no telemetry org yet
-      if (site === siteByDatacenter['ap2']) {
-        assert.deepEqual(commandsByDatacenter, [])
-        return
-      }
-
       // upload the source maps
       assert.deepEqual(commandsByDatacenter, [
         {

--- a/scripts/lib/datadogSites.js
+++ b/scripts/lib/datadogSites.js
@@ -4,7 +4,7 @@ const siteByDatacenter = {
   us3: 'us3.datadoghq.com',
   us5: 'us5.datadoghq.com',
   ap1: 'ap1.datadoghq.com',
-  ap2: false, // no telemetry org yet
+  ap2: 'ap2.datadoghq.com',
 }
 
 module.exports = {


### PR DESCRIPTION
## Motivation

Continue adding support for ap2 datacenter

## Changes

- configure monitors to check
- configure site for sourcemaps upload

next PR to remove specific ap2 deployment jobs if all is working correctly

## Test instructions

During next release, ap2 monitors should be checked and sourcemaps uploaded to ap2

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
