### PR TITLE
👷 update yarn version to 4.9.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "volta": {
     "node": "23.11.1",
-    "yarn": "1.22.22"
+    "yarn": "4.9.1"
   },
   "packageManager": "yarn@4.9.1"
 }


### PR DESCRIPTION
## Motivation

Following a recent Renovate [change](https://github.com/renovatebot/renovate/pull/35869), Renovate will now assume our repo is using the yarn version defined by volta (1.22.22) and adapt `yarn` command line arguments accordingly. But in reality, even if yarn 1.22.22 is specified in Volta, yarn will load the up-to-date version defined by the `packageManager` property and cached in the [.yarn/releases](https://github.com/DataDog/browser-sdk/tree/main/.yarn/releases) folder, so the `yarn` invocation [fails](https://github.com/DataDog/browser-sdk/pull/3589#issuecomment-2934130645).

## Changes

This PR updates the `volta.yarn` version to match the one in specified by `packageManager`.

Alternatives that have been considered:
* removing `volta.yarn` and relying only on `packageManager`
* removing `packageManager` and relying only on volta

We chose to be conservative and keep using both `volta.yarn` and `packageManager` properties.

## Test instructions

If renovate PRs pass, it should be good.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
