### PR TITLE
✨ [RUM-10144] apply context defined just after init to events generated during init

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,7 +56,7 @@ export {
 } from './domain/telemetry'
 export { monitored, monitor, callMonitored, setDebugMode, monitorError } from './tools/monitor'
 export type { Subscription } from './tools/observable'
-export { Observable } from './tools/observable'
+export { Observable, BufferedObservable } from './tools/observable'
 export type { SessionManager } from './domain/session/sessionManager'
 export { startSessionManager, stopSessionManager } from './domain/session/sessionManager'
 export {

--- a/packages/core/src/tools/boundedBuffer.ts
+++ b/packages/core/src/tools/boundedBuffer.ts
@@ -2,12 +2,18 @@ import { removeItem } from './utils/arrayUtils'
 
 const BUFFER_LIMIT = 500
 
+/**
+ * @deprecated Use `BufferedObservable` instead.
+ */
 export interface BoundedBuffer<T = void> {
   add: (callback: (arg: T) => void) => void
   remove: (callback: (arg: T) => void) => void
   drain: (arg: T) => void
 }
 
+/**
+ * @deprecated Use `BufferedObservable` instead.
+ */
 export function createBoundedBuffer<T = void>(): BoundedBuffer<T> {
   const buffer: Array<(arg: T) => void> = []
 

--- a/packages/core/src/tools/observable.ts
+++ b/packages/core/src/tools/observable.ts
@@ -1,31 +1,41 @@
+import { monitorError } from './monitor'
+
 export interface Subscription {
   unsubscribe: () => void
 }
 
+type Observer<T> = (data: T) => void
+
 // eslint-disable-next-line no-restricted-syntax
 export class Observable<T> {
-  private observers: Array<(data: T) => void> = []
+  protected observers: Array<Observer<T>> = []
   private onLastUnsubscribe?: () => void
 
   constructor(private onFirstSubscribe?: (observable: Observable<T>) => (() => void) | void) {}
 
-  subscribe(f: (data: T) => void): Subscription {
-    this.observers.push(f)
-    if (this.observers.length === 1 && this.onFirstSubscribe) {
-      this.onLastUnsubscribe = this.onFirstSubscribe(this) || undefined
-    }
+  subscribe(observer: Observer<T>): Subscription {
+    this.addObserver(observer)
     return {
-      unsubscribe: () => {
-        this.observers = this.observers.filter((other) => f !== other)
-        if (!this.observers.length && this.onLastUnsubscribe) {
-          this.onLastUnsubscribe()
-        }
-      },
+      unsubscribe: () => this.removeObserver(observer),
     }
   }
 
   notify(data: T) {
     this.observers.forEach((observer) => observer(data))
+  }
+
+  protected addObserver(observer: Observer<T>) {
+    this.observers.push(observer)
+    if (this.observers.length === 1 && this.onFirstSubscribe) {
+      this.onLastUnsubscribe = this.onFirstSubscribe(this) || undefined
+    }
+  }
+
+  protected removeObserver(observer: Observer<T>) {
+    this.observers = this.observers.filter((other) => observer !== other)
+    if (!this.observers.length && this.onLastUnsubscribe) {
+      this.onLastUnsubscribe()
+    }
   }
 }
 
@@ -36,4 +46,63 @@ export function mergeObservables<T>(...observables: Array<Observable<T>>) {
     )
     return () => subscriptions.forEach((subscription) => subscription.unsubscribe())
   })
+}
+
+// eslint-disable-next-line no-restricted-syntax
+export class BufferedObservable<T> extends Observable<T> {
+  private buffer: T[] = []
+
+  constructor(private maxBufferSize: number) {
+    // no onFirstSubscribe as it makes less sense with buffered data
+    super()
+  }
+
+  notify(data: T) {
+    this.buffer.push(data)
+    if (this.buffer.length > this.maxBufferSize) {
+      this.buffer.shift()
+    }
+    super.notify(data)
+  }
+
+  subscribe(observer: Observer<T>): Subscription {
+    let closed = false
+
+    const subscription = {
+      unsubscribe: () => {
+        closed = true
+        this.removeObserver(observer)
+      },
+    }
+
+    enqueueMicroTask(() => {
+      for (const data of this.buffer) {
+        if (closed) {
+          return
+        }
+        observer(data)
+      }
+
+      if (!closed) {
+        this.addObserver(observer)
+      }
+    })
+
+    return subscription
+  }
+
+  /**
+   * Drop buffered data and don't buffer future data. This is to avoid leaking memory when it's not
+   * needed anymore. This is not be required in most cases, but still useful to clarify our intent
+   * and lowering our memory impact.
+   */
+  unbuffer() {
+    enqueueMicroTask(() => {
+      this.maxBufferSize = this.buffer.length = 0
+    })
+  }
+}
+
+function enqueueMicroTask(callback: () => void) {
+  Promise.resolve().then(callback).catch(monitorError)
 }

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -27,8 +27,8 @@ describe('rum assembly', () => {
   describe('beforeSend', () => {
     describe('fields modification', () => {
       describe('modifiable fields', () => {
-        it('should allow modification', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should allow modification', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => (event.view.url = 'modified'),
             },
@@ -38,11 +38,12 @@ describe('rum assembly', () => {
             rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK, { view: { url: '/path?foo=bar' } }),
           })
 
-          expect(serverRumEvents[0].view.url).toBe('modified')
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].view.url).toBe('modified')
         })
 
-        it('should allow addition', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should allow addition', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => (event.view.name = 'added'),
             },
@@ -52,11 +53,12 @@ describe('rum assembly', () => {
             rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK, { view: { url: '/path?foo=bar' } }),
           })
 
-          expect(serverRumEvents[0].view.name).toBe('added')
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].view.name).toBe('added')
         })
 
-        it('should allow modification of view.performance.lcp.resource_url', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should allow modification of view.performance.lcp.resource_url', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => (event.view.performance.lcp.resource_url = 'modified_url'),
             },
@@ -68,12 +70,13 @@ describe('rum assembly', () => {
             }),
           })
 
-          expect((serverRumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
+          const rumEvents = await getRumEvents()
+          expect((rumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
         })
 
         describe('field resource.graphql on Resource events', () => {
-          it('by default, it should not be modifiable', () => {
-            const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+          it('by default, it should not be modifiable', async () => {
+            const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
               partialConfiguration: {
                 beforeSend: (event) => (event.resource!.graphql = { operationType: 'query' }),
               },
@@ -83,13 +86,14 @@ describe('rum assembly', () => {
               rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, { resource: { url: '/path?foo=bar' } }),
             })
 
-            expect((serverRumEvents[0] as RumResourceEvent).resource.graphql).toBeUndefined()
+            const rumEvents = await getRumEvents()
+            expect((rumEvents[0] as RumResourceEvent).resource.graphql).toBeUndefined()
           })
 
-          it('with the writable_resource_graphql experimental flag is set, it should be modifiable', () => {
+          it('with the writable_resource_graphql experimental flag is set, it should be modifiable', async () => {
             mockExperimentalFeatures([ExperimentalFeature.WRITABLE_RESOURCE_GRAPHQL])
 
-            const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+            const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
               partialConfiguration: {
                 beforeSend: (event) => (event.resource!.graphql = { operationType: 'query' }),
               },
@@ -99,14 +103,15 @@ describe('rum assembly', () => {
               rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, { resource: { url: '/path?foo=bar' } }),
             })
 
-            expect((serverRumEvents[0] as RumResourceEvent).resource.graphql).toEqual({ operationType: 'query' })
+            const rumEvents = await getRumEvents()
+            expect((rumEvents[0] as RumResourceEvent).resource.graphql).toEqual({ operationType: 'query' })
           })
         })
       })
 
       describe('context field', () => {
-        it('should allow modification on context field for events other than views', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should allow modification on context field for events other than views', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 event.context.foo = 'bar'
@@ -118,11 +123,12 @@ describe('rum assembly', () => {
             rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK),
           })
 
-          expect(serverRumEvents[0].context!.foo).toBe('bar')
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].context!.foo).toBe('bar')
         })
 
-        it('should allow replacing the context field for events other than views', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should allow replacing the context field for events other than views', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 event.context.foo = 'bar'
@@ -134,11 +140,12 @@ describe('rum assembly', () => {
             rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK),
           })
 
-          expect(serverRumEvents[0].context!.foo).toBe('bar')
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].context!.foo).toBe('bar')
         })
 
-        it('should empty the context field if set to null', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should empty the context field if set to null', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 event.context = null
@@ -151,11 +158,12 @@ describe('rum assembly', () => {
             customerContext: { foo: 'bar' },
           })
 
-          expect(serverRumEvents[0].context).toBeUndefined()
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].context).toBeUndefined()
         })
 
-        it('should empty the context field if set to undefined', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should empty the context field if set to undefined', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 event.context = undefined
@@ -168,11 +176,12 @@ describe('rum assembly', () => {
             customerContext: { foo: 'bar' },
           })
 
-          expect(serverRumEvents[0].context).toBeUndefined()
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].context).toBeUndefined()
         })
 
-        it('should empty the context field if deleted', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should empty the context field if deleted', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 delete event.context
@@ -185,11 +194,12 @@ describe('rum assembly', () => {
             customerContext: { foo: 'bar' },
           })
 
-          expect(serverRumEvents[0].context).toBeUndefined()
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].context).toBeUndefined()
         })
 
-        it('should define the context field even if the global context is empty', () => {
-          const { lifeCycle } = setupAssemblyTestWithDefaults({
+        it('should define the context field even if the global context is empty', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 expect(event.context).toEqual({})
@@ -200,10 +210,12 @@ describe('rum assembly', () => {
           notifyRawRumEvent(lifeCycle, {
             rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK),
           })
+
+          await getRumEvents()
         })
 
-        it('should accept modification on context field for view events', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should accept modification on context field for view events', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 event.context.foo = 'bar'
@@ -215,11 +227,12 @@ describe('rum assembly', () => {
             rawRumEvent: createRawRumEvent(RumEventType.VIEW),
           })
 
-          expect(serverRumEvents[0].context).toEqual({ foo: 'bar' })
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].context).toEqual({ foo: 'bar' })
         })
 
-        it('should reject replacing the context field to non-object', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should reject replacing the context field to non-object', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => {
                 event.context = 1
@@ -232,13 +245,14 @@ describe('rum assembly', () => {
             customerContext: { foo: 'bar' },
           })
 
-          expect(serverRumEvents[0].context!.foo).toBe('bar')
+          const rumEvents = await getRumEvents()
+          expect(rumEvents[0].context!.foo).toBe('bar')
         })
       })
 
       describe('allowed customer provided field', () => {
-        it('should allow modification of the error fingerprint', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it('should allow modification of the error fingerprint', async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: {
               beforeSend: (event) => (event.error.fingerprint = 'my_fingerprint'),
             },
@@ -248,12 +262,13 @@ describe('rum assembly', () => {
             rawRumEvent: createRawRumEvent(RumEventType.ERROR),
           })
 
-          expect((serverRumEvents[0] as RumErrorEvent).error.fingerprint).toBe('my_fingerprint')
+          const rumEvents = await getRumEvents()
+          expect((rumEvents[0] as RumErrorEvent).error.fingerprint).toBe('my_fingerprint')
         })
       })
 
-      it('should reject modification of field not sensitive, context or customer provided', () => {
-        const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+      it('should reject modification of field not sensitive, context or customer provided', async () => {
+        const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
           partialConfiguration: {
             beforeSend: (event: RumEvent) => ((event.view as any).id = 'modified'),
           },
@@ -265,11 +280,12 @@ describe('rum assembly', () => {
           }),
         })
 
-        expect(serverRumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+        const rumEvents = await getRumEvents()
+        expect(rumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
       })
 
-      it('should not allow to add a sensitive field on the wrong event type', () => {
-        const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+      it('should not allow to add a sensitive field on the wrong event type', async () => {
+        const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
           partialConfiguration: {
             beforeSend: (event) => {
               event.error = { message: 'added' }
@@ -281,13 +297,14 @@ describe('rum assembly', () => {
           rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         })
 
-        expect((serverRumEvents[0] as any).error?.message).toBeUndefined()
+        const rumEvents = await getRumEvents()
+        expect((rumEvents[0] as any).error?.message).toBeUndefined()
       })
     })
 
     describe('events dismission', () => {
-      it('should allow dismissing events other than views', () => {
-        const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+      it('should allow dismissing events other than views', async () => {
+        const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
           partialConfiguration: {
             beforeSend: () => false,
           },
@@ -317,11 +334,12 @@ describe('rum assembly', () => {
           }),
         })
 
-        expect(serverRumEvents.length).toBe(0)
+        const rumEvents = await getRumEvents()
+        expect(rumEvents.length).toBe(0)
       })
 
-      it('should not allow dismissing view events', () => {
-        const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+      it('should not allow dismissing view events', async () => {
+        const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
           partialConfiguration: {
             beforeSend: () => false,
           },
@@ -334,13 +352,14 @@ describe('rum assembly', () => {
           }),
         })
 
-        expect(serverRumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+        const rumEvents = await getRumEvents()
+        expect(rumEvents[0].view.id).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
         expect(displaySpy).toHaveBeenCalledWith("Can't dismiss view events using beforeSend!")
       })
     })
 
-    it('should not dismiss when true is returned', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+    it('should not dismiss when true is returned', async () => {
+      const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
         partialConfiguration: {
           beforeSend: () => true,
         },
@@ -352,11 +371,12 @@ describe('rum assembly', () => {
         }),
       })
 
-      expect(serverRumEvents.length).toBe(1)
+      const rumEvents = await getRumEvents()
+      expect(rumEvents.length).toBe(1)
     })
 
-    it('should not dismiss when undefined is returned', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+    it('should not dismiss when undefined is returned', async () => {
+      const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
         partialConfiguration: {
           beforeSend: () => undefined,
         },
@@ -368,19 +388,21 @@ describe('rum assembly', () => {
         }),
       })
 
-      expect(serverRumEvents.length).toBe(1)
+      const rumEvents = await getRumEvents()
+      expect(rumEvents.length).toBe(1)
     })
   })
 
   describe('customer context', () => {
-    it('should be merged with event attributes', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults()
+    it('should be merged with event attributes', async () => {
+      const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults()
       notifyRawRumEvent(lifeCycle, {
         customerContext: { foo: 'bar' },
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
       })
 
-      expect((serverRumEvents[0].context as any).foo).toEqual('bar')
+      const rumEvents = await getRumEvents()
+      expect((rumEvents[0].context as any).foo).toEqual('bar')
     })
   })
 
@@ -388,8 +410,8 @@ describe('rum assembly', () => {
     const extraConfigurationOptions = { service: 'default service', version: 'default version' }
 
     describe('fields service and version', () => {
-      it('it should be modifiable', () => {
-        const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+      it('it should be modifiable', async () => {
+        const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
           partialConfiguration: {
             ...extraConfigurationOptions,
             beforeSend: (event) => {
@@ -404,21 +426,22 @@ describe('rum assembly', () => {
         notifyRawRumEvent(lifeCycle, {
           rawRumEvent: createRawRumEvent(RumEventType.RESOURCE),
         })
-        expect((serverRumEvents[0] as RumResourceEvent).service).toBe('bar')
-        expect((serverRumEvents[0] as RumResourceEvent).version).toBe('0.2.0')
+        const rumEvents = await getRumEvents()
+        expect((rumEvents[0] as RumResourceEvent).service).toBe('bar')
+        expect((rumEvents[0] as RumResourceEvent).version).toBe('0.2.0')
 
         notifyRawRumEvent(lifeCycle, {
           rawRumEvent: createRawRumEvent(RumEventType.VIEW),
         })
-        expect((serverRumEvents[1] as RumViewEvent).service).toBe('bar')
-        expect((serverRumEvents[1] as RumViewEvent).version).toBe('0.2.0')
+        expect((rumEvents[1] as RumViewEvent).service).toBe('bar')
+        expect((rumEvents[1] as RumViewEvent).version).toBe('0.2.0')
       })
     })
   })
 
   describe('assemble hook', () => {
-    it('should add and override common properties', () => {
-      const { lifeCycle, hooks, serverRumEvents } = setupAssemblyTestWithDefaults({
+    it('should add and override common properties', async () => {
+      const { lifeCycle, hooks, getRumEvents } = setupAssemblyTestWithDefaults({
         partialConfiguration: { service: 'default service', version: 'default version' },
       })
 
@@ -432,13 +455,14 @@ describe('rum assembly', () => {
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
       })
-      expect(serverRumEvents[0].service).toEqual('new service')
-      expect(serverRumEvents[0].version).toEqual('new version')
-      expect(serverRumEvents[0].view.id).toEqual('new view id')
+      const rumEvents = await getRumEvents()
+      expect(rumEvents[0].service).toEqual('new service')
+      expect(rumEvents[0].version).toEqual('new version')
+      expect(rumEvents[0].view.id).toEqual('new view id')
     })
 
-    it('should not override customer context', () => {
-      const { lifeCycle, hooks, serverRumEvents } = setupAssemblyTestWithDefaults()
+    it('should not override customer context', async () => {
+      const { lifeCycle, hooks, getRumEvents } = setupAssemblyTestWithDefaults()
 
       hooks.register(HookNames.Assemble, ({ eventType }) => ({
         type: eventType,
@@ -449,38 +473,43 @@ describe('rum assembly', () => {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
         customerContext: { foo: 'customer context' },
       })
-      expect(serverRumEvents[0].context).toEqual({ foo: 'customer context' })
+      const rumEvents = await getRumEvents()
+      expect(rumEvents[0].context).toEqual({ foo: 'customer context' })
     })
   })
 
   describe('event generation condition', () => {
-    it('when tracked, it should generate event', () => {
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults()
+    it('when tracked, it should generate event', async () => {
+      const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults()
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
       })
-      expect(serverRumEvents.length).toBe(1)
+      const rumEvents = await getRumEvents()
+      expect(rumEvents.length).toBe(1)
     })
 
-    it('when not tracked, it should not generate event', () => {
+    it('when not tracked, it should not generate event', async () => {
       const sessionManager = createRumSessionManagerMock().setNotTracked()
-      const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({ sessionManager })
+      const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({ sessionManager })
 
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.VIEW),
       })
-      expect(serverRumEvents.length).toBe(0)
+      const rumEvents = await getRumEvents()
+      expect(rumEvents.length).toBe(0)
     })
 
-    it('should get session state from event start', () => {
+    it('should get session state from event start', async () => {
       const sessionManager = createRumSessionManagerMock()
       spyOn(sessionManager, 'findTrackedSession').and.callThrough()
-      const { lifeCycle } = setupAssemblyTestWithDefaults({ sessionManager })
+      const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({ sessionManager })
 
       notifyRawRumEvent(lifeCycle, {
         rawRumEvent: createRawRumEvent(RumEventType.ACTION),
         startTime: 123 as RelativeTime,
       })
+
+      await getRumEvents()
 
       expect(sessionManager.findTrackedSession).toHaveBeenCalledWith(123 as RelativeTime)
     })
@@ -500,8 +529,8 @@ describe('rum assembly', () => {
     },
   ].forEach(({ eventType, message }) => {
     describe(`${eventType} events limitation`, () => {
-      it(`stops sending ${eventType} events when reaching the limit`, () => {
-        const { lifeCycle, serverRumEvents, reportErrorSpy } = setupAssemblyTestWithDefaults({
+      it(`stops sending ${eventType} events when reaching the limit`, async () => {
+        const { lifeCycle, getRumEvents, reportErrorSpy } = setupAssemblyTestWithDefaults({
           partialConfiguration: { eventRateLimiterThreshold: 1 },
         })
 
@@ -512,8 +541,9 @@ describe('rum assembly', () => {
           rawRumEvent: createRawRumEvent(eventType, { date: 200 as TimeStamp }),
         })
 
-        expect(serverRumEvents.length).toBe(1)
-        expect(serverRumEvents[0].date).toBe(100)
+        const rumEvents = await getRumEvents()
+        expect(rumEvents.length).toBe(1)
+        expect(rumEvents[0].date).toBe(100)
         expect(reportErrorSpy).toHaveBeenCalledTimes(1)
         expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
           jasmine.objectContaining({
@@ -523,8 +553,8 @@ describe('rum assembly', () => {
         )
       })
 
-      it(`does not take discarded ${eventType} events into account`, () => {
-        const { lifeCycle, serverRumEvents, reportErrorSpy } = setupAssemblyTestWithDefaults({
+      it(`does not take discarded ${eventType} events into account`, async () => {
+        const { lifeCycle, getRumEvents, reportErrorSpy } = setupAssemblyTestWithDefaults({
           partialConfiguration: {
             eventRateLimiterThreshold: 1,
             beforeSend: (event) => {
@@ -547,8 +577,9 @@ describe('rum assembly', () => {
         notifyRawRumEvent(lifeCycle, {
           rawRumEvent: createRawRumEvent(eventType, { date: 200 as TimeStamp }),
         })
-        expect(serverRumEvents.length).toBe(1)
-        expect(serverRumEvents[0].date).toBe(200)
+        const rumEvents = await getRumEvents()
+        expect(rumEvents.length).toBe(1)
+        expect(rumEvents[0].date).toBe(200)
         expect(reportErrorSpy).not.toHaveBeenCalled()
       })
 
@@ -558,10 +589,12 @@ describe('rum assembly', () => {
           clock = mockClock()
         })
 
-        it(`allows to send new ${eventType} events after a minute`, () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+        it(`allows to send new ${eventType} events after a minute`, async () => {
+          const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults({
             partialConfiguration: { eventRateLimiterThreshold: 1 },
           })
+
+          const rumEvents = await getRumEvents()
 
           notifyRawRumEvent(lifeCycle, {
             rawRumEvent: createRawRumEvent(eventType, { date: 100 as TimeStamp }),
@@ -574,9 +607,9 @@ describe('rum assembly', () => {
             rawRumEvent: createRawRumEvent(eventType, { date: 300 as TimeStamp }),
           })
 
-          expect(serverRumEvents.length).toBe(2)
-          expect(serverRumEvents[0].date).toBe(100)
-          expect(serverRumEvents[1].date).toBe(300)
+          expect(rumEvents.length).toBe(2)
+          expect(rumEvents[0].date).toBe(100)
+          expect(rumEvents[1].date).toBe(300)
         })
       })
     })
@@ -618,7 +651,7 @@ function setupAssemblyTestWithDefaults({
   })
   const recorderApi = noopRecorderApi
   const viewHistory = { ...mockViewHistory(), findView: () => findView() }
-  startGlobalContext(hooks, mockRumConfiguration())
+  const globalContext = startGlobalContext(hooks, mockRumConfiguration())
   startSessionContext(hooks, rumSessionManager, recorderApi, viewHistory)
   startRumAssembly(mockRumConfiguration(partialConfiguration), lifeCycle, hooks, reportErrorSpy)
 
@@ -626,5 +659,16 @@ function setupAssemblyTestWithDefaults({
     subscription.unsubscribe()
   })
 
-  return { lifeCycle, hooks, reportErrorSpy, serverRumEvents, recorderApi }
+  return {
+    lifeCycle,
+    hooks,
+    reportErrorSpy,
+    getRumEvents: async () => {
+      // Wait for assembly to start producing events
+      await Promise.resolve()
+      return serverRumEvents
+    },
+    recorderApi,
+    globalContext,
+  }
 }

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -478,6 +478,34 @@ describe('rum assembly', () => {
     })
   })
 
+  describe('global context', () => {
+    it('applies global context to events', async () => {
+      const { lifeCycle, globalContext, getRumEvents } = setupAssemblyTestWithDefaults()
+
+      globalContext.setContext({ foo: 'bar' })
+
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
+      })
+
+      const rumEvents = await getRumEvents()
+      expect(rumEvents[0].context).toEqual({ foo: 'bar' })
+    })
+
+    it('applies global context to events generated before the global context is set', async () => {
+      const { lifeCycle, globalContext, getRumEvents } = setupAssemblyTestWithDefaults()
+
+      notifyRawRumEvent(lifeCycle, {
+        rawRumEvent: createRawRumEvent(RumEventType.ACTION),
+      })
+
+      globalContext.setContext({ foo: 'bar' })
+
+      const rumEvents = await getRumEvents()
+      expect(rumEvents[0].context).toEqual({ foo: 'bar' })
+    })
+  })
+
   describe('event generation condition', () => {
     it('when tracked, it should generate event', async () => {
       const { lifeCycle, getRumEvents } = setupAssemblyTestWithDefaults()

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -183,6 +183,23 @@ test.describe('API calls and events around init', () => {
       const viewContext = await page.evaluate(() => window.DD_RUM?.getViewContext())
       expect(viewContext).toEqual({ foo: 'bar' })
     })
+
+  createTest('context set right after init should be applied to events generated during init')
+    .withRum()
+    .withRumSlim()
+    .withRumInit((configuration) => {
+      window.DD_RUM!.init(configuration)
+      window.DD_RUM!.setViewContext({ viewContext: true })
+      window.DD_RUM!.setGlobalContext({ globalContext: true })
+      window.DD_RUM!.setUser({ id: 'user-id' })
+    })
+    .run(async ({ intakeRegistry, flushEvents }) => {
+      await flushEvents()
+
+      const initialView = intakeRegistry.rumViewEvents[0]
+      expect(initialView.context).toEqual({ viewContext: true, globalContext: true })
+      expect(initialView.usr).toEqual({ id: 'user-id' })
+    })
 })
 
 test.describe('beforeSend', () => {


### PR DESCRIPTION
## Motivation

Usually, context (global/user/account/feature flags etc.) is defined just after calling `RUM.init()`, which is an issue because events that are generated during `init()` will not have this context.

For now, this is only problematic for View events: RUM.init() generates a first View event that is missing the context defined right after. It is usually fine, as we can expect a RUM View Update to be generated at some point later. But sometimes no View Update happen for some reason (connectivity error, browser exiting abruptly...). In those cases, it is unexpected that the View isn't including the context.

This issue will be more pronounced when we'll start to collect errors that happen before init (in a future PR). In this case, we'll want the context to apply to those events (for example, to clearly identify which user was affected by such early error).

## Changes

This PR fixes this issue by slightly delaying the events assembly. It uses a new data structure, `BufferedObservable`, that will be used to progressively replace the `BoundedBuffer` and what we call "pre start strategies". This `BufferedObservable` is asynchrone, so we leverage this fact to delay the assembly.

## Test instructions

In the sandbox, define a user just after `init()`:

```
      DD_RUM.init({
        clientToken: 'xxx',
        applicationId: 'xxx',
        ...
      })
      DD_RUM.setUser({ id: 'foo' })

```

Using the devtools extension, look at individual View events by unchecking  `Show only the latest View event` in the "Events" tab.

When loading the sandbox URL, all View events should contain the `@usr.id`, even the very first View.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
