### PR TITLE
👷[FFL-125] support npm pre-release with uuid tagging on flagging package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Order is important, the last matching pattern takes the most precedence.
 
 # Global
-packages/flagging  @Datadog/feature-flagging-experimentation
 *                  @Datadog/rum-browser
+packages/flagging  @Datadog/feature-flagging-experimentation
 
 # Docs
 *README.md    @Datadog/rum-browser @DataDog/documentation

--- a/packages/flagging/INTEGRATE-FLAGGING-PACKAGE.sh
+++ b/packages/flagging/INTEGRATE-FLAGGING-PACKAGE.sh
@@ -21,22 +21,52 @@ if [ ! -d "$TARGET_PROJECT" ]; then
     exit 1
 fi
 
+# Store the original directory
+ORIGINAL_DIR=$(pwd)
+
 # Navigate to flagging package directory
 cd "$FLAGGING_PATH" || exit 1
 
+# Generate UUID and update package.json version
+echo "Updating package version with prerelease tag and UUID..."
+UUID=$(uuidgen)
+PACKAGE_JSON_PATH="packages/flagging/package.json"
+if [ ! -f "$PACKAGE_JSON_PATH" ]; then
+    echo "Error: package.json not found at $PACKAGE_JSON_PATH"
+    cd "$ORIGINAL_DIR"
+    exit 1
+fi
+
+# Read version from package.json
+CURRENT_VERSION=$(node -e "try { console.log(require('$ORIGINAL_DIR/$PACKAGE_JSON_PATH').version) } catch(e) { console.error('Error reading package.json:', e.message); process.exit(1); }")
+NEW_VERSION="${CURRENT_VERSION}-prerelease.${UUID}"
+echo "Current version: ${CURRENT_VERSION}"
+echo "Generated UUID: ${UUID}"
+echo "New version: ${NEW_VERSION}"
+
+# Update package.json
+node -e "const pkg = require('$ORIGINAL_DIR/$PACKAGE_JSON_PATH'); pkg.version = '${NEW_VERSION}'; require('fs').writeFileSync('$ORIGINAL_DIR/$PACKAGE_JSON_PATH', JSON.stringify(pkg, null, 2) + '\n');"
+
 # Build and pack the package with specific output name
 echo "Building and packing the flagging package..."
-yarn build || { echo "Build failed"; exit 1; }
+yarn build || { echo "Build failed"; cd "$ORIGINAL_DIR"; exit 1; }
 
 # Get package version from package.json
-PACKAGE_VERSION=$(node -p "require('./package.json').version")
+PACKAGE_VERSION=$(node -e "console.log(require('$ORIGINAL_DIR/$PACKAGE_JSON_PATH').version)")
 TGZ_FILE="datadog-browser-flagging-v${PACKAGE_VERSION}.tgz"
 
-yarn pack --out "$TGZ_FILE" || { echo "Pack failed"; exit 1; }
+yarn pack --out "$TGZ_FILE" || { echo "Pack failed"; cd "$ORIGINAL_DIR"; exit 1; }
 
 # Move the .tgz file to the target project
 echo "Moving $TGZ_FILE to target project..."
-cp "$TGZ_FILE" "$TARGET_PROJECT/" || { echo "Failed to copy package file"; exit 1; }
+cp "$TGZ_FILE" "$TARGET_PROJECT/" || { echo "Failed to copy package file"; cd "$ORIGINAL_DIR"; exit 1; }
+
+# Restore package.json to original state
+echo "Restoring package.json to original state..."
+git checkout -- "$PACKAGE_JSON_PATH" || { echo "Failed to restore package.json"; cd "$ORIGINAL_DIR"; exit 1; }
+
+# Return to original directory
+cd "$ORIGINAL_DIR"
 
 # Output installation instructions
 echo

--- a/packages/flagging/INTEGRATE-FLAGGING-PACKAGE.sh
+++ b/packages/flagging/INTEGRATE-FLAGGING-PACKAGE.sh
@@ -21,11 +21,8 @@ if [ ! -d "$TARGET_PROJECT" ]; then
     exit 1
 fi
 
-# Store the original directory
-ORIGINAL_DIR=$(pwd)
-
 # Navigate to flagging package directory
-cd "$FLAGGING_PATH" || exit 1
+pushd "$FLAGGING_PATH" || exit 1
 
 # Generate UUID and update package.json version
 echo "Updating package version with prerelease tag and UUID..."
@@ -33,40 +30,40 @@ UUID=$(uuidgen)
 PACKAGE_JSON_PATH="packages/flagging/package.json"
 if [ ! -f "$PACKAGE_JSON_PATH" ]; then
     echo "Error: package.json not found at $PACKAGE_JSON_PATH"
-    cd "$ORIGINAL_DIR"
+    popd
     exit 1
 fi
 
 # Read version from package.json
-CURRENT_VERSION=$(node -e "try { console.log(require('$ORIGINAL_DIR/$PACKAGE_JSON_PATH').version) } catch(e) { console.error('Error reading package.json:', e.message); process.exit(1); }")
+CURRENT_VERSION=$(node -e "try { console.log(require('$(pwd)/$PACKAGE_JSON_PATH').version) } catch(e) { console.error('Error reading package.json:', e.message); process.exit(1); }")
 NEW_VERSION="${CURRENT_VERSION}-prerelease.${UUID}"
 echo "Current version: ${CURRENT_VERSION}"
 echo "Generated UUID: ${UUID}"
 echo "New version: ${NEW_VERSION}"
 
 # Update package.json
-node -e "const pkg = require('$ORIGINAL_DIR/$PACKAGE_JSON_PATH'); pkg.version = '${NEW_VERSION}'; require('fs').writeFileSync('$ORIGINAL_DIR/$PACKAGE_JSON_PATH', JSON.stringify(pkg, null, 2) + '\n');"
+node -e "const pkg = require('$(pwd)/$PACKAGE_JSON_PATH'); pkg.version = '${NEW_VERSION}'; require('fs').writeFileSync('$(pwd)/$PACKAGE_JSON_PATH', JSON.stringify(pkg, null, 2) + '\n');"
 
 # Build and pack the package with specific output name
 echo "Building and packing the flagging package..."
-yarn build || { echo "Build failed"; cd "$ORIGINAL_DIR"; exit 1; }
+yarn build || { echo "Build failed"; popd; exit 1; }
 
 # Get package version from package.json
-PACKAGE_VERSION=$(node -e "console.log(require('$ORIGINAL_DIR/$PACKAGE_JSON_PATH').version)")
+PACKAGE_VERSION=$(node -e "console.log(require('$(pwd)/$PACKAGE_JSON_PATH').version)")
 TGZ_FILE="datadog-browser-flagging-v${PACKAGE_VERSION}.tgz"
 
-yarn pack --out "$TGZ_FILE" || { echo "Pack failed"; cd "$ORIGINAL_DIR"; exit 1; }
+yarn pack --out "$TGZ_FILE" || { echo "Pack failed"; popd; exit 1; }
 
 # Move the .tgz file to the target project
 echo "Moving $TGZ_FILE to target project..."
-cp "$TGZ_FILE" "$TARGET_PROJECT/" || { echo "Failed to copy package file"; cd "$ORIGINAL_DIR"; exit 1; }
+cp "$TGZ_FILE" "$TARGET_PROJECT/" || { echo "Failed to copy package file"; popd; exit 1; }
 
 # Restore package.json to original state
 echo "Restoring package.json to original state..."
-git checkout -- "$PACKAGE_JSON_PATH" || { echo "Failed to restore package.json"; cd "$ORIGINAL_DIR"; exit 1; }
+git checkout -- "$PACKAGE_JSON_PATH" || { echo "Failed to restore package.json"; popd; exit 1; }
 
 # Return to original directory
-cd "$ORIGINAL_DIR"
+popd
 
 # Output installation instructions
 echo


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

1. When packing artifacts as a dependency by a `web-ui` app, we need to generate a new `version` otherwise they are cached and not updated. Individual packages don't control the version, it is bumped together with other packages in this directory.
2. A bug in the codeowners file regarding matching order, last rule has highest precendence. The change in this ideally should only be reviewed by the ffe team but `rum-browser` is tagged.

## Changes

* When publishing the pre-release packed artifact, write to the flagging `package.json` as prerelease tag with a uuid; this breaks the cache in the application using it as a dependency.
* Restore the `package.json` file to its existing version
* Fix the codeowners file to have `packages/flagging` changes be routed to team `ffe`


<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

```
➜  browser-sdk git:(leo.romanovsky/flagging-version) ✗ pwd
/Users/leo.romanovsky/src/browser-sdk
...
➜  browser-sdk git:(leo.romanovsky/flagging-version) ✗ ./packages/flagging/INTEGRATE-FLAGGING-PACKAGE.sh . ~/
Updating package version with prerelease tag and UUID...
Current version: 6.9.0
Generated UUID: 4045F50A-A567-4D4E-BCBC-D13AB409E3A3
New version: 6.9.0-prerelease.4045F50A-A567-4D4E-BCBC-D13AB409E3A3
Building and packing the flagging package...
lerna notice cli v8.2.2

 Lerna (powered by Nx)   The task graph has a circular dependency

@datadog/browser-sdk-developer-extension:build --> @datadog/browser-logs:build --> @datadog/browser-rum:build --> @datadog/browser-logs:build
...
...

➤ YN0000: Package archive generated in /Users/leo.romanovsky/src/browser-sdk/datadog-browser-flagging-v6.9.0-prerelease.4045F50A-A567-4D4E-BCBC-D13AB409E3A3.tgz
➤ YN0000: Done in 0s 168ms
Moving datadog-browser-flagging-v6.9.0-prerelease.4045F50A-A567-4D4E-BCBC-D13AB409E3A3.tgz to target project...
Restoring package.json to original state...

Package successfully built and copied to target project.

If you are using yarn, run the following commands to complete the installation:

  cd /Users/leo.romanovsky
  yarn add ./datadog-browser-flagging-v6.9.0-prerelease.4045F50A-A567-4D4E-BCBC-D13AB409E3A3.tgz
```

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
