### PR TITLE
👷release: do not try to update lockfiles of ignore app

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -77,10 +77,8 @@ cmd_version () {
   node ./scripts/release/update-peer-dependency-versions.js
   lerna run pack --stream
   # keep test apps lockfiles up to date
-  cd test/apps
-  for app_dir in *; do
-    # unless the app is ignored
-    cat .gitignore | grep -q "$app_dir" && continue
+  for app_package_path in $(git ls-files test/apps/*/package.json); do
+    app_dir=$(dirname "$app_package_path");
     cd "$app_dir"
     yarn up
     git add yarn.lock


### PR DESCRIPTION
## Motivation

Following #3595, still an issue during the release command:
```
The following paths are ignored by one of your .gitignore files:
test/apps/allowed-tracking-origin
hint: Use -f if you really want to add them.
hint: Disable this message with "git config set advice.addIgnoredFile false"
```

## Changes

Skip lockfile update for app in `.gitignore` file 

## Test instructions

Tested locally by adding

```sh
cmd_foo() {
  # keep test apps lockfiles up to date
  for app_package_path in $(git ls-files test/apps/*/package.json); do
    app_dir=$(dirname "$app_package_path");
    cd "$app_dir"
    yarn up
    git add yarn.lock
    cd - > /dev/null
  done
}
```
and running
```
yarn build:testing-extensions
./scripts/cli foo
```



<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
