### PR TITLE
👷[RUM-9996] move ap2 deployment to minor dcs

### DIFF
--- a/.gitlab/deploy-auto.yml
+++ b/.gitlab/deploy-auto.yml
@@ -23,17 +23,7 @@ step-1_deploy-prod-minor-dcs:
     - .base-configuration
     - .deploy-prod
   variables:
-    UPLOAD_PATH: us3,us5,ap1
-
-step-1bis_deploy-wip-dcs:
-  needs:
-    - step-1_deploy-prod-minor-dcs
-  allow_failure: true
-  extends:
-    - .base-configuration
-    - .deploy-prod
-  variables:
-    UPLOAD_PATH: ap2
+    UPLOAD_PATH: us3,us5,ap1,ap2
 
 step-2_deploy-prod-eu1:
   needs:

--- a/.gitlab/deploy-manual.yml
+++ b/.gitlab/deploy-manual.yml
@@ -23,15 +23,7 @@ step-1_deploy-prod-minor-dcs:
     - .base-configuration
     - .deploy-prod
   variables:
-    UPLOAD_PATH: us3,us5,ap1
-
-step-1bis_deploy-wip-dc:
-  extends:
-    - .base-configuration
-    - .deploy-prod
-  allow_failure: true
-  variables:
-    UPLOAD_PATH: ap2
+    UPLOAD_PATH: us3,us5,ap1,ap2
 
 step-2_deploy-prod-eu1:
   extends:


### PR DESCRIPTION
## Motivation

Deployment to ap2 is stable, remove the dedicated deployment step

## Changes

- remove job `step-1bis_deploy-wip-dcs` for auto and manual deployments
- move ap2 to minor dcs deployment jobs

## Test instructions

next release should deploy to ap2

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
