### PR TITLE
FFL-158: fix flagging api path

### DIFF
--- a/packages/flagging/INTEGRATE-FLAGGING-PACKAGE.sh
+++ b/packages/flagging/INTEGRATE-FLAGGING-PACKAGE.sh
@@ -27,7 +27,7 @@ pushd "$FLAGGING_PATH" || exit 1
 # Generate UUID and update package.json version
 echo "Updating package version with prerelease tag and UUID..."
 UUID=$(uuidgen)
-PACKAGE_JSON_PATH="packages/flagging/package.json"
+PACKAGE_JSON_PATH="package.json"
 if [ ! -f "$PACKAGE_JSON_PATH" ]; then
     echo "Error: package.json not found at $PACKAGE_JSON_PATH"
     popd

--- a/packages/flagging/src/openfeature/provider.ts
+++ b/packages/flagging/src/openfeature/provider.ts
@@ -111,10 +111,7 @@ export class DatadogProvider implements Provider {
 async function fetchConfiguration(options: DatadogProviderOptions, context: EvaluationContext): Promise<Configuration> {
   const baseUrl = options.baseUrl || 'https://dd.datad0g.com'
 
-  const parameters = [
-    `application_id=${options.applicationId}`,
-    `client_token=${options.clientToken}`,
-  ]
+  const parameters = [`application_id=${options.applicationId}`, `client_token=${options.clientToken}`]
 
   const response = await fetch(`${baseUrl}/api/unstable/precompute-assignments?${parameters.join('&')}`, {
     method: 'POST',

--- a/packages/flagging/src/openfeature/provider.ts
+++ b/packages/flagging/src/openfeature/provider.ts
@@ -114,11 +114,14 @@ async function fetchConfiguration(options: DatadogProviderOptions, context: Eval
   const parameters = [
     `application_id=${options.applicationId}`,
     `client_token=${options.clientToken}`,
-    `dd_api_key=${options.clientToken}`,
   ]
 
-  const response = await fetch(`${baseUrl}/api/unstable/feature-flags/assignments?${parameters.join('&')}`, {
+  const response = await fetch(`${baseUrl}/api/unstable/precompute-assignments?${parameters.join('&')}`, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'DD-API-KEY': options.clientToken,
+    },
     body: JSON.stringify({
       context,
     }),


### PR DESCRIPTION
## Motivation

Want to connect the SDK to the ffe-service endpoint for precomputed assignments

## Changes

- fix the path portion
- fixed path in INTEGRATION script
- moved `DD-API-TOKEN` from URL to header
- added content-type header

## Test instructions
This branch is based on `flagging-dev`. Run the integration script and point it at the browser-flagging-package in `web-ui` as the destination.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
