### PR TITLE
temporarily add authorization via api key

### DIFF
--- a/packages/flagging/src/openfeature/provider.spec.ts
+++ b/packages/flagging/src/openfeature/provider.spec.ts
@@ -8,8 +8,11 @@ describe('DatadogProvider', () => {
 
   beforeEach(() => {
     provider = new DatadogProvider({
+      apiKey: 'xxx',
+      applicationKey: 'xxx',
       applicationId: 'xxx',
       clientToken: 'xxx',
+      env: 'test',
       baseUrl: 'http://localhost:8000',
     })
     mockLogger = {

--- a/packages/flagging/src/openfeature/provider.ts
+++ b/packages/flagging/src/openfeature/provider.ts
@@ -1,9 +1,9 @@
 import type {
-  Provider,
   EvaluationContext,
   JsonValue,
   Logger,
   Paradigm,
+  Provider,
   ProviderMetadata,
   ResolutionDetails,
 } from '@openfeature/web-sdk'
@@ -15,13 +15,28 @@ import { evaluate } from '../evaluation'
 
 export type DatadogProviderOptions = {
   /**
-   * The RUM application ID.
+   * The API key for Datadog. Required for authenticating your application with Datadog.
+   */
+  apiKey: string
+  /**
+   * The application key for Datadog. Required for authenticating your application with Datadog.
+   */
+  applicationKey: string
+
+  /**
+   * The application key for Datadog. Required for initializing the Datadog RUM client.
    */
   applicationId: string
+
   /**
-   * The client token for Datadog. Required for authenticating your application with Datadog.
+   * The client token for Datadog. Required for initializing the Datadog RUM client.
    */
   clientToken: string
+
+  /**
+   * The environment for Datadog.
+   */
+  env: string
 
   baseUrl?: string
 
@@ -111,13 +126,12 @@ export class DatadogProvider implements Provider {
 async function fetchConfiguration(options: DatadogProviderOptions, context: EvaluationContext): Promise<Configuration> {
   const baseUrl = options.baseUrl || 'https://dd.datad0g.com'
 
-  const parameters = [`application_id=${options.applicationId}`, `client_token=${options.clientToken}`]
-
-  const response = await fetch(`${baseUrl}/api/unstable/precompute-assignments?${parameters.join('&')}`, {
+  const response = await fetch(`${baseUrl}/api/unstable/precompute-assignments`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'DD-API-KEY': options.clientToken,
+      'dd-api-key': options.apiKey,
+      'dd-application-key': options.applicationKey,
     },
     body: JSON.stringify({
       context,


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

temporarily augmenting the sdk to accept api keys, which are normally for server context, to be able to authenticate with the backend service.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
