### PR TITLE
✨ [RUM-7213] DOM mutation ignoring

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -17,7 +17,6 @@ export enum ExperimentalFeature {
   PROFILING = 'profiling',
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
-  DOM_MUTATION_IGNORING = 'dom_mutation_ignoring',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.spec.ts
@@ -1,7 +1,7 @@
 import type { Subscription } from '@datadog/browser-core'
-import { ExperimentalFeature, Observable, ONE_SECOND } from '@datadog/browser-core'
+import { Observable, ONE_SECOND } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockClock, mockExperimentalFeatures } from '@datadog/browser-core/test'
+import { mockClock } from '@datadog/browser-core/test'
 import {
   appendElement,
   createMutationRecord,
@@ -90,11 +90,7 @@ describe('createPageActivityObservable', () => {
       expect(events).toEqual([{ isBusy: false }])
     })
 
-    describe('with DOM_MUTATION_IGNORING enabled', () => {
-      beforeEach(() => {
-        mockExperimentalFeatures([ExperimentalFeature.DOM_MUTATION_IGNORING])
-      })
-
+    describe('dom mutation ignoring', () => {
       it('does not collect DOM mutation when an element is added and the parent is ignored', () => {
         startListeningToPageActivities()
         const target = appendElement(`<div ${EXCLUDED_MUTATIONS_ATTRIBUTE}><button /></div>`)

--- a/packages/rum-core/src/domain/waitPageActivityEnd.ts
+++ b/packages/rum-core/src/domain/waitPageActivityEnd.ts
@@ -1,14 +1,5 @@
 import type { Subscription, TimeoutId, TimeStamp } from '@datadog/browser-core'
-import {
-  matchList,
-  monitor,
-  Observable,
-  timeStampNow,
-  setTimeout,
-  clearTimeout,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
-} from '@datadog/browser-core'
+import { matchList, monitor, Observable, timeStampNow, setTimeout, clearTimeout } from '@datadog/browser-core'
 import { createPerformanceObservable, RumPerformanceEntryType } from '../browser/performanceObservable'
 import type { RumMutationRecord } from '../browser/domMutationObservable'
 import { isElementNode } from '../browser/htmlDomUtils'
@@ -139,10 +130,7 @@ export function createPageActivityObservable(
 
     subscriptions.push(
       domMutationObservable.subscribe((mutations) => {
-        if (
-          !isExperimentalFeatureEnabled(ExperimentalFeature.DOM_MUTATION_IGNORING) ||
-          !mutations.every(isExcludedMutation)
-        ) {
+        if (!mutations.every(isExcludedMutation)) {
           notifyPageActivity()
         }
       }),


### PR DESCRIPTION
## Motivation

Ability to exclude certain DOM mutations from affecting the page loading time calculation

## Changes

Remove the experimental feature flag

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
