### PR TITLE
Revert "freeze prod and next major canary deploy jobs (#3618)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -334,30 +334,30 @@ deploy-staging:
     - node ./scripts/deploy/deploy.js staging staging root
     - node ./scripts/deploy/upload-source-maps.js staging root
 
-# deploy-prod-canary:
-#   stage: deploy:canary
-#   extends:
-#     - .base-configuration
-#     - .main
-#   script:
-#     - export BUILD_MODE=canary
-#     - yarn
-#     - yarn build:bundle
-#     - node ./scripts/deploy/deploy.js prod canary root
-#     - node ./scripts/deploy/upload-source-maps.js canary root
+deploy-prod-canary:
+  stage: deploy:canary
+  extends:
+    - .base-configuration
+    - .main
+  script:
+    - export BUILD_MODE=canary
+    - yarn
+    - yarn build:bundle
+    - node ./scripts/deploy/deploy.js prod canary root
+    - node ./scripts/deploy/upload-source-maps.js canary root
 
-# deploy-next-major-canary:
-#   stage: deploy
-#   extends:
-#     - .base-configuration
-#     - .next-major-branch
-#   script:
-#     - export BUILD_MODE=canary
-#     - VERSION=$(node -p -e "require('./lerna.json').version")
-#     - yarn
-#     - yarn build:bundle
-#     - node ./scripts/deploy/deploy.js prod v${VERSION%%.*}-canary root
-#     - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*}-canary root
+deploy-next-major-canary:
+  stage: deploy
+  extends:
+    - .base-configuration
+    - .next-major-branch
+  script:
+    - export BUILD_MODE=canary
+    - VERSION=$(node -p -e "require('./lerna.json').version")
+    - yarn
+    - yarn build:bundle
+    - node ./scripts/deploy/deploy.js prod v${VERSION%%.*}-canary root
+    - node ./scripts/deploy/upload-source-maps.js v${VERSION%%.*}-canary root
 
 deploy-manual:
   stage: deploy


### PR DESCRIPTION
This reverts commit 4935a3880a631a17e12a82751e4278cddd9ef25b.

## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
