### PR TITLE
👷 fix typecheck issue + increase base tsconfig coverage

### DIFF
--- a/sandbox/react-app/main.tsx
+++ b/sandbox/react-app/main.tsx
@@ -12,7 +12,7 @@ datadogRum.init({
   plugins: [reactPlugin({ router: true })],
 })
 
-datadogFlagging.init()
+datadogFlagging.init({})
 
 const router = createBrowserRouter(
   [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,21 @@
   "compilerOptions": {
     "types": ["jasmine"]
   },
-  "include": ["packages", "scripts", "test", "eslint.config.mjs", "eslint-local-rules"],
-  "exclude": ["packages/*/cjs", "packages/*/esm", "packages/*/bundle", "test/e2e", "test/apps", "developer-extension"]
+  "exclude": [
+    // Generated files
+    "packages/*/cjs",
+    "packages/*/esm",
+    "packages/*/bundle",
+
+    // Those folders have their own tsconfig.json
+    "test/e2e",
+    "test/apps",
+    "developer-extension",
+    "rum-events-format",
+
+    // Excluded for now, because this pulls in the Node.js types which conflict with the browser
+    // types. We should revisit this using "references" tsconfig files like vite does:
+    // https://github.com/vitejs/vite/blob/4b77d008aca457944f583ba8a1ff530d5df87cc1/packages/create-vite/template-react-ts/tsconfig.json
+    "performances"
+  ]
 }


### PR DESCRIPTION
## Motivation

When running `yarn dev`, a typecheck error is shown

## Changes

Fix the typecheck error + tweak the base tsconfig so we cover more files.

## Test instructions

* Run `yarn dev`, no error should be shown
* The CI will enforce this when it runs `yarn typecheck`.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
