### PR TITLE
♻️ [RUM-10074] Use createTest in developer extensions tests

### DIFF
--- a/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
+++ b/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
@@ -10,24 +10,13 @@ createTest('should switch between tabs')
 
     await page.goto(`chrome-extension://${extensionId}/panel.html`)
 
-    const developerExtension = new DeveloperExtensionPage(page)
+    const getSelectedTab = () => page.getByRole('tab', { selected: true })
+    const getTab = (name: string) => page.getByRole('tab', { name })
 
-    expect(await developerExtension.getSelectedTab().innerText()).toEqual('Events')
+    expect(await getSelectedTab().innerText()).toEqual('Events')
 
-    await developerExtension.getTab('Infos').click()
-    expect(await developerExtension.getSelectedTab().innerText()).toEqual('Infos')
+    await getTab('Infos').click()
+    expect(await getSelectedTab().innerText()).toEqual('Infos')
 
     flushBrowserLogs()
   })
-
-class DeveloperExtensionPage {
-  constructor(public readonly page: Page) {}
-
-  getTab(name: string) {
-    return this.page.getByRole('tab', { name })
-  }
-
-  getSelectedTab() {
-    return this.page.getByRole('tab', { selected: true })
-  }
-}

--- a/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
+++ b/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import { expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
 import { createTest } from '../../lib/framework'
 
 createTest('should switch between tabs')

--- a/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
+++ b/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
@@ -1,47 +1,24 @@
 import path from 'path'
-import { test as base, chromium, expect } from '@playwright/test'
-import type { Page, BrowserContext } from '@playwright/test'
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { createTest } from '../../lib/framework'
 
-const test = base.extend<{
-  context: BrowserContext
-  extensionId: string
-  developerExtension: DeveloperExtensionPage
-}>({
-  // eslint-disable-next-line no-empty-pattern
-  context: async ({}, use) => {
-    const pathToExtension = path.join(process.cwd(), 'developer-extension', 'dist')
+createTest('should switch between tabs')
+  .withExtension(path.join(process.cwd(), 'developer-extension', 'dist'))
+  .run(async ({ page, getExtensionId, flushBrowserLogs }) => {
+    const extensionId = await getExtensionId()
 
-    const context = await chromium.launchPersistentContext('', {
-      channel: 'chromium',
-      args: [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`],
-    })
-    await use(context)
-    await context.close()
-  },
-  extensionId: async ({ context }, use) => {
-    let [background] = context.serviceWorkers()
-    if (!background) {
-      background = await context.waitForEvent('serviceworker')
-    }
-
-    const extensionId = background.url().split('/')[2]
-    await use(extensionId)
-  },
-  developerExtension: async ({ page, extensionId }, use) => {
     await page.goto(`chrome-extension://${extensionId}/panel.html`)
 
-    await use(new DeveloperExtensionPage(page))
-  },
-})
+    flushBrowserLogs()
 
-test.describe('developer-extension', () => {
-  test('should switch between tabs', async ({ developerExtension: page }) => {
-    expect(await page.getSelectedTab().innerText()).toEqual('Events')
+    const developerExtension = new DeveloperExtensionPage(page)
 
-    await page.getTab('Infos').click()
-    expect(await page.getSelectedTab().innerText()).toEqual('Infos')
+    expect(await developerExtension.getSelectedTab().innerText()).toEqual('Events')
+
+    await developerExtension.getTab('Infos').click()
+    expect(await developerExtension.getSelectedTab().innerText()).toEqual('Infos')
   })
-})
 
 class DeveloperExtensionPage {
   constructor(public readonly page: Page) {}

--- a/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
+++ b/test/e2e/scenario/developer-extension/developerExtension.scenario.ts
@@ -10,14 +10,14 @@ createTest('should switch between tabs')
 
     await page.goto(`chrome-extension://${extensionId}/panel.html`)
 
-    flushBrowserLogs()
-
     const developerExtension = new DeveloperExtensionPage(page)
 
     expect(await developerExtension.getSelectedTab().innerText()).toEqual('Events')
 
     await developerExtension.getTab('Infos').click()
     expect(await developerExtension.getSelectedTab().innerText()).toEqual('Infos')
+
+    flushBrowserLogs()
   })
 
 class DeveloperExtensionPage {


### PR DESCRIPTION
## Motivation

Refactored developer extension scenario to use the `createTest` fixture.
This provides code reusability and makes it follow the other extensions testing format.

## Changes

Refactored `developerExtension.scenario.ts`

## Test instructions

Same e2e tests should pass. 

Note: I had to use `flushBrowserLogs()` because the test navigates to the `baseUrl` which creates console errors.
This wasn't tested before as we didn't navigate thru this page in the old test.

## Checklist

- [X ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
