### PR TITLE
Update changelog-to-confluence: Update secret names, name of page being published

### DIFF
--- a/.github/workflows/changelog-to-confluence.yml
+++ b/.github/workflows/changelog-to-confluence.yml
@@ -15,15 +15,15 @@ jobs:
       - name: Prepare Only Changelog
         run: |
           mkdir -p publish_folder
-          cp CHANGELOG.md publish_folder/
+          cp CHANGELOG.md publish_folder/browser-sdk-changelog.md
           echo "Publishing only CHANGELOG.md"
 
       - name: Publish Markdown to Confluence
         uses: markdown-confluence/publish-action@7767a0a7f438bb1497ee7ffd7d3d685b81dfe700 # v5
         with:
-          confluenceBaseUrl: ${{ secrets.CONFLUENCE_BASE_URL }}
+          confluenceBaseUrl: ${{ secrets.DATADOG_CONFLUENCE_BASE_URL }}
           confluenceParentId: ${{ secrets.CONFLUENCE_PARENT_ID }}
-          atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
-          atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+          atlassianUserName: ${{ secrets.CONFLUENCE_ROBOT_RUM_EMAIL }}
+          atlassianApiToken: ${{ secrets.CONFLUENCE_ROBOT_RUM_API_KEY }}
           contentRoot: '.'
           folderToPublish: 'publish_folder'


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
- For easier maintanenaince, the secrets variables were added to the Datadog Organization;
- In Confluence a page only can have an unique name for a certain space, which could create conflicts with other pages

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

- Updates secrets names on the Github Workflow
- Updates name of the page to be published

## Next Steps
- Remove previous github Secrets from the repo
  - `CONFLUENCE_BASE_URL`
  - `ATLASSIAN_USERNAME`
  - `ATLASSIAN_API_TOKEN`

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
