### PR TITLE
[RUM Profiler] Remove `profiling` experimental flag

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -14,7 +14,6 @@ import { objectHasValue } from './utils/objectUtils'
 
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
-  PROFILING = 'profiling',
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
 }

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -10,8 +10,6 @@ import {
   validateAndBuildConfiguration,
   isSampleRate,
   isNumber,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
 } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../../domainContext.types'
 import type { RumEvent } from '../../rumEvent.types'
@@ -228,8 +226,6 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
-  const profilingEnabled = isExperimentalFeatureEnabled(ExperimentalFeature.PROFILING)
-
   const sessionReplaySampleRate = initConfiguration.sessionReplaySampleRate ?? 0
 
   return {
@@ -263,7 +259,7 @@ export function validateAndBuildRumConfiguration(
       : TraceContextInjection.SAMPLED,
     plugins: initConfiguration.plugins || [],
     trackFeatureFlagsForEvents: initConfiguration.trackFeatureFlagsForEvents || [],
-    profilingSampleRate: profilingEnabled ? (initConfiguration.profilingSampleRate ?? 0) : 0, // Enforce 0 if profiling is not enabled, and set 0 as default when not set.
+    profilingSampleRate: initConfiguration.profilingSampleRate ?? 0,
     propagateTraceBaggage: !!initConfiguration.propagateTraceBaggage,
     ...baseConfiguration,
   }


### PR DESCRIPTION
## Motivation

RUM Profiler is in a state where we can start using it externally.
Let's remove the need need for the `profiling` experimental flag.

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

- Remove the `profiling` experimental flag, and remove its usage.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

- Run the Browser SDK without the `profiling` experimental flag, but still use the `profilingSampleRate`. 
- Assert you are able collect RUM Profiles.

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
