### PR TITLE
🐛 [RUM-146] Modify label behavior in dead click logic

### DIFF
--- a/packages/rum-core/src/domain/action/computeFrustration.spec.ts
+++ b/packages/rum-core/src/domain/action/computeFrustration.spec.ts
@@ -172,4 +172,34 @@ describe('isDead', () => {
       ).toBe(expected)
     })
   }
+
+  describe('label elements', () => {
+    it('does not consider as dead when the click target is a label referring to a text input', () => {
+      appendElement('<input type="text" id="test-input" />')
+      const label = appendElement('<label for="test-input">Click me</label>')
+
+      expect(
+        isDead(
+          createFakeClick({
+            hasPageActivity: false,
+            event: { target: label },
+          })
+        )
+      ).toBe(false)
+    })
+
+    it('considers as dead when the click target is a label referring to a checkbox', () => {
+      appendElement('<input type="checkbox" id="test-checkbox" />')
+      const label = appendElement('<label for="test-checkbox">Check me</label>')
+
+      expect(
+        isDead(
+          createFakeClick({
+            hasPageActivity: false,
+            event: { target: label },
+          })
+        )
+      ).toBe(true)
+    })
+  })
 })

--- a/packages/rum-core/src/domain/action/computeFrustration.ts
+++ b/packages/rum-core/src/domain/action/computeFrustration.ts
@@ -67,5 +67,20 @@ export function isDead(click: Click) {
   if (click.hasPageActivity || click.getUserActivity().input || click.getUserActivity().scroll) {
     return false
   }
-  return !click.event.target.matches(DEAD_CLICK_EXCLUDE_SELECTOR)
+
+  const target = click.event.target
+
+  if (target.matches(DEAD_CLICK_EXCLUDE_SELECTOR)) {
+    return false
+  }
+
+  if (target.tagName === 'LABEL' && target.hasAttribute('for')) {
+    const forId = target.getAttribute('for')
+    const referencedElement = document.getElementById(forId!)
+    if (referencedElement && referencedElement.matches(DEAD_CLICK_EXCLUDE_SELECTOR)) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -275,6 +275,19 @@ test.describe('action collection', () => {
       expect(actionEvents[0].action.frustration!.type).toHaveLength(0)
     })
 
+  createTest('do not consider a click on a label referring to a text input as "dead_click"')
+    .withRum({ trackUserInteractions: true })
+    .withBody(html` <input type="text" id="my-input" /><label for="my-input">Click me</label> `)
+    .run(async ({ intakeRegistry, flushEvents, page }) => {
+      const label = page.locator('label')
+      await label.click()
+      await flushEvents()
+      const actionEvents = intakeRegistry.rumActionEvents
+
+      expect(actionEvents).toHaveLength(1)
+      expect(actionEvents[0].action.frustration!.type).toHaveLength(0)
+    })
+
   createTest('do not consider clicks leading to scrolls as "dead_click"')
     .withRum({ trackUserInteractions: true })
     .withBody(html`


### PR DESCRIPTION
## Motivation

We discard dead clicks happening on input elements. But in some cases the click happens on the label 

## Changes

We should probably find a way to discard it as well.

## Test instructions

How to reproduce 

```
<input type=”file” id=”foo” />
<label for=”foo”>click me</label>
```
in html file and yarn dev

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
