### PR TITLE
🔊 [IR-39238] add cookie data in debug logs

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -95,12 +95,17 @@ export function startSessionManager<TrackingType extends string>(
 
     if (!session) {
       const rawSession = retrieveSessionCookie()
+      const sessionCookies = document.cookie.split(/\s*;\s*/).filter((cookie) => cookie.startsWith('_dd_s'))
 
       addTelemetryDebug('Unexpected session state', {
         session: rawSession,
         isSyntheticsTest: isSyntheticsTest(),
         createdTimestamp: rawSession?.created,
         expireTimestamp: rawSession?.expire,
+        cookie: {
+          count: sessionCookies.length,
+          ...sessionCookies,
+        },
       })
 
       return {


### PR DESCRIPTION
## Motivation

See if the unexpected session state is always related to multiple session cookies

## Changes

add cookie info to debug logs

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
