### PR TITLE
🐛 [IR-39238] ignore init() if Synthetics will inject its own instance of RUM

### DIFF
--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -193,6 +193,20 @@ describe('preStartRum', () => {
         expect(doStartRumSpy).not.toHaveBeenCalled()
       })
 
+      it('when undefined, ignores init() call if Synthetics will inject its own instance of RUM', () => {
+        mockSyntheticsWorkerValues({ injectsRum: true })
+
+        const strategy = createPreStartStrategy(
+          {},
+          createTrackingConsentState(),
+          createCustomVitalsState(),
+          doStartRumSpy
+        )
+        strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
+
+        expect(doStartRumSpy).not.toHaveBeenCalled()
+      })
+
       it('when false, does not ignore init() call even if Synthetics will inject its own instance of RUM', () => {
         mockSyntheticsWorkerValues({ injectsRum: true })
 

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -32,7 +32,7 @@ import type { StartRumResult } from './startRum'
 import type { RumPublicApiOptions, Strategy } from './rumPublicApi'
 
 export function createPreStartStrategy(
-  { ignoreInitIfSyntheticsWillInjectRum, startDeflateWorker }: RumPublicApiOptions,
+  { ignoreInitIfSyntheticsWillInjectRum = true, startDeflateWorker }: RumPublicApiOptions,
   trackingConsentState: TrackingConsentState,
   customVitalsState: CustomVitalsState,
   doStartRum: (

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -303,6 +303,19 @@ test.describe('allowedTrackingOrigins', () => {
     })
 })
 
+test.describe('Synthetics Browser Test', () => {
+  createTest('ignores init() call if Synthetics will inject its own instance of RUM')
+    .withRum()
+    .withRumInit((configuration) => {
+      ;(window as any)._DATADOG_SYNTHETICS_INJECTS_RUM = true
+      window.DD_RUM!.init(configuration)
+    })
+    .run(async ({ intakeRegistry, flushEvents }) => {
+      await flushEvents()
+      expect(intakeRegistry.rumViewEvents).toHaveLength(0)
+    })
+})
+
 function expectToHaveErrors(
   events: IntakeRegistry,
   ...errors: Array<{ message: string; viewId: string; context?: Context }>


### PR DESCRIPTION
## Motivation

We are seeing a lot of session in inconsistent state (cf incident 39238) coming from s8s browser tests. It turns out that even when the Synthetics worker is planning to inject RUM, we keep initializing the RUM version from the App.

This is a regression from #2575


## Changes

Make sure we ignore `init()` call when RUM is injected by the Synthetics worker.


## Test instructions

See e2e test

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
