### PR TITLE
👷 [RUM-9218] Adjust E2E setup to use cross-origin URLs for loading CDN bundles

### DIFF
--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -233,7 +233,7 @@ export type RumErrorEvent = CommonProperties &
       /**
        * The specific category of the error. It provides a high-level grouping for different types of errors.
        */
-      readonly category?: 'ANR' | 'App Hang' | 'Exception' | 'Watchdog Termination' | 'Memory Warning'
+      readonly category?: 'ANR' | 'App Hang' | 'Exception' | 'Watchdog Termination' | 'Memory Warning' | 'Network'
       /**
        * Whether the error has been handled manually in the source code or not
        */
@@ -555,6 +555,10 @@ export type RumLongTaskEvent = CommonProperties &
        * Whether the long task should be discarded or indexed
        */
       readonly discarded?: boolean
+      /**
+       * Profiling context
+       */
+      profiling?: ProfilingInternalContextSchema
       [k: string]: unknown
     }
     [k: string]: unknown
@@ -1175,6 +1179,10 @@ export type RumViewEvent = CommonProperties &
         readonly start_session_replay_recording_manually?: boolean
         [k: string]: unknown
       }
+      /**
+       * Profiling context
+       */
+      profiling?: ProfilingInternalContextSchema
       [k: string]: unknown
     }
     /**
@@ -1283,6 +1291,10 @@ export interface CommonProperties {
      * UUID of the application
      */
     readonly id: string
+    /**
+     * The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.
+     */
+    readonly current_locale?: string
     [k: string]: unknown
   }
   /**
@@ -1508,7 +1520,7 @@ export interface CommonProperties {
     /**
      * Device type info
      */
-    readonly type: 'mobile' | 'desktop' | 'tablet' | 'tv' | 'gaming_console' | 'bot' | 'other'
+    readonly type?: 'mobile' | 'desktop' | 'tablet' | 'tv' | 'gaming_console' | 'bot' | 'other'
     /**
      * Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.
      */
@@ -1525,6 +1537,30 @@ export interface CommonProperties {
      * The CPU architecture of the device that is reporting the error
      */
     readonly architecture?: string
+    /**
+     * The user’s locale as a language tag combining language and region, e.g. 'en-US'.
+     */
+    readonly locale?: string
+    /**
+     * Ordered list of the user’s preferred system languages as IETF language tags.
+     */
+    readonly locales?: string[]
+    /**
+     * The device’s current time zone identifier, e.g. 'Europe/Berlin'.
+     */
+    readonly time_zone?: string
+    /**
+     * Current battery level of the device (0.0 to 1.0).
+     */
+    readonly battery_level?: number
+    /**
+     * Whether the device is in power saving mode.
+     */
+    readonly power_saving_mode?: boolean
+    /**
+     * Current screen brightness level (0.0 to 1.0).
+     */
+    readonly brightness_level?: number
     [k: string]: unknown
   }
   /**
@@ -1568,6 +1604,10 @@ export interface CommonProperties {
        * The percentage of sessions with RUM & Session Replay pricing tracked
        */
       readonly session_replay_sample_rate?: number
+      /**
+       * The percentage of views profiled
+       */
+      readonly profiling_sample_rate?: number
       [k: string]: unknown
     }
     /**
@@ -1636,6 +1676,37 @@ export interface ActionChildProperties {
     readonly id: string | string[]
     [k: string]: unknown
   }
+  [k: string]: unknown
+}
+/**
+ * RUM Profiler Internal Context schema
+ */
+export interface ProfilingInternalContextSchema {
+  /**
+   * Used to track the status of the RUM Profiler.
+   *
+   * They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+   *
+   * - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
+   * - `running`: The Profiler is running.
+   * - `stopped`: The Profiler is stopped.
+   * - `error`: The Profiler encountered an error. See `error_reason` for more details.
+   */
+  readonly status?: 'starting' | 'running' | 'stopped' | 'error'
+  /**
+   * The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+   *
+   * Possible values:
+   * - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+   * - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+   * - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+   * - `unexpected-exception`: An exception occurred when starting the Profiler.
+   */
+  readonly error_reason?:
+    | 'not-supported-by-browser'
+    | 'failed-to-lazy-load'
+    | 'missing-document-policy-header'
+    | 'unexpected-exception'
   [k: string]: unknown
 }
 /**

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -53,11 +53,13 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
 })(window,document,'script','${url}','${globalName}')`
   }
 
+  const logsScriptUrl = `${servers.crossOrigin.url}/datadog-logs.js`
+  const rumScriptUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
+
   if (options.logs) {
-    const logsUrl = `${servers.crossOrigin.url}/datadog-logs.js`
     body += html`
       <script>
-        ${formatSnippet(logsUrl, 'DD_LOGS')}
+        ${formatSnippet(logsScriptUrl, 'DD_LOGS')}
         DD_LOGS.onReady(function () {
           DD_LOGS.setGlobalContext(${JSON.stringify(options.context)})
           ;(${options.logsInit.toString()})(${formatConfiguration(options.logs, servers)})
@@ -67,10 +69,9 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   }
 
   if (options.rum) {
-    const rumUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
     body += html`
       <script type="text/javascript">
-        ${formatSnippet(rumUrl, 'DD_RUM')}
+        ${formatSnippet(rumScriptUrl, 'DD_RUM')}
         DD_RUM.onReady(function () {
           DD_RUM.setGlobalContext(${JSON.stringify(options.context)})
           ;(${options.rumInit.toString()})(${formatConfiguration(options.rum, servers)})
@@ -92,9 +93,12 @@ export function bundleSetup(options: SetupOptions, servers: Servers) {
     header += setupEventBridge(servers)
   }
 
+  const logsScriptUrl = `${servers.crossOrigin.url}/datadog-logs.js`
+  const rumScriptUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
+
   if (options.logs) {
     header += html`
-      <script type="text/javascript" src="${servers.crossOrigin.url}/datadog-logs.js""></script>
+      <script type="text/javascript" src="${logsScriptUrl}"></script>
       <script type="text/javascript">
         DD_LOGS.setGlobalContext(${JSON.stringify(options.context)})
         ;(${options.logsInit.toString()})(${formatConfiguration(options.logs, servers)})
@@ -103,7 +107,6 @@ export function bundleSetup(options: SetupOptions, servers: Servers) {
   }
 
   if (options.rum) {
-    const rumScriptUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
     header += html`
       <script type="text/javascript" src="${rumScriptUrl}"></script>
       <script type="text/javascript">

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -53,8 +53,7 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
 })(window,document,'script','${url}','${globalName}')`
   }
 
-  const logsScriptUrl = `${servers.crossOrigin.url}/datadog-logs.js`
-  const rumScriptUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
+  const { logsScriptUrl, rumScriptUrl } = createCrossOriginScriptUrls(servers, options)
 
   if (options.logs) {
     body += html`
@@ -93,8 +92,7 @@ export function bundleSetup(options: SetupOptions, servers: Servers) {
     header += setupEventBridge(servers)
   }
 
-  const logsScriptUrl = `${servers.crossOrigin.url}/datadog-logs.js`
-  const rumScriptUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
+  const { logsScriptUrl, rumScriptUrl } = createCrossOriginScriptUrls(servers, options)
 
   if (options.logs) {
     header += html`
@@ -252,4 +250,11 @@ function formatConfiguration(initConfiguration: LogsInitConfiguration | RumInitC
     result = result.replace('"BEFORE_SEND"', initConfiguration.beforeSend.toString())
   }
   return result
+}
+
+function createCrossOriginScriptUrls(servers: Servers, options: SetupOptions) {
+  return {
+    logsScriptUrl: `${servers.crossOrigin.url}/datadog-logs.js`,
+    rumScriptUrl: `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`,
+  }
 }

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -54,9 +54,10 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   }
 
   if (options.logs) {
+    const logsUrl = `${servers.crossOrigin.url}/datadog-logs.js`
     body += html`
       <script>
-        ${formatSnippet('./datadog-logs.js', 'DD_LOGS')}
+        ${formatSnippet(logsUrl, 'DD_LOGS')}
         DD_LOGS.onReady(function () {
           DD_LOGS.setGlobalContext(${JSON.stringify(options.context)})
           ;(${options.logsInit.toString()})(${formatConfiguration(options.logs, servers)})
@@ -66,9 +67,10 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   }
 
   if (options.rum) {
+    const rumUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
     body += html`
       <script type="text/javascript">
-        ${formatSnippet(options.useRumSlim ? './datadog-rum-slim.js' : './datadog-rum.js', 'DD_RUM')}
+        ${formatSnippet(rumUrl, 'DD_RUM')}
         DD_RUM.onReady(function () {
           DD_RUM.setGlobalContext(${JSON.stringify(options.context)})
           ;(${options.rumInit.toString()})(${formatConfiguration(options.rum, servers)})
@@ -92,7 +94,7 @@ export function bundleSetup(options: SetupOptions, servers: Servers) {
 
   if (options.logs) {
     header += html`
-      <script type="text/javascript" src="./datadog-logs.js"></script>
+      <script type="text/javascript" src="${servers.crossOrigin.url}/datadog-logs.js""></script>
       <script type="text/javascript">
         DD_LOGS.setGlobalContext(${JSON.stringify(options.context)})
         ;(${options.logsInit.toString()})(${formatConfiguration(options.logs, servers)})
@@ -101,11 +103,9 @@ export function bundleSetup(options: SetupOptions, servers: Servers) {
   }
 
   if (options.rum) {
+    const rumScriptUrl = `${servers.crossOrigin.url}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`
     header += html`
-      <script
-        type="text/javascript"
-        src="${options.useRumSlim ? './datadog-rum-slim.js' : './datadog-rum.js'}"
-      ></script>
+      <script type="text/javascript" src="${rumScriptUrl}"></script>
       <script type="text/javascript">
         DD_RUM.setGlobalContext(${JSON.stringify(options.context)})
         ;(${options.rumInit.toString()})(${formatConfiguration(options.rum, servers)})

--- a/test/e2e/lib/framework/serverApps/mock.ts
+++ b/test/e2e/lib/framework/serverApps/mock.ts
@@ -97,7 +97,7 @@ export function createMockServerApp(servers: Servers, setup: string): MockServer
       'Content-Security-Policy',
       [
         `connect-src ${servers.intake.url} ${servers.base.url} ${servers.crossOrigin.url}`,
-        "script-src 'self' 'unsafe-inline'",
+        `script-src 'self' 'unsafe-inline' ${servers.crossOrigin.url}`,
         'worker-src blob:',
       ].join(';')
     )
@@ -110,7 +110,7 @@ export function createMockServerApp(servers: Servers, setup: string): MockServer
       'Content-Security-Policy',
       [
         `connect-src ${servers.intake.url} ${servers.base.url} ${servers.crossOrigin.url}`,
-        "script-src 'self' 'unsafe-inline'",
+        `script-src 'self' 'unsafe-inline' ${servers.crossOrigin.url}`,
       ].join(';')
     )
     res.send(setup)


### PR DESCRIPTION
## Motivation

Currently, our E2E test suite is loading bundles using a relative URL (ex: /datadog-rum.js). Because of this, we missed a faulty configuration change that broke Session Replay

## Changes

Let’s use a cross-origin URL to load our bundles in E2E tests. We could just use the [“crossOrigin” server](https://github.com/DataDog/browser-sdk/blob/42739576f614e5b25582706fd83833389c4a0231/test/e2e/lib/framework/httpServers.ts#L27) that we already use for some tests.



## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
