### PR TITLE
👷 ignore @playwright/test updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": ["!karma-webpack"]
+      "matchPackageNames": ["!karma-webpack", "!@playwright/test"]
     }
   ]
 }


### PR DESCRIPTION
## Motivation

By upgrading @playwright/test to 1.53.0, all the e2e tests on browserstack are failing with [those errors](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1006743291):

```
Error: browserType.connect: Error: Unknown scheme for Initializer: Selectors.
Error: browser.newContext: Error: Unknown scheme for Initializer: Selectors.
```

[This type of issue](https://github.com/microsoft/playwright/issues/9852#issuecomment-953899375) seemed to be related to a mismatch with the version used by browserstack server, which is indeed the case:

![Screenshot 2025-07-01 at 17 30 49](https://github.com/user-attachments/assets/fd565260-e1fc-4236-bfc9-9cce3d8b943a)

## Changes

Ignore @playwright/test updates while newer versions are not [supported by browserstack](https://www.browserstack.com/docs/automate/playwright/browsers-and-os#playwright-compatible-devices-and-browsers)

## Test instructions

After merge, @playwright/test should not be listed in [Update all non-major dependencies](https://github.com/DataDog/browser-sdk/issues/1897)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
