### PR TITLE
👷 add `step-7_` prefix to `create-github-release` ci job

### DIFF
--- a/.gitlab/deploy-auto.yml
+++ b/.gitlab/deploy-auto.yml
@@ -74,7 +74,7 @@ step-6_publish-developer-extension:
     - yarn
     - node ./scripts/deploy/publish-developer-extension.js
 
-create-github-release:
+step-7_create-github-release:
   needs:
     - step-6_publish-developer-extension
   stage: deploy

--- a/.gitlab/deploy-manual.yml
+++ b/.gitlab/deploy-manual.yml
@@ -66,7 +66,7 @@ step-6_publish-developer-extension:
     - yarn
     - node ./scripts/deploy/publish-developer-extension.js
 
-create-github-release:
+step-7_create-github-release:
   needs:
     - step-6_publish-developer-extension
   stage: deploy


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

`create-github-release` is already running after `step-6` but the gitlab UI is ordered alphabetically, showing that job first.
![Screenshot 2025-07-02 at 13 50 28](https://github.com/user-attachments/assets/ac9e8adc-39bc-4cfa-ada4-90f8f7c59092)

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

renamed `create-github-release` to `step-7_create-github-release`

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
