### PR TITLE
[RUM Profiler] add default view names to Profiles

### DIFF
--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -28,6 +28,7 @@ import { cleanupLongTaskRegistryAfterCollection, getLongTaskId } from './utils/l
 import { mayStoreLongTaskIdForProfilerCorrelation } from './profilingCorrelation'
 import { transport } from './transport/transport'
 import type { ProfilingContextManager } from './profilingContext'
+import { getCustomOrDefaultViewName } from './utils/getCustomOrDefaultViewName'
 
 export const DEFAULT_RUM_PROFILER_CONFIGURATION: RUMProfilerConfiguration = {
   sampleIntervalMs: 10, // Sample stack trace every 10ms
@@ -124,7 +125,7 @@ export function createRumProfiler(
     // Whenever the View is updated, we add a views entry to the profiler instance.
     const viewUpdatedSubscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
       // Note: `view.name` is only filled when users use manual view creation via `startView` method.
-      collectViewEntry({ viewId: view.id, viewName: view.name, startClocks: view.startClocks })
+      collectViewEntry({ viewId: view.id, viewName: getCustomOrDefaultViewName(view.name, document.location.pathname), startClocks: view.startClocks })
     })
     cleanupTasks.push(viewUpdatedSubscription.unsubscribe)
 

--- a/packages/rum/src/domain/profiling/utils/getCustomOrDefaultViewName.ts
+++ b/packages/rum/src/domain/profiling/utils/getCustomOrDefaultViewName.ts
@@ -1,0 +1,4 @@
+import { getDefaultViewName } from './getDefaultViewName';
+
+
+export const getCustomOrDefaultViewName = (customViewName: string | undefined, viewPathUrl: string) : string => customViewName || getDefaultViewName(viewPathUrl);

--- a/packages/rum/src/domain/profiling/utils/getDefaultViewName.spec.ts
+++ b/packages/rum/src/domain/profiling/utils/getDefaultViewName.spec.ts
@@ -1,0 +1,34 @@
+import { getDefaultViewName } from './getDefaultViewName'
+
+// Replicating the tests from SimpleUrlGroupingProcessorTest.java
+describe('getDefaultViewName', () => {
+  describe('url grouping', () => {
+    it('should handle empty path', () => {
+      expect(getDefaultViewName('')).toBe('/')
+    })
+
+    it('should handle simple URL path with numeric ID', () => {
+      expect(getDefaultViewName('/user/342')).toBe('/user/?')
+    })
+
+    it('should handle URL path with alphanumeric ID', () => {
+      expect(getDefaultViewName('/user/3A2')).toBe('/user/?')
+    })
+
+    it('should handle versioned URL path with alphanumeric ID', () => {
+      expect(getDefaultViewName('/v1/user/3A2')).toBe('/v1/user/?')
+    })
+
+    it('should handle versioned URL path with alphanumeric ID and additional segments', () => {
+      expect(getDefaultViewName('/v1/user/3A2/profile')).toBe('/v1/user/?/profile')
+    })
+
+    it('should handle multiple alphanumeric segments', () => {
+      expect(getDefaultViewName('/v1/user/3A2/profile/2A3')).toBe('/v1/user/?/profile/?')
+    })
+
+    it('should handle UUID and alphanumeric segments', () => {
+      expect(getDefaultViewName('/v1/user/dc893c65-a46d-4f63-a7be-e119b97b1b32/profile/2A3')).toBe('/v1/user/?/profile/?')
+    })
+  })
+})

--- a/packages/rum/src/domain/profiling/utils/getDefaultViewName.ts
+++ b/packages/rum/src/domain/profiling/utils/getDefaultViewName.ts
@@ -1,0 +1,15 @@
+
+// This is the regex used to extract the path from the url (from SimpleUrlGroupingProcessor.java)
+const PATH_MIXED_ALPHANUMERICS = new RegExp('(?<=/)(?![vV]\\d{1,2}/)(?:[^\\/\\d\\?]*[\\d]+[^\\/\\?]*)', 'g');
+
+
+export function getDefaultViewName(viewPathUrl: string):string {
+    if (!viewPathUrl) {
+        return '/';
+    } 
+
+    // Replace all the mixed alphanumerics with a ?
+    return viewPathUrl.replace(PATH_MIXED_ALPHANUMERICS, '?');
+}
+
+


### PR DESCRIPTION
## Motivation

- In case the RUM View names are not custom, the Profiler is not able to associate the default RUM View name to the Profile.
- In turn, this means the Profiling data is not linked directly to specific RUM View names and the filters on View names is useless.

Let's have the default RUM View name be determined directly in the SDK (for the Profiler only for now)

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

- Replicate BE "URL" processor to create a default view name based on URL.
- Add unit tests. 
- Use that default view name in case there is not default custom names.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

- Added unit tests to cover our back.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
