### PR TITLE
🏷️ add ap2 site to TypeScript types

### DIFF
--- a/packages/core/src/domain/intakeSites.ts
+++ b/packages/core/src/domain/intakeSites.ts
@@ -5,6 +5,7 @@ export type Site =
   | 'datadoghq.eu'
   | 'ddog-gov.com'
   | 'ap1.datadoghq.com'
+  | 'ap2.datadoghq.com'
 
 export const INTAKE_SITE_STAGING: Site = 'datad0g.com' as Site
 export const INTAKE_SITE_FED_STAGING: Site = 'dd0g-gov.com' as Site


### PR DESCRIPTION
## Motivation

Let customers using Typescript specify `site: 'ap2.datadoghq.com'` init param

## Changes

add `ap2.datadoghq.com` to the Site union type

## Test instructions

Configure the SDK with `site: 'ap2.datadoghq.com'`. No TypeScript issue should occur.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
