### PR TITLE
👷 add `--spec` option to `yarn test:unit`

### DIFF
--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -1,3 +1,4 @@
+const { parseArgs } = require('util')
 const webpackConfig = require('../../webpack.base')({
   mode: 'development',
   types: ['jasmine', 'chrome'],
@@ -16,17 +17,22 @@ if (testReportDirectory) {
   reporters.push('junit')
 }
 
+const FILES = [
+  // Make sure 'forEach.spec' is the first file to be loaded, so its `beforeEach` hook is executed
+  // before all other `beforeEach` hooks, and its `afterEach` hook is executed after all other
+  // `afterEach` hooks.
+  'packages/core/test/forEach.spec.ts',
+  'packages/rum/test/toto.css',
+]
+
+const FILES_SPECS = [
+  'packages/*/@(src|test)/**/*.spec.@(ts|tsx)',
+  'developer-extension/@(src|test)/**/*.spec.@(ts|tsx)',
+]
+
 module.exports = {
   basePath: '../..',
-  files: [
-    // Make sure 'forEach.spec' is the first file to be loaded, so its `beforeEach` hook is executed
-    // before all other `beforeEach` hooks, and its `afterEach` hook is executed after all other
-    // `afterEach` hooks.
-    'packages/core/test/forEach.spec.ts',
-    'packages/*/@(src|test)/**/*.spec.@(ts|tsx)',
-    'developer-extension/@(src|test)/**/*.spec.@(ts|tsx)',
-    'packages/rum/test/toto.css',
-  ],
+  files: getFiles(),
   frameworks: ['jasmine', 'webpack'],
   client: {
     jasmine: {
@@ -120,4 +126,22 @@ function overrideTsLoaderRule(module) {
   })
 
   return module
+}
+
+function getFiles() {
+  const { values } = parseArgs({
+    allowPositionals: true,
+    options: {
+      spec: {
+        type: 'string',
+        multiple: true,
+      },
+    },
+  })
+
+  if (values.spec) {
+    return FILES.concat(values.spec)
+  }
+
+  return FILES.concat(FILES_SPECS)
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Currently the only way to focus on a single test suite is to use `fdescribe` or `fit` method. The issue with this solution is it's require to edit test file which makes it harder to use by AI agent such as cursor.

This PR adds support for `--spec` flag on the various unit test commands, allowing faster testing feedback loop.

```
yarn test:unit --spec packages/core/src/browser/addEventListener.spec.ts
OR
yarn test:unit --spec "packages/**/addEventListener.spec.ts"
```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
