### PR TITLE
🐛 prevent log reporting after consent revocation

### DIFF
--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -8,7 +8,6 @@ import { setNavigatorOnLine, setNavigatorConnection, createHooks } from '../../.
 import type { Context } from '../../tools/serialisation/context'
 import { Observable } from '../../tools/observable'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
-import { createTrackingConsentState, TrackingConsent } from '../trackingConsent'
 import { HookNames } from '../../tools/abstractHooks'
 import {
   addTelemetryError,
@@ -24,7 +23,6 @@ import type { TelemetryEvent } from './telemetryEvent.types'
 
 function startAndSpyTelemetry(configuration?: Partial<Configuration>) {
   const observable = new Observable<TelemetryEvent & Context>()
-  const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
 
   const notifySpy = jasmine.createSpy('notified')
   observable.subscribe(notifySpy)
@@ -38,8 +36,7 @@ function startAndSpyTelemetry(configuration?: Partial<Configuration>) {
       ...configuration,
     } as Configuration,
     hooks,
-    observable,
-    trackingConsentState
+    observable
   )
 
   return {

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -8,6 +8,7 @@ import { setNavigatorOnLine, setNavigatorConnection, createHooks } from '../../.
 import type { Context } from '../../tools/serialisation/context'
 import { Observable } from '../../tools/observable'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
+import { createTrackingConsentState, TrackingConsent } from '../trackingConsent'
 import { HookNames } from '../../tools/abstractHooks'
 import {
   addTelemetryError,
@@ -23,6 +24,7 @@ import type { TelemetryEvent } from './telemetryEvent.types'
 
 function startAndSpyTelemetry(configuration?: Partial<Configuration>) {
   const observable = new Observable<TelemetryEvent & Context>()
+  const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
 
   const notifySpy = jasmine.createSpy('notified')
   observable.subscribe(notifySpy)
@@ -36,7 +38,8 @@ function startAndSpyTelemetry(configuration?: Partial<Configuration>) {
       ...configuration,
     } as Configuration,
     hooks,
-    observable
+    observable,
+    trackingConsentState
   )
 
   return {

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -22,7 +22,6 @@ import { canUseEventBridge, getEventBridge, startBatchWithReplica } from '../../
 import type { Encoder } from '../../tools/encoder'
 import type { PageMayExitEvent } from '../../browser/pageMayExitObservable'
 import { DeflateEncoderStreamId } from '../deflate'
-import type { TrackingConsentState } from '../trackingConsent'
 import { HookNames, DISCARDED } from '../../tools/abstractHooks'
 import type { AbstractHooks, DISCARDED as DISCARDED_TYPE } from '../../tools/abstractHooks'
 import type { TelemetryEvent } from './telemetryEvent.types'

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -78,13 +78,7 @@ export function startTelemetry(
 
   const { stop } = startTelemetryTransport(configuration, reportError, pageMayExitObservable, createEncoder, observable)
 
-  const { enabled } = startTelemetryCollection(
-    telemetryService,
-    configuration,
-    hooks,
-    observable,
-    trackingConsentState
-  )
+  const { enabled } = startTelemetryCollection(telemetryService, configuration, hooks, observable, trackingConsentState)
 
   return {
     stop,

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -71,14 +71,13 @@ export function startTelemetry(
   hooks: AbstractHooks,
   reportError: (error: RawError) => void,
   pageMayExitObservable: Observable<PageMayExitEvent>,
-  createEncoder: (streamId: DeflateEncoderStreamId) => Encoder,
-  trackingConsentState: TrackingConsentState
+  createEncoder: (streamId: DeflateEncoderStreamId) => Encoder
 ): Telemetry {
   const observable = new Observable<TelemetryEvent & Context>()
 
   const { stop } = startTelemetryTransport(configuration, reportError, pageMayExitObservable, createEncoder, observable)
 
-  const { enabled } = startTelemetryCollection(telemetryService, configuration, hooks, observable, trackingConsentState)
+  const { enabled } = startTelemetryCollection(telemetryService, configuration, hooks, observable)
 
   return {
     stop,
@@ -90,8 +89,7 @@ export function startTelemetryCollection(
   telemetryService: TelemetryService,
   configuration: Configuration,
   hooks: AbstractHooks,
-  observable: Observable<TelemetryEvent & Context>,
-  trackingConsentState: TrackingConsentState
+  observable: Observable<TelemetryEvent & Context>
 ) {
   const alreadySentEvents = new Set<string>()
 
@@ -108,7 +106,6 @@ export function startTelemetryCollection(
   onRawTelemetryEventCollected = (rawEvent: RawTelemetryEvent) => {
     const stringifiedEvent = jsonStringify(rawEvent)!
     if (
-      trackingConsentState.isGranted() &&
       telemetryEnabledPerType[rawEvent.type!] &&
       alreadySentEvents.size < configuration.maxTelemetryEventsPerPage &&
       !alreadySentEvents.has(stringifiedEvent)

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -292,19 +292,12 @@ describe('logs', () => {
   describe('tracking consent', () => {
     it('should not send logs after tracking consent is revoked', async () => {
       const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
-      
-      ;({ handleLog, stop: stopLogs } = startLogs(
-        baseConfiguration,
-        () => COMMON_CONTEXT,
-        trackingConsentState
-      ))
+
+      ;({ handleLog, stop: stopLogs } = startLogs(baseConfiguration, () => COMMON_CONTEXT, trackingConsentState))
       registerCleanupTask(stopLogs)
 
       // Log a message with consent granted - should be sent
-      handleLog(
-        { status: StatusType.info, message: 'message before revocation' },
-        logger
-      )
+      handleLog({ status: StatusType.info, message: 'message before revocation' }, logger)
 
       await interceptor.waitForAllFetchCalls()
       expect(requests.length).toEqual(1)
@@ -314,10 +307,7 @@ describe('logs', () => {
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
 
       // Log another message - should not be sent
-      handleLog(
-        { status: StatusType.info, message: 'message after revocation' },
-        logger
-      )
+      handleLog({ status: StatusType.info, message: 'message after revocation' }, logger)
 
       await interceptor.waitForAllFetchCalls()
       // Should still only have the first request

--- a/packages/logs/src/boot/startLogs.spec.ts
+++ b/packages/logs/src/boot/startLogs.spec.ts
@@ -51,7 +51,10 @@ const COMMON_CONTEXT = {
 }
 const DEFAULT_PAYLOAD = {} as Payload
 
-function startLogsWithDefaults({ configuration }: { configuration?: Partial<LogsConfiguration> } = {}) {
+function startLogsWithDefaults(
+  { configuration }: { configuration?: Partial<LogsConfiguration> } = {},
+  trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+) {
   const endpointBuilder = mockEndpointBuilder('https://localhost/v1/input/log')
   const { handleLog, stop, globalContext, accountContext, userContext } = startLogs(
     {
@@ -61,7 +64,7 @@ function startLogsWithDefaults({ configuration }: { configuration?: Partial<Logs
       ...configuration,
     },
     () => COMMON_CONTEXT,
-    createTrackingConsentState(TrackingConsent.GRANTED),
+    trackingConsentState,
     new BufferedObservable<BufferedData>(100)
   )
 
@@ -292,9 +295,7 @@ describe('logs', () => {
   describe('tracking consent', () => {
     it('should not send logs after tracking consent is revoked', async () => {
       const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
-
-      ;({ handleLog, stop: stopLogs } = startLogs(baseConfiguration, () => COMMON_CONTEXT, trackingConsentState))
-      registerCleanupTask(stopLogs)
+      const { handleLog, logger } = startLogsWithDefaults({}, trackingConsentState)
 
       // Log a message with consent granted - should be sent
       handleLog({ status: StatusType.info, message: 'message before revocation' }, logger)

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -60,7 +60,8 @@ export function startLogs(
     hooks,
     reportError,
     pageMayExitObservable,
-    createIdentityEncoder
+    createIdentityEncoder,
+    trackingConsentState
   )
   cleanupTasks.push(telemetry.stop)
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -60,8 +60,7 @@ export function startLogs(
     hooks,
     reportError,
     pageMayExitObservable,
-    createIdentityEncoder,
-    trackingConsentState
+    createIdentityEncoder
   )
   cleanupTasks.push(telemetry.stop)
 

--- a/packages/logs/src/boot/startLogs.ts
+++ b/packages/logs/src/boot/startLogs.ts
@@ -28,6 +28,7 @@ import type { CommonContext } from '../rawLogsEvent.types'
 import { createHooks } from '../domain/hooks'
 import { startRUMInternalContext } from '../domain/contexts/rumInternalContext'
 import { startSessionContext } from '../domain/contexts/sessionContext'
+import { startTrackingConsentContext } from '../domain/contexts/trackingConsentContext'
 
 const LOGS_STORAGE_KEY = 'logs'
 
@@ -68,6 +69,7 @@ export function startLogs(
       ? startLogsSessionManager(configuration, trackingConsentState)
       : startLogsSessionManagerStub(configuration)
 
+  startTrackingConsentContext(hooks, trackingConsentState)
   // Start user and account context first to allow overrides from global context
   startSessionContext(hooks, configuration, session)
   const accountContext = startAccountContext(hooks, configuration, LOGS_STORAGE_KEY)

--- a/packages/logs/src/domain/contexts/trackingConsentContext.spec.ts
+++ b/packages/logs/src/domain/contexts/trackingConsentContext.spec.ts
@@ -1,0 +1,57 @@
+import type { RelativeTime } from '@datadog/browser-core'
+import { DISCARDED, HookNames, createTrackingConsentState, TrackingConsent } from '@datadog/browser-core'
+import type { DefaultLogsEventAttributes, Hooks } from '../hooks'
+import { createHooks } from '../hooks'
+import { startTrackingConsentContext } from './trackingConsentContext'
+
+describe('tracking consent context', () => {
+  let hooks: Hooks
+
+  beforeEach(() => {
+    hooks = createHooks()
+  })
+
+  it('should discard logs if consent is not granted', () => {
+    const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
+    startTrackingConsentContext(hooks, trackingConsentState)
+
+    const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+      startTime: 0 as RelativeTime,
+    })
+
+    expect(defaultLogAttributes).toBe(DISCARDED)
+  })
+
+  it('should not discard logs if consent is granted and no startTime is provided', () => {
+    const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+    startTrackingConsentContext(hooks, trackingConsentState)
+
+    const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+      startTime: undefined as any,
+    }) as DefaultLogsEventAttributes
+
+    expect(defaultLogAttributes).toEqual({})
+  })
+
+  it('should not discard logs when startTime is provided (due to empty history)', () => {
+    const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+    startTrackingConsentContext(hooks, trackingConsentState)
+
+    const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+      startTime: 100 as RelativeTime,
+    })
+
+    expect(defaultLogAttributes).toEqual({})
+  })
+
+  it('should discard logs when startTime is provided and consent was not granted initially', () => {
+    const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
+    startTrackingConsentContext(hooks, trackingConsentState)
+
+    const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+      startTime: 100 as RelativeTime,
+    })
+
+    expect(defaultLogAttributes).toBe(DISCARDED)
+  })
+})

--- a/packages/logs/src/domain/contexts/trackingConsentContext.spec.ts
+++ b/packages/logs/src/domain/contexts/trackingConsentContext.spec.ts
@@ -30,7 +30,7 @@ describe('tracking consent context', () => {
       startTime: undefined as any,
     }) as DefaultLogsEventAttributes
 
-    expect(defaultLogAttributes).toEqual({})
+    expect(defaultLogAttributes).toBeUndefined()
   })
 
   it('should not discard logs when startTime is provided (due to empty history)', () => {
@@ -41,7 +41,7 @@ describe('tracking consent context', () => {
       startTime: 100 as RelativeTime,
     })
 
-    expect(defaultLogAttributes).toEqual({})
+    expect(defaultLogAttributes).toBeUndefined()
   })
 
   it('should discard logs when startTime is provided and consent was not granted initially', () => {

--- a/packages/logs/src/domain/contexts/trackingConsentContext.ts
+++ b/packages/logs/src/domain/contexts/trackingConsentContext.ts
@@ -3,7 +3,7 @@ import type { TrackingConsentState } from '@datadog/browser-core'
 import type { Hooks } from '../hooks'
 
 export function startTrackingConsentContext(hooks: Hooks, trackingConsentState: TrackingConsentState) {
-  hooks.register(HookNames.Assemble, () => {
+  function isConsented() {
     const wasConsented = trackingConsentState.isGranted()
 
     if (!wasConsented) {
@@ -11,15 +11,8 @@ export function startTrackingConsentContext(hooks: Hooks, trackingConsentState: 
     }
 
     return SKIPPED
-  })
+  }
 
-  hooks.register(HookNames.AssembleTelemetry, () => {
-    const wasConsented = trackingConsentState.isGranted()
-
-    if (!wasConsented) {
-      return DISCARDED
-    }
-
-    return SKIPPED
-  })
+  hooks.register(HookNames.Assemble, isConsented)
+  hooks.register(HookNames.AssembleTelemetry, isConsented)
 }

--- a/packages/logs/src/domain/contexts/trackingConsentContext.ts
+++ b/packages/logs/src/domain/contexts/trackingConsentContext.ts
@@ -12,4 +12,14 @@ export function startTrackingConsentContext(hooks: Hooks, trackingConsentState: 
 
     return SKIPPED
   })
+
+  hooks.register(HookNames.AssembleTelemetry, () => {
+    const wasConsented = trackingConsentState.isGranted()
+
+    if (!wasConsented) {
+      return DISCARDED
+    }
+
+    return SKIPPED
+  })
 }

--- a/packages/logs/src/domain/contexts/trackingConsentContext.ts
+++ b/packages/logs/src/domain/contexts/trackingConsentContext.ts
@@ -1,10 +1,10 @@
-import { DISCARDED, HookNames } from '@datadog/browser-core'
+import { DISCARDED, HookNames, SKIPPED } from '@datadog/browser-core'
 import type { TrackingConsentState } from '@datadog/browser-core'
 import type { Hooks } from '../hooks'
 
 export function startTrackingConsentContext(hooks: Hooks, trackingConsentState: TrackingConsentState) {
-  hooks.register(HookNames.Assemble, ({ startTime }) => {
-    const wasConsented = trackingConsentState.isGranted(startTime)
+  hooks.register(HookNames.Assemble, () => {
+    const wasConsented = trackingConsentState.isGranted()
 
     if (!wasConsented) {
       return DISCARDED

--- a/packages/logs/src/domain/contexts/trackingConsentContext.ts
+++ b/packages/logs/src/domain/contexts/trackingConsentContext.ts
@@ -1,0 +1,15 @@
+import { DISCARDED, HookNames } from '@datadog/browser-core'
+import type { TrackingConsentState } from '@datadog/browser-core'
+import type { Hooks } from '../hooks'
+
+export function startTrackingConsentContext(hooks: Hooks, trackingConsentState: TrackingConsentState) {
+  hooks.register(HookNames.Assemble, ({ startTime }) => {
+    const wasConsented = trackingConsentState.isGranted(startTime)
+
+    if (!wasConsented) {
+      return DISCARDED
+    }
+
+    return SKIPPED
+  })
+}

--- a/packages/logs/src/domain/hooks.ts
+++ b/packages/logs/src/domain/hooks.ts
@@ -16,7 +16,7 @@ export interface HookCallbackMap {
   [HookNamesAsConst.ASSEMBLE]: (param: { startTime: RelativeTime }) => DefaultLogsEventAttributes | SKIPPED | DISCARDED
   [HookNamesAsConst.ASSEMBLE_TELEMETRY]: (param: {
     startTime: RelativeTime
-  }) => DefaultTelemetryEventAttributes | SKIPPED
+  }) => DefaultTelemetryEventAttributes | SKIPPED | DISCARDED
 }
 
 export type Hooks = ReturnType<typeof createHooks>

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -99,8 +99,7 @@ export function startRum(
     hooks,
     reportError,
     pageMayExitObservable,
-    createEncoder,
-    trackingConsentState
+    createEncoder
   )
   cleanupTasks.push(telemetry.stop)
 

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -52,6 +52,7 @@ import { startRumAssembly } from '../domain/assembly'
 import { startSessionContext } from '../domain/contexts/sessionContext'
 import { startConnectivityContext } from '../domain/contexts/connectivityContext'
 import { startDefaultContext } from '../domain/contexts/defaultContext'
+import { startTrackingConsentContext } from '../domain/contexts/trackingConsentContext'
 import type { Hooks } from '../domain/hooks'
 import { createHooks } from '../domain/hooks'
 import { startEventCollection } from '../domain/event/eventCollection'
@@ -136,6 +137,7 @@ export function startRum(
   const featureFlagContexts = startFeatureFlagContexts(lifeCycle, hooks, configuration)
   startSessionContext(hooks, session, recorderApi, viewHistory)
   startConnectivityContext(hooks)
+  startTrackingConsentContext(hooks, trackingConsentState)
   const globalContext = startGlobalContext(hooks, configuration, 'rum', true)
   const userContext = startUserContext(hooks, configuration, session, 'rum')
   const accountContext = startAccountContext(hooks, configuration, 'rum')

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -98,7 +98,8 @@ export function startRum(
     hooks,
     reportError,
     pageMayExitObservable,
-    createEncoder
+    createEncoder,
+    trackingConsentState
   )
   cleanupTasks.push(telemetry.stop)
 

--- a/packages/rum-core/src/domain/contexts/trackingConsentContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/trackingConsentContext.spec.ts
@@ -1,0 +1,87 @@
+import type { RelativeTime } from '@datadog/browser-core'
+import { DISCARDED, HookNames, createTrackingConsentState, TrackingConsent } from '@datadog/browser-core'
+import type { DefaultRumEventAttributes, Hooks } from '../hooks'
+import { createHooks } from '../hooks'
+import { startTrackingConsentContext } from './trackingConsentContext'
+
+describe('tracking consent context', () => {
+  let hooks: Hooks
+
+  beforeEach(() => {
+    hooks = createHooks()
+  })
+
+  describe('for regular RUM events (Assemble hook)', () => {
+    it('should discard RUM events if consent is not granted', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
+      startTrackingConsentContext(hooks, trackingConsentState)
+
+      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+        eventType: 'view' as const,
+        startTime: 0 as RelativeTime,
+      })
+
+      expect(defaultLogAttributes).toBe(DISCARDED)
+    })
+
+    it('should not discard RUM events if consent is granted and no startTime is provided', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+      startTrackingConsentContext(hooks, trackingConsentState)
+
+      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+        eventType: 'view' as const,
+        startTime: undefined as any,
+      }) as DefaultRumEventAttributes
+
+      expect(defaultLogAttributes).toBeUndefined()
+    })
+
+    it('should not discard RUM events when startTime is provided (due to empty history)', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+      startTrackingConsentContext(hooks, trackingConsentState)
+
+      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+        eventType: 'view' as const,
+        startTime: 100 as RelativeTime,
+      })
+
+      expect(defaultLogAttributes).toBeUndefined()
+    })
+
+    it('should discard RUM events when startTime is provided and consent was not granted initially', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
+      startTrackingConsentContext(hooks, trackingConsentState)
+
+      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
+        eventType: 'view' as const,
+        startTime: 100 as RelativeTime,
+      })
+
+      expect(defaultLogAttributes).toBe(DISCARDED)
+    })
+  })
+
+  describe('for telemetry (AssembleTelemetry hook)', () => {
+    it('should discard telemetry if consent is not granted', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
+      startTrackingConsentContext(hooks, trackingConsentState)
+
+      const defaultLogAttributes = hooks.triggerHook(HookNames.AssembleTelemetry, {
+        startTime: 0 as RelativeTime,
+      })
+
+      expect(defaultLogAttributes).toBe(DISCARDED)
+    })
+
+    it('should not discard telemetry if consent is granted', () => {
+      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
+      startTrackingConsentContext(hooks, trackingConsentState)
+
+      const defaultLogAttributes = hooks.triggerHook(HookNames.AssembleTelemetry, {
+        startTime: 100 as RelativeTime,
+      })
+
+      expect(defaultLogAttributes).toBeUndefined()
+    })
+  })
+})

--- a/packages/rum-core/src/domain/contexts/trackingConsentContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/trackingConsentContext.spec.ts
@@ -1,6 +1,6 @@
 import type { RelativeTime } from '@datadog/browser-core'
 import { DISCARDED, HookNames, createTrackingConsentState, TrackingConsent } from '@datadog/browser-core'
-import type { DefaultRumEventAttributes, Hooks } from '../hooks'
+import type { Hooks } from '../hooks'
 import { createHooks } from '../hooks'
 import { startTrackingConsentContext } from './trackingConsentContext'
 

--- a/packages/rum-core/src/domain/contexts/trackingConsentContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/trackingConsentContext.spec.ts
@@ -11,56 +11,6 @@ describe('tracking consent context', () => {
     hooks = createHooks()
   })
 
-  describe('for regular RUM events (Assemble hook)', () => {
-    it('should discard RUM events if consent is not granted', () => {
-      const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
-      startTrackingConsentContext(hooks, trackingConsentState)
-
-      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
-        eventType: 'view' as const,
-        startTime: 0 as RelativeTime,
-      })
-
-      expect(defaultLogAttributes).toBe(DISCARDED)
-    })
-
-    it('should not discard RUM events if consent is granted and no startTime is provided', () => {
-      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
-      startTrackingConsentContext(hooks, trackingConsentState)
-
-      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
-        eventType: 'view' as const,
-        startTime: undefined as any,
-      }) as DefaultRumEventAttributes
-
-      expect(defaultLogAttributes).toBeUndefined()
-    })
-
-    it('should not discard RUM events when startTime is provided (due to empty history)', () => {
-      const trackingConsentState = createTrackingConsentState(TrackingConsent.GRANTED)
-      startTrackingConsentContext(hooks, trackingConsentState)
-
-      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
-        eventType: 'view' as const,
-        startTime: 100 as RelativeTime,
-      })
-
-      expect(defaultLogAttributes).toBeUndefined()
-    })
-
-    it('should discard RUM events when startTime is provided and consent was not granted initially', () => {
-      const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)
-      startTrackingConsentContext(hooks, trackingConsentState)
-
-      const defaultLogAttributes = hooks.triggerHook(HookNames.Assemble, {
-        eventType: 'view' as const,
-        startTime: 100 as RelativeTime,
-      })
-
-      expect(defaultLogAttributes).toBe(DISCARDED)
-    })
-  })
-
   describe('for telemetry (AssembleTelemetry hook)', () => {
     it('should discard telemetry if consent is not granted', () => {
       const trackingConsentState = createTrackingConsentState(TrackingConsent.NOT_GRANTED)

--- a/packages/rum-core/src/domain/contexts/trackingConsentContext.ts
+++ b/packages/rum-core/src/domain/contexts/trackingConsentContext.ts
@@ -3,16 +3,6 @@ import type { TrackingConsentState } from '@datadog/browser-core'
 import type { Hooks } from '../hooks'
 
 export function startTrackingConsentContext(hooks: Hooks, trackingConsentState: TrackingConsentState) {
-  hooks.register(HookNames.Assemble, () => {
-    const wasConsented = trackingConsentState.isGranted()
-
-    if (!wasConsented) {
-      return DISCARDED
-    }
-
-    return SKIPPED
-  })
-
   hooks.register(HookNames.AssembleTelemetry, () => {
     const wasConsented = trackingConsentState.isGranted()
 

--- a/packages/rum-core/src/domain/contexts/trackingConsentContext.ts
+++ b/packages/rum-core/src/domain/contexts/trackingConsentContext.ts
@@ -1,0 +1,25 @@
+import { DISCARDED, HookNames, SKIPPED } from '@datadog/browser-core'
+import type { TrackingConsentState } from '@datadog/browser-core'
+import type { Hooks } from '../hooks'
+
+export function startTrackingConsentContext(hooks: Hooks, trackingConsentState: TrackingConsentState) {
+  hooks.register(HookNames.Assemble, () => {
+    const wasConsented = trackingConsentState.isGranted()
+
+    if (!wasConsented) {
+      return DISCARDED
+    }
+
+    return SKIPPED
+  })
+
+  hooks.register(HookNames.AssembleTelemetry, () => {
+    const wasConsented = trackingConsentState.isGranted()
+
+    if (!wasConsented) {
+      return DISCARDED
+    }
+
+    return SKIPPED
+  })
+}

--- a/packages/rum-core/src/domain/hooks.ts
+++ b/packages/rum-core/src/domain/hooks.ts
@@ -23,7 +23,7 @@ export interface HookCallbackMap {
   }) => DefaultRumEventAttributes | SKIPPED | DISCARDED
   [HookNamesAsConst.ASSEMBLE_TELEMETRY]: (param: {
     startTime: RelativeTime
-  }) => DefaultTelemetryEventAttributes | SKIPPED
+  }) => DefaultTelemetryEventAttributes | SKIPPED | DISCARDED
 }
 
 export type Hooks = ReturnType<typeof createHooks>

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -114,7 +114,7 @@ test.describe('telemetry', () => {
       const telemetryEvents = intakeRegistry.telemetryUsageEvents
       expect(telemetryEvents.length).toBeGreaterThanOrEqual(2)
 
-      // Verify no telemetry for post-revocation action
+      // Verify no telemetry for post-revocation action or get-account
       const postRevocationEvents = telemetryEvents.filter(
         (event) => event.telemetry.usage.feature === 'add-action' || event.telemetry.usage.feature === 'get-account'
       )

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -3,7 +3,7 @@ import { createTest, html } from '../lib/framework'
 
 test.describe('telemetry', () => {
   createTest('send errors for logs')
-    .withLogs()
+    .withLogs({ trackingConsent: 'granted' })
     .run(async ({ intakeRegistry, page, flushEvents }) => {
       await page.evaluate(() => {
         const context = {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

A customer reported that Logs continue to send information even after consent has been revoked. We discovered that this issue arises from the PR that allows logs to be sent after the session has expired.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

This PR introduces consent context and utilizes it to verify whether the event was consented to be sent.

Additionally, the consent state is passed to telemetry and check every time we want to send any information.

> [!IMPORTANT]
> Although this change should be applied to all products (RUM and Logs), there is added complexity with the manual and automatic start views. This PR just focused on resolved the problem of blocking sending logs after the consent is revoked.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

**Case 1**
- _Check the consent was granted_
- Send a log with `DD_LOGS.logger.log('something')`
- _Verify that the log was sent_
- Revoke the consent
- Send another log `DD_LOGS.logger.log('else')`
- _Confirm that this log was not sent_

**Case 2**
- _Check the consent was granted_
- Wait for the session to expire
- Send a log with `DD_LOGS.logger.log('something')`
- _Verify that the log was sent_

**Case 3**
- _Check the consent was granted_
- Wait for telemetry to be sent
- _Check the telemetry was sent correctly_
- Revoke the consent
- _Check there are no more telemetry requests_

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [X] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
