### PR TITLE
👷 fix `yarn test` and `yarn test:unit:watch` commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "yarn test:unit:watch",
     "test:unit": "karma start ./test/unit/karma.local.conf.js",
     "test:script": "node --test --experimental-test-module-mocks './scripts/**/*.spec.*'",
-    "test:unit:watch": "yarn test:unit -- --no-single-run",
+    "test:unit:watch": "yarn test:unit --no-single-run",
     "test:unit:bs": "node ./scripts/test/bs-wrapper.js karma start test/unit/karma.bs.conf.js",
     "test:e2e:init": "yarn build && yarn build:apps && yarn playwright install chromium --with-deps",
     "test:e2e": "playwright test --config test/e2e/playwright.local.config.ts --project chromium",

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -131,6 +131,7 @@ function overrideTsLoaderRule(module) {
 function getFiles() {
   const { values } = parseArgs({
     allowPositionals: true,
+    strict: false,
     options: {
       spec: {
         type: 'string',


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

The previous fix was preventing the command from throwing an error, but was not _watching_
This PR makes the command watch for change properly

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
