### PR TITLE
♻️ Enforce using interface over type

### DIFF
--- a/developer-extension/src/common/extension.types.ts
+++ b/developer-extension/src/common/extension.types.ts
@@ -3,12 +3,12 @@ import type { LogsEvent } from '../../../packages/logs/src/logsEvent.types'
 import type { RumEvent } from '../../../packages/rum-core/src/rumEvent.types'
 import type { BrowserRecord, BrowserSegmentMetadata } from '../../../packages/rum/src/types'
 
-export type BackgroundToDevtoolsMessage = {
+export interface BackgroundToDevtoolsMessage {
   type: 'sdk-message'
   message: SdkMessage
 }
 
-export type DevtoolsToBackgroundMessage = {
+export interface DevtoolsToBackgroundMessage {
   type: 'update-net-request-rules'
   options: NetRequestRulesOptions
 }

--- a/developer-extension/src/content-scripts/main.ts
+++ b/developer-extension/src/content-scripts/main.ts
@@ -11,7 +11,7 @@ declare global {
   }
 }
 
-type SdkPublicApi = { [key: string]: (...args: any[]) => unknown }
+interface SdkPublicApi { [key: string]: (...args: any[]) => unknown }
 
 function main() {
   // Prevent multiple executions when the devetools are reconnecting

--- a/developer-extension/src/panel/hooks/useEvents/eventFilters.ts
+++ b/developer-extension/src/panel/hooks/useEvents/eventFilters.ts
@@ -9,7 +9,7 @@ export interface EventFilters {
   outdatedVersions: boolean
 }
 
-export type FacetValuesFilter = { type: 'include' | 'exclude'; facetValues: FacetValues }
+export interface FacetValuesFilter { type: 'include' | 'exclude'; facetValues: FacetValues }
 export interface FacetValues {
   [facetPath: string]: string[]
 }

--- a/developer-extension/src/panel/sessionReplayPlayer/sessionReplayPlayer.types.ts
+++ b/developer-extension/src/panel/sessionReplayPlayer/sessionReplayPlayer.types.ts
@@ -34,7 +34,7 @@ export interface Dimensions {
   height: number
 }
 
-export type StaticFrameContext = {
+export interface StaticFrameContext {
   origin: string
   featureFlags: { [flagName: string]: boolean }
   tabId: string
@@ -99,14 +99,14 @@ export type MessageBridgeUp = {
 /**
  * Message send by the sanboxing when iframe is ready
  */
-export type MessageBridgeUpReady = {
+export interface MessageBridgeUpReady {
   type: MessageBridgeUpType.READY
 }
 
 /**
  * Message send by the sanboxing when a record has been applied
  */
-export type MessageBridgeUpRecordApplied = {
+export interface MessageBridgeUpRecordApplied {
   type: MessageBridgeUpType.RECORD_APPLIED
   /** OrderId of the Record applied */
   orderId: number
@@ -117,7 +117,7 @@ export type MessageBridgeUpRecordApplied = {
 /**
  * Message send by the sanboxing when a log is sent
  */
-export type MessageBridgeUpLog = {
+export interface MessageBridgeUpLog {
   type: MessageBridgeUpType.LOG
   level: MessageBridgeUpLogLevel
   message: string
@@ -127,7 +127,7 @@ export type MessageBridgeUpLog = {
 /**
  * Message send by the sanboxing iframe when there is an error
  */
-export type MessageBridgeUpError = {
+export interface MessageBridgeUpError {
   type: MessageBridgeUpType.ERROR
   serialisedError: SerialisedError
   context?: { [key: string]: any }
@@ -136,7 +136,7 @@ export type MessageBridgeUpError = {
 /**
  * Message send by the sanboxing iframe with a custom timing
  */
-export type MessageBridgeUpTiming = {
+export interface MessageBridgeUpTiming {
   type: MessageBridgeUpType.METRIC_TIMING
   name: string
   duration: number
@@ -146,14 +146,14 @@ export type MessageBridgeUpTiming = {
 /**
  * Message send by the sanboxing iframe with a custom count
  */
-export type MessageBridgeUpIncrement = {
+export interface MessageBridgeUpIncrement {
   type: MessageBridgeUpType.METRIC_INCREMENT
   name: string
   value: number
   context?: { [key: string]: any }
 }
 
-export type MessageBridgeUpCapabilities = {
+export interface MessageBridgeUpCapabilities {
   type: MessageBridgeUpType.CAPABILITIES
   capabilities: {
     SERVICE_WORKER: boolean
@@ -161,26 +161,26 @@ export type MessageBridgeUpCapabilities = {
   }
 }
 
-export type MessageBridgeUpServiceWorkerActivated = {
+export interface MessageBridgeUpServiceWorkerActivated {
   type: MessageBridgeUpType.SERVICE_WORKER_ACTIVATED
 }
 
-export type MessageBridgeUpRendererDimensions = {
+export interface MessageBridgeUpRendererDimensions {
   type: MessageBridgeUpType.RENDERER_DIMENSIONS
   dimensions: Dimensions
 }
 
-export type ElementPositionResponse = {
+export interface ElementPositionResponse {
   cssSelector: string
   position: Omit<DOMRect, 'toJSON'>
 }
 
-export type MessageBridgeUpElementPosition = {
+export interface MessageBridgeUpElementPosition {
   type: MessageBridgeUpType.ELEMENT_POSITION
   positions: ElementPositionResponse[]
 }
 
-type MessageBridgeMetadata = {
+interface MessageBridgeMetadata {
   sentAt: number
 }
 
@@ -200,7 +200,7 @@ export type MessageBridgeDownElementPosition = {
   cssSelectors: string[]
 } & MessageBridgeMetadata
 
-export type SerialisedError = {
+export interface SerialisedError {
   name: string
   message: string
   stack?: string

--- a/developer-extension/src/panel/sessionReplayPlayer/startSessionReplayPlayer.ts
+++ b/developer-extension/src/panel/sessionReplayPlayer/startSessionReplayPlayer.ts
@@ -14,7 +14,7 @@ import { MessageBridgeDownType, MessageBridgeUpLogLevel, MessageBridgeUpType } f
 const sandboxLogger = createLogger('sandbox')
 
 export type SessionReplayPlayerStatus = 'loading' | 'waiting-for-full-snapshot' | 'ready'
-export type SessionReplayPlayerState = {
+export interface SessionReplayPlayerState {
   status: SessionReplayPlayerStatus
   recordCount: number
   excludeMouseMovements: boolean

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -157,6 +157,7 @@ export default tseslint.config(
       ],
       '@typescript-eslint/consistent-type-imports': ['error'],
       '@typescript-eslint/consistent-type-exports': 'error',
+      '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
       '@typescript-eslint/member-ordering': [
         'error',
         {

--- a/packages/core/src/browser/browser.types.ts
+++ b/packages/core/src/browser/browser.types.ts
@@ -61,7 +61,7 @@ export interface CookieStoreEventMap {
   change: CookieChangeEvent
 }
 
-export type CookieChangeItem = { name: string; value: string | undefined }
+export interface CookieChangeItem { name: string; value: string | undefined }
 
 export type CookieChangeEvent = Event & {
   changed: CookieChangeItem[]

--- a/packages/core/src/domain/context/contextManager.ts
+++ b/packages/core/src/domain/context/contextManager.ts
@@ -7,7 +7,7 @@ import { checkContext } from './contextUtils'
 
 export type ContextManager = ReturnType<typeof createContextManager>
 
-export type PropertiesConfig = {
+export interface PropertiesConfig {
   [key: string]: {
     required?: boolean
     type?: 'string'

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -9,7 +9,7 @@ import type { ErrorSource, ErrorHandling, RawError, RawErrorCause, ErrorWithCaus
 
 export const NO_ERROR_STACK_PRESENT_MESSAGE = 'No stack, consider using an instance of Error'
 
-type RawErrorParams = {
+interface RawErrorParams {
   stackTrace?: StackTrace
   originalError: unknown
   handlingStack?: string

--- a/packages/core/src/domain/error/error.types.ts
+++ b/packages/core/src/domain/error/error.types.ts
@@ -14,14 +14,14 @@ export interface ErrorWithCause extends Omit<Error, 'cause'> {
   cause?: unknown
 }
 
-export type RawErrorCause = {
+export interface RawErrorCause {
   message: string
   source: ErrorSource
   type?: string
   stack?: string
 }
 
-export type Csp = {
+export interface Csp {
   disposition: 'enforce' | 'report'
 }
 

--- a/packages/core/src/domain/session/sessionStoreOperations.ts
+++ b/packages/core/src/domain/session/sessionStoreOperations.ts
@@ -7,7 +7,7 @@ import type { SessionStoreStrategy } from './storeStrategies/sessionStoreStrateg
 import type { SessionState } from './sessionState'
 import { expandSessionState, isSessionInExpiredState } from './sessionState'
 
-type Operations = {
+interface Operations {
   process: (sessionState: SessionState) => SessionState | undefined
   after?: (sessionState: SessionState) => void
 }

--- a/packages/core/src/tools/instrumentMethod.ts
+++ b/packages/core/src/tools/instrumentMethod.ts
@@ -7,7 +7,7 @@ import { createHandlingStack } from './stackTrace/handlingStack'
  * Object passed to the callback of an instrumented method call. See `instrumentMethod` for more
  * info.
  */
-export type InstrumentedMethodCall<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET> = {
+export interface InstrumentedMethodCall<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET> {
   /**
    * The target object on which the method was called.
    */

--- a/packages/core/src/tools/readBytesFromStream.ts
+++ b/packages/core/src/tools/readBytesFromStream.ts
@@ -1,7 +1,7 @@
 import { monitor } from './monitor'
 import { noop } from './utils/functionUtils'
 
-type Options = {
+interface Options {
   bytesLimit: number
   collectStreamBody?: boolean
 }

--- a/packages/core/src/tools/serialisation/sanitize.ts
+++ b/packages/core/src/tools/serialisation/sanitize.ts
@@ -7,16 +7,16 @@ import { detachToJsonMethod } from './jsonStringify'
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 type PrimitivesAndFunctions = string | number | boolean | undefined | null | symbol | bigint | Function
 type ExtendedContextValue = PrimitivesAndFunctions | object | ExtendedContext | ExtendedContextArray
-type ExtendedContext = { [key: string]: ExtendedContextValue }
+interface ExtendedContext { [key: string]: ExtendedContextValue }
 type ExtendedContextArray = ExtendedContextValue[]
 
-type ContainerElementToProcess = {
+interface ContainerElementToProcess {
   source: ExtendedContextArray | ExtendedContext
   target: ContextArray | Context
   path: string
 }
 
-type SanitizedEvent = {
+interface SanitizedEvent {
   type: string
   isTrusted: boolean
   currentTarget: string | null | undefined

--- a/packages/core/src/tools/utils/timeUtils.ts
+++ b/packages/core/src/tools/utils/timeUtils.ts
@@ -10,7 +10,7 @@ export type Duration = number & { d: 'Duration in ms' }
 export type ServerDuration = number & { s: 'Duration in ns' }
 export type TimeStamp = number & { t: 'Epoch time' }
 export type RelativeTime = number & { r: 'Time relative to navigation start' } & { d: 'Duration in ms' }
-export type ClocksState = { relative: RelativeTime; timeStamp: TimeStamp }
+export interface ClocksState { relative: RelativeTime; timeStamp: TimeStamp }
 
 export function relativeToClocks(relative: RelativeTime) {
   return { relative, timeStamp: getCorrectedTimeStamp(relative) }

--- a/packages/logs/src/domain/hooks.ts
+++ b/packages/logs/src/domain/hooks.ts
@@ -4,7 +4,7 @@ import type { LogsEvent } from '../logsEvent.types'
 
 export type DefaultLogsEventAttributes = RecursivePartialExcept<LogsEvent>
 
-export type HookCallbackMap = {
+export interface HookCallbackMap {
   [HookNamesAsConst.ASSEMBLE]: (param: { startTime: RelativeTime }) => DefaultLogsEventAttributes | SKIPPED | DISCARDED
 }
 

--- a/packages/logs/src/domain/logsSessionManager.ts
+++ b/packages/logs/src/domain/logsSessionManager.ts
@@ -9,7 +9,7 @@ export interface LogsSessionManager {
   expireObservable: Observable<void>
 }
 
-export type LogsSession = {
+export interface LogsSession {
   id?: string // session can be tracked without id
   anonymousId?: string // device id lasts across session
 }

--- a/packages/logs/src/domainContext.types.ts
+++ b/packages/logs/src/domainContext.types.ts
@@ -8,15 +8,15 @@ export type LogsEventDomainContext<T extends ErrorSource = any> = T extends type
       ? LoggerLogsEventDomainContext
       : never
 
-export type NetworkLogsEventDomainContext = {
+export interface NetworkLogsEventDomainContext {
   isAborted: boolean
   handlingStack?: string
 }
 
-export type ConsoleLogsEventDomainContext = {
+export interface ConsoleLogsEventDomainContext {
   handlingStack: string
 }
 
-export type LoggerLogsEventDomainContext = {
+export interface LoggerLogsEventDomainContext {
   handlingStack: string
 }

--- a/packages/logs/src/rawLogsEvent.types.ts
+++ b/packages/logs/src/rawLogsEvent.types.ts
@@ -9,7 +9,7 @@ export type RawLogsEvent =
   | RawReportLogsEvent
   | RawRuntimeLogsEvent
 
-type Error = {
+interface Error {
   message?: string
   kind?: string
   stack?: string

--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -136,7 +136,7 @@ export interface RumLayoutShiftTiming {
 }
 
 // Documentation https://developer.chrome.com/docs/web-platform/long-animation-frames#better-attribution
-export type RumPerformanceScriptTiming = {
+export interface RumPerformanceScriptTiming {
   duration: Duration
   entryType: 'script'
   executionStart: RelativeTime
@@ -191,7 +191,7 @@ export type RumPerformanceEntry =
   | RumLayoutShiftTiming
   | RumFirstHiddenTiming
 
-export type EntryTypeToReturnType = {
+export interface EntryTypeToReturnType {
   [RumPerformanceEntryType.EVENT]: RumPerformanceEventTiming
   [RumPerformanceEntryType.FIRST_INPUT]: RumFirstInputTiming
   [RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT]: RumLargestContentfulPaintTiming

--- a/packages/rum-core/src/domain/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.ts
@@ -15,7 +15,7 @@ export const enum ActionNameSource {
   STANDARD_ATTRIBUTE = 'standard_attribute',
   BLANK = 'blank',
 }
-type ActionName = {
+interface ActionName {
   name: string
   nameSource: ActionNameSource
 }

--- a/packages/rum-core/src/domain/action/listenActionEvents.ts
+++ b/packages/rum-core/src/domain/action/listenActionEvents.ts
@@ -2,7 +2,7 @@ import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 import type { RelativeTime } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 
-export type ExtraPointerEventFields = {
+export interface ExtraPointerEventFields {
   target: Element
   timeStamp: RelativeTime
 }

--- a/packages/rum-core/src/domain/contexts/pageStateHistory.ts
+++ b/packages/rum-core/src/domain/contexts/pageStateHistory.ts
@@ -30,7 +30,7 @@ export const enum PageState {
   TERMINATED = 'terminated',
 }
 
-export type PageStateEntry = { state: PageState; startTime: RelativeTime }
+export interface PageStateEntry { state: PageState; startTime: RelativeTime }
 
 export interface PageStateHistory {
   wasInPageStateDuringPeriod: (state: PageState, startTime: RelativeTime, duration: Duration) => boolean

--- a/packages/rum-core/src/domain/hooks.ts
+++ b/packages/rum-core/src/domain/hooks.ts
@@ -13,7 +13,7 @@ import type { RumEvent } from '../rumEvent.types'
 // Ensuring the `type` field is always present improves type checking, especially in conditional logic in hooks (e.g., `if (eventType === 'view')`).
 export type DefaultRumEventAttributes = RecursivePartialExcept<RumEvent, 'type'>
 
-export type HookCallbackMap = {
+export interface HookCallbackMap {
   [HookNamesAsConst.ASSEMBLE]: (param: {
     eventType: RumEvent['type']
     startTime: RelativeTime

--- a/packages/rum-core/src/domain/plugins.ts
+++ b/packages/rum-core/src/domain/plugins.ts
@@ -2,7 +2,7 @@ import type { RumPublicApi, Strategy } from '../boot/rumPublicApi'
 import type { StartRumResult } from '../boot/startRum'
 import type { RumInitConfiguration } from './configuration'
 
-type OnRumStartOptions = {
+interface OnRumStartOptions {
   /**
    * @deprecated Use `addEvent` instead.
    */

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -27,7 +27,7 @@ export interface RumSessionManager {
   setForcedReplay: () => void
 }
 
-export type RumSession = {
+export interface RumSession {
   id: string
   sessionReplay: SessionReplayState
   anonymousId?: string

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
@@ -6,13 +6,13 @@ import { LifeCycleEventType } from './lifeCycle'
 
 export const MEASURES_PERIOD_DURATION = 10 * ONE_SECOND
 
-type Measure = {
+interface Measure {
   min: number
   max: number
   sum: number
 }
 
-type CurrentPeriodMeasures = {
+interface CurrentPeriodMeasures {
   batchCount: number
   batchBytesCount: Measure
   batchMessagesCount: Measure

--- a/packages/rum-core/src/domain/tracing/tracer.types.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.types.ts
@@ -7,4 +7,4 @@ import type { MatchOption } from '@datadog/browser-core'
  * b3multi: B3 Multiple Headers (X-B3-*)
  */
 export type PropagatorType = 'datadog' | 'b3' | 'b3multi' | 'tracecontext'
-export type TracingOption = { match: MatchOption; propagatorTypes: PropagatorType[] }
+export interface TracingOption { match: MatchOption; propagatorTypes: PropagatorType[] }

--- a/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -5,7 +5,7 @@ import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../..
 
 export type FirstHidden = ReturnType<typeof trackFirstHidden>
 
-export type Options = {
+export interface Options {
   viewStart: ClocksState
 }
 

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -192,7 +192,7 @@ export interface RumRect {
   height: number
 }
 
-export type PageStateServerEntry = { state: PageState; start: ServerDuration }
+export interface PageStateServerEntry { state: PageState; start: ServerDuration }
 
 export const ViewLoadingType = {
   INITIAL_LOAD: 'initial_load',

--- a/packages/rum-react/src/domain/reactRouter/types.ts
+++ b/packages/rum-react/src/domain/reactRouter/types.ts
@@ -6,7 +6,7 @@
 // * compatible with all react-router-dom versions we support
 // * include the minimal set of attributes used by our instrumentation functions.
 
-export type AnyRouteObject = {
+export interface AnyRouteObject {
   path?: string | undefined
   element?: React.ReactNode
 }
@@ -14,7 +14,7 @@ export type AnyUseRoute<Location extends AnyLocation> = (
   routes: AnyRouteObject[],
   location?: Location
 ) => React.ReactElement | null
-export type AnyRouteMatch = { route: AnyRouteObject; params: Record<string, string | undefined> }
+export interface AnyRouteMatch { route: AnyRouteObject; params: Record<string, string | undefined> }
 export type AnyLocation = { pathname: string } | string
 export type AnyCreateRouter<Options> = (
   routes: AnyRouteObject[],

--- a/packages/rum/src/domain/record/elementsScrollPositions.ts
+++ b/packages/rum/src/domain/record/elementsScrollPositions.ts
@@ -1,5 +1,5 @@
 export type ElementsScrollPositions = ReturnType<typeof createElementsScrollPositions>
-export type ScrollPositions = { scrollLeft: number; scrollTop: number }
+export interface ScrollPositions { scrollLeft: number; scrollTop: number }
 
 export function createElementsScrollPositions() {
   const scrollPositionsByElement = new WeakMap<Element, ScrollPositions>()

--- a/packages/rum/src/domain/record/trackers/tracker.types.ts
+++ b/packages/rum/src/domain/record/trackers/tracker.types.ts
@@ -1,1 +1,1 @@
-export type Tracker = { stop: () => void }
+export interface Tracker { stop: () => void }

--- a/test/browsers.conf.d.ts
+++ b/test/browsers.conf.d.ts
@@ -1,4 +1,4 @@
-export type BrowserConfiguration = {
+export interface BrowserConfiguration {
   sessionName: string
   name: string
   version?: string

--- a/test/e2e/lib/framework/intakeRegistry.ts
+++ b/test/e2e/lib/framework/intakeRegistry.ts
@@ -16,7 +16,7 @@ import type {
 import type { BrowserSegment } from '@datadog/browser-rum/src/types'
 import type { BrowserSegmentMetadataAndSegmentSizes } from '@datadog/browser-rum/src/domain/segmentCollection'
 
-type BaseIntakeRequest = {
+interface BaseIntakeRequest {
   isBridge: boolean
   encoding: string | null
 }


### PR DESCRIPTION
## Motivation

To ensure consistent API reference documentation, this PR reinforces our convention of using interface instead of type for object-like definitions.

## Changes

Replace type alias with interface for object definition

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
