### PR TITLE
🐛 [PANA-3447] Don't send customer data telemetry for any batch with no RUM events

### DIFF
--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
@@ -46,6 +46,8 @@ export function startCustomerDataTelemetry(
     if (!batchHasRumEvent) {
       return
     }
+    batchHasRumEvent = false
+
     currentPeriodMeasures.batchCount += 1
     updateMeasure(currentPeriodMeasures.batchBytesCount, bytesCount)
     updateMeasure(currentPeriodMeasures.batchMessagesCount, messagesCount)


### PR DESCRIPTION
## Motivation

We intended to only send customer data telemetry for batches with no RUM events. However, once we see a single RUM event in any batch, we never reset the `batchHasRumEvent` flag, so we will continue sending customer data telemetry for all future batches. This generates unnecessary network traffic and unnecessarily consumes telemetry event quota.

## Changes

This PR makes us reset the `batchHasRumEvent` flag after each batch is flushed, so that the code behaves as intended.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.