### PR TITLE
✨ [PANA-3449] Apply separate event limits for different kinds of telemetry

### DIFF
--- a/packages/core/src/domain/telemetry/index.ts
+++ b/packages/core/src/domain/telemetry/index.ts
@@ -9,6 +9,7 @@ export {
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
   addTelemetryUsage,
+  addTelemetryMetrics,
 } from './telemetry'
 
 export * from './rawTelemetryEvent.types'

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -60,8 +60,8 @@ const TELEMETRY_EXCLUDED_SITES: string[] = [INTAKE_SITE_US1_FED]
 
 // eslint-disable-next-line local-rules/disallow-side-effects
 let preStartTelemetryBuffer = createBoundedBuffer()
-let onRawTelemetryEventCollected = (event: RawTelemetryEvent) => {
-  preStartTelemetryBuffer.add(() => onRawTelemetryEventCollected(event))
+let onRawTelemetryEventCollected = (event: RawTelemetryEvent, kind: string) => {
+  preStartTelemetryBuffer.add(() => onRawTelemetryEventCollected(event, kind))
 }
 
 export function startTelemetry(
@@ -90,7 +90,7 @@ export function startTelemetryCollection(
   hooks: AbstractHooks,
   observable: Observable<TelemetryEvent & Context>
 ) {
-  const alreadySentEvents = new Set<string>()
+  const alreadySentEventsByKind: Record<string, Set<string>> = {}
 
   const telemetryEnabled =
     !TELEMETRY_EXCLUDED_SITES.includes(configuration.site) && performDraw(configuration.telemetrySampleRate)
@@ -102,30 +102,42 @@ export function startTelemetryCollection(
   }
 
   const runtimeEnvInfo = getRuntimeEnvInfo()
-  onRawTelemetryEventCollected = (rawEvent: RawTelemetryEvent) => {
-    const stringifiedEvent = jsonStringify(rawEvent)!
-    if (
-      telemetryEnabledPerType[rawEvent.type!] &&
-      alreadySentEvents.size < configuration.maxTelemetryEventsPerPage &&
-      !alreadySentEvents.has(stringifiedEvent)
-    ) {
-      const defaultTelemetryEventAttributes = hooks.triggerHook(HookNames.AssembleTelemetry, {
-        startTime: clocksNow().relative,
-      })
-
-      if (defaultTelemetryEventAttributes === DISCARDED) {
-        return
-      }
-      const event = toTelemetryEvent(
-        defaultTelemetryEventAttributes as RecursivePartial<TelemetryEvent>,
-        telemetryService,
-        rawEvent,
-        runtimeEnvInfo
-      )
-      observable.notify(event)
-      sendToExtension('telemetry', event)
-      alreadySentEvents.add(stringifiedEvent)
+  onRawTelemetryEventCollected = (rawEvent: RawTelemetryEvent, kind: string) => {
+    if (!telemetryEnabledPerType[rawEvent.type!]) {
+      return
     }
+
+    let alreadySentEvents = alreadySentEventsByKind[kind]
+    if (!alreadySentEvents) {
+      alreadySentEvents = alreadySentEventsByKind[kind] = new Set()
+    }
+
+    if (alreadySentEvents.size >= configuration.maxTelemetryEventsPerPage) {
+      return
+    }
+
+    const stringifiedEvent = jsonStringify(rawEvent)!
+    if (alreadySentEvents.has(stringifiedEvent)) {
+      return
+    }
+
+    const defaultTelemetryEventAttributes = hooks.triggerHook(HookNames.AssembleTelemetry, {
+      startTime: clocksNow().relative,
+    })
+
+    if (defaultTelemetryEventAttributes === DISCARDED) {
+      return
+    }
+
+    const event = toTelemetryEvent(
+      defaultTelemetryEventAttributes as RecursivePartial<TelemetryEvent>,
+      telemetryService,
+      rawEvent,
+      runtimeEnvInfo
+    )
+    observable.notify(event)
+    sendToExtension('telemetry', event)
+    alreadySentEvents.add(stringifiedEvent)
   }
   // need to be called after telemetry context is provided and observers are registered
   preStartTelemetryBuffer.drain()
@@ -225,8 +237,8 @@ export function startFakeTelemetry() {
 
 export function resetTelemetry() {
   preStartTelemetryBuffer = createBoundedBuffer()
-  onRawTelemetryEventCollected = (event: RawTelemetryEvent) => {
-    preStartTelemetryBuffer.add(() => onRawTelemetryEventCollected(event))
+  onRawTelemetryEventCollected = (event: RawTelemetryEvent, kind: string) => {
+    preStartTelemetryBuffer.add(() => onRawTelemetryEventCollected(event, kind))
   }
 }
 
@@ -240,35 +252,59 @@ export function isTelemetryReplicationAllowed(configuration: Configuration) {
 
 export function addTelemetryDebug(message: string, context?: Context) {
   displayIfDebugEnabled(ConsoleApiName.debug, message, context)
-  onRawTelemetryEventCollected({
-    type: TelemetryType.LOG,
-    message,
-    status: StatusType.debug,
-    ...context,
-  })
+  onRawTelemetryEventCollected(
+    {
+      type: TelemetryType.LOG,
+      message,
+      status: StatusType.debug,
+      ...context,
+    },
+    StatusType.debug
+  )
 }
 
 export function addTelemetryError(e: unknown, context?: Context) {
-  onRawTelemetryEventCollected({
-    type: TelemetryType.LOG,
-    status: StatusType.error,
-    ...formatError(e),
-    ...context,
-  })
+  onRawTelemetryEventCollected(
+    {
+      type: TelemetryType.LOG,
+      status: StatusType.error,
+      ...formatError(e),
+      ...context,
+    },
+    StatusType.error
+  )
 }
 
 export function addTelemetryConfiguration(configuration: RawTelemetryConfiguration) {
-  onRawTelemetryEventCollected({
-    type: TelemetryType.CONFIGURATION,
-    configuration,
-  })
+  onRawTelemetryEventCollected(
+    {
+      type: TelemetryType.CONFIGURATION,
+      configuration,
+    },
+    TelemetryType.CONFIGURATION
+  )
+}
+
+export function addTelemetryMetrics(kind: string, context?: Context) {
+  onRawTelemetryEventCollected(
+    {
+      type: TelemetryType.LOG,
+      message: kind,
+      status: StatusType.debug,
+      ...context,
+    },
+    kind
+  )
 }
 
 export function addTelemetryUsage(usage: RawTelemetryUsage) {
-  onRawTelemetryEventCollected({
-    type: TelemetryType.USAGE,
-    usage,
-  })
+  onRawTelemetryEventCollected(
+    {
+      type: TelemetryType.USAGE,
+      usage,
+    },
+    TelemetryType.USAGE
+  )
 }
 
 export function formatError(e: unknown) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export {
   isTelemetryReplicationAllowed,
   addTelemetryConfiguration,
   addTelemetryUsage,
+  addTelemetryMetrics,
 } from './domain/telemetry'
 export { monitored, monitor, callMonitored, setDebugMode, monitorError } from './tools/monitor'
 export type { Subscription } from './tools/observable'

--- a/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
+++ b/packages/rum-core/src/domain/startCustomerDataTelemetry.ts
@@ -1,5 +1,5 @@
 import type { Context, FlushEvent, Observable, Telemetry } from '@datadog/browser-core'
-import { performDraw, ONE_SECOND, addTelemetryDebug, setInterval } from '@datadog/browser-core'
+import { performDraw, ONE_SECOND, addTelemetryMetrics, setInterval } from '@datadog/browser-core'
 import type { RumConfiguration } from './configuration'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
@@ -61,7 +61,7 @@ function sendCurrentPeriodMeasures() {
     return
   }
 
-  addTelemetryDebug('Customer data measures', currentPeriodMeasures)
+  addTelemetryMetrics('Customer data measures', currentPeriodMeasures)
   initCurrentPeriodMeasures()
 }
 


### PR DESCRIPTION
## Motivation

We currently have a limit of 15 total telemetry events per page. This limit made sense when telemetry only contained error and usage information that is naturally low in volume. However, some of the newer kinds of telemetry track metrics (e.g. about the size of the network requests we're sending to the intake) that need to be updated periodically over the lifetime of the page. Both for cost reasons, and to minimize the consumption of bandwidth on customer sites, we still want to be aggressive about limiting this telemetry, but we now also need to ensure that the event limits are applied fairly to the different telemetry kinds. Otherwise, more chatty kinds of telemetry can easily starve lower-volume telemetry, preventing us from ever learning about, for example, errors that tend to happen only after the page has been open for a while.

## Changes

To ensure fairness between the different kinds of telemetry, I've added a new `kind` parameter to the internal `onRawTelemetryEventCollected` function. The telemetry event limit is now applied to each `kind` separately. With today's limit, this means that we can now send up to 15 errors, up to 15 debug messages, up to 15 usage events, and so forth. I've assigned the `kind`s in each of the functions we use to send telemetry (e.g. `addTelemetryError`) based on whichever was more specific of  either the `TelemetryType` or the `StatusType`.

I've also added a new telemetry sending function, `addTelemetryMetrics()`; this function is intended for use with customer data telemetry and the new session replay reliability telemetry bring added in #3688. For this function, the caller provides the `kind` directly; this allows different kinds of metrics to have independent event limits.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.