### PR TITLE
♻️ [Profiling] add missing monitors at profiler start/stop

### DIFF
--- a/packages/rum/src/domain/profiling/transport/transport.ts
+++ b/packages/rum/src/domain/profiling/transport/transport.ts
@@ -1,4 +1,4 @@
-import { addTelemetryDebug, currentDrift, type EndpointBuilder, type Payload } from '@datadog/browser-core'
+import { currentDrift, type EndpointBuilder, type Payload } from '@datadog/browser-core'
 import type { RumProfilerTrace } from '../types'
 
 interface ProfileEventAttributes {
@@ -37,8 +37,6 @@ const sendProfile: SendProfileFunction = (profilerTrace, endpointBuilder, applic
 
   // Create URL, public profiling intake.
   const profilingIntakeURL = endpointBuilder.build('fetch', payload)
-
-  addTelemetryDebug('Sending profile to public profiling intake', { profilingIntakeURL, applicationId, sessionId })
 
   // Send payload (event + profile as attachment).
   return fetch(profilingIntakeURL, {


### PR DESCRIPTION
## Motivation

Housekeeping

## Changes

- add missing monitors at profiler start/stop
- remove debug log for each intake request

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
