### PR TITLE
👷 use SIGKILL instead of SIGTERM to kill child jobs

### DIFF
--- a/scripts/test/bs-wrapper.js
+++ b/scripts/test/bs-wrapper.js
@@ -127,7 +127,10 @@ function runTests() {
 
     function killIt(message) {
       printError(`Killing the browserstack job because of ${message}`)
-      child.kill('SIGTERM')
+      // use 'SIGKILL' instead of 'SIGTERM' because Karma intercepts 'SIGTERM' and terminates the process with a 0 exit code,
+      // which is not what we want here (we want to indicate a failure).
+      // see https://github.com/karma-runner/karma/blob/master/lib/server.js#L391
+      child.kill('SIGKILL')
     }
   })
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Karma is [intercepting](https://github.com/karma-runner/karma/blob/master/lib/server.js#L391) `SIGTERM` and exit the process with a 0 status code which makes the CI job succeed even though there is some errors or it timeout.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

use `SIGKILL` instead of `SIGTERM`

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
