### PR TITLE
Bump device version unit tests

### DIFF
--- a/test/unit/browsers.conf.js
+++ b/test/unit/browsers.conf.js
@@ -44,7 +44,7 @@ const browserConfigurations = [
     name: 'safari',
     os: 'ios',
     osVersion: '14',
-    device: 'iPhone 11',
+    device: 'iPhone 12',
   },
 ]
 


### PR DESCRIPTION
## Motivation

Browser stack deprecated the `os_version` we had for Safari Mobile
<img width="769" height="149" alt="Screenshot 2025-07-18 at 11 45 12" src="https://github.com/user-attachments/assets/394fef2e-a409-4b6e-ba09-091e12d241d4" />


## Changes

Bumped Safari Mobile device to 'iPhone 12'

## Test instructions

Run `yarn test:unit:bs` all tests should pass.
<img width="1155" height="648" alt="Screenshot 2025-07-18 at 17 45 24" src="https://github.com/user-attachments/assets/4c37ff00-83b0-4206-9c5e-adfe7bbb3ea2" />


## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
