### PR TITLE
👷 reduce the number of concurrent workers used by playwright

### DIFF
--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -24,6 +24,7 @@ export const config: Config = {
   fullyParallel: true,
   forbidOnly: isCi,
   retries: isCi ? 2 : 0,
+  workers: 5,
   reporter: reporters,
   use: {
     trace: isCi ? 'off' : 'retain-on-failure',


### PR DESCRIPTION
Defaults to half of the number of logical CPU cores availables

## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Sometimes e2e jobs timeout, we suspect it do be due to the CI runner resources being limited. This PR reduce the number of concurrent worker used by playwright to 5 workers

The CI pipeline time will likely increase, but also be more stable.
If this increase too much, we could consider sharding to run e2e test in multiple CI runners

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
