### PR TITLE
👷 add a stale issue workflow

### DIFF
--- a/.github/workflows/state.yml
+++ b/.github/workflows/state.yml
@@ -1,0 +1,36 @@
+name: 'Automatically close stale issues'
+
+on:
+  schedule:
+    # Runs every day at 8:00 AM CET
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # See documentation at https://github.com/actions/stale?tab=readme-ov-file#all-options
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity and has the `need-info` label.
+
+            It will be closed if no further activity occurs within 3 days.
+
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity and has the `need-info` label.
+
+            It will be closed if no further activity occurs within 3 days.
+
+          stale-issue-label: 'stale'
+          close-issue-label: 'automatically closed'
+          only-labels: 'need-info'
+          days-before-issue-stale: 14
+          days-before-issue-close: 3


### PR DESCRIPTION

## Motivation

Automatically close issues and PRs after some inactivity.

[Inspiration](https://github.com/DataDog/dd-sdk-ios/blob/develop/.github/workflows/stale.yml)

## Changes

And a GitHub workflow to mark issues and PRs labeled with `need-info` as `stale` after 14 days, and closes them afterward.

## Test instructions

Check the GitHub action execution.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
