### PR TITLE
💥 [RUM-10952] Make allowedTrackingOrigins required in Browser Extensions

### DIFF
--- a/packages/core/src/domain/allowedTrackingOrigins.spec.ts
+++ b/packages/core/src/domain/allowedTrackingOrigins.spec.ts
@@ -1,7 +1,7 @@
 import { display } from '../tools/display'
 import {
   isAllowedTrackingOrigins,
-  WARN_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN,
+  ERROR_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN,
   ERROR_NOT_ALLOWED_TRACKING_ORIGIN,
 } from './allowedTrackingOrigins'
 
@@ -170,7 +170,7 @@ describe('checkForAllowedTrackingOrigins', () => {
   })
 
   describe('when configuration does not have allowedTrackingOrigins', () => {
-    it('should warn when in extension environment and allowedTrackingOrigins is undefined', () => {
+    it('should error when in extension environment and allowedTrackingOrigins is undefined', () => {
       const result = isAllowedTrackingOrigins(
         {
           ...DEFAULT_CONFIG,
@@ -179,8 +179,8 @@ describe('checkForAllowedTrackingOrigins', () => {
         'https://example.com',
         'Error: at chrome-extension://abcdefghijklmno/content.js:10:15'
       )
-      expect(displayWarnSpy).toHaveBeenCalledWith(WARN_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN)
-      expect(result).toBe(true)
+      expect(displayErrorSpy).toHaveBeenCalledWith(ERROR_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN)
+      expect(result).toBe(false)
     })
 
     it('should error when in extension environment and allowedTrackingOrigins is an empty array', () => {

--- a/packages/core/src/domain/allowedTrackingOrigins.ts
+++ b/packages/core/src/domain/allowedTrackingOrigins.ts
@@ -3,8 +3,8 @@ import { matchList } from '../tools/matchOption'
 import type { InitConfiguration } from './configuration'
 import { isUnsupportedExtensionEnvironment } from './extension/extensionUtils'
 
-export const WARN_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN =
-  'Running the Browser SDK in a Web extension content script is discouraged and will be forbidden in a future major release unless the `allowedTrackingOrigins` option is provided.'
+export const ERROR_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN =
+  'Running the Browser SDK in a Web extension content script is forbidden unless the `allowedTrackingOrigins` option is provided.'
 export const ERROR_NOT_ALLOWED_TRACKING_ORIGIN = 'SDK initialized on a non-allowed domain.'
 
 export function isAllowedTrackingOrigins(
@@ -15,8 +15,8 @@ export function isAllowedTrackingOrigins(
   const allowedTrackingOrigins = configuration.allowedTrackingOrigins
   if (!allowedTrackingOrigins) {
     if (isUnsupportedExtensionEnvironment(windowOrigin, errorStack)) {
-      display.warn(WARN_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN)
-      // TODO(next major): make `allowedTrackingOrigins` required in unsupported extension environments
+      display.error(ERROR_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN)
+      return false
     }
     return true
   }

--- a/test/apps/base-extension/yarn.lock
+++ b/test/apps/base-extension/yarn.lock
@@ -7,14 +7,14 @@ __metadata:
 
 "@datadog/browser-core@file:../../../packages/core/package.tgz::locator=rum-testing-extension%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-core@file:../../../packages/core/package.tgz#../../../packages/core/package.tgz::hash=904235&locator=rum-testing-extension%40workspace%3A."
-  checksum: 10c0/90e3652f85eda6d401dbc439eef5d165bfa79ebc2596cbb7e980e4e5e07f797fc07eee7c4afb0a92924cd25d877a1ccfcff57a04c12197489b5dbc91b98e46f9
+  resolution: "@datadog/browser-core@file:../../../packages/core/package.tgz#../../../packages/core/package.tgz::hash=f10257&locator=rum-testing-extension%40workspace%3A."
+  checksum: 10c0/aa770685d29cab307f98f38cec75fda56ecac969c2afec7c9b5de337c66fcbaa5307c27b8a68e8d242eb73d62106688e8c08f0aaa9f8d0f36fe14c996e5b753b
   languageName: node
   linkType: hard
 
 "@datadog/browser-logs@file:../../../packages/logs/package.tgz::locator=rum-testing-extension%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-logs@file:../../../packages/logs/package.tgz#../../../packages/logs/package.tgz::hash=e7eba9&locator=rum-testing-extension%40workspace%3A."
+  resolution: "@datadog/browser-logs@file:../../../packages/logs/package.tgz#../../../packages/logs/package.tgz::hash=a676b1&locator=rum-testing-extension%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
   peerDependencies:
@@ -22,22 +22,22 @@ __metadata:
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
-  checksum: 10c0/f9327956413e0211b672f776d64ce475005f623dc82899111508b10cf586857f3af96962a5e2aefb7f80df6ea5289c666f3aa754c88ee152917b9c03fa038a24
+  checksum: 10c0/241387cba98702ab6fff3ec413174b880f461ef29d15ce08dc6fd50c77bfdd191fedbe295848275b3e15612b1ea17bbc923e3fd4bb93d3c7967be12b7920dbae
   languageName: node
   linkType: hard
 
 "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz::locator=rum-testing-extension%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz#../../../packages/rum-core/package.tgz::hash=8c8dbe&locator=rum-testing-extension%40workspace%3A."
+  resolution: "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz#../../../packages/rum-core/package.tgz::hash=b450a6&locator=rum-testing-extension%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
-  checksum: 10c0/e37fb8514d425882843c7fbe78fc7ba44f5454246b38ed77d64a26e72eb5fdc21d14baca5036d648492254862e0b0c298fb7eab5ddd4c9a8ffcca8c55dd76182
+  checksum: 10c0/bc277df08b682abfe8fda9a6051b2e2ecdffa7f26c209c3dbed491df656467a523ac5acd1352c7eab29b12630b75ba0df3e82e0e9756f13b325505ff0e494178
   languageName: node
   linkType: hard
 
 "@datadog/browser-rum@file:../../../packages/rum/package.tgz::locator=rum-testing-extension%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-rum@file:../../../packages/rum/package.tgz#../../../packages/rum/package.tgz::hash=0a28dc&locator=rum-testing-extension%40workspace%3A."
+  resolution: "@datadog/browser-rum@file:../../../packages/rum/package.tgz#../../../packages/rum/package.tgz::hash=8c1e7b&locator=rum-testing-extension%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
     "@datadog/browser-rum-core": "npm:6.14.0"
@@ -46,7 +46,7 @@ __metadata:
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
-  checksum: 10c0/4a3959344f616491c54ca309239022c0c95d5ab0a8181bbfc8714d6c7e811f008d9e73b3a37a013d504ebeeb8d8017359f3920093edb59142a9ac8895d468b15
+  checksum: 10c0/eb2f0b4c582b0ffe9e42a9e70828399992f1c3e9e9f11b472cc94113de1fe79221f3823c3de0966f258d76c2bd488a09c72dbae257d4a30d487983bb36844d84
   languageName: node
   linkType: hard
 

--- a/test/apps/react/yarn.lock
+++ b/test/apps/react/yarn.lock
@@ -7,23 +7,23 @@ __metadata:
 
 "@datadog/browser-core@file:../../../packages/core/package.tgz::locator=react-app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-core@file:../../../packages/core/package.tgz#../../../packages/core/package.tgz::hash=904235&locator=react-app%40workspace%3A."
-  checksum: 10c0/90e3652f85eda6d401dbc439eef5d165bfa79ebc2596cbb7e980e4e5e07f797fc07eee7c4afb0a92924cd25d877a1ccfcff57a04c12197489b5dbc91b98e46f9
+  resolution: "@datadog/browser-core@file:../../../packages/core/package.tgz#../../../packages/core/package.tgz::hash=f10257&locator=react-app%40workspace%3A."
+  checksum: 10c0/aa770685d29cab307f98f38cec75fda56ecac969c2afec7c9b5de337c66fcbaa5307c27b8a68e8d242eb73d62106688e8c08f0aaa9f8d0f36fe14c996e5b753b
   languageName: node
   linkType: hard
 
 "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz::locator=react-app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz#../../../packages/rum-core/package.tgz::hash=8c8dbe&locator=react-app%40workspace%3A."
+  resolution: "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz#../../../packages/rum-core/package.tgz::hash=b450a6&locator=react-app%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
-  checksum: 10c0/e37fb8514d425882843c7fbe78fc7ba44f5454246b38ed77d64a26e72eb5fdc21d14baca5036d648492254862e0b0c298fb7eab5ddd4c9a8ffcca8c55dd76182
+  checksum: 10c0/bc277df08b682abfe8fda9a6051b2e2ecdffa7f26c209c3dbed491df656467a523ac5acd1352c7eab29b12630b75ba0df3e82e0e9756f13b325505ff0e494178
   languageName: node
   linkType: hard
 
 "@datadog/browser-rum-react@file:../../../packages/rum-react/package.tgz::locator=react-app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-rum-react@file:../../../packages/rum-react/package.tgz#../../../packages/rum-react/package.tgz::hash=f01596&locator=react-app%40workspace%3A."
+  resolution: "@datadog/browser-rum-react@file:../../../packages/rum-react/package.tgz#../../../packages/rum-react/package.tgz::hash=8a8c44&locator=react-app%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
     "@datadog/browser-rum-core": "npm:6.14.0"
@@ -39,13 +39,13 @@ __metadata:
       optional: true
     react-router-dom:
       optional: true
-  checksum: 10c0/0e3d4b7d1a32234d10fefb347e777cebf72b99ed9b4cdf1d2b5368deb4b4dd82e554c00b444367a5661feecbaab2d5ecac92d178f93a8fe9a5e2837316966c35
+  checksum: 10c0/527f0fb86e484803f363ce34412f2b4a8226a704bddc8f26454ff7ee7691ee1d5b086aa693acb0f493c04294adf5fbd5b37ef89aa5fa70f95b7e0f261d895815
   languageName: node
   linkType: hard
 
 "@datadog/browser-rum@file:../../../packages/rum/package.tgz::locator=react-app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-rum@file:../../../packages/rum/package.tgz#../../../packages/rum/package.tgz::hash=0a28dc&locator=react-app%40workspace%3A."
+  resolution: "@datadog/browser-rum@file:../../../packages/rum/package.tgz#../../../packages/rum/package.tgz::hash=8c1e7b&locator=react-app%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
     "@datadog/browser-rum-core": "npm:6.14.0"
@@ -54,7 +54,7 @@ __metadata:
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
-  checksum: 10c0/4a3959344f616491c54ca309239022c0c95d5ab0a8181bbfc8714d6c7e811f008d9e73b3a37a013d504ebeeb8d8017359f3920093edb59142a9ac8895d468b15
+  checksum: 10c0/eb2f0b4c582b0ffe9e42a9e70828399992f1c3e9e9f11b472cc94113de1fe79221f3823c3de0966f258d76c2bd488a09c72dbae257d4a30d487983bb36844d84
   languageName: node
   linkType: hard
 

--- a/test/apps/vanilla/yarn.lock
+++ b/test/apps/vanilla/yarn.lock
@@ -7,14 +7,14 @@ __metadata:
 
 "@datadog/browser-core@file:../../../packages/core/package.tgz::locator=app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-core@file:../../../packages/core/package.tgz#../../../packages/core/package.tgz::hash=904235&locator=app%40workspace%3A."
-  checksum: 10c0/90e3652f85eda6d401dbc439eef5d165bfa79ebc2596cbb7e980e4e5e07f797fc07eee7c4afb0a92924cd25d877a1ccfcff57a04c12197489b5dbc91b98e46f9
+  resolution: "@datadog/browser-core@file:../../../packages/core/package.tgz#../../../packages/core/package.tgz::hash=f10257&locator=app%40workspace%3A."
+  checksum: 10c0/aa770685d29cab307f98f38cec75fda56ecac969c2afec7c9b5de337c66fcbaa5307c27b8a68e8d242eb73d62106688e8c08f0aaa9f8d0f36fe14c996e5b753b
   languageName: node
   linkType: hard
 
 "@datadog/browser-logs@file:../../../packages/logs/package.tgz::locator=app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-logs@file:../../../packages/logs/package.tgz#../../../packages/logs/package.tgz::hash=e7eba9&locator=app%40workspace%3A."
+  resolution: "@datadog/browser-logs@file:../../../packages/logs/package.tgz#../../../packages/logs/package.tgz::hash=a676b1&locator=app%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
   peerDependencies:
@@ -22,22 +22,22 @@ __metadata:
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
-  checksum: 10c0/f9327956413e0211b672f776d64ce475005f623dc82899111508b10cf586857f3af96962a5e2aefb7f80df6ea5289c666f3aa754c88ee152917b9c03fa038a24
+  checksum: 10c0/241387cba98702ab6fff3ec413174b880f461ef29d15ce08dc6fd50c77bfdd191fedbe295848275b3e15612b1ea17bbc923e3fd4bb93d3c7967be12b7920dbae
   languageName: node
   linkType: hard
 
 "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz::locator=app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz#../../../packages/rum-core/package.tgz::hash=8c8dbe&locator=app%40workspace%3A."
+  resolution: "@datadog/browser-rum-core@file:../../../packages/rum-core/package.tgz#../../../packages/rum-core/package.tgz::hash=b450a6&locator=app%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
-  checksum: 10c0/e37fb8514d425882843c7fbe78fc7ba44f5454246b38ed77d64a26e72eb5fdc21d14baca5036d648492254862e0b0c298fb7eab5ddd4c9a8ffcca8c55dd76182
+  checksum: 10c0/bc277df08b682abfe8fda9a6051b2e2ecdffa7f26c209c3dbed491df656467a523ac5acd1352c7eab29b12630b75ba0df3e82e0e9756f13b325505ff0e494178
   languageName: node
   linkType: hard
 
 "@datadog/browser-rum@file:../../../packages/rum/package.tgz::locator=app%40workspace%3A.":
   version: 6.14.0
-  resolution: "@datadog/browser-rum@file:../../../packages/rum/package.tgz#../../../packages/rum/package.tgz::hash=0a28dc&locator=app%40workspace%3A."
+  resolution: "@datadog/browser-rum@file:../../../packages/rum/package.tgz#../../../packages/rum/package.tgz::hash=8c1e7b&locator=app%40workspace%3A."
   dependencies:
     "@datadog/browser-core": "npm:6.14.0"
     "@datadog/browser-rum-core": "npm:6.14.0"
@@ -46,7 +46,7 @@ __metadata:
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
-  checksum: 10c0/4a3959344f616491c54ca309239022c0c95d5ab0a8181bbfc8714d6c7e811f008d9e73b3a37a013d504ebeeb8d8017359f3920093edb59142a9ac8895d468b15
+  checksum: 10c0/eb2f0b4c582b0ffe9e42a9e70828399992f1c3e9e9f11b472cc94113de1fe79221f3823c3de0966f258d76c2bd488a09c72dbae257d4a30d487983bb36844d84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

After [incident-40275](https://dd.enterprise.slack.com/archives/C094KRRE401) where a customer's Extensions API Key was exposed. There was a security concern that this API would allow unauthorized data submission to Datadog from the customer's chrome extension.

## Changes

When there is no `allowedTrackingOrigins` configured and `isUnsupportedExtensionEnvironment` is true we throw a console error and prevent the start of the SDK. 

## Test instructions

Previous `unit` and `e2e` test should suffice.
If not, run locally a browser extension without `allowedTrackingOrigins`, the SDK should throw a console error and not initiate. 
Add the parameter with a valid url and everything should work as normal.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [X] Added unit tests for this change.
- [X] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
