### PR TITLE
👷 Bump OS and device version.

### DIFF
--- a/packages/rum-core/src/browser/performanceObservable.ts
+++ b/packages/rum-core/src/browser/performanceObservable.ts
@@ -58,9 +58,9 @@ export interface RumPerformanceResourceTiming {
   responseEnd: RelativeTime
   redirectStart: RelativeTime
   redirectEnd: RelativeTime
-  decodedBodySize: number
-  encodedBodySize: number
-  transferSize: number
+  decodedBodySize?: number
+  encodedBodySize?: number
+  transferSize?: number
   nextHopProtocol?: string
   renderBlockingStatus?: string
   traceId?: string

--- a/packages/rum-core/src/browser/performanceUtils.spec.ts
+++ b/packages/rum-core/src/browser/performanceUtils.spec.ts
@@ -32,13 +32,22 @@ describe('getNavigationEntry', () => {
       responseEnd: jasmine.any(Number),
       redirectStart: jasmine.any(Number),
       redirectEnd: jasmine.any(Number),
-      decodedBodySize: jasmine.any(Number),
-      encodedBodySize: jasmine.any(Number),
-      transferSize: jasmine.any(Number),
 
       toJSON: jasmine.any(Function),
     }
 
-    expect(getNavigationEntry()).toEqual(jasmine.objectContaining(expectation))
+    const navigationEntry = getNavigationEntry()
+
+    expect(navigationEntry).toEqual(jasmine.objectContaining(expectation))
+
+    if (navigationEntry.decodedBodySize) {
+      expect(navigationEntry.decodedBodySize).toEqual(jasmine.any(Number))
+    }
+    if (navigationEntry.encodedBodySize) {
+      expect(navigationEntry.encodedBodySize).toEqual(jasmine.any(Number))
+    }
+    if (navigationEntry.transferSize) {
+      expect(navigationEntry.transferSize).toEqual(jasmine.any(Number))
+    }
   })
 })

--- a/test/unit/browsers.conf.js
+++ b/test/unit/browsers.conf.js
@@ -43,8 +43,8 @@ const browserConfigurations = [
     sessionName: 'Safari mobile',
     name: 'safari',
     os: 'ios',
-    osVersion: '14',
-    device: 'iPhone 12',
+    osVersion: '15',
+    device: 'iPhone 13',
   },
 ]
 


### PR DESCRIPTION
## Motivation

Browser Stack Unit BS was flaky after this [fix](https://github.com/DataDog/browser-sdk/pull/3703)
This PR aims to resolve it. 

## Changes

Bumped device and OS version.
Fixed spec
Because the new version of Safari does not contain
`decodedBodySize: number
  encodedBodySize: number
  transferSize: number`
We set it up as optional and only test against them when they exist.

## Test instructions

Unit and UnisBS should pass.
<img width="2278" height="852" alt="image" src="https://github.com/user-attachments/assets/6ca380df-3f1e-48c6-bed5-26ca5e13120e" />


## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
