### PR TITLE
🔊 Add telemetry to isUnsupportedExtensionEnvironment

### DIFF
--- a/packages/core/src/domain/allowedTrackingOrigins.ts
+++ b/packages/core/src/domain/allowedTrackingOrigins.ts
@@ -2,6 +2,7 @@ import { display } from '../tools/display'
 import { matchList } from '../tools/matchOption'
 import type { InitConfiguration } from './configuration'
 import { isUnsupportedExtensionEnvironment } from './extension/extensionUtils'
+import { addTelemetryDebug } from './telemetry'
 
 export const WARN_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN =
   'Running the Browser SDK in a Web extension content script is discouraged and will be forbidden in a future major release unless the `allowedTrackingOrigins` option is provided.'
@@ -16,6 +17,7 @@ export function isAllowedTrackingOrigins(
   if (!allowedTrackingOrigins) {
     if (isUnsupportedExtensionEnvironment(windowOrigin, errorStack)) {
       display.warn(WARN_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN)
+      addTelemetryDebug(WARN_DOES_NOT_HAVE_ALLOWED_TRACKING_ORIGIN)
       // TODO(next major): make `allowedTrackingOrigins` required in unsupported extension environments
     }
     return true


### PR DESCRIPTION
## Motivation

Add a telemetry debug in isUnsupportedExtensionEnvironment to see how many users are affected in the future change where we will make `allowedTrackingOrigins` required.

## Changes

Added a telemetry debug

## Test instructions

All should remain the same

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
