### PR TITLE
👷 Bump OS and device version again

### DIFF
--- a/test/unit/browsers.conf.js
+++ b/test/unit/browsers.conf.js
@@ -43,8 +43,8 @@ const browserConfigurations = [
     sessionName: 'Safari mobile',
     name: 'safari',
     os: 'ios',
-    osVersion: '15',
-    device: 'iPhone 13',
+    osVersion: '17',
+    device: 'iPhone 15',
   },
 ]
 


### PR DESCRIPTION
## Motivation

Browser Stack Unit BS was flaky after this https://github.com/DataDog/browser-sdk/pull/3703 and this [one](https://github.com/DataDog/browser-sdk/pull/3716).
This PR aims to resolve it.
<img width="1538" height="298" alt="image" src="https://github.com/user-attachments/assets/e56e9de0-c6e1-4b60-9beb-d4b854ef409f" />

## Changes

Bumped device and OS version.
Tried to follow the deprecation message above so initial device was Iphone 15 and I tried every OS_Version until it was valid which is 17. 
More info [here](https://www.browserstack.com/list-of-browsers-and-platforms/playwright)

## Test instructions

Unit and UnisBS should pass.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
