### PR TITLE
♻️ use fetch to retrieve remote configuration

### DIFF
--- a/packages/core/test/interceptRequests.ts
+++ b/packages/core/test/interceptRequests.ts
@@ -54,7 +54,7 @@ export function interceptRequests() {
     requests.push({
       type: config?.keepalive ? 'fetch-keepalive' : 'fetch',
       url: url as string,
-      body: config!.body as string,
+      body: config?.body as string,
     })
     return fetchPromise()
       .then((response) => response as Response)

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -444,18 +444,21 @@ describe('preStartRum', () => {
       })
 
       it('should start with the remote configuration when a remoteConfigurationId is provided', (done) => {
-        interceptor.withMockXhr((xhr) => {
-          xhr.complete(200, '{"rum":{"sessionSampleRate":50}}')
-
-          expect(doStartRumSpy.calls.mostRecent().args[0].sessionSampleRate).toEqual(50)
-          done()
-        })
-
+        interceptor.withFetch(() =>
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ rum: { sessionSampleRate: 50 } }),
+          })
+        )
         const strategy = createPreStartStrategy(
           {},
           createTrackingConsentState(),
           createCustomVitalsState(),
-          doStartRumSpy
+          (configuration) => {
+            expect(configuration.sessionSampleRate).toEqual(50)
+            done()
+            return {} as StartRumResult
+          }
         )
         strategy.init(
           {
@@ -595,19 +598,17 @@ describe('preStartRum', () => {
     })
 
     it('returns the initConfiguration with the remote configuration when a remoteConfigurationId is provided', (done) => {
-      interceptor.withMockXhr((xhr) => {
-        xhr.complete(200, '{"rum":{"sessionSampleRate":50}}')
-
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ rum: { sessionSampleRate: 50 } }),
+        })
+      )
+      const strategy = createPreStartStrategy({}, createTrackingConsentState(), createCustomVitalsState(), () => {
         expect(strategy.initConfiguration?.sessionSampleRate).toEqual(50)
         done()
+        return {} as StartRumResult
       })
-
-      const strategy = createPreStartStrategy(
-        {},
-        createTrackingConsentState(),
-        createCustomVitalsState(),
-        doStartRumSpy
-      )
       strategy.init(
         {
           ...DEFAULT_INIT_CONFIGURATION,

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -22,7 +22,7 @@ describe('remoteConfiguration', () => {
   describe('fetchRemoteConfiguration', () => {
     const configuration = { remoteConfigurationId: 'xxx' } as RumInitConfiguration
 
-    it('should fetch the remote configuration', (done) => {
+    it('should fetch the remote configuration', async () => {
       interceptor.withFetch(() =>
         Promise.resolve({
           ok: true,
@@ -38,46 +38,43 @@ describe('remoteConfiguration', () => {
         })
       )
 
-      fetchRemoteConfiguration(configuration)
-        .then((remoteConfiguration) => {
-          expect(remoteConfiguration).toEqual({
-            applicationId: 'xxx',
-            sessionSampleRate: 50,
-            sessionReplaySampleRate: 50,
-            defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
-          })
-          done()
-        })
-        .catch(done.fail)
+      const fetchResult = await fetchRemoteConfiguration(configuration)
+      expect(fetchResult).toEqual({
+        ok: true,
+        value: {
+          applicationId: 'xxx',
+          sessionSampleRate: 50,
+          sessionReplaySampleRate: 50,
+          defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
+        },
+      })
     })
 
-    it('should throw an error if the fetching fails with a server error', (done) => {
+    it('should return an error if the fetching fails with a server error', async () => {
       interceptor.withFetch(() => Promise.reject(new Error('Server error')))
 
-      fetchRemoteConfiguration(configuration)
-        .then(() => done.fail())
-        .catch((error) => {
-          expect(error.message).toEqual('Error fetching the remote configuration.')
-          done()
-        })
+      const fetchResult = await fetchRemoteConfiguration(configuration)
+      expect(fetchResult).toEqual({
+        ok: false,
+        error: new Error('Error fetching the remote configuration.'),
+      })
     })
 
-    it('should throw an error if the fetching fails with a client error', (done) => {
+    it('should throw an error if the fetching fails with a client error', async () => {
       interceptor.withFetch(() =>
         Promise.resolve({
           ok: false,
         })
       )
 
-      fetchRemoteConfiguration(configuration)
-        .then(() => done.fail())
-        .catch((error) => {
-          expect(error.message).toEqual('Error fetching the remote configuration.')
-          done()
-        })
+      const fetchResult = await fetchRemoteConfiguration(configuration)
+      expect(fetchResult).toEqual({
+        ok: false,
+        error: new Error('Error fetching the remote configuration.'),
+      })
     })
 
-    it('should throw an error if the remote config does not contain rum config', (done) => {
+    it('should throw an error if the remote config does not contain rum config', async () => {
       interceptor.withFetch(() =>
         Promise.resolve({
           ok: true,
@@ -85,12 +82,11 @@ describe('remoteConfiguration', () => {
         })
       )
 
-      fetchRemoteConfiguration(configuration)
-        .then(() => done.fail())
-        .catch((error) => {
-          expect(error.message).toEqual('No remote configuration for RUM.')
-          done()
-        })
+      const fetchResult = await fetchRemoteConfiguration(configuration)
+      expect(fetchResult).toEqual({
+        ok: false,
+        error: new Error('No remote configuration for RUM.'),
+      })
     })
   })
 

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -1,4 +1,4 @@
-import { DefaultPrivacyLevel, display, INTAKE_SITE_US1 } from '@datadog/browser-core'
+import { DefaultPrivacyLevel, INTAKE_SITE_US1 } from '@datadog/browser-core'
 import { interceptRequests } from '@datadog/browser-core/test'
 import type { RumInitConfiguration } from './configuration'
 import type { RemoteConfiguration } from './remoteConfiguration'
@@ -13,65 +13,84 @@ const DEFAULT_INIT_CONFIGURATION: RumInitConfiguration = {
 }
 
 describe('remoteConfiguration', () => {
-  let displayErrorSpy: jasmine.Spy<typeof display.error>
   let interceptor: ReturnType<typeof interceptRequests>
 
   beforeEach(() => {
     interceptor = interceptRequests()
-    displayErrorSpy = spyOn(display, 'error')
   })
 
   describe('fetchRemoteConfiguration', () => {
     const configuration = { remoteConfigurationId: 'xxx' } as RumInitConfiguration
-    let remoteConfigurationCallback: jasmine.Spy
-
-    beforeEach(() => {
-      remoteConfigurationCallback = jasmine.createSpy()
-    })
 
     it('should fetch the remote configuration', (done) => {
-      interceptor.withMockXhr((xhr) => {
-        xhr.complete(200, '{"rum":{"sessionSampleRate":50,"sessionReplaySampleRate":50,"defaultPrivacyLevel":"allow"}}')
-
-        expect(remoteConfigurationCallback).toHaveBeenCalledWith({
-          sessionSampleRate: 50,
-          sessionReplaySampleRate: 50,
-          defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              rum: {
+                applicationId: 'xxx',
+                sessionSampleRate: 50,
+                sessionReplaySampleRate: 50,
+                defaultPrivacyLevel: 'allow',
+              },
+            }),
         })
+      )
 
-        done()
-      })
-      fetchRemoteConfiguration(configuration, remoteConfigurationCallback)
+      fetchRemoteConfiguration(configuration)
+        .then((remoteConfiguration) => {
+          expect(remoteConfiguration).toEqual({
+            applicationId: 'xxx',
+            sessionSampleRate: 50,
+            sessionReplaySampleRate: 50,
+            defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
+          })
+          done()
+        })
+        .catch(done.fail)
     })
 
-    it('should print an error if the fetching fails with a server error', (done) => {
-      interceptor.withMockXhr((xhr) => {
-        xhr.complete(500)
-        expect(remoteConfigurationCallback).not.toHaveBeenCalled()
-        expect(displayErrorSpy).toHaveBeenCalledOnceWith('Error fetching the remote configuration.')
-        done()
-      })
-      fetchRemoteConfiguration(configuration, remoteConfigurationCallback)
+    it('should throw an error if the fetching fails with a server error', (done) => {
+      interceptor.withFetch(() => Promise.reject(new Error('Server error')))
+
+      fetchRemoteConfiguration(configuration)
+        .then(() => done.fail())
+        .catch((error) => {
+          expect(error.message).toEqual('Error fetching the remote configuration.')
+          done()
+        })
     })
 
-    it('should print an error if the fetching fails with a client error', (done) => {
-      interceptor.withMockXhr((xhr) => {
-        xhr.complete(404)
-        expect(remoteConfigurationCallback).not.toHaveBeenCalled()
-        expect(displayErrorSpy).toHaveBeenCalledOnceWith('Error fetching the remote configuration.')
-        done()
-      })
-      fetchRemoteConfiguration(configuration, remoteConfigurationCallback)
+    it('should throw an error if the fetching fails with a client error', (done) => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: false,
+        })
+      )
+
+      fetchRemoteConfiguration(configuration)
+        .then(() => done.fail())
+        .catch((error) => {
+          expect(error.message).toEqual('Error fetching the remote configuration.')
+          done()
+        })
     })
 
-    it('should print an error if the remote config does not contain rum config', (done) => {
-      interceptor.withMockXhr((xhr) => {
-        xhr.complete(200, '{}')
-        expect(remoteConfigurationCallback).not.toHaveBeenCalled()
-        expect(displayErrorSpy).toHaveBeenCalledOnceWith('No remote configuration for RUM.')
-        done()
-      })
-      fetchRemoteConfiguration(configuration, remoteConfigurationCallback)
+    it('should throw an error if the remote config does not contain rum config', (done) => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        })
+      )
+
+      fetchRemoteConfiguration(configuration)
+        .then(() => done.fail())
+        .catch((error) => {
+          expect(error.message).toEqual('No remote configuration for RUM.')
+          done()
+        })
     })
   })
 


### PR DESCRIPTION
## Motivation

With IE drop in last major, we can now use fetch instead of xhr

## Changes

- use fetch to retrieve remote configuration
- switch to promise instead of callback

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
