### PR TITLE
GraphQL Poc

### DIFF
--- a/packages/rum-core/src/domain/requestCollection.ts
+++ b/packages/rum-core/src/domain/requestCollection.ts
@@ -59,6 +59,12 @@ export interface RequestCompleteEvent {
   error?: Error
   isAborted: boolean
   handlingStack?: string
+  graphql?: {
+    operationType?: string
+    operationName?: string
+    variables?: string
+    payload?: string
+  }
 }
 
 let nextRequestIndex = 1
@@ -108,6 +114,7 @@ export function trackXhr(lifeCycle: LifeCycle, configuration: RumConfiguration, 
           xhr: context.xhr,
           isAborted: context.isAborted,
           handlingStack: context.handlingStack,
+          graphql: context.graphql,
         })
         break
     }
@@ -153,6 +160,7 @@ export function trackFetch(lifeCycle: LifeCycle, tracer: Tracer) {
             input: context.input,
             isAborted: context.isAborted,
             handlingStack: context.handlingStack,
+            graphql: context.graphql,
           })
         })
         break

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -53,6 +53,12 @@ export interface RawRumResourceEvent {
     download?: ResourceEntryDetailsElement
     protocol?: string
     delivery_type?: DeliveryType
+    graphql?: {
+      operation_type: string
+      operation_name?: string
+      variables?: string
+      payload?: string
+    }
   }
   _dd: {
     trace_id?: string

--- a/packages/rum-graphql/package.json
+++ b/packages/rum-graphql/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@datadog/browser-rum-graphql",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "main": "cjs/entries/main.js",
+  "module": "esm/entries/main.js",
+  "types": "cjs/entries/main.d.ts",
+  "scripts": {
+    "build": "run-p build:cjs build:esm",
+    "build:cjs": "rm -rf cjs && tsc -p tsconfig.cjs.json --noCheck",
+    "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json --noCheck"
+  },
+  "dependencies": {
+    "@datadog/browser-core": "6.13.0"
+  },
+  "peerDependencies": {
+    "@apollo/client": ">=3.0.0",
+    "graphql": "^16.8.0"
+  },
+  "devDependencies": {
+    "@apollo/client": "^3.8.0",
+    "graphql": "^16.8.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DataDog/browser-sdk.git",
+    "directory": "packages/rum-graphql"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/rum-graphql/src/domain/datadogLink.ts
+++ b/packages/rum-graphql/src/domain/datadogLink.ts
@@ -1,0 +1,69 @@
+/* eslint-disable local-rules/disallow-side-effects */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ApolloLink, type Operation } from '@apollo/client'
+import type {
+  DefinitionNode,
+  OperationDefinitionNode,
+  OperationTypeNode, // "query" | "mutation" | "subscription"
+} from 'graphql'
+import { Kind } from 'graphql'
+
+import {
+  DATADOG_GRAPH_QL_OPERATION_TYPE_HEADER,
+  DATADOG_GRAPH_QL_OPERATION_NAME_HEADER,
+  DATADOG_GRAPH_QL_VARIABLES_HEADER,
+} from './graphqlHeaders'
+
+export function createDatadogLink(): ApolloLink {
+  return new ApolloLink((operation, forward) => {
+    if (!forward) {
+      return null
+    }
+
+    const operationType = getOperationType(operation)
+    const operationName = getOperationName(operation)
+    const variables = getVariables(operation)
+
+    operation.setContext(({ headers = {} }) => ({
+      headers: {
+        ...headers,
+        ...(operationType && {
+          [DATADOG_GRAPH_QL_OPERATION_TYPE_HEADER]: operationType,
+        }),
+        ...(operationName && {
+          [DATADOG_GRAPH_QL_OPERATION_NAME_HEADER]: operationName,
+        }),
+        ...(variables && {
+          [DATADOG_GRAPH_QL_VARIABLES_HEADER]: variables,
+        }),
+      },
+    }))
+
+    return forward(operation)
+  })
+}
+
+function isOperationDefinitionNode(node: DefinitionNode): node is OperationDefinitionNode {
+  return node.kind === Kind.OPERATION_DEFINITION
+}
+
+function getOperationType(op: Operation): OperationTypeNode | undefined {
+  const opDef = op.query.definitions.find(isOperationDefinitionNode)
+  return opDef?.operation
+}
+
+function getOperationName(operation: Operation): string | undefined {
+  return operation.operationName || undefined
+}
+
+function getVariables(operation: Operation): string | undefined {
+  if (operation.variables && Object.keys(operation.variables).length > 0) {
+    try {
+      return JSON.stringify(operation.variables)
+    } catch {
+      // If variables can't be serialized, ignore them
+      return undefined
+    }
+  }
+  return undefined
+}

--- a/packages/rum-graphql/src/domain/graphqlHeaders.ts
+++ b/packages/rum-graphql/src/domain/graphqlHeaders.ts
@@ -1,0 +1,13 @@
+// Custom headers used to pass GraphQL information from the Apollo Link to the SDK
+// These headers are not sent to the server, they are intercepted and removed by the SDK
+export const DATADOG_GRAPH_QL_OPERATION_TYPE_HEADER = '_dd-graphql-operation-type'
+export const DATADOG_GRAPH_QL_OPERATION_NAME_HEADER = '_dd-graphql-operation-name'
+export const DATADOG_GRAPH_QL_VARIABLES_HEADER = '_dd-graphql-variables'
+
+export function isDatadogGraphQLHeader(headerName: string): boolean {
+  return (
+    headerName === DATADOG_GRAPH_QL_OPERATION_TYPE_HEADER ||
+    headerName === DATADOG_GRAPH_QL_OPERATION_NAME_HEADER ||
+    headerName === DATADOG_GRAPH_QL_VARIABLES_HEADER
+  )
+}

--- a/packages/rum-graphql/src/entries/main.ts
+++ b/packages/rum-graphql/src/entries/main.ts
@@ -1,0 +1,1 @@
+export * from '../index'

--- a/packages/rum-graphql/src/index.ts
+++ b/packages/rum-graphql/src/index.ts
@@ -1,0 +1,7 @@
+export { createDatadogLink } from './domain/datadogLink'
+export {
+  DATADOG_GRAPH_QL_OPERATION_TYPE_HEADER,
+  DATADOG_GRAPH_QL_OPERATION_NAME_HEADER,
+  DATADOG_GRAPH_QL_VARIABLES_HEADER,
+  isDatadogGraphQLHeader,
+} from './domain/graphqlHeaders'

--- a/packages/rum-graphql/tsconfig.cjs.json
+++ b/packages/rum-graphql/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": true,
+    "module": "commonjs",
+    "rootDir": "./src/",
+    "outDir": "./cjs/"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.spec.ts", "./src/**/*.specHelper.ts"]
+} 

--- a/packages/rum-graphql/tsconfig.esm.json
+++ b/packages/rum-graphql/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": true,
+    "module": "es2015",
+    "rootDir": "./src/",
+    "outDir": "./esm/"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.spec.ts", "./src/**/*.specHelper.ts"]
+} 

--- a/sandbox/rum-graphql/app.js
+++ b/sandbox/rum-graphql/app.js
@@ -1,0 +1,156 @@
+import { datadogRum } from '@datadog/browser-rum'
+import { createDatadogLink } from '@datadog/browser-rum-graphql'
+import { ApolloClient, InMemoryCache, createHttpLink, from, gql } from '@apollo/client'
+
+// Initialize RUM (no plugin needed - enrichment happens automatically via headers)
+datadogRum.init({
+  applicationId: 'xxx',
+  clientToken: 'xxx',
+  site: 'datad0g.com',
+  service: 'xxx',
+  trackResources: true,
+  sessionReplaySampleRate: 100,
+  trackLongTasks: true,
+})
+
+// Create Apollo Client with Datadog Link
+const httpLink = createHttpLink({
+  uri: 'https://countries.trevorblades.com/graphql',
+})
+
+const client = new ApolloClient({
+  link: from([createDatadogLink(), httpLink]),
+  cache: new InMemoryCache(),
+})
+
+const GET_COUNTRIES = gql`
+  query GetCountries($filter: CountryFilterInput) {
+    countries(filter: $filter) {
+      code
+      name
+      emoji
+      capital
+    }
+  }
+`
+
+const GET_COUNTRY_BY_CODE = gql`
+  query GetCountryByCode($code: ID!) {
+    country(code: $code) {
+      code
+      name
+      emoji
+      capital
+      currency
+      languages {
+        code
+        name
+      }
+    }
+  }
+`
+
+const SEARCH_COUNTRIES = gql`
+  query SearchCountries {
+    countries {
+      code
+      name
+      emoji
+    }
+  }
+`
+
+async function loadCountries() {
+  try {
+    const result = await client.query({
+      query: GET_COUNTRIES,
+      variables: {
+        filter: {
+          continent: {
+            eq: 'EU',
+          },
+        },
+      },
+    })
+
+    displayResults('Countries in Europe', result.data.countries.slice(0, 5))
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+async function loadCountryDetails() {
+  try {
+    const result = await client.query({
+      query: GET_COUNTRY_BY_CODE,
+      variables: {
+        code: 'FR',
+      },
+    })
+
+    displayResults('France Details', [result.data.country])
+  } catch (error) {}
+}
+
+async function searchCountries() {
+  try {
+    const result = await client.query({
+      query: SEARCH_COUNTRIES,
+    })
+
+    displayResults('All Countries', result.data.countries.slice(0, 10))
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+function displayResults(title, data) {
+  const resultsDiv = document.getElementById('results')
+  resultsDiv.innerHTML = `
+    <h3>✅ ${title}</h3>
+    <pre>${JSON.stringify(data, null, 2)}</pre>
+  `
+}
+function initUI() {
+  document.body.innerHTML = `
+    <div style="max-width: 800px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
+      <h1>🚀 RUM GraphQL Integration Test</h1>
+      <p>This sandbox uses <strong>real Apollo Client</strong> with <code>@datadog/browser-rum-graphql</code></p>
+      
+      <div style="margin: 20px 0;">
+        <button onclick="loadCountries()" style="margin: 5px; padding: 10px 20px; background: #007cba; color: white; border: none; border-radius: 4px; cursor: pointer;">
+          Query: Load EU Countries
+        </button>
+        
+        <button onclick="loadCountryDetails()" style="margin: 5px; padding: 10px 20px; background: #28a745; color: white; border: none; border-radius: 4px; cursor: pointer;">
+          Query: Load France Details
+        </button>
+        
+        <button onclick="searchCountries()" style="margin: 5px; padding: 10px 20px; background: #ffc107; color: black; border: none; border-radius: 4px; cursor: pointer;">
+          Query: Search All Countries
+        </button>
+      </div>
+      
+      <div id="results" style="background: #f8f9fa; padding: 20px; border-radius: 4px; margin-top: 20px;">
+        <p>Click a button to test GraphQL integration</p>
+      </div>
+      
+      <div style="margin-top: 30px; padding: 20px; background: #e7f3ff; border-radius: 4px;">
+        <h3>💡 What's happening:</h3>
+        <ol>
+          <li><strong>createDatadogLink()</strong> automatically adds <code>_dd-graphql-*</code> headers</li>
+          <li><strong>RUM Core SDK</strong> intercepts these headers from network requests</li>
+          <li><strong>RUM Events</strong> are enriched with <code>resource.graphql</code> data</li>
+        </ol>
+        <p>Open DevTools → Network → Check GraphQL requests for custom headers!</p>
+        <p>Open Datadog RUM → Resources → Look for <code>resource.graphql</code> fields!</p>
+      </div>
+    </div>
+  `
+
+  window.loadCountries = loadCountries
+  window.loadCountryDetails = loadCountryDetails
+  window.searchCountries = searchCountries
+}
+
+initUI()

--- a/sandbox/rum-graphql/index.html
+++ b/sandbox/rum-graphql/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RUM GraphQL Test</title>
+    <script src="http://localhost:8080/datadog-rum.js"></script>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script src="/rum-graphql/main.js"></script>
+  </body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,6 +27,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/client@npm:^3.8.0":
+  version: 3.13.8
+  resolution: "@apollo/client@npm:3.13.8"
+  dependencies:
+    "@graphql-typed-document-node/core": "npm:^3.1.1"
+    "@wry/caches": "npm:^1.0.0"
+    "@wry/equality": "npm:^0.5.6"
+    "@wry/trie": "npm:^0.5.0"
+    graphql-tag: "npm:^2.12.6"
+    hoist-non-react-statics: "npm:^3.3.2"
+    optimism: "npm:^0.18.0"
+    prop-types: "npm:^15.7.2"
+    rehackt: "npm:^0.1.0"
+    symbol-observable: "npm:^4.0.0"
+    ts-invariant: "npm:^0.10.3"
+    tslib: "npm:^2.3.0"
+    zen-observable-ts: "npm:^1.2.5"
+  peerDependencies:
+    graphql: ^15.0.0 || ^16.0.0
+    graphql-ws: ^5.5.5 || ^6.0.3
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+  peerDependenciesMeta:
+    graphql-ws:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+    subscriptions-transport-ws:
+      optional: true
+  checksum: 10c0/0e5032c1ae1dbef72a01f87af06b84bf505d60e71eba7cb9f20f8284778d8ead65fc1b7eacc570eccb8d045577d7194e38401fbfbdf56c197e159ca91ef11755
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -265,6 +301,19 @@ __metadata:
   dependencies:
     "@datadog/browser-core": "npm:6.13.0"
     ajv: "npm:8.17.1"
+  languageName: unknown
+  linkType: soft
+
+"@datadog/browser-rum-graphql@workspace:packages/rum-graphql":
+  version: 0.0.0-use.local
+  resolution: "@datadog/browser-rum-graphql@workspace:packages/rum-graphql"
+  dependencies:
+    "@apollo/client": "npm:^3.8.0"
+    "@datadog/browser-core": "npm:6.13.0"
+    graphql: "npm:^16.8.0"
+  peerDependencies:
+    "@apollo/client": ">=3.0.0"
+    graphql: ^16.8.0
   languageName: unknown
   linkType: soft
 
@@ -561,6 +610,15 @@ __metadata:
   version: 0.2.10
   resolution: "@floating-ui/utils@npm:0.2.10"
   checksum: 10c0/e9bc2a1730ede1ee25843937e911ab6e846a733a4488623cd353f94721b05ec2c9ec6437613a2ac9379a94c2fd40c797a2ba6fa1df2716f5ce4aa6ddb1cf9ea4
+  languageName: node
+  linkType: hard
+
+"@graphql-typed-document-node/core@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "@graphql-typed-document-node/core@npm:3.2.0"
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 10c0/94e9d75c1f178bbae8d874f5a9361708a3350c8def7eaeb6920f2c820e82403b7d4f55b3735856d68e145e86c85cbfe2adc444fdc25519cd51f108697e99346c
   languageName: node
   linkType: hard
 
@@ -2358,6 +2416,42 @@ __metadata:
     webpack-dev-server:
       optional: true
   checksum: 10c0/65245e45bfa35e11a5b30631b99cfed0c1b39b2cc8320fa2d2a4185264535618827d349ec032c58af4201d6236cbc43bec894fcb840fdd06314611537a80e210
+  languageName: node
+  linkType: hard
+
+"@wry/caches@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@wry/caches@npm:1.0.1"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  checksum: 10c0/a7bca3377f1131d3f1080f2e39d0692c9d1ca86bfd55734786f167f46aad28a4c8e772107324e8319843fb8068fdf98abcdea376d8a589316b1f0cdadf81f8b1
+  languageName: node
+  linkType: hard
+
+"@wry/context@npm:^0.7.0":
+  version: 0.7.4
+  resolution: "@wry/context@npm:0.7.4"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  checksum: 10c0/6cc8249b8ba195cda7643bffb30969e33d54a99f118a29dd12f1c34064ee0adf04253cfa0ba5b9893afde0a9588745828962877b9585106f7488e8299757638b
+  languageName: node
+  linkType: hard
+
+"@wry/equality@npm:^0.5.6":
+  version: 0.5.7
+  resolution: "@wry/equality@npm:0.5.7"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  checksum: 10c0/8503ff6d4eb80f303d1387e71e51da59ccfc2160fa6d464618be80946fe43a654ea73f0c5b90d659fc4dfc3e38cbbdd6650d595fe5865be476636e444470853e
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wry/trie@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  checksum: 10c0/8c8cfcac96ba4bc69dabf02740e19e613f501b398e80bacc32cd95e87228f75ecb41cd1a76a65abae9756c0f61ab3536e0da52de28857456f9381ffdf5995d3e
   languageName: node
   linkType: hard
 
@@ -6003,6 +6097,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql-tag@npm:^2.12.6":
+  version: 2.12.6
+  resolution: "graphql-tag@npm:2.12.6"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  peerDependencies:
+    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 10c0/7763a72011bda454ed8ff1a0d82325f43ca6478e4ce4ab8b7910c4c651dd00db553132171c04d80af5d5aebf1ef6a8a9fd53ccfa33b90ddc00aa3d4be6114419
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.8.0":
+  version: 16.11.0
+  resolution: "graphql@npm:16.11.0"
+  checksum: 10c0/124da7860a2292e9acf2fed0c71fc0f6a9b9ca865d390d112bdd563c1f474357141501c12891f4164fe984315764736ad67f705219c62f7580681d431a85db88
+  languageName: node
+  linkType: hard
+
 "handlebars@npm:^4.7.7":
   version: 4.7.8
   resolution: "handlebars@npm:4.7.8"
@@ -6105,6 +6217,15 @@ __metadata:
   bin:
     he: bin/he
   checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: "npm:^16.7.0"
+  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
   languageName: node
   linkType: hard
 
@@ -7056,7 +7177,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^4.0.0":
+"js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 10c0/e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
@@ -7670,6 +7791,17 @@ __metadata:
     rfdc: "npm:^1.3.0"
     streamroller: "npm:^3.1.5"
   checksum: 10c0/05846e48f72d662800c8189bd178c42b4aa2f0c574cfc90a1942cf90b76f621c44019e26796c8fd88da1b6f0fe8272cba607cbaad6ae6ede50a7a096b58197ea
+  languageName: node
+  linkType: hard
+
+"loose-envify@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "loose-envify@npm:1.4.0"
+  dependencies:
+    js-tokens: "npm:^3.0.0 || ^4.0.0"
+  bin:
+    loose-envify: cli.js
+  checksum: 10c0/655d110220983c1a4b9c0c679a2e8016d4b67f6e9c7b5435ff5979ecdb20d0813f4dec0a08674fcbdd4846a3f07edbb50a36811fd37930b94aaa0d9daceb017e
   languageName: node
   linkType: hard
 
@@ -8709,7 +8841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4, object-assign@npm:^4.0.1":
+"object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
@@ -8823,6 +8955,18 @@ __metadata:
     is-docker: "npm:^2.1.1"
     is-wsl: "npm:^2.2.0"
   checksum: 10c0/bb6b3a58401dacdb0aad14360626faf3fb7fba4b77816b373495988b724fb48941cad80c1b65d62bb31a17609b2cd91c41a181602caea597ca80dfbcc27e84c9
+  languageName: node
+  linkType: hard
+
+"optimism@npm:^0.18.0":
+  version: 0.18.1
+  resolution: "optimism@npm:0.18.1"
+  dependencies:
+    "@wry/caches": "npm:^1.0.0"
+    "@wry/context": "npm:^0.7.0"
+    "@wry/trie": "npm:^0.5.0"
+    tslib: "npm:^2.3.0"
+  checksum: 10c0/1c1cd065d306de2220c6a2bdd8701cb7f9aadace36a9f16d6e02db2bee23b0291f15a1219b92cde5c66d816bd33dca876dfdcdbad04b4cf9b2a7fc5a1a221e77
   languageName: node
   linkType: hard
 
@@ -9615,6 +9759,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prop-types@npm:^15.7.2":
+  version: 15.8.1
+  resolution: "prop-types@npm:15.8.1"
+  dependencies:
+    loose-envify: "npm:^1.4.0"
+    object-assign: "npm:^4.1.1"
+    react-is: "npm:^16.13.1"
+  checksum: 10c0/59ece7ca2fb9838031d73a48d4becb9a7cc1ed10e610517c7d8f19a1e02fa47f7c27d557d8a5702bec3cfeccddc853579832b43f449e54635803f277b1c78077
+  languageName: node
+  linkType: hard
+
 "protocols@npm:^2.0.0, protocols@npm:^2.0.1":
   version: 2.0.2
   resolution: "protocols@npm:2.0.2"
@@ -9814,6 +9969,13 @@ __metadata:
   peerDependencies:
     react: ^19.1.0
   checksum: 10c0/3e26e89bb6c67c9a6aa86cb888c7a7f8258f2e347a6d2a15299c17eb16e04c19194e3452bc3255bd34000a61e45e2cb51e46292392340432f133e5a5d2dfb5fc
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+  version: 16.13.1
+  resolution: "react-is@npm:16.13.1"
+  checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
   languageName: node
   linkType: hard
 
@@ -10128,6 +10290,21 @@ __metadata:
   bin:
     regjsparser: bin/parser
   checksum: 10c0/99d3e4e10c8c7732eb7aa843b8da2fd8b647fe144d3711b480e4647dc3bff4b1e96691ccf17f3ace24aa866a50b064236177cb25e6e4fbbb18285d99edaed83b
+  languageName: node
+  linkType: hard
+
+"rehackt@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "rehackt@npm:0.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 10c0/3d838bfee84ec06c976f21027936f3b0fdb7660ab8a2d4d3f19c65e0daa78a268aa81352311352b8576b89a074714b36ae6cd5bdadb6e975eca079f2b342de73
   languageName: node
   linkType: hard
 
@@ -11169,6 +11346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"symbol-observable@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "symbol-observable@npm:4.0.0"
+  checksum: 10c0/5e9a3ab08263a6be8cbee76587ad5880dcc62a47002787ed5ebea56b1eb30dc87da6f0183d67e88286806799fbe21c69077fbd677be4be2188e92318d6c6f31d
+  languageName: node
+  linkType: hard
+
 "tabbable@npm:^6.0.0":
   version: 6.2.0
   resolution: "tabbable@npm:6.2.0"
@@ -11462,6 +11646,15 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/9806a38adea2db0f6aa217ccc6bc9c391ddba338a9fe3080676d0d50ed806d305bb90e8cef0276e793d28c8a929f400abb184ddd7ff83a416959c0f4d2ce754f
+  languageName: node
+  linkType: hard
+
+"ts-invariant@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "ts-invariant@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10c0/2fbc178d5903d325ee0b87fad38827eac11888b6e86979b06754fd4bcdcf44c2a99b8bcd5d59d149c0464ede55ae810b02a2aee6835ad10efe4dd0e22efd68c0
   languageName: node
   linkType: hard
 
@@ -12544,6 +12737,22 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zen-observable-ts@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "zen-observable-ts@npm:1.2.5"
+  dependencies:
+    zen-observable: "npm:0.8.15"
+  checksum: 10c0/21d586f3d0543e1d6f05d9333a137b407dbf337907c1ee1c2fa7a7da044f7e1262e4baf4ef8902f230c6f5acb561047659eb7df73df33307233cc451efe46db1
+  languageName: node
+  linkType: hard
+
+"zen-observable@npm:0.8.15":
+  version: 0.8.15
+  resolution: "zen-observable@npm:0.8.15"
+  checksum: 10c0/71cc2f2bbb537300c3f569e25693d37b3bc91f225cefce251a71c30bc6bb3e7f8e9420ca0eb57f2ac9e492b085b8dfa075fd1e8195c40b83c951dd59c6e4fbf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Extend FetchContextBase and XhrStartContext to include GraphQL fields.
- Implement header extraction for GraphQL operation type, name, and variables in fetch and XHR observables.
- Enhance request tracking to include GraphQL information in RUM events.
- Create a new rum-graphql package with Apollo Link integration to automatically add custom GraphQL headers.
- Add a sandbox application to demonstrate GraphQL integration with RUM.

## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
