### PR TITLE
👷 First deploy for api reference + fix yaml

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Build documentation
-        run: yarn build:docs:html
-
       - name: Build SDK
         run: yarn build
+
+      - name: Build documentation
+        run: yarn build:docs:html
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
## Motivation

During testing our api reference, the github pages was linked to the folder of the branch. Deleting the branch after merging pr seems to have corrupted it.

## Changes

Instead of waiting for the next tag release, we could fix it now by running the workflow manually
Added some fix also with the build.

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
