### PR TITLE
✨[RUM-10960][Remote config] add support for new static fields

### DIFF
--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.types.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.types.ts
@@ -43,5 +43,45 @@ export interface RumSdkConfig {
      * Privacy control for action name
      */
     enablePrivacyForActionName?: boolean
+    /**
+     * URLs where tracing is allowed
+     */
+    allowedTracingUrls?: {
+      match: {
+        /**
+         * Remote config serialized type of match
+         */
+        rcSerializedType: 'string' | 'regex'
+        /**
+         * Match value
+         */
+        value: string
+      }
+      /**
+       * List of propagator types
+       */
+      propagatorTypes: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[]
+    }[]
+    /**
+     * Origins where tracking is allowed
+     */
+    allowedTrackingOrigins?: {
+      /**
+       * Remote config serialized type of match
+       */
+      rcSerializedType: 'string' | 'regex'
+      /**
+       * Match value
+       */
+      value: string
+    }[]
+    /**
+     * The percentage of traces sampled
+     */
+    traceSampleRate?: number
+    /**
+     * Whether to track sessions across subdomains
+     */
+    trackSessionAcrossSubdomains?: boolean
   }
 }

--- a/remote-configuration/rum-sdk-config.json
+++ b/remote-configuration/rum-sdk-config.json
@@ -46,6 +46,71 @@
         "enablePrivacyForActionName": {
           "type": "boolean",
           "description": "Privacy control for action name"
+        },
+        "allowedTracingUrls": {
+          "type": "array",
+          "description": "URLs where tracing is allowed",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["match", "propagatorTypes"],
+            "properties": {
+              "match": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["rcSerializedType", "value"],
+                "properties": {
+                  "rcSerializedType": {
+                    "type": "string",
+                    "enum": ["string", "regex"],
+                    "description": "Remote config serialized type of match"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Match value"
+                  }
+                }
+              },
+              "propagatorTypes": {
+                "type": "array",
+                "description": "List of propagator types",
+                "items": {
+                  "type": "string",
+                  "enum": ["datadog", "b3", "b3multi", "tracecontext"]
+                }
+              }
+            }
+          }
+        },
+        "allowedTrackingOrigins": {
+          "type": "array",
+          "description": "Origins where tracking is allowed",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["rcSerializedType", "value"],
+            "properties": {
+              "rcSerializedType": {
+                "type": "string",
+                "enum": ["string", "regex"],
+                "description": "Remote config serialized type of match"
+              },
+              "value": {
+                "type": "string",
+                "description": "Match value"
+              }
+            }
+          }
+        },
+        "traceSampleRate": {
+          "type": "number",
+          "description": "The percentage of traces sampled",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "trackSessionAcrossSubdomains": {
+          "type": "boolean",
+          "description": "Whether to track sessions across subdomains"
         }
       }
     }


### PR DESCRIPTION
## Motivation

Support remote configuration of new fields:

- allowedTracingUrls
- allowedTrackingOrigins
- traceSampleRate
- trackSessionAcrossSubdomains

## Changes

- update remote config schema
- resolve applied value in a generic fashion

## Test instructions

Take a remote configuration with the new options configured
```
DD_RUM.init({
  remoteConfigurationId: 'my-id'
})
DD_RUM.getInitConfiguration()
```
The returned init configuration should match the remote configuration 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
