### PR TITLE
👷 hide tag sanitization console warning in unit tests

### DIFF
--- a/packages/logs/src/domain/logger.spec.ts
+++ b/packages/logs/src/domain/logger.spec.ts
@@ -1,5 +1,6 @@
 import type { ErrorWithCause } from '@datadog/browser-core'
-import { ErrorHandling, NO_ERROR_STACK_PRESENT_MESSAGE } from '@datadog/browser-core'
+import { display, ErrorHandling, NO_ERROR_STACK_PRESENT_MESSAGE } from '@datadog/browser-core'
+import { supportUnicodePropertyEscapes } from '@datadog/browser-core/src/domain/configuration/tags'
 import type { LogsMessage } from './logger'
 import { HandlerType, Logger, STATUSES } from './logger'
 import { StatusType } from './logger/isAuthorized'
@@ -188,6 +189,19 @@ describe('Logger', () => {
   })
 
   describe('tags', () => {
+    let displaySpy: jasmine.Spy<typeof display.warn>
+    function expectWarning() {
+      if (supportUnicodePropertyEscapes()) {
+        expect(displaySpy).toHaveBeenCalledOnceWith(
+          jasmine.stringMatching("Tag .* doesn't meet tag requirements and will be sanitized")
+        )
+      }
+    }
+
+    beforeEach(() => {
+      displaySpy = spyOn(display, 'warn')
+    })
+
     it('should add a key:value tag', () => {
       logger.addTag('foo', 'bar')
       expect(logger.getTags()).toEqual(['foo:bar'])
@@ -201,11 +215,13 @@ describe('Logger', () => {
     it('should sanitize a key with a comma', () => {
       logger.addTag('foo,bar', 'baz')
       expect(logger.getTags()).toEqual(['foo_bar:baz'])
+      expectWarning()
     })
 
     it('should sanitize a tag with a comma in the value', () => {
       logger.addTag('foo', 'baz,qux')
       expect(logger.getTags()).toEqual(['foo:baz_qux'])
+      expectWarning()
     })
 
     it('should remove tags with key', () => {
@@ -225,6 +241,7 @@ describe('Logger', () => {
       logger.addTag('foo,bar', 'baz')
       logger.removeTagsWithKey('foo,bar')
       expect(logger.getTags()).toEqual([])
+      expectWarning()
     })
 
     it('should not remove tags starting with the key', () => {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Some unit tests for the Logger are showing some console logs. This PR hides them.
<img width="1287" height="246" alt="Screenshot 2025-07-28 at 09 53 47" src="https://github.com/user-attachments/assets/aee9f81a-ddf3-4ce4-8398-b34b87cd1f98" />


## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
