### PR TITLE
👷 fix coverage report directory

### DIFF
--- a/test/envUtils.js
+++ b/test/envUtils.js
@@ -42,6 +42,8 @@ function getCoverageReportDirectory() {
   if (process.env.CI_JOB_NAME) {
     return `coverage/${process.env.CI_JOB_NAME}`
   }
+
+  return 'coverage'
 }
 
 module.exports = {

--- a/test/unit/karma.local.conf.js
+++ b/test/unit/karma.local.conf.js
@@ -4,8 +4,7 @@ const karmaBaseConf = require('./karma.base.conf')
 
 const coverageReports = ['text-summary']
 
-const coverageReportDirectory = getCoverageReportDirectory()
-if (coverageReportDirectory) {
+if (process.env.CI) {
   coverageReports.push('clover')
 }
 
@@ -16,7 +15,7 @@ module.exports = function (config) {
     browsers: ['ChromeHeadlessNoSandbox'],
     coverageIstanbulReporter: {
       reports: coverageReports,
-      dir: coverageReportDirectory,
+      dir: getCoverageReportDirectory(),
     },
     customLaunchers: {
       ChromeHeadlessNoSandbox: {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Unlike Karma reporters, Istanbul coverage reporter `dir` options (`coverageIstanbulReporter.dir`) does not fallback to a default directory if it is set to `undefined` and this breaks the `yarn test` command even when no reporters are writing to disk.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

- Make `getCoverageReportDirectory()` default to `coverage`
- Add `clover` coverage reported only when running in the CI. This was the intent before but it was inferred from the value of `getCoverageReportDirectory()`

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
