### PR TITLE
✨ [FFL-450] Add support for exposures track

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -2,13 +2,13 @@ import type { Payload } from '../../transport'
 import { timeStampNow } from '../../tools/utils/timeUtils'
 import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { generateUUID } from '../../tools/utils/stringUtils'
-import { INTAKE_SITE_FED_STAGING, INTAKE_SITE_US1, PCI_INTAKE_HOST_US1 } from '../intakeSites'
+import { INTAKE_SITE_FED_STAGING, INTAKE_SITE_STAGING, INTAKE_SITE_US1, PCI_INTAKE_HOST_US1 } from '../intakeSites'
 import type { InitConfiguration } from './configuration'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
 
-export type TrackType = 'logs' | 'rum' | 'replay' | 'profile'
+export type TrackType = 'logs' | 'rum' | 'replay' | 'profile' | 'exposures'
 export type ApiType =
   | 'fetch-keepalive'
   | 'fetch'
@@ -61,6 +61,10 @@ export function buildEndpointHost(
 
   if (trackType === 'logs' && initConfiguration.usePciIntake && site === INTAKE_SITE_US1) {
     return PCI_INTAKE_HOST_US1
+  }
+
+  if (trackType === 'exposures' && site === INTAKE_SITE_STAGING) {
+    return `event-platform-intake.${site}`
   }
 
   if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -2,7 +2,7 @@ import type { Payload } from '../../transport'
 import { timeStampNow } from '../../tools/utils/timeUtils'
 import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { generateUUID } from '../../tools/utils/stringUtils'
-import { INTAKE_SITE_FED_STAGING, INTAKE_SITE_STAGING, INTAKE_SITE_US1, PCI_INTAKE_HOST_US1 } from '../intakeSites'
+import { INTAKE_SITE_FED_STAGING, INTAKE_SITE_US1, PCI_INTAKE_HOST_US1 } from '../intakeSites'
 import type { InitConfiguration } from './configuration'
 
 // replaced at build time
@@ -61,10 +61,6 @@ export function buildEndpointHost(
 
   if (trackType === 'logs' && initConfiguration.usePciIntake && site === INTAKE_SITE_US1) {
     return PCI_INTAKE_HOST_US1
-  }
-
-  if (trackType === 'exposures' && site === INTAKE_SITE_STAGING) {
-    return `event-platform-intake.${site}`
   }
 
   if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -9,6 +9,7 @@ export interface TransportConfiguration {
   rumEndpointBuilder: EndpointBuilder
   sessionReplayEndpointBuilder: EndpointBuilder
   profilingEndpointBuilder: EndpointBuilder
+  exposuresEndpointBuilder: EndpointBuilder
   datacenter?: string | undefined
   replica?: ReplicaConfiguration
   site: Site
@@ -39,6 +40,7 @@ function computeEndpointBuilders(initConfiguration: InitConfiguration) {
     rumEndpointBuilder: createEndpointBuilder(initConfiguration, 'rum'),
     profilingEndpointBuilder: createEndpointBuilder(initConfiguration, 'profile'),
     sessionReplayEndpointBuilder: createEndpointBuilder(initConfiguration, 'replay'),
+    exposuresEndpointBuilder: createEndpointBuilder(initConfiguration, 'exposures'),
   }
 }
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
Adding support for new EVP exposures track, so that feature flagging SDK can send exposure events.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->
Adds new `exposures` track type to the core.

~The one difference from the rest of the tracks is that staging endpoint is `https://event-platform-intake.datad0g.com/api/v2/exposures` (production stays on `browser-intake-datadoghq.com`).~ Decided to use the same intake for now.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
