### PR TITLE
👷add back html coverage report

### DIFF
--- a/test/unit/karma.local.conf.js
+++ b/test/unit/karma.local.conf.js
@@ -2,7 +2,7 @@ const path = require('path')
 const { getCoverageReportDirectory } = require('../envUtils')
 const karmaBaseConf = require('./karma.base.conf')
 
-const coverageReports = ['text-summary']
+const coverageReports = ['text-summary', 'html']
 
 if (process.env.CI) {
   coverageReports.push('clover')


### PR DESCRIPTION
## Motivation

With or without coverage info on pull requests, I use this one to explore coverage info, I missed its removal in https://github.com/DataDog/browser-sdk/pull/3710

## Changes

Generate html coverage report when running unit tests

## Test instructions

```
yarn test:unit
open coverage/index.html
```

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
