### PR TITLE
👷 Allow `merge-into-stating` CI job to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -474,6 +474,7 @@ staging-reset-scheduled-failure:
 
 merge-into-staging:
   stage: pre-deploy
+  allow_failure: true
   extends:
     - .base-configuration
     - .main
@@ -485,6 +486,7 @@ merge-into-staging:
 
 merge-into-next-major:
   stage: pre-deploy
+  allow_failure: true
   extends:
     - .base-configuration
   only:


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Util now, when a PR is merged to main, we automatically merge main into staging. However, there is occasionally some conflict that can make the job fails and this prevent main from being deploy to canary. When this happen we need to fix staging and remember to re-run the failed job in order to have main deployed to canary.
 
## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

This PR allow the `merge-into-stating` job to fail, so that main is always deployed to canary. This is safe because:
- commits pushed to main are running all non browserstack tests anyway 
- PRs can't be merged to main without all test passing (including browserstack)
- if `merge-into-stating` fails, we still get a slack notification ([example](https://dd.slack.com/archives/CR1MFPWDD/p1753973908438199))

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
