### PR TITLE
✨ [RUM-REACT] Add React Router v7 support with dedicated entry point

### DIFF
--- a/packages/rum-react/README.md
+++ b/packages/rum-react/README.md
@@ -4,4 +4,24 @@ This package provides React and React ecosystem integrations for Datadog Browser
 
 See the [dedicated Datadog documentation][1] for more details.
 
+## React Router Support
+
+### React Router v6
+
+For React Router v6 (using react-router-dom), import from the default v6 path:
+
+```javascript
+import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v6'
+```
+
+### React Router v7
+
+For React Router v7 (which consolidates react-router-dom into react-router), import from the dedicated v7 path:
+
+```javascript
+import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v7'
+```
+
+The v7 entry point correctly imports from `react-router` instead of `react-router-dom`, supporting the new unified package structure in React Router v7.
+
 [1]: https://docs.datadoghq.com/integrations/rum_react

--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -5,6 +5,23 @@
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",
+  "exports": {
+    ".": {
+      "types": "./cjs/entries/main.d.ts",
+      "import": "./esm/entries/main.js",
+      "require": "./cjs/entries/main.js"
+    },
+    "./react-router-v6": {
+      "types": "./cjs/entries/reactRouter.d.ts",
+      "import": "./esm/entries/reactRouter.js",
+      "require": "./cjs/entries/reactRouter.js"
+    },
+    "./react-router-v7": {
+      "types": "./cjs/entries/reactRouterV7.d.ts",
+      "import": "./esm/entries/reactRouterV7.js",
+      "require": "./cjs/entries/reactRouterV7.js"
+    }
+  },
   "scripts": {
     "pack": "yarn pack",
     "build": "run-p build:cjs build:esm",
@@ -18,6 +35,7 @@
   },
   "peerDependencies": {
     "react": "18 || 19",
+    "react-router": "7",
     "react-router-dom": "6 || 7"
   },
   "peerDependenciesMeta": {
@@ -28,6 +46,9 @@
       "optional": true
     },
     "react": {
+      "optional": true
+    },
+    "react-router": {
       "optional": true
     },
     "react-router-dom": {

--- a/packages/rum-react/src/entries/reactRouterV7.ts
+++ b/packages/rum-react/src/entries/reactRouterV7.ts
@@ -1,0 +1,33 @@
+/* eslint-disable local-rules/disallow-side-effects */
+
+import {
+  createBrowserRouter as originalCreateBrowserRouter,
+  createHashRouter as originalCreateHashRouter,
+  createMemoryRouter as originalCreateMemoryRouter,
+  useRoutes as originalUseRoutes,
+  useLocation,
+  matchRoutes,
+  createRoutesFromChildren,
+} from 'react-router'
+import { wrapCreateRouter, createRoutesComponent, wrapUseRoutes } from '../domain/reactRouter'
+
+/** @function */
+export const createBrowserRouter = wrapCreateRouter(originalCreateBrowserRouter)
+
+/** @function */
+export const createHashRouter = wrapCreateRouter(originalCreateHashRouter)
+
+/** @function */
+export const createMemoryRouter = wrapCreateRouter(originalCreateMemoryRouter)
+
+/** @function */
+export const useRoutes = wrapUseRoutes({
+  useRoutes: originalUseRoutes,
+  useLocation,
+  matchRoutes,
+})
+
+export type { AnyLocation } from '../domain/reactRouter'
+
+/** @function */
+export const Routes = createRoutesComponent(useRoutes, createRoutesFromChildren)

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,6 +282,7 @@ __metadata:
     react-router-dom-6: "npm:react-router-dom@6.30.1"
   peerDependencies:
     react: 18 || 19
+    react-router: 7
     react-router-dom: 6 || 7
   peerDependenciesMeta:
     "@datadog/browser-rum":
@@ -289,6 +290,8 @@ __metadata:
     "@datadog/browser-rum-slim":
       optional: true
     react:
+      optional: true
+    react-router:
       optional: true
     react-router-dom:
       optional: true


### PR DESCRIPTION
## Motivation

React Router v7 consolidates react-router-dom into react-router, but the current implementation still imports from react-router-dom, causing module resolution errors. This PR adds a new entry point specifically for v7 that imports from the correct package.

Fixes #3690

## Changes

- Added new entry file src/entries/reactRouterV7.ts that imports from react-router
- Updated package.json to add exports for both v6 and v7 entry points
- Added react-router v7 to peerDependencies

## Testing

- Built the package successfully with both CJS and ESM outputs
- Tested in a real React Router v7 project

###  How to test
// For React Router v6
import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v6'

// For React Router v7
import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v7'