### PR TITLE
🐛 addReactError ignores error.dd_context

### DIFF
--- a/packages/rum-react/src/domain/error/addReactError.ts
+++ b/packages/rum-react/src/domain/error/addReactError.ts
@@ -15,6 +15,7 @@ import { onRumStart } from '../reactPlugin'
 export function addReactError(error: Error, info: ErrorInfo) {
   const handlingStack = createHandlingStack('react error')
   const startClocks = clocksNow()
+
   onRumStart((addEvent) => {
     callMonitored(() => {
       const rawError = computeRawError({
@@ -45,7 +46,7 @@ export function addReactError(error: Error, info: ErrorInfo) {
             source_type: 'browser',
             csp: rawError.csp,
           },
-          context: { framework: 'react' },
+          context: { framework: 'react', ...('dd_context' in error && error.dd_context ? error.dd_context : {}) },
         },
         {
           error: rawError.originalError,


### PR DESCRIPTION
## Motivation
Closes a bug where `addReactError` ignores `dd_context` on the error object
described in https://github.com/DataDog/browser-sdk/issues/3774
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->
addReactError drops error.dd_context, contrary to docs.
Refs: React helper — https://docs.datadoghq.com/integrations/rum-react/#reporting-react-errors-from-your-own-errorboundary · dd_context — https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/#attaching-local-error-context-with-dd_context


## Changes
* Merge error.dd_context into context in addReactError.
* Add unit test.


<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions
use `addReactError` with an error that has `dd_context`
<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [X] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
