### PR TITLE
[RUM Profiler] Fix discrepancy on view-id correlation

### DIFF
--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -276,6 +276,105 @@ describe('profiler', () => {
     expect(lastCall.views[1].viewId).toBe('view-profile')
     expect(lastCall.views[1].viewName).toBe('/v1/user/?/profile')
   })
+
+  it('should keep track of the latest view in the Profiler', async () => {
+    const { profiler, profilingContextManager, mockedRumProfilerTrace } = setupProfiler()
+
+    // Navigate to the user view
+    history.pushState({}, '', '/user/123')
+
+    const initialViewEntry = {
+      id: 'view-initial',
+      name: 'view-initial',
+      startClocks: {
+        relative: relativeNow(),
+        timeStamp: timeStampNow(),
+      },
+    }
+
+    profiler.start(initialViewEntry)
+
+    await waitForBoolean(() => profiler.isRunning())
+    expect(profilingContextManager.get()?.status).toBe('running')
+
+    // Navigate to a new profile view
+    history.pushState({}, '', '/v1/user/3A2/profile')
+
+    const nextViewEntry = {
+      id: 'view-next',
+      name: 'view-next',
+      startClocks: {
+        relative: relativeNow(),
+        timeStamp: timeStampNow(),
+      },
+    }
+
+    // Emit a view created event
+    lifeCycle.notify(LifeCycleEventType.VIEW_CREATED, nextViewEntry)
+
+    // Emulate visibility change to `hidden` state
+    setVisibilityState('hidden')
+
+    // Wait for profiler to pause
+    await waitForBoolean(() => profiler.isPaused())
+
+    // Assert that the profiler has collected data on pause.
+    expect(sendProfileSpy).toHaveBeenCalledTimes(1)
+
+    // Check the the sendProfilesSpy was called with the mocked trace
+    expect(sendProfileSpy).toHaveBeenCalledWith(
+      {
+        ...mockedRumProfilerTrace,
+        views: [
+          {
+            viewId: initialViewEntry.id,
+            viewName: initialViewEntry.name,
+            startClocks: initialViewEntry.startClocks,
+          },
+          {
+            viewId: nextViewEntry.id,
+            viewName: nextViewEntry.name,
+            startClocks: nextViewEntry.startClocks,
+          },
+        ],
+      },
+      jasmine.any(Object),
+      'session-id-1'
+    )
+
+    // Change back to visible
+    setVisibilityState('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    // Wait for profiler to restart
+    await waitForBoolean(() => profiler.isRunning())
+    expect(profilingContextManager.get()?.status).toBe('running')
+
+    // Stop collection of profile.
+    await profiler.stop()
+
+    // Wait for stop of collection.
+    await waitForBoolean(() => profiler.isStopped())
+    expect(profilingContextManager.get()?.status).toBe('stopped')
+
+    expect(sendProfileSpy).toHaveBeenCalledTimes(2)
+
+    // Check the the sendProfilesSpy was called with the mocked trace
+    expect(sendProfileSpy).toHaveBeenCalledWith(
+      {
+        ...mockedRumProfilerTrace,
+        views: [
+          {
+            viewId: nextViewEntry.id, // The view id should be the last one collected (in this case the "next" view)
+            viewName: nextViewEntry.name,
+            startClocks: nextViewEntry.startClocks,
+          },
+        ],
+      },
+      jasmine.any(Object),
+      'session-id-1'
+    )
+  })
 })
 
 function waitForBoolean(booleanCallback: () => boolean) {

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -128,12 +128,17 @@ export function createRumProfiler(
 
     // Whenever the View is updated, we add a views entry to the profiler instance.
     const viewUpdatedSubscription = lifeCycle.subscribe(LifeCycleEventType.VIEW_CREATED, (view) => {
-      // Note: `view.name` is only filled when users use manual view creation via `startView` method.
-      collectViewEntry({
+      const viewEntry = {
         viewId: view.id,
+        // Note: `viewName` is only filled when users use manual view creation via `startView` method.
         viewName: getCustomOrDefaultViewName(view.name, document.location.pathname),
         startClocks: view.startClocks,
-      })
+      }
+
+      collectViewEntry(viewEntry)
+
+      // Update last view entry
+      lastViewEntry = viewEntry
     })
     cleanupTasks.push(viewUpdatedSubscription.unsubscribe)
 


### PR DESCRIPTION
## Motivation

- We've identified a flaw in the view-id correlation for Profiles collected. This PR fixes it.
- The flaw can be summarized as : 
   - The view id associated with Profiles is always the initial view id defined when the Profiler initially started.
   - Any new view id created along the way only lives in the Profile that was active at the time, but not in the following profiles.

## Changes

- Whenever a "view" is created, we update the `lastViewEntry` that will be used for the next Profiler instance.

## Test instructions

- Added a unit test to cover regressions.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
