### PR TITLE
👷 [RUM-11361] Add octo policies

### DIFF
--- a/.github/chainguard/self.gitlab.pull_request.sts.yaml
+++ b/.github/chainguard/self.gitlab.pull_request.sts.yaml
@@ -1,11 +1,11 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/browser-sdk:refs/heads/main"
+subject_pattern: 'project_path:DataDog/browser-sdk:refs/heads/main'
 
 claim_pattern:
-  project_path: "DataDog/browser-sdk"
-  ref: "main"
-  ref_path: "refs/heads/main"
+  project_path: 'DataDog/browser-sdk'
+  ref: 'main'
+  ref_path: 'refs/heads/main'
 
 permissions:
   pull_requests: write

--- a/.github/chainguard/self.gitlab.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.read.sts.yaml
@@ -1,9 +1,9 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/browser-sdk"
+subject_pattern: 'project_path:DataDog/browser-sdk'
 
 claim_pattern:
-  project_path: "DataDog/browser-sdk"
+  project_path: 'DataDog/browser-sdk'
 
 permissions:
   contents: read

--- a/.github/chainguard/self.gitlab.release.sts.yaml
+++ b/.github/chainguard/self.gitlab.release.sts.yaml
@@ -1,10 +1,10 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/browser-sdk:ref_type:tag"
+subject_pattern: 'project_path:DataDog/browser-sdk:ref_type:tag'
 
 claim_pattern:
-  project_path: "DataDog/browser-sdk"
-  ref_type: "tag"
+  project_path: 'DataDog/browser-sdk'
+  ref_type: 'tag'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Motivation

Add Octo policies to prepare for personal access token replacement. Policies are fetched from the main branch, so we need to merge them first before testing the PAT migration: https://github.com/DataDog/browser-sdk/pull/3725

## Changes

Add policies

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
