### PR TITLE
👷 [RUM-11361] Fix read octo policy

### DIFF
--- a/.github/chainguard/self.gitlab.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.read.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: 'project_path:DataDog/browser-sdk'
+subject_pattern: 'project_path:DataDog/browser-sdk:.*'
 
 claim_pattern:
   project_path: 'DataDog/browser-sdk'


### PR DESCRIPTION
## Motivation

`subject_pattern` must be a regex

## Changes

Update `subject_pattern` of contents read policy

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
