### PR TITLE
🐛 Support error.dd_context for addReactError API

### DIFF
--- a/packages/rum-react/src/domain/error/addReactError.spec.ts
+++ b/packages/rum-react/src/domain/error/addReactError.spec.ts
@@ -39,4 +39,26 @@ describe('addReactError', () => {
       }
     )
   })
+
+  it('should merge dd_context from the original error with react error context', () => {
+    const addEventSpy = jasmine.createSpy()
+    initializeReactPlugin({
+      addEvent: addEventSpy,
+    })
+    const originalError = new Error('error message')
+    originalError.name = 'CustomError'
+    ;(originalError as any).dd_context = { component: 'Menu', param: 123 }
+
+    addReactError(originalError, {})
+
+    expect(addEventSpy.calls.mostRecent().args[1]).toEqual(
+      jasmine.objectContaining({
+        context: {
+          framework: 'react',
+          component: 'Menu',
+          param: 123,
+        },
+      })
+    )
+  })
 })

--- a/packages/rum-react/src/domain/error/addReactError.ts
+++ b/packages/rum-react/src/domain/error/addReactError.ts
@@ -45,7 +45,7 @@ export function addReactError(error: Error, info: ErrorInfo) {
             source_type: 'browser',
             csp: rawError.csp,
           },
-          context: { framework: 'react' },
+          context: { framework: 'react', ...rawError.context },
         },
         {
           error: rawError.originalError,


### PR DESCRIPTION
## Motivation

Attaching local error context with dd_context was not supported via addReactError API. This PR adds that support.
https://github.com/DataDog/browser-sdk/issues/3774

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
