### PR TITLE
✨[PANA-3819] Add telemetry for recorder initialization

### DIFF
--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -248,6 +248,7 @@ export interface RumConfiguration extends Configuration {
   subdomain?: string
   customerDataTelemetrySampleRate: number
   initialViewMetricsTelemetrySampleRate: number
+  recorderInitTelemetrySampleRate: number
   segmentTelemetrySampleRate: number
   traceContextInjection: TraceContextInjection
   plugins: RumPlugin[]
@@ -321,6 +322,7 @@ export function validateAndBuildRumConfiguration(
     enablePrivacyForActionName: !!initConfiguration.enablePrivacyForActionName,
     customerDataTelemetrySampleRate: 1,
     initialViewMetricsTelemetrySampleRate: 1,
+    recorderInitTelemetrySampleRate: 1,
     segmentTelemetrySampleRate: 1,
     traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
       ? initConfiguration.traceContextInjection

--- a/packages/rum/src/boot/lazyLoadRecorder.spec.ts
+++ b/packages/rum/src/boot/lazyLoadRecorder.spec.ts
@@ -1,5 +1,5 @@
-import type { DeflateWorker, Telemetry } from '@datadog/browser-core'
-import { display, resetTelemetry } from '@datadog/browser-core'
+import type { DeflateWorker, RawTelemetryEvent, Telemetry } from '@datadog/browser-core'
+import { display } from '@datadog/browser-core'
 import type { RecorderApi, RumSessionManager } from '@datadog/browser-rum-core'
 import { LifeCycle } from '@datadog/browser-rum-core'
 import type { MockTelemetry } from '@datadog/browser-core/test'
@@ -12,6 +12,19 @@ import * as replayStats from '../domain/replayStats'
 import { makeRecorderApi } from './recorderApi'
 import type { StartRecording } from './postStartStrategy'
 import { lazyLoadRecorder } from './lazyLoadRecorder'
+
+const RECORDER_INIT_TELEMETRY: RawTelemetryEvent = {
+  type: 'log',
+  status: 'debug',
+  message: 'Recorder init metrics',
+  metrics: {
+    forced: false,
+    loadRecorderModuleDuration: jasmine.any(Number),
+    recorderInitDuration: jasmine.any(Number),
+    result: 'recorder-load-failed',
+    waitForDocReadyDuration: jasmine.any(Number),
+  },
+}
 
 describe('lazyLoadRecorder', () => {
   let displaySpy: jasmine.Spy
@@ -43,22 +56,27 @@ describe('lazyLoadRecorder', () => {
     stopRecordingSpy = jasmine.createSpy('stopRecording')
     startRecordingSpy = jasmine.createSpy('startRecording')
 
-    // Workaround because using resolveTo(startRecordingSpy) was not working
-    loadRecorderSpy = jasmine.createSpy('loadRecorder').and.resolveTo((...args: any) => {
+    loadRecorderSpy = jasmine.createSpy('loadRecorder').and.callFake((...args) => {
       if (loadRecorderError) {
         return lazyLoadRecorder(() => Promise.reject(loadRecorderError))
       }
       startRecordingSpy(...args)
-      return {
+      return Promise.resolve({
         stop: stopRecordingSpy,
-      }
+      })
+    })
+
+    const configuration = mockRumConfiguration({
+      startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false,
+      recorderInitTelemetrySampleRate: 100,
+      telemetrySampleRate: 100,
     })
 
     recorderApi = makeRecorderApi(loadRecorderSpy, createDeflateWorkerSpy)
     rumInit = ({ worker } = {}) => {
       recorderApi.onRumStart(
         lifeCycle,
-        mockRumConfiguration({ startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false }),
+        configuration,
         sessionManager ?? createRumSessionManagerMock().setId('1234'),
         mockViewHistory(),
         worker,
@@ -69,11 +87,10 @@ describe('lazyLoadRecorder', () => {
     registerCleanupTask(() => {
       resetDeflateWorkerState()
       replayStats.resetReplayStats()
-      resetTelemetry()
     })
   }
 
-  it('should report an error but no telemetry if CSP blocks the module', async () => {
+  it('should report a console error and metrics but no telemetry error if CSP blocks the module', async () => {
     const loadRecorderError = new Error('Dynamic import was blocked due to Content Security Policy')
     setupRecorderApi({
       loadRecorderError,
@@ -87,10 +104,12 @@ describe('lazyLoadRecorder', () => {
 
     expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Recorder failed to start'), loadRecorderError)
     expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Please make sure CSP is correctly configured'))
-    expect(await telemetry.hasEvents()).toBe(false)
+
+    // There should be no actual telemetry error, but we should see the failure in the metrics.
+    expect(await telemetry.getEvents()).toEqual([RECORDER_INIT_TELEMETRY])
   })
 
-  it('should report an error but no telemetry if importing fails for non-CSP reasons', async () => {
+  it('should report a console error and metrics but no telemetry error if importing fails for non-CSP reasons', async () => {
     const loadRecorderError = new Error('Dynamic import failed')
     setupRecorderApi({
       loadRecorderError,
@@ -103,6 +122,8 @@ describe('lazyLoadRecorder', () => {
     await wait(0)
 
     expect(displaySpy).toHaveBeenCalledWith(jasmine.stringContaining('Recorder failed to start'), loadRecorderError)
-    expect(await telemetry.hasEvents()).toBe(false)
+
+    // There should be no actual telemetry error, but we should see the failure in the metrics.
+    expect(await telemetry.getEvents()).toEqual([RECORDER_INIT_TELEMETRY])
   })
 })

--- a/packages/rum/src/domain/startRecorderInitTelemetry.spec.ts
+++ b/packages/rum/src/domain/startRecorderInitTelemetry.spec.ts
@@ -1,0 +1,168 @@
+import type { Telemetry, RawTelemetryEvent } from '@datadog/browser-core'
+import { Observable } from '@datadog/browser-core'
+import type { MockTelemetry } from '@datadog/browser-core/test'
+import { registerCleanupTask, startMockTelemetry } from '@datadog/browser-core/test'
+import type { RumConfiguration } from '@datadog/browser-rum-core'
+import { mockRumConfiguration } from '@datadog/browser-rum-core/test'
+import type { RecorderInitEvent } from '../boot/postStartStrategy'
+import type { RecorderInitMetrics } from './startRecorderInitTelemetry'
+import { startRecorderInitTelemetry } from './startRecorderInitTelemetry'
+
+describe('startRecorderInitTelemetry', () => {
+  let observable: Observable<RecorderInitEvent>
+  let telemetry: MockTelemetry
+
+  const config: Partial<RumConfiguration> = {
+    recorderInitTelemetrySampleRate: 100,
+    telemetrySampleRate: 100,
+  }
+
+  function startRecorderInitTelemetryCollection(partialConfig: Partial<RumConfiguration> = config) {
+    const configuration = mockRumConfiguration(partialConfig)
+    observable = new Observable<RecorderInitEvent>()
+    telemetry = startMockTelemetry()
+    const { stop: stopRecorderInitTelemetry } = startRecorderInitTelemetry(
+      configuration,
+      { enabled: true } as Telemetry,
+      observable
+    )
+    registerCleanupTask(stopRecorderInitTelemetry)
+  }
+
+  it('should collect recorder init metrics telemetry', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.getEvents()).toEqual([expectedRecorderInitTelemetry()])
+  })
+
+  it('should not collect recorder init metrics telemetry twice', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.getEvents()).toEqual([expectedRecorderInitTelemetry()])
+
+    telemetry.reset()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.hasEvents()).toEqual(false)
+  })
+
+  it('should not collect recorder init metrics telemetry unless start time is known', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.hasEvents()).toEqual(false)
+  })
+
+  it('should collect recorder init metrics telemetry even without document-ready', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.getEvents()).toEqual([
+      expectedRecorderInitTelemetry({
+        waitForDocReadyDuration: undefined,
+      }),
+    ])
+  })
+
+  it('should collect recorder init metrics telemetry even without recorder-settled', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.getEvents()).toEqual([
+      expectedRecorderInitTelemetry({
+        loadRecorderModuleDuration: undefined,
+      }),
+    ])
+  })
+
+  it('should report if recording is aborted', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'aborted' })
+    expect(await telemetry.getEvents()).toEqual([
+      expectedRecorderInitTelemetry({
+        result: 'aborted',
+      }),
+    ])
+  })
+
+  it('should report if the deflate encoder fails to load', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'deflate-encoder-load-failed' })
+    expect(await telemetry.getEvents()).toEqual([
+      expectedRecorderInitTelemetry({
+        result: 'deflate-encoder-load-failed',
+      }),
+    ])
+  })
+
+  it('should report if the recorder module fails to load', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'recorder-load-failed' })
+    expect(await telemetry.getEvents()).toEqual([
+      expectedRecorderInitTelemetry({
+        result: 'recorder-load-failed',
+      }),
+    ])
+  })
+
+  it('should report if the recording was force-enabled', async () => {
+    startRecorderInitTelemetryCollection()
+    observable.notify({ type: 'start', forced: true })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.getEvents()).toEqual([
+      expectedRecorderInitTelemetry({
+        forced: true,
+      }),
+    ])
+  })
+
+  it('should not collect recorder init metrics telemetry when telemetry is disabled', async () => {
+    startRecorderInitTelemetryCollection({
+      telemetrySampleRate: 100,
+      initialViewMetricsTelemetrySampleRate: 0,
+    })
+    observable.notify({ type: 'start', forced: false })
+    observable.notify({ type: 'recorder-settled' })
+    observable.notify({ type: 'document-ready' })
+    observable.notify({ type: 'succeeded' })
+    expect(await telemetry.hasEvents()).toBe(false)
+  })
+})
+
+function expectedRecorderInitTelemetry(overrides: Partial<RecorderInitMetrics> = {}): RawTelemetryEvent {
+  return {
+    type: 'log',
+    status: 'debug',
+    message: 'Recorder init metrics',
+    metrics: {
+      forced: false,
+      loadRecorderModuleDuration: jasmine.any(Number),
+      recorderInitDuration: jasmine.any(Number),
+      result: 'succeeded',
+      waitForDocReadyDuration: jasmine.any(Number),
+      ...overrides,
+    },
+  }
+}

--- a/packages/rum/src/domain/startRecorderInitTelemetry.ts
+++ b/packages/rum/src/domain/startRecorderInitTelemetry.ts
@@ -1,0 +1,97 @@
+import type { Context, Duration, Telemetry, Observable, TimeStamp } from '@datadog/browser-core'
+import { performDraw, addTelemetryMetrics, noop, timeStampNow, elapsed } from '@datadog/browser-core'
+import type { RumConfiguration } from '@datadog/browser-rum-core'
+import type { RecorderInitEvent } from '../boot/postStartStrategy'
+
+const RECORDER_INIT_METRICS_TELEMETRY_NAME = 'Recorder init metrics'
+
+type RecorderInitResult = 'aborted' | 'deflate-encoder-load-failed' | 'recorder-load-failed' | 'succeeded'
+
+export interface RecorderInitMetrics extends Context {
+  forced: boolean
+  loadRecorderModuleDuration: number | undefined
+  recorderInitDuration: number
+  result: RecorderInitResult
+  waitForDocReadyDuration: number | undefined
+}
+
+export function startRecorderInitTelemetry(
+  configuration: RumConfiguration,
+  telemetry: Telemetry,
+  observable: Observable<RecorderInitEvent>
+) {
+  const recorderInitTelemetryEnabled = telemetry.enabled && performDraw(configuration.recorderInitTelemetrySampleRate)
+  if (!recorderInitTelemetryEnabled) {
+    return { stop: noop }
+  }
+
+  let startContext:
+    | {
+        forced: boolean
+        timestamp: TimeStamp
+      }
+    | undefined
+
+  let documentReadyDuration: Duration | undefined
+  let recorderSettledDuration: Duration | undefined
+
+  const { unsubscribe } = observable.subscribe((event) => {
+    switch (event.type) {
+      case 'start':
+        startContext = { forced: event.forced, timestamp: timeStampNow() }
+        documentReadyDuration = undefined
+        recorderSettledDuration = undefined
+        break
+
+      case 'document-ready':
+        if (startContext) {
+          documentReadyDuration = elapsed(startContext.timestamp, timeStampNow())
+        }
+        break
+
+      case 'recorder-settled':
+        if (startContext) {
+          recorderSettledDuration = elapsed(startContext.timestamp, timeStampNow())
+        }
+        break
+
+      case 'aborted':
+      case 'deflate-encoder-load-failed':
+      case 'recorder-load-failed':
+      case 'succeeded':
+        // Only send metrics for the first attempt at starting the recorder.
+        unsubscribe()
+
+        if (startContext) {
+          addTelemetryMetrics(RECORDER_INIT_METRICS_TELEMETRY_NAME, {
+            metrics: createRecorderInitMetrics(
+              startContext.forced,
+              recorderSettledDuration,
+              elapsed(startContext.timestamp, timeStampNow()),
+              event.type,
+              documentReadyDuration
+            ),
+          })
+        }
+        break
+    }
+  })
+
+  return { stop: unsubscribe }
+}
+
+function createRecorderInitMetrics(
+  forced: boolean,
+  loadRecorderModuleDuration: Duration | undefined,
+  recorderInitDuration: Duration,
+  result: RecorderInitResult,
+  waitForDocReadyDuration: Duration | undefined
+): RecorderInitMetrics {
+  return {
+    forced,
+    loadRecorderModuleDuration,
+    recorderInitDuration,
+    result,
+    waitForDocReadyDuration,
+  }
+}


### PR DESCRIPTION
## Motivation

We're investigating whether some changes to the initialization process for the session replay recorder could improve reliability and/or fidelity during early page load. To decide how best to approach the problem, and to evaluate any change we do make, it would be helpful to have some metrics about the recorder initialization process.

## Changes

This PR adds metrics for recorder initialization that are relevant to near-term arcs of work around session replay reliability and fidelity. The metrics (sampled at 1%) measure:
* How long it took to lazy-load the recorder module.
* How long it took to wait for the document to be ready. (Under the hood, this boils down to "how long did we wait for DOMContentLoaded?")
* How long recorder initialization took overall.
* Whether recorder initialization succeeded or failed, and if it failed, which failure code path was taken.
* Whether recorder startup was forced or automatic.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
