### PR TITLE
🎨 [PANA-3877] Consolidate sample rates for replay telemetry

### DIFF
--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -248,8 +248,7 @@ export interface RumConfiguration extends Configuration {
   subdomain?: string
   customerDataTelemetrySampleRate: number
   initialViewMetricsTelemetrySampleRate: number
-  recorderInitTelemetrySampleRate: number
-  segmentTelemetrySampleRate: number
+  replayTelemetrySampleRate: number
   traceContextInjection: TraceContextInjection
   plugins: RumPlugin[]
   trackFeatureFlagsForEvents: FeatureFlagsForEvents[]
@@ -322,8 +321,7 @@ export function validateAndBuildRumConfiguration(
     enablePrivacyForActionName: !!initConfiguration.enablePrivacyForActionName,
     customerDataTelemetrySampleRate: 1,
     initialViewMetricsTelemetrySampleRate: 1,
-    recorderInitTelemetrySampleRate: 1,
-    segmentTelemetrySampleRate: 1,
+    replayTelemetrySampleRate: 1,
     traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
       ? initConfiguration.traceContextInjection
       : TraceContextInjection.SAMPLED,

--- a/packages/rum/src/boot/lazyLoadRecorder.spec.ts
+++ b/packages/rum/src/boot/lazyLoadRecorder.spec.ts
@@ -67,8 +67,8 @@ describe('lazyLoadRecorder', () => {
     })
 
     const configuration = mockRumConfiguration({
+      replayTelemetrySampleRate: 100,
       startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false,
-      recorderInitTelemetrySampleRate: 100,
       telemetrySampleRate: 100,
     })
 

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -58,8 +58,8 @@ describe('makeRecorderApi', () => {
     })
 
     const configuration = mockRumConfiguration({
+      replayTelemetrySampleRate: 100,
       startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false,
-      recorderInitTelemetrySampleRate: 100,
       telemetrySampleRate: 100,
     })
 

--- a/packages/rum/src/domain/segmentCollection/startSegmentTelemetry.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/startSegmentTelemetry.spec.ts
@@ -15,7 +15,7 @@ describe('segmentTelemetry', () => {
 
   const config: Partial<RumConfiguration> = {
     maxTelemetryEventsPerPage: 2,
-    segmentTelemetrySampleRate: 100,
+    replayTelemetrySampleRate: 100,
     telemetrySampleRate: 100,
   }
 
@@ -152,8 +152,8 @@ describe('segmentTelemetry', () => {
 
   it('should not collect segment when telemetry disabled', async () => {
     setupSegmentTelemetryCollection({
+      replayTelemetrySampleRate: 0,
       telemetrySampleRate: 100,
-      segmentTelemetrySampleRate: 0,
     })
     generateReplayRequest({ result: 'success', isFullSnapshot: true })
     expect(await telemetry.hasEvents()).toBe(false)

--- a/packages/rum/src/domain/segmentCollection/startSegmentTelemetry.ts
+++ b/packages/rum/src/domain/segmentCollection/startSegmentTelemetry.ts
@@ -34,7 +34,7 @@ export function startSegmentTelemetry(
   telemetry: Telemetry,
   requestObservable: Observable<HttpRequestEvent<ReplayPayload>>
 ) {
-  const segmentTelemetryEnabled = telemetry.enabled && performDraw(configuration.segmentTelemetrySampleRate)
+  const segmentTelemetryEnabled = telemetry.enabled && performDraw(configuration.replayTelemetrySampleRate)
   if (!segmentTelemetryEnabled) {
     return { stop: noop }
   }

--- a/packages/rum/src/domain/startRecorderInitTelemetry.spec.ts
+++ b/packages/rum/src/domain/startRecorderInitTelemetry.spec.ts
@@ -13,7 +13,7 @@ describe('startRecorderInitTelemetry', () => {
   let telemetry: MockTelemetry
 
   const config: Partial<RumConfiguration> = {
-    recorderInitTelemetrySampleRate: 100,
+    replayTelemetrySampleRate: 100,
     telemetrySampleRate: 100,
   }
 

--- a/packages/rum/src/domain/startRecorderInitTelemetry.ts
+++ b/packages/rum/src/domain/startRecorderInitTelemetry.ts
@@ -20,7 +20,7 @@ export function startRecorderInitTelemetry(
   telemetry: Telemetry,
   observable: Observable<RecorderInitEvent>
 ) {
-  const recorderInitTelemetryEnabled = telemetry.enabled && performDraw(configuration.recorderInitTelemetrySampleRate)
+  const recorderInitTelemetryEnabled = telemetry.enabled && performDraw(configuration.replayTelemetrySampleRate)
   if (!recorderInitTelemetryEnabled) {
     return { stop: noop }
   }


### PR DESCRIPTION
## Motivation

This is a followup to #3793; per the review feedback there, we're starting to have a lot of different telemetry sample rates in the configuration, so it would make sense to consolidate sample rates related to replay telemetry.

## Changes

This PR consolidates `recorderInitTelemetrySampleRate` and `segmentTelemetrySampleRate`, replacing them with `replayTelemetrySampleRate`.

After some consideration, I didn't consolidate `initialViewMetricsTelemetrySampleRate` with the other two. Although I added that telemetry to support replay-related work, it's really just general browser SDK telemetry; it might make sense to consolidate it with any similar telemetry we end up adding in the future, instead. However, I'm happy to change course on that if it seems preferable to just bring everything together under a single sample rate.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
