### PR TITLE
👷 Fix create-github-release job

### DIFF
--- a/.gitlab/deploy-auto.yml
+++ b/.gitlab/deploy-auto.yml
@@ -6,6 +6,9 @@ stages:
 .base-configuration:
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
 
 .deploy-prod:
   stage: deploy

--- a/.gitlab/deploy-manual.yml
+++ b/.gitlab/deploy-manual.yml
@@ -6,6 +6,9 @@ stages:
 .base-configuration:
   tags: ['runner:main', 'size:large']
   image: $CI_IMAGE
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
 
 .deploy-prod:
   stage: deploy


### PR DESCRIPTION
## Motivation

Grant DDOCTOSTS_ID_TOKEN env access in GitLab deploy jobs to fix create-github-release

## Changes

```diff
.base-configuration:
  tags: ['runner:main', 'size:large']
  image: $CI_IMAGE
+  id_tokens:
+     DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
```

## Test instructions

Tested in this [pipeline job](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1097035948)  

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
