### PR TITLE
👷‍♀️ Add telemetry to debug text diff with tree walker

### DIFF
--- a/packages/rum-core/src/domain/action/getActionNameFromElement.ts
+++ b/packages/rum-core/src/domain/action/getActionNameFromElement.ts
@@ -255,8 +255,8 @@ function getTextualContent(
         userProgrammaticAttribute,
         privacyEnabledActionName
       )
-      if (treeWalkerText !== text.replace(/\s+/g, ' ').trim()) {
-        addTelemetryDebug('tree-walker-text-diff', { text, treeWalkerText })
+      if (treeWalkerText.toLowerCase() !== text.replace(/\s+/g, ' ').trim().toLowerCase()) {
+        addTelemetryDebug('tree-walker-text-diff', { text, treeWalkerText, selector: element.outerHTML })
       }
       return treeWalkerText
     }


### PR DESCRIPTION
## Motivation
We want to monitor the different results from tree walker approach and innerText.
<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes
Run both strategies behind the FF and send telemetries when they are different.
<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
