### PR TITLE
🐛 [PANA-3960] Allow more queued request data for better session replay reliability

### DIFF
--- a/packages/core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.spec.ts
@@ -2,6 +2,7 @@ import { mockClock, setNavigatorOnLine } from '../../test'
 import type { Clock } from '../../test'
 import { ErrorSource } from '../domain/error/error.types'
 import { Observable } from '../tools/observable'
+import { ONE_MEBI_BYTE } from '../tools/utils/byteUtils'
 import type { RetryState } from './sendWithRetryStrategy'
 import {
   newRetryState,
@@ -168,7 +169,7 @@ describe('sendWithRetryStrategy', () => {
       expect(reportErrorSpy).toHaveBeenCalled()
       expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
         jasmine.objectContaining({
-          message: 'Reached max logs events size queued for upload: 3MiB',
+          message: `Reached max logs events size queued for upload: ${MAX_QUEUE_BYTES_COUNT / ONE_MEBI_BYTE}MiB`,
           source: ErrorSource.AGENT,
         })
       )

--- a/packages/core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/core/src/transport/sendWithRetryStrategy.ts
@@ -10,7 +10,7 @@ import type { Payload, HttpRequestEvent, HttpResponse, BandwidthStats } from './
 
 export const MAX_ONGOING_BYTES_COUNT = 80 * ONE_KIBI_BYTE
 export const MAX_ONGOING_REQUESTS = 32
-export const MAX_QUEUE_BYTES_COUNT = 3 * ONE_MEBI_BYTE
+export const MAX_QUEUE_BYTES_COUNT = 20 * ONE_MEBI_BYTE
 export const MAX_BACKOFF_TIME = ONE_MINUTE
 export const INITIAL_BACKOFF_TIME = ONE_SECOND
 


### PR DESCRIPTION
## Motivation

Using the session replay telemetry we've recently added, we've observed that session replay data is sometimes getting dropped before it can be sent to the server because the internal queue used by `HttpRequest` fills up. We'd like to stop this from happening to improve session replay reliability.

## Changes

This PR increases the `HttpRequest` queue size limit from 3MiB to 20MiB. As of today, the backend limit for session replay requests is 10MiB, so 20MiB is large enough to hold two maximally-sized session replay requests. We believe this should allow enough capacity to handle realistic use cases, but we will monitor telemetry and consider increasing the queue size further if we see data that suggests otherwise.

## Checklist

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.