### PR TITLE
feat(rum-core): add data-dd-click-ignore to suppress rage/dead/error frustration signals

### DIFF
--- a/packages/rum-core/src/domain/action/clickIgnore.ts
+++ b/packages/rum-core/src/domain/action/clickIgnore.ts
@@ -1,0 +1,60 @@
+import { getParentNode, isElementNode } from '../../browser/htmlDomUtils'
+
+export const CLICK_IGNORE_ATTR_NAME = 'data-dd-click-ignore'
+
+export const ClickIgnoreFlag = {
+  RAGE: 1,
+  DEAD: 2,
+  ERROR: 4,
+} as const
+
+export const CLICK_IGNORE_ALL = ClickIgnoreFlag.RAGE | ClickIgnoreFlag.DEAD | ClickIgnoreFlag.ERROR
+
+const cache = new WeakMap<Element, number>()
+
+function parseTokens(value: string): number {
+  let mask = 0
+  const tokens = value
+    .split(/[\s,]+/)
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean)
+
+  for (const token of tokens) {
+    if (token === 'all') {
+      return CLICK_IGNORE_ALL
+    }
+    if (token === 'rage') {
+      mask |= ClickIgnoreFlag.RAGE
+    } else if (token === 'dead') {
+      mask |= ClickIgnoreFlag.DEAD
+    } else if (token === 'error') {
+      mask |= ClickIgnoreFlag.ERROR
+    }
+  }
+  return mask
+}
+
+export function getIgnoredForElement(element: Element): number {
+  const cached = cache.get(element)
+  if (cached !== undefined) {
+    return cached
+  }
+  let mask = 0
+  let node: Node | null = element
+  while (node) {
+    if (isElementNode(node)) {
+      const value = node.getAttribute(CLICK_IGNORE_ATTR_NAME)
+      if (value) {
+        const parsed = parseTokens(value)
+        mask |= parsed
+        if ((mask & CLICK_IGNORE_ALL) === CLICK_IGNORE_ALL) {
+          break
+        }
+      }
+    }
+    node = getParentNode(node)
+  }
+  cache.set(element, mask)
+  return mask
+}
+


### PR DESCRIPTION
Adds attribute-only opt-out for frustration classification using data-dd-click-ignore on clicked elements and ancestors (including Shadow DOM).

Fixes https://github.com/DataDog/browser-sdk/issues/3621.

Here's the output of the test suite when I run it locally:

```
~/code/browser-sdk feat/click-ignore-frustration*
❯ npm run test

> test
> yarn test:unit:watch

...

219 assets
2533 modules
webpack 5.101.0 compiled successfully in 7104 ms
02 09 2025 23:01:41.612:WARN [karma]: No captured browser, open http://localhost:9876/
02 09 2025 23:01:41.631:INFO [karma-server]: Karma v6.4.4 server started at http://localhost:9876/
02 09 2025 23:01:41.632:INFO [launcher]: Launching browsers ChromeHeadlessNoSandbox with concurrency unlimited
02 09 2025 23:01:41.634:INFO [launcher]: Starting browser ChromeHeadless
02 09 2025 23:01:42.711:INFO [Chrome Headless 139.0.0.0 (Mac OS 10.15.7)]: Connected on socket esFiyOkr2z-ayl-2AAAB with id 88912216
02 09 2025 23:01:57.041:INFO [jasmine-seed-reporter]: Chrome Headless 139.0.0.0 (Mac OS 10.15.7): Randomized with seed 73747

TOTAL: 2843 SUCCESS

=============================== Coverage summary ===============================
Statements   : 92.48% ( 6373/6891 )
Branches     : 88.26% ( 3860/4373 )
Functions    : 91.51% ( 1909/2086 )
Lines        : 92.6% ( 6203/6698 )
================================================================================

Chrome Headless 139.0.0.0 (Mac OS 10.15.7): Executed 2843 of 2844 (skipped 1) SUCCESS (13.652 secs / 13.39 secs)
TOTAL: 2843 SUCCESS
```