### PR TITLE
🔉  report missing configuration options

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -206,6 +206,14 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       use_allowed_tracing_urls?: boolean
       /**
+       * Whether the allowed GraphQL urls list is used
+       */
+      use_allowed_graph_ql_urls?: boolean
+      /**
+       * Whether GraphQL payload tracking is used for at least one GraphQL endpoint
+       */
+      use_track_graph_ql_payload?: boolean
+      /**
        * A list of selected tracing propagators
        */
       selected_tracing_propagators?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[]
@@ -443,6 +451,18 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        * The id of the remote configuration
        */
       remote_configuration_id?: string
+      /**
+       * Whether a proxy is used for remote configuration
+       */
+      use_remote_configuration_proxy?: boolean
+      /**
+       * The percentage of sessions with Profiling enabled
+       */
+      profiling_sample_rate?: number
+      /**
+       * Whether trace baggage is propagated to child spans
+       */
+      propagate_trace_baggage?: boolean
       [k: string]: unknown
     }
     [k: string]: unknown

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -540,22 +540,18 @@ describe('serializeRumConfiguration', () => {
       remoteConfigurationProxy: 'config',
       plugins: [{ name: 'foo', getConfigurationTelemetry: () => ({ bar: true }) }],
       trackFeatureFlagsForEvents: ['vital'],
-      profilingSampleRate: 0,
+      profilingSampleRate: 42,
       propagateTraceBaggage: true,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
       ? MapInitConfigurationKey<Key>
-      : Key extends 'workerUrl' | 'allowedTracingUrls' | 'excludedActivityUrls'
+      : Key extends 'workerUrl' | 'allowedTracingUrls' | 'excludedActivityUrls' | 'remoteConfigurationProxy'
         ? `use_${CamelToSnakeCase<Key>}`
         : Key extends 'trackLongTasks'
           ? 'track_long_task' // oops
-          : Key extends
-                | 'applicationId'
-                | 'subdomain'
-                | 'remoteConfigurationProxy'
-                | 'profilingSampleRate'
-                | 'propagateTraceBaggage'
+          : // The following options are not reported as telemetry. Please avoid adding more of them.
+            Key extends 'applicationId' | 'subdomain'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an
@@ -569,6 +565,7 @@ describe('serializeRumConfiguration', () => {
       session_replay_sample_rate: 60,
       trace_sample_rate: 50,
       trace_context_injection: TraceContextInjection.ALL,
+      propagate_trace_baggage: true,
       use_allowed_tracing_urls: true,
       selected_tracing_propagators: ['tracecontext', 'datadog'],
       use_excluded_activity_urls: true,
@@ -586,6 +583,8 @@ describe('serializeRumConfiguration', () => {
       plugins: [{ name: 'foo', bar: true }],
       track_feature_flags_for_events: ['vital'],
       remote_configuration_id: '123',
+      use_remote_configuration_proxy: true,
+      profiling_sample_rate: 42,
     })
   })
 })

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -394,6 +394,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
     start_session_replay_recording_manually: configuration.startSessionReplayRecordingManually,
     trace_sample_rate: configuration.traceSampleRate,
     trace_context_injection: configuration.traceContextInjection,
+    propagate_trace_baggage: configuration.propagateTraceBaggage,
     action_name_attribute: configuration.actionNameAttribute,
     use_allowed_tracing_urls:
       Array.isArray(configuration.allowedTracingUrls) && configuration.allowedTracingUrls.length > 0,
@@ -415,6 +416,8 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
     })),
     track_feature_flags_for_events: configuration.trackFeatureFlagsForEvents,
     remote_configuration_id: configuration.remoteConfigurationId,
+    profiling_sample_rate: configuration.profilingSampleRate,
+    use_remote_configuration_proxy: !!configuration.remoteConfigurationProxy,
     ...baseSerializedConfiguration,
   } satisfies RawTelemetryConfiguration
 }

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -826,7 +826,8 @@ export type RumResourceEvent = CommonProperties &
  * Schema of all properties of a View event
  */
 export type RumViewEvent = CommonProperties &
-  ViewContainerSchema & {
+  ViewContainerSchema &
+  StreamSchema & {
     /**
      * RUM event type
      */
@@ -1644,6 +1645,16 @@ export interface CommonProperties {
   context?: {
     [k: string]: unknown
   }
+  /**
+   * Stream properties
+   */
+  stream?: {
+    /**
+     * UUID of the stream
+     */
+    readonly id: string
+    [k: string]: unknown
+  }
   [k: string]: unknown
 }
 /**
@@ -1725,6 +1736,46 @@ export interface ProfilingInternalContextSchema {
     | 'failed-to-lazy-load'
     | 'missing-document-policy-header'
     | 'unexpected-exception'
+  [k: string]: unknown
+}
+/**
+ * Stream schema for media streaming properties
+ */
+export interface StreamSchema {
+  /**
+   * Stream properties
+   */
+  readonly stream?: {
+    /**
+     * current bitrate at the time of collection
+     */
+    bitrate?: number
+    /**
+     * How long is the content (VOD only) (in ms)
+     */
+    readonly duration?: number
+    /**
+     * Stream format
+     */
+    readonly format?: string
+    /**
+     * current frames per second at the time of collection
+     */
+    fps?: number
+    /**
+     * Stream resolution
+     */
+    readonly resolution?: string
+    /**
+     * current timestamp at the time of collection
+     */
+    timestamp?: number
+    /**
+     * how much did the media progress since the last context update (in ms)
+     */
+    watch_time?: number
+    [k: string]: unknown
+  }
   [k: string]: unknown
 }
 /**


### PR DESCRIPTION
## Motivation

Some new configuration options were not reported as telemetry. I am mostly interested in the `profiling_sample_rate` see when an org starts using profiling.

## Changes

Include those new configuration options in telemetry.

## Test instructions

Check if those options are reported as telemetry

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
