### PR TITLE
🚨 add a lint rule to forbid `declare global` usage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -375,6 +375,11 @@ export default tseslint.config(
           selector: 'TSEnumDeclaration:not([const=true])',
           message: 'When possible, use `const enum` as it produces less code when transpiled.',
         },
+
+        {
+          selector: 'TSModuleDeclaration[kind=global]',
+          message: 'Never declare global types as it will leak to the user app global scope.',
+        },
       ],
     },
   },


### PR DESCRIPTION
## Motivation

Types declared within a `declare global` block are leaking into the user codebase. Never do that.

## Changes

Add a lint to forbid using `declare global`.

## Test instructions

In a source file, add:

```
declare global {
  const toto: any
}
```

ESLint should show an error.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
