### PR TITLE
✅ fix flaky test

### DIFF
--- a/packages/core/src/tools/taskQueue.ts
+++ b/packages/core/src/tools/taskQueue.ts
@@ -20,6 +20,7 @@ export const MAX_EXECUTION_TIME_ON_TIMEOUT = 30
 
 export interface TaskQueue {
   push(task: Task): void
+  stop(): void
 }
 
 type Task = () => void
@@ -54,6 +55,9 @@ export function createTaskQueue(): TaskQueue {
       if (pendingTasks.push(task) === 1) {
         scheduleNextRun()
       }
+    },
+    stop() {
+      pendingTasks.length = 0
     },
   }
 }

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -85,6 +85,7 @@ export function startResourceCollection(
 
   return {
     stop: () => {
+      taskQueue.stop()
       performanceResourceSubscription.unsubscribe()
     },
   }


### PR DESCRIPTION


## Motivation

The task queue was not properly stopped when a test finished

Jasmine seed: 95071

## Changes

Stop the task queue when resource collection is stopped

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
