### PR TITLE
✨ [RUM-11701] Add unity as a source override

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -223,7 +223,7 @@ export interface InitConfiguration {
    *
    * @internal
    */
-  source?: 'browser' | 'flutter' | undefined
+  source?: 'browser' | 'flutter' | 'unity' | undefined
 
   /**
    * [Internal option] Additional configuration for the SDK.
@@ -286,7 +286,7 @@ export interface Configuration extends TransportConfiguration {
 
   // internal
   sdkVersion: string | undefined
-  source: 'browser' | 'flutter'
+  source: 'browser' | 'flutter' | 'unity'
   variant: string | undefined
 }
 

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -158,10 +158,16 @@ describe('endpointBuilder', () => {
       expect(endpoint).toContain('ddsource=browser')
     })
 
-    it('should source when provided', () => {
+    it('should use flutter source when provided', () => {
       const config = { ...initConfiguration, source: 'flutter' as const }
       const endpoint = createEndpointBuilder(config, 'rum').build('fetch', DEFAULT_PAYLOAD)
       expect(endpoint).toContain('ddsource=flutter')
+    })
+
+    it('should use unity source when provided', () => {
+      const config = { ...initConfiguration, source: 'unity' as const }
+      const endpoint = createEndpointBuilder(config, 'rum').build('fetch', DEFAULT_PAYLOAD)
+      expect(endpoint).toContain('ddsource=unity')
     })
   })
 })

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -13,7 +13,7 @@ export interface TransportConfiguration {
   datacenter?: string | undefined
   replica?: ReplicaConfiguration
   site: Site
-  source: 'browser' | 'flutter'
+  source: 'browser' | 'flutter' | 'unity'
 }
 
 export interface ReplicaConfiguration {
@@ -23,7 +23,7 @@ export interface ReplicaConfiguration {
 
 export function computeTransportConfiguration(initConfiguration: InitConfiguration): TransportConfiguration {
   const site = initConfiguration.site || INTAKE_SITE_US1
-  const source = initConfiguration.source === 'flutter' ? 'flutter' : 'browser'
+  const source = valiidateSource(initConfiguration.source)
 
   const endpointBuilders = computeEndpointBuilders({ ...initConfiguration, site, source })
   const replicaConfiguration = computeReplicaConfiguration({ ...initConfiguration, site, source })
@@ -34,6 +34,13 @@ export function computeTransportConfiguration(initConfiguration: InitConfigurati
     source,
     ...endpointBuilders,
   }
+}
+
+function valiidateSource(source: string | undefined) {
+  if (source === 'flutter' || source === 'unity') {
+    return source
+  }
+  return 'browser'
 }
 
 function computeEndpointBuilders(initConfiguration: InitConfiguration) {

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -36,7 +36,7 @@ export function computeTransportConfiguration(initConfiguration: InitConfigurati
   }
 }
 
-function valiidateSource(source: string | undefined) {
+function validateSource(source: string | undefined) {
   if (source === 'flutter' || source === 'unity') {
     return source
   }

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -23,7 +23,7 @@ export interface ReplicaConfiguration {
 
 export function computeTransportConfiguration(initConfiguration: InitConfiguration): TransportConfiguration {
   const site = initConfiguration.site || INTAKE_SITE_US1
-  const source = valiidateSource(initConfiguration.source)
+  const source = validateSource(initConfiguration.source)
 
   const endpointBuilders = computeEndpointBuilders({ ...initConfiguration, site, source })
   const replicaConfiguration = computeReplicaConfiguration({ ...initConfiguration, site, source })


### PR DESCRIPTION
## Motivation

Source overrides only currently support Flutter, and should support Unity as a source override as well.

## Changes

Add `unity` both to the allowed TypeScript definitions and to the check that validates proper sources. Add a unit tests that checks that the `unity` source is forwarded properly.

## Test instructions

To to staging

Override the configuration and add:

```js
"source": "unity",
```

Check that events are sending the new information

Check that events in https://dd.datad0g.com/rum/sessions?query=%40type%3Asession%20%40usr.id%3A33803929&agg_m=count&agg_m_source=base&agg_t=count&from_ts=1752574307484&to_ts=1753179107484&live=true shows the new information

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
