### PR TITLE
👷 [Performance script] fix regression on size increase warnings

### DIFF
--- a/scripts/performance/lib/reportAsAPrComment.spec.ts
+++ b/scripts/performance/lib/reportAsAPrComment.spec.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { createMessage } from './reportAsAPrComment.ts'
+
+void describe('reportAsAPrComment', () => {
+  void describe('createMessage', () => {
+    const TEST_BUNDLE = 'test'
+    const PR_NUMBER = 123
+
+    const BASE_BUNDLE_SIZES = [{ name: TEST_BUNDLE, value: 100 }]
+    const MEMORY_BASE_PERFORMANCE = [{ name: TEST_BUNDLE, value: 100 }]
+    const CPU_BASE_PERFORMANCE = [{ name: TEST_BUNDLE, value: 100 }]
+
+    const MEMORY_LOCAL_PERFORMANCE = [{ testProperty: TEST_BUNDLE, sdkMemoryBytes: 101, sdkMemoryPercentage: 10 }]
+    const CPU_LOCAL_PERFORMANCE = [{ name: TEST_BUNDLE, value: 101 }]
+
+    void it('should generate a report with performance results', () => {
+      const localBundleSizes = { test: 101 }
+
+      const message = createMessage(
+        BASE_BUNDLE_SIZES,
+        localBundleSizes,
+        MEMORY_BASE_PERFORMANCE,
+        MEMORY_LOCAL_PERFORMANCE,
+        CPU_BASE_PERFORMANCE,
+        CPU_LOCAL_PERFORMANCE,
+        PR_NUMBER
+      )
+
+      assert.equal(
+        message,
+        `| 📦 Bundle Name | Base Size | Local Size | 𝚫 | 𝚫% | Status |
+| --- | --- | --- | --- | --- | --- |
+| Test | 100 B | 101 B | 1 B | +1.00% | ✅ |
+</details>
+
+<details>
+<summary>🚀 CPU Performance</summary>
+
+| Action Name | Base Average Cpu Time (ms) | Local Average Cpu Time (ms) | 𝚫 |
+| --- | --- | --- | --- |
+| test | 100.000 | 101.000 | 1.000 |
+
+</details>
+
+<details>
+<summary>🧠 Memory Performance</summary>
+
+| Action Name | Base Consumption Memory (bytes) | Local Consumption Memory (bytes) | 𝚫 (bytes) |
+| --- | --- | --- | --- |
+| test | 100 B | 101 B | 1 B |
+
+</details>
+
+🔗 [RealWorld](https://datadoghq.dev/browser-sdk-test-playground/realworld-scenario/?prNumber=123)
+
+`
+      )
+    })
+
+    void it('should add a warning when the size increase is above the threshold', () => {
+      const localBundleSizes = { test: 150 }
+
+      const message = createMessage(
+        BASE_BUNDLE_SIZES,
+        localBundleSizes,
+        MEMORY_BASE_PERFORMANCE,
+        MEMORY_LOCAL_PERFORMANCE,
+        CPU_BASE_PERFORMANCE,
+        CPU_LOCAL_PERFORMANCE,
+        PR_NUMBER
+      )
+
+      assertContains(message, '| Test | 100 B | 150 B | 50 B | +50.00% | ⚠️ |')
+      assertContains(message, '⚠️ The increase is particularly high and exceeds 5%. Please check the changes.')
+    })
+  })
+})
+
+function assertContains(actual: string, expected: string) {
+  assert.ok(
+    actual.includes(expected),
+    ['Expected string to contain:', `  expected: "${expected}"`, `  actual:   "${actual}"`].join('\n')
+  )
+}

--- a/scripts/performance/lib/reportAsAPrComment.ts
+++ b/scripts/performance/lib/reportAsAPrComment.ts
@@ -52,12 +52,8 @@ export async function reportAsPrComment(
   const cpuBasePerformance = await fetchPerformanceMetrics('cpu', testNames, lastCommonCommit)
   const cpuLocalPerformance = await fetchPerformanceMetrics('cpu', testNames, LOCAL_COMMIT_SHA || '')
   const memoryBasePerformance = await fetchPerformanceMetrics('memory', testNames, lastCommonCommit)
-  const differenceBundle = compare(baseBundleSizes, localBundleSizes)
-  const differenceCpu = compare(cpuBasePerformance, cpuLocalPerformance)
   const commentId = await retrieveExistingCommentId(pr.number)
   const message = createMessage(
-    differenceBundle,
-    differenceCpu,
     baseBundleSizes,
     localBundleSizes,
     memoryBasePerformance,
@@ -129,9 +125,7 @@ async function updateOrAddComment(message: string, prNumber: number, commentId: 
   })
 }
 
-function createMessage(
-  differenceBundle: PerformanceDifference[],
-  differenceCpu: PerformanceDifference[],
+export function createMessage(
   baseBundleSizes: PerformanceMetric[],
   localBundleSizes: BundleSizes,
   memoryBasePerformance: PerformanceMetric[],
@@ -140,6 +134,8 @@ function createMessage(
   cpuLocalPerformance: PerformanceMetric[],
   prNumber: number
 ): string {
+  const differenceBundle = compare(baseBundleSizes, localBundleSizes)
+  const differenceCpu = compare(cpuBasePerformance, cpuLocalPerformance)
   let highIncreaseDetected = false
   const bundleRows = differenceBundle.map((diff, index) => {
     const baseSize = formatSize(baseBundleSizes[index].value)

--- a/scripts/performance/lib/reportAsAPrComment.ts
+++ b/scripts/performance/lib/reportAsAPrComment.ts
@@ -141,9 +141,9 @@ export function createMessage(
     const baseSize = formatSize(baseBundleSizes[index].value)
     const localSize = formatSize(localBundleSizes[diff.name])
     const diffSize = formatSize(diff.change)
-    const sign = typeof diff.percentageChange === 'number' && diff.percentageChange > 0 ? '+' : ''
+    const sign = (diff.percentageChange as number) > 0 ? '+' : ''
     let status = '✅'
-    if (typeof diff.percentageChange === 'number' && diff.percentageChange > SIZE_INCREASE_THRESHOLD) {
+    if ((diff.percentageChange as number) > SIZE_INCREASE_THRESHOLD) {
       status = '⚠️'
       highIncreaseDetected = true
     }


### PR DESCRIPTION
## Motivation

Regression introduced by the [migration of scripts to typescript](https://github.com/DataDog/browser-sdk/pull/3732).
Avoid to miss impactful size change by not having warnings added to the PR.

## Changes

- add unit tests on create message logic
- remove number type checks

## Test instructions

- PR without warning: [cf comment](https://github.com/DataDog/browser-sdk/pull/3845#issuecomment-3299483910)
- PR with warning: [cf comment](https://github.com/DataDog/browser-sdk/pull/3844#issuecomment-3299485520)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
