### PR TITLE
🔧 configure renovate to wait 1 week before upgrading dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [":dependencyDashboard", ":ignoreModulesAndTests", "group:monorepos", "group:recommended"],
   "labels": ["dependencies"],
   "commitMessagePrefix": "👷 ",
+  "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
   "schedule": ["every weekend"],


### PR DESCRIPTION

## Motivation

Mitigate the risk of pulling a vulnerable package in our CI.

There has been a lot of vulnerabilities in popular NPM packages lately, namely:

* https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised
* https://nx.dev/blog/s1ngularity-postmortem
* https://www.aikido.dev/blog/s1ngularity-nx-attackers-strike-again

Stay safe!

## Changes

Configure renovate to wait a week before upgrading a dependency version using the [minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) option.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
