### PR TITLE
[RUM Profiler] send view names as event attributes

### DIFF
--- a/packages/rum/src/domain/profiling/transport/buildProfileEventAttributes.spec.ts
+++ b/packages/rum/src/domain/profiling/transport/buildProfileEventAttributes.spec.ts
@@ -268,7 +268,7 @@ describe('buildProfileEventAttributes', () => {
 
     it('should handle profiler trace with empty string view names consistently', () => {
       const views = [
-        createMockViewEntry({ viewId: 'view-123', viewName: '' }),
+        createMockViewEntry({ viewId: 'view-123', viewName: '' }), // will be ignored
         createMockViewEntry({ viewId: 'view-456', viewName: 'Valid Page' }),
       ]
       const profilerTrace = createMockProfilerTrace({ views })
@@ -277,7 +277,7 @@ describe('buildProfileEventAttributes', () => {
 
       expect(result.view).toEqual({
         id: ['view-123', 'view-456'],
-        name: ['', 'Valid Page'],
+        name: ['Valid Page'],
       })
     })
   })

--- a/packages/rum/src/domain/profiling/transport/buildProfileEventAttributes.spec.ts
+++ b/packages/rum/src/domain/profiling/transport/buildProfileEventAttributes.spec.ts
@@ -1,0 +1,319 @@
+import { clocksOrigin } from '@datadog/browser-core'
+import type { RumProfilerTrace, RumViewEntry, RUMProfilerLongTaskEntry } from '../types'
+import { buildProfileEventAttributes, type ProfileEventAttributes } from './buildProfileEventAttributes'
+
+describe('buildProfileEventAttributes', () => {
+  const applicationId = 'test-app-id'
+  const sessionId = 'test-session-id'
+
+  function createMockViewEntry(overrides: Partial<RumViewEntry> = {}): RumViewEntry {
+    return {
+      startClocks: clocksOrigin(),
+      viewId: 'view-123',
+      viewName: 'Home Page',
+      ...overrides,
+    }
+  }
+
+  function createMockLongTaskEntry(overrides: Partial<RUMProfilerLongTaskEntry> = {}): RUMProfilerLongTaskEntry {
+    return {
+      id: 'longtask-456',
+      duration: 100 as any,
+      entryType: 'longtask',
+      startClocks: clocksOrigin(),
+      ...overrides,
+    }
+  }
+
+  function createMockProfilerTrace(overrides: Partial<RumProfilerTrace> = {}): RumProfilerTrace {
+    return {
+      startClocks: clocksOrigin(),
+      endClocks: clocksOrigin(),
+      clocksOrigin: clocksOrigin(),
+      sampleInterval: 10,
+      views: [],
+      longTasks: [],
+      resources: [],
+      frames: [],
+      stacks: [],
+      samples: [],
+      ...overrides,
+    }
+  }
+
+  describe('when creating basic profile event attributes', () => {
+    it('should include application id', () => {
+      const profilerTrace = createMockProfilerTrace()
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.application).toEqual({ id: applicationId })
+    })
+
+    it('should include session id when provided', () => {
+      const profilerTrace = createMockProfilerTrace()
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.session).toEqual({ id: sessionId })
+    })
+
+    it('should omit session when sessionId is undefined', () => {
+      const profilerTrace = createMockProfilerTrace()
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, undefined)
+
+      expect(result.session).toBeUndefined()
+    })
+
+    it('should omit session when sessionId is empty string', () => {
+      const profilerTrace = createMockProfilerTrace()
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, '')
+
+      expect(result.session).toBeUndefined()
+    })
+  })
+
+  describe('when handling views', () => {
+    it('should extract view ids and names from single view', () => {
+      const view = createMockViewEntry({
+        viewId: 'view-123',
+        viewName: 'Home Page',
+      })
+      const profilerTrace = createMockProfilerTrace({ views: [view] })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toEqual({
+        id: ['view-123'],
+        name: ['Home Page'],
+      })
+    })
+
+    it('should extract view ids and names from multiple views', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-123', viewName: 'Home Page' }),
+        createMockViewEntry({ viewId: 'view-456', viewName: 'About Page' }),
+        createMockViewEntry({ viewId: 'view-789', viewName: 'Contact Page' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ views })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toEqual({
+        id: ['view-123', 'view-456', 'view-789'],
+        name: ['Home Page', 'About Page', 'Contact Page'],
+      })
+    })
+
+    it('should handle views with undefined names', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-123', viewName: 'Home Page' }),
+        createMockViewEntry({ viewId: 'view-456', viewName: undefined }),
+        createMockViewEntry({ viewId: 'view-789', viewName: 'Contact Page' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ views })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toEqual({
+        id: ['view-123', 'view-456', 'view-789'],
+        name: ['Home Page', 'Contact Page'],
+      })
+    })
+
+    it('should remove duplicate view names', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-123', viewName: 'Home Page' }),
+        createMockViewEntry({ viewId: 'view-456', viewName: 'Home Page' }),
+        createMockViewEntry({ viewId: 'view-789', viewName: 'About Page' }),
+        createMockViewEntry({ viewId: 'view-abc', viewName: 'Home Page' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ views })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toEqual({
+        id: ['view-123', 'view-456', 'view-789', 'view-abc'],
+        name: ['Home Page', 'About Page'],
+      })
+    })
+
+    it('should handle all views without names', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-123', viewName: undefined }),
+        createMockViewEntry({ viewId: 'view-456', viewName: undefined }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ views })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toEqual({
+        id: ['view-123', 'view-456'],
+        name: [],
+      })
+    })
+
+    it('should omit view attribute when no views are present', () => {
+      const profilerTrace = createMockProfilerTrace({ views: [] })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toBeUndefined()
+    })
+  })
+
+  describe('when handling long tasks', () => {
+    it('should extract long task ids from single long task', () => {
+      const longTask = createMockLongTaskEntry({ id: 'longtask-123' })
+      const profilerTrace = createMockProfilerTrace({ longTasks: [longTask] })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.long_task).toEqual({
+        id: ['longtask-123'],
+      })
+    })
+
+    it('should extract long task ids from multiple long tasks', () => {
+      const longTasks = [
+        createMockLongTaskEntry({ id: 'longtask-123' }),
+        createMockLongTaskEntry({ id: 'longtask-456' }),
+        createMockLongTaskEntry({ id: 'longtask-789' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ longTasks })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.long_task).toEqual({
+        id: ['longtask-123', 'longtask-456', 'longtask-789'],
+      })
+    })
+
+    it('should filter out long tasks with undefined ids', () => {
+      const longTasks = [
+        createMockLongTaskEntry({ id: 'longtask-123' }),
+        createMockLongTaskEntry({ id: undefined }),
+        createMockLongTaskEntry({ id: 'longtask-789' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ longTasks })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.long_task).toEqual({
+        id: ['longtask-123', 'longtask-789'],
+      })
+    })
+
+    it('should omit long_task attribute when no long tasks have ids', () => {
+      const longTasks = [createMockLongTaskEntry({ id: undefined }), createMockLongTaskEntry({ id: undefined })]
+      const profilerTrace = createMockProfilerTrace({ longTasks })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.long_task).toBeUndefined()
+    })
+
+    it('should omit long_task attribute when no long tasks are present', () => {
+      const profilerTrace = createMockProfilerTrace({ longTasks: [] })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.long_task).toBeUndefined()
+    })
+  })
+
+  describe('when handling complex scenarios', () => {
+    it('should handle profiler trace with both views and long tasks', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-123', viewName: 'Home Page' }),
+        createMockViewEntry({ viewId: 'view-456', viewName: 'About Page' }),
+      ]
+      const longTasks = [
+        createMockLongTaskEntry({ id: 'longtask-123' }),
+        createMockLongTaskEntry({ id: 'longtask-456' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ views, longTasks })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      const expected: ProfileEventAttributes = {
+        application: { id: applicationId },
+        session: { id: sessionId },
+        view: {
+          id: ['view-123', 'view-456'],
+          name: ['Home Page', 'About Page'],
+        },
+        long_task: {
+          id: ['longtask-123', 'longtask-456'],
+        },
+      }
+
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle empty profiler trace', () => {
+      const profilerTrace = createMockProfilerTrace()
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      const expected: ProfileEventAttributes = {
+        application: { id: applicationId },
+        session: { id: sessionId },
+      }
+
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle profiler trace with empty string view names consistently', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-123', viewName: '' }),
+        createMockViewEntry({ viewId: 'view-456', viewName: 'Valid Page' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ views })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toEqual({
+        id: ['view-123', 'view-456'],
+        name: ['', 'Valid Page'],
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle profiler trace with duplicate view names and mixed undefined names', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-1', viewName: 'Page A' }),
+        createMockViewEntry({ viewId: 'view-2', viewName: undefined }),
+        createMockViewEntry({ viewId: 'view-3', viewName: 'Page A' }),
+        createMockViewEntry({ viewId: 'view-4', viewName: 'Page B' }),
+        createMockViewEntry({ viewId: 'view-5', viewName: undefined }),
+        createMockViewEntry({ viewId: 'view-6', viewName: 'Page A' }),
+      ]
+      const profilerTrace = createMockProfilerTrace({ views })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view).toEqual({
+        id: ['view-1', 'view-2', 'view-3', 'view-4', 'view-5', 'view-6'],
+        name: ['Page A', 'Page B'], // Duplicates removed
+      })
+    })
+
+    it('should preserve order of view ids but deduplicate names', () => {
+      const views = [
+        createMockViewEntry({ viewId: 'view-last', viewName: 'Page Z' }),
+        createMockViewEntry({ viewId: 'view-first', viewName: 'Page A' }),
+        createMockViewEntry({ viewId: 'view-middle', viewName: 'Page Z' }), // Duplicate name
+      ]
+      const profilerTrace = createMockProfilerTrace({ views })
+
+      const result = buildProfileEventAttributes(profilerTrace, applicationId, sessionId)
+
+      expect(result.view?.id).toEqual(['view-last', 'view-first', 'view-middle'])
+      expect(result.view?.name).toEqual(['Page Z', 'Page A']) // Order based on first occurrence
+    })
+  })
+})

--- a/packages/rum/src/domain/profiling/transport/buildProfileEventAttributes.ts
+++ b/packages/rum/src/domain/profiling/transport/buildProfileEventAttributes.ts
@@ -1,0 +1,66 @@
+import type { RumProfilerTrace, RumViewEntry } from '../types'
+
+export interface ProfileEventAttributes {
+  application: { id: string }
+  session?: { id: string }
+  view?: { id: string[]; name: string[] }
+  long_task?: { id: string[] }
+}
+
+/**
+ * Builds attributes for the Profile Event.
+ *
+ * @param profilerTrace - Profiler trace
+ * @param applicationId - application id.
+ * @param sessionId - session id.
+ * @returns Additional attributes.
+ */
+export function buildProfileEventAttributes(
+  profilerTrace: RumProfilerTrace,
+  applicationId: string,
+  sessionId: string | undefined
+): ProfileEventAttributes {
+  const attributes: ProfileEventAttributes = {
+    application: {
+      id: applicationId,
+    },
+  }
+  if (sessionId) {
+    attributes.session = {
+      id: sessionId,
+    }
+  }
+
+  // Extract view ids and names from the profiler trace and add them as attributes of the profile event.
+  // This will be used to filter the profiles by @view.id and/or @view.name.
+  const { ids, names } = extractViewIdsAndNames(profilerTrace.views)
+
+  if (ids.length) {
+    attributes.view = {
+      id: ids,
+      name: names,
+    }
+  }
+  const longTaskIds: string[] = profilerTrace.longTasks.map((longTask) => longTask.id).filter((id) => id !== undefined)
+
+  if (longTaskIds.length) {
+    attributes.long_task = { id: longTaskIds }
+  }
+  return attributes
+}
+
+function extractViewIdsAndNames(views: RumViewEntry[]): { ids: string[]; names: string[] } {
+  const result: { ids: string[]; names: string[] } = { ids: [], names: [] }
+  for (const view of views) {
+    result.ids.push(view.viewId)
+
+    if (view.viewName) {
+      result.names.push(view.viewName)
+    }
+  }
+
+  // Remove duplicates
+  result.names = Array.from(new Set(result.names))
+
+  return result
+}


### PR DESCRIPTION
## Motivation

We want to allow filtering by view name in the Profiling explorer (ie. `@view.name:/my-view`). 
In order to make the view name query-able, we need to pass it as the event's attributes (just as we do for view ids)

<img width="962" height="505" alt="Screenshot 2025-09-17 at 14 39 06" src="https://github.com/user-attachments/assets/8004ff41-141e-4ed4-97d2-34b5df255dbf" />


## Changes

- new `view.name` attribute in the Profile's `event.json` sent to intake.

## Test instructions

- Browse a website with this version of the SDK, with the RUM Profiler active.
- After a while (tipically a minute of navigation), assert you can see a call the the profile intake.
- Assert you can see the `event.json` sent includes the new `view.name` attribute.
- Go over the Profiling's Explorer [page](https://app.datadoghq.com/profiling/explorer) 
- Filter using the search bar to `@view.name:<the-view-you-were-browsing>` and you should see a Flame Graph.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
