### PR TITLE
🐛 [PANA-4236] Fix flaky startRecorderInitTelemetry test

### DIFF
--- a/packages/rum/src/domain/startRecorderInitTelemetry.spec.ts
+++ b/packages/rum/src/domain/startRecorderInitTelemetry.spec.ts
@@ -141,7 +141,7 @@ describe('startRecorderInitTelemetry', () => {
   it('should not collect recorder init metrics telemetry when telemetry is disabled', async () => {
     startRecorderInitTelemetryCollection({
       telemetrySampleRate: 100,
-      initialViewMetricsTelemetrySampleRate: 0,
+      replayTelemetrySampleRate: 0,
     })
     observable.notify({ type: 'start', forced: false })
     observable.notify({ type: 'recorder-settled' })


### PR DESCRIPTION
## Motivation

The `should not collect recorder init metrics telemetry when telemetry is disabled` test in `startRecorderInitTelemetry.spec.ts` was identified as flaky; we should fix this.

## Changes

This test is intended to:
1. Set the recorder init metrics telemetry sample rate to zero.
2. Do some things that would generate recorder init metrics telemetry.
3. Verify that no telemetry was actually generated.

It had a bug in step one; it used the wrong configuration option to set the sample rate to zero. Because the wrong option was used, the sample rate was actually 1%, causing the test to flake at about that rate.

This PR fixes the issues by updating the test to use the correct configuration option.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.