### PR TITLE
👷 [ci] when a request fails, display the response error

### DIFF
--- a/scripts/lib/executionUtils.ts
+++ b/scripts/lib/executionUtils.ts
@@ -46,7 +46,14 @@ interface FetchError extends Error {
 export async function fetchHandlingError(url: string, options?: RequestInit): Promise<Response> {
   const response = await fetch(url, options)
   if (!response.ok) {
-    const error = new Error(`HTTP Error Response: ${response.status} ${response.statusText}`) as FetchError
+    let cause: unknown
+    const body = await response.text()
+    try {
+      cause = JSON.parse(body)
+    } catch {
+      cause = body
+    }
+    const error = new Error(`HTTP Error Response: ${response.status} ${response.statusText}`, { cause }) as FetchError
     error.status = response.status
     throw error
   }

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -110,13 +110,17 @@ export function initGitConfig(repository: string): void {
 export const LOCAL_BRANCH = process.env.CI_COMMIT_REF_NAME
 
 async function callGitHubApi<T>(method: string, path: string, token: OctoStsToken, body?: any): Promise<T> {
-  const response = await fetchHandlingError(`https://api.github.com/repos/DataDog/browser-sdk/${path}`, {
-    method,
-    headers: {
-      Authorization: `token ${token.value}`,
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  })
-  return (await response.json()) as Promise<T>
+  try {
+    const response = await fetchHandlingError(`https://api.github.com/repos/DataDog/browser-sdk/${path}`, {
+      method,
+      headers: {
+        Authorization: `token ${token.value}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    })
+    return (await response.json()) as Promise<T>
+  } catch (error) {
+    throw new Error(`Failed to call GitHub API: ${method} ${path}`, { cause: error })
+  }
 }


### PR DESCRIPTION
## Motivation

Help debugging failing scripts

## Changes

* Add the response body as an error `cause`. Node.js will pick it up when displaying the error.
* Add context on which github API we were trying to call

It looks like this:

```
Script exited with error: Error: Failed to call GitHub API: GET releases/tags/v6.20.0
    at callGitHubApi (file:///Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/scripts/lib/gitUtils.ts:124:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async createGitHubRelease (file:///Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/scripts/lib/gitUtils.ts:51:5)
    at async file:///Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/scripts/release/create-github-release.ts:18:21 {
  [cause]: Error: HTTP Error Response: 401 Unauthorized
      at fetchHandlingError (file:///Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/scripts/lib/executionUtils.ts:56:19)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async callGitHubApi (file:///Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/scripts/lib/gitUtils.ts:114:22)
      at async createGitHubRelease (file:///Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/scripts/lib/gitUtils.ts:51:5)
      at async file:///Users/benoit.zugmeyer/go/src/github.com/DataDog/browser-sdk/scripts/release/create-github-release.ts:18:21 {
    status: 401,
    [cause]: {
      message: 'Bad credentials',
      documentation_url: 'https://docs.github.com/rest',
      status: '401'
    }
  }
}
```

## Test instructions

Modify a script to use a hardcoded dummy token like `"xxx"`. Run the script, look at the error.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
