### PR TITLE
👷🐛 fix `create-github-release`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,7 +105,6 @@ export default tseslint.config(
       'no-inner-declarations': 'error',
       'no-new-func': 'error',
       'no-new-wrappers': 'error',
-      'no-return-await': 'error',
       'no-sequences': 'error',
       'no-template-curly-in-string': 'error',
       'no-undef-init': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -201,6 +201,10 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { args: 'all', argsIgnorePattern: '^_', vars: 'all' }],
       '@typescript-eslint/triple-slash-reference': ['error', { path: 'always', types: 'prefer-import', lib: 'always' }],
+      '@typescript-eslint/no-floating-promises': [
+        'error',
+        { allowForKnownSafeCalls: [{ from: 'package', name: ['describe', 'it', 'test'], package: 'node:test' }] },
+      ],
 
       'import/no-cycle': 'error',
       'import/no-default-export': 'error',

--- a/scripts/deploy/deploy.spec.ts
+++ b/scripts/deploy/deploy.spec.ts
@@ -14,7 +14,7 @@ interface PullRequest {
   ['number']: number
 }
 
-void describe('deploy', () => {
+describe('deploy', () => {
   const commandMock = mock.fn()
   const fetchPRMock = mock.fn<() => Promise<PullRequest>>()
   let deploy: (env: string, version: string, uploadPathTypes: string[]) => Promise<void>
@@ -45,7 +45,7 @@ void describe('deploy', () => {
     commands = mockCommandImplementation(commandMock)
   })
 
-  void it('should deploy root packages', async () => {
+  it('should deploy root packages', async () => {
     await deploy('prod', 'v6', ['root'])
 
     assert.deepEqual(getS3Commands(), [
@@ -87,7 +87,7 @@ void describe('deploy', () => {
     ])
   })
 
-  void it('should deploy datacenter packages', async () => {
+  it('should deploy datacenter packages', async () => {
     await deploy('prod', 'v6', ['us1'])
 
     assert.deepEqual(getS3Commands(), [
@@ -124,7 +124,7 @@ void describe('deploy', () => {
     ])
   })
 
-  void it('should deploy staging packages', async () => {
+  it('should deploy staging packages', async () => {
     await deploy('staging', 'staging', ['root'])
 
     assert.deepEqual(getS3Commands(), [
@@ -162,7 +162,7 @@ void describe('deploy', () => {
     ])
   })
 
-  void it('should deploy PR packages', async () => {
+  it('should deploy PR packages', async () => {
     // mock the PR number fetch
     fetchPRMock.mock.mockImplementation(() => Promise.resolve({ ['number']: 123 }))
 

--- a/scripts/deploy/upload-source-maps.spec.ts
+++ b/scripts/deploy/upload-source-maps.spec.ts
@@ -19,7 +19,7 @@ interface CommandDetail {
   env?: Record<string, string>
 }
 
-void describe('upload-source-maps', () => {
+describe('upload-source-maps', () => {
   const commandMock = mock.fn()
   let commands: CommandDetail[]
 
@@ -55,7 +55,7 @@ void describe('upload-source-maps', () => {
     }
   }
 
-  void it('should upload root packages source maps', async () => {
+  it('should upload root packages source maps', async () => {
     await uploadSourceMaps('v6', ['root'])
 
     forEachDatacenter((site) => {
@@ -106,7 +106,7 @@ void describe('upload-source-maps', () => {
     })
   })
 
-  void it('should upload datacenter packages source maps', async () => {
+  it('should upload datacenter packages source maps', async () => {
     await uploadSourceMaps('v6', ['us1'])
 
     assert.deepEqual(commands, [
@@ -128,7 +128,7 @@ void describe('upload-source-maps', () => {
     ])
   })
 
-  void it('should upload staging packages source maps', async () => {
+  it('should upload staging packages source maps', async () => {
     await uploadSourceMaps('staging', ['root'])
 
     // rename the files with the version suffix
@@ -189,7 +189,7 @@ void describe('upload-source-maps', () => {
     ])
   })
 
-  void it('should upload canary packages source maps', async () => {
+  it('should upload canary packages source maps', async () => {
     await uploadSourceMaps('canary', ['root'])
 
     // rename the files with the version suffix

--- a/scripts/lib/executionUtils.spec.ts
+++ b/scripts/lib/executionUtils.spec.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { findError } from './executionUtils.ts'
+
+describe('findError', () => {
+  it('finds the provided error', () => {
+    const error = new Error('foo')
+    assert.equal(findError(error, Error), error)
+  })
+
+  it('finds an error in the cause chain', () => {
+    class MyError extends Error {}
+    const cause = new MyError('foo')
+    const error = new Error('bar', { cause })
+    assert.equal(findError(error, MyError), cause)
+  })
+})

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -8,7 +8,7 @@ import {
   getGithubPullRequestToken,
   type OctoStsToken,
 } from './secrets.ts'
-import { fetchHandlingError } from './executionUtils.ts'
+import { FetchError, fetchHandlingError, findError } from './executionUtils.ts'
 
 interface GitHubPR {
   // eslint-disable-next-line id-denylist
@@ -51,7 +51,8 @@ export async function createGitHubRelease({ version, body }: GitHubReleaseParams
     await callGitHubApi('GET', `releases/tags/${version}`, readToken)
     throw new Error(`Release ${version} already exists`)
   } catch (error) {
-    if ((error as any).status !== 404) {
+    const fetchError = findError(error, FetchError)
+    if (!fetchError || fetchError.response.status !== 404) {
       throw error
     }
   }

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -58,7 +58,7 @@ export async function createGitHubRelease({ version, body }: GitHubReleaseParams
 
   // content write
   using releaseToken = getGithubReleaseToken()
-  return callGitHubApi<GitHubRelease>('POST', 'releases', releaseToken, {
+  return await callGitHubApi<GitHubRelease>('POST', 'releases', releaseToken, {
     tag_name: version,
     name: version,
     body,

--- a/scripts/performance/lib/reportAsAPrComment.spec.ts
+++ b/scripts/performance/lib/reportAsAPrComment.spec.ts
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { createMessage } from './reportAsAPrComment.ts'
 
-void describe('reportAsAPrComment', () => {
-  void describe('createMessage', () => {
+describe('reportAsAPrComment', () => {
+  describe('createMessage', () => {
     const TEST_BUNDLE = 'test'
     const PR_NUMBER = 123
 
@@ -14,7 +14,7 @@ void describe('reportAsAPrComment', () => {
     const MEMORY_LOCAL_PERFORMANCE = [{ testProperty: TEST_BUNDLE, sdkMemoryBytes: 101, sdkMemoryPercentage: 10 }]
     const CPU_LOCAL_PERFORMANCE = [{ name: TEST_BUNDLE, value: 101 }]
 
-    void it('should generate a report with performance results', () => {
+    it('should generate a report with performance results', () => {
       const localBundleSizes = { test: 101 }
 
       const message = createMessage(
@@ -58,7 +58,7 @@ void describe('reportAsAPrComment', () => {
       )
     })
 
-    void it('should add a warning when the size increase is above the threshold', () => {
+    it('should add a warning when the size increase is above the threshold', () => {
       const localBundleSizes = { test: 150 }
 
       const message = createMessage(


### PR DESCRIPTION
## Motivation

The 'create-github-release' script failed because of an authentication issue. We were deleting the octo token too early.

## Changes


This commit fixes the problem by `await`ing the call to the GitHub API. It also removes the deprecated ['no-return-await' ESLint rule](https://eslint.org/docs/latest/rules/no-return-await) as it's not recommended anymore.

Test script:

```js
createGitHubRelease();

async function createGitHubRelease() {
  using token = getToken();
  return callGitHubApi(token);
}

function getToken() {
  console.log("Create token");
  return {
    [Symbol.dispose]() {
      console.log("DISPOSE");
    },
  };
}

async function callGitHubApi(_token) {
  console.log("Calling API...");
  await Promise.resolve();
  console.log("API called");
}
```

`DISPOSE` is called too soon. This logs:

```
Create token
Calling API...
DISPOSE
API called
```

Using `return await callGitHubApi(token);` fixes the issue.

## Test instructions

Let's see during the next release 🤞 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
