### PR TITLE
👷 [mob-session] make `test-performances` more resilient

### DIFF
--- a/scripts/lib/computeBundleSize.ts
+++ b/scripts/lib/computeBundleSize.ts
@@ -79,15 +79,3 @@ export function calculateBundleSizes(): BundleSizes {
 
   return bundleSizes
 }
-
-export function formatSize(bytes: number | null): string {
-  if (bytes === null) {
-    return 'N/A'
-  }
-
-  if (bytes < 1024) {
-    return `${Math.round(bytes)} B`
-  }
-
-  return `${(bytes / 1024).toFixed(2)} KiB`
-}

--- a/scripts/lib/executionUtils.ts
+++ b/scripts/lib/executionUtils.ts
@@ -39,6 +39,25 @@ export function printLog(...params: any[]): void {
   console.log(greenColor, ...params, resetColor)
 }
 
+export function formatSize(bytes: number | null, { includeSign = false } = {}): string {
+  if (bytes === null) {
+    return 'N/A'
+  }
+
+  const sign = includeSign && bytes > 0 ? '+' : ''
+
+  if (bytes < 1024) {
+    return `${sign}${Math.round(bytes)} B`
+  }
+
+  return `${sign}${(bytes / 1024).toFixed(2)} KiB`
+}
+
+export function formatPercentage(percentage: number, { includeSign = false } = {}): string {
+  const sign = includeSign && percentage > 0 ? '+' : ''
+  return `${sign}${(percentage * 100).toFixed(2)}%`
+}
+
 /**
  * Find an error of type T in the provided error or its causes.
  */

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -66,16 +66,6 @@ export async function createGitHubRelease({ version, body }: GitHubReleaseParams
   })
 }
 
-export async function getPrComments(prNumber: number): Promise<Array<{ id: number; body: string }>> {
-  using readToken = getGithubReadToken()
-  const response = await callGitHubApi<Array<{ id: number; body: string }>>(
-    'GET',
-    `issues/${prNumber}/comments`,
-    readToken
-  )
-  return response
-}
-
 export function createPullRequest(mainBranch: string) {
   using token = getGithubPullRequestToken()
   command`gh auth login --with-token`.withInput(token.value).run()

--- a/scripts/performance/index.ts
+++ b/scripts/performance/index.ts
@@ -1,26 +1,24 @@
-import { runMain } from '../lib/executionUtils.ts'
-import { calculateBundleSizes } from '../lib/computeBundleSize.ts'
-import { reportAsPrComment } from './lib/reportAsAPrComment.ts'
-import { reportToDatadog } from './lib/reportToDatadog.ts'
-import { computeCpuPerformance } from './lib/computeCpuPerformance.ts'
-import { computeMemoryPerformance } from './lib/computeMemoryPerformance.ts'
-
-interface UncompressedBundleSizes {
-  [key: string]: number
-}
+import { printLog, runMain } from '../lib/executionUtils.ts'
+import { fetchPR, getLastCommonCommit, LOCAL_BRANCH } from '../lib/gitUtils.ts'
+import { PrComment } from './lib/reportAsAPrComment.ts'
+import { computeAndReportMemoryPerformance } from './lib/memoryPerformance.ts'
+import { computeAndReportBundleSizes } from './lib/bundleSizes.ts'
+import { computeAndReportCpuPerformance } from './lib/cpuPerformance.ts'
 
 runMain(async () => {
-  const localBundleSizes = extractUncompressedBundleSizes(calculateBundleSizes())
-  const localMemoryPerformance = await computeMemoryPerformance()
-  await computeCpuPerformance()
-  await reportToDatadog(localMemoryPerformance, 'memoryPerformance')
-  await reportToDatadog(localBundleSizes, 'bundleSizes')
-  await reportAsPrComment(localBundleSizes, localMemoryPerformance)
-})
+  const pr = await fetchPR(LOCAL_BRANCH!)
+  if (!pr) {
+    throw new Error('No pull requests found for the branch')
+  }
+  const prComment = new PrComment(pr.number)
+  const lastCommonCommit = getLastCommonCommit(pr.base.ref)
 
-// keep compatibility with the logs and PR comment format
-function extractUncompressedBundleSizes(
-  bundleSizes: Record<string, { uncompressed: number }>
-): UncompressedBundleSizes {
-  return Object.fromEntries(Object.entries(bundleSizes).map(([key, size]) => [key, size.uncompressed]))
-}
+  printLog('Bundle sizes...')
+  await computeAndReportBundleSizes(lastCommonCommit, prComment)
+
+  printLog('Memory performance...')
+  await computeAndReportMemoryPerformance(lastCommonCommit, prComment)
+
+  printLog('CPU performance...')
+  await computeAndReportCpuPerformance(lastCommonCommit, prComment)
+})

--- a/scripts/performance/lib/bundleSizes.ts
+++ b/scripts/performance/lib/bundleSizes.ts
@@ -1,0 +1,90 @@
+import { formatPercentage, formatSize } from '../../lib/executionUtils.ts'
+import { calculateBundleSizes } from '../../lib/computeBundleSize.ts'
+import type { PerformanceMetric } from './fetchPerformanceMetrics.ts'
+import { fetchPerformanceMetrics } from './fetchPerformanceMetrics.ts'
+import { markdownArray, type PrComment } from './reportAsAPrComment.ts'
+import { reportToDatadog } from './reportToDatadog.ts'
+
+// The value is set to 5% as it's around 10 times the average value for small PRs.
+const SIZE_INCREASE_THRESHOLD = 5
+
+export async function computeAndReportBundleSizes(lastCommonCommit: string, prComment: PrComment) {
+  let localBundleSizes: PerformanceMetric[]
+  let baseBundleSizes: PerformanceMetric[]
+  try {
+    localBundleSizes = extractUncompressedBundleSizes(calculateBundleSizes())
+    baseBundleSizes = await fetchPerformanceMetrics(
+      'bundle',
+      localBundleSizes.map((bundleSize) => bundleSize.name),
+      lastCommonCommit
+    )
+  } catch (e) {
+    await prComment.setBundleSizes('Error computing bundle sizes')
+    throw e
+  }
+
+  await reportToDatadog({
+    message: 'Browser SDK bundles sizes',
+    bundle_sizes: Object.fromEntries(localBundleSizes.map(({ name, value }) => [name, value])),
+  })
+
+  await prComment.setBundleSizes(
+    formatBundleSizes({
+      baseBundleSizes,
+      localBundleSizes,
+    })
+  )
+}
+
+function extractUncompressedBundleSizes(bundleSizes: Record<string, { uncompressed: number }>): PerformanceMetric[] {
+  return Object.entries(bundleSizes).map(([key, size]) => ({ name: key, value: size.uncompressed }))
+}
+
+export function formatBundleSizes({
+  baseBundleSizes,
+  localBundleSizes,
+}: {
+  baseBundleSizes: PerformanceMetric[]
+  localBundleSizes: PerformanceMetric[]
+}) {
+  let highIncreaseDetected = false
+  let message = markdownArray({
+    headers: ['📦 Bundle Name', 'Base Size', 'Local Size', '𝚫', '𝚫%', 'Status'],
+    rows: localBundleSizes.map((localBundleSize) => {
+      const baseBundleSize = baseBundleSizes.find((baseBundleSize) => baseBundleSize.name === localBundleSize.name)
+
+      if (!baseBundleSize) {
+        return [formatBundleName(localBundleSize.name), 'N/A', formatSize(localBundleSize.value), 'N/A', 'N/A', 'N/A']
+      }
+
+      const percentageChange = (localBundleSize.value - baseBundleSize.value) / baseBundleSize.value
+
+      let status = '✅'
+      if (percentageChange > SIZE_INCREASE_THRESHOLD) {
+        status = '⚠️'
+        highIncreaseDetected = true
+      }
+      return [
+        formatBundleName(localBundleSize.name),
+        formatSize(baseBundleSize.value),
+        formatSize(localBundleSize.value),
+        formatSize(localBundleSize.value - baseBundleSize.value, { includeSign: true }),
+        formatPercentage(percentageChange, { includeSign: true }),
+        status,
+      ]
+    }),
+  })
+
+  if (highIncreaseDetected) {
+    message += `\n⚠️ The increase is particularly high and exceeds ${SIZE_INCREASE_THRESHOLD}%. Please check the changes.`
+  }
+
+  return message
+}
+
+function formatBundleName(bundleName: string): string {
+  return bundleName
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}

--- a/scripts/performance/lib/constants.ts
+++ b/scripts/performance/lib/constants.ts
@@ -1,0 +1,43 @@
+export interface Test {
+  name: string
+  button: string
+  property: string
+}
+
+export const TESTS: Test[] = [
+  {
+    name: 'RUM - add global context',
+    button: '#rum-add-global-context',
+    property: 'addglobalcontext',
+  },
+  {
+    name: 'RUM - add action',
+    button: '#rum-add-action',
+    property: 'addaction',
+  },
+  {
+    name: 'RUM - add error',
+    button: '#rum-add-error',
+    property: 'adderror',
+  },
+  {
+    name: 'RUM - add timing',
+    button: '#rum-add-timing',
+    property: 'addtiming',
+  },
+  {
+    name: 'RUM - start view',
+    button: '#rum-start-view',
+    property: 'startview',
+  },
+  {
+    name: 'RUM - start/stop session replay recording',
+    button: '#rum-start-stop-session-replay-recording',
+    property: 'startstopsessionreplayrecording',
+  },
+  {
+    name: 'Logs - log message',
+    button: '#logs-log-message',
+    property: 'logmessage',
+  },
+]

--- a/scripts/performance/lib/cpuPerformance.ts
+++ b/scripts/performance/lib/cpuPerformance.ts
@@ -1,13 +1,18 @@
-import { fetchHandlingError, timeout } from '../../lib/executionUtils.ts'
+import { fetchHandlingError, formatPercentage, timeout } from '../../lib/executionUtils.ts'
 import { getOrg2ApiKey, getOrg2AppKey } from '../../lib/secrets.ts'
 import { fetchPR, LOCAL_BRANCH } from '../../lib/gitUtils.ts'
-import { LOCAL_COMMIT_SHA } from './reportAsAPrComment.ts'
+import type { PrComment } from './reportAsAPrComment.ts'
+import { markdownArray } from './reportAsAPrComment.ts'
+import type { PerformanceMetric } from './fetchPerformanceMetrics.ts'
+import { fetchPerformanceMetrics } from './fetchPerformanceMetrics.ts'
+import { TESTS } from './constants.ts'
 
 const API_KEY = getOrg2ApiKey()
 const APP_KEY = getOrg2AppKey()
 const TIMEOUT_IN_MS = 15000
 const TEST_PUBLIC_ID = 'vcg-7rk-5av'
 const RETRIES_NUMBER = 6
+const LOCAL_COMMIT_SHA = process.env.CI_COMMIT_SHORT_SHA
 
 interface SyntheticsTestResult {
   results: Array<{
@@ -20,13 +25,41 @@ interface SyntheticsTestStatus {
   status?: number
 }
 
-export async function computeCpuPerformance(): Promise<void> {
+export async function computeAndReportCpuPerformance(lastCommonCommit: string, prComment: PrComment) {
+  let baseCpuPerformances: PerformanceMetric[]
+  let localCpuPerformances: PerformanceMetric[]
+  try {
+    localCpuPerformances = await computeCpuPerformance()
+    baseCpuPerformances = await fetchPerformanceMetrics(
+      'cpu',
+      localCpuPerformances.map((cpuPerformance) => cpuPerformance.name),
+      lastCommonCommit
+    )
+  } catch (error) {
+    await prComment.setCpuPerformance('Error computing CPU performance')
+    throw error
+  }
+
+  await prComment.setCpuPerformance(
+    formatCpuPerformance({
+      baseCpuPerformances,
+      localCpuPerformances,
+    })
+  )
+}
+
+async function computeCpuPerformance(): Promise<PerformanceMetric[]> {
   const pr = LOCAL_BRANCH ? await fetchPR(LOCAL_BRANCH) : null
   const commitSha = LOCAL_COMMIT_SHA || ''
   const resultId = pr
     ? await triggerSyntheticsTest(pr.number.toString(), commitSha)
     : await triggerSyntheticsTest('', commitSha)
   await waitForSyntheticsTestToFinish(resultId, RETRIES_NUMBER)
+  return fetchPerformanceMetrics(
+    'cpu',
+    TESTS.map((test) => test.property),
+    LOCAL_COMMIT_SHA || ''
+  )
 }
 
 async function triggerSyntheticsTest(prNumber: string, commitId: string): Promise<string> {
@@ -75,4 +108,34 @@ async function waitForSyntheticsTestToFinish(resultId: string, retriesNumber: nu
     await timeout(TIMEOUT_IN_MS)
   }
   throw new Error('Synthetics test did not finish within the specified number of retries')
+}
+
+function formatCpuPerformance({
+  baseCpuPerformances,
+  localCpuPerformances,
+}: {
+  baseCpuPerformances: PerformanceMetric[]
+  localCpuPerformances: PerformanceMetric[]
+}) {
+  return markdownArray({
+    headers: ['Action Name', 'Base CPU Time (ms)', 'Local CPU Time (ms)', '𝚫 (%)'],
+    rows: localCpuPerformances.map((localCpuPerformance) => {
+      const baseCpuPerformance = baseCpuPerformances.find(
+        (baseCpuPerformance) => baseCpuPerformance.name === localCpuPerformance.name
+      )
+
+      if (!baseCpuPerformance) {
+        return [localCpuPerformance.name, 'N/A', String(localCpuPerformance.value), 'N/A']
+      }
+
+      return [
+        TESTS.find((test) => test.property === localCpuPerformance.name)!.name,
+        String(baseCpuPerformance.value),
+        String(localCpuPerformance.value),
+        formatPercentage((localCpuPerformance.value - baseCpuPerformance.value) / baseCpuPerformance.value, {
+          includeSign: true,
+        }),
+      ]
+    }),
+  })
 }

--- a/scripts/performance/lib/memoryPerformance.ts
+++ b/scripts/performance/lib/memoryPerformance.ts
@@ -1,67 +1,52 @@
 import type { Browser, CDPSession, Page, Protocol } from 'puppeteer'
 import puppeteer from 'puppeteer'
 import { fetchPR, LOCAL_BRANCH } from '../../lib/gitUtils.ts'
+import { formatSize, printLog } from '../../lib/executionUtils.ts'
+import { markdownArray, type PrComment } from './reportAsAPrComment.ts'
+import type { Test } from './constants.ts'
+import { TESTS } from './constants.ts'
+import type { PerformanceMetric } from './fetchPerformanceMetrics.ts'
+import { fetchPerformanceMetrics } from './fetchPerformanceMetrics.ts'
+import { reportToDatadog } from './reportToDatadog.ts'
 
 const NUMBER_OF_RUNS = 30 // Rule of thumb: this should be enough to get a good average
 const BATCH_SIZE = 2
-
-interface Test {
-  name: string
-  button: string
-  property: string
-}
-
-interface MemoryResult {
-  testProperty: string
-  sdkMemoryBytes: number
-  sdkMemoryPercentage: number
-}
 
 interface TestRunResult {
   medianPercentage: number
   medianBytes: number
 }
 
-const TESTS: Test[] = [
-  {
-    name: 'RUM - add global context',
-    button: '#rum-add-global-context',
-    property: 'addglobalcontext',
-  },
-  {
-    name: 'RUM - add action',
-    button: '#rum-add-action',
-    property: 'addaction',
-  },
-  {
-    name: 'RUM - add error',
-    button: '#rum-add-error',
-    property: 'adderror',
-  },
-  {
-    name: 'RUM - add timing',
-    button: '#rum-add-timing',
-    property: 'addtiming',
-  },
-  {
-    name: 'RUM - start view',
-    button: '#rum-start-view',
-    property: 'startview',
-  },
-  {
-    name: 'RUM - start/stop session replay recording',
-    button: '#rum-start-stop-session-replay-recording',
-    property: 'startstopsessionreplayrecording',
-  },
-  {
-    name: 'Logs - log message',
-    button: '#logs-log-message',
-    property: 'logmessage',
-  },
-]
+export async function computeAndReportMemoryPerformance(lastCommonCommit: string, prComment: PrComment) {
+  let localMemoryPerformances: PerformanceMetric[]
+  let baseMemoryPerformances: PerformanceMetric[]
+  try {
+    localMemoryPerformances = await computeMemoryPerformance()
+    baseMemoryPerformances = await fetchPerformanceMetrics(
+      'memory',
+      localMemoryPerformances.map((memoryPerformance) => memoryPerformance.name),
+      lastCommonCommit
+    )
+  } catch (error) {
+    await prComment.setMemoryPerformance('Error computing memory performance')
+    throw error
+  }
 
-export async function computeMemoryPerformance(): Promise<MemoryResult[]> {
-  const results: MemoryResult[] = []
+  await reportToDatadog({
+    message: 'Browser SDK memory consumption',
+    ...Object.fromEntries(localMemoryPerformances.map(({ name, value }) => [name, { memory_bytes: value }])),
+  })
+
+  await prComment.setMemoryPerformance(
+    formatMemoryPerformance({
+      baseMemoryPerformances,
+      localMemoryPerformances,
+    })
+  )
+}
+
+export async function computeMemoryPerformance(): Promise<PerformanceMetric[]> {
+  const results: PerformanceMetric[] = []
   const pr = LOCAL_BRANCH ? await fetchPR(LOCAL_BRANCH) : null
   const benchmarkUrl = pr
     ? `https://datadoghq.dev/browser-sdk-test-playground/performance/memory?prNumber=${pr.number}`
@@ -74,15 +59,14 @@ export async function computeMemoryPerformance(): Promise<MemoryResult[]> {
   return results
 }
 
-async function runTests(tests: Test[], benchmarkUrl: string, cb: (result: MemoryResult) => void): Promise<void> {
+async function runTests(tests: Test[], benchmarkUrl: string, cb: (result: PerformanceMetric) => void): Promise<void> {
   await Promise.all(
     tests.map(async (test) => {
       const testName = test.name
       const testButton = test.button
-      const testProperty = test.property
       const allBytesMeasurements: number[] = []
       const allPercentageMeasurements: number[] = []
-      console.log(`Running test for: ${testButton}`)
+      printLog(`Running test for: ${testButton}`)
       for (let j = 0; j < NUMBER_OF_RUNS; j++) {
         const { medianPercentage, medianBytes } = await runTest(testButton, benchmarkUrl)
         allPercentageMeasurements.push(medianPercentage)
@@ -90,10 +74,10 @@ async function runTests(tests: Test[], benchmarkUrl: string, cb: (result: Memory
       }
       const sdkMemoryPercentage = average(allPercentageMeasurements)
       const sdkMemoryBytes = average(allBytesMeasurements)
-      console.log(
+      printLog(
         `Average percentage of memory used by SDK for ${testName} over ${NUMBER_OF_RUNS} runs: ${sdkMemoryPercentage}%  for ${sdkMemoryBytes} bytes`
       )
-      cb({ testProperty, sdkMemoryBytes, sdkMemoryPercentage })
+      cb({ name: test.property, value: sdkMemoryBytes })
     })
   )
 }
@@ -174,4 +158,34 @@ function average(values: number[]): number {
 function median(values: number[]): number {
   values.sort((a, b) => a - b)
   return values[Math.floor(values.length / 2)]
+}
+
+function formatMemoryPerformance({
+  baseMemoryPerformances,
+  localMemoryPerformances,
+}: {
+  baseMemoryPerformances: PerformanceMetric[]
+  localMemoryPerformances: PerformanceMetric[]
+}) {
+  return markdownArray({
+    headers: ['Action Name', 'Base Consumption Memory (bytes)', 'Local Consumption Memory (bytes)', '𝚫 (bytes)'],
+    rows: localMemoryPerformances.map((localMemoryPerformance) => {
+      const baseMemoryPerformance = baseMemoryPerformances.find(
+        (baseMemoryPerformance) => baseMemoryPerformance.name === localMemoryPerformance.name
+      )
+
+      if (!baseMemoryPerformance) {
+        return [localMemoryPerformance.name, 'N/A', formatSize(localMemoryPerformance.value), 'N/A']
+      }
+
+      return [
+        TESTS.find((test) => test.property === localMemoryPerformance.name)!.name,
+        formatSize(baseMemoryPerformance.value),
+        formatSize(localMemoryPerformance.value),
+        formatSize(localMemoryPerformance.value - baseMemoryPerformance.value, {
+          includeSign: true,
+        }),
+      ]
+    }),
+  })
 }

--- a/scripts/performance/lib/memoryPerformance.ts
+++ b/scripts/performance/lib/memoryPerformance.ts
@@ -168,7 +168,7 @@ function formatMemoryPerformance({
   localMemoryPerformances: PerformanceMetric[]
 }) {
   return markdownArray({
-    headers: ['Action Name', 'Base Consumption Memory (bytes)', 'Local Consumption Memory (bytes)', '𝚫 (bytes)'],
+    headers: ['Action Name', 'Base Memory Consumption', 'Local Memory Consumption', '𝚫'],
     rows: localMemoryPerformances.map((localMemoryPerformance) => {
       const baseMemoryPerformance = baseMemoryPerformances.find(
         (baseMemoryPerformance) => baseMemoryPerformance.name === localMemoryPerformance.name

--- a/scripts/performance/lib/reportAsAPrComment.spec.ts
+++ b/scripts/performance/lib/reportAsAPrComment.spec.ts
@@ -1,85 +1,46 @@
 import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
-import { createMessage } from './reportAsAPrComment.ts'
+import { describe, it, mock } from 'node:test'
+import { PrComment } from './reportAsAPrComment.ts'
 
-describe('reportAsAPrComment', () => {
-  describe('createMessage', () => {
-    const TEST_BUNDLE = 'test'
-    const PR_NUMBER = 123
+describe('PrComment', () => {
+  it('should send a comment with performance results', async () => {
+    const fetchMock = mock.method(globalThis, 'fetch')
+    fetchMock.mock.mockImplementation(() => Promise.resolve({ ok: true } as Response))
 
-    const BASE_BUNDLE_SIZES = [{ name: TEST_BUNDLE, value: 100 }]
-    const MEMORY_BASE_PERFORMANCE = [{ name: TEST_BUNDLE, value: 100 }]
-    const CPU_BASE_PERFORMANCE = [{ name: TEST_BUNDLE, value: 100 }]
+    const prComment = new PrComment(123)
 
-    const MEMORY_LOCAL_PERFORMANCE = [{ testProperty: TEST_BUNDLE, sdkMemoryBytes: 101, sdkMemoryPercentage: 10 }]
-    const CPU_LOCAL_PERFORMANCE = [{ name: TEST_BUNDLE, value: 101 }]
+    await prComment.setBundleSizes('RUM: 10KB')
 
-    it('should generate a report with performance results', () => {
-      const localBundleSizes = { test: 101 }
+    const [url, options] = fetchMock.mock.calls[0].arguments
+    assert.equal(url, 'https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment')
 
-      const message = createMessage(
-        BASE_BUNDLE_SIZES,
-        localBundleSizes,
-        MEMORY_BASE_PERFORMANCE,
-        MEMORY_LOCAL_PERFORMANCE,
-        CPU_BASE_PERFORMANCE,
-        CPU_LOCAL_PERFORMANCE,
-        PR_NUMBER
-      )
-
-      assert.equal(
-        message,
-        `| 📦 Bundle Name | Base Size | Local Size | 𝚫 | 𝚫% | Status |
-| --- | --- | --- | --- | --- | --- |
-| Test | 100 B | 101 B | 1 B | +1.00% | ✅ |
-</details>
+    const { body } = options as RequestInit
+    const payload = JSON.parse(body as string)
+    assert.equal(payload.pr_url, 'https://github.com/DataDog/browser-sdk/pull/123')
+    assert.equal(payload.header, 'Bundles Sizes Evolution')
+    assert.equal(payload.org, 'DataDog')
+    assert.equal(payload.repo, 'browser-sdk')
+    assert.equal(
+      payload.message,
+      `
+RUM: 10KB
 
 <details>
 <summary>🚀 CPU Performance</summary>
 
-| Action Name | Base Average Cpu Time (ms) | Local Average Cpu Time (ms) | 𝚫 |
-| --- | --- | --- | --- |
-| test | 100.000 | 101.000 | 1.000 |
+Pending...
 
 </details>
 
 <details>
 <summary>🧠 Memory Performance</summary>
 
-| Action Name | Base Consumption Memory (bytes) | Local Consumption Memory (bytes) | 𝚫 (bytes) |
-| --- | --- | --- | --- |
-| test | 100 B | 101 B | 1 B |
+Pending...
 
 </details>
 
 🔗 [RealWorld](https://datadoghq.dev/browser-sdk-test-playground/realworld-scenario/?prNumber=123)
-
 `
-      )
-    })
-
-    it('should add a warning when the size increase is above the threshold', () => {
-      const localBundleSizes = { test: 150 }
-
-      const message = createMessage(
-        BASE_BUNDLE_SIZES,
-        localBundleSizes,
-        MEMORY_BASE_PERFORMANCE,
-        MEMORY_LOCAL_PERFORMANCE,
-        CPU_BASE_PERFORMANCE,
-        CPU_LOCAL_PERFORMANCE,
-        PR_NUMBER
-      )
-
-      assertContains(message, '| Test | 100 B | 150 B | 50 B | +50.00% | ⚠️ |')
-      assertContains(message, '⚠️ The increase is particularly high and exceeds 5%. Please check the changes.')
-    })
+    )
   })
 })
-
-function assertContains(actual: string, expected: string) {
-  assert.ok(
-    actual.includes(expected),
-    ['Expected string to contain:', `  expected: "${expected}"`, `  actual:   "${actual}"`].join('\n')
-  )
-}

--- a/scripts/performance/lib/reportAsAPrComment.ts
+++ b/scripts/performance/lib/reportAsAPrComment.ts
@@ -1,114 +1,62 @@
 import { command } from '../../lib/command.ts'
-import { formatSize } from '../../lib/computeBundleSize.ts'
 import { fetchHandlingError } from '../../lib/executionUtils.ts'
-import { LOCAL_BRANCH, getLastCommonCommit, fetchPR, getPrComments } from '../../lib/gitUtils.ts'
-import { fetchPerformanceMetrics } from './fetchPerformanceMetrics.ts'
 
 const PR_COMMENT_HEADER = 'Bundles Sizes Evolution'
 const PR_COMMENTER_AUTH_TOKEN = command`authanywhere --raw`.run()
-// The value is set to 5% as it's around 10 times the average value for small PRs.
-const SIZE_INCREASE_THRESHOLD = 5
-export const LOCAL_COMMIT_SHA = process.env.CI_COMMIT_SHORT_SHA
 
-interface BundleSizes {
-  [key: string]: number
-}
+export class PrComment {
+  prNumber: number
+  bundleSizesSection: string = 'Pending...'
+  memoryPerformanceSection: string = 'Pending...'
+  cpuPerformanceSection: string = 'Pending...'
 
-interface MemoryPerformance {
-  testProperty: string
-  sdkMemoryBytes: number
-  sdkMemoryPercentage: number
-}
-
-interface PerformanceMetric {
-  name: string
-  value: number | null
-}
-
-interface PerformanceDifference {
-  name: string
-  change: number | null
-  percentageChange: string | number | null
-}
-
-export async function reportAsPrComment(
-  localBundleSizes: BundleSizes,
-  memoryLocalPerformance: MemoryPerformance[]
-): Promise<void> {
-  if (!LOCAL_BRANCH) {
-    console.log('LOCAL_BRANCH is not defined')
-    return
+  constructor(prNumber: number) {
+    this.prNumber = prNumber
   }
 
-  const pr = await fetchPR(LOCAL_BRANCH)
-  if (!pr) {
-    console.log('No pull requests found for the branch')
-    return
+  async setBundleSizes(newSection: string) {
+    this.bundleSizesSection = newSection
+    await this.updateComment()
   }
-  const lastCommonCommit = getLastCommonCommit(pr.base.ref)
-  const packageNames = Object.keys(localBundleSizes)
-  const testNames = memoryLocalPerformance.map((obj) => obj.testProperty)
-  const baseBundleSizes = await fetchPerformanceMetrics('bundle', packageNames, lastCommonCommit)
-  const cpuBasePerformance = await fetchPerformanceMetrics('cpu', testNames, lastCommonCommit)
-  const cpuLocalPerformance = await fetchPerformanceMetrics('cpu', testNames, LOCAL_COMMIT_SHA || '')
-  const memoryBasePerformance = await fetchPerformanceMetrics('memory', testNames, lastCommonCommit)
-  const commentId = await retrieveExistingCommentId(pr.number)
-  const message = createMessage(
-    baseBundleSizes,
-    localBundleSizes,
-    memoryBasePerformance,
-    memoryLocalPerformance,
-    cpuBasePerformance,
-    cpuLocalPerformance,
-    pr.number
-  )
-  await updateOrAddComment(message, pr.number, commentId)
-}
 
-function compare(
-  baseResults: PerformanceMetric[],
-  localResults: BundleSizes | PerformanceMetric[]
-): PerformanceDifference[] {
-  return baseResults.map((baseResult) => {
-    let localResult: number | undefined | null = null
+  async setMemoryPerformance(newSection: string) {
+    this.memoryPerformanceSection = newSection
+    await this.updateComment()
+  }
 
-    if (Array.isArray(localResults)) {
-      const localResultObj = localResults.find((result) => result.name === baseResult.name)
-      localResult = localResultObj ? localResultObj.value : null
-    } else {
-      localResult = localResults[baseResult.name]
-    }
+  async setCpuPerformance(newSection: string) {
+    this.cpuPerformanceSection = newSection
+    await this.updateComment()
+  }
 
-    let change = null
-    let percentageChange: string | number | null = null
+  formatComment() {
+    return `
+${this.bundleSizesSection}
 
-    if (baseResult.value && localResult) {
-      change = localResult - baseResult.value
-      percentageChange = ((change / baseResult.value) * 100).toFixed(2)
-    } else if (localResult) {
-      change = localResult
-      percentageChange = 'N/A'
-    }
+<details>
+<summary>🚀 CPU Performance</summary>
 
-    return {
-      name: baseResult.name,
-      change,
-      percentageChange,
-    }
-  })
-}
+${this.cpuPerformanceSection}
 
-async function retrieveExistingCommentId(prNumber: number): Promise<number | undefined> {
-  const comments = await getPrComments(prNumber)
+</details>
 
-  const targetComment = comments.find((comment) => comment.body.startsWith(`## ${PR_COMMENT_HEADER}`))
-  if (targetComment !== undefined) {
-    return targetComment.id
+<details>
+<summary>🧠 Memory Performance</summary>
+
+${this.memoryPerformanceSection}
+
+</details>
+
+🔗 [RealWorld](https://datadoghq.dev/browser-sdk-test-playground/realworld-scenario/?prNumber=${this.prNumber})
+`
+  }
+
+  async updateComment() {
+    await updatePrComment(this.prNumber, this.formatComment())
   }
 }
 
-async function updateOrAddComment(message: string, prNumber: number, commentId: number | undefined): Promise<void> {
-  const method = commentId ? 'PATCH' : 'POST'
+async function updatePrComment(prNumber: number, message: string): Promise<void> {
   const payload = {
     pr_url: `https://github.com/DataDog/browser-sdk/pull/${prNumber}`,
     message,
@@ -117,7 +65,7 @@ async function updateOrAddComment(message: string, prNumber: number, commentId: 
     repo: 'browser-sdk',
   }
   await fetchHandlingError('https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment', {
-    method,
+    method: 'PATCH',
     headers: {
       Authorization: `Bearer ${PR_COMMENTER_AUTH_TOKEN}`,
     },
@@ -125,97 +73,12 @@ async function updateOrAddComment(message: string, prNumber: number, commentId: 
   })
 }
 
-export function createMessage(
-  baseBundleSizes: PerformanceMetric[],
-  localBundleSizes: BundleSizes,
-  memoryBasePerformance: PerformanceMetric[],
-  memoryLocalPerformance: MemoryPerformance[],
-  cpuBasePerformance: PerformanceMetric[],
-  cpuLocalPerformance: PerformanceMetric[],
-  prNumber: number
-): string {
-  const differenceBundle = compare(baseBundleSizes, localBundleSizes)
-  const differenceCpu = compare(cpuBasePerformance, cpuLocalPerformance)
-  let highIncreaseDetected = false
-  const bundleRows = differenceBundle.map((diff, index) => {
-    const baseSize = formatSize(baseBundleSizes[index].value)
-    const localSize = formatSize(localBundleSizes[diff.name])
-    const diffSize = formatSize(diff.change)
-    const sign = (diff.percentageChange as number) > 0 ? '+' : ''
-    let status = '✅'
-    if ((diff.percentageChange as number) > SIZE_INCREASE_THRESHOLD) {
-      status = '⚠️'
-      highIncreaseDetected = true
-    }
-    return [formatBundleName(diff.name), baseSize, localSize, diffSize, `${sign}${diff.percentageChange}%`, status]
-  })
-
-  let message = markdownArray({
-    headers: ['📦 Bundle Name', 'Base Size', 'Local Size', '𝚫', '𝚫%', 'Status'],
-    rows: bundleRows,
-  })
-
-  message += '</details>\n\n'
-
-  if (highIncreaseDetected) {
-    message += `\n⚠️ The increase is particularly high and exceeds ${SIZE_INCREASE_THRESHOLD}%. Please check the changes.`
-  }
-
-  const cpuRows = cpuBasePerformance.map((cpuTestPerformance, index) => {
-    const localCpuPerf = cpuLocalPerformance[index]
-    const diffCpuPerf = differenceCpu[index]
-    const baseCpuTestValue = cpuTestPerformance.value !== null ? cpuTestPerformance.value.toFixed(3) : 'N/A'
-    const localCpuTestValue = localCpuPerf.value !== null ? localCpuPerf.value.toFixed(3) : 'N/A'
-    const diffCpuTestValue = diffCpuPerf.change !== null ? diffCpuPerf.change.toFixed(3) : 'N/A'
-    return [cpuTestPerformance.name, baseCpuTestValue, localCpuTestValue, diffCpuTestValue]
-  })
-
-  message += '<details>\n<summary>🚀 CPU Performance</summary>\n\n'
-  message += markdownArray({
-    headers: ['Action Name', 'Base Average Cpu Time (ms)', 'Local Average Cpu Time (ms)', '𝚫'],
-    rows: cpuRows,
-  })
-  message += '\n</details>\n\n'
-
-  const memoryRows = memoryBasePerformance.map((baseMemoryPerf, index) => {
-    const memoryTestPerformance = memoryLocalPerformance[index]
-    const baseMemoryTestValue = baseMemoryPerf.value
-    const localMemoryTestValue = memoryTestPerformance.sdkMemoryBytes
-    return [
-      memoryTestPerformance.testProperty,
-      formatSize(baseMemoryTestValue),
-      formatSize(localMemoryTestValue),
-      typeof localMemoryTestValue === 'number' && typeof baseMemoryTestValue === 'number'
-        ? formatSize(localMemoryTestValue - baseMemoryTestValue)
-        : 'N/A',
-    ]
-  })
-
-  message += '<details>\n<summary>🧠 Memory Performance</summary>\n\n'
-  message += markdownArray({
-    headers: ['Action Name', 'Base Consumption Memory (bytes)', 'Local Consumption Memory (bytes)', '𝚫 (bytes)'],
-    rows: memoryRows,
-  })
-  message += '\n</details>\n\n'
-
-  message += `🔗 [RealWorld](https://datadoghq.dev/browser-sdk-test-playground/realworld-scenario/?prNumber=${prNumber})\n\n`
-
-  return message
-}
-
-function formatBundleName(bundleName: string): string {
-  return bundleName
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
-}
-
 interface MarkdownArrayOptions {
   headers: string[]
   rows: string[][]
 }
 
-function markdownArray({ headers, rows }: MarkdownArrayOptions): string {
+export function markdownArray({ headers, rows }: MarkdownArrayOptions): string {
   let markdown = `| ${headers.join(' | ')} |\n| ${new Array(headers.length).fill('---').join(' | ')} |\n`
   rows.forEach((row) => {
     markdown += `| ${row.join(' | ')} |\n`

--- a/scripts/performance/lib/reportToDatadog.ts
+++ b/scripts/performance/lib/reportToDatadog.ts
@@ -2,101 +2,25 @@ import { fetchHandlingError } from '../../lib/executionUtils.ts'
 import { getOrg2ApiKey } from '../../lib/secrets.ts'
 import { browserSdkVersion } from '../../lib/browserSdkVersion.ts'
 
-const LOG_INTAKE_URL = 'https://http-intake.logs.datadoghq.com/api/v2/logs'
-const LOG_INTAKE_REQUEST_HEADERS = {
-  'DD-API-KEY': getOrg2ApiKey(),
-  'Content-Type': 'application/json',
-}
-
-interface BundleSizesLog {
-  message: string
-  service: string
-  ddsource: string
-  env: string
-  bundle_sizes: Record<string, number>
-  version: string
-  commit: string | undefined
-  branch: string | undefined
-}
-
-interface MemoryPerformanceData {
-  testProperty: string
-  sdkMemoryBytes: number
-  sdkMemoryPercentage: number
-}
-
-interface MemoryPerformanceLog {
-  message: string
-  service: string
-  ddsource: string
-  env: string
-  version: string
-  commit: string | undefined
-  branch: string | undefined
-  [key: string]: any
-}
-
-type LogData = BundleSizesLog[] | MemoryPerformanceLog[]
-
 export async function reportToDatadog(
-  data: Record<string, number> | MemoryPerformanceData[],
-  dataType: 'bundleSizes' | 'memoryPerformance'
+  logData: Record<string, number | string | Record<string, number>>
 ): Promise<void> {
-  let logData: LogData
-  switch (dataType) {
-    case 'bundleSizes':
-      logData = createBundleSizesLogData(data as Record<string, number>, browserSdkVersion)
-      break
-    case 'memoryPerformance':
-      logData = createMemoryPerformanceLogData(data as MemoryPerformanceData[], browserSdkVersion)
-      break
-  }
-  await sendLogToOrg2(logData)
-}
-
-function createBundleSizesLogData(bundleSizes: Record<string, number>, browserSdkVersion: string): BundleSizesLog[] {
-  return [
-    {
-      message: 'Browser SDK bundles sizes',
-      service: 'browser-sdk',
-      ddsource: 'browser-sdk',
-      env: 'ci',
-      bundle_sizes: bundleSizes,
-      version: browserSdkVersion,
-      commit: process.env.CI_COMMIT_SHORT_SHA,
-      branch: process.env.CI_COMMIT_REF_NAME,
-    },
-  ]
-}
-
-function createMemoryPerformanceLogData(
-  memoryPerformance: MemoryPerformanceData[],
-  browserSdkVersion: string
-): MemoryPerformanceLog[] {
-  const memoryPerformanceData = Object.fromEntries(
-    memoryPerformance.map(({ testProperty, sdkMemoryBytes, sdkMemoryPercentage }) => [
-      testProperty,
-      { memory_bytes: sdkMemoryBytes, memory_percentage: sdkMemoryPercentage },
-    ])
-  )
-  return [
-    {
-      message: 'Browser SDK memory consumption',
-      service: 'browser-sdk',
-      ddsource: 'browser-sdk',
-      env: 'ci',
-      ...memoryPerformanceData,
-      version: browserSdkVersion,
-      commit: process.env.CI_COMMIT_SHORT_SHA,
-      branch: process.env.CI_COMMIT_REF_NAME,
-    },
-  ]
-}
-
-async function sendLogToOrg2(logData: LogData = []): Promise<void> {
-  await fetchHandlingError(LOG_INTAKE_URL, {
+  await fetchHandlingError('https://http-intake.logs.datadoghq.com/api/v2/logs', {
     method: 'POST',
-    headers: LOG_INTAKE_REQUEST_HEADERS,
-    body: JSON.stringify(logData),
+    headers: {
+      'DD-API-KEY': getOrg2ApiKey(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify([
+      {
+        service: 'browser-sdk',
+        ddsource: 'browser-sdk',
+        env: 'ci',
+        version: browserSdkVersion,
+        commit: process.env.CI_COMMIT_SHORT_SHA,
+        branch: process.env.CI_COMMIT_REF_NAME,
+        ...logData,
+      },
+    ]),
   })
 }

--- a/scripts/show-bundle-size.ts
+++ b/scripts/show-bundle-size.ts
@@ -1,5 +1,5 @@
-import { calculateBundleSizes, formatSize } from './lib/computeBundleSize.ts'
-import { printLog, runMain } from './lib/executionUtils.ts'
+import { calculateBundleSizes } from './lib/computeBundleSize.ts'
+import { formatSize, printLog, runMain } from './lib/executionUtils.ts'
 
 const COL_WIDTH = 12
 


### PR DESCRIPTION
## Motivation

The "bundle sizes" PR comment was proven very valuable, however the `test-performances` job is sometimes failing.

## Changes

Make the `test-performances` script more resilient by clearly separating the three tasks (bundle sizes, memory and CPU). Each task can update its own part of the PR comment, so if a task fails it doesn't prevent the other tasks to succeed.

## Test instructions

See [this PR comment](https://github.com/apps/cit-pr-commenter)


## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
