### PR TITLE
🔧 ignore internal Docker package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
+  "ignoreDeps": ["registry.ddbuild.io/dd-octo-sts"],
   "schedule": ["every weekend"],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "lockFileMaintenance": { "enabled": true },


### PR DESCRIPTION
## Motivation

Renovate emits a warning because it couldn't resolve the dd-octo-sts docker dependency, see https://github.com/DataDog/browser-sdk/issues/1897

## Changes

Ignore the dependency. The dep name was taken from renovate logs.

## Test instructions

Let's see if the renovate warning is fixed during the next renovate run.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
