### PR TITLE
👷🐛[performance] fix reporting on main branch

### DIFF
--- a/scripts/performance/index.ts
+++ b/scripts/performance/index.ts
@@ -1,24 +1,26 @@
 import { printLog, runMain } from '../lib/executionUtils.ts'
-import { fetchPR, getLastCommonCommit, LOCAL_BRANCH } from '../lib/gitUtils.ts'
-import { PrComment } from './lib/reportAsAPrComment.ts'
+import { fetchPR, LOCAL_BRANCH, getLastCommonCommit } from '../lib/gitUtils.ts'
+import { Pr } from './lib/reportAsAPrComment.ts'
 import { computeAndReportMemoryPerformance } from './lib/memoryPerformance.ts'
 import { computeAndReportBundleSizes } from './lib/bundleSizes.ts'
 import { computeAndReportCpuPerformance } from './lib/cpuPerformance.ts'
 
 runMain(async () => {
-  const pr = await fetchPR(LOCAL_BRANCH!)
-  if (!pr) {
-    throw new Error('No pull requests found for the branch')
+  const githubPr = await fetchPR(LOCAL_BRANCH!)
+  let pr: Pr | undefined
+  if (!githubPr) {
+    printLog('No pull requests found for the branch, reporting only (normal for main)')
+  } else {
+    const lastCommonCommit = getLastCommonCommit(githubPr.base.ref)
+    pr = new Pr(githubPr.number, lastCommonCommit)
   }
-  const prComment = new PrComment(pr.number)
-  const lastCommonCommit = getLastCommonCommit(pr.base.ref)
 
   printLog('Bundle sizes...')
-  await computeAndReportBundleSizes(lastCommonCommit, prComment)
+  await computeAndReportBundleSizes(pr)
 
   printLog('Memory performance...')
-  await computeAndReportMemoryPerformance(lastCommonCommit, prComment)
+  await computeAndReportMemoryPerformance(pr)
 
   printLog('CPU performance...')
-  await computeAndReportCpuPerformance(lastCommonCommit, prComment)
+  await computeAndReportCpuPerformance(pr)
 })

--- a/scripts/performance/lib/reportAsAPrComment.spec.ts
+++ b/scripts/performance/lib/reportAsAPrComment.spec.ts
@@ -1,15 +1,15 @@
 import assert from 'node:assert/strict'
 import { describe, it, mock } from 'node:test'
-import { PrComment } from './reportAsAPrComment.ts'
+import { Pr } from './reportAsAPrComment.ts'
 
 describe('PrComment', () => {
   it('should send a comment with performance results', async () => {
     const fetchMock = mock.method(globalThis, 'fetch')
     fetchMock.mock.mockImplementation(() => Promise.resolve({ ok: true } as Response))
 
-    const prComment = new PrComment(123)
+    const pr = new Pr(123, 'abc')
 
-    await prComment.setBundleSizes('RUM: 10KB')
+    await pr.setBundleSizes('RUM: 10KB')
 
     const [url, options] = fetchMock.mock.calls[0].arguments
     assert.equal(url, 'https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment')

--- a/scripts/performance/lib/reportAsAPrComment.ts
+++ b/scripts/performance/lib/reportAsAPrComment.ts
@@ -4,14 +4,16 @@ import { fetchHandlingError } from '../../lib/executionUtils.ts'
 const PR_COMMENT_HEADER = 'Bundles Sizes Evolution'
 const PR_COMMENTER_AUTH_TOKEN = command`authanywhere --raw`.run()
 
-export class PrComment {
+export class Pr {
   prNumber: number
+  lastCommonCommit: string
   bundleSizesSection: string = 'Pending...'
   memoryPerformanceSection: string = 'Pending...'
   cpuPerformanceSection: string = 'Pending...'
 
-  constructor(prNumber: number) {
+  constructor(prNumber: number, lastCommonCommit: string) {
     this.prNumber = prNumber
+    this.lastCommonCommit = lastCommonCommit
   }
 
   async setBundleSizes(newSection: string) {


### PR DESCRIPTION
## Motivation

With latest refactoring, reporting is not done on main because no PR is opened

## Changes

if no pr is opened, still report local metrics to datadog

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
