### PR TITLE
[devext] fix `yarn dev` command

### DIFF
--- a/developer-extension/package.json
+++ b/developer-extension/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "rm -rf dist && webpack --disable-interpret --mode production",
-    "dev": "rm -rf dist && webpack --disable-interpret --mode development && webpack serve --mode development --config-name=panel --hot"
+    "dev": "rm -rf dist && webpack --disable-interpret --mode development && webpack serve --disable-interpret --mode development --config-name=panel --hot"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",

--- a/developer-extension/webpack.config.ts
+++ b/developer-extension/webpack.config.ts
@@ -2,6 +2,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin'
 import { WebextensionPlugin } from '@webextension-toolbox/webpack-webextension-plugin'
 import CopyPlugin from 'copy-webpack-plugin'
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin'
+import reactRefreshTypeScript from 'react-refresh-typescript'
 import webpack from 'webpack'
 import { createDefinePlugin } from '../webpack.base.ts'
 import packageJson from './package.json' with { type: 'json' }
@@ -166,7 +167,7 @@ export default (_env: unknown, argv: { mode?: webpack.Configuration['mode'] }) =
               onlyCompileBundledFiles: true,
               ...(isDevelopment && {
                 getCustomTransformers: () => ({
-                  before: [new ReactRefreshWebpackPlugin()],
+                  before: [reactRefreshTypeScript()],
                 }),
               }),
               transpileOnly: true,


### PR DESCRIPTION
## Motivation

This was broken when we migrated webpack.config files to TS.

## Changes

Fix [react-refresh-typescript](https://www.npmjs.com/package/react-refresh-typescript) usage

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
