### PR TITLE
[RUM-11434] Remove ff for graphql tracking

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -17,7 +17,6 @@ export enum ExperimentalFeature {
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
   WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
   USE_TREE_WALKER_FOR_ACTION_NAME = 'use_tree_walker_for_action_name',
-  GRAPHQL_TRACKING = 'graphql_tracking',
   FEATURE_OPERATION_VITAL = 'feature_operation_vital',
   SHORT_SESSION_INVESTIGATION = 'short_session_investigation',
 }

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -1,6 +1,6 @@
 import type { Duration, RelativeTime, ServerDuration, TaskQueue, TimeStamp } from '@datadog/browser-core'
-import { createTaskQueue, ExperimentalFeature, noop, RequestType, ResourceType } from '@datadog/browser-core'
-import { mockExperimentalFeatures, registerCleanupTask } from '@datadog/browser-core/test'
+import { createTaskQueue, noop, RequestType, ResourceType } from '@datadog/browser-core'
+import { registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumFetchResourceEventDomainContext, RumXhrResourceEventDomainContext } from '../../domainContext.types'
 import {
   collectAndValidateRawRumEvents,
@@ -152,9 +152,6 @@ describe('resourceCollection', () => {
   })
 
   describe('GraphQL metadata enrichment', () => {
-    beforeEach(() => {
-      mockExperimentalFeatures([ExperimentalFeature.GRAPHQL_TRACKING])
-    })
     interface TestCase {
       requestType: RequestType
       name: string
@@ -277,34 +274,6 @@ describe('resourceCollection', () => {
         })
       })
     })
-  })
-
-  it('should not track GraphQL when feature flag is disabled', () => {
-    mockExperimentalFeatures([])
-    setupResourceCollection({
-      trackResources: true,
-      allowedGraphQlUrls: [{ match: 'https://api.example.com/graphql', trackPayload: true }],
-    })
-
-    const requestBody = JSON.stringify({
-      query: 'query GetUser { user { name } }',
-    })
-
-    notifyRequest({
-      request: {
-        type: RequestType.FETCH,
-        url: 'https://api.example.com/graphql',
-        method: 'POST' as const,
-        init: {
-          method: 'POST' as const,
-          body: requestBody,
-        },
-        input: 'https://api.example.com/graphql',
-      },
-    })
-
-    const resourceEvent = rawRumEvents[0].rawRumEvent as any
-    expect(resourceEvent.resource.graphql).toBeUndefined()
   })
 
   describe('with trackEarlyRequests enabled', () => {

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -7,8 +7,6 @@ import {
   toServerDuration,
   relativeToClocks,
   createTaskQueue,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
 } from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type { RumPerformanceResourceTiming } from '../../browser/performanceObservable'
@@ -178,10 +176,6 @@ function computeGraphQlMetaData(
   request: RequestCompleteEvent,
   configuration: RumConfiguration
 ): GraphQlMetadata | undefined {
-  if (!isExperimentalFeatureEnabled(ExperimentalFeature.GRAPHQL_TRACKING)) {
-    return
-  }
-
   const graphQlConfig = findGraphQlConfiguration(request.url, configuration)
   if (!graphQlConfig) {
     return

--- a/test/e2e/scenario/rum/graphql.scenario.ts
+++ b/test/e2e/scenario/rum/graphql.scenario.ts
@@ -4,7 +4,6 @@ import { createTest } from '../../lib/framework'
 function buildGraphQlConfig({ trackPayload = false }: { trackPayload?: boolean } = {}) {
   return {
     allowedGraphQlUrls: [{ match: (url: string) => url.includes('graphql'), trackPayload }],
-    enableExperimentalFeatures: ['graphql_tracking'],
   }
 }
 


### PR DESCRIPTION
## Motivation

After testing the graphql tracking on datadog internal app we can now remove the feature flag.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
