### PR TITLE
🎨 [PANA-4372] Explicitly scope serialization state

### DIFF
--- a/packages/rum/src/domain/record/nodeIds.spec.ts
+++ b/packages/rum/src/domain/record/nodeIds.spec.ts
@@ -1,0 +1,98 @@
+import type { NodeId, NodeIds } from './nodeIds'
+import { createNodeIds, NodeIdConstants } from './nodeIds'
+
+describe('NodeIds', () => {
+  let nodeIds: NodeIds
+
+  beforeEach(() => {
+    nodeIds = createNodeIds()
+  })
+
+  describe('assign', () => {
+    it('assigns node ids in order', () => {
+      for (let id = NodeIdConstants.FIRST_ID as NodeId; id < NodeIdConstants.FIRST_ID + 3; id++) {
+        const node = document.createElement('div')
+        expect(nodeIds.assign(node)).toBe(id)
+        expect(nodeIds.assign(node)).toBe(id)
+      }
+    })
+
+    it('reuses any existing node id', () => {
+      nodeIds.assign(document.createElement('div'))
+      nodeIds.assign(document.createElement('div'))
+      const node = document.createElement('div')
+      const nodeId = nodeIds.assign(node)
+      expect(nodeIds.assign(node)).toBe(nodeId)
+      expect(nodeIds.get(node)).toBe(nodeId)
+    })
+  })
+
+  describe('get', () => {
+    it('returns undefined for DOM Nodes that have not been assigned an id', () => {
+      expect(nodeIds.get(document.createElement('div'))).toBe(undefined)
+    })
+
+    it('returns the serialized Node id when available', () => {
+      const node = document.createElement('div')
+      nodeIds.assign(node)
+      expect(nodeIds.get(node)).toBe(NodeIdConstants.FIRST_ID as NodeId)
+    })
+  })
+
+  describe('areAssignedForNodeAndAncestors', () => {
+    it('returns false for DOM Nodes that have not been assigned an id', () => {
+      expect(nodeIds.areAssignedForNodeAndAncestors(document.createElement('div'))).toBe(false)
+    })
+
+    it('returns true for DOM Nodes that have been assigned an id', () => {
+      const node = document.createElement('div')
+      nodeIds.assign(node)
+      expect(nodeIds.areAssignedForNodeAndAncestors(node)).toBe(true)
+    })
+
+    it('returns false for DOM Nodes when an ancestor has not been assigned an id', () => {
+      const node = document.createElement('div')
+      nodeIds.assign(node)
+
+      const parent = document.createElement('div')
+      parent.appendChild(node)
+      nodeIds.assign(parent)
+
+      const grandparent = document.createElement('div')
+      grandparent.appendChild(parent)
+
+      expect(nodeIds.areAssignedForNodeAndAncestors(node)).toBe(false)
+    })
+
+    it('returns true for DOM Nodes when all ancestors have been assigned an id', () => {
+      const node = document.createElement('div')
+      nodeIds.assign(node)
+
+      const parent = document.createElement('div')
+      parent.appendChild(node)
+      nodeIds.assign(parent)
+
+      const grandparent = document.createElement('div')
+      grandparent.appendChild(parent)
+      nodeIds.assign(grandparent)
+
+      expect(nodeIds.areAssignedForNodeAndAncestors(node)).toBe(true)
+    })
+
+    it('returns true for DOM Nodes in shadow subtrees', () => {
+      const node = document.createElement('div')
+      nodeIds.assign(node)
+
+      const parent = document.createElement('div')
+      parent.appendChild(node)
+      nodeIds.assign(parent)
+
+      const grandparent = document.createElement('div')
+      const shadowRoot = grandparent.attachShadow({ mode: 'open' })
+      shadowRoot.appendChild(parent)
+      nodeIds.assign(grandparent)
+
+      expect(nodeIds.areAssignedForNodeAndAncestors(node)).toBe(true)
+    })
+  })
+})

--- a/packages/rum/src/domain/record/nodeIds.ts
+++ b/packages/rum/src/domain/record/nodeIds.ts
@@ -1,0 +1,46 @@
+import { getParentNode, isNodeShadowRoot } from '@datadog/browser-rum-core'
+
+export type NodeWithSerializedNode = Node & { __brand: 'NodeWithSerializedNode' }
+export type NodeId = number & { __brand: 'NodeId' }
+
+export const enum NodeIdConstants {
+  FIRST_ID = 1,
+}
+
+export interface NodeIds {
+  assign(node: Node): NodeId
+  get(node: Node): NodeId | undefined
+  areAssignedForNodeAndAncestors(node: Node): node is NodeWithSerializedNode
+}
+
+export function createNodeIds(): NodeIds {
+  const nodeIds = new WeakMap<Node, NodeId>()
+  let nextNodeId = NodeIdConstants.FIRST_ID
+
+  const get = (node: Node): NodeId | undefined => nodeIds.get(node)
+
+  return {
+    assign: (node: Node): NodeId => {
+      // Try to reuse any existing id.
+      let nodeId = get(node)
+      if (nodeId === undefined) {
+        nodeId = nextNodeId++ as NodeId
+        nodeIds.set(node, nodeId)
+      }
+      return nodeId
+    },
+
+    get,
+
+    areAssignedForNodeAndAncestors: (node: Node): node is NodeWithSerializedNode => {
+      let current: Node | null = node
+      while (current) {
+        if (get(current) === undefined && !isNodeShadowRoot(current)) {
+          return false
+        }
+        current = getParentNode(current)
+      }
+      return true
+    },
+  }
+}

--- a/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
+++ b/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
@@ -8,6 +8,8 @@ import {
   createElementsScrollPositions,
   createSerializationStats,
 } from '..'
+import { createNodeIds } from '../nodeIds'
+import { createSerializationScope } from './serializationScope'
 
 export const makeHtmlDoc = (htmlContent: string, privacyTag: string) => {
   try {
@@ -50,6 +52,7 @@ export const generateLeanSerializedDoc = (htmlContent: string, privacyTag: strin
         elementsScrollPositions: createElementsScrollPositions(),
       },
       configuration: {} as RumConfiguration,
+      scope: createSerializationScope(createNodeIds()),
     })! as unknown as Record<string, unknown>
   ) as unknown as SerializedNodeWithId
   return serializedDoc

--- a/packages/rum/src/domain/record/serialization/index.ts
+++ b/packages/rum/src/domain/record/serialization/index.ts
@@ -1,14 +1,10 @@
-export {
-  getElementInputValue,
-  getSerializedNodeId,
-  hasSerializedNode,
-  nodeAndAncestorsHaveSerializedNode,
-} from './serializationUtils'
-export type { NodeWithSerializedNode } from './serialization.types'
+export { getElementInputValue } from './serializationUtils'
 export { SerializationContextStatus } from './serialization.types'
 export type { SerializationContext } from './serialization.types'
 export { serializeDocument } from './serializeDocument'
 export { serializeNodeWithId } from './serializeNode'
 export { serializeAttribute } from './serializeAttribute'
+export type { SerializationScope } from './serializationScope'
+export { createSerializationScope } from './serializationScope'
 export { createSerializationStats, updateSerializationStats, aggregateSerializationStats } from './serializationStats'
 export type { SerializationMetric, SerializationStats } from './serializationStats'

--- a/packages/rum/src/domain/record/serialization/serialization.types.ts
+++ b/packages/rum/src/domain/record/serialization/serialization.types.ts
@@ -1,6 +1,7 @@
 import type { RumConfiguration, NodePrivacyLevel } from '@datadog/browser-rum-core'
 import type { ElementsScrollPositions } from '../elementsScrollPositions'
 import type { ShadowRootsController } from '../shadowRootsController'
+import type { SerializationScope } from './serializationScope'
 import type { SerializationStats } from './serializationStats'
 
 // Those values are the only one that can be used when inheriting privacy levels from parent to
@@ -42,6 +43,5 @@ export interface SerializeOptions {
   parentNodePrivacyLevel: ParentNodePrivacyLevel
   serializationContext: SerializationContext
   configuration: RumConfiguration
+  scope: SerializationScope
 }
-
-export type NodeWithSerializedNode = Node & { s: 'Node with serialized node' }

--- a/packages/rum/src/domain/record/serialization/serializationScope.ts
+++ b/packages/rum/src/domain/record/serialization/serializationScope.ts
@@ -1,0 +1,9 @@
+import type { NodeIds } from '../nodeIds'
+
+export interface SerializationScope {
+  nodeIds: NodeIds
+}
+
+export function createSerializationScope(nodeIds: NodeIds): SerializationScope {
+  return { nodeIds }
+}

--- a/packages/rum/src/domain/record/serialization/serializationUtils.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializationUtils.spec.ts
@@ -1,39 +1,5 @@
 import { NodePrivacyLevel } from '@datadog/browser-rum-core'
-import {
-  getSerializedNodeId,
-  hasSerializedNode,
-  setSerializedNodeId,
-  getElementInputValue,
-  switchToAbsoluteUrl,
-} from './serializationUtils'
-
-describe('serialized Node storage in DOM Nodes', () => {
-  describe('hasSerializedNode', () => {
-    it('returns false for DOM Nodes that are not yet serialized', () => {
-      expect(hasSerializedNode(document.createElement('div'))).toBe(false)
-    })
-
-    it('returns true for DOM Nodes that have been serialized', () => {
-      const node = document.createElement('div')
-      setSerializedNodeId(node, 42)
-
-      expect(hasSerializedNode(node)).toBe(true)
-    })
-  })
-
-  describe('getSerializedNodeId', () => {
-    it('returns undefined for DOM Nodes that are not yet serialized', () => {
-      expect(getSerializedNodeId(document.createElement('div'))).toBe(undefined)
-    })
-
-    it('returns the serialized Node id', () => {
-      const node = document.createElement('div')
-      setSerializedNodeId(node, 42)
-
-      expect(getSerializedNodeId(node)).toBe(42)
-    })
-  })
-})
+import { getElementInputValue, switchToAbsoluteUrl } from './serializationUtils'
 
 describe('getElementInputValue', () => {
   it('returns "undefined" for a non-input element', () => {

--- a/packages/rum/src/domain/record/serialization/serializationUtils.ts
+++ b/packages/rum/src/domain/record/serialization/serializationUtils.ts
@@ -1,34 +1,6 @@
 import { buildUrl } from '@datadog/browser-core'
-import { getParentNode, isNodeShadowRoot, CENSORED_STRING_MARK, shouldMaskNode } from '@datadog/browser-rum-core'
+import { CENSORED_STRING_MARK, shouldMaskNode } from '@datadog/browser-rum-core'
 import type { NodePrivacyLevel } from '@datadog/browser-rum-core'
-import type { NodeWithSerializedNode } from './serialization.types'
-
-const serializedNodeIds = new WeakMap<Node, number>()
-
-export function hasSerializedNode(node: Node): node is NodeWithSerializedNode {
-  return serializedNodeIds.has(node)
-}
-
-export function nodeAndAncestorsHaveSerializedNode(node: Node): node is NodeWithSerializedNode {
-  let current: Node | null = node
-  while (current) {
-    if (!hasSerializedNode(current) && !isNodeShadowRoot(current)) {
-      return false
-    }
-    current = getParentNode(current)
-  }
-  return true
-}
-
-export function getSerializedNodeId(node: NodeWithSerializedNode): number
-export function getSerializedNodeId(node: Node): number | undefined
-export function getSerializedNodeId(node: Node) {
-  return serializedNodeIds.get(node)
-}
-
-export function setSerializedNodeId(node: Node, serializeNodeId: number) {
-  serializedNodeIds.set(node, serializeNodeId)
-}
 
 /**
  * Get the element "value" to be serialized as an attribute or an input update record. It respects

--- a/packages/rum/src/domain/record/serialization/serializeDocument.ts
+++ b/packages/rum/src/domain/record/serialization/serializeDocument.ts
@@ -3,11 +3,13 @@ import type { RumConfiguration } from '@datadog/browser-rum-core'
 import type { SerializedNodeWithId } from '../../../types'
 import type { SerializationContext } from './serialization.types'
 import { serializeNodeWithId } from './serializeNode'
+import type { SerializationScope } from './serializationScope'
 import { updateSerializationStats } from './serializationStats'
 
 export function serializeDocument(
   document: Document,
   configuration: RumConfiguration,
+  scope: SerializationScope,
   serializationContext: SerializationContext
 ): SerializedNodeWithId {
   const serializationStart = timeStampNow()
@@ -15,6 +17,7 @@ export function serializeDocument(
     serializationContext,
     parentNodePrivacyLevel: configuration.defaultPrivacyLevel,
     configuration,
+    scope,
   })
   updateSerializationStats(
     serializationContext.serializationStats,

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -17,6 +17,7 @@ import { appendElement } from '../../../../../rum-core/test'
 import type { ElementsScrollPositions } from '../elementsScrollPositions'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import type { ShadowRootCallBack, ShadowRootsController } from '../shadowRootsController'
+import { createNodeIds } from '../nodeIds'
 import {
   HTML,
   generateLeanSerializedDoc,
@@ -29,8 +30,9 @@ import {
 import { serializeDocument } from './serializeDocument'
 import type { SerializationContext, SerializeOptions } from './serialization.types'
 import { SerializationContextStatus } from './serialization.types'
-import { hasSerializedNode } from './serializationUtils'
 import { serializeChildNodes, serializeDocumentNode, serializeNodeWithId } from './serializeNode'
+import type { SerializationScope } from './serializationScope'
+import { createSerializationScope } from './serializationScope'
 import { createSerializationStats } from './serializationStats'
 
 const DEFAULT_CONFIGURATION = {} as RumConfiguration
@@ -51,25 +53,26 @@ function getDefaultSerializationContext(): SerializationContext {
   }
 }
 
-function getDefaultOptions(): SerializeOptions {
-  return {
+describe('serializeNodeWithId', () => {
+  let addShadowRootSpy: jasmine.Spy<ShadowRootCallBack>
+  let scope: SerializationScope
+
+  const getDefaultOptions = (): SerializeOptions => ({
     parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
     serializationContext: getDefaultSerializationContext(),
     configuration: DEFAULT_CONFIGURATION,
-  }
-}
-
-describe('serializeNodeWithId', () => {
-  let addShadowRootSpy: jasmine.Spy<ShadowRootCallBack>
+    scope,
+  })
 
   beforeEach(() => {
     addShadowRootSpy = jasmine.createSpy<ShadowRootCallBack>()
+    scope = createSerializationScope(createNodeIds())
   })
 
   describe('document serialization', () => {
     it('serializes a document', () => {
       const document = new DOMParser().parseFromString('<!doctype html><html>foo</html>', 'text/html')
-      expect(serializeDocument(document, DEFAULT_CONFIGURATION, getDefaultSerializationContext())).toEqual({
+      expect(serializeDocument(document, DEFAULT_CONFIGURATION, scope, getDefaultSerializationContext())).toEqual({
         type: NodeType.Document,
         childNodes: [
           jasmine.objectContaining({ type: NodeType.DocumentType, name: 'html', publicId: '', systemId: '' }),
@@ -813,7 +816,7 @@ describe('serializeNodeWithId', () => {
     it('does not serialize ignored nodes', () => {
       const scriptElement = document.createElement('script')
       serializeNodeWithId(scriptElement, getDefaultOptions())
-      expect(hasSerializedNode(scriptElement)).toBe(false)
+      expect(scope.nodeIds.get(scriptElement)).toBe(undefined)
     })
 
     it('ignores script tags', () => {
@@ -988,8 +991,17 @@ describe('serializeNodeWithId', () => {
 
 describe('serializeDocumentNode handles', function testAllowDomTree() {
   const toJSONObj = (data: any) => JSON.parse(JSON.stringify(data)) as unknown
+  let scope: SerializationScope
+
+  const getDefaultOptions = (): SerializeOptions => ({
+    parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
+    serializationContext: getDefaultSerializationContext(),
+    configuration: DEFAULT_CONFIGURATION,
+    scope,
+  })
 
   beforeEach(() => {
+    scope = createSerializationScope(createNodeIds())
     registerCleanupTask(() => {
       if (isAdoptedStyleSheetsSupported()) {
         document.adoptedStyleSheets = []
@@ -1005,7 +1017,7 @@ describe('serializeDocumentNode handles', function testAllowDomTree() {
       const styleSheet = new window.CSSStyleSheet()
       styleSheet.insertRule('div { width: 100%; }')
       document.adoptedStyleSheets = [styleSheet]
-      expect(serializeDocument(document, DEFAULT_CONFIGURATION, getDefaultSerializationContext())).toEqual({
+      expect(serializeDocument(document, DEFAULT_CONFIGURATION, scope, getDefaultSerializationContext())).toEqual({
         type: NodeType.Document,
         childNodes: [
           jasmine.objectContaining({ type: NodeType.DocumentType }),

--- a/packages/rum/src/domain/record/serialization/serializeNode.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.ts
@@ -20,7 +20,7 @@ import type {
   TextNode,
 } from '../../../types'
 import { NodeType } from '../../../types'
-import { getSerializedNodeId, getValidTagName, setSerializedNodeId } from './serializationUtils'
+import { getValidTagName } from './serializationUtils'
 import type { SerializeOptions } from './serialization.types'
 import { serializeStyleSheets } from './serializeStyleSheets'
 import { serializeAttributes } from './serializeAttributes'
@@ -31,20 +31,13 @@ export function serializeNodeWithId(node: Node, options: SerializeOptions): Seri
     return null
   }
 
-  // Try to reuse the previous id
-  const id = getSerializedNodeId(node) || generateNextId()
+  const id = options.scope.nodeIds.assign(node)
   const serializedNodeWithId = serializedNode as SerializedNodeWithId
   serializedNodeWithId.id = id
-  setSerializedNodeId(node, id)
   if (options.serializedNodeIds) {
     options.serializedNodeIds.add(id)
   }
   return serializedNodeWithId
-}
-
-let _nextId = 1
-export function generateNextId(): number {
-  return _nextId++
 }
 
 export function serializeChildNodes(node: Node, options: SerializeOptions): SerializedNodeWithId[] {

--- a/packages/rum/src/domain/record/shadowRootsController.ts
+++ b/packages/rum/src/domain/record/shadowRootsController.ts
@@ -2,6 +2,7 @@ import type { RumConfiguration } from '@datadog/browser-rum-core'
 import type { BrowserIncrementalSnapshotRecord } from '../../types'
 import { trackInput, trackMutation, trackScroll } from './trackers'
 import type { ElementsScrollPositions } from './elementsScrollPositions'
+import type { SerializationScope } from './serialization'
 
 interface ShadowRootController {
   stop: () => void
@@ -19,6 +20,7 @@ export interface ShadowRootsController {
 
 export const initShadowRootsController = (
   configuration: RumConfiguration,
+  scope: SerializationScope,
   callback: (record: BrowserIncrementalSnapshotRecord) => void,
   elementsScrollPositions: ElementsScrollPositions
 ): ShadowRootsController => {
@@ -29,11 +31,11 @@ export const initShadowRootsController = (
       if (controllerByShadowRoot.has(shadowRoot)) {
         return
       }
-      const mutationTracker = trackMutation(callback, configuration, shadowRootsController, shadowRoot)
+      const mutationTracker = trackMutation(callback, configuration, scope, shadowRootsController, shadowRoot)
       // The change event does not bubble up across the shadow root, we have to listen on the shadow root
-      const inputTracker = trackInput(configuration, callback, shadowRoot)
+      const inputTracker = trackInput(configuration, scope, callback, shadowRoot)
       // The scroll event does not bubble up across the shadow root, we have to listen on the shadow root
-      const scrollTracker = trackScroll(configuration, callback, elementsScrollPositions, shadowRoot)
+      const scrollTracker = trackScroll(configuration, scope, callback, elementsScrollPositions, shadowRoot)
       controllerByShadowRoot.set(shadowRoot, {
         flush: () => mutationTracker.flush(),
         stop: () => {

--- a/packages/rum/src/domain/record/startFullSnapshots.spec.ts
+++ b/packages/rum/src/domain/record/startFullSnapshots.spec.ts
@@ -7,7 +7,8 @@ import { appendElement } from '../../../../rum-core/test'
 import { startFullSnapshots } from './startFullSnapshots'
 import { createElementsScrollPositions } from './elementsScrollPositions'
 import type { ShadowRootsController } from './shadowRootsController'
-import type { SerializationStats } from './serialization'
+import { createSerializationScope, type SerializationStats } from './serialization'
+import { createNodeIds } from './nodeIds'
 
 describe('startFullSnapshots', () => {
   const viewStartClock = { relative: 1, timeStamp: 1 as TimeStamp }
@@ -23,6 +24,7 @@ describe('startFullSnapshots', () => {
       {} as ShadowRootsController,
       lifeCycle,
       {} as RumConfiguration,
+      createSerializationScope(createNodeIds()),
       noop,
       emitCallback
     )

--- a/packages/rum/src/domain/record/startFullSnapshots.ts
+++ b/packages/rum/src/domain/record/startFullSnapshots.ts
@@ -6,7 +6,7 @@ import type { BrowserRecord } from '../../types'
 import { RecordType } from '../../types'
 import type { ElementsScrollPositions } from './elementsScrollPositions'
 import type { ShadowRootsController } from './shadowRootsController'
-import type { SerializationContext, SerializationStats } from './serialization'
+import type { SerializationContext, SerializationScope, SerializationStats } from './serialization'
 import { createSerializationStats, SerializationContextStatus, serializeDocument } from './serialization'
 import { getVisualViewport } from './viewports'
 
@@ -15,6 +15,7 @@ export function startFullSnapshots(
   shadowRootsController: ShadowRootsController,
   lifeCycle: LifeCycle,
   configuration: RumConfiguration,
+  scope: SerializationScope,
   flushMutations: () => void,
   emit: (record: BrowserRecord, stats?: SerializationStats) => void
 ) {
@@ -47,7 +48,7 @@ export function startFullSnapshots(
     emit(
       {
         data: {
-          node: serializeDocument(document, configuration, serializationContext),
+          node: serializeDocument(document, configuration, scope, serializationContext),
           initialOffset: {
             left: getScrollX(),
             top: getScrollY(),

--- a/packages/rum/src/domain/record/trackers/trackInput.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackInput.spec.ts
@@ -4,9 +4,16 @@ import { createNewEvent, mockClock, registerCleanupTask } from '@datadog/browser
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT } from '@datadog/browser-rum-core'
 import { appendElement } from '../../../../../rum-core/test'
-import { serializeDocument, SerializationContextStatus, createSerializationStats } from '../serialization'
+import type { SerializationScope } from '../serialization'
+import {
+  serializeDocument,
+  SerializationContextStatus,
+  createSerializationStats,
+  createSerializationScope,
+} from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import { IncrementalSource, RecordType } from '../../../types'
+import { createNodeIds } from '../nodeIds'
 import type { InputCallback } from './trackInput'
 import { trackInput } from './trackInput'
 import { DEFAULT_CONFIGURATION, DEFAULT_SHADOW_ROOT_CONTROLLER } from './trackers.specHelper'
@@ -18,13 +25,16 @@ describe('trackInput', () => {
   let input: HTMLInputElement
   let clock: Clock | undefined
   let configuration: RumConfiguration
+  let scope: SerializationScope
 
   beforeEach(() => {
     configuration = { defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW } as RumConfiguration
     inputCallbackSpy = jasmine.createSpy()
+    scope = createSerializationScope(createNodeIds())
+
     input = appendElement('<div><input target /></div>') as HTMLInputElement
 
-    serializeDocument(document, DEFAULT_CONFIGURATION, {
+    serializeDocument(document, DEFAULT_CONFIGURATION, scope, {
       serializationStats: createSerializationStats(),
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
       status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
@@ -37,7 +47,7 @@ describe('trackInput', () => {
   })
 
   it('collects input values when an "input" event is dispatched', () => {
-    inputTracker = trackInput(configuration, inputCallbackSpy)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy)
     dispatchInputEvent('foo')
 
     expect(inputCallbackSpy).toHaveBeenCalledOnceWith({
@@ -53,7 +63,7 @@ describe('trackInput', () => {
 
   it('collects input values when a property setter is used', () => {
     clock = mockClock()
-    inputTracker = trackInput(configuration, inputCallbackSpy)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy)
     input.value = 'foo'
 
     clock.tick(0)
@@ -71,7 +81,7 @@ describe('trackInput', () => {
 
   it('does not invoke callback when the value does not change', () => {
     clock = mockClock()
-    inputTracker = trackInput(configuration, inputCallbackSpy)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy)
     input.value = 'foo'
     clock.tick(0)
 
@@ -86,7 +96,7 @@ describe('trackInput', () => {
     const host = document.createElement('div')
     host.attachShadow({ mode: 'open' })
 
-    inputTracker = trackInput(configuration, inputCallbackSpy, host.shadowRoot!)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy, host.shadowRoot!)
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set).toBe(originalSetter)
@@ -94,7 +104,7 @@ describe('trackInput', () => {
 
   // cannot trigger an event in a Shadow DOM because event with `isTrusted:false` do not cross the root
   it('collects input values when an "input" event is composed', () => {
-    inputTracker = trackInput(configuration, inputCallbackSpy)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy)
     dispatchInputEventWithInShadowDom('foo')
 
     expect(inputCallbackSpy).toHaveBeenCalledOnceWith({
@@ -110,7 +120,7 @@ describe('trackInput', () => {
 
   it('masks input values according to the element privacy level', () => {
     configuration.defaultPrivacyLevel = DefaultPrivacyLevel.ALLOW
-    inputTracker = trackInput(configuration, inputCallbackSpy)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy)
     input.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
 
     dispatchInputEvent('foo')
@@ -120,7 +130,7 @@ describe('trackInput', () => {
 
   it('masks input values according to a parent element privacy level', () => {
     configuration.defaultPrivacyLevel = DefaultPrivacyLevel.ALLOW
-    inputTracker = trackInput(configuration, inputCallbackSpy)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy)
     input.parentElement!.setAttribute(PRIVACY_ATTR_NAME, PRIVACY_ATTR_VALUE_MASK_USER_INPUT)
 
     dispatchInputEvent('foo')
@@ -130,7 +140,7 @@ describe('trackInput', () => {
 
   it('masks input values according to a the default privacy level', () => {
     configuration.defaultPrivacyLevel = DefaultPrivacyLevel.MASK
-    inputTracker = trackInput(configuration, inputCallbackSpy)
+    inputTracker = trackInput(configuration, scope, inputCallbackSpy)
 
     dispatchInputEvent('foo')
 

--- a/packages/rum/src/domain/record/trackers/trackMediaInteraction.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackMediaInteraction.spec.ts
@@ -2,9 +2,15 @@ import { DefaultPrivacyLevel } from '@datadog/browser-core'
 import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { appendElement } from '../../../../../rum-core/test'
-import { serializeDocument, SerializationContextStatus, createSerializationStats } from '../serialization'
+import {
+  serializeDocument,
+  SerializationContextStatus,
+  createSerializationStats,
+  createSerializationScope,
+} from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import { IncrementalSource, MediaInteractionType, RecordType } from '../../../types'
+import { createNodeIds } from '../nodeIds'
 import type { InputCallback } from './trackInput'
 import { DEFAULT_CONFIGURATION, DEFAULT_SHADOW_ROOT_CONTROLLER } from './trackers.specHelper'
 import { trackMediaInteraction } from './trackMediaInteraction'
@@ -22,13 +28,14 @@ describe('trackMediaInteraction', () => {
 
     audio = appendElement('<audio controls autoplay target></audio>') as HTMLAudioElement
 
-    serializeDocument(document, DEFAULT_CONFIGURATION, {
+    const scope = createSerializationScope(createNodeIds())
+    serializeDocument(document, DEFAULT_CONFIGURATION, scope, {
       serializationStats: createSerializationStats(),
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
       status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
       elementsScrollPositions: createElementsScrollPositions(),
     })
-    mediaInteractionTracker = trackMediaInteraction(configuration, mediaInteractionCallback)
+    mediaInteractionTracker = trackMediaInteraction(configuration, scope, mediaInteractionCallback)
 
     registerCleanupTask(() => {
       mediaInteractionTracker.stop()

--- a/packages/rum/src/domain/record/trackers/trackMediaInteraction.ts
+++ b/packages/rum/src/domain/record/trackers/trackMediaInteraction.ts
@@ -4,14 +4,15 @@ import { NodePrivacyLevel, getNodePrivacyLevel } from '@datadog/browser-rum-core
 import type { BrowserIncrementalSnapshotRecord, MediaInteractionData } from '../../../types'
 import { IncrementalSource, MediaInteractionType } from '../../../types'
 import { getEventTarget } from '../eventsUtils'
-import { getSerializedNodeId, hasSerializedNode } from '../serialization'
 import { assembleIncrementalSnapshot } from '../assembly'
+import type { SerializationScope } from '../serialization'
 import type { Tracker } from './tracker.types'
 
 export type MediaInteractionCallback = (incrementalSnapshotRecord: BrowserIncrementalSnapshotRecord) => void
 
 export function trackMediaInteraction(
   configuration: RumConfiguration,
+  scope: SerializationScope,
   mediaInteractionCb: MediaInteractionCallback
 ): Tracker {
   return addEventListeners(
@@ -20,16 +21,19 @@ export function trackMediaInteraction(
     [DOM_EVENT.PLAY, DOM_EVENT.PAUSE],
     (event) => {
       const target = getEventTarget(event)
+      if (!target) {
+        return
+      }
+      const id = scope.nodeIds.get(target)
       if (
-        !target ||
-        getNodePrivacyLevel(target, configuration.defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN ||
-        !hasSerializedNode(target)
+        id === undefined ||
+        getNodePrivacyLevel(target, configuration.defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN
       ) {
         return
       }
       mediaInteractionCb(
         assembleIncrementalSnapshot<MediaInteractionData>(IncrementalSource.MediaInteraction, {
-          id: getSerializedNodeId(target),
+          id,
           type: event.type === DOM_EVENT.PLAY ? MediaInteractionType.Play : MediaInteractionType.Pause,
         })
       )

--- a/packages/rum/src/domain/record/trackers/trackMouseInteraction.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackMouseInteraction.spec.ts
@@ -3,10 +3,16 @@ import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { appendElement } from '../../../../../rum-core/test'
 import { IncrementalSource, MouseInteractionType, RecordType } from '../../../types'
-import { serializeDocument, SerializationContextStatus, createSerializationStats } from '../serialization'
+import {
+  serializeDocument,
+  SerializationContextStatus,
+  createSerializationStats,
+  createSerializationScope,
+} from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import type { RecordIds } from '../recordIds'
 import { initRecordIds } from '../recordIds'
+import { createNodeIds } from '../nodeIds'
 import type { MouseInteractionCallback } from './trackMouseInteraction'
 import { trackMouseInteraction } from './trackMouseInteraction'
 import { DEFAULT_CONFIGURATION, DEFAULT_SHADOW_ROOT_CONTROLLER } from './trackers.specHelper'
@@ -24,7 +30,8 @@ describe('trackMouseInteraction', () => {
     a = appendElement('<a tabindex="0"></a>') as HTMLAnchorElement // tabindex 0 makes the element focusable
     a.dispatchEvent(createNewEvent(DOM_EVENT.FOCUS))
 
-    serializeDocument(document, DEFAULT_CONFIGURATION, {
+    const scope = createSerializationScope(createNodeIds())
+    serializeDocument(document, DEFAULT_CONFIGURATION, scope, {
       serializationStats: createSerializationStats(),
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
       status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
@@ -33,7 +40,7 @@ describe('trackMouseInteraction', () => {
 
     mouseInteractionCallbackSpy = jasmine.createSpy()
     recordIds = initRecordIds()
-    mouseInteractionTracker = trackMouseInteraction(configuration, mouseInteractionCallbackSpy, recordIds)
+    mouseInteractionTracker = trackMouseInteraction(configuration, scope, mouseInteractionCallbackSpy, recordIds)
 
     registerCleanupTask(() => {
       mouseInteractionTracker.stop()

--- a/packages/rum/src/domain/record/trackers/trackMouseInteraction.ts
+++ b/packages/rum/src/domain/record/trackers/trackMouseInteraction.ts
@@ -5,8 +5,8 @@ import type { MouseInteraction, MouseInteractionData, BrowserIncrementalSnapshot
 import { IncrementalSource, MouseInteractionType } from '../../../types'
 import { assembleIncrementalSnapshot } from '../assembly'
 import { getEventTarget } from '../eventsUtils'
-import { getSerializedNodeId, hasSerializedNode } from '../serialization'
 import type { RecordIds } from '../recordIds'
+import type { SerializationScope } from '../serialization'
 import { tryToComputeCoordinates } from './trackMove'
 import type { Tracker } from './tracker.types'
 
@@ -35,18 +35,19 @@ export type MouseInteractionCallback = (record: BrowserIncrementalSnapshotRecord
 
 export function trackMouseInteraction(
   configuration: RumConfiguration,
+  scope: SerializationScope,
   mouseInteractionCb: MouseInteractionCallback,
   recordIds: RecordIds
 ): Tracker {
   const handler = (event: MouseEvent | TouchEvent | FocusEvent) => {
     const target = getEventTarget(event)
+    const id = scope.nodeIds.get(target)
     if (
-      getNodePrivacyLevel(target, configuration.defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN ||
-      !hasSerializedNode(target)
+      id === undefined ||
+      getNodePrivacyLevel(target, configuration.defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN
     ) {
       return
     }
-    const id = getSerializedNodeId(target)
     const type = eventTypeToMouseInteraction[event.type as keyof typeof eventTypeToMouseInteraction]
 
     let interaction: MouseInteraction

--- a/packages/rum/src/domain/record/trackers/trackMove.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackMove.spec.ts
@@ -1,8 +1,14 @@
 import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
-import { createSerializationStats, SerializationContextStatus, serializeDocument } from '../serialization'
+import {
+  createSerializationScope,
+  createSerializationStats,
+  SerializationContextStatus,
+  serializeDocument,
+} from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import { IncrementalSource, RecordType } from '../../../types'
+import { createNodeIds } from '../nodeIds'
 import type { MousemoveCallBack } from './trackMove'
 import { trackMove } from './trackMove'
 import { DEFAULT_CONFIGURATION, DEFAULT_SHADOW_ROOT_CONTROLLER } from './trackers.specHelper'
@@ -15,7 +21,9 @@ describe('trackMove', () => {
 
   beforeEach(() => {
     configuration = {} as RumConfiguration
-    serializeDocument(document, DEFAULT_CONFIGURATION, {
+
+    const scope = createSerializationScope(createNodeIds())
+    serializeDocument(document, DEFAULT_CONFIGURATION, scope, {
       serializationStats: createSerializationStats(),
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
       status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
@@ -23,7 +31,7 @@ describe('trackMove', () => {
     })
 
     mouseMoveCallbackSpy = jasmine.createSpy()
-    moveTracker = trackMove(configuration, mouseMoveCallbackSpy)
+    moveTracker = trackMove(configuration, scope, mouseMoveCallbackSpy)
 
     registerCleanupTask(() => {
       moveTracker.stop()

--- a/packages/rum/src/domain/record/trackers/trackMove.ts
+++ b/packages/rum/src/domain/record/trackers/trackMove.ts
@@ -1,40 +1,46 @@
 import { addEventListeners, DOM_EVENT, throttle } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
-import { getSerializedNodeId, hasSerializedNode } from '../serialization'
 import type { BrowserIncrementalSnapshotRecord, MousemoveData, MousePosition } from '../../../types'
 import { IncrementalSource } from '../../../types'
 import { getEventTarget, isTouchEvent } from '../eventsUtils'
 import { convertMouseEventToLayoutCoordinates } from '../viewports'
 import { assembleIncrementalSnapshot } from '../assembly'
+import type { SerializationScope } from '../serialization'
 import type { Tracker } from './tracker.types'
 
 const MOUSE_MOVE_OBSERVER_THRESHOLD = 50
 
 export type MousemoveCallBack = (incrementalSnapshotRecord: BrowserIncrementalSnapshotRecord) => void
 
-export function trackMove(configuration: RumConfiguration, moveCb: MousemoveCallBack): Tracker {
+export function trackMove(
+  configuration: RumConfiguration,
+  scope: SerializationScope,
+  moveCb: MousemoveCallBack
+): Tracker {
   const { throttled: updatePosition, cancel: cancelThrottle } = throttle(
     (event: MouseEvent | TouchEvent) => {
       const target = getEventTarget(event)
-      if (hasSerializedNode(target)) {
-        const coordinates = tryToComputeCoordinates(event)
-        if (!coordinates) {
-          return
-        }
-        const position: MousePosition = {
-          id: getSerializedNodeId(target),
-          timeOffset: 0,
-          x: coordinates.x,
-          y: coordinates.y,
-        }
-
-        moveCb(
-          assembleIncrementalSnapshot<MousemoveData>(
-            isTouchEvent(event) ? IncrementalSource.TouchMove : IncrementalSource.MouseMove,
-            { positions: [position] }
-          )
-        )
+      const id = scope.nodeIds.get(target)
+      if (id === undefined) {
+        return
       }
+      const coordinates = tryToComputeCoordinates(event)
+      if (!coordinates) {
+        return
+      }
+      const position: MousePosition = {
+        id,
+        timeOffset: 0,
+        x: coordinates.x,
+        y: coordinates.y,
+      }
+
+      moveCb(
+        assembleIncrementalSnapshot<MousemoveData>(
+          isTouchEvent(event) ? IncrementalSource.TouchMove : IncrementalSource.MouseMove,
+          { positions: [position] }
+        )
+      )
     },
     MOUSE_MOVE_OBSERVER_THRESHOLD,
     {

--- a/packages/rum/src/domain/record/trackers/trackMutation.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackMutation.spec.ts
@@ -11,10 +11,17 @@ import {
 import { createMutationPayloadValidator } from '../../../../test'
 import type { AttributeMutation, Attributes, BrowserMutationPayload } from '../../../types'
 import { NodeType } from '../../../types'
-import { serializeDocument, SerializationContextStatus, createSerializationStats } from '../serialization'
+import type { SerializationScope } from '../serialization'
+import {
+  serializeDocument,
+  SerializationContextStatus,
+  createSerializationStats,
+  createSerializationScope,
+} from '../serialization'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import type { ShadowRootCallBack } from '../shadowRootsController'
 import { appendElement, appendText } from '../../../../../rum-core/test'
+import { createNodeIds } from '../nodeIds'
 import { sortAddedAndMovedNodes, trackMutation } from './trackMutation'
 import type { MutationCallBack, MutationTracker } from './trackMutation'
 import { DEFAULT_SHADOW_ROOT_CONTROLLER } from './trackers.specHelper'
@@ -25,10 +32,12 @@ describe('trackMutation', () => {
 
   let addShadowRootSpy: jasmine.Spy<ShadowRootCallBack>
   let removeShadowRootSpy: jasmine.Spy<ShadowRootCallBack>
+  let scope: SerializationScope
 
   beforeEach(() => {
     addShadowRootSpy = jasmine.createSpy<ShadowRootCallBack>()
     removeShadowRootSpy = jasmine.createSpy<ShadowRootCallBack>()
+    scope = createSerializationScope(createNodeIds())
   })
 
   function startMutationCollection(defaultPrivacyLevel: DefaultPrivacyLevel = DefaultPrivacyLevel.ALLOW) {
@@ -39,6 +48,7 @@ describe('trackMutation', () => {
       {
         defaultPrivacyLevel,
       } as RumConfiguration,
+      scope,
       { ...DEFAULT_SHADOW_ROOT_CONTROLLER, addShadowRoot: addShadowRootSpy, removeShadowRoot: removeShadowRootSpy },
       document
     )
@@ -55,6 +65,7 @@ describe('trackMutation', () => {
       {
         defaultPrivacyLevel: NodePrivacyLevel.ALLOW,
       } as RumConfiguration,
+      scope,
       {
         serializationStats: createSerializationStats(),
         shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,

--- a/packages/rum/src/domain/record/trackers/trackMutation.ts
+++ b/packages/rum/src/domain/record/trackers/trackMutation.ts
@@ -25,12 +25,9 @@ import type {
   TextMutation,
   BrowserIncrementalSnapshotRecord,
 } from '../../../types'
-import type { NodeWithSerializedNode, SerializationContext, SerializationStats } from '../serialization'
+import type { SerializationContext, SerializationScope, SerializationStats } from '../serialization'
 import {
   getElementInputValue,
-  getSerializedNodeId,
-  hasSerializedNode,
-  nodeAndAncestorsHaveSerializedNode,
   serializeNodeWithId,
   SerializationContextStatus,
   serializeAttribute,
@@ -40,6 +37,7 @@ import {
 import { createMutationBatch } from '../mutationBatch'
 import type { ShadowRootCallBack, ShadowRootsController } from '../shadowRootsController'
 import { assembleIncrementalSnapshot } from '../assembly'
+import type { NodeWithSerializedNode } from '../nodeIds'
 import type { Tracker } from './tracker.types'
 
 export type MutationCallBack = (
@@ -57,6 +55,7 @@ export type MutationTracker = Tracker & { flush: () => void }
 export function trackMutation(
   mutationCallback: MutationCallBack,
   configuration: RumConfiguration,
+  scope: SerializationScope,
   shadowRootsController: ShadowRootsController,
   target: Node
 ): MutationTracker {
@@ -70,6 +69,7 @@ export function trackMutation(
       mutations.concat(observer.takeRecords() as RumMutationRecord[]),
       mutationCallback,
       configuration,
+      scope,
       shadowRootsController
     )
   })
@@ -100,6 +100,7 @@ function processMutations(
   mutations: RumMutationRecord[],
   mutationCallback: MutationCallBack,
   configuration: RumConfiguration,
+  scope: SerializationScope,
   shadowRootsController: ShadowRootsController
 ) {
   const nodePrivacyLevelCache: NodePrivacyLevelCache = new Map()
@@ -119,7 +120,7 @@ function processMutations(
   const filteredMutations = mutations.filter(
     (mutation): mutation is WithSerializedTarget<RumMutationRecord> =>
       mutation.target.isConnected &&
-      nodeAndAncestorsHaveSerializedNode(mutation.target) &&
+      scope.nodeIds.areAssignedForNodeAndAncestors(mutation.target) &&
       getNodePrivacyLevel(mutation.target, configuration.defaultPrivacyLevel, nodePrivacyLevelCache) !==
         NodePrivacyLevel.HIDDEN
   )
@@ -131,6 +132,7 @@ function processMutations(
       (mutation): mutation is WithSerializedTarget<RumChildListMutationRecord> => mutation.type === 'childList'
     ),
     configuration,
+    scope,
     serializationStats,
     shadowRootsController,
     nodePrivacyLevelCache
@@ -142,6 +144,7 @@ function processMutations(
         mutation.type === 'characterData' && !hasBeenSerialized(mutation.target)
     ),
     configuration,
+    scope,
     nodePrivacyLevelCache
   )
 
@@ -151,6 +154,7 @@ function processMutations(
         mutation.type === 'attributes' && !hasBeenSerialized(mutation.target)
     ),
     configuration,
+    scope,
     nodePrivacyLevelCache
   )
 
@@ -167,6 +171,7 @@ function processMutations(
 function processChildListMutations(
   mutations: Array<WithSerializedTarget<RumChildListMutationRecord>>,
   configuration: RumConfiguration,
+  scope: SerializationScope,
   serializationStats: SerializationStats,
   shadowRootsController: ShadowRootsController,
   nodePrivacyLevelCache: NodePrivacyLevelCache
@@ -240,6 +245,7 @@ function processChildListMutations(
       parentNodePrivacyLevel,
       serializationContext,
       configuration,
+      scope,
     })
     updateSerializationStats(serializationStats, 'serializationDuration', elapsed(serializationStart, timeStampNow()))
     if (!serializedNode) {
@@ -249,32 +255,33 @@ function processChildListMutations(
     const parentNode = getParentNode(node)!
     addedNodeMutations.push({
       nextId: getNextSibling(node),
-      parentId: getSerializedNodeId(parentNode)!,
+      parentId: scope.nodeIds.get(parentNode)!,
       node: serializedNode,
     })
   }
   // Finally, we emit remove mutations.
   const removedNodeMutations: RemovedNodeMutation[] = []
   removedNodes.forEach((parent, node) => {
-    if (hasSerializedNode(node)) {
-      removedNodeMutations.push({
-        parentId: getSerializedNodeId(parent),
-        id: getSerializedNodeId(node),
-      })
+    const parentId = scope.nodeIds.get(parent)
+    const id = scope.nodeIds.get(node)
+    if (parentId !== undefined && id !== undefined) {
+      removedNodeMutations.push({ parentId, id })
     }
   })
 
   return { adds: addedNodeMutations, removes: removedNodeMutations, hasBeenSerialized }
 
   function hasBeenSerialized(node: Node) {
-    return hasSerializedNode(node) && serializedNodeIds.has(getSerializedNodeId(node))
+    const id = scope.nodeIds.get(node)
+    return id !== undefined && serializedNodeIds.has(id)
   }
 
   function getNextSibling(node: Node): null | number {
     let nextSibling = node.nextSibling
     while (nextSibling) {
-      if (hasSerializedNode(nextSibling)) {
-        return getSerializedNodeId(nextSibling)
+      const id = scope.nodeIds.get(nextSibling)
+      if (id !== undefined) {
+        return id
       }
       nextSibling = nextSibling.nextSibling
     }
@@ -286,6 +293,7 @@ function processChildListMutations(
 function processCharacterDataMutations(
   mutations: Array<WithSerializedTarget<RumCharacterDataMutationRecord>>,
   configuration: RumConfiguration,
+  scope: SerializationScope,
   nodePrivacyLevelCache: NodePrivacyLevelCache
 ) {
   const textMutations: TextMutation[] = []
@@ -307,6 +315,11 @@ function processCharacterDataMutations(
       continue
     }
 
+    const id = scope.nodeIds.get(mutation.target)
+    if (id === undefined) {
+      continue
+    }
+
     const parentNodePrivacyLevel = getNodePrivacyLevel(
       getParentNode(mutation.target)!,
       configuration.defaultPrivacyLevel,
@@ -317,7 +330,7 @@ function processCharacterDataMutations(
     }
 
     textMutations.push({
-      id: getSerializedNodeId(mutation.target),
+      id,
       value: getTextContent(mutation.target, parentNodePrivacyLevel) ?? null,
     })
   }
@@ -328,6 +341,7 @@ function processCharacterDataMutations(
 function processAttributesMutations(
   mutations: Array<WithSerializedTarget<RumAttributesMutationRecord>>,
   configuration: RumConfiguration,
+  scope: SerializationScope,
   nodePrivacyLevelCache: NodePrivacyLevelCache
 ) {
   const attributeMutations: AttributeMutation[] = []
@@ -354,6 +368,12 @@ function processAttributesMutations(
     if (uncensoredValue === mutation.oldValue) {
       continue
     }
+
+    const id = scope.nodeIds.get(mutation.target)
+    if (id === undefined) {
+      continue
+    }
+
     const privacyLevel = getNodePrivacyLevel(mutation.target, configuration.defaultPrivacyLevel, nodePrivacyLevelCache)
     const attributeValue = serializeAttribute(mutation.target, privacyLevel, mutation.attributeName!, configuration)
 
@@ -372,10 +392,7 @@ function processAttributesMutations(
 
     let emittedMutation = emittedMutations.get(mutation.target)
     if (!emittedMutation) {
-      emittedMutation = {
-        id: getSerializedNodeId(mutation.target),
-        attributes: {},
-      }
+      emittedMutation = { id, attributes: {} }
       attributeMutations.push(emittedMutation)
       emittedMutations.set(mutation.target, emittedMutation)
     }

--- a/packages/rum/src/domain/record/trackers/trackScroll.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackScroll.spec.ts
@@ -2,10 +2,16 @@ import { DefaultPrivacyLevel } from '@datadog/browser-core'
 import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { appendElement } from '../../../../../rum-core/test'
-import { serializeDocument, SerializationContextStatus, createSerializationStats } from '../serialization'
+import {
+  serializeDocument,
+  SerializationContextStatus,
+  createSerializationStats,
+  createSerializationScope,
+} from '../serialization'
 import type { ElementsScrollPositions } from '../elementsScrollPositions'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import { IncrementalSource, RecordType } from '../../../types'
+import { createNodeIds } from '../nodeIds'
 import type { InputCallback } from './trackInput'
 import { DEFAULT_CONFIGURATION, DEFAULT_SHADOW_ROOT_CONTROLLER } from './trackers.specHelper'
 import { trackScroll } from './trackScroll'
@@ -25,13 +31,14 @@ describe('trackScroll', () => {
 
     div = appendElement('<div target></div>') as HTMLDivElement
 
-    serializeDocument(document, DEFAULT_CONFIGURATION, {
+    const scope = createSerializationScope(createNodeIds())
+    serializeDocument(document, DEFAULT_CONFIGURATION, scope, {
       serializationStats: createSerializationStats(),
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
       status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,
       elementsScrollPositions,
     })
-    scrollTracker = trackScroll(configuration, scrollCallback, elementsScrollPositions)
+    scrollTracker = trackScroll(configuration, scope, scrollCallback, elementsScrollPositions)
 
     registerCleanupTask(() => {
       scrollTracker.stop()

--- a/packages/rum/src/domain/record/trackers/trackScroll.ts
+++ b/packages/rum/src/domain/record/trackers/trackScroll.ts
@@ -3,10 +3,10 @@ import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { getScrollX, getScrollY, getNodePrivacyLevel, NodePrivacyLevel } from '@datadog/browser-rum-core'
 import type { ElementsScrollPositions } from '../elementsScrollPositions'
 import { getEventTarget } from '../eventsUtils'
-import { getSerializedNodeId, hasSerializedNode } from '../serialization'
 import { IncrementalSource } from '../../../types'
 import type { BrowserIncrementalSnapshotRecord, ScrollData } from '../../../types'
 import { assembleIncrementalSnapshot } from '../assembly'
+import type { SerializationScope } from '../serialization'
 import type { Tracker } from './tracker.types'
 
 const SCROLL_OBSERVER_THRESHOLD = 100
@@ -15,20 +15,23 @@ export type ScrollCallback = (incrementalSnapshotRecord: BrowserIncrementalSnaps
 
 export function trackScroll(
   configuration: RumConfiguration,
+  scope: SerializationScope,
   scrollCb: ScrollCallback,
   elementsScrollPositions: ElementsScrollPositions,
   target: Document | ShadowRoot = document
 ): Tracker {
   const { throttled: updatePosition, cancel: cancelThrottle } = throttle((event: Event) => {
     const target = getEventTarget(event) as HTMLElement | Document
+    if (!target) {
+      return
+    }
+    const id = scope.nodeIds.get(target)
     if (
-      !target ||
-      getNodePrivacyLevel(target, configuration.defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN ||
-      !hasSerializedNode(target)
+      id === undefined ||
+      getNodePrivacyLevel(target, configuration.defaultPrivacyLevel) === NodePrivacyLevel.HIDDEN
     ) {
       return
     }
-    const id = getSerializedNodeId(target)
     const scrollPositions =
       target === document
         ? {

--- a/packages/rum/src/domain/record/trackers/trackViewportResize.spec.ts
+++ b/packages/rum/src/domain/record/trackers/trackViewportResize.spec.ts
@@ -1,10 +1,16 @@
 import { DefaultPrivacyLevel } from '@datadog/browser-core'
 import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
-import { serializeDocument, SerializationContextStatus, createSerializationStats } from '../serialization'
+import {
+  serializeDocument,
+  SerializationContextStatus,
+  createSerializationStats,
+  createSerializationScope,
+} from '../serialization'
 import type { ElementsScrollPositions } from '../elementsScrollPositions'
 import { createElementsScrollPositions } from '../elementsScrollPositions'
 import { RecordType } from '../../../types'
+import { createNodeIds } from '../nodeIds'
 import { DEFAULT_CONFIGURATION, DEFAULT_SHADOW_ROOT_CONTROLLER } from './trackers.specHelper'
 import type { VisualViewportResizeCallback } from './trackViewportResize'
 import { trackVisualViewportResize } from './trackViewportResize'
@@ -25,7 +31,8 @@ describe('trackViewportResize', () => {
     elementsScrollPositions = createElementsScrollPositions()
     visualViewportResizeCallback = jasmine.createSpy()
 
-    serializeDocument(document, DEFAULT_CONFIGURATION, {
+    const scope = createSerializationScope(createNodeIds())
+    serializeDocument(document, DEFAULT_CONFIGURATION, scope, {
       serializationStats: createSerializationStats(),
       shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,
       status: SerializationContextStatus.INITIAL_FULL_SNAPSHOT,


### PR DESCRIPTION
## Motivation

I'm preparing to implement a prototype of a new DOM serialization algorithm behind a feature flag. To cleanly integrate this new algorithm into the existing code, we need to add a small amount of abstraction.

This PR focuses on adding an abstraction layer around node ids. Currently, the association between DOM nodes and their ids is tracked using global variables which persist across views; however, with the new algorithm, each view needs its own node id namespace. To abstract over this difference cleanly, it's helpful to get rid of the global variables and create an object to provide an explicit lifetime to this state.

## Changes

This PR adds a new `SerializationScope` type which tracks state associated with a specific stream of serialized events. It also removes the global variables we use right now to track node ids and moves them onto a new `NodeIds` type which is exposed via `SerializationScope`. The new `SerializationScope` type is plumbed to the various places in the code which need it.

There is not yet a mechanism for resetting the state associated with the `SerializationScope` when the view changes; in this PR, the focus is on maintaining existing behavior as much as possible, and in any case today's algorithm would not use this functionality. This mechanism will be added in a future PR.

Future PRs will also add more state to `SerializationScope`. Some of this will be associated with the new DOM serialization algorithm, but there is also existing state with similar lifetime requirements (e.g. `ElementScrollPositions`) that would probably make sense to fold into `SerializationScope`.

Note that while this PR is intended to maintain existing behavior, it _does_ actually change things slightly, because the lifetime of node ids is now tied to a particular invocation of `record()`. This means that stopping and starting recording will reset node ids. I think this is fine, and indeed desirable, but it's something to be aware of.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
