### PR TITLE
👥 [PANA-4375] Transfer replay code to session-replay-sdk team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,11 @@
 # Order is important, the last matching pattern takes the most precedence.
 
 # Global
-packages/flagging  @Datadog/feature-flagging-experimentation
-*                  @Datadog/rum-browser
+packages/flagging                          @Datadog/feature-flagging-experimentation
+packages/rum/src/domain/record             @Datadog/session-replay-sdk
+packages/rum/src/domain/segmentCollection  @Datadog/session-replay-sdk
+packages/rum/src/domain/*.ts               @Datadog/session-replay-sdk
+*                                          @Datadog/rum-browser
 
 # Docs
 *README.md    @Datadog/rum-browser @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 
 # Global
 packages/flagging                          @Datadog/feature-flagging-experimentation
-packages/rum/src/domain/record             @Datadog/session-replay-sdk
-packages/rum/src/domain/segmentCollection  @Datadog/session-replay-sdk
-packages/rum/src/domain/*.ts               @Datadog/session-replay-sdk
+packages/rum/src/domain/record             @Datadog/rum-browser @Datadog/session-replay-sdk
+packages/rum/src/domain/segmentCollection  @Datadog/rum-browser @Datadog/session-replay-sdk
+packages/rum/src/domain/*.ts               @Datadog/rum-browser @Datadog/session-replay-sdk
 *                                          @Datadog/rum-browser
 
 # Docs


### PR DESCRIPTION
## Motivation

As we begin to transition to a more platform-like model for the browser SDK, it makes sense to gradually transition ownership of some team-specific code to the appropriate teams. My hope is that this will reduce the degree to which browser SDK team members are on the critical path for wide variety of projects, enabling various teams to work in parallel a bit more easily.

## Changes

This PR transfers ownership of the session replay code to the new `session-replay-sdk` Github team.

Note that in the short term, I still anticipate that changes will need review from the browser SDK team, but I'm planning to add `session-replay-sdk` team members as additional reviewers, in the hope that eventually the more isolated PRs will no longer require browser SDK team review. (Though we can work out the details there later; I think we're still quite far from that being possible!)