### PR TITLE
🎨 [PANA-4378] Eliminate need for getTextContent's ignoreWhiteSpace option

### DIFF
--- a/packages/rum-core/src/domain/privacy.ts
+++ b/packages/rum-core/src/domain/privacy.ts
@@ -173,17 +173,14 @@ function isFormElement(node: Node | null): boolean {
  */
 const censorText = (text: string) => text.replace(/\S/g, TEXT_MASKING_CHAR)
 
-export function getTextContent(
-  textNode: Node,
-  ignoreWhiteSpace: boolean,
-  parentNodePrivacyLevel: NodePrivacyLevel
-): string | undefined {
+export function getTextContent(textNode: Node, parentNodePrivacyLevel: NodePrivacyLevel): string | undefined {
   // The parent node may not be a html element which has a tagName attribute.
   // So just let it be undefined which is ok in this use case.
   const parentTagName = textNode.parentElement?.tagName
   let textContent = textNode.textContent || ''
 
-  if (ignoreWhiteSpace && !textContent.trim()) {
+  const shouldIgnoreWhiteSpace = parentTagName === 'HEAD'
+  if (shouldIgnoreWhiteSpace && !textContent.trim()) {
     return
   }
 

--- a/packages/rum/src/domain/record/serialization/serialization.types.ts
+++ b/packages/rum/src/domain/record/serialization/serialization.types.ts
@@ -39,7 +39,6 @@ export type SerializationContext =
 
 export interface SerializeOptions {
   serializedNodeIds?: Set<number>
-  ignoreWhiteSpace?: boolean
   parentNodePrivacyLevel: ParentNodePrivacyLevel
   serializationContext: SerializationContext
   configuration: RumConfiguration

--- a/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.spec.ts
@@ -777,10 +777,12 @@ describe('serializeNodeWithId', () => {
       })
     })
 
-    it('does not serialize text nodes with only white space if the ignoreWhiteSpace option is specified', () => {
-      expect(
-        serializeNodeWithId(document.createTextNode('   '), { ...getDefaultOptions(), ignoreWhiteSpace: true })
-      ).toEqual(null)
+    it('does not serialize text nodes with only white space if the parent is a HEAD element', () => {
+      const head = document.getElementsByTagName('head')[0]
+      const textNode = document.createTextNode('   ')
+      head.appendChild(textNode)
+      expect(serializeNodeWithId(textNode, getDefaultOptions())).toEqual(null)
+      head.removeChild(textNode)
     })
   })
 

--- a/packages/rum/src/domain/record/serialization/serializeNode.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.ts
@@ -167,13 +167,12 @@ function serializeElementNode(element: Element, options: SerializeOptions): Elem
     // We should not create a new object systematically as it could impact performances. Try to reuse
     // the same object as much as possible, and clone it only if we need to.
     let childNodesSerializationOptions
-    if (options.parentNodePrivacyLevel === nodePrivacyLevel && options.ignoreWhiteSpace === (tagName === 'head')) {
+    if (options.parentNodePrivacyLevel === nodePrivacyLevel) {
       childNodesSerializationOptions = options
     } else {
       childNodesSerializationOptions = {
         ...options,
         parentNodePrivacyLevel: nodePrivacyLevel,
-        ignoreWhiteSpace: tagName === 'head',
       }
     }
     childNodes = serializeChildNodes(element, childNodesSerializationOptions)
@@ -199,7 +198,7 @@ function isSVGElement(el: Element): boolean {
  */
 
 function serializeTextNode(textNode: Text, options: SerializeOptions): TextNode | undefined {
-  const textContent = getTextContent(textNode, options.ignoreWhiteSpace || false, options.parentNodePrivacyLevel)
+  const textContent = getTextContent(textNode, options.parentNodePrivacyLevel)
   if (textContent === undefined) {
     return
   }

--- a/packages/rum/src/domain/record/trackers/trackMutation.ts
+++ b/packages/rum/src/domain/record/trackers/trackMutation.ts
@@ -318,8 +318,7 @@ function processCharacterDataMutations(
 
     textMutations.push({
       id: getSerializedNodeId(mutation.target),
-      // TODO: pass a valid "ignoreWhiteSpace" argument
-      value: getTextContent(mutation.target, false, parentNodePrivacyLevel) ?? null,
+      value: getTextContent(mutation.target, parentNodePrivacyLevel) ?? null,
     })
   }
 


### PR DESCRIPTION
## Motivation

When implementing the new DOM serialization algorithm, I noticed that `getTextContent()`'s `ignoreWhiteSpace` option introduces unnecessary complexity. This option is supposed to be set when serializing text nodes which are direct children of `HEAD` elements, and unset otherwise. Checking that condition can be a bit of a headache:
* `serializeNode.ts` needs to thread this knowledge through every recursive call it makes as part of the `SerializeOptions` object, and has even gone so far as to implement optimizations to reduce the cost of doing so. 😓 
* `trackMutations.ts` currently simply doesn't handle this correctly, and has a `TODO` comment about fixing the issue.

In the new code I'm working on, I similarly found that it would be preferable to not have to check this condition.

## Changes

It's actually quite easy to check this condition _inside_ `getTextContent()`; we are already looking at the parent element's tag name for other reasons. So, this PR removes the `ignoreWhiteSpace` option, and totally encapsulates its logic inside `getTextContent()`.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
