### PR TITLE
🔥 [RUM-11434] Remove writable_resource_graphql experimental feature

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -15,7 +15,6 @@ import { objectHasValue } from './utils/objectUtils'
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
-  WRITABLE_RESOURCE_GRAPHQL = 'writable_resource_graphql',
   USE_TREE_WALKER_FOR_ACTION_NAME = 'use_tree_walker_for_action_name',
   GRAPHQL_TRACKING = 'graphql_tracking',
   FEATURE_OPERATION_VITAL = 'feature_operation_vital',

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,11 +1,5 @@
 import type { ClocksState, RelativeTime, TimeStamp } from '@datadog/browser-core'
-import {
-  ErrorSource,
-  HookNames,
-  ONE_MINUTE,
-  display,
-  startGlobalContext,
-} from '@datadog/browser-core'
+import { ErrorSource, HookNames, ONE_MINUTE, display, startGlobalContext } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { registerCleanupTask, mockClock } from '@datadog/browser-core/test'
 import {
@@ -75,7 +69,6 @@ describe('rum assembly', () => {
 
           expect((serverRumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
         })
-
       })
 
       describe('context field', () => {

--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -1,14 +1,13 @@
 import type { ClocksState, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import {
   ErrorSource,
-  ExperimentalFeature,
   HookNames,
   ONE_MINUTE,
   display,
   startGlobalContext,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
-import { mockExperimentalFeatures, registerCleanupTask, mockClock } from '@datadog/browser-core/test'
+import { registerCleanupTask, mockClock } from '@datadog/browser-core/test'
 import {
   createRumSessionManagerMock,
   createRawRumEvent,
@@ -77,37 +76,6 @@ describe('rum assembly', () => {
           expect((serverRumEvents[0].view as any).performance.lcp.resource_url).toBe('modified_url')
         })
 
-        describe('field resource.graphql on Resource events', () => {
-          it('by default, it should not be modifiable', () => {
-            const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-              partialConfiguration: {
-                beforeSend: (event) => (event.resource!.graphql = { operationType: 'query' }),
-              },
-            })
-
-            notifyRawRumEvent(lifeCycle, {
-              rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, { resource: { url: '/path?foo=bar' } }),
-            })
-
-            expect((serverRumEvents[0] as RumResourceEvent).resource.graphql).toBeUndefined()
-          })
-
-          it('with the writable_resource_graphql experimental flag is set, it should be modifiable', () => {
-            mockExperimentalFeatures([ExperimentalFeature.WRITABLE_RESOURCE_GRAPHQL])
-
-            const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-              partialConfiguration: {
-                beforeSend: (event) => (event.resource!.graphql = { operationType: 'query' }),
-              },
-            })
-
-            notifyRawRumEvent(lifeCycle, {
-              rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, { resource: { url: '/path?foo=bar' } }),
-            })
-
-            expect((serverRumEvents[0] as RumResourceEvent).resource.graphql).toEqual({ operationType: 'query' })
-          })
-        })
       })
 
       describe('context field', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -4,8 +4,6 @@ import {
   isEmptyObject,
   display,
   createEventRateLimiter,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
   HookNames,
   DISCARDED,
   buildTags,
@@ -61,9 +59,6 @@ export function startRumAssembly(
     },
     [RumEventType.RESOURCE]: {
       'resource.url': 'string',
-      ...(isExperimentalFeatureEnabled(ExperimentalFeature.WRITABLE_RESOURCE_GRAPHQL)
-        ? { 'resource.graphql': 'object' }
-        : {}),
       ...USER_CUSTOMIZABLE_FIELD_PATHS,
       ...VIEW_MODIFIABLE_FIELD_PATHS,
       ...ROOT_MODIFIABLE_FIELD_PATHS,


### PR DESCRIPTION
## Motivation

As we now have a way to collect graphql request via new init parameter (see : https://github.com/DataDog/browser-sdk/pull/3805) we don't need this experimental feature anymore. 

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
