### PR TITLE
🎨 [PANA-4398] Convert SerializeOptions#parentNodePrivacyLevel into a normal function argument

### DIFF
--- a/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
+++ b/packages/rum/src/domain/record/serialization/htmlAst.specHelper.ts
@@ -43,8 +43,7 @@ const DEFAULT_SHADOW_ROOT_CONTROLLER = {
 export const generateLeanSerializedDoc = (htmlContent: string, privacyTag: string) => {
   const newDoc = makeHtmlDoc(htmlContent, privacyTag)
   const serializedDoc = removeIdFieldsRecursivelyClone(
-    serializeNodeWithId(newDoc, {
-      parentNodePrivacyLevel: NodePrivacyLevel.ALLOW,
+    serializeNodeWithId(newDoc, NodePrivacyLevel.ALLOW, {
       serializationContext: {
         serializationStats: createSerializationStats(),
         shadowRootsController: DEFAULT_SHADOW_ROOT_CONTROLLER,

--- a/packages/rum/src/domain/record/serialization/serialization.types.ts
+++ b/packages/rum/src/domain/record/serialization/serialization.types.ts
@@ -7,7 +7,7 @@ import type { SerializationStats } from './serializationStats'
 // Those values are the only one that can be used when inheriting privacy levels from parent to
 // children during serialization, since HIDDEN and IGNORE shouldn't serialize their children. This
 // ensures that no children are serialized when they shouldn't.
-export type ParentPrivacyLevel =
+export type ParentNodePrivacyLevel =
   | typeof NodePrivacyLevel.ALLOW
   | typeof NodePrivacyLevel.MASK
   | typeof NodePrivacyLevel.MASK_USER_INPUT

--- a/packages/rum/src/domain/record/serialization/serialization.types.ts
+++ b/packages/rum/src/domain/record/serialization/serialization.types.ts
@@ -7,7 +7,7 @@ import type { SerializationStats } from './serializationStats'
 // Those values are the only one that can be used when inheriting privacy levels from parent to
 // children during serialization, since HIDDEN and IGNORE shouldn't serialize their children. This
 // ensures that no children are serialized when they shouldn't.
-type ParentNodePrivacyLevel =
+export type ParentPrivacyLevel =
   | typeof NodePrivacyLevel.ALLOW
   | typeof NodePrivacyLevel.MASK
   | typeof NodePrivacyLevel.MASK_USER_INPUT
@@ -40,7 +40,6 @@ export type SerializationContext =
 
 export interface SerializeOptions {
   serializedNodeIds?: Set<number>
-  parentNodePrivacyLevel: ParentNodePrivacyLevel
   serializationContext: SerializationContext
   configuration: RumConfiguration
   scope: SerializationScope

--- a/packages/rum/src/domain/record/serialization/serializeDocument.ts
+++ b/packages/rum/src/domain/record/serialization/serializeDocument.ts
@@ -13,9 +13,8 @@ export function serializeDocument(
   serializationContext: SerializationContext
 ): SerializedNodeWithId {
   const serializationStart = timeStampNow()
-  const serializedNode = serializeNodeWithId(document, {
+  const serializedNode = serializeNodeWithId(document, configuration.defaultPrivacyLevel, {
     serializationContext,
-    parentNodePrivacyLevel: configuration.defaultPrivacyLevel,
     configuration,
     scope,
   })

--- a/packages/rum/src/domain/record/serialization/serializeNode.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.ts
@@ -21,16 +21,16 @@ import type {
 } from '../../../types'
 import { NodeType } from '../../../types'
 import { getValidTagName } from './serializationUtils'
-import type { ParentPrivacyLevel, SerializeOptions } from './serialization.types'
+import type { ParentNodePrivacyLevel, SerializeOptions } from './serialization.types'
 import { serializeStyleSheets } from './serializeStyleSheets'
 import { serializeAttributes } from './serializeAttributes'
 
 export function serializeNodeWithId(
   node: Node,
-  parentPrivacyLevel: ParentPrivacyLevel,
+  parentNodePrivacyLevel: ParentNodePrivacyLevel,
   options: SerializeOptions
 ): SerializedNodeWithId | null {
-  const serializedNode = serializeNode(node, parentPrivacyLevel, options)
+  const serializedNode = serializeNode(node, parentNodePrivacyLevel, options)
   if (!serializedNode) {
     return null
   }
@@ -46,12 +46,12 @@ export function serializeNodeWithId(
 
 export function serializeChildNodes(
   node: Node,
-  parentPrivacyLevel: ParentPrivacyLevel,
+  parentNodePrivacyLevel: ParentNodePrivacyLevel,
   options: SerializeOptions
 ): SerializedNodeWithId[] {
   const result: SerializedNodeWithId[] = []
   forEachChildNodes(node, (childNode) => {
-    const serializedChildNode = serializeNodeWithId(childNode, parentPrivacyLevel, options)
+    const serializedChildNode = serializeNodeWithId(childNode, parentNodePrivacyLevel, options)
     if (serializedChildNode) {
       result.push(serializedChildNode)
     }
@@ -61,20 +61,20 @@ export function serializeChildNodes(
 
 function serializeNode(
   node: Node,
-  parentPrivacyLevel: ParentPrivacyLevel,
+  parentNodePrivacyLevel: ParentNodePrivacyLevel,
   options: SerializeOptions
 ): SerializedNode | undefined {
   switch (node.nodeType) {
     case node.DOCUMENT_NODE:
-      return serializeDocumentNode(node as Document, parentPrivacyLevel, options)
+      return serializeDocumentNode(node as Document, parentNodePrivacyLevel, options)
     case node.DOCUMENT_FRAGMENT_NODE:
-      return serializeDocumentFragmentNode(node as DocumentFragment, parentPrivacyLevel, options)
+      return serializeDocumentFragmentNode(node as DocumentFragment, parentNodePrivacyLevel, options)
     case node.DOCUMENT_TYPE_NODE:
       return serializeDocumentTypeNode(node as DocumentType)
     case node.ELEMENT_NODE:
-      return serializeElementNode(node as Element, parentPrivacyLevel, options)
+      return serializeElementNode(node as Element, parentNodePrivacyLevel, options)
     case node.TEXT_NODE:
-      return serializeTextNode(node as Text, parentPrivacyLevel)
+      return serializeTextNode(node as Text, parentNodePrivacyLevel)
     case node.CDATA_SECTION_NODE:
       return serializeCDataNode()
   }
@@ -82,19 +82,19 @@ function serializeNode(
 
 export function serializeDocumentNode(
   document: Document,
-  parentPrivacyLevel: ParentPrivacyLevel,
+  parentNodePrivacyLevel: ParentNodePrivacyLevel,
   options: SerializeOptions
 ): DocumentNode {
   return {
     type: NodeType.Document,
-    childNodes: serializeChildNodes(document, parentPrivacyLevel, options),
+    childNodes: serializeChildNodes(document, parentNodePrivacyLevel, options),
     adoptedStyleSheets: serializeStyleSheets(document.adoptedStyleSheets),
   }
 }
 
 function serializeDocumentFragmentNode(
   element: DocumentFragment,
-  parentPrivacyLevel: ParentPrivacyLevel,
+  parentNodePrivacyLevel: ParentNodePrivacyLevel,
   options: SerializeOptions
 ): DocumentFragmentNode | undefined {
   const isShadowRoot = isNodeShadowRoot(element)
@@ -104,7 +104,7 @@ function serializeDocumentFragmentNode(
 
   return {
     type: NodeType.DocumentFragment,
-    childNodes: serializeChildNodes(element, parentPrivacyLevel, options),
+    childNodes: serializeChildNodes(element, parentNodePrivacyLevel, options),
     isShadowRoot,
     adoptedStyleSheets: isShadowRoot ? serializeStyleSheets(element.adoptedStyleSheets) : undefined,
   }
@@ -139,7 +139,7 @@ function serializeDocumentTypeNode(documentType: DocumentType): DocumentTypeNode
 
 function serializeElementNode(
   element: Element,
-  parentPrivacyLevel: ParentPrivacyLevel,
+  parentNodePrivacyLevel: ParentNodePrivacyLevel,
   options: SerializeOptions
 ): ElementNode | undefined {
   const tagName = getValidTagName(element.tagName)
@@ -147,7 +147,7 @@ function serializeElementNode(
 
   // For performance reason, we don't use getNodePrivacyLevel directly: we leverage the
   // parentNodePrivacyLevel option to avoid iterating over all parents
-  const nodePrivacyLevel = reducePrivacyLevel(getNodeSelfPrivacyLevel(element), parentPrivacyLevel)
+  const nodePrivacyLevel = reducePrivacyLevel(getNodeSelfPrivacyLevel(element), parentNodePrivacyLevel)
 
   if (nodePrivacyLevel === NodePrivacyLevel.HIDDEN) {
     const { width, height } = element.getBoundingClientRect()
@@ -199,8 +199,8 @@ function isSVGElement(el: Element): boolean {
  * for privacy level.
  */
 
-function serializeTextNode(textNode: Text, parentPrivacyLevel: ParentPrivacyLevel): TextNode | undefined {
-  const textContent = getTextContent(textNode, parentPrivacyLevel)
+function serializeTextNode(textNode: Text, parentNodePrivacyLevel: ParentNodePrivacyLevel): TextNode | undefined {
+  const textContent = getTextContent(textNode, parentNodePrivacyLevel)
   if (textContent === undefined) {
     return
   }

--- a/packages/rum/src/domain/record/trackers/trackMutation.ts
+++ b/packages/rum/src/domain/record/trackers/trackMutation.ts
@@ -230,19 +230,18 @@ function processChildListMutations(
       continue
     }
 
-    const parentNodePrivacyLevel = getNodePrivacyLevel(
+    const parentPrivacyLevel = getNodePrivacyLevel(
       node.parentNode!,
       configuration.defaultPrivacyLevel,
       nodePrivacyLevelCache
     )
-    if (parentNodePrivacyLevel === NodePrivacyLevel.HIDDEN || parentNodePrivacyLevel === NodePrivacyLevel.IGNORE) {
+    if (parentPrivacyLevel === NodePrivacyLevel.HIDDEN || parentPrivacyLevel === NodePrivacyLevel.IGNORE) {
       continue
     }
 
     const serializationStart = timeStampNow()
-    const serializedNode = serializeNodeWithId(node, {
+    const serializedNode = serializeNodeWithId(node, parentPrivacyLevel, {
       serializedNodeIds,
-      parentNodePrivacyLevel,
       serializationContext,
       configuration,
       scope,

--- a/packages/rum/src/domain/record/trackers/trackMutation.ts
+++ b/packages/rum/src/domain/record/trackers/trackMutation.ts
@@ -230,17 +230,17 @@ function processChildListMutations(
       continue
     }
 
-    const parentPrivacyLevel = getNodePrivacyLevel(
+    const parentNodePrivacyLevel = getNodePrivacyLevel(
       node.parentNode!,
       configuration.defaultPrivacyLevel,
       nodePrivacyLevelCache
     )
-    if (parentPrivacyLevel === NodePrivacyLevel.HIDDEN || parentPrivacyLevel === NodePrivacyLevel.IGNORE) {
+    if (parentNodePrivacyLevel === NodePrivacyLevel.HIDDEN || parentNodePrivacyLevel === NodePrivacyLevel.IGNORE) {
       continue
     }
 
     const serializationStart = timeStampNow()
-    const serializedNode = serializeNodeWithId(node, parentPrivacyLevel, {
+    const serializedNode = serializeNodeWithId(node, parentNodePrivacyLevel, {
       serializedNodeIds,
       serializationContext,
       configuration,


### PR DESCRIPTION
## Motivation

`SerializeOptions#parentNodePrivacyLevel` doesn't really make sense as member of `SerializeOptions`; as the name implies, it's a value that's only applicable for a particular node's children. This scope mismatch has led to the implementation of some optimizations in the code that try to avoid copying `SerializeOptions` constantly during serialization, but the more natural fix is simply to pass this value around as a normal function parameter.

## Changes

This PR converts `SerializeOptions#parentNodePrivacyLevel` into a normal function parameter, updates all call sites, and removes the now-unnecessary code for the optimization described above.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
