### PR TITLE
🔊 delay the session cookie debug telemetry date

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -213,7 +213,7 @@ function detectSessionIdChange(configuration: Configuration, initialSessionState
         const time = dateNow() - sdkInitTime
         getSessionCookies()
           .then((cookie) => {
-            // monitor-until: 2025-10-01, after investigation done
+            // monitor-until: 2025-12-01, after RUM-10845 investigation done
             addTelemetryDebug('Session cookie changed', {
               time,
               session_age: sessionAge,


### PR DESCRIPTION
## Motivation

Keep the session cookie telemetry until RUM-10845 is closed.

## Changes

Update the telemetry expiration date

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
