### PR TITLE
📝  Update AllowedTrackingOrigins description

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -134,7 +134,7 @@ export interface InitConfiguration {
   /**
    * List of origins where the SDK is allowed to run when used in a browser extension context.
    * Matches urls against the extensions origin.
-   * If not provided and the SDK is running in a browser extension, a warning will be displayed.
+   * If not provided and the SDK is running in a browser extension, the SDK will not run.
    */
   allowedTrackingOrigins?: MatchOption[] | undefined
 


### PR DESCRIPTION
## Motivation

After making `allowedTrackingOrigins` required in the SDK, [PR](https://github.com/DataDog/browser-sdk/pull/3885), we need to update it's documentation so that the [Docs](https://datadoghq.dev/browser-sdk/interfaces/_datadog_browser-rum.RumInitConfiguration.html#allowedtrackingorigins) are up to date. 

## Changes

Changed the parameter's description.

## Test instructions

No changes.

## Checklist

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
