### PR TITLE
`LogsEventDomainContext`: fallback to `undefined` instead of `never`

### DIFF
--- a/packages/logs/src/domainContext.types.ts
+++ b/packages/logs/src/domainContext.types.ts
@@ -6,7 +6,7 @@ export type LogsEventDomainContext<T extends ErrorSource = any> = T extends type
     ? ConsoleLogsEventDomainContext
     : T extends typeof ErrorSource.LOGGER
       ? LoggerLogsEventDomainContext
-      : never
+      : undefined
 
 export interface NetworkLogsEventDomainContext {
   isAborted: boolean


### PR DESCRIPTION
## Motivation

This will blow up at runtime, but there's no TypeScript error:

```ts
beforeSend: (event, ctx) => {
  // ❌ No TypeScript error
  'foo' in ctx;
```

This PR fixes the types so we do get a TypeScript error.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
