### PR TITLE
👷 fix check-release script to ignore sub-packages

### DIFF
--- a/test/apps/base-extension/package.json
+++ b/test/apps/base-extension/package.json
@@ -1,6 +1,5 @@
 {
   "name": "rum-testing-extension",
-  "version": "1.0.0",
   "private": true,
   "scripts": {
     "build": "webpack"

--- a/test/apps/react-router-v6-app/package.json
+++ b/test/apps/react-router-v6-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-v6-app",
-  "version": "0.0.0",
+  "private": true,
   "scripts": {
     "build": "webpack"
   },

--- a/test/apps/vanilla/package.json
+++ b/test/apps/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "private": true,
   "scripts": {
     "build": "webpack --config ./webpack.web.js",
     "compat:tsc": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Since #3894, subpackage of rum-react have a `name` property in their package.json, which mean we are checking their version (`undefined`) matches the current release, which [fails](https://gitlab.ddbuild.io/datadog/browser-sdk/builds/1193151544)

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

refactor `checkPackageJsonVersion()` to ignore private packages and fix various package to mark them as private and remove their version number.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
