### PR TITLE
👷 Add check to skip private packages in update-peer-dependency-versions script

### DIFF
--- a/scripts/release/update-peer-dependency-versions.ts
+++ b/scripts/release/update-peer-dependency-versions.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { runMain } from '../lib/executionUtils.ts'
 import { modifyFile } from '../lib/filesUtils.ts'
 import { command } from '../lib/command.ts'
@@ -17,6 +18,11 @@ const JSON_FILES = packagesDirectoryNames.map((packageName) => `./packages/${pac
 // [2]: https://github.com/lerna/lerna/issues/1575
 runMain(async () => {
   for (const jsonFile of JSON_FILES) {
+    const packageJson = JSON.parse(readFileSync(jsonFile, 'utf8'))
+    if (packageJson?.private) {
+      continue
+    }
+
     await modifyFile(jsonFile, updateJsonPeerDependencies)
   }
   // update yarn.lock to match the updated JSON files


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

`yarn version` skips updating the dependencies of package that don't have a version specified. because we removed the version in #3928, it does not update the dependencies, but our `update-peer-dependency-version` still run, creating an inconsistency between dependency and peer-dependency versions.

This PR ignore private packages when updating peer dependency, bringing the versioning closer to how `yarn version` works.

When the package will not be private anymore, the dependencies and peer dependencies will be updated and verified as expected

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
