### PR TITLE
🔊 Add experimental features to default context hook

### DIFF
--- a/packages/rum-core/src/domain/contexts/defaultContext.ts
+++ b/packages/rum-core/src/domain/contexts/defaultContext.ts
@@ -1,4 +1,11 @@
-import { canUseEventBridge, currentDrift, HookNames, round, timeStampNow } from '@datadog/browser-core'
+import {
+  canUseEventBridge,
+  currentDrift,
+  getExperimentalFeatures,
+  HookNames,
+  round,
+  timeStampNow,
+} from '@datadog/browser-core'
 import type { RumConfiguration } from '../configuration'
 import type { DefaultRumEventAttributes, DefaultTelemetryEventAttributes, Hooks } from '../hooks'
 
@@ -22,6 +29,7 @@ export function startDefaultContext(
           session_sample_rate: round(configuration.sessionSampleRate, 3),
           session_replay_sample_rate: round(configuration.sessionReplaySampleRate, 3),
           profiling_sample_rate: round(configuration.profilingSampleRate, 3),
+          experimental_features: Array.from(getExperimentalFeatures()),
         },
         browser_sdk_version: canUseEventBridge() ? __BUILD_ENV__SDK_VERSION__ : undefined,
         sdk_name: sdkName,


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Add experimental flag to the private context. This will help to filter out events from an experiments when needed.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
