### PR TITLE
📝 [DOCS-12292] Improve Vital API documentation

### DIFF
--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -34,7 +34,8 @@ export interface VitalOptions {
 /**
  * Duration vital options
  */
-export type DurationVitalOptions = VitalOptions
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface DurationVitalOptions extends VitalOptions {}
 export interface FeatureOperationOptions extends VitalOptions {
   operationKey?: string
 }


### PR DESCRIPTION
## Motivation

Add a note about vital startTime expecting a timestamp in milliseconds

## Changes

- Document all the duration options properties, including startTime:

| before | after |
| --- | -- |
| <img width="592" height="123" alt="Screenshot 2025-11-05 at 11 11 47" src="https://github.com/user-attachments/assets/2c7fc4bd-7a9e-4647-bbc7-0137ef509a11" /> | <img width="591" height="188" alt="Screenshot 2025-11-05 at 11 11 20" src="https://github.com/user-attachments/assets/783b3fe3-1068-414a-a869-e9dd9ca5a1d1" /> |


- Use an interface for DurationVitalOptions to link it properly in the doc

| before | after |
| --- | -- |
| <img width="595" height="158" alt="Screenshot 2025-11-05 at 11 10 58" src="https://github.com/user-attachments/assets/96582c09-e24c-4029-9e00-4fbc526ae072" /> | <img width="593" height="157" alt="Screenshot 2025-11-05 at 11 10 50" src="https://github.com/user-attachments/assets/4a17e57c-fe48-4d23-867a-91e85d25abcf" /> |

## Test instructions

```
yarn build:docs:html
open docs/index.html
```

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
