### PR TITLE
🔉 add trace sample rate in events

### DIFF
--- a/packages/rum-core/src/domain/contexts/defaultContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/defaultContext.spec.ts
@@ -55,7 +55,11 @@ describe('startDefaultContext', () => {
     })
 
     it('should set the configured sample rates', () => {
-      startDefaultContext(hooks, mockRumConfiguration({ sessionSampleRate: 10, sessionReplaySampleRate: 20 }), 'rum')
+      startDefaultContext(
+        hooks,
+        mockRumConfiguration({ sessionSampleRate: 10, sessionReplaySampleRate: 20, traceSampleRate: 30 }),
+        'rum'
+      )
 
       const event = hooks.triggerHook(HookNames.Assemble, {
         eventType: 'view',
@@ -64,6 +68,7 @@ describe('startDefaultContext', () => {
 
       expect(event._dd!.configuration!.session_sample_rate).toBe(10)
       expect(event._dd!.configuration!.session_replay_sample_rate).toBe(20)
+      expect(event._dd!.configuration!.trace_sample_rate).toBe(30)
       expect(event._dd!.configuration!.profiling_sample_rate).toBe(0)
       expect(event._dd!.sdk_name).toBe('rum')
     })

--- a/packages/rum-core/src/domain/contexts/defaultContext.ts
+++ b/packages/rum-core/src/domain/contexts/defaultContext.ts
@@ -22,6 +22,7 @@ export function startDefaultContext(
           session_sample_rate: round(configuration.sessionSampleRate, 3),
           session_replay_sample_rate: round(configuration.sessionReplaySampleRate, 3),
           profiling_sample_rate: round(configuration.profilingSampleRate, 3),
+          trace_sample_rate: round(configuration.traceSampleRate, 3),
           beta_encode_cookie_options: configuration.betaEncodeCookieOptions,
         },
         browser_sdk_version: canUseEventBridge() ? __BUILD_ENV__SDK_VERSION__ : undefined,


### PR DESCRIPTION
## Motivation

Be informed, at the session level, of the configured trace sample rate.

## Changes

Similarly to replay, session and profiling, report `traceSampleRate` within events.

## Test instructions

Open the sandbox. Look at generated events. They should have the `_dd.configuration.trace_sample_rate` property.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
