### PR TITLE
🔧 factorize typedoc category order

### DIFF
--- a/packages/logs/typedoc.json
+++ b/packages/logs/typedoc.json
@@ -1,15 +1,4 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/entries/main.ts"],
-
-  "categoryOrder": [
-    "Init",
-    "Authentication",
-    "Privacy",
-    "Data Collection",
-    "Session Persistence",
-    "Transport",
-    "*",
-    "Other"
-  ]
+  "entryPoints": ["src/entries/main.ts"]
 }

--- a/packages/rum-react/typedoc.json
+++ b/packages/rum-react/typedoc.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/entries/main.ts"],
-  "categoryOrder": ["Main", "Error", "*", "Other"]
+  "entryPoints": ["src/entries/main.ts"]
 }

--- a/packages/rum-slim/typedoc.json
+++ b/packages/rum-slim/typedoc.json
@@ -1,18 +1,4 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/entries/main.ts"],
-
-  "categoryOrder": [
-    "Init",
-    "Authentication",
-    "Privacy",
-    "Data Collection",
-    "Session Replay",
-    "Tracing",
-    "Profiling",
-    "Session Persistence",
-    "Transport",
-    "*",
-    "Other"
-  ]
+  "entryPoints": ["src/entries/main.ts"]
 }

--- a/packages/rum/typedoc.json
+++ b/packages/rum/typedoc.json
@@ -1,18 +1,4 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/entries/main.ts"],
-
-  "categoryOrder": [
-    "Init",
-    "Authentication",
-    "Privacy",
-    "Data Collection",
-    "Session Replay",
-    "Tracing",
-    "Profiling",
-    "Session Persistence",
-    "Transport",
-    "*",
-    "Other"
-  ]
+  "entryPoints": ["src/entries/main.ts"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -19,6 +19,23 @@
   },
   "packageOptions": {
     "excludeInternal": true,
+
+    "categoryOrder": [
+      "Init",
+      "Main",
+      "Authentication",
+      "Privacy",
+      "Data Collection",
+      "Error",
+      "Session Replay",
+      "Tracing",
+      "Profiling",
+      "Session Persistence",
+      "Transport",
+      "*",
+      "Other"
+    ],
+
     "kindSortOrder": [
       "Reference",
       "Project",


### PR DESCRIPTION

## Motivation

Reduces packages boilerplate.

## Changes

Factorize the order of the categories in the main typedoc.json files. This should not have any change on the documentation output.

## Test instructions

Run `yarn build:docs:html`, look at the result. Categories should keep the same order as before.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
