### PR TITLE
✨[RUM-12672] Allow graphql variables field to be modifiable in beforeSend

### DIFF
--- a/packages/rum-core/src/domain/assembly.spec.ts
+++ b/packages/rum-core/src/domain/assembly.spec.ts
@@ -240,56 +240,6 @@ describe('rum assembly', () => {
 
           expect((serverRumEvents[0] as RumResourceEvent).resource.graphql!.variables).toBe('{"modified":"value"}')
         })
-
-        it('should allow modification of resource.graphql.operationName property', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-            partialConfiguration: {
-              beforeSend: (event) => {
-                if (event.resource!.graphql) {
-                  event.resource!.graphql.operationName = 'ModifiedOperation'
-                }
-              },
-            },
-          })
-
-          notifyRawRumEvent(lifeCycle, {
-            rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, {
-              resource: {
-                graphql: {
-                  operationType: 'mutation',
-                  operationName: 'OriginalOperation',
-                },
-              },
-            }),
-          })
-
-          expect((serverRumEvents[0] as RumResourceEvent).resource.graphql!.operationName).toBe('ModifiedOperation')
-        })
-
-        it('should allow modification of resource.graphql.payload property', () => {
-          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
-            partialConfiguration: {
-              beforeSend: (event) => {
-                if (event.resource!.graphql) {
-                  event.resource!.graphql.payload = 'modified payload'
-                }
-              },
-            },
-          })
-
-          notifyRawRumEvent(lifeCycle, {
-            rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, {
-              resource: {
-                graphql: {
-                  operationType: 'query',
-                  payload: 'original payload',
-                },
-              },
-            }),
-          })
-
-          expect((serverRumEvents[0] as RumResourceEvent).resource.graphql!.payload).toBe('modified payload')
-        })
       })
 
       it('should reject modification of field not sensitive, context or customer provided', () => {

--- a/packages/rum-core/src/domain/assembly.ts
+++ b/packages/rum-core/src/domain/assembly.ts
@@ -59,7 +59,7 @@ export function startRumAssembly(
     },
     [RumEventType.RESOURCE]: {
       'resource.url': 'string',
-      'resource.graphql': 'object',
+      'resource.graphql.variables': 'string',
       ...USER_CUSTOMIZABLE_FIELD_PATHS,
       ...VIEW_MODIFIABLE_FIELD_PATHS,
       ...ROOT_MODIFIABLE_FIELD_PATHS,


### PR DESCRIPTION
## Motivation

Include graphQL in beforeSend, this time without experimental feature to allow customers to modify sensitive variables data in the graphQL request.

See : https://github.com/DataDog/browser-sdk/issues/3948

## Changes

- resource.graphql.variables is now a modifiable field
- new test without experimental feature taking into account

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
