### PR TITLE
🐛 Do not report telemetry errors related to failed response body 

### DIFF
--- a/packages/core/src/browser/fetchObservable.ts
+++ b/packages/core/src/browser/fetchObservable.ts
@@ -151,10 +151,15 @@ async function afterSend(
   if (responseBodyCondition !== ResponseBodyAction.IGNORE) {
     const clonedResponse = tryToClone(response)
     if (clonedResponse && clonedResponse.body) {
-      const bytes = await readBytesFromStream(clonedResponse.body, {
-        collectStreamBody: responseBodyCondition === ResponseBodyAction.COLLECT,
-      })
-      context.responseBody = bytes && new TextDecoder().decode(bytes)
+      try {
+        const bytes = await readBytesFromStream(clonedResponse.body, {
+          collectStreamBody: responseBodyCondition === ResponseBodyAction.COLLECT,
+        })
+        context.responseBody = bytes && new TextDecoder().decode(bytes)
+      } catch {
+        // Ignore errors when reading the response body (e.g., stream aborted, network errors)
+        // This is not critical and should not be reported as an SDK error
+      }
     }
   }
 


### PR DESCRIPTION
## Motivation

After merging [the GraphQL response errors tracking PR](https://github.com/DataDog/browser-sdk/pull/3921), telemetry errors started appearing regularly: "TypeError: Error in input stream", "network error", and "AbortError: BodyStreamBuffer was aborted". The refactor from callbacks to async/await changed error propagation behavior. Previously, stream reading errors were handled locally in callbacks. Now, exceptions in readBytesFromStream() propagate up and are caught by .catch(monitorError), reporting them as SDK errors. These are normal runtime conditions, not SDK bugs.

## Changes

Wrap readBytesFromStream() in a try/catch block to restore the previous behavior of silently ignoring stream errors. 

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
