### PR TITLE
🧹 Refactor Puppeteer imports to use named import 'launch' 

### DIFF
--- a/performances/src/main.ts
+++ b/performances/src/main.ts
@@ -1,5 +1,5 @@
 import type { Page } from 'puppeteer'
-import puppeteer from 'puppeteer'
+import { launch } from 'puppeteer'
 import { formatProfilingResults } from './format'
 import { startProfiling } from './profilers/startProfiling'
 import type { ProfilingResults, ProfilingOptions } from './profiling.types'
@@ -49,7 +49,7 @@ async function profileScenario(
   options: ProfilingOptions,
   runScenario: (page: Page, takeMeasurements: () => Promise<void>) => Promise<void>
 ) {
-  const browser = await puppeteer.launch({
+  const browser = await launch({
     defaultViewport: { width: 1366, height: 768 },
     // Twitter detects headless browsing and refuses to load
     headless: false,

--- a/scripts/performance/lib/memoryPerformance.ts
+++ b/scripts/performance/lib/memoryPerformance.ts
@@ -1,5 +1,5 @@
 import type { Browser, CDPSession, Page, Protocol } from 'puppeteer'
-import puppeteer from 'puppeteer'
+import { launch } from 'puppeteer'
 import { fetchPR, LOCAL_BRANCH } from '../../lib/gitUtils.ts'
 import { formatSize, printLog } from '../../lib/executionUtils.ts'
 import { markdownArray, type Pr } from './reportAsAPrComment.ts'
@@ -84,7 +84,7 @@ async function runTests(tests: Test[], benchmarkUrl: string, cb: (result: Perfor
 }
 
 async function runTest(testButton: string, benchmarkUrl: string): Promise<TestRunResult> {
-  const browser: Browser = await puppeteer.launch({
+  const browser: Browser = await launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
   })
   const page: Page = await browser.newPage()

--- a/test/e2e/scenario/rum/s8sInject.scenario.ts
+++ b/test/e2e/scenario/rum/s8sInject.scenario.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs'
-import puppeteer from 'puppeteer'
+import { launch } from 'puppeteer'
 import { test, expect } from '@playwright/test'
 import { getSdkBundlePath } from '../../lib/framework'
 import { APPLICATION_ID, CLIENT_TOKEN } from '../../lib/helpers/configuration'
@@ -14,7 +14,7 @@ test.describe('Inject RUM with Puppeteer', () => {
 
 async function injectRumWithPuppeteer() {
   const ddRUM = fs.readFileSync(getSdkBundlePath('rum', '/datadog-rum.js'), 'utf8')
-  const puppeteerBrowser = await puppeteer.launch({ headless: true, devtools: true, args: ['--no-sandbox'] })
+  const puppeteerBrowser = await launch({ headless: true, devtools: true, args: ['--no-sandbox'] })
   let injected = true
 
   const page = await puppeteerBrowser.newPage()


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Get rid of these warnings:
```
❯ yarn lint

/Users/thomas.lebeau/go/src/github.com/DataDog/browser-sdk/performances/src/main.ts
  52:25  warning  Caution: `puppeteer` also has a named export `launch`. Check if you meant to write `import {launch} from 'puppeteer'` instead  import/no-named-as-default-member

/Users/thomas.lebeau/go/src/github.com/DataDog/browser-sdk/scripts/performance/lib/memoryPerformance.ts
  87:34  warning  Caution: `puppeteer` also has a named export `launch`. Check if you meant to write `import {launch} from 'puppeteer'` instead  import/no-named-as-default-member

/Users/thomas.lebeau/go/src/github.com/DataDog/browser-sdk/test/e2e/scenario/rum/s8sInject.scenario.ts
  17:34  warning  Caution: `puppeteer` also has a named export `launch`. Check if you meant to write `import {launch} from 'puppeteer'` instead  import/no-named-as-default-member

✖ 3 problems (0 errors, 3 warnings
```

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

use `import { launch } from 'puppeteer'` instead of `import puppeteer from 'puppeteer'`

Puppeteer exposes both:
```js
/**
 * @public
 */
exports.launch = puppeteer.launch, 
/**
 * @public
 */
exports.default = puppeteer;
```

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
