### PR TITLE
👷  Reduce packages boilerplate a bit more

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:apps": "node scripts/build/build-test-apps.ts",
     "build:docs:json": "typedoc --logLevel Verbose --json ./docs.json",
     "build:docs:html": "typedoc --out ./docs",
+    "pack": "yarn workspaces foreach --all --parallel --include '@datadog/*' exec yarn pack",
     "format": "prettier --check .",
     "lint": "NODE_OPTIONS='--max-old-space-size=4096' eslint .",
     "typecheck": "tsc -b --noEmit true",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,6 @@
   "types": "cjs/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --modules"
   },
   "repository": {

--- a/packages/flagging/package.json
+++ b/packages/flagging/package.json
@@ -6,7 +6,6 @@
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --modules --bundle datadog-flagging.js",
     "build:bundle": "node ../../scripts/build/build-package.ts --bundle datadog-flagging.js"
   },

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -6,7 +6,6 @@
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --modules --bundle datadog-logs.js",
     "build:bundle": "node ../../scripts/build/build-package.ts --bundle datadog-logs.js"
   },

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -6,7 +6,6 @@
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --modules"
   },
   "dependencies": {

--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -6,7 +6,6 @@
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --modules",
     "prepack": "npm run build"
   },

--- a/packages/rum-slim/package.json
+++ b/packages/rum-slim/package.json
@@ -6,7 +6,6 @@
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --modules --bundle datadog-rum-slim.js",
     "build:bundle": "node ../../scripts/build/build-package.ts --bundle datadog-rum-slim.js"
   },

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -6,7 +6,6 @@
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --modules --bundle datadog-rum.js",
     "build:bundle": "node ../../scripts/build/build-package.ts --bundle datadog-rum.js"
   },

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -4,7 +4,6 @@
   "license": "Apache-2.0",
   "main": "bundle/worker.js",
   "scripts": {
-    "pack": "yarn pack",
     "build": "node ../../scripts/build/build-package.ts --bundle worker.js",
     "build:bundle": "yarn build"
   },

--- a/scripts/build/build-test-apps.ts
+++ b/scripts/build/build-test-apps.ts
@@ -12,7 +12,7 @@ const OTHER_EXTENSIONS: Array<{ name: string; options?: { runAt?: string } }> = 
 
 runMain(async () => {
   printLog('Packing packages...')
-  command`yarn lerna run pack`.run()
+  command`yarn run pack`.run()
 
   buildApp('test/apps/vanilla')
   buildApp('test/apps/react-router-v6-app')

--- a/scripts/check-typescript-compatibility.ts
+++ b/scripts/check-typescript-compatibility.ts
@@ -13,8 +13,8 @@ interface TypeScriptCheck {
 
 runMain(() => {
   printLog('Building project...')
-  command`yarn build`.run()
-  command`lerna run pack --stream`.run()
+  command`yarn run build`.run()
+  command`yarn run pack`.run()
 
   printLog('Setting up test environment...')
   command`yarn install --no-immutable`.withCurrentWorkingDirectory(TEST_APP_DIR).run()

--- a/scripts/cli
+++ b/scripts/cli
@@ -66,7 +66,7 @@ cmd_release () {
 cmd_version () {
   node ./scripts/release/generate-changelog/index.ts
   node ./scripts/release/update-peer-dependency-versions.ts
-  lerna run pack --stream
+  yarn run pack
   # keep test apps lockfiles up to date
   for app_package_path in $(git ls-files test/apps/*/package.json); do
     app_dir=$(dirname "$app_package_path");
@@ -83,8 +83,8 @@ cmd_woke () {
 }
 
 cmd_check_server_side_rendering_compatibility () {
-  yarn build
-  yarn lerna run pack --stream
+  yarn run build
+  yarn run pack
   cd test/apps/vanilla
   rm -rf node_modules
   yarn install --no-immutable


### PR DESCRIPTION
## Motivation

My goal is to reduce packages boilerplate a bit more by removing the need to declare a `pack` script in each package.json.

## Changes

This PR is using `yarn workspaces foreach exec` to run `yarn pack` in each package instead of using a package script.

I took the opportunity of revisiting how we execute stuff in workspaces to use `yarn workspaces` instead of `lerna` in more places. This was not really needed for my goals, but:

* The output is smaller, more readable than lerna
* It has less overhead than lerna
* It doesn't take `peerDependencies` into account when executing commands in topological order, so it doesn't complain about recursive dependencies and parallelize more things.
* We progressively reduce our dependency on lerna, and we might want to remove it totally some day.

## Test instructions

If CI is green, it should be alright.

Run `yarn build`, `yarn build:bundle` and check if things are built correctly
Run `yarn run pack` and verify that a `package.tgz` archive has been generated in each package folder (`ls packages/*/package.tgz`)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
