### PR TITLE
👷 fix: Add name field to e2e package.json

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "test-e2e",
   "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5324,12 +5324,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"e2e-079dc0@workspace:test/e2e":
-  version: 0.0.0-use.local
-  resolution: "e2e-079dc0@workspace:test/e2e"
-  languageName: unknown
-  linkType: soft
-
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -12705,6 +12699,12 @@ __metadata:
   checksum: 10c0/f2838dc65ac2ac6a31c7233065364080de73cc363ecb8fe723a54f663b2fa9429abf08bc3920a6bea85c5c7c29908ffcf822baf1572574f8d3859a009bbf2327
   languageName: node
   linkType: hard
+
+"test-e2e@workspace:test/e2e":
+  version: 0.0.0-use.local
+  resolution: "test-e2e@workspace:test/e2e"
+  languageName: unknown
+  linkType: soft
 
 "text-decoder@npm:^1.1.0":
   version: 1.2.3


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

the publish to npm step [fails](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1230692436) because lerna does not handle properly a package without name introduced in #3906 

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

add `name` property to `test/e2e/package.json`

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
