### PR TITLE
👷 Fix gitignore with e2e test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ docs/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-/test-results/
-/playwright-report/
 /blob-report/
 /playwright/.cache/
+test-results/
+playwright-report/
 .vscode


### PR DESCRIPTION
## Motivation

Since https://github.com/DataDog/browser-sdk/pull/3906 added a package.json in test/e2e/ , Playwright now considers test/e2e/ as the package root and generates its output directories (test-results/ and playwright-report/) there instead of at the project root, causing these generated directories to appear as untracked files.


## Changes

Update .gitignore to ignore Playwright output

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
