### PR TITLE
👷 remove version number from private packages

### DIFF
--- a/test/apps/react-heavy-spa/package.json
+++ b/test/apps/react-heavy-spa/package.json
@@ -1,7 +1,6 @@
 {
   "name": "heavy-spa",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/test/apps/react-shopist-like/package.json
+++ b/test/apps/react-shopist-like/package.json
@@ -1,7 +1,6 @@
 {
   "name": "react-shopist",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite --open",


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

The release fail because private package should not have version numbers. (see check-release job)

Another PR will follow to check for these version number on every PR to catch these error earlier

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
