### PR TITLE
👷 handle undefined api key for source-maps upload to new DC

### DIFF
--- a/scripts/deploy/upload-source-maps.ts
+++ b/scripts/deploy/upload-source-maps.ts
@@ -88,10 +88,13 @@ function uploadToDatadog(
   sites: string[]
 ): void {
   for (const site of sites) {
-    if (!site) {
-      printLog(`No source maps upload configured for ${site}, skipping...`)
+    const apiKey = getTelemetryOrgApiKey(site)
+
+    if (!apiKey) {
+      printLog(`No API key configured for ${site}, skipping...`)
       continue
     }
+
     printLog(`Uploading ${packageName} source maps with prefix ${prefix} for ${site}...`)
 
     command`
@@ -103,7 +106,7 @@ function uploadToDatadog(
         --repository-url https://www.github.com/datadog/browser-sdk
     `
       .withEnvironment({
-        DATADOG_API_KEY: getTelemetryOrgApiKey(site),
+        DATADOG_API_KEY: apiKey,
         DATADOG_SITE: site,
       })
       .run()

--- a/scripts/lib/secrets.ts
+++ b/scripts/lib/secrets.ts
@@ -42,14 +42,22 @@ export function getOrg2AppKey(): string {
   return getSecretKey('ci.browser-sdk.datadog_ci_application_key')
 }
 
-export function getTelemetryOrgApiKey(site: string): string {
+export function getTelemetryOrgApiKey(site: string): string | undefined {
   const normalizedSite = site.replaceAll('.', '-')
-  return getSecretKey(`ci.browser-sdk.source-maps.${normalizedSite}.ci_api_key`)
+  try {
+    return getSecretKey(`ci.browser-sdk.source-maps.${normalizedSite}.ci_api_key`)
+  } catch {
+    return
+  }
 }
 
-export function getTelemetryOrgApplicationKey(site: string): string {
+export function getTelemetryOrgApplicationKey(site: string): string | undefined {
   const normalizedSite = site.replaceAll('.', '-')
-  return getSecretKey(`ci.browser-sdk.telemetry.${normalizedSite}.ci_app_key`)
+  try {
+    return getSecretKey(`ci.browser-sdk.telemetry.${normalizedSite}.ci_app_key`)
+  } catch {
+    return
+  }
 }
 
 export function getNpmToken(): string {


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

When deploying to a new DC, the API key for uploading sourcemaps is not set up yet, in that case we should skip uploading source maps.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
