### PR TITLE
[dependabot npm disable] Temporarily disable npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,14 @@ updates:
       interval: 'daily'
     open-pull-requests-limit: 0
     commit-message:
-      prefix: '👷'
-
+      prefix: "\U0001F477"
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: 'daily'
     open-pull-requests-limit: 0
     commit-message:
-      prefix: '👷'
+      prefix: "\U0001F477"
     ignore:
       # update karma-webpack: RUM-3130
       - dependency-name: 'karma-webpack'


### PR DESCRIPTION
This PR temporarily disables Dependabot **npm version updates** by setting `open-pull-requests-limit: 0` for all `package-ecosystem: npm` entries.

Use the matching `enable` script (or manually remove that field) to re-enable npm version updates later.