### PR TITLE
Add CLA bot GitHub action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: "CLA Assistant"
+name: 'CLA Assistant'
 on:
   issue_comment:
     types: [created]
@@ -28,7 +28,7 @@ jobs:
           scope: DataDog/cla-signatures
           policy: self.write-signatures-browser-sdk
 
-      - name: "CLA Assistant"
+      - name: 'CLA Assistant'
         if: github.event_name != 'merge_group' && ((github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target')
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
@@ -41,7 +41,7 @@ jobs:
           remote-repository-name: cla-signatures
           remote-organization-name: DataDog
 
-         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #allowlist: user1,bot*
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
           #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'


### PR DESCRIPTION
## Motivation

We are modifying the way we manage CLA signatures at Datadog

## Changes

This PR introduces a new GitHub action to request contributors to sign Datadog's CLA by adding a comment to their first PR in the repository.

## Test instructions

Once merged, I can test it by creating a no-op PR and sign the CLA myself

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
