### PR TITLE
⚗ use deterministic session ids when possible

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -49,17 +49,18 @@ export function startSessionManager<TrackingType extends string>(
   configuration: Configuration,
   productKey: string,
   computeTrackingType: (rawTrackingType?: string) => TrackingType,
-  trackingConsentState: TrackingConsentState
+  trackingConsentState: TrackingConsentState,
+  applicationId?: string
 ): SessionManager<TrackingType> {
   const renewObservable = new Observable<void>()
   const expireObservable = new Observable<void>()
-
   // TODO - Improve configuration type and remove assertion
   const sessionStore = startSessionStore(
     configuration.sessionStoreStrategyType!,
     configuration,
     productKey,
-    computeTrackingType
+    computeTrackingType,
+    applicationId
   )
   stopCallbacks.push(() => sessionStore.stop())
 

--- a/packages/core/src/tools/utils/stringUtils.spec.ts
+++ b/packages/core/src/tools/utils/stringUtils.spec.ts
@@ -1,74 +1,154 @@
-import {
-  safeTruncate,
-  findCommaSeparatedValue,
-  findCommaSeparatedValues,
-  findAllCommaSeparatedValues,
-} from './stringUtils'
+import { generateUUID, findCommaSeparatedValue, findAllCommaSeparatedValues, safeTruncate } from './stringUtils'
 
-describe('stringUtils', () => {
-  describe('safeTruncate', () => {
-    it('should truncate a string', () => {
-      const truncated = safeTruncate('1234😎7890', 6)
-      expect(truncated.length).toBe(6)
-      expect(truncated).toBe('1234😎')
+describe('generateUUID', () => {
+  describe('deterministic UUID generation', () => {
+    it('should generate deterministic UUID when both deviceId and applicationId are provided', () => {
+      const deviceId = 'a1b2c3d4-e5f6-7890-1234-567890abcdef'
+      const applicationId = 'app-123-456'
+
+      const uuid1 = generateUUID(deviceId, applicationId)
+      const uuid2 = generateUUID(deviceId, applicationId)
+
+      // Same inputs should produce same output
+      expect(uuid1).toBe(uuid2)
+      // Should be valid UUID format
+      expect(uuid1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/)
     })
 
-    it('should not break a surrogate characters pair', () => {
-      const truncated = safeTruncate('12345😎890', 6)
-      expect(truncated.length).toBe(7)
-      expect(truncated).toBe('12345😎')
+    it('should generate different UUIDs for different deviceIds', () => {
+      const deviceId1 = 'a1b2c3d4-e5f6-7890-1234-567890abcdef'
+      const deviceId2 = 'f0e1d2c3-b4a5-9687-7685-fedcba098765'
+      const applicationId = 'app-123'
+
+      const uuid1 = generateUUID(deviceId1, applicationId)
+      const uuid2 = generateUUID(deviceId2, applicationId)
+
+      expect(uuid1).not.toBe(uuid2)
     })
 
-    it('should add the suffix when the string is truncated', () => {
-      const truncated = safeTruncate('12345😎890', 6, '...')
-      expect(truncated).toBe('12345😎...')
+    it('should generate different UUIDs for different applicationIds', () => {
+      const deviceId = 'a1b2c3d4-e5f6-7890-1234-567890abcdef'
+      const applicationId1 = 'app-123'
+      const applicationId2 = 'app-456'
+
+      const uuid1 = generateUUID(deviceId, applicationId1)
+      const uuid2 = generateUUID(deviceId, applicationId2)
+
+      expect(uuid1).not.toBe(uuid2)
     })
 
-    it('should not add the suffix when the string is not truncated', () => {
-      const truncated = safeTruncate('1234😎', 5, '...')
-      expect(truncated).toBe('1234😎')
-    })
-  })
+    it('should generate deterministic UUID that changes over time windows', () => {
+      const deviceId = 'a1b2c3d4-e5f6-7890-1234-567890abcdef'
+      const applicationId = 'app-123'
 
-  describe('findCommaSeparatedValue', () => {
-    it('returns the value from a comma separated hash', () => {
-      expect(findCommaSeparatedValue('foo=a;bar=b', 'foo')).toBe('a')
-      expect(findCommaSeparatedValue('foo=a;bar=b', 'bar')).toBe('b')
-    })
+      const uuid1 = generateUUID(deviceId, applicationId)
 
-    it('is white-spaces tolerant', () => {
-      expect(findCommaSeparatedValue('   foo  =   a;  bar  =   b', 'foo')).toBe('a')
-      expect(findCommaSeparatedValue('   foo  =   a;  bar  =   b', 'bar')).toBe('b')
-    })
+      // Fast-forward time by more than SESSION_DURATION (15 minutes)
+      const originalDateNow = Date.now
+      Date.now = () => originalDateNow() + 16 * 60 * 1000
 
-    it('supports values containing an = character', () => {
-      expect(findCommaSeparatedValue('foo=a=b', 'foo')).toBe('a=b')
-    })
+      const uuid2 = generateUUID(deviceId, applicationId)
 
-    it('supports keys containing `-`', () => {
-      expect(findCommaSeparatedValue('foo-bar=baz', 'foo-bar')).toBe('baz')
-    })
+      // Restore Date.now
+      Date.now = originalDateNow
 
-    it('returns undefined if the value is not found', () => {
-      expect(findCommaSeparatedValue('foo=a;bar=b', 'baz')).toBe(undefined)
-    })
-  })
-
-  describe('findCommaSeparatedValues', () => {
-    it('returns the values from a comma separated hash', () => {
-      const expectedValues = new Map<string, string>()
-      expectedValues.set('foo', 'a')
-      expectedValues.set('bar', 'b')
-      expect(findCommaSeparatedValues('foo=a;bar=b')).toEqual(expectedValues)
+      // UUIDs should be different due to different time fence
+      expect(uuid1).not.toBe(uuid2)
     })
   })
 
-  describe('findAllCommaSeparatedValues', () => {
-    it('returns all the values from a comma separated hash', () => {
-      const expectedValues = new Map<string, string[]>()
-      expectedValues.set('foo', ['a', 'c'])
-      expectedValues.set('bar', ['b'])
-      expect(findAllCommaSeparatedValues('foo=a;bar=b;foo=c')).toEqual(expectedValues)
+  describe('random UUID generation (fallback)', () => {
+    it('should generate random UUID when deviceId is empty', () => {
+      const uuid1 = generateUUID('', 'app-123')
+      const uuid2 = generateUUID('', 'app-123')
+
+      // Should be different (random)
+      expect(uuid1).not.toBe(uuid2)
+      // Should be valid UUID format
+      expect(uuid1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
     })
+
+    it('should generate random UUID when applicationId is empty', () => {
+      const uuid1 = generateUUID('device-123', '')
+      const uuid2 = generateUUID('device-123', '')
+
+      // Should be different (random)
+      expect(uuid1).not.toBe(uuid2)
+      expect(uuid1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    })
+
+    it('should generate random UUID when both parameters are empty', () => {
+      const uuid1 = generateUUID('', '')
+      const uuid2 = generateUUID('', '')
+
+      expect(uuid1).not.toBe(uuid2)
+      expect(uuid1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    })
+
+    it('should generate random UUID when called with no parameters', () => {
+      const uuid1 = generateUUID()
+      const uuid2 = generateUUID()
+
+      expect(uuid1).not.toBe(uuid2)
+      expect(uuid1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    })
+  })
+})
+
+describe('findCommaSeparatedValue', () => {
+  it('returns the value from a comma separated hash', () => {
+    expect(findCommaSeparatedValue('foo=a;bar=b', 'foo')).toBe('a')
+    expect(findCommaSeparatedValue('foo=a;bar=b', 'bar')).toBe('b')
+  })
+
+  it('returns the first value if multiple values with the same key', () => {
+    expect(findCommaSeparatedValue('k1=v1;k1=v2', 'k1')).toEqual('v1')
+  })
+
+  it('returns undefined if the key is not present', () => {
+    expect(findCommaSeparatedValue('k1=v1;k2=v2', 'k3')).toBeUndefined()
+  })
+
+  it('supports semi-colon as value separator', () => {
+    expect(findCommaSeparatedValue('k1=v1;k2=v2', 'k1')).toEqual('v1')
+  })
+
+  it('is white-spaces tolerant', () => {
+    expect(findCommaSeparatedValue('   foo  =   a;  bar  =   b', 'foo')).toBe('a')
+    expect(findCommaSeparatedValue('   foo  =   a;  bar  =   b', 'bar')).toBe('b')
+  })
+})
+
+describe('findAllCommaSeparatedValues', () => {
+  it('returns all the values from a comma separated hash', () => {
+    const expectedValues = new Map<string, string[]>()
+    expectedValues.set('foo', ['a', 'c'])
+    expectedValues.set('bar', ['b'])
+    expect(findAllCommaSeparatedValues('foo=a;bar=b;foo=c')).toEqual(expectedValues)
+  })
+
+  it('returns an empty map if no key-value pairs', () => {
+    const result = findAllCommaSeparatedValues('')
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('safeTruncate', () => {
+  it('returns the full string if shorter than length', () => {
+    expect(safeTruncate('hello', 10)).toBe('hello')
+  })
+
+  it('truncates string to specified length', () => {
+    expect(safeTruncate('hello world', 5)).toBe('hello')
+  })
+
+  it('handles emoji/surrogate pairs correctly', () => {
+    const emojiString = 'hello😀world'
+    // The emoji is at position 5, if we truncate at 5, we should get the emoji too
+    expect(safeTruncate(emojiString, 6).length).toBeGreaterThanOrEqual(6)
+  })
+
+  it('adds suffix when truncating', () => {
+    expect(safeTruncate('hello world', 5, '...')).toBe('hello...')
   })
 })

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -54,7 +54,8 @@ export function startRumSessionManager(
     configuration,
     RUM_SESSION_KEY,
     (rawTrackingType) => computeTrackingType(configuration, rawTrackingType),
-    trackingConsentState
+    trackingConsentState,
+    configuration.applicationId
   )
 
   sessionManager.expireObservable.subscribe(() => {


### PR DESCRIPTION
## Motivation

This PR changes the way we generate UUIDs so session ids are no longer random, but based on a seed that combines the 15-minute period of time the session was create, the app id and the anonymous user id.
This way, any session created in the same device within this 15 minutes time divisions would have the exact same id. As such, if any of the conditions that cause sessions to be terminated and created rapidly happens, all the microsessions would have a constant id, in practice consolidating them as a single session. 

## Changes

This PR changes how we generate UUIDs: When anonymous_id and app_id are available, we generate the UUID based on them. If they are not available, we still generate a random id.

## Test instructions
1. Make sure you are testing this branch in an environment where trackAnonymousUsers is set to true and it's not loading the logs SDK in parallel to RUM SDK
2. Load your site and make sure a session is created. 
3. Force the SDK to create a new session (by, for example, editing the cookie to change the  `expire` value to 0 and then reloading the page: Don't delete the cookie or use the extension to kill the session, since this would delete the anonymous_id and change the generated session id)
4. check the session id of the new session is the same than the previous one. Let at least 15 minutes pass and repeat the process: the session id should now be different, but still consistent if you keep trying (for another 15 minutes)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
