### PR TITLE
👷 configure renovate to not create PRs before stable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
   "labels": ["dependencies"],
   "commitMessagePrefix": "👷 ",
   "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
   "ignoreDeps": ["registry.ddbuild.io/dd-octo-sts"],


### PR DESCRIPTION
## Motivation

Following https://github.com/DataDog/browser-sdk/pull/3850, the dependency PRs are created before the the stability check passes (cf current https://github.com/DataDog/browser-sdk/pull/3981).
It could be nicer if the PR is created when it is ready to be merged.

## Changes

Delay PR creation following [renovate docs](https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days):

> **Suppress branch/PR creation for X days**
> If you use minimumReleaseAge=3 days, prCreation="not-pending" and internalChecksFilter="strict" then Renovate only creates branches when 3 (or more days) have passed since the version was released. We recommend you set dependencyDashboard=true, so you can see these pending PRs.

## Test instructions

Let's see if it behaves as expected after merging

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
