### PR TITLE
👷Exclude renovate from CLA Assistant check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,6 +40,7 @@ jobs:
           branch: 'browser-sdk'
           remote-repository-name: cla-signatures
           remote-organization-name: DataDog
+          allowlist: renovate,renovate[bot]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #allowlist: user1,bot*


### PR DESCRIPTION
## Motivation

CLA Assistant check fails on renovate PR (ex: https://github.com/DataDog/browser-sdk/pull/3980):

<img width="492" height="32" alt="Screenshot 2025-12-08 at 11 00 20" src="https://github.com/user-attachments/assets/b2958a2b-3017-47d2-bedc-7dcc7da541b3" />


## Changes

Add renovate to CLA allowlist

## Test instructions

Future renovate PRs should not fail CLA check

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
