### PR TITLE
👷 Include test apps in renovate scan

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [":dependencyDashboard", ":ignoreModulesAndTests", "group:monorepos", "group:recommended"],
+  "extends": [":dependencyDashboard", "group:monorepos", "group:recommended"],
   "labels": ["dependencies"],
   "commitMessagePrefix": "👷 ",
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
## Motivation

[Test apps](https://github.com/DataDog/browser-sdk/tree/main/test/apps) are currently not scanned by [renovate](https://developer.mend.io/github/DataDog/browser-sdk):

<img width="446" height="320" alt="Screenshot 2025-12-08 at 16 35 43" src="https://github.com/user-attachments/assets/af1bdb1d-f3ff-4ae9-adf6-cb162b63be64" />

So their dependencies are not updated and can lead to dependabot alerts that won't be resolved by lock files maintenance

## Changes

Remove `:ignoreModulesAndTests` [preset](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) to scan the `test` directory

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

Let's see if everything is scanned properly after the merge

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
