### PR TITLE
[RUM Browser Profiler] stop profiler when session expires

### DIFF
--- a/packages/rum/src/boot/profilerApi.ts
+++ b/packages/rum/src/boot/profilerApi.ts
@@ -61,8 +61,16 @@ export function makeProfilerApi(): ProfilerApi {
           return
         }
 
-        profiler = createRumProfiler(configuration, lifeCycle, sessionManager, profilingContextManager, createEncoder)
-        profiler.start(viewHistory.findView())
+        profiler = createRumProfiler(
+          configuration,
+          lifeCycle,
+          sessionManager,
+          profilingContextManager,
+          createEncoder,
+          viewHistory,
+          undefined
+        )
+        profiler.start()
       })
       .catch(monitorError)
   }

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -19,7 +19,7 @@ import type {
   RumConfiguration,
   RumSessionManager,
   TransportPayload,
-  ViewHistoryEntry,
+  ViewHistory,
 } from '@datadog/browser-rum-core'
 import {
   createFormDataTransport,
@@ -33,6 +33,7 @@ import type {
   Profiler,
   RUMProfiler,
   RUMProfilerConfiguration,
+  RumProfilerStoppedInstance,
   RumViewEntry,
 } from './types'
 import { getNumberOfSamples } from './utils/getNumberOfSamples'
@@ -55,6 +56,7 @@ export function createRumProfiler(
   session: RumSessionManager,
   profilingContextManager: ProfilingContextManager,
   createEncoder: (streamId: DeflateEncoderStreamId) => Encoder,
+  viewHistory: ViewHistory,
   profilerConfiguration: RUMProfilerConfiguration = DEFAULT_RUM_PROFILER_CONFIGURATION
 ): RUMProfiler {
   const transport = createFormDataTransport(configuration, lifeCycle, createEncoder, DeflateEncoderStreamId.PROFILING)
@@ -65,12 +67,27 @@ export function createRumProfiler(
   // Global clean-up tasks for listeners that are not specific to a profiler instance (eg. visibility change, before unload)
   const globalCleanupTasks: Array<() => void> = []
 
-  let instance: RumProfilerInstance = { state: 'stopped' }
+  let instance: RumProfilerInstance = { state: 'stopped', stateReason: 'initializing' }
 
-  function start(viewEntry: ViewHistoryEntry | undefined): void {
+  // Stops the profiler when session expires
+  lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
+    stopProfiling('session-expired').catch(monitorError)
+  })
+
+  // Start the profiler again when session is renewed
+  lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
+    if (instance.state === 'stopped' && instance.stateReason === 'session-expired') {
+      start() // Only restart the profiler if it was stopped due to session expiration. Avoid restarting the profiler if it was stopped manually by the user.
+    }
+  })
+
+  // Public API to start the profiler.
+  function start(): void {
     if (instance.state === 'running') {
       return
     }
+
+    const viewEntry = viewHistory.findView()
 
     // Add initial view
     // Note: `viewEntry.name` is only filled when users use manual view creation via `startView` method.
@@ -88,19 +105,18 @@ export function createRumProfiler(
       addEventListener(configuration, window, DOM_EVENT.BEFORE_UNLOAD, handleBeforeUnload).stop
     )
 
-    // Subscribe to session expiration to stop profiling when session ends
-    const sessionExpiredSubscription = lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
-      stop().catch(monitorError)
-    })
-    globalCleanupTasks.push(sessionExpiredSubscription.unsubscribe)
-
     // Start profiler instance
     startNextProfilerInstance()
   }
 
+  // Public API to manually stop the profiler.
   async function stop() {
+    await stopProfiling('stopped-by-user')
+  }
+
+  async function stopProfiling(reason: RumProfilerStoppedInstance['stateReason']) {
     // Stop current profiler instance
-    await stopProfilerInstance('stopped')
+    await stopProfilerInstance(reason)
 
     // Cleanup global listeners
     globalCleanupTasks.forEach((task) => task())
@@ -280,17 +296,30 @@ export function createRumProfiler(
       .catch(monitorError)
   }
 
-  async function stopProfilerInstance(nextState: 'paused' | 'stopped') {
+  async function stopProfilerInstance(stateReason: RumProfilerStoppedInstance['stateReason']) {
     if (instance.state !== 'running') {
       return
     }
+    await onPauseOrStopProfilerInstance()
+    instance = { state: 'stopped', stateReason }
+  }
 
+  async function pauseProfilerInstance() {
+    if (instance.state !== 'running') {
+      return
+    }
+    await onPauseOrStopProfilerInstance()
+    instance = { state: 'paused' }
+  }
+
+  async function onPauseOrStopProfilerInstance() {
+    if (instance.state !== 'running') {
+      return
+    }
     // Cleanup tasks
     instance.cleanupTasks.forEach((cleanupTask) => cleanupTask())
 
     await collectProfilerInstance(instance)
-
-    instance = { state: nextState }
   }
 
   function collectViewEntry(viewEntry: RumViewEntry | undefined): void {
@@ -349,7 +378,7 @@ export function createRumProfiler(
       // paused by visibility change and stopped by user.
       // If profiler is paused by the visibility change, we should resume when
       // tab becomes visible again. That's not the case when user stops the profiler.
-      stopProfilerInstance('paused').catch(monitorError)
+      pauseProfilerInstance().catch(monitorError)
     } else if (document.visibilityState === 'visible' && instance.state === 'paused') {
       // Resume when tab becomes visible again
       startNextProfilerInstance()

--- a/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
+++ b/packages/rum/src/domain/profiling/types/rumProfiler.types.ts
@@ -1,5 +1,4 @@
 import type { TimeoutId, ClocksState, Duration } from '@datadog/browser-core'
-import type { ViewHistoryEntry } from '@datadog/browser-rum-core'
 import type { ProfilerTrace, Profiler } from './profilerApi.types'
 
 export interface RumViewEntry {
@@ -48,6 +47,7 @@ export interface RumProfilerTrace extends ProfilerTrace, RumProfilerEnrichmentDa
  */
 export interface RumProfilerStoppedInstance {
   readonly state: 'stopped'
+  readonly stateReason: 'session-expired' | 'stopped-by-user' | 'initializing'
 }
 
 /**
@@ -78,7 +78,7 @@ export interface RumProfilerRunningInstance extends RumProfilerEnrichmentData {
 export type RumProfilerInstance = RumProfilerStoppedInstance | RumProfilerPausedInstance | RumProfilerRunningInstance
 
 export interface RUMProfiler {
-  start: (viewEntry: ViewHistoryEntry | undefined) => void
+  start: () => void
   stop: () => Promise<void>
   isStopped: () => boolean
   isRunning: () => boolean


### PR DESCRIPTION
## Motivation

RUM Browser SDK should stop the Profiler once the Session is expired. 

This PR also adds a "reason" for being stopped to the Profiler instance, in order to handle cases where user manually stopped the Profiler and it should not be re-activated after a session renew.

## Changes

- Make the Profiler listen to the SESSION_EXPIRED event, and stop the profiler once triggered.
- Add a `stateReason` to stopped instances. 
- Check that `stateReason` to avoid restarting the Profiler once it has been stopped by user.
- Keep `.start()` and `.stop()` API for the "user-controlled" state (may be an official API later)
- Have an internal `stopProfiler` function that handles all the required clean-up and data collection on stop, called whatever the reason for stop. 
- Differentiate between `pause` and `stop` via `pauseProfilerInstance` and `stopProfilerInstance` to allow providing a reason for one and not the other, keeping all functions focused on their use-cases.

## Test instructions

- Added a few unit tests with start/stop of the profiler.
- In an app, you can run `DD_RUM.setTrackingConsent('not-granted')` and assert the Profiler is stopped, no more profiles are sent after that point.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
