### PR TITLE
✨[PANA-5156] Expose better session replay internal API

### DIFF
--- a/packages/rum/src/domain/record/index.ts
+++ b/packages/rum/src/domain/record/index.ts
@@ -1,3 +1,4 @@
+export { takeFullSnapshot, takeNodeSnapshot } from './internalApi'
 export { record } from './record'
 export type { SerializationMetric, SerializationStats } from './serialization'
 export { createSerializationStats, aggregateSerializationStats } from './serialization'

--- a/packages/rum/src/domain/record/internalApi.spec.ts
+++ b/packages/rum/src/domain/record/internalApi.spec.ts
@@ -1,0 +1,122 @@
+import { NodeType, RecordType } from '../../types'
+import { appendElement } from '../../../../rum-core/test'
+import { takeFullSnapshot, takeNodeSnapshot } from './internalApi'
+
+describe('takeFullSnapshot', () => {
+  it('should produce Meta, Focus, and FullSnapshot records', () => {
+    expect(takeFullSnapshot()).toEqual(
+      jasmine.arrayContaining([
+        {
+          data: {
+            height: jasmine.any(Number),
+            href: window.location.href,
+            width: jasmine.any(Number),
+          },
+          type: RecordType.Meta,
+          timestamp: jasmine.any(Number),
+        },
+        {
+          data: {
+            has_focus: document.hasFocus(),
+          },
+          type: RecordType.Focus,
+          timestamp: jasmine.any(Number),
+        },
+        {
+          data: {
+            node: jasmine.any(Object),
+            initialOffset: {
+              left: jasmine.any(Number),
+              top: jasmine.any(Number),
+            },
+          },
+          type: RecordType.FullSnapshot,
+          timestamp: jasmine.any(Number),
+        },
+      ])
+    )
+  })
+
+  it('should produce VisualViewport records when supported', () => {
+    if (!window.visualViewport) {
+      pending('visualViewport not supported')
+    }
+
+    expect(takeFullSnapshot()).toEqual(
+      jasmine.arrayContaining([
+        {
+          data: jasmine.any(Object),
+          type: RecordType.VisualViewport,
+          timestamp: jasmine.any(Number),
+        },
+      ])
+    )
+  })
+})
+
+describe('takeNodeSnapshot', () => {
+  it('should serialize nodes', () => {
+    const node = appendElement('<div>Hello <b>world</b></div>', document.body)
+    expect(takeNodeSnapshot(node)).toEqual({
+      type: NodeType.Element,
+      id: 0,
+      tagName: 'div',
+      isSVG: undefined,
+      attributes: {},
+      childNodes: [
+        {
+          type: NodeType.Text,
+          id: 1,
+          textContent: 'Hello ',
+        },
+        {
+          type: NodeType.Element,
+          id: 2,
+          tagName: 'b',
+          isSVG: undefined,
+          attributes: {},
+          childNodes: [
+            {
+              type: NodeType.Text,
+              id: 3,
+              textContent: 'world',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('should serialize shadow hosts', () => {
+    const node = appendElement('<div>Hello</div>', document.body)
+    const shadowRoot = node.attachShadow({ mode: 'open' })
+    shadowRoot.appendChild(document.createTextNode('world'))
+    expect(takeNodeSnapshot(node)).toEqual({
+      type: NodeType.Element,
+      id: 0,
+      tagName: 'div',
+      isSVG: undefined,
+      attributes: {},
+      childNodes: [
+        {
+          type: NodeType.Text,
+          id: 1,
+          textContent: 'Hello',
+        },
+        {
+          type: NodeType.DocumentFragment,
+          id: 2,
+          isShadowRoot: true,
+          adoptedStyleSheets: undefined,
+          childNodes: [
+            {
+              type: NodeType.Text,
+              id: 3,
+              textContent: 'world',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/packages/rum/src/domain/record/internalApi.ts
+++ b/packages/rum/src/domain/record/internalApi.ts
@@ -1,0 +1,88 @@
+import { noop, timeStampNow } from '@datadog/browser-core'
+import type { RumConfiguration } from '@datadog/browser-rum-core'
+import { getNodePrivacyLevel, NodePrivacyLevel } from '@datadog/browser-rum-core'
+import type { BrowserRecord, SerializedNodeWithId } from '../../types'
+import { takeFullSnapshot as doTakeFullSnapshot } from './startFullSnapshots'
+import type { ShadowRootsController } from './shadowRootsController'
+import type { RecordingScope } from './recordingScope'
+import { createRecordingScope } from './recordingScope'
+import { createElementsScrollPositions } from './elementsScrollPositions'
+import { createEventIds } from './eventIds'
+import { createNodeIds } from './nodeIds'
+import type { EmitRecordCallback } from './record.types'
+import type { SerializationTransaction } from './serialization'
+import { SerializationKind, serializeInTransaction, serializeNode } from './serialization'
+
+/**
+ * Take a full snapshot of the document, generating the same records that the browser SDK
+ * would generate.
+ *
+ * This is an internal API function. Be sure to update Datadog-internal callers if you
+ * change its signature or behavior.
+ */
+export function takeFullSnapshot({
+  configuration,
+}: { configuration?: Partial<RumConfiguration> } = {}): BrowserRecord[] {
+  const records: BrowserRecord[] = []
+  const emitRecord: EmitRecordCallback = (record: BrowserRecord) => {
+    records.push(record)
+  }
+
+  doTakeFullSnapshot(
+    timeStampNow(),
+    SerializationKind.INITIAL_FULL_SNAPSHOT,
+    emitRecord,
+    noop,
+    createTemporaryRecordingScope(configuration)
+  )
+
+  return records
+}
+
+/**
+ * Take a snapshot of a DOM node, generating the serialized representation that the
+ * browser SDK would generate.
+ *
+ * This is an internal API function. Be sure to update Datadog-internal callers if you
+ * change its signature or behavior.
+ */
+export function takeNodeSnapshot(
+  node: Node,
+  { configuration }: { configuration?: Partial<RumConfiguration> } = {}
+): SerializedNodeWithId | null {
+  let serializedNode: SerializedNodeWithId | null = null
+
+  serializeInTransaction(
+    SerializationKind.INITIAL_FULL_SNAPSHOT,
+    noop,
+    noop,
+    createTemporaryRecordingScope(configuration),
+    (transaction: SerializationTransaction): void => {
+      const privacyLevel = getNodePrivacyLevel(node, transaction.scope.configuration.defaultPrivacyLevel)
+      if (privacyLevel === NodePrivacyLevel.HIDDEN || privacyLevel === NodePrivacyLevel.IGNORE) {
+        return
+      }
+      serializedNode = serializeNode(node, privacyLevel, transaction)
+    }
+  )
+
+  return serializedNode
+}
+
+function createTemporaryRecordingScope(configuration?: Partial<RumConfiguration>): RecordingScope {
+  return createRecordingScope(
+    {
+      defaultPrivacyLevel: NodePrivacyLevel.ALLOW,
+      ...configuration,
+    } as RumConfiguration,
+    createElementsScrollPositions(),
+    createEventIds(),
+    createNodeIds(),
+    {
+      addShadowRoot: noop,
+      removeShadowRoot: noop,
+      flush: noop,
+      stop: noop,
+    } as ShadowRootsController
+  )
+}

--- a/packages/rum/src/entries/internal.ts
+++ b/packages/rum/src/entries/internal.ts
@@ -15,4 +15,4 @@ export {
 
 export * from '../types'
 
-export { serializeNode, serializeNode as serializeNodeWithId } from '../domain/record'
+export { takeFullSnapshot, takeNodeSnapshot, serializeNode as serializeNodeWithId } from '../domain/record'


### PR DESCRIPTION
## Motivation

The session replay code in the browser SDK currently exposes a small internal API. This API's primary use case is to support unit testing of Datadog-internal code that integrates with session replay in some way.

Today, unfortunately, this API is quite unstable and hard to use correctly. The reason is that the function we expose (`serializeNodeWithId`) is too low-level. Using this function requires constructing a very complex configuration object, involving constants and functions with types that aren't exposed outside of the SDK code. Worse, the details of this configuration object have been changing quite a bit lately, so keeping up with the changes is becoming harder and harder.

Instead of exposing an unstable internal function, let's define an explicit, stable internal API that callers in other repos can depend on. (Of course, stability is relative here; this API is explicitly not subject to semver.)

## Changes

This PR exposes two new internal API functions:
* `takeFullSnapshot()` takes a snapshot of the entire document.
* `takeNodeSnapshot()` snapshots the DOM subtree of an individual node.

Both require no configuration at all, though you can pass in a partial `RumConfiguration` to override the defaults if you want.

I've added tests for these functions to demonstrate usage and show that they work as expected.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->