### PR TITLE
👷 Ensure that renovate do a full install

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "skipInstalls": false,
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
## Motivation

Following #4019, renovate actually don't run postinstall as they excecute `yarn install --mode=update-lockfile`, see [source](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/npm/post-update/yarn.ts#L166)

## Changes

Add [`skipInstalls: false`](https://docs.renovatebot.com/configuration-options/#skipinstalls) to force a full install by renovate

## Test instructions

After merge, next renovate run should install the package with the tarballs allowing to install the test apps without issue 🤞

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
