### PR TITLE
👷 Enable more renovate flags...

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,8 @@
     "enabled": true
   },
   "skipInstalls": false,
+  "allowScripts": true,
+  "ignoreScripts": false,
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
## Motivation

Following [#4021](https://github.com/DataDog/browser-sdk/pull/4019), renovate now runs the install with `yarn install --mode=skip-build` which also skips postinstall

## Changes

Looking at the [doc](https://docs.renovatebot.com/configuration-options/#ignorescripts):

```
# ignoreScripts
Set this to false if allowScripts=true and you wish to run scripts when updating lock files.
```

So hopefully adding `allowScripts=true` and `ignoreScripts=false` should trigger post install scripts

## Test instructions

After merge, next renovate run should install the package with the tarballs allowing to install the test apps without issue :crossed_fingers:

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
