### PR TITLE
🐛 fix developer extension packaging

### DIFF
--- a/scripts/deploy/publish-developer-extension.ts
+++ b/scripts/deploy/publish-developer-extension.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import chromeWebstoreUpload from 'chrome-webstore-upload'
 import { printLog, runMain } from '../lib/executionUtils.ts'
 import { command } from '../lib/command.ts'
@@ -15,7 +16,8 @@ runMain(async () => {
   command`yarn build`.withEnvironment({ BUILD_MODE: 'release' }).run()
 
   printLog('Zipping extension files')
-  command`zip -jr ${ZIP_FILE_NAME} developer-extension/.output/chrome-mv3`.run()
+  const zipPath = path.resolve(ZIP_FILE_NAME)
+  command`zip -r ${zipPath} .`.withCurrentWorkingDirectory('developer-extension/.output/chrome-mv3').run()
 
   printLog('Publish Developer extension')
   await uploadAndPublish()


### PR DESCRIPTION


## Motivation

Since the wxt migration, the developer extension build is using subfolders ('chunks/', 'assets/'). The way we used zip removed those subfolders entirely, so some file failed to load.

## Changes

Make sure the zip command does not strip folders.

## Test instructions

You can run `node scripts/deploy/publish-developer-extension.ts` to build and package the extension. The script fails because you don't have authentications to publish the extension, but you should still have a `developer-extension.zip` file in the repo root. Ensure that this archive contains `chunks` and `assets` folders:

```
unzip -l developer-extension.zip
Archive:  developer-extension.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    15774  12-10-2025 17:05   icon.png
    65983  12-10-2025 17:05   background.js
      357  12-10-2025 17:05   devtools.html
     1138  12-10-2025 17:05   contentScriptIsolated.js
        0  12-10-2025 17:05   chunks/
      118  12-10-2025 17:05   chunks/devtools-N5SpxP-n.js
    21234  12-10-2025 17:05   chunks/startRecording-Tq6kCe-q.js
     6078  12-10-2025 17:05   chunks/profiler-SIPotMh0.js
   634316  12-10-2025 17:05   chunks/panel-NpiZJTsr.js
      779  12-10-2025 17:05   chunks/_virtual_wxt-html-plugins-DPbbfBKe.js
      457  12-10-2025 17:05   panel.html
      324  12-10-2025 17:05   manifest.json
     2370  12-10-2025 17:05   contentScriptMain.js
        0  12-10-2025 17:05   assets/
   206327  12-10-2025 17:05   assets/panel-BNELzgi4.css
---------                     -------
   955255                     15 files
```

You can extract that zip file and load it as a local extension to make sure it works.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
