### PR TITLE
🐛 clear chain after finalize

### DIFF
--- a/packages/rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.ts
@@ -125,7 +125,10 @@ export function trackClickActions(
       const rageClick = click.clone()
       currentClickChain = createClickChain(click, (clicks) => {
         finalizeClicks(clicks, rageClick)
-        // currentClickChain = undefined
+        // Clear the reference to allow garbage collection. Without this, the finalize callback
+        // retains a closure reference to the old click chain, preventing it from being cleaned up
+        // and causing a memory leak as click chains accumulate over time.
+        currentClickChain = undefined
       })
     }
   }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

A memory leak occurs when the detached elements of a click chain are collected.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

This PR frees the current click chain, releasing the memory related to the event targets clicked in the chain.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

- Go to https://app.datadoghq.com/rum/list
- Open dev tools
- Navigate to the `Memory` tab
- Take a heap snapshot
- Click on `Set Up Manually`
- Click on `React`
- Close the modal
- Take another heap snapshot
- Compare both snapshots
- _Check that there are several buttons (originally from the modal) that are retained in memory due to the click chain_

Repeat the same steps with the SDK from this branch.

- _Check there are no buttons from the modal retained in memory_

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
