### PR TITLE
👷 when webpack has errors, print stats and fail the script

### DIFF
--- a/scripts/build/build-package.ts
+++ b/scripts/build/build-package.ts
@@ -63,16 +63,24 @@ async function buildBundle({ filename, verbose }: { filename: string; verbose: b
       (error, stats) => {
         if (error) {
           reject(error)
-          return
+        } else if (!stats) {
+          reject(new Error('Webpack did not return stats'))
+        } else if (stats.hasErrors()) {
+          printStats(stats)
+          reject(new Error('Failed to build bundle due to Webpack errors'))
+        } else {
+          if (verbose) {
+            printStats(stats)
+          }
+          resolve()
         }
-
-        if (verbose) {
-          console.log(stats!.toString({ colors: true }))
-        }
-        resolve()
       }
     )
   })
+
+  function printStats(stats: webpack.Stats) {
+    console.log(stats.toString({ colors: true }))
+  }
 }
 
 async function buildModules({ outDir, module, verbose }: { outDir: string; module: string; verbose: boolean }) {


### PR DESCRIPTION
## Motivation

I observed that when there is a TS typecheck error, `yarn build:bundle` succeeds but don't produce the `bundle/` folder 😨  

## Changes

This PR ensure that the build fails and the typecheck error is reported.

## Test instructions

Try it:
* change something to create a typecheck error. For example, in any source file, make a typo in a TS type
* run `yarn build:bundle`. It should fail.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
