### PR TITLE
🎨 [PANA-5222] Make CODEOWNERS more accurate for recording code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,13 @@
 # Order is important, the last matching pattern takes the most precedence.
 
+# Default
+*    @Datadog/rum-browser
+
 # Global
-packages/flagging                          @Datadog/feature-flagging-experimentation
-packages/rum/src/domain/record             @Datadog/rum-browser @Datadog/session-replay-sdk
-packages/rum/src/domain/segmentCollection  @Datadog/rum-browser @Datadog/session-replay-sdk
-packages/rum/src/domain/*.ts               @Datadog/rum-browser @Datadog/session-replay-sdk
-*                                          @Datadog/rum-browser
+packages/flagging                               @Datadog/feature-flagging-experimentation
+packages/rum/src/domain/record/**               @Datadog/rum-browser @Datadog/session-replay-sdk
+packages/rum/src/domain/segmentCollection/**    @Datadog/rum-browser @Datadog/session-replay-sdk
+packages/rum/src/domain/*.ts                    @Datadog/rum-browser @Datadog/session-replay-sdk
 
 # Docs
 *README.md    @Datadog/rum-browser @DataDog/documentation


### PR DESCRIPTION
## Motivation

It looks like our `CODEOWNERS` configuration is not quite right for the session replay recording code. In #3998 , a member of the `session-replay-sdk` team approved the PR, but Github still wants approval from `rum-browser`.

## Changes

I made two changes:
- The `CODEOWNERS` directives for the session replay recording code now use `**` to include all subdirectories.
- The default `*` rule is now placed first. It makes sense that the default would be the first rule, since in `CODEOWNERS` later rules override earlier ones; [Github's example](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file) uses this approach.