### PR TITLE
🐛 Update graphql errors_count field to error_count

### DIFF
--- a/packages/rum-core/src/domain/resource/graphql.spec.ts
+++ b/packages/rum-core/src/domain/resource/graphql.spec.ts
@@ -305,7 +305,7 @@ describe('GraphQL detection and metadata extraction', () => {
       })
 
       expect(result?.operationType).toBe('query')
-      expect(result?.errors_count).toBe(1)
+      expect(result?.error_count).toBe(1)
       expect(result?.errors).toEqual([{ message: 'Not found', path: undefined, locations: undefined, code: undefined }])
     })
 
@@ -325,7 +325,7 @@ describe('GraphQL detection and metadata extraction', () => {
       })
 
       expect(result?.operationType).toBe('query')
-      expect(result?.errors_count).toBeUndefined()
+      expect(result?.error_count).toBeUndefined()
       expect(result?.errors).toBeUndefined()
     })
 
@@ -348,7 +348,7 @@ describe('GraphQL detection and metadata extraction', () => {
       })
 
       expect(result?.operationType).toBe('query')
-      expect(result?.errors_count).toBe(2)
+      expect(result?.error_count).toBe(2)
       expect(result?.errors).toEqual([
         { message: 'Error 1', path: undefined, locations: undefined, code: undefined },
         { message: 'Error 2', path: undefined, locations: undefined, code: undefined },

--- a/packages/rum-core/src/domain/resource/graphql.ts
+++ b/packages/rum-core/src/domain/resource/graphql.ts
@@ -19,7 +19,7 @@ export interface GraphQlMetadata {
   operationName?: string
   variables?: string
   payload?: string
-  errors_count?: number
+  error_count?: number
   errors?: GraphQlError[]
 }
 
@@ -35,7 +35,7 @@ export function extractGraphQlMetadata(
   if (graphQlConfig.trackResponseErrors && request.responseBody) {
     const responseErrors = parseGraphQlResponse(request.responseBody)
     if (responseErrors) {
-      metadata.errors_count = responseErrors.length
+      metadata.error_count = responseErrors.length
       metadata.errors = responseErrors
     }
   }

--- a/test/e2e/scenario/rum/graphql.scenario.ts
+++ b/test/e2e/scenario/rum/graphql.scenario.ts
@@ -107,7 +107,7 @@ test.describe('GraphQL tracking', () => {
         operationName: 'GetUser',
         variables: undefined,
         payload: undefined,
-        errors_count: 1,
+        error_count: 1,
         errors: [
           {
             message: 'Field "unknownField" does not exist',
@@ -136,7 +136,7 @@ test.describe('GraphQL tracking', () => {
       await flushEvents()
       const resourceEvent = intakeRegistry.rumResourceEvents.find((event) => event.resource.url.includes('/graphql'))!
       expect(resourceEvent).toBeDefined()
-      expect(resourceEvent.resource.graphql?.errors_count).toBe(2)
+      expect(resourceEvent.resource.graphql?.error_count).toBe(2)
       expect(resourceEvent.resource.graphql?.errors).toEqual([
         { message: 'User not found' },
         { message: 'Insufficient permissions', code: 'UNAUTHORIZED' },
@@ -159,7 +159,7 @@ test.describe('GraphQL tracking', () => {
       await flushEvents()
       const resourceEvent = intakeRegistry.rumResourceEvents.find((event) => event.resource.url.includes('/graphql'))!
       expect(resourceEvent).toBeDefined()
-      expect(resourceEvent.resource.graphql?.errors_count).toBeUndefined()
+      expect(resourceEvent.resource.graphql?.error_count).toBeUndefined()
       expect(resourceEvent.resource.graphql?.errors).toBeUndefined()
     })
 })


### PR DESCRIPTION
## Motivation

To match graphQL attribute generated by IOS sdk and also match rum-event-format, we should update the naming in the SDK.

## Changes

Change errors_count to error_count. This could be a breaking change for dashboard/query please modify the field name in consequences. 

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
