### PR TITLE
🔊 add debug logs to npm publishing command

### DIFF
--- a/scripts/deploy/publish-npm.ts
+++ b/scripts/deploy/publish-npm.ts
@@ -10,5 +10,5 @@ runMain(() => {
   printLog('Publishing')
   // eslint-disable-next-line no-template-curly-in-string
   fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_authToken=${NPM_TOKEN}')
-  command`yarn lerna publish from-package --yes`.withEnvironment({ NPM_TOKEN: getNpmToken() }).run()
+  command`yarn lerna publish from-package --yes`.withEnvironment({ NPM_TOKEN: getNpmToken() }).withLogs().run()
 })


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

the publish to npm job [still fails](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1303251449) for unknown reason, let's add some log to see if we can understand what is going wrong.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
