### PR TITLE
👷 update the token to AWS after renewing it

### DIFF
--- a/scripts/release/renew-token.ts
+++ b/scripts/release/renew-token.ts
@@ -120,7 +120,7 @@ async function callNpmApi<T>({
     process.exit(1)
   }
 
-  return responseBody
+  return responseBody as T
 }
 
 function findPublisheablePackages() {


### PR DESCRIPTION
## Motivation

After renewing the token, we should update it in AWS.

## Changes

Update the token after renewing it. 
Also, make sure we are correctly logged in with the right account.

## Test instructions

Run the script with `node scripts/release/renew-token.ts`, follow the instructions

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
