### PR TITLE
👷 disable deploy-prod-canary during the freeze

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -345,30 +345,30 @@ deploy-staging:
     - node ./scripts/deploy/deploy.ts staging staging root
     - node ./scripts/deploy/upload-source-maps.ts staging root
 
-deploy-prod-canary:
-  stage: deploy:canary
-  extends:
-    - .base-configuration
-    - .main
-  script:
-    - export BUILD_MODE=canary
-    - yarn
-    - yarn build:bundle
-    - node ./scripts/deploy/deploy.ts prod canary root
-    - node ./scripts/deploy/upload-source-maps.ts canary root
+# deploy-prod-canary:
+#   stage: deploy:canary
+#   extends:
+#     - .base-configuration
+#     - .main
+#   script:
+#     - export BUILD_MODE=canary
+#     - yarn
+#     - yarn build:bundle
+#     - node ./scripts/deploy/deploy.ts prod canary root
+#     - node ./scripts/deploy/upload-source-maps.ts canary root
 
-deploy-next-major-canary:
-  stage: deploy
-  extends:
-    - .base-configuration
-    - .next-major-branch
-  script:
-    - export BUILD_MODE=canary
-    - VERSION=$(node -p -e "require('./lerna.json').version")
-    - yarn
-    - yarn build:bundle
-    - node ./scripts/deploy/deploy.ts prod v${VERSION%%.*}-canary root
-    - node ./scripts/deploy/upload-source-maps.ts v${VERSION%%.*}-canary root
+# deploy-next-major-canary:
+#   stage: deploy
+#   extends:
+#     - .base-configuration
+#     - .next-major-branch
+#   script:
+#     - export BUILD_MODE=canary
+#     - VERSION=$(node -p -e "require('./lerna.json').version")
+#     - yarn
+#     - yarn build:bundle
+#     - node ./scripts/deploy/deploy.ts prod v${VERSION%%.*}-canary root
+#     - node ./scripts/deploy/upload-source-maps.ts v${VERSION%%.*}-canary root
 
 deploy-manual:
   stage: deploy


### PR DESCRIPTION
## Motivation

Allows merging PRs on main without deploying canary.

Similar past PR for reference: #3984 

## Changes

Comment out `deploy-prod-canary` and `deploy-next-major-canary` jobs in gitlab config.
## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
