### PR TITLE
feat: add file property on RumError

### DIFF
--- a/packages/core/src/domain/error/error.spec.ts
+++ b/packages/core/src/domain/error/error.spec.ts
@@ -100,21 +100,21 @@ describe('computeRawError', () => {
           column: 15,
           func: 'foo',
           line: 52,
-          url: 'http://path/to/file.js',
+          url: 'http://path/to/file-1.js',
         },
         {
           args: [],
           column: undefined,
           func: '?',
           line: 12,
-          url: 'http://path/to/file.js',
+          url: 'http://path/to/file-2.js',
         },
         {
           args: ['baz'],
           column: undefined,
           func: '?',
           line: undefined,
-          url: 'http://path/to/file.js',
+          url: 'http://path/to/file-3.js',
         },
       ],
     }
@@ -128,10 +128,11 @@ describe('computeRawError', () => {
 
     expect(formatted.message).toEqual('oh snap!')
     expect(formatted.stack).toEqual(`TypeError: oh snap!
-  at foo(1, bar) @ http://path/to/file.js:52:15
-  at <anonymous> @ http://path/to/file.js:12
-  at <anonymous>(baz) @ http://path/to/file.js`)
+  at foo(1, bar) @ http://path/to/file-1.js:52:15
+  at <anonymous> @ http://path/to/file-2.js:12
+  at <anonymous>(baz) @ http://path/to/file-3.js`)
     expect(formatted.type).toEqual('TypeError')
+    expect(formatted.file).toEqual('http://path/to/file-1.js')
   })
 
   it('should set handling according to given parameter', () => {

--- a/packages/core/src/domain/error/error.ts
+++ b/packages/core/src/domain/error/error.ts
@@ -44,6 +44,7 @@ function computeErrorBase({
     type: stackTrace ? stackTrace.name : undefined,
     message: computeMessage(stackTrace, isErrorInstance, nonErrorPrefix, originalError),
     stack: stackTrace ? toStackTraceString(stackTrace) : useFallbackStack ? NO_ERROR_STACK_PRESENT_MESSAGE : undefined,
+    file: stackTrace?.stack[0]?.url,
   }
 }
 

--- a/packages/core/src/domain/error/error.types.ts
+++ b/packages/core/src/domain/error/error.types.ts
@@ -30,6 +30,7 @@ export interface RawError {
   message: string
   type?: string
   stack?: string
+  file?: string
   source: ErrorSource
   originalError?: unknown
   handling?: ErrorHandling

--- a/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
+++ b/packages/logs/src/domain/createErrorFieldFromRawError.spec.ts
@@ -15,6 +15,7 @@ describe('createErrorFieldFromRawError', () => {
     type: 'qux',
     message: 'quux',
     stack: 'quuz',
+    file: 'https://example.com/quux.js',
     causes: [],
     fingerprint: 'corge',
     csp: {

--- a/packages/rum-core/src/domain/error/errorCollection.ts
+++ b/packages/rum-core/src/domain/error/errorCollection.ts
@@ -78,6 +78,7 @@ function processError(error: RawError): RawRumEventCollectedData<RawRumErrorEven
       message: error.message,
       source: error.source,
       stack: error.stack,
+      file: error.file,
       handling_stack: error.handlingStack,
       component_stack: error.componentStack,
       type: error.type,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -96,6 +96,7 @@ export interface RawRumErrorEvent {
     id: string
     type?: string
     stack?: string
+    file?: string
     handling_stack?: string
     component_stack?: string
     fingerprint?: string


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

Close #4054 

Introducing file property on RumErrorEvent to accurately identity from which errors are coming.

Added file property on rum-event-schema repository as well.
see: https://github.com/DataDog/rum-events-format/pull/331

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
