### PR TITLE
🐛 [RUM-13693] make sure click actions are flushed on page exit

### DIFF
--- a/packages/rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.spec.ts
@@ -7,6 +7,7 @@ import {
   DefaultPrivacyLevel,
   Observable,
   ExperimentalFeature,
+  PageExitReason,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, mockClock, mockExperimentalFeatures } from '@datadog/browser-core/test'
@@ -219,6 +220,21 @@ describe('trackClickActions', () => {
 
     expect(events.length).toBe(1)
     expect(events[0].duration).toBe((2 * BEFORE_PAGE_ACTIVITY_VALIDATION_DELAY) as Duration)
+  })
+
+  it('ongoing click action is stopped on page exit', () => {
+    startClickActionsTracking()
+    emulateClick()
+
+    clock.tick(12)
+
+    lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, {
+      reason: PageExitReason.HIDDEN,
+    })
+
+    expect(events.length).toBe(1)
+    expect(events[0].duration).toBe(12 as Duration)
+    expect(events[0].frustrationTypes).toEqual([])
   })
 
   it('collect click actions even if another one is ongoing', () => {


### PR DESCRIPTION
## Motivation

When a click results in a page navigation (ex: clicking on a link), the click action is likely to be missing.

This is because whenever a click happens, we wait a bit before reporting it to compute frustration signals. As a reminder:

* for ‘rage clicks’ we wait a bit (1 second) to see if there is another click quickly following the click
* for ‘dead clicks’ we wait a bit (100ms) to see if there is any page activity following the click
* for ‘error clicks' we wait a bit (100ms) to see if there is any error following the click

When the page is exiting, we don’t have time to wait for frustration signals: we should send the click action as soon as possible.

This looks like a regression brought by https://github.com/datadog/browser-sdk/pull/3446 : since this PR, we don’t end the view anymore on unload, but we relied on [the view ending](https://github.com/DataDog/browser-sdk/blob/29c97c4c810ca4a854d7c653b071511656e3f6bc/packages/rum-core/src/domain/action/trackClickActions.ts#L229-L231) to flush the click.

## Changes

Stop/flush click actions whenever the page might exit.

## Test instructions

To reproduce, in the sandbox, add the following:

```html
 <script type="module">
      function getAnotherUrl() {
        const url = new URL(window.location.href)
        url.searchParams.set('foo', Math.random())
        return url.href
      }

      const button = document.createElement('button')
      button.innerText = 'Hard reload'
      button.addEventListener('click', () => {
        window.location.href = getAnotherUrl()
      })
      document.body.append(button)

      const button2 = document.createElement('button')
      button2.innerText = 'Soft reload'
      button2.addEventListener('click', () => {
        history.pushState(null, null, getAnotherUrl())
      })
      document.body.append(button2)
</script>
```

Click on the “Soft reload” button → the click action is correctly sent

Click on the “Hard reload” button → the click action isn’t sent. With this change, the click action should be sent.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
