### PR TITLE
✨ [PANA-5359] - Support Change records in the developer extension

### DIFF
--- a/developer-extension/src/common/packagesUrlConstants.ts
+++ b/developer-extension/src/common/packagesUrlConstants.ts
@@ -5,7 +5,7 @@ export const DEV_RUM_URL = `${DEV_SERVER_ORIGIN}/datadog-rum.js`
 
 // To follow web-ui development, this version will need to be manually updated from time to time.
 // When doing that, be sure to update types and implement any protocol changes.
-export const PROD_REPLAY_SANDBOX_VERSION = '0.119.0'
+export const PROD_REPLAY_SANDBOX_VERSION = '0.135.0'
 export const PROD_REPLAY_SANDBOX_ORIGIN = 'https://session-replay-datadoghq.com'
 export const PROD_REPLAY_SANDBOX_URL = `${PROD_REPLAY_SANDBOX_ORIGIN}/${PROD_REPLAY_SANDBOX_VERSION}/index.html`
 


### PR DESCRIPTION
## Motivation

The new encoding for DOM mutations being added in #4060 involves a new record type, `BrowserChangeRecord`. I've added support for `BrowserChangeRecord`s to the replay sandbox. However, they don't yet work in the developer extension, because the replay sandbox version it's using is too old.

## Changes

This PR updates the developer extension to use the latest version of the replay sandbox, bringing in support for playing back sessions that include `BrowserChangeRecord`s.

## Test instructions

1. Check out this PR's branch.
2. Build the extension locally and load it using Chrome's extension manager in the usual way.
3. Go to staging. (It currently has the new serialization code; hopefully this doesn't get reset on Monday!)
4. Use the developer extension to enable the `use_change_records` experimental feature.
5. Confirm that Live Replay in the extension still works.

## Checklist

- [x] Tested locally
- [x] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.