### PR TITLE
🔧 fix deploy auto notification job dependency

### DIFF
--- a/.gitlab/deploy-auto.yml
+++ b/.gitlab/deploy-auto.yml
@@ -121,7 +121,7 @@ notify-deploy-ready:
 notify-deploy-success:
   stage: post-notify
   needs:
-    - step-6_publish-developer-extension
+    - step-8_create-github-release
   extends:
     - .prepare_notification
   script:


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

fix release pipeline error:
```
Unable to create pipeline
  notify-deploy-success job: undefined need: step-6_publish-developer-extension
```

`step-6_publish-developer-extension` was renamed `step-7_...`. However, the last job is `step-8_create-github-release` so I guess it should depend on that one instead.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
