### PR TITLE
🔧 Update deploy-*.yml to use arch:amd64 runner

### DIFF
--- a/.gitlab/deploy-auto.yml
+++ b/.gitlab/deploy-auto.yml
@@ -4,7 +4,8 @@ stages:
   - post-notify
 
 .base-configuration:
-  tags: ['runner:main', 'size:large']
+  tags:
+    - 'arch:amd64'
   image: $CI_IMAGE
   id_tokens:
     DDOCTOSTS_ID_TOKEN:

--- a/.gitlab/deploy-manual.yml
+++ b/.gitlab/deploy-manual.yml
@@ -4,7 +4,8 @@ stages:
   - post-notify
 
 .base-configuration:
-  tags: ['runner:main', 'size:large']
+  tags:
+    - 'arch:amd64'
   image: $CI_IMAGE
   id_tokens:
     DDOCTOSTS_ID_TOKEN:


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

A year and a half ago we [upgraded the main runner](https://github.com/DataDog/browser-sdk/pull/2928) to `arch:amd64`, but we missed the deploy pipelines.

I believe the deprecated runner is the reason the deploy job [fails to fetch the runtime metadata service token](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1349356158) from vault.



## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

uses `arch:amd64` runner in both deploy-auto and deploy-manual pipeline

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->


I've ran a [test job](https://github.com/DataDog/browser-sdk/commit/7bda42cdb0299f517d928ecb1e278d360b793286#diff-6fdcbe7f6f8567b9e0e6b56365daecf236bac5f581a5b3e9d467756b6fd444a8) (in a [separate branch](https://github.com/DataDog/browser-sdk/compare/thomas.lebeau/test-datacenter-list)) both with the [new](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1349401092) and the [older deprecated runner](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1349418525) and this seems to work.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
