### PR TITLE
Revert "🐛 [PANA-5375] Treat Change records as full snapshots when appropriate"

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -19,7 +19,6 @@ export enum ExperimentalFeature {
   FEATURE_OPERATION_VITAL = 'feature_operation_vital',
   SHORT_SESSION_INVESTIGATION = 'short_session_investigation',
   AVOID_FETCH_KEEPALIVE = 'avoid_fetch_keepalive',
-  USE_CHANGE_RECORDS = 'use_change_records',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,21 +1,8 @@
 import type { TimeStamp, HttpRequest, HttpRequestEvent, Telemetry } from '@datadog/browser-core'
-import {
-  PageExitReason,
-  DefaultPrivacyLevel,
-  noop,
-  DeflateEncoderStreamId,
-  Observable,
-  ExperimentalFeature,
-} from '@datadog/browser-core'
+import { PageExitReason, DefaultPrivacyLevel, noop, DeflateEncoderStreamId, Observable } from '@datadog/browser-core'
 import type { ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType, startViewHistory } from '@datadog/browser-rum-core'
-import {
-  collectAsyncCalls,
-  createNewEvent,
-  mockEventBridge,
-  mockExperimentalFeatures,
-  registerCleanupTask,
-} from '@datadog/browser-core/test'
+import { collectAsyncCalls, createNewEvent, mockEventBridge, registerCleanupTask } from '@datadog/browser-core/test'
 import type { ViewEndedEvent } from 'packages/rum-core/src/domain/view/trackViews'
 import type { RumSessionManagerMock } from '../../../rum-core/test'
 import { appendElement, createRumSessionManagerMock, mockRumConfiguration } from '../../../rum-core/test'
@@ -84,35 +71,6 @@ describe('startRecording', () => {
   })
 
   it('sends recorded segments with valid context', async () => {
-    setupStartRecording()
-    flushSegment(lifeCycle)
-
-    const requests = await readSentRequests(1)
-    expect(requests[0].segment).toEqual(jasmine.any(Object))
-    expect(requests[0].event).toEqual({
-      application: {
-        id: 'appId',
-      },
-      creation_reason: 'init',
-      end: jasmine.stringMatching(/^\d{13}$/),
-      has_full_snapshot: true,
-      records_count: recordsPerFullSnapshot(),
-      session: {
-        id: 'session-id',
-      },
-      start: jasmine.any(Number),
-      raw_segment_size: jasmine.any(Number),
-      compressed_segment_size: jasmine.any(Number),
-      view: {
-        id: 'view-id',
-      },
-      index_in_view: 0,
-      source: 'browser',
-    })
-  })
-
-  it('sends recorded segments with valid context when Change records are enabled', async () => {
-    mockExperimentalFeatures([ExperimentalFeature.USE_CHANGE_RECORDS])
     setupStartRecording()
     flushSegment(lifeCycle)
 

--- a/packages/rum/src/domain/segmentCollection/segment.spec.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.spec.ts
@@ -23,11 +23,6 @@ const FULL_SNAPSHOT_RECORD: BrowserRecord = {
   timestamp: RECORD_TIMESTAMP,
   data: {} as any,
 }
-const CHANGE_RECORD: BrowserRecord = {
-  type: RecordType.Change,
-  timestamp: RECORD_TIMESTAMP,
-  data: [] as any,
-}
 const ENCODED_SEGMENT_HEADER_BYTES_COUNT = 12 // {"records":[
 const ENCODED_RECORD_BYTES_COUNT = 25
 const ENCODED_META_BYTES_COUNT = 193 // this should stay accurate as long as less than 10 records are added
@@ -199,16 +194,6 @@ describe('Segment', () => {
         const segment = createTestSegment()
         segment.addRecord(FULL_SNAPSHOT_RECORD, noop)
         expect(flushAndGetMetadata(segment).has_full_snapshot).toEqual(true)
-      })
-
-      it('sets has_full_snapshot to true if the first segment has a Change', () => {
-        const segment1 = createTestSegment()
-        segment1.addRecord(CHANGE_RECORD, noop)
-        expect(flushAndGetMetadata(segment1).has_full_snapshot).toEqual(true)
-
-        const segment2 = createTestSegment()
-        segment2.addRecord(CHANGE_RECORD, noop)
-        expect(flushAndGetMetadata(segment2).has_full_snapshot).toEqual(false)
       })
 
       it("doesn't overrides has_full_snapshot to false once it has been set to true", () => {

--- a/packages/rum/src/domain/segmentCollection/segment.ts
+++ b/packages/rum/src/domain/segmentCollection/segment.ts
@@ -49,8 +49,7 @@ export function createSegment({
     metadata.start = Math.min(metadata.start, record.timestamp)
     metadata.end = Math.max(metadata.end, record.timestamp)
     metadata.records_count += 1
-    metadata.has_full_snapshot ||=
-      record.type === RecordType.FullSnapshot || (record.type === RecordType.Change && metadata.index_in_view === 0)
+    metadata.has_full_snapshot ||= record.type === RecordType.FullSnapshot
 
     const prefix = encoder.isEmpty ? '{"records":[' : ','
     encoder.write(prefix + JSON.stringify(record), (additionalEncodedBytesCount) => {


### PR DESCRIPTION
Reverts DataDog/browser-sdk#4078