### PR TITLE
🔊 extend or remove expired telemetry debug

### DIFF
--- a/packages/rum-core/src/domain/resource/requestRegistry.ts
+++ b/packages/rum-core/src/domain/resource/requestRegistry.ts
@@ -19,7 +19,7 @@ export function createRequestRegistry(lifeCycle: LifeCycle): RequestRegistry {
   const subscription = lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, (request) => {
     requests.add(request)
     if (requests.size > MAX_REQUESTS) {
-      // monitor-until: 2026-01-01, after early request collection GA
+      // monitor-until: 2026-06-01, after early request collection is the default in v7
       addTelemetryDebug('Too many requests')
       requests.delete(requests.values().next().value!)
     }

--- a/packages/rum/src/boot/profilerApi.ts
+++ b/packages/rum/src/boot/profilerApi.ts
@@ -9,7 +9,7 @@ import type {
 } from '@datadog/browser-rum-core'
 import type { DeflateEncoderStreamId, Encoder } from '@datadog/browser-core'
 import { isSampled } from '@datadog/browser-rum-core'
-import { addTelemetryDebug, monitorError } from '@datadog/browser-core'
+import { monitorError } from '@datadog/browser-core'
 import type { RUMProfiler } from '../domain/profiling/types'
 import { isProfilingSupported } from '../domain/profiling/profilingSupported'
 import { startProfilingContext } from '../domain/profiling/profilingContext'
@@ -57,8 +57,6 @@ export function makeProfilerApi(): ProfilerApi {
     lazyLoadProfiler()
       .then((createRumProfiler) => {
         if (!createRumProfiler) {
-          // monitor-until: 2026-01-01, reconsider after profiling GA
-          addTelemetryDebug('[DD_RUM] Failed to lazy load the RUM Profiler')
           profilingContextManager.set({ status: 'error', error_reason: 'failed-to-lazy-load' })
           return
         }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

- Extend early data collection telemetry, let's see after v7 is released and EDC is enabled by default.
- Remove debug telemetry for profiler failing to load as profiler is GA and there the information is also available in view and long_task event in `@_dd.profiling.*`

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
