### PR TITLE
🐛 [RUM-13741] Fix sibling uniqueness check for elements in DocumentFragment

### DIFF
--- a/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.spec.ts
@@ -219,4 +219,23 @@ describe('isSelectorUniqueAmongSiblings', () => {
     `)
     expect(isSelectorUniqueAmongSiblings(element, 'DIV', 'HR')).toBeTrue()
   })
+
+  it('returns false when element is in DocumentFragment with matching siblings', () => {
+    const fragment = document.createDocumentFragment()
+    const div1 = document.createElement('div')
+    const div2 = document.createElement('div')
+    fragment.appendChild(div1)
+    fragment.appendChild(div2)
+
+    // The function should return false because div2 matches 'DIV' selector
+    expect(isSelectorUniqueAmongSiblings(div1, 'DIV', undefined)).toBeFalse()
+  })
+
+  it('returns true when element is in DocumentFragment with no matching siblings', () => {
+    const fragment = document.createDocumentFragment()
+    const div = document.createElement('div')
+    fragment.appendChild(div)
+
+    expect(isSelectorUniqueAmongSiblings(div, 'DIV', undefined)).toBeTrue()
+  })
 })

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -249,10 +249,22 @@ export function isSelectorUniqueAmongSiblings(
     isSiblingMatching = (sibling) => sibling.querySelector(scopedSelector) !== null
   }
 
-  const parent = currentElement.parentElement!
-  let sibling = parent.firstElementChild
+  // Check siblings by iterating directly through previousElementSibling and nextElementSibling.
+  // This works even when parentElement is null (e.g., when parent is a DocumentFragment).
+
+  // Check previous siblings
+  let sibling = currentElement.previousElementSibling
   while (sibling) {
-    if (sibling !== currentElement && isSiblingMatching(sibling)) {
+    if (isSiblingMatching(sibling)) {
+      return false
+    }
+    sibling = sibling.previousElementSibling
+  }
+
+  // Check next siblings
+  sibling = currentElement.nextElementSibling
+  while (sibling) {
+    if (isSiblingMatching(sibling)) {
       return false
     }
     sibling = sibling.nextElementSibling


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

This fixes a [recurrent error](https://dd-rum-telemetry.datadoghq.com/logs?query=source%3Abrowser%20status%3Aerror%20firstElementChild&agg_m=count&agg_m_source=base&agg_q=%40org_id&agg_t=count&clustering_pattern_field_path=message&cols=%40type%2Cservice%2C%40org_id%2C%40http.useragent_details.browser.family&flat_group_bys=true&messageDisplay=inline&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1768833902164&to_ts=1769093102164&live=true) in the sdk telemetry.

The error happens because `currentElement.parentElement` can actually be `null`, for example when the parent is a document fragment (in that case the parent is a `Document`, not an `Element`.)

Instead of relying on `parent.firstElementChild` to iterate siblings, the fix uses direct sibling traversal:
- Check `previousElementSibling` (backward)
- Check `nextElementSibling` (forward)

This approach works regardless of parent type, including when `parentElement` is `null`.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

- Replaced `parent.firstElementChild` iteration with direct `previousElementSibling` and `nextElementSibling` traversal
- Added tests for DocumentFragment scenarios with matching and non-matching siblings

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
