### PR TITLE
👷 Bump iOS version

### DIFF
--- a/test/unit/browsers.conf.ts
+++ b/test/unit/browsers.conf.ts
@@ -42,7 +42,7 @@ export const browserConfigurations: BrowserConfiguration[] = [
     sessionName: 'Safari mobile',
     name: 'safari',
     os: 'ios',
-    osVersion: '15',
-    device: 'iPhone 13',
+    osVersion: '16',
+    device: 'iPhone 14',
   },
 ]


### PR DESCRIPTION
## Motivation

Connection to Browserstack iPhone 13 iOS 15 is very slow lately (~8 min) which reach our timeout for capture + disconnection tolerance (2min + 3 * 2min), failing most of our pipelines.

## Changes

I've opened a support ticket to Browserstack but in the mean time, let's temporarily use a newer version.

Considered alternatives:
- removing iOS from the conf
- increasing the disconnection tolerance

## Test instructions

unit-bs should pass 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
