### PR TITLE
🐛 Support stylesheet serialization in Safari iOS 16.x

### DIFF
--- a/packages/rum/src/domain/record/serialization/serializeStyleSheets.ts
+++ b/packages/rum/src/domain/record/serialization/serializeStyleSheets.ts
@@ -8,7 +8,7 @@ export function serializeStyleSheets(
   if (cssStyleSheets === undefined || cssStyleSheets.length === 0) {
     return undefined
   }
-  return cssStyleSheets.map((cssStyleSheet) => {
+  const serializeStylesheet = (cssStyleSheet: CSSStyleSheet) => {
     const rules = cssStyleSheet.cssRules || cssStyleSheet.rules
     const cssRules = Array.from(rules, (cssRule) => cssRule.cssText)
     transaction.addMetric(
@@ -22,5 +22,15 @@ export function serializeStyleSheets(
       media: cssStyleSheet.media.length > 0 ? Array.from(cssStyleSheet.media) : undefined,
     }
     return styleSheet
-  })
+  }
+  // Safari iOS 16.x implements adoptedStyleSheets as a FrozenArray that:
+  // - can't be iterated over through map or for...of
+  // - can't be converted to regular array with Array.from
+  // - can't be detected with Array.isArray or Object.isFrozen
+  // Use index access to avoid the issue
+  const styleSheets: StyleSheet[] = []
+  for (let index = 0; index < cssStyleSheets.length; index++) {
+    styleSheets.push(serializeStylesheet(cssStyleSheets[index]))
+  }
+  return styleSheets
 }


### PR DESCRIPTION
## Motivation

Since the bump of safari iOS version, one test is failing inconsistently:

```
 serializeDocumentNode handles
    with dynamic stylesheet
      ✗ serializes a document with adoptedStyleSheets [Mobile Safari 16.4 (iOS 16.4.1)]
	Expected $.adoptedStyleSheets.length = 0 to equal 1.
```

It seems that Safari started the adoptedStyleSheets implementation with FrozenArray around 16.x version.
- [ObservableArray, and its use by adoptedStyleSheets · Issue #693 · w3ctag/design-reviews](https://github.com/w3ctag/design-reviews/issues/693)
- [Instead of assignable FrozenArray, use add / remove · Issue #45 · WICG/construct-stylesheets](https://github.com/WICG/construct-stylesheets/issues/45)
- [adoptedStyleSheets (ObservableArray) has non-writable length](https://bugs.webkit.org/show_bug.cgi?id=260716)

In this case, the use of map simply returns an empty array without any error.

## Changes

Use a regular for loop to iterate over CSSStyleSheet array.

## Test instructions

I've managed to see the fix working where the issue should have happened.
We should not see this test fail anymore.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
