### PR TITLE
👷 set NEXT_MAJOR_BRANCH to v7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
   GIT_REPOSITORY: 'git@github.com:DataDog/browser-sdk.git'
   MAIN_BRANCH: 'main'
-  NEXT_MAJOR_BRANCH: ''
+  NEXT_MAJOR_BRANCH: 'v7'
   CHROME_PACKAGE_VERSION: 139.0.7258.66-1
   FF_TIMESTAMPS: 'true' # Enable timestamps for gitlab-ci logs
 


### PR DESCRIPTION
## Motivation

Preparation for the v7 major release.

## Changes

Configure GitLab CI to target `v7` as the next major branch, enabling CI workflows to build and test against the upcoming major version.

## Test instructions

N/A - CI configuration change

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file