### PR TITLE
Benoit/experimental vite test runner

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -25,6 +25,7 @@ dev,@types/node-forge,MIT,Copyright Microsoft Corporation
 dev,@types/pako,MIT,Copyright Microsoft Corporation
 dev,@types/react,MIT,Copyright Microsoft Corporation
 dev,@types/react-dom,MIT,Copyright Microsoft Corporation
+dev,@types/ws,MIT,Copyright Microsoft Corporation
 dev,@wxt-dev/module-react,MIT,Copyright (c) 2023 Aaron
 dev,@vitejs/plugin-react,MIT,Copyright (c) 2019-present Evan You & Vite Contributors
 dev,ajv,MIT,Copyright 2015-2017 Evgeny Poberezkin
@@ -76,4 +77,5 @@ dev,vite,MIT,Copyright (c) 2019-present, VoidZero Inc. and Vite contributors
 dev,webpack,MIT,Copyright JS Foundation and other contributors
 dev,webpack-cli,MIT,Copyright JS Foundation and other contributors
 dev,webpack-dev-middleware,MIT,Copyright JS Foundation and other contributors
+dev,ws,MIT,Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com> Copyright (c) 2013 Arnout Kazemier and contributors Copyright (c) 2016 Luigi Pinca and contributors
 dev,wxt,MIT,Copyright (c) 2023 Aaron

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,7 @@ export default tseslint.config(
           './test/e2e/tsconfig.json',
           './test/performance/tsconfig.json',
           './test/apps/**/tsconfig.json',
+          './test/unit/vite-experiment/tsconfig.json',
         ],
         sourceType: 'module',
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "version": "scripts/cli version",
     "test": "yarn test:unit:watch",
     "test:unit": "karma start ./test/unit/karma.local.conf.js",
+    "test:unit:patou": "node ./test/unit/vite-experiment/main.ts --headless",
     "test:script": "node --test --experimental-test-module-mocks './scripts/**/*.spec.*'",
     "test:unit:watch": "yarn test:unit --no-single-run",
     "test:unit:bs": "node ./scripts/test/bs-wrapper.ts karma start test/unit/karma.bs.conf.js",
@@ -56,6 +57,7 @@
     "@types/jasmine": "3.10.19",
     "@types/node": "25.2.0",
     "@types/node-forge": "1.3.14",
+    "@types/ws": "8.18.1",
     "ajv": "8.17.1",
     "browserstack-local": "1.5.8",
     "chrome-webstore-upload": "4.0.3",
@@ -97,9 +99,11 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",
     "undici": "7.19.1",
+    "vite": "7.3.1",
     "webpack": "5.105.0",
     "webpack-cli": "6.0.1",
-    "webpack-dev-middleware": "7.4.5"
+    "webpack-dev-middleware": "7.4.5",
+    "ws": "8.19.0"
   },
   "resolutions": {
     "puppeteer-core@npm:21.11.0/ws": "8.17.1"

--- a/test/unit/vite-experiment/browser/allJsonSchemas.ts
+++ b/test/unit/vite-experiment/browser/allJsonSchemas.ts
@@ -1,0 +1,2 @@
+const modules = import.meta.glob('../../../../rum-events-format/schemas/**/*.json', { eager: true })
+export const allJsonSchemas = Object.values(modules)

--- a/test/unit/vite-experiment/browser/bootstrap.ts
+++ b/test/unit/vite-experiment/browser/bootstrap.ts
@@ -1,0 +1,118 @@
+import type { TestRunOptions, ServerMessage } from '../types/messages.ts'
+import { createJasmineReporter } from './reporter.ts'
+
+// Vite defines `module.exports` when loading Jasmine, and Jasmine assumes it's in Node.js, so it
+// uses `global` instead of `window` as a global variable.
+window.global = globalThis
+// Jasmine uses an undeclared variable `i`, which breaks in strict mode
+// https://github.com/jasmine/jasmine/blob/v3.99.1/lib/jasmine-core/jasmine.js#L3369
+window.i = undefined
+
+const { default: jasmineRequire } = await import('jasmine-core/lib/jasmine-core/jasmine.js')
+
+main().catch((error) => {
+  console.error(error)
+})
+
+async function main() {
+  const jasmine = jasmineRequire.core(jasmineRequire)
+  const env = jasmine.getEnv({ global: globalThis })
+  Object.assign(globalThis, jasmineRequire.interface(jasmine, env))
+
+  const ws = await createWebSocketClient()
+  const options = await waitForRunTestsMessage(ws)
+
+  const jasmineConfig: jasmine.Configuration = {}
+
+  if (options.seed) {
+    jasmineConfig.seed = options.seed
+  }
+
+  if (options.stopOnFailure) {
+    jasmineConfig.stopOnSpecFailure = true
+  }
+
+  env.configure(jasmineConfig)
+  env.addReporter(createJasmineReporter(ws))
+
+  try {
+    const { specFileCount } = await loadSpecFiles()
+    console.log(`Loaded ${specFileCount} spec files`)
+  } catch (error) {
+    console.error('Failed to load specs:', error)
+    document.body.innerHTML = `<h1 style="color: red;">Failed to load specs</h1><pre>${error instanceof Error ? error.stack : String(error)}</pre>`
+    return
+  }
+
+  // TODO: remove me. This removes the event listener added in forEach.spec.ts, because it prevent the
+  // page from refreshing when using watch mode. This listener might be useful for Karma so let's keep
+  // it for now.
+  afterEach(() => {
+    window.onbeforeunload = null
+  })
+
+  await env.execute()
+
+  document.body.innerHTML = '<h1>Test suite complete (see console)</h1>'
+}
+
+function createWebSocketClient(): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://${window.location.host}`)
+
+  return new Promise<WebSocket>((resolve, reject) => {
+    ws.onopen = () => {
+      console.log('Connected to CLI via WebSocket')
+      resolve(ws)
+    }
+
+    ws.onerror = (error) => {
+      document.body.innerHTML = '<h1 style="color: red;">WebSocket connection failed</h1>'
+      reject(new Error('WebSocket connection failed', { cause: error }))
+    }
+  })
+}
+
+function waitForRunTestsMessage(ws: WebSocket): Promise<TestRunOptions> {
+  return new Promise<TestRunOptions>((resolve, reject) => {
+    const messageHandler = (event: MessageEvent) => {
+      try {
+        const message: ServerMessage = JSON.parse(event.data)
+        if (message.type === 'run-tests') {
+          ws.removeEventListener('message', messageHandler)
+          resolve(message.data)
+        }
+      } catch (error) {
+        reject(new Error('Error parsing message', { cause: error }))
+      }
+    }
+
+    ws.addEventListener('message', messageHandler)
+  })
+}
+
+async function loadSpecFiles() {
+  // Use eager: false to prevent immediate evaluation
+  const specImports = {
+    ...import.meta.glob('../../../../packages/**/*.spec.{ts,tsx}', { eager: false }),
+    ...import.meta.glob('../../../../developer-extension/**/*.spec.{ts,tsx}', { eager: false }),
+  }
+
+  const forEachSpecModules: Array<() => Promise<unknown>> = []
+  const otherSpecModules: Array<() => Promise<unknown>> = []
+
+  for (const [path, module] of Object.entries(specImports)) {
+    if (path.includes('forEach.spec.ts')) {
+      forEachSpecModules.push(module)
+    } else {
+      otherSpecModules.push(module)
+    }
+  }
+
+  // Make sure 'forEach.spec' are the first files to be evaluated, so their `beforeEach` hooks are
+  // executed before all other `beforeEach` hooks, and their `afterEach` hook are executed after all
+  // other `afterEach` hooks.
+  await Promise.all(forEachSpecModules.map((module) => module()))
+  await Promise.all(otherSpecModules.map((module) => module()))
+
+  return { specFileCount: Object.keys(specImports).length }
+}

--- a/test/unit/vite-experiment/browser/reporter.ts
+++ b/test/unit/vite-experiment/browser/reporter.ts
@@ -1,0 +1,122 @@
+import type { ClientMessage } from '../types/messages'
+
+export function createJasmineReporter(ws: WebSocket) {
+  const specResults: jasmine.SpecResult[] = []
+  const suitesResults: jasmine.SuiteResult[] = []
+  let overallResult: jasmine.JasmineDoneInfo | undefined
+
+  function sendMessage(message: ClientMessage) {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message))
+    }
+  }
+
+  return {
+    jasmineStarted(data: jasmine.JasmineStartedInfo) {
+      sendMessage({
+        type: 'jasmine-started',
+        data,
+      })
+    },
+
+    jasmineDone(result: jasmine.JasmineDoneInfo) {
+      overallResult = result
+      sendMessage({
+        type: 'jasmine-done',
+        data: result,
+      })
+
+      console.group('Test execution complete')
+
+      if (overallResult?.order.random) {
+        console.log(`Jasmine randomized with seed: ${overallResult.order.seed}`)
+      }
+
+      function countSpecsByStatus(status: string) {
+        return specResults.reduce((count, spec) => (spec.status === status ? count + 1 : count), 0)
+      }
+
+      console.log(
+        `%c${countSpecsByStatus('passed')} passed, %c${countSpecsByStatus('failed')} failed, %c${countSpecsByStatus(
+          'excluded'
+        )} excluded, %c${countSpecsByStatus('pending')} pending`,
+        'color: green',
+        'color: red',
+        'color: gray',
+        'color: gray'
+      )
+      console.groupEnd()
+
+      const failedSpecs = specResults.filter((spec: any) => spec.status === 'failed')
+      if (failedSpecs.length > 0) {
+        console.group('\nFailed tests:')
+        failedSpecs.forEach((spec: any) => {
+          console.group(`\n❌ ${spec.fullName}`)
+          printFailedExpectations(spec.failedExpectations)
+          console.groupEnd()
+        })
+        console.groupEnd()
+      }
+
+      const failedSuites = suitesResults.filter((suite: any) => suite.status === 'failed')
+      if (failedSuites.length > 0) {
+        console.group('\nFailed suites:')
+        failedSuites.forEach((suite: any) => {
+          console.group(`\n❌ ${suite.fullName}`)
+          printFailedExpectations(suite.failedExpectations)
+          console.groupEnd()
+        })
+        console.groupEnd()
+      }
+
+      if (overallResult?.failedExpectations.length ?? 0 > 0) {
+        console.group('\nGlobal failed expectations:')
+        printFailedExpectations(overallResult.failedExpectations)
+        console.groupEnd()
+      }
+
+      function printFailedExpectations(expectations: any[]) {
+        expectations.forEach((expectation: any) => {
+          console.error(expectation.stack)
+        })
+      }
+    },
+
+    suiteStarted(result: jasmine.SuiteResult) {
+      sendMessage({
+        type: 'suite-started',
+        data: result,
+      })
+    },
+
+    suiteDone(result: jasmine.SuiteResult) {
+      suitesResults.push(result)
+      sendMessage({
+        type: 'suite-done',
+        data: result,
+      })
+    },
+
+    specStarted(result: jasmine.SpecResult) {
+      sendMessage({
+        type: 'spec-started',
+        data: result,
+      })
+    },
+
+    specDone(specResult: jasmine.SpecResult) {
+      specResults.push(specResult)
+
+      if (specResult.status === 'passed') {
+        console.log(specResult.fullName, '✅')
+      } else if (specResult.status === 'failed') {
+        console.error(specResult.fullName, '❌')
+      }
+
+      sendMessage({
+        type: 'spec-done',
+        data: specResult,
+      })
+    },
+  }
+}

--- a/test/unit/vite-experiment/chromeLauncher.ts
+++ b/test/unit/vite-experiment/chromeLauncher.ts
@@ -1,0 +1,26 @@
+import { type Browser, launch } from 'puppeteer'
+
+export interface Chrome {
+  goTo(url: string): Promise<void>
+  close(): Promise<void>
+}
+
+export async function startChrome(): Promise<Chrome> {
+  console.log('Launching Chrome with Puppeteer...')
+
+  const browser: Browser = await launch({
+    headless: true,
+  })
+
+  return {
+    async goTo(url: string) {
+      const page = (await browser.pages())[0]
+      await page.goto(url)
+    },
+
+    async close() {
+      console.log('Closing Chrome...')
+      await browser.close()
+    },
+  }
+}

--- a/test/unit/vite-experiment/cliReporter.ts
+++ b/test/unit/vite-experiment/cliReporter.ts
@@ -1,0 +1,123 @@
+import type { EventEmitter } from 'node:events'
+import type { TestRunOptions } from './types/messages.ts'
+
+// Type for Connection from testRunner.ts
+interface Connection extends EventEmitter {
+  on(event: 'jasmine-started', listener: (info: jasmine.JasmineStartedInfo) => void): this
+  on(event: 'spec-done', listener: (result: jasmine.SpecResult) => void): this
+  on(event: 'jasmine-done', listener: (result: jasmine.JasmineDoneInfo) => void): this
+  on(event: 'close', listener: () => void): this
+  on(event: 'error', listener: (error: Error) => void): this
+}
+
+export function attachCliReporter(
+  connection: Connection,
+  options: TestRunOptions & { specPattern: string | undefined; watch: boolean }
+) {
+  console.log('Browser connected')
+
+  if (options.specPattern) {
+    console.log(`Running specs matching: ${options.specPattern}`)
+  }
+  if (options.watch) {
+    console.log('Watch mode enabled - server will stay running')
+  }
+  if (options.seed) {
+    console.log(`Using seed: ${options.seed}`)
+  }
+  if (options.stopOnFailure) {
+    console.log('Stop on failure enabled')
+  }
+
+  let totalSpecs = 0
+  let completedSpecs = 0
+  const specResults: jasmine.SpecResult[] = []
+
+  connection.on('jasmine-started', (info: jasmine.JasmineStartedInfo) => {
+    totalSpecs = info.totalSpecsDefined
+    console.log(`\nStarting test execution: ${totalSpecs} specs`)
+    if (info.order.random) {
+      console.log(`Randomized with seed: ${info.order.seed}`)
+    }
+    console.log('')
+  })
+
+  connection.on('spec-done', (result: jasmine.SpecResult) => {
+    completedSpecs++
+    specResults.push(result)
+
+    // Print progress indicator
+    let indicator: string
+    if (result.status === 'passed') {
+      indicator = '.'
+    } else if (result.status === 'failed') {
+      indicator = 'F'
+    } else if (result.status === 'pending') {
+      indicator = '*'
+    } else if (result.status === 'excluded') {
+      indicator = '⊘'
+    } else {
+      indicator = '?'
+    }
+
+    process.stdout.write(indicator)
+
+    // Print progress counter every 50 specs
+    if (completedSpecs % 50 === 0) {
+      process.stdout.write(` ${completedSpecs}/${totalSpecs}\n`)
+    }
+  })
+
+  connection.on('jasmine-done', (_result: jasmine.JasmineDoneInfo) => {
+    // Print newline if we didn't just print a progress line
+    if (completedSpecs % 50 !== 0) {
+      process.stdout.write('\n')
+    }
+
+    console.log('')
+    console.log('============================================================')
+    console.log('TEST RESULTS')
+    console.log('============================================================')
+
+    // Count specs by status
+    const passedCount = specResults.filter((s) => s.status === 'passed').length
+    const failedCount = specResults.filter((s) => s.status === 'failed').length
+    const pendingCount = specResults.filter((s) => s.status === 'pending').length
+    const excludedCount = specResults.filter((s) => s.status === 'excluded').length
+
+    console.log(
+      `✅ ${passedCount} passed | ❌ ${failedCount} failed | ⏭️  ${pendingCount} pending | ⊘ ${excludedCount} excluded`
+    )
+
+    // Print failed tests
+    const failedSpecs = specResults.filter((s) => s.status === 'failed')
+    if (failedSpecs.length > 0) {
+      console.log('')
+      console.log('Failed tests:')
+      console.log('')
+      for (const spec of failedSpecs) {
+        console.log(`  ❌ ${spec.fullName}`)
+        for (const expectation of spec.failedExpectations) {
+          console.log(`     Error: ${expectation.message}`)
+          if (expectation.stack) {
+            // Print only the first few lines of stack trace
+            const stackLines = expectation.stack.split('\n').slice(0, 5)
+            for (const line of stackLines) {
+              console.log(`    ${line}`)
+            }
+          }
+        }
+        console.log('')
+      }
+    }
+    console.log('============================================================')
+  })
+
+  connection.on('close', () => {
+    console.log('\nBrowser disconnected')
+  })
+
+  connection.on('error', (error: Error) => {
+    console.error('Connection error:', error)
+  })
+}

--- a/test/unit/vite-experiment/index.html
+++ b/test/unit/vite-experiment/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Datadog Browser SDK unit tests runner</title>
+  </head>
+  <body>
+    <script type="module" src="./browser/bootstrap.ts"></script>
+  </body>
+</html>

--- a/test/unit/vite-experiment/main.ts
+++ b/test/unit/vite-experiment/main.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import { parseArgs } from 'node:util'
+import type { TestRunResults } from './testRunner.ts'
+import { TestRunner } from './testRunner.ts'
+import type { TestRunOptions } from './types/messages.ts'
+import { attachCliReporter } from './cliReporter.ts'
+import { startChrome } from './chromeLauncher.ts'
+import { startServer } from './server.ts'
+
+const { values: args } = parseArgs({
+  options: {
+    spec: {
+      type: 'string',
+      short: 's',
+      description: 'Focus on a specific spec file pattern',
+    },
+    watch: {
+      type: 'boolean',
+      short: 'w',
+      description: 'Watch mode - keep server running after tests complete',
+      default: false,
+    },
+    seed: {
+      type: 'string',
+      description: 'Random seed for test execution',
+    },
+    'stop-on-failure': {
+      type: 'boolean',
+      description: 'Stop test execution on first failure',
+      default: false,
+    },
+    headless: {
+      type: 'boolean',
+      description: 'Launch Chrome headless automatically',
+      default: false,
+    },
+  },
+})
+
+const [httpServer, chrome] = await Promise.all([
+  startServer({ watch: args.watch, specPattern: args.spec }),
+  args.headless ? startChrome() : undefined,
+])
+
+const testRunner = new TestRunner(httpServer)
+
+testRunner.on('connection', async (connection) => {
+  const testRunOptions: TestRunOptions = {
+    seed: args.seed,
+    stopOnFailure: args['stop-on-failure'],
+  }
+
+  attachCliReporter(connection, { ...testRunOptions, specPattern: args.spec, watch: args.watch })
+
+  let result: TestRunResults | undefined
+  try {
+    result = await connection.run(testRunOptions)
+  } catch (error) {
+    console.error('Test run error:', error)
+  }
+
+  if (args.watch) {
+    console.log('Waiting for changes...')
+  } else {
+    const success = result !== undefined && result.specResults.every((spec) => spec.status !== 'failed')
+    exit(success ? 0 : 1)
+  }
+})
+
+if (chrome) {
+  await chrome.goTo('http://localhost:8080')
+}
+
+function exit(exitCode: number) {
+  void Promise.resolve()
+    .then(() => chrome?.close())
+    .finally(() => process.exit(exitCode))
+}

--- a/test/unit/vite-experiment/server.ts
+++ b/test/unit/vite-experiment/server.ts
@@ -1,0 +1,60 @@
+import type http from 'node:http'
+import { resolve } from 'path'
+import express from 'express'
+import { createServer as createViteServer } from 'vite'
+import { buildEnvKeys, getBuildEnvValue } from '../../../scripts/lib/buildEnv.ts'
+
+const ROOT = resolve(import.meta.dirname, '../../..')
+
+export async function startServer({
+  watch,
+  specPattern,
+}: {
+  watch: boolean
+  specPattern: string | undefined
+}): Promise<http.Server> {
+  console.log('Starting Vite dev server...')
+
+  const viteServer = await createViteServer({
+    root: import.meta.dirname,
+    server: { middlewareMode: true, watch: watch ? {} : null },
+    resolve: {
+      alias: [
+        { find: /^@datadog\/browser-([^\\/]+)$/, replacement: `${ROOT}/packages/$1/src` },
+        { find: /^@datadog\/browser-(.+\/.*)$/, replacement: `${ROOT}/packages/$1` },
+        { find: /^packages\/(.*)$/, replacement: `${ROOT}/packages/$1` },
+        { find: /^\.\/allJsonSchemas$/, replacement: `${import.meta.dirname}/browser/allJsonSchemas.ts` },
+      ],
+    },
+    define: Object.fromEntries(
+      buildEnvKeys.map((key) => [`__BUILD_ENV__${key}__`, JSON.stringify(getBuildEnvValue(key))])
+    ),
+    plugins: [
+      {
+        name: 'filter-spec-files',
+        load(id) {
+          if (specPattern && !id.endsWith('forEach.spec.ts') && id.endsWith('.spec.ts') && !id.includes(specPattern)) {
+            return ''
+          }
+        },
+      },
+    ],
+  })
+
+  const app = express()
+  app.use(viteServer.middlewares)
+
+  const httpServer = await new Promise<http.Server>((resolve, reject) => {
+    const server = app.listen(8080, (error) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(server)
+      }
+    })
+  })
+
+  console.log('Vite dev server started on http://localhost:8080')
+
+  return httpServer
+}

--- a/test/unit/vite-experiment/testRunner.ts
+++ b/test/unit/vite-experiment/testRunner.ts
@@ -1,0 +1,115 @@
+import EventEmitter from 'node:events'
+import type http from 'node:http'
+import { WebSocketServer, type WebSocket } from 'ws'
+import type { ClientMessage, ServerMessage, TestRunOptions } from './types/messages'
+
+interface TestRunnerEventMap {
+  connection: [Connection]
+}
+
+export class TestRunner extends EventEmitter<TestRunnerEventMap> {
+  constructor(httpServer: http.Server) {
+    super()
+    const wss = new WebSocketServer({ server: httpServer })
+
+    wss.on('connection', (ws) => {
+      this.emit('connection', new Connection(ws))
+    })
+  }
+}
+
+interface ConnectionEventMap {
+  'jasmine-started': [jasmine.JasmineStartedInfo]
+  'spec-started': [jasmine.SpecResult]
+  'spec-done': [jasmine.SpecResult]
+  'suite-started': [jasmine.SuiteResult]
+  'suite-done': [jasmine.SuiteResult]
+  'jasmine-done': [jasmine.JasmineDoneInfo]
+  close: []
+  error: [Error]
+}
+
+export interface TestRunResults {
+  specResults: jasmine.SpecResult[]
+  suitesResults: jasmine.SuiteResult[]
+  overallResult: jasmine.JasmineDoneInfo
+}
+
+export class Connection extends EventEmitter<ConnectionEventMap> {
+  private ws: WebSocket
+  constructor(ws: WebSocket) {
+    super()
+
+    this.ws = ws
+
+    ws.on('message', (data) => {
+      let message: ClientMessage
+
+      if (!Buffer.isBuffer(data)) {
+        this.emit('error', new Error('Error while parsing message from browser: not a buffer'))
+        return
+      }
+
+      try {
+        message = JSON.parse(data.toString())
+      } catch (error) {
+        this.emit('error', new Error('Error while parsing message from browser', { cause: error }))
+        return
+      }
+
+      this.emit(
+        message.type,
+        message.data as any // We know incoming messages are associated with the correct payload
+      )
+    })
+  }
+
+  run(options: TestRunOptions): Promise<TestRunResults> {
+    return new Promise((resolve, reject) => {
+      const specResults: jasmine.SpecResult[] = []
+      const suitesResults: jasmine.SuiteResult[] = []
+      const onError = (error: any) => {
+        cleanup()
+        reject(new Error('Test run error', { cause: error }))
+      }
+      const onClose = () => {
+        cleanup()
+        reject(new Error('Test run error: connection closed'))
+      }
+      const onSpecDone = (specResult: jasmine.SpecResult) => {
+        specResults.push(specResult)
+      }
+      const onSuiteDone = (suiteResult: jasmine.SuiteResult) => {
+        suitesResults.push(suiteResult)
+      }
+      const onJasmineDone = (result: jasmine.JasmineDoneInfo) => {
+        cleanup()
+        resolve({
+          specResults,
+          suitesResults,
+          overallResult: result,
+        })
+      }
+      const cleanup = () => {
+        this.off('error', onError)
+        this.off('close', onClose)
+        this.off('spec-done', onSpecDone)
+        this.off('suite-done', onSuiteDone)
+        this.off('jasmine-done', onJasmineDone)
+      }
+      this.on('error', onError)
+      this.on('close', onClose)
+      this.on('spec-done', onSpecDone)
+      this.on('suite-done', onSuiteDone)
+      this.on('jasmine-done', onJasmineDone)
+      this.send({
+        type: 'run-tests',
+        data: options,
+      })
+    })
+  }
+
+  private send(message: ServerMessage) {
+    this.ws.send(JSON.stringify(message))
+  }
+}

--- a/test/unit/vite-experiment/tsconfig.json
+++ b/test/unit/vite-experiment/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "preserve",
+    "target": "ES2024",
+    "lib": ["ES2024", "DOM"],
+    "types": ["node", "jasmine", "vite/client"],
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["**/*.ts", "types/**/*.d.ts", "../../../scripts/lib/buildEnv.ts"]
+}

--- a/test/unit/vite-experiment/types/globals.d.ts
+++ b/test/unit/vite-experiment/types/globals.d.ts
@@ -1,0 +1,5 @@
+// Extend Window interface for Jasmine compatibility
+interface Window {
+  global: typeof globalThis
+  i: any
+}

--- a/test/unit/vite-experiment/types/jasmineCore.d.ts
+++ b/test/unit/vite-experiment/types/jasmineCore.d.ts
@@ -1,0 +1,15 @@
+declare module 'jasmine-core/lib/jasmine-core/jasmine.js' {
+  interface JasmineCore {
+    getEnv(options?: { global?: typeof globalThis }): jasmine.Env
+  }
+
+  interface JasmineRequire {
+    core(jasmineRequire: JasmineRequire): JasmineCore
+    interface(jasmine: JasmineCore, env: jasmine.Env): any
+  }
+
+  const jasmineRequire: JasmineRequire
+
+  // eslint-disable-next-line import/no-default-export
+  export default jasmineRequire
+}

--- a/test/unit/vite-experiment/types/messages.ts
+++ b/test/unit/vite-experiment/types/messages.ts
@@ -1,0 +1,18 @@
+export type ClientMessage =
+  | { type: 'jasmine-started'; data: jasmine.JasmineStartedInfo }
+  | { type: 'suite-started'; data: jasmine.SuiteResult }
+  | { type: 'spec-started'; data: jasmine.SpecResult }
+  | { type: 'spec-done'; data: jasmine.SpecResult }
+  | { type: 'suite-done'; data: jasmine.SuiteResult }
+  | { type: 'jasmine-done'; data: jasmine.JasmineDoneInfo }
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ServerMessage = {
+  type: 'run-tests'
+  data: TestRunOptions
+}
+
+export interface TestRunOptions {
+  seed?: string
+  stopOnFailure?: boolean
+}

--- a/tsconfig.default.json
+++ b/tsconfig.default.json
@@ -22,6 +22,9 @@
     "test/e2e",
     "test/lib",
 
+    // Files included in ./test/unit/vite-experiment/tsconfig.json
+    "test/unit/vite-experiment",
+
     // Files included in ./test/performance/tsconfig.json
     "test/performance",
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./tsconfig.scripts.json" },
     { "path": "./developer-extension/tsconfig.json" },
     { "path": "./test/e2e/tsconfig.json" },
-    { "path": "./test/performance/tsconfig.json" }
+    { "path": "./test/performance/tsconfig.json" },
+    { "path": "./test/unit/vite-experiment/tsconfig.json" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,6 +3085,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ws@npm:8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
+  languageName: node
+  linkType: hard
+
 "@types/yauzl@npm:^2.9.1":
   version: 2.10.3
   resolution: "@types/yauzl@npm:2.10.3"
@@ -4458,6 +4467,7 @@ __metadata:
     "@types/jasmine": "npm:3.10.19"
     "@types/node": "npm:25.2.0"
     "@types/node-forge": "npm:1.3.14"
+    "@types/ws": "npm:8.18.1"
     ajv: "npm:8.17.1"
     browserstack-local: "npm:1.5.8"
     chrome-webstore-upload: "npm:4.0.3"
@@ -4499,9 +4509,11 @@ __metadata:
     typescript: "npm:5.9.3"
     typescript-eslint: "npm:8.54.0"
     undici: "npm:7.19.1"
+    vite: "npm:7.3.1"
     webpack: "npm:5.105.0"
     webpack-cli: "npm:6.0.1"
     webpack-dev-middleware: "npm:7.4.5"
+    ws: "npm:8.19.0"
   languageName: unknown
   linkType: soft
 
@@ -15051,7 +15063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.4.19 || ^6.3.4 || ^7.0.0, vite@npm:^7.3.1":
+"vite@npm:7.3.1, vite@npm:^5.4.19 || ^6.3.4 || ^7.0.0, vite@npm:^7.3.1":
   version: 7.3.1
   resolution: "vite@npm:7.3.1"
   dependencies:
@@ -15598,7 +15610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.19.0":
+"ws@npm:8.19.0, ws@npm:^8.19.0":
   version: 8.19.0
   resolution: "ws@npm:8.19.0"
   peerDependencies:


### PR DESCRIPTION
# Patou test runner

## Motivation

Karma has [been deprecated for three years](https://github.com/karma-runner/karma/commit/450fdfdac5b999967daec1020f1ac69cf9b854ab) now. While Karma still "does the job" and there is no urgency to migrate away from it, it could be interesting to explore alternative. The immediate consequences of Karma being deprecated are:

* it blocks us from upgrading Jasmine
* we can't expect any new feature/fixes/QoL updates

Considered alternatives:

* [Modern Web](https://modern-web.dev/): doesn't support Jasmine out of the box, but it seems easy enough to implement. To be explored
* [Vitest Browser Mode](https://vitest.dev/guide/browser/): modern approach with many features, used to require playwright but seems to support webdriverio now? To be explored. We made [an attempt](https://github.com/DataDog/browser-sdk/tree/congyao/mob-friday-migrate-vitest-2) previously
* Roll our own solution 🤓: in this PR, we explore how a custom-made solution could look like.


## TODO

- [x] communication channel between the CLI and browser execution
- [x] command line arguments:`--watch`, `--spec`, `--seed`, `--stop-on-failure`
- [x] exit (with exit code) when the test suite finishes
- [x] display execution status in CLI output
- [ ] capture console logs and uncaught errors and stuff and print them in the CLI output (with sourcemap support)
- [ ] junit reporter to upload to datadog
- [ ] istanbul test coverage
- [x] find a good name
- [ ] run tests on browser stack
- [ ] make it a library?
- [ ] user agent parser to display the browser name/version

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

Run `yarn test:unit:patou` to run unit tests in the experimental test runner. You can also invoke it directly, with:

```
node test/unit/vite-experiment/main.ts
```

See `--help` for usage.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
