### PR TITLE
🔧 Add integration-branch config for v7

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -15,6 +15,16 @@ contacts:
     contact: browser-sdk-deploy
 ---
 schema-version: v1
+kind: integration-branch
+name: $NEXT_MAJOR_BRANCH
+team: rum-browser
+update_automatically: false # update_automatically is updating the integration branch on a schedule, instead we're updating it in a CI job for any commit to the base branch.
+reset_pattern: '' # This branch should never be reseted
+contacts:
+  - type: slack
+    contact: browser-sdk-deploy
+---
+schema-version: v1
 kind: buildimpactanalysis
 team: ci-platforms
 enabled_strategies:


### PR DESCRIPTION
## Motivation

The `merge-into-next-major` CI job is [failing](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/jobs/1389173426) because the v7 branch is not configured as an integration branch in devflow:

```
The v7 branch of browser-sdk is not set up as an integration branch!
```

See: [Integration Branches documentation](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3127904638/Integration+Branches#Configuration)

## Changes

Add integration-branch configuration for `$NEXT_MAJOR_BRANCH` (v7) in `repository.datadog.yml`.

## Test instructions

- Verify CI passes
- Verify `merge-into-next-major` job no longer fails after merge

## Checklist

- [x] Tested locally
- [ ] ~~Tested on staging~~
- [ ] ~~Added unit tests for this change.~~
- [ ] ~~Added e2e/integration tests for this change.~~
- [ ] ~~Updated documentation and/or relevant AGENTS.md file~~