### PR TITLE
🔧 Use hardcoded v7 instead of $NEXT_MAJOR_BRANCH variable

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -16,7 +16,7 @@ contacts:
 ---
 schema-version: v1
 kind: integration-branch
-name: $NEXT_MAJOR_BRANCH
+name: v7
 team: rum-browser
 update_automatically: false # update_automatically is updating the integration branch on a schedule, instead we're updating it in a CI job for any commit to the base branch.
 reset_pattern: '' # This branch should never be reseted


### PR DESCRIPTION
## Motivation

The `$NEXT_MAJOR_BRANCH` variable in `repository.datadog.yml` is not being expanded, causing issues with the integration branch configuration. Hardcoding `v7` directly ensures the configuration works correctly.

## Changes

- Replace `$NEXT_MAJOR_BRANCH` with hardcoded `v7` in the integration-branch name field in `repository.datadog.yml`

## Test instructions

- Verify the integration branch configuration is correctly recognized with the value `v7`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file