### PR TITLE
🐛 Fix source maps upload for versioned canary builds

### DIFF
--- a/scripts/deploy/upload-source-maps.spec.ts
+++ b/scripts/deploy/upload-source-maps.spec.ts
@@ -228,7 +228,54 @@ describe('upload-source-maps', () => {
       },
     ])
 
-    // upload the source maps
+    // upload the source maps only to datadoghq.com
+    assert.deepEqual(getSourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
+    ])
+  })
+
+  it('should upload versioned canary packages source maps (e.g. v7-canary)', async () => {
+    await uploadSourceMaps('v7-canary', ['root'])
+
+    // rename the files with the version suffix
+    assert.deepEqual(getFileRenamingCommands(), [
+      {
+        command: 'mv packages/logs/bundle/datadog-logs.js packages/logs/bundle/datadog-logs-v7-canary.js',
+      },
+      {
+        command: 'mv packages/logs/bundle/datadog-logs.js.map packages/logs/bundle/datadog-logs-v7-canary.js.map',
+      },
+      {
+        command: 'mv packages/rum/bundle/datadog-rum.js packages/rum/bundle/datadog-rum-v7-canary.js',
+      },
+      {
+        command: 'mv packages/rum/bundle/datadog-rum.js.map packages/rum/bundle/datadog-rum-v7-canary.js.map',
+      },
+      {
+        command:
+          'mv packages/rum-slim/bundle/datadog-rum-slim.js packages/rum-slim/bundle/datadog-rum-slim-v7-canary.js',
+      },
+      {
+        command:
+          'mv packages/rum-slim/bundle/datadog-rum-slim.js.map packages/rum-slim/bundle/datadog-rum-slim-v7-canary.js.map',
+      },
+    ])
+
+    // upload the source maps only to datadoghq.com (same as plain 'canary')
     assert.deepEqual(getSourceMapCommands(), [
       {
         command:

--- a/scripts/deploy/upload-source-maps.ts
+++ b/scripts/deploy/upload-source-maps.ts
@@ -14,15 +14,13 @@ import { buildRootUploadPath, buildDatacenterUploadPath, buildBundleFolder, pack
  */
 
 async function getSitesByVersion(version: string): Promise<string[]> {
-  switch (version) {
-    case 'staging':
-      return ['datad0g.com', 'datadoghq.com']
-    case 'canary':
-      return ['datadoghq.com']
-    default: {
-      return (await getAllDatacentersMetadata()).map((dc) => dc.site)
-    }
+  if (version === 'staging') {
+    return ['datad0g.com', 'datadoghq.com']
   }
+  if (version.endsWith('canary')) {
+    return ['datadoghq.com']
+  }
+  return (await getAllDatacentersMetadata()).map((dc) => dc.site)
 }
 
 if (!process.env.NODE_TEST_CONTEXT) {


### PR DESCRIPTION
## Motivation

Versions ending with `canary` (e.g. `v7-canary`) were uploading source maps to all datacenters instead of only `datadoghq.com`. This is because the `getSitesByVersion` function only matched the exact string `canary`.

## Changes

- Changed `getSitesByVersion` to use `version.endsWith('canary')` instead of exact match
- Any version ending with `canary` (e.g. `canary`, `v7-canary`) now returns only `['datadoghq.com']`

## Test instructions

Run `yarn test:script --test-name-pattern="upload-source-maps"` to verify all tests pass.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file