### PR TITLE
👷 fix code coverage upload

### DIFF
--- a/scripts/test/export-test-result.ts
+++ b/scripts/test/export-test-result.ts
@@ -19,7 +19,7 @@ runMain(() => {
     })
     .withLogs()
     .run()
-  command`datadog-ci coverage upload --tags service:browser-sdk --tags env:ci --tags test.type:${testType} ${coverageFolder}`
+  command`datadog-ci coverage upload --flags service:browser-sdk --flags env:ci --flags test.type:${testType} ${coverageFolder}`
     .withEnvironment({
       DATADOG_API_KEY: getOrg2ApiKey(),
     })


### PR DESCRIPTION
## Motivation

datadog-ci v5.6 removed the --tags option, which makes coverage upload fail.

## Changes

Use --flags instead of --tags

## Test instructions

Let's see if it works in CI

[Looks like it's working again](https://app.datadoghq.com/ci/code-coverage/github.com%2Fdatadog%2Fbrowser-sdk/pull-requests/4155?currentTab=changed-files&filterBy=codeowner)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
