### PR TITLE
👷 allow gh-worker-dd-devflow bots to bypass CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,7 +40,7 @@ jobs:
           branch: 'browser-sdk'
           remote-repository-name: cla-signatures
           remote-organization-name: DataDog
-          allowlist: renovate,renovate[bot],campaigner-prod
+          allowlist: renovate,renovate[bot],campaigner-prod,gh-worker-dd-devflow-*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #allowlist: user1,bot*


### PR DESCRIPTION
## Motivation

Prevent PRs created by devflow to fail on CLA check, cf https://github.com/DataDog/browser-sdk/pull/4160

## Changes

Add `gh-worker-dd-devflow-*` to CLA allowlist

As the actual bot name is containing a version key (`gh-worker-dd-devflow-36fce6 `), using the `*` like in the example (`#allowlist: user1,bot*`) should do the trick.

## Test instructions

It probably needs to be merged before being taken into account

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
