### PR TITLE
♻️ [PANA-5948] Make some small improvements to ItemId management

### DIFF
--- a/packages/rum/src/domain/record/itemIds.spec.ts
+++ b/packages/rum/src/domain/record/itemIds.spec.ts
@@ -51,6 +51,33 @@ describe('ItemIds', () => {
         })
       })
 
+      describe('delete', () => {
+        it('allows an item to be re-inserted and receive a new id', () => {
+          const item = createItem()
+          expect(itemIds.getOrInsert(item)).toBe(firstId)
+          expect(itemIds.getOrInsert(item)).toBe(firstId)
+
+          itemIds.delete(item)
+
+          expect(itemIds.getOrInsert(item)).toBe((firstId + 1) as ItemId)
+          expect(itemIds.getOrInsert(item)).toBe((firstId + 1) as ItemId)
+        })
+
+        it('does not change the next assigned id', () => {
+          const item = createItem()
+          expect(itemIds.getOrInsert(item)).toBe(firstId)
+          expect(itemIds.getOrInsert(item)).toBe(firstId)
+          expect(itemIds.nextId).toBe((firstId + 1) as ItemId)
+
+          itemIds.delete(item)
+          expect(itemIds.nextId).toBe((firstId + 1) as ItemId)
+
+          const newItem = createItem()
+          expect(itemIds.getOrInsert(newItem)).toBe((firstId + 1) as ItemId)
+          expect(itemIds.getOrInsert(newItem)).toBe((firstId + 1) as ItemId)
+        })
+      })
+
       describe('get', () => {
         it('returns undefined for items that have not been assigned an id', () => {
           expect(itemIds.get(createItem())).toBe(undefined)
@@ -79,6 +106,21 @@ describe('ItemIds', () => {
           const itemId = itemIds.getOrInsert(item)
           expect(itemIds.getOrInsert(item)).toBe(itemId)
           expect(itemIds.get(item)).toBe(itemId)
+        })
+      })
+
+      describe('nextId getter', () => {
+        it('initially returns the first id', () => {
+          expect(itemIds.nextId).toBe(firstId)
+        })
+
+        it('increments after each insertion', () => {
+          for (let id = firstId; id < firstId + 3; id++) {
+            const item = createItem()
+            expect(itemIds.getOrInsert(item)).toBe(id)
+            expect(itemIds.getOrInsert(item)).toBe(id)
+            expect(itemIds.nextId).toBe((id + 1) as ItemId)
+          }
         })
       })
 

--- a/packages/rum/src/domain/record/itemIds.ts
+++ b/packages/rum/src/domain/record/itemIds.ts
@@ -36,8 +36,10 @@ export function createStyleSheetIds(): StyleSheetIds {
 
 export interface ItemIds<ItemType, ItemId extends number> {
   clear(this: void): void
+  delete(this: void, item: ItemType): void
   get(this: void, item: ItemType): ItemId | undefined
   getOrInsert(this: void, item: ItemType): ItemId
+  get nextId(): ItemId
   get size(): number
 }
 
@@ -50,6 +52,7 @@ function createWeakIdMap<ItemType extends object, ItemId extends number>(firstId
 }
 
 interface MapLike<Key, Value> {
+  delete(key: Key): void
   get(key: Key): Value | undefined
   set(key: Key, value: Value): void
 }
@@ -65,8 +68,14 @@ function createItemIds<ItemType, ItemId extends number>(
 
   return {
     clear(): void {
+      if (nextId === firstId) {
+        return
+      }
       map = createMap()
       nextId = firstId
+    },
+    delete(object: ItemType): void {
+      map.delete(object)
     },
     get,
     getOrInsert(object: ItemType): ItemId {
@@ -77,6 +86,9 @@ function createItemIds<ItemType, ItemId extends number>(
         map.set(object, id)
       }
       return id
+    },
+    get nextId(): ItemId {
+      return nextId
     },
     get size(): number {
       return nextId - firstId

--- a/packages/rum/src/domain/record/recordingScope.ts
+++ b/packages/rum/src/domain/record/recordingScope.ts
@@ -32,12 +32,13 @@ export function createRecordingScope(
   const nodeIds = createNodeIds()
   const stringIds = createStringIds()
   const styleSheetIds = createStyleSheetIds()
-  return {
+
+  const scope: RecordingScope = {
     resetIds(): void {
-      eventIds.clear()
-      nodeIds.clear()
-      stringIds.clear()
-      styleSheetIds.clear()
+      scope.eventIds.clear()
+      scope.nodeIds.clear()
+      scope.stringIds.clear()
+      scope.styleSheetIds.clear()
     },
 
     configuration,
@@ -48,4 +49,6 @@ export function createRecordingScope(
     stringIds,
     styleSheetIds,
   }
+
+  return scope
 }

--- a/packages/rum/src/domain/record/startFullSnapshots.ts
+++ b/packages/rum/src/domain/record/startFullSnapshots.ts
@@ -69,9 +69,7 @@ export function takeFullSnapshot(
   })
 
   if (isExperimentalFeatureEnabled(ExperimentalFeature.USE_CHANGE_RECORDS)) {
-    if (kind === SerializationKind.SUBSEQUENT_FULL_SNAPSHOT) {
-      scope.resetIds()
-    }
+    scope.resetIds()
     serializeChangesInTransaction(
       kind,
       emitRecord,


### PR DESCRIPTION
## Motivation

Change records are a new, experimental data format for session replay data that's designed to record the same information in a more compact, more compressible form.

We've already landed support for recording full snapshots as Change records behind an experiment flag. The next step is to introduce support for incremental snapshots, as well. This requires making improvements to a number of different aspects of the recording code. This PR is the second in a series that will work toward the goal of supporting incremental snapshots; for the previous PR, see #4163.

## Changes

This PR makes some small improvements to the code surrounding the `ItemIds` interface, which is used to track the identifiers assigned to various kinds of DOM-related objects during recording.

In particular:
1. A `delete()` method has been added, making it possible to delete an item id. This allows you to reinsert the same item and assign it a new id, which is something that the new serialization algorithm requires.
2. A `nextId` getter has been added, making it possible to determine what the next item id will be before actually assigning it. This, too, is helpful for implementing the new serialization algorithm.
3. The existing `clear()` method now does nothing if no ids have been assigned. This is just a small performance optimization.

Related code has been updated:
1. In `startFullSnapshots.ts`, we now always call `scope.resetIds()` when generating a Change record, regardless of whether we're generating the initial full snapshot or a subsequent one. We avoided calling it for the first full snapshot as a small performance optimization, but now `ItemIds#clear()` avoids the unnecessary work automatically.
2. In `recordingScope.ts`, the implementation of `scope.resetIds()` now calls `clear()` on the `ItemIds` instances that are _currently_ stored on the `RecordingScope`, instead of just the ones that were passed in when the `RecordingScope` was constructed. This is helpful for testing the new serialization algorithm, since it allows us to wrap these `ItemIds` instance in test code with version that check assertions.
3. Tests have been added for the new methods. (The behavior change in `clear()` is not visible, so there's no test, but the existing tests continue to pass.)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file