### PR TITLE
👷 Show actual scenario file locations in E2E test output

### DIFF
--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -27,6 +27,13 @@ export interface SetupOptions {
     logsConfiguration?: LogsInitConfiguration
   }
   hostName?: string
+  callerLocation?: CallerLocation
+}
+
+export interface CallerLocation {
+  file: string
+  line: number
+  column: number
 }
 
 export interface WorkerOptions {


### PR DESCRIPTION
## Motivation

E2E test output always showed the same file location for every test, regardless of which scenario file defined it:

```
[435/711] [Firefox] › test/e2e/lib/framework/createTest.ts:228:3 › rum views › send performance timings along the view events
[436/711] [Firefox] › test/e2e/lib/framework/createTest.ts:228:3 › rum views › loading time › has a loading time
[437/711] [Firefox] › test/e2e/lib/framework/createTest.ts:228:3 › rum views › loading time › does not have a loading time when DOM mutations are notified continuously
```

This happened because Playwright determines test location from the call stack when `test()` is called, and all tests were registered via `declareTest()` in `createTest.ts`.

## Changes

Capture the caller location when `createTest()` is called in a scenario file, then pass it to Playwright's internal `TestTypeImpl._createTest()` which accepts a custom location — bypassing the automatic stack-trace-based detection.

```
[1/7] [chromium] › test/e2e/scenario/rum/views.scenario.ts:5:13 › rum views › send performance timings along the view events
[2/7] [chromium] › test/e2e/scenario/rum/views.scenario.ts:53:15 › rum views › loading time › excludes some dom mutation when computing the loading time
[3/7] [chromium] › test/e2e/scenario/rum/views.scenario.ts:71:13 › rum views › send performance first input delay
[4/7] [chromium] › test/e2e/scenario/rum/views.scenario.ts:34:15 › rum views › loading time › has a loading time
[5/7] [chromium] › test/e2e/scenario/rum/views.scenario.ts:43:15 › rum views › loading time › does not have a loading time when DOM mutations are notified continuously
[6/7] [chromium] › test/e2e/scenario/rum/views.scenario.ts:88:15 › rum views › anchor navigation › don't create a new view when it is an Anchor navigation
[7/7] [chromium] › test/e2e/scenario/rum/views.scenario.ts:105:15 › rum views › anchor navigation › create a new view on hash change
```

> [!Note]
>This relies on Playwright's internal `TestTypeImpl` accessed via `Symbol("testType")` on the test function. This pattern has been stable since at least Playwright v1.34 and is also used by [gherkin-wrapper](https://github.com/microsoft/playwright/issues/23157). A fallback to the standard `test()` API is included if the internal API is unavailable.

## Test instructions

- Run `yarn test:e2e -g "init"` — 37 tests should pass with correct scenario file locations

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file