### PR TITLE
✅ fix flaky test

### DIFF
--- a/packages/core/test/registerCleanupTask.ts
+++ b/packages/core/test/registerCleanupTask.ts
@@ -1,9 +1,13 @@
-const cleanupTasks: Array<() => void> = []
+type CleanupTask = () => unknown
 
-export function registerCleanupTask(task: () => void) {
+const cleanupTasks: CleanupTask[] = []
+
+export function registerCleanupTask(task: CleanupTask) {
   cleanupTasks.unshift(task)
 }
 
-afterEach(() => {
-  cleanupTasks.splice(0).forEach((task) => task())
+afterEach(async () => {
+  for (const task of cleanupTasks.splice(0)) {
+    await task()
+  }
 })

--- a/packages/core/test/wait.ts
+++ b/packages/core/test/wait.ts
@@ -7,3 +7,13 @@ export function wait(durationMs: number = 0): Promise<void> {
 export function waitNextMicrotask(): Promise<void> {
   return Promise.resolve()
 }
+
+export function waitAfterNextPaint() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        resolve()
+      })
+    })
+  })
+}

--- a/packages/rum-core/src/browser/scroll.spec.ts
+++ b/packages/rum-core/src/browser/scroll.spec.ts
@@ -1,29 +1,19 @@
-import { DOM_EVENT } from '@datadog/browser-core'
+import { waitAfterNextPaint } from 'packages/core/test'
 import { getScrollX, getScrollY } from './scroll'
 
 describe('scroll', () => {
-  let testDidScroll: boolean
-
   beforeEach(() => {
     document.body.style.setProperty('margin-bottom', '5000px')
-    testDidScroll = false
   })
 
   afterEach(async () => {
     document.body.style.removeProperty('margin-bottom')
     window.scrollTo(0, 0)
 
-    // Those tests are triggering asynchronous events that might impact tests run after them. To
-    // avoid that, we wait for the events before continuing to the next test.
-    await Promise.all([
-      window.visualViewport &&
-        waitForEvents(
-          window.visualViewport,
-          DOM_EVENT.RESIZE,
-          2 // We add then remove the scrollbar, so the resize event is triggered twice
-        ),
-      testDidScroll && waitForEvents(window, DOM_EVENT.SCROLL, 1),
-    ])
+    // Those tests are triggering asynchronous events (notably: window scroll and visualViewport
+    // resize) that might impact tests run after them. To avoid that, we wait for the events before
+    // continuing to the next test.
+    await waitAfterNextPaint()
   })
 
   describe('getScrollX/Y', () => {
@@ -38,7 +28,6 @@ describe('scroll', () => {
       const SCROLL_DOWN_PX = 100
 
       window.scrollTo(0, SCROLL_DOWN_PX)
-      testDidScroll = true
 
       expect(getScrollX()).toBe(0)
       expect(getScrollY()).toBe(100)
@@ -47,27 +36,3 @@ describe('scroll', () => {
     })
   })
 })
-
-function waitForEvents(target: EventTarget, eventName: string, count: number) {
-  return new Promise<void>((resolve) => {
-    let counter = 0
-
-    function listener() {
-      counter++
-      if (counter === count) {
-        done()
-      }
-    }
-
-    function done() {
-      target.removeEventListener(eventName, listener)
-      resolve()
-    }
-
-    target.addEventListener(eventName, listener)
-
-    // In some cases, events are not triggered consistently. This have been observed in Safari. To
-    // avoid waiting forever, we use a timeout.
-    setTimeout(done, 1000)
-  })
-}


### PR DESCRIPTION


## Motivation

`viewportObservable.spec.ts` changes the page to add scrollbars, causing some asynchronous events to be fired *after* the test has completed. If `recorder.spec.ts` is executed just after, its test might fail because it'll record those asynchronous events.

This is the same issue we had with `scroll.spec.ts`. In the past, we tried to be smart and predict which events will be triggered, and wait for them. But it's a bit complex and not reliable on every browsers.

## Changes


This commit simplifies this workaround by waiting for two frames. When scrolling/changing viewport, the browser will first paint it, and then emit events. The second frame should reliably come after events are emitted (tested in Chrome, Firefox and Safari).

## Test instructions

Reproduce flaky test:

```
git checkout 56a15f139dec81f010396e6a32e172b2291efcc4
yarn test:unit --seed 26598
```

Confirm that it's gone when running the tests with the same seed after applying this PR changes

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
