### PR TITLE
🐛 [RUM Profiler] Fix stateReason not updated on stop and cleanup tasks accumulation

### DIFF
--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -652,11 +652,8 @@ describe('profiler', () => {
 
     expect(profiler.isStopped()).toBe(true)
 
-    // Session is renewed
+    // Session is renewed — start() is called synchronously, so no need to wait
     lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
-
-    // Wait a bit to ensure profiler doesn't restart
-    await new Promise((resolve) => setTimeout(resolve, 100))
 
     // Profiler should remain stopped - user's explicit stop should take priority over session expiration
     expect(profiler.isStopped()).toBe(true)

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -255,17 +255,17 @@ export function createRumProfiler(
   }
 
   function stopProfilerInstance(stateReason: RumProfilerStoppedInstance['stateReason']) {
-    if (instance.state === 'paused') {
-      // If paused, profiler data was already collected during pause, just update state
-      instance = { state: 'stopped', stateReason }
-      return
-    }
     if (instance.state !== 'running') {
-      // Update stateReason when already stopped and the user explicitly stops the profiler,
-      // so that SESSION_RENEWED does not override the user's intent.
-      if (instance.state === 'stopped' && stateReason === 'stopped-by-user') {
+      if (
+        // If paused, profiler data was already collected during pause, just update state
+        instance.state === 'paused' ||
+        // Update stateReason when already stopped and the user explicitly stops the profiler,
+        // so that SESSION_RENEWED does not override the user's intent.
+        (instance.state === 'stopped' && stateReason === 'stopped-by-user')
+      ) {
         instance = { state: 'stopped', stateReason }
       }
+
       return
     }
 


### PR DESCRIPTION
## Motivation

Two issues found in the profiler state machine after the recent sync state fix (#4152):

1. `stopProfilerInstance` does not update `stateReason` when the profiler is already in `stopped` state. If `SESSION_EXPIRED` fires first (setting `stateReason` to `session-expired`), then the user calls `stop()`, the reason stays `session-expired`. On the next `SESSION_RENEWED`, the profiler restarts against the user's intent.

2. `globalCleanupTasks` array is never cleared after `forEach` cleanup in `stopProfiling`. Stale function references accumulate across start/stop cycles.

## Changes

- `stopProfilerInstance`: when already stopped, update `stateReason` if the new reason is `stopped-by-user`, so that `SESSION_RENEWED` respects the user's explicit stop.
- `stopProfiling`: reset `globalCleanupTasks.length = 0` after invoking all cleanup functions.

## Test instructions

- Run `yarn test:unit --spec packages/rum/src/domain/profiling/profiler.spec.ts`
- New test: "should not restart profiling on session renewal if user called stop after session expiration"

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file