### PR TITLE
Changed tracked action to accept ClocksState

### DIFF
--- a/packages/rum-core/src/domain/action/trackAction.spec.ts
+++ b/packages/rum-core/src/domain/action/trackAction.spec.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime, TimeStamp } from '@datadog/browser-core'
+import type { Duration, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import { RumEventType } from '../../rawRumEvent.types'
@@ -34,6 +34,16 @@ describe('trackAction', () => {
 
       expect(action1.id).not.toBe(action2.id)
     })
+
+    it('should compute duration from timestamps, not relative times', () => {
+      const startClocks = { relative: 100 as RelativeTime, timeStamp: 1000 as TimeStamp }
+      const trackedAction = actionTracker.createTrackedAction(startClocks)
+
+      const endClocks = { relative: 300 as RelativeTime, timeStamp: 1050 as TimeStamp }
+      trackedAction.stop(endClocks)
+
+      expect(trackedAction.duration).toBe(50 as Duration)
+    })
   })
 
   describe('event counting', () => {
@@ -65,7 +75,7 @@ describe('trackAction', () => {
     })
 
     it('should stop counting events after action is stopped', () => {
-      trackedAction.stop(200 as RelativeTime)
+      trackedAction.stop({ relative: 200 as RelativeTime, timeStamp: 1100 as TimeStamp })
 
       lifeCycle.notify(LifeCycleEventType.RUM_EVENT_COLLECTED, {
         type: RumEventType.ERROR,
@@ -93,7 +103,7 @@ describe('trackAction', () => {
       const startClocks = { relative: 100 as RelativeTime, timeStamp: 1000 as TimeStamp }
       const trackedAction = actionTracker.createTrackedAction(startClocks)
 
-      trackedAction.stop(200 as RelativeTime)
+      trackedAction.stop({ relative: 200 as RelativeTime, timeStamp: 1100 as TimeStamp })
 
       expect(actionTracker.findActionId()).toBeUndefined()
     })
@@ -102,7 +112,7 @@ describe('trackAction', () => {
       const startClocks = { relative: 100 as RelativeTime, timeStamp: 1000 as TimeStamp }
       const trackedAction = actionTracker.createTrackedAction(startClocks)
 
-      trackedAction.stop(200 as RelativeTime)
+      trackedAction.stop({ relative: 200 as RelativeTime, timeStamp: 1100 as TimeStamp })
 
       expect(actionTracker.findActionId(150 as RelativeTime)).toEqual([trackedAction.id])
     })
@@ -111,7 +121,7 @@ describe('trackAction', () => {
       const startClocks = { relative: 100 as RelativeTime, timeStamp: 1000 as TimeStamp }
       const trackedAction = actionTracker.createTrackedAction(startClocks)
 
-      trackedAction.stop(200 as RelativeTime)
+      trackedAction.stop({ relative: 200 as RelativeTime, timeStamp: 1100 as TimeStamp })
 
       expect(actionTracker.findActionId(250 as RelativeTime)).toBeUndefined()
     })

--- a/packages/rum-core/src/domain/action/trackAction.ts
+++ b/packages/rum-core/src/domain/action/trackAction.ts
@@ -14,7 +14,7 @@ export interface TrackedAction {
   startClocks: ClocksState
   duration: Duration | undefined
   counts: ActionCounts
-  stop: (endTime: RelativeTime) => void
+  stop: (endClocks: ClocksState) => void
   discard: () => void
 }
 
@@ -65,9 +65,9 @@ export function startActionTracker(lifeCycle: LifeCycle): ActionTracker {
       get counts() {
         return eventCountsSubscription.eventCounts
       },
-      stop(endTime: RelativeTime) {
-        historyEntry.close(endTime)
-        duration = elapsed(startClocks.relative, endTime)
+      stop(endClocks: ClocksState) {
+        historyEntry.close(endClocks.relative)
+        duration = elapsed(startClocks.timeStamp, endClocks.timeStamp)
         cleanup()
       },
       discard() {

--- a/packages/rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.ts
@@ -1,5 +1,5 @@
 import type { Duration, ClocksState, TimeStamp } from '@datadog/browser-core'
-import { timeStampNow, Observable, getRelativeTime, relativeToClocks } from '@datadog/browser-core'
+import { timeStampNow, Observable, timeStampToClocks, relativeToClocks } from '@datadog/browser-core'
 import { isNodeShadowHost } from '../../browser/htmlDomUtils'
 import type { FrustrationType } from '../../rawRumEvent.types'
 import { ActionType } from '../../rawRumEvent.types'
@@ -297,7 +297,7 @@ function newClick(
     activityEndTime = newActivityEndTime
     status = ClickStatus.STOPPED
     if (activityEndTime) {
-      trackedAction.stop(getRelativeTime(activityEndTime))
+      trackedAction.stop(timeStampToClocks(activityEndTime))
     } else {
       trackedAction.discard()
     }

--- a/packages/rum-core/src/domain/action/trackManualActions.ts
+++ b/packages/rum-core/src/domain/action/trackManualActions.ts
@@ -80,7 +80,7 @@ export function trackManualActions(
       return
     }
 
-    activeAction.trackedAction.stop(stopClocks.relative)
+    activeAction.trackedAction.stop(stopClocks)
 
     const frustrationTypes: FrustrationType[] = []
     if (activeAction.trackedAction.counts.errorCount > 0) {


### PR DESCRIPTION
## Motivation

This [PR](https://github.com/DataDog/browser-sdk/pull/4038) changed action duration from: 
`duration: activityEndTime && elapsed(startClocks.timeStamp, activityEndTime),` to 
`duration = elapsed(startClocks.relative, endTime)`. 


## Changes

Change `TrackedAction.stop()` to accept ClocksState instead of RelativeTime, compute duration using timestamps.

## Test instructions

Unit test should suffice.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
