### PR TITLE
[RUM/PROF] Add profiling context to actions and vitals' _dd field

### DIFF
--- a/packages/rum/src/domain/profiling/profilingContext.spec.ts
+++ b/packages/rum/src/domain/profiling/profilingContext.spec.ts
@@ -13,7 +13,7 @@ describe('Profiling Context', () => {
 
     profilingContextManager.set({ status: 'running' })
 
-    for (const eventType of [RumEventType.VIEW, RumEventType.LONG_TASK]) {
+    for (const eventType of [RumEventType.VIEW, RumEventType.LONG_TASK, RumEventType.ACTION, RumEventType.VITAL]) {
       const eventAttributes = hooks.triggerHook(HookNames.Assemble, {
         eventType,
         startTime: relativeTime,
@@ -28,7 +28,7 @@ describe('Profiling Context', () => {
       )
     }
 
-    for (const eventType of [RumEventType.ERROR, RumEventType.ACTION, RumEventType.RESOURCE, RumEventType.VITAL]) {
+    for (const eventType of [RumEventType.ERROR, RumEventType.RESOURCE]) {
       const eventAttributes = hooks.triggerHook(HookNames.Assemble, {
         eventType,
         startTime: relativeTime,

--- a/packages/rum/src/domain/profiling/profilingContext.ts
+++ b/packages/rum/src/domain/profiling/profilingContext.ts
@@ -13,7 +13,12 @@ export function startProfilingContext(hooks: Hooks): ProfilingContextManager {
   }
 
   hooks.register(HookNames.Assemble, ({ eventType }) => {
-    if (eventType !== RumEventType.VIEW && eventType !== RumEventType.LONG_TASK) {
+    if (
+      eventType !== RumEventType.VIEW &&
+      eventType !== RumEventType.LONG_TASK &&
+      eventType !== RumEventType.ACTION &&
+      eventType !== RumEventType.VITAL
+    ) {
       return SKIPPED
     }
 


### PR DESCRIPTION
## Motivation

Currently, only long tasks and views have a `_dd.profiling` object with profiler status. We want to add this to actions and vitals too, as this is useful to provide relevant empty states for those events in the frontend in case a profile is missing.

## Changes

- Add action and vital event types to the whitelist of events that should have the `_dd.profiling` object
- Update the related tests

## Test instructions

- In the file `sandbox/react-app/main.tsx`, add:
```ts
profilingSampleRate: 100,
  site: 'datadoghq.com',
  service: 'sandbox-react-app',
  env: 'development',
```
to the SDK configuration, and add
```tsx
  useEffect(() => {
    datadogRum.startDurationVital('test vital')

    const timeout = setTimeout(() => {
      datadogRum.stopDurationVital('test vital')
    }, 1000)

    return () => {
      clearTimeout(timeout)
    }
  }, [])
```
to create vital events.
- Wait for a batch of RUM events to be sent, and look at the network payload
- actions and vitals should have a `profiling` entry in their `_dd` object

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file