### PR TITLE
🐛 Regenerate anonymousId when session cookie is altered without preserving aid

### DIFF
--- a/packages/core/src/domain/session/sessionStore.ts
+++ b/packages/core/src/domain/session/sessionStore.ts
@@ -230,6 +230,9 @@ export function startSessionStore<TrackingType extends string>(
       sessionState.id = generateUUID()
       sessionState.created = String(dateNow())
     }
+    if (configuration.trackAnonymousUser && !sessionState.anonymousId) {
+      sessionState.anonymousId = generateUUID()
+    }
   }
 
   function hasSessionInCache() {


### PR DESCRIPTION
## Motivation

When a session cookie is altered externally to `isExpired=1` without preserving the `aid` (anonymous ID) field, the SDK creates a new session but does not regenerate the `anonymousId`. This means the new session loses its anonymous user tracking.

In practice, this can happen when using the **"End current session"** action from the Datadog browser dev tools extension, which sets `isExpired=1` on the cookie without preserving the `aid` field.

## Changes

- **`packages/core/src/domain/session/sessionStore.ts`**: When expanding a session state during `expandOrRenewSession`, if `trackAnonymousUser` is enabled and the session state has no `anonymousId`, regenerate one. This covers the case where the session cookie was altered to strip the `aid` field.

- **`test/e2e/scenario/rum/sessions.scenario.ts`**: Added an E2E test that verifies a new anonymous ID is generated after cookie alteration. The test:
  1. Captures the initial session ID and anonymous ID
  2. Overwrites the cookie with `isExpired=1` (stripping `aid`)
  3. Triggers a user interaction to start a new session
  4. Asserts the new session has a fresh session ID and a fresh anonymous ID

## Test instructions

Run the E2E session tests:

```bash
yarn test:e2e -g \"session cookie alteration\"
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file