### PR TITLE
[PANA-6072] PoC - add composedPathSelector to click actions target

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -138,6 +138,13 @@ export interface InitConfiguration {
    */
   allowedTrackingOrigins?: MatchOption[] | undefined
 
+  /**
+   * Optional list of HTML attributes allowed to be used in the action selector collection.
+   * Matches attributes against the event target and its ancestors.
+   * If not provided, the SDK will use a default list of HTML attributes.
+   */
+  allowedHtmlAttributes?: MatchOption[] | undefined
+  
   // transport options
   /**
    * Optional proxy URL, for example: https://www.proxy.com/path.

--- a/packages/rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.ts
@@ -13,6 +13,7 @@ import type { RumConfiguration } from '../configuration'
 import type { RumMutationRecord } from '../../browser/domMutationObservable'
 import { startEventTracker } from '../eventTracker'
 import type { StoppedEvent, DiscardedEvent, EventTracker } from '../eventTracker'
+import { getComposedPathSelector } from '../getComposedPathSelector'
 import type { ClickChain } from './clickChain'
 import { createClickChain } from './clickChain'
 import { getActionNameFromElement } from './getActionNameFromElement'
@@ -36,6 +37,7 @@ export interface ClickAction {
   nameSource: ActionNameSource
   target?: {
     selector: string | undefined
+    composed_path_selector?: string
     width: number
     height: number
   }
@@ -231,10 +233,12 @@ function computeClickActionBase(
   nodePrivacyLevel: NodePrivacyLevel,
   configuration: RumConfiguration
 ): ClickActionBase {
+  const eventPath = event.composedPath()
+
   const selectorTarget = event.target
   const rect = selectorTarget.getBoundingClientRect()
   const selector = getSelectorFromElement(selectorTarget, configuration.actionNameAttribute)
-
+  const composedPathSelector = getComposedPathSelector(eventPath, configuration.actionNameAttribute, configuration.allowedHtmlAttributes || [])
   if (selector) {
     updateInteractionSelector(event.timeStamp, selector)
   }
@@ -248,6 +252,7 @@ function computeClickActionBase(
       width: Math.round(rect.width),
       height: Math.round(rect.height),
       selector,
+      composed_path_selector: composedPathSelector ?? undefined,
     },
     position: {
       // Use clientX and Y because for SVG element offsetX and Y are relatives to the <svg> element

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -321,6 +321,7 @@ export interface RumConfiguration extends Configuration {
   profilingSampleRate: number
   propagateTraceBaggage: boolean
   allowedGraphQlUrls: GraphQlUrlOption[]
+  allowedHtmlAttributes?: MatchOption[]
 }
 
 export function validateAndBuildRumConfiguration(
@@ -400,6 +401,7 @@ export function validateAndBuildRumConfiguration(
     profilingSampleRate: initConfiguration.profilingSampleRate ?? 0,
     propagateTraceBaggage: !!initConfiguration.propagateTraceBaggage,
     allowedGraphQlUrls,
+    allowedHtmlAttributes: Array.isArray(initConfiguration.allowedHtmlAttributes) ? initConfiguration.allowedHtmlAttributes.filter(isMatchOption) : [],
     ...baseConfiguration,
   }
 }

--- a/packages/rum-core/src/domain/getComposedPathSelector.spec.ts
+++ b/packages/rum-core/src/domain/getComposedPathSelector.spec.ts
@@ -1,0 +1,375 @@
+import { registerCleanupTask } from '@datadog/browser-core/test'
+import { appendElement } from '../../test'
+import {
+  getComposedPathSelector,
+} from './getComposedPathSelector'
+
+describe('getSelectorFromComposedPath', () => {
+  describe('getComposedPathSelector', () => {
+    it('returns an empty string for an empty composedPath', () => {
+      const result = getComposedPathSelector([], undefined, [])
+      expect(result).toEqual('')
+    })
+
+    it('filters out non-Element items from composedPath', () => {
+      const element = appendElement('<div id="test"></div>')
+      const composedPath: EventTarget[] = [element, document, window]
+
+      const result = getComposedPathSelector(composedPath, undefined, [])
+
+      expect(result).toBe('div')
+    })
+
+    describe('element data extraction', () => {
+      it('extracts tag name from element', () => {
+        const element = appendElement('<button></button>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('button')
+      })
+
+      it('extracts id from element when present', () => {
+        const element = appendElement('<div id="my-id"></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div#my-id')
+      })
+
+      it('does not include id when not present', () => {
+        const element = appendElement('<div></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div')
+      })
+
+      it('extracts classes from element', () => {
+        const element = appendElement('<div class="foo bar baz"></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div.foo.bar.baz')
+      })
+
+      it('returns empty array for classes when none present', () => {
+        const element = appendElement('<div></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div')
+      })
+    })
+
+    describe('safe attribute filtering', () => {
+      it('only collects allowlisted attributes', () => {
+        const element = appendElement('<div data-testid="test-btn" data-random="secret"></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div[data-testid="test-btn"]')
+      })
+
+      it('collects multiple safe attributes', () => {
+        const element = appendElement('<div data-testid="foo" data-qa="bar" data-cy="baz"></div>')
+                const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div[data-testid="foo"][data-qa="bar"][data-cy="baz"]')
+      })
+
+      it('does not collect non-allowlisted attributes', () => {
+        const element = appendElement('<div data-user-email="john@example.com" title="secret info"></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div')
+      })
+
+      it('collects data-dd-action-name attribute', () => {
+        const element = appendElement('<div data-dd-action-name="Submit Form"></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div[data-dd-action-name="Submit Form"]')
+      })
+
+      it('collects role attribute', () => {
+        const element = appendElement('<div role="button"></div>')
+          const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div[role="button"]')
+      })
+
+      it('collects type attribute', () => {
+        const element = appendElement('<input type="submit" />')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('input[type="submit"]')
+      })
+    })
+
+    describe('duplicate removal', () => {
+      it('removes duplicate classes that appear in parent elements', () => {
+        const parent = document.createElement('div')
+        parent.className = 'shared-class parent-only'
+        const child = document.createElement('span')
+        child.className = 'shared-class child-only'
+        parent.appendChild(child)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        // composedPath goes from target (child) to ancestors
+        const composedPath = [child, parent]
+          const result = getComposedPathSelector(composedPath, undefined, [])
+
+        // Child should have both classes initially
+        expect(result).toBe('span.child-only')
+        // Parent keeps all its classes
+        expect(result).toBe('div.shared-class.parent-only')
+      })
+
+      it('removes duplicate attribute values that appear in parent elements', () => {
+        const parent = document.createElement('div')
+        parent.setAttribute('data-testid', 'shared-testid')
+        parent.setAttribute('data-qa', 'parent-qa')
+        const child = document.createElement('span')
+        child.setAttribute('data-testid', 'shared-testid')
+        child.setAttribute('data-cy', 'child-cy')
+        parent.appendChild(child)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const composedPath = [child, parent]
+        const result = getComposedPathSelector(composedPath, undefined, [])
+
+        // Child should not have the duplicated attribute value
+        expect(result).toBe('span[data-cy="child-cy"]')
+        // Parent keeps its attributes
+        expect(result).toBe('div[data-testid="shared-testid"][data-qa="parent-qa"]')
+      })
+
+      it('handles multiple levels of nesting', () => {
+        const grandparent = document.createElement('div')
+        grandparent.className = 'level-gp shared'
+        grandparent.setAttribute('data-testid', 'gp-id')
+
+        const parent = document.createElement('div')
+        parent.className = 'level-parent shared'
+        parent.setAttribute('data-testid', 'parent-id')
+
+        const child = document.createElement('span')
+        child.className = 'level-child shared'
+        child.setAttribute('data-testid', 'child-id')
+
+        grandparent.appendChild(parent)
+        parent.appendChild(child)
+        document.body.appendChild(grandparent)
+        registerCleanupTask(() => grandparent.remove())
+
+        const composedPath = [child, parent, grandparent]
+        const result = getComposedPathSelector(composedPath, undefined, [])
+
+        // Child: only unique classes and attributes
+        expect(result).toBe('span.level-child[data-testid="child-id"]')
+
+        // Parent: unique + those from grandparent that are not in parent
+        expect(result).toBe('div.level-parent[data-testid="parent-id"]')
+
+        // Grandparent: keeps everything
+        expect(result).toBe('div.level-gp.shared[data-testid="gp-id"]')
+      })
+
+      it('does not remove attributes with different values', () => {
+        const parent = document.createElement('div')
+        parent.setAttribute('data-testid', 'parent-value')
+        const child = document.createElement('span')
+        child.setAttribute('data-testid', 'child-value')
+        parent.appendChild(child)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const composedPath = [child, parent]
+        const result = getComposedPathSelector(composedPath, undefined, [])
+
+        expect(result).toBe('span[data-testid="child-value"]')
+        expect(result).toBe('div[data-testid="parent-value"]')
+      })
+    })
+
+    describe('ShadowDOM support', () => {
+      it('handles ShadowRoot in composedPath by skipping it', () => {
+        const host = document.createElement('div')
+        const shadowRoot = host.attachShadow({ mode: 'open' })
+        const shadowButton = document.createElement('button')
+        shadowButton.className = 'shadow-btn'
+        shadowRoot.appendChild(shadowButton)
+        document.body.appendChild(host)
+        registerCleanupTask(() => host.remove())
+
+        // Simulating a composedPath that includes ShadowRoot
+        const composedPath = [shadowButton, shadowRoot as unknown as EventTarget, host]
+          const result = getComposedPathSelector(composedPath, undefined, [])
+
+        expect(result).toBe('button.shadow-btn')
+      })
+    })
+
+    describe('nthChild and nthOfType', () => {
+      it('does not include nthChild when element is the only child', () => {
+        const parent = document.createElement('div')
+        const child = document.createElement('span')
+        parent.appendChild(child)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const result = getComposedPathSelector([child], undefined, [])
+
+        expect(result).toBe('span')
+      })
+
+      it('includes nthChild when element has siblings', () => {
+        const parent = document.createElement('div')
+        const child1 = document.createElement('span')
+        const child2 = document.createElement('span')
+        const child3 = document.createElement('span')
+        parent.appendChild(child1)
+        parent.appendChild(child2)
+        parent.appendChild(child3)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const result = getComposedPathSelector([child2], undefined, [])
+
+        expect(result).toBe('span:nth-child(2)')
+      })
+
+      it('calculates nthChild correctly for first child', () => {
+        const parent = document.createElement('div')
+        const child1 = document.createElement('span')
+        const child2 = document.createElement('div')
+        parent.appendChild(child1)
+        parent.appendChild(child2)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const result = getComposedPathSelector([child1], undefined, [])
+
+        expect(result).toBe('span:nth-child(1)')
+      })
+
+      it('does not include nthOfType when element is unique of its type', () => {
+        const parent = document.createElement('div')
+        const span = document.createElement('span')
+        const div = document.createElement('div')
+        parent.appendChild(span)
+        parent.appendChild(div)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const result = getComposedPathSelector([span], undefined, [])
+
+        // span is unique of type, but not unique child (has sibling)
+        expect(result).toBe('span:nth-child(1)')
+      })
+
+      it('includes nthOfType when element has siblings of the same type', () => {
+        const parent = document.createElement('div')
+        const span1 = document.createElement('span')
+        const span2 = document.createElement('span')
+        const div = document.createElement('div')
+        parent.appendChild(span1)
+        parent.appendChild(div)
+        parent.appendChild(span2)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const result = getComposedPathSelector([span2], undefined, [])
+
+        expect(result).toBe('span:nth-of-type(2)')
+      })
+
+      it('calculates nthOfType correctly among mixed siblings', () => {
+        const parent = document.createElement('div')
+        const button1 = document.createElement('button')
+        const span = document.createElement('span')
+        const button2 = document.createElement('button')
+        const div = document.createElement('div')
+        const button3 = document.createElement('button')
+        parent.appendChild(button1)
+        parent.appendChild(span)
+        parent.appendChild(button2)
+        parent.appendChild(div)
+        parent.appendChild(button3)
+        document.body.appendChild(parent)
+        registerCleanupTask(() => parent.remove())
+
+        const result = getComposedPathSelector([button2], undefined, [])
+
+        expect(result).toBe('button:nth-child(3):nth-of-type(2)')
+      })
+
+      it('handles elements in composedPath with their position data', () => {
+        const grandparent = document.createElement('div')
+        const parent = document.createElement('section')
+        const sibling = document.createElement('article')
+        const target = document.createElement('button')
+
+        grandparent.appendChild(parent)
+        grandparent.appendChild(sibling)
+        parent.appendChild(target)
+        document.body.appendChild(grandparent)
+        registerCleanupTask(() => grandparent.remove())
+
+        const composedPath = [target, parent, grandparent]
+        const result = getComposedPathSelector(composedPath, undefined, [])
+
+        // target is only child
+        expect(result).toBe('button')
+
+        // parent has a sibling (sibling), but is unique of type
+        expect(result).toBe('section:nth-child(1);article:nth-child(2);button')
+      })
+
+      it('does not include nthChild or nthOfType for elements without parent', () => {
+        // Detached element with no parent
+        const element = document.createElement('div')
+
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div')
+      })
+    })
+
+    describe('allowed html attributes', () => {
+      it('includes allowed html attributes', () => {
+        const element = appendElement('<div data-test-allowed="test-btn" data-random="secret"></div>')
+        const result = getComposedPathSelector([element], undefined, ['data-test-allowed'])
+
+        expect(result).toBe('div[data-test-allowed="test-btn"]')
+      })
+    })
+
+    describe('edge cases', () => {
+      it('handles elements with empty class attribute', () => {
+        const element = appendElement('<div class=""></div>')
+        const result = getComposedPathSelector([element], undefined, [])
+
+        expect(result).toBe('div')
+      })
+
+      it('handles elements with whitespace-only class', () => {
+        const element = document.createElement('div')
+        element.setAttribute('class', '   ')
+        document.body.appendChild(element)
+        registerCleanupTask(() => element.remove())
+
+        const result = getComposedPathSelector([element], undefined, [])
+        expect(result).toBe('div')
+      })
+
+      it('handles SVG elements', () => {
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+        svg.setAttribute('data-testid', 'my-svg')
+        document.body.appendChild(svg)
+        registerCleanupTask(() => svg.remove())
+
+          const result = getComposedPathSelector([svg], undefined, [])
+
+        expect(result).toBe('svg[data-testid="my-svg"]')
+      })
+    })
+  })
+})

--- a/packages/rum-core/src/domain/getComposedPathSelector.ts
+++ b/packages/rum-core/src/domain/getComposedPathSelector.ts
@@ -1,0 +1,237 @@
+
+import { safeTruncate, ONE_KIBI_BYTE, matchList } from '@datadog/browser-core';
+import type { MatchOption } from '@datadog/browser-core';
+import { STABLE_ATTRIBUTES, isGeneratedValue, getIDSelector, getTagNameSelector } from './getSelectorFromElement'
+
+
+
+const FILTERED_TAGNAMES = ['HTML', 'BODY'];
+
+/**
+ * arbitrary value, we want to truncate the selector if it exceeds the limit
+ */
+const CHARACTER_LIMIT = 2 * ONE_KIBI_BYTE; 
+
+/**
+ * separator between elements in the selector
+ */
+const SEPARATOR = ';';
+
+/**
+ * suffix to indicate truncation
+ */
+const TRUNCATION_SUFFIX = '...';
+
+/**
+ * Safe attributes that can be collected without PII concerns.
+ * These are commonly used for testing, accessibility, and UI identification.
+ */
+export const SAFE_ATTRIBUTES = STABLE_ATTRIBUTES.concat([
+  // Additional safe attributes
+  'role', // Accessibility role (button, navigation, etc.)
+  'type', // Input type (submit, button, text, etc.)
+  'name', // Form element names (typically non-PII)
+  'disabled', // Element state
+  'readonly', // Element state
+  'checked', // Checkbox/radio state
+  'selected', // Option state
+  'aria-expanded', // Accessibility state
+  'aria-selected', // Accessibility state
+  'aria-pressed', // Accessibility state
+  'aria-checked', // Accessibility state
+  'aria-disabled', // Accessibility state
+  'aria-hidden', // Accessibility state
+  'aria-haspopup', // Accessibility state
+  'aria-controls', // Accessibility relationship
+  'aria-describedby', // Accessibility relationship
+  'aria-labelledby', // Accessibility relationship
+  'tabindex', // Focus management
+  'contenteditable', // Editable state
+  'draggable', // Drag state
+  'target', // Link target (_blank, _self, etc.)
+  'rel', // Link relationship
+  'download', // Download attribute
+  'method', // Form method
+  'action', // Form action (path only, no query params with PII)
+  'enctype', // Form encoding type
+  'autocomplete', // Form autocomplete hint
+  'inputmode', // Input mode hint
+  'enterkeyhint', // Enter key hint
+]);
+
+/**
+ * Data extracted from an element in the composedPath.
+ */
+export interface ComposedPathElementData {
+  /** The tag name of the element (e.g., 'DIV', 'BUTTON') */
+  tagName: string
+  /** The element's id attribute, if present */
+  id?: string
+  /** Array of class names (with duplicates from parents removed) */
+  classes: string[]
+  /** Safe attributes collected from the element (with duplicate values from parents removed) */
+  attributes: Record<string, string>
+  /** The 1-based position among all siblings (only set if element has siblings) */
+  nthChild?: number
+  /** The 1-based position among siblings of the same tag type (only set if not unique of type) */
+  nthOfType?: number
+}
+
+/**
+ * Extracts a selector string from a MouseEvent composedPath.
+ *
+ * This function:
+ * 1. Filters out non-Element items (Document, Window, ShadowRoot)
+ * 2. Extracts a selector string from each element
+ * 3. Truncates the selector string if it exceeds the character limit
+ * 4. Returns the selector string
+ *
+ * @param composedPath - The composedPath from a MouseEvent
+ * @returns A selector string
+ */
+export function getComposedPathSelector(composedPath: EventTarget[], actionNameAttribute: string | undefined, attributesAllowList: MatchOption[]): string {
+  // Filter to only include Element nodes
+  const elements = composedPath.filter(isElement).filter((el) => !FILTERED_TAGNAMES.includes(el.tagName))
+
+  if (elements.length === 0) {
+    return '';
+  }
+
+  const allowedAttributes = [actionNameAttribute ? [actionNameAttribute] : [], SAFE_ATTRIBUTES, attributesAllowList].flat()
+
+  let result: string = '';
+
+  for (let i = 0; i < elements.length; i++) {
+    const element = elements[i]
+    const elementData = extractRawElementData(element, allowedAttributes)
+    const selectorString = getSelectorStringFromComposedPathElementData(elementData);
+    const tmpResult = result + selectorString;
+    if (tmpResult.length >= CHARACTER_LIMIT) {
+      result = safeTruncate(tmpResult, CHARACTER_LIMIT - TRUNCATION_SUFFIX.length, TRUNCATION_SUFFIX);
+      break;
+    }
+    result = tmpResult;
+  }
+
+  return result;
+}
+
+function getSelectorStringFromComposedPathElementData(elementData: ComposedPathElementData): string {
+  let selector = elementData.tagName
+  if (elementData.id) {
+    selector += elementData.id
+  }
+  elementData.classes.forEach((c) => {
+    selector += `.${CSS.escape(c)}`
+  })
+  Object.entries(elementData.attributes).forEach(([key, value]) => {
+    selector += `[${CSS.escape(key)}="${CSS.escape(value)}"]`
+  })
+  if (elementData.nthChild) {
+    selector += `:nth-child(${elementData.nthChild})`
+  }
+  if (elementData.nthOfType) {
+    selector += `:nth-of-type(${elementData.nthOfType})`
+  }
+  return selector + SEPARATOR;
+}
+
+/**
+ * Type guard to check if an EventTarget is an Element.
+ */
+function isElement(target: EventTarget): target is Element {
+  return target instanceof Element
+}
+
+/**
+ * Extracts raw data from an element without deduplication.
+ */
+function extractRawElementData(element: Element, allowedAttributes: MatchOption[]): ComposedPathElementData {
+  const tagName = getTagNameSelector(element)
+  const id = getIDSelector(element)
+  const classes = getElementClassList(element)
+  const attributes = extractSafeAttributes(element, allowedAttributes)
+  const { nthChild, nthOfType } = computePositionData(element)
+
+  return {
+    tagName,
+    id,
+    classes,
+    attributes,
+    nthChild,
+    nthOfType,
+  }
+}
+
+function getElementClassList(element: Element): string[] {
+  return Array.from(element.classList).filter((c) => c.trim() !== '' && !isGeneratedValue(c))
+}
+
+/**
+ * Computes the nthChild and nthOfType positions for an element.
+ *
+ * - nthChild: 1-based position among all siblings. Only set if element has siblings.
+ * - nthOfType: 1-based position among siblings of the same tag type. Only set if not unique of type.
+ */
+function computePositionData(element: Element): { nthChild?: number; nthOfType?: number } {
+  const parent = element.parentElement
+  if (!parent) {
+    return {}
+  }
+
+  const siblings = Array.from(parent.children)
+  const totalSiblings = siblings.length
+
+  // If element is the only child, no position data needed
+  if (totalSiblings <= 1) {
+    return {}
+  }
+
+  // Calculate nthChild (1-based index among all siblings)
+  let childIndex = 0
+  for (let i = 0; i < siblings.length; i++) {
+    if (siblings[i] === element) {
+      childIndex = i + 1 // 1-based
+      break
+    }
+  }
+  const nthChild: number | undefined = childIndex
+
+  // Calculate nthOfType (1-based index among siblings of the same tag type)
+  let nthOfType: number | undefined
+  const sameTypeSiblings = siblings.filter((sibling) => sibling.tagName === element.tagName)
+
+  // Only set nthOfType if there are multiple siblings of the same type
+  if (sameTypeSiblings.length > 1) {
+    let typeIndex = 0
+    for (let i = 0; i < sameTypeSiblings.length; i++) {
+      if (sameTypeSiblings[i] === element) {
+        typeIndex = i + 1 // 1-based
+        break
+      }
+    }
+    nthOfType = typeIndex
+  }
+
+  return { nthChild, nthOfType }
+}
+
+/**
+ * Extracts only the safe (allowlisted) attributes from an element.
+ */
+function extractSafeAttributes(element: Element, allowedAttributes: MatchOption[]): Record<string, string> {
+  const result: Record<string, string> = {}
+
+  if (!element.hasAttributes()) {
+    return result
+  }
+
+  const attributes = Array.from(element.attributes)
+  for (const attr of attributes) {
+    if(matchList(allowedAttributes, attr.name)) {
+      result[attr.name] = CSS.escape(attr.value);
+    }
+  }
+
+  return result
+}

--- a/packages/rum-core/src/domain/getSelectorFromElement.ts
+++ b/packages/rum-core/src/domain/getSelectorFromElement.ts
@@ -77,7 +77,7 @@ export function getSelectorFromElement(
   return targetElementSelector
 }
 
-function isGeneratedValue(value: string) {
+export function isGeneratedValue(value: string) {
   // To compute the "URL path group", the backend replaces every URL path parts as a question mark
   // if it thinks the part is an identifier. The condition it uses is to checks whether a digit is
   // present.
@@ -88,7 +88,7 @@ function isGeneratedValue(value: string) {
   return /[0-9]/.test(value)
 }
 
-function getIDSelector(element: Element): string | undefined {
+export function getIDSelector(element: Element): string | undefined {
   if (element.id && !isGeneratedValue(element.id)) {
     return `#${CSS.escape(element.id)}`
   }
@@ -109,7 +109,7 @@ function getClassSelector(element: Element): string | undefined {
   }
 }
 
-function getTagNameSelector(element: Element): string {
+export function getTagNameSelector(element: Element): string {
   return CSS.escape(element.tagName)
 }
 

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -328,6 +328,7 @@ export interface RawRumActionEvent {
         selector?: string
         width?: number
         height?: number
+        composed_path_selector?: string
       }
       name_source?: string
       position?: {


### PR DESCRIPTION
## Motivation
[PANA-6072] 

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

## Changes

This adds a composedPath based selector string that will be used in Product Analytics action management.
[For more info](https://datadoghq.atlassian.net/wiki/spaces/PANA/pages/5678432338)

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
