### PR TITLE
feat: Add `attrUnmaskAllowlist` RUM config option

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -250,6 +250,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       use_excluded_activity_urls?: boolean
       /**
+       * Whether the attribute unmask allowlist is used for Session Replay
+       */
+      use_attr_unmask_allowlist?: boolean
+      /**
        * Whether the Worker is loaded from an external URL
        */
       use_worker_url?: boolean

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -613,6 +613,7 @@ describe('serializeRumConfiguration', () => {
       traceSampleRate: 50,
       traceContextInjection: TraceContextInjection.ALL,
       defaultPrivacyLevel: 'allow',
+      attrUnmaskAllowlist: [],
       enablePrivacyForActionName: false,
       subdomain: 'foo',
       sessionReplaySampleRate: 60,
@@ -639,6 +640,7 @@ describe('serializeRumConfiguration', () => {
             | 'workerUrl'
             | 'allowedTracingUrls'
             | 'excludedActivityUrls'
+            | 'attrUnmaskAllowlist'
             | 'remoteConfigurationProxy'
             | 'allowedGraphQlUrls'
         ? `use_${CamelToSnakeCase<Key>}`
@@ -675,6 +677,7 @@ describe('serializeRumConfiguration', () => {
       start_session_replay_recording_manually: true,
       action_name_attribute: 'test-id',
       default_privacy_level: 'allow',
+      use_attr_unmask_allowlist: false,
       enable_privacy_for_action_name: false,
       track_resources: true,
       track_long_task: true,

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -153,6 +153,15 @@ export interface RumInitConfiguration extends InitConfiguration {
   defaultPrivacyLevel?: DefaultPrivacyLevel | undefined
 
   /**
+   * List of attribute names that should not be masked when privacy level is mask or mask-unless-allowlisted.
+   * Attributes in this list will be recorded with their original values in Session Replay.
+   *
+   * @category Privacy
+   * @defaultValue []
+   */
+  attrUnmaskAllowlist?: string[] | undefined
+
+  /**
    * If you are accessing Datadog through a custom subdomain, you can set `subdomain` to include your custom domain in the `getSessionReplayLink()` returned URL .
    *
    * See [Connect Session Replay To Your Third-Party Tools](https://docs.datadoghq.com/real_user_monitoring/guide/connect-session-replay-to-your-third-party-tools) for further information.
@@ -305,6 +314,7 @@ export interface RumConfiguration extends Configuration {
   compressIntakeRequests: boolean
   applicationId: string
   defaultPrivacyLevel: DefaultPrivacyLevel
+  attrUnmaskAllowlist: string[]
   enablePrivacyForActionName: boolean
   sessionReplaySampleRate: number
   startSessionReplayRecordingManually: boolean
@@ -351,6 +361,10 @@ export function validateAndBuildRumConfiguration(
     return
   }
 
+  if (initConfiguration.attrUnmaskAllowlist !== undefined && !Array.isArray(initConfiguration.attrUnmaskAllowlist)) {
+    display.warn('attrUnmaskAllowlist should be an array')
+  }
+
   const allowedTracingUrls = validateAndBuildTracingOptions(initConfiguration)
   if (!allowedTracingUrls) {
     return
@@ -391,6 +405,7 @@ export function validateAndBuildRumConfiguration(
     defaultPrivacyLevel: objectHasValue(DefaultPrivacyLevel, initConfiguration.defaultPrivacyLevel)
       ? initConfiguration.defaultPrivacyLevel
       : DefaultPrivacyLevel.MASK,
+    attrUnmaskAllowlist: Array.isArray(initConfiguration.attrUnmaskAllowlist) ? initConfiguration.attrUnmaskAllowlist : [],
     enablePrivacyForActionName: !!initConfiguration.enablePrivacyForActionName,
     traceContextInjection: objectHasValue(TraceContextInjection, initConfiguration.traceContextInjection)
       ? initConfiguration.traceContextInjection
@@ -531,6 +546,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
     selected_tracing_propagators: getSelectedTracingPropagators(configuration),
     default_privacy_level: configuration.defaultPrivacyLevel,
     enable_privacy_for_action_name: configuration.enablePrivacyForActionName,
+    use_attr_unmask_allowlist: isNonEmptyArray(configuration.attrUnmaskAllowlist),
     use_excluded_activity_urls: isNonEmptyArray(configuration.excludedActivityUrls),
     use_worker_url: !!configuration.workerUrl,
     compress_intake_requests: configuration.compressIntakeRequests,

--- a/packages/rum-core/src/domain/privacy.ts
+++ b/packages/rum-core/src/domain/privacy.ts
@@ -163,6 +163,12 @@ export function shouldMaskAttribute(
   if (nodePrivacyLevel !== NodePrivacyLevel.MASK && nodePrivacyLevel !== NodePrivacyLevel.MASK_UNLESS_ALLOWLISTED) {
     return false
   }
+
+  const attrUnmaskAllowlist: string[] = configuration.attrUnmaskAllowlist ?? []
+  if (attrUnmaskAllowlist.includes(attributeName)) {
+    return false
+  }
+
   if (
     attributeName === PRIVACY_ATTR_NAME ||
     STABLE_ATTRIBUTES.includes(attributeName) ||

--- a/packages/rum/src/domain/record/serialization/serializeAttribute.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeAttribute.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@datadog/browser-rum-core'
 import { serializeAttribute, MAX_ATTRIBUTE_VALUE_CHAR_LENGTH } from './serializeAttribute'
 
-const DEFAULT_CONFIGURATION = {} as RumConfiguration
+const DEFAULT_CONFIGURATION = { attrUnmaskAllowlist: [] as string[] } as RumConfiguration
 
 describe('serializeAttribute', () => {
   it('truncates "data:" URIs after long string length', () => {

--- a/packages/rum/src/domain/record/test/rumConfiguration.specHelper.ts
+++ b/packages/rum/src/domain/record/test/rumConfiguration.specHelper.ts
@@ -1,4 +1,7 @@
 import { NodePrivacyLevel } from '@datadog/browser-rum-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 
-export const DEFAULT_CONFIGURATION = { defaultPrivacyLevel: NodePrivacyLevel.ALLOW } as RumConfiguration
+export const DEFAULT_CONFIGURATION = {
+  defaultPrivacyLevel: NodePrivacyLevel.ALLOW,
+  attrUnmaskAllowlist: [] as string[],
+} as RumConfiguration


### PR DESCRIPTION
## Motivation

When masking is enabled, RUM automatically masks all `data-*` attributes to prevent data leakage and slim down replay frame payloads. However, some UI libraries use CSS selectors that target certain `data-*` attributes and values, which can lead to breakage of styles and rendering issues during replay playback. We need a way to maintain these styles during playback and this seems like a relatively straightforward way to do so.

I thought about making this a map of attributes and allowed values for each attribute, but wanted to keep the surface of the checks small. There may be some perf optimization needed for such a high-frequency check but tested this as a proof-of-concept locally and saw the results I was after, so just starting with this base implementation to get a temperature check on a feature like this.

## Changes

- Adds a `attrUnmaskAllowlist` option to the RUM configuration
- Reads from this list when present to determine masking behavior for attributes

## Test instructions

- Create an element with CSS rules targeting specific `data-*` attribute values (ie. `data-state=open`)
- Initiate a RUM session with replay enabled and no `attrUnmaskAllowlist` provided
- Verify that the replay does not render the intended styles due to masking the attribute value
- Update the config to include a relevant `attrUnmaskAllowlist`
- Verify that the next replay DOES render the intended styles due to preservation of the attribute value

Once again I will likely need integration test help as I'm unable to run suites beyond the unit tests.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
