### PR TITLE
✅ Fix flaky remote configuration E2E tests

### DIFF
--- a/test/e2e/scenario/rum/remoteConfiguration.scenario.ts
+++ b/test/e2e/scenario/rum/remoteConfiguration.scenario.ts
@@ -89,6 +89,7 @@ test.describe('remote configuration', () => {
       </script>
     `)
     .run(async ({ page }) => {
+      await waitForRemoteConfigurationToBeApplied(page)
       const initConfiguration = await page.evaluate(() => window.DD_RUM!.getInitConfiguration()!)
       expect(initConfiguration.version).toBe('js-version')
     })
@@ -109,6 +110,7 @@ test.describe('remote configuration', () => {
       </script>
     `)
     .run(async ({ page }) => {
+      await waitForRemoteConfigurationToBeApplied(page)
       const initConfiguration = await page.evaluate(() => window.DD_RUM!.getInitConfiguration()!)
       expect(initConfiguration.version).toBe('localStorage-version')
     })
@@ -134,6 +136,7 @@ test.describe('remote configuration', () => {
       </script>
     `)
     .run(async ({ page }) => {
+      await waitForRemoteConfigurationToBeApplied(page)
       const initConfiguration = await page.evaluate(() => window.DD_RUM!.getInitConfiguration()!)
       expect(initConfiguration.version).toBe('1.2.3')
     })
@@ -149,6 +152,7 @@ test.describe('remote configuration', () => {
       },
     })
     .run(async ({ page }) => {
+      await waitForRemoteConfigurationToBeApplied(page)
       const initConfiguration = await page.evaluate(() => window.DD_RUM!.getInitConfiguration()!)
       expect(initConfiguration.version).toBeUndefined()
     })
@@ -174,6 +178,7 @@ test.describe('remote configuration', () => {
       </script>
     `)
     .run(async ({ page }) => {
+      await waitForRemoteConfigurationToBeApplied(page)
       const initConfiguration = await page.evaluate(() => window.DD_RUM!.getInitConfiguration()!)
       expect(initConfiguration.version).toBeUndefined()
     })


### PR DESCRIPTION
## Motivation

Several E2E tests in the remote configuration scenario were flaky because they were reading `initConfiguration` before the remote configuration had been fully applied. This caused intermittent failures depending on timing.

## Changes

Added `waitForRemoteConfigurationToBeApplied(page)` before calling `page.evaluate(() => window.DD_RUM!.getInitConfiguration()!)` in 5 test cases that verify remote configuration is correctly applied:

- Test that verifies JS remote config version is applied
- Test that verifies localStorage remote config version is applied
- Test that verifies remote config version overrides local config
- Test that verifies remote config is not applied when disabled
- Test that verifies remote config is not applied when it doesn't match

## Test instructions

1. Run `yarn test:e2e -g "remote configuration"` — previously flaky tests should now pass consistently

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file