### PR TITLE
 ⚗ [POC] Android E2E tests using Playwright emulator

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,6 +238,25 @@ e2e:
   after_script:
     - node ./scripts/test/export-test-result.ts e2e
 
+e2e-android:
+  extends:
+    - .base-configuration
+    - .feature-branches
+  tags:
+    - 'macos:sonoma'
+    - 'specific:true'
+  interruptible: true
+  timeout: 40 minutes
+  artifacts:
+    when: always
+    reports:
+      junit: test-report/e2e-android/*.xml
+  script:
+    - yarn
+    - yarn build
+    - yarn build:apps
+    - FORCE_COLOR=1 CI_JOB_NAME=e2e-android yarn test:e2e:android
+
 check-licenses:
   extends:
     - .base-configuration

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:e2e:init": "yarn build && yarn build:apps && yarn playwright install chromium --with-deps",
     "test:e2e": "playwright test --config test/e2e/playwright.local.config.ts --project chromium",
     "test:e2e:bs": "node --env-file-if-exists=.env ./scripts/test/bs-wrapper.ts playwright test --config test/e2e/playwright.bs.config.ts",
+    "test:e2e:android": "ANDROID_E2E=true playwright test --config test/e2e/android/playwright.android.config.ts",
     "test:e2e:ci": "yarn test:e2e:init && yarn test:e2e",
     "test:e2e:ci:bs": "yarn build && yarn build:apps && yarn test:e2e:bs",
     "test:compat:tsc": "node scripts/check-typescript-compatibility.ts",

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -30,6 +30,28 @@ yarn build:apps --app vanilla
 yarn build:apps --app vanilla --app react-heavy-spa
 ```
 
+### Android E2E Tests
+
+```bash
+# Run E2E tests on an Android emulator
+yarn test:e2e:android
+
+# Use a specific AVD (defaults to "test_device")
+ANDROID_AVD="My_Device" yarn test:e2e:android
+```
+
+**Prerequisites:**
+
+- Android Studio installed
+- `emulator` and `adb` on `$PATH` — add this to your `~/.zshrc`:
+  ```bash
+  export ANDROID_HOME="$HOME/Library/Android/sdk"
+  export PATH="$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools"
+  ```
+- An AVD created (CI uses `test_device`, locally you can override with `ANDROID_AVD`)
+
+The global setup starts the emulator, sets up `adb reverse` port forwarding, and installs a recent Chromium. When running locally, the dev server and Next.js app are auto-started by the Playwright config (in CI they are started separately). Tests run sequentially on a single worker using the `bundle` setup only.
+
 ## Test Apps
 
 Located in `test/apps/`:

--- a/test/e2e/android/androidFixture.ts
+++ b/test/e2e/android/androidFixture.ts
@@ -1,0 +1,66 @@
+import type { BrowserContext } from '@playwright/test'
+import { test as base } from '@playwright/test'
+import type { AndroidDevice } from 'playwright'
+
+const DEVICE_CONNECTION_TIMEOUT = 30_000
+const DEVICE_CONNECTION_RETRY_INTERVAL = 2_000
+
+let cachedDevice: AndroidDevice | undefined
+let cachedContext: BrowserContext | undefined
+
+async function getOrCreateContext(): Promise<{ device: AndroidDevice; context: BrowserContext }> {
+  if (cachedDevice && cachedContext) {
+    try {
+      cachedContext.pages()
+      return { device: cachedDevice, context: cachedContext }
+    } catch {
+      cachedContext = undefined
+    }
+  }
+
+  if (!cachedDevice) {
+    cachedDevice = await connectDevice()
+  }
+
+  cachedContext = await cachedDevice.launchBrowser({ pkg: 'org.chromium.chrome' })
+  return { device: cachedDevice, context: cachedContext }
+}
+
+export const test = base.extend<{ context: BrowserContext }>({
+  // eslint-disable-next-line no-empty-pattern
+  context: async ({}, use) => {
+    const { context } = await getOrCreateContext()
+    await use(context)
+  },
+  page: async ({ context }, use) => {
+    const page = await context.newPage()
+    await use(page)
+    // Unregister service workers to prevent stale state across tests
+    try {
+      await page.evaluate(async () => {
+        const regs = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(regs.map((r) => r.unregister()))
+      })
+    } catch {
+      // ignore
+    }
+    await page.close()
+  },
+})
+
+async function connectDevice() {
+  const { _android } = await import('playwright')
+  const startTime = Date.now()
+
+  while (Date.now() - startTime < DEVICE_CONNECTION_TIMEOUT) {
+    const devices = await _android.devices()
+    if (devices.length > 0) {
+      return devices[0]
+    }
+    await new Promise((resolve) => setTimeout(resolve, DEVICE_CONNECTION_RETRY_INTERVAL))
+  }
+
+  throw new Error(`No Android device found within ${DEVICE_CONNECTION_TIMEOUT / 1000}s`)
+}
+
+export { expect } from '@playwright/test'

--- a/test/e2e/android/globalSetup.ts
+++ b/test/e2e/android/globalSetup.ts
@@ -1,0 +1,124 @@
+import { execSync, spawn } from 'child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+
+const BOOT_TIMEOUT_MS = 300_000
+const BOOT_POLL_INTERVAL_MS = 2_000
+
+const DEV_SERVER_PORT = 8080
+// Port range covering httpServers.ts (9200-9400) and dynamic server ports (9000-9199)
+const PORT_RANGE_START = 9000
+const PORT_RANGE_END = 9400
+
+// eslint-disable-next-line import/no-default-export
+export default async function globalSetup() {
+  console.log('Starting Android emulator...')
+
+  const emulatorProcess = spawn(
+    'emulator',
+    [
+      '-avd',
+      process.env.ANDROID_AVD || 'test_device',
+      '-no-window',
+      '-no-audio',
+      '-no-snapshot',
+      '-no-boot-anim',
+      '-gpu',
+      'auto',
+    ],
+    {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      detached: true,
+    }
+  )
+  emulatorProcess.unref()
+
+  await waitForBoot()
+  setupAdbReverse()
+  await installChromium()
+}
+
+async function waitForBoot() {
+  const startTime = Date.now()
+
+  while (Date.now() - startTime < BOOT_TIMEOUT_MS) {
+    try {
+      const result = execSync('adb shell getprop sys.boot_completed', { encoding: 'utf-8', timeout: 5_000 }).trim()
+      if (result === '1') {
+        console.log(`Emulator booted in ${Math.round((Date.now() - startTime) / 1000)}s`)
+        return
+      }
+    } catch {
+      // adb not yet connected, keep polling
+    }
+    await new Promise((resolve) => setTimeout(resolve, BOOT_POLL_INTERVAL_MS))
+  }
+
+  throw new Error(`Emulator failed to boot within ${BOOT_TIMEOUT_MS / 1000}s`)
+}
+
+function setupAdbReverse() {
+  console.log('Setting up adb reverse port forwarding...')
+  execSync(`adb reverse tcp:${DEV_SERVER_PORT} tcp:${DEV_SERVER_PORT}`)
+  for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
+    execSync(`adb reverse tcp:${port} tcp:${port}`)
+  }
+  console.log(`Forwarded ports: ${DEV_SERVER_PORT}, ${PORT_RANGE_START}-${PORT_RANGE_END}`)
+}
+
+// The default Chrome on the emulator is too old for modern web APIs.
+// Install a recent Chromium from Google's snapshot storage.
+async function installChromium() {
+  console.log('Installing Chromium on emulator...')
+
+  try {
+    const revisionResponse = await fetch(
+      'https://storage.googleapis.com/chromium-browser-snapshots/Android_Arm64/LAST_CHANGE'
+    )
+    const revision = (await revisionResponse.text()).trim()
+    console.log(`Latest Chromium ARM64 snapshot revision: ${revision}`)
+
+    const downloadUrl = `https://storage.googleapis.com/chromium-browser-snapshots/Android_Arm64/${revision}/chrome-android.zip`
+    console.log(`Downloading from ${downloadUrl}`)
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chromium-android-'))
+    const zipPath = path.join(tmpDir, 'chrome-android.zip')
+
+    const downloadResponse = await fetch(downloadUrl)
+    if (!downloadResponse.ok) {
+      console.log(`Download failed: ${downloadResponse.status}`)
+      return
+    }
+
+    const buffer = Buffer.from(await downloadResponse.arrayBuffer())
+    fs.writeFileSync(zipPath, buffer)
+    console.log(`Downloaded ${(buffer.length / 1024 / 1024).toFixed(1)}MB`)
+
+    execSync(`unzip -o "${zipPath}" -d "${tmpDir}"`, { timeout: 60_000 })
+
+    const apks = execSync(`find "${tmpDir}" -name "*.apk"`, { encoding: 'utf-8', timeout: 5_000 })
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+
+    const chromeApk = apks.find((a) => path.basename(a) === 'ChromePublic.apk')
+    if (!chromeApk) {
+      console.log('ChromePublic.apk not found in download')
+      return
+    }
+
+    const result = execSync(`adb install -r -d "${chromeApk}"`, { encoding: 'utf-8', timeout: 120_000 })
+    console.log(`Install result: ${result.trim()}`)
+
+    const versionInfo = execSync('adb shell dumpsys package org.chromium.chrome | grep versionName', {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    }).trim()
+    console.log(`Chromium installed: ${versionInfo}`)
+
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  } catch (error) {
+    console.log('Chromium install failed (non-fatal):', error)
+  }
+}

--- a/test/e2e/android/globalTeardown.ts
+++ b/test/e2e/android/globalTeardown.ts
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process'
+
+// eslint-disable-next-line import/no-default-export
+export default function globalTeardown() {
+  console.log('Shutting down Android emulator...')
+  try {
+    execSync('adb emu kill', { timeout: 10_000 })
+    console.log('Emulator stopped')
+  } catch {
+    console.warn('Failed to stop emulator (it may have already exited)')
+  }
+}

--- a/test/e2e/android/playwright.android.config.ts
+++ b/test/e2e/android/playwright.android.config.ts
@@ -5,9 +5,11 @@ import { getTestReportDirectory } from '../../envUtils'
 
 const isLocal = !process.env.CI
 const NEXTJS_PORT = 9100
+const VUE_ROUTER_APP_PORT = 9150
 
 // Set eagerly so test workers can read it at import time via process.env
 process.env.NEXTJS_APP_ROUTER_PORT = String(NEXTJS_PORT)
+process.env.VUE_ROUTER_APP_PORT = String(VUE_ROUTER_APP_PORT)
 
 const testReportDirectory = getTestReportDirectory()
 const reporters: ReporterDescription[] = [['line']]
@@ -55,6 +57,18 @@ export default defineConfig({
       command: `lsof -ti :${NEXTJS_PORT} | xargs kill -9 2>/dev/null; yarn start --port ${NEXTJS_PORT}`,
       wait: {
         stdout: /- Local:\s+http:\/\/localhost:(?<nextjs_app_router_port>\d+)/,
+      },
+    },
+    {
+      name: 'vue router app',
+      stdout: 'pipe' as const,
+      cwd: path.join(__dirname, '../../apps/vue-router-app'),
+      command: `lsof -ti :${VUE_ROUTER_APP_PORT} | xargs kill -9 2>/dev/null; yarn ${isLocal ? 'dev' : 'preview'} --port ${VUE_ROUTER_APP_PORT}`,
+      // NO_COLOR=1 prevents Vite from wrapping "Local" in ANSI bold codes when
+      // FORCE_COLOR=1 is set in CI, which would break the wait.stdout regex.
+      env: { NO_COLOR: '1' },
+      wait: {
+        stdout: /Local:\s+http:\/\/localhost:(?<vue_router_app_port>\d+)/,
       },
     },
   ],

--- a/test/e2e/android/playwright.android.config.ts
+++ b/test/e2e/android/playwright.android.config.ts
@@ -1,0 +1,61 @@
+import path from 'path'
+import type { ReporterDescription } from '@playwright/test'
+import { defineConfig } from '@playwright/test'
+import { getTestReportDirectory } from '../../envUtils'
+
+const isLocal = !process.env.CI
+const NEXTJS_PORT = 9100
+
+// Set eagerly so test workers can read it at import time via process.env
+process.env.NEXTJS_APP_ROUTER_PORT = String(NEXTJS_PORT)
+
+const testReportDirectory = getTestReportDirectory()
+const reporters: ReporterDescription[] = [['line']]
+
+if (testReportDirectory) {
+  reporters.push(['junit', { outputFile: path.join(process.cwd(), testReportDirectory, 'results.xml') }])
+} else {
+  reporters.push(['html'])
+}
+
+// eslint-disable-next-line import/no-default-export
+export default defineConfig({
+  testDir: '../scenario',
+  testMatch: ['**/*.scenario.ts'],
+  tsconfig: '../tsconfig.json',
+  globalSetup: './globalSetup.ts',
+  globalTeardown: './globalTeardown.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: 1,
+  timeout: 60_000,
+  reporter: reporters,
+  projects: [{ name: 'android' }],
+  use: {
+    trace: 'retain-on-failure',
+  },
+  webServer: [
+    ...(isLocal
+      ? [
+          {
+            name: 'dev server',
+            stdout: 'pipe' as const,
+            cwd: path.join(__dirname, '../../..'),
+            command: 'yarn dev-server start --no-daemon',
+            wait: {
+              stdout: /Dev server listening on port (?<dev_server_port>\d+)/,
+            },
+          },
+        ]
+      : []),
+    {
+      name: 'nextjs app router',
+      stdout: 'pipe' as const,
+      cwd: path.join(__dirname, '../../apps/nextjs'),
+      command: `lsof -ti :${NEXTJS_PORT} | xargs kill -9 2>/dev/null; yarn start --port ${NEXTJS_PORT}`,
+      wait: {
+        stdout: /- Local:\s+http:\/\/localhost:(?<nextjs_app_router_port>\d+)/,
+      },
+    },
+  ],
+})

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -10,6 +10,7 @@ import { DEFAULT_LOGS_CONFIGURATION, DEFAULT_RUM_CONFIGURATION } from '../helper
 import { validateRumFormat } from '../helpers/validation'
 import type { BrowserConfiguration } from '../../../browsers.conf'
 import { NEXTJS_APP_ROUTER_PORT, VUE_ROUTER_APP_PORT } from '../helpers/playwright'
+import { test as androidTest } from '../../android/androidFixture'
 import { IntakeRegistry } from './intakeRegistry'
 import { flushEvents } from './flushEvents'
 import type { Servers } from './httpServers'
@@ -20,7 +21,7 @@ import { createIntakeServerApp } from './serverApps/intake'
 import { createMockServerApp } from './serverApps/mock'
 import type { Extension } from './createExtension'
 import type { Worker } from './createWorker'
-import { isBrowserStack } from './environment'
+import { isAndroid, isBrowserStack } from './environment'
 
 export function createTest(title: string) {
   return new TestBuilder(title, captureCallerLocation())
@@ -54,7 +55,7 @@ class TestBuilder {
   private baseUrlHooks: UrlHook[] = []
   private eventBridge = false
   private setups: Array<{ factory: SetupFactory; name?: string }> = DEFAULT_SETUPS
-  private testFixture: typeof test = test
+  private testFixture: typeof test = isAndroid ? androidTest : test
   private extension: {
     rumConfiguration?: RumInitConfiguration
     logsConfiguration?: LogsInitConfiguration

--- a/test/e2e/lib/framework/environment.ts
+++ b/test/e2e/lib/framework/environment.ts
@@ -1,2 +1,3 @@
 export const isBrowserStack = Boolean(process.env.BROWSER_STACK)
 export const isContinuousIntegration = Boolean(process.env.CI)
+export const isAndroid = Boolean(process.env.ANDROID_E2E)

--- a/test/e2e/lib/framework/flushEvents.ts
+++ b/test/e2e/lib/framework/flushEvents.ts
@@ -1,6 +1,10 @@
 import type { Page } from '@playwright/test'
+import { isAndroid } from './environment'
 import { getTestServers, waitForServersIdle } from './httpServers'
 import { waitForRequests } from './waitForRequests'
+
+// The Android emulator has higher latency over ADB, so we need longer delays
+const FLUSH_DURATION = isAndroid ? 500 : 200
 
 export async function flushEvents(page: Page) {
   await waitForRequests(page)
@@ -21,6 +25,6 @@ export async function flushEvents(page: Page) {
   // The issue mainly occurs with local e2e tests (not browserstack), because the network latency is
   // very low (same machine), so the request resolves very quickly. In real life conditions, this
   // issue is mitigated, because requests will likely take a few milliseconds to reach the server.
-  await page.goto(`${servers.base.origin}/ok?duration=200`)
+  await page.goto(`${servers.base.origin}/ok?duration=${FLUSH_DURATION}`)
   await waitForServersIdle()
 }

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -2,7 +2,7 @@ import { generateUUID, INTAKE_URL_PARAMETERS } from '@datadog/browser-core'
 import type { LogsInitConfiguration } from '@datadog/browser-logs'
 import type { RumInitConfiguration, RemoteConfiguration } from '@datadog/browser-rum-core'
 import type test from '@playwright/test'
-import { isBrowserStack, isContinuousIntegration } from './environment'
+import { isAndroid, isBrowserStack, isContinuousIntegration } from './environment'
 import type { Servers } from './httpServers'
 
 export interface SetupOptions {
@@ -45,9 +45,9 @@ export type SetupFactory = (options: SetupOptions, servers: Servers) => string
 export type UrlHook = (baseUrl: URL, servers: Servers, options: SetupOptions) => void
 
 // By default, run tests only with the 'bundle' setup outside of the CI (to run faster on the
-// developer laptop) or with Browser Stack (to limit flakiness).
+// developer laptop), with Browser Stack (to limit flakiness), or with Android (single setup).
 export const DEFAULT_SETUPS =
-  !isContinuousIntegration || isBrowserStack
+  !isContinuousIntegration || isBrowserStack || isAndroid
     ? [{ name: 'bundle', factory: bundleSetup }]
     : [
         { name: 'async', factory: asyncSetup },

--- a/test/e2e/lib/framework/waitForRequests.ts
+++ b/test/e2e/lib/framework/waitForRequests.ts
@@ -3,7 +3,7 @@ import { isAndroid } from './environment'
 import { waitForServersIdle } from './httpServers'
 
 // The Android emulator has higher latency over ADB, so we need longer delays
-const WAIT_DELAY = isAndroid ? 500 : 200
+const WAIT_DELAY = isAndroid ? 900 : 200
 
 /**
  * Wait for browser requests to be sent and finished.

--- a/test/e2e/lib/framework/waitForRequests.ts
+++ b/test/e2e/lib/framework/waitForRequests.ts
@@ -1,5 +1,9 @@
 import type { Page } from '@playwright/test'
+import { isAndroid } from './environment'
 import { waitForServersIdle } from './httpServers'
+
+// The Android emulator has higher latency over ADB, so we need longer delays
+const WAIT_DELAY = isAndroid ? 500 : 200
 
 /**
  * Wait for browser requests to be sent and finished.
@@ -13,12 +17,13 @@ import { waitForServersIdle } from './httpServers'
  */
 export async function waitForRequests(page: Page) {
   await page.evaluate(
-    () =>
+    (delay) =>
       new Promise((resolve) => {
         setTimeout(() => {
           resolve(undefined)
-        }, 200)
-      })
+        }, delay)
+      }),
+    WAIT_DELAY
   )
   await waitForServersIdle()
 }

--- a/test/e2e/scenario/profiling.scenario.ts
+++ b/test/e2e/scenario/profiling.scenario.ts
@@ -137,6 +137,10 @@ test.describe('profiling', () => {
     .withRum({ profilingSampleRate: 100, compressIntakeRequests: true })
     .withBasePath('/?js-profiling=true')
     .run(async ({ intakeRegistry, flushEvents, page }) => {
+      test.skip(
+        test.info().project.name === 'android',
+        'CompressionStream is not reliable on Android emulator Chromium'
+      )
       await generateLongTask(page)
 
       await flushEvents()

--- a/test/e2e/scenario/recorder/viewports.scenario.ts
+++ b/test/e2e/scenario/recorder/viewports.scenario.ts
@@ -283,7 +283,7 @@ async function layoutScrollTo(page: Page, scrollX: number, scrollY: number) {
     { scrollX, scrollY }
   )
   const { scrollX: nextScrollX, scrollY: nextScrollY } = await getWindowScroll(page)
-  // Ensure our methods are applied correctly
-  expect(scrollX).toBe(nextScrollX)
-  expect(scrollY).toBe(nextScrollY)
+  // Use toBeCloseTo because mobile DPI can cause sub-pixel scroll differences
+  expect(nextScrollX).toBeCloseTo(scrollX, 0)
+  expect(nextScrollY).toBeCloseTo(scrollY, 0)
 }

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -123,6 +123,10 @@ test.describe('action collection', () => {
       </script>
     `)
     .run(async ({ intakeRegistry, flushEvents, page }) => {
+      test.skip(
+        test.info().project.name === 'android',
+        'On Android emulator, the XHR completes after the SDK closes the action due to higher latency'
+      )
       const button = page.locator('button')
       await button.click()
       await waitForServersIdle()

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -701,6 +701,10 @@ test.describe('custom actions with startAction/stopAction', () => {
   createTest('track multiple concurrent custom actions with actionKey')
     .withRum({ enableExperimentalFeatures: ['start_stop_action'] })
     .run(async ({ intakeRegistry, flushEvents, page }) => {
+      test.skip(
+        test.info().project.name === 'android',
+        'Custom action events are not reliably flushed before navigation under Android emulator ADB latency'
+      )
       await page.evaluate(() => {
         window.DD_RUM!.startAction('click', { actionKey: 'button1' })
         window.DD_RUM!.startAction('click', { actionKey: 'button2' })

--- a/test/e2e/scenario/rum/init.scenario.ts
+++ b/test/e2e/scenario/rum/init.scenario.ts
@@ -36,6 +36,10 @@ test.describe('API calls and events around init', () => {
       setTimeout(() => window.DD_RUM!.init(configuration), 30)
     })
     .run(async ({ intakeRegistry, flushEvents }) => {
+      test.skip(
+        test.info().project.name === 'android',
+        'Tight setTimeout sequencing (10/20/30ms) is unreliable under Android emulator ADB latency'
+      )
       await flushEvents()
 
       const initialView = intakeRegistry.rumViewEvents[0]

--- a/test/envUtils.ts
+++ b/test/envUtils.ts
@@ -1,6 +1,10 @@
 import os from 'os'
 
 export function getIp() {
+  // The emulator reaches the host via `adb reverse`, so localhost is correct
+  if (process.env.ANDROID_E2E) {
+    return 'localhost'
+  }
   const networkInterface = (Object.values(os.networkInterfaces()) as os.NetworkInterfaceInfo[][])
     .flat()
     .find(({ family, internal }) => family === 'IPv4' && !internal)


### PR DESCRIPTION
## Motivation

We run E2E tests on desktop browsers only. This PR adds Android emulator support to run our existing E2E suite on mobile Chromium via Playwright's native Android API.

## Changes

- `test/e2e/android/` — global setup (emulator boot, `adb reverse` port forwarding, Chromium install), teardown, Playwright config, custom device fixture
- Integrate into `createTest`: when `ANDROID_E2E` is set, tests use the Android fixture with `bundle` setup only
- Auto-start dev server, Next.js app, and Vue router app locally; in CI they are started separately
- Increase `waitForRequests` delay on Android (200ms → 900ms) and `flushEvents` navigation delay (200ms → 500ms) to account for ADB round-trip latency between host and emulator
- Return `localhost` from `getIp()` for Android since the emulator reaches the host through `adb reverse`
- Relax scroll position assertions in viewport tests for sub-pixel DPI rounding on mobile
- Add `yarn test:e2e:android` script and `e2e-android` CI job

## Skipped tests on Android

4 tests are skipped due to Android emulator constraints. This PR is more a setup / POC. Fixing them will require reworking the test logic itself and will be handled in follow-up PRs.

| Test |  Probable Reason |
|------|--------|
| `profiling › send compressed profile events` | `CompressionStream` API not available on emulator Chromium |
| `actions › associate a request to its action` | ADB latency: SDK closes the click action before the XHR completes |
| `actions › track multiple concurrent custom actions` | Custom action events not flushed before the flush navigation |
| `init › views automatically tracked` | Relies on tight `setTimeout` sequencing (10/20/30ms) broken by ADB latency |

## Test instructions

**Prerequisites:** [Android Studio](https://developer.android.com/studio) installed.

1. Add Android SDK tools to your PATH (add to `~/.zshrc` for persistence):
   ```bash
   export ANDROID_HOME="$HOME/Library/Android/sdk"
   export PATH="$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools"
   ```

2. Create an AVD — **must use `google_apis` (not `google_apis_playstore`)**:
   ```bash
   sdkmanager "system-images;android-35;google_apis;arm64-v8a"
   avdmanager create avd -n test_device -k "system-images;android-35;google_apis;arm64-v8a"
   ```

3. Install, build, and run:
   ```bash
   yarn
   yarn build
   yarn build:apps
   yarn test:e2e:android
   ```

   If you have an AVD with a different name:
   ```bash
   ANDROID_AVD="Your_AVD_Name" yarn test:e2e:android
   ```

## Checklist

- [x] Tested locally
- [x] Tested on CI
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file