### PR TITLE
👷 Skip BrowserStack tests on next major branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,6 +59,8 @@ stages:
       - /^staging-[0-9]+$/
       - /^release\//
       - schedules
+    variables:
+      - $CI_COMMIT_REF_NAME == $NEXT_MAJOR_BRANCH
 
 .feature-branches:
   except:


### PR DESCRIPTION
## Motivation

BrowserStack resources are limited and valuable. When syncing the v7 (next major) branch with `main`, we don't want every sync to consume these precious BrowserStack slots. Unit tests and E2E tests still run on the next major branch, providing a sufficient level of safety without burning BrowserStack capacity on routine syncs.

## Changes

- Updated `.gitlab-ci.yml` to exclude the `NEXT_MAJOR_BRANCH` variable from the BrowserStack test pipeline by adding a variables condition to the existing exclusion rules.

## Test instructions

Verify that the GitLab CI pipeline on the next major branch no longer triggers BrowserStack tests. Unit and E2E tests should still run normally.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file