### PR TITLE
👷 use dynamic port for dev server to avoid conflicts

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title>Sandbox</title>
-    <script src="http://localhost:8080/datadog-rum.js"></script>
-    <script src="http://localhost:8080/datadog-logs.js"></script>
-    <script src="http://localhost:8080/datadog-flagging.js"></script>
+    <script src="/datadog-rum.js"></script>
+    <script src="/datadog-logs.js"></script>
+    <script src="/datadog-flagging.js"></script>
     <script>
       DD_RUM.init({
         clientToken: 'xxx',

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,3 +1,4 @@
+import type { AddressInfo } from 'node:net'
 import express from 'express'
 import middleware from 'webpack-dev-middleware'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
@@ -7,7 +8,8 @@ import webpackBase from '../webpack.base.ts'
 import { printLog, runMain } from './lib/executionUtils.ts'
 
 const sandboxPath = './sandbox'
-const port = 8080
+const START_PORT = 8080
+const MAX_PORT = 8180
 
 const PACKAGES_WITH_BUNDLE = ['rum', 'rum-slim', 'logs', 'flagging', 'worker']
 
@@ -19,8 +21,21 @@ runMain(() => {
   })
   app.use(createStaticSandboxApp())
   app.use('/react-app', createReactApp())
-  app.listen(port, () => printLog(`Server listening on port ${port}.`))
+  listenOnAvailablePort(app, START_PORT)
 })
+
+function listenOnAvailablePort(app: express.Application, port: number): void {
+  const server = app.listen(port)
+  server.on('listening', () => printLog(`Server listening on port ${(server.address() as AddressInfo).port}.`))
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE' && port < MAX_PORT) {
+      printLog(`Port ${port} is already in use, trying ${port + 1}...`)
+      server.close(() => listenOnAvailablePort(app, port + 1))
+    } else {
+      throw err
+    }
+  })
+}
 
 function createStaticSandboxApp(): express.Application {
   const app = express()

--- a/test/e2e/lib/helpers/playwright.ts
+++ b/test/e2e/lib/helpers/playwright.ts
@@ -3,7 +3,7 @@ import type { BrowserConfiguration } from '../../../browsers.conf'
 import { getBuildInfos } from '../../../envUtils.ts'
 import packageJson from '../../../../package.json' with { type: 'json' }
 
-export const DEV_SERVER_BASE_URL = 'http://localhost:8080'
+export const DEV_SERVER_BASE_URL = `http://localhost:${process.env.DEV_SERVER_PORT}`
 
 export function getPlaywrightConfigBrowserName(name: string): PlaywrightWorkerOptions['browserName'] {
   if (name.includes('firefox')) {

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import type { ReporterDescription, Config } from '@playwright/test'
 import { getTestReportDirectory } from '../envUtils'
-import { DEV_SERVER_BASE_URL } from './lib/helpers/playwright'
 
 const isCi = !!process.env.CI
 const isLocal = !isCi
@@ -36,8 +35,9 @@ export const config: Config = {
         stdout: 'pipe',
         cwd: path.join(__dirname, '../..'),
         command: 'yarn dev',
-        url: DEV_SERVER_BASE_URL,
-        reuseExistingServer: true,
+        wait: {
+          stdout: /Server listening on port (?<dev_server_port>\d+)/,
+        },
       }
     : undefined,
 }


### PR DESCRIPTION
## Motivation

When using multiple git worktrees (e.g. for parallel AI-assisted workflows), each worktree needs its own dev server instance. With a hardcoded port, only one can run at a time — the others fail to start and the e2e will run against the existing dev server that might not have the correct changes. 

This change makes the dev server automatically pick an available port in the 8080-8180 range so multiple instances can coexist without conflicts.

## Changes

- Dev server now tries ports 8080–8180 and binds to the first available one
- Sandbox `<script>` src paths updated to relative URLs (no longer hardcoded to `localhost:8080`)
- Playwright config waits for the server's startup log to capture the actual port dynamically

## Known limitations

The developer extension still has hardcoded `http://localhost:8080` constants (`developer-extension/src/common/packagesUrlConstants.ts`). The right fix is more involved — the extension should either **discover running dev server instances** by probing the port range, or allow the user to **configure which port to connect to**. Left for a follow-up.

## Test instructions

1. Start `yarn dev` in two worktrees simultaneously
2. Confirm each binds to a different port
4. Run `yarn test:e2e` to confirm E2E tests connect to the correct server

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file