### PR TITLE
🐛 [RUM Profiler] Fix long tasks query using wrong clock for duration computation

### DIFF
--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -860,6 +860,58 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('stopped')
   })
 
+  it('should not include long tasks outside the profiling window when clocks drift', async () => {
+    const clock = mockClock()
+    const timeOrigin = performance.timing.navigationStart
+    const { profiler, addLongTask } = setupProfiler()
+
+    profiler.start()
+    expect(profiler.isRunning()).toBe(true)
+
+    // Add a long task at T=100ms (inside the profile window)
+    clock.tick(100)
+    addLongTask({
+      id: 'long-task-inside',
+      startClocks: clocksNow(),
+      duration: 50 as Duration,
+      entryType: RumPerformanceEntryType.LONG_ANIMATION_FRAME,
+    })
+
+    // Add a long task at T=1000ms (outside the actual profile relative window)
+    clock.tick(900)
+    addLongTask({
+      id: 'long-task-outside',
+      startClocks: clocksNow(),
+      duration: 50 as Duration,
+      entryType: RumPerformanceEntryType.LONG_ANIMATION_FRAME,
+    })
+
+    // Advance to T=1100ms
+    clock.tick(100)
+
+    // Simulate clock drift: Date.now() drifted 1000ms ahead of performance.now()
+    // This mimics NTP sync or system clock adjustments in production
+    ;(performance.now as jasmine.Spy).and.callFake(() => Date.now() - timeOrigin - 1000)
+
+    // Stop profiler — state changes synchronously, data collection is async via Promise
+    profiler.stop()
+    expect(profiler.isStopped()).toBe(true)
+
+    // Flush microtasks for profiler.stop() Promise and transport.send()
+    await waitNextMicrotask()
+    await waitNextMicrotask()
+
+    expect(interceptor.requests.length).toBe(1)
+    const request = await readFormDataRequest<ProfileEventPayload>(interceptor.requests[0])
+    const trace = request['wall-time.json']
+
+    // Should only include the long task that occurred during the actual profiling window.
+    // Without the fix (using timeStamp for duration), both long tasks would be included
+    // because the inflated timeStamp-based duration extends the query window.
+    expect(trace.longTasks.length).toBe(1)
+    expect(trace.longTasks[0].id).toBe('long-task-inside')
+  })
+
   it('should restart profiling when session expires while paused and then renews', async () => {
     const { profiler, profilingContextManager } = setupProfiler()
 

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -234,7 +234,7 @@ export function createRumProfiler(
       .stop()
       .then((trace) => {
         const endClocks = clocksNow()
-        const duration = elapsed(startClocks.timeStamp, endClocks.timeStamp)
+        const duration = elapsed(startClocks.relative, endClocks.relative)
         const longTasks = longTaskHistory.findAll(startClocks.relative, duration)
         const actions = actionHistory.findAll(startClocks.relative, duration)
         const vitals = vitalHistory.findAll(startClocks.relative, duration)


### PR DESCRIPTION
## Motivation

Profiles were sometimes sent with long tasks that did not actually occur during the profiling window. This was caused by a clock mismatch: the duration used to query the long task history was computed from `TimeStamp` (`Date.now()`), while the query start parameter used `RelativeTime` (`performance.now()`).

`Date.now()` can drift relative to `performance.now()` due to NTP sync, system clock adjustments, or sleep/wake cycles. When `Date.now()` jumps forward, the computed duration is inflated, extending the query window and pulling in unrelated long tasks.

## Changes

- Use `elapsed(startClocks.relative, endClocks.relative)` instead of `elapsed(startClocks.timeStamp, endClocks.timeStamp)` in `collectProfilerInstance`, so the duration is consistent with the `RelativeTime`-based `findAll` query.
- Add a unit test that simulates clock drift between `Date.now()` and `performance.now()` and verifies that only long tasks within the actual profiling window are included.

## Test instructions

Run profiler unit tests:
```bash
yarn test:unit --spec packages/rum/src/domain/profiling/profiler.spec.ts
```

To verify the fix, revert the one-line change in `profiler.ts` (switch back to `startClocks.timeStamp, endClocks.timeStamp`) and observe the new test failing with `Expected 2 to be 1`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file