### PR TITLE
🐛 Compute duration from timestamps in event tracker

### DIFF
--- a/packages/rum-core/src/domain/eventTracker.spec.ts
+++ b/packages/rum-core/src/domain/eventTracker.spec.ts
@@ -85,6 +85,17 @@ describe('eventTracker', () => {
         })
       )
     })
+
+    it('should compute duration from timestamps, not relative times', () => {
+      const startClocks = { relative: 100 as RelativeTime, timeStamp: 1000 as TimeStamp }
+      tracker.start('key1', startClocks, { value: 'data1' })
+
+      const endClocks = { relative: 300 as RelativeTime, timeStamp: 1050 as TimeStamp }
+
+      const stopped = tracker.stop('key1', endClocks)
+
+      expect(stopped?.duration).toBe(50 as Duration)
+    })
   })
 
   describe('findId', () => {

--- a/packages/rum-core/src/domain/eventTracker.ts
+++ b/packages/rum-core/src/domain/eventTracker.ts
@@ -103,7 +103,7 @@ export function startEventTracker<TData>(lifeCycle: LifeCycle): EventTracker<TDa
 
     event.historyEntry.close(stopClocks.relative)
 
-    const duration = elapsed(event.startClocks.relative, stopClocks.relative)
+    const duration = elapsed(event.startClocks.timeStamp, stopClocks.timeStamp)
 
     const counts = event.eventCounts?.eventCounts
 


### PR DESCRIPTION
## Motivation

This https://github.com/DataDog/browser-sdk/pull/4038 changed action duration from:
duration: activityEndTime && elapsed(startClocks.timeStamp, activityEndTime), to
duration = elapsed(startClocks.relative, endTime).

We fixed it [in](https://github.com/DataDog/browser-sdk/pull/4177) but did not apply this fix when we merged [start-stop Resources](https://github.com/DataDog/browser-sdk/pull/4110) which removed that file.  

## Changes

Change `eventTracker` `stop()` to accept ClocksState instead of RelativeTime, compute duration using timestamps.

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [X] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
