### PR TITLE
♻️ Extract buildSiteHost from buildEndpointHost in browser-core

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -1,6 +1,6 @@
 import type { Payload } from '../../transport'
 import type { InitConfiguration } from './configuration'
-import { createEndpointBuilder } from './endpointBuilder'
+import { buildSiteHost, createEndpointBuilder } from './endpointBuilder'
 
 const DEFAULT_PAYLOAD = {} as Payload
 
@@ -169,5 +169,27 @@ describe('endpointBuilder', () => {
       const endpoint = createEndpointBuilder(config, 'rum').build('fetch', DEFAULT_PAYLOAD)
       expect(endpoint).toContain('ddsource=unity')
     })
+  })
+})
+
+describe('buildSiteHost', () => {
+  it('should return default US1 host when no site provided', () => {
+    expect(buildSiteHost()).toBe('browser-intake-datadoghq.com')
+  })
+
+  it('should return US1 host for datadoghq.com', () => {
+    expect(buildSiteHost('datadoghq.com')).toBe('browser-intake-datadoghq.com')
+  })
+
+  it('should return EU host for datadoghq.eu', () => {
+    expect(buildSiteHost('datadoghq.eu')).toBe('browser-intake-datadoghq.eu')
+  })
+
+  it('should return fed staging host', () => {
+    expect(buildSiteHost('dd0g-gov.com')).toBe('http-intake.logs.dd0g-gov.com')
+  })
+
+  it('should handle multi-part domains', () => {
+    expect(buildSiteHost('us3.datadoghq.com')).toBe('browser-intake-us3-datadoghq.com')
   })
 })

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -56,6 +56,20 @@ function createEndpointUrlWithParametersBuilder(
   return (parameters) => `https://${host}${path}?${parameters}`
 }
 
+/**
+ * Convert a Datadog site to its intake host domain.
+ * For use by packages that only need site-based host resolution without full InitConfiguration.
+ */
+export function buildSiteHost(site: string = INTAKE_SITE_US1): string {
+  if (site === INTAKE_SITE_FED_STAGING) {
+    return `http-intake.logs.${site}`
+  }
+
+  const domainParts = site.split('.')
+  const extension = domainParts.pop()
+  return `browser-intake-${domainParts.join('-')}.${extension!}`
+}
+
 export function buildEndpointHost(
   trackType: TrackType,
   initConfiguration: InitConfiguration & { usePciIntake?: boolean }
@@ -70,13 +84,7 @@ export function buildEndpointHost(
     return `${internalAnalyticsSubdomain}.${INTAKE_SITE_US1}`
   }
 
-  if (site === INTAKE_SITE_FED_STAGING) {
-    return `http-intake.logs.${site}`
-  }
-
-  const domainParts = site.split('.')
-  const extension = domainParts.pop()
-  return `browser-intake-${domainParts.join('-')}.${extension!}`
+  return buildSiteHost(site)
 }
 
 /**

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -7,5 +7,5 @@ export {
   serializeConfiguration,
 } from './configuration'
 export type { EndpointBuilder, TrackType } from './endpointBuilder'
-export { createEndpointBuilder, buildEndpointHost } from './endpointBuilder'
+export { createEndpointBuilder, buildEndpointHost, buildSiteHost } from './endpointBuilder'
 export { computeTransportConfiguration, isIntakeUrl } from './transportConfiguration'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export {
   serializeConfiguration,
   isSampleRate,
   buildEndpointHost,
+  buildSiteHost,
   isIntakeUrl,
 } from './domain/configuration'
 export * from './domain/intakeSites'

--- a/packages/rum-vue/package.json
+++ b/packages/rum-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-vue",
-  "version": "6.30.1",
+  "version": "6.31.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -10,8 +10,8 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.30.1",
-    "@datadog/browser-rum-core": "6.30.1"
+    "@datadog/browser-core": "6.31.0",
+    "@datadog/browser-rum-core": "6.31.0"
   },
   "peerDependencies": {
     "vue": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,13 +270,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:6.30.1":
-  version: 6.30.1
-  resolution: "@datadog/browser-core@npm:6.30.1"
-  checksum: 10c0/3a17ddcfbc1d8321941f8119958e8e050f83eb9f7bc7895c30e6e73d33f66fd50e1194756e0dc10830e59721a1fd7829e57e236c73588471d413596566e1f2c4
-  languageName: node
-  linkType: hard
-
 "@datadog/browser-core@npm:6.31.0, @datadog/browser-core@workspace:*, @datadog/browser-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-core@workspace:packages/core"
@@ -298,15 +291,6 @@ __metadata:
       optional: true
   languageName: unknown
   linkType: soft
-
-"@datadog/browser-rum-core@npm:6.30.1":
-  version: 6.30.1
-  resolution: "@datadog/browser-rum-core@npm:6.30.1"
-  dependencies:
-    "@datadog/browser-core": "npm:6.30.1"
-  checksum: 10c0/c26fec4859856b287c90ce3eb631f6b2703869d2fdf2119df5b33a3a3abf4016147de3ba7a95fa0973bd322b2b0655e4ca7310ff91461583536d8665186d37b7
-  languageName: node
-  linkType: hard
 
 "@datadog/browser-rum-core@npm:6.31.0, @datadog/browser-rum-core@workspace:*, @datadog/browser-rum-core@workspace:packages/rum-core":
   version: 0.0.0-use.local
@@ -386,8 +370,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-vue@workspace:packages/rum-vue"
   dependencies:
-    "@datadog/browser-core": "npm:6.30.1"
-    "@datadog/browser-rum-core": "npm:6.30.1"
+    "@datadog/browser-core": "npm:6.31.0"
+    "@datadog/browser-rum-core": "npm:6.31.0"
     "@vue/test-utils": "npm:2.4.6"
     vue: "npm:3.5.29"
     vue-router: "npm:4.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@datadog/browser-core@npm:6.30.1":
+  version: 6.30.1
+  resolution: "@datadog/browser-core@npm:6.30.1"
+  checksum: 10c0/3a17ddcfbc1d8321941f8119958e8e050f83eb9f7bc7895c30e6e73d33f66fd50e1194756e0dc10830e59721a1fd7829e57e236c73588471d413596566e1f2c4
+  languageName: node
+  linkType: hard
+
 "@datadog/browser-core@npm:6.31.0, @datadog/browser-core@workspace:*, @datadog/browser-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-core@workspace:packages/core"
@@ -291,6 +298,15 @@ __metadata:
       optional: true
   languageName: unknown
   linkType: soft
+
+"@datadog/browser-rum-core@npm:6.30.1":
+  version: 6.30.1
+  resolution: "@datadog/browser-rum-core@npm:6.30.1"
+  dependencies:
+    "@datadog/browser-core": "npm:6.30.1"
+  checksum: 10c0/c26fec4859856b287c90ce3eb631f6b2703869d2fdf2119df5b33a3a3abf4016147de3ba7a95fa0973bd322b2b0655e4ca7310ff91461583536d8665186d37b7
+  languageName: node
+  linkType: hard
 
 "@datadog/browser-rum-core@npm:6.31.0, @datadog/browser-rum-core@workspace:*, @datadog/browser-rum-core@workspace:packages/rum-core":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Motivation

Downstream packages (`@datadog/browser-remote-config`, `@datadog/browser-sdk-endpoint`) need to resolve a Datadog site string to its CDN host without depending on the full `InitConfiguration` type. Previously this required a type-assertion hack.

## Changes

- Extract `buildSiteHost(site?)` from `buildEndpointHost` in `packages/core`
- `buildEndpointHost` delegates to `buildSiteHost` for the common case — no behavior change
- Export `buildSiteHost` from the core package public API

## Testing

```bash
yarn test:unit --spec packages/core/src/domain/configuration/endpointBuilder.spec.ts
yarn typecheck
```

---
> Part of SSI Phase 6 stacked PRs. Next: `@datadog/browser-remote-config` standalone package.