### PR TITLE
✨ Add @datadog/browser-remote-config standalone package

### DIFF
--- a/eslint-local-rules/disallowSideEffects.ts
+++ b/eslint-local-rules/disallowSideEffects.ts
@@ -41,6 +41,7 @@ const pathsWithSideEffect = new Set([
   `${packagesRoot}/rum/src/entries/main.ts`,
   `${packagesRoot}/rum-slim/src/entries/main.ts`,
   `${packagesRoot}/debugger/src/entries/main.ts`,
+  `${packagesRoot}/remote-config/src/entries/main.ts`,
 ])
 
 // Those packages are known to have no side effects when evaluated

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -56,6 +56,9 @@ export default defineConfig(
       'developer-extension/.wxt',
       'developer-extension/dist',
       '.claude/worktrees',
+      'developer-extension/.output',
+      // Auto-generated file — do not lint
+      'packages/rum/src/types/profiling.ts',
     ],
   },
 
@@ -399,6 +402,7 @@ export default defineConfig(
           selector: 'TSEnumDeclaration:not([const=true])',
           message: 'When possible, use `const enum` as it produces less code when transpiled.',
         },
+
         {
           selector: 'TSModuleDeclaration[kind=global]',
           message: 'Never declare global types as it will leak to the user app global scope.',

--- a/packages/remote-config/.npmignore
+++ b/packages/remote-config/.npmignore
@@ -1,0 +1,6 @@
+*
+!/cjs/**/*
+!/esm/**/*
+!/src/**/*
+/src/**/*.spec.ts
+/src/**/*.specHelper.ts

--- a/packages/remote-config/LICENSE
+++ b/packages/remote-config/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019-Present Datadog, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/remote-config/README.md
+++ b/packages/remote-config/README.md
@@ -1,0 +1,209 @@
+# @datadog/browser-remote-config
+
+Lightweight package for fetching and parsing Datadog Remote Configuration for the Browser RUM SDK.
+
+## Overview
+
+This package provides utilities to fetch and parse remote configurations from Datadog, allowing you to manage RUM SDK settings remotely without needing to redeploy your application.
+
+## Installation
+
+```bash
+npm install @datadog/browser-remote-config
+```
+
+## Usage
+
+### Basic Example
+
+```typescript
+import { fetchRemoteConfiguration } from '@datadog/browser-remote-config'
+
+const result = await fetchRemoteConfiguration({
+  applicationId: 'your-app-id',
+  remoteConfigurationId: 'your-remote-config-id',
+})
+
+if (result.ok) {
+  console.log('Remote config loaded:', result.value)
+  // Use result.value to configure your SDK
+} else {
+  console.error('Failed to load remote config:', result.error)
+}
+```
+
+### Integration with Datadog RUM
+
+```typescript
+import { fetchRemoteConfiguration } from '@datadog/browser-remote-config'
+import { datadogRum } from '@datadog/browser-rum'
+
+// Fetch remote configuration
+const remoteConfigResult = await fetchRemoteConfiguration({
+  applicationId: 'your-app-id',
+  remoteConfigurationId: 'your-remote-config-id',
+})
+
+// Merge with local configuration
+const config = {
+  applicationId: 'your-app-id',
+  clientToken: 'your-client-token',
+  site: 'datadoghq.com',
+  // ... other config options
+}
+
+if (remoteConfigResult.ok && remoteConfigResult.value?.rum) {
+  // Merge remote configuration fields
+  Object.assign(config, remoteConfigResult.value.rum)
+}
+
+// Initialize SDK with merged configuration
+datadogRum.init(config)
+datadogRum.startSessionReplayRecording()
+```
+
+### Using Custom Proxy
+
+If you need to route requests through a custom proxy:
+
+```typescript
+const result = await fetchRemoteConfiguration({
+  applicationId: 'your-app-id',
+  remoteConfigurationId: 'your-remote-config-id',
+  remoteConfigurationProxy: 'https://your-proxy.com/config',
+})
+```
+
+## API Reference
+
+### `fetchRemoteConfiguration(options)`
+
+Fetches remote configuration from Datadog servers.
+
+**Parameters:**
+
+- `applicationId` (string): Your Datadog application ID
+- `remoteConfigurationId` (string): The ID of the remote configuration
+- `remoteConfigurationProxy` (string, optional): Custom proxy URL
+- `site` (string, optional): Datadog site ('datadoghq.com', 'datadoghq.eu', etc.)
+
+**Returns:** Promise<RemoteConfigResult>
+
+```typescript
+type RemoteConfigResult = { ok: true; value: RumRemoteConfiguration } | { ok: false; error: Error }
+```
+
+### `buildEndpoint(options)`
+
+Constructs the endpoint URL for remote configuration fetch.
+
+**Parameters:**
+
+- Same as `fetchRemoteConfiguration`
+
+**Returns:** string (the endpoint URL)
+
+### `resolveDynamicValues(configValue, options)`
+
+Advanced function to resolve dynamic configuration values (cookies, DOM selectors, JS paths).
+
+Used internally for processing remote configuration with dynamic sources.
+
+## Remote Configuration Format
+
+Remote configurations support static values and dynamic sources:
+
+### Static Values
+
+```json
+{
+  "rum": {
+    "sessionSampleRate": 100,
+    "env": "production"
+  }
+}
+```
+
+### Dynamic Values from Cookies
+
+```json
+{
+  "rum": {
+    "version": {
+      "rcSerializedType": "dynamic",
+      "strategy": "cookie",
+      "name": "app_version"
+    }
+  }
+}
+```
+
+### Dynamic Values from DOM
+
+```json
+{
+  "rum": {
+    "env": {
+      "rcSerializedType": "dynamic",
+      "strategy": "dom",
+      "selector": "[data-env]",
+      "attribute": "data-env"
+    }
+  }
+}
+```
+
+### Dynamic Values from JavaScript
+
+```json
+{
+  "rum": {
+    "version": {
+      "rcSerializedType": "dynamic",
+      "strategy": "js",
+      "path": "window.APP.version"
+    }
+  }
+}
+```
+
+### Value Extraction with Regex
+
+```json
+{
+  "rum": {
+    "version": {
+      "rcSerializedType": "dynamic",
+      "strategy": "cookie",
+      "name": "version_string",
+      "extractor": {
+        "rcSerializedType": "regex",
+        "value": "v(\\d+\\.\\d+\\.\\d+)"
+      }
+    }
+  }
+}
+```
+
+## Supported Configuration Fields
+
+The following fields can be set via remote configuration:
+
+- `applicationId` - The RUM application ID
+- `service` - Service name
+- `env` - Environment
+- `version` - Version (supports dynamic resolution)
+- `sessionSampleRate` - Session sample rate (0-100)
+- `sessionReplaySampleRate` - Session replay sample rate (0-100)
+- `defaultPrivacyLevel` - Default privacy level for session replay
+- `enablePrivacyForActionName` - Enable privacy for action names
+- `traceSampleRate` - Trace sample rate (0-100)
+- `trackSessionAcrossSubdomains` - Track sessions across subdomains
+- `allowedTracingUrls` - URLs where tracing is allowed
+- `allowedTrackingOrigins` - Origins where tracking is allowed
+- `user` - User context (supports dynamic resolution)
+- `context` - Global context (supports dynamic resolution)
+
+## License
+
+Apache 2.0

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@datadog/browser-remote-config",
+  "version": "7.2.0",
+  "license": "Apache-2.0",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "cjs/index.d.ts",
+  "files": [
+    "cjs",
+    "esm",
+    "src",
+    "!src/**/*.spec.ts",
+    "!src/**/*.specHelper.ts"
+  ],
+  "scripts": {
+    "build": "node ../../scripts/build/build-package.ts --modules"
+  },
+  "dependencies": {
+    "@datadog/browser-core": "7.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DataDog/browser-sdk.git",
+    "directory": "packages/remote-config"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/remote-config/src/entries/main.ts
+++ b/packages/remote-config/src/entries/main.ts
@@ -1,0 +1,33 @@
+import { defineGlobal, globalObject } from '@datadog/browser-core'
+import {
+  fetchRemoteConfiguration,
+  buildEndpoint,
+  resolveDynamicValues,
+  browserContextItemHandler,
+} from '../remoteConfiguration'
+
+function resolveDynamicValuesForBrowser(
+  configValue: unknown,
+  options: {
+    onCookie?: (value: string | undefined) => void
+    onDom?: (value: string | null | undefined) => void
+    onJs?: (value: unknown) => void
+  } = {}
+): unknown {
+  return resolveDynamicValues(configValue, {
+    ...options,
+    contextItemHandler: browserContextItemHandler,
+  })
+}
+
+const ddRemoteConfig = {
+  fetchRemoteConfiguration,
+  buildEndpoint,
+  resolveDynamicValues: resolveDynamicValuesForBrowser,
+}
+
+interface BrowserWindow {
+  DD_REMOTE_CONFIG?: typeof ddRemoteConfig
+}
+
+defineGlobal(globalObject as BrowserWindow, 'DD_REMOTE_CONFIG', ddRemoteConfig)

--- a/packages/remote-config/src/index.ts
+++ b/packages/remote-config/src/index.ts
@@ -1,0 +1,10 @@
+export { fetchRemoteConfiguration, buildEndpoint, resolveDynamicValues } from './remoteConfiguration'
+export type { RemoteConfiguration, RumRemoteConfiguration, RemoteConfigResult } from './remoteConfiguration'
+export { parseJsonPath } from './jsonPathParser'
+export type {
+  RumSdkConfig,
+  DynamicOption,
+  SerializedRegex,
+  MatchOption,
+  ContextItem,
+} from './remoteConfiguration.types'

--- a/packages/remote-config/src/jsonPathParser.spec.ts
+++ b/packages/remote-config/src/jsonPathParser.spec.ts
@@ -1,0 +1,172 @@
+import { parseJsonPath } from './jsonPathParser'
+
+describe('jsonPathParser', () => {
+  describe('parseJsonPath', () => {
+    describe('valid paths', () => {
+      it('should parse simple dot notation', () => {
+        expect(parseJsonPath('foo')).toEqual(['foo'])
+        expect(parseJsonPath('foo.bar')).toEqual(['foo', 'bar'])
+        expect(parseJsonPath('foo.bar.baz')).toEqual(['foo', 'bar', 'baz'])
+      })
+
+      it('should parse bracket notation with string keys', () => {
+        expect(parseJsonPath("['foo']")).toEqual(['foo'])
+        expect(parseJsonPath('["foo"]')).toEqual(['foo'])
+        expect(parseJsonPath("['foo']['bar']")).toEqual(['foo', 'bar'])
+        expect(parseJsonPath('["foo"]["bar"]')).toEqual(['foo', 'bar'])
+      })
+
+      it('should parse bracket notation with numeric indices', () => {
+        expect(parseJsonPath('[0]')).toEqual(['0'])
+        expect(parseJsonPath('[42]')).toEqual(['42'])
+        expect(parseJsonPath('[0][1][2]')).toEqual(['0', '1', '2'])
+      })
+
+      it('should parse mixed dot and bracket notation', () => {
+        expect(parseJsonPath("foo['bar']")).toEqual(['foo', 'bar'])
+        expect(parseJsonPath("foo.bar['baz']")).toEqual(['foo', 'bar', 'baz'])
+        expect(parseJsonPath("['foo'].bar")).toEqual(['foo', 'bar'])
+        expect(parseJsonPath("foo['bar'].baz[0]")).toEqual(['foo', 'bar', 'baz', '0'])
+      })
+
+      it('should parse paths starting with bracket notation', () => {
+        expect(parseJsonPath("['foo']")).toEqual(['foo'])
+        expect(parseJsonPath("['foo'].bar")).toEqual(['foo', 'bar'])
+        expect(parseJsonPath('[0].foo')).toEqual(['0', 'foo'])
+      })
+
+      it('should handle identifiers with special characters', () => {
+        expect(parseJsonPath('_foo')).toEqual(['_foo'])
+        expect(parseJsonPath('$foo')).toEqual(['$foo'])
+        expect(parseJsonPath('foo_bar')).toEqual(['foo_bar'])
+        expect(parseJsonPath('foo$bar')).toEqual(['foo$bar'])
+        expect(parseJsonPath('foo123')).toEqual(['foo123'])
+      })
+
+      it('should handle escaped characters in bracket notation', () => {
+        expect(parseJsonPath("['foo\\'bar']")).toEqual(["foo'bar"])
+        expect(parseJsonPath('["foo\\"bar"]')).toEqual(['foo"bar'])
+        expect(parseJsonPath("['foo\\\\bar']")).toEqual(['foo\\bar'])
+        expect(parseJsonPath("['foo\\nbar']")).toEqual(['foo\nbar'])
+        expect(parseJsonPath("['foo\\tbar']")).toEqual(['foo\tbar'])
+      })
+
+      it('should handle Unicode escape sequences', () => {
+        expect(parseJsonPath("['foo\\u0041bar']")).toEqual(['fooAbar'])
+        expect(parseJsonPath("['\\u0042\\u0043']")).toEqual(['BC'])
+      })
+
+      it('should handle single and double quotes interchangeably', () => {
+        expect(parseJsonPath("['foo']")).toEqual(['foo'])
+        expect(parseJsonPath('["foo"]')).toEqual(['foo'])
+        expect(parseJsonPath("['foo']['bar']")).toEqual(['foo', 'bar'])
+        expect(parseJsonPath('["foo"]["bar"]')).toEqual(['foo', 'bar'])
+        expect(parseJsonPath('[\'foo\']["bar"]')).toEqual(['foo', 'bar'])
+      })
+
+      it('should parse complex real-world-like paths', () => {
+        expect(parseJsonPath('window.APP.version')).toEqual(['window', 'APP', 'version'])
+        expect(parseJsonPath("window['APP'].settings['debug-mode']")).toEqual([
+          'window',
+          'APP',
+          'settings',
+          'debug-mode',
+        ])
+        expect(parseJsonPath('data.users[0].name')).toEqual(['data', 'users', '0', 'name'])
+      })
+    })
+
+    describe('invalid paths', () => {
+      it('should return empty array for unclosed bracket', () => {
+        expect(parseJsonPath("['foo")).toEqual([])
+        expect(parseJsonPath("foo['bar")).toEqual([])
+      })
+
+      it('should return empty array for unclosed quote', () => {
+        expect(parseJsonPath("['foo")).toEqual([])
+      })
+
+      it('should return empty array for invalid syntax', () => {
+        expect(parseJsonPath('foo.')).toEqual([])
+        expect(parseJsonPath('foo..')).toEqual([])
+        expect(parseJsonPath('.foo')).toEqual([])
+      })
+
+      it('should return empty array for invalid escape sequences', () => {
+        expect(parseJsonPath("['foo\\xbar']")).toEqual([])
+      })
+
+      it('should return empty array for mismatched quotes', () => {
+        expect(parseJsonPath('[\'foo"]')).toEqual([])
+        expect(parseJsonPath('["foo\']')).toEqual([])
+      })
+
+      it('should return empty array for invalid bracket combinations', () => {
+        expect(parseJsonPath('foo]]')).toEqual([])
+        expect(parseJsonPath('foo[[')).toEqual([])
+      })
+
+      it('should return empty array for trailing dots', () => {
+        expect(parseJsonPath('foo.bar.')).toEqual([])
+      })
+
+      it('should return empty array for invalid numeric indices', () => {
+        expect(parseJsonPath('foo[bar]')).toEqual([])
+      })
+    })
+
+    describe('edge cases', () => {
+      it('should handle empty string', () => {
+        expect(parseJsonPath('')).toEqual([])
+      })
+
+      it('should handle very long paths', () => {
+        const path = 'a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p'
+        const result = parseJsonPath(path)
+        expect(result.length).toBe(16)
+        expect(result[0]).toBe('a')
+        expect(result[15]).toBe('p')
+      })
+
+      it('should handle many array indices', () => {
+        const path = '[0][1][2][3][4][5]'
+        expect(parseJsonPath(path)).toEqual(['0', '1', '2', '3', '4', '5'])
+      })
+
+      it('should handle keys with numbers', () => {
+        expect(parseJsonPath('foo123')).toEqual(['foo123'])
+        expect(parseJsonPath('foo123.bar456')).toEqual(['foo123', 'bar456'])
+      })
+
+      it('should handle underscores and dollar signs', () => {
+        expect(parseJsonPath('_foo$bar')).toEqual(['_foo$bar'])
+        expect(parseJsonPath('$window')).toEqual(['$window'])
+        expect(parseJsonPath('_private')).toEqual(['_private'])
+      })
+    })
+
+    describe('special characters in keys', () => {
+      it('should handle keys with hyphens', () => {
+        expect(parseJsonPath("['foo-bar']")).toEqual(['foo-bar'])
+        expect(parseJsonPath("['data-version']")).toEqual(['data-version'])
+      })
+
+      it('should handle keys with spaces', () => {
+        expect(parseJsonPath("['foo bar']")).toEqual(['foo bar'])
+        expect(parseJsonPath('["my key"]')).toEqual(['my key'])
+      })
+
+      it('should handle keys with special symbols', () => {
+        expect(parseJsonPath("['foo@bar']")).toEqual(['foo@bar'])
+        expect(parseJsonPath("['foo#bar']")).toEqual(['foo#bar'])
+        expect(parseJsonPath("['foo.bar']")).toEqual(['foo.bar'])
+      })
+
+      it('should handle empty keys', () => {
+        // Empty keys are invalid in the parser
+        expect(parseJsonPath("['']")).toEqual([])
+        expect(parseJsonPath('[""]')).toEqual([])
+      })
+    })
+  })
+})

--- a/packages/remote-config/src/jsonPathParser.ts
+++ b/packages/remote-config/src/jsonPathParser.ts
@@ -1,0 +1,214 @@
+/**
+ * Terminology inspired from https://www.rfc-editor.org/rfc/rfc9535.html
+ *
+ * jsonpath-query      = segment*
+ * segment             = .name-shorthand / bracketed-selection
+ * bracketed-selection = ['name-selector'] / ["name-selector"] / [index-selector]
+ *
+ * Useful references:
+ * - https://goessner.net/articles/JsonPath/
+ * - https://jsonpath.com/
+ * - https://github.com/jsonpath-standard
+ */
+
+interface ParsingContext {
+  quote: string | undefined
+  escapeSequence: string | undefined
+}
+
+/**
+ * Extract selectors from a simple JSON path expression, return [] for an invalid path
+ *
+ * Supports:
+ * - Dot notation: `foo.bar.baz`
+ * - Bracket notation: `['foo']["bar"]`
+ * - Array indices: `items[0]`, `data['users'][1]`
+ *
+ * Examples:
+ * parseJsonPath("['foo'].bar[12]")
+ * => ['foo', 'bar', '12']
+ *
+ * parseJsonPath("['foo")
+ * => []
+ */
+export function parseJsonPath(path: string): string[] {
+  const selectors: string[] = []
+  let previousToken = Token.START
+  let currentToken: Token | undefined
+  const parsingContext: ParsingContext = { quote: undefined, escapeSequence: undefined }
+  let currentSelector = ''
+  for (const char of path) {
+    // find which kind of token is this char
+    currentToken = ALLOWED_NEXT_TOKENS[previousToken].find((token) => TOKEN_PREDICATE[token](char, parsingContext))
+    if (!currentToken) {
+      return []
+    }
+    if (parsingContext.escapeSequence !== undefined && currentToken !== Token.ESCAPE_SEQUENCE_CHAR) {
+      if (!isValidEscapeSequence(parsingContext.escapeSequence)) {
+        return []
+      }
+      currentSelector += resolveEscapeSequence(parsingContext.escapeSequence)
+      parsingContext.escapeSequence = undefined
+    }
+    if (ALLOWED_SELECTOR_TOKENS.includes(currentToken)) {
+      // buffer the char if it belongs to the selector
+      // ex: foo['bar']
+      //      ^    ^
+      currentSelector += char
+    } else if (ALLOWED_SELECTOR_DELIMITER_TOKENS.includes(currentToken) && currentSelector !== '') {
+      // close the current path part if we have reach a path part delimiter
+      // ex: foo.bar['qux']
+      //        ^   ^     ^
+      selectors.push(currentSelector)
+      currentSelector = ''
+    } else if (currentToken === Token.ESCAPE_SEQUENCE_CHAR) {
+      parsingContext.escapeSequence = parsingContext.escapeSequence ? `${parsingContext.escapeSequence}${char}` : char
+    } else if (currentToken === Token.QUOTE_START) {
+      parsingContext.quote = char
+    } else if (currentToken === Token.QUOTE_END) {
+      parsingContext.quote = undefined
+    }
+    previousToken = currentToken
+  }
+  if (!ALLOWED_NEXT_TOKENS[previousToken].includes(Token.END)) {
+    return []
+  }
+  if (currentSelector !== '') {
+    selectors.push(currentSelector)
+  }
+  return selectors
+}
+
+/**
+ * List of all tokens in the path
+ *
+ * @example                        foo.bar['qu\'x'][0]
+ *                                |   |   |        |  |
+ * Token sequence:                |   |   |        |  |
+ * 1. START (before first char) <-+   |   |        |  |
+ * 2. NAME_SHORTHAND_FIRST_CHAR: f    |   |        |  |
+ * 3. NAME_SHORTHAND_CHAR: oo         |   |        |  |
+ * 4. DOT: . <------------------------+   |        |  |
+ * 5. NAME_SHORTHAND_FIRST_CHAR: b        |        |  |
+ * 6. NAME_SHORTHAND_CHAR: ar             |        |  |
+ * 7. BRACKET_START: [ <------------------+        |  |
+ * 8. QUOTE_START: '                               |  |
+ * 9. NAME_SELECTOR_CHAR: qu                       |  |
+ * 10. ESCAPE: \                                   |  |
+ * 11. ESCAPABLE_CHAR: '                           |  |
+ * 12. NAME_SELECTOR_CHAR: x                       |  |
+ * 13. QUOTE_END: '                                |  |
+ * 14. BRACKET_END: ]                              |  |
+ * 15. BRACKET_START: [ <--------------------------+  |
+ * 16. DIGIT: 0                                       |
+ * 17. BRACKET_END: ]                                 |
+ * 18. END (after last char) <------------------------+
+ */
+const enum Token {
+  START,
+  END,
+
+  NAME_SHORTHAND_FIRST_CHAR,
+  NAME_SHORTHAND_CHAR,
+  DOT,
+
+  BRACKET_START,
+  BRACKET_END,
+  DIGIT,
+
+  QUOTE_START,
+  QUOTE_END,
+  NAME_SELECTOR_CHAR,
+  ESCAPE,
+  ESCAPE_SEQUENCE_CHAR,
+}
+
+const NAME_SHORTHAND_FIRST_CHAR_REGEX = /[a-zA-Z_$]/
+const NAME_SHORTHAND_CHAR_REGEX = /[a-zA-Z0-9_$]/
+const DIGIT_REGEX = /[0-9]/
+const UNICODE_CHAR_REGEX = /[a-fA-F0-9]/
+const QUOTE_CHARS = '\'"'
+
+const TOKEN_PREDICATE: { [token in Token]: (char: string, parsingContext: ParsingContext) => boolean } = {
+  // no char should match to START or END
+  [Token.START]: () => false,
+  [Token.END]: () => false,
+
+  [Token.NAME_SHORTHAND_FIRST_CHAR]: (char) => NAME_SHORTHAND_FIRST_CHAR_REGEX.test(char),
+  [Token.NAME_SHORTHAND_CHAR]: (char) => NAME_SHORTHAND_CHAR_REGEX.test(char),
+  [Token.DOT]: (char) => char === '.',
+
+  [Token.BRACKET_START]: (char) => char === '[',
+  [Token.BRACKET_END]: (char) => char === ']',
+  [Token.DIGIT]: (char) => DIGIT_REGEX.test(char),
+
+  [Token.QUOTE_START]: (char) => QUOTE_CHARS.includes(char),
+  [Token.QUOTE_END]: (char, parsingContext) => char === parsingContext.quote,
+  [Token.NAME_SELECTOR_CHAR]: () => true, // any char can be used in name selector
+  [Token.ESCAPE]: (char) => char === '\\',
+  [Token.ESCAPE_SEQUENCE_CHAR]: (char, parsingContext) => {
+    if (parsingContext.escapeSequence === undefined) {
+      // see https://www.rfc-editor.org/rfc/rfc9535.html#name-semantics-3
+      return `${parsingContext.quote}/\\bfnrtu`.includes(char)
+    } else if (parsingContext.escapeSequence.startsWith('u') && parsingContext.escapeSequence.length < 5) {
+      return UNICODE_CHAR_REGEX.test(char)
+    }
+    return false
+  },
+}
+
+const ALLOWED_NEXT_TOKENS: { [token in Token]: Token[] } = {
+  [Token.START]: [Token.NAME_SHORTHAND_FIRST_CHAR, Token.BRACKET_START],
+  [Token.END]: [],
+
+  [Token.NAME_SHORTHAND_FIRST_CHAR]: [Token.NAME_SHORTHAND_CHAR, Token.DOT, Token.BRACKET_START, Token.END],
+  [Token.NAME_SHORTHAND_CHAR]: [Token.NAME_SHORTHAND_CHAR, Token.DOT, Token.BRACKET_START, Token.END],
+  [Token.DOT]: [Token.NAME_SHORTHAND_FIRST_CHAR],
+
+  [Token.BRACKET_START]: [Token.QUOTE_START, Token.DIGIT],
+  [Token.BRACKET_END]: [Token.DOT, Token.BRACKET_START, Token.END],
+  [Token.DIGIT]: [Token.DIGIT, Token.BRACKET_END],
+
+  [Token.QUOTE_START]: [Token.ESCAPE, Token.QUOTE_END, Token.NAME_SELECTOR_CHAR],
+  [Token.QUOTE_END]: [Token.BRACKET_END],
+  [Token.NAME_SELECTOR_CHAR]: [Token.ESCAPE, Token.QUOTE_END, Token.NAME_SELECTOR_CHAR],
+  [Token.ESCAPE]: [Token.ESCAPE_SEQUENCE_CHAR],
+  [Token.ESCAPE_SEQUENCE_CHAR]: [Token.ESCAPE_SEQUENCE_CHAR, Token.ESCAPE, Token.QUOTE_END, Token.NAME_SELECTOR_CHAR],
+}
+
+// foo['bar\n'][12]
+// ^^    ^ ^^   ^
+const ALLOWED_SELECTOR_TOKENS = [
+  Token.NAME_SHORTHAND_FIRST_CHAR,
+  Token.NAME_SHORTHAND_CHAR,
+  Token.DIGIT,
+  Token.NAME_SELECTOR_CHAR,
+]
+
+// foo.bar['qux']
+//    ^   ^     ^
+const ALLOWED_SELECTOR_DELIMITER_TOKENS = [Token.DOT, Token.BRACKET_START, Token.BRACKET_END]
+
+function isValidEscapeSequence(escapeSequence: string): boolean {
+  return '"\'/\\bfnrt'.includes(escapeSequence) || (escapeSequence.startsWith('u') && escapeSequence.length === 5)
+}
+
+const ESCAPED_CHARS: { [key: string]: string } = {
+  '"': '"',
+  "'": "'",
+  '/': '/',
+  '\\': '\\',
+  b: '\b',
+  f: '\f',
+  n: '\n',
+  r: '\r',
+  t: '\t',
+}
+
+function resolveEscapeSequence(escapeSequence: string): string {
+  if (escapeSequence.startsWith('u')) {
+    // build Unicode char from code
+    return String.fromCharCode(parseInt(escapeSequence.slice(1), 16))
+  }
+  return ESCAPED_CHARS[escapeSequence]
+}

--- a/packages/remote-config/src/remoteConfiguration.spec.ts
+++ b/packages/remote-config/src/remoteConfiguration.spec.ts
@@ -1,0 +1,590 @@
+import { display, setCookie, deleteCookie, ONE_MINUTE } from '@datadog/browser-core'
+import { interceptRequests, registerCleanupTask } from '@datadog/browser-core/test'
+import {
+  fetchRemoteConfiguration,
+  buildEndpoint,
+  resolveDynamicValues,
+  browserContextItemHandler,
+} from './remoteConfiguration'
+import { parseJsonPath } from './jsonPathParser'
+
+describe('remoteConfiguration', () => {
+  describe('buildEndpoint', () => {
+    it('should build the default endpoint', () => {
+      const endpoint = buildEndpoint({
+        applicationId: 'my-app',
+        remoteConfigurationId: '0e008b1b-8600-4709-9d1d-f4edcfdf5587',
+      })
+      expect(endpoint).toMatch(/^https:\/\/sdk-configuration\.browser-intake-datadoghq\.com\/v1\/[^/]+\.json$/)
+    })
+
+    it('should build endpoint with custom site', () => {
+      const endpoint = buildEndpoint({
+        applicationId: 'my-app',
+        remoteConfigurationId: '0e008b1b-8600-4709-9d1d-f4edcfdf5587',
+        site: 'datadoghq.eu',
+      })
+      expect(endpoint).toMatch(/^https:\/\/sdk-configuration\.browser-intake-datadoghq\.eu\/v1\/[^/]+\.json$/)
+    })
+
+    it('should use custom proxy when provided', () => {
+      const customProxy = 'https://custom.proxy.com/config'
+      const endpoint = buildEndpoint({
+        applicationId: 'my-app',
+        remoteConfigurationId: '0e008b1b-8600-4709-9d1d-f4edcfdf5587',
+        remoteConfigurationProxy: customProxy,
+      })
+      expect(endpoint).toBe(customProxy)
+    })
+
+    it('should encode the remote configuration ID', () => {
+      const endpoint = buildEndpoint({
+        applicationId: 'my-app',
+        remoteConfigurationId: 'id/with/slashes',
+      })
+      expect(endpoint).toContain(encodeURIComponent('id/with/slashes'))
+    })
+  })
+
+  describe('fetchRemoteConfiguration', () => {
+    let interceptor: ReturnType<typeof interceptRequests>
+
+    beforeEach(() => {
+      interceptor = interceptRequests()
+    })
+
+    it('should fetch the remote configuration', async () => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              rum: {
+                applicationId: 'my-app',
+                sessionSampleRate: 50,
+                sessionReplaySampleRate: 75,
+                env: 'production',
+              },
+            }),
+        })
+      )
+
+      const result = await fetchRemoteConfiguration({
+        applicationId: 'my-app',
+        remoteConfigurationId: 'config-id',
+      })
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toEqual({
+          applicationId: 'my-app',
+          sessionSampleRate: 50,
+          sessionReplaySampleRate: 75,
+          env: 'production',
+        })
+      }
+    })
+
+    it('should return error on network failure', async () => {
+      interceptor.withFetch(() => Promise.reject(new Error('Network error')))
+
+      const result = await fetchRemoteConfiguration({
+        applicationId: 'my-app',
+        remoteConfigurationId: 'config-id',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBeDefined()
+        expect(result.error.message).toBe('Error fetching the remote configuration.')
+      }
+    })
+
+    it('should return error on HTTP error response', async () => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+        })
+      )
+
+      const result = await fetchRemoteConfiguration({
+        applicationId: 'my-app',
+        remoteConfigurationId: 'config-id',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBeDefined()
+      }
+    })
+
+    it('should return error if response has no rum config', async () => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        })
+      )
+
+      const result = await fetchRemoteConfiguration({
+        applicationId: 'my-app',
+        remoteConfigurationId: 'config-id',
+      })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.message).toBe('No remote configuration for RUM.')
+      }
+    })
+
+    it('should parse JSON response correctly', async () => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              rum: {
+                applicationId: 'app123',
+                service: 'my-service',
+                env: 'staging',
+                version: { rcSerializedType: 'dynamic', strategy: 'cookie', name: 'app_version' },
+                sessionSampleRate: 100,
+                traceSampleRate: 50,
+              },
+            }),
+        })
+      )
+
+      const result = await fetchRemoteConfiguration({
+        applicationId: 'app123',
+        remoteConfigurationId: 'config-id',
+      })
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value.service).toBe('my-service')
+        expect(result.value.traceSampleRate).toBe(50)
+      }
+    })
+
+    it('should pass signal to fetch', async () => {
+      if (typeof AbortController === 'undefined') {
+        pending('AbortController not supported in this browser')
+        return
+      }
+      const controller = new AbortController()
+      const fetchSpy = interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ rum: { applicationId: 'my-app' } }),
+        })
+      )
+
+      await fetchRemoteConfiguration({
+        applicationId: 'my-app',
+        remoteConfigurationId: 'config-id',
+        signal: controller.signal,
+      })
+
+      expect(fetchSpy.calls.mostRecent().args[1]?.signal).toBe(controller.signal)
+    })
+  })
+
+  describe('resolveDynamicValues', () => {
+    describe('static values', () => {
+      it('should return static string values as-is', () => {
+        const value = resolveDynamicValues('static-value')
+        expect(value).toBe('static-value')
+      })
+
+      it('should return numbers as-is', () => {
+        const value = resolveDynamicValues(42)
+        expect(value).toBe(42)
+      })
+
+      it('should return booleans as-is', () => {
+        const value = resolveDynamicValues(true)
+        expect(value).toBe(true)
+      })
+
+      it('should resolve arrays recursively', () => {
+        const value = resolveDynamicValues([
+          { rcSerializedType: 'string', value: 'a' },
+          { rcSerializedType: 'string', value: 'b' },
+        ])
+        expect(value).toEqual(['a', 'b'])
+      })
+    })
+
+    describe('serialized strings', () => {
+      it('should unwrap serialized string values', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'string',
+          value: 'my-value',
+        })
+        expect(value).toBe('my-value')
+      })
+    })
+
+    describe('regex values', () => {
+      it('should create RegExp from regex serialization', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'regex',
+          value: '^test-.*',
+        })
+        expect(value).toEqual(/^test-.*/)
+      })
+
+      it('should handle invalid regex gracefully', () => {
+        const displaySpy = spyOn(display, 'error')
+        const value = resolveDynamicValues({
+          rcSerializedType: 'regex',
+          value: 'invalid(?|regex)',
+        })
+        expect(value).toBeUndefined()
+        expect(displaySpy).toHaveBeenCalledWith("Invalid regex in the remote configuration: 'invalid(?|regex)'")
+      })
+    })
+
+    describe('dynamic cookie values', () => {
+      const COOKIE_NAME = 'test-cookie'
+
+      beforeEach(() => {
+        setCookie(COOKIE_NAME, 'cookie-value', ONE_MINUTE)
+        registerCleanupTask(() => deleteCookie(COOKIE_NAME))
+      })
+
+      it('should resolve cookie values', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'cookie',
+          name: COOKIE_NAME,
+        })
+        expect(value).toBe('cookie-value')
+      })
+
+      it('should call callback when resolving cookie', () => {
+        const onCookie = jasmine.createSpy()
+        resolveDynamicValues(
+          {
+            rcSerializedType: 'dynamic',
+            strategy: 'cookie',
+            name: COOKIE_NAME,
+          },
+          { onCookie }
+        )
+        expect(onCookie).toHaveBeenCalledWith('cookie-value')
+      })
+
+      it('should resolve to undefined if cookie missing', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'cookie',
+          name: 'nonexistent',
+        })
+        expect(value).toBeUndefined()
+      })
+
+      it('should apply regex extractor to cookie value', () => {
+        setCookie(COOKIE_NAME, 'v1.2.3', ONE_MINUTE)
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'cookie',
+          name: COOKIE_NAME,
+          extractor: {
+            rcSerializedType: 'regex',
+            value: 'v(\\d+)',
+          },
+        })
+        expect(value).toBe('1')
+      })
+    })
+
+    describe('dynamic DOM values', () => {
+      it('should resolve DOM text content', () => {
+        const element = document.createElement('div')
+        element.textContent = 'content-value'
+        element.id = 'test-element'
+        document.body.appendChild(element)
+        registerCleanupTask(() => element.remove())
+
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'dom',
+          selector: '#test-element',
+        })
+        expect(value).toBe('content-value')
+      })
+
+      it('should resolve DOM attribute values', () => {
+        const element = document.createElement('div')
+        element.setAttribute('data-version', 'attr-value')
+        element.id = 'test-attr-element'
+        document.body.appendChild(element)
+        registerCleanupTask(() => element.remove())
+
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'dom',
+          selector: '#test-attr-element',
+          attribute: 'data-version',
+        })
+        expect(value).toBe('attr-value')
+      })
+
+      it('should return undefined if element not found', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'dom',
+          selector: '#nonexistent-element',
+        })
+        expect(value).toBeUndefined()
+      })
+
+      it('should report error for invalid selectors', () => {
+        const displaySpy = spyOn(display, 'error')
+        resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'dom',
+          selector: ':invalid(selector)',
+        })
+        expect(displaySpy).toHaveBeenCalled()
+      })
+
+      it('should not allow reading password input values', () => {
+        const input = document.createElement('input')
+        input.type = 'password'
+        input.value = 'secret'
+        input.id = 'password-input'
+        document.body.appendChild(input)
+        registerCleanupTask(() => input.remove())
+
+        const displaySpy = spyOn(display, 'error')
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'dom',
+          selector: '#password-input',
+          attribute: 'value',
+        })
+        expect(value).toBeUndefined()
+        expect(displaySpy).toHaveBeenCalled()
+      })
+
+      it('should call callback when resolving DOM value', () => {
+        const element = document.createElement('div')
+        element.textContent = 'test-content'
+        element.id = 'callback-test'
+        document.body.appendChild(element)
+        registerCleanupTask(() => element.remove())
+
+        const onDom = jasmine.createSpy()
+        resolveDynamicValues(
+          {
+            rcSerializedType: 'dynamic',
+            strategy: 'dom',
+            selector: '#callback-test',
+          },
+          { onDom }
+        )
+        expect(onDom).toHaveBeenCalledWith('test-content')
+      })
+    })
+
+    describe('dynamic JS path values', () => {
+      beforeEach(() => {
+        ;(window as any).testApp = {
+          version: '2.0.0',
+          config: {
+            env: 'staging',
+          },
+        }
+        registerCleanupTask(() => {
+          delete (window as any).testApp
+        })
+      })
+
+      it('should resolve window path values', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'js',
+          path: 'testApp.version',
+        })
+        expect(value).toBe('2.0.0')
+      })
+
+      it('should resolve nested window paths', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'js',
+          path: 'testApp.config.env',
+        })
+        expect(value).toBe('staging')
+      })
+
+      it('should return undefined if path does not exist', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'js',
+          path: 'testApp.nonexistent.path',
+        })
+        expect(value).toBeUndefined()
+      })
+
+      it('should handle bracket notation paths', () => {
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'js',
+          path: "testApp['version']",
+        })
+        expect(value).toBe('2.0.0')
+      })
+
+      it('should call callback when resolving JS value', () => {
+        const onJs = jasmine.createSpy()
+        resolveDynamicValues(
+          {
+            rcSerializedType: 'dynamic',
+            strategy: 'js',
+            path: 'testApp.version',
+          },
+          { onJs }
+        )
+        expect(onJs).toHaveBeenCalledWith('2.0.0')
+      })
+    })
+
+    describe('complex nested structures', () => {
+      it('should resolve nested configuration objects', () => {
+        const config = {
+          service: 'my-service',
+          urls: [
+            { rcSerializedType: 'string', value: 'url1' },
+            { rcSerializedType: 'string', value: 'url2' },
+          ],
+          settings: {
+            level: 2,
+            enabled: true,
+          },
+        }
+        const resolved = resolveDynamicValues(config)
+        expect(resolved).toEqual({
+          service: 'my-service',
+          urls: ['url1', 'url2'],
+          settings: {
+            level: 2,
+            enabled: true,
+          },
+        })
+      })
+    })
+
+    describe('unsupported strategies', () => {
+      it('should handle unsupported strategies gracefully', () => {
+        const displaySpy = spyOn(display, 'error')
+        const value = resolveDynamicValues({
+          rcSerializedType: 'dynamic',
+          strategy: 'unsupported' as any,
+        })
+        expect(value).toBeUndefined()
+        expect(displaySpy).toHaveBeenCalledWith('Unsupported remote configuration: "strategy": "unsupported"')
+      })
+
+      it('should handle unsupported serialized types', () => {
+        const displaySpy = spyOn(display, 'error')
+        const value = resolveDynamicValues({
+          rcSerializedType: 'unsupported',
+          value: 'test',
+        })
+        expect(value).toBeUndefined()
+        expect(displaySpy).toHaveBeenCalledWith('Unsupported remote configuration: "rcSerializedType": "unsupported"')
+      })
+    })
+
+    describe('ContextItem[] detection', () => {
+      it('should transform a ContextItem[] into a plain object via getter', () => {
+        const items = [
+          { key: 'id', value: { rcSerializedType: 'dynamic' as const, strategy: 'cookie' as const, name: 'user_id' } },
+        ]
+        const result = resolveDynamicValues({ user: items }, { contextItemHandler: browserContextItemHandler }) as any
+        expect(result.user).toEqual({ id: undefined }) // cookie not set in test env
+      })
+
+      it('should re-evaluate on each read', () => {
+        let callCount = 0
+        const items = [
+          { key: 'id', value: { rcSerializedType: 'dynamic' as const, strategy: 'cookie' as const, name: 'user_id' } },
+        ]
+        // onCookie from the outer options is captured in the getter closure at creation time;
+        // each property read re-invokes the resolver with those same captured options
+        const result = resolveDynamicValues(
+          { user: items },
+          {
+            onCookie: () => {
+              callCount++
+            },
+            contextItemHandler: browserContextItemHandler,
+          }
+        ) as any
+        // access the property twice to trigger the getter each time
+        void result.user
+        void result.user
+        const userValue = result.user // third getter call
+        expect(userValue).toEqual({ id: undefined })
+        expect(callCount).toBe(3)
+      })
+
+      it('should NOT treat an empty array as ContextItem[]', () => {
+        const result = resolveDynamicValues({ items: [] }) as any
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+
+      it('should NOT treat an array without rcSerializedType on value as ContextItem[]', () => {
+        const result = resolveDynamicValues({ items: [{ key: 'foo', value: 'bar' }] }) as any
+        expect(Array.isArray(result.items)).toBe(true)
+      })
+
+      it('should be enumerable (JSON.stringify invokes getter)', () => {
+        const items = [
+          { key: 'id', value: { rcSerializedType: 'dynamic' as const, strategy: 'cookie' as const, name: 'user_id' } },
+        ]
+        const result = resolveDynamicValues({ user: items }, { contextItemHandler: browserContextItemHandler }) as any
+        // direct enumerability check
+        const descriptor = Object.getOwnPropertyDescriptor(result, 'user')
+        expect(descriptor?.enumerable).toBe(true)
+        // JSON.stringify invokes enumerable getters
+        const json = JSON.parse(JSON.stringify(result))
+        // JSON.stringify drops undefined values, so the round-tripped object is {}
+        expect(json.user).toEqual({})
+      })
+    })
+  })
+
+  describe('parseJsonPath', () => {
+    it('should parse dot notation paths', () => {
+      expect(parseJsonPath('foo.bar.baz')).toEqual(['foo', 'bar', 'baz'])
+    })
+
+    it('should parse bracket notation paths', () => {
+      expect(parseJsonPath("['foo']['bar']")).toEqual(['foo', 'bar'])
+    })
+
+    it('should parse mixed notation paths', () => {
+      expect(parseJsonPath("foo['bar'].baz")).toEqual(['foo', 'bar', 'baz'])
+    })
+
+    it('should parse array indices', () => {
+      expect(parseJsonPath('items[0]')).toEqual(['items', '0'])
+    })
+
+    it('should return empty array for invalid paths', () => {
+      expect(parseJsonPath("['foo")).toEqual([])
+      expect(parseJsonPath('foo.')).toEqual([])
+      expect(parseJsonPath('foo..bar')).toEqual([])
+    })
+
+    it('should handle escaped quotes', () => {
+      expect(parseJsonPath("['foo\\'bar']")).toEqual(["foo'bar"])
+    })
+  })
+})

--- a/packages/remote-config/src/remoteConfiguration.ts
+++ b/packages/remote-config/src/remoteConfiguration.ts
@@ -1,0 +1,307 @@
+import { display, buildEndpointUrl, getCookie, isIndexableObject, fetch } from '@datadog/browser-core'
+import type { RumSdkConfig, DynamicOption, ContextItem } from './remoteConfiguration.types'
+import { parseJsonPath } from './jsonPathParser'
+
+export type RemoteConfiguration = RumSdkConfig
+export type RumRemoteConfiguration = Exclude<RemoteConfiguration['rum'], undefined>
+
+export type RemoteConfigResult = { ok: true; value: RumRemoteConfiguration } | { ok: false; error: Error }
+
+const REMOTE_CONFIGURATION_VERSION = 'v1'
+
+/**
+ * Fetch remote configuration from Datadog servers.
+ *
+ * @param options - Configuration options for fetching remote configuration
+ * @param options.applicationId - Datadog application ID
+ * @param options.remoteConfigurationId - Remote configuration ID
+ * @param options.remoteConfigurationProxy - Optional proxy URL for remote configuration
+ * @param options.site - Optional Datadog site
+ * @param options.signal - Optional AbortSignal for cancellation
+ * @returns Promise with result containing the remote configuration or error
+ * @example
+ * ```ts
+ * const result = await fetchRemoteConfiguration({
+ *   applicationId: 'abc123',
+ *   remoteConfigurationId: '0e008b1b-8600-4709-9d1d-f4edcfdf5587'
+ * })
+ *
+ * if (result.ok) {
+ *   console.log(result.value?.rum)
+ * } else {
+ *   console.error(result.error)
+ * }
+ * ```
+ */
+export async function fetchRemoteConfiguration(options: {
+  applicationId: string
+  remoteConfigurationId: string
+  remoteConfigurationProxy?: string
+  site?: string
+  signal?: AbortSignal
+}): Promise<RemoteConfigResult> {
+  let response: Response | undefined
+  try {
+    response = await fetch(buildEndpoint(options), { signal: options.signal })
+  } catch {
+    response = undefined
+  }
+  if (!response || !response.ok) {
+    return {
+      ok: false,
+      error: new Error('Error fetching the remote configuration.'),
+    }
+  }
+  const remoteConfiguration: RemoteConfiguration = await response.json()
+  if (remoteConfiguration.rum) {
+    return {
+      ok: true,
+      value: remoteConfiguration.rum,
+    }
+  }
+  return {
+    ok: false,
+    error: new Error('No remote configuration for RUM.'),
+  }
+}
+
+/**
+ * Build the endpoint URL for remote configuration fetch.
+ *
+ * @param options - Configuration options
+ * @param options.applicationId - Datadog application ID
+ * @param options.remoteConfigurationId - Remote configuration ID
+ * @param options.remoteConfigurationProxy - Optional proxy URL for remote configuration
+ * @param options.site - Optional Datadog site
+ * @returns The endpoint URL
+ * @example
+ * ```ts
+ * const url = buildEndpoint({
+ *   applicationId: 'abc123',
+ *   remoteConfigurationId: '0e008b1b-8600-4709-9d1d-f4edcfdf5587'
+ * })
+ * // => 'https://sdk-configuration.datadoghq.com/v1/0e008b1b-8600-4709-9d1d-f4edcfdf5587.json'
+ * ```
+ */
+export function buildEndpoint(options: {
+  applicationId: string
+  remoteConfigurationId: string
+  remoteConfigurationProxy?: string
+  site?: string
+}): string {
+  if (options.remoteConfigurationProxy) {
+    return options.remoteConfigurationProxy
+  }
+  return buildEndpointUrl({
+    site: options.site,
+    subdomain: 'sdk-configuration',
+    path: `/${REMOTE_CONFIGURATION_VERSION}/${encodeURIComponent(options.remoteConfigurationId)}.json`,
+  })
+}
+
+// ==========================================
+// Below are internal helper functions used by rum-core for applying remote configuration
+// Exposed for testing and advanced use cases
+// ==========================================
+
+/**
+ * Resolve dynamic configuration values (cookies, DOM selectors, JS paths).
+ * This is exposed for internal SDK use and advanced test scenarios.
+ *
+ * @internal
+ */
+export function resolveDynamicValues(
+  configValue: unknown,
+  options: {
+    onCookie?: (value: string | undefined) => void
+    onDom?: (value: string | null | undefined) => void
+    onJs?: (value: unknown) => void
+    contextItemHandler?: (items: ContextItem[], resolve: (value: unknown) => unknown) => unknown
+  } = {}
+): unknown {
+  if (Array.isArray(configValue)) {
+    return configValue.map((item) => resolveDynamicValues(item, options))
+  }
+  if (isIndexableObject(configValue)) {
+    if (isSerializedOption(configValue)) {
+      const type = (configValue as any).rcSerializedType
+      switch (type) {
+        case 'string':
+          return (configValue as any).value
+        case 'regex':
+          return resolveRegex((configValue as any).value as string)
+        case 'dynamic':
+          return resolveDynamicOption(configValue as DynamicOption, options)
+        default:
+          display.error(`Unsupported remote configuration: "rcSerializedType": "${type as string}"`)
+          return
+      }
+    }
+    const result: { [key: string]: unknown } = {}
+    for (const key in configValue) {
+      if (Object.prototype.hasOwnProperty.call(configValue, key)) {
+        const val = (configValue as { [key: string]: unknown })[key]
+        if (options.contextItemHandler && isContextItemArray(val)) {
+          const items = val
+          const handler = options.contextItemHandler
+          const resolve = (v: unknown) => resolveDynamicValues(v, options)
+          Object.defineProperty(result, key, {
+            get: () => handler(items, resolve),
+            enumerable: true,
+            configurable: true,
+          })
+        } else {
+          result[key] = resolveDynamicValues(val, options)
+        }
+      }
+    }
+    return result
+  }
+  return configValue
+}
+
+function resolveDynamicOption(
+  property: DynamicOption,
+  options: {
+    onCookie?: (value: string | undefined) => void
+    onDom?: (value: string | null | undefined) => void
+    onJs?: (value: unknown) => void
+  }
+): unknown {
+  const strategy = property.strategy
+  let resolvedValue: unknown
+  switch (strategy) {
+    case 'cookie':
+      resolvedValue = resolveCookieValue(property, options)
+      break
+    case 'dom':
+      resolvedValue = resolveDomValue(property, options)
+      break
+    case 'js':
+      resolvedValue = resolveJsValue(property, options)
+      break
+    default:
+      display.error(`Unsupported remote configuration: "strategy": "${strategy as string}"`)
+      return
+  }
+  const extractor = property.extractor
+  if (extractor !== undefined && typeof resolvedValue === 'string') {
+    return extractValue(extractor, resolvedValue)
+  }
+  return resolvedValue
+}
+
+function resolveCookieValue(
+  { name }: { name: string },
+  options: { onCookie?: (value: string | undefined) => void } = {}
+) {
+  const value = getCookie(name)
+  options.onCookie?.(value)
+  return value
+}
+
+function resolveDomValue(
+  { selector, attribute }: { selector: string; attribute?: string },
+  options: { onDom?: (value: string | null | undefined) => void } = {}
+) {
+  let element: Element | null
+  try {
+    element = document.querySelector(selector)
+  } catch {
+    display.error(`Invalid selector in the remote configuration: '${selector}'`)
+    options.onDom?.(undefined)
+    return
+  }
+  if (!element) {
+    options.onDom?.(undefined)
+    return
+  }
+  if (isForbidden(element, attribute)) {
+    display.error(`Forbidden element selected by the remote configuration: '${selector}'`)
+    options.onDom?.(undefined)
+    return
+  }
+  const domValue = attribute !== undefined ? element.getAttribute(attribute) : element.textContent
+  options.onDom?.(domValue)
+  return domValue
+}
+
+function isForbidden(element: Element, attribute: string | undefined) {
+  return element.getAttribute('type') === 'password' && attribute === 'value'
+}
+
+function resolveJsValue({ path }: { path: string }, options: { onJs?: (value: unknown) => void } = {}): unknown {
+  let current = window as unknown as { [key: string]: unknown }
+  const pathParts = parseJsonPath(path)
+  if (pathParts.length === 0) {
+    display.error(`Invalid JSON path in the remote configuration: '${path}'`)
+    options.onJs?.(undefined)
+    return
+  }
+  for (const pathPart of pathParts) {
+    if (!(pathPart in current)) {
+      options.onJs?.(undefined)
+      return
+    }
+    try {
+      current = current[pathPart] as { [key: string]: unknown }
+    } catch (e) {
+      display.error(`Error accessing: '${path}'`, e)
+      options.onJs?.(undefined)
+      return
+    }
+  }
+  options.onJs?.(current)
+  return current
+}
+
+function resolveRegex(pattern: string): RegExp | undefined {
+  try {
+    return new RegExp(pattern)
+  } catch {
+    display.error(`Invalid regex in the remote configuration: '${pattern}'`)
+  }
+}
+
+function extractValue(extractor: { value: string }, candidate: string) {
+  const resolvedExtractor = resolveRegex(extractor.value)
+  if (resolvedExtractor === undefined) {
+    return
+  }
+  const regexResult = resolvedExtractor.exec(candidate)
+  if (regexResult === null) {
+    return
+  }
+  const [match, capture] = regexResult
+  return capture ? capture : match
+}
+
+function isSerializedOption(value: object): value is { rcSerializedType: string; [key: string]: unknown } {
+  return 'rcSerializedType' in value
+}
+
+function isContextItemArray(value: unknown): value is ContextItem[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (item) =>
+        isIndexableObject(item) &&
+        typeof (item as { key?: unknown }).key === 'string' &&
+        isIndexableObject((item as { value?: unknown }).value) &&
+        (item as { value: { rcSerializedType?: unknown } }).value.rcSerializedType === 'dynamic'
+    )
+  )
+}
+
+/**
+ * Resolves ContextItem arrays using live browser APIs (cookies, DOM, window.*).
+ *
+ * @internal
+ */
+export function browserContextItemHandler(
+  items: ContextItem[],
+  resolve: (value: unknown) => unknown
+): Record<string, unknown> {
+  return Object.fromEntries(items.map(({ key, value }) => [key, resolve(value)]))
+}

--- a/packages/remote-config/src/remoteConfiguration.types.ts
+++ b/packages/remote-config/src/remoteConfiguration.types.ts
@@ -1,0 +1,161 @@
+/* eslint-disable */
+/**
+ * DO NOT MODIFY IT BY HAND. Run `yarn json-schemas:sync` instead.
+ */
+
+export type DynamicOption =
+  | {
+      rcSerializedType: 'dynamic'
+      strategy: 'js'
+      path: string
+      extractor?: SerializedRegex
+      [k: string]: unknown
+    }
+  | {
+      rcSerializedType: 'dynamic'
+      strategy: 'cookie'
+      name: string
+      extractor?: SerializedRegex
+      [k: string]: unknown
+    }
+  | {
+      rcSerializedType: 'dynamic'
+      strategy: 'dom'
+      selector: string
+      attribute?: string
+      extractor?: SerializedRegex
+      [k: string]: unknown
+    }
+  | {
+      rcSerializedType: 'dynamic'
+      strategy: 'localStorage'
+      key: string
+      extractor?: SerializedRegex
+      [k: string]: unknown
+    }
+
+/**
+ * RUM Browser & Mobile SDKs Remote Configuration properties
+ */
+export interface RumSdkConfig {
+  /**
+   * RUM feature Remote Configuration properties
+   */
+  rum?: {
+    /**
+     * UUID of the application
+     */
+    applicationId: string
+    /**
+     * The service name for this application
+     */
+    service?: string
+    /**
+     * The environment for this application
+     */
+    env?: string
+    /**
+     * The version for this application
+     */
+    version?:
+      | {
+          rcSerializedType: 'dynamic'
+          strategy: 'js'
+          path: string
+          extractor?: SerializedRegex
+          [k: string]: unknown
+        }
+      | {
+          rcSerializedType: 'dynamic'
+          strategy: 'cookie'
+          name: string
+          extractor?: SerializedRegex
+          [k: string]: unknown
+        }
+      | {
+          rcSerializedType: 'dynamic'
+          strategy: 'dom'
+          selector: string
+          attribute?: string
+          extractor?: SerializedRegex
+          [k: string]: unknown
+        }
+      | {
+          rcSerializedType: 'dynamic'
+          strategy: 'localStorage'
+          key: string
+          extractor?: SerializedRegex
+          [k: string]: unknown
+        }
+    /**
+     * The percentage of sessions tracked
+     */
+    sessionSampleRate?: number
+    /**
+     * The percentage of sessions with RUM & Session Replay pricing tracked
+     */
+    sessionReplaySampleRate?: number
+    /**
+     * Session replay default privacy level
+     */
+    defaultPrivacyLevel?: string
+    /**
+     * Privacy control for action name
+     */
+    enablePrivacyForActionName?: boolean
+    /**
+     * URLs where tracing is allowed
+     */
+    allowedTracingUrls?: {
+      match: MatchOption
+      /**
+       * List of propagator types
+       */
+      propagatorTypes?: ('datadog' | 'b3' | 'b3multi' | 'tracecontext')[] | null
+    }[]
+    /**
+     * Origins where tracking is allowed
+     */
+    allowedTrackingOrigins?: MatchOption[]
+    /**
+     * The percentage of traces sampled
+     */
+    traceSampleRate?: number
+    /**
+     * Whether to track sessions across subdomains
+     */
+    trackSessionAcrossSubdomains?: boolean
+    /**
+     * Function to define user information
+     */
+    user?: ContextItem[]
+    /**
+     * Function to define global context
+     */
+    context?: ContextItem[]
+  }
+}
+export interface SerializedRegex {
+  /**
+   * Remote config serialized type for regex extraction
+   */
+  rcSerializedType: 'regex'
+  /**
+   * Regex pattern for value extraction
+   */
+  value: string
+}
+export interface MatchOption {
+  /**
+   * Remote config serialized type of match
+   */
+  rcSerializedType: 'string' | 'regex'
+  /**
+   * Match value
+   */
+  value: string
+}
+export interface ContextItem {
+  key: string
+  value: DynamicOption
+}

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -13,6 +13,7 @@ import {
   DefaultPrivacyLevel,
   startTelemetry,
   startSessionManager,
+  CustomerContextKey,
 } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import {
@@ -1059,6 +1060,104 @@ describe('preStartRum', () => {
       strategy.startView({ name: 'foo' })
 
       expect(startTelemetrySpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('user and globalContext from initConfiguration', () => {
+    it('applies user from initConfiguration to the user context manager at start', async () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+      const setContextSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        [CustomerContextKey.userContext]: { setContext: setContextSpy },
+      } as unknown as StartRumResult)
+
+      strategy.init({ ...DEFAULT_INIT_CONFIGURATION, user: { id: 'u1', name: 'Alice' } }, PUBLIC_API)
+      await collectAsyncCalls(setContextSpy, 1)
+
+      expect(setContextSpy).toHaveBeenCalledOnceWith({ id: 'u1', name: 'Alice' })
+    })
+
+    it('applies globalContext from initConfiguration to the global context manager at start', async () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+      const setContextSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        [CustomerContextKey.globalContext]: { setContext: setContextSpy },
+      } as unknown as StartRumResult)
+
+      strategy.init({ ...DEFAULT_INIT_CONFIGURATION, globalContext: { plan: 'pro', region: 'eu' } }, PUBLIC_API)
+      await collectAsyncCalls(setContextSpy, 1)
+
+      expect(setContextSpy).toHaveBeenCalledOnceWith({ plan: 'pro', region: 'eu' })
+    })
+
+    it('does not apply user context if not provided in initConfiguration', async () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+      const setContextSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        [CustomerContextKey.userContext]: { setContext: setContextSpy },
+      } as unknown as StartRumResult)
+
+      strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
+      await collectAsyncCalls(doStartRumSpy, 1)
+
+      expect(setContextSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not apply globalContext if not provided in initConfiguration', async () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+      const setContextSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        [CustomerContextKey.globalContext]: { setContext: setContextSpy },
+      } as unknown as StartRumResult)
+
+      strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
+      await collectAsyncCalls(doStartRumSpy, 1)
+
+      expect(setContextSpy).not.toHaveBeenCalled()
+    })
+
+    it('applies user from initConfiguration only after SDK start (drain), not at init time', async () => {
+      const trackingConsentState = createTrackingConsentState()
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults({ trackingConsentState })
+
+      const setContextSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        [CustomerContextKey.userContext]: { setContext: setContextSpy },
+      } as unknown as StartRumResult)
+
+      // init with tracking consent NOT_GRANTED — SDK will not start yet
+      strategy.init(
+        { ...DEFAULT_INIT_CONFIGURATION, user: { id: 'u1' }, trackingConsent: TrackingConsent.NOT_GRANTED },
+        PUBLIC_API
+      )
+
+      // SDK hasn't started — setContext should not have been called on the post-start manager yet
+      expect(setContextSpy).not.toHaveBeenCalled()
+
+      // Grant consent — triggers tryStartRum and drain
+      trackingConsentState.update(TrackingConsent.GRANTED)
+      await collectAsyncCalls(setContextSpy, 1)
+
+      // Now the drain has replayed — setContext should have been called
+      expect(setContextSpy).toHaveBeenCalledOnceWith({ id: 'u1' })
+    })
+
+    it('applies user context even when user is an empty object (user: {} is a valid User value)', async () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+      const setContextSpy = jasmine.createSpy()
+      doStartRumSpy.and.returnValue({
+        [CustomerContextKey.userContext]: { setContext: setContextSpy },
+      } as unknown as StartRumResult)
+
+      strategy.init({ ...DEFAULT_INIT_CONFIGURATION, user: {} }, PUBLIC_API)
+      await collectAsyncCalls(setContextSpy, 1)
+
+      expect(setContextSpy).toHaveBeenCalled()
     })
   })
 })

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -151,6 +151,13 @@ export function createPreStartStrategy(
     // Update the exposed initConfiguration to reflect the bridge and remote configuration overrides
     cachedInitConfiguration = initConfiguration
 
+    if (initConfiguration.user) {
+      userContext.setContext(initConfiguration.user)
+    }
+    if (initConfiguration.globalContext) {
+      globalContext.setContext(initConfiguration.globalContext)
+    }
+
     if (cachedConfiguration) {
       displayAlreadyInitializedError('DD_RUM', initConfiguration)
       return

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -832,6 +832,8 @@ describe('serializeRumConfiguration', () => {
       profilingSampleRate: 42,
       propagateTraceBaggage: true,
       trackResourceHeaders: true,
+      user: { id: 'user-id' },
+      globalContext: { foo: 'bar' },
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -847,7 +849,8 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
             // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
-            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration'
+            // user and globalContext are excluded from telemetry because they contain PII (user identity and arbitrary customer data)
+            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration' | 'user' | 'globalContext'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -1,4 +1,11 @@
-import type { Configuration, InitConfiguration, MatchOption, RawTelemetryConfiguration } from '@datadog/browser-core'
+import type {
+  Configuration,
+  InitConfiguration,
+  MatchOption,
+  RawTelemetryConfiguration,
+  User,
+  Context,
+} from '@datadog/browser-core'
 import {
   isMatchOption,
   serializeConfiguration,
@@ -343,6 +350,23 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @category Data Collection
    */
   allowedGraphQlUrls?: Array<MatchOption | GraphQlUrlOption> | undefined
+
+  /**
+   * Sets the initial user context for the session. Equivalent to calling `datadogRum.setUser()`
+   * immediately after `init()`. Can be overridden at any time via `datadogRum.setUser()`.
+   *
+   * @category Data Collection
+   */
+  user?: User | undefined
+
+  /**
+   * Sets initial global context properties for the session. Equivalent to calling
+   * `datadogRum.setGlobalContextProperty()` for each key immediately after `init()`.
+   * Can be overridden at any time via `datadogRum.setGlobalContextProperty()`.
+   *
+   * @category Data Collection
+   */
+  globalContext?: Context | undefined
 }
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -54,6 +54,9 @@ export type _ = Assert<
   ResolvedRumRemoteConfiguration & {
     // clientToken is not part of the remote configuration but required in init configuration
     clientToken: string
+    // user and globalContext are set via initConfiguration but not via remote configuration
+    user: RumInitConfiguration['user']
+    globalContext: RumInitConfiguration['globalContext']
   } extends RumInitConfiguration
     ? true
     : false

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,6 +383,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@datadog/browser-remote-config@workspace:packages/remote-config":
+  version: 0.0.0-use.local
+  resolution: "@datadog/browser-remote-config@workspace:packages/remote-config"
+  dependencies:
+    "@datadog/browser-core": "npm:7.2.0"
+  languageName: unknown
+  linkType: soft
+
 "@datadog/browser-rum-angular@workspace:packages/rum-angular":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-angular@workspace:packages/rum-angular"


### PR DESCRIPTION
## Motivation

Customers using SSI (Server-Side Instrumentation) need to fetch remote configuration independently of the RUM SDK, at build time or server-side. This package provides that capability as a standalone, lightweight module.

## Changes

### New package: `@datadog/browser-remote-config`

- `fetchRemoteConfiguration(options)` — fetch remote config with 30s timeout
- `RemoteConfigResult` — discriminated union (`{ ok: true; value } | { ok: false; error }`) for safe TypeScript narrowing without non-null assertions
- `AbortSignal` support — pass a signal for cancellation (e.g. `AbortSignal.timeout(30_000)`)
- Dynamic value resolution — cookies (`$cookie:name`), DOM selectors (`$dom:selector`), JS paths (`$js:path`)
- Uses `buildSiteHost` from `@datadog/browser-core` (PR1) — no type-assertion hack

### Purely additive

rum-core's existing `remoteConfigurationId` init option is untouched. This PR only adds the new package.

## Testing

```bash
yarn test:unit --spec packages/remote-config/src/remoteConfiguration.spec.ts
yarn test:unit --spec packages/remote-config/src/jsonPathParser.spec.ts
yarn typecheck
```

---
> Part of SSI Phase 6 stacked PRs. Stacks on: ♻️ Extract buildSiteHost (#4238). Next: `@datadog/browser-sdk-endpoint` package.