### PR TITLE
✨ Add @datadog/browser-sdk-endpoint package and CDN bundle generator CLI

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,7 @@ export default tseslint.config(
         project: [
           './tsconfig.default.json',
           './tsconfig.scripts.json',
+          './packages/endpoint/tsconfig.json',
           './developer-extension/tsconfig.json',
           './test/e2e/tsconfig.json',
           './test/performance/tsconfig.json',

--- a/packages/endpoint/.npmignore
+++ b/packages/endpoint/.npmignore
@@ -1,0 +1,4 @@
+*
+!/src/**/*
+/src/**/*.spec.ts
+/src/**/*.specHelper.ts

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@datadog/browser-sdk-endpoint",
+  "version": "6.28.0",
+  "license": "Apache-2.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@datadog/browser-remote-config": "6.28.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/endpoint/src/bundleGenerator.spec.ts
+++ b/packages/endpoint/src/bundleGenerator.spec.ts
@@ -1,0 +1,419 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import {
+  generateCombinedBundle,
+  generateBundle,
+  type SdkVariant,
+  type CombineBundleOptions,
+} from './bundleGenerator.ts'
+
+describe('generateCombinedBundle', () => {
+  const mockSdkCode = 'window.DD_RUM = { init: function(config) { this.config = config; } };'
+  const mockConfig = {
+    applicationId: 'test-app-id',
+    sessionSampleRate: 100,
+    service: 'test-service',
+    env: 'test',
+  }
+
+  it('wraps code in IIFE', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    assert.ok(bundle.startsWith('/**'), 'Should start with comment header')
+    assert.ok(bundle.includes('(function() {'), 'Should contain IIFE start')
+    assert.ok(bundle.includes('})();'), 'Should contain IIFE end')
+    assert.ok(bundle.includes("'use strict';"), 'Should include use strict directive')
+  })
+
+  it('includes SDK variant in header', () => {
+    const bundleRum = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    const bundleRumSlim = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum-slim',
+    })
+
+    assert.ok(bundleRum.includes('SDK Variant: rum'), 'Should include rum variant in header')
+    assert.ok(bundleRumSlim.includes('SDK Variant: rum-slim'), 'Should include rum-slim variant in header')
+  })
+
+  it('embeds config as JSON', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    assert.ok(bundle.includes('"applicationId": "test-app-id"'), 'Should contain applicationId')
+    assert.ok(bundle.includes('"sessionSampleRate": 100'), 'Should contain sessionSampleRate')
+    assert.ok(bundle.includes('"service": "test-service"'), 'Should contain service')
+    assert.ok(bundle.includes('"env": "test"'), 'Should contain env')
+  })
+
+  it('includes auto-initialization code', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    assert.ok(bundle.includes('window.DD_RUM.init'), 'Should include DD_RUM.init call')
+    assert.ok(bundle.includes('__DATADOG_REMOTE_CONFIG__'), 'Should reference embedded config')
+  })
+
+  it('includes SDK code in output', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    assert.ok(bundle.includes(mockSdkCode), 'Should include SDK code')
+  })
+
+  it('generates valid JavaScript', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    // Verify JavaScript is syntactically valid
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    assert.doesNotThrow(() => new Function(bundle), 'Generated code should be valid JavaScript')
+  })
+
+  it('handles config with nested objects', () => {
+    const configWithNested = {
+      applicationId: 'test-app-id',
+      allowedTracingUrls: [{ match: { rcSerializedType: 'string' as const, value: 'https://example.com' } }],
+    }
+
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: configWithNested,
+      variant: 'rum',
+    })
+
+    assert.ok(bundle.includes('"allowedTracingUrls"'), 'Should contain nested object')
+    assert.ok(bundle.includes('"rcSerializedType": "string"'), 'Should contain nested serialized type')
+  })
+
+  it('handles config with special characters in strings', () => {
+    const configWithSpecialChars = {
+      applicationId: 'test-app-id',
+      service: 'test-service-with-"quotes"-and-\\backslash',
+    }
+
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: configWithSpecialChars,
+      variant: 'rum',
+    })
+
+    // JSON.stringify should properly escape special characters
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    assert.doesNotThrow(() => new Function(bundle), 'Generated code with special chars should be valid JavaScript')
+  })
+})
+
+describe('determinism', () => {
+  const mockSdkCode = 'window.DD_RUM = { init: function(config) { this.config = config; } };'
+  const mockConfig = {
+    applicationId: 'test-app-id',
+    sessionSampleRate: 100,
+    service: 'test-service',
+    env: 'production',
+    version: '1.0.0',
+  }
+
+  it('produces identical output for identical inputs', () => {
+    const options: CombineBundleOptions = {
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    }
+
+    const bundle1 = generateCombinedBundle(options)
+    const bundle2 = generateCombinedBundle(options)
+
+    assert.strictEqual(bundle1, bundle2, 'Bundles should be byte-identical')
+  })
+
+  it('produces identical output across multiple runs', () => {
+    const options: CombineBundleOptions = {
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum-slim',
+    }
+
+    // Generate 10 times and verify all are identical
+    const bundles = Array.from({ length: 10 }, () => generateCombinedBundle(options))
+    const firstBundle = bundles[0]
+
+    for (let i = 1; i < bundles.length; i++) {
+      assert.strictEqual(bundles[i], firstBundle, `Bundle ${i} should match first bundle`)
+    }
+  })
+
+  it('bundle contains no build timestamps', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    // Check for common timestamp patterns
+    assert.ok(!bundle.includes('Date.now()'), 'Should not contain Date.now()')
+
+    // Check for Unix timestamps (13 digits starting with 17)
+    const unixTimestampRegex = /17\d{11}/
+    assert.ok(!unixTimestampRegex.test(bundle), 'Should not contain Unix timestamps')
+
+    // Check for ISO date strings (but allow version strings like 6.26.0)
+    const isoDateRegex = /202\d-\d{2}-\d{2}/
+    assert.ok(!isoDateRegex.test(bundle), 'Should not contain ISO dates')
+  })
+
+  it('bundle contains no random values', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: mockConfig,
+      variant: 'rum',
+    })
+
+    // Check for Math.random() calls
+    assert.ok(!bundle.includes('Math.random()'), 'Should not contain Math.random()')
+
+    // Check for crypto.randomUUID() calls
+    assert.ok(!bundle.includes('randomUUID'), 'Should not contain randomUUID')
+  })
+
+  it('JSON key ordering is consistent', () => {
+    // Different object creation order should still produce same output
+    const config1 = {
+      applicationId: 'test',
+      sessionSampleRate: 100,
+      env: 'test',
+    }
+
+    const bundle1 = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: config1,
+      variant: 'rum',
+    })
+
+    // Note: JSON.stringify preserves insertion order in modern JS engines,
+    // so config1 and config2 will produce different JSON strings.
+    // This is expected behavior - same logical config with different key order
+    // is technically different input.
+
+    // What we verify is that the SAME input always produces the SAME output
+    const bundleAgain = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      config: config1,
+      variant: 'rum',
+    })
+
+    assert.strictEqual(bundle1, bundleAgain, 'Same config object should produce identical output')
+  })
+})
+
+describe('edge cases', () => {
+  it('handles empty SDK code', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: '',
+      config: { applicationId: 'test' },
+      variant: 'rum',
+    })
+
+    assert.ok(bundle.includes('// SDK bundle (rum) from CDN'), 'Should include SDK comment')
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    assert.doesNotThrow(() => new Function(bundle), 'Empty SDK code should still produce valid JavaScript')
+  })
+
+  it('handles minimal config', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: 'window.DD_RUM = {};',
+      config: { applicationId: 'minimal-app' },
+      variant: 'rum-slim',
+    })
+
+    assert.ok(bundle.includes('"applicationId": "minimal-app"'), 'Should contain minimal config')
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    assert.doesNotThrow(() => new Function(bundle), 'Minimal config should produce valid JavaScript')
+  })
+
+  it('handles config with undefined values (they are omitted by JSON.stringify)', () => {
+    const configWithUndefined = {
+      applicationId: 'test',
+      service: undefined,
+      env: 'test',
+    } as { applicationId: string; service?: string; env: string }
+
+    const bundle = generateCombinedBundle({
+      sdkCode: 'window.DD_RUM = {};',
+      config: configWithUndefined,
+      variant: 'rum',
+    })
+
+    // undefined values are omitted by JSON.stringify
+    assert.ok(!bundle.includes('"service"'), 'Undefined values should be omitted')
+    assert.ok(bundle.includes('"applicationId"'), 'Defined values should be present')
+  })
+
+  it('handles config with null values', () => {
+    const configWithNull = {
+      applicationId: 'test',
+      service: null,
+    } as unknown as { applicationId: string; service: string | null }
+
+    const bundle = generateCombinedBundle({
+      sdkCode: 'window.DD_RUM = {};',
+      config: configWithNull as { applicationId: string },
+      variant: 'rum',
+    })
+
+    assert.ok(bundle.includes('"service": null'), 'Null values should be included')
+  })
+})
+
+describe('generateBundle() input validation', () => {
+  it('throws if applicationId is missing', async () => {
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: '',
+          remoteConfigurationId: 'cfg-1',
+          variant: 'rum',
+        }),
+      (error: Error) => {
+        assert.ok(error.message.includes('applicationId'), 'Error should mention applicationId')
+        assert.ok(error.message.includes('required'), 'Error should mention required')
+        return true
+      }
+    )
+  })
+
+  it('throws if applicationId is not a string', async () => {
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: 123 as unknown as string,
+          remoteConfigurationId: 'cfg-1',
+          variant: 'rum',
+        }),
+      (error: Error) => {
+        assert.ok(error.message.includes('applicationId'), 'Error should mention applicationId')
+        return true
+      }
+    )
+  })
+
+  it('throws if remoteConfigurationId is missing', async () => {
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: 'app-1',
+          remoteConfigurationId: '',
+          variant: 'rum',
+        }),
+      (error: Error) => {
+        assert.ok(error.message.includes('remoteConfigurationId'), 'Error should mention remoteConfigurationId')
+        assert.ok(error.message.includes('required'), 'Error should mention required')
+        return true
+      }
+    )
+  })
+
+  it('throws if remoteConfigurationId is not a string', async () => {
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: 'app-1',
+          remoteConfigurationId: null as unknown as string,
+          variant: 'rum',
+        }),
+      (error: Error) => {
+        assert.ok(error.message.includes('remoteConfigurationId'), 'Error should mention remoteConfigurationId')
+        return true
+      }
+    )
+  })
+
+  it('throws if variant is invalid', async () => {
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: 'app-1',
+          remoteConfigurationId: 'cfg-1',
+          variant: 'invalid' as SdkVariant,
+        }),
+      (error: Error) => {
+        assert.ok(error.message.includes('variant'), 'Error should mention variant')
+        assert.ok(error.message.includes('rum'), 'Error should suggest valid values')
+        assert.ok(error.message.includes('rum-slim'), 'Error should suggest valid values')
+        assert.ok(error.message.includes('invalid'), 'Error should include the invalid value')
+        return true
+      }
+    )
+  })
+
+  it('throws if site is not a string when provided', async () => {
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: 'app-1',
+          remoteConfigurationId: 'cfg-1',
+          variant: 'rum',
+          site: 123 as unknown as string,
+        }),
+      (error: Error) => {
+        assert.ok(error.message.includes('site'), 'Error should mention site')
+        return true
+      }
+    )
+  })
+
+  it('throws if datacenter is not a string when provided', async () => {
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: 'app-1',
+          remoteConfigurationId: 'cfg-1',
+          variant: 'rum',
+          datacenter: false as unknown as string,
+        }),
+      (error: Error) => {
+        assert.ok(error.message.includes('datacenter'), 'Error should mention datacenter')
+        return true
+      }
+    )
+  })
+
+  it('validation errors are thrown before any network requests', async () => {
+    // If validation fails, fetchConfig and downloadSDK should never be called.
+    // We verify this by confirming error is thrown synchronously-ish (no network timeout).
+    const start = Date.now()
+    await assert.rejects(
+      () =>
+        generateBundle({
+          applicationId: '',
+          remoteConfigurationId: 'cfg-1',
+          variant: 'rum',
+        }),
+      Error
+    )
+    const elapsed = Date.now() - start
+    assert.ok(elapsed < 100, `Validation should be fast (took ${elapsed}ms), proving no network call was made`)
+  })
+})

--- a/packages/endpoint/src/bundleGenerator.ts
+++ b/packages/endpoint/src/bundleGenerator.ts
@@ -1,0 +1,136 @@
+import type { SdkVariant } from './sdkDownloader.ts'
+
+export type { SdkVariant } from './sdkDownloader.ts'
+
+export interface FetchConfigOptions {
+  applicationId: string
+  remoteConfigurationId: string
+  site?: string
+}
+
+export interface CombineBundleOptions {
+  sdkCode: string
+  config: {
+    applicationId: string
+    [key: string]: unknown
+  }
+  variant: SdkVariant
+  sdkVersion?: string
+}
+
+export interface GenerateBundleOptions {
+  applicationId: string
+  remoteConfigurationId: string
+  variant: SdkVariant
+  site?: string
+  datacenter?: string
+}
+
+const CONFIG_FETCH_TIMEOUT_MS = 30_000
+
+export async function fetchConfig(options: FetchConfigOptions): Promise<{
+  ok: true
+  value: {
+    applicationId: string
+    [key: string]: unknown
+  }
+}> {
+  const { fetchRemoteConfiguration } = await import('@datadog/browser-remote-config')
+  const result = await fetchRemoteConfiguration({
+    applicationId: options.applicationId,
+    remoteConfigurationId: options.remoteConfigurationId,
+    site: options.site,
+    signal: AbortSignal.timeout(CONFIG_FETCH_TIMEOUT_MS),
+  })
+
+  if (!result.ok) {
+    throw new Error(
+      `Failed to fetch remote configuration: ${result.error.message}\n` +
+        `Verify applicationId "${options.applicationId}" and ` +
+        `configId "${options.remoteConfigurationId}" are correct.`
+    )
+  }
+
+  return { ok: true, value: result.value }
+}
+
+export function generateCombinedBundle(options: CombineBundleOptions): string {
+  const { sdkCode, config, variant, sdkVersion } = options
+  const configJson = JSON.stringify(config, null, 2)
+  const versionDisplay = sdkVersion ?? 'unknown'
+
+  return `/**
+ * Datadog Browser SDK with Embedded Remote Configuration
+ * SDK Variant: ${variant}
+ * SDK Version: ${versionDisplay}
+ *
+ * This bundle includes:
+ * - Pre-fetched remote configuration
+ * - Minified SDK code from CDN
+ *
+ * No additional network requests needed for SDK initialization.
+ */
+(function() {
+  'use strict';
+
+  // Embedded remote configuration
+  var __DATADOG_REMOTE_CONFIG__ = ${configJson};
+
+  // SDK bundle (${variant}) from CDN
+  ${sdkCode}
+
+  // Auto-initialize with embedded config
+  if (typeof window !== 'undefined' && typeof window.DD_RUM !== 'undefined') {
+    window.DD_RUM.init(__DATADOG_REMOTE_CONFIG__);
+  }
+})();
+`
+}
+
+const VALID_VARIANTS: SdkVariant[] = ['rum', 'rum-slim']
+
+export async function generateBundle(options: GenerateBundleOptions): Promise<string> {
+  if (!options.applicationId || typeof options.applicationId !== 'string') {
+    throw new Error("Option 'applicationId' is required and must be a non-empty string.")
+  }
+
+  if (!options.remoteConfigurationId || typeof options.remoteConfigurationId !== 'string') {
+    throw new Error(
+      "Option 'remoteConfigurationId' is required and must be a non-empty string. " +
+        'Get this from Datadog UI > Remote Configuration.'
+    )
+  }
+
+  if (!VALID_VARIANTS.includes(options.variant)) {
+    throw new Error(
+      `Option 'variant' must be 'rum' or 'rum-slim', got '${String(options.variant)}'. ` +
+        'Check your build configuration.'
+    )
+  }
+
+  if (options.site !== undefined && typeof options.site !== 'string') {
+    throw new Error("Option 'site' must be a string when provided (e.g. 'datadoghq.com' or 'datadoghq.eu').")
+  }
+
+  if (options.datacenter !== undefined && typeof options.datacenter !== 'string') {
+    throw new Error("Option 'datacenter' must be a string when provided (e.g. 'us1').")
+  }
+
+  const configResult = await fetchConfig({
+    applicationId: options.applicationId,
+    remoteConfigurationId: options.remoteConfigurationId,
+    site: options.site,
+  })
+
+  const { downloadSDK } = await import('./sdkDownloader.ts')
+  const sdkCode = await downloadSDK({
+    variant: options.variant,
+    datacenter: options.datacenter,
+  })
+
+  return generateCombinedBundle({
+    sdkCode,
+    config: configResult.value,
+    variant: options.variant,
+  })
+}

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -1,0 +1,5 @@
+export { generateBundle, generateCombinedBundle, fetchConfig } from './bundleGenerator.ts'
+export type { GenerateBundleOptions, CombineBundleOptions, FetchConfigOptions } from './bundleGenerator.ts'
+
+// eslint-disable-next-line local-rules/disallow-side-effects -- Node.js build tool, not browser SDK
+export type { RumRemoteConfiguration, RemoteConfigResult } from '@datadog/browser-remote-config'

--- a/packages/endpoint/src/sdkDownloader.spec.ts
+++ b/packages/endpoint/src/sdkDownloader.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, mock, beforeEach } from 'node:test'
+import assert from 'node:assert'
+import https from 'node:https'
+import { EventEmitter } from 'node:events'
+import { downloadSDK, clearSdkCache } from './sdkDownloader.ts'
+
+// All tests should pass `version: '6.26.0'` explicitly in DownloadSDKOptions
+// to avoid hitting the getDefaultVersion() path (which reads package.json)
+
+describe('downloadSDK() caching', () => {
+  function createMockResponse(data: string, statusCode = 200) {
+    const response = new EventEmitter() as EventEmitter & { statusCode: number }
+    response.statusCode = statusCode
+    process.nextTick(() => {
+      response.emit('data', data)
+      response.emit('end')
+    })
+    return response
+  }
+
+  beforeEach(() => {
+    clearSdkCache()
+    mock.restoreAll()
+  })
+
+  it('caches SDK after first download', async () => {
+    let callCount = 0
+    mock.method(https, 'get', (_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      cb(createMockResponse('/* SDK CODE */'))
+      return new EventEmitter()
+    })
+
+    const result = await downloadSDK({ variant: 'rum', version: '6.26.0' })
+    assert.strictEqual(result, '/* SDK CODE */')
+    assert.strictEqual(callCount, 1, 'https.get should be called once')
+  })
+
+  it('returns cached SDK on second call without network request', async () => {
+    let callCount = 0
+    mock.method(https, 'get', (_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      cb(createMockResponse('/* SDK CODE */'))
+      return new EventEmitter()
+    })
+
+    const result1 = await downloadSDK({ variant: 'rum', version: '6.26.0' })
+    const result2 = await downloadSDK({ variant: 'rum', version: '6.26.0' })
+    assert.strictEqual(result1, result2, 'Same SDK code returned from cache')
+    assert.strictEqual(callCount, 1, 'https.get should only be called once (cache hit on second call)')
+  })
+
+  it('caches different variants separately', async () => {
+    let callCount = 0
+    mock.method(https, 'get', (url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      const variant = url.includes('rum-slim') ? 'slim' : 'full'
+      cb(createMockResponse(`/* SDK ${variant} */`))
+      return new EventEmitter()
+    })
+
+    const rum = await downloadSDK({ variant: 'rum', version: '6.26.0' })
+    const rumSlim = await downloadSDK({ variant: 'rum-slim', version: '6.26.0' })
+    const rumAgain = await downloadSDK({ variant: 'rum', version: '6.26.0' })
+
+    assert.strictEqual(rum, '/* SDK full */')
+    assert.strictEqual(rumSlim, '/* SDK slim */')
+    assert.strictEqual(rumAgain, '/* SDK full */')
+    assert.strictEqual(callCount, 2, 'Only 2 network requests (one per variant)')
+  })
+
+  it('caches different datacenters separately', async () => {
+    let callCount = 0
+    mock.method(https, 'get', (url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      const dc = url.includes('eu1') ? 'eu1' : 'us1'
+      cb(createMockResponse(`/* SDK ${dc} */`))
+      return new EventEmitter()
+    })
+
+    const us1 = await downloadSDK({ variant: 'rum', datacenter: 'us1', version: '6.26.0' })
+    const eu1 = await downloadSDK({ variant: 'rum', datacenter: 'eu1', version: '6.26.0' })
+    const us1Again = await downloadSDK({ variant: 'rum', datacenter: 'us1', version: '6.26.0' })
+
+    assert.strictEqual(us1, '/* SDK us1 */')
+    assert.strictEqual(eu1, '/* SDK eu1 */')
+    assert.strictEqual(us1Again, '/* SDK us1 */')
+    assert.strictEqual(callCount, 2, 'Only 2 network requests (one per datacenter)')
+  })
+
+  it('cache hit is fast compared to network fetch', async () => {
+    mock.method(https, 'get', (_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      cb(createMockResponse('/* SDK CODE */'))
+      return new EventEmitter()
+    })
+
+    await downloadSDK({ variant: 'rum', version: '6.26.0' })
+
+    const start = Date.now()
+    await downloadSDK({ variant: 'rum', version: '6.26.0' })
+    const elapsed = Date.now() - start
+
+    assert.ok(elapsed < 5, `Cache hit should be fast (took ${elapsed}ms)`)
+  })
+
+  it('clearSdkCache empties the cache', async () => {
+    let callCount = 0
+    mock.method(https, 'get', (_url: string, _opts: unknown, cb: (res: unknown) => void) => {
+      callCount++
+      cb(createMockResponse('/* SDK CODE */'))
+      return new EventEmitter()
+    })
+
+    await downloadSDK({ variant: 'rum', version: '6.26.0' })
+    clearSdkCache()
+    await downloadSDK({ variant: 'rum', version: '6.26.0' })
+
+    assert.strictEqual(callCount, 2, 'After cache clear, network request should be made again')
+  })
+})

--- a/packages/endpoint/src/sdkDownloader.ts
+++ b/packages/endpoint/src/sdkDownloader.ts
@@ -1,0 +1,92 @@
+// eslint-disable-next-line local-rules/disallow-side-effects, local-rules/enforce-prod-deps-imports -- Node.js build tool
+import https from 'node:https'
+// eslint-disable-next-line local-rules/disallow-side-effects, local-rules/enforce-prod-deps-imports -- Node.js build tool
+import { createRequire } from 'node:module'
+
+export type SdkVariant = 'rum' | 'rum-slim'
+
+export interface DownloadSDKOptions {
+  variant: SdkVariant
+  datacenter?: string
+  version?: string
+}
+
+const CDN_HOST = 'https://www.datadoghq-browser-agent.com'
+const DEFAULT_DATACENTER = 'us1'
+
+const sdkCache = new Map<string, string>()
+
+function getDefaultVersion(): string {
+  const require = createRequire(import.meta.url)
+  const pkg = require('@datadog/browser-remote-config/package.json') as { version: string }
+  return pkg.version
+}
+
+function getMajorVersion(version: string): number {
+  const major = parseInt(version.split('.')[0], 10)
+  if (isNaN(major)) {
+    throw new Error(`Invalid SDK version format: ${version}`)
+  }
+  return major
+}
+
+export async function downloadSDK(options: SdkVariant | DownloadSDKOptions): Promise<string> {
+  const variant = typeof options === 'string' ? options : options.variant
+  const datacenter = typeof options === 'string' ? DEFAULT_DATACENTER : (options.datacenter ?? DEFAULT_DATACENTER)
+  const version = typeof options === 'string' ? getDefaultVersion() : (options.version ?? getDefaultVersion())
+  const majorVersion = getMajorVersion(version)
+
+  const cacheKey = `${variant}-${majorVersion}-${datacenter}`
+  const cached = sdkCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const cdnUrl = `${CDN_HOST}/${datacenter}/v${majorVersion}/datadog-${variant}.js`
+
+  const sdkCode = await new Promise<string>((resolve, reject) => {
+    const request = https.get(cdnUrl, { timeout: 30000 }, (res) => {
+      let data = ''
+
+      if (res.statusCode === 404) {
+        reject(
+          new Error(
+            `SDK bundle not found at ${cdnUrl}\n` +
+              `Check that variant "${variant}" (major version: v${majorVersion}) is correct.\n` +
+              `Full SDK version: ${version}`
+          )
+        )
+        return
+      }
+
+      if (!res.statusCode || res.statusCode >= 400) {
+        reject(new Error(`Failed to download SDK from CDN: HTTP ${res.statusCode}\nURL: ${cdnUrl}`))
+        return
+      }
+
+      res.on('data', (chunk: Buffer | string) => {
+        data += String(chunk)
+      })
+
+      res.on('end', () => {
+        resolve(data)
+      })
+    })
+
+    request.on('error', (error: Error) => {
+      reject(new Error(`Network error downloading SDK from CDN:\nURL: ${cdnUrl}\nError: ${error.message}`))
+    })
+
+    request.on('timeout', () => {
+      request.destroy()
+      reject(new Error(`Timeout downloading SDK from CDN (30s):\nURL: ${cdnUrl}`))
+    })
+  })
+
+  sdkCache.set(cacheKey, sdkCode)
+  return sdkCode
+}
+
+export function clearSdkCache(): void {
+  sdkCache.clear()
+}

--- a/packages/endpoint/tsconfig.json
+++ b/packages/endpoint/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": true,
+    "rootDir": "./src/",
+    "module": "preserve",
+    "target": "ES2024",
+    "lib": ["ES2024", "DOM"],
+    "types": ["node"],
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": []
+}

--- a/scripts/build/generate-cdn-bundle.spec.ts
+++ b/scripts/build/generate-cdn-bundle.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * CDN Bundle Generator CLI Tests
+ *
+ * Tests for the CLI entry point and integration tests for the full generation flow.
+ * Uses Node.js built-in test runner (node:test).
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+
+const CLI_PATH = './scripts/build/generate-cdn-bundle.ts'
+
+/**
+ * Helper to run the CLI with given arguments
+ */
+function runCLI(args: string[]): { stdout: string; stderr: string; exitCode: number | null } {
+  const result = spawnSync('node', [CLI_PATH, ...args], {
+    encoding: 'utf-8',
+    timeout: 30000,
+  })
+
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    exitCode: result.status,
+  }
+}
+
+describe('CLI argument validation', () => {
+  it('shows help with --help flag', () => {
+    const result = runCLI(['--help'])
+
+    assert.strictEqual(result.exitCode, 0, 'Should exit with code 0')
+    assert.ok(result.stdout.includes('Usage:'), 'Should show usage information')
+    assert.ok(result.stdout.includes('--applicationId'), 'Should list applicationId option')
+    assert.ok(result.stdout.includes('--configId'), 'Should list configId option')
+    assert.ok(result.stdout.includes('--variant'), 'Should list variant option')
+  })
+
+  it('shows help with -h flag', () => {
+    const result = runCLI(['-h'])
+
+    assert.strictEqual(result.exitCode, 0, 'Should exit with code 0')
+    assert.ok(result.stdout.includes('Usage:'), 'Should show usage information')
+  })
+
+  it('exits with error when missing required arguments', () => {
+    const result = runCLI([])
+
+    assert.strictEqual(result.exitCode, 1, 'Should exit with code 1')
+    assert.ok(result.stdout.includes('Missing required arguments'), 'Should indicate missing arguments')
+    assert.ok(result.stdout.includes('--applicationId'), 'Should list missing applicationId')
+    assert.ok(result.stdout.includes('--configId'), 'Should list missing configId')
+    assert.ok(result.stdout.includes('--variant'), 'Should list missing variant')
+  })
+
+  it('exits with error when only applicationId is provided', () => {
+    const result = runCLI(['--applicationId', 'test-app'])
+
+    assert.strictEqual(result.exitCode, 1, 'Should exit with code 1')
+    assert.ok(result.stdout.includes('--configId'), 'Should list missing configId')
+    assert.ok(result.stdout.includes('--variant'), 'Should list missing variant')
+  })
+
+  it('exits with error when invalid variant is provided', () => {
+    const result = runCLI(['--applicationId', 'test-app', '--configId', 'test-config', '--variant', 'invalid-variant'])
+
+    assert.strictEqual(result.exitCode, 1, 'Should exit with code 1')
+    assert.ok(result.stdout.includes('Invalid variant'), 'Should indicate invalid variant')
+    assert.ok(result.stdout.includes('rum') && result.stdout.includes('rum-slim'), 'Should suggest valid variants')
+  })
+
+  it('accepts valid rum variant', () => {
+    // This will fail at fetch stage, but validates variant was accepted
+    const result = runCLI(['--applicationId', 'test-app', '--configId', 'invalid-config-id', '--variant', 'rum'])
+
+    // Should fail with exit code 2 (network/runtime error), not 1 (validation error)
+    assert.strictEqual(result.exitCode, 2, 'Should exit with code 2 for runtime error')
+    assert.ok(!result.stdout.includes('Invalid variant'), 'Should not show invalid variant error')
+  })
+
+  it('accepts valid rum-slim variant', () => {
+    // This will fail at fetch stage, but validates variant was accepted
+    const result = runCLI(['--applicationId', 'test-app', '--configId', 'invalid-config-id', '--variant', 'rum-slim'])
+
+    // Should fail with exit code 2 (network/runtime error), not 1 (validation error)
+    assert.strictEqual(result.exitCode, 2, 'Should exit with code 2 for runtime error')
+    assert.ok(!result.stdout.includes('Invalid variant'), 'Should not show invalid variant error')
+  })
+
+  it('accepts short flags', () => {
+    // This will fail at fetch stage, but validates short flags are parsed
+    const result = runCLI(['-a', 'test-app', '-c', 'invalid-config-id', '-v', 'rum'])
+
+    // Should fail with exit code 2 (network/runtime error), not 1 (validation error)
+    assert.strictEqual(result.exitCode, 2, 'Should exit with code 2 for runtime error')
+  })
+})
+
+describe('error handling', () => {
+  it('provides helpful error message for invalid config ID', () => {
+    const result = runCLI([
+      '--applicationId',
+      'test-app',
+      '--configId',
+      'definitely-not-a-valid-config-id',
+      '--variant',
+      'rum',
+    ])
+
+    assert.strictEqual(result.exitCode, 2, 'Should exit with code 2')
+    assert.ok(
+      result.stdout.includes('Failed to fetch') || result.stdout.includes('Error') || result.stdout.includes('error'),
+      'Should show error message'
+    )
+  })
+})
+
+describe('output format', () => {
+  // Note: These tests require mocking or a real config ID to fully test
+  // For now, we verify the output structure expectations
+
+  it('includes progress messages when generating', () => {
+    const result = runCLI(['--applicationId', 'test-app', '--configId', 'test-config', '--variant', 'rum'])
+
+    // First step should show "Fetching remote configuration..."
+    assert.ok(result.stdout.includes('Fetching remote configuration'), 'Should show fetching message')
+  })
+})
+
+describe('integration: generateCombinedBundle output validation', () => {
+  // These tests verify that the generated output is valid JavaScript
+  // without requiring actual network calls
+
+  it('generated bundle template produces valid JavaScript', async () => {
+    const { generateCombinedBundle } = await import('../../packages/endpoint/src/bundleGenerator.ts')
+
+    const bundle = generateCombinedBundle({
+      sdkCode: `
+        window.DD_RUM = window.DD_RUM || {};
+        window.DD_RUM.init = function(config) {
+          console.log('DD_RUM initialized with', config);
+        };
+      `,
+      config: {
+        applicationId: 'test-app-id',
+        sessionSampleRate: 100,
+        service: 'test-service',
+        env: 'test',
+      },
+      variant: 'rum',
+    })
+
+    // Verify it's valid JavaScript
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    assert.doesNotThrow(() => new Function(bundle), 'Generated bundle should be valid JavaScript')
+
+    // Verify structure
+    assert.ok(bundle.includes('Datadog Browser SDK'), 'Should have header comment')
+    assert.ok(bundle.includes('(function()'), 'Should be wrapped in IIFE')
+    assert.ok(bundle.includes('__DATADOG_REMOTE_CONFIG__'), 'Should define config variable')
+    assert.ok(bundle.includes('DD_RUM.init'), 'Should call init')
+  })
+
+  it('generated bundle executes without error in simulated browser environment', async () => {
+    const { generateCombinedBundle } = await import('../../packages/endpoint/src/bundleGenerator.ts')
+
+    const bundle = generateCombinedBundle({
+      sdkCode: `
+        (function() {
+          window.DD_RUM = window.DD_RUM || {};
+          window.DD_RUM.init = function(config) {
+            window.DD_RUM._config = config;
+          };
+        })();
+      `,
+      config: {
+        applicationId: 'exec-test-app',
+        sessionSampleRate: 50,
+      },
+      variant: 'rum',
+    })
+
+    // Simulate browser environment
+    const mockWindow = {
+      DD_RUM: undefined as unknown,
+    }
+
+    // Create a function that executes the bundle with our mock window
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    const executeBundle = new Function('window', bundle) as (w: unknown) => void
+
+    assert.doesNotThrow(() => {
+      executeBundle(mockWindow)
+    }, 'Bundle should execute without throwing')
+
+    // Verify the SDK was "initialized" with our config
+    assert.ok(mockWindow.DD_RUM !== undefined, 'DD_RUM should be defined after bundle execution')
+  })
+})

--- a/scripts/build/generate-cdn-bundle.ts
+++ b/scripts/build/generate-cdn-bundle.ts
@@ -1,0 +1,127 @@
+/**
+ * CDN Bundle Generator CLI
+ *
+ * Generates a combined SDK + remote configuration bundle by:
+ * 1. Fetching remote configuration from Datadog servers
+ * 2. Downloading pre-built SDK from Datadog CDN
+ * 3. Combining them into a single JavaScript file
+ */
+
+import { parseArgs } from 'node:util'
+import * as fs from 'node:fs/promises'
+import { runMain, printLog, printError } from '../lib/executionUtils.ts'
+import { fetchConfig, generateCombinedBundle } from '../../packages/endpoint/src/index.ts'
+import { downloadSDK } from '../../packages/endpoint/src/sdkDownloader.ts'
+import type { SdkVariant } from '../../packages/endpoint/src/sdkDownloader.ts'
+
+function printHelp(): void {
+  console.log(`
+Usage: npx tsx scripts/build/generate-cdn-bundle.ts [options]
+
+Generates a combined Datadog Browser SDK bundle with embedded remote configuration.
+
+Options:
+  -a, --applicationId  Datadog application ID (required)
+  -c, --configId       Remote configuration ID (required)
+  -v, --variant        SDK variant: "rum" or "rum-slim" (required)
+  -o, --output         Output file path (default: stdout)
+  -s, --site           Datadog site (default: datadoghq.com)
+  -h, --help           Show this help message
+
+Example:
+  npx tsx scripts/build/generate-cdn-bundle.ts \\
+    --applicationId abc123 \\
+    --configId def456 \\
+    --variant rum \\
+    --output ./datadog-rum-bundle.js
+
+Notes:
+  - The generated bundle is self-contained and requires no additional network requests
+  - Both "rum" (full) and "rum-slim" (lightweight) variants are supported
+  - The bundle auto-initializes when loaded in a browser
+`)
+}
+
+function validateVariant(variant: string | undefined): variant is SdkVariant {
+  return variant === 'rum' || variant === 'rum-slim'
+}
+
+runMain(async () => {
+  const { values } = parseArgs({
+    options: {
+      applicationId: { type: 'string', short: 'a' },
+      configId: { type: 'string', short: 'c' },
+      variant: { type: 'string', short: 'v' },
+      output: { type: 'string', short: 'o' },
+      site: { type: 'string', short: 's' },
+      help: { type: 'boolean', short: 'h' },
+    },
+  })
+
+  if (values.help) {
+    printHelp()
+    return
+  }
+
+  // Validate required arguments
+  const missingArgs: string[] = []
+  if (!values.applicationId) {
+    missingArgs.push('--applicationId')
+  }
+  if (!values.configId) {
+    missingArgs.push('--configId')
+  }
+  if (!values.variant) {
+    missingArgs.push('--variant')
+  }
+
+  if (missingArgs.length > 0) {
+    printError(`Missing required arguments: ${missingArgs.join(', ')}`)
+    printHelp()
+    process.exit(1)
+  }
+
+  // Validate variant
+  if (!validateVariant(values.variant)) {
+    printError(`Invalid variant "${values.variant}". Must be "rum" or "rum-slim".`)
+    process.exit(1)
+  }
+
+  const variant: SdkVariant = values.variant
+
+  try {
+    // Step 1: Fetch remote configuration
+    printLog('Fetching remote configuration...')
+    const configResult = await fetchConfig({
+      applicationId: values.applicationId!,
+      remoteConfigurationId: values.configId!,
+      site: values.site,
+    })
+
+    // Step 2: Download SDK from CDN
+    printLog(`Downloading SDK (${variant}) from CDN...`)
+    const sdkCode = await downloadSDK(variant)
+
+    // Step 3: Generate combined bundle
+    printLog('Generating combined bundle...')
+    const bundle = generateCombinedBundle({
+      sdkCode,
+      config: configResult.value,
+      variant,
+    })
+
+    // Step 4: Output result
+    if (values.output) {
+      await fs.writeFile(values.output, bundle, 'utf-8')
+      printLog(`Bundle written to ${values.output}`)
+      printLog(`Bundle size: ${(bundle.length / 1024).toFixed(2)} KiB`)
+    } else {
+      console.log(bundle)
+    }
+
+    printLog('Done.')
+  } catch (error) {
+    printError(`Error: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(2)
+  }
+})

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -29,7 +29,7 @@ const FILES = [
 ]
 
 const FILES_SPECS = [
-  'packages/*/@(src|test)/**/*.spec.@(ts|tsx)',
+  'packages/!(endpoint)/@(src|test)/**/*.spec.@(ts|tsx)',
   'developer-extension/@(src|test)/**/*.spec.@(ts|tsx)',
 ]
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,7 +37,8 @@
 
       "@datadog/browser-worker": ["./packages/worker/src/entries/main"],
 
-      "@datadog/browser-remote-config": ["./packages/remote-config/src/index.ts"]
+      "@datadog/browser-sdk-endpoint": ["./packages/endpoint/src/index.ts"],
+      "@datadog/browser-sdk-endpoint/*": ["./packages/endpoint/src/*"]
     }
   }
 }

--- a/tsconfig.default.json
+++ b/tsconfig.default.json
@@ -16,6 +16,7 @@
     // Files included in ./tsconfig.scripts.json
     "**/webpack.*",
     "scripts",
+    "packages/endpoint",
     "test/envUtils.ts",
 
     // Files included in ./test/e2e/tsconfig.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./tsconfig.default.json" },
     { "path": "./tsconfig.scripts.json" },
+    { "path": "./packages/endpoint/tsconfig.json" },
     { "path": "./developer-extension/tsconfig.json" },
     { "path": "./test/e2e/tsconfig.json" },
     { "path": "./test/performance/tsconfig.json" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-remote-config@workspace:packages/remote-config":
+"@datadog/browser-remote-config@npm:6.28.0, @datadog/browser-remote-config@workspace:packages/remote-config":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-remote-config@workspace:packages/remote-config"
   dependencies:
@@ -418,6 +418,14 @@ __metadata:
     react-dom: "npm:19.2.4"
     typescript: "npm:5.9.3"
     wxt: "npm:0.20.17"
+  languageName: unknown
+  linkType: soft
+
+"@datadog/browser-sdk-endpoint@workspace:packages/endpoint":
+  version: 0.0.0-use.local
+  resolution: "@datadog/browser-sdk-endpoint@workspace:packages/endpoint"
+  dependencies:
+    "@datadog/browser-remote-config": "npm:6.28.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Motivation

Build tools (webpack, Vite, Node.js scripts) need a programmatic API to generate CDN bundles with embedded remote configuration. This PR adds that API as a published Node.js package, plus a CLI wrapper.

## Changes

### New package: `@datadog/browser-sdk-endpoint`

- `generateBundle(options)` — high-level async function with full input validation
- `fetchConfig(options)` — fetches remote config (delegates to `@datadog/browser-remote-config`)
- `downloadSDK(options)` — downloads SDK from Datadog CDN with in-memory caching (keyed by variant+datacenter; avoids re-fetching during watch mode)
- `generateCombinedBundle(options)` — low-level combinator: wraps SDK + config in an IIFE
- `clearSdkCache()` — test utility

### CLI: `scripts/build/generate-cdn-bundle.ts`

```
generate-cdn-bundle --applicationId <id> --configId <id> --variant rum|rum-slim [--output file]
```

### Infrastructure

- Excluded from Karma browser test runner (Node.js-only package)
- ESLint configured to disable browser-specific rules for Node.js files
- `tsconfig.base.json` path alias for `@datadog/browser-sdk-endpoint`

## Testing

```bash
yarn test:script
yarn typecheck
```

---
> Part of SSI Phase 6 stacked PRs. Stacks on: ✨ @datadog/browser-remote-config (#4239). Next: E2E tests.