### PR TITLE
Replace misleading Base64 type alias with actual value type

### DIFF
--- a/packages/flagging/src/interfaces.ts
+++ b/packages/flagging/src/interfaces.ts
@@ -16,8 +16,6 @@ export type BasePrecomputedFlag = {
   doLog: boolean
 }
 
-type Base64 = string
-
 export interface FlagEvaluationWithoutDetails {
   flagKey: string
   format: string
@@ -32,7 +30,7 @@ export interface FlagEvaluationWithoutDetails {
 }
 
 export interface PrecomputedFlag extends BasePrecomputedFlag {
-  variationValue: Base64
+  variationValue: string | number | boolean
 }
 
 export interface Subject {


### PR DESCRIPTION
## Motivation

The `type Base64 = string` alias on `PrecomputedFlag.variationValue` is misleading — nothing is actually base64 encoded in the precomputed flags. Test data and runtime values are raw primitives (`"red"`, `true`, `42`, `3.14`).

## Changes

- Remove the `Base64` type alias from `interfaces.ts`
- Replace `variationValue: Base64` with `variationValue: string | number | boolean` to accurately represent the possible variation values

## Decisions

- Used a union type rather than `unknown` so consumers get type safety without needing to cast