### PR TITLE
Remove dead FlagEvaluationWithoutDetails code from precomputeClient

### DIFF
--- a/packages/flagging/src/interfaces.ts
+++ b/packages/flagging/src/interfaces.ts
@@ -18,19 +18,6 @@ export type BasePrecomputedFlag = {
 
 type Base64 = string
 
-export interface FlagEvaluationWithoutDetails {
-  flagKey: string
-  format: string
-  subjectKey: string
-  subjectAttributes: Attributes
-  allocationKey: string | null
-  variation: Variation | null
-  extraLogging: Record<string, string>
-  // whether to log assignment event
-  doLog: boolean
-  entityId: number | null
-}
-
 export interface PrecomputedFlag extends BasePrecomputedFlag {
   variationValue: Base64
 }
@@ -38,11 +25,6 @@ export interface PrecomputedFlag extends BasePrecomputedFlag {
 export interface Subject {
   key: string
   attributes: ContextAttributes
-}
-
-export interface Variation {
-  key: string
-  value: string | number | boolean
 }
 
 export const enum VariationType {

--- a/packages/flagging/src/precomputeClient.ts
+++ b/packages/flagging/src/precomputeClient.ts
@@ -4,7 +4,7 @@
 import type { ISyncStore } from './configuration-store/configurationStore'
 import type { IConfigurationWire, IPrecomputedConfigurationResponse } from './configuration-wire/configurationWireTypes'
 import { precomputedFlagsStorageFactory } from './configurationFactory'
-import type { FlagEvaluationWithoutDetails, PrecomputedFlag, Subject } from './interfaces'
+import type { PrecomputedFlag, Subject } from './interfaces'
 import { VariationType } from './interfaces'
 
 // Instantiate the precomputed flags and bandits stores with memory-only implementation.
@@ -88,40 +88,16 @@ export class PrecomputeClient {
     _expectedType: VariationType,
     valueTransformer: (value: unknown) => T = (v) => v as T
   ): T {
-    // validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank')
-
     const precomputedFlag = this.getPrecomputedFlag(flagKey)
 
     if (precomputedFlag === null) {
       return defaultValue
     }
 
-    const result: FlagEvaluationWithoutDetails = {
-      flagKey,
-      format: 'PRECOMPUTED',
-      subjectKey: this.subject.key ?? '',
-      subjectAttributes: {
-        ...this.subject.attributes?.numericAttributes,
-        ...this.subject.attributes?.categoricalAttributes,
-      },
-      variation: {
-        key: precomputedFlag.variationKey ?? '',
-        value: precomputedFlag.variationValue,
-      },
-      allocationKey: precomputedFlag.allocationKey ?? '',
-      extraLogging: precomputedFlag.extraLogging ?? {},
-      doLog: precomputedFlag.doLog,
-      entityId: null,
-    }
-
     try {
-      const transformedValue =
-        result.variation?.value !== undefined ? valueTransformer(result.variation.value) : defaultValue
-      // TODO: add logging or open feature hook
-      // if (result?.doLog) {
-      //   this.logAssignment(result)
-      // }
-      return transformedValue
+      return precomputedFlag.variationValue !== undefined
+        ? valueTransformer(precomputedFlag.variationValue)
+        : defaultValue
     } catch {
       return defaultValue
     }


### PR DESCRIPTION
## Motivation

The `getPrecomputedAssignment` method constructs a full `FlagEvaluationWithoutDetails` object on every flag evaluation (~15 lines) but only `result.variation.value` is ever read. The logging block is commented out with a TODO.

## Changes

- Simplify `getPrecomputedAssignment` to read `precomputedFlag.variationValue` directly
- Remove unused `FlagEvaluationWithoutDetails` interface from `interfaces.ts`
- Remove unused `Variation` interface from `interfaces.ts`
- Remove unused `FlagEvaluationWithoutDetails` import from `precomputeClient.ts`

## Decisions

- Details and assignment logging will be implemented in a separate PR matching the iOS/Android SDK implementation