### PR TITLE
Validate expectedType in getPrecomputedAssignment

### DIFF
--- a/packages/flagging/src/precomputeClient.spec.ts
+++ b/packages/flagging/src/precomputeClient.spec.ts
@@ -159,5 +159,28 @@ describe('PrecomputeClient', () => {
         })
       })
     })
+
+    describe('type mismatch behavior', () => {
+      it('should return default when calling getBooleanAssignment on a STRING flag', () => {
+        const client = offlinePrecomputedInit({ precomputedConfiguration: JSON.stringify(mockPrecomputedConfig) })
+        expect(client!.getBooleanAssignment('string-flag', false)).toBe(false)
+      })
+
+      it('should return default when calling getStringAssignment on a BOOLEAN flag', () => {
+        const client = offlinePrecomputedInit({ precomputedConfiguration: JSON.stringify(mockPrecomputedConfig) })
+        expect(client!.getStringAssignment('boolean-flag', 'fallback')).toBe('fallback')
+      })
+
+      it('should return default when calling getIntegerAssignment on a STRING flag', () => {
+        const client = offlinePrecomputedInit({ precomputedConfiguration: JSON.stringify(mockPrecomputedConfig) })
+        expect(client!.getIntegerAssignment('string-flag', 99)).toBe(99)
+      })
+
+      it('should return default when calling getJSONAssignment on a STRING flag', () => {
+        const client = offlinePrecomputedInit({ precomputedConfiguration: JSON.stringify(mockPrecomputedConfig) })
+        const fallback = { fallback: true }
+        expect(client!.getJSONAssignment('string-flag', fallback)).toEqual(fallback)
+      })
+    })
   })
 })

--- a/packages/flagging/src/precomputeClient.ts
+++ b/packages/flagging/src/precomputeClient.ts
@@ -85,14 +85,16 @@ export class PrecomputeClient {
   private getPrecomputedAssignment<T>(
     flagKey: string,
     defaultValue: T,
-    _expectedType: VariationType,
+    expectedType: VariationType,
     valueTransformer: (value: unknown) => T = (v) => v as T
   ): T {
-    // validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank')
-
     const precomputedFlag = this.getPrecomputedFlag(flagKey)
 
     if (precomputedFlag === null) {
+      return defaultValue
+    }
+
+    if (precomputedFlag.variationType !== expectedType) {
       return defaultValue
     }
 


### PR DESCRIPTION
## Motivation

The `_expectedType: VariationType` parameter in `getPrecomputedAssignment` was accepted but never used. A consumer calling `getBooleanAssignment` on a `STRING`-typed flag would silently receive the string value cast via `v as T` with no error.

## Changes

- Validate that the flag's `variationType` matches the expected type before returning the value
- Return the default value when there is a type mismatch
- Rename `_expectedType` to `expectedType` (no longer unused)
- Add 4 test cases covering type mismatch scenarios (bool/string/integer/json on wrong flag types)

## Decisions

- Returns default value on mismatch rather than throwing, consistent with the existing pattern of graceful degradation throughout the client