### PR TITLE
Fix global DD_FLAGGING initialization

### DIFF
--- a/packages/flagging/src/entries/main.ts
+++ b/packages/flagging/src/entries/main.ts
@@ -8,8 +8,6 @@ interface BrowserWindow extends Window {
   DD_FLAGGING?: DatadogProvider
 }
 
-defineGlobal(
-  getGlobalObject<BrowserWindow>(),
-  'DD_FLAGGING',
-  new DatadogProvider(offlineClientInit({ precomputedConfiguration: '' }) ?? undefined)
-)
+// CDN placeholder: provider without a precompute client returns defaults for
+// all evaluations. Users must call offlineClientInit() to bootstrap real flags.
+defineGlobal(getGlobalObject<BrowserWindow>(), 'DD_FLAGGING', new DatadogProvider())


### PR DESCRIPTION
## Motivation

The global `DD_FLAGGING` initialization called `offlinePrecomputedInit({ precomputedConfiguration: '' })` which always fails JSON parsing, returns `null`, and creates a `DatadogProvider(undefined)`. This is misleading — it looks like a bug rather than intentional behavior.

## Changes

- Replace the failing `offlinePrecomputedInit` call with a plain `new DatadogProvider()` constructor
- Add a comment explaining this is a CDN placeholder that returns defaults until the user calls `offlineClientInit()`

## Decisions

- The CDN global remains a default-only provider — users must explicitly initialize via `offlineClientInit()` to get real flag evaluations