### PR TITLE
Fix OpenFeature resolution reason (STATIC vs DEFAULT)

### DIFF
--- a/packages/flagging/src/openfeature/provider.spec.ts
+++ b/packages/flagging/src/openfeature/provider.spec.ts
@@ -1,13 +1,13 @@
 import { StandardResolutionReasons, type EvaluationContext, type Logger } from '@openfeature/core'
+import mockPrecomputedConfig from '../../test/data/precomputed-v1-deobfuscated.json'
+import { offlinePrecomputedInit } from '../precomputeClient'
 import { DatadogProvider } from './provider'
 
 describe('DatadogProvider', () => {
-  let provider: DatadogProvider
   let mockLogger: Logger
   let mockContext: EvaluationContext
 
   beforeEach(() => {
-    provider = new DatadogProvider()
     mockLogger = {
       debug: jasmine.createSpy('debug'),
       info: jasmine.createSpy('info'),
@@ -19,54 +19,78 @@ describe('DatadogProvider', () => {
 
   describe('metadata', () => {
     it('should have correct metadata', () => {
+      const provider = new DatadogProvider()
       expect(provider.metadata).toEqual({
         name: 'datadog',
       })
     })
 
     it('should run on client', () => {
+      const provider = new DatadogProvider()
       expect(provider.runsOn).toBe('client')
     })
   })
 
-  describe('resolveBooleanEvaluation', () => {
-    it('should return default value with DEFAULT reason', () => {
+  describe('without precompute client', () => {
+    let provider: DatadogProvider
+
+    beforeEach(() => {
+      provider = new DatadogProvider()
+    })
+
+    it('should return default boolean with DEFAULT reason', () => {
       const result = provider.resolveBooleanEvaluation('test-flag', true, mockContext, mockLogger)
-      expect(result).toEqual({
-        value: true,
-        reason: StandardResolutionReasons.DEFAULT,
-      })
+      expect(result).toEqual({ value: true, reason: StandardResolutionReasons.DEFAULT })
     })
-  })
 
-  describe('resolveStringEvaluation', () => {
-    it('should return default value with DEFAULT reason', () => {
+    it('should return default string with DEFAULT reason', () => {
       const result = provider.resolveStringEvaluation('test-flag', 'default', mockContext, mockLogger)
-      expect(result).toEqual({
-        value: 'default',
-        reason: StandardResolutionReasons.DEFAULT,
-      })
+      expect(result).toEqual({ value: 'default', reason: StandardResolutionReasons.DEFAULT })
     })
-  })
 
-  describe('resolveNumberEvaluation', () => {
-    it('should return default value with DEFAULT reason', () => {
+    it('should return default number with DEFAULT reason', () => {
       const result = provider.resolveNumberEvaluation('test-flag', 42, mockContext, mockLogger)
-      expect(result).toEqual({
-        value: 42,
-        reason: StandardResolutionReasons.DEFAULT,
-      })
+      expect(result).toEqual({ value: 42, reason: StandardResolutionReasons.DEFAULT })
     })
-  })
 
-  describe('resolveObjectEvaluation', () => {
-    it('should return default value with DEFAULT reason', () => {
+    it('should return default object with DEFAULT reason', () => {
       const defaultValue = { key: 'value' }
       const result = provider.resolveObjectEvaluation('test-flag', defaultValue, mockContext, mockLogger)
-      expect(result).toEqual({
-        value: defaultValue,
-        reason: StandardResolutionReasons.DEFAULT,
-      })
+      expect(result).toEqual({ value: defaultValue, reason: StandardResolutionReasons.DEFAULT })
+    })
+  })
+
+  describe('with precompute client', () => {
+    let provider: DatadogProvider
+
+    beforeEach(() => {
+      const client = offlinePrecomputedInit({ precomputedConfiguration: JSON.stringify(mockPrecomputedConfig) })
+      provider = new DatadogProvider(client!)
+    })
+
+    it('should resolve boolean flag with STATIC reason', () => {
+      const result = provider.resolveBooleanEvaluation('boolean-flag', false, mockContext, mockLogger)
+      expect(result).toEqual({ value: true, reason: StandardResolutionReasons.STATIC })
+    })
+
+    it('should resolve string flag with STATIC reason', () => {
+      const result = provider.resolveStringEvaluation('string-flag', 'default', mockContext, mockLogger)
+      expect(result).toEqual({ value: 'red', reason: StandardResolutionReasons.STATIC })
+    })
+
+    it('should resolve number flag with STATIC reason', () => {
+      const result = provider.resolveNumberEvaluation('integer-flag', 0, mockContext, mockLogger)
+      expect(result).toEqual({ value: 42, reason: StandardResolutionReasons.STATIC })
+    })
+
+    it('should resolve object flag with STATIC reason', () => {
+      const result = provider.resolveObjectEvaluation('json-flag', {}, mockContext, mockLogger)
+      expect(result).toEqual({ value: { key: 'value', prop: 123 }, reason: StandardResolutionReasons.STATIC })
+    })
+
+    it('should return DEFAULT reason for non-existent flag', () => {
+      const result = provider.resolveBooleanEvaluation('non-existent', false, mockContext, mockLogger)
+      expect(result).toEqual({ value: false, reason: StandardResolutionReasons.DEFAULT })
     })
   })
 })

--- a/packages/flagging/src/openfeature/provider.ts
+++ b/packages/flagging/src/openfeature/provider.ts
@@ -1,7 +1,15 @@
 /* eslint-disable no-restricted-syntax */
 // We need to use a class here to properly implement the OpenFeature Provider interface
 // which requires class methods and properties. This is a valid exception to the no-classes rule.
-import type { EvaluationContext, JsonValue, Logger, Paradigm, Provider, ResolutionDetails } from '@openfeature/web-sdk'
+import {
+  StandardResolutionReasons,
+  type EvaluationContext,
+  type JsonValue,
+  type Logger,
+  type Paradigm,
+  type Provider,
+  type ResolutionDetails,
+} from '@openfeature/web-sdk'
 import type { PrecomputeClient } from '../precomputeClient'
 
 export class DatadogProvider implements Provider {
@@ -22,9 +30,12 @@ export class DatadogProvider implements Provider {
     _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<boolean> {
+    if (!this.precomputeClient || !this.precomputeClient.hasFlag(flagKey)) {
+      return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT }
+    }
     return {
-      value: this.precomputeClient?.getBooleanAssignment(flagKey, defaultValue) ?? defaultValue,
-      reason: 'DEFAULT',
+      value: this.precomputeClient.getBooleanAssignment(flagKey, defaultValue),
+      reason: StandardResolutionReasons.STATIC,
     }
   }
 
@@ -34,9 +45,12 @@ export class DatadogProvider implements Provider {
     _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<string> {
+    if (!this.precomputeClient || !this.precomputeClient.hasFlag(flagKey)) {
+      return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT }
+    }
     return {
-      value: this.precomputeClient?.getStringAssignment(flagKey, defaultValue) ?? defaultValue,
-      reason: 'DEFAULT',
+      value: this.precomputeClient.getStringAssignment(flagKey, defaultValue),
+      reason: StandardResolutionReasons.STATIC,
     }
   }
 
@@ -46,9 +60,12 @@ export class DatadogProvider implements Provider {
     _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<number> {
+    if (!this.precomputeClient || !this.precomputeClient.hasFlag(flagKey)) {
+      return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT }
+    }
     return {
-      value: this.precomputeClient?.getNumericAssignment(flagKey, defaultValue) ?? defaultValue,
-      reason: 'DEFAULT',
+      value: this.precomputeClient.getNumericAssignment(flagKey, defaultValue),
+      reason: StandardResolutionReasons.STATIC,
     }
   }
 
@@ -58,14 +75,17 @@ export class DatadogProvider implements Provider {
     _context: EvaluationContext,
     _logger: Logger
   ): ResolutionDetails<T> {
-    const value =
-      typeof defaultValue === 'object' && defaultValue !== null && this.precomputeClient
-        ? (this.precomputeClient.getJSONAssignment(flagKey, defaultValue as object) as T)
-        : defaultValue
-
+    if (
+      !this.precomputeClient ||
+      !this.precomputeClient.hasFlag(flagKey) ||
+      typeof defaultValue !== 'object' ||
+      defaultValue === null
+    ) {
+      return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT }
+    }
     return {
-      value,
-      reason: 'DEFAULT',
+      value: this.precomputeClient.getJSONAssignment(flagKey, defaultValue as object) as T,
+      reason: StandardResolutionReasons.STATIC,
     }
   }
 }

--- a/packages/flagging/src/precomputeClient.ts
+++ b/packages/flagging/src/precomputeClient.ts
@@ -52,6 +52,10 @@ export class PrecomputeClient {
     this.precomputedFlagStore = precomputedFlagStore
   }
 
+  public hasFlag(flagKey: string): boolean {
+    return this.getPrecomputedFlag(flagKey) !== null
+  }
+
   public getStringAssignment(flagKey: string, defaultValue: string): string {
     return this.getPrecomputedAssignment(flagKey, defaultValue, VariationType.STRING)
   }


### PR DESCRIPTION
## Motivation

The OpenFeature provider always returned `reason: 'DEFAULT'` even when a precomputed flag was successfully resolved. Per the [OpenFeature spec](https://openfeature.dev/specification/types#resolution-details), `STATIC` should be used when values come from a pre-evaluated store, and `DEFAULT` only when no flag was found.

## Changes

- Add `hasFlag(flagKey)` method to `PrecomputeClient` to check flag existence
- Use `StandardResolutionReasons` constants from `@openfeature/web-sdk` instead of string literals
- Return `STATIC` reason when a flag is resolved from the store
- Return `DEFAULT` reason when falling back to the default value (no client, or flag not found)
- Replace existing default-only provider tests with comprehensive tests covering both resolved (STATIC) and missing (DEFAULT) scenarios using a real `PrecomputeClient`

## Decisions

- Used `STATIC` over `CACHED` since precomputed values are a static evaluation store, not a cache of dynamic evaluations
- Added `hasFlag()` as a lightweight existence check rather than changing the assignment method signatures