### PR TITLE
🐛 fix stale closure bug in watchCookieFallback

### DIFF
--- a/packages/rum-core/src/browser/cookieObservable.spec.ts
+++ b/packages/rum-core/src/browser/cookieObservable.spec.ts
@@ -78,4 +78,34 @@ describe('cookieObservable', () => {
 
     expect(cookieChange).toBeUndefined()
   })
+
+  it('should not re-notify observers if the cookie has not changed since last notification when cookieStore is not supported', () => {
+    Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
+    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+
+    const cookieChanges: Array<string | undefined> = []
+    subscription = observable.subscribe((change) => cookieChanges.push(change))
+
+    setCookie(COOKIE_NAME, 'foo', COOKIE_DURATION)
+    clock.tick(WATCH_COOKIE_INTERVAL_DELAY) // detects 'foo'
+    clock.tick(WATCH_COOKIE_INTERVAL_DELAY) // no change since last notification
+
+    expect(cookieChanges).toEqual(['foo'])
+  })
+
+  it('should notify observers on consecutive cookie changes when cookieStore is not supported', () => {
+    Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
+    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+
+    const cookieChanges: Array<string | undefined> = []
+    subscription = observable.subscribe((change) => cookieChanges.push(change))
+
+    setCookie(COOKIE_NAME, 'foo', COOKIE_DURATION)
+    clock.tick(WATCH_COOKIE_INTERVAL_DELAY)
+
+    setCookie(COOKIE_NAME, 'bar', COOKIE_DURATION)
+    clock.tick(WATCH_COOKIE_INTERVAL_DELAY)
+
+    expect(cookieChanges).toEqual(['foo', 'bar'])
+  })
 })

--- a/packages/rum-core/src/browser/cookieObservable.ts
+++ b/packages/rum-core/src/browser/cookieObservable.ts
@@ -49,10 +49,11 @@ function listenToCookieStoreChange(configuration: Configuration) {
 export const WATCH_COOKIE_INTERVAL_DELAY = ONE_SECOND
 
 function watchCookieFallback(cookieName: string, callback: (event: string | undefined) => void) {
-  const previousCookieValue = findCommaSeparatedValue(document.cookie, cookieName)
+  let previousCookieValue = findCommaSeparatedValue(document.cookie, cookieName)
   const watchCookieIntervalId = setInterval(() => {
     const cookieValue = findCommaSeparatedValue(document.cookie, cookieName)
     if (cookieValue !== previousCookieValue) {
+      previousCookieValue = cookieValue
       callback(cookieValue)
     }
   }, WATCH_COOKIE_INTERVAL_DELAY)


### PR DESCRIPTION
## Motivation

`watchCookieFallback` polls `document.cookie` every second to detect session cookie changes. A stale closure bug caused `previousCookieValue` to never update after the first detected change:

- After the first change fires the callback, subsequent ticks keep comparing against the **original** value — so the callback fires again on every tick until the cookie reverts, then silently misses the revert.

## Changes

- `watchCookieFallback` in `packages/rum-core/src/browser/cookieObservable.ts`: change `const previousCookieValue` → `let previousCookieValue` and add `previousCookieValue = cookieValue` inside the interval callback on change detection.
- Two new regression tests in `cookieObservable.spec.ts` covering no-re-notification and consecutive cookie changes.

## Test instructions

Run the unit tests:
```
yarn test:unit --spec packages/rum-core/src/browser/cookieObservable.spec.ts
```

All 5 tests should pass, including the 2 new regression tests.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file