### PR TITLE
🐛 fix LogsEventDomainContext fallback to undefined instead of never

### DIFF
--- a/packages/logs/src/domainContext.types.ts
+++ b/packages/logs/src/domainContext.types.ts
@@ -6,7 +6,7 @@ export type LogsEventDomainContext<T extends ErrorSource = any> = T extends type
     ? ConsoleLogsEventDomainContext
     : T extends typeof ErrorSource.LOGGER
       ? LoggerLogsEventDomainContext
-      : never
+      : undefined
 
 export interface NetworkLogsEventDomainContext {
   isAborted: boolean


### PR DESCRIPTION
## Motivation

When using `never` as the fallback type in `LogsEventDomainContext`, TypeScript silently allows unsafe code like `'foo' in ctx` without raising a type error, even though it would blow up at runtime.

Fixes #3916

## Changes

Change the `never` fallback to `undefined` in `LogsEventDomainContext` so TypeScript properly surfaces the type error.

## Test instructions

N/A — type-only change.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file