### PR TITLE
👷 upgrade minimatch to 10.2.4 to fix npm publish packaging issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "karma-spec-reporter": "0.0.36",
     "karma-webpack": "5.0.0",
     "lerna": "9.0.4",
-    "minimatch": "10.2.3",
+    "minimatch": "10.2.4",
     "node-forge": "1.3.3",
     "prettier": "3.8.1",
     "puppeteer": "24.37.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4390,7 +4390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
+"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
   version: 2.0.2
   resolution: "brace-expansion@npm:2.0.2"
   dependencies:
@@ -4461,7 +4461,7 @@ __metadata:
     karma-spec-reporter: "npm:0.0.36"
     karma-webpack: "npm:5.0.0"
     lerna: "npm:9.0.4"
-    minimatch: "npm:10.2.3"
+    minimatch: "npm:10.2.4"
     node-forge: "npm:1.3.3"
     prettier: "npm:3.8.1"
     puppeteer: "npm:24.37.5"
@@ -10312,12 +10312,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.2.3, minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.1.2, minimatch@npm:^10.2.2":
-  version: 10.2.3
-  resolution: "minimatch@npm:10.2.3"
+"minimatch@npm:10.2.4, minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.1.2, minimatch@npm:^10.2.2":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
   dependencies:
     brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/d9ae5f355e8bb77a42dd8c20b950141cec8773ef8716a2bb6df7a6840cc44a00ed828883884e4f1c7b5cb505fa06a17e3ea9ca2edb18fd1dec865ea7f9fcf0e5
+  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
   languageName: node
   linkType: hard
 
@@ -10331,29 +10331,29 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
 "minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
   dependencies:
     brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
+  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
   languageName: node
   linkType: hard
 
 "minimatch@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

minimatch 10.2.3 had a bug causing negated `.npmignore` patterns like `!/cjs/**/*` to be
incorrectly applied, silently omitting entire directories from published packages.
This caused a packaging incident where published packages were missing files.

Likely related to https://github.com/isaacs/minimatch/issues/284

10.2.4 fixes this.

## Changes

Bump `minimatch` from 10.2.3 to 10.2.4 in `package.json` and update `yarn.lock`
(also pulls in patch fixes for transitive `minimatch` 3.x, 5.x, and 9.x).

## Test instructions

Run the following script to verify all packages include their expected files (this is a
simplification of what Lerna uses internally to compute the list of files to publish, [here](https://github.com/lerna/lerna/blob/f69bd628ec5d699c2c4af455074befba95aee394/libs/core/src/lib/pack-directory.ts#L72-L76)):

```js
import packlist from 'npm-packlist'
import Arborist from '@npmcli/arborist'

for (const pkg of ['rum', 'rum-core', 'rum-slim', 'logs', 'core']) {
  const arborist = new Arborist({ path: `./packages/${pkg}` })
  const tree = await arborist.loadActual()
  const files = await packlist(tree)
  console.log(`packages/${pkg}: ${files.length} files`)
}
```

Expected: 
```
packages/rum: 581 files
packages/rum-core: 710 files
packages/rum-slim: 31 files
packages/logs: 199 files
packages/core: 731 files
```

On main (incorrect):
```
packages/rum: 250 files
packages/rum-core: 305 files
packages/rum-slim: 14 files
packages/logs: 86 files
packages/core: 314 files
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file