### PR TITLE
🐛 filter non-directory entries in packagesDirectoryNames

### DIFF
--- a/scripts/lib/packagesDirectoryNames.ts
+++ b/scripts/lib/packagesDirectoryNames.ts
@@ -1,3 +1,5 @@
 import { readdirSync } from 'node:fs'
 
-export const packagesDirectoryNames: string[] = readdirSync('packages')
+export const packagesDirectoryNames: string[] = readdirSync('packages', { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)


### PR DESCRIPTION
## Motivation

`readdirSync('packages')` returns all entries in the directory, including non-directory files (e.g., `.DS_Store`). This causes downstream scripts like `yarn release` to fail when they expect only package directory names.

## Changes

Use `readdirSync` with `{ withFileTypes: true }` and filter to only include actual directories before extracting names.

## Test instructions

- Add a non-directory file in `packages/` (e.g., `touch packages/.DS_Store`)
- Run `yarn release` and verify it no longer picks up the spurious entry

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file