### PR TITLE
🐛 retry transient 503 errors in telemetry error checking

### DIFF
--- a/scripts/deploy/lib/checkTelemetryErrors.spec.ts
+++ b/scripts/deploy/lib/checkTelemetryErrors.spec.ts
@@ -2,8 +2,6 @@ import assert from 'node:assert/strict'
 import path from 'node:path'
 import type { Mock } from 'node:test'
 import { afterEach, before, describe, it, mock } from 'node:test'
-import type { Response, RequestInit } from 'undici'
-import type { fetchHandlingError } from 'scripts/lib/executionUtils.ts'
 import { mockModule } from './testHelpers.ts'
 import type { QueryResultBucket } from './checkTelemetryErrors.ts'
 
@@ -37,15 +35,14 @@ const TELEMETRY_ERROR_ON_SPECIFIC_MESSAGE_MOCK = [
 
 describe('check-telemetry-errors', () => {
   let checkTelemetryErrors: (datacenters: string[], version: string) => Promise<void>
-  const fetchHandlingErrorMock: Mock<typeof fetchHandlingError> = mock.fn()
+  const fetchMock: Mock<typeof globalThis.fetch> = mock.fn()
 
-  function mockFetchHandlingError(
-    responseBuckets: [QueryResultBucket[], QueryResultBucket[], QueryResultBucket[]]
-  ): void {
+  function mockFetch(responseBuckets: [QueryResultBucket[], QueryResultBucket[], QueryResultBucket[]]): void {
     for (let i = 0; i < 3; i++) {
-      fetchHandlingErrorMock.mock.mockImplementationOnce(
-        (_url: string, _options?: RequestInit) =>
+      fetchMock.mock.mockImplementationOnce(
+        () =>
           Promise.resolve({
+            ok: true,
             json: () =>
               Promise.resolve({
                 data: {
@@ -64,8 +61,9 @@ describe('check-telemetry-errors', () => {
       getTelemetryOrgApplicationKey: () => FAKE_APPLICATION_KEY,
     })
 
+    await mockModule('undici', { fetch: fetchMock })
+
     await mockModule(path.resolve(import.meta.dirname, '../../lib/executionUtils.ts'), {
-      fetchHandlingError: fetchHandlingErrorMock,
       timeout: mock.fn(() => Promise.resolve()),
     })
 
@@ -82,11 +80,11 @@ describe('check-telemetry-errors', () => {
   })
 
   afterEach(() => {
-    fetchHandlingErrorMock.mock.resetCalls()
+    fetchMock.mock.resetCalls()
   })
 
   it('should not throw an error if no telemetry errors are found for a given datacenter', async () => {
-    mockFetchHandlingError([
+    mockFetch([
       NO_TELEMETRY_ERRORS_MOCK,
       NO_TELEMETRY_ERRORS_ON_SPECIFIC_ORG_MOCK,
       NO_TELEMETRY_ERROR_ON_SPECIFIC_MESSAGE_MOCK,
@@ -96,7 +94,7 @@ describe('check-telemetry-errors', () => {
   })
 
   it('should throw an error if telemetry errors are found for a given datacenter', async () => {
-    mockFetchHandlingError([
+    mockFetch([
       TELEMETRY_ERRORS_MOCK,
       NO_TELEMETRY_ERRORS_ON_SPECIFIC_ORG_MOCK,
       NO_TELEMETRY_ERROR_ON_SPECIFIC_MESSAGE_MOCK,
@@ -105,7 +103,7 @@ describe('check-telemetry-errors', () => {
   })
 
   it('should throw an error if telemetry errors on specific org are found for a given datacenter', async () => {
-    mockFetchHandlingError([
+    mockFetch([
       NO_TELEMETRY_ERRORS_MOCK,
       TELEMETRY_ERRORS_ON_SPECIFIC_ORG_MOCK,
       NO_TELEMETRY_ERROR_ON_SPECIFIC_MESSAGE_MOCK,
@@ -118,7 +116,7 @@ describe('check-telemetry-errors', () => {
   })
 
   it('should throw an error if telemetry errors on specific message are found for a given datacenter', async () => {
-    mockFetchHandlingError([
+    mockFetch([
       NO_TELEMETRY_ERRORS_MOCK,
       NO_TELEMETRY_ERRORS_ON_SPECIFIC_ORG_MOCK,
       TELEMETRY_ERROR_ON_SPECIFIC_MESSAGE_MOCK,
@@ -132,9 +130,10 @@ describe('check-telemetry-errors', () => {
 
   it('should throw an error if the API returns an unexpected response format', async () => {
     // Mock first API call with invalid response (missing data.buckets)
-    fetchHandlingErrorMock.mock.mockImplementationOnce(
-      (_url: string, _options?: RequestInit) =>
+    fetchMock.mock.mockImplementationOnce(
+      () =>
         Promise.resolve({
+          ok: true,
           json: () =>
             Promise.resolve({
               error: 'Something went wrong',
@@ -148,9 +147,10 @@ describe('check-telemetry-errors', () => {
 
   it('should throw an error if buckets have invalid structure', async () => {
     // Mock first API call with invalid bucket structure (missing computes.c0)
-    fetchHandlingErrorMock.mock.mockImplementationOnce(
-      (_url: string, _options?: RequestInit) =>
+    fetchMock.mock.mockImplementationOnce(
+      () =>
         Promise.resolve({
+          ok: true,
           json: () =>
             Promise.resolve({
               data: {

--- a/scripts/deploy/lib/checkTelemetryErrors.ts
+++ b/scripts/deploy/lib/checkTelemetryErrors.ts
@@ -1,8 +1,8 @@
 /**
  * Check telemetry errors
  */
-import { Agent } from 'undici'
-import { printLog, fetchHandlingError, timeout, findError, FetchError } from '../../lib/executionUtils.ts'
+import { Agent, fetch, type Response } from 'undici'
+import { printLog, timeout, createFetchError } from '../../lib/executionUtils.ts'
 import { getTelemetryOrgApiKey, getTelemetryOrgApplicationKey } from '../../lib/secrets.ts'
 import { getDatacenterMetadata } from '../../lib/datacenter.ts'
 
@@ -109,71 +109,76 @@ async function queryLogsApi(
   apiKey: string,
   applicationKey: string,
   query: Query,
-  agent: Agent
+  agent: Agent,
+  attempt: number = 1
 ): Promise<QueryResultBucket[]> {
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      const response = await fetchHandlingError(`https://api.${site}/api/v2/logs/analytics/aggregate`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'DD-API-KEY': apiKey,
-          'DD-APPLICATION-KEY': applicationKey,
+  const response = await fetch(`https://api.${site}/api/v2/logs/analytics/aggregate`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'DD-API-KEY': apiKey,
+      'DD-APPLICATION-KEY': applicationKey,
+    },
+    body: JSON.stringify({
+      compute: [
+        {
+          aggregation: 'count',
         },
-        body: JSON.stringify({
-          compute: [
-            {
-              aggregation: 'count',
-            },
-          ],
-          ...(query.groupBy
-            ? {
-                group_by: [
-                  {
-                    facet: query.groupBy,
-                    sort: {
-                      type: 'measure',
-                      aggregation: 'count',
-                    },
-                  },
-                ],
-              }
-            : {}),
-          filter: {
-            from: `now-${TIME_WINDOW_IN_MINUTES}m`,
-            to: 'now',
-            query: query.query,
-          },
-        }),
-        // Use dedicated agent to avoid connection pool conflicts
-        dispatcher: agent,
-      })
+      ],
+      ...(query.groupBy
+        ? {
+            group_by: [
+              {
+                facet: query.groupBy,
+                sort: {
+                  type: 'measure',
+                  aggregation: 'count',
+                },
+              },
+            ],
+          }
+        : {}),
+      filter: {
+        from: `now-${TIME_WINDOW_IN_MINUTES}m`,
+        to: 'now',
+        query: query.query,
+      },
+    }),
+    // Use dedicated agent to avoid connection pool conflicts.
+    dispatcher: agent,
+  })
 
-      const data = (await response.json()) as QueryResult
-
-      if (
-        !data ||
-        !data.data ||
-        !Array.isArray(data.data.buckets) ||
-        !data.data.buckets.every((bucket) => bucket.computes && typeof bucket.computes.c0 === 'number')
-      ) {
-        throw new Error(`Unexpected response from the API: ${JSON.stringify(data)}`)
-      }
-
-      return data.data.buckets
-    } catch (error) {
-      const fetchError = findError(error, FetchError)
-      if (!fetchError || fetchError.response.status !== 503 || attempt === MAX_RETRIES) {
-        throw error
-      }
-      printLog(
-        `503 Service Unavailable, retrying in ${RATE_LIMIT_DELAY_MS / 1000}s (attempt ${attempt}/${MAX_RETRIES})...`
-      )
-      await timeout(RATE_LIMIT_DELAY_MS)
-    }
+  if (shouldRetry(response, attempt)) {
+    printLog(
+      `503 Service Unavailable, retrying in ${RATE_LIMIT_DELAY_MS / 1000}s (attempt ${attempt}/${MAX_RETRIES})...`
+    )
+    await timeout(RATE_LIMIT_DELAY_MS)
+    return queryLogsApi(site, apiKey, applicationKey, query, agent, attempt + 1)
   }
 
-  throw new Error('Unexpected: retry loop exited without returning or throwing')
+  if (!response.ok) {
+    throw await createFetchError(response)
+  }
+
+  const data = (await response.json()) as QueryResult
+
+  if (!isValidData(data)) {
+    throw new Error(`Unexpected response from the API: ${JSON.stringify(data)}`)
+  }
+
+  return data.data.buckets
+}
+
+function shouldRetry(response: Response, attempt: number): boolean {
+  return response.status === 503 && attempt < MAX_RETRIES
+}
+
+function isValidData(data: QueryResult): boolean {
+  return (
+    data?.data &&
+    Array.isArray(data.data.buckets) &&
+    data.data.buckets.every((bucket) => bucket.computes && typeof bucket.computes.c0 === 'number')
+  )
 }
 
 function computeLogsLink(site: string, query: Query): string {

--- a/scripts/lib/executionUtils.ts
+++ b/scripts/lib/executionUtils.ts
@@ -89,17 +89,21 @@ export class FetchError extends Error {
   }
 }
 
+export async function createFetchError(response: Response): Promise<FetchError> {
+  let cause: unknown
+  const body = await response.text()
+  try {
+    cause = JSON.parse(body)
+  } catch {
+    cause = body
+  }
+  return new FetchError(response, { cause })
+}
+
 export async function fetchHandlingError(url: string, options?: RequestInit): Promise<Response> {
   const response = await fetch(url, options)
   if (!response.ok) {
-    let cause: unknown
-    const body = await response.text()
-    try {
-      cause = JSON.parse(body)
-    } catch {
-      cause = body
-    }
-    throw new FetchError(response, { cause })
+    throw await createFetchError(response)
   }
 
   return response


### PR DESCRIPTION
## Motivation

The deploy-to-prod CI job polls the Datadog Logs Analytics API every 60 seconds for 30 minutes after deployment. A transient `503 Service Unavailable` response (e.g. from rate limiting) crashes the script immediately since `fetchHandlingError` throws on any non-OK response with no retry logic.

## Changes

Add retry logic in `queryLogsApi` (`scripts/deploy/lib/checkTelemetryErrors.ts`):

- Wrap the `fetchHandlingError` call in a retry loop (up to 3 attempts)
- On 503, wait `RATE_LIMIT_DELAY_MS` (6s) before retrying
- Use existing `findError`/`FetchError` utilities to detect the error type
- Log each retry with `printLog` for CI visibility
- Re-throw immediately on non-503 errors or after exhausting retries

## Test instructions

- `yarn typecheck` passes
- `yarn test:script` passes

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file