### PR TITLE
♻️ [PANA-6193] Add an Observer for DOM serializations

### DIFF
--- a/packages/rum/src/domain/record/record.types.ts
+++ b/packages/rum/src/domain/record/record.types.ts
@@ -1,5 +1,22 @@
-import type { BrowserRecord } from '../../types'
-import type { SerializationStats } from './serialization'
+import type { RumMutationRecord } from '@datadog/browser-rum-core'
+import type { TimeStamp } from '@datadog/browser-core'
+import type { BrowserFullSnapshotRecord, BrowserIncrementalSnapshotRecord, BrowserRecord } from '../../types'
+import type { SerializationKind, SerializationStats } from './serialization'
 
 export type EmitRecordCallback<Record extends BrowserRecord = BrowserRecord> = (record: Record) => void
 export type EmitStatsCallback = (stats: SerializationStats) => void
+
+export type SerializeEvent =
+  | {
+      type: 'full'
+      kind: SerializationKind
+      target: Document
+      timestamp: TimeStamp
+      v1: BrowserFullSnapshotRecord
+    }
+  | {
+      type: 'incremental'
+      target: RumMutationRecord[]
+      timestamp: TimeStamp
+      v1: BrowserIncrementalSnapshotRecord
+    }

--- a/packages/rum/src/domain/record/recordingScope.ts
+++ b/packages/rum/src/domain/record/recordingScope.ts
@@ -1,9 +1,11 @@
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 
+import { Observable } from '@datadog/browser-core'
 import type { ElementsScrollPositions } from './elementsScrollPositions'
 import { createEventIds, createNodeIds, createStringIds, createStyleSheetIds } from './itemIds'
 import type { EventIds, NodeIds, StringIds, StyleSheetIds } from './itemIds'
 import type { ShadowRootsController } from './shadowRootsController'
+import type { SerializeEvent } from './record.types'
 
 /**
  * State associated with a stream of session replay records. When a new stream of records
@@ -18,6 +20,7 @@ export interface RecordingScope {
   elementsScrollPositions: ElementsScrollPositions
   eventIds: EventIds
   nodeIds: NodeIds
+  serializeObservable: Observable<SerializeEvent>
   shadowRootsController: ShadowRootsController
   stringIds: StringIds
   styleSheetIds: StyleSheetIds
@@ -45,6 +48,7 @@ export function createRecordingScope(
     elementsScrollPositions,
     eventIds,
     nodeIds,
+    serializeObservable: new Observable<SerializeEvent>(),
     shadowRootsController,
     stringIds,
     styleSheetIds,

--- a/packages/rum/src/domain/record/serialization/serializeFullSnapshot.ts
+++ b/packages/rum/src/domain/record/serialization/serializeFullSnapshot.ts
@@ -34,5 +34,13 @@ export function serializeFullSnapshot(
       timestamp,
     }
     transaction.add(record)
+
+    scope.serializeObservable.notify({
+      type: 'full',
+      kind,
+      target: document,
+      timestamp,
+      v1: record,
+    })
   })
 }

--- a/packages/rum/src/domain/record/serialization/serializeMutations.ts
+++ b/packages/rum/src/domain/record/serialization/serializeMutations.ts
@@ -124,6 +124,13 @@ function processMutations(
     timestamp
   )
   transaction.add(record)
+
+  transaction.scope.serializeObservable.notify({
+    type: 'incremental',
+    target: mutations,
+    timestamp,
+    v1: record,
+  })
 }
 
 function processChildListMutations(


### PR DESCRIPTION
## Motivation

This PR is part of the PR stack that implements support for incremental snapshots in the new session replay data format.

When I added support for full snapshot Change records, I ensured consistency with the old format using a test helper that ran both serialization functions and compared their output; if the output of the new ("Change") serialization logic, when converted to the old ("V1") format, matched the output of the V1 serialization logic exactly, then I could be confident that the results would be identical in replay as well.

Doing the same for incremental snapshots is a bit more complex, because the incremental snapshots build on the full snapshot and on each other. There's no single function that a similar test helper could wrap; we need to perform a comparison continuously, as each incremental serialization is performed, and in a stateful way that takes into account the previous snapshots.

To make this simpler, it would be helpful if there was a way to observe each DOM serialization as it occurs; test code could then react to each V1 serialization by performing the corresponding Change serialization and comparing the output, just as before.

## Changes

This PR adds an `Observable` to `RecordingScope` that emits an event whenever a serialization occurs. A future PR, which depends on a few other changes, will add a test helper that uses this `Observable` to continuously validate the Change serialization logic whenever V1 serializations are performed in tests.

I don't expect any use cases for this `Observable` outside of tests, so once the V1 serialization logic is removed and the tests are updated to be written in terms of Change records directly, I will remove this `Observable` as well. So, it's a temporary thing, but it will be quite useful while I'm validating the correctness of the new data format.

This PR includes no tests, since this is test-only code.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
