### PR TITLE
[PROF-13923] Upload source maps to org2 on every deployment

### DIFF
--- a/scripts/deploy/upload-source-maps.spec.ts
+++ b/scripts/deploy/upload-source-maps.spec.ts
@@ -5,12 +5,17 @@ import type { Datacenter } from '../lib/datacenter.ts'
 import { mockModule, mockCommandImplementation, replaceChunkHashes, mockFetchHandlingError } from './lib/testHelpers.ts'
 
 const FAKE_API_KEY = 'FAKE_API_KEY'
+const ORG2_API_KEY = 'ORG2_API_KEY'
 const ENV_STAGING = {
   DATADOG_API_KEY: FAKE_API_KEY,
   DATADOG_SITE: 'datad0g.com',
 }
 const ENV_PROD = {
   DATADOG_API_KEY: FAKE_API_KEY,
+  DATADOG_SITE: 'datadoghq.com',
+}
+const ENV_ORG2_PROD = {
+  DATADOG_API_KEY: ORG2_API_KEY,
   DATADOG_SITE: 'datadoghq.com',
 }
 
@@ -28,7 +33,15 @@ describe('upload-source-maps', () => {
   let getAllDatacentersMetadata: () => Promise<Datacenter[]>
 
   function getSourceMapCommands(): CommandDetail[] {
-    return commands.filter(({ command }) => command.includes('datadog-ci sourcemaps'))
+    return commands.filter(
+      ({ command, env }) => command.includes('datadog-ci sourcemaps') && env?.DATADOG_API_KEY === FAKE_API_KEY
+    )
+  }
+
+  function getOrg2SourceMapCommands(): CommandDetail[] {
+    return commands.filter(
+      ({ command, env }) => command.includes('datadog-ci sourcemaps') && env?.DATADOG_API_KEY === ORG2_API_KEY
+    )
   }
 
   function getFileRenamingCommands(): CommandDetail[] {
@@ -43,6 +56,7 @@ describe('upload-source-maps', () => {
     })
     await mockModule(path.resolve(import.meta.dirname, '../lib/secrets.ts'), {
       getTelemetryOrgApiKey: () => FAKE_API_KEY,
+      getOrg2ApiKey: () => ORG2_API_KEY,
     })
 
     // These MUST be dynamic imports because that is the only way to ensure the
@@ -72,7 +86,9 @@ describe('upload-source-maps', () => {
     await uploadSourceMaps('v6', ['root'])
 
     await forEachDatacenter((site) => {
-      const commandsByDatacenter = commands.filter(({ env }) => env?.DATADOG_SITE === site)
+      const commandsByDatacenter = commands.filter(
+        ({ env }) => env?.DATADOG_SITE === site && env?.DATADOG_API_KEY === FAKE_API_KEY
+      )
       const env = { DATADOG_API_KEY: FAKE_API_KEY, DATADOG_SITE: site }
 
       // rename the files with the version suffix
@@ -117,12 +133,31 @@ describe('upload-source-maps', () => {
         },
       ])
     })
+
+    // upload the source maps to org2
+    assert.deepEqual(getOrg2SourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+    ])
   })
 
   it('should upload datacenter packages source maps', async () => {
     await uploadSourceMaps('v6', ['us1'])
 
-    assert.deepEqual(commands, [
+    assert.deepEqual(getSourceMapCommands(), [
       {
         command:
           'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix /us1/v6 --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
@@ -137,6 +172,24 @@ describe('upload-source-maps', () => {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix /us1/v6 --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_PROD,
+      },
+    ])
+
+    assert.deepEqual(getOrg2SourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net/us1/v6 --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net/us1/v6 --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net/us1/v6 --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
       },
     ])
   })
@@ -200,6 +253,24 @@ describe('upload-source-maps', () => {
         env: ENV_PROD,
       },
     ])
+
+    assert.deepEqual(getOrg2SourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+    ])
   })
 
   it('should upload canary packages source maps', async () => {
@@ -244,6 +315,24 @@ describe('upload-source-maps', () => {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_PROD,
+      },
+    ])
+
+    assert.deepEqual(getOrg2SourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
       },
     ])
   })
@@ -291,6 +380,24 @@ describe('upload-source-maps', () => {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_PROD,
+      },
+    ])
+
+    assert.deepEqual(getOrg2SourceMapCommands(), [
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/logs/bundle --service browser-logs-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-logs/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
       },
     ])
   })

--- a/scripts/deploy/upload-source-maps.ts
+++ b/scripts/deploy/upload-source-maps.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { printLog, runMain } from '../lib/executionUtils.ts'
 import { command } from '../lib/command.ts'
 import { getBuildEnvValue } from '../lib/buildEnv.ts'
-import { getTelemetryOrgApiKey } from '../lib/secrets.ts'
+import { getTelemetryOrgApiKey, getOrg2ApiKey } from '../lib/secrets.ts'
 import { getAllDatacentersMetadata, getDatacenterMetadata } from '../lib/datacenter.ts'
 import { forEachFile } from '../lib/filesUtils.ts'
 import { buildRootUploadPath, buildDatacenterUploadPath, buildBundleFolder, packages } from './lib/deploymentUtils.ts'
@@ -66,6 +66,7 @@ async function uploadSourceMaps(
     }
     const prefix = path.dirname(`/${uploadPath}`)
     uploadToDatadog(packageName, service, prefix, bundleFolder, sites)
+    uploadToOrg2(packageName, service, prefix, bundleFolder)
   }
 }
 
@@ -83,6 +84,29 @@ async function renameFilesWithVersionSuffix(bundleFolder: string, version: strin
     console.log(`Renaming ${bundlePath} to ${uploadPath}`)
     command`mv ${bundlePath} ${uploadPath}`.run()
   })
+}
+
+const ORG2_CLOUDFRONT_BASE_URL = 'https://d20xtzwzcl0ceb.cloudfront.net'
+
+function uploadToOrg2(packageName: string, service: string, prefix: string, bundleFolder: string): void {
+  const apiKey = getOrg2ApiKey()
+  const org2Prefix = `${ORG2_CLOUDFRONT_BASE_URL}${prefix === '/' ? '' : prefix}`
+
+  printLog(`Uploading ${packageName} source maps with prefix ${org2Prefix} for org2...`)
+
+  command`
+    datadog-ci sourcemaps upload ${bundleFolder}
+      --service ${service}
+      --release-version ${getBuildEnvValue('SDK_VERSION')}
+      --minified-path-prefix ${org2Prefix}
+      --project-path @datadog/browser-${packageName}/
+      --repository-url https://www.github.com/datadog/browser-sdk
+  `
+    .withEnvironment({
+      DATADOG_API_KEY: apiKey,
+      DATADOG_SITE: 'datadoghq.com',
+    })
+    .run()
 }
 
 function uploadToDatadog(


### PR DESCRIPTION
## Motivation

To enable deobfuscation of browser SDK frames in Datadog profiles (PROF-13923), source maps need to be available in org2. Previously they were only uploaded to the telemetry org.

## Changes

- In `upload-source-maps.ts`: add a `uploadToOrg2` function that uploads source maps to `datadoghq.com` using the existing `getOrg2ApiKey()` secret.
- The upload uses the same prefix, service, and release version as the corresponding telemetry org upload
- Tests updated to mock `getOrg2ApiKey` and assert the org2 upload commands are produced for all deploy scenarios

## Test instructions

Run `yarn build:bundle && yarn test:script --spec scripts/deploy/upload-source-maps.spec.ts` — all 5 upload-source-maps tests should pass.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file