### PR TITLE
🐛 [PANA-6258] More robustly prevent serialization of <style> children

### DIFF
--- a/packages/rum/src/domain/record/serialization/conversions/changeDecoder.ts
+++ b/packages/rum/src/domain/record/serialization/conversions/changeDecoder.ts
@@ -1,0 +1,192 @@
+import { ChangeType } from '../../../../types'
+import type {
+  AddDocTypeNodeChange,
+  AddElementNodeChange,
+  AddNodeChange,
+  AddStyleSheetChange,
+  AddTextNodeChange,
+  AttributeAssignmentOrDeletion,
+  AttributeChange,
+  BrowserChangeRecord,
+  Change,
+  StyleSheetRules,
+  TextChange,
+} from '../../../../types'
+import type { StringTable } from './stringTable'
+import { createStringTable } from './stringTable'
+
+/**
+ * ChangeDecoder converts a BrowserChangeRecord, or a stream of BrowserChangeRecords, into
+ * a more human-readable form by:
+ * - Removing AddString changes (string table definitions).
+ * - Replacing string table references in all other changes with their literal values.
+ *
+ * This makes it easier to visualize the contents of BrowserChangeRecords or to write test
+ * expectations against the record's content.
+ */
+export interface ChangeDecoder {
+  decode(record: BrowserChangeRecord): BrowserChangeRecord
+
+  stringTable: StringTable
+}
+
+export function createChangeDecoder(): ChangeDecoder {
+  const self: ChangeDecoder = {
+    decode(record: BrowserChangeRecord): BrowserChangeRecord {
+      return decodeChangeRecord(record, self.stringTable)
+    },
+
+    stringTable: createStringTable(),
+  }
+
+  return self
+}
+
+function decodeChangeRecord(record: BrowserChangeRecord, stringTable: StringTable): BrowserChangeRecord {
+  const decodedData: Change[] = []
+
+  for (const change of record.data) {
+    switch (change[0]) {
+      case ChangeType.AddString:
+        // Update the string table.
+        for (let i = 1; i < change.length; i++) {
+          stringTable.add(change[i] as string)
+        }
+
+        // Deliberately don't include this change in the decoded record.
+        break
+
+      case ChangeType.AddNode: {
+        const decoded: [typeof ChangeType.AddNode, ...AddNodeChange[]] = [ChangeType.AddNode]
+        for (let i = 1; i < change.length; i++) {
+          decoded.push(decodeAddNodeChange(change[i] as AddNodeChange, stringTable))
+        }
+        decodedData.push(decoded)
+        break
+      }
+
+      case ChangeType.RemoveNode:
+        decodedData.push(change)
+        break
+
+      case ChangeType.Attribute: {
+        const decoded: [typeof ChangeType.Attribute, ...AttributeChange[]] = [ChangeType.Attribute]
+        for (let i = 1; i < change.length; i++) {
+          decoded.push(decodeAttributeChange(change[i] as AttributeChange, stringTable))
+        }
+        decodedData.push(decoded)
+        break
+      }
+
+      case ChangeType.Text: {
+        const decoded: [typeof ChangeType.Text, ...TextChange[]] = [ChangeType.Text]
+        for (let i = 1; i < change.length; i++) {
+          decoded.push(decodeTextChange(change[i] as TextChange, stringTable))
+        }
+        decodedData.push(decoded)
+        break
+      }
+
+      case ChangeType.Size:
+      case ChangeType.ScrollPosition:
+      case ChangeType.AttachedStyleSheets:
+      case ChangeType.MediaPlaybackState:
+      case ChangeType.VisualViewport:
+        decodedData.push(change)
+        break
+
+      case ChangeType.AddStyleSheet: {
+        const decoded: [typeof ChangeType.AddStyleSheet, ...AddStyleSheetChange[]] = [ChangeType.AddStyleSheet]
+        for (let i = 1; i < change.length; i++) {
+          decoded.push(decodeAddStyleSheetChange(change[i] as AddStyleSheetChange, stringTable))
+        }
+        decodedData.push(decoded)
+        break
+      }
+
+      default:
+        change satisfies never
+        throw new Error(`Unsupported ChangeType: ${change[0] as any}`)
+    }
+  }
+
+  return { ...record, data: decodedData }
+}
+
+function decodeAddNodeChange(change: AddNodeChange, stringTable: StringTable): AddNodeChange {
+  const insertionPoint = change[0]
+  const nodeName = stringTable.decode(change[1])
+
+  switch (nodeName) {
+    case '#cdata-section':
+    case '#document':
+    case '#document-fragment':
+    case '#shadow-root':
+      return [insertionPoint, nodeName]
+
+    case '#doctype': {
+      const [, , name, publicId, systemId] = change as AddDocTypeNodeChange
+      return [
+        insertionPoint,
+        '#doctype',
+        stringTable.decode(name),
+        stringTable.decode(publicId),
+        stringTable.decode(systemId),
+      ]
+    }
+
+    case '#text': {
+      const [, , textContent] = change as AddTextNodeChange
+      return [insertionPoint, '#text', stringTable.decode(textContent)]
+    }
+
+    default: {
+      const decodedChange: AddElementNodeChange = [insertionPoint, nodeName]
+
+      const [, , ...attrs] = change as AddElementNodeChange
+      for (const [name, value] of attrs) {
+        decodedChange.push([stringTable.decode(name), stringTable.decode(value)])
+      }
+
+      return decodedChange
+    }
+  }
+}
+
+function decodeAttributeChange(change: AttributeChange, stringTable: StringTable): AttributeChange {
+  const [nodeId, ...mutations] = change
+
+  const decodedMutations: AttributeAssignmentOrDeletion[] = mutations.map((mutation) => {
+    if (mutation.length === 1) {
+      return [stringTable.decode(mutation[0])]
+    }
+    return [stringTable.decode(mutation[0]), stringTable.decode(mutation[1])]
+  })
+
+  const decodedChange: AttributeChange = [nodeId]
+  decodedChange.push(...decodedMutations)
+  return decodedChange
+}
+
+function decodeTextChange(change: TextChange, stringTable: StringTable): TextChange {
+  return [change[0], stringTable.decode(change[1])]
+}
+
+function decodeAddStyleSheetChange(change: AddStyleSheetChange, stringTable: StringTable): AddStyleSheetChange {
+  const rules = change[0]
+  const decodedRules: StyleSheetRules = Array.isArray(rules)
+    ? rules.map((rule) => stringTable.decode(rule))
+    : stringTable.decode(rules)
+
+  if (change.length === 1) {
+    return [decodedRules]
+  }
+
+  const decodedMediaList = change[1].map((item) => stringTable.decode(item))
+
+  if (change.length === 2) {
+    return [decodedRules, decodedMediaList]
+  }
+
+  return [decodedRules, decodedMediaList, change[2]]
+}

--- a/packages/rum/src/domain/record/serialization/conversions/index.ts
+++ b/packages/rum/src/domain/record/serialization/conversions/index.ts
@@ -1,5 +1,7 @@
 export type { ChangeConverter } from './changeConverter'
 export { createChangeConverter } from './changeConverter'
+export type { ChangeDecoder } from './changeDecoder'
+export { createChangeDecoder } from './changeDecoder'
 export type { MutationLog } from './mutationLog'
 export type { NodeIdRemapper } from './nodeIdRemapper'
 export { createCopyingNodeIdRemapper, createIdentityNodeIdRemapper } from './nodeIdRemapper'

--- a/packages/rum/src/domain/record/serialization/serializeNodeAsChange.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNodeAsChange.spec.ts
@@ -1,0 +1,82 @@
+import type { TimeStamp } from '@datadog/browser-core'
+import { noop } from '@datadog/browser-core'
+import { NodePrivacyLevel } from '@datadog/browser-rum-core'
+import { appendElement } from 'packages/rum-core/test'
+import { createRecordingScopeForTesting } from '../test/recordingScope.specHelper'
+import type { RecordingScope } from '../recordingScope'
+import { ChangeType, RecordType, type BrowserChangeRecord, type BrowserRecord } from '../../../types'
+import type { ChangeDecoder } from './conversions'
+import { createChangeDecoder } from './conversions'
+import { serializeNodeAsChange } from './serializeNodeAsChange'
+import type { ChangeSerializationTransaction } from './serializationTransaction'
+import { SerializationKind, serializeChangesInTransaction } from './serializationTransaction'
+import { createRootInsertionCursor } from './insertionCursor'
+
+describe('serializeNodeAsChange', () => {
+  let changeDecoder: ChangeDecoder
+  let scope: RecordingScope
+
+  beforeEach(() => {
+    changeDecoder = createChangeDecoder()
+    scope = createRecordingScopeForTesting()
+  })
+
+  describe('for <style> elements', () => {
+    it('serializes the <style> element', () => {
+      const record = serialize('<style id="foo"></style>')
+      expect(record?.data).toEqual([[ChangeType.AddNode, [null, 'STYLE', ['id', 'foo']]]])
+    })
+
+    it('serializes the contents of the associated stylesheet', () => {
+      const css = 'div { color: green; }'
+      const record = serialize(`<style>${css}</style>`)
+      expect(record?.data).toEqual([
+        [ChangeType.AddNode, [null, 'STYLE']],
+        [ChangeType.AddStyleSheet, [css]],
+        [ChangeType.AttachedStyleSheets, [0, 0]],
+      ])
+    })
+  })
+
+  describe('for <style> element children', () => {
+    it('does not serialize them', () => {
+      const css = 'div { color: green; }'
+      const record = serialize(`<style>${css}</style>`, { target: (node: Node) => node.firstChild! })
+      expect(record).toBeUndefined()
+    })
+  })
+
+  function serialize(
+    html: string,
+    { target }: { target?: (node: Node) => Node } = {}
+  ): BrowserChangeRecord | undefined {
+    const subtreeRoot = appendElement(html)
+    const targetNode = target?.(subtreeRoot) ?? subtreeRoot
+
+    let emittedRecord: BrowserRecord | undefined
+
+    serializeChangesInTransaction(
+      SerializationKind.INITIAL_FULL_SNAPSHOT,
+      (record: BrowserRecord) => {
+        emittedRecord = record
+      },
+      noop,
+      scope,
+      0 as TimeStamp,
+      (transaction: ChangeSerializationTransaction) => {
+        const insertionCursor = createRootInsertionCursor(scope.nodeIds)
+        serializeNodeAsChange(insertionCursor, targetNode, NodePrivacyLevel.ALLOW, transaction)
+      }
+    )
+
+    if (!emittedRecord) {
+      return undefined
+    }
+
+    if (emittedRecord.type !== RecordType.Change) {
+      throw new Error('Expected serialization to yield a BrowserChangeRecord')
+    }
+
+    return changeDecoder.decode(emittedRecord)
+  }
+})

--- a/packages/rum/src/domain/record/serialization/serializeNodeAsChange.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNodeAsChange.ts
@@ -23,6 +23,12 @@ export function serializeNodeAsChange(
   parentPrivacyLevel: NodePrivacyLevel,
   transaction: ChangeSerializationTransaction
 ): void {
+  // Ignore the children of <style> elements; the CSS rules they contain are already
+  // serialized as StyleSheetSnapshots.
+  if (node.parentNode?.nodeName === 'STYLE') {
+    return
+  }
+
   let privacyLevel: NodePrivacyLevel
 
   const selfPrivacyLevel = getNodeSelfPrivacyLevel(node)
@@ -71,12 +77,6 @@ export function serializeNodeAsChange(
     case node.DOCUMENT_TYPE_NODE:
     case node.TEXT_NODE:
       return
-  }
-
-  // Ignore the children of <style> elements; the CSS rules they contain are already
-  // serialized as StyleSheetSnapshots.
-  if (node.nodeName === 'STYLE') {
-    return
   }
 
   cursor.descend()


### PR DESCRIPTION
## Motivation

Our DOM serialization code is designed to not serialize children of a `<style>` element. We don't serialize them because their content is already captured in structured form as a stylesheet. (For V1 records, the "structured form" is a virtual `_cssText` attribute; for Change records, it's a change of `ChangeType.AddStyleSheet`.)

However, `serializeNodeAsChange()` has a bug: if we pass it the child of a `<style>` element _directly_, we will serialize it! This is because we only check if the node we're about to serialize is the child of a `<style>` element when we recursively visit children. The node which is initially passed to `serializeNodeAsChange()` is never checked, so we always serialize it. For full snapshots, this is not a problem, but for incremental snapshots, this can cause us to effectively serialize stylesheets twice in some cases: once as a `ChangeType.AddStyleSheet`, and once as a text node.

## Changes

This PR moves the check from the point where we recursively visit children to the top of `serializeNodeAsChange()`. This ensures that, even if a child of a `<style>` element is passed in directly, we won't serialize it.

To ensure that this bug doesn't regress, I've added unit tests, and to make them easier, I've added a new helper: `ChangeDecoder`. `ChangeDecoder` replaces string table references in Change records with the literal strings they represent. This makes it easier to write tests, since Change records are easier to write by hand if you don't need to take the string table into account, and it's also helpful in situations where we want to visualize the content of Change records in a way that's easier for humans to read.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
