### PR TITLE
🔧 fix root package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-sdk",
-  "version": "6.30.1",
+  "version": "7.0.0-alpha.0",
   "description": "browser SDK",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Motivation

https://github.com/DataDog/browser-sdk/pull/4275 has been merged in main, introducing a version field in `package.json`. This version needs to be adjusted for v7.

## Changes

Adjust root package.json version

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
