### PR TITLE
🎨 Rename mockedLocationHref to locationHref

### DIFF
--- a/packages/rum-core/src/domain/contexts/urlContexts.ts
+++ b/packages/rum-core/src/domain/contexts/urlContexts.ts
@@ -41,8 +41,8 @@ export function startUrlContexts(
   let previousViewUrl: string | undefined
 
   lifeCycle.subscribe(LifeCycleEventType.BEFORE_VIEW_CREATED, ({ startClocks, url }) => {
-    const mockedLocationHref = mockable(location).href
-    const viewUrl = url !== undefined ? buildUrl(url, mockedLocationHref).href : mockedLocationHref
+    const locationHref = mockable(location).href
+    const viewUrl = url !== undefined ? buildUrl(url, locationHref).href : locationHref
     urlContextHistory.add(
       buildUrlContext({
         url: viewUrl,


### PR DESCRIPTION
## Motivation

PR [#4199](https://github.com/DataDog/browser-sdk/pull/4199) introduced a new variable `mockedLocationHref` which is not clear what it does as it does not mock anything. 

## Changes

Rename `mockedLocationHref` to `locationHref`

## Test instructions

Tests should pass

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
