### PR TITLE
[PROF-13950] ⚡️ Memoize getTimeZone to avoid repeated Intl.DateTimeFormat instantiation

### DIFF
--- a/packages/core/src/tools/utils/timezone.ts
+++ b/packages/core/src/tools/utils/timezone.ts
@@ -1,13 +1,12 @@
-function resolveTimeZone() {
-  try {
-    return new Intl.DateTimeFormat().resolvedOptions().timeZone
-  } catch {
-    return undefined
-  }
-}
-
-const timeZone = resolveTimeZone()
+let cachedTimeZone: string | undefined | null = null
 
 export function getTimeZone() {
-  return timeZone
+  if (cachedTimeZone === null) {
+    try {
+      cachedTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone
+    } catch {
+      cachedTimeZone = undefined
+    }
+  }
+  return cachedTimeZone
 }


### PR DESCRIPTION
## Motivation

`new Intl.DateTimeFormat()` can be an expensive browser API call (involves locale negotiation and timezone resolution). It was being executed on every `VIEW_UPDATED` lifecycle event via `getTimeZone()` in `processViewUpdate()`.

`VIEW_UPDATED` fires frequently: on every captured action, error, resource, long task, CLS/LCP/FCP update, context change, and more. Since the timezone never changes during a page session, this repeated work was pure waste.

Related: PROF-13950

Identified while looking at some RUM Browser Profiler INP:
<img width="2376" height="276" alt="Screenshot 2026-03-09 at 15 41 07" src="https://github.com/user-attachments/assets/ce11c495-cccd-40c2-a73e-52a710f0a143" />

## Changes

Memoize the timezone value at module load time in `packages/core/src/tools/utils/timezone.ts`. `resolveTimeZone()` runs once, the result is stored in a module-level constant, and `getTimeZone()` simply returns it.

No behavior change — the returned value is identical.

## Test instructions

No specific repro needed. Verify that `getTimeZone()` still returns the correct timezone string in unit tests.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file