### PR TITLE
🐛 [DRAFT] Fix #3935: Include pre-start context in first view event

### DIFF
--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -549,6 +549,69 @@ describe('preStartRum', () => {
     })
   })
 
+  describe('passes pre-start contexts to doStartRum', () => {
+    function mockStartRumResult(): StartRumResult {
+      return {
+        globalContext: { setContext: noop } as any,
+        userContext: { setContext: noop } as any,
+        accountContext: { setContext: noop } as any,
+      } as unknown as StartRumResult
+    }
+
+    it('should pass global context set before init to doStartRum', () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+      doStartRumSpy.and.returnValue(mockStartRumResult())
+
+      strategy.globalContext.setContextProperty('foo', 'bar')
+      strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
+
+      expect(doStartRumSpy).toHaveBeenCalledTimes(1)
+      const initialContexts = doStartRumSpy.calls.mostRecent().args[5]
+      expect(initialContexts).toBeDefined()
+      expect(initialContexts.globalContext).toEqual({ foo: 'bar' })
+    })
+
+    it('should pass user context set before init to doStartRum', () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+      doStartRumSpy.and.returnValue(mockStartRumResult())
+
+      strategy.userContext.setContextProperty('id', 'user-123')
+      strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
+
+      expect(doStartRumSpy).toHaveBeenCalledTimes(1)
+      const initialContexts = doStartRumSpy.calls.mostRecent().args[5]
+      expect(initialContexts).toBeDefined()
+      expect(initialContexts.userContext).toEqual({ id: 'user-123' })
+    })
+
+    it('should pass account context set before init to doStartRum', () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+      doStartRumSpy.and.returnValue(mockStartRumResult())
+
+      strategy.accountContext.setContextProperty('id', 'account-456')
+      strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
+
+      expect(doStartRumSpy).toHaveBeenCalledTimes(1)
+      const initialContexts = doStartRumSpy.calls.mostRecent().args[5]
+      expect(initialContexts).toBeDefined()
+      expect(initialContexts.accountContext).toEqual({ id: 'account-456' })
+    })
+
+    it('should pass empty contexts when nothing is set before init', () => {
+      const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+      doStartRumSpy.and.returnValue(mockStartRumResult())
+
+      strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
+
+      expect(doStartRumSpy).toHaveBeenCalledTimes(1)
+      const initialContexts = doStartRumSpy.calls.mostRecent().args[5]
+      expect(initialContexts).toBeDefined()
+      expect(initialContexts.globalContext).toEqual({})
+      expect(initialContexts.userContext).toEqual({})
+      expect(initialContexts.accountContext).toEqual({})
+    })
+  })
+
   describe('buffers API calls before starting RUM', () => {
     let strategy: Strategy
     let doStartRumSpy: jasmine.Spy<DoStartRum>

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -49,12 +49,19 @@ import { callPluginsMethod } from '../domain/plugins'
 import type { StartRumResult } from './startRum'
 import type { RumPublicApiOptions, Strategy } from './rumPublicApi'
 
+export interface InitialContexts {
+  globalContext: Context
+  userContext: Context
+  accountContext: Context
+}
+
 export type DoStartRum = (
   configuration: RumConfiguration,
   deflateWorker: DeflateWorker | undefined,
   initialViewOptions: ViewOptions | undefined,
   telemetry: Telemetry,
-  hooks: Hooks
+  hooks: Hooks,
+  initialContexts: InitialContexts
 ) => StartRumResult
 
 export function createPreStartStrategy(
@@ -117,7 +124,20 @@ export function createPreStartStrategy(
       initialViewOptions = firstStartViewCall.options
     }
 
-    const startRumResult = doStartRum(cachedConfiguration, deflateWorker, initialViewOptions, telemetry, hooks)
+    const initialContexts: InitialContexts = {
+      globalContext: globalContext.getContext(),
+      userContext: userContext.getContext(),
+      accountContext: accountContext.getContext(),
+    }
+
+    const startRumResult = doStartRum(
+      cachedConfiguration,
+      deflateWorker,
+      initialViewOptions,
+      telemetry,
+      hooks,
+      initialContexts
+    )
 
     bufferApiCalls.drain(startRumResult)
   }

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -590,7 +590,7 @@ export function makeRumPublicApi(
     options,
     trackingConsentState,
     customVitalsState,
-    (configuration, deflateWorker, initialViewOptions, telemetry, hooks) => {
+    (configuration, deflateWorker, initialViewOptions, telemetry, hooks, initialContexts) => {
       const createEncoder =
         deflateWorker && options.createDeflateEncoder
           ? (streamId: DeflateEncoderStreamId) => options.createDeflateEncoder!(configuration, deflateWorker, streamId)
@@ -607,7 +607,8 @@ export function makeRumPublicApi(
         bufferedDataObservable,
         telemetry,
         hooks,
-        options.sdkName
+        options.sdkName,
+        initialContexts
       )
 
       recorderApi.onRumStart(

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -104,6 +104,75 @@ describe('rum session', () => {
   })
 })
 
+describe('initial view event with pre-start contexts', () => {
+  it('should include global context on the first view event when initial contexts are provided', () => {
+    const lifeCycle = new LifeCycle()
+    const sessionManager = createRumSessionManagerMock().setId('42')
+    const hooks = createHooks()
+    const serverRumEvents = collectServerEvents(lifeCycle)
+
+    const initialContexts = {
+      globalContext: { foo: 'bar' },
+      userContext: {},
+      accountContext: {},
+    }
+
+    const { stop } = startRumEventCollection(
+      lifeCycle,
+      hooks,
+      mockRumConfiguration(),
+      sessionManager,
+      noopRecorderApi,
+      undefined,
+      createCustomVitalsState(),
+      new Observable(),
+      undefined,
+      noop,
+      initialContexts
+    )
+
+    registerCleanupTask(stop)
+
+    // The first event should be a view with global context
+    expect(serverRumEvents.length).toBeGreaterThanOrEqual(1)
+    expect(serverRumEvents[0].type).toEqual('view')
+    expect(serverRumEvents[0].context).toEqual({ foo: 'bar' })
+  })
+
+  it('should include user context on the first view event when initial contexts are provided', () => {
+    const lifeCycle = new LifeCycle()
+    const sessionManager = createRumSessionManagerMock().setId('42')
+    const hooks = createHooks()
+    const serverRumEvents = collectServerEvents(lifeCycle)
+
+    const initialContexts = {
+      globalContext: {},
+      userContext: { id: 'user-123', name: 'Test User' },
+      accountContext: {},
+    }
+
+    const { stop } = startRumEventCollection(
+      lifeCycle,
+      hooks,
+      mockRumConfiguration(),
+      sessionManager,
+      noopRecorderApi,
+      undefined,
+      createCustomVitalsState(),
+      new Observable(),
+      undefined,
+      noop,
+      initialContexts
+    )
+
+    registerCleanupTask(stop)
+
+    expect(serverRumEvents.length).toBeGreaterThanOrEqual(1)
+    expect(serverRumEvents[0].type).toEqual('view')
+    expect(serverRumEvents[0].usr).toEqual(jasmine.objectContaining({ id: 'user-123', name: 'Test User' }))
+  })
+})
+
 describe('rum session keep alive', () => {
   let lifeCycle: LifeCycle
   let clock: Clock

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -13,6 +13,7 @@ import {
   createPageMayExitObservable,
   canUseEventBridge,
   addTelemetryDebug,
+  isEmptyObject,
   startAccountContext,
   startGlobalContext,
   startUserContext,
@@ -55,6 +56,7 @@ import { startEventCollection } from '../domain/event/eventCollection'
 import { startInitialViewMetricsTelemetry } from '../domain/view/viewMetrics/startInitialViewMetricsTelemetry'
 import { startSourceCodeContext } from '../domain/contexts/sourceCodeContext'
 import type { RecorderApi, ProfilerApi } from './rumPublicApi'
+import type { InitialContexts } from './preStartRum'
 
 export type StartRum = typeof startRum
 export type StartRumResult = ReturnType<StartRum>
@@ -74,7 +76,8 @@ export function startRum(
   bufferedDataObservable: BufferedObservable<BufferedData>,
   telemetry: Telemetry,
   hooks: Hooks,
-  sdkName?: SdkName
+  sdkName?: SdkName,
+  initialContexts?: InitialContexts
 ) {
   const cleanupTasks: Array<() => void> = []
   const lifeCycle = new LifeCycle()
@@ -127,7 +130,8 @@ export function startRum(
     customVitalsState,
     bufferedDataObservable,
     sdkName,
-    reportError
+    reportError,
+    initialContexts
   )
   cleanupTasks.push(stopRumEventCollection)
   bufferedDataObservable.unbuffer()
@@ -158,7 +162,8 @@ export function startRumEventCollection(
   customVitalsState: CustomVitalsState,
   bufferedDataObservable: Observable<BufferedData>,
   sdkName: SdkName | undefined,
-  reportError: (error: RawError) => void
+  reportError: (error: RawError) => void,
+  initialContexts?: InitialContexts
 ) {
   const cleanupTasks: Array<() => void> = []
 
@@ -180,6 +185,16 @@ export function startRumEventCollection(
   const globalContext = startGlobalContext(hooks, configuration, 'rum', true)
   const userContext = startUserContext(hooks, configuration, session, 'rum')
   const accountContext = startAccountContext(hooks, configuration, 'rum')
+
+  // Initialize context managers with pre-start values so the first view event
+  // includes any context set before init() was called (see #3935)
+  if (initialContexts) {
+    globalContext.setContext(initialContexts.globalContext)
+    userContext.setContext(initialContexts.userContext)
+    if (!isEmptyObject(initialContexts.accountContext)) {
+      accountContext.setContext(initialContexts.accountContext)
+    }
+  }
 
   const actionCollection = startActionCollection(
     lifeCycle,


### PR DESCRIPTION
<!-- rfc-publish: rick.klein/3935/missing-global-context-init -->
# RFC: Include Pre-Start Context in First RUM View Event

**Status:** Complete

**Branch:** `rick.klein/3935/missing-global-context-init`

**Last updated:** 2026-03-10

**PR:** [PR #4304](https://github.com/DataDog/browser-sdk/pull/4304)

## Summary

The first RUM view event emitted after `DD_RUM.init()` is missing global context, user context, and account context that were set before initialization. This RFC describes a fix that passes pre-start context values through the initialization chain so they are applied to the real context managers before the first view event fires.

## Motivation

Users of the Browser SDK commonly set context before calling `init()`:

```javascript
DD_RUM.setGlobalContext({ team: 'checkout' })
DD_RUM.setUser({ id: 'user-123' })
DD_RUM.init({ applicationId: '...', clientToken: '...' })
```

The first view event emitted during `init()` is missing this context. All subsequent events include it correctly. This is [issue #3935](https://github.com/DataDog/browser-sdk/issues/3935).

**Root cause:** During `init()`, `startRumEventCollection()` creates new, empty context managers, then starts assembly (which registers context hooks), then starts view collection. The first view event fires **synchronously** during `startViewCollection()`. The pre-start buffered API calls (including `setContext()`) are drained **after** `startRum()` returns — too late for the first view event.

The initialization sequence:

1. `tryStartRum()` calls `doStartRum()` (which calls `startRum()` → `startRumEventCollection()`)
2. Inside `startRumEventCollection()`: new empty context managers are created → assembly hooks registered → `startViewCollection()` fires the first view event synchronously
3. `doStartRum()` returns
4. `bufferApiCalls.drain()` replays buffered `setContext()` calls — but the first view event already shipped

## Solution

### Approach

Snapshot the pre-start context values in `tryStartRum()` and pass them through the initialization chain (`doStartRum` → `startRum` → `startRumEventCollection`). The real context managers are initialized with these values **before** `startViewCollection()` is called, ensuring the first view event includes them.

This is a synchronous, forward-pass approach — no timing changes, no microtask delays, no changes to the buffer drain order.

### Architecture

The fix threads an `InitialContexts` object through three functions:

1. **`preStartRum.ts`** (`tryStartRum`): Snapshots pre-start context values into an `InitialContexts` object and passes it to `doStartRum()`
2. **`rumPublicApi.ts`**: Forwards `initialContexts` from `doStartRum` callback to `startRum()`
3. **`startRum.ts`** (`startRumEventCollection`): After creating context managers but **before** starting view collection, calls `setContext()` on each manager with the initial values

### Schema

The `InitialContexts` interface added in `packages/rum-core/src/boot/preStartRum.ts`:

```typescript
export interface InitialContexts {
  globalContext: Context
  userContext: Context
  accountContext: Context
}
```

The `DoStartRum` type signature updated to include `initialContexts`:

```typescript
export type DoStartRum = (
  configuration: RumConfiguration,
  deflateWorker: DeflateWorker | undefined,
  initialViewOptions: ViewOptions | undefined,
  telemetry: Telemetry,
  hooks: Hooks,
  initialContexts: InitialContexts
) => StartRumResult
```

## Testing

Run `yarn test:unit --spec packages/rum-core/src/boot/preStartRum.spec.ts` and `yarn test:unit --spec packages/rum-core/src/boot/startRum.spec.ts` to validate the fix.

**Unit tests** (4 new tests in `preStartRum.spec.ts`): Verify that `doStartRum` receives the correct initial context values for global context, user context, account context, and the empty-context case.

**Integration tests** (2 new tests in `startRum.spec.ts`): Verify the first collected view event includes global context (`context` field) and user context (`usr` field) when `initialContexts` is passed to `startRumEventCollection`.

## References

- [Issue #3935](https://github.com/DataDog/browser-sdk/issues/3935) — Initial version of RUM view event is missing global context
- [PR #3597](https://github.com/DataDog/browser-sdk/pull/3597) — Alternative approach using `enqueueMicroTask()` to delay the first view update