### PR TITLE
⬆️ [PANA-6354] Update replay sandbox version in extension to support Change records

### DIFF
--- a/developer-extension/src/common/packagesUrlConstants.ts
+++ b/developer-extension/src/common/packagesUrlConstants.ts
@@ -5,7 +5,7 @@ export const DEV_RUM_URL = `${DEV_SERVER_ORIGIN}/datadog-rum.js`
 
 // To follow web-ui development, this version will need to be manually updated from time to time.
 // When doing that, be sure to update types and implement any protocol changes.
-export const PROD_REPLAY_SANDBOX_VERSION = '0.135.0'
+export const PROD_REPLAY_SANDBOX_VERSION = '0.137.0'
 export const PROD_REPLAY_SANDBOX_ORIGIN = 'https://session-replay-datadoghq.com'
 export const PROD_REPLAY_SANDBOX_URL = `${PROD_REPLAY_SANDBOX_ORIGIN}/${PROD_REPLAY_SANDBOX_VERSION}/index.html`
 


### PR DESCRIPTION
## Motivation

Currently the Live Replay feature of the browser SDK extension is broken when incremental Change records are enabled, because it's using an old version of the session replay sandbox.

## Changes

This PR updates the version of the session replay sandbox used in the browser SDK extension to match the version that we're currently using in the Datadog UI. This will give it complete Change record support as well as a slew of recent bug fixes.

## Test instructions

Load the browser SDK extension locally and try out Live Replay on staging. With the change in this PR, it should work.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
