### PR TITLE
🎨 [PANA-6365] Fix type definition for RumMutationRecord

### DIFF
--- a/packages/rum-core/src/browser/domMutationObservable.ts
+++ b/packages/rum-core/src/browser/domMutationObservable.ts
@@ -11,7 +11,7 @@ export interface RumAttributesMutationRecord {
   type: 'attributes'
   target: Element
   oldValue: string | null
-  attributeName: string | null
+  attributeName: string
 }
 
 export interface RumChildListMutationRecord {

--- a/packages/rum/src/domain/record/serialization/serializeMutations.ts
+++ b/packages/rum/src/domain/record/serialization/serializeMutations.ts
@@ -296,13 +296,13 @@ function processAttributesMutations(
   const handledElements = new Map<Element, Set<string>>()
   const filteredMutations = mutations.filter((mutation) => {
     const handledAttributes = handledElements.get(mutation.target)
-    if (handledAttributes && handledAttributes.has(mutation.attributeName!)) {
+    if (handledAttributes && handledAttributes.has(mutation.attributeName)) {
       return false
     }
     if (!handledAttributes) {
-      handledElements.set(mutation.target, new Set([mutation.attributeName!]))
+      handledElements.set(mutation.target, new Set([mutation.attributeName]))
     } else {
-      handledAttributes.add(mutation.attributeName!)
+      handledAttributes.add(mutation.attributeName)
     }
     return true
   })
@@ -310,7 +310,7 @@ function processAttributesMutations(
   // Emit mutations
   const emittedMutations = new Map<Element, AttributeMutation>()
   for (const mutation of filteredMutations) {
-    const uncensoredValue = mutation.target.getAttribute(mutation.attributeName!)
+    const uncensoredValue = mutation.target.getAttribute(mutation.attributeName)
     if (uncensoredValue === mutation.oldValue) {
       continue
     }
@@ -328,7 +328,7 @@ function processAttributesMutations(
     const attributeValue = serializeAttribute(
       mutation.target,
       privacyLevel,
-      mutation.attributeName!,
+      mutation.attributeName,
       transaction.scope.configuration
     )
 
@@ -352,7 +352,7 @@ function processAttributesMutations(
       emittedMutations.set(mutation.target, emittedMutation)
     }
 
-    emittedMutation.attributes[mutation.attributeName!] = transformedValue
+    emittedMutation.attributes[mutation.attributeName] = transformedValue
   }
 
   return attributeMutations

--- a/packages/rum/src/domain/record/serialization/serializeMutationsAsChange.ts
+++ b/packages/rum/src/domain/record/serialization/serializeMutationsAsChange.ts
@@ -61,7 +61,7 @@ function processMutations(mutations: RumMutationRecord[], transaction: ChangeSer
           attributes = new Map<AttributeName, OldValue>()
           attributeMutations.set(node, attributes)
         }
-        const attributeName = mutation.attributeName!
+        const attributeName = mutation.attributeName
         if (!attributes.has(attributeName)) {
           attributes.set(attributeName, mutation.oldValue)
         }


### PR DESCRIPTION
## Motivation

The type definition for `RumMutationRecord` has a problem: when you narrow the type to `RumAttributesMutationRecord`, [`attributeName` should become non-nullable](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord/attributeName), but it doesn't. This is because of a mistake in the definition of `RumAttributesMutationRecord`. We should fix this so that we can remove unnecessary non-null assertions from our code.

## Changes

The fix is to remove `null` from the type of `attributeName` in the definition of `RumAttributesMutationRecord`. This PR does this and then removes the unnecessary non-null assertions from other parts of the code.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
