### PR TITLE
🔧 Fix octo-sts pull_request policy subject pattern

### DIFF
--- a/.github/chainguard/self.gitlab.pull_request.sts.yaml
+++ b/.github/chainguard/self.gitlab.pull_request.sts.yaml
@@ -1,11 +1,11 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: 'project_path:DataDog/browser-sdk:refs/heads/main'
+subject_pattern: 'project_path:DataDog/browser-sdk:ref_type:branch:ref:main'
 
 claim_pattern:
   project_path: 'DataDog/browser-sdk'
+  ref_type: 'branch'
   ref: 'main'
-  ref_path: 'refs/heads/main'
 
 permissions:
   pull_requests: write


### PR DESCRIPTION
## Motivation

The `bump-chrome-version` CI job (and any other job using `getGithubPullRequestToken()`) has been failing for months due to a subject format change in GitLab CI. As a result, the Chrome version used in tests has been stuck at 139 for ~7 months.

The error:
```
trust policy: subject_pattern "project_path:DataDog/browser-sdk:ref_type:branch:ref:main"
did not match "project_path:DataDog/browser-sdk:refs/heads/main"
```

GitLab updated the default OIDC `sub` claim format from `refs/heads/main` to `ref_type:branch:ref:main` (see [GitLab OIDC docs](https://docs.gitlab.com/ci/secrets/id_token_authentication/)).

## Changes

Update `.github/chainguard/self.gitlab.pull_request.sts.yaml` to use the new subject format, aligning it with the format already used by the `release` policy.

## Checklist

- [x] Tested locally
- [ ] ~~Tested on staging~~
- [ ] ~~Added unit tests for this change.~~
- [ ] ~~Added e2e/integration tests for this change.~~
- [ ] ~~Updated documentation and/or relevant AGENTS.md file~~