### PR TITLE
👷 Add ci.browser-sdk to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,7 +40,7 @@ jobs:
           branch: 'browser-sdk'
           remote-repository-name: cla-signatures
           remote-organization-name: DataDog
-          allowlist: renovate,renovate[bot],campaigner-prod,gh-worker-dd-devflow-*
+          allowlist: renovate,renovate[bot],campaigner-prod,gh-worker-dd-devflow-*,ci.browser-sdk
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #allowlist: user1,bot*


### PR DESCRIPTION
## Motivation

The bump chrome version CI job (e.g. #4311) creates PRs committed by `ci.browser-sdk`, which triggers the CLA check unnecessarily.

## Changes

Add `ci.browser-sdk` to the CLA workflow allowlist so automated PRs from this bot skip the CLA check.

## Test instructions

Verify the CLA check no longer triggers on PRs authored by `ci.browser-sdk`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file