### PR TITLE
👷 Sign CI Docker image with ddsign

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,8 +122,13 @@ ci-image:
   when: manual
   tags: ['arch:amd64']
   image: $BUILD_STABLE_REGISTRY/images/docker:27.3.1
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   script:
-    - docker buildx build --platform linux/amd64 --build-arg CHROME_PACKAGE_VERSION=$CHROME_PACKAGE_VERSION --tag $CI_IMAGE --push .
+    - METADATA_FILE=$(mktemp)
+    - docker buildx build --platform linux/amd64 --build-arg CHROME_PACKAGE_VERSION=$CHROME_PACKAGE_VERSION --tag $CI_IMAGE --push --metadata-file $METADATA_FILE .
+    - ddsign sign $CI_IMAGE --docker-metadata-file $METADATA_FILE
 
 ########################################################################################################################
 # Tests


### PR DESCRIPTION
## Motivation

Sign the CI Docker image using `ddsign` for image integrity verification.

## Changes

- Add `DDSIGN_ID_TOKEN` id_token with `image-integrity` audience to the `ci-image` job
- Capture Docker build metadata to a temp file via `--metadata-file`
- Sign the pushed image with `ddsign sign` using the metadata file

## Test instructions

```
ddsign verify registry.ddbuild.io/ci/browser-sdk:102@$(crane digest registry.ddbuild.io/ci/browser-sdk:102)
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file