### PR TITLE
✨ Add addVueError for Vue error tracking

### DIFF
--- a/packages/rum-vue/src/domain/error/addVueError.spec.ts
+++ b/packages/rum-vue/src/domain/error/addVueError.spec.ts
@@ -1,0 +1,68 @@
+import { RumEventType } from '@datadog/browser-rum-core'
+import { computeStackTrace, toStackTraceString } from '@datadog/browser-core'
+import { initializeVuePlugin } from '../../../test/initializeVuePlugin'
+import { addVueError } from './addVueError'
+
+describe('addVueError', () => {
+  it('reports the error to the SDK', () => {
+    const addEventSpy = jasmine.createSpy()
+    initializeVuePlugin({ addEvent: addEventSpy })
+
+    const error = new Error('something broke')
+    error.name = 'VueError'
+
+    addVueError(error, null, 'mounted hook')
+
+    expect(addEventSpy).toHaveBeenCalledOnceWith(
+      jasmine.any(Number),
+      {
+        type: RumEventType.ERROR,
+        date: jasmine.any(Number),
+        error: jasmine.objectContaining({
+          id: jasmine.any(String),
+          type: 'VueError',
+          message: 'something broke',
+          stack: toStackTraceString(computeStackTrace(error)),
+          handling_stack: jasmine.any(String),
+          component_stack: 'mounted hook',
+          source_type: 'browser',
+          handling: 'handled',
+        }),
+        context: { framework: 'vue' },
+      },
+      {
+        error,
+        handlingStack: jasmine.any(String),
+      }
+    )
+  })
+
+  it('handles empty info gracefully', () => {
+    const addEventSpy = jasmine.createSpy()
+    initializeVuePlugin({ addEvent: addEventSpy })
+    addVueError(new Error('oops'), null, '')
+    expect(addEventSpy).toHaveBeenCalledTimes(1)
+    const payload = addEventSpy.calls.mostRecent().args[1]
+    expect(payload.error.component_stack).toBeUndefined()
+  })
+
+  it('should merge dd_context from the original error with vue error context', () => {
+    const addEventSpy = jasmine.createSpy()
+    initializeVuePlugin({ addEvent: addEventSpy })
+    const originalError = new Error('error message')
+    originalError.name = 'CustomError'
+    ;(originalError as any).dd_context = { component: 'Menu', param: 123 }
+
+    addVueError(originalError, null, 'mounted hook')
+
+    expect(addEventSpy.calls.mostRecent().args[1]).toEqual(
+      jasmine.objectContaining({
+        context: {
+          framework: 'vue',
+          component: 'Menu',
+          param: 123,
+        },
+      })
+    )
+  })
+})

--- a/packages/rum-vue/src/domain/error/addVueError.ts
+++ b/packages/rum-vue/src/domain/error/addVueError.ts
@@ -1,0 +1,76 @@
+import type { ComponentPublicInstance } from 'vue'
+import {
+  callMonitored,
+  clocksNow,
+  computeRawError,
+  createHandlingStack,
+  ErrorHandling,
+  ErrorSource,
+  generateUUID,
+  NonErrorPrefix,
+} from '@datadog/browser-core'
+import { RumEventType } from '@datadog/browser-rum-core'
+import { onVueStart } from '../vuePlugin'
+
+/**
+ * Add a Vue error to the RUM session.
+ *
+ * @category Error
+ * @example
+ * ```ts
+ * import { createApp } from 'vue'
+ * import { addVueError } from '@datadog/browser-rum-vue'
+ *
+ * const app = createApp(App)
+ * // Report all Vue errors to Datadog automatically
+ * app.config.errorHandler = addVueError
+ * ```
+ */
+export function addVueError(
+  error: unknown,
+  // Required by Vue's app.config.errorHandler signature, but not used by the SDK
+  _instance: ComponentPublicInstance | null,
+  info: string
+) {
+  const handlingStack = createHandlingStack('vue error')
+  const startClocks = clocksNow()
+  onVueStart((addEvent) => {
+    callMonitored(() => {
+      const rawError = computeRawError({
+        originalError: error,
+        handlingStack,
+        componentStack: info || undefined,
+        startClocks,
+        source: ErrorSource.CUSTOM,
+        handling: ErrorHandling.HANDLED,
+        nonErrorPrefix: NonErrorPrefix.PROVIDED,
+      })
+
+      addEvent(
+        startClocks.relative,
+        {
+          type: RumEventType.ERROR,
+          date: rawError.startClocks.timeStamp,
+          error: {
+            id: generateUUID(),
+            message: rawError.message,
+            source: rawError.source,
+            stack: rawError.stack,
+            handling_stack: rawError.handlingStack,
+            component_stack: rawError.componentStack,
+            type: rawError.type,
+            handling: rawError.handling,
+            causes: rawError.causes,
+            source_type: 'browser',
+            csp: rawError.csp,
+          },
+          context: { framework: 'vue', ...rawError.context },
+        },
+        {
+          error: rawError.originalError,
+          handlingStack: rawError.handlingStack,
+        }
+      )
+    })
+  })
+}

--- a/packages/rum-vue/src/entries/main.ts
+++ b/packages/rum-vue/src/entries/main.ts
@@ -1,2 +1,3 @@
 export type { VuePluginConfiguration, VuePlugin } from '../domain/vuePlugin'
 export { vuePlugin } from '../domain/vuePlugin'
+export { addVueError } from '../domain/error/addVueError'


### PR DESCRIPTION
## Motivation

Second of four stacked PRs. Adds error tracking — capturing Vue component errors and forwarding them to RUM with Vue-specific context.

## Changes

Exports \`addVueError\`, which matches Vue's \`app.config.errorHandler\` signature exactly so it can be assigned directly:

```ts
app.config.errorHandler = addVueError
```

No wrapper needed. Vue's \`info\` string (e.g. \`"mounted hook"\`, \`"v-on handler"\`) maps to \`component_stack\` in the error event, and \`context.framework\` is set to \`"vue"\` for filtering in dashboards. Errors thrown before \`datadogRum.init()\` are queued via \`onVueStart\` and flushed when RUM starts.

## Test instructions

```bash
yarn test:unit --spec packages/rum-vue/src/domain/error/addVueError.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change
- [ ] Added e2e/integration tests
- [ ] Updated documentation

---

**Stack:** [PR 1: foundation](https://github.com/DataDog/browser-sdk/pull/4321) → this PR → PR 3: router → PR 4: tracker + sample app