### PR TITLE
✨ Add Vue Router v4 integration

### DIFF
--- a/packages/rum-vue/src/domain/router/startVueRouterView.spec.ts
+++ b/packages/rum-vue/src/domain/router/startVueRouterView.spec.ts
@@ -1,0 +1,50 @@
+import { display } from '@datadog/browser-core'
+import type { RouteLocationMatched } from 'vue-router'
+import { initializeVuePlugin } from '../../../test/initializeVuePlugin'
+import { startVueRouterView, computeViewName } from './startVueRouterView'
+
+describe('startVueRouterView', () => {
+  it('starts a new view with the computed view name', () => {
+    const startViewSpy = jasmine.createSpy()
+    initializeVuePlugin({
+      configuration: { router: true },
+      publicApi: { startView: startViewSpy },
+    })
+
+    startVueRouterView([{ path: '/' }, { path: 'user' }, { path: ':id' }] as unknown as RouteLocationMatched[])
+
+    expect(startViewSpy).toHaveBeenCalledOnceWith('/user/:id')
+  })
+
+  it('warns if router: true is missing from plugin config', () => {
+    const warnSpy = spyOn(display, 'warn')
+    initializeVuePlugin({ configuration: {} })
+    startVueRouterView([] as unknown as RouteLocationMatched[])
+    expect(warnSpy).toHaveBeenCalledOnceWith(
+      '`router: true` is missing from the vue plugin configuration, the view will not be tracked.'
+    )
+  })
+})
+
+describe('computeViewName', () => {
+  it('returns empty string for empty matched array', () => {
+    expect(computeViewName([])).toBe('')
+  })
+
+  it('returns the path for a simple route', () => {
+    expect(computeViewName([{ path: '/users' }] as unknown as RouteLocationMatched[])).toBe('/users')
+  })
+
+  it('returns the most specific matched path for nested routes', () => {
+    // Vue Router normalizes nested matched paths to absolute paths
+    expect(computeViewName([{ path: '/users' }, { path: '/users/:id' }] as unknown as RouteLocationMatched[])).toBe(
+      '/users/:id'
+    )
+  })
+
+  it('ignores records without a path', () => {
+    expect(
+      computeViewName([{ path: '/users' }, { path: '' }, { path: '/users/:id' }] as unknown as RouteLocationMatched[])
+    ).toBe('/users/:id')
+  })
+})

--- a/packages/rum-vue/src/domain/router/startVueRouterView.ts
+++ b/packages/rum-vue/src/domain/router/startVueRouterView.ts
@@ -1,0 +1,42 @@
+import { display } from '@datadog/browser-core'
+import type { RouteLocationMatched } from 'vue-router'
+import { onVueInit } from '../vuePlugin'
+
+export function startVueRouterView(matched: RouteLocationMatched[]) {
+  onVueInit((configuration, rumPublicApi) => {
+    if (!configuration.router) {
+      display.warn('`router: true` is missing from the vue plugin configuration, the view will not be tracked.')
+      return
+    }
+    rumPublicApi.startView(computeViewName(matched))
+  })
+}
+
+export function computeViewName(matched: RouteLocationMatched[]): string {
+  if (!matched || matched.length === 0) {
+    return ''
+  }
+
+  let viewName = '/'
+
+  for (const routeRecord of matched) {
+    const path = routeRecord.path
+    if (!path) {
+      continue
+    }
+
+    // Note: Vue Router normalizes all paths in the matched array to absolute paths,
+    // so the relative-path branch below is purely defensive and not expected to be
+    // hit in practice. It mirrors the React Router implementation for consistency.
+    if (path.startsWith('/')) {
+      viewName = path
+    } else {
+      if (!viewName.endsWith('/')) {
+        viewName += '/'
+      }
+      viewName += path
+    }
+  }
+
+  return viewName
+}

--- a/packages/rum-vue/src/domain/router/vueRouter.spec.ts
+++ b/packages/rum-vue/src/domain/router/vueRouter.spec.ts
@@ -1,0 +1,68 @@
+import { createMemoryHistory } from 'vue-router'
+import { initializeVuePlugin } from '../../../test/initializeVuePlugin'
+import { createRouter } from './vueRouter'
+
+describe('createRouter (wrapped)', () => {
+  it('calls startView on navigation', (done) => {
+    const startViewSpy = jasmine.createSpy()
+    initializeVuePlugin({
+      configuration: { router: true },
+      publicApi: { startView: startViewSpy },
+    })
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: {} },
+        { path: '/about', component: {} },
+      ],
+    })
+
+    router
+      .push('/')
+      .then(() => {
+        expect(startViewSpy).toHaveBeenCalledWith('/')
+        return router.push('/about')
+      })
+      .then(() => {
+        expect(startViewSpy).toHaveBeenCalledWith('/about')
+        done()
+      })
+      .catch(done.fail)
+  })
+
+  it('does not call startView when navigation is blocked', (done) => {
+    const startViewSpy = jasmine.createSpy()
+    initializeVuePlugin({
+      configuration: { router: true },
+      publicApi: { startView: startViewSpy },
+    })
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: {} },
+        { path: '/protected', component: {} },
+      ],
+    })
+
+    // Block all navigations to /protected
+    router.beforeEach((to) => {
+      if (to.path === '/protected') {
+        return false
+      }
+    })
+
+    router
+      .push('/')
+      .then(() => {
+        startViewSpy.calls.reset()
+        return router.push('/protected')
+      })
+      .then(() => {
+        expect(startViewSpy).not.toHaveBeenCalled()
+        done()
+      })
+      .catch(done.fail)
+  })
+})

--- a/packages/rum-vue/src/domain/router/vueRouter.ts
+++ b/packages/rum-vue/src/domain/router/vueRouter.ts
@@ -1,0 +1,18 @@
+import { createRouter as originalCreateRouter, isNavigationFailure, NavigationFailureType } from 'vue-router'
+import type { RouterOptions, Router } from 'vue-router'
+import { startVueRouterView } from './startVueRouterView'
+
+export function createRouter(options: RouterOptions): Router {
+  const router = originalCreateRouter(options)
+
+  // afterEach fires for the initial navigation when the app is mounted via app.use(router).
+  // In tests without mounting, an explicit router.push() is needed to trigger the hook.
+  router.afterEach((to, _from, failure) => {
+    if (failure && !isNavigationFailure(failure, NavigationFailureType.duplicated)) {
+      return
+    }
+    startVueRouterView(to.matched)
+  })
+
+  return router
+}

--- a/packages/rum-vue/src/entries/vueRouter.ts
+++ b/packages/rum-vue/src/entries/vueRouter.ts
@@ -1,1 +1,1 @@
-export {}
+export { createRouter } from '../domain/router/vueRouter'


### PR DESCRIPTION
## Motivation

Third of four stacked PRs. Adds Vue Router v4 view tracking — automatically creating a RUM view on each navigation with a parameterized route name instead of a raw URL.

## Changes

Exports a wrapped \`createRouter\` from \`@datadog/browser-rum-vue/vue-router-v4\` — a drop-in replacement for the standard \`vue-router\` import:

```ts
// before
import { createRouter } from 'vue-router'

// after
import { createRouter } from '@datadog/browser-rum-vue/vue-router-v4'
```

On each navigation, \`afterEach\` fires \`startView()\` with the parameterized route name (e.g. \`/users/:id\` rather than \`/users/42\`). One non-obvious detail: \`afterEach\` fires even for guard-blocked navigations, so we filter those out via the \`failure\` parameter — see the inline comment on the diff for the full reasoning.

Also requires \`vuePlugin({ router: true })\` to set \`trackViewsManually: true\` at init — otherwise the SDK's automatic URL tracking and the router integration would both fire, creating duplicate views.

## Test instructions

```bash
yarn test:unit --spec packages/rum-vue/src/domain/router/startVueRouterView.spec.ts
yarn test:unit --spec packages/rum-vue/src/domain/router/vueRouter.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change
- [ ] Added e2e/integration tests
- [ ] Updated documentation

---

**Stack:** [PR 1: foundation](https://github.com/DataDog/browser-sdk/pull/4321) → [PR 2: error tracking](https://github.com/DataDog/browser-sdk/pull/4322) → this PR → PR 4: tracker + sample app