### PR TITLE
✨ Add @datadog/browser-remote-config standalone package and @datadog/browser-sdk-endpoint bundle generator

### DIFF
--- a/packages/endpoint/LICENSE
+++ b/packages/endpoint/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019-Present Datadog, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/endpoint/README.md
+++ b/packages/endpoint/README.md
@@ -1,0 +1,135 @@
+# @datadog/browser-sdk-endpoint
+
+Node.js package for generating self-contained Datadog Browser SDK bundles with embedded remote configuration. Designed for CI/CD pipelines, SSR frameworks, and custom build tooling.
+
+## Installation
+
+```bash
+npm install @datadog/browser-sdk-endpoint
+```
+
+## Usage
+
+### Generate a bundle (CI / build script)
+
+Fetch remote configuration, download the SDK from CDN, and produce a single self-executing IIFE in one call:
+
+```typescript
+import { generateBundle } from '@datadog/browser-sdk-endpoint'
+import { writeFileSync } from 'node:fs'
+
+const bundle = await generateBundle({
+  applicationId: 'your-app-id',
+  remoteConfigurationId: 'your-config-id',
+  variant: 'rum',          // 'rum' | 'rum-slim' | 'logs' | 'rum-and-logs'
+  site: 'datadoghq.com',   // optional, defaults to datadoghq.com
+})
+
+writeFileSync('public/datadog-sdk.js', bundle)
+```
+
+Then in your HTML, set `window.__DD_BASE_CONFIG__` with the fields that belong to the page (not the remote config) before loading the bundle:
+
+```html
+<script>
+  window.__DD_BASE_CONFIG__ = {
+    clientToken: 'your-client-token',
+    site: 'datadoghq.com'
+  }
+</script>
+<script src="/datadog-sdk.js"></script>
+```
+
+The bundle merges `__DD_BASE_CONFIG__` with the embedded remote configuration and calls `DD_RUM.init()` automatically — no additional `init()` call needed in your app code.
+
+### SSR: inject configuration at render time
+
+If you use server-side rendering and want to avoid a separate bundle generation step, you can fetch the remote configuration per request, serialize it to an inline JS expression, and inject it into the HTML response. The SDK is loaded separately; only the configuration is embedded.
+
+```typescript
+import { fetchRemoteConfiguration } from '@datadog/browser-remote-config'
+import { resolveDynamicValues, serializeConfigToJs } from '@datadog/browser-remote-config/node'
+
+// In your SSR handler (Express, Next.js getServerSideProps, etc.)
+const result = await fetchRemoteConfiguration({
+  applicationId: 'your-app-id',
+  remoteConfigurationId: 'your-config-id',
+})
+
+if (result.ok) {
+  const configJs = serializeConfigToJs(resolveDynamicValues(result.value))
+
+  // Inject into <head> before the SDK script tag
+  // configJs is a JS object literal — dynamic values (cookies, DOM, window.*) are
+  // serialized as inline expressions that evaluate in the browser at page load time
+  html += `<script>window.__DD_RC_CONFIG__ = ${configJs}</script>`
+}
+```
+
+Then in your client-side code:
+
+```typescript
+import { datadogRum } from '@datadog/browser-rum'
+
+datadogRum.init({
+  applicationId: 'your-app-id',
+  clientToken: 'your-client-token',
+  site: 'datadoghq.com',
+  ...window.__DD_RC_CONFIG__
+})
+```
+
+`resolveDynamicValues` from the Node entry point serializes `DynamicOption` fields (cookie, JS path, DOM, localStorage) as inline JS expressions rather than evaluating them on the server. Those expressions run against live browser APIs when the `<script>` tag is parsed, so dynamic values like a cookie-based user ID are resolved at the right time.
+
+### Build blocks (advanced)
+
+Use `fetchConfig`, `generateCombinedBundle`, and `downloadSDK` separately for custom pipelines:
+
+```typescript
+import { fetchConfig, generateCombinedBundle } from '@datadog/browser-sdk-endpoint'
+import { resolveDynamicValues, serializeConfigToJs } from '@datadog/browser-remote-config/node'
+import { downloadSDK } from '@datadog/browser-sdk-endpoint'
+
+const configResult = await fetchConfig({
+  applicationId: 'your-app-id',
+  remoteConfigurationId: 'your-config-id',
+})
+
+const configJs = serializeConfigToJs(resolveDynamicValues(configResult.value))
+const sdkCode = await downloadSDK({ variant: 'rum' })
+
+const bundle = generateCombinedBundle({ sdkCode, configJs, variant: 'rum' })
+```
+
+## API
+
+### `generateBundle(options)`
+
+Fetches remote configuration, downloads the SDK from CDN, and returns a combined bundle string.
+
+- `applicationId` (string, required)
+- `remoteConfigurationId` (string, required)
+- `variant` (`'rum' | 'rum-slim' | 'logs' | 'rum-and-logs'`, required)
+- `site` (string, optional) — Datadog site, e.g. `'datadoghq.eu'`
+- `datacenter` (string, optional) — CDN datacenter, e.g. `'us1'`
+
+### `fetchConfig(options)`
+
+Fetches and validates remote configuration. Throws on network error or invalid config ID.
+
+- `applicationId`, `remoteConfigurationId`, `site` — same as above
+
+### `generateCombinedBundle(options)`
+
+Assembles a self-executing IIFE from pre-fetched parts.
+
+- `sdkCode` (string) — SDK source downloaded from CDN
+- `configJs` (string) — serialized config from `serializeConfigToJs`
+- `variant` — SDK variant label embedded in the bundle comment
+- `sdkVersion` (string, optional) — version label embedded in the bundle comment
+
+### `downloadSDK(options)`
+
+Downloads the SDK bundle from the Datadog CDN. Results are cached in memory per variant + datacenter.
+
+- `variant`, `datacenter`, `version` (optional — defaults to the package version)

--- a/packages/endpoint/README.md
+++ b/packages/endpoint/README.md
@@ -21,8 +21,8 @@ import { writeFileSync } from 'node:fs'
 const bundle = await generateBundle({
   applicationId: 'your-app-id',
   remoteConfigurationId: 'your-config-id',
-  variant: 'rum',          // 'rum' | 'rum-slim' | 'logs' | 'rum-and-logs'
-  site: 'datadoghq.com',   // optional, defaults to datadoghq.com
+  variant: 'rum', // 'rum' | 'rum-slim' | 'logs' | 'rum-and-logs'
+  site: 'datadoghq.com', // optional, defaults to datadoghq.com
 })
 
 writeFileSync('public/datadog-sdk.js', bundle)
@@ -34,7 +34,7 @@ Then in your HTML, set `window.__DD_BASE_CONFIG__` with the fields that belong t
 <script>
   window.__DD_BASE_CONFIG__ = {
     clientToken: 'your-client-token',
-    site: 'datadoghq.com'
+    site: 'datadoghq.com',
   }
 </script>
 <script src="/datadog-sdk.js"></script>
@@ -75,7 +75,7 @@ datadogRum.init({
   applicationId: 'your-app-id',
   clientToken: 'your-client-token',
   site: 'datadoghq.com',
-  ...window.__DD_RC_CONFIG__
+  ...window.__DD_RC_CONFIG__,
 })
 ```
 

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@datadog/browser-sdk-endpoint",
+  "version": "6.28.0",
+  "license": "Apache-2.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@datadog/browser-remote-config": "6.28.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-sdk-endpoint",
-  "version": "6.28.0",
+  "version": "7.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -8,7 +8,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@datadog/browser-remote-config": "6.28.0"
+    "@datadog/browser-remote-config": "7.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -2,12 +2,18 @@
   "name": "@datadog/browser-sdk-endpoint",
   "version": "7.2.0",
   "license": "Apache-2.0",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "cjs/index.d.ts",
   "files": [
+    "cjs",
+    "esm",
     "src",
     "!src/**/*.spec.ts"
   ],
+  "scripts": {
+    "build": "tsc --project tsconfig.build.cjs.json && tsc --project tsconfig.build.esm.json"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -4,6 +4,10 @@
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "files": [
+    "src",
+    "!src/**/*.spec.ts"
+  ],
   "engines": {
     "node": ">=18"
   },

--- a/packages/endpoint/src/bundleGenerator.spec.ts
+++ b/packages/endpoint/src/bundleGenerator.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { generateCombinedBundle } from './bundleGenerator.ts'
+import { INLINE_HELPERS } from './helpers.ts'
+
+const mockSdkCode = 'window.DD_RUM = { init: function(c) { this.config = c; } };'
+
+describe('generateCombinedBundle', () => {
+  it('wraps output in an IIFE', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      configJs: '{ "sessionSampleRate": 24 }',
+      variant: 'rum',
+    })
+    assert.ok(bundle.includes('(function() {'), 'Should contain IIFE start')
+    assert.ok(bundle.includes('})();'), 'Should contain IIFE end')
+    assert.ok(bundle.includes("'use strict';"), 'Should include use strict')
+  })
+
+  it('embeds configJs verbatim without re-serializing', () => {
+    const configJs = '{ "sessionSampleRate": 24, "user": { id: __dd_getJs(\'window.user\') } }'
+    const bundle = generateCombinedBundle({ sdkCode: mockSdkCode, configJs, variant: 'rum' })
+    assert.ok(bundle.includes(configJs), 'Should embed configJs verbatim')
+  })
+
+  it('always includes all six inline helpers', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      configJs: '{ "sessionSampleRate": 100 }',
+      variant: 'rum',
+    })
+    assert.ok(bundle.includes('__dd_getCookie'), 'Should include cookie helper')
+    assert.ok(bundle.includes('__dd_getJs'), 'Should include JS helper')
+    assert.ok(bundle.includes('__dd_getDomText'), 'Should include DOM text helper')
+    assert.ok(bundle.includes('__dd_getDomAttr'), 'Should include DOM attr helper')
+    assert.ok(bundle.includes('__dd_getLocalStorage'), 'Should include localStorage helper')
+    assert.ok(bundle.includes('__dd_extract'), 'Should include extract helper')
+  })
+
+  it('includes variant in header comment', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      configJs: '{}',
+      variant: 'rum-slim',
+    })
+    assert.ok(bundle.includes('SDK Variant: rum-slim'), 'Should include variant in header')
+  })
+
+  it('includes SDK version in header when provided', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      configJs: '{}',
+      variant: 'rum',
+      sdkVersion: '6.28.0',
+    })
+    assert.ok(bundle.includes('SDK Version: 6.28.0'), 'Should include version in header')
+  })
+
+  it('calls DD_RUM.init with the embedded config variable', () => {
+    const bundle = generateCombinedBundle({
+      sdkCode: mockSdkCode,
+      configJs: '{ "sessionSampleRate": 50 }',
+      variant: 'rum',
+    })
+    assert.ok(bundle.includes('window.DD_RUM.init(__DATADOG_REMOTE_CONFIG__)'), 'Should call DD_RUM.init')
+  })
+
+  it('a config with only static values contains no helper calls in the config section', () => {
+    const configJs = '{ "sessionSampleRate": 24, "env": "prod" }'
+    const bundle = generateCombinedBundle({ sdkCode: mockSdkCode, configJs, variant: 'rum' })
+    // helpers are present as function definitions but not called from the config
+    const configSection = bundle.split('var __DATADOG_REMOTE_CONFIG__')[1].split(';')[0]
+    assert.ok(!configSection.includes('__dd_getCookie('), 'Static config should not call cookie helper')
+    assert.ok(!configSection.includes('__dd_getJs('), 'Static config should not call JS helper')
+  })
+
+  it('a config with dynamic values embeds helper calls in the config section', () => {
+    const configJs = '{ "user": { id: __dd_getJs(\'window.user\') } }'
+    const bundle = generateCombinedBundle({ sdkCode: mockSdkCode, configJs, variant: 'rum' })
+    const configSection = bundle.split('var __DATADOG_REMOTE_CONFIG__')[1].split(';')[0]
+    assert.ok(configSection.includes("__dd_getJs('window.user')"), 'Dynamic config should call JS helper')
+  })
+})
+
+describe('INLINE_HELPERS', () => {
+  it('defines all six helper functions', () => {
+    assert.ok(INLINE_HELPERS.includes('function __dd_getCookie'), 'Should define getCookie')
+    assert.ok(INLINE_HELPERS.includes('function __dd_getJs'), 'Should define getJs')
+    assert.ok(INLINE_HELPERS.includes('function __dd_getDomText'), 'Should define getDomText')
+    assert.ok(INLINE_HELPERS.includes('function __dd_getDomAttr'), 'Should define getDomAttr')
+    assert.ok(INLINE_HELPERS.includes('function __dd_getLocalStorage'), 'Should define getLocalStorage')
+    assert.ok(INLINE_HELPERS.includes('function __dd_extract'), 'Should define extract')
+  })
+
+  it('is valid JavaScript', () => {
+    // Wrapping in a function and parsing via Function constructor validates syntax
+    assert.doesNotThrow(() => new Function(INLINE_HELPERS), 'INLINE_HELPERS should be valid JS')
+  })
+})

--- a/packages/endpoint/src/bundleGenerator.spec.ts
+++ b/packages/endpoint/src/bundleGenerator.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import { generateCombinedBundle } from './bundleGenerator.ts'
-import { INLINE_HELPERS } from './helpers.ts'
+import { generateCombinedBundle } from './bundleGenerator'
+import { INLINE_HELPERS } from './helpers'
 
 const mockSdkCode = 'window.DD_RUM = { init: function(c) { this.config = c; } };'
 

--- a/packages/endpoint/src/bundleGenerator.spec.ts
+++ b/packages/endpoint/src/bundleGenerator.spec.ts
@@ -94,6 +94,7 @@ describe('INLINE_HELPERS', () => {
 
   it('is valid JavaScript', () => {
     // Wrapping in a function and parsing via Function constructor validates syntax
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func -- intentional syntax validation
     assert.doesNotThrow(() => new Function(INLINE_HELPERS), 'INLINE_HELPERS should be valid JS')
   })
 })

--- a/packages/endpoint/src/bundleGenerator.ts
+++ b/packages/endpoint/src/bundleGenerator.ts
@@ -1,6 +1,8 @@
 import type { SdkVariant } from './sdkDownloader.ts'
-import { getDefaultVersion } from './sdkDownloader.ts'
+import { getDefaultVersion, downloadSDK } from './sdkDownloader.ts'
 import { INLINE_HELPERS } from './helpers.ts'
+import { fetchRemoteConfiguration } from '@datadog/browser-remote-config'
+import { resolveDynamicValues, serializeConfigToJs } from '@datadog/browser-remote-config/node'
 
 export type { SdkVariant } from './sdkDownloader.ts'
 
@@ -26,10 +28,9 @@ export interface GenerateBundleOptions {
 }
 
 const CONFIG_FETCH_TIMEOUT_MS = 30_000
-const VALID_VARIANTS: SdkVariant[] = ['rum', 'rum-slim']
+const VALID_VARIANTS: SdkVariant[] = ['rum', 'rum-slim', 'logs', 'rum-and-logs']
 
 export async function fetchConfig(options: FetchConfigOptions) {
-  const { fetchRemoteConfiguration } = await import('@datadog/browser-remote-config')
   const result = await fetchRemoteConfiguration({
     applicationId: options.applicationId,
     remoteConfigurationId: options.remoteConfigurationId,
@@ -69,9 +70,11 @@ export function generateCombinedBundle(options: CombineBundleOptions): string {
   // SDK bundle (${variant}) from CDN
   ${sdkCode}
 
-  // Auto-initialize
-  if (typeof window !== 'undefined' && window.DD_RUM) {
-    window.DD_RUM.init(__DATADOG_REMOTE_CONFIG__);
+  // Auto-initialize — merge base config (clientToken, site, etc.) set by the page before this script
+  var __DD_CONFIG__ = Object.assign({}, window.__DD_BASE_CONFIG__ || {}, __DATADOG_REMOTE_CONFIG__);
+  if (typeof window !== 'undefined') {
+    if (window.DD_RUM) { window.DD_RUM.init(__DD_CONFIG__); }
+    if (window.DD_LOGS) { window.DD_LOGS.init(__DD_CONFIG__); }
   }
 })();`
 }
@@ -93,11 +96,9 @@ export async function generateBundle(options: GenerateBundleOptions): Promise<st
     site: options.site,
   })
 
-  const { resolveDynamicValues, serializeConfigToJs } = await import('@datadog/browser-remote-config/node')
   const resolved = resolveDynamicValues(configResult.value)
   const configJs = serializeConfigToJs(resolved)
 
-  const { downloadSDK } = await import('./sdkDownloader.ts')
   const sdkCode = await downloadSDK({ variant: options.variant, datacenter: options.datacenter })
   const sdkVersion = getDefaultVersion()
 

--- a/packages/endpoint/src/bundleGenerator.ts
+++ b/packages/endpoint/src/bundleGenerator.ts
@@ -1,4 +1,5 @@
 import type { SdkVariant } from './sdkDownloader.ts'
+import { getDefaultVersion } from './sdkDownloader.ts'
 import { INLINE_HELPERS } from './helpers.ts'
 
 export type { SdkVariant } from './sdkDownloader.ts'
@@ -98,6 +99,7 @@ export async function generateBundle(options: GenerateBundleOptions): Promise<st
 
   const { downloadSDK } = await import('./sdkDownloader.ts')
   const sdkCode = await downloadSDK({ variant: options.variant, datacenter: options.datacenter })
+  const sdkVersion = getDefaultVersion()
 
-  return generateCombinedBundle({ sdkCode, configJs, variant: options.variant })
+  return generateCombinedBundle({ sdkCode, configJs, variant: options.variant, sdkVersion })
 }

--- a/packages/endpoint/src/bundleGenerator.ts
+++ b/packages/endpoint/src/bundleGenerator.ts
@@ -1,0 +1,103 @@
+import type { SdkVariant } from './sdkDownloader.ts'
+import { INLINE_HELPERS } from './helpers.ts'
+
+export type { SdkVariant } from './sdkDownloader.ts'
+
+export interface FetchConfigOptions {
+  applicationId: string
+  remoteConfigurationId: string
+  site?: string
+}
+
+export interface CombineBundleOptions {
+  sdkCode: string
+  configJs: string
+  variant: SdkVariant
+  sdkVersion?: string
+}
+
+export interface GenerateBundleOptions {
+  applicationId: string
+  remoteConfigurationId: string
+  variant: SdkVariant
+  site?: string
+  datacenter?: string
+}
+
+const CONFIG_FETCH_TIMEOUT_MS = 30_000
+const VALID_VARIANTS: SdkVariant[] = ['rum', 'rum-slim']
+
+export async function fetchConfig(options: FetchConfigOptions) {
+  const { fetchRemoteConfiguration } = await import('@datadog/browser-remote-config')
+  const result = await fetchRemoteConfiguration({
+    applicationId: options.applicationId,
+    remoteConfigurationId: options.remoteConfigurationId,
+    site: options.site,
+    signal: AbortSignal.timeout(CONFIG_FETCH_TIMEOUT_MS),
+  })
+
+  if (!result.ok) {
+    throw new Error(
+      `Failed to fetch remote configuration: ${result.error.message}\n` +
+        `Verify applicationId "${options.applicationId}" and ` +
+        `configId "${options.remoteConfigurationId}" are correct.`
+    )
+  }
+
+  return { ok: true as const, value: result.value }
+}
+
+export function generateCombinedBundle(options: CombineBundleOptions): string {
+  const { sdkCode, configJs, variant, sdkVersion } = options
+  const versionDisplay = sdkVersion ?? 'unknown'
+
+  return `/**
+ * Datadog Browser SDK with Embedded Remote Configuration
+ * SDK Variant: ${variant}
+ * SDK Version: ${versionDisplay}
+ */
+(function() {
+  'use strict';
+
+  // Inline helpers for dynamic value resolution
+  ${INLINE_HELPERS}
+
+  // Embedded remote configuration
+  var __DATADOG_REMOTE_CONFIG__ = ${configJs};
+
+  // SDK bundle (${variant}) from CDN
+  ${sdkCode}
+
+  // Auto-initialize
+  if (typeof window !== 'undefined' && window.DD_RUM) {
+    window.DD_RUM.init(__DATADOG_REMOTE_CONFIG__);
+  }
+})();`
+}
+
+export async function generateBundle(options: GenerateBundleOptions): Promise<string> {
+  if (!options.applicationId || typeof options.applicationId !== 'string') {
+    throw new Error("Option 'applicationId' is required and must be a non-empty string.")
+  }
+  if (!options.remoteConfigurationId || typeof options.remoteConfigurationId !== 'string') {
+    throw new Error("Option 'remoteConfigurationId' is required and must be a non-empty string.")
+  }
+  if (!VALID_VARIANTS.includes(options.variant)) {
+    throw new Error(`Option 'variant' must be 'rum' or 'rum-slim', got '${String(options.variant)}'.`)
+  }
+
+  const configResult = await fetchConfig({
+    applicationId: options.applicationId,
+    remoteConfigurationId: options.remoteConfigurationId,
+    site: options.site,
+  })
+
+  const { resolveDynamicValues, serializeConfigToJs } = await import('@datadog/browser-remote-config/node')
+  const resolved = resolveDynamicValues(configResult.value)
+  const configJs = serializeConfigToJs(resolved)
+
+  const { downloadSDK } = await import('./sdkDownloader.ts')
+  const sdkCode = await downloadSDK({ variant: options.variant, datacenter: options.datacenter })
+
+  return generateCombinedBundle({ sdkCode, configJs, variant: options.variant })
+}

--- a/packages/endpoint/src/bundleGenerator.ts
+++ b/packages/endpoint/src/bundleGenerator.ts
@@ -2,11 +2,11 @@
 import { fetchRemoteConfiguration } from '@datadog/browser-remote-config'
 // eslint-disable-next-line local-rules/disallow-side-effects -- Node.js build tool, not browser SDK
 import { resolveDynamicValues, serializeConfigToJs } from '@datadog/browser-remote-config/node'
-import type { SdkVariant } from './sdkDownloader.ts'
-import { getDefaultVersion, downloadSDK } from './sdkDownloader.ts'
-import { INLINE_HELPERS } from './helpers.ts'
+import type { SdkVariant } from './sdkDownloader'
+import { getDefaultVersion, downloadSDK } from './sdkDownloader'
+import { INLINE_HELPERS } from './helpers'
 
-export type { SdkVariant } from './sdkDownloader.ts'
+export type { SdkVariant } from './sdkDownloader'
 
 export interface FetchConfigOptions {
   applicationId: string

--- a/packages/endpoint/src/bundleGenerator.ts
+++ b/packages/endpoint/src/bundleGenerator.ts
@@ -1,8 +1,10 @@
+// eslint-disable-next-line local-rules/disallow-side-effects -- Node.js build tool, not browser SDK
+import { fetchRemoteConfiguration } from '@datadog/browser-remote-config'
+// eslint-disable-next-line local-rules/disallow-side-effects -- Node.js build tool, not browser SDK
+import { resolveDynamicValues, serializeConfigToJs } from '@datadog/browser-remote-config/node'
 import type { SdkVariant } from './sdkDownloader.ts'
 import { getDefaultVersion, downloadSDK } from './sdkDownloader.ts'
 import { INLINE_HELPERS } from './helpers.ts'
-import { fetchRemoteConfiguration } from '@datadog/browser-remote-config'
-import { resolveDynamicValues, serializeConfigToJs } from '@datadog/browser-remote-config/node'
 
 export type { SdkVariant } from './sdkDownloader.ts'
 

--- a/packages/endpoint/src/helpers.ts
+++ b/packages/endpoint/src/helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * Inline browser helper functions embedded in generated bundles.
+ * Minimal vanilla JS — no dependencies, no transpilation needed.
+ */
+export const INLINE_HELPERS = `\
+function __dd_getCookie(n){var m=document.cookie.match(new RegExp('(?:^|; )'+encodeURIComponent(n)+'=([^;]*)'));return m?decodeURIComponent(m[1]):undefined}
+function __dd_getJs(p){try{return p.split('.').reduce(function(o,k){return o[k]},window)}catch(e){return undefined}}
+function __dd_getDomText(s){try{var e=document.querySelector(s);return e?e.textContent:undefined}catch(e){return undefined}}
+function __dd_getDomAttr(s,a){try{var e=document.querySelector(s);return e?e.getAttribute(a):undefined}catch(e){return undefined}}
+function __dd_getLocalStorage(k){try{return localStorage.getItem(k)}catch(e){return undefined}}
+function __dd_extract(v,p){if(v==null)return undefined;var m=new RegExp(p).exec(String(v));return m?m[1]!==undefined?m[1]:m[0]:undefined}`

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -1,0 +1,2 @@
+export { generateBundle, generateCombinedBundle, fetchConfig } from './bundleGenerator.ts'
+export type { GenerateBundleOptions, CombineBundleOptions, FetchConfigOptions } from './bundleGenerator.ts'

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -1,2 +1,3 @@
 export { generateBundle, generateCombinedBundle, fetchConfig } from './bundleGenerator.ts'
 export type { GenerateBundleOptions, CombineBundleOptions, FetchConfigOptions } from './bundleGenerator.ts'
+export type { SdkVariant } from './sdkDownloader.ts'

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -1,3 +1,3 @@
-export { generateBundle, generateCombinedBundle, fetchConfig } from './bundleGenerator.ts'
-export type { GenerateBundleOptions, CombineBundleOptions, FetchConfigOptions } from './bundleGenerator.ts'
-export type { SdkVariant } from './sdkDownloader.ts'
+export { generateBundle, generateCombinedBundle, fetchConfig } from './bundleGenerator'
+export type { GenerateBundleOptions, CombineBundleOptions, FetchConfigOptions } from './bundleGenerator'
+export type { SdkVariant } from './sdkDownloader'

--- a/packages/endpoint/src/sdkDownloader.ts
+++ b/packages/endpoint/src/sdkDownloader.ts
@@ -1,0 +1,92 @@
+// eslint-disable-next-line local-rules/disallow-side-effects, local-rules/enforce-prod-deps-imports -- Node.js build tool
+import https from 'node:https'
+// eslint-disable-next-line local-rules/disallow-side-effects, local-rules/enforce-prod-deps-imports -- Node.js build tool
+import { createRequire } from 'node:module'
+
+export type SdkVariant = 'rum' | 'rum-slim'
+
+export interface DownloadSDKOptions {
+  variant: SdkVariant
+  datacenter?: string
+  version?: string
+}
+
+const CDN_HOST = 'https://www.datadoghq-browser-agent.com'
+const DEFAULT_DATACENTER = 'us1'
+
+const sdkCache = new Map<string, string>()
+
+function getDefaultVersion(): string {
+  const require = createRequire(import.meta.url)
+  const pkg = require('@datadog/browser-remote-config/package.json') as { version: string }
+  return pkg.version
+}
+
+function getMajorVersion(version: string): number {
+  const major = parseInt(version.split('.')[0], 10)
+  if (isNaN(major)) {
+    throw new Error(`Invalid SDK version format: ${version}`)
+  }
+  return major
+}
+
+export async function downloadSDK(options: SdkVariant | DownloadSDKOptions): Promise<string> {
+  const variant = typeof options === 'string' ? options : options.variant
+  const datacenter = typeof options === 'string' ? DEFAULT_DATACENTER : (options.datacenter ?? DEFAULT_DATACENTER)
+  const version = typeof options === 'string' ? getDefaultVersion() : (options.version ?? getDefaultVersion())
+  const majorVersion = getMajorVersion(version)
+
+  const cacheKey = `${variant}-${majorVersion}-${datacenter}`
+  const cached = sdkCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const cdnUrl = `${CDN_HOST}/${datacenter}/v${majorVersion}/datadog-${variant}.js`
+
+  const sdkCode = await new Promise<string>((resolve, reject) => {
+    const request = https.get(cdnUrl, { timeout: 30000 }, (res) => {
+      let data = ''
+
+      if (res.statusCode === 404) {
+        reject(
+          new Error(
+            `SDK bundle not found at ${cdnUrl}\n` +
+              `Check that variant "${variant}" (major version: v${majorVersion}) is correct.\n` +
+              `Full SDK version: ${version}`
+          )
+        )
+        return
+      }
+
+      if (!res.statusCode || res.statusCode >= 400) {
+        reject(new Error(`Failed to download SDK from CDN: HTTP ${res.statusCode}\nURL: ${cdnUrl}`))
+        return
+      }
+
+      res.on('data', (chunk: Buffer | string) => {
+        data += String(chunk)
+      })
+
+      res.on('end', () => {
+        resolve(data)
+      })
+    })
+
+    request.on('error', (error: Error) => {
+      reject(new Error(`Network error downloading SDK from CDN:\nURL: ${cdnUrl}\nError: ${error.message}`))
+    })
+
+    request.on('timeout', () => {
+      request.destroy()
+      reject(new Error(`Timeout downloading SDK from CDN (30s):\nURL: ${cdnUrl}`))
+    })
+  })
+
+  sdkCache.set(cacheKey, sdkCode)
+  return sdkCode
+}
+
+export function clearSdkCache(): void {
+  sdkCache.clear()
+}

--- a/packages/endpoint/src/sdkDownloader.ts
+++ b/packages/endpoint/src/sdkDownloader.ts
@@ -16,7 +16,7 @@ const DEFAULT_DATACENTER = 'us1'
 
 const sdkCache = new Map<string, string>()
 
-function getDefaultVersion(): string {
+export function getDefaultVersion(): string {
   const require = createRequire(import.meta.url)
   const pkg = require('@datadog/browser-remote-config/package.json') as { version: string }
   return pkg.version

--- a/packages/endpoint/src/sdkDownloader.ts
+++ b/packages/endpoint/src/sdkDownloader.ts
@@ -3,7 +3,14 @@ import https from 'node:https'
 // eslint-disable-next-line local-rules/disallow-side-effects, local-rules/enforce-prod-deps-imports -- Node.js build tool
 import { createRequire } from 'node:module'
 
-export type SdkVariant = 'rum' | 'rum-slim'
+export type SdkVariant = 'rum' | 'rum-slim' | 'logs' | 'rum-and-logs'
+
+// Variants that map to a single CDN file
+const CDN_VARIANTS: Record<Exclude<SdkVariant, 'rum-and-logs'>, string> = {
+  rum: 'rum',
+  'rum-slim': 'rum-slim',
+  logs: 'logs',
+}
 
 export interface DownloadSDKOptions {
   variant: SdkVariant
@@ -34,7 +41,18 @@ export async function downloadSDK(options: SdkVariant | DownloadSDKOptions): Pro
   const variant = typeof options === 'string' ? options : options.variant
   const datacenter = typeof options === 'string' ? DEFAULT_DATACENTER : (options.datacenter ?? DEFAULT_DATACENTER)
   const version = typeof options === 'string' ? getDefaultVersion() : (options.version ?? getDefaultVersion())
+
+  // rum-and-logs: download both SDKs and concatenate
+  if (variant === 'rum-and-logs') {
+    const [rum, logs] = await Promise.all([
+      downloadSDK({ variant: 'rum', datacenter, version }),
+      downloadSDK({ variant: 'logs', datacenter, version }),
+    ])
+    return `${rum}\n${logs}`
+  }
+
   const majorVersion = getMajorVersion(version)
+  const cdnVariant = CDN_VARIANTS[variant]
 
   const cacheKey = `${variant}-${majorVersion}-${datacenter}`
   const cached = sdkCache.get(cacheKey)
@@ -42,7 +60,7 @@ export async function downloadSDK(options: SdkVariant | DownloadSDKOptions): Pro
     return cached
   }
 
-  const cdnUrl = `${CDN_HOST}/${datacenter}/v${majorVersion}/datadog-${variant}.js`
+  const cdnUrl = `${CDN_HOST}/${datacenter}/v${majorVersion}/datadog-${cdnVariant}.js`
 
   const sdkCode = await new Promise<string>((resolve, reject) => {
     const request = https.get(cdnUrl, { timeout: 30000 }, (res) => {

--- a/packages/endpoint/src/sdkDownloader.ts
+++ b/packages/endpoint/src/sdkDownloader.ts
@@ -1,7 +1,5 @@
 // eslint-disable-next-line local-rules/disallow-side-effects, local-rules/enforce-prod-deps-imports -- Node.js build tool
 import https from 'node:https'
-// eslint-disable-next-line local-rules/disallow-side-effects, local-rules/enforce-prod-deps-imports -- Node.js build tool
-import { createRequire } from 'node:module'
 
 export type SdkVariant = 'rum' | 'rum-slim' | 'logs' | 'rum-and-logs'
 
@@ -24,7 +22,7 @@ const DEFAULT_DATACENTER = 'us1'
 const sdkCache = new Map<string, string>()
 
 export function getDefaultVersion(): string {
-  const require = createRequire(import.meta.url)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Node.js build tool, read version from dependency
   const pkg = require('@datadog/browser-remote-config/package.json') as { version: string }
   return pkg.version
 }

--- a/packages/endpoint/tsconfig.build.cjs.json
+++ b/packages/endpoint/tsconfig.build.cjs.json
@@ -1,15 +1,18 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "declaration": true,
+    "module": "commonjs",
     "target": "ES2024",
     "lib": ["ES2024", "DOM"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "outDir": "./cjs",
+    "paths": {}
   },
   "include": ["./src/**/*.ts"],
-  "exclude": []
+  "exclude": ["./src/**/*.spec.ts"]
 }

--- a/packages/endpoint/tsconfig.build.esm.json
+++ b/packages/endpoint/tsconfig.build.esm.json
@@ -1,15 +1,18 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "declaration": true,
+    "module": "es2020",
     "target": "ES2024",
     "lib": ["ES2024", "DOM"],
     "types": ["node"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "outDir": "./esm",
+    "paths": {}
   },
   "include": ["./src/**/*.ts"],
-  "exclude": []
+  "exclude": ["./src/**/*.spec.ts"]
 }

--- a/packages/endpoint/tsconfig.json
+++ b/packages/endpoint/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": true,
+    "rootDir": "./src/",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "target": "ES2024",
+    "lib": ["ES2024", "DOM"],
+    "types": ["node"],
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": []
+}

--- a/packages/endpoint/tsconfig.json
+++ b/packages/endpoint/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "declaration": true,
-    "rootDir": "./src/",
     "module": "preserve",
     "moduleResolution": "bundler",
     "target": "ES2024",

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -12,6 +12,10 @@
     "!src/**/*.spec.ts",
     "!src/**/*.specHelper.ts"
   ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./node": "./src/entries/node.ts"
+  },
   "scripts": {
     "build": "node ../../scripts/build/build-package.ts --modules"
   },

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -14,7 +14,8 @@
   ],
   "exports": {
     ".": "./src/index.ts",
-    "./node": "./src/entries/node.ts"
+    "./node": "./src/entries/node.ts",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "node ../../scripts/build/build-package.ts --modules"

--- a/packages/remote-config/src/entries/node.ts
+++ b/packages/remote-config/src/entries/node.ts
@@ -1,0 +1,28 @@
+import {
+  resolveDynamicValues as resolveDynamicValuesFn,
+  fetchRemoteConfiguration,
+  buildEndpoint,
+} from '../remoteConfiguration'
+import { nodeContextItemHandler } from '../nodeResolution'
+
+/**
+ * Resolve dynamic RC values for Node.js code generation.
+ * DynamicOption fields are converted to inline JS expression strings (CodeExpression)
+ * rather than resolved against live browser APIs.
+ */
+export function resolveDynamicValues(
+  configValue: unknown,
+  options: {
+    onCookie?: (value: string | undefined) => void
+    onDom?: (value: string | null | undefined) => void
+    onJs?: (value: unknown) => void
+  } = {}
+): unknown {
+  return resolveDynamicValuesFn(configValue, {
+    ...options,
+    contextItemHandler: nodeContextItemHandler,
+  })
+}
+
+export { serializeConfigToJs } from '../nodeResolution'
+export { fetchRemoteConfiguration, buildEndpoint } from '../remoteConfiguration'

--- a/packages/remote-config/src/entries/node.ts
+++ b/packages/remote-config/src/entries/node.ts
@@ -1,8 +1,4 @@
-import {
-  resolveDynamicValues as resolveDynamicValuesFn,
-  fetchRemoteConfiguration,
-  buildEndpoint,
-} from '../remoteConfiguration'
+import { resolveDynamicValues as resolveDynamicValuesFn } from '../remoteConfiguration'
 import { nodeContextItemHandler } from '../nodeResolution'
 
 /**

--- a/packages/remote-config/src/nodeResolution.spec.ts
+++ b/packages/remote-config/src/nodeResolution.spec.ts
@@ -110,12 +110,10 @@ describe('nodeContextItemHandler', () => {
     expect(result.code).toContain("__dd_getJs('window.env')")
   })
 
-  it('should skip items where resolve returns undefined', () => {
-    const items: ContextItem[] = [
-      { key: 'id', value: { rcSerializedType: 'dynamic', strategy: 'js', path: 'window.user' } },
-    ]
+  it('should skip items where value is undefined (malformed ContextItem)', () => {
+    const items = [{ key: 'id', value: undefined as any }]
     const result = nodeContextItemHandler(items, () => undefined) as CodeExpression
-    expect(result.code).toBe('{  }')
+    expect(result.code).toBe('{}')
   })
 })
 

--- a/packages/remote-config/src/nodeResolution.spec.ts
+++ b/packages/remote-config/src/nodeResolution.spec.ts
@@ -1,4 +1,10 @@
-import { serializeDynamicValueToJs } from './nodeResolution'
+import {
+  serializeDynamicValueToJs,
+  nodeContextItemHandler,
+  serializeConfigToJs,
+  CodeExpression,
+} from './nodeResolution'
+import type { ContextItem, DynamicOption } from './remoteConfiguration.types'
 
 describe('serializeDynamicValueToJs', () => {
   it('should serialize cookie strategy', () => {
@@ -73,5 +79,94 @@ describe('serializeDynamicValueToJs', () => {
       name: 'foo',
     } as any)
     expect(result).toBe('undefined')
+  })
+})
+
+describe('nodeContextItemHandler', () => {
+  const resolve = (v: unknown): unknown => {
+    if (typeof v === 'object' && v !== null && 'strategy' in v) {
+      return { __isCodeExpression: true as const, code: serializeDynamicValueToJs(v as DynamicOption) }
+    }
+    return v
+  }
+
+  it('should convert a single ContextItem to a JS object literal CodeExpression', () => {
+    const items: ContextItem[] = [
+      { key: 'id', value: { rcSerializedType: 'dynamic', strategy: 'js', path: 'window.user' } },
+    ]
+    const result = nodeContextItemHandler(items, resolve) as CodeExpression
+    expect(result.__isCodeExpression).toBe(true)
+    expect(result.code).toContain('"id"')
+    expect(result.code).toContain("__dd_getJs('window.user')")
+  })
+
+  it('should handle multiple keys', () => {
+    const items: ContextItem[] = [
+      { key: 'id', value: { rcSerializedType: 'dynamic', strategy: 'cookie', name: 'uid' } },
+      { key: 'env', value: { rcSerializedType: 'dynamic', strategy: 'js', path: 'window.env' } },
+    ]
+    const result = nodeContextItemHandler(items, resolve) as CodeExpression
+    expect(result.code).toContain("__dd_getCookie('uid')")
+    expect(result.code).toContain("__dd_getJs('window.env')")
+  })
+
+  it('should skip items where resolve returns undefined', () => {
+    const items: ContextItem[] = [
+      { key: 'id', value: { rcSerializedType: 'dynamic', strategy: 'js', path: 'window.user' } },
+    ]
+    const result = nodeContextItemHandler(items, () => undefined) as CodeExpression
+    expect(result.code).toBe('{  }')
+  })
+})
+
+describe('serializeConfigToJs', () => {
+  it('should serialize primitive values', () => {
+    expect(serializeConfigToJs(24)).toBe('24')
+    expect(serializeConfigToJs('hello')).toBe('"hello"')
+    expect(serializeConfigToJs(true)).toBe('true')
+    expect(serializeConfigToJs(null)).toBe('null')
+  })
+
+  it('should inline a CodeExpression as raw code', () => {
+    const expr: CodeExpression = { __isCodeExpression: true, code: "__dd_getJs('window.user')" }
+    expect(serializeConfigToJs(expr)).toBe("__dd_getJs('window.user')")
+  })
+
+  it('should serialize a plain object recursively', () => {
+    const result = serializeConfigToJs({ sessionSampleRate: 24, env: 'prod' })
+    expect(result).toContain('"sessionSampleRate": 24')
+    expect(result).toContain('"env": "prod"')
+  })
+
+  it('should inline CodeExpression values within an object', () => {
+    const config = {
+      sessionSampleRate: 24,
+      user: { __isCodeExpression: true as const, code: "{ id: __dd_getJs('window.user') }" },
+    }
+    const result = serializeConfigToJs(config)
+    expect(result).toContain('"sessionSampleRate": 24')
+    expect(result).toContain('"user": { id: __dd_getJs(\'window.user\') }')
+  })
+
+  it('should serialize arrays', () => {
+    expect(serializeConfigToJs([1, 'two', true])).toBe('[1, "two", true]')
+  })
+
+  it('should return {} for an empty object', () => {
+    expect(serializeConfigToJs({})).toBe('{}')
+  })
+
+  it('should handle a realistic full config with mixed static and dynamic values', () => {
+    const config = {
+      applicationId: 'd717cc88-ced7-4830-a377-14433a5c7bb0',
+      sessionSampleRate: 24,
+      env: 'remote_config_demo',
+      user: { __isCodeExpression: true as const, code: "{ 'id': __dd_getJs('window.user') }" },
+    }
+    const result = serializeConfigToJs(config)
+    expect(result).toContain('"applicationId": "d717cc88-ced7-4830-a377-14433a5c7bb0"')
+    expect(result).toContain('"sessionSampleRate": 24')
+    expect(result).toContain('"env": "remote_config_demo"')
+    expect(result).toContain("\"user\": { 'id': __dd_getJs('window.user') }")
   })
 })

--- a/packages/remote-config/src/nodeResolution.spec.ts
+++ b/packages/remote-config/src/nodeResolution.spec.ts
@@ -57,6 +57,15 @@ describe('serializeDynamicValueToJs', () => {
     expect(result).toBe("__dd_extract(__dd_getCookie('version_string'),'v(\\\\d+)')")
   })
 
+  it('should escape special characters in string values', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'cookie',
+      name: 'foo\nbar\u2028baz',
+    })
+    expect(result).toBe("__dd_getCookie('foo\\nbar\\u2028baz')")
+  })
+
   it('should return "undefined" literal for unknown strategy', () => {
     const result = serializeDynamicValueToJs({
       rcSerializedType: 'dynamic',

--- a/packages/remote-config/src/nodeResolution.spec.ts
+++ b/packages/remote-config/src/nodeResolution.spec.ts
@@ -1,0 +1,68 @@
+import { serializeDynamicValueToJs } from './nodeResolution'
+
+describe('serializeDynamicValueToJs', () => {
+  it('should serialize cookie strategy', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'cookie',
+      name: 'user_id',
+    })
+    expect(result).toBe("__dd_getCookie('user_id')")
+  })
+
+  it('should serialize js strategy', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'js',
+      path: 'window.user',
+    })
+    expect(result).toBe("__dd_getJs('window.user')")
+  })
+
+  it('should serialize dom strategy (text content)', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'dom',
+      selector: '[data-env]',
+    })
+    expect(result).toBe("__dd_getDomText('[data-env]')")
+  })
+
+  it('should serialize dom strategy (attribute)', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'dom',
+      selector: '[data-env]',
+      attribute: 'data-env',
+    })
+    expect(result).toBe("__dd_getDomAttr('[data-env]','data-env')")
+  })
+
+  it('should serialize localStorage strategy', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'localStorage',
+      key: 'app_version',
+    })
+    expect(result).toBe("__dd_getLocalStorage('app_version')")
+  })
+
+  it('should wrap expression with extractor when present', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'cookie',
+      name: 'version_string',
+      extractor: { rcSerializedType: 'regex', value: 'v(\\d+)' },
+    })
+    expect(result).toBe("__dd_extract(__dd_getCookie('version_string'),'v(\\\\d+)')")
+  })
+
+  it('should return "undefined" literal for unknown strategy', () => {
+    const result = serializeDynamicValueToJs({
+      rcSerializedType: 'dynamic',
+      strategy: 'unknown' as any,
+      name: 'foo',
+    } as any)
+    expect(result).toBe('undefined')
+  })
+})

--- a/packages/remote-config/src/nodeResolution.spec.ts
+++ b/packages/remote-config/src/nodeResolution.spec.ts
@@ -1,9 +1,5 @@
-import {
-  serializeDynamicValueToJs,
-  nodeContextItemHandler,
-  serializeConfigToJs,
-  CodeExpression,
-} from './nodeResolution'
+import type { CodeExpression } from './nodeResolution'
+import { serializeDynamicValueToJs, nodeContextItemHandler, serializeConfigToJs } from './nodeResolution'
 import type { ContextItem, DynamicOption } from './remoteConfiguration.types'
 
 describe('serializeDynamicValueToJs', () => {
@@ -94,7 +90,7 @@ describe('nodeContextItemHandler', () => {
     const items: ContextItem[] = [
       { key: 'id', value: { rcSerializedType: 'dynamic', strategy: 'js', path: 'window.user' } },
     ]
-    const result = nodeContextItemHandler(items, resolve) as CodeExpression
+    const result = nodeContextItemHandler(items, resolve)
     expect(result.__isCodeExpression).toBe(true)
     expect(result.code).toContain('"id"')
     expect(result.code).toContain("__dd_getJs('window.user')")
@@ -105,14 +101,14 @@ describe('nodeContextItemHandler', () => {
       { key: 'id', value: { rcSerializedType: 'dynamic', strategy: 'cookie', name: 'uid' } },
       { key: 'env', value: { rcSerializedType: 'dynamic', strategy: 'js', path: 'window.env' } },
     ]
-    const result = nodeContextItemHandler(items, resolve) as CodeExpression
+    const result = nodeContextItemHandler(items, resolve)
     expect(result.code).toContain("__dd_getCookie('uid')")
     expect(result.code).toContain("__dd_getJs('window.env')")
   })
 
   it('should skip items where value is undefined (malformed ContextItem)', () => {
     const items = [{ key: 'id', value: undefined as any }]
-    const result = nodeContextItemHandler(items, () => undefined) as CodeExpression
+    const result = nodeContextItemHandler(items, () => undefined)
     expect(result.code).toBe('{}')
   })
 })

--- a/packages/remote-config/src/nodeResolution.ts
+++ b/packages/remote-config/src/nodeResolution.ts
@@ -24,10 +24,17 @@ export function isCodeExpression(value: unknown): value is CodeExpression {
 
 /**
  * Serialize a string as a single-quoted JS string literal.
- * Escapes backslashes and single quotes so the result is valid JS.
+ * Escapes backslashes, single quotes, and control characters so the result is valid JS.
  */
 function jsStringLiteral(value: string): string {
-  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+  return `'${value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')}'`
 }
 
 export function serializeDynamicValueToJs(option: DynamicOption): string {
@@ -49,7 +56,7 @@ export function serializeDynamicValueToJs(option: DynamicOption): string {
       expr = `__dd_getLocalStorage(${jsStringLiteral(option.key)})`
       break
     default:
-      display.warn(`Unsupported remote configuration strategy: "${(option as DynamicOption).strategy}"`)
+      display.error(`Unsupported remote configuration strategy: "${(option as DynamicOption).strategy}"`)
       return 'undefined'
   }
 
@@ -65,7 +72,7 @@ export function serializeDynamicValueToJs(option: DynamicOption): string {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-export function nodeContextItemHandler(items: ContextItem[], resolve: (value: unknown) => unknown): unknown {
+export function nodeContextItemHandler(items: ContextItem[], resolve: (value: unknown) => unknown): CodeExpression {
   const entries = items
     .map(({ key, value }) => {
       if (value === undefined) return null
@@ -90,7 +97,7 @@ export function serializeConfigToJs(config: unknown): string {
     const entries = Object.entries(config as Record<string, unknown>).map(
       ([k, v]) => `${JSON.stringify(k)}: ${serializeConfigToJs(v)}`
     )
-    return `{ ${entries.join(', ')} }`
+    return entries.length ? `{ ${entries.join(', ')} }` : '{}'
   }
   return JSON.stringify(config)
 }

--- a/packages/remote-config/src/nodeResolution.ts
+++ b/packages/remote-config/src/nodeResolution.ts
@@ -1,0 +1,96 @@
+import { display, isIndexableObject } from '@datadog/browser-core'
+import type { DynamicOption, ContextItem } from './remoteConfiguration.types'
+
+// ---------------------------------------------------------------------------
+// CodeExpression — internal marker for raw JS code strings
+// ---------------------------------------------------------------------------
+
+export interface CodeExpression {
+  __isCodeExpression: true
+  code: string
+}
+
+export function codeExpression(code: string): CodeExpression {
+  return { __isCodeExpression: true, code }
+}
+
+export function isCodeExpression(value: unknown): value is CodeExpression {
+  return isIndexableObject(value) && (value as unknown as CodeExpression).__isCodeExpression === true
+}
+
+// ---------------------------------------------------------------------------
+// serializeDynamicValueToJs
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a string as a single-quoted JS string literal.
+ * Escapes backslashes and single quotes so the result is valid JS.
+ */
+function jsStringLiteral(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
+
+export function serializeDynamicValueToJs(option: DynamicOption): string {
+  let expr: string
+  switch (option.strategy) {
+    case 'cookie':
+      expr = `__dd_getCookie(${jsStringLiteral(option.name)})`
+      break
+    case 'js':
+      expr = `__dd_getJs(${jsStringLiteral(option.path)})`
+      break
+    case 'dom':
+      expr =
+        option.attribute !== undefined
+          ? `__dd_getDomAttr(${jsStringLiteral(option.selector)},${jsStringLiteral(option.attribute)})`
+          : `__dd_getDomText(${jsStringLiteral(option.selector)})`
+      break
+    case 'localStorage':
+      expr = `__dd_getLocalStorage(${jsStringLiteral(option.key)})`
+      break
+    default:
+      display.warn(`Unsupported remote configuration strategy: "${(option as DynamicOption).strategy}"`)
+      return 'undefined'
+  }
+
+  if (option.extractor !== undefined) {
+    expr = `__dd_extract(${expr},${jsStringLiteral(option.extractor.value)})`
+  }
+
+  return expr
+}
+
+// ---------------------------------------------------------------------------
+// nodeContextItemHandler and serializeConfigToJs — implemented in Task 2
+// ---------------------------------------------------------------------------
+
+/** @internal */
+export function nodeContextItemHandler(items: ContextItem[], resolve: (value: unknown) => unknown): unknown {
+  const entries = items
+    .map(({ key, value }) => {
+      if (value === undefined) return null
+      const resolved = resolve(value)
+      if (resolved === undefined) return null
+      const code = isCodeExpression(resolved) ? resolved.code : JSON.stringify(resolved)
+      return `${JSON.stringify(key)}: ${code}`
+    })
+    .filter((entry): entry is string => entry !== null)
+
+  return codeExpression(`{ ${entries.join(', ')} }`)
+}
+
+export function serializeConfigToJs(config: unknown): string {
+  if (isCodeExpression(config)) {
+    return config.code
+  }
+  if (Array.isArray(config)) {
+    return `[${config.map(serializeConfigToJs).join(', ')}]`
+  }
+  if (isIndexableObject(config)) {
+    const entries = Object.entries(config as Record<string, unknown>).map(
+      ([k, v]) => `${JSON.stringify(k)}: ${serializeConfigToJs(v)}`
+    )
+    return `{ ${entries.join(', ')} }`
+  }
+  return JSON.stringify(config)
+}

--- a/packages/remote-config/src/nodeResolution.ts
+++ b/packages/remote-config/src/nodeResolution.ts
@@ -72,18 +72,20 @@ export function serializeDynamicValueToJs(option: DynamicOption): string {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-export function nodeContextItemHandler(items: ContextItem[], resolve: (value: unknown) => unknown): CodeExpression {
+export function nodeContextItemHandler(
+  items: ContextItem[],
+  // resolve is intentionally unused — ContextItem values are always DynamicOption,
+  // so we serialize them directly to JS expressions rather than resolving live values.
+  _resolve: (value: unknown) => unknown
+): CodeExpression {
   const entries = items
     .map(({ key, value }) => {
       if (value === undefined) return null
-      const resolved = resolve(value)
-      if (resolved === undefined) return null
-      const code = isCodeExpression(resolved) ? resolved.code : JSON.stringify(resolved)
-      return `${JSON.stringify(key)}: ${code}`
+      return `${JSON.stringify(key)}: ${serializeDynamicValueToJs(value)}`
     })
     .filter((entry): entry is string => entry !== null)
 
-  return codeExpression(`{ ${entries.join(', ')} }`)
+  return codeExpression(entries.length ? `{ ${entries.join(', ')} }` : '{}')
 }
 
 export function serializeConfigToJs(config: unknown): string {

--- a/packages/remote-config/src/nodeResolution.ts
+++ b/packages/remote-config/src/nodeResolution.ts
@@ -71,7 +71,11 @@ export function serializeDynamicValueToJs(option: DynamicOption): string {
 // nodeContextItemHandler and serializeConfigToJs — implemented in Task 2
 // ---------------------------------------------------------------------------
 
-/** @internal */
+/**
+ * Convert ContextItem[] to a JS object literal CodeExpression for Node code generation.
+ *
+ * @internal
+ */
 export function nodeContextItemHandler(
   items: ContextItem[],
   // resolve is intentionally unused — ContextItem values are always DynamicOption,
@@ -80,7 +84,9 @@ export function nodeContextItemHandler(
 ): CodeExpression {
   const entries = items
     .map(({ key, value }) => {
-      if (value === undefined) return null
+      if (value === undefined) {
+        return null
+      }
       return `${JSON.stringify(key)}: ${serializeDynamicValueToJs(value)}`
     })
     .filter((entry): entry is string => entry !== null)

--- a/packages/remote-config/src/remoteConfiguration.spec.ts
+++ b/packages/remote-config/src/remoteConfiguration.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './remoteConfiguration'
 import { parseJsonPath } from './jsonPathParser'
 
-describe('remoteConfiguration', () => {
+describe('browser-remote-config', () => {
   describe('buildEndpoint', () => {
     it('should build the default endpoint', () => {
       const endpoint = buildEndpoint({

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -32,7 +32,7 @@ const FILES = [
 ]
 
 const FILES_SPECS = [
-  'packages/*/@(src|test)/**/*.spec.@(ts|tsx)',
+  'packages/!(@(endpoint))/@(src|test)/**/*.spec.@(ts|tsx)',
   'developer-extension/@(src|test)/**/*.spec.@(ts|tsx)',
 ]
 

--- a/tsconfig.default.json
+++ b/tsconfig.default.json
@@ -22,6 +22,9 @@
     "eslint-local-rules",
     "test/unit",
 
+    // Files included in ./packages/endpoint/tsconfig.json
+    "packages/endpoint",
+
     // Files included in ./test/e2e/tsconfig.json
     "test/e2e",
     "test/lib",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./tsconfig.default.json" },
     { "path": "./tsconfig.scripts.json" },
+    { "path": "./packages/endpoint/tsconfig.json" },
     { "path": "./developer-extension/tsconfig.json" },
     { "path": "./test/e2e/tsconfig.json" },
     { "path": "./test/performance/tsconfig.json" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,7 +383,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-remote-config@workspace:packages/remote-config":
+"@datadog/browser-remote-config@npm:6.28.0, @datadog/browser-remote-config@workspace:packages/remote-config":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-remote-config@workspace:packages/remote-config"
   dependencies:
@@ -576,6 +576,14 @@ __metadata:
     react-dom: "npm:19.2.6"
     typescript: "npm:6.0.3"
     wxt: "npm:0.20.26"
+  languageName: unknown
+  linkType: soft
+
+"@datadog/browser-sdk-endpoint@workspace:packages/endpoint":
+  version: 0.0.0-use.local
+  resolution: "@datadog/browser-sdk-endpoint@workspace:packages/endpoint"
+  dependencies:
+    "@datadog/browser-remote-config": "npm:6.28.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,7 +383,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-remote-config@npm:6.28.0, @datadog/browser-remote-config@workspace:packages/remote-config":
+"@datadog/browser-remote-config@npm:7.2.0, @datadog/browser-remote-config@workspace:packages/remote-config":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-remote-config@workspace:packages/remote-config"
   dependencies:
@@ -583,7 +583,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-sdk-endpoint@workspace:packages/endpoint"
   dependencies:
-    "@datadog/browser-remote-config": "npm:6.28.0"
+    "@datadog/browser-remote-config": "npm:7.2.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Motivation

Right now the only way to use remote configuration with the RUM SDK is to pass \`remoteConfigurationId\` to \`DD_RUM.init()\`, which triggers a fetch to the RC endpoint at page load. This PR is the foundation for SSI (Server-Side Injection): pre-fetch the RC on the server, generate a self-contained bundle with the SDK and config embedded, serve it as a single \`<script>\` tag. No RC fetch at page load, no \`init()\` call needed in app code.

## Changes

Two packages:

**\`@datadog/browser-remote-config\`** extracts the RC logic into a standalone package. The main addition is a \`contextItemHandler\` strategy on \`resolveDynamicValues\` that controls how \`ContextItem[]\` arrays (the \`user\` and \`context\` fields in the RC schema) get resolved. The browser entry point uses getter properties that evaluate against live browser APIs at read time. The Node entry point serializes them as inline JS expressions instead (\`__dd_getJs('window.user')\`) for embedding in generated bundles.

**\`@datadog/browser-sdk-endpoint\`** is a Node.js package that fetches the RC config, runs the code-gen path to turn \`DynamicOption\` descriptors into inline expressions, downloads the SDK from CDN, and assembles a self-contained IIFE. The \`generateBundle\` API is designed to sit behind an Express endpoint with per-config caching.

The \`contextItemHandler\` strategy is the architectural backbone. The browser handler returns a plain object via getters. The Node handler returns a \`CodeExpression\` (a branded marker type) that tells \`serializeConfigToJs\` to inline the string as raw JS rather than JSON-encode it. That distinction is what lets the same config tree produce either a live-resolved object in the browser or a JS object literal with embedded expressions in a bundle.

One non-obvious thing worth calling out: \`nodeContextItemHandler\` receives a \`resolve\` callback from \`resolveDynamicValues\`, but calling \`resolve(dynamicOption)\` in Node context would try to run the live browser resolvers (\`window.*\`, \`getCookie\`) and crash. The handler ignores \`_resolve\` entirely and calls \`serializeDynamicValueToJs\` directly. Safe because \`ContextItem.value\` is always a \`DynamicOption\`.

## Test instructions

1. \`yarn test:unit --spec packages/remote-config/src/remoteConfiguration.spec.ts\` (46 tests)
2. \`yarn test:unit --spec packages/remote-config/src/nodeResolution.spec.ts\` (18 tests)
3. \`node --test packages/endpoint/src/bundleGenerator.spec.ts\` (10 tests)

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change. (endpoint package needs a more involved test setup, leaving for follow-up)
- [ ] Updated documentation and/or relevant AGENTS.md file