### PR TITLE
🔥 Remove usePciIntake option

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -119,39 +119,6 @@ describe('endpointBuilder', () => {
     })
   })
 
-  describe('PCI compliance intake with option', () => {
-    it('should return PCI compliance intake endpoint if site is us1', () => {
-      const config: InitConfiguration & { usePciIntake?: boolean } = {
-        clientToken,
-        usePciIntake: true,
-        site: 'datadoghq.com',
-      }
-      expect(createEndpointBuilder(config, 'logs').build('fetch', DEFAULT_PAYLOAD)).toContain(
-        'https://pci.browser-intake-datadoghq.com'
-      )
-    })
-    it('should not return PCI compliance intake endpoint if site is not us1', () => {
-      const config: InitConfiguration & { usePciIntake?: boolean } = {
-        clientToken,
-        usePciIntake: true,
-        site: 'ap1.datadoghq.com',
-      }
-      expect(createEndpointBuilder(config, 'logs').build('fetch', DEFAULT_PAYLOAD)).not.toContain(
-        'https://pci.browser-intake-datadoghq.com'
-      )
-    })
-    it('should not return PCI compliance intake endpoint if and site is us1 and track is not logs', () => {
-      const config: InitConfiguration & { usePciIntake?: boolean } = {
-        clientToken,
-        usePciIntake: true,
-        site: 'datadoghq.com',
-      }
-      expect(createEndpointBuilder(config, 'rum').build('fetch', DEFAULT_PAYLOAD)).not.toContain(
-        'https://pci.browser-intake-datadoghq.com'
-      )
-    })
-  })
-
   describe('source configuration', () => {
     it('should use the default source when no configuration is provided', () => {
       const endpoint = createEndpointBuilder(initConfiguration, 'rum').build('fetch', DEFAULT_PAYLOAD)

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -2,7 +2,7 @@ import type { Payload } from '../../transport'
 import { timeStampNow } from '../../tools/utils/timeUtils'
 import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { generateUUID } from '../../tools/utils/stringUtils'
-import { INTAKE_SITE_FED_STAGING, INTAKE_SITE_US1, PCI_INTAKE_HOST_US1 } from '../intakeSites'
+import { INTAKE_SITE_FED_STAGING, INTAKE_SITE_US1 } from '../intakeSites'
 import type { InitConfiguration } from './configuration'
 
 // replaced at build time
@@ -52,19 +52,12 @@ function createEndpointUrlWithParametersBuilder(
   if (typeof proxy === 'function') {
     return (parameters) => proxy({ path, parameters })
   }
-  const host = buildEndpointHost(trackType, initConfiguration)
+  const host = buildEndpointHost(initConfiguration)
   return (parameters) => `https://${host}${path}?${parameters}`
 }
 
-export function buildEndpointHost(
-  trackType: TrackType,
-  initConfiguration: InitConfiguration & { usePciIntake?: boolean }
-) {
+export function buildEndpointHost(initConfiguration: InitConfiguration) {
   const { site = INTAKE_SITE_US1, internalAnalyticsSubdomain } = initConfiguration
-
-  if (trackType === 'logs' && initConfiguration.usePciIntake && site === INTAKE_SITE_US1) {
-    return PCI_INTAKE_HOST_US1
-  }
 
   if (internalAnalyticsSubdomain && site === INTAKE_SITE_US1) {
     return `${internalAnalyticsSubdomain}.${INTAKE_SITE_US1}`

--- a/packages/logs/src/domain/configuration.spec.ts
+++ b/packages/logs/src/domain/configuration.spec.ts
@@ -74,24 +74,6 @@ describe('validateAndBuildLogsConfiguration', () => {
       ).toEqual(['error'])
     })
   })
-
-  describe('PCI compliant intake option', () => {
-    let warnSpy: jasmine.Spy<typeof display.warn>
-
-    beforeEach(() => {
-      warnSpy = spyOn(display, 'warn')
-    })
-    it('should display warning with wrong PCI intake configuration', () => {
-      validateAndBuildLogsConfiguration({
-        ...DEFAULT_INIT_CONFIGURATION,
-        site: 'us3.datadoghq.com',
-        usePciIntake: true,
-      })
-      expect(warnSpy).toHaveBeenCalledOnceWith(
-        'PCI compliance for Logs is only available for Datadog organizations in the US1 site. Default intake will be used.'
-      )
-    })
-  })
 })
 
 describe('validateAndBuildForwardOption', () => {
@@ -137,7 +119,6 @@ describe('serializeLogsConfiguration', () => {
       forwardErrorsToLogs: true,
       forwardConsoleLogs: 'all',
       forwardReports: 'all',
-      usePciIntake: false,
     }
 
     type MapLogsInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -155,7 +136,6 @@ describe('serializeLogsConfiguration', () => {
       forward_errors_to_logs: true,
       forward_console_logs: 'all',
       forward_reports: 'all',
-      use_pci_intake: false,
     })
   })
 })

--- a/packages/logs/src/domain/configuration.ts
+++ b/packages/logs/src/domain/configuration.ts
@@ -68,14 +68,6 @@ export interface LogsInitConfiguration extends InitConfiguration {
    * @category Data Collection
    */
   forwardReports?: RawReportType[] | 'all' | undefined
-
-  /**
-   * Use PCI-compliant intake. See [PCI DSS Compliance](https://docs.datadoghq.com/data_security/pci_compliance/?tab=logmanagement) for further information.
-   *
-   * @category Privacy
-   * @defaultValue false
-   */
-  usePciIntake?: boolean
 }
 
 /**
@@ -105,12 +97,6 @@ export function validateAndBuildLogsConfiguration(
   initConfiguration: LogsInitConfiguration,
   errorStack?: string
 ): LogsConfiguration | undefined {
-  if (initConfiguration.usePciIntake === true && initConfiguration.site && initConfiguration.site !== 'datadoghq.com') {
-    display.warn(
-      'PCI compliance for Logs is only available for Datadog organizations in the US1 site. Default intake will be used.'
-    )
-  }
-
   const baseConfiguration = validateAndBuildConfiguration(initConfiguration, errorStack)
 
   const forwardConsoleLogs = validateAndBuildForwardOption<ConsoleApiName>(
@@ -166,7 +152,6 @@ export function serializeLogsConfiguration(configuration: LogsInitConfiguration)
     forward_errors_to_logs: configuration.forwardErrorsToLogs,
     forward_console_logs: configuration.forwardConsoleLogs,
     forward_reports: configuration.forwardReports,
-    use_pci_intake: configuration.usePciIntake,
     ...baseSerializedInitConfiguration,
   } satisfies RawTelemetryConfiguration
 }

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -314,5 +314,5 @@ export function buildEndpoint(configuration: RumInitConfiguration) {
   if (configuration.remoteConfigurationProxy) {
     return configuration.remoteConfigurationProxy
   }
-  return `https://sdk-configuration.${buildEndpointHost('rum', configuration)}/${REMOTE_CONFIGURATION_VERSION}/${encodeURIComponent(configuration.remoteConfigurationId!)}.json`
+  return `https://sdk-configuration.${buildEndpointHost(configuration)}/${REMOTE_CONFIGURATION_VERSION}/${encodeURIComponent(configuration.remoteConfigurationId!)}.json`
 }


### PR DESCRIPTION
## Motivation

Remove the `usePciIntake` option from the Logs SDK.

## Changes

- Removed `usePciIntake` option from `LogsInitConfiguration` interface
- Removed PCI intake host logic from `buildEndpointHost` in `endpointBuilder.ts` (also removed the `trackType` parameter since it was only used for PCI routing)
- Removed the warning displayed when `usePciIntake` is set on a non-US1 site
- Removed `use_pci_intake` from serialized telemetry configuration
- Updated `buildEndpoint` in `remoteConfiguration.ts` to use the updated `buildEndpointHost` signature
- Removed all associated tests

## Test instructions

Run unit tests:
```
yarn test:unit --spec packages/core/src/domain/configuration/endpointBuilder.spec.ts
yarn test:unit --spec packages/logs/src/domain/configuration.spec.ts
```

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file