### PR TITLE
👷 NextJS- Make NextJS plugin private

### DIFF
--- a/packages/rum-nextjs/package.json
+++ b/packages/rum-nextjs/package.json
@@ -10,8 +10,8 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@datadog/browser-core": "*",
-    "@datadog/browser-rum-core": "*"
+    "@datadog/browser-core": "6.31.0",
+    "@datadog/browser-rum-core": "6.31.0"
   },
   "peerDependencies": {
     "next": ">=13.0.0",

--- a/test/apps/nextjs/yarn.lock
+++ b/test/apps/nextjs/yarn.lock
@@ -23,10 +23,10 @@ __metadata:
 
 "@datadog/browser-rum-nextjs@file:../../../packages/rum-nextjs/package.tgz::locator=nextjs%40workspace%3A.":
   version: 0.0.0
-  resolution: "@datadog/browser-rum-nextjs@file:../../../packages/rum-nextjs/package.tgz#../../../packages/rum-nextjs/package.tgz::hash=39591d&locator=nextjs%40workspace%3A."
+  resolution: "@datadog/browser-rum-nextjs@file:../../../packages/rum-nextjs/package.tgz#../../../packages/rum-nextjs/package.tgz::hash=72ad74&locator=nextjs%40workspace%3A."
   dependencies:
-    "@datadog/browser-core": "npm:*"
-    "@datadog/browser-rum-core": "npm:*"
+    "@datadog/browser-core": "npm:6.31.0"
+    "@datadog/browser-rum-core": "npm:6.31.0"
   peerDependencies:
     next: ">=13.0.0"
     react: ">=18.0.0"
@@ -35,7 +35,7 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: 10c0/ea9ae1f0ed92787ff87330c0ba57de561fd95fdb82725e826bee35b7db6862c1cd288b7d87b9a14eaf3908ed08f76a75f7ae6c1a76ff606192cec51e762062e8
+  checksum: 10c0/4b71f2d2e40522120685bfb2457b17febae3f339ca19bc84d58a35f47da1c7a6a49ec13eaec8d62a7f8d61c4d4611293ff7053e338490a74b6f58263e1bc84e6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,7 +270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:*, @datadog/browser-core@npm:6.31.0, @datadog/browser-core@workspace:*, @datadog/browser-core@workspace:packages/core":
+"@datadog/browser-core@npm:6.31.0, @datadog/browser-core@workspace:*, @datadog/browser-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-core@workspace:packages/core"
   dependencies:
@@ -292,7 +292,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/browser-rum-core@npm:*, @datadog/browser-rum-core@npm:6.31.0, @datadog/browser-rum-core@workspace:*, @datadog/browser-rum-core@workspace:packages/rum-core":
+"@datadog/browser-rum-core@npm:6.31.0, @datadog/browser-rum-core@workspace:*, @datadog/browser-rum-core@workspace:packages/rum-core":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-core@workspace:packages/rum-core"
   dependencies:
@@ -305,8 +305,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-rum-nextjs@workspace:packages/rum-nextjs"
   dependencies:
-    "@datadog/browser-core": "npm:*"
-    "@datadog/browser-rum-core": "npm:*"
+    "@datadog/browser-core": "npm:6.31.0"
+    "@datadog/browser-rum-core": "npm:6.31.0"
     "@types/react": "npm:19.2.11"
     next: "npm:15.5.10"
     react: "npm:19.2.4"


### PR DESCRIPTION
## Motivation

Like [PR](https://github.com/DataDog/browser-sdk/pull/4350), makes package private so as to not release it.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
