### PR TITLE
🔧 make rum-vue package private until it's ready

### DIFF
--- a/packages/rum-vue/package.json
+++ b/packages/rum-vue/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@datadog/browser-rum-vue",
-  "version": "6.31.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",


### PR DESCRIPTION
## Motivation

The \`@datadog/browser-rum-vue\` package was just scaffolded but it's not ready
to be published yet. This adds \`"private": true\` to its package.json so we
don't accidentally release it before it's done.

## Changes

One line added to \`packages/rum-vue/package.json\`. npm (and yarn) refuse to
publish private packages, so this acts as a safety net until we're ready to
remove it.

## Test instructions

No real testing needed here. You can verify by running
\`yarn workspace @datadog/browser-rum-vue npm publish --dry-run\` and confirming
it errors with a "private package" message.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file