### PR TITLE
🔥 remove betaTrackActionsInShadowDom and make shadow DOM action tracking the default

### DIFF
--- a/packages/rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.spec.ts
@@ -641,8 +641,8 @@ describe('trackClickActions', () => {
       shadowHost.remove()
     })
 
-    it('with betaTrackActionsInShadowDom, gets action name from composedPath', () => {
-      startClickActionsTracking({ betaTrackActionsInShadowDom: true })
+    it('gets action name from composedPath', () => {
+      startClickActionsTracking()
 
       emulateClick({
         target: shadowHost,
@@ -658,8 +658,8 @@ describe('trackClickActions', () => {
       expect(events[0].name).toBe('Shadow Button')
     })
 
-    it('with betaTrackActionsInShadowDom, gets selector with shadow marker from composedPath', () => {
-      startClickActionsTracking({ betaTrackActionsInShadowDom: true })
+    it('gets selector with shadow marker from composedPath', () => {
+      startClickActionsTracking()
 
       emulateClick({
         target: shadowHost,
@@ -674,24 +674,6 @@ describe('trackClickActions', () => {
       expect(events.length).toBe(1)
       expect(events[0].target?.selector).toContain(SHADOW_DOM_MARKER)
       expect(events[0].target?.selector).toContain('BUTTON')
-    })
-
-    it('without betaTrackActionsInShadowDom, selector uses shadow host', () => {
-      startClickActionsTracking({ betaTrackActionsInShadowDom: false })
-
-      emulateClick({
-        target: shadowHost,
-        activity: {},
-        eventProperty: {
-          composed: true,
-          composedPath: () => [shadowButton, shadowHost.shadowRoot, shadowHost, document.body, document],
-        },
-      })
-      clock.tick(EXPIRE_DELAY)
-
-      expect(events.length).toBe(1)
-      expect(events[0].target?.selector).toBe('#shadow-host')
-      expect(events[0].target?.selector).not.toContain(SHADOW_DOM_MARKER)
     })
   })
 })

--- a/packages/rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/rum-core/src/domain/action/trackClickActions.ts
@@ -121,14 +121,10 @@ function processPointerDown(
   pointerDownEvent: MouseEventOnElement,
   windowOpenObservable: Observable<void>
 ) {
-  const targetForPrivacy = configuration.betaTrackActionsInShadowDom
-    ? getEventTarget(pointerDownEvent)
-    : pointerDownEvent.target
-
   let nodePrivacyLevel: NodePrivacyLevel
 
   if (configuration.enablePrivacyForActionName) {
-    nodePrivacyLevel = getNodePrivacyLevel(targetForPrivacy, configuration.defaultPrivacyLevel)
+    nodePrivacyLevel = getNodePrivacyLevel(getEventTarget(pointerDownEvent), configuration.defaultPrivacyLevel)
   } else {
     nodePrivacyLevel = NodePrivacyLevel.ALLOW
   }
@@ -231,7 +227,7 @@ function computeClickActionBase(
   nodePrivacyLevel: NodePrivacyLevel,
   configuration: RumConfiguration
 ): ClickActionBase {
-  const target = configuration.betaTrackActionsInShadowDom ? getEventTarget(event) : event.target
+  const target = getEventTarget(event)
 
   const rect = target.getBoundingClientRect()
   const selector = getSelectorFromElement(target, configuration.actionNameAttribute)

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -628,7 +628,6 @@ describe('serializeRumConfiguration', () => {
       trackFeatureFlagsForEvents: ['vital'],
       profilingSampleRate: 42,
       propagateTraceBaggage: true,
-      betaTrackActionsInShadowDom: true,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -643,8 +642,7 @@ describe('serializeRumConfiguration', () => {
         : Key extends 'trackLongTasks'
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
-            // TODO: Add betaTrackActionsInShadowDom to rum-events-format and remove from this exclusion
-            Key extends 'applicationId' | 'subdomain' | 'betaTrackActionsInShadowDom'
+            Key extends 'applicationId' | 'subdomain'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -204,15 +204,6 @@ export interface RumInitConfiguration extends InitConfiguration {
    */
   actionNameAttribute?: string | undefined
 
-  /**
-   * Enables accurate action names for clicks inside Shadow DOM elements.
-   * ⚠️ This is a beta feature and will be updated in the future with selector tracking.
-   *
-   * @category Beta
-   * @defaultValue false
-   */
-  betaTrackActionsInShadowDom?: boolean | undefined
-
   // view options
   /**
    * Allows you to control RUM views creation. See [Override default RUM view names](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/?tab=npm#override-default-rum-view-names) for further information.
@@ -297,7 +288,6 @@ export interface GraphQlUrlOption {
 export interface RumConfiguration extends Configuration {
   // Built from init configuration
   actionNameAttribute: string | undefined
-  betaTrackActionsInShadowDom: boolean
   traceSampleRate: number
   rulePsr: number | undefined
   allowedTracingUrls: TracingOption[]
@@ -369,7 +359,6 @@ export function validateAndBuildRumConfiguration(
   return {
     applicationId: initConfiguration.applicationId,
     actionNameAttribute: initConfiguration.actionNameAttribute,
-    betaTrackActionsInShadowDom: !!initConfiguration.betaTrackActionsInShadowDom,
     sessionReplaySampleRate,
     startSessionReplayRecordingManually:
       initConfiguration.startSessionReplayRecordingManually !== undefined

--- a/test/e2e/scenario/rum/actions.scenario.ts
+++ b/test/e2e/scenario/rum/actions.scenario.ts
@@ -515,36 +515,8 @@ test.describe('action collection', () => {
 })
 
 test.describe('action collection with shadow DOM', () => {
-  createTest('without betaTrackActionsInShadowDom, click inside shadow DOM uses shadow host as target')
+  createTest('get action name from element inside shadow DOM')
     .withRum({ trackUserInteractions: true })
-    .withBody(html`
-      <my-button id="shadow-host"></my-button>
-      <script>
-        class MyButton extends HTMLElement {
-          constructor() {
-            super()
-            this.attachShadow({ mode: 'open' })
-            const button = document.createElement('button')
-            button.textContent = 'Shadow Button'
-            this.shadowRoot.appendChild(button)
-          }
-        }
-        customElements.define('my-button', MyButton)
-      </script>
-    `)
-    .run(async ({ intakeRegistry, flushEvents, page }) => {
-      const button = page.locator('my-button').first().locator('button')
-      await button.click()
-      await flushEvents()
-
-      const actionEvents = intakeRegistry.rumActionEvents
-      expect(actionEvents).toHaveLength(1)
-      expect(actionEvents[0].action?.target?.name).toBe('')
-      expect(actionEvents[0]._dd.action?.target?.selector).toBe('#shadow-host')
-    })
-
-  createTest('with betaTrackActionsInShadowDom, get action name from element inside shadow DOM')
-    .withRum({ trackUserInteractions: true, betaTrackActionsInShadowDom: true })
     .withBody(html`
       <my-button id="shadow-host"></my-button>
       <script>
@@ -571,8 +543,8 @@ test.describe('action collection with shadow DOM', () => {
       expect(actionEvents[0]._dd.action?.target?.selector).toEqual('#shadow-host::shadow BUTTON')
     })
 
-  createTest('with betaTrackActionsInShadowDom, traverse shadow boundary for data-dd-action-name')
-    .withRum({ trackUserInteractions: true, betaTrackActionsInShadowDom: true })
+  createTest('traverse shadow boundary for data-dd-action-name')
+    .withRum({ trackUserInteractions: true })
     .withBody(html`
       <my-button id="shadow-host" data-dd-action-name="Custom Shadow Action"></my-button>
       <script>
@@ -598,8 +570,8 @@ test.describe('action collection with shadow DOM', () => {
       expect(actionEvents[0].action?.target?.name).toBe('Custom Shadow Action')
     })
 
-  createTest('with betaTrackActionsInShadowDom, selector includes stable attributes from inside shadow DOM')
-    .withRum({ trackUserInteractions: true, betaTrackActionsInShadowDom: true })
+  createTest('selector includes stable attributes from inside shadow DOM')
+    .withRum({ trackUserInteractions: true })
     .withBody(html`
       <my-button id="shadow-host"></my-button>
       <script>


### PR DESCRIPTION
## Motivation

The `betaTrackActionsInShadowDom` option let users opt into accurate action names and selectors for clicks inside Shadow DOM elements. The feature is now stable enough to become the default for all users — no configuration needed.

## Changes

- Remove `betaTrackActionsInShadowDom` from the public API and internal configuration; shadow DOM traversal is now always active
- Update unit and E2E tests to reflect the new default behavior

## Test instructions

```bash
# Start the dev server
yarn dev-server start

cat > sandbox/test-shadow-dom-actions.html << 'HTMLEOF'
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>Test shadow DOM actions</title>
    <script src="/datadog-rum.js"></script>
    <script>
      DD_RUM.init({
        clientToken: 'xxx',
        applicationId: 'xxx',
        proxy: '/proxy',
        trackUserInteractions: true,
      })
    </script>
  </head>
  <body>
    <my-button id="shadow-host"></my-button>
    <my-button id="shadow-host-named" data-dd-action-name="Custom Shadow Action"></my-button>
    <script>
      class MyButton extends HTMLElement {
        constructor() {
          super()
          this.attachShadow({ mode: 'open' })
          const button = document.createElement('button')
          button.textContent = 'Shadow Button'
          button.setAttribute('data-testid', 'shadow-btn')
          this.shadowRoot.appendChild(button)
        }
      }
      customElements.define('my-button', MyButton)
    </script>
  </body>
</html>
HTMLEOF

yarn dev-server intake clear
agent-browser open http://localhost:8080/test-shadow-dom-actions.html
agent-browser click '#shadow-host'
agent-browser click '#shadow-host-named'
agent-browser tab new
yarn dev-server intake rum-actions | jq '{name: .action.target.name, selector: ._dd.action.target.selector}'

# Expected:
# { "name": "Shadow Button", "selector": "#shadow-host::shadow BUTTON[data-testid=\"shadow-btn\"]" }
# { "name": "Custom Shadow Action", "selector": "MY-BUTTON[data-dd-action-name=\"Custom\\ Shadow\\ Action\"]::shadow BUTTON[data-testid=\"shadow-btn\"]" }

yarn dev-server stop
rm sandbox/test-shadow-dom-actions.html
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file