### PR TITLE
🐛 [RUM-11614][URL polyfill] Handle null iframe.contentWindow

### DIFF
--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -42,7 +42,7 @@ export function getPristineWindow() {
       iframe = document.createElement('iframe')
       iframe.style.display = 'none'
       document.body.appendChild(iframe)
-      pristineWindow = iframe.contentWindow as Window & typeof globalThis
+      pristineWindow = (iframe.contentWindow ?? globalObject) as Window & typeof globalThis
     } catch {
       pristineWindow = globalObject as unknown as Window & typeof globalThis
     }


### PR DESCRIPTION
## Motivation

Telemetry error:
``` 
Cannot read properties of null (reading 'URL')
Cannot read properties of undefined (reading 'URL')
```
<img width="646" height="246" alt="Screenshot 2026-03-20 at 10 44 13" src="https://github.com/user-attachments/assets/b92af9ed-8c47-4c78-af57-40cdde499739" />


## Changes

`iframe.contentWindow` can be null:

<img width="582" height="106" alt="Screenshot 2026-03-20 at 10 45 27" src="https://github.com/user-attachments/assets/de401886-dcc0-4640-ae56-6b74aa6ac6a2" />


Let's fallback to `globalObject` in this case.

## Test instructions

Let's see if the issue keeps appearing afterwards

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
