### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@ packages/rum/src/domain/segmentCollection/**    @Datadog/rum-browser @Datadog/se
 packages/rum/src/domain/*.ts                    @Datadog/rum-browser @Datadog/session-replay-sdk
 
 # Docs
-README.md    @Datadog/rum-browser @DataDog/documentation
+/README.md    @Datadog/rum-browser @DataDog/documentation


### PR DESCRIPTION
## Motivation

The docs team can continue to review the main README, but we don't need to be codeowners of all README files in this repo.
