### PR TITLE
♻️ replace direct session state writes with a priority-based scheduling system

### DIFF
--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -253,7 +253,7 @@ describe('startSessionManager', () => {
 
       sessionManager.expire()
       sessionManager.expire()
-      await collectAsyncCalls(sessionObservableSpy, 3)
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(expireSpy).toHaveBeenCalledTimes(1)
     })
@@ -290,6 +290,79 @@ describe('startSessionManager', () => {
 
       expect(sessionManager.findSession()).toBeDefined()
       expect(sessionManager.findSession()!.id).not.toBe(initialId)
+    })
+  })
+
+  describe('operation scheduling', () => {
+    it('should apply ForceExpire instead of ExpandOrRenew when expire() is called while a storage write is pending', async () => {
+      // This simulates the race condition that motivated the scheduleOperation system:
+      // activity triggers an ExpandOrRenew (storage write queued but not yet executed, like
+      // when waiting for a navigator.locks acquisition), then expire() is called before
+      // the write completes. Without the scheduling system, the pending ExpandOrRenew
+      // would overwrite the session back to active, causing a spurious renewObservable.
+
+      const sessionManager = await startSessionManagerWithDefaults()
+      const renewSpy = jasmine.createSpy('renew')
+      sessionManager.renewObservable.subscribe(renewSpy)
+
+      // Activity triggers ExpandOrRenew — the fn is queued but hasn't run yet (async strategy)
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+
+      // expire() is called before the fn runs, superseding ExpandOrRenew with ForceExpire
+      sessionManager.expire()
+      expect(sessionManager.findSession()).toBeUndefined() // in-memory already closed
+
+      // The deferred fn runs: reads ForceExpire (not ExpandOrRenew) from scheduledOperation
+      await collectAsyncCalls(sessionObservableSpy, 2)
+
+      expect(renewSpy).not.toHaveBeenCalled()
+      expect(fakeStrategy.getInternalState().isExpired).toBe(EXPIRED)
+    })
+
+    it('should apply ForceExpire even if ExpandOrRenew is scheduled after it', async () => {
+      // Reverse of the previous test: expire() is called first, then activity triggers
+      // ExpandOrRenew. ForceExpire has higher priority and should still win.
+
+      const sessionManager = await startSessionManagerWithDefaults()
+      const renewSpy = jasmine.createSpy('renew')
+      sessionManager.renewObservable.subscribe(renewSpy)
+
+      // expire() schedules ForceExpire — fn is deferred
+      sessionManager.expire()
+      expect(sessionManager.findSession()).toBeUndefined() // in-memory already closed
+
+      // Activity triggers ExpandOrRenew while ForceExpire is still pending
+      // It has lower priority so it does not supersede ForceExpire
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+
+      // The deferred fn runs: applies ForceExpire (not ExpandOrRenew)
+      await collectAsyncCalls(sessionObservableSpy, 2)
+
+      expect(renewSpy).not.toHaveBeenCalled()
+      expect(fakeStrategy.getInternalState().isExpired).toBe(EXPIRED)
+    })
+
+    it('should ignore a pending operation if the session was externally expired before the write runs', async () => {
+      // If another tab expires the session between scheduling an operation and running it,
+      // the operation should be skipped — it was intended for a session that no longer exists.
+
+      const sessionManager = await startSessionManagerWithDefaults()
+      const renewSpy = jasmine.createSpy('renew')
+      sessionManager.renewObservable.subscribe(renewSpy)
+
+      // Activity triggers ExpandOrRenew for the current session — fn is deferred
+      document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+
+      // Another tab expires the session before the fn runs
+      fakeStrategy.simulateExternalChange({ isExpired: EXPIRED })
+      expect(sessionManager.findSession()).toBeUndefined()
+
+      // The deferred ExpandOrRenew fn runs: currentState.id (undefined) !== op.sessionId,
+      // so it is skipped — the expired session is left unchanged
+      await collectAsyncCalls(sessionObservableSpy, 3)
+
+      expect(renewSpy).not.toHaveBeenCalled()
+      expect(fakeStrategy.getInternalState().isExpired).toBe(EXPIRED)
     })
   })
 
@@ -580,7 +653,7 @@ describe('startSessionManager', () => {
 
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
-      await collectAsyncCalls(sessionObservableSpy, 3) // 1 for initial session, 1 for expire, 1 for renew
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       const secondId = sessionManager.findSession()!.id
 
@@ -605,7 +678,7 @@ describe('startSessionManager', () => {
 
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
-      await collectAsyncCalls(sessionObservableSpy, 3) // 1 for initial session, 1 for expire, 1 for renew
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       expect(currentSession!).toBeDefined()
     })

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -719,17 +719,35 @@ describe('startSessionManager', () => {
       expect(sessionManager.findSession()!.id).toBe(initialId)
     })
 
-    it('should reinitialize session in store when store is empty', async () => {
+    it('should soft-expire the session when it timed out during the freeze', async () => {
+      const sessionManager = await startSessionManagerWithDefaults()
+      const initialId = sessionManager.findSession()!.id
+
+      // Simulate the session timing out while the browser was frozen (expire in the past)
+      fakeStrategy.simulateExternalChange({
+        id: initialId,
+        expire: String(Date.now() - 1),
+        created: String(Date.now() - SESSION_TIME_OUT_DELAY),
+      })
+
+      window.dispatchEvent(createNewEvent(DOM_EVENT.RESUME))
+
+      const state = fakeStrategy.getInternalState()
+      expect(state.isExpired).toBe(EXPIRED)
+      expect(state.id).toBeUndefined()
+    })
+
+    it('should do nothing when store is empty (e.g. cleared by an ad blocker)', async () => {
       await startSessionManagerWithDefaults()
 
-      // Simulate store being cleared (e.g., by another tab or browser clearing storage)
+      // Simulate store being cleared (e.g., by an ad blocker)
       fakeStrategy.simulateExternalChange({})
 
       window.dispatchEvent(createNewEvent(DOM_EVENT.RESUME))
 
-      // initializeSession on empty state creates an expired state
+      // Store should remain empty — we bail out rather than reinitializing
       const state = fakeStrategy.getInternalState()
-      expect(state.isExpired).toBe(EXPIRED)
+      expect(state.isExpired).toBeUndefined()
     })
   })
 

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -171,6 +171,7 @@ describe('startSessionManager', () => {
 
       // Expire the session
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(renewSpy).not.toHaveBeenCalled()
 
@@ -196,8 +197,10 @@ describe('startSessionManager', () => {
       sessionManager.renewObservable.subscribe(renewSpy)
 
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       clock.tick(VISIBILITY_CHECK_DELAY)
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       expect(renewSpy).not.toHaveBeenCalled()
     })
@@ -213,14 +216,18 @@ describe('startSessionManager', () => {
 
       // Multiple rapid clicks within the throttle window
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+      await collectAsyncCalls(sessionObservableSpy, 2)
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+      await collectAsyncCalls(sessionObservableSpy, 2)
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       // Only one call (leading edge) should have fired immediately
       expect(fakeStrategy.setSessionState.calls.count() - callCountBefore).toBe(1)
 
       // After throttle delay, the trailing call fires (from the queued clicks)
       clock.tick(ONE_SECOND)
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       // Leading (1) + trailing (1) = 2 calls total
       expect(fakeStrategy.setSessionState.calls.count() - callCountBefore).toBe(2)
@@ -234,6 +241,7 @@ describe('startSessionManager', () => {
       sessionManager.expireObservable.subscribe(expireSpy)
 
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(expireSpy).toHaveBeenCalledTimes(1)
     })
@@ -245,6 +253,7 @@ describe('startSessionManager', () => {
 
       sessionManager.expire()
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       expect(expireSpy).toHaveBeenCalledTimes(1)
     })
@@ -257,6 +266,7 @@ describe('startSessionManager', () => {
       expect(stateBefore.id).toBeDefined()
 
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       const stateAfter = fakeStrategy.getInternalState()
       expect(stateAfter.isExpired).toBe(EXPIRED)
@@ -267,11 +277,13 @@ describe('startSessionManager', () => {
       const initialId = sessionManager.findSession()!.id
 
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
       expect(sessionManager.findSession()).toBeUndefined()
 
       // Wait for throttle
       clock.tick(ONE_SECOND)
 
+      await collectAsyncCalls(sessionObservableSpy, 2)
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       await collectAsyncCalls(sessionObservableSpy, 3) // 1 for initial session, 1 for expire, 1 for renew
@@ -297,7 +309,11 @@ describe('startSessionManager', () => {
       // Wait for throttle to clear before dispatching activity
       clock.tick(ONE_SECOND)
 
+      await collectAsyncCalls(sessionObservableSpy, 2) // 1 for initial session, 1 for expire
+
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
+
+      await collectAsyncCalls(sessionObservableSpy, 3) // 1 for renew
 
       // Session should still be active (expire time was extended)
       const state = fakeStrategy.getInternalState()
@@ -315,6 +331,7 @@ describe('startSessionManager', () => {
       const initialExpire = fakeStrategy.getInternalState().expire
 
       clock.tick(VISIBILITY_CHECK_DELAY)
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       // Visibility check should have expanded the session
       const newExpire = fakeStrategy.getInternalState().expire
@@ -326,11 +343,13 @@ describe('startSessionManager', () => {
 
       const sessionManager = await startSessionManagerWithDefaults()
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       const stateAfterExpire = fakeStrategy.getInternalState()
       expect(stateAfterExpire.isExpired).toBe(EXPIRED)
 
       clock.tick(VISIBILITY_CHECK_DELAY)
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       // expandOnly should not modify an expired session
       const state = fakeStrategy.getInternalState()
@@ -411,6 +430,9 @@ describe('startSessionManager', () => {
 
       // First expire
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
+
+      sessionObservableSpy.calls.reset()
 
       // Then another tab creates a new session
       fakeStrategy.simulateExternalChange({
@@ -418,6 +440,7 @@ describe('startSessionManager', () => {
         expire: String(Date.now() + SESSION_EXPIRATION_DELAY),
         created: String(Date.now()),
       })
+      await collectAsyncCalls(sessionObservableSpy, 1)
 
       expect(renewSpy).toHaveBeenCalledTimes(1)
       expect(sessionManager.findSession()!.id).toBe('new-session-from-other-tab')
@@ -432,6 +455,7 @@ describe('startSessionManager', () => {
       expect(sessionManager.findSession()).toBeDefined()
 
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(sessionManager.findSession()).toBeUndefined()
       expect(fakeStrategy.getInternalState().isExpired).toBe(EXPIRED)
@@ -442,6 +466,7 @@ describe('startSessionManager', () => {
       const sessionManager = await startSessionManagerWithDefaults({ trackingConsentState })
 
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       clock.tick(ONE_SECOND)
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
@@ -455,6 +480,7 @@ describe('startSessionManager', () => {
       const initialId = sessionManager.findSession()!.id
 
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(sessionManager.findSession()).toBeUndefined()
 
@@ -476,6 +502,7 @@ describe('startSessionManager', () => {
       expect(fakeStrategy.getInternalState().anonymousId).toBeDefined()
 
       trackingConsentState.update(TrackingConsent.NOT_GRANTED)
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(fakeStrategy.getInternalState().anonymousId).toBeUndefined()
     })
@@ -533,6 +560,7 @@ describe('startSessionManager', () => {
       const sessionManager = await startSessionManagerWithDefaults()
 
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(sessionManager.findSession()).toBeUndefined()
     })
@@ -545,8 +573,11 @@ describe('startSessionManager', () => {
       // Advance time, expire, then renew
       clock.tick(10 * ONE_SECOND)
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       clock.tick(10 * ONE_SECOND)
+      await collectAsyncCalls(sessionObservableSpy, 2)
+
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       await collectAsyncCalls(sessionObservableSpy, 3) // 1 for initial session, 1 for expire, 1 for renew
@@ -570,6 +601,8 @@ describe('startSessionManager', () => {
 
       sessionManager.expire()
       clock.tick(ONE_SECOND)
+      await collectAsyncCalls(sessionObservableSpy, 2)
+
       document.dispatchEvent(createNewEvent(DOM_EVENT.CLICK))
 
       await collectAsyncCalls(sessionObservableSpy, 3) // 1 for initial session, 1 for expire, 1 for renew
@@ -585,6 +618,7 @@ describe('startSessionManager', () => {
       })
 
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       // expireObservable fires before sessionContextHistory.closeActive, so the session is still findable
       expect(currentSession!).toBeDefined()
@@ -596,7 +630,9 @@ describe('startSessionManager', () => {
 
         clock.tick(10 * ONE_SECOND)
         sessionManager.expire()
+        await collectAsyncCalls(sessionObservableSpy, 2)
         clock.tick(10 * ONE_SECOND)
+        await collectAsyncCalls(sessionObservableSpy, 2)
 
         expect(sessionManager.findSession(clock.relative(15 * ONE_SECOND), { returnInactive: true })).toBeDefined()
         expect(sessionManager.findSession(clock.relative(15 * ONE_SECOND), { returnInactive: false })).toBeUndefined()
@@ -626,7 +662,9 @@ describe('startSessionManager', () => {
 
       clock.tick(10 * ONE_SECOND)
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
       clock.tick(10 * ONE_SECOND)
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(sessionManager.findTrackedSession(clock.relative(5 * ONE_SECOND))).toBeDefined()
       expect(sessionManager.findTrackedSession(clock.relative(15 * ONE_SECOND))).toBeUndefined()
@@ -647,6 +685,7 @@ describe('startSessionManager', () => {
       const sessionManager = await startSessionManagerWithDefaults()
 
       sessionManager.expire()
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(sessionManager.findTrackedSession(undefined, { returnInactive: true })).toBeDefined()
     })
@@ -692,6 +731,7 @@ describe('startSessionManager', () => {
       const callCountBefore = fakeStrategy.setSessionState.calls.count()
 
       sessionManager.updateSessionState({ extra: 'value' })
+      await collectAsyncCalls(sessionObservableSpy, 2)
 
       expect(fakeStrategy.setSessionState.calls.count()).toBe(callCountBefore + 1)
       expect(fakeStrategy.getInternalState().extra).toBe('value')
@@ -730,7 +770,11 @@ describe('startSessionManager', () => {
         created: String(Date.now() - SESSION_TIME_OUT_DELAY),
       })
 
+      await collectAsyncCalls(sessionObservableSpy, 2)
+
       window.dispatchEvent(createNewEvent(DOM_EVENT.RESUME))
+
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       const state = fakeStrategy.getInternalState()
       expect(state.isExpired).toBe(EXPIRED)
@@ -743,7 +787,11 @@ describe('startSessionManager', () => {
       // Simulate store being cleared (e.g., by an ad blocker)
       fakeStrategy.simulateExternalChange({})
 
+      await collectAsyncCalls(sessionObservableSpy, 2)
+
       window.dispatchEvent(createNewEvent(DOM_EVENT.RESUME))
+
+      await collectAsyncCalls(sessionObservableSpy, 3)
 
       // Store should remain empty — we bail out rather than reinitializing
       const state = fakeStrategy.getInternalState()

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -80,7 +80,7 @@ export function startSessionManager(
   stopCallbacks.push(() => sessionContextHistory.stop())
 
   const { throttled: throttledExpandOrRenew, cancel: cancelExpandOrRenew } = throttle(() => {
-    strategy.setSessionState((state) => expandOrRenew(state, configuration)).catch(monitorError)
+    strategy.setSessionState((state) => expandOrRenew(state, configuration, trackingConsentState)).catch(monitorError)
   }, ONE_SECOND)
   stopCallbacks.push(cancelExpandOrRenew)
 
@@ -111,8 +111,8 @@ export function startSessionManager(
   async function resolveInitialState() {
     let state: SessionState = {}
     await strategy.setSessionState((currentState) => {
-      const initialState = initializeSession(currentState, configuration)
-      state = expandOrRenew(initialState, configuration)
+      const initialState = initializeSession(currentState, configuration, trackingConsentState)
+      state = expandOrRenew(initialState, configuration, trackingConsentState)
       return state
     })
     return state
@@ -136,11 +136,7 @@ export function startSessionManager(
         strategy
           .setSessionState((state) => {
             if (isSessionInExpiredState(state)) {
-              if (!trackingConsentState.isGranted()) {
-                delete state.anonymousId
-              }
-
-              return getExpiredSessionState(state, configuration)
+              return getExpiredSessionState(state, configuration, trackingConsentState)
             }
 
             return state
@@ -154,7 +150,9 @@ export function startSessionManager(
   function setupSessionTracking() {
     trackingConsentState.observable.subscribe(() => {
       if (trackingConsentState.isGranted()) {
-        strategy.setSessionState((state) => expandOrRenew(state, configuration)).catch(monitorError)
+        strategy
+          .setSessionState((state) => expandOrRenew(state, configuration, trackingConsentState))
+          .catch(monitorError)
       } else {
         expire()
       }
@@ -170,7 +168,9 @@ export function startSessionManager(
         strategy.setSessionState((state) => expandOnly(state)).catch(monitorError)
       })
       trackResume(configuration, () => {
-        strategy.setSessionState((state) => initializeSession(state, configuration)).catch(monitorError)
+        strategy
+          .setSessionState((state) => initializeSession(state, configuration, trackingConsentState))
+          .catch(monitorError)
       })
     }
   }
@@ -243,19 +243,11 @@ export function startSessionManager(
   function expire() {
     cancelExpandOrRenew()
     // Update in-memory state synchronously so events stop being collected immediately
-    const expiredState = getExpiredSessionState(sessionContextHistory.find(), configuration)
-    if (!trackingConsentState.isGranted()) {
-      delete expiredState.anonymousId
-    }
+    const expiredState = getExpiredSessionState(sessionContextHistory.find(), configuration, trackingConsentState)
     handleStateChange(expiredState, { from: 'expire' })
     // Persist to storage asynchronously
     strategy
-      .setSessionState((state) => {
-        if (!trackingConsentState.isGranted()) {
-          delete state.anonymousId
-        }
-        return getExpiredSessionState(state, configuration)
-      })
+      .setSessionState((state) => getExpiredSessionState(state, configuration, trackingConsentState))
       .catch(monitorError)
   }
 

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -22,6 +22,7 @@ import {
   getExpiredSessionState,
   initializeSession,
   isSessionInExpiredState,
+  isSessionInNotStartedState,
 } from './sessionState'
 import { getSessionStoreStrategy } from './sessionStore'
 
@@ -58,6 +59,19 @@ export const VISIBILITY_CHECK_DELAY = ONE_MINUTE
 const SESSION_CONTEXT_TIMEOUT_DELAY = SESSION_TIME_OUT_DELAY
 let stopCallbacks: Array<() => void> = []
 
+// The order of this enum reflects the priority of operations: higher values take precedence when
+// multiple operations are scheduled before the storage write occurs.
+const enum OperationType {
+  // Extend the session expiry if already active (e.g. page still visible)
+  ExpandOnly,
+  // Extend the session expiry, or create a new session if expired (e.g. user activity)
+  ExpandOrRenew,
+  // Transition to expired state if the session has timed out (e.g. expiration timer fires or browser resumes)
+  SoftExpire,
+  // Force the session into expired state regardless of current state (e.g. consent revoked)
+  ForceExpire,
+}
+
 export function startSessionManager(
   configuration: Configuration,
   trackingConsentState: TrackingConsentState,
@@ -66,6 +80,7 @@ export function startSessionManager(
   const renewObservable = new Observable<SessionRenewalEvent>()
   const expireObservable = new Observable<void>()
   let expireContext: SessionDebugContext | undefined
+  let scheduledOperation: { type: OperationType; sessionId: string | undefined } | undefined
 
   if (!configuration.sessionStoreStrategyType) {
     display.warn('No storage available for session. We will not send any data.')
@@ -80,7 +95,7 @@ export function startSessionManager(
   stopCallbacks.push(() => sessionContextHistory.stop())
 
   const { throttled: throttledExpandOrRenew, cancel: cancelExpandOrRenew } = throttle(() => {
-    strategy.setSessionState((state) => expandOrRenew(state, configuration, trackingConsentState)).catch(monitorError)
+    scheduleOperation(OperationType.ExpandOrRenew)
   }, ONE_SECOND)
   stopCallbacks.push(cancelExpandOrRenew)
 
@@ -133,15 +148,7 @@ export function startSessionManager(
     if (state.expire && !isSessionInExpiredState(state)) {
       const delay = Number(state.expire) - dateNow()
       expirationTimeoutId = setTimeout(() => {
-        strategy
-          .setSessionState((state) => {
-            if (isSessionInExpiredState(state)) {
-              return getExpiredSessionState(state, configuration, trackingConsentState)
-            }
-
-            return state
-          })
-          .catch(monitorError)
+        scheduleOperation(OperationType.SoftExpire)
       }, delay)
     }
   }
@@ -150,9 +157,7 @@ export function startSessionManager(
   function setupSessionTracking() {
     trackingConsentState.observable.subscribe(() => {
       if (trackingConsentState.isGranted()) {
-        strategy
-          .setSessionState((state) => expandOrRenew(state, configuration, trackingConsentState))
-          .catch(monitorError)
+        scheduleOperation(OperationType.ExpandOrRenew)
       } else {
         expire()
       }
@@ -165,14 +170,10 @@ export function startSessionManager(
         }
       })
       trackVisibility(configuration, () => {
-        strategy.setSessionState((state) => expandOnly(state)).catch(monitorError)
+        scheduleOperation(OperationType.ExpandOnly)
       })
       trackResume(configuration, () => {
-        strategy
-          .setSessionState((state) =>
-            isSessionInExpiredState(state) ? getExpiredSessionState(state, configuration, trackingConsentState) : state
-          )
-          .catch(monitorError)
+        scheduleOperation(OperationType.SoftExpire)
       })
     }
   }
@@ -243,14 +244,45 @@ export function startSessionManager(
   }
 
   function expire() {
-    cancelExpandOrRenew()
+    // Persist to storage asynchronously
+    scheduleOperation(OperationType.ForceExpire)
     // Update in-memory state synchronously so events stop being collected immediately
     const expiredState = getExpiredSessionState(sessionContextHistory.find(), configuration, trackingConsentState)
     handleStateChange(expiredState, { from: 'expire' })
-    // Persist to storage asynchronously
-    strategy
-      .setSessionState((state) => getExpiredSessionState(state, configuration, trackingConsentState))
-      .catch(monitorError)
+  }
+
+  function scheduleOperation(type: OperationType) {
+    const hadOperationScheduled = !!scheduledOperation
+    if (!scheduledOperation || type >= scheduledOperation.type) {
+      scheduledOperation = { type, sessionId: sessionContextHistory.find()?.id }
+    }
+
+    if (!hadOperationScheduled) {
+      strategy
+        .setSessionState((state) => {
+          const operation = scheduledOperation!
+          scheduledOperation = undefined
+
+          if (state.id !== operation.sessionId) {
+            return state
+          }
+
+          switch (operation.type) {
+            case OperationType.ExpandOnly:
+              return expandOnly(state)
+            case OperationType.ExpandOrRenew:
+              return expandOrRenew(state, configuration, trackingConsentState)
+            case OperationType.SoftExpire:
+              if (isSessionInExpiredState(state)) {
+                return getExpiredSessionState(state, configuration, trackingConsentState)
+              }
+              return state
+            case OperationType.ForceExpire:
+              return getExpiredSessionState(state, configuration, trackingConsentState)
+          }
+        })
+        .catch(monitorError)
+    }
   }
 
   function buildSessionContext(sessionState: SessionState): SessionContext {

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -17,10 +17,9 @@ import { getCookies } from '../../browser/cookie'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import type { SessionState } from './sessionState'
 import {
-  expandOnly,
-  expandOrRenew,
-  getExpiredSessionState,
-  initializeSession,
+  createNewSessionState,
+  expandSessionState,
+  createExpiredSessionState,
   isSessionInExpiredState,
   isSessionInNotStartedState,
 } from './sessionState'
@@ -126,8 +125,11 @@ export function startSessionManager(
   async function resolveInitialState() {
     let state: SessionState = {}
     await strategy.setSessionState((currentState) => {
-      const initialState = initializeSession(currentState, configuration, trackingConsentState)
-      state = expandOrRenew(initialState, configuration, trackingConsentState)
+      if (isSessionInExpiredState(currentState) || !currentState.id) {
+        state = createNewSessionState(state, configuration)
+      } else {
+        state = currentState
+      }
       return state
     })
     return state
@@ -145,7 +147,7 @@ export function startSessionManager(
 
   function scheduleExpirationTimeout(state: SessionState) {
     clearTimeout(expirationTimeoutId)
-    if (state.expire && !isSessionInExpiredState(state)) {
+    if (state.expire) {
       const delay = Number(state.expire) - dateNow()
       expirationTimeoutId = setTimeout(() => {
         scheduleOperation(OperationType.SoftExpire)
@@ -247,8 +249,10 @@ export function startSessionManager(
     // Persist to storage asynchronously
     scheduleOperation(OperationType.ForceExpire)
     // Update in-memory state synchronously so events stop being collected immediately
-    const expiredState = getExpiredSessionState(sessionContextHistory.find(), configuration, trackingConsentState)
-    handleStateChange(expiredState, { from: 'expire' })
+    if (sessionContextHistory.find()) {
+      expireObservable.notify()
+      sessionContextHistory.closeActive(relativeNow())
+    }
   }
 
   function scheduleOperation(type: OperationType) {
@@ -267,18 +271,29 @@ export function startSessionManager(
             return state
           }
 
+          // prevent renewing if state is altered by a 3rd party (e.g. adblocker deleting the cookie)
+          if (isSessionInNotStartedState(state)) {
+            return state
+          }
+
           switch (operation.type) {
             case OperationType.ExpandOnly:
-              return expandOnly(state)
+              if (!isSessionInExpiredState(state)) {
+                expandSessionState(state)
+              }
+              return state
             case OperationType.ExpandOrRenew:
-              return expandOrRenew(state, configuration, trackingConsentState)
+              if (isSessionInExpiredState(state)) {
+                return createNewSessionState(state, configuration)
+              }
+              return state
             case OperationType.SoftExpire:
               if (isSessionInExpiredState(state)) {
-                return getExpiredSessionState(state, configuration, trackingConsentState)
+                return createExpiredSessionState(state, configuration, trackingConsentState)
               }
               return state
             case OperationType.ForceExpire:
-              return getExpiredSessionState(state, configuration, trackingConsentState)
+              return createExpiredSessionState(state, configuration, trackingConsentState)
           }
         })
         .catch(monitorError)

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -169,7 +169,9 @@ export function startSessionManager(
       })
       trackResume(configuration, () => {
         strategy
-          .setSessionState((state) => initializeSession(state, configuration, trackingConsentState))
+          .setSessionState((state) =>
+            isSessionInExpiredState(state) ? getExpiredSessionState(state, configuration, trackingConsentState) : state
+          )
           .catch(monitorError)
       })
     }

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -3,6 +3,7 @@ import { objectEntries } from '../../tools/utils/polyfills'
 import { dateNow } from '../../tools/utils/timeUtils'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { Configuration } from '../configuration'
+import type { TrackingConsentState } from '../trackingConsent'
 import { SESSION_EXPIRATION_DELAY, SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import { isValidSessionString, SESSION_ENTRY_REGEXP, SESSION_ENTRY_SEPARATOR } from './sessionStateValidation'
 export const EXPIRED = '1'
@@ -19,12 +20,13 @@ export interface SessionState {
 
 export function getExpiredSessionState(
   previousSessionState: { anonymousId?: string } | undefined,
-  configuration: Configuration
+  configuration: Configuration,
+  trackingConsestState: TrackingConsentState
 ): SessionState {
   const expiredSessionState: SessionState = {
     isExpired: EXPIRED,
   }
-  if (configuration.trackAnonymousUser && previousSessionState?.anonymousId) {
+  if (configuration.trackAnonymousUser && trackingConsestState.isGranted() && previousSessionState?.anonymousId) {
     expiredSessionState.anonymousId = previousSessionState?.anonymousId
   }
 
@@ -85,17 +87,22 @@ export function toSessionState(sessionString: string | undefined | null) {
   return session
 }
 
-export function initializeSession(state: SessionState, configuration: Configuration): SessionState {
+export function initializeSession(
+  state: SessionState,
+  configuration: Configuration,
+  trackingConsestState: TrackingConsentState
+): SessionState {
   if (isSessionInNotStartedState(state)) {
-    if (configuration.trackAnonymousUser) {
-      state.anonymousId = generateUUID()
-    }
-    return getExpiredSessionState(state, configuration)
+    return getExpiredSessionState(state, configuration, trackingConsestState)
   }
   return state
 }
 
-export function expandOrRenew(state: SessionState, configuration: Configuration): SessionState {
+export function expandOrRenew(
+  state: SessionState,
+  configuration: Configuration,
+  trackingConsestState: TrackingConsentState
+): SessionState {
   // prevent renewing if state is altered by a 3rd party (e.g. adblocker deleting the cookie)
   if (isSessionInNotStartedState(state)) {
     return state
@@ -104,15 +111,15 @@ export function expandOrRenew(state: SessionState, configuration: Configuration)
   let newState = state
 
   if (isSessionInExpiredState(state)) {
-    newState = getExpiredSessionState(state, configuration)
+    newState = getExpiredSessionState(state, configuration, trackingConsestState)
   }
 
   if (!newState.id) {
     newState.id = generateUUID()
     newState.created = String(dateNow())
-  }
-  if (configuration.trackAnonymousUser && !newState.anonymousId) {
-    newState.anonymousId = generateUUID()
+    if (configuration.trackAnonymousUser && !newState.anonymousId) {
+      newState.anonymousId = generateUUID()
+    }
   }
 
   delete newState.isExpired

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -18,8 +18,8 @@ export interface SessionState {
   [key: string]: string | undefined
 }
 
-export function getExpiredSessionState(
-  previousSessionState: { anonymousId?: string } | undefined,
+export function createExpiredSessionState(
+  previousSessionState: SessionState,
   configuration: Configuration,
   trackingConsestState: TrackingConsentState
 ): SessionState {
@@ -33,12 +33,22 @@ export function getExpiredSessionState(
   return expiredSessionState
 }
 
-export function isSessionInNotStartedState(session: SessionState) {
-  return isEmptyObject(session)
+export function createNewSessionState(previousSessionState: SessionState, configuration: Configuration): SessionState {
+  const newSessionState = {
+    ...previousSessionState,
+    id: generateUUID(),
+    created: String(dateNow()),
+    expire: String(dateNow() + SESSION_EXPIRATION_DELAY),
+  }
+  if (configuration.trackAnonymousUser && !newSessionState.anonymousId) {
+    newSessionState.anonymousId = generateUUID()
+  }
+  delete newSessionState.isExpired
+  return newSessionState
 }
 
-export function isSessionStarted(session: SessionState) {
-  return !isSessionInNotStartedState(session)
+export function isSessionInNotStartedState(session: SessionState) {
+  return isEmptyObject(session)
 }
 
 export function isSessionInExpiredState(session: SessionState) {
@@ -85,53 +95,4 @@ export function toSessionState(sessionString: string | undefined | null) {
     })
   }
   return session
-}
-
-export function initializeSession(
-  state: SessionState,
-  configuration: Configuration,
-  trackingConsestState: TrackingConsentState
-): SessionState {
-  if (isSessionInNotStartedState(state)) {
-    return getExpiredSessionState(state, configuration, trackingConsestState)
-  }
-  return state
-}
-
-export function expandOrRenew(
-  state: SessionState,
-  configuration: Configuration,
-  trackingConsestState: TrackingConsentState
-): SessionState {
-  // prevent renewing if state is altered by a 3rd party (e.g. adblocker deleting the cookie)
-  if (isSessionInNotStartedState(state)) {
-    return state
-  }
-
-  let newState = state
-
-  if (isSessionInExpiredState(state)) {
-    newState = getExpiredSessionState(state, configuration, trackingConsestState)
-  }
-
-  if (!newState.id) {
-    newState.id = generateUUID()
-    newState.created = String(dateNow())
-    if (configuration.trackAnonymousUser && !newState.anonymousId) {
-      newState.anonymousId = generateUUID()
-    }
-  }
-
-  delete newState.isExpired
-  expandSessionState(newState)
-
-  return newState
-}
-
-export function expandOnly(state: SessionState): SessionState {
-  if (isSessionInExpiredState(state) || isSessionInNotStartedState(state) || !state.id) {
-    return state
-  }
-  expandSessionState(state)
-  return state
 }

--- a/packages/core/test/fakeSessionStoreStrategy.ts
+++ b/packages/core/test/fakeSessionStoreStrategy.ts
@@ -21,6 +21,7 @@ export function createFakeSessionStoreStrategy({
     setSessionState: jasmine
       .createSpy('setSessionState')
       .and.callFake(async (fn: (state: SessionState) => SessionState): Promise<void> => {
+        await Promise.resolve()
         session = fn({ ...session })
         await Promise.resolve()
         sessionObservable.notify({ cookieValue: undefined, sessionState: { ...session } })


### PR DESCRIPTION
## Motivation

The session manager had a race condition: when user activity triggered a throttled
`expandOrRenew` write, and `expire()` was called before that write completed (e.g.
consent revoked, or the browser waking from sleep), the stale write would complete
after the in-memory session was already closed — causing a spurious `renewObservable`
notification.

This PR is an attempt to fix that issue by enforcing stronger guards on operations made by the Session Manager. It also simplifies a bit those operations.

## Changes

- Simplification: don't reinitialize session on browser resume. When the cookie is absent on resume, bail out rather than creating a spurious expired session state. This was probably a mistake in the original session manager, and changing this to a "soft-expire" makes more sense.

- **✅ make `fakeSessionStoreStrategy` fully async**: aligns the test helper with real-world async lock behavior, making race conditions testable.

- **♻️ priority-based operation scheduler**: replace direct `strategy.setSessionState` calls with a scheduler that deduplicates concurrent writes and always applies the highest-priority operation. A session ID guard also discards operations scheduled for a session that has since changed externally.

- **♻️ inline session state transitions**: simplify `sessionState.ts` by replacing the higher-level `expandOrRenew`/`expandOnly`/`initializeSession` helpers with lower-level primitives (`createNewSessionState`, `expandSessionState`) used directly in the scheduler.

## Test instructions

Try various cookies scenario using the playground (`stopSession()`, `setTrackingConsent()`, renew on click, edit the cookie in the devtools, etc.)

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file