### PR TITLE
👷 Remove safari mobile from browsers.conf

### DIFF
--- a/test/unit/browsers.conf.ts
+++ b/test/unit/browsers.conf.ts
@@ -38,11 +38,4 @@ export const browserConfigurations: BrowserConfiguration[] = [
     osVersion: '12.0',
     device: 'Google Pixel 6 Pro',
   },
-  {
-    sessionName: 'Safari mobile',
-    name: 'safari',
-    os: 'ios',
-    osVersion: '16',
-    device: 'iPhone 14',
-  },
 ]


### PR DESCRIPTION
## Motivation

Remove Safari BS tests until we can investigate and fix the issue as to not block releases

## Changes

Remove mobile safari from `test/unit/browsers.conf.ts`

## Test instructions

CI should pass. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
