### PR TITLE
🐛 Prevent cross-tab session adoption after expiry

### DIFF
--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -405,7 +405,7 @@ describe('startSessionManager', () => {
       expect(sessionManager.findSession()).toBeUndefined()
     })
 
-    it('should fire renewObservable when external change creates a session from expired state', async () => {
+    it('should not adopt a session created by another tab after expiry', async () => {
       const sessionManager = await startSessionManagerWithDefaults()
       const renewSpy = jasmine.createSpy('renew')
       sessionManager.renewObservable.subscribe(renewSpy)
@@ -420,8 +420,8 @@ describe('startSessionManager', () => {
         created: String(Date.now()),
       })
 
-      expect(renewSpy).toHaveBeenCalledTimes(1)
-      expect(sessionManager.findSession()!.id).toBe('new-session-from-other-tab')
+      expect(renewSpy).not.toHaveBeenCalled()
+      expect(sessionManager.findSession()).toBeUndefined()
     })
   })
 

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -102,7 +102,10 @@ export function startSessionManager(
   })
   stopCallbacks.push(() => sessionContextHistory.stop())
 
+  let sessionExpired = false
+
   const { throttled: throttledExpandOrRenew, cancel: cancelExpandOrRenew } = throttle(() => {
+    sessionExpired = false
     strategy.setSessionState((state) => expandOrRenew(state, configuration)).catch(monitorError)
   }, ONE_SECOND)
   stopCallbacks.push(cancelExpandOrRenew)
@@ -178,6 +181,7 @@ export function startSessionManager(
   function setupSessionTracking() {
     trackingConsentState.observable.subscribe(() => {
       if (trackingConsentState.isGranted()) {
+        sessionExpired = false
         strategy.setSessionState((state) => expandOrRenew(state, configuration)).catch(monitorError)
       } else {
         expire()
@@ -244,11 +248,18 @@ export function startSessionManager(
         locksAvailable: Boolean(globalThis.navigator?.locks),
         cookieStoreAvailable: Boolean(globalThis.cookieStore),
       }
+      if (!hasSession) {
+        sessionExpired = true
+      }
       expireObservable.notify()
       sessionContextHistory.closeActive(relativeNow())
     }
 
     if (hasSession && (!hadSession || sessionIdChanged)) {
+      if (sessionExpired) {
+        // Don't adopt another tab's session — this tab needs its own user interaction to renew
+        return
+      }
       // New session appeared
       sessionContextHistory.add(buildSessionContext(newState), relativeNow())
       renewObservable.notify({

--- a/test/e2e/scenario/rum/multiTabSessions.scenario.ts
+++ b/test/e2e/scenario/rum/multiTabSessions.scenario.ts
@@ -38,9 +38,6 @@ test.describe('multi-tab sessions', () => {
       expect(tab1Renewed).toBeDefined()
       expect(tab1Renewed).not.toBe(tab1Session)
 
-      // Wait for Tab 2's poll cycle to pick up the cookie change
-      await page2.waitForTimeout(1100)
-
       // Tab 2 should NOT have adopted the new session (no user interaction in Tab 2)
       const tab2AfterRenewal = await page2.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
       expect(tab2AfterRenewal).toBeUndefined()

--- a/test/e2e/scenario/rum/multiTabSessions.scenario.ts
+++ b/test/e2e/scenario/rum/multiTabSessions.scenario.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+import { expireSession } from '../../lib/helpers/session'
+import { createTest } from '../../lib/framework'
+
+test.describe('multi-tab sessions', () => {
+  createTest('session expiry and renewal across tabs')
+    .withRum()
+    .run(async ({ page, browserContext, baseUrl }) => {
+      // --- Step 1: Both tabs have an active session ---
+      const tab1Session = await page.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
+      expect(tab1Session).toBeDefined()
+
+      const page2 = await browserContext.newPage()
+      await page2.goto(baseUrl)
+
+      const tab2Session = await page2.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
+      expect(tab2Session).toBeDefined()
+      expect(tab2Session).toBe(tab1Session)
+
+      // --- Step 2: Expire the session, verify both tabs detect it ---
+      await expireSession(page, browserContext)
+
+      // Wait for Tab 2 to also detect the expiry via cookie polling (1s interval)
+      await page2.waitForTimeout(1100)
+
+      const tab1AfterExpiry = await page.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
+      const tab2AfterExpiry = await page2.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
+      expect(tab1AfterExpiry).toBeUndefined()
+      expect(tab2AfterExpiry).toBeUndefined()
+
+      // --- Step 3: Renew session in Tab 1 via user interaction ---
+      await page.locator('html').click()
+
+      // Wait for the new session to be created and the next poll cycle
+      await page.waitForTimeout(1100)
+
+      const tab1Renewed = await page.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
+      expect(tab1Renewed).toBeDefined()
+      expect(tab1Renewed).not.toBe(tab1Session)
+
+      // Wait for Tab 2's poll cycle to pick up the cookie change
+      await page2.waitForTimeout(1100)
+
+      // Tab 2 should NOT have adopted the new session (no user interaction in Tab 2)
+      const tab2AfterRenewal = await page2.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
+      expect(tab2AfterRenewal).toBeUndefined()
+
+      // --- Step 4: Tab 2 renews via its own user interaction ---
+      await page2.locator('html').click()
+      await page2.waitForTimeout(1100)
+
+      const tab2Renewed = await page2.evaluate(() => window.DD_RUM!.getInternalContext()?.session_id)
+      expect(tab2Renewed).toBeDefined()
+      expect(tab2Renewed).toBe(tab1Renewed)
+
+      await page2.close()
+    })
+})


### PR DESCRIPTION
## Motivation

In v7, when a session expires in a multi-tab scenario, Tab 2 could silently adopt a new session created by Tab 1 without any user interaction. This is a behavior change from v6, where each tab was required to renew its session through its own user interaction after expiry. This PR restores the v6 behavior.

## Changes

- Track session expiry state per tab with a `sessionExpired` flag in the session manager
- After expiry, ignore new sessions written to the cookie by other tabs — each tab must renew via its own user interaction (click, tracking consent grant, or explicit `expandOrRenew` call)
- Update the existing unit test to assert the non-adoption behavior
- Add a multi-tab E2E test covering the full lifecycle: shared session, expiry, independent renewal, and eventual session convergence

## Test instructions

1. `yarn test:unit --spec packages/core/src/domain/session/sessionManager.spec.ts`
2. `yarn test:e2e -g "multi-tab sessions"`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file