### PR TITLE
👷 Use 15-minute cache for next major canary S3 uploads

### DIFF
--- a/scripts/deploy/deploy.spec.ts
+++ b/scripts/deploy/deploy.spec.ts
@@ -162,6 +162,80 @@ describe('deploy', () => {
     ])
   })
 
+  it('should deploy canary packages', async () => {
+    await deploy('prod', 'canary', ['root'])
+
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/datadog-logs-canary.js',
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/datadog-rum-canary.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-canary.js',
+        env,
+      },
+    ])
+
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-canary.js,/datadog-rum-slim-canary.js`,
+        env,
+      },
+    ])
+  })
+
+  it('should deploy next major canary packages', async () => {
+    await deploy('prod', 'v7-canary', ['root'])
+
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/datadog-logs-v7-canary.js',
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/datadog-rum-v7-canary.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-v7-canary.js',
+        env,
+      },
+    ])
+
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v7-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v7-canary.js,/datadog-rum-slim-v7-canary.js`,
+        env,
+      },
+    ])
+  })
+
   it('should deploy PR packages', async () => {
     // mock the PR number fetch
     fetchPRMock.mock.mockImplementation(() => Promise.resolve({ ['number']: 123 }))

--- a/scripts/deploy/deploy.ts
+++ b/scripts/deploy/deploy.ts
@@ -117,7 +117,7 @@ function uploadToS3(awsConfig: AwsConfig, bundlePath: string, uploadPath: string
   const accessToS3 = generateEnvironmentForRole(awsConfig.accountId, 'build-stable-browser-agent-artifacts-s3-write')
 
   const browserCache =
-    version === 'staging' || version === 'canary' || version === 'pull-request'
+    version === 'staging' || version === 'canary' || version.endsWith('-canary') || version === 'pull-request'
       ? 15 * ONE_MINUTE_IN_SECOND
       : 4 * ONE_HOUR_IN_SECOND
   const cacheControl = `max-age=${browserCache}, s-maxage=60`


### PR DESCRIPTION
## Motivation

The next major canary deploy (e.g. `v7-canary`) was getting a 4-hour browser cache (`max-age=14400`) instead of the expected 15-minute cache (`max-age=900`). This is because `uploadToS3` only checked for the exact string `'canary'`, which doesn't match versioned canary strings like `v7-canary`.

## Changes

- Added `version.endsWith('-canary')` check in `deploy.ts` so versioned canary deploys get the same 15-minute cache as the main canary
- Added unit tests for both `canary` and `v7-canary` deploy scenarios

## Test instructions

Run `yarn build:bundle && yarn test:script` and verify the new "should deploy canary packages" and "should deploy next major canary packages" tests pass with `max-age=900`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file