### PR TITLE
💥 add `session_renewal` view loading type for session-renewed views

### DIFF
--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -222,6 +222,15 @@ describe('view lifecycle', () => {
       expect(getViewCreateCount()).toBe(2)
     })
 
+    it('should use session_renewal loading type for the new view', () => {
+      const { getViewUpdate, getViewUpdateCount } = viewTest
+
+      lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+
+      expect(getViewUpdate(getViewUpdateCount() - 1).loadingType).toBe(ViewLoadingType.SESSION_RENEWAL)
+    })
+
     it('should use the current view name, service and version for the new view', () => {
       const { getViewCreateCount, getViewCreate, startView } = viewTest
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -154,8 +154,8 @@ export function trackViews(
       context.is_session_renewal = true
       context.renew_event = event as any
 
-      // Renew view on session renewal
-      currentView = startNewView(ViewLoadingType.ROUTE_CHANGE, undefined, {
+      currentView = startNewView(ViewLoadingType.SESSION_RENEWAL, undefined, {
+        // Renew view on session renewal
         name: currentView.name,
         service: currentView.service,
         version: currentView.version,

--- a/packages/rum-core/src/rawRumEvent.types.ts
+++ b/packages/rum-core/src/rawRumEvent.types.ts
@@ -238,6 +238,7 @@ export interface PageStateServerEntry {
 export const ViewLoadingType = {
   INITIAL_LOAD: 'initial_load',
   ROUTE_CHANGE: 'route_change',
+  SESSION_RENEWAL: 'session_renewal',
   BF_CACHE: 'bf_cache',
 } as const
 

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1732,6 +1732,8 @@ export interface ViewProperties {
       | 'fragment_redisplay'
       | 'view_controller_display'
       | 'view_controller_redisplay'
+      | 'session_renewal'
+      | 'bf_cache'
     /**
      * Time spent on the view in ns
      */


### PR DESCRIPTION
## Motivation

When a RUM session is renewed (e.g. after expiry), a new view is created to track
activity in the new session. Previously this view was reported with
`view.loading_type: route_change`, making it indistinguishable from a regular
client-side navigation. This makes it hard for customers to filter or understand
these views in dashboards and explorers.

## Changes

- Add `session_renewal` as a new `view.loading_type` value, emitted when a view is
  created as a result of a session renewal
- Update the rum-events-format schema to include the new value

## Test instructions

1. Start the dev sandbox (`yarn dev`) and open `http://localhost:8080`
2. Initialize RUM with a short session duration or expire the session manually
3. When the session renews, observe a new view event in the Network tab — it should
   have `view.loading_type: "session_renewal"`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file