### PR TITLE
📈 Add telemetry metric for session manager init duration

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -4,6 +4,7 @@ import type { RelativeTime, TimeStamp } from '../../tools/utils/timeUtils'
 import {
   clocksOrigin,
   dateNow,
+  elapsed,
   ONE_HOUR,
   ONE_MINUTE,
   ONE_SECOND,
@@ -20,6 +21,7 @@ import type { TrackingConsentState } from '../trackingConsent'
 import { isWorkerEnvironment } from '../../tools/globalObject'
 import { display } from '../../tools/display'
 import { isSampled } from '../sampler'
+import { TelemetryMetrics, addTelemetryMetrics } from '../telemetry'
 import { monitorError } from '../../tools/monitor'
 import { getCookies } from '../../browser/cookie'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
@@ -85,6 +87,7 @@ export async function startSessionManager(
   configuration: Configuration,
   trackingConsentState: TrackingConsentState
 ): Promise<SessionManager | undefined> {
+  const startTime = relativeNow()
   const renewObservable = new Observable<SessionRenewalEvent>()
   const expireObservable = new Observable<void>()
   let expireContext: SessionDebugContext | undefined
@@ -133,6 +136,12 @@ export async function startSessionManager(
   scheduleExpirationTimeout(initialState)
   subscribeToSessionChanges()
   setupSessionTracking()
+
+  // monitor-until: 2026-10-15
+  addTelemetryMetrics(TelemetryMetrics.SESSION_MANAGER_INIT_METRICS_TELEMETRY_NAME, {
+    metrics: { duration: elapsed(startTime, relativeNow()) },
+  })
+
   return buildSessionManager()
 
   async function resolveInitialState() {

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -69,6 +69,7 @@ export const enum TelemetryMetrics {
   RECORDER_INIT_METRICS_TELEMETRY_NAME = 'Recorder init metrics',
   SEGMENT_METRICS_TELEMETRY_NAME = 'Segment network request metrics',
   INITIAL_VIEW_METRICS_TELEMETRY_NAME = 'Initial view metrics',
+  SESSION_MANAGER_INIT_METRICS_TELEMETRY_NAME = 'Session manager init metrics',
 }
 
 const METRIC_SAMPLE_RATE = 1


### PR DESCRIPTION
## Motivation

The session manager is now async. We want to measure how long initialization takes in the wild to understand its impact on SDK startup time.

## Changes

- Add a new `SESSION_MANAGER_INIT_METRICS_TELEMETRY_NAME` telemetry metric
- Measure `elapsed` time from the start of `startSessionManager()` to successful initialization using `relativeNow()` (`performance.now()`)
- Metric is emitted for both RUM and Logs (since both call `startSessionManager`)
- Only emitted on successful initialization (early returns for missing strategy, stopped thread, or revoked consent are skipped)
- Includes a `monitor-until: 2026-10-15` comment

## Test instructions

- Existing session manager unit tests pass (54/54)
- Typecheck passes

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file