### PR TITLE
[RUM-15273] 🔊 Add telemetry for trackResourceHeaders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ For deeper context, see:
 
 - `addTelemetryUsage` tracks **which public API the customer calls and which options they pass** (static call-site information)
 - Do NOT include runtime state analysis (e.g., whether a view was active, whether a value was overwritten) in telemetry usage — that belongs elsewhere
+- In serialized telemetry configuration, the `use_` prefix is reserved for boolean fields that track whether a complex configuration option is used (e.g. `use_allowed_tracing_urls`)
 
 ### Auto-Generated Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ For deeper context, see:
 
 - `addTelemetryUsage` tracks **which public API the customer calls and which options they pass** (static call-site information)
 - Do NOT include runtime state analysis (e.g., whether a view was active, whether a value was overwritten) in telemetry usage — that belongs elsewhere
-- In serialized telemetry configuration, the `use_` prefix is reserved for boolean fields that track whether a complex configuration option is used (e.g. `use_allowed_tracing_urls`)
+- In serialized telemetry configuration, the `use_` prefix is reserved for boolean fields that track the usage of a configuration option that might contain customer data (e.g. `use_allowed_tracing_urls`)
 
 ### Auto-Generated Files
 

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -473,7 +473,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
       /**
        * How the SDK tracks resource request/response headers
        */
-      use_track_resource_headers?: 'default_headers' | 'custom'
+      track_resource_headers?: 'default_headers' | 'custom'
       /**
        * Whether the beta encode cookie options is enabled
        */
@@ -985,6 +985,6 @@ export interface AndroidNetworkInstrumentation {
   /**
    * The network instrumentation API used
    */
-  type: 'CRONET' | 'OKHTTP'
+  type: 'CRONET' | 'OKHTTP' | 'LEGACY_OKHTTP'
   [k: string]: unknown
 }

--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -471,6 +471,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       propagate_trace_baggage?: boolean
       /**
+       * How the SDK tracks resource request/response headers
+       */
+      use_track_resource_headers?: 'default_headers' | 'custom'
+      /**
        * Whether the beta encode cookie options is enabled
        */
       beta_encode_cookie_options?: boolean

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -635,6 +635,43 @@ describe('validateAndBuildRumConfiguration', () => {
         expect(serializeRumConfiguration(wrongTracingConfig).selected_tracing_propagators).toEqual([])
       })
     })
+
+    describe('use_track_resource_headers telemetry', () => {
+      it('should omit use_track_resource_headers when trackResourceHeaders is undefined or false', () => {
+        expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).use_track_resource_headers).toBeUndefined()
+        expect(
+          serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: false })
+            .use_track_resource_headers
+        ).toBeUndefined()
+      })
+
+      it('should set use_track_resource_headers to default_headers when trackResourceHeaders is true', () => {
+        expect(
+          serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: true })
+            .use_track_resource_headers
+        ).toBe('default_headers')
+      })
+
+      it('should set use_track_resource_headers to custom when trackResourceHeaders is an array', () => {
+        expect(
+          serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: [] })
+            .use_track_resource_headers
+        ).toBe('custom')
+        expect(
+          serializeRumConfiguration({
+            ...DEFAULT_INIT_CONFIGURATION,
+            trackResourceHeaders: [{ name: 'x-foo' }],
+          }).use_track_resource_headers
+        ).toBe('custom')
+      })
+
+      it('should omit use_track_resource_headers when trackResourceHeaders has an unexpected type', () => {
+        expect(
+          serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: 42 as any })
+            .use_track_resource_headers
+        ).toBeUndefined()
+      })
+    })
   })
 
   describe('workerUrl', () => {
@@ -812,19 +849,23 @@ describe('serializeRumConfiguration', () => {
         ? `use_${CamelToSnakeCase<Key>}`
         : Key extends 'trackLongTasks'
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
-          : // The following options are not reported as telemetry. Please avoid adding more of them.
-            // TODO: Add betaTrackActionsInShadowDom and trackResourceHeaders to rum-events-format telemetry schema and remove from this exclusion
-            Key extends 'applicationId' | 'subdomain' | 'betaTrackActionsInShadowDom' | 'trackResourceHeaders'
-            ? never
-            : CamelToSnakeCase<Key>
+          : Key extends 'trackResourceHeaders'
+            ? 'use_track_resource_headers'
+            : // The following options are not reported as telemetry. Please avoid adding more of them.
+              // TODO: Add betaTrackActionsInShadowDom to rum-events-format telemetry schema and remove from this exclusion
+              Key extends 'applicationId' | 'subdomain' | 'betaTrackActionsInShadowDom'
+              ? never
+              : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an
     // object containing all expected properties.
-    const serializedConfiguration: ExtractTelemetryConfiguration<
+    const serializedConfiguration = serializeRumConfiguration(
+      exhaustiveRumInitConfiguration
+    ) as ExtractTelemetryConfiguration<
       | MapRumInitConfigurationKey<keyof RumInitConfiguration>
       | 'selected_tracing_propagators'
       | 'use_track_graph_ql_payload'
       | 'use_track_graph_ql_response_errors'
-    > = serializeRumConfiguration(exhaustiveRumInitConfiguration)
+    >
 
     expect(serializedConfiguration).toEqual({
       ...SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION,
@@ -855,6 +896,7 @@ describe('serializeRumConfiguration', () => {
       remote_configuration_id: '123',
       use_remote_configuration_proxy: true,
       profiling_sample_rate: 42,
+      use_track_resource_headers: 'default_headers',
     })
   })
 })

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -846,26 +846,23 @@ describe('serializeRumConfiguration', () => {
             | 'excludedActivityUrls'
             | 'remoteConfigurationProxy'
             | 'allowedGraphQlUrls'
+            | 'trackResourceHeaders'
         ? `use_${CamelToSnakeCase<Key>}`
         : Key extends 'trackLongTasks'
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
-          : Key extends 'trackResourceHeaders'
-            ? 'use_track_resource_headers'
-            : // The following options are not reported as telemetry. Please avoid adding more of them.
-              // TODO: Add betaTrackActionsInShadowDom to rum-events-format telemetry schema and remove from this exclusion
-              Key extends 'applicationId' | 'subdomain' | 'betaTrackActionsInShadowDom'
-              ? never
-              : CamelToSnakeCase<Key>
+          : // The following options are not reported as telemetry. Please avoid adding more of them.
+            // TODO: Add betaTrackActionsInShadowDom to rum-events-format telemetry schema and remove from this exclusion
+            Key extends 'applicationId' | 'subdomain' | 'betaTrackActionsInShadowDom'
+            ? never
+            : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an
     // object containing all expected properties.
-    const serializedConfiguration = serializeRumConfiguration(
-      exhaustiveRumInitConfiguration
-    ) as ExtractTelemetryConfiguration<
+    const serializedConfiguration: ExtractTelemetryConfiguration<
       | MapRumInitConfigurationKey<keyof RumInitConfiguration>
       | 'selected_tracing_propagators'
       | 'use_track_graph_ql_payload'
       | 'use_track_graph_ql_response_errors'
-    >
+    > = serializeRumConfiguration(exhaustiveRumInitConfiguration)
 
     expect(serializedConfiguration).toEqual({
       ...SERIALIZED_EXHAUSTIVE_INIT_CONFIGURATION,

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -636,39 +636,38 @@ describe('validateAndBuildRumConfiguration', () => {
       })
     })
 
-    describe('use_track_resource_headers telemetry', () => {
-      it('should omit use_track_resource_headers when trackResourceHeaders is undefined or false', () => {
-        expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).use_track_resource_headers).toBeUndefined()
+    describe('track_resource_headers telemetry', () => {
+      it('should omit track_resource_headers when trackResourceHeaders is undefined or false', () => {
+        expect(serializeRumConfiguration(DEFAULT_INIT_CONFIGURATION).track_resource_headers).toBeUndefined()
         expect(
           serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: false })
-            .use_track_resource_headers
+            .track_resource_headers
         ).toBeUndefined()
       })
 
-      it('should set use_track_resource_headers to default_headers when trackResourceHeaders is true', () => {
+      it('should set track_resource_headers to default_headers when trackResourceHeaders is true', () => {
         expect(
           serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: true })
-            .use_track_resource_headers
+            .track_resource_headers
         ).toBe('default_headers')
       })
 
-      it('should set use_track_resource_headers to custom when trackResourceHeaders is an array', () => {
+      it('should set track_resource_headers to custom when trackResourceHeaders is an array', () => {
         expect(
-          serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: [] })
-            .use_track_resource_headers
+          serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: [] }).track_resource_headers
         ).toBe('custom')
         expect(
           serializeRumConfiguration({
             ...DEFAULT_INIT_CONFIGURATION,
             trackResourceHeaders: [{ name: 'x-foo' }],
-          }).use_track_resource_headers
+          }).track_resource_headers
         ).toBe('custom')
       })
 
-      it('should omit use_track_resource_headers when trackResourceHeaders has an unexpected type', () => {
+      it('should omit track_resource_headers when trackResourceHeaders has an unexpected type', () => {
         expect(
           serializeRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackResourceHeaders: 42 as any })
-            .use_track_resource_headers
+            .track_resource_headers
         ).toBeUndefined()
       })
     })
@@ -846,7 +845,6 @@ describe('serializeRumConfiguration', () => {
             | 'excludedActivityUrls'
             | 'remoteConfigurationProxy'
             | 'allowedGraphQlUrls'
-            | 'trackResourceHeaders'
         ? `use_${CamelToSnakeCase<Key>}`
         : Key extends 'trackLongTasks'
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
@@ -893,7 +891,7 @@ describe('serializeRumConfiguration', () => {
       remote_configuration_id: '123',
       use_remote_configuration_proxy: true,
       profiling_sample_rate: 42,
-      use_track_resource_headers: 'default_headers',
+      track_resource_headers: 'default_headers',
     })
   })
 })

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -628,6 +628,17 @@ function hasGraphQlResponseErrorsTracking(allowedGraphQlUrls: RumInitConfigurati
   )
 }
 
+function getTrackResourceHeadersTelemetryValue(
+  trackResourceHeaders: RumInitConfiguration['trackResourceHeaders']
+): 'default_headers' | 'custom' | undefined {
+  if (trackResourceHeaders === true) {
+    return 'default_headers'
+  }
+  if (Array.isArray(trackResourceHeaders)) {
+    return 'custom'
+  }
+}
+
 export function serializeRumConfiguration(configuration: RumInitConfiguration) {
   const baseSerializedConfiguration = serializeConfiguration(configuration)
 
@@ -662,6 +673,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
     remote_configuration_id: configuration.remoteConfigurationId,
     profiling_sample_rate: configuration.profilingSampleRate,
     use_remote_configuration_proxy: !!configuration.remoteConfigurationProxy,
+    use_track_resource_headers: getTrackResourceHeadersTelemetryValue(configuration.trackResourceHeaders),
     ...baseSerializedConfiguration,
   } satisfies RawTelemetryConfiguration
 }

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -642,7 +642,7 @@ function getTrackResourceHeadersTelemetryValue(
 export function serializeRumConfiguration(configuration: RumInitConfiguration) {
   const baseSerializedConfiguration = serializeConfiguration(configuration)
 
-  // `use_` prefix is for boolean telemetry options that track complex configuration options
+  // `use_` prefix is for telemetry options that track usage of a configuration option as a boolean to avoid capturing customer data
   return {
     session_replay_sample_rate: configuration.sessionReplaySampleRate,
     start_session_replay_recording_manually: configuration.startSessionReplayRecordingManually,

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -642,6 +642,7 @@ function getTrackResourceHeadersTelemetryValue(
 export function serializeRumConfiguration(configuration: RumInitConfiguration) {
   const baseSerializedConfiguration = serializeConfiguration(configuration)
 
+  // `use_` prefix is for boolean telemetry options that track complex configuration options
   return {
     session_replay_sample_rate: configuration.sessionReplaySampleRate,
     start_session_replay_recording_manually: configuration.startSessionReplayRecordingManually,
@@ -673,7 +674,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
     remote_configuration_id: configuration.remoteConfigurationId,
     profiling_sample_rate: configuration.profilingSampleRate,
     use_remote_configuration_proxy: !!configuration.remoteConfigurationProxy,
-    use_track_resource_headers: getTrackResourceHeadersTelemetryValue(configuration.trackResourceHeaders),
+    track_resource_headers: getTrackResourceHeadersTelemetryValue(configuration.trackResourceHeaders),
     ...baseSerializedConfiguration,
   } satisfies RawTelemetryConfiguration
 }

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -1732,6 +1732,8 @@ export interface ViewProperties {
       | 'fragment_redisplay'
       | 'view_controller_display'
       | 'view_controller_redisplay'
+      | 'session_renewal'
+      | 'bf_cache'
     /**
      * Time spent on the view in ns
      */

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -862,7 +862,7 @@ export type RumResourceEvent = CommonProperties &
         /**
          * HTTP headers of the resource request
          */
-        readonly headers?: {
+        headers?: {
           [k: string]: string
         }
         [k: string]: unknown
@@ -874,7 +874,7 @@ export type RumResourceEvent = CommonProperties &
         /**
          * HTTP headers of the resource response
          */
-        readonly headers?: {
+        headers?: {
           [k: string]: string
         }
         [k: string]: unknown


### PR DESCRIPTION
## Motivation

We want to track how customers configure `trackResourceHeaders` (default preset vs custom array) to understand adoption patterns. This adds a `use_track_resource_headers` field to the telemetry configuration event.

## Changes

- Bump `rum-events-format` submodule for the new `use_track_resource_headers` telemetry configuration schema field
- Regenerate telemetry event types
- Add `getTrackResourceHeadersTelemetryValue` helper that maps the init configuration value:
  - `trackResourceHeaders: true` → `"default_headers"`
  - `trackResourceHeaders: [...]` (array) → `"custom"`
  - `undefined` / `false` → omitted from the telemetry event
- Wire the helper into `serializeRumConfiguration`

## Test instructions

1. Start the dev server:

```bash
yarn dev-server start
```

2. Create `sandbox/test-track-resource-headers-telemetry.html`:

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>Test trackResourceHeaders telemetry</title>
    <script src="/datadog-rum.js"></script>
    <script>
      DD_RUM.init({
        clientToken: 'xxx',
        applicationId: 'xxx',
        proxy: '/proxy',
        trackResourceHeaders: true,
      })
    </script>
  </head>
  <body>
    <p>trackResourceHeaders: true</p>
  </body>
</html>
```

3. Open the page and flush events:

```bash
yarn dev-server intake clear
agent-browser open http://localhost:8081/test-track-resource-headers-telemetry.html
agent-browser tab new
```

4. Verify the telemetry configuration event contains `use_track_resource_headers: "default_headers"`:

```bash
yarn dev-server intake telemetry-configuration-events --format json | jq '.[0].telemetry.configuration.use_track_resource_headers'
# Expected: "default_headers"
```

5. To test the `custom` case, change the init config to `trackResourceHeaders: [{ name: 'x-custom' }]`, close the browser, clear intake, and repeat steps 3-4. Expected value: `"custom"`.

6. Clean up:

```bash
yarn dev-server stop
rm sandbox/test-track-resource-headers-telemetry.html
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file