### PR TITLE
✅ improve E2E test reliability on BrowserStack

### DIFF
--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -457,8 +457,10 @@ function tearDownPassedTest({ intakeRegistry, withBrowserLogs }: TestContext) {
   })
 }
 
-async function tearDownTest({ flushEvents, deleteAllCookies }: TestContext) {
-  await flushEvents()
+async function tearDownTest({ page, flushEvents, deleteAllCookies }: TestContext) {
+  if (!page.url().includes('/flush')) {
+    await flushEvents()
+  }
   await deleteAllCookies()
 
   if (test.info().status === 'passed' && test.info().retry > 0) {

--- a/test/e2e/lib/framework/flushEvents.ts
+++ b/test/e2e/lib/framework/flushEvents.ts
@@ -4,23 +4,6 @@ import { waitForRequests } from './waitForRequests'
 
 export async function flushEvents(page: Page) {
   await waitForRequests(page)
-
   const servers = await getTestServers()
-
-  // TODO: use /empty instead of /ok
-  //
-  // The RUM session replay recorder code uses a Web Worker to format the request data to be sent to
-  // the intake.  Because all Worker communication is asynchronous, it cannot send its request
-  // during the "beforeunload" event, but a few milliseconds after. Thus, when navigating, if the
-  // future page loads very quickly, the page unload may occur before the recorder has time to send
-  // its last segment.
-  //
-  // To avoid flaky e2e tests, we currently use /ok with a duration, to allow a bit more time to
-  // send requests to intakes when the "beforeunload" event is dispatched.
-  //
-  // The issue mainly occurs with local e2e tests (not browserstack), because the network latency is
-  // very low (same machine), so the request resolves very quickly. In real life conditions, this
-  // issue is mitigated, because requests will likely take a few milliseconds to reach the server.
-  await page.goto(`${servers.base.origin}/ok?duration=200`)
-  await waitForServersIdle()
+  await Promise.all([waitForServersIdle(), page.goto(`${servers.base.origin}/flush`)])
 }

--- a/test/e2e/lib/framework/httpServers.ts
+++ b/test/e2e/lib/framework/httpServers.ts
@@ -43,8 +43,11 @@ export async function getTestServers() {
 }
 
 export async function waitForServersIdle() {
+  // Wait for `idleWaitDuration` ms before checking idle state, to account for requests that may
+  // still be in-flight from the browser and haven't reached the server yet.
+  await new Promise((resolve) => setTimeout(resolve, idleWaitDuration))
   const servers = await getTestServers()
-  return Promise.all([servers.base.waitForIdle(), servers.crossOrigin.waitForIdle(), servers.intake.waitForIdle()])
+  await Promise.all([servers.base.waitForIdle(), servers.crossOrigin.waitForIdle(), servers.intake.waitForIdle()])
 }
 
 async function createServer<App extends ServerApp>(): Promise<Server<App>> {

--- a/test/e2e/lib/framework/httpServers.ts
+++ b/test/e2e/lib/framework/httpServers.ts
@@ -1,5 +1,7 @@
 import * as http from 'http'
 import type { AddressInfo } from 'net'
+import { test } from '@playwright/test'
+import type { Browser } from '@playwright/test'
 import { getIp } from '../../../envUtils'
 
 const MAX_SERVER_CREATION_RETRY = 5
@@ -54,6 +56,9 @@ async function createServer<App extends ServerApp>(): Promise<Server<App>> {
   server.on('request', (req: http.IncomingMessage, res: http.ServerResponse) => {
     if (serverApp) {
       serverApp(req, res)
+    } else {
+      res.writeHead(202)
+      res.end()
     }
   })
 
@@ -109,7 +114,25 @@ function createServerIdleWaiter(server: http.Server) {
   return () => idleWaiter.idlePromise
 }
 
-const IDLE_WAIT_DURATION = 500
+let idleWaitDuration = 500
+
+test.beforeAll(async ({ browser }) => {
+  const latency = await measureServerLatency(browser)
+  idleWaitDuration = Math.max(500, latency * 1.5)
+  console.log(`Server latency: ${latency}ms`)
+})
+
+async function measureServerLatency(browser: Browser): Promise<number> {
+  // We measure the round-trip time to the test server to calibrate how long we wait after the
+  // last pending request before considering the server idle. In BrowserStack, the browser runs
+  // remotely, so this latency can be significant.
+  const { intake: server } = await getTestServers()
+  const page = await browser.newPage()
+  const start = Date.now()
+  await page.goto(server.origin)
+  return Date.now() - start
+}
+
 function createIdleWaiter() {
   let idlePromise = Promise.resolve()
 
@@ -139,7 +162,7 @@ function createIdleWaiter() {
           waitTimeoutId = setTimeout(() => {
             resolveIdlePromise!()
             resolveIdlePromise = undefined
-          }, IDLE_WAIT_DURATION)
+          }, idleWaitDuration)
         }
       })
     },

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -265,7 +265,8 @@ export function microfrontendSetup(options: SetupOptions, servers: Servers) {
 
 function basePage({ header, body, footer }: { header?: string; body?: string; footer?: string }) {
   // prettier-ignore
-  return html`<!doctype html><html><head>${header || ''}</head><body>${body || ''}</body>${footer || ''}</html>`
+  // The empty favicon avoids a /favicon.ico request from the browser.
+  return html`<!doctype html><html><head><link rel="icon" href="data:,"/>${header || ''}</head><body>${body || ''}</body>${footer || ''}</html>`
 }
 
 // html is a simple template string tag to allow prettier to format various setups as HTML

--- a/test/e2e/lib/framework/serverApps/mock.ts
+++ b/test/e2e/lib/framework/serverApps/mock.ts
@@ -92,6 +92,14 @@ export function createMockServerApp(servers: Servers, setup: string, setupOption
     res.header('content-type', 'text/css').end()
   })
 
+  app.get('/flush', (_req, res) => {
+    // The RUM session replay recorder uses a Web Worker to format request data, so it cannot send
+    // its last segment during the "beforeunload" event — only a few milliseconds after. If the next
+    // page loads too quickly, the segment may be lost. /flush responds after 200ms to give the
+    // recorder time to send, and returns HTML with an empty favicon to avoid a spurious favicon request.
+    setTimeout(() => res.send('<!doctype html><html><head><link rel="icon" href="data:,"/></head></html>'), 200)
+  })
+
   app.all('/ok', (req, res) => {
     // Express will automatically append charset to the Content-Type header
     res.header('Content-Type', 'text/plain')

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -23,6 +23,7 @@ export const config: Config = {
   tsconfig: './tsconfig.json',
   fullyParallel: true,
   forbidOnly: isCi,
+  maxFailures: isCi ? 1 : 0,
   retries: isCi ? 2 : 0,
   workers: 5,
   reporter: reporters,


### PR DESCRIPTION
## Motivation

E2E tests running on BrowserStack have been flaky due to high network latency between the remote browser and the local test server. Several issues compounded this:

- The idle wait duration was fixed at 500ms regardless of actual latency, causing `waitForServersIdle()` to return before all requests had arrived
- Requests sent by the browser could still be in-flight when `waitForServersIdle()` was called, making it return immediately despite pending network activity
- The browser was issuing spurious `/favicon.ico` requests that added noise to server idle tracking

## Changes

- Measure browser-to-server latency once per worker before tests run, and use `Math.max(500, latency * 1.5)` as the idle wait duration
- `waitForServersIdle()` now waits `idleWaitDuration` ms upfront to let in-flight requests arrive before checking idle state
- Add a dedicated `/flush` route (replaces `/ok?duration=200`) that delays 200ms and returns HTML — used when navigating away to flush SDK events, including session replay Web Worker segments
- Suppress spurious `/favicon.ico` requests by embedding an empty favicon in all test pages
- Skip redundant `flushEvents()` in teardown when the page is already on `/flush`
- Stop the CI test run after the first failure (post-retries) to save time

## Test instructions

Run the E2E tests on BrowserStack and verify that previously flaky tests pass consistently.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file