### PR TITLE
RUM-15488: add US2_FED intake site

### DIFF
--- a/packages/core/src/domain/intakeSites.ts
+++ b/packages/core/src/domain/intakeSites.ts
@@ -4,6 +4,7 @@ export type Site =
   | 'us5.datadoghq.com'
   | 'datadoghq.eu'
   | 'ddog-gov.com'
+  | 'us2.ddog-gov.com'
   | 'ap1.datadoghq.com'
   | 'ap2.datadoghq.com'
   | (string & {})
@@ -13,6 +14,7 @@ export const INTAKE_SITE_FED_STAGING: Site = 'dd0g-gov.com'
 export const INTAKE_SITE_US1: Site = 'datadoghq.com'
 export const INTAKE_SITE_EU1: Site = 'datadoghq.eu'
 export const INTAKE_SITE_US1_FED: Site = 'ddog-gov.com'
+export const INTAKE_SITE_US2_FED: Site = 'us2.ddog-gov.com'
 
 export const PCI_INTAKE_HOST_US1 = 'pci.browser-intake-datadoghq.com'
 export const INTAKE_URL_PARAMETERS = ['ddsource', 'dd-api-key', 'dd-request-id']

--- a/packages/core/src/domain/telemetry/telemetry.spec.ts
+++ b/packages/core/src/domain/telemetry/telemetry.spec.ts
@@ -4,7 +4,7 @@ import { callMonitored } from '../../tools/monitor'
 import type { ExperimentalFeature } from '../../tools/experimentalFeatures'
 import { addExperimentalFeatures } from '../../tools/experimentalFeatures'
 import { validateAndBuildConfiguration, type Configuration } from '../configuration'
-import { INTAKE_SITE_US1_FED, INTAKE_SITE_US1 } from '../intakeSites'
+import { INTAKE_SITE_US1_FED, INTAKE_SITE_US2_FED, INTAKE_SITE_US1 } from '../intakeSites'
 import {
   setNavigatorOnLine,
   setNavigatorConnection,
@@ -424,6 +424,7 @@ describe('telemetry', () => {
   describe('excluded sites', () => {
     ;[
       { site: INTAKE_SITE_US1_FED, enabled: false },
+      { site: INTAKE_SITE_US2_FED, enabled: false },
       { site: INTAKE_SITE_US1, enabled: true },
     ].forEach(({ site, enabled }) => {
       it(`should be ${enabled ? 'enabled' : 'disabled'} on ${site}`, async () => {

--- a/packages/core/src/domain/telemetry/telemetry.ts
+++ b/packages/core/src/domain/telemetry/telemetry.ts
@@ -5,7 +5,7 @@ import { toStackTraceString } from '../../tools/stackTrace/handlingStack'
 import { getExperimentalFeatures } from '../../tools/experimentalFeatures'
 import type { Configuration } from '../configuration'
 import { buildTags } from '../tags'
-import { INTAKE_SITE_STAGING, INTAKE_SITE_US1_FED } from '../intakeSites'
+import { INTAKE_SITE_STAGING, INTAKE_SITE_US1_FED, INTAKE_SITE_US2_FED } from '../intakeSites'
 import { BufferedObservable, Observable } from '../../tools/observable'
 import { clocksNow } from '../../tools/utils/timeUtils'
 import { displayIfDebugEnabled, startMonitorErrorCollection } from '../../tools/monitor'
@@ -73,7 +73,7 @@ export const enum TelemetryMetrics {
 
 const METRIC_SAMPLE_RATE = 1
 
-const TELEMETRY_EXCLUDED_SITES: string[] = [INTAKE_SITE_US1_FED]
+const TELEMETRY_EXCLUDED_SITES: string[] = [INTAKE_SITE_US1_FED, INTAKE_SITE_US2_FED]
 const MAX_TELEMETRY_EVENTS_PER_PAGE = 15
 
 let telemetryObservable: BufferedObservable<{ rawEvent: RawTelemetryEvent; metricName?: string }> | undefined


### PR DESCRIPTION
## What does this PR do?
Add `us2.ddog-gov.com` as a new `INTAKE_SITE_US2_FED` site. Exclude it from telemetry, matching the existing US1_FED behavior.

Informed from Fabric team that `browser-intake-us2-ddog-gov.com` is intake URL for RUM.

## References
- JIRA: [RUM-15488](https://datadoghq.atlassian.net/browse/RUM-15488)

[RUM-15488]: https://datadoghq.atlassian.net/browse/RUM-15488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ