### PR TITLE
🐛 Handle null deadline in taskQueue requestIdleCallback

### DIFF
--- a/packages/core/src/tools/taskQueue.spec.ts
+++ b/packages/core/src/tools/taskQueue.spec.ts
@@ -1,4 +1,4 @@
-import { mockClock, mockRequestIdleCallback } from '../../test'
+import { mockClock, mockRequestIdleCallback, registerCleanupTask } from '../../test'
 import { createTaskQueue, MAX_EXECUTION_TIME_ON_TIMEOUT } from './taskQueue'
 
 describe('createTaskQueue', () => {
@@ -57,4 +57,37 @@ describe('createTaskQueue', () => {
     expect(task2).toHaveBeenCalled()
     expect(task3).not.toHaveBeenCalled()
   })
+
+  it('runs pending tasks when requestIdleCallback invokes the callback with no deadline', () => {
+    const clock = mockClock()
+    replaceRequestIdleCallbackWithPolyfillShim()
+
+    const taskQueue = createTaskQueue()
+    const task1 = jasmine.createSpy('task1')
+    const task2 = jasmine.createSpy('task2')
+    const task3 = jasmine.createSpy('task3')
+
+    taskQueue.push(task1)
+    taskQueue.push(task2)
+    taskQueue.push(task3)
+
+    clock.tick(0)
+
+    expect(task1).toHaveBeenCalled()
+    expect(task2).toHaveBeenCalled()
+    expect(task3).toHaveBeenCalled()
+  })
 })
+
+function replaceRequestIdleCallbackWithPolyfillShim() {
+  const originalRequestIdleCallback = window.requestIdleCallback
+  const originalCancelIdleCallback = window.cancelIdleCallback
+  // Reproduces `(cb) => setTimeout(cb, 0)` — invokes the callback with no argument.
+  window.requestIdleCallback = ((cb: () => void) =>
+    setTimeout(() => cb(), 0) as unknown as number) as typeof window.requestIdleCallback
+  window.cancelIdleCallback = ((id: number) => clearTimeout(id)) as typeof window.cancelIdleCallback
+  registerCleanupTask(() => {
+    window.requestIdleCallback = originalRequestIdleCallback
+    window.cancelIdleCallback = originalCancelIdleCallback
+  })
+}

--- a/packages/core/src/tools/taskQueue.ts
+++ b/packages/core/src/tools/taskQueue.ts
@@ -28,9 +28,11 @@ type Task = () => void
 export function createTaskQueue(): TaskQueue {
   const pendingTasks: Task[] = []
 
-  function run(deadline: IdleDeadline) {
+  function run(deadline: IdleDeadline | null) {
     let executionTimeRemaining: () => number
-    if (deadline.didTimeout) {
+    // `deadline` can be null when `requestIdleCallback` is replaced by a page-injected polyfill
+    // (e.g. `setTimeout(cb, 0)` in some WKWebViews) that invokes the callback with no argument.
+    if (!deadline || deadline.didTimeout) {
       const start = performance.now()
       executionTimeRemaining = () => MAX_EXECUTION_TIME_ON_TIMEOUT - (performance.now() - start)
     } else {


### PR DESCRIPTION
## Motivation

Some page-injected `requestIdleCallback` polyfills (e.g. `setTimeout(cb, 0)` in some WKWebViews) invoke the callback without an `IdleDeadline` argument. The current implementation assumes `deadline` is always defined and throws when accessing `deadline.didTimeout`, breaking the task queue.

Observed in SDK self-telemetry (US3, last 7d): ~89k `TypeError`s across 6 customer orgs, 100% WebKit (iOS Mobile Safari, desktop Safari, Chrome Mobile iOS, and in-app WKWebViews), ~99.8% on SDK v6.32.0.

Sample stack trace:

```
TypeError: null is not an object (evaluating 'e.didTimeout')
  at e @ https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum.js:1:73320
  at u @ https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum.js:1:12650
  at <anonymous> @ https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum.js:1:12602
```

Mapped to source: \`taskQueue.ts\` \`run()\` → \`monitor.ts\` \`callMonitored\` → \`monitor.ts\` wrapper.

## Changes

- Accept \`IdleDeadline | null\` in the task queue \`run\` callback
- Treat a missing deadline the same as \`didTimeout\` (fall back to \`MAX_EXECUTION_TIME_ON_TIMEOUT\` budget)
- Add unit test covering the null-deadline case

## Test instructions

- \`yarn test:unit --spec packages/core/src/tools/taskQueue.spec.ts\`
- Manually: override \`window.requestIdleCallback\` with \`(cb) => setTimeout(cb, 0)\` before SDK init and verify no runtime error.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file