### PR TITLE
Document optional browser debugger version

### DIFF
--- a/packages/debugger/README.md
+++ b/packages/debugger/README.md
@@ -17,9 +17,11 @@ datadogDebugger.init({
   site: '<DATADOG_SITE>',
   service: 'my-web-application',
   //  env: 'production',
-  //  version: '1.0.0',
+  //  version: 'my-deployed-build-version',
 })
 ```
+
+If provided, `version` should be set to the immutable deployed browser build identifier used for source map upload and browser build resolution. If omitted, debugger delivery and snapshots still work, but browser build lookup and source-aware resolution may be unavailable.
 
 If [Datadog RUM][3] is also initialized on the page, debugger snapshots automatically include RUM context (session, view, user action) without any additional configuration.
 

--- a/packages/debugger/src/entries/main.ts
+++ b/packages/debugger/src/entries/main.ts
@@ -88,6 +88,7 @@ export interface DebuggerPublicApi extends PublicApi {
    *   service: 'my-app',
    *   site: 'datadoghq.com',
    *   env: 'production'
+   *   version: 'my-deployed-build-version',
    * })
    * ```
    */


### PR DESCRIPTION
## Motivation

Browser Live Debugger can use `version` to resolve browser builds back to uploaded sourcemap metadata, but `version` should remain optional so the product still works when applications do not provide it. The SDK docs and API examples should make that graceful-degradation behavior explicit.

## Changes

- document `version` as optional in the Browser Debugger package
- clarify that, when provided, `version` should be the immutable deployed browser build identifier
- clarify that omitting `version` still allows debugger delivery and snapshots to work, but browser build lookup and source-aware resolution may be unavailable
- update the `datadogDebugger.init()` example in the public API docs to reflect the optional `version` field

## Test instructions

- Review the updated Browser Debugger README and API docs in:
  - `packages/debugger/README.md`
  - `packages/debugger/src/entries/main.ts`
- Confirm the docs now describe:
  - `version` as optional
  - the recommended meaning of `version` when present
  - graceful degradation when `version` is absent

## Checklist

- ~Tested locally~
- ~Tested on staging~
- ~Added unit tests for this change.~
- ~Added e2e/integration tests for this change.~
- [x] Updated documentation and/or relevant AGENTS.md file
