### PR TITLE
Tighten Live Debugger global hook typing

### DIFF
--- a/packages/debugger/src/entries/main.ts
+++ b/packages/debugger/src/entries/main.ts
@@ -13,6 +13,13 @@ import { startDeliveryApiPolling } from '../domain/deliveryApi'
 import { getProbes } from '../domain/probes'
 import { startDebuggerBatch } from '../transport/startDebuggerBatch'
 
+type DebuggerInstrumentationGlobal = typeof globalThis & {
+  $dd_entry?: typeof onEntry
+  $dd_return?: typeof onReturn
+  $dd_throw?: typeof onThrow
+  $dd_probes?: typeof getProbes
+}
+
 /**
  * Configuration options for initializing the Live Debugger SDK
  */
@@ -98,10 +105,11 @@ function makeDebuggerPublicApi(): DatadogDebugger {
 
       // Expose internal hooks on globalThis for instrumented code
       if (typeof globalThis !== 'undefined') {
-        ;(globalThis as any).$dd_entry = onEntry
-        ;(globalThis as any).$dd_return = onReturn
-        ;(globalThis as any).$dd_throw = onThrow
-        ;(globalThis as any).$dd_probes = getProbes
+        const debuggerGlobal = globalThis as DebuggerInstrumentationGlobal
+        debuggerGlobal.$dd_entry = onEntry
+        debuggerGlobal.$dd_return = onReturn
+        debuggerGlobal.$dd_throw = onThrow
+        debuggerGlobal.$dd_probes = getProbes
       }
 
       startDeliveryApiPolling({


### PR DESCRIPTION
## Motivation

Avoid unsafe `any` casts in the Live Debugger global hook setup.

## Changes

Replace `any` casts used when assigning `$dd_entry`, `$dd_return`, `$dd_throw`, and `$dd_probes` on `globalThis` with a small explicit `DebuggerInstrumentationGlobal` type in `packages/debugger/src/entries/main.ts`.

## Test instructions

1. Inspect `packages/debugger/src/entries/main.ts`.
2. Confirm the debugger globals are still assigned during `init()`.
3. Confirm the change is type-only and does not alter the runtime hook wiring.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
