### PR TITLE
⚗️ Default debugger version and embed build identity in snapshots

### DIFF
--- a/packages/debugger/README.md
+++ b/packages/debugger/README.md
@@ -16,9 +16,13 @@ datadogDebugger.init({
   site: '<DATADOG_SITE>',
   service: 'my-web-application',
   //  env: 'production',
-  //  version: '1.0.0',
+  //  version: 'my-deployed-build-version',
 })
 ```
+
+When you also use the Datadog Live Debugger build plugin, `init().version` defaults to the build-time `liveDebugger.version` metadata injected into the bundle. If you pass both values explicitly and they differ, the SDK keeps the `init()` value and logs a warning.
+
+If provided, `version` should be set to the immutable deployed browser build identifier used for source map upload and browser build resolution. If omitted, debugger delivery and snapshots still work, but browser build lookup and source-aware resolution may be unavailable.
 
 ## Troubleshooting
 

--- a/packages/debugger/src/domain/api.ts
+++ b/packages/debugger/src/domain/api.ts
@@ -44,7 +44,7 @@ export function resetDebuggerTransport(): void {
  * @param self - The 'this' context
  * @param args - Function arguments
  */
-export function onEntry(probes: InitializedProbe[], self: any, args: Record<string, any>): void {
+export function onEntry(probes: InitializedProbe[], self: any, args: Record<string, any> = {}): void {
   const start = performance.now()
   const captureCtx: CaptureContext = { deadline: start + SNAPSHOT_TIMEOUT_MS, timedOut: false }
 
@@ -125,8 +125,8 @@ export function onReturn(
   probes: InitializedProbe[],
   value: any,
   self: any,
-  args: Record<string, any>,
-  locals: Record<string, any>
+  args: Record<string, any> = {},
+  locals: Record<string, any> = {}
 ): any {
   const end = performance.now()
   const captureCtx: CaptureContext = { deadline: performance.now() + SNAPSHOT_TIMEOUT_MS, timedOut: false }
@@ -195,7 +195,7 @@ export function onReturn(
  * @param self - The 'this' context
  * @param args - Function arguments
  */
-export function onThrow(probes: InitializedProbe[], error: Error, self: any, args: Record<string, any>): void {
+export function onThrow(probes: InitializedProbe[], error: Error, self: any, args: Record<string, any> = {}): void {
   const end = performance.now()
   const captureCtx: CaptureContext = { deadline: performance.now() + SNAPSHOT_TIMEOUT_MS, timedOut: false }
 

--- a/packages/debugger/src/entries/main.spec.ts
+++ b/packages/debugger/src/entries/main.spec.ts
@@ -1,6 +1,30 @@
+import { display } from '@datadog/browser-core'
+import { registerCleanupTask, replaceMockableWithSpy } from '@datadog/browser-core/test'
+import { initDebuggerTransport } from '../domain/api'
+import { startDeliveryApiPolling } from '../domain/deliveryApi'
+import { startDebuggerBatch } from '../transport/startDebuggerBatch'
+import type { BrowserWindow } from './main'
 import { datadogDebugger } from './main'
 
 describe('datadogDebugger', () => {
+  const browserWindow: BrowserWindow = window
+
+  beforeEach(() => {
+    delete browserWindow.__DD_LIVE_DEBUGGER_BUILD__
+    delete browserWindow.$dd_entry
+    delete browserWindow.$dd_return
+    delete browserWindow.$dd_throw
+    delete browserWindow.$dd_probes
+
+    registerCleanupTask(() => {
+      delete browserWindow.__DD_LIVE_DEBUGGER_BUILD__
+      delete browserWindow.$dd_entry
+      delete browserWindow.$dd_return
+      delete browserWindow.$dd_throw
+      delete browserWindow.$dd_probes
+    })
+  })
+
   it('should only expose init, version, and onReady', () => {
     expect(datadogDebugger).toEqual({
       init: jasmine.any(Function),
@@ -8,4 +32,67 @@ describe('datadogDebugger', () => {
       onReady: jasmine.any(Function),
     })
   })
+
+  it('should default the init version from build-plugin metadata', async () => {
+    browserWindow.__DD_LIVE_DEBUGGER_BUILD__ = { version: 'build-version' }
+    replaceMockableWithSpy(startDebuggerBatch).and.callFake(() => ({
+      flushController: undefined as any,
+      add: () => undefined,
+      flush: () => undefined,
+      stop: () => undefined,
+      upsert: () => undefined,
+    }))
+    const initTransportSpy = replaceMockableWithSpy(initDebuggerTransport)
+    const startDeliveryApiPollingSpy = replaceMockableWithSpy(startDeliveryApiPolling)
+
+    datadogDebugger.init({
+      clientToken: 'client-token',
+      service: 'service-name',
+      env: 'staging',
+    })
+
+    await flushPromises()
+
+    expect(initTransportSpy).toHaveBeenCalledWith(
+      jasmine.objectContaining({ version: 'build-version' }),
+      jasmine.anything()
+    )
+    expect(startDeliveryApiPollingSpy).toHaveBeenCalledWith(jasmine.objectContaining({ version: 'build-version' }))
+    expect(browserWindow.$dd_entry).toBeDefined()
+    expect(browserWindow.$dd_return).toBeDefined()
+    expect(browserWindow.$dd_throw).toBeDefined()
+    expect(browserWindow.$dd_probes).toBeDefined()
+  })
+
+  it('should warn when the explicit init version mismatches build-plugin metadata', async () => {
+    browserWindow.__DD_LIVE_DEBUGGER_BUILD__ = { version: 'build-version' }
+    replaceMockableWithSpy(startDebuggerBatch).and.callFake(() => ({
+      flushController: undefined as any,
+      add: () => undefined,
+      flush: () => undefined,
+      stop: () => undefined,
+      upsert: () => undefined,
+    }))
+    replaceMockableWithSpy(initDebuggerTransport)
+    const startDeliveryApiPollingSpy = replaceMockableWithSpy(startDeliveryApiPolling)
+    const warnSpy = spyOn(display, 'warn')
+
+    datadogDebugger.init({
+      clientToken: 'client-token',
+      service: 'service-name',
+      env: 'staging',
+      version: 'runtime-version',
+    })
+
+    await flushPromises()
+
+    expect(warnSpy).toHaveBeenCalledWith(jasmine.stringMatching(/does not match the build-plugin version/))
+    expect(startDeliveryApiPollingSpy).toHaveBeenCalledWith(jasmine.objectContaining({ version: 'runtime-version' }))
+  })
 })
+
+async function flushPromises() {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
+}

--- a/packages/debugger/src/entries/main.ts
+++ b/packages/debugger/src/entries/main.ts
@@ -6,18 +6,15 @@
  * @see [Live Debugger Documentation](https://docs.datadoghq.com/tracing/live_debugger/)
  */
 
-import { defineGlobal, getGlobalObject, makePublicApi } from '@datadog/browser-core'
+import { defineGlobal, display, getGlobalObject, makePublicApi, mockable } from '@datadog/browser-core'
 import type { PublicApi, Site } from '@datadog/browser-core'
-import { onEntry, onReturn, onThrow, initDebuggerTransport } from '../domain/api'
+import { initDebuggerTransport, onEntry, onReturn, onThrow } from '../domain/api'
 import { startDeliveryApiPolling } from '../domain/deliveryApi'
 import { getProbes } from '../domain/probes'
 import { startDebuggerBatch } from '../transport/startDebuggerBatch'
 
-type DebuggerInstrumentationGlobal = typeof globalThis & {
-  $dd_entry?: typeof onEntry
-  $dd_return?: typeof onReturn
-  $dd_throw?: typeof onThrow
-  $dd_probes?: typeof getProbes
+export interface DebuggerBuildMetadata {
+  version?: string
 }
 
 /**
@@ -120,10 +117,36 @@ export interface DatadogDebugger extends PublicApi {
    *   service: 'my-app',
    *   site: 'datadoghq.com',
    *   env: 'production'
+   *   version: 'my-deployed-build-version',
    * })
    * ```
    */
   init: (initConfiguration: DebuggerInitConfiguration) => void
+}
+
+export interface BrowserWindow extends Window {
+  DD_DEBUGGER?: DatadogDebugger
+  __DD_LIVE_DEBUGGER_BUILD__?: DebuggerBuildMetadata
+  $dd_entry?: typeof onEntry
+  $dd_return?: typeof onReturn
+  $dd_throw?: typeof onThrow
+  $dd_probes?: typeof getProbes
+}
+
+function resolveDebuggerVersion(initConfiguration: DebuggerInitConfiguration): string | undefined {
+  const buildVersion = getGlobalObject<BrowserWindow>().__DD_LIVE_DEBUGGER_BUILD__?.version
+
+  if (
+    initConfiguration.version !== undefined &&
+    buildVersion !== undefined &&
+    initConfiguration.version !== buildVersion
+  ) {
+    display.warn(
+      `Debugger: init version "${initConfiguration.version}" does not match the build-plugin version "${buildVersion}". Using the init version.`
+    )
+  }
+
+  return initConfiguration.version ?? buildVersion
 }
 
 /**
@@ -132,27 +155,30 @@ export interface DatadogDebugger extends PublicApi {
 function makeDebuggerPublicApi(): DatadogDebugger {
   return makePublicApi<DatadogDebugger>({
     init: (initConfiguration: DebuggerInitConfiguration) => {
-      // Initialize debugger's own transport
-      const batch = startDebuggerBatch(initConfiguration)
-      initDebuggerTransport(initConfiguration, batch)
-
-      // Expose internal hooks on globalThis for instrumented code
-      if (typeof globalThis !== 'undefined') {
-        const debuggerGlobal = globalThis as DebuggerInstrumentationGlobal
-        debuggerGlobal.$dd_entry = onEntry
-        debuggerGlobal.$dd_return = onReturn
-        debuggerGlobal.$dd_throw = onThrow
-        debuggerGlobal.$dd_probes = getProbes
+      const resolvedConfiguration = {
+        ...initConfiguration,
+        version: resolveDebuggerVersion(initConfiguration),
       }
 
-      startDeliveryApiPolling({
-        service: initConfiguration.service,
-        clientToken: initConfiguration.clientToken,
-        site: initConfiguration.site,
-        proxy: initConfiguration.proxy,
-        env: initConfiguration.env,
-        version: initConfiguration.version,
-        pollInterval: initConfiguration.pollInterval,
+      // Initialize debugger's own transport
+      const batch = mockable(startDebuggerBatch)(resolvedConfiguration)
+      mockable(initDebuggerTransport)(resolvedConfiguration, batch)
+
+      // Expose internal hooks on globalThis for instrumented code
+      const debuggerGlobal = getGlobalObject<BrowserWindow>()
+      debuggerGlobal.$dd_entry = onEntry
+      debuggerGlobal.$dd_return = onReturn
+      debuggerGlobal.$dd_throw = onThrow
+      debuggerGlobal.$dd_probes = getProbes
+
+      mockable(startDeliveryApiPolling)({
+        service: resolvedConfiguration.service,
+        clientToken: resolvedConfiguration.clientToken,
+        site: resolvedConfiguration.site,
+        proxy: resolvedConfiguration.proxy,
+        env: resolvedConfiguration.env,
+        version: resolvedConfiguration.version,
+        pollInterval: resolvedConfiguration.pollInterval,
       })
     },
   })
@@ -166,9 +192,5 @@ function makeDebuggerPublicApi(): DatadogDebugger {
  * @see [Live Debugger Documentation](https://docs.datadoghq.com/tracing/live_debugger/)
  */
 export const datadogDebugger = makeDebuggerPublicApi()
-
-export interface BrowserWindow extends Window {
-  DD_DEBUGGER?: DatadogDebugger
-}
 
 defineGlobal(getGlobalObject<BrowserWindow>(), 'DD_DEBUGGER', datadogDebugger)


### PR DESCRIPTION
## Motivation

The Browser Debugger SDK should be able to pick up the browser build version injected by the Live Debugger build plugin so applications do not need to pass the same deployed build identifier into `datadogDebugger.init()` a second time.

The debugger snapshot payload also needs `applicationId` and `version` so downstream browser-build and source-resolution flows can identify the correct browser build when git tags are unavailable.

## Changes

### Version defaulting from build metadata

- default `datadogDebugger.init().version` from the build-plugin metadata when callers omit `version`
- keep an explicit `init({ version })` value authoritative and warn if it disagrees with the injected build-plugin version
- document that `version` is optional, but browser build lookup and source-aware resolution depend on an immutable deployed build identifier when available

### Snapshot build identity

- include `applicationId` and `version` as a structured `build` object inside the `debugger.snapshot` payload (`debugger.snapshot.build = { applicationId, version }`)
- this replaces the earlier approach of putting `application_id` as a top-level field and duplicating `application_id`/`version` into `ddtags`, which was vulnerable to tag collision from downstream enrichment
- the `build` object rides on the existing `@debugger.snapshot` column projection, so the web UI reads it without any query changes

### Version documentation

- document that `version` is optional in the Browser Debugger README and API docs
- clarify that when provided, `version` should be the immutable deployed browser build identifier
- clarify graceful degradation when `version` is absent

## Test instructions

Run:

```bash
yarn test:unit --spec packages/debugger/src/entries/main.spec.ts
yarn test:unit --spec packages/debugger/src/domain/api.spec.ts
```

## Part of larger effort

This PR is one part of the browser Live Debugger source-resolution work across multiple repositories:

- https://github.com/DataDog/dd-source/pull/415107
- https://github.com/DataDog/dd-source/pull/418329
- https://github.com/DataDog/debugger-backend/pull/2053
- https://github.com/DataDog/web-ui/pull/298258
- https://github.com/DataDog/build-plugins/pull/325
- https://github.com/DataDog/build-plugins/pull/326

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file