### PR TITLE
Fix TanStack Router lint resolution in test app

### DIFF
--- a/test/apps/tanstack-router-app/tsconfig.json
+++ b/test/apps/tanstack-router-app/tsconfig.json
@@ -4,6 +4,10 @@
     "strict": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@datadog/browser-rum-react/tanstack-router": ["../../../packages/rum-react/src/entries/tanstackRouter"]
+    },
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "target": "ES2018",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,6 +32,7 @@
       "@datadog/browser-rum-react/internal": ["./packages/rum-react/src/entries/internal"],
       "@datadog/browser-rum-react/react-router-v6": ["./packages/rum-react/src/entries/reactRouterV6"],
       "@datadog/browser-rum-react/react-router-v7": ["./packages/rum-react/src/entries/reactRouterV7"],
+      "@datadog/browser-rum-react/tanstack-router": ["./packages/rum-react/src/entries/tanstackRouter"],
 
       "@datadog/browser-rum-vue": ["./packages/rum-vue/src/entries/main"],
       "@datadog/browser-rum-vue/vue-router-v4": ["./packages/rum-vue/src/entries/vueRouter"],


### PR DESCRIPTION
## Motivation

The TanStack Router test app was already importing `@datadog/browser-rum-react/tanstack-router`, but our TypeScript config did not include a matching path alias for that subpath. As a result, type-aware ESLint could not resolve the import and `yarn lint` failed.

## Changes

- add the missing `@datadog/browser-rum-react/tanstack-router` path alias to the repo-level `tsconfig.base.json`
- add the same path mapping to `test/apps/tanstack-router-app/tsconfig.json` so the test app's local type-aware linting also resolves the package correctly

This is a config-only fix. It does not change runtime behavior.

## Test instructions

1. Check out this branch.
2. Run `yarn lint` from the repository root.
3. Confirm the previous lint error in `test/apps/tanstack-router-app/app.tsx` no longer appears.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
