### PR TITLE
👷 Draft-aware BrowserStack jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,6 +283,7 @@ unit-bs:
     - .bs-allowed-branches
   interruptible: true
   resource_group: browserstack
+  when: manual
   artifacts:
     reports:
       junit: test-report/unit-bs/*.xml
@@ -302,6 +303,7 @@ e2e-bs:
   interruptible: true
   resource_group: browserstack
   timeout: 35 minutes
+  when: manual
   artifacts:
     when: always
     reports:
@@ -311,6 +313,28 @@ e2e-bs:
     - FORCE_COLOR=1 node scripts/test/ci-bs.ts test:e2e:ci
   after_script:
     - node ./scripts/test/export-test-result.ts e2e-bs
+
+unit-bs-auto-play:
+  stage: browserstack
+  needs: ['unit']
+  extends:
+    - .base-configuration
+    - .bs-allowed-branches
+  interruptible: true
+  script:
+    - yarn
+    - node scripts/test/play-bs-job.ts unit-bs
+
+e2e-bs-auto-play:
+  stage: browserstack
+  needs: ['e2e']
+  extends:
+    - .base-configuration
+    - .bs-allowed-branches
+  interruptible: true
+  script:
+    - yarn
+    - node scripts/test/play-bs-job.ts e2e-bs
 
 script-tests:
   extends:

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -15,6 +15,7 @@ interface GitHubPR {
   number: number
   title: string
   body: string
+  draft: boolean
   base: {
     ref: string
   }

--- a/scripts/test/play-bs-job.ts
+++ b/scripts/test/play-bs-job.ts
@@ -23,7 +23,18 @@ runMain(async () => {
     throw new Error('CI_COMMIT_REF_NAME is not set; cannot determine current branch.')
   }
 
-  const pr = await fetchPR(LOCAL_BRANCH)
+  let pr: Awaited<ReturnType<typeof fetchPR>>
+  try {
+    pr = await fetchPR(LOCAL_BRANCH)
+  } catch (error) {
+    // Multiple open PRs for a single branch is ambiguous; leave the job manual
+    // rather than fail the pipeline. See scripts/lib/gitUtils.ts `fetchPR`.
+    if (error instanceof Error && error.message.includes('Multiple pull requests')) {
+      printLog(`Multiple open PRs for this branch; ${jobName} remains manual.`)
+      return
+    }
+    throw error
+  }
 
   if (!pr || pr.draft) {
     printLog(

--- a/scripts/test/play-bs-job.ts
+++ b/scripts/test/play-bs-job.ts
@@ -1,0 +1,77 @@
+import { parseArgs } from 'node:util'
+import { command } from '../lib/command.ts'
+import { printLog, runMain, fetchHandlingError } from '../lib/executionUtils.ts'
+import { fetchPR, LOCAL_BRANCH } from '../lib/gitUtils.ts'
+
+const BTI_CI_API_TOKEN_URL = 'https://bti-ci-api.us1.ddbuild.io/internal/ci/gitlab/token'
+
+interface BtiGitlabTokenResponse {
+  token: string
+}
+
+interface GitLabJob {
+  id: number
+  name: string
+}
+
+runMain(async () => {
+  const {
+    positionals: [jobName],
+  } = parseArgs({ allowPositionals: true })
+
+  if (!LOCAL_BRANCH) {
+    throw new Error('CI_COMMIT_REF_NAME is not set; cannot determine current branch.')
+  }
+
+  const pr = await fetchPR(LOCAL_BRANCH)
+
+  if (!pr || pr.draft) {
+    printLog(
+      pr
+        ? `PR #${pr.number} is a draft; ${jobName} remains manual.`
+        : `No open PR found for this branch; ${jobName} remains manual.`
+    )
+    return
+  }
+
+  // GitLab-injected predefined variables: https://docs.gitlab.com/ci/variables/predefined_variables/
+  const { CI_API_V4_URL, CI_PROJECT_ID, CI_PIPELINE_ID } = process.env
+  if (!CI_API_V4_URL || !CI_PROJECT_ID || !CI_PIPELINE_ID) {
+    throw new Error('Missing GitLab CI environment variables required to play jobs via the API.')
+  }
+
+  const gitlabToken = await getGitlabProjectToken()
+
+  const jobs = await gitlabApi<GitLabJob[]>(
+    `${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipelines/${CI_PIPELINE_ID}/jobs?scope[]=manual`,
+    gitlabToken
+  )
+
+  const job = jobs.find((j) => j.name === jobName)
+  if (!job) {
+    throw new Error(`Could not find manual job "${jobName}" in pipeline ${CI_PIPELINE_ID}.`)
+  }
+
+  await gitlabApi(`${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/jobs/${job.id}/play`, gitlabToken, 'POST')
+  printLog(`PR #${pr.number} is open and ready for review; played ${jobName} (job id ${job.id}).`)
+})
+
+// Exchange the CI job's SDM JWT for a short-lived GitLab project access token via bti-ci-api.
+// https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5421924354
+// https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5318837137
+async function getGitlabProjectToken(): Promise<string> {
+  const jwt = command`authanywhere --audience sdm --raw`.run().trim()
+  const response = await fetchHandlingError(`${BTI_CI_API_TOKEN_URL}?owner=DataDog&repository=browser-sdk`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  })
+  const { token } = (await response.json()) as BtiGitlabTokenResponse
+  return token
+}
+
+async function gitlabApi<T = unknown>(url: string, token: string, method: 'GET' | 'POST' = 'GET'): Promise<T> {
+  const response = await fetchHandlingError(url, {
+    method,
+    headers: { 'PRIVATE-TOKEN': token },
+  })
+  return (await response.json()) as T
+}


### PR DESCRIPTION
## Motivation

BrowserStack (BS) jobs currently run on every pipeline, including draft PRs, consuming parallelism budget on work that is not yet ready for review. This change makes BS jobs opt-in (manual) on drafts and automatic once the PR is ready for review.

## Changes

- Make `unit-bs` and `e2e-bs` manual (`when: manual`, `allow_failure: true`). On drafts / branches without a PR, they stay as a "play" button and don't block the pipeline.
- Add `unit-bs-auto-play` and `e2e-bs-auto-play` jobs (`needs: ['unit']` / `needs: ['e2e']`). Each runs `scripts/test/play-bs-job.ts <job-name>`, which:
  - Calls `fetchPR` to check the branch's PR state.
  - If the PR is open and not a draft, obtains a short-lived GitLab project access token via [bti-ci-api](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5421924354) (SDM JWT via `authanywhere`), then `POST /jobs/:id/play` to trigger the matching manual BS job.
  - Otherwise no-ops — the BS job stays as a play button.
- Expose `draft: boolean` on the `GitHubPR` interface returned by `fetchPR`.

## Test instructions

On CI:

1. Open this PR as a draft and push a commit.
2. In the pipeline UI, confirm `unit-bs` and `e2e-bs` show as manual (play button). Confirm `unit-bs-auto-play` / `e2e-bs-auto-play` succeed and log `PR #<n> is a draft; <job> remains manual.`.
3. Mark the PR as ready for review and push another commit or re-run the two `*-bs-auto-play` jobs.
4. Confirm `unit-bs-auto-play` / `e2e-bs-auto-play` play the BS jobs automatically (log: `played <job> (job id …)`), and `unit-bs` / `e2e-bs` run to completion.
5. Optional: flip back to draft + push. BS jobs should return to manual on the next pipeline.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file