### PR TITLE
[RUM-15280] ✨ Expose DEFAULT_TRACKED_RESOURCE_HEADERS on RumPublicApi

### DIFF
--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -45,6 +45,7 @@ import type { ViewHistory } from '../domain/contexts/viewHistory'
 import type { RumSessionManager } from '../domain/rumSessionManager'
 import type { ReplayStats } from '../rawRumEvent.types'
 import { ActionType, VitalType } from '../rawRumEvent.types'
+import { DEFAULT_TRACKED_RESOURCE_HEADERS } from '../domain/configuration'
 import type { RumConfiguration, RumInitConfiguration } from '../domain/configuration'
 import type { ViewOptions } from '../domain/view/trackViews'
 import type {
@@ -513,6 +514,13 @@ export interface RumPublicApi extends PublicApi {
    * @hidden // TODO: replace by @since when GA
    */
   failFeatureOperation: (name: string, failureReason: FailureReason, options?: FeatureOperationOptions) => void
+
+  /**
+   * List of default headers to use in the {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders} option.
+   *
+   * @hidden
+   */
+  DEFAULT_TRACKED_RESOURCE_HEADERS: typeof DEFAULT_TRACKED_RESOURCE_HEADERS
 }
 
 export interface RecorderApi {
@@ -962,6 +970,7 @@ export function makeRumPublicApi(
       addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'fail' })
       strategy.addOperationStepVital(name, 'end', options, failureReason)
     }),
+    DEFAULT_TRACKED_RESOURCE_HEADERS,
   })
 
   return rumPublicApi

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -516,7 +516,7 @@ export interface RumPublicApi extends PublicApi {
   failFeatureOperation: (name: string, failureReason: FailureReason, options?: FeatureOperationOptions) => void
 
   /**
-   * List of default headers to use in the {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders} option.
+   * List of default headers used by the {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders} option. See configuration example for extending them.
    *
    * @hidden
    */

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -268,7 +268,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @example
    * // Collect default headers plus custom ones for all URLs
    * trackResourceHeaders: [
-   *   { name: (h) => DEFAULT_TRACKED_RESOURCE_HEADERS.includes(h) },
+   *   ...DEFAULT_TRACKED_RESOURCE_HEADERS.map((h) => ({ name: h })),
    *   { name: 'x-request-id' },
    * ]
    * @example

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -19,6 +19,35 @@ import type { PropagatorType, TracingOption } from '../tracing/tracer.types'
 
 export const DEFAULT_PROPAGATOR_TYPES: PropagatorType[] = ['tracecontext', 'datadog']
 
+/**
+ * Default list of headers collected on resource events when {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders}
+ * is set to `true`. Re-exported by the `@datadog/browser-rum` and `@datadog/browser-rum-slim` packages, and exposed on the
+ * `DD_RUM` global object when the SDK is loaded via the CDN, so it can be referenced when building a custom matcher list.
+ *
+ * @example NPM
+ * ```ts
+ * import { datadogRum, DEFAULT_TRACKED_RESOURCE_HEADERS } from '@datadog/browser-rum'
+ *
+ * datadogRum.init({
+ *   // ...
+ *   trackResourceHeaders: [
+ *     ...DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
+ *     { name: 'x-request-id' },
+ *   ],
+ * })
+ * ```
+ * @example CDN
+ * ```ts
+ * DD_RUM.init({
+ *   // ...
+ *   trackResourceHeaders: [
+ *     ...DD_RUM.DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
+ *     { name: 'x-request-id' },
+ *   ],
+ * })
+ * ```
+ * @hidden
+ */
 export const DEFAULT_TRACKED_RESOURCE_HEADERS = [
   'cache-control',
   'etag',

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -466,6 +466,33 @@ test.describe('resource headers with trackResourceHeaders', () => {
       expect(fetchEvent!.resource.request).toBeUndefined()
       expect(fetchEvent!.resource.response?.headers?.['cache-control']).toBeUndefined()
     })
+
+  createTest('collect default and custom headers using DEFAULT_TRACKED_RESOURCE_HEADERS pattern')
+    .withRum({ enableExperimentalFeatures: ['track_resource_headers'] })
+    .withRumInit((configuration) => {
+      configuration.trackResourceHeaders = [
+        ...window.DD_RUM!.DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
+        { name: 'x-request-id' },
+      ]
+      window.DD_RUM!.init(configuration)
+    })
+    .run(async ({ intakeRegistry, flushEvents, page }) => {
+      const url = okUrl({
+        'Cache-Control': 'no-cache',
+        ETag: 'abc123',
+        'X-Request-Id': 'req-1',
+      })
+      await page.evaluate((u) => fetch(u), url)
+
+      await flushEvents()
+
+      const resourceEvent = intakeRegistry.rumResourceEvents.find((r) => r.resource.type === 'fetch')
+      expect(resourceEvent).toBeDefined()
+      const headers = resourceEvent!.resource.response!.headers!
+      expect(headers['cache-control']).toBe('no-cache')
+      expect(headers['etag']).toBe('abc123')
+      expect(headers['x-request-id']).toBe('req-1')
+    })
 })
 
 test.describe('manual resources with startResource/stopResource', () => {


### PR DESCRIPTION
## Motivation

Dogfooding feedback on `trackResourceHeaders`: customers using the CDN bundle have no runtime access to the default header list, so they can't extend it (e.g. `[...defaults, 'x-my-header']`) without hardcoding. Named exports from `entries/main.ts` reach NPM users but not the `window.DD_RUM` global, so the constant needs to be attached to the public API object itself.

## Changes

- Expose `DEFAULT_TRACKED_RESOURCE_HEADERS` as a property on `RumPublicApi` (marked `@hidden` for now), so CDN users can access it as `window.DD_RUM.DEFAULT_TRACKED_RESOURCE_HEADERS`.
- Update the `trackResourceHeaders` JSDoc example in `RumInitConfiguration` to use `...DEFAULT_TRACKED_RESOURCE_HEADERS.map((h) => ({ name: h }))` instead of the `name: (h) => ...includes(h)` predicate form — matches how customers actually want to extend the defaults.

Note: this introduces a non-function, non-state property on `RumPublicApi` for the first time; every other member is either a method, a `ContextManager`, `initConfiguration`, or `version`.

## Test instructions

1. Check out the branch and run `yarn build` (or `yarn dev`).
2. Load the sandbox page with the CDN bundle in a browser.
3. In DevTools console, run:
   ```js
   window.DD_RUM.DEFAULT_TRACKED_RESOURCE_HEADERS
   ```
   Expect the array `['cache-control', 'etag', 'age', 'expires', 'content-type', 'content-encoding', 'vary', 'content-length', 'server-timing', 'x-cache']`.
4. Verify it can be used to extend the config:
   ```js
   window.DD_RUM.init({
     applicationId: '<APP_ID>',
     clientToken: '<CLIENT_TOKEN>',
     trackResourceHeaders: [
       ...window.DD_RUM.DEFAULT_TRACKED_RESOURCE_HEADERS.map((h) => ({ name: h })),
       { name: 'x-request-id' },
     ],
   })
   ```
   and that a resource event carries the expected headers.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

[RUM-15273]: https://datadoghq.atlassian.net/browse/RUM-15273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ