### PR TITLE
⚗️ 🐛 validate feature-operation name against schema character set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 
 ---
 
+## Unreleased
+
+**Public Changes:**
+
+- ⚗️🐛 fix(rum): validate `startFeatureOperation` / `succeedFeatureOperation` / `failFeatureOperation` `name`. Blank/empty names are dropped with a warning (matches the backend's own non-empty precondition). Names that fail the backend-accepted character-set pattern `[\w.@$-]*` also warn via `display.warn` but are still emitted, so a future backend policy relaxation does not force an SDK bump. Still gated behind the `feature_operation_vital` experimental flag. [RUM]
+
+---
+
 ## v6.32.0
 
 **Public Changes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,6 @@
 
 ---
 
-## Unreleased
-
-**Public Changes:**
-
-- ⚗️🐛 fix(rum): validate `startFeatureOperation` / `succeedFeatureOperation` / `failFeatureOperation` `name`. Blank/empty names are dropped with a warning (matches the backend's own non-empty precondition). Names that fail the backend-accepted character-set pattern `[\w.@$-]*` also warn via `display.warn` but are still emitted, so a future backend policy relaxation does not force an SDK bump. Still gated behind the `feature_operation_vital` experimental flag. [RUM]
-
----
-
 ## v6.32.0
 
 **Public Changes:**

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -271,12 +271,6 @@ describe('vitalCollection', () => {
         })
       })
 
-      // Mirrors the backend's `[\w.@$-]*` server-side validation regex. Names
-      // that fail the pattern generate a `display.warn` but the event is
-      // still emitted — the backend is the single source of truth, so a
-      // client-side drop would force a customer SDK bump if the policy is
-      // ever relaxed. Blank/empty names are dropped with a warning instead,
-      // matching the backend's own non-empty precondition.
       describe('operation name character set', () => {
         beforeEach(() => {
           addExperimentalFeatures([ExperimentalFeature.FEATURE_OPERATION_VITAL])

--- a/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.spec.ts
@@ -1,6 +1,6 @@
 import type { Duration } from '@datadog/browser-core'
 import { mockClock, type Clock } from '@datadog/browser-core/test'
-import { addExperimentalFeatures, clocksNow, ExperimentalFeature, generateUUID } from '@datadog/browser-core'
+import { addExperimentalFeatures, clocksNow, display, ExperimentalFeature, generateUUID } from '@datadog/browser-core'
 import { collectAndValidateRawRumEvents, mockPageStateHistory } from '../../../test'
 import type { RawRumEvent, RawRumVitalEvent } from '../../rawRumEvent.types'
 import { VitalType, RumEventType } from '../../rawRumEvent.types'
@@ -268,6 +268,60 @@ describe('vitalCollection', () => {
 
         expect(rawRumEvents[0].domainContext).toEqual({
           handlingStack: 'Error\n    at foo\n    at bar',
+        })
+      })
+
+      // Mirrors the backend's `[\w.@$-]*` server-side validation regex. Names
+      // that fail the pattern generate a `display.warn` but the event is
+      // still emitted — the backend is the single source of truth, so a
+      // client-side drop would force a customer SDK bump if the policy is
+      // ever relaxed. Blank/empty names are dropped with a warning instead,
+      // matching the backend's own non-empty precondition.
+      describe('operation name character set', () => {
+        beforeEach(() => {
+          addExperimentalFeatures([ExperimentalFeature.FEATURE_OPERATION_VITAL])
+          spyOn(display, 'warn')
+        })
+        ;['user login', 'api/v1', 'checkout:step', 'a,b', 'login!', 'login\ttwo', 'ログイン', 'login🔐'].forEach(
+          (invalidName) => {
+            it(`should warn but still emit on name outside the backend pattern: ${JSON.stringify(invalidName)}`, () => {
+              vitalCollection.addOperationStepVital(invalidName, 'start')
+
+              expect(rawRumEvents.length).toBe(1)
+              expect((rawRumEvents[0].rawRumEvent as RawRumVitalEvent).vital.name).toBe(invalidName)
+              expect(display.warn).toHaveBeenCalledTimes(1)
+              expect((display.warn as jasmine.Spy).calls.mostRecent().args[0]).toContain('does not match')
+              expect((display.warn as jasmine.Spy).calls.mostRecent().args[0]).toContain('still be sent')
+            })
+          }
+        )
+        ;['', '   ', '\t\n'].forEach((blankName) => {
+          it(`should reject and warn on blank name: ${JSON.stringify(blankName)}`, () => {
+            vitalCollection.addOperationStepVital(blankName, 'start')
+
+            expect(rawRumEvents.length).toBe(0)
+            expect(display.warn).toHaveBeenCalledTimes(1)
+            expect((display.warn as jasmine.Spy).calls.mostRecent().args[0]).toContain('cannot be empty or blank')
+          })
+        })
+        ;['login', 'step42', 'login-v2', 'user_login', 'login.v2', 'login@prod', 'login$1', 'LoginV2'].forEach(
+          (validName) => {
+            it(`should accept name that matches the backend pattern without warning: ${JSON.stringify(validName)}`, () => {
+              vitalCollection.addOperationStepVital(validName, 'start')
+
+              expect(rawRumEvents.length).toBe(1)
+              expect((rawRumEvents[0].rawRumEvent as RawRumVitalEvent).vital.name).toBe(validName)
+              expect(display.warn).not.toHaveBeenCalled()
+            })
+          }
+        )
+
+        it('should not restrict operationKey to the same character set', () => {
+          vitalCollection.addOperationStepVital('foo', 'start', { operationKey: 'session 42 / user foo' })
+
+          expect(rawRumEvents.length).toBe(1)
+          expect((rawRumEvents[0].rawRumEvent as RawRumVitalEvent).vital.operation_key).toBe('session 42 / user foo')
+          expect(display.warn).not.toHaveBeenCalled()
         })
       })
 

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -256,8 +256,6 @@ function processVital(vital: DurationVital | OperationStepVital): RawRumEventCol
 }
 
 /**
- * Validates a feature-operation `vital.name`.
- *
  * Blank / empty names are rejected (the backend rejects them with its own
  * non-empty precondition before evaluating the character-set regex). Names
  * that fail the backend's `[\w.@$-]*` character-set regex trigger a warning

--- a/packages/rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/rum-core/src/domain/vital/vitalCollection.ts
@@ -2,6 +2,7 @@ import type { ClocksState, Duration } from '@datadog/browser-core'
 import {
   clocksNow,
   combine,
+  display,
   elapsed,
   ExperimentalFeature,
   generateUUID,
@@ -121,6 +122,10 @@ export function startVitalCollection(
     failureReason?: FailureReason
   ) {
     if (!isExperimentalFeatureEnabled(ExperimentalFeature.FEATURE_OPERATION_VITAL)) {
+      return
+    }
+
+    if (!validateOperationName(name)) {
       return
     }
 
@@ -248,4 +253,31 @@ function processVital(vital: DurationVital | OperationStepVital): RawRumEventCol
     duration: type === VitalType.DURATION ? vital.duration : undefined,
     domainContext: handlingStack ? { handlingStack } : {},
   }
+}
+
+/**
+ * Validates a feature-operation `vital.name`.
+ *
+ * Blank / empty names are rejected (the backend rejects them with its own
+ * non-empty precondition before evaluating the character-set regex). Names
+ * that fail the backend's `[\w.@$-]*` character-set regex trigger a warning
+ * but the event is still emitted — the backend is the source of truth on
+ * character-set policy, so client-side drop would force a customer SDK bump
+ * if the rule is ever relaxed.
+ *
+ * Returns `true` when the event should be emitted.
+ */
+const BACKEND_OPERATION_NAME_REGEX = /^[\w.@$-]*$/
+
+function validateOperationName(name: string): boolean {
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    display.warn('Feature operation name cannot be empty or blank. Event will not be sent.')
+    return false
+  }
+  if (!BACKEND_OPERATION_NAME_REGEX.test(name)) {
+    display.warn(
+      `Feature operation name '${name}' does not match the backend-accepted pattern [\\w.@$-]* (letters, digits, _ . @ $ -). The event will still be sent and may be rejected by the backend.`
+    )
+  }
+  return true
 }


### PR DESCRIPTION
## Motivation

The authoritative `_vital-common-schema.json` restricts `vital.name` to the character set `[\w.@$-]*` (letters, digits, `_`, `.`, `@`, `$`, `-`) and the backend enforces this as a server-side regex on the facet path. The Browser SDK previously had no input validation on feature-operation vitals — blank names, whitespace-only names, and names with disallowed characters were all silently accepted and shipped to intake.

This PR brings the Browser SDK in line with the cross-SDK contract shared with iOS, Android, Roku, C++, and Electron

## Changes

Adds validation in `addOperationStepVital` (inside the existing `FEATURE_OPERATION_VITAL` feature-flag gate):

- **Blank / whitespace-only `name`** → `display.warn` (`"Feature operation name cannot be empty or blank. Event will not be sent."`), event dropped.
- **Name with characters outside `[\w.@$-]*`** → `display.warn` quoting the exact backend pattern, event still emitted. The backend is the source of truth on the policy, so a client-side drop would force customers to bump the SDK if the rule is ever relaxed.
- **Valid `name`** → silent emit.
- **`operation_key`** is not subject to this rule (no schema restriction).

JS `\w` is always ASCII so no special handling is needed — the non-ASCII test case `'ログイン'` pins that ASCII-only semantics are retained.

## Test instructions

```
yarn test:unit --spec packages/rum-core/src/domain/vital/vitalCollection.spec.ts
```

The new tests exercise blank-drop, disallowed-character warn+emit (including Unicode and emoji), valid silent emit, and confirm `operation_key` with spaces/slashes still emits silently.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file (CHANGELOG Unreleased entry)