### PR TITLE
📝 Add DO NOT MODIFY IT BY HAND comment to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- DO NOT MODIFY IT BY HAND. This file is generated automatically during the release process. -->
+
 # Changelog
 
 > **Legend**

--- a/scripts/release/generate-changelog/lib/addNewChangesToChangelog.ts
+++ b/scripts/release/generate-changelog/lib/addNewChangesToChangelog.ts
@@ -20,6 +20,8 @@ export const addNewChangesToChangelog = async (previousContent: string): Promise
   const changeLists = getChangeLists()
 
   return `\
+<!-- DO NOT MODIFY IT BY HAND. This file is generated automatically during the release process. -->
+
 # Changelog
 
 ${emojisLegend}


### PR DESCRIPTION
## Motivation

`CHANGELOG.md` is generated automatically during the release process, but nothing in the file itself signals this to contributors (or coding agents). This can lead to accidental manual edits that get overwritten on the next release.

## Changes

Added an HTML comment at the top of `CHANGELOG.md` marking it as auto-generated:

```
<!-- DO NOT MODIFY IT BY HAND. This file is generated automatically during the release process. -->
```

This aligns with the existing "Auto-Generated Files" rule in `AGENTS.md`, which instructs contributors to respect `DO NOT MODIFY IT BY HAND` headers — now `CHANGELOG.md` carries that header too.

## Test instructions

Visual check of the diff — no runtime impact.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)