### PR TITLE
fix 🐛: fix regexp for cookie parsing

### DIFF
--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -31,7 +31,13 @@ export function setCookie(name: string, value: string, expireDelay: number = 0, 
  * If there are multiple cookies with the same name, returns the first one
  */
 export function getCookie(name: string) {
-  return findCommaSeparatedValue(document.cookie, name)
+  const value = findCommaSeparatedValue(document.cookie, name)
+
+  if (value === '') {
+    return
+  }
+
+  return value
 }
 
 /**

--- a/packages/core/src/tools/utils/stringUtils.spec.ts
+++ b/packages/core/src/tools/utils/stringUtils.spec.ts
@@ -61,8 +61,22 @@ describe('stringUtils', () => {
       expect(findCommaSeparatedValue('foo=a;bar=b', 'baz')).toBe(undefined)
     })
 
-    it('returns undefined if the value is empty', () => {
-      expect(findCommaSeparatedValue('foo=', 'foo')).toBe(undefined)
+    it('returns empty string if the value is empty', () => {
+      expect(findCommaSeparatedValue('foo=', 'foo')).toBe('')
+    })
+
+    it('supports cookie string with leading empty value', () => {
+      const cookieStringWithLeadingEmptyValue = 'first=;second=second'
+
+      expect(findCommaSeparatedValue(cookieStringWithLeadingEmptyValue, 'first')).toBe('')
+      expect(findCommaSeparatedValue(cookieStringWithLeadingEmptyValue, 'second')).toBe('second')
+    })
+
+    it('supports cookie string with trailing empty value', () => {
+      const cookieStringWithTrailingEmptyValue = 'first=first;second='
+
+      expect(findCommaSeparatedValue(cookieStringWithTrailingEmptyValue, 'first')).toBe('first')
+      expect(findCommaSeparatedValue(cookieStringWithTrailingEmptyValue, 'second')).toBe('')
     })
   })
 

--- a/packages/core/src/tools/utils/stringUtils.ts
+++ b/packages/core/src/tools/utils/stringUtils.ts
@@ -12,7 +12,7 @@ export function generateUUID(placeholder?: string): string {
 // Assuming input string is following the HTTP Cookie format defined in
 // https://www.ietf.org/rfc/rfc2616.txt and https://www.ietf.org/rfc/rfc6265.txt, we don't need to
 // be too strict with this regex.
-const COMMA_SEPARATED_KEY_VALUE = /(\S+?)\s*=\s*(.+?)(?:;|$)/g
+const COMMA_SEPARATED_KEY_VALUE = /(\S+?)\s*=\s*(.*?)(?:;|$)/g
 
 /**
  * Returns the value of the key with the given name

--- a/packages/rum-core/src/browser/cookieObservable.ts
+++ b/packages/rum-core/src/browser/cookieObservable.ts
@@ -5,8 +5,8 @@ import {
   Observable,
   addEventListener,
   ONE_SECOND,
-  findCommaSeparatedValue,
   DOM_EVENT,
+  getCookie,
 } from '@datadog/browser-core'
 
 export interface CookieStoreWindow {
@@ -49,9 +49,9 @@ function listenToCookieStoreChange(configuration: Configuration) {
 export const WATCH_COOKIE_INTERVAL_DELAY = ONE_SECOND
 
 function watchCookieFallback(cookieName: string, callback: (event: string | undefined) => void) {
-  let previousCookieValue = findCommaSeparatedValue(document.cookie, cookieName)
+  let previousCookieValue = getCookie(cookieName)
   const watchCookieIntervalId = setInterval(() => {
-    const cookieValue = findCommaSeparatedValue(document.cookie, cookieName)
+    const cookieValue = getCookie(cookieName)
     if (cookieValue !== previousCookieValue) {
       previousCookieValue = cookieValue
       callback(cookieValue)


### PR DESCRIPTION
## Motivation

Currently used helper does not take into account the parsing of cookies which have empty values (eg `"foo=; hello=world"`) which leads to several problems:

1. sdk not starting due to having a corrupt cookie (`cookie` is a default session strategy and we check if this strategy is available in [areCookiesAuthorized](https://github.com/DataDog/browser-sdk/blob/8d9036eac1d1f9c8e4856c119f67c6efd7564b3f/packages/core/src/browser/cookie.ts#L67) by tryint to set a test cookie value & then read from this cookie; this check will fail if empty cookie goes before the test cookie)
2. sdk reporting incorrect cookie values

## Changes

Fixed common utility function, updated corresponding unit test

## Test instructions

https://regex101.com/r/3K03iT/1 - buggy behavior
https://regex101.com/r/3K03iT/2 - behavior after fix

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
