### PR TITLE
feat(core): expose createFlagEvaluationEndpointBuilder for external SDK packages

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -8,6 +8,10 @@ import type { InitConfiguration } from './configuration'
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
 
+// Note: 'flagevaluation' is intentionally not wired into TransportConfiguration or computeEndpointBuilders.
+// It is used by external SDK packages (e.g. @datadog/openfeature-browser) via the public
+// createFlagEvaluationEndpointBuilder function. Adding it here makes the intake path
+// (/api/v2/flagevaluation) an explicit part of the contract.
 export type TrackType = 'logs' | 'rum' | 'replay' | 'profile' | 'exposures' | 'flagevaluation'
 export type ApiType =
   | 'fetch'
@@ -54,6 +58,18 @@ function createEndpointUrlWithParametersBuilder(
   }
   const host = buildEndpointHost(trackType, initConfiguration)
   return (parameters) => `https://${host}${path}?${parameters}`
+}
+
+/**
+ * Build an EndpointBuilder for the flagevaluation intake track. Intended for use by external SDK
+ * packages (e.g. @datadog/openfeature-browser) that need to send flag evaluation data to the
+ * Datadog intake without depending on internal browser-core APIs.
+ */
+export function createFlagEvaluationEndpointBuilder(
+  initConfiguration: InitConfiguration,
+  extraParameters?: string[]
+) {
+  return createEndpointBuilder(initConfiguration, 'flagevaluation', extraParameters)
 }
 
 export function buildEndpointHost(

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -65,10 +65,7 @@ function createEndpointUrlWithParametersBuilder(
  * packages (e.g. @datadog/openfeature-browser) that need to send flag evaluation data to the
  * Datadog intake without depending on internal browser-core APIs.
  */
-export function createFlagEvaluationEndpointBuilder(
-  initConfiguration: InitConfiguration,
-  extraParameters?: string[]
-) {
+export function createFlagEvaluationEndpointBuilder(initConfiguration: InitConfiguration, extraParameters?: string[]) {
   return createEndpointBuilder(initConfiguration, 'flagevaluation', extraParameters)
 }
 

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -7,5 +7,5 @@ export {
   serializeConfiguration,
 } from './configuration'
 export type { EndpointBuilder, TrackType } from './endpointBuilder'
-export { createEndpointBuilder, buildEndpointHost } from './endpointBuilder'
+export { createEndpointBuilder, buildEndpointHost, createFlagEvaluationEndpointBuilder } from './endpointBuilder'
 export { computeTransportConfiguration, isIntakeUrl } from './transportConfiguration'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export {
   isSampleRate,
   buildEndpointHost,
   isIntakeUrl,
+  createFlagEvaluationEndpointBuilder,
 } from './domain/configuration'
 export * from './domain/intakeSites'
 export type { TrackingConsentState } from './domain/trackingConsent'


### PR DESCRIPTION
## Problem

External packages (specifically `@datadog/openfeature-browser` in DataDog/openfeature-js-client) need to build intake endpoint URLs for the `flagevaluation` track type. Currently there is no public API for this — the package resorts to a deep private subpath import (`@datadog/browser-core/cjs/domain/configuration`) to access `createEndpointBuilder` directly.

## Solution

Add a purpose-specific public wrapper `createFlagEvaluationEndpointBuilder` instead of exporting the generic `createEndpointBuilder`.

This approach:
- Hides `TrackType` and the `'flagevaluation'` literal from external callers
- Provides a single point of change if the track type name ever changes
- Keeps `createEndpointBuilder` and `TrackType` off the public surface of `@datadog/browser-core`

## Changes

**`packages/core/src/domain/configuration/endpointBuilder.ts`**
- Updated comment on `TrackType` to reference the new public function
- Added `createFlagEvaluationEndpointBuilder` as an exported function

**`packages/core/src/domain/configuration/index.ts`**
- Added `createFlagEvaluationEndpointBuilder` to the internal barrel

**`packages/core/src/index.ts`**
- Added `createFlagEvaluationEndpointBuilder` to public exports
- Removed `createEndpointBuilder` and `TrackType` from public exports (kept internal)
- `EndpointBuilder` type remains exported so consumers can annotate variables

## Notes

- A companion PR in DataDog/openfeature-js-client (TBD) will update `@datadog/openfeature-browser` to use this function instead of the deep subpath import.
- `createEndpointBuilder` and `TrackType` remain available from the internal barrel for use by other packages in this repo.