### PR TITLE
👷 split renovate all-minor-patch group from test apps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,14 @@
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["package.json", "packages/**", "developer-extension/**"],
+      "matchPackageNames": ["!karma-webpack", "!@playwright/test"]
+    },
+    {
+      "groupName": "all non-major test-app dependencies",
+      "groupSlug": "all-minor-patch-test-apps",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFileNames": ["test/apps/**"],
       "matchPackageNames": ["!karma-webpack", "!@playwright/test"]
     },
     {


### PR DESCRIPTION
## Motivation

The weekend Renovate job keeps running out of memory while resolving the lockfile for the `all-minor-patch` group. The job covers 16 package files at once (root + `packages/**` + `developer-extension/**` + `test/apps/**`), which produces a single very large `yarn install` pass.

Splitting the group into two smaller ones reduces the per-run install footprint, so each pass has a smaller graph to resolve.

## Changes

- Split the `all non-major dependencies` group: SDK packages (`packages/**`, `developer-extension/**`, root) stay in `all-minor-patch`; test apps (`test/apps/**`) move to a new `all-minor-patch-test-apps` group.
- Each group keeps the same `karma-webpack` / `@playwright/test` exclusions and update-type filter.
- Net effect: two smaller weekend PRs instead of one large one.

## Test instructions

- Validate from the Renovate dry-run that two grouped PRs are produced (one per group) instead of one combined PR.
- After merge, trigger a manual run from the Renovate dashboard and confirm both groups complete successfully.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file