### PR TITLE
Revert "👷 split renovate all-minor-patch group from test apps"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,14 +19,6 @@
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchFileNames": ["package.json", "packages/**", "developer-extension/**"],
-      "matchPackageNames": ["!karma-webpack", "!@playwright/test"]
-    },
-    {
-      "groupName": "all non-major test-app dependencies",
-      "groupSlug": "all-minor-patch-test-apps",
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchFileNames": ["test/apps/**"],
       "matchPackageNames": ["!karma-webpack", "!@playwright/test"]
     },
     {


### PR DESCRIPTION
Reverts DataDog/browser-sdk#4529

The job is still failing, cf https://developer.mend.io/github/DataDog/browser-sdk/-/job/bebd9389-57a7-433a-b248-79b921393c3c