### PR TITLE
🐛 fix session lifetime bugs for long-lived pages and multi-tab scenarios

### DIFF
--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -373,6 +373,29 @@ describe('startSessionManager', () => {
       expect(expireSpy).toHaveBeenCalledTimes(1)
       expect(sessionManager.findSession()).toBeUndefined()
     })
+
+    it('should expire session after SESSION_TIME_OUT_DELAY even on a continuously visible page', async () => {
+      setPageVisibility('visible')
+      const sessionManager = await startSessionManagerWithDefaults()
+      const expireSpy = jasmine.createSpy('expire')
+      sessionManager.expireObservable.subscribe(expireSpy)
+
+      expect(sessionManager.findSession()).toBeDefined()
+
+      // Fast forward to the end of the session
+      clock.tick(SESSION_TIME_OUT_DELAY)
+      // Drain the pending setSessionState microtasks so that scheduleExpirationTimeout runs
+      // and registers the 0ms expiry timeout.
+      await Promise.resolve()
+      // Fire the 0ms expiry timeout.
+      clock.tick(0)
+
+      await collectAsyncCalls(expireSpy, 1)
+
+      expect(fakeStrategy.getInternalState()).toEqual({ isExpired: EXPIRED })
+      expect(expireSpy).toHaveBeenCalledTimes(1)
+      expect(sessionManager.findSession()).toBeUndefined()
+    })
   })
 
   describe('cross-tab changes (simulateExternalChange)', () => {

--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -340,6 +340,24 @@ describe('startSessionManager', () => {
       expect(state.isExpired).toBe(EXPIRED)
     })
 
+    it('should not expand another tab session via visibility check after expiration', async () => {
+      const sessionManager = await startSessionManagerWithDefaults()
+      sessionManager.expire()
+
+      // Simulate another tab writing its own session to the shared store
+      const otherTabExpire = String(Date.now() + SESSION_EXPIRATION_DELAY)
+      fakeStrategy.simulateExternalChange({
+        id: 'other-tab-session',
+        created: String(Date.now()),
+        expire: otherTabExpire,
+      })
+
+      clock.tick(VISIBILITY_CHECK_DELAY)
+
+      // The other tab's expire should not have been pushed forward
+      expect(fakeStrategy.getInternalState().expire).toBe(otherTabExpire)
+    })
+
     it('should expire session after SESSION_EXPIRATION_DELAY without any activity in a hidden tab', async () => {
       const sessionManager = await startSessionManagerWithDefaults()
       const expireSpy = jasmine.createSpy('expire')

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -165,7 +165,7 @@ export async function startSessionManager(
   function scheduleExpirationTimeout(state: SessionState) {
     clearTimeout(expirationTimeoutId)
     const expireDate = getExpireDate(state)
-    if (expireDate && !isSessionInExpiredState(state)) {
+    if (expireDate) {
       const delay = expireDate - dateNow()
       expirationTimeoutId = setTimeout(() => {
         strategy

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -202,7 +202,9 @@ export async function startSessionManager(
         }
       })
       trackVisibility(configuration, () => {
-        strategy.setSessionState((state) => expandOnly(state)).catch(monitorError)
+        if (!sessionExpired) {
+          strategy.setSessionState((state) => expandOnly(state)).catch(monitorError)
+        }
       })
       trackResume(configuration, () => {
         strategy.setSessionState((state) => initializeSession(state, configuration)).catch(monitorError)

--- a/packages/core/src/domain/session/sessionState.spec.ts
+++ b/packages/core/src/domain/session/sessionState.spec.ts
@@ -1,8 +1,10 @@
+import type { TimeStamp } from '../../tools/utils/timeUtils'
 import { dateNow } from '../../tools/utils/timeUtils'
-import { SESSION_EXPIRATION_DELAY, SESSION_NOT_TRACKED } from './sessionConstants'
+import { SESSION_EXPIRATION_DELAY, SESSION_NOT_TRACKED, SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import type { SessionState } from './sessionState'
 import {
   expandSessionState,
+  getExpireDate,
   isSessionInExpiredState,
   toSessionString,
   toSessionState,
@@ -36,15 +38,15 @@ describe('session state utilities', () => {
     it('should correctly identify a session in expired state', () => {
       expect(isSessionInExpiredState(EXPIRED_SESSION)).toBe(true)
       expect(isSessionInExpiredState({ created: dateNowWithOffset(-1000 * 60 * 60 * 4) })).toBe(true)
-      expect(isSessionInExpiredState({ expire: dateNowWithOffset(-100) })).toBe(true)
+      expect(isSessionInExpiredState({ created: dateNowWithOffset(-100), expire: dateNowWithOffset(-100) })).toBe(true)
+      expect(isSessionInExpiredState({ first: SESSION_NOT_TRACKED })).toBe(true)
+      expect(isSessionInExpiredState({ first: 'tracked' })).toBe(true)
     })
 
     it('should correctly identify a session in live state', () => {
       expect(isSessionInExpiredState({ created: dateNowWithOffset(-1000), expire: dateNowWithOffset(1000) })).toBe(
         false
       )
-      expect(isSessionInExpiredState({ first: SESSION_NOT_TRACKED })).toBe(false)
-      expect(isSessionInExpiredState({ first: 'tracked' })).toBe(false)
     })
   })
 
@@ -74,6 +76,36 @@ describe('session state utilities', () => {
     it('should handle invalid session strings', () => {
       const sessionString = '{invalid: true}'
       expect(toSessionState(sessionString)).toEqual(NOT_STARTED_SESSION)
+    })
+  })
+
+  describe('getExpireDate', () => {
+    it('should return undefined when expire and created are both absent', () => {
+      expect(getExpireDate({})).toBeUndefined()
+    })
+
+    it('should return undefined when only expire is set', () => {
+      expect(getExpireDate({ expire: String(dateNow() + SESSION_EXPIRATION_DELAY) })).toBeUndefined()
+    })
+
+    it('should return undefined when only created is set', () => {
+      expect(getExpireDate({ created: String(dateNow()) })).toBeUndefined()
+    })
+
+    it('should return expire date when it is before the cap', () => {
+      const createdDate = dateNow()
+      const expireDate = dateNow() + SESSION_EXPIRATION_DELAY // 15 min, well before the 4h cap
+      expect(getExpireDate({ created: String(createdDate), expire: String(expireDate) })).toBe(expireDate as TimeStamp)
+    })
+
+    it('should cap expire date when expandOnly pushes it past the max-age deadline', () => {
+      const createdDate = dateNow() - SESSION_TIME_OUT_DELAY + 1000 // session nearly 4h old
+      const expireDate = dateNow() + SESSION_EXPIRATION_DELAY // expandOnly pushed expire well into the future
+      const maxExpireDate = createdDate + SESSION_TIME_OUT_DELAY
+
+      expect(getExpireDate({ created: String(createdDate), expire: String(expireDate) })).toBe(
+        maxExpireDate as TimeStamp
+      )
     })
   })
 

--- a/packages/core/src/domain/session/sessionState.ts
+++ b/packages/core/src/domain/session/sessionState.ts
@@ -23,7 +23,11 @@ export function getCreatedDate(state: SessionState): TimeStamp | undefined {
 }
 
 export function getExpireDate(state: SessionState): TimeStamp | undefined {
-  return state.expire ? (Number(state.expire) as TimeStamp) : undefined
+  const expireDate = state.expire && (Number(state.expire) as TimeStamp)
+  const createdDate = getCreatedDate(state)
+  if (expireDate && createdDate) {
+    return Math.min(expireDate, createdDate + SESSION_TIME_OUT_DELAY) as TimeStamp
+  }
 }
 
 export function getExpiredSessionState(
@@ -54,14 +58,8 @@ export function isSessionInExpiredState(session: SessionState) {
 
 // An active session is a session in either `Tracked` or `NotTracked` state
 function isActiveSession(sessionState: SessionState) {
-  // created and expire can be undefined for versions which was not storing them
-  // these checks could be removed when older versions will not be available/live anymore
-  const createdDate = getCreatedDate(sessionState)
   const expireDate = getExpireDate(sessionState)
-  return (
-    (createdDate === undefined || dateNow() - createdDate < SESSION_TIME_OUT_DELAY) &&
-    (expireDate === undefined || dateNow() < expireDate)
-  )
+  return expireDate ? dateNow() < expireDate : false
 }
 
 export function expandSessionState(session: SessionState) {

--- a/test/e2e/scenario/rum/sessions.scenario.ts
+++ b/test/e2e/scenario/rum/sessions.scenario.ts
@@ -68,6 +68,63 @@ test.describe('rum sessions', () => {
       })
   })
 
+  test.describe('cross-tab session isolation', () => {
+    createTest('a tab should not collect events under another tab session until an interaction happens')
+      .withRum()
+      .run(async ({ page, intakeRegistry, flushEvents }) => {
+        await expireSession(page, page.context())
+
+        // Simulate another tab opening a fresh session
+        const otherSessionId = '00000000-0000-0000-0000-000000000000'
+        await setCookie(
+          page,
+          SESSION_STORE_KEY,
+          `id=${otherSessionId}&created=${Date.now()}&expire=${Date.now() + 15 * ONE_MINUTE}`,
+          ONE_HOUR
+        )
+
+        await page.evaluate(() => {
+          window.DD_RUM!.addAction('not collected')
+        })
+
+        // Makes the tab picks up the new session
+        await page.locator('html').click()
+
+        await page.evaluate(() => {
+          window.DD_RUM!.addAction('collected')
+        })
+
+        await flushEvents()
+
+        const actionEvents = intakeRegistry.rumActionEvents
+        expect(actionEvents).toHaveLength(1)
+        expect(actionEvents[0].action.target!.name).toBe('collected')
+        expect(actionEvents[0].session.id).toBe(otherSessionId)
+      })
+
+    createTest('a visible tab with an expired session should not extend another tab session')
+      .withRum()
+      .withMockClock()
+      .run(async ({ page, browserContext }) => {
+        // Expire the current session
+        await expireSession(page, browserContext)
+
+        // Simulate another tab opening a fresh session
+        const otherTabExpire = Date.now() + 15 * ONE_MINUTE
+        await setCookie(
+          page,
+          SESSION_STORE_KEY,
+          `id=other-tab-session&created=${Date.now()}&expire=${otherTabExpire}`,
+          ONE_HOUR
+        )
+
+        await page.clock.fastForward(ONE_MINUTE)
+
+        const cookie = await findSessionCookie(browserContext)
+        expect(Number(cookie?.expire)).toEqual(otherTabExpire)
+      })
+  })
+
   test.describe('session expiration', () => {
     createTest("don't send events when session is expired")
       // prevent recording start to generate late events


### PR DESCRIPTION
## Motivation

On pages that stay open indefinitely (e.g. TV dashboards, monitoring screens), three session lifetime bugs were found in v7:

1. **Sessions never expired by inactivity on visible pages.** `trackVisibility` calls `expandOnly` every minute via `setInterval` while the page is visible, perpetually pushing the inactivity timeout forward. As a result, sessions on always-visible pages would only ever expire at the hard 4-hour max — but even that was broken (see bug 3).

2. **An expired tab extended another tab's session.** After a tab's session expired, `trackVisibility`'s interval kept firing and calling `expandOnly` on whatever session was in the shared cookie — inadvertently extending a background tab's freshly-started session instead of leaving it alone.

3. **Sessions on always-visible pages never expired at the 4-hour hard cap.** `getExpireDate` did not cap the returned value, so `scheduleExpirationTimeout` kept rescheduling indefinitely and the session never expired at all. Even after fixing `getExpireDate` to cap at `created + SESSION_TIME_OUT_DELAY`, a guard `!isSessionInExpiredState(state)` in `scheduleExpirationTimeout` prevented the expiry timeout from being scheduled once the cap was reached.

## Changes

- **Bug 1 & 3 — `getExpireDate` now caps at `created + SESSION_TIME_OUT_DELAY`.** `scheduleExpirationTimeout` relies on this value to set its timer, so the expiry timeout now always fires at most 4 h after session creation, no matter how many times `expandOnly` has extended `state.expire`.

- **Bug 2 — `trackVisibility` now guards on `!sessionExpired`** (matching the existing guard on `trackActivity`), so once a tab's session has expired it no longer calls `expandOnly` on the shared cookie and cannot extend another tab's session.

- **Bug 3 — `scheduleExpirationTimeout` no longer skips scheduling when the session is in expired state.** Previously a `!isSessionInExpiredState(state)` guard prevented the timeout from being registered exactly when the session had just hit the hard cap, causing the expiry to never fire on always-visible pages.

- Unit tests for `getExpireDate` capping behavior, cross-tab isolation, and always-visible page expiration at the 4h cap
- E2E tests for cross-tab session isolation: expired tab must not extend another tab's session, and must not collect events under another tab's session ID

## Test instructions

1. Open the sandbox page and leave it visible with no interaction for >15 minutes — the session should expire at 15 minutes (inactivity timeout)
2. Open the sandbox in two tabs. Expire tab 1's session by waiting 4 hours or using `DD_RUM.stopSession()`. Open tab 2 in the background — its session should expire after 15 minutes of inactivity, not be extended by tab 1
3. Open the sandbox page on an always-visible screen and leave it for >4 hours — the session should expire at the 4-hour hard cap even with no user interaction

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file