### PR TITLE
[demo split #4449] 1/5 — Foundation: expose core hooks for the live debugger package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,10 @@ test/e2e/scenario/recorder/**                   @Datadog/rum-browser @Datadog/se
 
 # Docs
 /README.md    @Datadog/rum-browser @DataDog/documentation
+
+# Debugger
+packages/debugger                                               @Datadog/rum-browser @DataDog/debugger
+packages/debugger/README.md                                     @Datadog/rum-browser @DataDog/debugger @DataDog/documentation
+test/apps/instrumentation-overhead                              @Datadog/rum-browser @DataDog/debugger
+test/e2e/scenario/debugger.scenario.ts                          @Datadog/rum-browser @DataDog/debugger
+test/performance/scenarios/instrumentationOverhead.scenario.ts  @Datadog/rum-browser @DataDog/debugger

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -38,6 +38,7 @@ dev,@vitejs/plugin-react,MIT,Copyright (c) 2019-present Evan You & Vite Contribu
 dev,@vitejs/plugin-vue,MIT,Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
 dev,@module-federation/enhanced,MIT, Copyright (c) 2020 ScriptedAlchemy LLC (Zack Jackson) Zhou Shaw (zhouxiao)
 dev,@vue/test-utils,MIT,Copyright (c) 2021-present vuejs
+dev,acorn,MIT,Copyright (C) 2012-2022 by various contributors (see AUTHORS)
 dev,ajv,MIT,Copyright 2015-2017 Evgeny Poberezkin
 dev,babel-loader,MIT,Copyright (c) 2014-2019 Luís Couto <hello@luiscouto.pt>
 dev,browserstack-local,MIT,Copyright 2016 BrowserStack

--- a/eslint-local-rules/disallowSideEffects.js
+++ b/eslint-local-rules/disallowSideEffects.js
@@ -29,6 +29,7 @@ const pathsWithSideEffect = new Set([
   `${packagesRoot}/logs/src/entries/main.ts`,
   `${packagesRoot}/rum/src/entries/main.ts`,
   `${packagesRoot}/rum-slim/src/entries/main.ts`,
+  `${packagesRoot}/debugger/src/entries/main.ts`,
 ])
 
 // Those packages are known to have no side effects when evaluated

--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -276,7 +276,7 @@ export interface InitConfiguration {
    *
    * @internal
    */
-  source?: 'browser' | 'flutter' | 'unity' | undefined
+  source?: 'browser' | 'flutter' | 'unity' | 'dd_debugger' | undefined
 
   /**
    * [Internal option] Additional configuration for the SDK.
@@ -311,6 +311,8 @@ export interface ReplicaUserConfiguration {
   clientToken: string
 }
 
+export type SdkSource = 'browser' | 'flutter' | 'unity'
+
 export interface Configuration extends TransportConfiguration {
   // Built from init configuration
   beforeSend: GenericBeforeSendCallback | undefined
@@ -331,8 +333,12 @@ export interface Configuration extends TransportConfiguration {
 
   // internal
   sdkVersion: string | undefined
-  source: 'browser' | 'flutter' | 'unity'
+  source: SdkSource
   variant: string | undefined
+}
+
+function toSdkSource(source: TransportConfiguration['source']): SdkSource {
+  return source === 'dd_debugger' ? 'browser' : source
 }
 
 function isString(tag: unknown, tagName: string): tag is string | undefined | null {
@@ -398,6 +404,8 @@ export function validateAndBuildConfiguration(
     return
   }
 
+  const transportConfiguration = computeTransportConfiguration(initConfiguration)
+
   return {
     beforeSend:
       initConfiguration.beforeSend && catchUserErrors(initConfiguration.beforeSend, 'beforeSend threw an error:'),
@@ -423,7 +431,8 @@ export function validateAndBuildConfiguration(
     variant: initConfiguration.variant,
     sdkVersion: initConfiguration.sdkVersion,
 
-    ...computeTransportConfiguration(initConfiguration),
+    ...transportConfiguration,
+    source: toSdkSource(transportConfiguration.source),
   }
 }
 

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -8,7 +8,7 @@ import type { InitConfiguration } from './configuration'
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
 
-export type TrackType = 'logs' | 'rum' | 'replay' | 'profile' | 'exposures' | 'flagevaluation'
+export type TrackType = 'logs' | 'rum' | 'replay' | 'profile' | 'exposures' | 'flagevaluation' | 'debugger'
 export type ApiType =
   | 'fetch'
   | 'beacon'

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -11,10 +11,11 @@ export interface TransportConfiguration {
   profilingEndpointBuilder: EndpointBuilder
   exposuresEndpointBuilder: EndpointBuilder
   flagEvaluationEndpointBuilder: EndpointBuilder
+  debuggerEndpointBuilder: EndpointBuilder
   datacenter?: string | undefined
   replica?: ReplicaConfiguration
   site: Site
-  source: 'browser' | 'flutter' | 'unity'
+  source: 'browser' | 'flutter' | 'unity' | 'dd_debugger'
 }
 
 export interface ReplicaConfiguration {
@@ -38,7 +39,7 @@ export function computeTransportConfiguration(initConfiguration: InitConfigurati
 }
 
 function validateSource(source: string | undefined) {
-  if (source === 'flutter' || source === 'unity') {
+  if (source === 'flutter' || source === 'unity' || source === 'dd_debugger') {
     return source
   }
   return 'browser'
@@ -52,6 +53,7 @@ function computeEndpointBuilders(initConfiguration: InitConfiguration) {
     sessionReplayEndpointBuilder: createEndpointBuilder(initConfiguration, 'replay'),
     exposuresEndpointBuilder: createEndpointBuilder(initConfiguration, 'exposures'),
     flagEvaluationEndpointBuilder: createEndpointBuilder(initConfiguration, 'flagevaluation'),
+    debuggerEndpointBuilder: createEndpointBuilder(initConfiguration, 'debugger'),
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export {
   isSampleRate,
   buildEndpointHost,
   isIntakeUrl,
+  computeTransportConfiguration,
 } from './domain/configuration'
 export * from './domain/intakeSites'
 export type { TrackingConsentState } from './domain/trackingConsent'
@@ -57,7 +58,15 @@ export {
   SESSION_NOT_TRACKED,
   SessionPersistence,
 } from './domain/session/sessionConstants'
-export type { BandwidthStats, HttpRequest, HttpRequestEvent, Payload, FlushEvent, FlushReason } from './transport'
+export type {
+  Batch,
+  BandwidthStats,
+  HttpRequest,
+  HttpRequestEvent,
+  Payload,
+  FlushEvent,
+  FlushReason,
+} from './transport'
 export {
   createHttpRequest,
   canUseEventBridge,

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -2,6 +2,7 @@ export type { BandwidthStats, HttpRequest, HttpRequestEvent, Payload, RetryInfo 
 export { createHttpRequest } from './httpRequest'
 export type { BrowserWindowWithEventBridge, DatadogEventBridge } from './eventBridge'
 export { canUseEventBridge, bridgeSupports, getEventBridge, BridgeCapability } from './eventBridge'
+export type { Batch } from './batch'
 export { createBatch } from './batch'
 export type { FlushController, FlushEvent, FlushReason } from './flushController'
 export { createFlushController, FLUSH_DURATION_LIMIT } from './flushController'

--- a/test/unit/browsers.conf.ts
+++ b/test/unit/browsers.conf.ts
@@ -2,6 +2,11 @@
 
 import type { BrowserConfiguration } from '../browsers.conf'
 
+// The ECMAScript version supported by the oldest browser in the list below (Chrome 63 → ES2017).
+// Used by tests that validate runtime-generated code strings (e.g. the expression compiler) which
+// bypass TypeScript/webpack transpilation and must only use syntax supported by all target browsers.
+export const OLDEST_BROWSER_ECMA_VERSION = 2017
+
 export const browserConfigurations: BrowserConfiguration[] = [
   {
     sessionName: 'Edge',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -41,7 +41,9 @@
 
       "@datadog/browser-rum-nextjs": ["./packages/rum-nextjs/src/entries/main"],
 
-      "@datadog/browser-worker": ["./packages/worker/src/entries/main"]
+      "@datadog/browser-worker": ["./packages/worker/src/entries/main"],
+
+      "@datadog/browser-debugger": ["./packages/debugger/src/entries/main"]
     }
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,7 +7,7 @@
   ],
   "entryPointStrategy": "packages",
   "includeVersion": true,
-  "exclude": ["packages/core", "packages/rum-core", "packages/worker"],
+  "exclude": ["packages/core", "packages/rum-core", "packages/worker", "packages/debugger"],
   "validation": {
     "notExported": true,
     "invalidLink": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@datadog/browser-debugger@workspace:packages/debugger":
+  version: 0.0.0-use.local
+  resolution: "@datadog/browser-debugger@workspace:packages/debugger"
+  dependencies:
+    "@datadog/browser-core": "npm:6.32.0"
+    acorn: "npm:8.16.0"
+  languageName: unknown
+  linkType: soft
+
 "@datadog/browser-logs@workspace:*, @datadog/browser-logs@workspace:packages/logs":
   version: 0.0.0-use.local
   resolution: "@datadog/browser-logs@workspace:packages/logs"
@@ -3209,7 +3218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.15.0, acorn@npm:^8.16.0":
+"acorn@npm:8.16.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:


### PR DESCRIPTION
> **DEMO — split of #4449.** This is one of 5 stacked **draft** PRs that breaks
> [#4449 — Add Live Debugger package](https://github.com/DataDog/browser-sdk/pull/4449)
> into reviewable increments. **Original PR is untouched.** This stack is for
> demonstrating tooling (`jj split` for the surgery, `gh` for the stack);
> all of the underlying code is Thomas Watson's work and credited via
> `Co-authored-by:` trailers.
>
> ### Stack
> 1. #4532 — Foundation — expose core hooks for the live debugger package _(12 files / +56-10)_ **← you are here**
> 2. #4533 — Package — add `@datadog/browser-debugger` _(25 files / +6433)_  
> 3. #4534 — E2E framework — extend test framework for the debugger package _(12 files / +129-8)_  
> 4. #4535 — E2E scenarios — add debugger e2e scenarios _(3 files / +318-2)_  
> 5. #4536 — Perf benchmarks — add instrumentation overhead benchmarks _(12 files / +1222-9)_  
>
> Each PR's base branch is the previous PR's head, so reviewing in order is
> the intended path. Stack constructed with [`jj`](https://github.com/jj-vcs/jj):
> all 4 commits from #4449 were squashed into one change, then peeled into 5
> with `jj split <paths>`, then pushed with `jj git push`.

---

## What this PR contains (1/5 — Foundation)

Pre-requisite changes to `@datadog/browser-core` and project-level config that
the rest of the stack depends on. Intentionally small — this is the
foundation that everything builds on.

### Changes
- **`packages/core`**
  - `domain/configuration/configuration.ts`, `endpointBuilder.ts`,
    `transportConfiguration.ts` — add `'dd_debugger'` as a valid transport
    source, mapped to `'browser'`.
  - `src/index.ts`, `transport/index.ts` — export `Batch` type and
    `computeTransportConfiguration` so the debugger package can build its
    own transport.
- **Tooling**
  - `eslint-local-rules/disallowSideEffects.js` — allow the debugger entry
    point to register `globalThis` hooks.
  - `tsconfig.base.json` — register the new package path.
  - `typedoc.json` — exclude the package from generated docs (per-spec, since
    this is internal-only until validated in production).
  - `.github/CODEOWNERS`, `LICENSE-3rdparty.csv`, `test/unit/browsers.conf.ts`,
    `yarn.lock` — wiring updates.

12 files, +56 / -10.

### Why this stack
PR #4449 lands 64 files in a single ~8.2k-line PR, which is hard to review
end-to-end. Splitting into reviewable increments (this stack) keeps each PR
focused on a single concern and makes regressions easier to bisect.