### PR TITLE
🐛 don't adopt another tab's session when it replaces ours directly

### DIFF
--- a/packages/core/src/domain/session/sessionManager.spec.ts
+++ b/packages/core/src/domain/session/sessionManager.spec.ts
@@ -399,26 +399,20 @@ describe('startSessionManager', () => {
   })
 
   describe('cross-tab changes (simulateExternalChange)', () => {
-    it('should fire expireObservable and renewObservable when external change has a different session ID', async () => {
+    it('should not adopt a session created by another tab when it replaces our session directly', async () => {
       const sessionManager = await startSessionManagerWithDefaults()
-      const expireSpy = jasmine.createSpy('expire')
       const renewSpy = jasmine.createSpy('renew')
-      sessionManager.expireObservable.subscribe(expireSpy)
       sessionManager.renewObservable.subscribe(renewSpy)
 
-      const initialId = sessionManager.findSession()!.id
-
-      // Another tab changes the session
+      // Another tab expires our session and immediately starts a new one
       fakeStrategy.simulateExternalChange({
         id: 'other-tab-session',
         expire: String(Date.now() + SESSION_EXPIRATION_DELAY),
         created: String(Date.now()),
       })
 
-      expect(expireSpy).toHaveBeenCalledTimes(1)
-      expect(renewSpy).toHaveBeenCalledTimes(1)
-      expect(sessionManager.findSession()!.id).toBe('other-tab-session')
-      expect(sessionManager.findSession()!.id).not.toBe(initialId)
+      expect(renewSpy).not.toHaveBeenCalled()
+      expect(sessionManager.findSession()).toBeUndefined()
     })
 
     it('should update session context in history when forcedReplay changes externally', async () => {

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -257,9 +257,7 @@ export async function startSessionManager(
         locksAvailable: Boolean(globalThis.navigator?.locks),
         cookieStoreAvailable: Boolean(globalThis.cookieStore),
       }
-      if (!hasSession) {
-        sessionExpired = true
-      }
+      sessionExpired = true
       expireObservable.notify()
       sessionContextHistory.closeActive(relativeNow())
     }


### PR DESCRIPTION
## Motivation

When a tab's session was replaced by another tab's session directly (ID-to-ID, without going through an intermediate expired state), the current tab would silently adopt the foreign session and start sending events under it — without any user interaction. Users on multi-tab setups could find their session data mixed across tabs unexpectedly.

## Changes

- Remove the `!hasSession` guard on `sessionExpired = true` so that a direct session ID replacement is treated the same as a normal expiry: this tab marks itself as expired and waits for a user interaction before starting a new session.

## Test instructions

1. Open the sandbox in two tabs. In tab 1, expire the session with `DD_RUM.stopSession()`.
2. In tab 2, simulate a new session by setting the cookie directly (e.g. via DevTools) to a new `id=...&created=...&expire=...` value.
3. Interact with tab 1 — it should start its own fresh session, not adopt tab 2's session ID.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file