### PR TITLE
👷 Renovate: tweak memory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,6 @@
     }
   ],
   "toolSettings": {
-    "nodeMaxMemory": 4096
+    "nodeMaxMemory": 2048
   }
 }


### PR DESCRIPTION
## Motivation

Following #4529, tweak the memory hint used by renovate to see if it can prevent the OOM that we are facing.

## Changes

As per [mend team recommendation](https://github.com/renovatebot/renovate/discussions/42959#discussioncomment-16740245), let's try with something ~2GB.


## Test instructions

After merge, launch a manual scan

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
