### PR TITLE
🔬 gate session renewal debug context behind a feature flag

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -24,6 +24,7 @@ import { isSampled } from '../sampler'
 import { TelemetryMetrics, addTelemetryMetrics } from '../telemetry'
 import { monitorError } from '../../tools/monitor'
 import { getCookies } from '../../browser/cookie'
+import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../tools/experimentalFeatures'
 import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import type { SessionState } from './sessionState'
@@ -41,7 +42,7 @@ import { getSessionStoreStrategy } from './sessionStore'
 export interface SessionManager {
   findSession: (startTime?: RelativeTime, options?: { returnInactive: boolean }) => SessionContext | undefined
   findTrackedSession: (startTime?: RelativeTime, options?: { returnInactive: boolean }) => SessionContext | undefined
-  renewObservable: Observable<SessionRenewalEvent>
+  renewObservable: Observable<SessionRenewalEvent | undefined>
   expireObservable: Observable<void>
   expire: () => void
   updateSessionState: (state: Partial<SessionState>) => void
@@ -88,7 +89,7 @@ export async function startSessionManager(
   trackingConsentState: TrackingConsentState
 ): Promise<SessionManager | undefined> {
   const startTime = relativeNow()
-  const renewObservable = new Observable<SessionRenewalEvent>()
+  const renewObservable = new Observable<SessionRenewalEvent | undefined>()
   const expireObservable = new Observable<void>()
   let expireContext: SessionDebugContext | undefined
 
@@ -248,14 +249,16 @@ export async function startSessionManager(
 
     if (hadSession && (!hasSession || sessionIdChanged)) {
       // Session expired or replaced
-      expireContext = {
-        previousSession: previousSession && { ...previousSession },
-        newState: { ...newState },
-        from,
-        cookieValues,
-        cookies: getCookies(SESSION_STORE_KEY),
-        locksAvailable: Boolean(globalThis.navigator?.locks),
-        cookieStoreAvailable: Boolean(globalThis.cookieStore),
+      if (isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_RENEWAL_DEBUG_CONTEXT)) {
+        expireContext = {
+          previousSession: previousSession && { ...previousSession },
+          newState: { ...newState },
+          from,
+          cookieValues,
+          cookies: getCookies(SESSION_STORE_KEY),
+          locksAvailable: Boolean(globalThis.navigator?.locks),
+          cookieStoreAvailable: Boolean(globalThis.cookieStore),
+        }
       }
       if (!hasSession) {
         sessionExpired = true
@@ -271,18 +274,22 @@ export async function startSessionManager(
       }
       // New session appeared
       sessionContextHistory.add(buildSessionContext(newState), relativeNow())
-      renewObservable.notify({
-        expire: expireContext,
-        renew: {
-          previousSession: previousSession && { ...previousSession },
-          newState: { ...newState },
-          from,
-          cookieValues,
-          cookies: getCookies(SESSION_STORE_KEY),
-          locksAvailable: Boolean(globalThis.navigator?.locks),
-          cookieStoreAvailable: Boolean(globalThis.cookieStore),
-        },
-      })
+      renewObservable.notify(
+        isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_RENEWAL_DEBUG_CONTEXT)
+          ? {
+              expire: expireContext,
+              renew: {
+                previousSession: previousSession && { ...previousSession },
+                newState: { ...newState },
+                from,
+                cookieValues,
+                cookies: getCookies(SESSION_STORE_KEY),
+                locksAvailable: Boolean(globalThis.navigator?.locks),
+                cookieStoreAvailable: Boolean(globalThis.cookieStore),
+              },
+            }
+          : undefined
+      )
     } else if (hadSession && hasSession && !sessionIdChanged) {
       // Same session,
       // Mutate the session context in the history for replay forced changes

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -20,6 +20,7 @@ export enum ExperimentalFeature {
   START_STOP_RESOURCE = 'start_stop_resource',
   TOO_MANY_REQUESTS_INVESTIGATION = 'too_many_requests_investigation',
   TRACK_RESOURCE_HEADERS = 'track_resource_headers',
+  SESSION_RENEWAL_DEBUG_CONTEXT = 'session_renewal_debug_context',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()

--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -96,7 +96,7 @@ export interface LifeCycleEventMap {
   [LifeCycleEventTypeAsConst.REQUEST_STARTED]: RequestStartEvent
   [LifeCycleEventTypeAsConst.REQUEST_COMPLETED]: RequestCompleteEvent
   [LifeCycleEventTypeAsConst.SESSION_EXPIRED]: void
-  [LifeCycleEventTypeAsConst.SESSION_RENEWED]: SessionRenewalEvent
+  [LifeCycleEventTypeAsConst.SESSION_RENEWED]: SessionRenewalEvent | undefined
   [LifeCycleEventTypeAsConst.PAGE_MAY_EXIT]: PageMayExitEvent
   [LifeCycleEventTypeAsConst.RAW_RUM_EVENT_COLLECTED]: RawRumEventCollectedData
   [LifeCycleEventTypeAsConst.RUM_EVENT_COLLECTED]: AssembledRumEvent

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -151,8 +151,10 @@ export function trackViews(
   function startViewLifeCycle() {
     lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, (event) => {
       const context = currentView.contextManager.getContext()
-      context.is_session_renewal = true
-      context.renew_event = event as any
+      if (event) {
+        context.is_session_renewal = true
+        context.renew_event = event as any
+      }
 
       currentView = startNewView(ViewLoadingType.SESSION_RENEWAL, undefined, {
         // Renew view on session renewal


### PR DESCRIPTION
## Motivation

The session renewal debug context (`SessionRenewalEvent` payload — cookie reads, session state
snapshots, and the `is_session_renewal`/`renew_event` fields attached to view contexts) was
unconditionally collected on every session renewal. This adds unnecessary overhead and pollutes
view context for all users. Gating it behind a flag allows enabling it only when actively
investigating session lifecycle issues.

## Changes

- Add `session_renewal_debug_context` experimental feature flag
- Gate collection of `SessionDebugContext` (cookie reads, state snapshots) behind the flag; `renewObservable` notifies with `undefined` when the flag is off
- Gate attaching `is_session_renewal` / `renew_event` to the renewed view context behind the flag

## Test instructions

1. Run `yarn dev` and open the sandbox at `http://localhost:8080`
2. Without the flag: trigger a session renewal (e.g. expire the session cookie and interact with the page). Confirm no `renew_event` or `is_session_renewal` fields appear on the resulting view event.
3. With the flag enabled (add `session_renewal_debug_context` to `enableExperimentalFeatures` in `sandbox/index.html`): repeat and confirm `renew_event` with full debug context appears on the view.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file