### PR TITLE
✨ [RUM-16070] GA trackResourceHeaders

### DIFF
--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -19,7 +19,6 @@ export enum ExperimentalFeature {
   START_STOP_ACTION = 'start_stop_action',
   START_STOP_RESOURCE = 'start_stop_resource',
   TOO_MANY_REQUESTS_INVESTIGATION = 'too_many_requests_investigation',
-  TRACK_RESOURCE_HEADERS = 'track_resource_headers',
   SESSION_RENEWAL_DEBUG_CONTEXT = 'session_renewal_debug_context',
 }
 

--- a/packages/rum-core/src/boot/rumPublicApi.ts
+++ b/packages/rum-core/src/boot/rumPublicApi.ts
@@ -526,8 +526,6 @@ export interface RumPublicApi extends PublicApi {
 
   /**
    * List of default headers used by the {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders} option. See configuration example for extending them.
-   *
-   * @hidden
    */
   DEFAULT_TRACKED_RESOURCE_HEADERS: typeof DEFAULT_TRACKED_RESOURCE_HEADERS
 }

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -46,7 +46,6 @@ export const DEFAULT_PROPAGATOR_TYPES: PropagatorType[] = ['tracecontext', 'data
  *   ],
  * })
  * ```
- * @hidden
  */
 export const DEFAULT_TRACKED_RESOURCE_HEADERS = [
   'cache-control',
@@ -290,7 +289,6 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @example
    * // Extract a partial value from a header
    * trackResourceHeaders: [{ url: /\/api\//, name: 'server-timing', extractor: /dur=(\d+)/, location: 'response' }]
-   * @hidden
    */
   trackResourceHeaders?: boolean | MatchHeader[] | undefined
 

--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -1,18 +1,7 @@
-import type { Duration, RelativeTime, ServerDuration, TaskQueue, TimeStamp, MatchOption } from '@datadog/browser-core'
-import {
-  createTaskQueue,
-  elapsed,
-  RequestType,
-  ResourceType,
-  toServerDuration,
-  addExperimentalFeatures,
-  ExperimentalFeature,
-  display,
-} from '@datadog/browser-core'
+import type { Duration, MatchOption, RelativeTime, ServerDuration, TaskQueue, TimeStamp } from '@datadog/browser-core'
+import { createTaskQueue, display, elapsed, RequestType, ResourceType, toServerDuration } from '@datadog/browser-core'
 import type { MockTelemetry } from '@datadog/browser-core/test'
-import { replaceMockable, registerCleanupTask, startMockTelemetry } from '@datadog/browser-core/test'
-import { resetExperimentalFeatures } from '@datadog/browser-core/src/tools/experimentalFeatures'
-import type { RumResourceEventDomainContext } from '../../domainContext.types'
+import { registerCleanupTask, replaceMockable, startMockTelemetry } from '@datadog/browser-core/test'
 import {
   collectAndValidateRawRumEvents,
   createPerformanceEntry,
@@ -20,18 +9,19 @@ import {
   mockPerformanceObserver,
   mockRumConfiguration,
 } from '../../../test'
+import type { RumPerformanceEntry, RumPerformanceResourceTiming } from '../../browser/performanceObservable'
+import { RumPerformanceEntryType } from '../../browser/performanceObservable'
+import { getNavigationEntry } from '../../browser/performanceUtils'
+import type { RumResourceEventDomainContext } from '../../domainContext.types'
 import type { RawRumEvent, RawRumResourceEvent } from '../../rawRumEvent.types'
 import { RumEventType } from '../../rawRumEvent.types'
+import type { MatchHeader, RumConfiguration } from '../configuration'
+import { validateAndBuildRumConfiguration } from '../configuration'
 import type { RawRumEventCollectedData } from '../lifeCycle'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { RequestCompleteEvent } from '../requestCollection'
-import type { RumConfiguration, MatchHeader } from '../configuration'
-import { validateAndBuildRumConfiguration } from '../configuration'
-import type { RumPerformanceEntry, RumPerformanceResourceTiming } from '../../browser/performanceObservable'
-import { RumPerformanceEntryType } from '../../browser/performanceObservable'
-import { createSpanIdentifier, createTraceIdentifier } from '../tracing/identifier'
 import { getDocumentTraceId } from '../tracing/getDocumentTraceId'
-import { getNavigationEntry } from '../../browser/performanceUtils'
+import { createSpanIdentifier, createTraceIdentifier } from '../tracing/identifier'
 import { startResourceCollection } from './resourceCollection'
 
 function buildMatchHeadersForAllUrls(headerNames: MatchOption[]): MatchHeader[] {
@@ -532,10 +522,6 @@ describe('resourceCollection', () => {
   })
 
   describe('network headers', () => {
-    beforeEach(() => {
-      addExperimentalFeatures([ExperimentalFeature.TRACK_RESOURCE_HEADERS])
-    })
-
     describe('Fetch', () => {
       it('should extract matching response headers from Fetch', () => {
         setupResourceCollection({
@@ -721,21 +707,6 @@ describe('resourceCollection', () => {
       const event = rawRumEvents[0].rawRumEvent as RawRumResourceEvent
       expect(event.resource.response!.headers!['x-foo']).toBe('bar')
       expect(event.resource.response!.headers!['content-type']).toBeUndefined()
-    })
-
-    it('should not collect headers when experimental feature is disabled', () => {
-      resetExperimentalFeatures()
-      setupResourceCollection({ trackResourceHeaders: buildMatchHeadersForAllUrls(['content-type']) })
-
-      notifyRequest({
-        request: {
-          type: RequestType.FETCH,
-          response: new Response('', { headers: { 'Content-Type': 'text/html' } }),
-        },
-      })
-
-      const event = rawRumEvents[0].rawRumEvent as RawRumResourceEvent
-      expect(event.resource.response).toBeUndefined()
     })
 
     describe('forbidden headers', () => {

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -6,8 +6,6 @@ import {
   createTaskQueue,
   mockable,
   runOnReadyState,
-  isExperimentalFeatureEnabled,
-  ExperimentalFeature,
   matchList,
   safeTruncate,
   display,
@@ -102,9 +100,7 @@ function assembleResource(
   const startClocks = relativeToClocks(entry.startTime)
   const duration = computeResourceEntryDuration(entry)
 
-  const networkHeaders = isExperimentalFeatureEnabled(ExperimentalFeature.TRACK_RESOURCE_HEADERS)
-    ? computeNetworkHeaders(request, configuration)
-    : undefined
+  const networkHeaders = computeNetworkHeaders(request, configuration)
 
   const resourceEvent = combine(
     {

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -395,7 +395,6 @@ function expectToHaveValidTimings(resourceEvent: RumResourceEvent) {
 
 test.describe('resource headers with trackResourceHeaders', () => {
   const TRACK_RESOURCE_HEADERS_CONFIG = {
-    enableExperimentalFeatures: ['track_resource_headers'],
     trackResourceHeaders: true,
   }
 
@@ -478,7 +477,7 @@ test.describe('resource headers with trackResourceHeaders', () => {
     })
 
   createTest('collect default and custom headers using DEFAULT_TRACKED_RESOURCE_HEADERS pattern')
-    .withRum({ enableExperimentalFeatures: ['track_resource_headers'] })
+    .withRum()
     .withRumInit((configuration) => {
       configuration.trackResourceHeaders = [
         ...window.DD_RUM!.DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),


### PR DESCRIPTION
## Motivation

`trackResourceHeaders` was previously gated behind the `track_resource_headers` experimental feature and hidden from the customer-facing TSDoc with `@hidden`. The capture, validation and telemetry-serialization paths have been stable for a while — this PR makes the option generally available so customers can opt in by setting `trackResourceHeaders` alone (no experimental flag needed) and discover the option in the published API docs.

## Changes

- Drop the runtime gate in `resourceCollection.ts` — `computeNetworkHeaders` is now called unconditionally; the option's own validation (empty array by default) keeps it off unless the customer enables it.
- Remove the `TRACK_RESOURCE_HEADERS` entry from `ExperimentalFeature` (`packages/core/src/tools/experimentalFeatures.ts`).
- Remove the obsolete `should not collect headers when experimental feature is disabled` unit test and the `addExperimentalFeatures(...)` setup in `resourceCollection.spec.ts`. Drop the unused `addExperimentalFeatures` / `ExperimentalFeature` / `resetExperimentalFeatures` imports there.
- Drop `enableExperimentalFeatures: ['track_resource_headers']` from the E2E setup in `test/e2e/scenario/rum/resources.scenario.ts`.
- Remove the `@hidden` TSDoc directives on `trackResourceHeaders`, `DEFAULT_TRACKED_RESOURCE_HEADERS` (in both `configuration.ts` and `rumPublicApi.ts`).

The validation logic (`validateAndBuildTrackResourceHeaders`), capture logic (`computeNetworkHeaders` / `filterHeaders`) and telemetry serialization (`track_resource_headers: 'default_headers' | 'custom'`) are unchanged.

## Test instructions

### Automated

```bash
yarn test:unit
yarn build:apps && yarn test:e2e -g "trackResourceHeaders"
```

### Manual test

```bash
# 1. From a clean working tree on this branch:
yarn dev-server start
yarn dev-server intake clear

# 2. Create a sandbox page that opts in WITHOUT enableExperimentalFeatures:
cat > sandbox/test-track-resource-headers.html <<'HTML'
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>Test trackResourceHeaders GA</title>
    <script src="/datadog-rum.js"></script>
    <script>
      DD_RUM.init({
        clientToken: 'xxx',
        applicationId: 'xxx',
        trackResources: true,
        proxy: '/proxy',
        trackResourceHeaders: [
          ...DD_RUM.DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
          { name: 'x-custom' },
        ],
      })
    </script>
  </head>
  <body>
    <button id="fire-fetch"
      onclick="fetch('/datadog-rum.js?probe=' + Date.now(), { headers: { 'X-Custom': 'hello-from-sandbox', 'Content-Type': 'application/json' } })">
      fire fetch
    </button>
  </body>
</html>
HTML

# 3. Open the page in a browser, click the button, and inspect the captured fetch resource:
#    http://localhost:8080/test-track-resource-headers.html

# 4. After the events are flushed (e.g. open another tab):
yarn dev-server intake rum-resources --format json \
  | jq -c 'select(.resource.url | contains("datadog-rum.js?probe=")) | {request_headers: .resource.request.headers, response_headers: .resource.response.headers}'
```

Expected output (one matching resource event):

```
{"request_headers":{"content-type":"application/json","x-custom":"hello-from-sandbox"},"response_headers":{"content-length":"...","content-type":"text/javascript; charset=utf-8"}}
```

Cleanup: `yarn dev-server stop && rm sandbox/test-track-resource-headers.html`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file