### PR TITLE
🐛 [PANA-7217] Limit the size of the string table in session replay recordings

### DIFF
--- a/packages/rum/src/domain/record/itemIds.ts
+++ b/packages/rum/src/domain/record/itemIds.ts
@@ -20,6 +20,9 @@ export type StringId = number & { __brand: 'StringId' }
 export type StringIds = ItemIds<string, StringId>
 export const enum StringIdConstants {
   FIRST_ID = 0,
+
+  // An arbitrarily-chosen soft limit on the maximum size of the string id map.
+  SOFT_MAX_SIZE = 1000000,
 }
 export function createStringIds(): StringIds {
   return createIdMap(StringIdConstants.FIRST_ID as StringId)

--- a/packages/rum/src/domain/record/serialization/changeEncoder.spec.ts
+++ b/packages/rum/src/domain/record/serialization/changeEncoder.spec.ts
@@ -141,6 +141,45 @@ describe('ChangeEncoder', () => {
     })
   })
 
+  describe('soft max size of the string table', () => {
+    // Simulates a full string table without actually inserting a million entries.
+    const simulateFullStringTable = () => {
+      Object.defineProperty(stringIds, 'size', { get: () => 1_000_000, configurable: true })
+    }
+
+    it('does not add new strings to the table once the soft max size is reached', () => {
+      simulateFullStringTable()
+
+      encoder.add(ChangeType.Text, [0, 'new-string'])
+      const changes = encoder.flush()
+
+      // The new string remains as a literal in the change data and no AddString is emitted.
+      expect(changes).toEqual([[ChangeType.Text, [0, 'new-string']]])
+    })
+
+    it('still reuses existing string ids once the soft max size is reached', () => {
+      const existingId = stringIds.getOrInsert('existing')
+      simulateFullStringTable()
+
+      encoder.add(ChangeType.Text, [0, 'existing'])
+      const changes = encoder.flush()
+
+      // No AddString is emitted, but the existing string is still replaced with its id.
+      expect(changes).toEqual([[ChangeType.Text, [0, existingId]]])
+    })
+
+    it('handles a mix of new and existing strings once the soft max size is reached', () => {
+      const fooId = stringIds.getOrInsert('foo')
+      simulateFullStringTable()
+
+      encoder.add(ChangeType.AddNode, [null, 'foo', ['class', 'bar']])
+      const changes = encoder.flush()
+
+      // 'foo' is replaced with its existing id; 'class' and 'bar' stay as literals.
+      expect(changes).toEqual([[ChangeType.AddNode, [null, fooId, ['class', 'bar']]]])
+    })
+  })
+
   describe('flush', () => {
     it('returns an empty array when no changes have been added', () => {
       const changes = encoder.flush()

--- a/packages/rum/src/domain/record/serialization/changeEncoder.spec.ts
+++ b/packages/rum/src/domain/record/serialization/changeEncoder.spec.ts
@@ -1,6 +1,6 @@
 import { ChangeType } from '../../../types'
 import type { StringId } from '../itemIds'
-import { createStringIds } from '../itemIds'
+import { createStringIds, StringIdConstants } from '../itemIds'
 import type { ChangeEncoder } from './changeEncoder'
 import { createChangeEncoder } from './changeEncoder'
 
@@ -144,7 +144,7 @@ describe('ChangeEncoder', () => {
   describe('soft max size of the string table', () => {
     // Simulates a full string table without actually inserting a million entries.
     const simulateFullStringTable = () => {
-      Object.defineProperty(stringIds, 'size', { get: () => 1_000_000, configurable: true })
+      Object.defineProperty(stringIds, 'size', { get: () => StringIdConstants.SOFT_MAX_SIZE, configurable: true })
     }
 
     it('does not add new strings to the table once the soft max size is reached', () => {

--- a/packages/rum/src/domain/record/serialization/changeEncoder.ts
+++ b/packages/rum/src/domain/record/serialization/changeEncoder.ts
@@ -1,5 +1,6 @@
 import type { Change } from '../../../types'
 import { ChangeType } from '../../../types'
+import { StringIdConstants } from '../itemIds'
 import type { StringIds } from '../itemIds'
 
 type ChangeData<T extends ChangeType> =
@@ -32,10 +33,17 @@ export function createChangeEncoder(stringIds: StringIds): ChangeEncoder {
     for (let index = 0, length = array.length; index < length; index++) {
       const item = array[index]
       if (typeof item === 'string') {
-        const previousSize = stringIds.size
-        array[index] = stringIds.getOrInsert(item)
-        if (stringIds.size > previousSize) {
-          add(ChangeType.AddString, item)
+        const currentSize = stringIds.size
+        if (currentSize < (StringIdConstants.SOFT_MAX_SIZE as number)) {
+          // Insert this string into the string table.
+          array[index] = stringIds.getOrInsert(item)
+          if (stringIds.size > currentSize) {
+            add(ChangeType.AddString, item)
+          }
+        } else {
+          // The string table is full. If this string is already in the string table, use
+          // the existing entry, but if it's not there, don't insert it.
+          array[index] = stringIds.get(item) ?? item
         }
       } else if (Array.isArray(item)) {
         convertStringsToStringReferences(item)


### PR DESCRIPTION
## Motivation

The new DOM serialization algorithm in v7 of the browser SDK constructs a string table, allowing strings to be deduplicated across records. This greatly improves the space efficiency of session replay recordings.

There's a known issue with this string table: if a view lasts for a very long time, the string table can grow to be quite large. We should apply a limit to the size of the string table to ensure that we limit the amount of memory the recording process uses.

In the short term, the easiest approach is to just stop adding entries to the string table once it grows above an arbitrary maximum size, and that's what this PR implements. However, this is a bit of a bummer, because it means that views that hit this threshold will not benefit from the string table as much as they otherwise could. It would likely be better to reset the string table when it gets too large, repopulating it from that point. That change is a bit more complicated, since it requires a tweak to the data format (we should be explicit about when the reset happens to ensure that the recorder and the player agree), so I don't want to start with it, but I plan to revisit this issue in the near future.

## Changes

This PR adds a `StringIdConstants.SOFT_MAX_SIZE` constant defining the size limit for the string table. This limit is set arbitrarily for now; I plan to add telemetry to gather data about how large these string tables are in practice, and I'll adjust the limit in the future based on that data.

The size limit is enforced by `ChangeEncoder`, which is the infrastructure that actually replaces strings in the recorded event stream with references to the string table. The data format was designed to allow either a literal string or a string table reference in any position where a string can be used, so it's fine if `ChangeEncoder` simply declines to replace strings once the size limit is hit. Even if the string table is maxed out, a string can still be replaced with a string table reference if the string is already in the table, so we still get value from the string table even in this situation.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
