### PR TITLE
[Browser Profiler] 🐛 use profiling start time to look up session id

### DIFF
--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -129,6 +129,7 @@ describe('profiler', () => {
     return {
       profiler,
       profilingContextManager,
+      sessionManager,
       mockedRumProfilerTrace,
       addLongTask: (longTask: LongTaskContext) => {
         longTaskHistory.add(longTask, relativeNow()).close(addDuration(relativeNow(), longTask.duration))
@@ -910,6 +911,26 @@ describe('profiler', () => {
     // because the inflated timeStamp-based duration extends the query window.
     expect(trace.longTasks.length).toBe(1)
     expect(trace.longTasks[0].id).toBe('long-task-inside')
+  })
+
+  it('should use the profiling start time when looking up the session id', async () => {
+    const clock = mockClock()
+    const { profiler, sessionManager } = setupProfiler()
+    const findTrackedSessionSpy = spyOn(sessionManager, 'findTrackedSession').and.callThrough()
+
+    profiler.start()
+    expect(profiler.isRunning()).toBe(true)
+
+    const expectedStartTime = relativeNow()
+
+    clock.tick(1000)
+
+    profiler.stop()
+
+    await waitNextMicrotask()
+    await waitNextMicrotask()
+
+    expect(findTrackedSessionSpy).toHaveBeenCalledWith(expectedStartTime)
   })
 
   it('should restart profiling when session expires while paused and then renews', async () => {

--- a/packages/rum/src/domain/profiling/profiler.ts
+++ b/packages/rum/src/domain/profiling/profiler.ts
@@ -1,4 +1,4 @@
-import type { Encoder } from '@datadog/browser-core'
+import type { Encoder, RelativeTime } from '@datadog/browser-core'
 import {
   addEventListener,
   clearTimeout,
@@ -257,7 +257,8 @@ export function createRumProfiler(
             vitals,
             views,
             sampleInterval: profilerConfiguration.sampleIntervalMs,
-          })
+          }),
+          startClocks.relative
         )
       })
       .catch(monitorError)
@@ -318,9 +319,8 @@ export function createRumProfiler(
     instance.views.push(viewEntry)
   }
 
-  function handleProfilerTrace(trace: BrowserProfilerTrace): void {
-    // Find current session to assign it to the Profile.
-    const sessionId = session.findTrackedSession()?.id
+  function handleProfilerTrace(trace: BrowserProfilerTrace, startTime: RelativeTime): void {
+    const sessionId = session.findTrackedSession(startTime)?.id
     const payload = assembleProfilingPayload(trace, configuration, sessionId)
 
     void transport.send(payload as unknown as TransportPayload)


### PR DESCRIPTION
## Motivation

When a profiling session ends, data collection is asynchronous (fire-and-forget). The session ID was previously looked up at collection time via `findTrackedSession()` with no argument, which returns the *current* session. If the RUM session expired between profiling start and the async collection completing, `findTrackedSession()` returns `undefined` and the profile is sent without a session ID.

Fixes PROF-14412.

## Changes

- `profiler.ts`: `handleProfilerTrace` now receives `startTime: RelativeTime` (the profiling instance's `startClocks.relative`) and passes it to `findTrackedSession(startTime)`. This looks up the session that was active at profiling start rather than at collection time.
- `profiler.spec.ts`: Added test verifying `findTrackedSession` is called with the profiling start time; exposed `sessionManager` from the `setupProfiler` helper.

## Test instructions

1. No manual repro steps — the race condition (session expiry between profiling start and async collection) is not easily triggered manually.
2. Unit test covers the fix: `should use the profiling start time when looking up the session id`.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file