### PR TITLE
✨ [Synthetics] Read customer RUM applicationId in Assemble hook

### DIFF
--- a/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/syntheticsContext.spec.ts
@@ -12,6 +12,10 @@ describe('getSyntheticsContext', () => {
     hooks = createHooks()
   })
 
+  afterEach(() => {
+    delete (window as unknown as { DD_RUM?: unknown }).DD_RUM
+  })
+
   describe('assemble hook', () => {
     it('should set the synthetics context defined by global variables', () => {
       mockSyntheticsWorkerValues({ context: { test_id: 'foo', result_id: 'bar' } }, 'globals')
@@ -169,6 +173,76 @@ describe('getSyntheticsContext', () => {
       } as AssembleHookParams)
 
       expect(defaultRumEventAttributes).toBeUndefined()
+    })
+
+    describe('original_application_id', () => {
+      beforeEach(() => {
+        mockSyntheticsWorkerValues({ context: { test_id: 'foo', result_id: 'bar' } }, 'globals')
+        startSyntheticsContext(hooks)
+      })
+
+      it('should include original_application_id when DD_RUM.getInitConfiguration returns an applicationId', () => {
+        ;(window as unknown as { DD_RUM: unknown }).DD_RUM = {
+          getInitConfiguration: () => ({ applicationId: 'cust-app-id' }),
+        }
+
+        const result = hooks.triggerHook(HookNames.Assemble, {
+          eventType: 'view',
+          startTime: 0 as RelativeTime,
+        } as AssembleHookParams)
+
+        expect((result as any).synthetics.original_application_id).toBe('cust-app-id')
+      })
+
+      it('should not include original_application_id when DD_RUM is absent', () => {
+        const result = hooks.triggerHook(HookNames.Assemble, {
+          eventType: 'view',
+          startTime: 0 as RelativeTime,
+        } as AssembleHookParams)
+
+        expect((result as any).synthetics).not.toEqual(
+          jasmine.objectContaining({ original_application_id: jasmine.anything() })
+        )
+      })
+
+      it('should not include original_application_id when getInitConfiguration returns no applicationId', () => {
+        ;(window as unknown as { DD_RUM: unknown }).DD_RUM = {
+          getInitConfiguration: () => ({}),
+        }
+
+        const result = hooks.triggerHook(HookNames.Assemble, {
+          eventType: 'view',
+          startTime: 0 as RelativeTime,
+        } as AssembleHookParams)
+
+        expect((result as any).synthetics).not.toEqual(
+          jasmine.objectContaining({ original_application_id: jasmine.anything() })
+        )
+      })
+
+      it('should not throw and should not include original_application_id when getInitConfiguration throws', () => {
+        ;(window as unknown as { DD_RUM: unknown }).DD_RUM = {
+          getInitConfiguration: () => {
+            throw new Error('not ready')
+          },
+        }
+
+        expect(() => {
+          hooks.triggerHook(HookNames.Assemble, {
+            eventType: 'view',
+            startTime: 0 as RelativeTime,
+          } as AssembleHookParams)
+        }).not.toThrow()
+
+        const result = hooks.triggerHook(HookNames.Assemble, {
+          eventType: 'view',
+          startTime: 0 as RelativeTime,
+        } as AssembleHookParams)
+
+        expect((result as any).synthetics).not.toEqual(
+          jasmine.objectContaining({ original_application_id: jasmine.anything() })
+        )
+      })
     })
   })
 })

--- a/packages/rum-core/src/domain/contexts/syntheticsContext.ts
+++ b/packages/rum-core/src/domain/contexts/syntheticsContext.ts
@@ -1,6 +1,7 @@
 import {
   SKIPPED,
   getSyntheticsContext,
+  getGlobalObject,
   HookNames,
   willSyntheticsInjectRum,
   isSyntheticsTest,
@@ -8,11 +9,25 @@ import {
 import { SessionType } from '../rumSessionManager'
 import type { DefaultRumEventAttributes, Hooks } from '../hooks'
 
+interface CustomerRumGlobal {
+  getInitConfiguration?(): { applicationId?: string } | undefined
+}
+
+function getCustomerRumApplicationId(): string | undefined {
+  try {
+    return getGlobalObject<{ DD_RUM?: CustomerRumGlobal }>().DD_RUM?.getInitConfiguration()?.applicationId
+  } catch {
+    return undefined
+  }
+}
+
 export function startSyntheticsContext(hooks: Hooks) {
   hooks.register(HookNames.Assemble, ({ eventType }): DefaultRumEventAttributes | SKIPPED => {
     if (!isSyntheticsTest()) {
       return SKIPPED
     }
+
+    const originalApplicationId = getCustomerRumApplicationId()
 
     return {
       type: eventType,
@@ -22,6 +37,7 @@ export function startSyntheticsContext(hooks: Hooks) {
       synthetics: {
         ...getSyntheticsContext(),
         injected: willSyntheticsInjectRum(),
+        ...(originalApplicationId !== undefined && { original_application_id: originalApplicationId }),
       },
     }
   })


### PR DESCRIPTION
## What does this PR do?

In `startSyntheticsContext`, reads `window.DD_RUM?.getInitConfiguration()?.applicationId` directly in the Assemble hook and includes it as `synthetics.original_application_id` on every RUM event when running in a Synthetics test.

## Motivation

When Synthetics injects its own RUM SDK (`DD_RUM_SYNTHETICS`), the customer's `DD_RUM.init()` short-circuits early — but `cachedInitConfiguration` is stored before the bail-out, so `getInitConfiguration()?.applicationId` is always available. Reading it per-event in the Assemble hook (alongside the existing `getSyntheticsContext()` spread) avoids any interception logic in the Synthetics worker (no `defineProperty`, no `init` wrapping).

This follows the same pattern established in #4236: future fields flow through to `synthetics.*` automatically without requiring SDK changes.

## Testing

- Added unit tests covering: applicationId present, DD_RUM absent, no applicationId returned, `getInitConfiguration` throws
- All 3820 existing tests continue to pass

## Who will it impact

Synthetics browser tests where the customer instruments their app with `DD_RUM` — `synthetics.original_application_id` will now be set on all injected RUM events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)