### PR TITLE
🐛 tolerate Cypress.env throwing under allowCypressEnv: false

### DIFF
--- a/packages/rum-core/src/domain/contexts/ciVisibilityContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/ciVisibilityContext.spec.ts
@@ -1,5 +1,5 @@
 import type { Configuration, RelativeTime } from '@datadog/browser-core'
-import { HookNames, Observable } from '@datadog/browser-core'
+import { display, HookNames, Observable } from '@datadog/browser-core'
 import { mockCiVisibilityValues } from '../../../test'
 import type { CookieObservable } from '../../browser/cookieObservable'
 import { SessionType } from '../rumSessionManager'
@@ -105,6 +105,47 @@ describe('startCiVisibilityContext', () => {
       } as AssembleHookParams)
 
       expect(defaultRumEventAttributes).toBeUndefined()
+    })
+
+    it('should not throw and emit a warning when Cypress.env throws', () => {
+      const displaySpy = spyOn(display, 'warn')
+      mockCiVisibilityValues(undefined, 'globals-throws')
+
+      expect(() => {
+        ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+      }).not.toThrow()
+
+      const defaultRumEventAttributes = hooks.triggerHook(HookNames.Assemble, {
+        eventType: 'view',
+        startTime: 0 as RelativeTime,
+      } as AssembleHookParams)
+
+      expect(defaultRumEventAttributes).toBeUndefined()
+      expect(displaySpy).toHaveBeenCalledTimes(1)
+      expect(displaySpy.calls.mostRecent().args[0]).toContain('5.88.0')
+    })
+
+    it('should not emit a warning when Cypress.env returns a value', () => {
+      const displaySpy = spyOn(display, 'warn')
+      mockCiVisibilityValues('trace_id_value')
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+
+      expect(displaySpy).not.toHaveBeenCalled()
+    })
+
+    it('should not emit a warning when the cookie is set', () => {
+      const displaySpy = spyOn(display, 'warn')
+      mockCiVisibilityValues('trace_id_value', 'cookies')
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+
+      expect(displaySpy).not.toHaveBeenCalled()
+    })
+
+    it('should not emit a warning when Cypress is not present', () => {
+      const displaySpy = spyOn(display, 'warn')
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hooks, cookieObservable))
+
+      expect(displaySpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/rum-core/src/domain/contexts/ciVisibilityContext.ts
+++ b/packages/rum-core/src/domain/contexts/ciVisibilityContext.ts
@@ -1,5 +1,5 @@
-import { getInitCookie, HookNames, SKIPPED } from '@datadog/browser-core'
 import type { Configuration } from '@datadog/browser-core'
+import { display, getInitCookie, HookNames, SKIPPED } from '@datadog/browser-core'
 import { createCookieObservable } from '../../browser/cookieObservable'
 import { SessionType } from '../rumSessionManager'
 import type { DefaultRumEventAttributes, Hooks } from '../hooks'
@@ -19,8 +19,7 @@ export function startCiVisibilityContext(
   hooks: Hooks,
   cookieObservable = createCookieObservable(configuration, CI_VISIBILITY_TEST_ID_COOKIE_NAME)
 ) {
-  let testExecutionId =
-    getInitCookie(CI_VISIBILITY_TEST_ID_COOKIE_NAME) || (window as CiTestWindow).Cypress?.env('traceId')
+  let testExecutionId = getInitCookie(CI_VISIBILITY_TEST_ID_COOKIE_NAME) || readCypressTraceId()
 
   const cookieObservableSubscription = cookieObservable.subscribe((value) => {
     testExecutionId = value
@@ -46,5 +45,20 @@ export function startCiVisibilityContext(
     stop: () => {
       cookieObservableSubscription.unsubscribe()
     },
+  }
+}
+
+function readCypressTraceId(): string | undefined {
+  const cypress = (window as CiTestWindow).Cypress
+  if (!cypress) {
+    return undefined
+  }
+  try {
+    return cypress.env('traceId')
+  } catch {
+    display.warn(
+      'Failed to read Cypress test execution id via Cypress.env(). Upgrade dd-trace-js to >= 5.88.0 to keep RUM ↔ test correlation working.'
+    )
+    return undefined
   }
 }

--- a/packages/rum-core/test/mockCiVisibilityValues.ts
+++ b/packages/rum-core/test/mockCiVisibilityValues.ts
@@ -5,7 +5,10 @@ import { CI_VISIBILITY_TEST_ID_COOKIE_NAME, type CiTestWindow } from '../src/dom
 // Duration to create a cookie lasting at least until the end of the test
 const COOKIE_DURATION = ONE_MINUTE
 
-export function mockCiVisibilityValues(testExecutionId: unknown, method: 'globals' | 'cookies' = 'globals') {
+export function mockCiVisibilityValues(
+  testExecutionId: unknown,
+  method: 'globals' | 'cookies' | 'globals-throws' = 'globals'
+) {
   switch (method) {
     case 'globals':
       ;(window as CiTestWindow).Cypress = {
@@ -16,6 +19,15 @@ export function mockCiVisibilityValues(testExecutionId: unknown, method: 'global
         },
       }
 
+      break
+    case 'globals-throws':
+      ;(window as CiTestWindow).Cypress = {
+        env: () => {
+          throw new Error(
+            'Cypress.env() does not work when allowCypressEnv is set to false. Please migrate to cy.env() or leverage other stateful methods to manage variables. The variable being accessed was: traceId'
+          )
+        },
+      }
       break
     case 'cookies':
       if (typeof testExecutionId === 'string') {


### PR DESCRIPTION
## Motivation

A telemetry error is observed in customer data:

> `CypressError: Cypress.env() does not work when allowCypressEnv is set to false. ... The variable being accessed was: traceId`

The SDK reads `window.Cypress.env('traceId')` at boot in `ciVisibilityContext.ts` as a secondary transport for the CI Visibility test execution id (the primary is the `datadog-ci-visibility-test-execution-id` cookie). Under [Cypress 15.10+](https://www.cypress.io/blog/environment-variable-access-in-cypress-v15-10-0-migrating-to-cy-env-and-cypress-expose) with `allowCypressEnv: false`, the call itself throws regardless of whether a value was set.

The legacy env path is still used: it serves customers on `dd-trace-js < 5.88.0` (where the plugin still wrote via `Cypress.env`). Removing the read would silently break correlation for them.

## Changes

- Wrap the `Cypress.env('traceId')` read in try/catch in `ciVisibilityContext.ts` so the throw no longer bubbles up
- Emit a `display.warn(...)` only when the env read actually throws, prompting customers to upgrade `dd-trace-js >= 5.88.0` (the version that switched the writer to the cookie via [dd-trace-js#7600](https://github.com/DataDog/dd-trace-js/pull/7600)).

## Test instructions

- `yarn test:unit --spec packages/rum-core/src/domain/contexts/ciVisibilityContext.spec.ts` — 9 specs pass (5 existing + 4 new).

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file