### PR TITLE
📝 update CDN URLs to v7 and clear NEXT_MAJOR_BRANCH

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
   GIT_REPOSITORY: 'git@github.com:DataDog/browser-sdk.git'
   MAIN_BRANCH: 'main'
-  NEXT_MAJOR_BRANCH: 'v7'
+  NEXT_MAJOR_BRANCH: ''
   CHROME_PACKAGE_VERSION: 147.0.7727.55-1
   FF_TIMESTAMPS: 'true' # Enable timestamps for gitlab-ci logs
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Datadog provides one CDN bundle per [site][70]:
 
 | Site    | logs                                                           | rum                                                           | rum-slim                                                           |
 | ------- | -------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| US1     | https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js |
-| US3     | https://www.datadoghq-browser-agent.com/us3/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum-slim.js |
-| US5     | https://www.datadoghq-browser-agent.com/us5/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/us5/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/us5/v6/datadog-rum-slim.js |
-| EU1     | https://www.datadoghq-browser-agent.com/eu1/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum-slim.js |
-| AP1     | https://www.datadoghq-browser-agent.com/ap1/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/ap1/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/ap1/v6/datadog-rum-slim.js |
-| US1-FED | https://www.datadoghq-browser-agent.com/datadog-logs-v6.js     | https://www.datadoghq-browser-agent.com/datadog-rum-v6.js     | https://www.datadoghq-browser-agent.com/datadog-rum-slim-v6.js     |
+| US1     | https://www.datadoghq-browser-agent.com/us1/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum-slim.js |
+| US3     | https://www.datadoghq-browser-agent.com/us3/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/us3/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/us3/v7/datadog-rum-slim.js |
+| US5     | https://www.datadoghq-browser-agent.com/us5/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/us5/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/us5/v7/datadog-rum-slim.js |
+| EU1     | https://www.datadoghq-browser-agent.com/eu1/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/eu1/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/eu1/v7/datadog-rum-slim.js |
+| AP1     | https://www.datadoghq-browser-agent.com/ap1/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/ap1/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/ap1/v7/datadog-rum-slim.js |
+| US1-FED | https://www.datadoghq-browser-agent.com/datadog-logs-v7.js     | https://www.datadoghq-browser-agent.com/datadog-rum-v7.js     | https://www.datadoghq-browser-agent.com/datadog-rum-slim-v7.js     |
 
 [1]: https://github.githubassets.com/favicons/favicon.png
 [2]: https://imgix.datadoghq.com/img/favicons/favicon-32x32.png


### PR DESCRIPTION
## Motivation

Now that `v7` is the next major branch in active development, the README's CDN bundle URLs should point to `/v7/` paths, and the `NEXT_MAJOR_BRANCH` CI variable should be cleared since there is no further "next major" beyond v7 at this time.

## Changes

- Update CDN bundle URLs in `README.md` from `/v6/` to `/v7/` (including US1-FED `*-v6.js` -> `*-v7.js`)
- Clear `NEXT_MAJOR_BRANCH` in `.gitlab-ci.yml`

## Test instructions

- Review the diff in `README.md` and `.gitlab-ci.yml`
- Confirm CI passes on this branch

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file