### PR TITLE
👷 add dd-octo-sts[bot] to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,7 +40,7 @@ jobs:
           branch: 'browser-sdk'
           remote-repository-name: cla-signatures
           remote-organization-name: DataDog
-          allowlist: renovate,renovate[bot],campaigner-prod,gh-worker-dd-devflow-*,dd-devflow[bot],ci.browser-sdk
+          allowlist: renovate,renovate[bot],campaigner-prod,gh-worker-dd-devflow-*,dd-devflow[bot],dd-octo-sts[bot],ci.browser-sdk
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #allowlist: user1,bot*


### PR DESCRIPTION
## Motivation

The `dd-octo-sts[bot]` GitHub App authors automated PRs in this repo (e.g. the automated Chrome browser version bump PRs). Its commits are currently flagged by the CLA check, so add it to the allowlist alongside the other bots.

## Changes

- Add `@dd-octo-sts[bot]` to the CLA allowlist in `.github/workflows/cla.yml`.

## Test instructions

Verify the CLA check passes on subsequent automated PRs authored by `dd-octo-sts[bot]` (e.g. Chrome bump PRs) once merged.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file