### PR TITLE
👷 Renovate: pin angular-app to its current Angular version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,11 @@
       "matchFileNames": ["test/apps/react-router-v6-app/**"],
       "matchDepNames": ["react-router-dom"],
       "enabled": false
+    },
+    {
+      "matchFileNames": ["test/apps/angular-app/**"],
+      "matchPackageNames": ["@angular/**"],
+      "enabled": false
     }
   ],
   "toolSettings": {

--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,8 @@
     },
     {
       "matchFileNames": ["test/apps/angular-app/**"],
-      "matchPackageNames": ["@angular/**"],
+      "matchPackageNames": ["@angular/**", "typescript"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
## Motivation

The `test/apps/angular-app` test app is intentionally pinned to a specific Angular version to exercise SDK behavior on that version. Renovate has been opening upgrade PRs for `@angular/*` packages in this app (e.g. #4482), which is not desired here.

This mirrors the existing pattern already used for `react-router-v6-app` / `react-router-dom`.

## Changes

- Disable Renovate updates for `@angular/*` packages scoped to `test/apps/angular-app/**`.

## Test instructions

- Inspect `renovate.json` and confirm the new `packageRules` entry matches the existing `react-router-v6-app` rule structure.
- Future Renovate runs should no longer open PRs upgrading `@angular/*` in `test/apps/angular-app`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file