### PR TITLE
🐛 Drain SDK idle-callback queue before flushing in e2e tests

### DIFF
--- a/test/e2e/lib/framework/waitForRequests.ts
+++ b/test/e2e/lib/framework/waitForRequests.ts
@@ -21,16 +21,9 @@ export async function waitForRequests(page: Page) {
         // first batch of tasks are also processed. A 500ms watchdog covers pages where
         // requestIdleCallback is throttled or unavailable (e.g. the empty /flush page during
         // teardown).
-        let done = false
-        const finish = () => {
-          if (!done) {
-            done = true
-            resolve()
-          }
-        }
-        setTimeout(finish, 500)
+        setTimeout(resolve, 500)
         const ric = window.requestIdleCallback?.bind(window) ?? ((cb: IdleRequestCallback) => setTimeout(cb, 50))
-        ric(() => ric(() => setTimeout(finish, 0)))
+        ric(() => ric(() => setTimeout(resolve, 0)))
       })
   )
   await waitForServersIdle()

--- a/test/e2e/lib/framework/waitForRequests.ts
+++ b/test/e2e/lib/framework/waitForRequests.ts
@@ -8,16 +8,29 @@ import { waitForServersIdle } from './httpServers'
  * callback might *not* have reached the local server when `browser.execute` finishes. Thus, calling
  * `waitForServersIdle()` directly might be flaky, because no request might be pending yet.
  *
- * As a workaround, this function delays the `waitForServersIdle()` call by doing a browser
- * roundtrip, ensuring requests have plenty of time to reach the local server.
+ * The SDK also defers some bookkeeping (notably resource event emission) onto an idle-callback
+ * task queue, so we drain it explicitly via two `requestIdleCallback` round-trips before letting
+ * the test assert on captured events.
  */
 export async function waitForRequests(page: Page) {
   await page.evaluate(
     () =>
-      new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(undefined)
-        }, 200)
+      new Promise<void>((resolve) => {
+        // Drain the SDK's idle-callback task queue (used to defer resource event emission) before
+        // letting the test assert on captured events. Two passes ensure tasks enqueued by the
+        // first batch of tasks are also processed. A 500ms watchdog covers pages where
+        // requestIdleCallback is throttled or unavailable (e.g. the empty /flush page during
+        // teardown).
+        let done = false
+        const finish = () => {
+          if (!done) {
+            done = true
+            resolve()
+          }
+        }
+        setTimeout(finish, 500)
+        const ric = window.requestIdleCallback?.bind(window) ?? ((cb: IdleRequestCallback) => setTimeout(cb, 50))
+        ric(() => ric(() => setTimeout(finish, 0)))
       })
   )
   await waitForServersIdle()


### PR DESCRIPTION
## Motivation

E2E tests (notably the microfrontend fetch/XHR scenarios) were flaky because the SDK defers some bookkeeping — particularly resource event emission — onto an idle-callback task queue. The previous `waitForRequests` helper just slept 200ms via `setTimeout`, which was not always enough for those deferred tasks to run before the test asserted on captured events.

## Changes

- Replace the fixed 200ms `setTimeout` in `waitForRequests` with two `requestIdleCallback` round-trips to drain the SDK's idle-callback queue (including tasks enqueued by the first batch).
- Keep a 500ms watchdog as a fallback for environments where `requestIdleCallback` is throttled or unavailable (e.g. the empty `/flush` page during teardown).

## Test instructions

- Run the E2E suite: `yarn test:e2e`
- Re-run microfrontend fetch/XHR scenarios multiple times to confirm the flake no longer reproduces.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file