### PR TITLE
👷 Auto-cancel interruptible jobs on new commits

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,10 @@ variables:
   CHROME_PACKAGE_VERSION: 148.0.7778.96-1
   FF_TIMESTAMPS: 'true' # Enable timestamps for gitlab-ci logs
 
+workflow:
+  auto_cancel:
+    on_new_commit: interruptible
+
 cache:
   key:
     files:


### PR DESCRIPTION
## Motivation

When pushing several commits in quick succession to a branch, in-flight pipelines keep running and consume CI resources even though only the latest one matters. This is especially wasteful for jobs queued behind `resource_group: browserstack`, where superseded commits can sit in the BS queue for an hour and still run to completion.

GitLab's documented default for `workflow.auto_cancel.on_new_commit` is `conservative`, which should already cancel interruptible jobs on new commits to the same ref. In practice this doesn't seem to be working for our project anymore — pushing a new commit while a pipeline is still in the test stage does not cancel the older pipeline, even though all running jobs are marked `interruptible: true`.

Setting the keyword explicitly fixes this.

## Changes

- Add `workflow.auto_cancel.on_new_commit: interruptible` to `.gitlab-ci.yml` so pipelines superseded by a newer commit on the same branch are cancelled automatically.

## Test instructions

Validated on this branch by pushing back-to-back commits:

- **Without the fix** — pipeline [111916157](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/pipelines/111916157) (commit 1) was *not* cancelled when commit 2 was pushed; jobs kept running and `unit-bs` / `e2e-bs` stayed queued in `waiting_for_resource`.
- **With the fix** — pipeline [111916287](https://gitlab.ddbuild.io/DataDog/browser-sdk/-/pipelines/111916287) (commit 3, which introduced the fix) was correctly cancelled when commit 4 was pushed: all interruptible jobs (incl. `unit-bs` and `e2e-bs`) transitioned to `canceled`.

The empty `🧪 test` commits on this branch were used purely to exercise the behaviour and will be dropped when squashing the PR to main.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file