### PR TITLE
🐛 improve early request collection reliability in Firefox

### DIFF
--- a/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -1,7 +1,7 @@
 import type { Duration, MatchOption, RelativeTime, ServerDuration, TaskQueue, TimeStamp } from '@datadog/browser-core'
 import { createTaskQueue, display, elapsed, RequestType, ResourceType, toServerDuration } from '@datadog/browser-core'
-import type { MockTelemetry } from '@datadog/browser-core/test'
-import { registerCleanupTask, replaceMockable, startMockTelemetry } from '@datadog/browser-core/test'
+import type { Clock, MockTelemetry } from '@datadog/browser-core/test'
+import { mockClock, registerCleanupTask, replaceMockable, startMockTelemetry } from '@datadog/browser-core/test'
 import {
   collectAndValidateRawRumEvents,
   createPerformanceEntry,
@@ -22,7 +22,7 @@ import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { RequestCompleteEvent } from '../requestCollection'
 import { getDocumentTraceId } from '../tracing/getDocumentTraceId'
 import { createSpanIdentifier, createTraceIdentifier } from '../tracing/identifier'
-import { startResourceCollection } from './resourceCollection'
+import { REQUEST_MATCHING_DELAY, startResourceCollection } from './resourceCollection'
 
 function buildMatchHeadersForAllUrls(headerNames: MatchOption[]): MatchHeader[] {
   return headerNames.map((name) => ({ name }))
@@ -36,6 +36,7 @@ describe('resourceCollection', () => {
   let notifyPerformanceEntries: (entries: RumPerformanceEntry[]) => void
   let rawRumEvents: Array<RawRumEventCollectedData<RawRumEvent>> = []
   let taskQueuePushSpy: jasmine.Spy<TaskQueue['push']>
+  let clock: Clock
 
   function setupResourceCollection(partialConfig: Partial<RumConfiguration> = { trackResources: true }) {
     const { triggerOnDomLoaded } = mockDocumentReadyState()
@@ -55,6 +56,7 @@ describe('resourceCollection', () => {
   }
 
   beforeEach(() => {
+    clock = mockClock()
     ;({ notifyPerformanceEntries } = mockPerformanceObserver())
   })
 
@@ -1277,6 +1279,9 @@ describe('resourceCollection', () => {
   })
 
   function runTasks() {
+    // Request-type entries are queued through a `setTimeout(…, REQUEST_MATCHING_DELAY)` before
+    // they reach the task queue — advance past it so they get pushed.
+    clock.tick(REQUEST_MATCHING_DELAY)
     taskQueuePushSpy.calls.allArgs().forEach(([task]) => {
       task()
     })

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -61,6 +61,9 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Rum
         // The PerformanceObserver callback can fire before the fetch's resolve microtask runs
         // (notably on Firefox), so the matching REQUEST_COMPLETED isn't in the registry yet.
         // Defer the lookup to give the request time to land before we look it up.
+        //
+        // Note: we could clear the timeout on stop(), but this requires a bit of bookkeeping that
+        // is not necessary right now. We could reevaluate in the future.
         setTimeout(
           () => handleResource(() => assembleResource(entry, requestRegistry.getMatchingRequest(entry), configuration)),
           REQUEST_MATCHING_DELAY

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -1,3 +1,4 @@
+import type { Duration } from '@datadog/browser-core'
 import {
   combine,
   generateUUID,
@@ -11,6 +12,7 @@ import {
   display,
   addTelemetryDebug,
   RequestType,
+  setTimeout,
 } from '@datadog/browser-core'
 import type { MatchHeader, RumConfiguration } from '../configuration'
 import { RumPerformanceEntryType, createPerformanceObservable } from '../../browser/performanceObservable'
@@ -36,12 +38,15 @@ import {
   sanitizeIfLongDataUrl,
 } from './resourceUtils'
 import type { ResourceLikeEntry } from './resourceUtils'
-import type { RequestRegistry } from './requestRegistry'
 import { createRequestRegistry } from './requestRegistry'
 import type { GraphQlMetadata } from './graphql'
 import { extractGraphQlMetadata, findGraphQlConfiguration } from './graphql'
 import type { ManualResourceData } from './trackManualResources'
 import { trackManualResources } from './trackManualResources'
+
+// Delay before looking up the request matching a request-type performance entry. See the call
+// site in `startResourceCollection` for the rationale.
+export const REQUEST_MATCHING_DELAY = 50 as Duration
 
 export function startResourceCollection(lifeCycle: LifeCycle, configuration: RumConfiguration) {
   const taskQueue = mockable(createTaskQueue)()
@@ -52,12 +57,22 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Rum
     buffered: true,
   }).subscribe((entries) => {
     for (const entry of entries) {
-      handleResource(() => assembleResource(entry, requestRegistry, configuration))
+      if (isResourceEntryRequestType(entry)) {
+        // The PerformanceObserver callback can fire before the fetch's resolve microtask runs
+        // (notably on Firefox), so the matching REQUEST_COMPLETED isn't in the registry yet.
+        // Defer the lookup to give the request time to land before we look it up.
+        setTimeout(
+          () => handleResource(() => assembleResource(entry, requestRegistry.getMatchingRequest(entry), configuration)),
+          REQUEST_MATCHING_DELAY
+        )
+      } else {
+        handleResource(() => assembleResource(entry, undefined, configuration))
+      }
     }
   })
 
   const { stop: stopRunOnReadyState } = runOnReadyState(configuration, 'interactive', () => {
-    handleResource(() => assembleResource(getNavigationEntry(), requestRegistry, configuration))
+    handleResource(() => assembleResource(getNavigationEntry(), undefined, configuration))
   })
 
   function handleResource(computeRawEvent: () => RawRumEventCollectedData<RawRumResourceEvent> | undefined) {
@@ -86,10 +101,9 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Rum
 
 function assembleResource(
   entry: ResourceLikeEntry,
-  requestRegistry: RequestRegistry,
+  request: RequestCompleteEvent | undefined,
   configuration: RumConfiguration
 ): RawRumEventCollectedData<RawRumResourceEvent> | undefined {
-  const request = isResourceEntryRequestType(entry) ? requestRegistry.getMatchingRequest(entry) : undefined
   const tracingInfo = request
     ? computeRequestTracingInfo(request, configuration)
     : computeResourceEntryTracingInfo(entry, configuration)


### PR DESCRIPTION
## Motivation

The microfrontend e2e test `microfrontend > RUM > with beforeSend > expose handling stack for fetch requests › async` fails ~70% of the time on `firefox-pinned` (10 failed / 6 flaky / 4 passed out of 20 reproductions). The same race affects any fetch resource event in production: `event.context.handlingStack` (and the rest of the request-derived domain context — `requestInit`, `response`, `error`, …) is intermittently `undefined` for fetch resources on Firefox.

## Root cause

When a fetch resolves, two things happen around the same time:

- the browser dispatches a `PerformanceResourceTiming` entry to our observer
- `afterSend()` resumes from `await responsePromise` and notifies `REQUEST_COMPLETED`

On Firefox the observer task can fire **before** the resolve microtask runs, so the request isn't in the `requestRegistry` yet when `assembleResource()` looks it up via `requestRegistry.getMatchingRequest()`. The lookup returns `undefined` and the resulting resource event is missing all request-derived domain context.

This was introduced by [#4285 `always collect early requests`](https://github.com/DataDog/browser-sdk/pull/4285) (commit `2b71062e7`), which switched from request-driven (`performance.getEntriesByName()` at `REQUEST_COMPLETED` time) to entry-driven matching.

CI logs of the failing case make the ordering obvious:

```
[failure run]
[DEBUG resourceCollection assembleResource]
  entryStartTime:90, matchedRequest:null, registrySnapshot:[]   ← runs first, registry empty
[DEBUG requestRegistry REQUEST_COMPLETED]
  url:.../ok, startRel:89, hasHandlingStack:true, nowRel:121     ← arrives too late
```

## Changes

- `startResourceCollection`: for request-type entries (`fetch` / `xmlhttprequest` initiator), defer the registry lookup by `REQUEST_MATCHING_DELAY` (50 ms) via `setTimeout`. In practice the matching `REQUEST_COMPLETED` arrives within ~30 ms even on slow CI runners, so 50 ms is a generous bound.
- `assembleResource` now takes the resolved `request` directly instead of pulling it from the registry — the matching policy is owned by the call site where the timing context is clear.
- `requestRegistry` is unchanged; `getMatchingRequest` is still synchronous.
- Unit tests drive the new delay through `mockClock.tick(REQUEST_MATCHING_DELAY)` inside `runTasks`.

## Test instructions

Repro on the e2e suite (Firefox is the most reliable, but the race is browser-agnostic):

```bash
yarn playwright test --config test/e2e/playwright.config.ts --project firefox-pinned \
  --repeat-each=20 \
  -g 'microfrontend RUM with beforeSend expose handling stack for fetch requests async'
```

CI validation (e2e job scoped to the failing test, `--repeat-each=20`):

| pipeline | chromium | firefox-pinned | webkit-pinned |
| --- | --- | --- | --- |
| before fix | 20/20 | 4/20 (10 failed, 6 flaky) | 20/20 |
| after fix | 20/20 | **20/20** | 20/20 |

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change. <!-- existing test now passes reliably; new e2e infra not needed -->
- [ ] Updated documentation and/or relevant AGENTS.md file
