### PR TITLE
👷 use BrowserStack plan endpoint to gate test runs

### DIFF
--- a/scripts/test/bs-wrapper.ts
+++ b/scripts/test/bs-wrapper.ts
@@ -21,7 +21,7 @@ import { browserStackRequest } from '../lib/bsUtils.ts'
 
 const AVAILABILITY_CHECK_DELAY = 30_000
 const NO_OUTPUT_TIMEOUT = 5 * 60_000
-const BS_BUILD_URL = 'https://api.browserstack.com/automate/builds.json?status=running'
+const BS_PLAN_URL = 'https://api.browserstack.com/automate/plan.json'
 
 const bsLocal = new browserStack.Local()
 
@@ -44,15 +44,21 @@ runMain(async () => {
 })
 
 async function waitForAvailability(): Promise<void> {
-  while (await hasRunningBuild()) {
+  while (await hasParallelSessionsInUse()) {
     printLog('Other build running, waiting...')
     await timeout(AVAILABILITY_CHECK_DELAY)
   }
 }
 
-async function hasRunningBuild(): Promise<boolean> {
-  const builds = (await browserStackRequest(BS_BUILD_URL)) as any[]
-  return builds.length > 0
+async function hasParallelSessionsInUse(): Promise<boolean> {
+  // Use the plan endpoint rather than listing running builds: zombie builds (where the driver
+  // never connected) stay reported as "running" indefinitely, but they don't actually consume
+  // parallel slots. The plan endpoint reflects the real slot usage that BrowserStack gates on.
+  const plan = (await browserStackRequest(BS_PLAN_URL)) as {
+    parallel_sessions_running: number
+    queued_sessions: number
+  }
+  return plan.parallel_sessions_running + plan.queued_sessions > 0
 }
 
 function startBsLocal(): Promise<void> {


### PR DESCRIPTION
## Motivation

While investigating why our CI was blocked from launching new BrowserStack runs, we found that a previous CI job (`unit-bs` on a now-cancelled pipeline) had left **5 sessions stuck in the `running` state on BrowserStack** even though the job had failed over an hour earlier. The driver client never connected (sessions are internally `queued`), so neither `DELETE /automate/sessions/{id}` nor `DELETE /automate/builds/{id}` can clear them — only BS support can.

`waitForAvailability()` in `scripts/test/bs-wrapper.ts` queries `/automate/builds.json?status=running`, which counts these zombie builds and would block local test runs indefinitely until BS support clears them.

The BrowserStack dashboard, however, correctly showed **"Parallels 0/5 running | 0 queued"** — because zombie builds don't actually consume parallel slots. That state is exposed via `/automate/plan.json` (`parallel_sessions_running` + `queued_sessions`), which is what BS itself gates new sessions on.

## Changes

- Replace `BS_BUILD_URL` (`/automate/builds.json?status=running`) with `BS_PLAN_URL` (`/automate/plan.json`) in `scripts/test/bs-wrapper.ts`
- Rename `hasRunningBuild` → `hasParallelSessionsInUse`
- Use `parallel_sessions_running + queued_sessions > 0` as the availability gate
- Add a comment explaining the zombie-build edge case

## Test instructions

1. Set `BS_USERNAME` / `BS_ACCESS_KEY` env vars
2. Run `yarn typecheck` (passes)
3. Manual sanity check:
   ```bash
   curl -s -u "$BS_USERNAME:$BS_ACCESS_KEY" https://api.browserstack.com/automate/plan.json
   ```
   should return `{ parallel_sessions_running, queued_sessions, ... }`
4. Run a BS test job (e.g. `yarn test:unit:bs`) and verify it proceeds when no other parallel sessions are active

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file