### PR TITLE
[chain-pr 1/6] Core transport: SdkSource type and Batch export

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -311,6 +311,8 @@ export interface ReplicaUserConfiguration {
   clientToken: string
 }
 
+export type SdkSource = 'browser' | 'flutter' | 'unity'
+
 export interface Configuration extends TransportConfiguration {
   // Built from init configuration
   beforeSend: GenericBeforeSendCallback | undefined
@@ -331,7 +333,7 @@ export interface Configuration extends TransportConfiguration {
 
   // internal
   sdkVersion: string | undefined
-  source: 'browser' | 'flutter' | 'unity'
+  source: SdkSource
   variant: string | undefined
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export {
   isSampleRate,
   buildEndpointHost,
   isIntakeUrl,
+  computeTransportConfiguration,
 } from './domain/configuration'
 export * from './domain/intakeSites'
 export type { TrackingConsentState } from './domain/trackingConsent'
@@ -57,7 +58,15 @@ export {
   SESSION_NOT_TRACKED,
   SessionPersistence,
 } from './domain/session/sessionConstants'
-export type { BandwidthStats, HttpRequest, HttpRequestEvent, Payload, FlushEvent, FlushReason } from './transport'
+export type {
+  Batch,
+  BandwidthStats,
+  HttpRequest,
+  HttpRequestEvent,
+  Payload,
+  FlushEvent,
+  FlushReason,
+} from './transport'
 export {
   createHttpRequest,
   canUseEventBridge,

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -2,6 +2,7 @@ export type { BandwidthStats, HttpRequest, HttpRequestEvent, Payload, RetryInfo 
 export { createHttpRequest } from './httpRequest'
 export type { BrowserWindowWithEventBridge, DatadogEventBridge } from './eventBridge'
 export { canUseEventBridge, bridgeSupports, getEventBridge, BridgeCapability } from './eventBridge'
+export type { Batch } from './batch'
 export { createBatch } from './batch'
 export type { FlushController, FlushEvent, FlushReason } from './flushController'
 export { createFlushController, FLUSH_DURATION_LIMIT } from './flushController'


### PR DESCRIPTION
> This PR is part of a chain split from #0 _watson/DEBUG-5296/add-live-debugger_ by chain-pr.

## Changes

Extracts shared SdkSource type, exports Batch, and exports computeTransportConfiguration so that the new debugger package can consume them.

## Chain

→ #4577 — Core transport: SdkSource type and Batch export
  #4578 — Endpoint builder: debugger track and TransportSource
  #4579 — Debugger package configuration and tooling
  #4580 — Debugger domain implementation and tests
  #4581 — E2E framework support for debugger
  #4582 — Performance benchmark app and scenario for instrumentation overhead

---
_Draft — pending author review. Merge in order unless marked parallel._
<!-- chain-pr-meta: {"groupId":1,"dependsOn":[],"originalPR":0,"totalGroups":6,"enforcement":"block","chainPRNumbers":{"1":4577,"2":4578,"3":4579,"4":4580,"5":4581,"6":4582}} -->