### PR TITLE
[chain-pr 2/6] Endpoint builder: debugger track and TransportSource

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -8,7 +8,7 @@ import type { InitConfiguration } from './configuration'
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
 
-export type TrackType = 'logs' | 'rum' | 'replay' | 'profile' | 'exposures' | 'flagevaluation'
+export type TrackType = 'logs' | 'rum' | 'replay' | 'profile' | 'exposures' | 'flagevaluation' | 'debugger'
 export type ApiType =
   | 'fetch'
   | 'beacon'
@@ -16,10 +16,26 @@ export type ApiType =
   // a Node.js script).
   | 'manual'
 
+/**
+ * Source values supported by the transport layer for the `ddsource` URL parameter.
+ *
+ * `'dd_debugger'` is internal to the Live Debugger SDK and is not part of
+ * `InitConfiguration.source`. It can only be supplied by passing it as the
+ * `sourceOverride` argument of `computeTransportConfiguration`.
+ */
+export type TransportSource = 'browser' | 'flutter' | 'unity' | 'dd_debugger'
+
+// Internal: the endpoint builder accepts a wider `source` than the public
+// `InitConfiguration.source` so that `computeTransportConfiguration` can pass
+// the validated/overridden transport source through to URL building.
+type EndpointBuilderInitConfiguration = Omit<InitConfiguration, 'source'> & {
+  source?: TransportSource
+}
+
 export type EndpointBuilder = ReturnType<typeof createEndpointBuilder>
 
 export function createEndpointBuilder(
-  initConfiguration: InitConfiguration,
+  initConfiguration: EndpointBuilderInitConfiguration,
   trackType: TrackType,
   extraParameters?: string[]
 ) {
@@ -40,7 +56,7 @@ export function createEndpointBuilder(
  * request, as only parameters are changing.
  */
 function createEndpointUrlWithParametersBuilder(
-  initConfiguration: InitConfiguration,
+  initConfiguration: EndpointBuilderInitConfiguration,
   trackType: TrackType
 ): (parameters: string) => string {
   const path = `/api/v2/${trackType}`
@@ -58,7 +74,7 @@ function createEndpointUrlWithParametersBuilder(
 
 export function buildEndpointHost(
   trackType: TrackType,
-  initConfiguration: InitConfiguration & { usePciIntake?: boolean }
+  initConfiguration: Omit<InitConfiguration, 'source'> & { usePciIntake?: boolean }
 ) {
   const { site = INTAKE_SITE_US1, internalAnalyticsSubdomain } = initConfiguration
 
@@ -84,7 +100,7 @@ export function buildEndpointHost(
  * request, as they change randomly.
  */
 function buildEndpointParameters(
-  { clientToken, internalAnalyticsSubdomain, source = 'browser' }: InitConfiguration,
+  { clientToken, internalAnalyticsSubdomain, source = 'browser' }: EndpointBuilderInitConfiguration,
   trackType: TrackType,
   api: ApiType,
   { retry, encoding }: Payload,

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -1,7 +1,7 @@
 import type { Site } from '../intakeSites'
 import { INTAKE_SITE_US1, INTAKE_URL_PARAMETERS } from '../intakeSites'
-import type { InitConfiguration } from './configuration'
-import type { EndpointBuilder } from './endpointBuilder'
+import type { InitConfiguration, SdkSource } from './configuration'
+import type { EndpointBuilder, TransportSource } from './endpointBuilder'
 import { createEndpointBuilder } from './endpointBuilder'
 
 export interface TransportConfiguration {
@@ -11,10 +11,11 @@ export interface TransportConfiguration {
   profilingEndpointBuilder: EndpointBuilder
   exposuresEndpointBuilder: EndpointBuilder
   flagEvaluationEndpointBuilder: EndpointBuilder
+  debuggerEndpointBuilder: EndpointBuilder
   datacenter?: string | undefined
   replica?: ReplicaConfiguration
   site: Site
-  source: 'browser' | 'flutter' | 'unity'
+  source: TransportSource
 }
 
 export interface ReplicaConfiguration {
@@ -22,12 +23,39 @@ export interface ReplicaConfiguration {
   rumEndpointBuilder: EndpointBuilder
 }
 
-export function computeTransportConfiguration(initConfiguration: InitConfiguration): TransportConfiguration {
-  const site = initConfiguration.site || INTAKE_SITE_US1
-  const source = validateSource(initConfiguration.source)
+// Internal: init configuration once the transport source has been resolved
+// (validated user value or `sourceOverride` from `computeTransportConfiguration`).
+type ResolvedSourceInitConfiguration = Omit<InitConfiguration, 'source'> & {
+  source: TransportSource
+}
 
-  const endpointBuilders = computeEndpointBuilders({ ...initConfiguration, site, source })
-  const replicaConfiguration = computeReplicaConfiguration({ ...initConfiguration, site, source })
+/**
+ * Compute the transport configuration (endpoint builders, replica, etc.) for an
+ * SDK init configuration.
+ *
+ * When called without `sourceOverride`, the resulting `source` is whatever was
+ * provided in `initConfiguration.source` (validated to a `SdkSource`, defaulting
+ * to `browser`).
+ *
+ * When called with `sourceOverride`, that value is used instead.
+ */
+export function computeTransportConfiguration(
+  initConfiguration: InitConfiguration
+): TransportConfiguration & { source: SdkSource }
+export function computeTransportConfiguration(
+  initConfiguration: InitConfiguration,
+  sourceOverride: TransportSource
+): TransportConfiguration
+export function computeTransportConfiguration(
+  initConfiguration: InitConfiguration,
+  sourceOverride?: TransportSource
+): TransportConfiguration {
+  const site = initConfiguration.site || INTAKE_SITE_US1
+  const source: TransportSource = sourceOverride ?? validateSource(initConfiguration.source)
+
+  const resolvedConfiguration: ResolvedSourceInitConfiguration = { ...initConfiguration, site, source }
+  const endpointBuilders = computeEndpointBuilders(resolvedConfiguration)
+  const replicaConfiguration = computeReplicaConfiguration(resolvedConfiguration)
 
   return {
     replica: replicaConfiguration,
@@ -37,14 +65,14 @@ export function computeTransportConfiguration(initConfiguration: InitConfigurati
   }
 }
 
-function validateSource(source: string | undefined) {
+function validateSource(source: string | undefined): SdkSource {
   if (source === 'flutter' || source === 'unity') {
     return source
   }
   return 'browser'
 }
 
-function computeEndpointBuilders(initConfiguration: InitConfiguration) {
+function computeEndpointBuilders(initConfiguration: ResolvedSourceInitConfiguration) {
   return {
     logsEndpointBuilder: createEndpointBuilder(initConfiguration, 'logs'),
     rumEndpointBuilder: createEndpointBuilder(initConfiguration, 'rum'),
@@ -52,15 +80,18 @@ function computeEndpointBuilders(initConfiguration: InitConfiguration) {
     sessionReplayEndpointBuilder: createEndpointBuilder(initConfiguration, 'replay'),
     exposuresEndpointBuilder: createEndpointBuilder(initConfiguration, 'exposures'),
     flagEvaluationEndpointBuilder: createEndpointBuilder(initConfiguration, 'flagevaluation'),
+    debuggerEndpointBuilder: createEndpointBuilder(initConfiguration, 'debugger'),
   }
 }
 
-function computeReplicaConfiguration(initConfiguration: InitConfiguration): ReplicaConfiguration | undefined {
+function computeReplicaConfiguration(
+  initConfiguration: ResolvedSourceInitConfiguration
+): ReplicaConfiguration | undefined {
   if (!initConfiguration.replica) {
     return
   }
 
-  const replicaConfiguration: InitConfiguration = {
+  const replicaConfiguration: ResolvedSourceInitConfiguration = {
     ...initConfiguration,
     site: INTAKE_SITE_US1,
     clientToken: initConfiguration.replica.clientToken,


### PR DESCRIPTION
> This PR is part of a chain split from #0 _watson/DEBUG-5296/add-live-debugger_ by chain-pr.

## Changes

Adds 'debugger' track type, TransportSource type, the debugger endpoint builder, and the sourceOverride overload to computeTransportConfiguration. Depends on the SdkSource extraction.

## Chain

  #4577 — Core transport: SdkSource type and Batch export
→ #4578 — Endpoint builder: debugger track and TransportSource
  #4579 — Debugger package configuration and tooling
  #4580 — Debugger domain implementation and tests
  #4581 — E2E framework support for debugger
  #4582 — Performance benchmark app and scenario for instrumentation overhead

---
_Draft — pending author review. Merge in order unless marked parallel._
<!-- chain-pr-meta: {"groupId":2,"dependsOn":[1],"originalPR":0,"totalGroups":6,"enforcement":"block","chainPRNumbers":{"1":4577,"2":4578,"3":4579,"4":4580,"5":4581,"6":4582}} -->