### PR TITLE
[chain-pr 5/6] E2E framework support for debugger

### DIFF
--- a/test/apps/vanilla/app.ts
+++ b/test/apps/vanilla/app.ts
@@ -1,10 +1,12 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
+import { datadogDebugger } from '@datadog/browser-debugger'
 
 declare global {
   interface Window {
     LOGS_INIT?: () => void
     RUM_INIT?: () => void
+    DEBUGGER_INIT?: () => void
   }
 }
 
@@ -16,9 +18,14 @@ if (typeof window !== 'undefined') {
   if (window.RUM_INIT) {
     window.RUM_INIT()
   }
+
+  if (window.DEBUGGER_INIT) {
+    window.DEBUGGER_INIT()
+  }
 } else {
   // compat test
   datadogLogs.init({ clientToken: 'xxx', beforeSend: undefined })
   datadogRum.init({ clientToken: 'xxx', applicationId: 'xxx', beforeSend: undefined })
   datadogRum.setUser({ id: undefined })
+  datadogDebugger.init({ clientToken: 'xxx', service: 'xxx' })
 }

--- a/test/apps/vanilla/package.json
+++ b/test/apps/vanilla/package.json
@@ -8,13 +8,17 @@
   },
   "peerDependencies": {
     "@datadog/browser-logs": "*",
-    "@datadog/browser-rum": "*"
+    "@datadog/browser-rum": "*",
+    "@datadog/browser-debugger": "*"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {
       "optional": true
     },
     "@datadog/browser-rum": {
+      "optional": true
+    },
+    "@datadog/browser-debugger": {
       "optional": true
     }
   },
@@ -25,7 +29,8 @@
     "@datadog/browser-rum-core": "file:../../../packages/rum-core/package.tgz",
     "@datadog/browser-rum-react": "file:../../../packages/rum-react/package.tgz",
     "@datadog/browser-rum-slim": "file:../../../packages/rum-slim/package.tgz",
-    "@datadog/browser-worker": "file:../../../packages/worker/package.tgz"
+    "@datadog/browser-worker": "file:../../../packages/worker/package.tgz",
+    "@datadog/browser-debugger": "file:../../../packages/debugger/package.tgz"
   },
   "devDependencies": {
     "ts-loader": "9.5.7",

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -1,4 +1,5 @@
 import type { LogsInitConfiguration } from '@datadog/browser-logs'
+import type { DebuggerInitConfiguration } from '@datadog/browser-debugger'
 import type { RumInitConfiguration, RemoteConfiguration } from '@datadog/browser-rum-core'
 import type { BrowserContext, Page } from '@playwright/test'
 import { test, expect } from '@playwright/test'
@@ -6,7 +7,11 @@ import { addTag, addTestOptimizationTags } from '../helpers/tags'
 import { getRunId } from '../../../envUtils'
 import type { BrowserLog } from '../helpers/browser'
 import { BrowserLogsManager, deleteAllCookies, getBrowserName, sendXhr } from '../helpers/browser'
-import { DEFAULT_LOGS_CONFIGURATION, DEFAULT_RUM_CONFIGURATION } from '../helpers/configuration'
+import {
+  DEFAULT_DEBUGGER_CONFIGURATION,
+  DEFAULT_LOGS_CONFIGURATION,
+  DEFAULT_RUM_CONFIGURATION,
+} from '../helpers/configuration'
 import { validateRumFormat } from '../helpers/validation'
 import type { BrowserConfiguration } from '../../../browsers.conf'
 import { NEXTJS_APP_ROUTER_PORT, NUXT_APP_PORT, VUE_ROUTER_APP_PORT } from '../helpers/playwright'
@@ -48,6 +53,7 @@ class TestBuilder {
   private rumConfiguration: RumInitConfiguration | undefined = undefined
   private alsoRunWithRumSlim = false
   private logsConfiguration: LogsInitConfiguration | undefined = undefined
+  private debuggerConfiguration: DebuggerInitConfiguration | undefined = undefined
   private remoteConfiguration?: RemoteConfiguration = undefined
   private head = ''
   private body = ''
@@ -88,6 +94,11 @@ class TestBuilder {
 
   withLogs(logsInitConfiguration?: Partial<LogsInitConfiguration>) {
     this.logsConfiguration = { ...DEFAULT_LOGS_CONFIGURATION, ...logsInitConfiguration }
+    return this
+  }
+
+  withDebugger(debuggerInitConfiguration?: Partial<DebuggerInitConfiguration>) {
+    this.debuggerConfiguration = { ...DEFAULT_DEBUGGER_CONFIGURATION, ...debuggerInitConfiguration }
     return this
   }
 
@@ -218,6 +229,7 @@ class TestBuilder {
       head: this.head,
       logs: this.logsConfiguration,
       rum: this.rumConfiguration,
+      debugger: this.debuggerConfiguration,
       remoteConfiguration: this.remoteConfiguration,
       rumInit: this.rumInit,
       logsInit: this.logsInit,

--- a/test/e2e/lib/framework/httpServers.ts
+++ b/test/e2e/lib/framework/httpServers.ts
@@ -14,6 +14,7 @@ export type ServerApp = (req: http.IncomingMessage, res: http.ServerResponse) =>
 
 export type MockServerApp = ServerApp & {
   getLargeResponseWroteSize(): number
+  setDebuggerProbes(probes: object[]): void
 }
 
 export interface Server<App extends ServerApp> {

--- a/test/e2e/lib/framework/index.ts
+++ b/test/e2e/lib/framework/index.ts
@@ -1,5 +1,9 @@
 export { createTest } from './createTest'
-export { DEFAULT_RUM_CONFIGURATION, DEFAULT_LOGS_CONFIGURATION } from '../helpers/configuration'
+export {
+  DEFAULT_RUM_CONFIGURATION,
+  DEFAULT_LOGS_CONFIGURATION,
+  DEFAULT_DEBUGGER_CONFIGURATION,
+} from '../helpers/configuration'
 export { createExtension } from './createExtension'
 export { createWorker } from './createWorker'
 export {
@@ -13,6 +17,7 @@ export {
 } from './pageSetups'
 export { IntakeRegistry } from './intakeRegistry'
 export { getTestServers, waitForServersIdle } from './httpServers'
+export type { Servers } from './httpServers'
 export { flushEvents } from './flushEvents'
 export { waitForRequests } from './waitForRequests'
 export { LARGE_RESPONSE_MIN_BYTE_SIZE } from './serverApps/mock'

--- a/test/e2e/lib/framework/intakeProxyMiddleware.ts
+++ b/test/e2e/lib/framework/intakeProxyMiddleware.ts
@@ -51,7 +51,17 @@ export type ProfileIntakeRequest = {
   }
 } & BaseIntakeRequest
 
-export type IntakeRequest = LogsIntakeRequest | RumIntakeRequest | ReplayIntakeRequest | ProfileIntakeRequest
+export type DebuggerIntakeRequest = {
+  intakeType: 'debugger'
+  events: Array<Record<string, unknown>>
+} & BaseIntakeRequest
+
+export type IntakeRequest =
+  | LogsIntakeRequest
+  | RumIntakeRequest
+  | ReplayIntakeRequest
+  | ProfileIntakeRequest
+  | DebuggerIntakeRequest
 
 interface IntakeRequestInfos {
   isBridge: boolean
@@ -104,7 +114,13 @@ function computeIntakeRequestInfos(req: express.Request): IntakeRequestInfos {
   let intakeType: IntakeRequest['intakeType']
   // pathname = /api/v2/rum
   const endpoint = pathname.split(/[/?]/)[3]
-  if (endpoint === 'logs' || endpoint === 'rum' || endpoint === 'replay' || endpoint === 'profile') {
+  if (
+    endpoint === 'logs' ||
+    endpoint === 'rum' ||
+    endpoint === 'replay' ||
+    endpoint === 'profile' ||
+    endpoint === 'debugger'
+  ) {
     intakeType = endpoint
   } else {
     throw new Error("Can't find intake type")
@@ -124,13 +140,13 @@ function readIntakeRequest(req: express.Request, infos: IntakeRequestInfos): Pro
   if (infos.intakeType === 'profile') {
     return readProfileIntakeRequest(req, infos as IntakeRequestInfos & { intakeType: 'profile' })
   }
-  return readRumOrLogsIntakeRequest(req, infos as IntakeRequestInfos & { intakeType: 'rum' | 'logs' })
+  return readEventIntakeRequest(req, infos as IntakeRequestInfos & { intakeType: 'rum' | 'logs' | 'debugger' })
 }
 
-async function readRumOrLogsIntakeRequest(
+async function readEventIntakeRequest(
   req: express.Request,
-  infos: IntakeRequestInfos & { intakeType: 'rum' | 'logs' }
-): Promise<RumIntakeRequest | LogsIntakeRequest> {
+  infos: IntakeRequestInfos & { intakeType: 'rum' | 'logs' | 'debugger' }
+): Promise<RumIntakeRequest | LogsIntakeRequest | DebuggerIntakeRequest> {
   const rawBody = await readStream(req)
   const encodedBody = infos.encoding === 'deflate' ? inflateSync(rawBody) : rawBody
 

--- a/test/e2e/lib/framework/intakeRegistry.ts
+++ b/test/e2e/lib/framework/intakeRegistry.ts
@@ -14,6 +14,7 @@ import type {
   TelemetryUsageEvent,
 } from '@datadog/browser-core'
 import type {
+  DebuggerIntakeRequest,
   IntakeRequest,
   LogsIntakeRequest,
   ProfileIntakeRequest,
@@ -138,6 +139,18 @@ export class IntakeRegistry {
   get profileEvents() {
     return this.profileRequests.map((request) => request.event)
   }
+
+  //
+  // Debugger
+  //
+
+  get debuggerRequests() {
+    return this.requests.filter(isDebuggerIntakeRequest)
+  }
+
+  get debuggerEvents() {
+    return this.debuggerRequests.flatMap((request) => request.events)
+  }
 }
 
 function isLogsIntakeRequest(request: IntakeRequest): request is LogsIntakeRequest {
@@ -154,6 +167,10 @@ function isReplayIntakeRequest(request: IntakeRequest): request is ReplayIntakeR
 
 function isProfileIntakeRequest(request: IntakeRequest): request is ProfileIntakeRequest {
   return request.intakeType === 'profile'
+}
+
+function isDebuggerIntakeRequest(request: IntakeRequest): request is DebuggerIntakeRequest {
+  return request.intakeType === 'debugger'
 }
 
 function isRumEvent(event: RumEvent | TelemetryEvent): event is RumEvent {

--- a/test/e2e/lib/framework/pageSetups.ts
+++ b/test/e2e/lib/framework/pageSetups.ts
@@ -1,6 +1,7 @@
 import { generateUUID, INTAKE_URL_PARAMETERS } from '@datadog/browser-core'
 import type { LogsInitConfiguration } from '@datadog/browser-logs'
 import type { RumInitConfiguration, RemoteConfiguration } from '@datadog/browser-rum-core'
+import type { DebuggerInitConfiguration } from '@datadog/browser-debugger'
 import type test from '@playwright/test'
 import { isBrowserStack, isContinuousIntegration } from './environment'
 import type { Servers } from './httpServers'
@@ -11,6 +12,7 @@ export interface SetupOptions {
   logs?: LogsInitConfiguration
   logsInit: (initConfiguration: LogsInitConfiguration) => void
   rumInit: (initConfiguration: RumInitConfiguration) => void
+  debugger?: DebuggerInitConfiguration
   remoteConfiguration?: RemoteConfiguration
   eventBridge?: EventBridgeOptions
   head?: string
@@ -79,7 +81,7 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
 })(window,document,'script','${url}','${globalName}')`
   }
 
-  const { logsScriptUrl, rumScriptUrl } = createCrossOriginScriptUrls(servers, options)
+  const { logsScriptUrl, rumScriptUrl, debuggerScriptUrl } = createCrossOriginScriptUrls(servers, options)
 
   if (options.logs) {
     footer += html`<script>
@@ -97,6 +99,15 @@ n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       DD_RUM.onReady(function () {
         DD_RUM.setGlobalContext(${JSON.stringify(options.context)})
         ;(${options.rumInit.toString()})(${formatConfiguration(options.rum, servers)})
+      })
+    </script>`
+  }
+
+  if (options.debugger) {
+    footer += html`<script type="text/javascript">
+      ${formatSnippet(debuggerScriptUrl, 'DD_DEBUGGER')}
+      DD_DEBUGGER.onReady(function () {
+        DD_DEBUGGER.init(${formatConfiguration(options.debugger, servers)})
       })
     </script>`
   }
@@ -119,7 +130,7 @@ export function bundleSetup(options: SetupOptions, servers: Servers) {
     header += setupExtension(options, servers)
   }
 
-  const { logsScriptUrl, rumScriptUrl } = createCrossOriginScriptUrls(servers, options)
+  const { logsScriptUrl, rumScriptUrl, debuggerScriptUrl } = createCrossOriginScriptUrls(servers, options)
 
   if (options.logs) {
     header += html`<script type="text/javascript" src="${logsScriptUrl}"></script>`
@@ -135,6 +146,15 @@ export function bundleSetup(options: SetupOptions, servers: Servers) {
       DD_RUM.setGlobalContext(${JSON.stringify(options.context)})
       ;(${options.rumInit.toString()})(${formatConfiguration(options.rum, servers)})
     </script>`
+  }
+
+  if (options.debugger) {
+    header += html`
+      <script type="text/javascript" src="${debuggerScriptUrl}"></script>
+      <script type="text/javascript">
+        DD_DEBUGGER.init(${formatConfiguration(options.debugger, servers)})
+      </script>
+    `
   }
 
   return basePage({
@@ -168,6 +188,14 @@ export function npmSetup(options: SetupOptions, servers: Servers) {
       window.RUM_INIT = () => {
         window.DD_RUM.setGlobalContext(${JSON.stringify(options.context)})
         ;(${options.rumInit.toString()})(${formatConfiguration(options.rum, servers)})
+      }
+    </script>`
+  }
+
+  if (options.debugger) {
+    header += html`<script type="text/javascript">
+      window.DEBUGGER_INIT = () => {
+        window.DD_DEBUGGER.init(${formatConfiguration(options.debugger, servers)})
       }
     </script>`
   }
@@ -352,7 +380,10 @@ function isJsonIncompatibleValue(value: unknown): value is JsonIncompatibleValue
   return typeof value === 'function' || value instanceof RegExp
 }
 
-export function formatConfiguration(initConfiguration: LogsInitConfiguration | RumInitConfiguration, servers: Servers) {
+export function formatConfiguration(
+  initConfiguration: LogsInitConfiguration | RumInitConfiguration | DebuggerInitConfiguration,
+  servers: Servers
+) {
   const jsonIncompatibles = new Map<string, JsonIncompatibleValue>()
 
   let result = JSON.stringify(
@@ -387,5 +418,6 @@ export function createCrossOriginScriptUrls(servers: Servers, options: SetupOpti
   return {
     logsScriptUrl: `${servers.crossOrigin.origin}/datadog-logs.js`,
     rumScriptUrl: `${servers.crossOrigin.origin}/${options.useRumSlim ? 'datadog-rum-slim.js' : 'datadog-rum.js'}`,
+    debuggerScriptUrl: `${servers.crossOrigin.origin}/datadog-debugger.js`,
   }
 }

--- a/test/e2e/lib/framework/serverApps/mock.ts
+++ b/test/e2e/lib/framework/serverApps/mock.ts
@@ -15,6 +15,7 @@ export function createMockServerApp(servers: Servers, setup: string, setupOption
   const { remoteConfiguration, worker } = setupOptions ?? {}
   const app = express()
   let largeResponseBytesWritten = 0
+  let debuggerProbes: object[] = []
 
   app.use(cors())
   app.disable('etag') // disable automatic resource caching
@@ -227,9 +228,16 @@ export function createMockServerApp(servers: Servers, setup: string, setupOption
     res.send(JSON.stringify(remoteConfiguration))
   })
 
+  app.post('/api/ui/debugger/probe-delivery', (_req, res) => {
+    res.json({ nextCursor: '', updates: debuggerProbes, deletions: [] })
+  })
+
   return Object.assign(app, {
     getLargeResponseWroteSize() {
       return largeResponseBytesWritten
+    },
+    setDebuggerProbes(probes: object[]) {
+      debuggerProbes = probes
     },
   })
 }

--- a/test/e2e/lib/helpers/configuration.ts
+++ b/test/e2e/lib/helpers/configuration.ts
@@ -25,3 +25,8 @@ export const DEFAULT_LOGS_CONFIGURATION = {
   telemetryUsageSampleRate: 100,
   telemetryConfigurationSampleRate: 100,
 }
+
+export const DEFAULT_DEBUGGER_CONFIGURATION = {
+  clientToken: CLIENT_TOKEN,
+  service: 'browser-sdk-e2e-test',
+}

--- a/test/e2e/lib/types/global.ts
+++ b/test/e2e/lib/types/global.ts
@@ -1,10 +1,12 @@
 import type { LogsGlobal } from '@datadog/browser-logs'
+import type { DatadogDebugger } from '@datadog/browser-debugger'
 import type { RumGlobal } from '@datadog/browser-rum'
 
 declare global {
   interface Window {
     DD_LOGS?: LogsGlobal
     DD_RUM?: RumGlobal
+    DD_DEBUGGER?: DatadogDebugger
     DD_SOURCE_CODE_CONTEXT?: { [stack: string]: { service: string; version?: string } }
   }
 }

--- a/test/e2e/scenario/debugger.scenario.ts
+++ b/test/e2e/scenario/debugger.scenario.ts
@@ -1,0 +1,289 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, camelcase */
+import { test, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { createTest } from '../lib/framework'
+import type { Servers } from '../lib/framework'
+
+function setDebuggerProbes(servers: Servers, probes: object[]) {
+  servers.base.app.setDebuggerProbes(probes)
+}
+
+function makeProbe({
+  id = 'test-probe-1',
+  version = 1,
+  typeName = 'TestModule',
+  methodName = 'testFunction',
+  template = 'Probe hit',
+  captureSnapshot = true,
+  evaluateAt = 'EXIT' as const,
+  condition,
+  segments,
+}: {
+  id?: string
+  version?: number
+  typeName?: string
+  methodName?: string
+  template?: string
+  captureSnapshot?: boolean
+  evaluateAt?: 'ENTRY' | 'EXIT'
+  condition?: { dsl: string; json: unknown }
+  segments?: Array<{ str?: string; dsl?: string; json?: unknown }>
+} = {}) {
+  return {
+    id,
+    version,
+    type: 'LOG_PROBE',
+    where: { typeName, methodName },
+    template,
+    segments: segments ?? [{ str: template }],
+    captureSnapshot,
+    capture: {},
+    sampling: { snapshotsPerSecond: 5000 },
+    evaluateAt,
+    when: condition,
+  }
+}
+
+/**
+ * Injects an instrumented function into the page that calls the debugger hooks.
+ * The function is named `testFunction` and registered under the `TestModule;testFunction` function ID.
+ */
+async function injectInstrumentedFunction(page: Page) {
+  await page.evaluate(() => {
+    const $dd_probes = (globalThis as any).$dd_probes as (id: string) => unknown[] | undefined
+    const $dd_entry = (globalThis as any).$dd_entry as (probes: unknown[], self: unknown, args: object) => void
+    const $dd_return = (globalThis as any).$dd_return as (
+      probes: unknown[],
+      value: unknown,
+      self: unknown,
+      args: object,
+      locals: object
+    ) => unknown
+
+    ;(window as any).testFunction = function testFunction(a: unknown, b: unknown) {
+      const probes = $dd_probes('TestModule;testFunction')
+      if (probes) {
+        $dd_entry(probes, this, { a, b })
+      }
+      const result = String(a) + String(b)
+      const returnValue = result
+      if (probes) {
+        return $dd_return(probes, returnValue, this, { a, b }, { result })
+      }
+      return returnValue
+    }
+  })
+}
+
+/**
+ * Injects an instrumented function that throws, triggering `$dd_throw`.
+ */
+async function injectThrowingFunction(page: Page) {
+  await page.evaluate(() => {
+    const $dd_probes = (globalThis as any).$dd_probes as (id: string) => unknown[] | undefined
+    const $dd_entry = (globalThis as any).$dd_entry as (probes: unknown[], self: unknown, args: object) => void
+    const $dd_throw = (globalThis as any).$dd_throw as (
+      probes: unknown[],
+      error: Error,
+      self: unknown,
+      args: object
+    ) => void
+
+    ;(window as any).throwingFunction = function throwingFunction(msg: string) {
+      const probes = $dd_probes('TestModule;throwingFunction')
+      if (probes) {
+        $dd_entry(probes, this, { msg })
+      }
+      try {
+        throw new Error(msg)
+      } catch (e) {
+        if (probes) {
+          $dd_throw(probes, e as Error, this, { msg })
+        }
+        throw e
+      }
+    }
+  })
+}
+
+test.describe('debugger', () => {
+  createTest('send debugger snapshot when instrumented function is called')
+    .withDebugger()
+    .run(async ({ intakeRegistry, flushEvents, page, servers }) => {
+      const probe = makeProbe()
+      setDebuggerProbes(servers, [probe])
+
+      await page.reload()
+      await injectInstrumentedFunction(page)
+
+      await page.evaluate(() => {
+        ;(window as any).testFunction('hello', ' world')
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+
+      const event = intakeRegistry.debuggerEvents[0]
+      expect(event.message).toBe('Probe hit')
+      expect(event.service).toBe('browser-sdk-e2e-test')
+
+      const snapshot = (event.debugger as any).snapshot
+      expect(snapshot.probe.id).toBe('test-probe-1')
+      expect(snapshot.language).toBe('javascript')
+      expect(snapshot.duration).toBeGreaterThan(0)
+    })
+
+  createTest('capture function arguments and return value')
+    .withDebugger()
+    .run(async ({ intakeRegistry, flushEvents, page, servers }) => {
+      const probe = makeProbe({ captureSnapshot: true })
+      setDebuggerProbes(servers, [probe])
+
+      await page.reload()
+      await injectInstrumentedFunction(page)
+
+      await page.evaluate(() => {
+        ;(window as any).testFunction('foo', 'bar')
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+
+      const snapshot = (intakeRegistry.debuggerEvents[0].debugger as any).snapshot
+      expect(snapshot.captures).toBeDefined()
+      expect(snapshot.captures.return).toBeDefined()
+
+      const returnCapture = snapshot.captures.return
+      expect(returnCapture.locals['@return']).toBeDefined()
+      expect(returnCapture.locals['@return'].value).toBe('foobar')
+    })
+
+  createTest('capture exception in snapshot on throw')
+    .withDebugger()
+    .run(async ({ intakeRegistry, flushEvents, page, servers }) => {
+      const probe = makeProbe({
+        typeName: 'TestModule',
+        methodName: 'throwingFunction',
+      })
+      setDebuggerProbes(servers, [probe])
+
+      await page.reload()
+      await injectThrowingFunction(page)
+
+      await page.evaluate(() => {
+        try {
+          ;(window as any).throwingFunction('test error')
+        } catch {
+          // expected
+        }
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+
+      const snapshot = (intakeRegistry.debuggerEvents[0].debugger as any).snapshot
+      expect(snapshot.captures.return.throwable).toBeDefined()
+      expect(snapshot.captures.return.throwable.message).toBe('test error')
+    })
+
+  createTest('evaluate probe message template with expression segments')
+    .withDebugger()
+    .run(async ({ intakeRegistry, flushEvents, page, servers }) => {
+      const probe = makeProbe({
+        template: '',
+        segments: [
+          { str: 'Result is: ' },
+          { dsl: 'a', json: { ref: 'a' } },
+          { str: ' and ' },
+          { dsl: 'b', json: { ref: 'b' } },
+        ],
+      })
+      setDebuggerProbes(servers, [probe])
+
+      await page.reload()
+      await injectInstrumentedFunction(page)
+
+      await page.evaluate(() => {
+        ;(window as any).testFunction('X', 'Y')
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+      expect(intakeRegistry.debuggerEvents[0].message).toBe('Result is: X and Y')
+    })
+
+  createTest('do not send snapshot when probe condition is not met')
+    .withDebugger()
+    .run(async ({ intakeRegistry, flushEvents, page, servers }) => {
+      const probe = makeProbe({
+        evaluateAt: 'EXIT',
+        condition: {
+          dsl: '$dd_return == "match"',
+          json: { eq: [{ ref: '$dd_return' }, 'match'] },
+        },
+      })
+      setDebuggerProbes(servers, [probe])
+
+      await page.reload()
+      await injectInstrumentedFunction(page)
+
+      await page.evaluate(() => {
+        ;(window as any).testFunction('no', 'match')
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents).toHaveLength(0)
+    })
+
+  createTest('send snapshot when probe condition is met')
+    .withDebugger()
+    .run(async ({ intakeRegistry, flushEvents, page, servers }) => {
+      const probe = makeProbe({
+        evaluateAt: 'EXIT',
+        condition: {
+          dsl: '$dd_return == "foobar"',
+          json: { eq: [{ ref: '$dd_return' }, 'foobar'] },
+        },
+      })
+      setDebuggerProbes(servers, [probe])
+
+      await page.reload()
+      await injectInstrumentedFunction(page)
+
+      await page.evaluate(() => {
+        ;(window as any).testFunction('foo', 'bar')
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+      expect(intakeRegistry.debuggerEvents[0].message).toBe('Probe hit')
+    })
+
+  createTest('omit trace correlation data when no active span is available')
+    .withRum()
+    .withDebugger()
+    .run(async ({ intakeRegistry, flushEvents, page, servers }) => {
+      const probe = makeProbe()
+      setDebuggerProbes(servers, [probe])
+
+      await page.reload()
+      await injectInstrumentedFunction(page)
+
+      await page.evaluate(() => {
+        ;(window as any).testFunction('hello', ' world')
+      })
+
+      await flushEvents()
+
+      expect(intakeRegistry.debuggerEvents.length).toBeGreaterThanOrEqual(1)
+
+      const event = intakeRegistry.debuggerEvents[0]
+      expect(event.dd).toBeUndefined()
+    })
+})


### PR DESCRIPTION
> This PR is part of a chain split from #0 _watson/DEBUG-5296/add-live-debugger_ by chain-pr.

## Changes

Extends the e2e test framework to support the debugger SDK: configuration defaults, page setups, intake proxy, intake registry, mock server, and the debugger e2e scenario.

## Chain

  #4577 — Core transport: SdkSource type and Batch export
  #4578 — Endpoint builder: debugger track and TransportSource
  #4579 — Debugger package configuration and tooling
  #4580 — Debugger domain implementation and tests
→ #4581 — E2E framework support for debugger
  #4582 — Performance benchmark app and scenario for instrumentation overhead

---
_Draft — pending author review. Merge in order unless marked parallel._
<!-- chain-pr-meta: {"groupId":5,"dependsOn":[4],"originalPR":0,"totalGroups":6,"enforcement":"block","chainPRNumbers":{"1":4577,"2":4578,"3":4579,"4":4580,"5":4581,"6":4582}} -->