### PR TITLE
🐛 make sure we don't postpone batch indefinitely when upserting a view

### DIFF
--- a/packages/core/src/transport/batch.spec.ts
+++ b/packages/core/src/transport/batch.spec.ts
@@ -68,16 +68,17 @@ describe('batch', () => {
       )
     })
 
-    it('should remove the estimated message bytes count when replacing a message', () => {
+    it('should adjust the bytes count when replacing a message with the same key', () => {
       batch.add(SMALL_MESSAGE)
       batch.upsert(SMALL_MESSAGE, 'a')
 
       flushController.notifyBeforeAddMessage.calls.reset()
+      flushController.notifyAfterAddMessage.calls.reset()
 
       batch.upsert(SMALL_MESSAGE, 'a')
 
-      expect(flushController.notifyAfterRemoveMessage).toHaveBeenCalledOnceWith(SMALL_MESSAGE_BYTES_COUNT)
-      expect(flushController.notifyBeforeAddMessage).toHaveBeenCalledOnceWith(SMALL_MESSAGE_BYTES_COUNT)
+      expect(flushController.notifyBeforeAddMessage).not.toHaveBeenCalled()
+      expect(flushController.notifyAfterAddMessage).toHaveBeenCalledOnceWith(0) // same size, diff = 0
       expect(flushController.bytesCount).toEqual(
         // Note: contrary to added messages (see test above), we don't take separators into account
         // when upserting messages, because it's irrelevant: upserted messages size are not yet

--- a/packages/core/src/transport/batch.ts
+++ b/packages/core/src/transport/batch.ts
@@ -30,27 +30,22 @@ export function createBatch({
   const flushSubscription = flushController.flushObservable.subscribe((event) => flush(event))
 
   function push(serializedMessage: string, estimatedMessageBytesCount: number, key?: string) {
-    flushController.notifyBeforeAddMessage(estimatedMessageBytesCount)
-
     if (key !== undefined) {
+      let bytesDiff: number
+      if (upsertBuffer[key] !== undefined) {
+        bytesDiff = estimatedMessageBytesCount - encoder.estimateEncodedBytesCount(upsertBuffer[key])
+      } else {
+        flushController.notifyBeforeAddMessage(estimatedMessageBytesCount)
+        bytesDiff = 0
+      }
       upsertBuffer[key] = serializedMessage
-      flushController.notifyAfterAddMessage()
+      flushController.notifyAfterAddMessage(bytesDiff)
     } else {
+      flushController.notifyBeforeAddMessage(estimatedMessageBytesCount)
       encoder.write(encoder.isEmpty ? serializedMessage : `\n${serializedMessage}`, (realMessageBytesCount) => {
         flushController.notifyAfterAddMessage(realMessageBytesCount - estimatedMessageBytesCount)
       })
     }
-  }
-
-  function hasMessageFor(key?: string): key is string {
-    return key !== undefined && upsertBuffer[key] !== undefined
-  }
-
-  function remove(key: string) {
-    const removedMessage = upsertBuffer[key]
-    delete upsertBuffer[key]
-    const messageBytesCount = encoder.estimateEncodedBytesCount(removedMessage)
-    flushController.notifyAfterRemoveMessage(messageBytesCount)
   }
 
   function addOrUpdate(message: Context, key?: string) {
@@ -63,10 +58,6 @@ export function createBatch({
         `Discarded a message whose size was bigger than the maximum allowed size ${MESSAGE_BYTES_LIMIT / ONE_KIBI_BYTE}KiB. ${MORE_DETAILS} ${DOCS_TROUBLESHOOTING}/#technical-limitations`
       )
       return
-    }
-
-    if (hasMessageFor(key)) {
-      remove(key)
     }
 
     push(serializedMessage, estimatedMessageBytesCount, key)

--- a/packages/core/src/transport/flushController.spec.ts
+++ b/packages/core/src/transport/flushController.spec.ts
@@ -132,15 +132,13 @@ describe('flushController', () => {
       expect(flushSpy).toHaveBeenCalled()
     })
 
-    it('does not take removed messages into account', () => {
+    it('triggers bytes_limit when replacing a message increases the total above the limit', () => {
       flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
       flushController.notifyAfterAddMessage()
-      flushController.notifyAfterRemoveMessage(SMALL_MESSAGE_BYTE_COUNT)
 
-      flushController.notifyBeforeAddMessage(BYTES_LIMIT - SMALL_MESSAGE_BYTE_COUNT)
-      flushController.notifyAfterAddMessage()
+      flushController.notifyAfterAddMessage(BYTES_LIMIT - SMALL_MESSAGE_BYTE_COUNT)
 
-      expect(flushSpy).not.toHaveBeenCalled()
+      expect(flushSpy).toHaveBeenCalled()
     })
 
     it('does not notify when the bytes limit will be reached if no message was added yet', () => {
@@ -186,16 +184,13 @@ describe('flushController', () => {
       expect(flushSpy).not.toHaveBeenCalled()
     })
 
-    it('does not take removed messages into account', () => {
+    it('does not change the messages count when replacing a message', () => {
       for (let i = 0; i < MESSAGES_LIMIT - 1; i += 1) {
         flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
         flushController.notifyAfterAddMessage()
       }
 
-      flushController.notifyAfterRemoveMessage(SMALL_MESSAGE_BYTE_COUNT)
-
-      flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
-      flushController.notifyAfterAddMessage()
+      flushController.notifyAfterAddMessage(0)
 
       expect(flushSpy).not.toHaveBeenCalled()
     })
@@ -242,39 +237,6 @@ describe('flushController', () => {
     it('does not notify if no message was added yet', () => {
       clock.tick(FLUSH_DURATION_LIMIT)
       expect(flushSpy).not.toHaveBeenCalled()
-    })
-
-    it('does not notify if a message was added then removed', () => {
-      flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
-      flushController.notifyAfterAddMessage()
-      flushController.notifyAfterRemoveMessage(SMALL_MESSAGE_BYTE_COUNT)
-      clock.tick(FLUSH_DURATION_LIMIT)
-      expect(flushSpy).not.toHaveBeenCalled()
-    })
-
-    it('notifies if a message was added, and another was added then removed', () => {
-      flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
-      flushController.notifyAfterAddMessage()
-
-      flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
-      flushController.notifyAfterAddMessage()
-      flushController.notifyAfterRemoveMessage(SMALL_MESSAGE_BYTE_COUNT)
-
-      clock.tick(FLUSH_DURATION_LIMIT)
-      expect(flushSpy).toHaveBeenCalled()
-    })
-
-    it('does not notify prematurely if a message was added then removed then another was added', () => {
-      flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
-      flushController.notifyAfterAddMessage()
-      flushController.notifyAfterRemoveMessage(SMALL_MESSAGE_BYTE_COUNT)
-      clock.tick(FLUSH_DURATION_LIMIT / 2)
-      flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
-      flushController.notifyAfterAddMessage()
-      clock.tick(FLUSH_DURATION_LIMIT / 2)
-      expect(flushSpy).not.toHaveBeenCalled()
-      clock.tick(FLUSH_DURATION_LIMIT / 2)
-      expect(flushSpy).toHaveBeenCalled()
     })
   })
 })

--- a/packages/core/src/transport/flushController.ts
+++ b/packages/core/src/transport/flushController.ts
@@ -139,23 +139,5 @@ export function createFlushController({ pageMayExitObservable, sessionExpireObse
         flush(forcedFlushReason ?? 'bytes_limit')
       }
     },
-
-    /**
-     * Notifies that a message was removed from a pool of pending messages waiting to be flushed.
-     *
-     * This function needs to be called synchronously, right after removing the message, so no flush
-     * event can happen after removing the message and before `notifyAfterRemoveMessage`.
-     *
-     * @param messageBytesCount - the message bytes count that was added to the pool. Should
-     * correspond to the sum of bytes counts passed to `notifyBeforeAddMessage` and
-     * `notifyAfterAddMessage`.
-     */
-    notifyAfterRemoveMessage(messageBytesCount: number) {
-      currentBytesCount -= messageBytesCount
-      currentMessagesCount -= 1
-      if (currentMessagesCount === 0) {
-        cancelDurationLimitTimeout()
-      }
-    },
   }
 }

--- a/packages/core/test/emulate/mockFlushController.ts
+++ b/packages/core/test/emulate/mockFlushController.ts
@@ -22,12 +22,6 @@ export function createMockFlushController() {
       .and.callFake((messageBytesCountDiff = 0) => {
         currentBytesCount += messageBytesCountDiff
       }),
-    notifyAfterRemoveMessage: jasmine
-      .createSpy<FlushController['notifyAfterRemoveMessage']>()
-      .and.callFake((messageBytesCount) => {
-        currentBytesCount -= messageBytesCount
-        currentMessagesCount -= 1
-      }),
     get messagesCount() {
       return currentMessagesCount
     },


### PR DESCRIPTION
## Motivation

Backport of v7 commit [`0fd15958a`](https://github.com/DataDog/browser-sdk/pull/4462/commits/0fd15958a70589db9fd5ac1962a46d8dd35ff09a) (originally squashed into [#4462](https://github.com/DataDog/browser-sdk/pull/4462) on the v7 branch).

`FlushController` had a bug where the duration_limit timer could be repeatedly cancelled and rescheduled when a batch contained a single upserted message. Because `Batch.addOrUpdate` called `remove(key)` then `push(...)` on every upsert with the same key, `currentMessagesCount` dropped to `0` between the two calls, which triggered `cancelDurationLimitTimeout()`. The subsequent `push` then rescheduled the timer from scratch. As long as the upsert cadence (e.g. throttled view updates every 3s) was shorter than `FLUSH_DURATION_LIMIT` (30s), the timer never fired.

In practice this happened most often for view events being upserted with no accompanying resource/action/error events in the same batch — a common state for idle / backgrounded tabs and quickly-closed pages. The buffered view event was only flushed when something else triggered it (page exit, session expire, `messages_limit`, `bytes_limit`). When the page died before any of those ran (tab discarded, OS reclaim, crash, mobile background kill), **the view event was lost entirely**, silently under-reporting view durations in RUM.

Observed impact in our own dashboards after the v7 fix landed: total view count rose ~17.5% and `view.time_spent` p90/p95/p99 jumped sharply (p95 ~+114%) while p50/p75 were flat or slightly lower — the signature of recovering previously-dropped views at both tails of the distribution, not of inflating individual durations.

## Changes

- Drop `notifyAfterRemoveMessage` from `FlushController` entirely.
- In `Batch.push`, when upserting a key that already has a buffered message, call `notifyAfterAddMessage(bytesDiff)` instead of remove-then-add. This adjusts only the byte count and never touches `currentMessagesCount` or the duration_limit timer.
- Update specs and `mockFlushController` accordingly.

This is a straight cherry-pick from v7 — no behavioral divergence between the two branches in this area.

## Test instructions

- \`yarn test:unit --spec packages/core/src/transport/flushController.spec.ts --spec packages/core/src/transport/batch.spec.ts\` — 41 tests pass.
- \`yarn typecheck\` and \`yarn lint\` clean.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file