### PR TITLE
[chain-pr 1/12] Bump versions to v7.0.0 and update build/release configs

### DIFF
--- a/.claude/skills/manual-testing/SKILL.md
+++ b/.claude/skills/manual-testing/SKILL.md
@@ -5,7 +5,7 @@ description: Run a manual test of the current change end-to-end and output repro
 
 ## Step 1: Understand the change
 
-Review the current diff to identify what SDK behavior changed and what events/fields need to be verified.
+If you don't have the PR changes in memory, review all commits in the PR to identify what SDK behavior changed and what events/fields need to be verified.
 
 ## Step 2: Start the dev server
 
@@ -51,6 +51,13 @@ yarn dev-server intake <selector> | jq '<field>'
 ```
 
 Use `yarn dev-server intake --help` to find the right selector.
+
+To evaluate JavaScript on the page (e.g. to inspect `window` state set by `beforeSend`), switch focus back to tab 0 first, then use `agent-browser eval`:
+
+```bash
+agent-browser tab 0
+agent-browser eval 'window.someValue'
+```
 
 ## Step 5: Verify the output matches expectations, then present the test instructions
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
   GIT_REPOSITORY: 'git@github.com:DataDog/browser-sdk.git'
   MAIN_BRANCH: 'main'
-  NEXT_MAJOR_BRANCH: 'v7'
+  NEXT_MAJOR_BRANCH: ''
   CHROME_PACKAGE_VERSION: 148.0.7778.96-1
   FF_TIMESTAMPS: 'true' # Enable timestamps for gitlab-ci logs
 
@@ -374,11 +374,10 @@ deploy-next-major-canary:
     - .next-major-branch
   script:
     - export BUILD_MODE=canary
-    - VERSION=$(node -p -e "require('./package.json').version")
     - yarn
     - yarn build:bundle
-    - node ./scripts/deploy/deploy.ts prod v${VERSION%%.*}-canary root
-    - node ./scripts/deploy/upload-source-maps.ts v${VERSION%%.*}-canary root
+    - node ./scripts/deploy/deploy.ts prod ${NEXT_MAJOR_BRANCH}-canary root
+    - node ./scripts/deploy/upload-source-maps.ts ${NEXT_MAJOR_BRANCH}-canary root
 
 deploy-manual:
   stage: deploy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ For deeper context, see:
 - Test framework: Jasmine + Karma. Spec files co-located with implementation: `feature.ts` → `feature.spec.ts`
 - Focus tests with `fit()` / `fdescribe()`, skip with `xit()` / `xdescribe()`
 - Use `registerCleanupTask()` for cleanup, NOT `afterEach()`
+- Prefer `collectAsyncCalls(spy, n)` over `waitFor(() => spy.calls.count() > 0)` for waiting on spy calls
+- Don't destructure methods from `spy.calls` (e.g., `argsFor`, `mostRecent`) - use `calls.argsFor()` to avoid `@typescript-eslint/unbound-method` errors
 - Mock values/functions: wrap with `mockable()` in source, use `replaceMockable()` or `replaceMockableWithSpy()` in tests (auto-cleanup)
 
 ### Naming Conventions
@@ -117,6 +119,12 @@ For deeper context, see:
 ## Commit Messages
 
 Use gitmoji conventions — see `docs/DEVELOPMENT.md` for the full reference.
+
+## Manual Testing with Chrome MCP
+
+`yarn dev` serves the sandbox at `http://localhost:8080` (increments port if busy). The sandbox page (`sandbox/index.html`) loads the SDK bundles and calls `DD_LOGS.init()` / `DD_RUM.init()`.
+
+To test with specific config options (e.g. `forwardErrorsToLogs: true`), just edit `sandbox/index.html` temporarily. The dev server reloads on change, so navigate to `http://localhost:8080` after saving and use `evaluate_script` to run test code.
 
 ## Git Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,82 @@
 
 ---
 
+## v7.0.0
+
+This is the v7 major release. It removes deprecated options and legacy code paths accumulated over the v6 line, modernizes the build, and ships a more reliable session manager.
+
+- **Smaller, faster bundle** — dropping legacy browser shims and switching to ESM dynamic imports reduces the SDK footprint on modern browsers.
+- **Better privacy out of the box** — safer default privacy settings mean less risk of capturing sensitive content without explicit configuration.
+- **More reliable sessions** — modernized session manager with bug fixes, including around very short repetitive sessions.
+- **Higher-quality data** — deterministic sampling (consistent decisions across products), aborted requests no longer polluting error metrics, and a new `session_renewal` view loading type to better understand session boundaries.
+- **A cleaner API** — deprecated options and beta flags removed; what's left is the supported, stable surface going forward.
+
+**Migrating from v6:**
+
+- Follow the [v6 → v7 migration guide](https://github.com/DataDog/documentation/blob/8ed5928d4cf04351f6ec6f6e8d605267def58351/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md) in the Datadog documentation.
+- For automated assistance, use the [`upgrade-browser-sdk-v7` Claude Code skill](https://github.com/DataDog/browser-sdk/blob/main/.claude/skills/upgrade-browser-sdk-v7/SKILL.md) shipped in this repo.
+
+**Public Changes:**
+
+- 💥 remove fake resource timing for document resources ([#4406](https://github.com/DataDog/browser-sdk/pull/4406)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 add `session_renewal` view loading type for session-renewed views ([#4478](https://github.com/DataDog/browser-sdk/pull/4478)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 always collect early requests ([#4285](https://github.com/DataDog/browser-sdk/pull/4285)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 replace DurationVitalReference with vitalKey option in start/stopDurationVital ([#4403](https://github.com/DataDog/browser-sdk/pull/4403)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 Rename chunk files to include "datadog" prefix for cross-bundler naming ([#4391](https://github.com/DataDog/browser-sdk/pull/4391)) [RUM]
+- 💥 Remove deprecated `strategy` from plugin API ([#4382](https://github.com/DataDog/browser-sdk/pull/4382)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 [RUM-8693] Decouple forwardErrorsToLogs from console.error log capture ([#4356](https://github.com/DataDog/browser-sdk/pull/4356)) [LOGS]
+- 💥 remove trackBfcacheViews and track bfcache restores by default ([#4228](https://github.com/DataDog/browser-sdk/pull/4228)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 default privacy settings to improve privacy out of the box ([#4279](https://github.com/DataDog/browser-sdk/pull/4279)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 Remove FID (First Input Delay) tracking ([#4223](https://github.com/DataDog/browser-sdk/pull/4223)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 [RUM-970] do not collect network errors for aborted requests ([#4225](https://github.com/DataDog/browser-sdk/pull/4225)) [LOGS]
+- 💥 [RUM-14058] Use tree walker for action name computation ([#3972](https://github.com/DataDog/browser-sdk/pull/3972)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 enable propagateTraceBaggage by default ([#4226](https://github.com/DataDog/browser-sdk/pull/4226)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 use ESM dynamic imports for CDN async chunks ([#4217](https://github.com/DataDog/browser-sdk/pull/4217))
+- 💥 drop old-browser compatibility code for ES2020 baseline ([#4428](https://github.com/DataDog/browser-sdk/pull/4428)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 remove internalAnalyticsSubdomain and INTAKE_SITE_FED_STAGING ([#4354](https://github.com/DataDog/browser-sdk/pull/4354)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 remove betaTrackActionsInShadowDom and make shadow DOM action tracking the default ([#4355](https://github.com/DataDog/browser-sdk/pull/4355)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 💥 Remove deprecated allowFallbackToLocalStorage option ([#4329](https://github.com/DataDog/browser-sdk/pull/4329)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 [RUM-11273] Remove usePciIntake option ([#4335](https://github.com/DataDog/browser-sdk/pull/4335)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 Remove old cookie migration ([#4198](https://github.com/DataDog/browser-sdk/pull/4198)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 💥 Remove betaEncodeCookieOptions and always encode cookie options ([#4195](https://github.com/DataDog/browser-sdk/pull/4195)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ✨ [RUM-15280] Expose DEFAULT_TRACKED_RESOURCE_HEADERS on RumPublicApi ([#4523](https://github.com/DataDog/browser-sdk/pull/4523)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- ✨ Make nuxt package public ([#4520](https://github.com/DataDog/browser-sdk/pull/4520)) [RUM-NUXT]
+- ✨ [PANA-6624] Enable the new session replay serialization algorithm by default ([#4507](https://github.com/DataDog/browser-sdk/pull/4507)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ✨ Rename session store key to `_dd_s_v2` with legacy migration ([#4459](https://github.com/DataDog/browser-sdk/pull/4459)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ✨ make all sampling decisions deterministic ([#4194](https://github.com/DataDog/browser-sdk/pull/4194)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 [PANA-7217] Limit the size of the string table in session replay recordings ([#4544](https://github.com/DataDog/browser-sdk/pull/4544)) [RUM]
+- 🐛 don't adopt another tab's session when it replaces ours directly ([#4537](https://github.com/DataDog/browser-sdk/pull/4537)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 fix session lifetime bugs for long-lived pages and multi-tab scenarios ([#4531](https://github.com/DataDog/browser-sdk/pull/4531)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 fix regexp for cookie parsing ([#4527](https://github.com/DataDog/browser-sdk/pull/4527)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 Prevent cross-tab session adoption after expiry ([#4475](https://github.com/DataDog/browser-sdk/pull/4475)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 make sure we never send data for very old sessions ([#4462](https://github.com/DataDog/browser-sdk/pull/4462)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 Ignore cookie observable updates missing the c marker ([#4437](https://github.com/DataDog/browser-sdk/pull/4437)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 Add telemetry debug for Cookie Store API set failures ([#4432](https://github.com/DataDog/browser-sdk/pull/4432)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🐛 Fix InvalidStateError when tracing buffered XHR requests ([#4423](https://github.com/DataDog/browser-sdk/pull/4423)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 📝 Add Claude Code skill for v6 to v7 SDK migration ([#4486](https://github.com/DataDog/browser-sdk/pull/4486))
+
+**Internal Changes:**
+
+- 👷 Renovate: tweak memory ([#4539](https://github.com/DataDog/browser-sdk/pull/4539))
+- 👷 Use 15-minute cache for next major canary S3 uploads ([#4476](https://github.com/DataDog/browser-sdk/pull/4476))
+- 👷 bump rum-vue version to 7.0.0-alpha.0 ([#4351](https://github.com/DataDog/browser-sdk/pull/4351)) [RUM-VUE]
+- 👷 Bump rum-nextjs version to 7.0.0-alpha.0 ([#4295](https://github.com/DataDog/browser-sdk/pull/4295)) [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE]
+- 🔧 use NEXT_MAJOR_BRANCH variable for canary deploy versioning ([#4407](https://github.com/DataDog/browser-sdk/pull/4407))
+- 🔧 Decouple v7 SDK artifact version from package.json version ([#4401](https://github.com/DataDog/browser-sdk/pull/4401)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🔧 Bump @datadog/browser-rum-angular to 7.0.0-alpha.0 ([#4394](https://github.com/DataDog/browser-sdk/pull/4394)) [RUM-ANGULAR]
+- 🔧 fix root package.json version ([#4286](https://github.com/DataDog/browser-sdk/pull/4286))
+- 🤖 bring v7 upgrade skill to `main` ([#4541](https://github.com/DataDog/browser-sdk/pull/4541))
+- ♻️ Replace BoundedBuffer with BufferedObservable and track dropped data via telemetry ([#4489](https://github.com/DataDog/browser-sdk/pull/4489)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 📈 Add telemetry metric for session manager init duration ([#4488](https://github.com/DataDog/browser-sdk/pull/4488)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ♻️ Route fetch, XHR, and console through bufferedDataObservable ([#4470](https://github.com/DataDog/browser-sdk/pull/4470)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ♻️ Refactor startSessionManager to return a Promise instead of using a callback ([#4438](https://github.com/DataDog/browser-sdk/pull/4438)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ♻️ decouple session change notification from state reading ([#4457](https://github.com/DataDog/browser-sdk/pull/4457)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- 🔍 add cookie value and debug context to session renewal event ([#4433](https://github.com/DataDog/browser-sdk/pull/4433)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ♻️ Rewrite SessionManager with reactive strategy interface ([#4348](https://github.com/DataDog/browser-sdk/pull/4348)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ♻️ Simplify session managers by removing product-specific wrappers ([#4204](https://github.com/DataDog/browser-sdk/pull/4204)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ♻️ Make session manager injectable and isolate for v7 rewrite ([#4157](https://github.com/DataDog/browser-sdk/pull/4157)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+- ♻️ Async session manager ([#4131](https://github.com/DataDog/browser-sdk/pull/4131)) [LOGS] [RUM] [RUM-ANGULAR] [RUM-NEXTJS] [RUM-NUXT] [RUM-SLIM] [RUM-VUE] [WORKER]
+
 ## v6.33.0
 
 **Public Changes:**

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Datadog provides one CDN bundle per [site][70]:
 
 | Site    | logs                                                           | rum                                                           | rum-slim                                                           |
 | ------- | -------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| US1     | https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js |
-| US3     | https://www.datadoghq-browser-agent.com/us3/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum-slim.js |
-| US5     | https://www.datadoghq-browser-agent.com/us5/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/us5/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/us5/v6/datadog-rum-slim.js |
-| EU1     | https://www.datadoghq-browser-agent.com/eu1/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum-slim.js |
-| AP1     | https://www.datadoghq-browser-agent.com/ap1/v6/datadog-logs.js | https://www.datadoghq-browser-agent.com/ap1/v6/datadog-rum.js | https://www.datadoghq-browser-agent.com/ap1/v6/datadog-rum-slim.js |
-| US1-FED | https://www.datadoghq-browser-agent.com/datadog-logs-v6.js     | https://www.datadoghq-browser-agent.com/datadog-rum-v6.js     | https://www.datadoghq-browser-agent.com/datadog-rum-slim-v6.js     |
+| US1     | https://www.datadoghq-browser-agent.com/us1/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum-slim.js |
+| US3     | https://www.datadoghq-browser-agent.com/us3/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/us3/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/us3/v7/datadog-rum-slim.js |
+| US5     | https://www.datadoghq-browser-agent.com/us5/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/us5/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/us5/v7/datadog-rum-slim.js |
+| EU1     | https://www.datadoghq-browser-agent.com/eu1/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/eu1/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/eu1/v7/datadog-rum-slim.js |
+| AP1     | https://www.datadoghq-browser-agent.com/ap1/v7/datadog-logs.js | https://www.datadoghq-browser-agent.com/ap1/v7/datadog-rum.js | https://www.datadoghq-browser-agent.com/ap1/v7/datadog-rum-slim.js |
+| US1-FED | https://www.datadoghq-browser-agent.com/datadog-logs-v7.js     | https://www.datadoghq-browser-agent.com/datadog-rum-v7.js     | https://www.datadoghq-browser-agent.com/datadog-rum-slim-v7.js     |
 
 [1]: https://github.githubassets.com/favicons/favicon.png
 [2]: https://imgix.datadoghq.com/img/favicons/favicon-32x32.png

--- a/developer-extension/package.json
+++ b/developer-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-sdk-developer-extension",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "private": true,
   "scripts": {
     "build": "wxt build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-sdk",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "description": "browser SDK",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-core",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-logs",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -19,10 +19,10 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0"
   },
   "peerDependencies": {
-    "@datadog/browser-rum": "6.33.0"
+    "@datadog/browser-rum": "7.0.0"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-rum": {

--- a/packages/rum-angular/package.json
+++ b/packages/rum-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-angular",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -17,8 +17,8 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0",
-    "@datadog/browser-rum-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0",
+    "@datadog/browser-rum-core": "7.0.0"
   },
   "peerDependencies": {
     "@angular/core": ">=15 <=21",

--- a/packages/rum-core/package.json
+++ b/packages/rum-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-core",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -17,7 +17,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0"
   },
   "devDependencies": {
     "ajv": "8.20.0"

--- a/packages/rum-nextjs/package.json
+++ b/packages/rum-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-nextjs",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -17,9 +17,9 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0",
-    "@datadog/browser-rum-core": "6.33.0",
-    "@datadog/browser-rum-react": "6.33.0"
+    "@datadog/browser-core": "7.0.0",
+    "@datadog/browser-rum-core": "7.0.0",
+    "@datadog/browser-rum-react": "7.0.0"
   },
   "peerDependencies": {
     "next": ">=13.0.0",

--- a/packages/rum-nuxt/package.json
+++ b/packages/rum-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-nuxt",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -17,8 +17,8 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0",
-    "@datadog/browser-rum-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0",
+    "@datadog/browser-rum-core": "7.0.0"
   },
   "peerDependencies": {
     "nuxt": "3 || 4",

--- a/packages/rum-react/package.json
+++ b/packages/rum-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-react",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -21,8 +21,8 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0",
-    "@datadog/browser-rum-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0",
+    "@datadog/browser-rum-core": "7.0.0"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.64.0 <2",

--- a/packages/rum-slim/package.json
+++ b/packages/rum-slim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-slim",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -19,11 +19,11 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0",
-    "@datadog/browser-rum-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0",
+    "@datadog/browser-rum-core": "7.0.0"
   },
   "peerDependencies": {
-    "@datadog/browser-logs": "6.33.0"
+    "@datadog/browser-logs": "7.0.0"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {

--- a/packages/rum-vue/package.json
+++ b/packages/rum-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum-vue",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -18,8 +18,8 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0",
-    "@datadog/browser-rum-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0",
+    "@datadog/browser-rum-core": "7.0.0"
   },
   "peerDependencies": {
     "vue": "^3.5.0",

--- a/packages/rum/BROWSER_SUPPORT.md
+++ b/packages/rum/BROWSER_SUPPORT.md
@@ -16,11 +16,10 @@
 | tracing           | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ❌  | ✅    |
 | route change      | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ❌  | ✅    |
 | loading time      | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ❌  | ✅    |
-| resource timing   | ✅     | ✅      | ⚠️(2)  | ✅   | ✅             | ⚠️(2)      | ❌  | ✅    |
+| resource timing   | ✅     | ✅      | ⚠️(1)  | ✅   | ✅             | ⚠️(1)      | ❌  | ✅    |
 | navigation timing | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ❌  | ✅    |
-| web vitals        | ✅     | ⚠️(1)   | ⚠️(1)  | ✅   | ✅             | ⚠️(1)      | ❌  | ✅    |
+| web vitals        | ✅     | ❌      | ❌     | ✅   | ✅             | ❌         | ❌  | ✅    |
 | FCP               | ✅     | ✅      | ✅     | ✅   | ✅             | ✅         | ❌  | ✅    |
 
-1. FID only
-2. size information not available
-3. firstByte and download only
+1. size information not available
+2. firstByte and download only

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-rum",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
@@ -21,11 +21,11 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0",
-    "@datadog/browser-rum-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0",
+    "@datadog/browser-rum-core": "7.0.0"
   },
   "peerDependencies": {
-    "@datadog/browser-logs": "6.33.0"
+    "@datadog/browser-logs": "7.0.0"
   },
   "peerDependenciesMeta": {
     "@datadog/browser-logs": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/browser-worker",
-  "version": "6.33.0",
+  "version": "7.0.0",
   "license": "Apache-2.0",
   "main": "bundle/worker.js",
   "files": [
@@ -15,7 +15,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@datadog/browser-core": "6.33.0"
+    "@datadog/browser-core": "7.0.0"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,7 @@
     "module": "ES2020",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES2018",
+    "target": "ES2020",
     "sourceMap": true,
     "jsx": "react",
     "skipLibCheck": true,

--- a/webpack.base.ts
+++ b/webpack.base.ts
@@ -30,8 +30,10 @@ export default ({
         : // Include a content hash in chunk names in production.
           `chunks/[name]-[contenthash]-${filename}`,
     path: path.resolve('./bundle'),
+    chunkFormat: 'module',
+    chunkLoading: 'import',
   },
-  target: ['web', 'es2018'],
+  target: ['web', 'es2020'],
   devtool: false,
   module: {
     rules: [
@@ -67,7 +69,7 @@ export default ({
       new TerserPlugin({
         extractComments: false,
         terserOptions: {
-          ecma: 2018,
+          ecma: 2020,
           module: true,
           compress: {
             passes: 4,


### PR DESCRIPTION
> This PR is part of a chain split from #0 _v7_ by chain-pr.

## Changes

Version bumps across all package.json files, root package.json, gitlab CI changes for canary deploy versioning, and tsconfig/webpack target bumps to ES2020. Includes README, CHANGELOG, and developer-extension version bump.

## Split overview

| # | PR | Type | Title |
|---|---|---|---|
| 1 | — | config | Bump versions to v7.0.0 and update build/release configs |
| 2 | — | refactor | Drop legacy browser shims and ES2020 polyfills in core utilities |
| 3 | — | refactor | Replace BoundedBuffer with BufferedObservable and add onDrop |
| 4 | — | refactor | Add deterministic sampling helpers and shared session/telemetry context |
| 5 | — | refactor | Rewrite session storage strategies as reactive setSessionState API |
| 6 | — | refactor | Rewrite SessionManager with async start, deterministic sampling, and Promise-based init |
| 7 | — | feature | Migrate core domain modules to new session manager and bufferedData |
| 8 | — | feature | Migrate Logs SDK to async SessionManager and bufferedData consumers |
| 9 | — | feature | Migrate RUM core to async SessionManager and unified domain types |
| 10 | — | feature | Rewrite Session Replay recording engine on the new change-encoder pipeline |
| 11 | — | config | Update sandbox, dev tooling, scripts, and developer-extension for v7 |
| 12 | — | test | Migrate e2e and performance test apps and scenarios to v7 APIs |

```mermaid
graph LR
    G1["group 1 — Bump versions to v7.0.0 and update build/release configs"]
    G2["group 2 — Drop legacy browser shims and ES2020 polyfills in core utilities"]
    G3["group 3 — Replace BoundedBuffer with BufferedObservable and add onDrop"]
    G4["group 4 — Add deterministic sampling helpers and shared session/telemetry context"]
    G5["group 5 — Rewrite session storage strategies as reactive setSessionState API"]
    G6["group 6 — Rewrite SessionManager with async start, deterministic sampling, and Promise-based init"]
    G7["group 7 — Migrate core domain modules to new session manager and bufferedData"]
    G8["group 8 — Migrate Logs SDK to async SessionManager and bufferedData consumers"]
    G9["group 9 — Migrate RUM core to async SessionManager and unified domain types"]
    G10["group 10 — Rewrite Session Replay recording engine on the new change-encoder pipeline"]
    G11["group 11 — Update sandbox, dev tooling, scripts, and developer-extension for v7"]
    G12["group 12 — Migrate e2e and performance test apps and scenarios to v7 APIs"]
    G1 --> G2
    G1 --> G3
    G1 --> G4
    G1 --> G5
    G3 --> G6
    G4 --> G6
    G5 --> G6
    G6 --> G7
    G6 --> G8
    G7 --> G8
    G6 --> G9
    G7 --> G9
    G9 --> G10
    G10 --> G11
    G10 --> G12
    G11 --> G12
```

---
_Draft — pending author review. Merge in order unless marked parallel._