### PR TITLE
[chain-pr 3/12] Replace BoundedBuffer with BufferedObservable and add onDrop

### DIFF
--- a/packages/core/src/domain/context/defineContextMethod.ts
+++ b/packages/core/src/domain/context/defineContextMethod.ts
@@ -1,7 +1,7 @@
 import type { RawTelemetryUsage, RawTelemetryUsageFeature } from '../telemetry'
 import { addTelemetryUsage } from '../telemetry'
 import { monitor } from '../../tools/monitor'
-import type { BoundedBuffer } from '../../tools/boundedBuffer'
+import type { BufferedObservable } from '../../tools/observable'
 import type { ContextManager } from './contextManager'
 import type { ContextManagerMethod, CustomerContextKey } from './contextConstants'
 
@@ -22,10 +22,10 @@ export function defineContextMethod<MethodName extends ContextManagerMethod, Key
 export function bufferContextCalls<Key extends string, StartResult extends Record<Key, ContextManager>>(
   preStartContextManager: ContextManager,
   name: Key,
-  bufferApiCalls: BoundedBuffer<StartResult>
+  bufferApiCalls: BufferedObservable<(startResult: StartResult) => void>
 ) {
   preStartContextManager.changeObservable.subscribe(() => {
     const context = preStartContextManager.getContext()
-    bufferApiCalls.add((startResult) => startResult[name].setContext(context))
+    bufferApiCalls.notify((startResult) => startResult[name].setContext(context))
   })
 }

--- a/packages/core/src/tools/observable.spec.ts
+++ b/packages/core/src/tools/observable.spec.ts
@@ -256,4 +256,42 @@ describe('BufferedObservable', () => {
     expect(observer).toHaveBeenCalledWith('first')
     expect(observer).toHaveBeenCalledWith('second')
   })
+
+  it('calls onDrop with the number of dropped items when unbuffering', async () => {
+    const onDrop = jasmine.createSpy('onDrop')
+    const observable = new BufferedObservable<string>(2, onDrop)
+    observable.notify('first') // dropped
+    observable.notify('second') // dropped
+    observable.notify('third')
+    observable.notify('fourth')
+
+    observable.unbuffer()
+    await waitNextMicrotask()
+
+    expect(onDrop).toHaveBeenCalledOnceWith(2)
+  })
+
+  it('does not call onDrop when no data was dropped', async () => {
+    const onDrop = jasmine.createSpy('onDrop')
+    const observable = new BufferedObservable<string>(2, onDrop)
+    observable.notify('first')
+    observable.notify('second')
+
+    observable.unbuffer()
+    await waitNextMicrotask()
+
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('does not call onDrop when no callback is provided', async () => {
+    const observable = new BufferedObservable<string>(2)
+    observable.notify('first') // dropped
+    observable.notify('second')
+    observable.notify('third')
+
+    expect(() => {
+      observable.unbuffer()
+    }).not.toThrow()
+    await waitNextMicrotask()
+  })
 })

--- a/packages/core/src/tools/observable.ts
+++ b/packages/core/src/tools/observable.ts
@@ -51,8 +51,12 @@ export function mergeObservables<T>(...observables: Array<Observable<T>>) {
 // eslint-disable-next-line no-restricted-syntax
 export class BufferedObservable<T> extends Observable<T> {
   private buffer: T[] = []
+  private droppedCount = 0
 
-  constructor(private maxBufferSize: number) {
+  constructor(
+    private maxBufferSize: number,
+    private onDrop?: (count: number) => void
+  ) {
     super()
   }
 
@@ -60,6 +64,7 @@ export class BufferedObservable<T> extends Observable<T> {
     this.buffer.push(data)
     if (this.buffer.length > this.maxBufferSize) {
       this.buffer.shift()
+      this.droppedCount++
     }
     super.notify(data)
   }
@@ -98,6 +103,9 @@ export class BufferedObservable<T> extends Observable<T> {
    */
   unbuffer() {
     queueMicrotask(() => {
+      if (this.droppedCount > 0 && this.onDrop) {
+        this.onDrop(this.droppedCount)
+      }
       this.maxBufferSize = this.buffer.length = 0
     })
   }


### PR DESCRIPTION
> This PR is part of a chain split from #0 _v7_ by chain-pr.

## Changes

Remove the deprecated BoundedBuffer abstraction in favor of BufferedObservable, adding an onDrop callback for telemetry. Update bufferContextCalls and core index exports accordingly.

## Refactoring rationale

Consolidates two overlapping buffering abstractions into one. BoundedBuffer is removed entirely and bufferContextCalls is reimplemented on top of BufferedObservable. The new onDrop callback enables tracking of dropped data via telemetry, which downstream consumers (preStartRum/preStartLogs) rely on.

---
_Draft — pending author review. Merge in order unless marked parallel._