### PR TITLE
[chain-pr 4/12] Add deterministic sampling helpers and shared session/telemetry context

### DIFF
--- a/packages/core/src/domain/contexts/telemetrySessionContext.spec.ts
+++ b/packages/core/src/domain/contexts/telemetrySessionContext.spec.ts
@@ -1,0 +1,55 @@
+import type { Hooks } from '../../../test'
+import { createHooks, createSessionManagerMock, MOCK_SESSION_ID } from '../../../test'
+import type { RelativeTime } from '../../tools/utils/timeUtils'
+import { HookNames } from '../../tools/abstractHooks'
+import { startTelemetrySessionContext } from './telemetrySessionContext'
+
+describe('telemetrySessionContext', () => {
+  let hooks: Hooks
+
+  beforeEach(() => {
+    hooks = createHooks()
+  })
+
+  it('should include session id and anonymous_id in assembled telemetry', () => {
+    startTelemetrySessionContext(hooks, createSessionManagerMock())
+
+    const result = hooks.triggerHook(HookNames.AssembleTelemetry, { startTime: 0 as RelativeTime })
+
+    expect(result).toEqual({
+      session: { id: MOCK_SESSION_ID },
+      anonymous_id: 'device-123',
+    })
+  })
+
+  it('should contribute nothing when no tracked session is found', () => {
+    startTelemetrySessionContext(hooks, createSessionManagerMock().setNotTracked())
+
+    const result = hooks.triggerHook(HookNames.AssembleTelemetry, { startTime: 0 as RelativeTime })
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should merge extraContext into the result', () => {
+    startTelemetrySessionContext(hooks, createSessionManagerMock(), { application: { id: 'app-789' } })
+
+    const result = hooks.triggerHook(HookNames.AssembleTelemetry, { startTime: 0 as RelativeTime })
+
+    expect(result).toEqual({
+      session: { id: MOCK_SESSION_ID },
+      anonymous_id: 'device-123',
+      application: { id: 'app-789' },
+    })
+  })
+
+  it('should pass startTime to findTrackedSession', () => {
+    const sessionManager = createSessionManagerMock()
+    spyOn(sessionManager, 'findTrackedSession').and.callThrough()
+
+    startTelemetrySessionContext(hooks, sessionManager)
+
+    hooks.triggerHook(HookNames.AssembleTelemetry, { startTime: 42 as RelativeTime })
+
+    expect(sessionManager.findTrackedSession).toHaveBeenCalledWith(42 as RelativeTime)
+  })
+})

--- a/packages/core/src/domain/contexts/telemetrySessionContext.ts
+++ b/packages/core/src/domain/contexts/telemetrySessionContext.ts
@@ -1,0 +1,26 @@
+import type { SessionManager } from '../session/sessionManager'
+import type { AbstractHooks } from '../../tools/abstractHooks'
+import { HookNames, SKIPPED } from '../../tools/abstractHooks'
+import type { Context } from '../../tools/serialisation/context'
+
+export function startTelemetrySessionContext(
+  hooks: AbstractHooks,
+  sessionManager: SessionManager,
+  extraContext?: Context
+) {
+  hooks.register(HookNames.AssembleTelemetry, ({ startTime }) => {
+    const session = sessionManager.findTrackedSession(startTime)
+
+    if (!session) {
+      return SKIPPED
+    }
+
+    return {
+      session: {
+        id: session.id,
+      },
+      anonymous_id: session.anonymousId,
+      ...extraContext,
+    }
+  })
+}

--- a/packages/core/src/domain/contexts/userContext.spec.ts
+++ b/packages/core/src/domain/contexts/userContext.spec.ts
@@ -16,7 +16,7 @@ describe('user context', () => {
     findTrackedSession: () =>
       ({
         anonymousId: 'device-123',
-      }) as SessionContext<string>,
+      }) as SessionContext,
   }
 
   beforeEach(() => {
@@ -97,18 +97,6 @@ describe('user context', () => {
           id: '123',
           anonymous_id: 'foo',
         },
-      })
-    })
-  })
-
-  describe('assemble telemetry hook', () => {
-    it('should set the anonymous_id', () => {
-      const defaultRumEventAttributes = hooks.triggerHook(HookNames.AssembleTelemetry, {
-        startTime: 0 as RelativeTime,
-      })
-
-      expect(defaultRumEventAttributes).toEqual({
-        anonymous_id: 'device-123',
       })
     })
   })

--- a/packages/core/src/domain/contexts/userContext.ts
+++ b/packages/core/src/domain/contexts/userContext.ts
@@ -46,10 +46,6 @@ export function startUserContext(
     }
   })
 
-  hooks.register(HookNames.AssembleTelemetry, ({ startTime }) => ({
-    anonymous_id: sessionManager.findTrackedSession(startTime)?.anonymousId,
-  }))
-
   return userContextManager
 }
 

--- a/packages/core/src/domain/sampler.spec.ts
+++ b/packages/core/src/domain/sampler.spec.ts
@@ -1,0 +1,97 @@
+import { HIGH_HASH_UUID, LOW_HASH_UUID } from '../../test'
+import { correctedChildSampleRate, isSampled, resetSampleDecisionCache, sampleUsingKnuthFactor } from './sampler'
+
+// UUID chosen arbitrarily, to be used when the test doesn't actually depend on it.
+const ARBITRARY_UUID = '1ff81c8c-6e32-473b-869b-55af08048323'
+
+describe('isSampled', () => {
+  it('returns true when sampleRate is 100', () => {
+    expect(isSampled(ARBITRARY_UUID, 100)).toBeTrue()
+  })
+
+  it('returns false when sampleRate is 0', () => {
+    expect(isSampled(ARBITRARY_UUID, 0)).toBeFalse()
+  })
+
+  it('a session id with a low hash value should be sampled with a rate close to 0%', () => {
+    expect(isSampled(LOW_HASH_UUID, 0.1)).toBeTrue()
+    resetSampleDecisionCache()
+    expect(isSampled(LOW_HASH_UUID, 0.01)).toBeTrue()
+    resetSampleDecisionCache()
+    expect(isSampled(LOW_HASH_UUID, 0.001)).toBeTrue()
+    resetSampleDecisionCache()
+    expect(isSampled(LOW_HASH_UUID, 0.0001)).toBeTrue()
+    resetSampleDecisionCache()
+    // At some point the sample rate is so low that the session is not sampled even if the hash
+    // is low. This is not an error: we can probably find a UUID with an even lower hash.
+    expect(isSampled(LOW_HASH_UUID, 0.0000000001)).toBeFalse()
+  })
+
+  it('a session id with a high hash value should not be sampled even if the rate is close to 100%', () => {
+    expect(isSampled(HIGH_HASH_UUID, 99.9)).toBeFalse()
+    resetSampleDecisionCache()
+    expect(isSampled(HIGH_HASH_UUID, 99.99)).toBeFalse()
+    resetSampleDecisionCache()
+    expect(isSampled(HIGH_HASH_UUID, 99.999)).toBeFalse()
+    resetSampleDecisionCache()
+    expect(isSampled(HIGH_HASH_UUID, 99.9999)).toBeFalse()
+    resetSampleDecisionCache()
+    // At some point the sample rate is so high that the session is sampled even if the hash is
+    // high. This is not an error: we can probably find a UUID with an even higher hash.
+    expect(isSampled(HIGH_HASH_UUID, 99.9999999999)).toBeTrue()
+  })
+})
+
+describe('correctedChildSampleRate', () => {
+  it('should apply the correction formula', () => {
+    expect(correctedChildSampleRate(60, 20)).toBe(12)
+  })
+
+  it('should return the child rate unchanged when parent is 100%', () => {
+    expect(correctedChildSampleRate(100, 50)).toBe(50)
+  })
+
+  it('should return 0 when child rate is 0', () => {
+    expect(correctedChildSampleRate(60, 0)).toBe(0)
+  })
+
+  it('should return 0 when parent rate is 0', () => {
+    expect(correctedChildSampleRate(0, 50)).toBe(0)
+  })
+
+  it('should return the parent rate when child rate is 100%', () => {
+    expect(correctedChildSampleRate(60, 100)).toBe(60)
+  })
+})
+
+describe('sampleUsingKnuthFactor', () => {
+  it('sampling should be based on the trace id', () => {
+    // Generated using the dd-trace-go implementation with the following program: https://go.dev/play/p/CUrDJtze8E_e
+    const inputs: Array<[bigint, number, boolean]> = [
+      [5577006791947779410n, 94.0509, true],
+      [15352856648520921629n, 43.7714, true],
+      [3916589616287113937n, 68.6823, true],
+      [894385949183117216n, 30.0912, true],
+      [12156940908066221323n, 46.889, true],
+
+      [9828766684487745566n, 15.6519, false],
+      [4751997750760398084n, 81.364, false],
+      [11199607447739267382n, 38.0657, false],
+      [6263450610539110790n, 21.8553, false],
+      [1874068156324778273n, 36.0871, false],
+    ]
+
+    for (const [identifier, sampleRate, expected] of inputs) {
+      expect(sampleUsingKnuthFactor(identifier, sampleRate))
+        .withContext(`identifier=${identifier}, sampleRate=${sampleRate}`)
+        .toBe(expected)
+    }
+  })
+
+  it('should cache sampling decision per sampling rate', () => {
+    // For the same session id, the sampling decision should be different for trace and profiling, eg. trace should not cache profiling decisions and vice versa
+    expect(isSampled(HIGH_HASH_UUID, 99.9999999999)).toBeTrue()
+    expect(isSampled(HIGH_HASH_UUID, 0.0000001)).toBeFalse()
+    expect(isSampled(HIGH_HASH_UUID, 99.9999999999)).toBeTrue()
+  })
+})

--- a/packages/core/src/domain/sampler.ts
+++ b/packages/core/src/domain/sampler.ts
@@ -1,8 +1,10 @@
-import { performDraw } from '@datadog/browser-core'
+export function correctedChildSampleRate(parentRate: number, childRate: number): number {
+  return (parentRate * childRate) / 100
+}
 
 const sampleDecisionCache: Map<number, { sessionId: string; decision: boolean }> = new Map()
 
-export function isSampled(sessionId: string, sampleRate: number) {
+export function isSampled(sessionId: string, sampleRate: number): boolean {
   // Shortcuts for common cases. This is not strictly necessary, but it makes the code faster for
   // customers willing to ingest all traces.
   if (sampleRate === 100) {
@@ -18,15 +20,7 @@ export function isSampled(sessionId: string, sampleRate: number) {
     return cachedDecision.decision
   }
 
-  let decision: boolean
-  // @ts-expect-error BigInt might not be defined in every browser we support
-  if (window.BigInt) {
-    decision = sampleUsingKnuthFactor(BigInt(`0x${sessionId.split('-')[4]}`), sampleRate)
-  } else {
-    // For simplicity, we don't use consistent sampling for browser without BigInt support
-    // TODO: remove this when all browser we support have BigInt support
-    decision = performDraw(sampleRate)
-  }
+  const decision = sampleUsingKnuthFactor(BigInt(`0x${sessionId.split('-')[4]}`), sampleRate)
   sampleDecisionCache.set(sampleRate, { sessionId, decision })
   return decision
 }
@@ -43,7 +37,7 @@ export function resetSampleDecisionCache() {
  * @param identifier - The identifier to use for sampling.
  * @param sampleRate - The sample rate in percentage between 0 and 100.
  */
-export function sampleUsingKnuthFactor(identifier: bigint, sampleRate: number) {
+export function sampleUsingKnuthFactor(identifier: bigint, sampleRate: number): boolean {
   // The formula is:
   //
   //   (identifier * knuthFactor) % 2^64 < sampleRate * 2^64
@@ -63,8 +57,8 @@ export function sampleUsingKnuthFactor(identifier: bigint, sampleRate: number) {
   // should adhere to the spec and is a bit simpler than using a 2^64-1 limit as there are less
   // BigInt arithmetic to write. In practice this does not matter, as we are using floating point
   // numbers in the end, and Number(2n**64n-1n) === Number(2n**64n).
-  const knuthFactor = BigInt('1111111111111111111')
-  const twoPow64 = BigInt('0x10000000000000000') // 2n ** 64n
+  const knuthFactor = 1111111111111111111n
+  const twoPow64 = 2n ** 64n
   const hash = (identifier * knuthFactor) % twoPow64
   return Number(hash) <= (sampleRate / 100) * Number(twoPow64)
 }

--- a/packages/core/test/forEach.spec.ts
+++ b/packages/core/test/forEach.spec.ts
@@ -9,6 +9,7 @@ import { resetReplayStats } from '../../rum/src/domain/replayStats'
 import { resetInteractionCountPolyfill } from '../../rum-core/src/domain/view/viewMetrics/interactionCountPolyfill'
 import { resetMonitor } from '../src/tools/monitor'
 import { resetTelemetry } from '../src/domain/telemetry'
+import { resetSampleDecisionCache } from '../src/domain/sampler'
 import { startLeakDetection } from './leakDetection'
 import type { BuildEnvWindow } from './buildEnv'
 ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'test'
@@ -37,6 +38,7 @@ afterEach(() => {
   resetMonitor()
   resetTelemetry()
   resetInteractionCountPolyfill()
+  resetSampleDecisionCache()
   resetExperimentalFeatures()
   resetManageResourceTimingBufferFull()
 })

--- a/packages/core/test/sampling.ts
+++ b/packages/core/test/sampling.ts
@@ -1,0 +1,6 @@
+// UUID known to yield a low hash value using the Knuth formula, making it more likely to be sampled
+export const LOW_HASH_UUID = '29a4b5e3-9859-4290-99fa-4bc4a1a348b9'
+// UUID known to yield a high hash value using the Knuth formula, making it less likely to be sampled
+export const HIGH_HASH_UUID = '5321b54a-d6ec-4b24-996d-dd70c617e09a'
+// UUID known to yield a mid-range hash value (~50.7%) using the Knuth formula
+export const MID_HASH_UUID = '88ef85ab-7902-45f0-b93b-2def1ec3e5fe'


### PR DESCRIPTION
> This PR is part of a chain split from #0 _v7_ by chain-pr.

## Changes

Move isSampled / sampleUsingKnuthFactor / correctedChildSampleRate from rum-core into core. Add startTelemetrySessionContext shared hook in core/contexts. Update userContext to drop AssembleTelemetry registration. Add sampling test fixtures (LOW_HASH_UUID, HIGH_HASH_UUID, MID_HASH_UUID).

## Refactoring rationale

Moves the deterministic sampling primitives from rum-core to core so both RUM and Logs (and the developer extension) can apply consistent sampling decisions. Introduces a shared telemetry session context hook, replacing scattered AssembleTelemetry registrations. This is a structural prerequisite for the unified session manager that follows.

---
_Draft — pending author review. Merge in order unless marked parallel._