### PR TITLE
[chain-pr 11/12] Update sandbox, dev tooling, scripts, and developer-extension for v7

### DIFF
--- a/developer-extension/src/content-scripts/main.ts
+++ b/developer-extension/src/content-scripts/main.ts
@@ -172,19 +172,11 @@ function loadSdkScriptFromURL(url: string) {
   if (xhr.status === 200) {
     let sdkCode = xhr.responseText
 
-    // Webpack expects the script to be loaded with a `<script src="...">` tag to get its URL to
-    // know where to load the relative chunks. By loading it with an XHR and evaluating it in an
-    // inline script tag, Webpack does not know where to load the chunks from.
-    //
-    // Let's replace Webpack logic that breaks with our own logic to define the URL. It's not
-    // pretty, but loading the script this way isn't either, so...
-    //
-    // We'll probably have to revisit when using actual `import()` expressions instead of relying on
-    // Webpack runtime to load the chunks.
-    sdkCode = sdkCode.replace(
-      'if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");',
-      `if (!scriptUrl) scriptUrl = ${JSON.stringify(url)};`
-    )
+    // Webpack chunks are loaded via ESM dynamic imports with relative paths (e.g. `import('./chunks/...')`).
+    // Since this script is injected inline rather than loaded via `<script src>`, relative import()
+    // paths would resolve against the page URL instead of the SDK URL. Replace them with absolute URLs.
+    const baseUrl = url.slice(0, url.lastIndexOf('/') + 1)
+    sdkCode = sdkCode.replaceAll(/\bimport\(['"]\.\/['"]/g, `import('${baseUrl}'`)
 
     const script = document.createElement('script')
     script.type = 'text/javascript'

--- a/developer-extension/src/panel/sampler.ts
+++ b/developer-extension/src/panel/sampler.ts
@@ -1,4 +1,4 @@
-import { isSampled } from '@datadog/browser-rum-core'
+import { isSampled } from '@datadog/browser-core'
 
 export function computeRumTrackingType(
   sessionId: string,

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>Sandbox</title>
-    <script src="/datadog-rum.js"></script>
-    <script src="/datadog-logs.js"></script>
+    <script src="/datadog-rum.js" crossorigin></script>
+    <script src="/datadog-logs.js" crossorigin></script>
     <script>
       DD_RUM.init({
         clientToken: 'xxx',

--- a/scripts/deploy/deploy.spec.ts
+++ b/scripts/deploy/deploy.spec.ts
@@ -57,12 +57,12 @@ describe('deploy', () => {
       },
       {
         // Profiler chunk
-        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       {
         // RUM chunks: We don't suffix chunk names as they are referenced by the main bundle. Renaming them would require updates via Webpack, adding unnecessary complexity for minimal value.
-        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       // RUM bundle
@@ -81,7 +81,7 @@ describe('deploy', () => {
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v6.js,/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v6.js,/datadog-rum-slim-v6.js`,
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v6.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v6.js,/datadog-rum-slim-v6.js`,
         env,
       },
     ])
@@ -98,11 +98,11 @@ describe('deploy', () => {
       },
       // RUM Profiler Chunk
       {
-        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/us1/v6/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/us1/v6/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       {
-        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/us1/v6/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/us1/v6/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       {
@@ -118,7 +118,7 @@ describe('deploy', () => {
     ])
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /us1/v6/datadog-logs.js,/us1/v6/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/datadog-rum.js,/us1/v6/datadog-rum-slim.js`,
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /us1/v6/datadog-logs.js,/us1/v6/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/datadog-rum.js,/us1/v6/datadog-rum-slim.js`,
         env,
       },
     ])
@@ -135,11 +135,11 @@ describe('deploy', () => {
       },
       // RUM Profiler Chunk
       {
-        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       {
-        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       {
@@ -156,7 +156,81 @@ describe('deploy', () => {
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /datadog-logs-staging.js,/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-staging.js,/datadog-rum-slim-staging.js`,
+        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /datadog-logs-staging.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-staging.js,/datadog-rum-slim-staging.js`,
+        env,
+      },
+    ])
+  })
+
+  it('should deploy canary packages', async () => {
+    await deploy('prod', 'canary', ['root'])
+
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/datadog-logs-canary.js',
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/datadog-rum-canary.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-canary.js',
+        env,
+      },
+    ])
+
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-canary.js,/datadog-rum-slim-canary.js`,
+        env,
+      },
+    ])
+  })
+
+  it('should deploy next major canary packages', async () => {
+    await deploy('prod', 'v7-canary', ['root'])
+
+    assert.deepEqual(getS3Commands(), [
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/logs/bundle/datadog-logs.js s3://browser-agent-artifacts-prod/datadog-logs-v7-canary.js',
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-prod/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/datadog-rum.js s3://browser-agent-artifacts-prod/datadog-rum-v7-canary.js',
+        env,
+      },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-v7-canary.js',
+        env,
+      },
+    ])
+
+    assert.deepEqual(getCloudfrontCommands(), [
+      {
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v7-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v7-canary.js,/datadog-rum-slim-v7-canary.js`,
         env,
       },
     ])
@@ -176,11 +250,11 @@ describe('deploy', () => {
       },
       // RUM Profiler Chunk
       {
-        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/pull-request/123/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/pull-request/123/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       {
-        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/pull-request/123/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
+        command: `aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum/bundle/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js s3://browser-agent-artifacts-staging/pull-request/123/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js`,
         env,
       },
       {
@@ -197,7 +271,7 @@ describe('deploy', () => {
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /pull-request/123/datadog-logs.js,/pull-request/123/chunks/profiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/chunks/recorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/datadog-rum.js,/pull-request/123/datadog-rum-slim.js`,
+        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /pull-request/123/datadog-logs.js,/pull-request/123/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/datadog-rum.js,/pull-request/123/datadog-rum-slim.js`,
         env,
       },
     ])

--- a/scripts/deploy/deploy.ts
+++ b/scripts/deploy/deploy.ts
@@ -117,7 +117,7 @@ function uploadToS3(awsConfig: AwsConfig, bundlePath: string, uploadPath: string
   const accessToS3 = generateEnvironmentForRole(awsConfig.accountId, 'build-stable-browser-agent-artifacts-s3-write')
 
   const browserCache =
-    version === 'staging' || version === 'canary' || version === 'pull-request'
+    version === 'staging' || version === 'canary' || version.endsWith('-canary') || version === 'pull-request'
       ? 15 * ONE_MINUTE_IN_SECOND
       : 4 * ONE_HOUR_IN_SECOND
   const cacheControl = `max-age=${browserCache}, s-maxage=60`

--- a/scripts/deploy/lib/deploymentUtils.ts
+++ b/scripts/deploy/lib/deploymentUtils.ts
@@ -9,7 +9,7 @@ export const packages: Package[] = [
   { packageName: 'rum-slim', service: 'browser-rum-sdk' },
 ]
 
-// ex: datadog-rum-v4.js, chunks/recorder-8d8a8dfab6958424038f-datadog-rum.js
+// ex: datadog-rum-v4.js, chunks/datadogRecorder-8d8a8dfab6958424038f-datadog-rum.js
 export const buildRootUploadPath = (filePath: string, version: string): string => {
   // We don't suffix chunk names as they are referenced by the main bundle. Renaming them would require updates via Webpack, adding unnecessary complexity for minimal value.
   if (filePath.includes('chunks')) {
@@ -22,11 +22,11 @@ export const buildRootUploadPath = (filePath: string, version: string): string =
   return `${basePath}-${version}.${ext}`
 }
 
-// ex: us1/v4/datadog-rum.js, eu1/v4/chunks/recorder-8d8a8dfab6958424038f-datadog-rum.js
+// ex: us1/v4/datadog-rum.js, eu1/v4/chunks/datadogRecorder-8d8a8dfab6958424038f-datadog-rum.js
 export const buildDatacenterUploadPath = (datacenter: string, filePath: string, version: string): string =>
   `${datacenter}/${version}/${filePath}`
 
-// ex: pull-request/2781/datadog-rum.js, pull-request/2781/chunks/recorder-8d8a8dfab6958424038f-datadog-rum.js
+// ex: pull-request/2781/datadog-rum.js, pull-request/2781/chunks/datadogRecorder-8d8a8dfab6958424038f-datadog-rum.js
 export const buildPullRequestUploadPath = (filePath: string, version: string): string =>
   `pull-request/${version}/${filePath}`
 

--- a/scripts/lib/browserSdkVersion.ts
+++ b/scripts/lib/browserSdkVersion.ts
@@ -1,3 +1,10 @@
 import packageJson from '../../package.json' with { type: 'json' }
 
+// The npm package version, used to ensure all packages are consistently versioned.
+// On main, this is the same as browserSdkVersion below.
+export const releaseVersion = packageJson.version
+
+// The version baked into built SDK artifacts and the developer extension. Usually the same as
+// releaseVersion, but can differ on long-lived branches where we want canary builds to display
+// a future major version without bumping package.json (which would cause merge conflicts with main).
 export const browserSdkVersion = packageJson.version

--- a/scripts/lib/checkBrowserSdkPackageJsonFiles.ts
+++ b/scripts/lib/checkBrowserSdkPackageJsonFiles.ts
@@ -1,4 +1,4 @@
-import { browserSdkVersion as releaseVersion } from './browserSdkVersion.ts'
+import { releaseVersion } from './browserSdkVersion.ts'
 import { printLog } from './executionUtils.ts'
 import type { PackageJsonInfo } from './filesUtils.ts'
 import { findPackageJsonFiles } from './filesUtils.ts'

--- a/scripts/lib/computeBundleSize.ts
+++ b/scripts/lib/computeBundleSize.ts
@@ -16,8 +16,8 @@ interface BundleSizes {
 function getPackageName(file: string): string | undefined {
   if (file.includes('chunk')) {
     const { chunkName, packageName } =
-      file.match(/chunks\/(?<chunkName>[a-z0-9]*)-[a-z0-9]*-datadog-(?<packageName>[a-z-]*)\.js/)?.groups ?? {}
-    return `${packageName}_${chunkName}`
+      file.match(/chunks\/(?<chunkName>[a-zA-Z0-9]*)-[a-z0-9]*-datadog-(?<packageName>[a-z-]*)\.js/)?.groups ?? {}
+    return `${packageName}_${chunkName.replace(/^datadog/, '').toLowerCase()}`
   }
 
   return file


### PR DESCRIPTION
> This PR is part of a chain split from #0 _v7_ by chain-pr.

## Changes

Add crossorigin to sandbox script tags, rename profiler/recorder chunk names → datadogProfiler/datadogRecorder in deploy scripts, decouple browserSdkVersion from releaseVersion, update content-script SDK loader for ESM dynamic imports, switch developer-extension sampler import to core, fix bundle size grouping, support next-major canary version variants in deploy.

---
_Draft — pending author review. Merge in order unless marked parallel._