### PR TITLE
Default args and locals params in debugger snapshot hooks

### DIFF
--- a/packages/debugger/src/domain/api.ts
+++ b/packages/debugger/src/domain/api.ts
@@ -44,7 +44,7 @@ export function resetDebuggerTransport(): void {
  * @param self - The 'this' context
  * @param args - Function arguments
  */
-export function onEntry(probes: InitializedProbe[], self: any, args: Record<string, any>): void {
+export function onEntry(probes: InitializedProbe[], self: any, args: Record<string, any> = {}): void {
   const start = performance.now()
   const captureCtx: CaptureContext = { deadline: start + SNAPSHOT_TIMEOUT_MS, timedOut: false }
 
@@ -125,8 +125,8 @@ export function onReturn(
   probes: InitializedProbe[],
   value: any,
   self: any,
-  args: Record<string, any>,
-  locals: Record<string, any>
+  args: Record<string, any> = {},
+  locals: Record<string, any> = {}
 ): any {
   const end = performance.now()
   const captureCtx: CaptureContext = { deadline: performance.now() + SNAPSHOT_TIMEOUT_MS, timedOut: false }
@@ -195,7 +195,7 @@ export function onReturn(
  * @param self - The 'this' context
  * @param args - Function arguments
  */
-export function onThrow(probes: InitializedProbe[], error: Error, self: any, args: Record<string, any>): void {
+export function onThrow(probes: InitializedProbe[], error: Error, self: any, args: Record<string, any> = {}): void {
   const end = performance.now()
   const captureCtx: CaptureContext = { deadline: performance.now() + SNAPSHOT_TIMEOUT_MS, timedOut: false }
 


### PR DESCRIPTION
## Motivation

The Live Debugger build plugin (in `DataDog/build-plugins`) generates instrumented code that wraps every monitored function with calls to four global hooks: `$dd_probes`, `$dd_entry`, `$dd_return`, and `$dd_throw`. The entry/return/throw hooks currently require the build plugin to always pass an `args` helper, and `$dd_return` also requires a `locals` helper, even when:

- the function has no parameters (nothing to capture as `args`), or
- the probe is not configured to capture locals (so `locals` would always be empty).

Today the plugin works around this by emitting `() => ({})` helpers in those cases, which adds dead code to the hot path and inflates the instrumented bundle. Making these parameters optional on the runtime side unlocks a follow-up build-plugin change that simply omits the argument at the call site.

## Changes

`packages/debugger/src/domain/api.ts`:

- `onEntry(probes, self, args)` → `onEntry(probes, self, args = {})`
- `onReturn(probes, value, self, args, locals)` → `onReturn(probes, value, self, args = {}, locals = {})`
- `onThrow(probes, error, self, args)` → `onThrow(probes, error, self, args = {})`

No behavioral change for any existing call site: callers that pass a `Record<string, any>` (including the build plugin's current `$dd_e()` / `$dd_l()` helpers) behave identically. The defaults only kick in when an argument is omitted — which is what the build plugin will start doing for parameter-less functions and probes without local capture in a follow-up.

Notes:

- `args` is spread into the context used for condition / message evaluation and into the captured snapshot (`captureFields(args, …)`). Spreading `{}` is a no-op, so behavior is preserved.
- `locals` in `onReturn` is treated the same way (`...locals` + `captureFields(locals, …)`).
- This is a pure typing/runtime relaxation; no public API surface changes.

## Test instructions

End-to-end behavior with the build plugin will be exercised once the corresponding `build-plugins` change lands (omitting the trailing args/locals helpers in generated code).

## Checklist

- [x] Tested locally
- [ ] Tested on staging — not applicable; pure runtime relaxation with no protocol or transport change.
- [ ] Added unit tests for this change — covered by the existing `api.spec.ts` suite; the change is a type-level relaxation (defaulting optional parameters to `{}`). Happy to add an explicit "called with no args/locals" case if reviewers prefer.
- [ ] Added e2e/integration tests for this change — will be covered end-to-end by the follow-up `build-plugins` PR that exercises the new call shape.
- [ ] Updated documentation and/or relevant AGENTS.md file — no documented contract changes.
