### PR TITLE
👷 allocate 4 CPUs to performance-benchmark job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -599,7 +599,9 @@ bump-chrome-version-scheduled-failure:
 
 performance-benchmark:
   stage: task
-  extends: .base-configuration
+  extends:
+    - .base-configuration
+    - .resource-allocation-4-cpus
   only:
     variables:
       - $TARGET_TASK_NAME == "performance-benchmark-scheduled"


### PR DESCRIPTION
## Motivation

The `performance-benchmark` job runs `yarn build:apps` so it also need more resources since #4567 

## Changes

- Extend `performance-benchmark` with `.resource-allocation-4-cpus` in `.gitlab-ci.yml` to allocate 4 CPUs to the job.

## Test instructions

- Trigger the scheduled `performance-benchmark` task and verify the job runs with 4 CPUs allocated.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file