### PR TITLE
✅ fix flaky cookieAccess tests in slow CI

### DIFF
--- a/packages/core/src/browser/cookieAccess.spec.ts
+++ b/packages/core/src/browser/cookieAccess.spec.ts
@@ -2,7 +2,7 @@ import type { Clock } from '../../test'
 import { collectAsyncCalls, mockClock, registerCleanupTask, replaceMockable } from '../../test'
 import type { Configuration } from '../domain/configuration'
 import { detectVersion, isChromium } from '../tools/utils/browserDetection'
-import { dateNow } from '../tools/utils/timeUtils'
+import { dateNow, ONE_MINUTE } from '../tools/utils/timeUtils'
 import type { CookieOptions } from './cookie'
 import { deleteCookie, getCookie, setCookie } from './cookie'
 import type { CookieStoreWindow } from './browser.types'
@@ -108,14 +108,14 @@ describe('cookieAccess', () => {
       describe('getAllAndSet', () => {
         it('should pass current cookie values to callback', async () => {
           const { setCookieWithCleanup } = setup()
-          await setCookieWithCleanup(COOKIE_NAME, 'value1', 1000)
+          await setCookieWithCleanup(COOKIE_NAME, 'value1', ONE_MINUTE)
 
           const cookieAccess = createCookieAccess(COOKIE_NAME, MOCK_CONFIGURATION, COOKIE_OPTIONS)
 
           let capturedValues: string[] | undefined
           await cookieAccess.getAllAndSet((values) => {
             capturedValues = values
-            return { value: 'new', expireDelay: 1000 }
+            return { value: 'new', expireDelay: ONE_MINUTE }
           })
 
           expect(capturedValues).toEqual(['value1'])
@@ -128,7 +128,7 @@ describe('cookieAccess', () => {
           let capturedValues: string[] | undefined
           await cookieAccess.getAllAndSet((values) => {
             capturedValues = values
-            return { value: 'new', expireDelay: 1000 }
+            return { value: 'new', expireDelay: ONE_MINUTE }
           })
 
           expect(capturedValues).toEqual([])
@@ -138,7 +138,7 @@ describe('cookieAccess', () => {
           setup()
           const cookieAccess = createCookieAccess(COOKIE_NAME, MOCK_CONFIGURATION, COOKIE_OPTIONS)
 
-          await cookieAccess.getAllAndSet(() => ({ value: 'hello', expireDelay: 1000 }))
+          await cookieAccess.getAllAndSet(() => ({ value: 'hello', expireDelay: ONE_MINUTE }))
 
           expect(getCookie(COOKIE_NAME)).toBe('hello')
         })
@@ -150,15 +150,15 @@ describe('cookieAccess', () => {
           }
 
           const { setCookieWithCleanup } = setup()
-          await setCookieWithCleanup(COOKIE_NAME, 'value1', 1000)
-          await setCookieWithCleanup(COOKIE_NAME, 'value2', 1000, { secure: true, partitioned: true })
+          await setCookieWithCleanup(COOKIE_NAME, 'value1', ONE_MINUTE)
+          await setCookieWithCleanup(COOKIE_NAME, 'value2', ONE_MINUTE, { secure: true, partitioned: true })
 
           const cookieAccess = createCookieAccess(COOKIE_NAME, MOCK_CONFIGURATION, COOKIE_OPTIONS)
 
           let capturedValues: string[] | undefined
           await cookieAccess.getAllAndSet((values) => {
             capturedValues = values
-            return { value: 'new', expireDelay: 1000 }
+            return { value: 'new', expireDelay: ONE_MINUTE }
           })
 
           expect(capturedValues).toEqual(['value1', 'value2'])
@@ -173,7 +173,7 @@ describe('cookieAccess', () => {
           const subscription = cookieAccess.observable.subscribe(spy)
           registerCleanupTask(() => subscription.unsubscribe())
 
-          await setCookieWithCleanup(COOKIE_NAME, 'external', 1000)
+          await setCookieWithCleanup(COOKIE_NAME, 'external', ONE_MINUTE)
           await flushObservable(spy)
 
           expect(spy).toHaveBeenCalledTimes(1)
@@ -181,7 +181,7 @@ describe('cookieAccess', () => {
 
         it('should notify when cookie is deleted externally', async () => {
           const { flushObservable, setCookieWithCleanup } = setup()
-          await setCookieWithCleanup(COOKIE_NAME, 'existing', 1000)
+          await setCookieWithCleanup(COOKIE_NAME, 'existing', ONE_MINUTE)
 
           const cookieAccess = createCookieAccess(COOKIE_NAME, MOCK_CONFIGURATION, COOKIE_OPTIONS)
           const spy = jasmine.createSpy('observer')
@@ -196,7 +196,7 @@ describe('cookieAccess', () => {
 
         it('should not notify when cookie value is unchanged', async () => {
           const { clock, setCookieWithCleanup } = setup()
-          await setCookieWithCleanup(COOKIE_NAME, 'stable', 1000)
+          await setCookieWithCleanup(COOKIE_NAME, 'stable', ONE_MINUTE)
 
           const cookieAccess = createCookieAccess(COOKIE_NAME, MOCK_CONFIGURATION, COOKIE_OPTIONS)
           const spy = jasmine.createSpy('observer')
@@ -215,7 +215,7 @@ describe('cookieAccess', () => {
           const subscription = cookieAccess.observable.subscribe(spy)
           registerCleanupTask(() => subscription.unsubscribe())
 
-          await cookieAccess.getAllAndSet(() => ({ value: 'written', expireDelay: 1000 }))
+          await cookieAccess.getAllAndSet(() => ({ value: 'written', expireDelay: ONE_MINUTE }))
           await flushObservable(spy)
 
           expect(spy).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Motivation

The `document.cookie fallback` variant of `cookieAccess.spec` is occasionally flaky on CI. The failure mode is `should notify when cookie is changed externally` reporting:

> Expected spy observer to have been called once. It was called 0 times.

The test is unrelated to any specific feature work — it can be reproduced from `main` on slow CI runs.

## Changes

The root cause is a real-time / mock-time mismatch. When `mockClock()` is installed, `new Date()` returns the mocked time. `setCookie()` computes the cookie's expiry from `new Date()` + `expireDelay`, but since `mockClock()` initializes the mocked time to the current real time, the absolute expiry the browser sees is `REAL_T_install + expireDelay`. The browser then expires cookies against **real** wall-clock time — it doesn't know anything about the mock.

With the previous `expireDelay = 1000` ms, any CI run slow enough for >1 s of real time to elapse between `mockClock()` and the polling interval reading `document.cookie` would see the cookie already expired. `getCookies()` returned `[]`, matched `previousCookieValues = []` captured at construction, and the observable never notified.

Fix in `packages/core/src/browser/cookieAccess.spec.ts`: bump the test cookie `expireDelay` from `1000` ms to `ONE_MINUTE` at every call site, leaving real time comfortable headroom to elapse during a slow test without the cookie disappearing.

No production code changes — this is test-only.

## Test instructions

To stress the random ordering (including the originally failing seed `00743`):

```bash
for seed in 00001 00100 00743 12345 99999 50000; do
  yarn test:unit --spec packages/core/src/browser/cookieAccess.spec.ts --seed $seed
done
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change
- [ ] Added e2e/integration tests for this change
- [ ] Updated documentation and/or relevant AGENTS.md file