### PR TITLE
👷 bump performance test SDK bundle to v7

### DIFF
--- a/test/performance/configuration.ts
+++ b/test/performance/configuration.ts
@@ -1,4 +1,4 @@
-export const SDK_BUNDLE_URL = 'https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js'
+export const SDK_BUNDLE_URL = 'https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js'
 export const APPLICATION_ID = '9fa62a5b-8a7e-429d-8466-8b111a4d4693'
 export const CLIENT_TOKEN = 'pubab31fd1ab9d01d2b385a8aa3dd403b1d'
 export const DATADOG_SITE = 'datadoghq.com'


### PR DESCRIPTION
## Motivation

The performance benchmark test was loading the SDK bundle from the `/v6/` CDN path. Now that v7 is released, the benchmark should measure against the current major version to provide meaningful performance signals going forward.

## Changes

- Update `SDK_BUNDLE_URL` in `test/performance/configuration.ts` from `/v6/datadog-rum.js` to `/v7/datadog-rum.js`.

## Test instructions

- Run the performance benchmark job and confirm it loads the v7 bundle from the CDN.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file