### PR TITLE
test(e2e): work around Playwright WebKit click and session bugs

### DIFF
--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -28,21 +28,17 @@ import type { Worker } from './createWorker'
 import { isBrowserStack } from './environment'
 
 /**
- * Init script applied to every WebKit context to work around two Playwright-specific
- * quirks observed on the bundled WebKit (Safari 26). Real Safari users are unaffected;
- * these only manifest in Playwright's WebKit fork.
+ * Init script applied to every WebKit context to work around a Playwright-specific
+ * quirk observed on the bundled WebKit (Safari 26). Real Safari users are unaffected;
+ * this only manifests in Playwright's WebKit fork.
  *
- * 1. Trusted PointerEvent.timeStamp returns a Cocoa-epoch-derived value (~8e11 ms)
+ * Trusted PointerEvent.timeStamp returns a Cocoa-epoch-derived value (~8e11 ms)
  * instead of a DOMHighResTimeStamp. The SDK feeds it into relativeToClocks() and
  * trips the "clock looks weird" guard in trackClickActions — every click action is
  * silently discarded. We wrap Event.prototype.timeStamp to fall back to
  * performance.now() when the raw value is implausibly large (>1 year).
  *
- * 2. window.cookieStore.set() resolves without error but does not persist. The SDK
- * picks the CookieStore strategy, the next poll sees an empty cookie, the session
- * expires within ~50ms, and every later event is dropped by the session hook. We
- * remove window.cookieStore so the SDK falls back to its document.cookie path
- * (which works correctly on Playwright WebKit).
+ * Upstream issue: https://github.com/microsoft/playwright/issues/40822
  */
 const WEBKIT_PLAYWRIGHT_WORKAROUND = `
 (() => {
@@ -66,13 +62,6 @@ const WEBKIT_PLAYWRIGHT_WORKAROUND = `
       },
     });
   }
-  try {
-    Object.defineProperty(window, 'cookieStore', {
-      value: undefined,
-      configurable: true,
-      writable: false,
-    });
-  } catch (e) {}
 })();
 `
 

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -27,6 +27,55 @@ import type { Extension } from './createExtension'
 import type { Worker } from './createWorker'
 import { isBrowserStack } from './environment'
 
+/**
+ * Init script applied to every WebKit context to work around two Playwright-specific
+ * quirks observed on the bundled WebKit (Safari 26). Real Safari users are unaffected;
+ * these only manifest in Playwright's WebKit fork.
+ *
+ * 1. Trusted PointerEvent.timeStamp returns a Cocoa-epoch-derived value (~8e11 ms)
+ * instead of a DOMHighResTimeStamp. The SDK feeds it into relativeToClocks() and
+ * trips the "clock looks weird" guard in trackClickActions — every click action is
+ * silently discarded. We wrap Event.prototype.timeStamp to fall back to
+ * performance.now() when the raw value is implausibly large (>1 year).
+ *
+ * 2. window.cookieStore.set() resolves without error but does not persist. The SDK
+ * picks the CookieStore strategy, the next poll sees an empty cookie, the session
+ * expires within ~50ms, and every later event is dropped by the session hook. We
+ * remove window.cookieStore so the SDK falls back to its document.cookie path
+ * (which works correctly on Playwright WebKit).
+ */
+const WEBKIT_PLAYWRIGHT_WORKAROUND = `
+(() => {
+  // event.timeStamp is a DOMHighResTimeStamp (ms since performance.timeOrigin), so
+  // it should always be well below a year. Anything larger is the Cocoa-epoch leak
+  // observed on Playwright's bundled WebKit (~8e11 ms, ~25 years).
+  const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+  const desc = Object.getOwnPropertyDescriptor(Event.prototype, 'timeStamp');
+  if (desc && desc.get) {
+    const origGetter = desc.get;
+    const cache = new WeakMap();
+    Object.defineProperty(Event.prototype, 'timeStamp', {
+      configurable: true,
+      get() {
+        const raw = origGetter.call(this);
+        if (raw < ONE_YEAR_MS) return raw;
+        if (cache.has(this)) return cache.get(this);
+        const fallback = performance.now();
+        cache.set(this, fallback);
+        return fallback;
+      },
+    });
+  }
+  try {
+    Object.defineProperty(window, 'cookieStore', {
+      value: undefined,
+      configurable: true,
+      writable: false,
+    });
+  } catch (e) {}
+})();
+`
+
 export function createTest(title: string) {
   return new TestBuilder(title, captureCallerLocation())
 }
@@ -348,6 +397,10 @@ function declareTest(title: string, setupOptions: SetupOptions, factory: SetupFa
     const browserName = getBrowserName(test.info().project.name)
     addTag('test.browserName', browserName)
     addTestOptimizationTags(test.info().project.metadata as BrowserConfiguration)
+
+    if (browserName === 'webkit') {
+      await context.addInitScript(WEBKIT_PLAYWRIGHT_WORKAROUND)
+    }
 
     const servers = await getTestServers()
     const baseUrl = new URL(servers.base.origin)


### PR DESCRIPTION
## Motivation

Running the e2e suite with `--project=webkit`  currently fails on some click-action and session-dependent scenario. Two unrelated quirks in Playwright's WebKit fork combine to silently break the SDK:

1. **Trusted `PointerEvent.timeStamp` returns a Cocoa-epoch-derived value (~8e11 ms)** instead of a `DOMHighResTimeStamp`. The SDK feeds it into `relativeToClocks(...)` in `trackClickActions`, computes a click-start ~25 years in the future, and the "clock looks weird" guard discards every click.


## Changes

- Add a `WEBKIT_PLAYWRIGHT_WORKAROUND` init script in `test/e2e/lib/framework/createTest.ts`.
- Apply it via `context.addInitScript(...)` in `declareTest` when `browserName === 'webkit'`.

The workaround wraps `Event.prototype.timeStamp` to fall back to `performance.now()` when the raw value is implausibly large (>1 year)

## Test instructions

`yarn playwright test --config test/e2e/playwright.config.ts --project=webkit test/e2e/scenario/rum/actions.scenario.ts` should pass all three variants. Without this change, all three fail.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file