### PR TITLE
👷 add CI check enforcing gitmoji PR title convention

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,29 @@
+name: 'Lint PR title'
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Check PR title follows gitmoji convention
+        env:
+          # Passing via env (not inline ${{ }}) avoids shell injection via PR titles.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/check-pr-title.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,5 +130,5 @@ To test with specific config options (e.g. `forwardErrorsToLogs: true`), just ed
 
 - Branch naming: `<username>/<feature>` (e.g., `john.doe/fix-session-bug`)
 - Always branch from `main` unless explicitly decided otherwise
-- PR title follows commit message convention (used when squashing to main)
+- PR title **must** follows commit message convention (see @docs/DEVELOPMENT.md)
 - PR template at `.github/PULL_REQUEST_TEMPLATE.md` - use it for all PRs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,5 +130,5 @@ To test with specific config options (e.g. `forwardErrorsToLogs: true`), just ed
 
 - Branch naming: `<username>/<feature>` (e.g., `john.doe/fix-session-bug`)
 - Always branch from `main` unless explicitly decided otherwise
-- PR title **must** follows commit message convention (see @docs/DEVELOPMENT.md)
+- PR title **must** follow commit message convention (see @docs/DEVELOPMENT.md)
 - PR template at `.github/PULL_REQUEST_TEMPLATE.md` - use it for all PRs

--- a/scripts/check-pr-title.spec.ts
+++ b/scripts/check-pr-title.spec.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { isValidPrTitle } from './check-pr-title.ts'
+
+describe('isValidPrTitle', () => {
+  it('accepts titles starting with an allowed emoji', () => {
+    assert.equal(isValidPrTitle('✨ Add new feature'), true)
+    assert.equal(isValidPrTitle('🐛 Fix bug'), true)
+    assert.equal(isValidPrTitle('👷 Update CI'), true)
+    assert.equal(isValidPrTitle('♻️ Refactor module'), true)
+  })
+
+  it('accepts the performance emoji with or without the variation selector', () => {
+    assert.equal(isValidPrTitle('⚡️ Speed up'), true)
+    assert.equal(isValidPrTitle('⚡ Speed up'), true)
+  })
+
+  it('rejects titles without any allowed emoji prefix', () => {
+    assert.equal(isValidPrTitle('Add new feature'), false)
+    assert.equal(isValidPrTitle('feat: add thing'), false)
+    assert.equal(isValidPrTitle(''), false)
+  })
+
+  it('rejects titles where the emoji is not at the start', () => {
+    assert.equal(isValidPrTitle('Fix ✨ thing'), false)
+  })
+
+  it('rejects emojis that are not in the allowed list', () => {
+    assert.equal(isValidPrTitle('🚀 Launch'), false)
+    assert.equal(isValidPrTitle('📦 Package'), false)
+  })
+})

--- a/scripts/check-pr-title.ts
+++ b/scripts/check-pr-title.ts
@@ -1,0 +1,34 @@
+import { printError, printLog, runMain } from './lib/executionUtils.ts'
+import { GITMOJI, normalizeGitmoji } from './lib/gitmoji.ts'
+
+export function isValidPrTitle(title: string): boolean {
+  const normalized = normalizeGitmoji(title)
+  return GITMOJI.some(({ emoji }) => normalized.startsWith(normalizeGitmoji(emoji)))
+}
+
+export function formatAllowedPrefixes(): string {
+  return GITMOJI.map(({ emoji, label }) => `  ${emoji} ${label}`).join('\n')
+}
+
+if (!process.env.NODE_TEST_CONTEXT) {
+  runMain(() => {
+    const title = process.env.PR_TITLE
+
+    if (title === undefined) {
+      throw new Error('PR_TITLE environment variable is not set.')
+    }
+
+    if (isValidPrTitle(title)) {
+      printLog(`PR title OK: ${title}`)
+      return
+    }
+
+    printError(
+      'PR title must start with one of the allowed gitmoji prefixes.\n\n' +
+        `Current title: ${title}\n\n` +
+        `Allowed prefixes:\n${formatAllowedPrefixes()}\n\n` +
+        'See docs/DEVELOPMENT.md for the full convention.'
+    )
+    process.exit(1)
+  })
+}

--- a/scripts/lib/gitmoji.ts
+++ b/scripts/lib/gitmoji.ts
@@ -1,0 +1,43 @@
+// Canonical gitmoji prefix convention. Must stay in sync with docs/DEVELOPMENT.md.
+// The order within each category is the priority used by the changelog generator.
+
+export type GitmojiCategory = 'public' | 'internal'
+
+export interface Gitmoji {
+  emoji: string
+  label: string
+  category: GitmojiCategory
+}
+
+export const GITMOJI: readonly Gitmoji[] = [
+  // User-facing changes
+  { emoji: '💥', label: 'Breaking change', category: 'public' },
+  { emoji: '✨', label: 'New feature', category: 'public' },
+  { emoji: '🐛', label: 'Bug fix', category: 'public' },
+  { emoji: '⚡️', label: 'Performance', category: 'public' },
+  { emoji: '📝', label: 'Documentation', category: 'public' },
+  { emoji: '⚗️', label: 'Experimental', category: 'public' },
+
+  // Internal changes
+  { emoji: '👷', label: 'Build/CI', category: 'internal' },
+  { emoji: '♻️', label: 'Refactor', category: 'internal' },
+  { emoji: '🎨', label: 'Code structure', category: 'internal' },
+  { emoji: '✅', label: 'Tests', category: 'internal' },
+  { emoji: '🔧', label: 'Configuration', category: 'internal' },
+  { emoji: '🔥', label: 'Removal', category: 'internal' },
+  { emoji: '👌', label: 'Code review', category: 'internal' },
+  { emoji: '🚨', label: 'Linting', category: 'internal' },
+  { emoji: '🧹', label: 'Cleanup', category: 'internal' },
+  { emoji: '🔊', label: 'Logging', category: 'internal' },
+]
+
+// Strip the Unicode variation selector (U+FE0F) so '⚡' and '⚡️' compare equal.
+const VARIATION_SELECTOR = /️/g
+export const normalizeGitmoji = (value: string): string => value.replace(VARIATION_SELECTOR, '')
+
+export const PUBLIC_EMOJI_PRIORITY: readonly string[] = GITMOJI.filter((g) => g.category === 'public').map(
+  (g) => g.emoji
+)
+export const INTERNAL_EMOJI_PRIORITY: readonly string[] = GITMOJI.filter((g) => g.category === 'internal').map(
+  (g) => g.emoji
+)

--- a/scripts/lib/gitmoji.ts
+++ b/scripts/lib/gitmoji.ts
@@ -35,9 +35,11 @@ export const GITMOJI: readonly Gitmoji[] = [
 const VARIATION_SELECTOR = /️/g
 export const normalizeGitmoji = (value: string): string => value.replace(VARIATION_SELECTOR, '')
 
-export const PUBLIC_EMOJI_PRIORITY: readonly string[] = GITMOJI.filter((g) => g.category === 'public').map(
-  (g) => g.emoji
+// Exported priorities are normalized so they match the output of `\p{Extended_Pictographic}`,
+// which strips the U+FE0F variation selector.
+export const PUBLIC_EMOJI_PRIORITY: readonly string[] = GITMOJI.filter((g) => g.category === 'public').map((g) =>
+  normalizeGitmoji(g.emoji)
 )
-export const INTERNAL_EMOJI_PRIORITY: readonly string[] = GITMOJI.filter((g) => g.category === 'internal').map(
-  (g) => g.emoji
+export const INTERNAL_EMOJI_PRIORITY: readonly string[] = GITMOJI.filter((g) => g.category === 'internal').map((g) =>
+  normalizeGitmoji(g.emoji)
 )

--- a/scripts/lib/gitmoji.ts
+++ b/scripts/lib/gitmoji.ts
@@ -32,7 +32,7 @@ export const GITMOJI: readonly Gitmoji[] = [
 ]
 
 // Strip the Unicode variation selector (U+FE0F) so '⚡' and '⚡️' compare equal.
-const VARIATION_SELECTOR = /️/g
+const VARIATION_SELECTOR = /\uFE0F/g
 export const normalizeGitmoji = (value: string): string => value.replace(VARIATION_SELECTOR, '')
 
 // Exported priorities are normalized so they match the output of `\p{Extended_Pictographic}`,

--- a/scripts/release/generate-changelog/lib/addNewChangesToChangelog.ts
+++ b/scripts/release/generate-changelog/lib/addNewChangesToChangelog.ts
@@ -98,7 +98,7 @@ function getLastReleaseTagName(): string {
   return match[1]
 }
 
-function sortByEmojiPriority(a: string, b: string, priorityList: string[]): number {
+function sortByEmojiPriority(a: string, b: string, priorityList: readonly string[]): number {
   const getFirstRelevantEmojiIndex = (text: string): number => {
     const emoji = findFirstEmoji(text)
     return emoji && priorityList.includes(emoji) ? priorityList.indexOf(emoji) : Number.MAX_VALUE
@@ -106,7 +106,7 @@ function sortByEmojiPriority(a: string, b: string, priorityList: string[]): numb
   return getFirstRelevantEmojiIndex(a) - getFirstRelevantEmojiIndex(b)
 }
 
-function formatChangeList(title: string, changes: string[], priority: string[]): string {
+function formatChangeList(title: string, changes: string[], priority: readonly string[]): string {
   if (!changes.length) {
     return ''
   }

--- a/scripts/release/generate-changelog/lib/constants.ts
+++ b/scripts/release/generate-changelog/lib/constants.ts
@@ -1,17 +1,4 @@
+export { PUBLIC_EMOJI_PRIORITY, INTERNAL_EMOJI_PRIORITY } from '../../../lib/gitmoji.ts'
+
 export const CONTRIBUTING_FILE = 'docs/DEVELOPMENT.md'
 export const CHANGELOG_FILE = 'CHANGELOG.md'
-export const PUBLIC_EMOJI_PRIORITY: string[] = ['💥', '✨', '🐛', '⚡', '📝']
-export const INTERNAL_EMOJI_PRIORITY: string[] = [
-  '👷',
-  '🔧',
-  '📦', // build conf
-  '♻️',
-  '🎨', // refactoring
-  '🧪',
-  '✅', // tests
-  '🔇',
-  '🔊', // telemetry
-  '👌',
-  '📄',
-  '⚗️', // experiment
-]


### PR DESCRIPTION
## Motivation

PR titles become commit messages on `main` (squash merge) and feed the changelog generator, which requires a gitmoji prefix. Today nothing prevents a PR from landing with a non-conforming title, which then needs a manual fix-up.

## Changes

- Add a `Lint PR title` GitHub Actions workflow that runs on PR open/edit/reopen and rejects titles missing an allowed gitmoji prefix.
- Extract the canonical gitmoji list into `scripts/lib/gitmoji.ts` (single source of truth) and refactor the changelog generator to consume it instead of its own local copy.
- Add `scripts/check-pr-title.ts` + spec, invoked from the workflow via `PR_TITLE` env var (passed through env, not inline, to avoid shell injection).

## Test instructions

- Run `yarn test:script` and check `scripts/check-pr-title.spec.ts` passes.
- Locally: `PR_TITLE='✨ something' node scripts/check-pr-title.ts` exits 0; `PR_TITLE='no prefix' node scripts/check-pr-title.ts` exits 1 with the allowed-prefix list.
- Once merged, opening a PR with a non-gitmoji title should fail the `Lint PR title` check.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file