### PR TITLE
👷 support Claude worktree setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ test/e2e/.pinned-browsers/
 # Claude Code local files
 *.local.md
 .claude/settings.local.json
+.claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.claude/settings.local.json
+.env

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default tseslint.config(
       'generated-docs',
       'developer-extension/.wxt',
       'developer-extension/dist',
+      '.claude/worktrees',
     ],
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,6 +68,7 @@ export default tseslint.config(
 
     languageOptions: {
       parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
         project: [
           './tsconfig.default.json',
           './tsconfig.scripts.json',


### PR DESCRIPTION
## Motivation

Make working in Claude Code worktrees seamless by carrying over local-only files (e.g. `.claude/settings.local.json`, `.env`) into new worktrees, and ignoring the worktrees directory from git.

## Changes

- Add `.worktreeinclude` listing files to copy into new worktrees (`.claude/settings.local.json`, `.env`).
- Ignore `.claude/worktrees/` in `.gitignore`.
- Set `tsconfigRootDir` in `eslint.config.mjs` so ESLint resolves tsconfig paths correctly when running from a worktree.

## Test instructions

- Create a new Claude worktree and confirm `.claude/settings.local.json` and `.env` (if present) are copied over.
- Run `yarn lint` from a worktree and confirm no tsconfig resolution errors.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file