### PR TITLE
🐛 Add context to session manager error telemetry

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -109,7 +109,9 @@ export async function startSessionManager(
 
   const { throttled: throttledExpandOrRenew, cancel: cancelExpandOrRenew } = throttle(() => {
     sessionExpired = false
-    strategy.setSessionState((state) => expandOrRenew(state, configuration)).catch(monitorError)
+    strategy
+      .setSessionState((state) => expandOrRenew(state, configuration))
+      .catch((error) => monitorError(new Error(`Error while expanding or renewing session on activity: ${error}`)))
   }, ONE_SECOND)
   stopCallbacks.push(cancelExpandOrRenew)
 
@@ -121,7 +123,9 @@ export async function startSessionManager(
     stopped = true
   })
 
-  const initialState = await resolveInitialState().catch(monitorError)
+  const initialState = await resolveInitialState().catch((error) =>
+    monitorError(new Error(`Error while resolving initial session state: ${error}`))
+  )
   if (!initialState || stopped) {
     return
   }
@@ -181,7 +185,7 @@ export async function startSessionManager(
 
             return state
           })
-          .catch(monitorError)
+          .catch((error) => monitorError(new Error(`Error while expiring session on timeout: ${error}`)))
       }, delay)
     }
   }
@@ -190,7 +194,9 @@ export async function startSessionManager(
     trackingConsentState.observable.subscribe(() => {
       if (trackingConsentState.isGranted()) {
         sessionExpired = false
-        strategy.setSessionState((state) => expandOrRenew(state, configuration)).catch(monitorError)
+        strategy
+          .setSessionState((state) => expandOrRenew(state, configuration))
+          .catch((error) => monitorError(new Error(`Error while expanding or renewing session on consent: ${error}`)))
       } else {
         expire()
       }
@@ -204,11 +210,15 @@ export async function startSessionManager(
       })
       trackVisibility(configuration, () => {
         if (!sessionExpired) {
-          strategy.setSessionState((state) => expandOnly(state)).catch(monitorError)
+          strategy
+            .setSessionState((state) => expandOnly(state))
+            .catch((error) => monitorError(new Error(`Error while expanding session on visibility: ${error}`)))
         }
       })
       trackResume(configuration, () => {
-        strategy.setSessionState((state) => initializeSession(state, configuration)).catch(monitorError)
+        strategy
+          .setSessionState((state) => initializeSession(state, configuration))
+          .catch((error) => monitorError(new Error(`Error while initializing session on resume: ${error}`)))
       })
     }
   }
@@ -233,7 +243,9 @@ export async function startSessionManager(
       expireObservable,
       expire,
       updateSessionState: (partialState) => {
-        strategy.setSessionState((state) => ({ ...state, ...partialState })).catch(monitorError)
+        strategy
+          .setSessionState((state) => ({ ...state, ...partialState }))
+          .catch((error) => monitorError(new Error(`Error while updating session state: ${error}`)))
       },
     }
   }
@@ -312,7 +324,7 @@ export async function startSessionManager(
         }
         return getExpiredSessionState(state, configuration)
       })
-      .catch(monitorError)
+      .catch((error) => monitorError(new Error(`Error while persisting expired session state: ${error}`)))
   }
 
   function buildSessionContext(sessionState: SessionState): SessionContext {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -37,7 +37,7 @@ export function initCookieStrategy(cookieOptions: CookieOptions, configuration: 
       .then((cookieValues) => {
         sessionObservable.notify({ cookieValues, sessionState: findMatchingSessionState(cookieValues, opts) })
       })
-      .catch(monitorError)
+      .catch((error) => monitorError(new Error(`Error while reading session cookies on change: ${error}`)))
   })
 
   function applyAndWrite(fn: (state: SessionState) => SessionState) {

--- a/test/e2e/scenario/telemetry.scenario.ts
+++ b/test/e2e/scenario/telemetry.scenario.ts
@@ -153,7 +153,7 @@ test.describe('telemetry', () => {
         expect(intakeRegistry.telemetryErrorEvents).toHaveLength(1)
         const error = intakeRegistry.telemetryErrorEvents[0]
         expect(error.service).toEqual('browser-logs-sdk')
-        expect(error.telemetry.message).toBe('expected error')
+        expect(error.telemetry.message).toBe('Error while resolving initial session state: Error: expected error')
         expect(error.telemetry.error!.kind).toBe('Error')
         expect(error.telemetry.status).toBe('error')
         intakeRegistry.empty()
@@ -167,7 +167,7 @@ test.describe('telemetry', () => {
         expect(intakeRegistry.telemetryErrorEvents).toHaveLength(1)
         const error = intakeRegistry.telemetryErrorEvents[0]
         expect(error.service).toEqual('browser-rum-sdk')
-        expect(error.telemetry.message).toBe('expected error')
+        expect(error.telemetry.message).toBe('Error while resolving initial session state: Error: expected error')
         expect(error.telemetry.error!.kind).toBe('Error')
         expect(error.telemetry.status).toBe('error')
         intakeRegistry.empty()


### PR DESCRIPTION
## Motivation

The telemetry error monitor (per-org) was flapping overnight because of `AbortError: Promise was rejected because the browsing context is going away`. All `.catch(monitorError)` calls in the session manager produce the same error message, so there's no way to tell which operation is the source.

## Changes

Each `.catch(monitorError)` in `sessionManager.ts` (8 call sites) and `sessionInCookie.ts` (1 call site) now wraps the error in a `new Error()` with a descriptive prefix. Telemetry messages will look like `Error while expanding or renewing session on activity: AbortError: Promise was rejected because the browsing context is going away` instead of just the raw error.

## Test instructions

Observability-only change. After deployment, check [telemetry error logs](https://dd-rum-telemetry.datadoghq.com/logs?query=source%3Abrowser+status%3Aerror+%22Error+while%22) and verify the messages include the operation context.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file