### PR TITLE
👷 disable reviewers-approval mergegate rule

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -38,3 +38,11 @@ kind: adms # Automated Dependency Management Service
 auto-version-updates:
   disabled:
     reason: We use renovate for now
+---
+schema-version: v1
+kind: mergegate
+name: rum-browser
+rules:
+  - require: reviewers-approval
+    enforcement: disabled
+  - require: all-files-are-owned


### PR DESCRIPTION
## Motivation

The `reviewers-approval` mergegate rule is redundant with GitHub's native branch protection requiring PR review approvals before merge. Disabling it removes duplicated enforcement.

## Changes

- Add a `mergegate` config block to `repository.datadog.yml` with `reviewers-approval` set to `disabled`.
- Keep `all-files-are-owned` enforced.

## Test instructions

No runtime impact on the SDK. Verify the mergegate config is picked up on the PR checks.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file