### PR TITLE
♻️ [PANA-7375] Eliminate unnecessary conditional node serialization

### DIFF
--- a/packages/rum-core/src/domain/privacy.ts
+++ b/packages/rum-core/src/domain/privacy.ts
@@ -220,37 +220,23 @@ export function censorText(text: string): string {
   return text.replace(/\S/g, TEXT_MASKING_CHAR)
 }
 
-export function getTextContent(textNode: Node, parentNodePrivacyLevel: NodePrivacyLevel): string | undefined {
+export function getTextContent(textNode: Node, parentNodePrivacyLevel: NodePrivacyLevel): string {
   // The parent node may not be a html element which has a tagName attribute.
   // So just let it be undefined which is ok in this use case.
   const parentTagName = textNode.parentElement?.tagName
   let textContent = textNode.textContent || ''
-
-  const shouldIgnoreWhiteSpace = parentTagName === 'HEAD'
-  if (shouldIgnoreWhiteSpace && !textContent.trim()) {
-    return
-  }
-
   const nodePrivacyLevel = parentNodePrivacyLevel
 
-  const isScript = parentTagName === 'SCRIPT'
-
-  if (isScript) {
+  if (parentTagName === 'SCRIPT') {
     // For perf reasons, we don't record script (heuristic)
     textContent = CENSORED_STRING_MARK
   } else if (nodePrivacyLevel === NodePrivacyLevel.HIDDEN) {
     // Should never occur, but just in case, we set to CENSORED_MARK.
     textContent = CENSORED_STRING_MARK
   } else if (shouldMaskNode(textNode, nodePrivacyLevel)) {
-    if (
-      // Scrambling the child list breaks text nodes for DATALIST/SELECT/OPTGROUP
-      parentTagName === 'DATALIST' ||
-      parentTagName === 'SELECT' ||
-      parentTagName === 'OPTGROUP'
-    ) {
-      if (!textContent.trim()) {
-        return
-      }
+    if (parentTagName === 'DATALIST' || parentTagName === 'SELECT' || parentTagName === 'OPTGROUP') {
+      // Masking the child list breaks text nodes for DATALIST/SELECT/OPTGROUP.
+      // TODO: Reinvestigate this.
     } else if (parentTagName === 'OPTION') {
       // <Option> has low entropy in charset + text length, so use `CENSORED_STRING_MARK` when masked
       textContent = CENSORED_STRING_MARK
@@ -258,6 +244,12 @@ export function getTextContent(textNode: Node, parentNodePrivacyLevel: NodePriva
       textContent = censorText(textContent)
     }
   }
+
+  const shouldCollapseWhiteSpace = parentTagName === 'HEAD'
+  if (shouldCollapseWhiteSpace && !textContent.trim()) {
+    return ''
+  }
+
   return textContent
 }
 

--- a/packages/rum/src/domain/record/serialization/serializeMutations.ts
+++ b/packages/rum/src/domain/record/serialization/serializeMutations.ts
@@ -214,7 +214,7 @@ function processCharacterDataMutations(
       continue // Mutations to this node should be ignored.
     }
 
-    const content = getTextContent(node, parentNodePrivacyLevel) ?? ''
+    const content = getTextContent(node, parentNodePrivacyLevel)
     transaction.setText(nodeId, content)
   }
 }

--- a/packages/rum/src/domain/record/serialization/serializeNode.node.spec.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.node.spec.ts
@@ -101,15 +101,6 @@ describe('serializeNode for DOM nodes', () => {
       })
       expect(record?.data).toEqual([[ChangeType.AddNode, [null, '#text', '']]])
     })
-
-    it('does not serialize a whitespace-only node if the parent is a <head> element', async () => {
-      const record = await serializeHtml('<!doctype HTML><head>    </head>', {
-        input: 'document',
-        target: (node: Node) => (node as Document).head.firstChild!,
-        whitespace: 'keep',
-      })
-      expect(record?.data).toBeUndefined()
-    })
   })
 
   describe('for HTML elements', () => {
@@ -184,7 +175,7 @@ describe('serializeNode for DOM nodes', () => {
   })
 
   describe('for <head> elements', () => {
-    it('does not serialize whitespace', async () => {
+    it('serializes the element', async () => {
       const record = await serializeHtml('<!doctype HTML><head>  <title>  foo </title>  </head>', {
         input: 'document',
         whitespace: 'keep',
@@ -196,9 +187,11 @@ describe('serializeNode for DOM nodes', () => {
           [1, '#doctype', 'html', '', ''],
           [0, 'HTML'],
           [1, 'HEAD'],
-          [1, 'TITLE'],
+          [1, '#text', ''],
+          [0, 'TITLE'],
           [1, '#text', '  foo '],
-          [4, 'BODY'],
+          [4, '#text', ''],
+          [6, 'BODY'],
         ],
         [ChangeType.ScrollPosition, [0, 0, 0]],
       ])

--- a/packages/rum/src/domain/record/serialization/serializeNode.ts
+++ b/packages/rum/src/domain/record/serialization/serializeNode.ts
@@ -169,11 +169,8 @@ function serializeTextNode(
   privacyLevel: NodePrivacyLevel,
   transaction: SerializationTransaction
 ): void {
-  const textContent = getTextContent(textNode, privacyLevel)
-  if (textContent === undefined) {
-    return
-  }
   const { insertionPoint } = cursor.advance(textNode)
+  const textContent = getTextContent(textNode, privacyLevel)
   transaction.addNode(insertionPoint, '#text', textContent)
 }
 
@@ -192,7 +189,9 @@ function serializeHiddenNodePlaceholder(
   transaction: SerializationTransaction
 ): void {
   // We only generate placeholders for element nodes; other hidden nodes are simply not
-  // serialized.
+  // serialized. (But note that a non-element node can only be hidden if it's a descendant
+  // of another hidden node, since only element nodes can have a different privacy level
+  // than their parent.)
   if (!isElementNode(node)) {
     return
   }


### PR DESCRIPTION
## Motivation

There's an awkward edge case that exists today: in very narrow circumstances, we decline to serialize nodes when "bulk serializing" a DOM subtree based on certain conditions, but we _will_ serialize those exact same nodes if they're mutated later.

This breaks some invariants that you'd expect to hold. For example, you'd expect that if you encounter an unserialized node, then one of these three things must be true:
1. The node's parent also has not been serialized.
2. The node has a different privacy level than its parent, such that it's excluded from serialization.
3. The node has been newly added to the document since we last processed mutations.

Conditional serialization adds a fourth, non-obvious case to this list.

Similarly (and this is a case I had reason to care about recently), you might expect that this sequence of actions:
1. Populate the document.
2. Take a full snapshot.
3. Set the text content of a text node to 'foo'.
4. Take an incremental snapshot.

Would be guaranteed to produce the same final rendering as this sequence of actions:
1. Populate the document.
2. Set the text content of a text node to 'foo'.
3. Take a full snapshot.

However, today, this isn't necessarily so! That's because we apply conditional serialization to text nodes, and changing the text content of a text node can change whether it's included in the full snapshot. If it's not included, subsequent incremental mutations won't be captured either, even if the condition is satisfied as a result of the change. However, the next time a full snapshot is taken, the node will reappear -- hence the reason why the two sequences of action above can produce different results.

We should view this as a bug. There are two ways we could fix it:
1. We could detect when the conditions that led us to decline to serialize a node have changed, and consider whether we need to serialize it again.
2. We could just remove the unnecessary conditional serialization logic for these nodes.

I've chosen path #2; given the very limited circumstances in which we apply conditional serialization, and the very limited benefit we obtain from it, I think the best path forward is simply to remove it and eliminate this source of complexity.

## Changes

We conditionally decline to serialize nodes in two circumstances today:
1. Text nodes which are direct children of `<head>` are not serialized if they contain only whitespace.
2. Text nodes which are direct children of `<datalist>`, `<select>`, or `<optgroup>`are not serialized if they contain only whitespace and they would otherwise be masked.

In both of these situations, we now unconditionally serialize the nodes.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
