### PR TITLE
📝 group subdomain option with Session Replay in docs

### DIFF
--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -196,6 +196,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    *
    * See [Connect Session Replay To Your Third-Party Tools](https://docs.datadoghq.com/real_user_monitoring/guide/connect-session-replay-to-your-third-party-tools) for further information.
    *
+   * @category Session Replay
    */
   subdomain?: string
 


### PR DESCRIPTION
## Motivation

The `subdomain` option in `RumInitConfiguration` is documented as a way to customize the URL returned by `getSessionReplayLink()`. However, its JSDoc is missing a `@category` tag, so it ends up grouped under the default "Other" section in the generated docs instead of with the rest of the Session Replay options.

## Changes

Add `@category Session Replay` to the `subdomain` JSDoc in `packages/rum-core/src/domain/configuration/configuration.ts` so it shows up under the Session Replay group, alongside `sessionReplaySampleRate` and `startSessionReplayRecordingManually`.

## Test instructions

- Regenerate the API reference docs and verify that `subdomain` now appears under the Session Replay category instead of Other.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file