### PR TITLE
[PROF-13798] ✨ Add subdomain support to ProxyFn for quota check

### DIFF
--- a/packages/core/src/domain/configuration/configuration.ts
+++ b/packages/core/src/domain/configuration/configuration.ts
@@ -272,7 +272,7 @@ type GenericBeforeSendCallback = (event: any, context?: any) => unknown
  * path: /api/vX/product
  * parameters: xxx=yyy&zzz=aaa
  */
-export type ProxyFn = (options: { path: string; parameters: string }) => string
+export type ProxyFn = (options: { path: string; parameters: string; subdomain?: string }) => string
 
 /**
  * @internal

--- a/packages/core/src/domain/configuration/transportConfiguration.ts
+++ b/packages/core/src/domain/configuration/transportConfiguration.ts
@@ -1,6 +1,6 @@
 import type { Site } from '../intakeSites'
 import { INTAKE_SITE_US1, INTAKE_URL_PARAMETERS } from '../intakeSites'
-import type { InitConfiguration, SdkSource } from './configuration'
+import type { InitConfiguration, ProxyFn, SdkSource } from './configuration'
 import type { EndpointBuilder, TransportSource } from './endpointBuilder'
 import { createEndpointBuilder } from './endpointBuilder'
 
@@ -15,6 +15,7 @@ export interface TransportConfiguration {
   datacenter?: string | undefined
   replica?: ReplicaConfiguration
   clientToken: string
+  proxy?: string | ProxyFn | undefined
   site: Site
   source: SdkSource
 }
@@ -57,6 +58,7 @@ export function computeTransportConfiguration(
 
   return {
     clientToken: initConfiguration.clientToken,
+    proxy: initConfiguration.proxy,
     replica: replicaConfiguration,
     site,
     source,

--- a/packages/rum/src/domain/profiling/quotaCheck.spec.ts
+++ b/packages/rum/src/domain/profiling/quotaCheck.spec.ts
@@ -112,4 +112,26 @@ describe('checkProfilingQuota', () => {
       'https://quota.browser-intake-datad0g.com/api/v2/profiling/quota?session_id=session-abc'
     )
   })
+
+  it('routes through proxy when proxy is configured as a string, adding ddforwardSubdomain=quota', async () => {
+    interceptor.withFetch(backendResponse(true, 'quota_ok'))
+    await checkProfilingQuota(mockRumConfiguration({ proxy: 'http://proxy.example.com' }), 'session-abc')
+    expect(interceptor.requests[0].url).toBe(
+      'http://proxy.example.com?ddforward=%2Fapi%2Fv2%2Fprofiling%2Fquota%3Fsession_id%3Dsession-abc&ddforwardSubdomain=quota'
+    )
+  })
+
+  it('routes through proxy when proxy is configured as a function, passing subdomain=quota', async () => {
+    interceptor.withFetch(backendResponse(true, 'quota_ok'))
+    await checkProfilingQuota(
+      mockRumConfiguration({
+        proxy: ({ path, parameters, subdomain }) =>
+          `https://${subdomain}.browser-intake-datadoghq.com${path}?${parameters}`,
+      }),
+      'session-abc'
+    )
+    expect(interceptor.requests[0].url).toBe(
+      'https://quota.browser-intake-datadoghq.com/api/v2/profiling/quota?session_id=session-abc'
+    )
+  })
 })

--- a/packages/rum/src/domain/profiling/quotaCheck.ts
+++ b/packages/rum/src/domain/profiling/quotaCheck.ts
@@ -29,8 +29,21 @@ function parseQuotaResult(body: unknown, httpStatusFallback: QuotaResult): Quota
 }
 
 function buildQuotaUrl(configuration: RumConfiguration, sessionId: string): string {
+  const path = '/api/v2/profiling/quota'
+  const parameters = `session_id=${sessionId}`
+  const proxy = configuration.proxy
   const host = `quota.${buildEndpointHost({ site: configuration.site, clientToken: configuration.clientToken })}`
-  return `https://${host}/api/v2/profiling/quota?session_id=${sessionId}`
+
+  if (typeof proxy === 'string') {
+    // ddforwardSubdomain tells the proxy which intake subdomain to target.
+    return `${proxy}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}&ddforwardSubdomain=quota`
+  }
+
+  if (typeof proxy === 'function') {
+    return proxy({ path, parameters, subdomain: 'quota' })
+  }
+
+  return `https://${host}${path}?${parameters}`
 }
 
 export function checkProfilingQuota(

--- a/test/e2e/lib/framework/serverApps/intake.ts
+++ b/test/e2e/lib/framework/serverApps/intake.ts
@@ -11,6 +11,16 @@ export function createIntakeServerApp(intakeRegistry: IntakeRegistry) {
 
   app.post('/', createIntakeProxyMiddleware({ onRequest: (request) => intakeRegistry.push(request) }))
 
+  // Quota admission check — always admit in the test environment.
+  // Triggered via proxy-as-string with ddforwardSubdomain=quota.
+  app.get('/', (req, res) => {
+    if (req.query.ddforwardSubdomain === 'quota') {
+      res.json({ data: { id: 'test', type: 'profiling-quota', attributes: { admitted: true, reason: 'quota_ok' } } })
+    } else {
+      res.status(404).end()
+    }
+  })
+
   app.post('/api/unstable/debugger/frontend/probes', (_req, res) => {
     res.json({ nextCursor: '', updates: debuggerProbes, deletions: [] })
   })


### PR DESCRIPTION
## Motivation

The quota admission endpoint lives on a subdomain (`quota.browser-intake-*`) that differs from the standard intake host. The existing `ProxyFn` signature has no way to express this, so proxy implementations can't route quota requests to the right backend.

Stacks on top of [#4514](https://github.com/DataDog/browser-sdk/pull/4514).

## Changes

- **`ProxyFn`**: adds optional `subdomain?: string` to the options object, allowing proxy implementations to target intake subdomains.
- **`checkProfilingQuota`**: passes `subdomain: 'quota'` when calling a function proxy.
- **proxy-as-string path**: appends `ddforwardSubdomain=quota` to the forwarded URL so the proxy server can identify quota requests without inspecting the full path.
- **E2E intake server**: detects `ddforwardSubdomain=quota` and returns a static admit response.

## Note

`subdomain` is optional and defaults to nothing, so existing proxy implementations are unaffected.