### PR TITLE
👷 E2E scope WebKit workaround to macOS only

### DIFF
--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -387,7 +387,9 @@ function declareTest(title: string, setupOptions: SetupOptions, factory: SetupFa
     addTag('test.browserName', browserName)
     addTestOptimizationTags(test.info().project.metadata as BrowserConfiguration)
 
-    if (browserName === 'webkit') {
+    // The bug only reproduces on Playwright's macOS WebKit build; skip on every other platform
+    // (notably Linux CI runners) to avoid installing the prototype override where it serves no purpose.
+    if (browserName === 'webkit' && process.platform === 'darwin') {
       await context.addInitScript(WEBKIT_PLAYWRIGHT_WORKAROUND)
     }
 


### PR DESCRIPTION
## Motivation

The `Event.prototype.timeStamp` override added in #4616 only needs to run on Playwright's macOS WebKit, which is where the Cocoa-epoch timestamp bug lives. Linux runners (CI) aren't affected, so installing the prototype override there is just dead overhead.

## Changes

Gated the `addInitScript` call behind `process.platform === 'darwin'`.

## Test instructions

Run `yarn test:e2e --project=webkit test/e2e/scenario/rum/actions.scenario.ts` locally on macOS — should stay green.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file