### PR TITLE
✨ add `required` option for remote configuration

### DIFF
--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -518,6 +518,75 @@ describe('preStartRum', () => {
         await interceptor.waitForAllFetchCalls()
         expect(interceptor.requests.some((r) => r.url.includes(REMOTE_CONFIGURATION_ID))).toBeTrue()
       })
+
+      describe('with required: true', () => {
+        const CACHE_KEY = `dd_rc_${REMOTE_CONFIGURATION_ID}`
+
+        it('should not start the SDK on cache miss', async () => {
+          const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+          strategy.init(
+            {
+              ...DEFAULT_INIT_CONFIGURATION,
+              remoteConfiguration: { id: REMOTE_CONFIGURATION_ID, required: true },
+            },
+            PUBLIC_API
+          )
+
+          await interceptor.waitForAllFetchCalls()
+          expect(doStartRumSpy).not.toHaveBeenCalled()
+        })
+
+        it('should still trigger a background fetch on cache miss', async () => {
+          const { strategy } = createPreStartStrategyWithDefaults()
+
+          strategy.init(
+            {
+              ...DEFAULT_INIT_CONFIGURATION,
+              remoteConfiguration: { id: REMOTE_CONFIGURATION_ID, required: true },
+            },
+            PUBLIC_API
+          )
+
+          await interceptor.waitForAllFetchCalls()
+          expect(interceptor.requests.some((r) => r.url.includes(REMOTE_CONFIGURATION_ID))).toBeTrue()
+        })
+
+        it('should start the SDK with the cached configuration on cache hit', async () => {
+          localStorage.setItem(
+            CACHE_KEY,
+            JSON.stringify({ version: 1, config: { sessionSampleRate: 75 }, fetchedAt: 1000 })
+          )
+          const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+          strategy.init(
+            {
+              ...DEFAULT_INIT_CONFIGURATION,
+              remoteConfiguration: { id: REMOTE_CONFIGURATION_ID, required: true },
+            },
+            PUBLIC_API
+          )
+
+          await collectAsyncCalls(doStartRumSpy, 1)
+          expect(doStartRumSpy.calls.mostRecent().args[0].sessionSampleRate).toBe(75)
+        })
+
+        it('should not start the SDK on cache error', async () => {
+          localStorage.setItem(CACHE_KEY, 'not-json')
+          const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
+
+          strategy.init(
+            {
+              ...DEFAULT_INIT_CONFIGURATION,
+              remoteConfiguration: { id: REMOTE_CONFIGURATION_ID, required: true },
+            },
+            PUBLIC_API
+          )
+
+          await interceptor.waitForAllFetchCalls()
+          expect(doStartRumSpy).not.toHaveBeenCalled()
+        })
+      })
     })
 
     describe('plugins', () => {

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -261,7 +261,11 @@ export function createPreStartStrategy(
             })
             .catch(monitorError)
         } else {
-          doInit(getRemoteConfiguration(initConfiguration, supportedContextManagers), errorStack)
+          const resolvedInitConfiguration = getRemoteConfiguration(initConfiguration, supportedContextManagers)
+
+          if (resolvedInitConfiguration) {
+            doInit(resolvedInitConfiguration, errorStack)
+          }
         }
       } else {
         doInit(initConfiguration, errorStack)

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -149,11 +149,14 @@ export interface RumInitConfiguration extends InitConfiguration {
   /**
    * [Internal option] Remote configuration descriptor. By default the SDK reads a cached
    * configuration synchronously and refreshes it in the background. Set `sync: true` to fall back
-   * to the legacy blocking fetch.
+   * to the legacy blocking fetch. Set `required: true` to prevent the SDK from starting on the
+   * current page load when the remote configuration cache is empty or unreadable (the background
+   * fetch still runs to populate the cache for the next load). Ignored when `sync: true` is set
+   * or when the legacy `remoteConfigurationId` field is used.
    *
    * @internal
    */
-  remoteConfiguration?: { id: string; sync?: boolean } | undefined
+  remoteConfiguration?: { id: string; sync?: boolean; required?: boolean } | undefined
 
   /**
    * [Internal option] set a proxy URL for the remote configuration

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -813,8 +813,9 @@ describe('remoteConfiguration', () => {
 
       const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
 
-      expect(result.applicationId).toBe('cached-app')
-      expect(result.clientToken).toBe('xxx')
+      expect(result).toBeDefined()
+      expect(result!.applicationId).toBe('cached-app')
+      expect(result!.clientToken).toBe('xxx')
       await flushBackgroundSync()
     })
 
@@ -866,6 +867,55 @@ describe('remoteConfiguration', () => {
           Promise.resolve({ ok: true, json: () => Promise.resolve({ rum: FRESH_RUM_CONFIG }) })
         )
       }
+    })
+
+    describe('with required: true', () => {
+      beforeEach(() => {
+        initConfiguration = {
+          ...initConfiguration,
+          remoteConfiguration: { id: REMOTE_CONFIGURATION_ID, required: true },
+        }
+      })
+
+      it('should apply cached configuration on cache hit', async () => {
+        withCachedEntry(CACHED_RUM_CONFIG)
+        withFetchSuccess()
+
+        const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
+
+        expect(result).toBeDefined()
+        expect(result!.applicationId).toBe('cached-app')
+        await flushBackgroundSync()
+      })
+
+      it('should return undefined on cache miss', async () => {
+        withFetchSuccess()
+
+        const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
+
+        expect(result).toBeUndefined()
+        await flushBackgroundSync()
+      })
+
+      it('should return undefined on cache error', async () => {
+        localStorage.setItem(CACHE_KEY, 'not-json')
+        withFetchSuccess()
+
+        const result = getRemoteConfiguration(initConfiguration, supportedContextManagers)
+
+        expect(result).toBeUndefined()
+        await flushBackgroundSync()
+      })
+
+      it('should still trigger a background fetch on cache miss', async () => {
+        withFetchSuccess()
+
+        getRemoteConfiguration(initConfiguration, supportedContextManagers)
+        await flushBackgroundSync()
+
+        const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!)
+        expect(stored.config).toEqual(FRESH_RUM_CONFIG)
+      })
     })
   })
 })

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -349,7 +349,7 @@ function doBackgroundCacheSync(
 export function getRemoteConfiguration(
   initConfiguration: RumInitConfiguration,
   supportedContextManagers: SupportedContextManagers
-): RumInitConfiguration {
+): RumInitConfiguration | undefined {
   const configurationCache = createConfigurationCache({
     remoteConfigurationId: getRemoteConfigurationId(initConfiguration)!,
   })
@@ -361,7 +361,13 @@ export function getRemoteConfiguration(
 
   doBackgroundCacheSync(initConfiguration, configurationCache, metrics)
 
-  return cacheResult.status === 'hit'
-    ? applyRemoteConfiguration(initConfiguration, cacheResult.config, supportedContextManagers, metrics)
-    : initConfiguration
+  if (cacheResult.status === 'hit') {
+    return applyRemoteConfiguration(initConfiguration, cacheResult.config, supportedContextManagers, metrics)
+  }
+
+  if (initConfiguration.remoteConfiguration?.required) {
+    return
+  }
+
+  return initConfiguration
 }


### PR DESCRIPTION
## Motivation

Customers may want to enable the SDK only if a Remote Configuration is in cache; to prevent the SDK from starting with an outdated in-code config at the first launch

## Changes

Adds `required: boolean` flag to the `remoteConfiguration` init field:

  ```ts
  DD_RUM.init({
    ...,
    remoteConfiguration: { 
        id: '<rc-id>',
        required: true 
    },
  })
  ```

 When `required: true`:
  - **Cache hit** — SDK starts with the cached remote configuration applied (unchanged  behavior).
  - **Cache miss / cache error** — SDK does  **not** start on the current page load. The background fetch still runs and populates the cache so the next page load can start normally.

  The flag is ignored when `sync: true` is set or when the legacy `remoteConfigurationId` field is used (in both cases the fetch is already blocking and the SDK already skips startup on failure).


## Test instructions

1. add `remote-config.json` file to sandbox directory
2. update parameters, passed to `DD_RUM.init` adding `remoteConfiguration: { id: 'remote-config-test', required: true }`, `remoteConfigurationProxy: '/remote-config.json'`
3. check that remote config from file is requested and written to localStorage on the first page load (localStorage.getItem('dd_rc_remote-config-test')
4. check that `DD_RUM.getInternalContext()` returns undefined on the first page load
5. check that `DD_RUM.getInternalContext()` returns valid `RumInternalContext` on the second page load

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
