### PR TITLE
fix(view-update): exclude _dd.application from VIEW_UPDATE payloads

### DIFF
--- a/packages/rum-core/src/transport/startRumBatch.spec.ts
+++ b/packages/rum-core/src/transport/startRumBatch.spec.ts
@@ -205,6 +205,20 @@ describe('computeAssembledViewDiff', () => {
 
     expect(current.service).toBe(currentService)
   })
+
+  it('should exclude _dd.application from view_update (SDK init-time config, never changes)', () => {
+    const application = { rum_enabled: true, product_analytics_enabled: false }
+    const last = makeAssembledView({ _dd: { document_version: 1, format_version: 2, sdk_name: 'rum', configuration: { start_session_replay_recording_manually: false }, application } })
+    const current = makeAssembledView({
+      _dd: { document_version: 2, format_version: 2, sdk_name: 'rum', configuration: { start_session_replay_recording_manually: false }, application },
+      view: { id: 'view-1', name: 'Home', url: '/home', referrer: '', is_active: true, action: { count: 1 }, error: { count: 0 }, long_task: { count: 0 }, resource: { count: 0 }, time_spent: 100 },
+    })
+
+    const result = computeAssembledViewDiff(current, last)!
+
+    expect((result._dd as any).application).toBeUndefined()
+    expect((result._dd as any).document_version).toBe(2) // required field still present
+  })
 })
 
 describe('startRumBatch partial_view_updates routing', () => {

--- a/packages/rum-core/src/transport/startRumBatch.ts
+++ b/packages/rum-core/src/transport/startRumBatch.ts
@@ -30,7 +30,10 @@ export function computeAssembledViewDiff(
     // context, connectivity, usr, device, privacy are objects — use REPLACE to avoid partial updates
     replaceKeys: new Set(['view.custom_timings', 'context', 'connectivity', 'usr', 'device', 'privacy']),
     appendKeys: new Set(['_dd.page_states']),
-    // Ignore always-required fields — they are added back via combine regardless of changes
+    // Ignore always-required fields — they are added back via combine regardless of changes.
+    // Also ignore SDK init-time config booleans that never change after initialisation:
+    // _dd.application.{rum_enabled, product_analytics_enabled, error_focused_mode_enabled,
+    // product_analytics_preview_enabled} are set once at init and constant for the session.
     ignoreKeys: new Set([
       'date',
       'type',
@@ -40,6 +43,7 @@ export function computeAssembledViewDiff(
       'view.url',
       '_dd.document_version',
       '_dd.format_version',
+      '_dd.application',
     ]),
   })
 


### PR DESCRIPTION
## Problem

\`_dd.application\` contains four SDK init-time config booleans set once at SDK initialisation and constant for the session:
- \`rum_enabled\`
- \`product_analytics_enabled\`
- \`error_focused_mode_enabled\`
- \`product_analytics_preview_enabled\`

\`computeAssembledViewDiff\` uses \`diffMerge\` which recurses into nested objects and naturally omits unchanged fields — so these fields are already excluded in the common case. However they are not in \`ignoreKeys\`, which leaves the intent implicit and risks future regressions if \`ignoreKeys\` logic or \`diffMerge\` changes.

Backend observability data (PR #136915, \`sdk_source:browser\`, 18.5 h, ~341 K VIEW_UPDATEs on staging) confirmed 32.4% redundancy across all four fields — arriving unchanged on ~1 in 3 VIEW_UPDATEs driven by periodic checkpoint VIEW resets.

## Solution

Add \`_dd.application\` to the \`ignoreKeys\` set in \`computeAssembledViewDiff\`. The baseline VIEW always carries the full \`_dd.application\` object; VIEW_UPDATEs never need to re-send it.

## Changes

- \`startRumBatch.ts\`: add \`'_dd.application'\` to \`ignoreKeys\`
- \`startRumBatch.spec.ts\`: add test verifying \`_dd.application\` is absent from diff output