### PR TITLE
🧹 [Profiler] Remove dead page.route() quota mock from E2E profiling scenario

### DIFF
--- a/test/e2e/scenario/profiling.scenario.ts
+++ b/test/e2e/scenario/profiling.scenario.ts
@@ -3,19 +3,8 @@ import type { Page } from '@playwright/test'
 import { createTest } from '../lib/framework'
 
 test.describe('profiling', () => {
-  test.beforeEach(async ({ page, browserName }) => {
+  test.beforeEach(({ browserName }) => {
     test.skip(browserName !== 'chromium', 'JS Profiling API is only available in Chromium')
-    // ↑ throws TestSkipError on Firefox/WebKit — nothing below runs
-
-    await page.route('https://quota.browser-intake-datadoghq.com/api/v2/profiling/quota*', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/vnd.api+json',
-        body: JSON.stringify({
-          data: { id: 'test', type: 'profiling-quota', attributes: { admitted: true, reason: 'quota_ok' } },
-        }),
-      })
-    )
   })
 
   createTest('send profile events when profiling is enabled')


### PR DESCRIPTION
## Motivation

Stacks on top of [#4638](https://github.com/DataDog/browser-sdk/pull/4638).

In E2E tests, `proxy` is always set to `servers.intake.origin` (hardcoded in `pageSetups.ts`). This means the quota check always routes through the intake server — the `page.route()` mock for `quota.browser-intake-datadoghq.com` inherited from the first PR was never firing. The intake server's GET handler handles the quota request instead.

## Changes

- Remove the `page.route()` quota mock from the `test.beforeEach` in `profiling.scenario.ts` — dead code in this context.
- Restore the `test.beforeEach` to its original single-purpose form (chromium skip guard only).