### PR TITLE
🐛 Forward initial loader errors to RouterProvider's onError

### DIFF
--- a/packages/rum-react/src/domain/reactRouter/createRouter.spec.ts
+++ b/packages/rum-react/src/domain/reactRouter/createRouter.spec.ts
@@ -109,7 +109,7 @@ describe('wrapCreateRouter — initial error forwarding', () => {
     expect(spy).toHaveBeenCalledOnceWith(fakeRouter.state, errorOpts)
   })
 
-  it('forwards an async newErrors notification', () => {
+  it('forwards an async newErrors notification that fires before the next subscriber attaches', () => {
     const { fakeRouter, notify } = buildFakeRouter()
     notify(errorOpts)
     const spy = jasmine.createSpy<AnyRouterSubscriber>()
@@ -125,14 +125,33 @@ describe('wrapCreateRouter — initial error forwarding', () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it('forwards only once — subsequent error navigations are not replayed', () => {
-    const { fakeRouter, notify } = buildFakeRouter(errorOpts)
-    const firstSpy = jasmine.createSpy<AnyRouterSubscriber>()
-    fakeRouter.subscribe(firstSpy)
-    notify(errorOpts)
-    const secondSpy = jasmine.createSpy<AnyRouterSubscriber>()
-    fakeRouter.subscribe(secondSpy)
-    expect(firstSpy).toHaveBeenCalledTimes(1)
-    expect(secondSpy).not.toHaveBeenCalled()
+  it('does not replay errors that arrive after the next subscriber attached', () => {
+    // No initial buffered error. RouterProvider subscribes, then a navigation
+    // error fires and is broadcast to all subscribers — RouterProvider gets it
+    // directly. A later resubscribe (e.g. RouterProvider's setState identity
+    // changes when an inline onError prop changes) must NOT receive a stale
+    // replay, otherwise onError would fire twice for the same error.
+    const subscribers: AnyRouterSubscriber[] = []
+    const fakeRouter: AnyRouter = {
+      state: { location: { pathname: '/foo' }, matches: [] },
+      subscribe(fn) {
+        subscribers.push(fn)
+        return noop
+      },
+    }
+    wrapCreateRouter((_r: unknown[], _o?: unknown) => fakeRouter)([], {})
+
+    const routerProvider = jasmine.createSpy<AnyRouterSubscriber>()
+    fakeRouter.subscribe(routerProvider)
+
+    // Broadcast as react-router would for a post-mount navigation error
+    for (const sub of [...subscribers]) {
+      sub(fakeRouter.state, errorOpts)
+    }
+    expect(routerProvider).toHaveBeenCalledTimes(1)
+
+    const resubscribed = jasmine.createSpy<AnyRouterSubscriber>()
+    fakeRouter.subscribe(resubscribed)
+    expect(resubscribed).not.toHaveBeenCalled()
   })
 })

--- a/packages/rum-react/src/domain/reactRouter/createRouter.spec.ts
+++ b/packages/rum-react/src/domain/reactRouter/createRouter.spec.ts
@@ -2,6 +2,7 @@ import { createMemoryRouter as createMemoryRouterV7 } from 'react-router-dom'
 import { createMemoryRouter as createMemoryRouterV6 } from 'react-router-dom-6'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'
 import { wrapCreateRouter } from './createRouter'
+import type { AnyRouter, AnyRouterSubscriber } from './types'
 
 describe('createRouter', () => {
   const versions = [
@@ -75,4 +76,63 @@ describe('createRouter', () => {
       })
     })
   }
+})
+
+// Regression tests for https://github.com/DataDog/browser-sdk/issues/4657
+describe('wrapCreateRouter — initial error forwarding', () => {
+  const errorOpts = { newErrors: { '0': new Error('loader error') }, deletedFetchers: [] }
+  const normalOpts = { newErrors: null, deletedFetchers: [] }
+  const noop = () => undefined
+
+  function buildFakeRouter(syncReplay?: typeof errorOpts) {
+    let ourCallback: AnyRouterSubscriber | undefined
+    const fakeRouter: AnyRouter = {
+      state: { location: { pathname: '/foo' }, matches: [] },
+      subscribe(fn) {
+        if (!ourCallback) {
+          ourCallback = fn
+          if (syncReplay) {
+            fn(fakeRouter.state, syncReplay)
+          }
+        }
+        return noop
+      },
+    }
+    wrapCreateRouter((_r: unknown[], _o?: unknown) => fakeRouter)([], {})
+    return { fakeRouter, notify: (opts: typeof errorOpts | typeof normalOpts) => ourCallback!(fakeRouter.state, opts) }
+  }
+
+  it('forwards a synchronous buffer replay (react-router ≥7.15.1)', () => {
+    const { fakeRouter } = buildFakeRouter(errorOpts)
+    const spy = jasmine.createSpy<AnyRouterSubscriber>()
+    fakeRouter.subscribe(spy)
+    expect(spy).toHaveBeenCalledOnceWith(fakeRouter.state, errorOpts)
+  })
+
+  it('forwards an async newErrors notification', () => {
+    const { fakeRouter, notify } = buildFakeRouter()
+    notify(errorOpts)
+    const spy = jasmine.createSpy<AnyRouterSubscriber>()
+    fakeRouter.subscribe(spy)
+    expect(spy).toHaveBeenCalledOnceWith(fakeRouter.state, errorOpts)
+  })
+
+  it('does not forward when there is no error', () => {
+    const { fakeRouter, notify } = buildFakeRouter()
+    notify(normalOpts)
+    const spy = jasmine.createSpy<AnyRouterSubscriber>()
+    fakeRouter.subscribe(spy)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('forwards only once — subsequent error navigations are not replayed', () => {
+    const { fakeRouter, notify } = buildFakeRouter(errorOpts)
+    const firstSpy = jasmine.createSpy<AnyRouterSubscriber>()
+    fakeRouter.subscribe(firstSpy)
+    notify(errorOpts)
+    const secondSpy = jasmine.createSpy<AnyRouterSubscriber>()
+    fakeRouter.subscribe(secondSpy)
+    expect(firstSpy).toHaveBeenCalledTimes(1)
+    expect(secondSpy).not.toHaveBeenCalled()
+  })
 })

--- a/packages/rum-react/src/domain/reactRouter/createRouter.ts
+++ b/packages/rum-react/src/domain/reactRouter/createRouter.ts
@@ -7,7 +7,27 @@ export function wrapCreateRouter<CreateRouter extends AnyCreateRouter<any>>(
   return ((routes, options) => {
     const router = originalCreateRouter(routes, options)
     let location = router.state.location.pathname
-    router.subscribe((routerState) => {
+
+    // We subscribe before RouterProvider, so initial loader-error notifications
+    // reach us instead of it (consuming the react-router ≥7.15.1 one-shot buffer,
+    // or arriving before RouterProvider's deferred useLayoutEffect). Forward the
+    // first such notification to the next subscriber so RouterProvider's onError
+    // still fires.
+    let hasForwardedInitialErrors = false
+
+    router.subscribe((routerState, opts) => {
+      if (opts?.newErrors && !hasForwardedInitialErrors) {
+        hasForwardedInitialErrors = true
+        const capturedState = routerState
+        const capturedOpts = opts
+        const originalSubscribe = router.subscribe.bind(router)
+        router.subscribe = (fn) => {
+          router.subscribe = originalSubscribe
+          const unsubscribe = originalSubscribe(fn)
+          fn(capturedState, capturedOpts)
+          return unsubscribe
+        }
+      }
       const newPathname = routerState.location.pathname
       if (location !== newPathname) {
         startReactRouterView(routerState.matches)

--- a/packages/rum-react/src/domain/reactRouter/createRouter.ts
+++ b/packages/rum-react/src/domain/reactRouter/createRouter.ts
@@ -1,5 +1,5 @@
 import { startReactRouterView } from './startReactRouterView'
-import type { AnyCreateRouter } from './types'
+import type { AnyCreateRouter, AnyRouterSubscriberOpts } from './types'
 
 export function wrapCreateRouter<CreateRouter extends AnyCreateRouter<any>>(
   originalCreateRouter: CreateRouter
@@ -9,24 +9,20 @@ export function wrapCreateRouter<CreateRouter extends AnyCreateRouter<any>>(
     let location = router.state.location.pathname
 
     // We subscribe before RouterProvider, so initial loader-error notifications
-    // reach us instead of it (consuming the react-router ≥7.15.1 one-shot buffer,
-    // or arriving before RouterProvider's deferred useLayoutEffect). Forward the
-    // first such notification to the next subscriber so RouterProvider's onError
-    // still fires.
-    let hasForwardedInitialErrors = false
+    // reach us instead of it — either via react-router ≥7.15.1's one-shot
+    // buffer replay (sync) or as a regular broadcast before RouterProvider's
+    // deferred useLayoutEffect (async). Capture any such error and replay it
+    // to the next subscriber so RouterProvider's onError still fires.
+    // The next-subscriber patch is installed eagerly so a single flag
+    // (hasNextSubscriberAttached) reliably tells us whether an incoming error
+    // is pre- or post-RouterProvider — only pre-RouterProvider errors are
+    // captured, avoiding duplicate onError on later resubscribes.
+    let pendingInitialError: { state: typeof router.state; opts: AnyRouterSubscriberOpts } | null = null
+    let hasNextSubscriberAttached = false
 
     router.subscribe((routerState, opts) => {
-      if (opts?.newErrors && !hasForwardedInitialErrors) {
-        hasForwardedInitialErrors = true
-        const capturedState = routerState
-        const capturedOpts = opts
-        const originalSubscribe = router.subscribe.bind(router)
-        router.subscribe = (fn) => {
-          router.subscribe = originalSubscribe
-          const unsubscribe = originalSubscribe(fn)
-          fn(capturedState, capturedOpts)
-          return unsubscribe
-        }
+      if (opts?.newErrors && !hasNextSubscriberAttached) {
+        pendingInitialError = { state: routerState, opts }
       }
       const newPathname = routerState.location.pathname
       if (location !== newPathname) {
@@ -34,6 +30,19 @@ export function wrapCreateRouter<CreateRouter extends AnyCreateRouter<any>>(
         location = newPathname
       }
     })
+
+    const originalSubscribe = router.subscribe.bind(router)
+    router.subscribe = (fn) => {
+      hasNextSubscriberAttached = true
+      router.subscribe = originalSubscribe
+      const unsubscribe = originalSubscribe(fn)
+      if (pendingInitialError) {
+        fn(pendingInitialError.state, pendingInitialError.opts)
+        pendingInitialError = null
+      }
+      return unsubscribe
+    }
+
     startReactRouterView(router.state.matches)
     return router
   }) as CreateRouter

--- a/packages/rum-react/src/domain/reactRouter/types.ts
+++ b/packages/rum-react/src/domain/reactRouter/types.ts
@@ -19,10 +19,17 @@ export interface AnyRouteMatch {
   params: Record<string, string | undefined>
 }
 export type AnyLocation = { pathname?: string } | string
-export type AnyCreateRouter<Options> = (
-  routes: AnyRouteObject[],
-  options?: Options
-) => {
+// Opaque second arg to subscriber callbacks — forwarded verbatim when replaying
+// initial-error notifications to subscribers that attach after us.
+export type AnyRouterSubscriberOpts = Record<string, unknown>
+export type AnyRouterSubscriber = (
+  routerState: { location: { pathname: string }; matches: AnyRouteMatch[] },
+  opts?: AnyRouterSubscriberOpts
+) => void
+
+export interface AnyRouter {
   state: { location: { pathname: string }; matches: AnyRouteMatch[] }
-  subscribe: (callback: (routerState: { location: { pathname: string }; matches: AnyRouteMatch[] }) => void) => void
+  subscribe: (callback: AnyRouterSubscriber) => () => void
 }
+
+export type AnyCreateRouter<Options> = (routes: AnyRouteObject[], options?: Options) => AnyRouter

--- a/scripts/build/build-test-apps.ts
+++ b/scripts/build/build-test-apps.ts
@@ -158,13 +158,40 @@ async function buildReactRouterv7App() {
   await modifyFile(path.join(appPath, 'package.json'), (content: string) =>
     content
       .replace(/"name": "react-router-v6-app"/, '"name": "react-router-v7-app"')
-      .replace(/"react-router-dom": "[^"]*"/, '"react-router": "7.0.2"')
+      .replace(/"react-router-dom": "[^"]*"/, '"react-router": "7.15.1"')
   )
 
   await modifyFile(path.join(appPath, 'app.tsx'), (content: string) =>
     content
       .replace('@datadog/browser-rum-react/react-router-v6', '@datadog/browser-rum-react/react-router-v7')
       .replace("from 'react-router-dom'", "from 'react-router'")
+      // Inject a loader that throws synchronously when ?test-loader-error is present,
+      // and an onError marker on RouterProvider. Used by the regression test for #4657.
+      .replace(
+        /({\s*index: true,\s*Component: HomePage,\s*},)/,
+        `{
+        index: true,
+        loader: ({ request }: { request: Request }) => {
+          if (new URL(request.url).searchParams.has('test-loader-error')) {
+            throw new Error('Synchronous loader error')
+          }
+          return null
+        },
+        Component: HomePage,
+      },`
+      )
+      .replace(
+        /<RouterProvider router={router} \/>/,
+        `<RouterProvider
+      router={router}
+      onError={(error: unknown) => {
+        const el = document.createElement('div')
+        el.setAttribute('data-testid', 'on-error-fired')
+        el.textContent = (error as Error).message ?? String(error)
+        document.body.appendChild(el)
+      }}
+    />`
+      )
   )
 
   await modifyFile(path.join(appPath, 'webpack.config.js'), (content: string) =>

--- a/scripts/build/build-test-apps.ts
+++ b/scripts/build/build-test-apps.ts
@@ -165,21 +165,8 @@ async function buildReactRouterv7App() {
     content
       .replace('@datadog/browser-rum-react/react-router-v6', '@datadog/browser-rum-react/react-router-v7')
       .replace("from 'react-router-dom'", "from 'react-router'")
-      // Inject a loader that throws synchronously when ?test-loader-error is present,
-      // and an onError marker on RouterProvider. Used by the regression test for #4657.
-      .replace(
-        /({\s*index: true,\s*Component: HomePage,\s*},)/,
-        `{
-        index: true,
-        loader: ({ request }: { request: Request }) => {
-          if (new URL(request.url).searchParams.has('test-loader-error')) {
-            throw new Error('Synchronous loader error')
-          }
-          return null
-        },
-        Component: HomePage,
-      },`
-      )
+      // Add an onError marker on RouterProvider — v7-only prop, exercised by the
+      // regression test for https://github.com/DataDog/browser-sdk/issues/4657.
       .replace(
         /<RouterProvider router={router} \/>/,
         `<RouterProvider

--- a/test/apps/react-router-v6-app/app.tsx
+++ b/test/apps/react-router-v6-app/app.tsx
@@ -135,6 +135,15 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
+        // Throws on demand to exercise initial loader-error handling. Used by the
+        // e2e regression test for https://github.com/DataDog/browser-sdk/issues/4657
+        // (only exercised on the v7 build — v6 has no equivalent initial-error bug).
+        loader: ({ request }: { request: Request }) => {
+          if (new URL(request.url).searchParams.has('test-loader-error')) {
+            throw new Error('Synchronous loader error')
+          }
+          return null
+        },
         Component: HomePage,
       },
       {

--- a/test/e2e/scenario/plugins/reactPlugin.scenario.ts
+++ b/test/e2e/scenario/plugins/reactPlugin.scenario.ts
@@ -94,6 +94,20 @@ test.describe('plugin: react', () => {
             expect(browserLogs.filter((log) => log.level === 'error').length).toBeGreaterThan(0)
           })
         })
+
+      if (appName === 'react-router-v7-app') {
+        createTest('should call RouterProvider onError when initial route loader throws synchronously')
+          .withRum()
+          .withApp(appName)
+          .withBasePath('/?test-loader-error')
+          .run(async ({ page, flushBrowserLogs }) => {
+            await page.waitForSelector('[data-testid="on-error-fired"]', { timeout: 10000 })
+            const errorText = await page.textContent('[data-testid="on-error-fired"]')
+            expect(errorText).toBe('Synchronous loader error')
+
+            flushBrowserLogs()
+          })
+      }
     })
   }
 })


### PR DESCRIPTION
## Motivation

`wrapCreateRouter` subscribes synchronously when the router is created, before `<RouterProvider>` mounts. As a result, the initial loader-error notification reaches our subscriber first and never makes it to RouterProvider, its `onError` callback is silently skipped.

Two paths lead to this, both broken by our wrapper:
- `react-router` ≥7.15.1 buffers the initial state update when no subscriber is attached and replays it one-shot to the first subscriber.
- In React's concurrent mode, the loader-error notification can fire after our subscribe but before `RouterProvider`'s deferred `useLayoutEffect`.

Fixes #4657.

## Changes

- `wrapCreateRouter` now detects when a notification carries `newErrors` and forwards it (one-shot) to the next subscriber via a temporary `router.subscribe` wrapper. RouterProvider's `setState` is then called with the same payload, triggering `onError` as expected.
- Adds the missing second argument (`opts`) to the subscriber type so we can pass it through verbatim.
- Bumps `react-router` in the v7 test app to `7.15.1` and adds a regression e2e test that mounts the SPA with a route whose loader throws synchronously and asserts that `onError` fires.

## Test instructions

```bash
yarn test:unit --spec packages/rum-react/src/domain/reactRouter/createRouter.spec.ts
yarn test:e2e -g "should call RouterProvider onError when initial route loader throws synchronously"
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file