### PR TITLE
🐛 [devext] support v7 _dd_s_v2 session cookie

### DIFF
--- a/developer-extension/src/panel/components/tabs/infosTab.tsx
+++ b/developer-extension/src/panel/components/tabs/infosTab.tsx
@@ -322,9 +322,12 @@ function endSession() {
   const fourHours = 1000 * 60 * 60 * 4
   const expires = new Date(Date.now() + fourHours).toUTCString()
 
+  // Expire both the legacy ('_dd_s') and current ('_dd_s_v2') cookies — whichever
+  // one is set, the SDK will see an expired session on next read.
   evalInWindow(
     `
       document.cookie = '_dd_s=isExpired=1; expires=${expires}; path=/'
+      document.cookie = '_dd_s_v2=isExpired=1; expires=${expires}; path=/'
     `
   ).catch((error) => logger.error('Error while ending session:', error))
 }

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -72,12 +72,17 @@ async function getInfos(): Promise<SdkInfos> {
           }))
         }
 
-        const cookieRawValue = document.cookie
-          .split(';')
-          .map(cookie => cookie.match(/(\\S*?)=(.*)/)?.slice(1) || [])
-          .find(([name, _]) => name === '_dd_s')
-          ?.[1]
+        // SDK v7 renamed the session cookie from '_dd_s' to '_dd_s_v2'. Prefer the new name,
+        // fall back to the legacy one so this works for both v6 and v7 apps.
+        function findCookieValue(name) {
+          return document.cookie
+            .split(';')
+            .map(c => c.match(/(\\S*?)=(.*)/)?.slice(1) || [])
+            .find(([cookieName]) => cookieName === name)
+            ?.[1]
+        }
 
+        const cookieRawValue = findCookieValue('_dd_s_v2') ?? findCookieValue('_dd_s')
         const cookie = cookieRawValue && Object.fromEntries(
           cookieRawValue.split('&').map(value => value.split('='))
         )


### PR DESCRIPTION
## Motivation

The Session column in the developer extension's Infos tab was empty for any v7 app. The extension still reads the session cookie under `_dd_s`, but v7 renamed it to `_dd_s_v2` (`packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts`). With nothing read from the cookie, Id / Logs / RUM / Created / Expire all came up empty even when the SDK was tracking the session normally.

## Changes

- `useSdkInfos.ts` now reads `_dd_s_v2` first and falls back to `_dd_s`, so the panel renders for both v6 and v7 apps.
- `endSession()` now writes the expiry to both cookie names — whichever is set will be picked up by the SDK on next read. Avoids guessing which one is active.

## Test instructions

1. Build the extension: `yarn build` (or `yarn build:dev` in `developer-extension/`).
2. Load `developer-extension/dist` as an unpacked extension in Chrome.
3. Open any page running a v7 RUM SDK (e.g. `yarn dev` sandbox on this branch).
4. DevTools → Datadog Browser SDK → Infos tab → the Session column should show Id, Created, Expire, and a computed RUM/Logs tracking type.
5. Click "End current session" → reload → a new session id appears.
6. Repeat on a v6 app to confirm the legacy `_dd_s` path still works.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file