### PR TITLE
⚗️ auto-disable Live Debugger after prolonged Delivery API outage

### DIFF
--- a/packages/debugger/src/domain/deliveryApi.spec.ts
+++ b/packages/debugger/src/domain/deliveryApi.spec.ts
@@ -383,6 +383,44 @@ describe('deliveryApi', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1)
     })
 
+    // 408 (Request Timeout) and 429 (Too Many Requests) are 4xx statuses that
+    // are nevertheless expected to recover on their own - the request just took
+    // too long, or the client/proxy is temporarily rate-limited. They should
+    // follow the same transient-failure path as 5xx rather than trip the breaker
+    // on a single response. This matches core's transport retry predicate
+    // (`shouldRetryRequest` in `sendWithRetryStrategy.ts`).
+    for (const status of [408, 429]) {
+      it(`should treat ${status} as a transient failure rather than tripping immediately`, async () => {
+        respondWith({}, status)
+        startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+        await flushPromises()
+
+        // Just shy of five minutes of continuous failures - should still be polling.
+        const ticks = Math.floor((FIVE_MINUTES_MS - POLL_INTERVAL_MS) / POLL_INTERVAL_MS)
+        for (let i = 0; i < ticks; i++) {
+          await tickAndFlush(POLL_INTERVAL_MS)
+        }
+        const callsBefore = fetchSpy.calls.count()
+        await tickAndFlush(POLL_INTERVAL_MS)
+        expect(fetchSpy.calls.count()).toBe(callsBefore + 1)
+      })
+
+      it(`should eventually trip on continuous ${status} responses past the window`, async () => {
+        respondWith({}, status)
+        startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+        await flushPromises()
+
+        const ticks = Math.ceil(FIVE_MINUTES_MS / POLL_INTERVAL_MS) + 1
+        for (let i = 0; i < ticks; i++) {
+          await tickAndFlush(POLL_INTERVAL_MS)
+        }
+
+        const callsAtTrip = fetchSpy.calls.count()
+        await tickAndFlush(POLL_INTERVAL_MS * 10)
+        expect(fetchSpy.calls.count()).toBe(callsAtTrip)
+      })
+    }
+
     it('should reset the failure window after a successful response', async () => {
       respondWithNetworkError()
       startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
@@ -459,6 +497,58 @@ describe('deliveryApi', () => {
       const callsBefore = fetchSpy.calls.count()
       await tickAndFlush(POLL_INTERVAL_MS)
       expect(fetchSpy.calls.count()).toBe(callsBefore + 1)
+    })
+
+    it('should not re-install probes from an in-flight poll that is aborted by tripping', async () => {
+      // First poll: hangs indefinitely so it's still in-flight when the breaker
+      // trips. The fixture honors the AbortSignal exactly like a real fetch
+      // would: rejecting with AbortError when the controller calls abort().
+      let resolveFirstPoll!: (response: unknown) => void
+      const firstPollFetchOptions: { signal?: AbortSignal } = {}
+      fetchSpy.and.callFake((_url: string, options: { signal?: AbortSignal }) => {
+        firstPollFetchOptions.signal = options.signal
+        return new Promise((resolve, reject) => {
+          resolveFirstPoll = resolve
+          options.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The user aborted a request', 'AbortError'))
+          })
+        })
+      })
+
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      // Quick check that the source passes an AbortSignal at all.
+      expect(firstPollFetchOptions.signal).toBeTruthy()
+
+      // Subsequent polls fail and trip the breaker.
+      respondWithNetworkError()
+      const ticks = Math.ceil(FIVE_MINUTES_MS / POLL_INTERVAL_MS) + 1
+      for (let i = 0; i < ticks; i++) {
+        await tickAndFlush(POLL_INTERVAL_MS)
+      }
+
+      // Breaker has tripped: polling stopped, probes cleared, and the in-flight
+      // poll's signal must have been aborted.
+      expect(getProbes('test.js;testMethod')).toBeUndefined()
+      expect(firstPollFetchOptions.signal!.aborted).toBeTrue()
+      const callsAtTrip = fetchSpy.calls.count()
+
+      // Even if the hung response somehow still resolves with probe updates
+      // after the abort, the poll has already rejected with AbortError and
+      // returned - the success path can never run.
+      resolveFirstPoll({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ nextCursor: 'late', updates: [makeProbe({ id: 'late-probe' })], deletions: [] }),
+        text: () => Promise.resolve(''),
+      })
+      await flushPromises()
+
+      expect(getProbes('test.js;testMethod')).toBeUndefined()
+      // No new fetches should have been issued either.
+      await tickAndFlush(POLL_INTERVAL_MS * 5)
+      expect(fetchSpy.calls.count()).toBe(callsAtTrip)
     })
 
     it('should warn when tripping', async () => {

--- a/packages/debugger/src/domain/deliveryApi.spec.ts
+++ b/packages/debugger/src/domain/deliveryApi.spec.ts
@@ -311,6 +311,170 @@ describe('deliveryApi', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('circuit breaker', () => {
+    const FIVE_MINUTES_MS = 5 * 60 * 1000
+    const POLL_INTERVAL_MS = 5000
+
+    function respondWithNetworkError() {
+      fetchSpy.and.returnValue(Promise.reject(new Error('network error')))
+    }
+
+    async function tickAndFlush(ms: number) {
+      clock.tick(ms)
+      await flushPromises()
+    }
+
+    it('should keep polling while failures last less than five minutes', async () => {
+      respondWithNetworkError()
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+
+      // Just shy of five minutes of continuous failures.
+      const ticks = Math.floor((FIVE_MINUTES_MS - POLL_INTERVAL_MS) / POLL_INTERVAL_MS)
+      for (let i = 0; i < ticks; i++) {
+        await tickAndFlush(POLL_INTERVAL_MS)
+      }
+
+      const callsBefore = fetchSpy.calls.count()
+      await tickAndFlush(POLL_INTERVAL_MS)
+      expect(fetchSpy.calls.count()).toBe(callsBefore + 1)
+    })
+
+    it('should stop polling after five minutes of continuous network failures', async () => {
+      respondWithNetworkError()
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+
+      // Run for slightly over five minutes of continuous failures.
+      const ticks = Math.ceil(FIVE_MINUTES_MS / POLL_INTERVAL_MS) + 1
+      for (let i = 0; i < ticks; i++) {
+        await tickAndFlush(POLL_INTERVAL_MS)
+      }
+
+      const callsAtTrip = fetchSpy.calls.count()
+      await tickAndFlush(POLL_INTERVAL_MS * 10)
+      expect(fetchSpy.calls.count()).toBe(callsAtTrip)
+    })
+
+    it('should stop polling after five minutes of continuous 5xx responses', async () => {
+      respondWith({}, 500)
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+
+      const ticks = Math.ceil(FIVE_MINUTES_MS / POLL_INTERVAL_MS) + 1
+      for (let i = 0; i < ticks; i++) {
+        await tickAndFlush(POLL_INTERVAL_MS)
+      }
+
+      const callsAtTrip = fetchSpy.calls.count()
+      await tickAndFlush(POLL_INTERVAL_MS * 10)
+      expect(fetchSpy.calls.count()).toBe(callsAtTrip)
+    })
+
+    it('should treat 4xx responses as a config issue and trip immediately', async () => {
+      respondWith({}, 403)
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+
+      // No grace period for 4xx - the next tick should not poll.
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      await tickAndFlush(POLL_INTERVAL_MS * 10)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reset the failure window after a successful response', async () => {
+      respondWithNetworkError()
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+
+      // Almost five minutes of failures.
+      await tickAndFlush(FIVE_MINUTES_MS - POLL_INTERVAL_MS)
+
+      // One success resets the window.
+      respondWith({ nextCursor: '', updates: [], deletions: [] })
+      await tickAndFlush(POLL_INTERVAL_MS)
+
+      // Back to failing - should get a fresh 5-minute window.
+      respondWithNetworkError()
+      await tickAndFlush(FIVE_MINUTES_MS - POLL_INTERVAL_MS)
+
+      const callsBefore = fetchSpy.calls.count()
+      await tickAndFlush(POLL_INTERVAL_MS)
+      expect(fetchSpy.calls.count()).toBe(callsBefore + 1)
+    })
+
+    it('should clear active probes when tripping', async () => {
+      respondWith({
+        nextCursor: 'cursor-1',
+        updates: [makeProbe({ id: 'probe-1', version: 1 })],
+        deletions: [],
+      })
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+      expect(getProbes('test.js;testMethod')).toBeDefined()
+
+      respondWithNetworkError()
+      const ticks = Math.ceil(FIVE_MINUTES_MS / POLL_INTERVAL_MS) + 1
+      for (let i = 0; i < ticks; i++) {
+        await tickAndFlush(POLL_INTERVAL_MS)
+      }
+
+      expect(getProbes('test.js;testMethod')).toBeUndefined()
+    })
+
+    it('should honor a configured maxUnreachableDuration', async () => {
+      const customWindow = 30_000
+      respondWithNetworkError()
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS, maxUnreachableDuration: customWindow }))
+      await flushPromises()
+
+      // Just shy of the custom window - should still be polling.
+      const ticks = Math.floor((customWindow - POLL_INTERVAL_MS) / POLL_INTERVAL_MS)
+      for (let i = 0; i < ticks; i++) {
+        await tickAndFlush(POLL_INTERVAL_MS)
+      }
+      const callsBeforeTrip = fetchSpy.calls.count()
+      await tickAndFlush(POLL_INTERVAL_MS)
+      expect(fetchSpy.calls.count()).toBe(callsBeforeTrip + 1)
+
+      // One more tick past the custom window should trip and stop polling.
+      await tickAndFlush(POLL_INTERVAL_MS)
+      const callsAtTrip = fetchSpy.calls.count()
+      await tickAndFlush(POLL_INTERVAL_MS * 10)
+      expect(fetchSpy.calls.count()).toBe(callsAtTrip)
+    })
+
+    it('should fall back to the default maxUnreachableDuration when option is invalid', async () => {
+      respondWithNetworkError()
+      startDeliveryApiPolling(
+        // -1 is invalid; should be ignored and the 5-minute default used.
+        makeConfig({ pollInterval: POLL_INTERVAL_MS, maxUnreachableDuration: -1 })
+      )
+      await flushPromises()
+
+      // Way past any "reasonable" misinterpretation - if -1 were honored,
+      // polling would have already stopped. Confirm we're still polling at 30s.
+      await tickAndFlush(30_000)
+      const callsBefore = fetchSpy.calls.count()
+      await tickAndFlush(POLL_INTERVAL_MS)
+      expect(fetchSpy.calls.count()).toBe(callsBefore + 1)
+    })
+
+    it('should warn when tripping', async () => {
+      const warnSpy = spyOn(display, 'warn')
+      respondWithNetworkError()
+      startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
+      await flushPromises()
+
+      const ticks = Math.ceil(FIVE_MINUTES_MS / POLL_INTERVAL_MS) + 1
+      for (let i = 0; i < ticks; i++) {
+        await tickAndFlush(POLL_INTERVAL_MS)
+      }
+
+      expect(warnSpy).toHaveBeenCalledWith(jasmine.stringMatching(/circuit breaker/i))
+    })
+  })
 })
 
 async function flushPromises() {

--- a/packages/debugger/src/domain/deliveryApi.ts
+++ b/packages/debugger/src/domain/deliveryApi.ts
@@ -5,6 +5,7 @@ import {
   display,
   fetch,
   getGlobalObject,
+  isServerError,
   mockable,
   setInterval,
   clearInterval,
@@ -54,6 +55,8 @@ let pollIntervalId: TimeoutId | undefined
 let currentCursor: string | undefined
 let knownProbeIds = new Set<string>()
 let firstFailureAtMs: number | undefined
+let tripped = false
+let sessionAbortController: AbortController | undefined
 
 /**
  * Start polling the Datadog Delivery API for probe updates.
@@ -94,6 +97,9 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
     serviceVersion: config.version,
   }
 
+  sessionAbortController = new AbortController()
+  const signal = sessionAbortController.signal
+
   const poll = async () => {
     try {
       const body: Record<string, unknown> = { ...baseRequestBody }
@@ -105,6 +111,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
         method: 'POST',
         headers,
         body: JSON.stringify(body),
+        signal,
       })
 
       if (!response.ok) {
@@ -116,12 +123,15 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
           // ignore
         }
         display.error(`Debugger: Delivery API poll failed with status ${response.status}`, errorBody)
-        // 4xx is a client/config issue (bad token, wrong service, etc) and is not
-        // expected to recover on its own, so trip immediately. 5xx is treated as
-        // a transient server issue and only trips after the failure window.
-        if (response.status >= 400 && response.status < 500) {
-          tripCircuitBreaker(`status ${response.status}`)
-        } else if (response.status >= 500 && noteFailureAndCheckTrip(maxUnreachableDuration)) {
+        // 408 (request timeout), 429 (rate limited), and 5xx are transient: they
+        // only trip the breaker after the unreachable-duration window. Other 4xx
+        // responses indicate a client/config issue (bad token, wrong service, …)
+        // that is not expected to self-recover, so we trip immediately.
+        if (isTransientFailureStatus(response.status)) {
+          if (noteFailureAndCheckTrip(maxUnreachableDuration)) {
+            tripCircuitBreaker(`status ${response.status}`)
+          }
+        } else {
           tripCircuitBreaker(`status ${response.status}`)
         }
         return
@@ -168,6 +178,11 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
         }
       }
     } catch (err) {
+      // Aborts are intentional (the breaker tripped while this poll was in flight)
+      // and shouldn't be logged or counted against the failure window.
+      if (err instanceof DOMException && err.code === DOMException.ABORT_ERR) {
+        return
+      }
       display.error('Debugger: Delivery API poll error:', err as Error)
       if (noteFailureAndCheckTrip(maxUnreachableDuration)) {
         tripCircuitBreaker('network error')
@@ -192,10 +207,23 @@ export function clearDeliveryApiState(): void {
   currentCursor = undefined
   knownProbeIds = new Set<string>()
   firstFailureAtMs = undefined
+  tripped = false
+  sessionAbortController?.abort()
+  sessionAbortController = undefined
   if (pollIntervalId !== undefined) {
     clearInterval(pollIntervalId)
     pollIntervalId = undefined
   }
+}
+
+/**
+ * Returns true for HTTP statuses that represent a transient server-side or
+ * infrastructure issue worth waiting out (server errors, request timeouts,
+ * rate limits). Mirrors the retry predicate in core's transport layer
+ * (`shouldRetryRequest` in `sendWithRetryStrategy`) so the two stay in sync.
+ */
+function isTransientFailureStatus(status: number): boolean {
+  return isServerError(status) || status === 408 || status === 429
 }
 
 /**
@@ -217,12 +245,17 @@ function noteFailureAndCheckTrip(maxUnreachableDurationMs: number): boolean {
  * only resets via clearDeliveryApiState (used in tests).
  */
 function tripCircuitBreaker(reason: string): void {
+  if (tripped) {
+    return
+  }
+  tripped = true
   display.warn(
     `Debugger: Delivery API circuit breaker tripped (${reason}). Disabling Live Debugger for the rest of the page lifetime.`
   )
   // monitor-until: forever, to keep an eye on how often the Live Debugger gets disabled in the wild
   addTelemetryDebug('Delivery API circuit breaker tripped', { reason })
   stopDeliveryApiPolling()
+  sessionAbortController?.abort()
   clearProbes()
   knownProbeIds = new Set<string>()
 }

--- a/packages/debugger/src/domain/deliveryApi.ts
+++ b/packages/debugger/src/domain/deliveryApi.ts
@@ -1,5 +1,7 @@
 import type { TimeoutId, Site } from '@datadog/browser-core'
 import {
+  addTelemetryDebug,
+  dateNow,
   display,
   fetch,
   getGlobalObject,
@@ -8,12 +10,20 @@ import {
   clearInterval,
   INTAKE_SITE_US1,
 } from '@datadog/browser-core'
-import { addProbe, removeProbe } from './probes'
+import { addProbe, clearProbes, removeProbe } from './probes'
 import type { Probe } from './probes'
 
 declare const __BUILD_ENV__SDK_VERSION__: string
 
 const DELIVERY_API_PATH = '/api/unstable/debugger/frontend/probes'
+
+/**
+ * If the Delivery API stays unreachable for this long, polling stops and
+ * all active probes are cleared. Short network glitches (under this
+ * threshold) are tolerated transparently. Can be overridden via the
+ * `maxUnreachableDuration` init option.
+ */
+const DEFAULT_MAX_UNREACHABLE_DURATION_MS = 5 * 60 * 1000
 
 export interface DeliveryApiConfiguration {
   service: string
@@ -23,6 +33,7 @@ export interface DeliveryApiConfiguration {
   env?: string
   version?: string
   pollInterval?: number
+  maxUnreachableDuration?: number
 }
 
 export function buildDeliveryApiUrl(site: Site = INTAKE_SITE_US1, proxy?: string): string {
@@ -42,6 +53,7 @@ interface DeliveryApiResponse {
 let pollIntervalId: TimeoutId | undefined
 let currentCursor: string | undefined
 let knownProbeIds = new Set<string>()
+let firstFailureAtMs: number | undefined
 
 /**
  * Start polling the Datadog Delivery API for probe updates.
@@ -60,6 +72,13 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
   }
 
   const pollInterval = config.pollInterval || 60_000
+  // Only accept a positive finite number; ignore zero/negative/NaN/undefined.
+  const maxUnreachableDuration =
+    typeof config.maxUnreachableDuration === 'number' &&
+    Number.isFinite(config.maxUnreachableDuration) &&
+    config.maxUnreachableDuration > 0
+      ? config.maxUnreachableDuration
+      : DEFAULT_MAX_UNREACHABLE_DURATION_MS
   const url = buildDeliveryApiUrl(config.site, config.proxy)
   const headers: Record<string, string> = {
     'Content-Type': 'application/json; charset=utf-8',
@@ -97,8 +116,19 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
           // ignore
         }
         display.error(`Debugger: Delivery API poll failed with status ${response.status}`, errorBody)
+        // 4xx is a client/config issue (bad token, wrong service, etc) and is not
+        // expected to recover on its own, so trip immediately. 5xx is treated as
+        // a transient server issue and only trips after the failure window.
+        if (response.status >= 400 && response.status < 500) {
+          tripCircuitBreaker(`status ${response.status}`)
+        } else if (response.status >= 500 && noteFailureAndCheckTrip(maxUnreachableDuration)) {
+          tripCircuitBreaker(`status ${response.status}`)
+        }
         return
       }
+
+      // Server is reachable - reset the failure window.
+      firstFailureAtMs = undefined
 
       const data: DeliveryApiResponse = await response.json()
 
@@ -139,6 +169,9 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
       }
     } catch (err) {
       display.error('Debugger: Delivery API poll error:', err as Error)
+      if (noteFailureAndCheckTrip(maxUnreachableDuration)) {
+        tripCircuitBreaker('network error')
+      }
     }
   }
 
@@ -158,8 +191,38 @@ export function stopDeliveryApiPolling(): void {
 export function clearDeliveryApiState(): void {
   currentCursor = undefined
   knownProbeIds = new Set<string>()
+  firstFailureAtMs = undefined
   if (pollIntervalId !== undefined) {
     clearInterval(pollIntervalId)
     pollIntervalId = undefined
   }
+}
+
+/**
+ * Record a transient failure (5xx or network error). Returns true if the
+ * continuous failure window has reached the trip threshold.
+ */
+function noteFailureAndCheckTrip(maxUnreachableDurationMs: number): boolean {
+  const now = dateNow()
+  if (firstFailureAtMs === undefined) {
+    firstFailureAtMs = now
+    return false
+  }
+  return now - firstFailureAtMs >= maxUnreachableDurationMs
+}
+
+/**
+ * Permanently shut down the Live Debugger: stop polling and clear all
+ * active probes. The breaker is "single-shot" for the page lifetime - it
+ * only resets via clearDeliveryApiState (used in tests).
+ */
+function tripCircuitBreaker(reason: string): void {
+  display.warn(
+    `Debugger: Delivery API circuit breaker tripped (${reason}). Disabling Live Debugger for the rest of the page lifetime.`
+  )
+  // monitor-until: forever, to keep an eye on how often the Live Debugger gets disabled in the wild
+  addTelemetryDebug('Delivery API circuit breaker tripped', { reason })
+  stopDeliveryApiPolling()
+  clearProbes()
+  knownProbeIds = new Set<string>()
 }

--- a/packages/debugger/src/entries/main.ts
+++ b/packages/debugger/src/entries/main.ts
@@ -106,6 +106,20 @@ export interface DebuggerInitConfiguration {
   maxNonSnapshotsPerProbeLifetime?: number
 
   /**
+   * Maximum duration, in milliseconds, that the Delivery API may stay
+   * unreachable (network errors or 5xx responses) before the Live Debugger
+   * SDK automatically and permanently disables itself for the rest of the
+   * page lifetime. Short network glitches under this threshold are
+   * tolerated transparently.
+   *
+   * Must be a positive finite number; otherwise the default is used.
+   *
+   * @category Delivery API
+   * @defaultValue 300000
+   */
+  maxUnreachableDuration?: number
+
+  /**
    * A proxy URL for routing SDK requests. When set, delivery API requests are
    * sent to `{proxy}/api/unstable/debugger/frontend/probes` instead of the
    * default Datadog API host derived from `site`.
@@ -195,6 +209,7 @@ function makeDebuggerPublicApi(): DatadogDebugger {
         env: resolvedConfiguration.env,
         version: resolvedConfiguration.version,
         pollInterval: resolvedConfiguration.pollInterval,
+        maxUnreachableDuration: resolvedConfiguration.maxUnreachableDuration,
       })
     },
   })


### PR DESCRIPTION
## Motivation

If the Live Debugger Delivery API becomes unavailable (network outage, server-side issue, misconfiguration, …) the SDK currently keeps polling it forever, logging an error on every failed request. Aside from the noise, this means stale probes stay installed indefinitely with no way to update or remove them.

We want to tolerate transient glitches (the common case) but automatically and permanently disable the Live Debugger when the Delivery API has been unreachable for long enough that something is clearly wrong.

## Changes

Added a circuit breaker on the Delivery API polling loop in `packages/debugger/src/domain/deliveryApi.ts`:

- **Tolerated transparently**: network errors (`fetch` throws) and 5xx responses, as long as they don't span more than 5 continuous minutes.
- **Recovery**: any 2xx response resets the failure window — short glitches are forgiven.
- **Trips immediately on 4xx**: these are config issues (bad client token, wrong service, …) that won't self-recover; no point waiting.
- **Trips after 5 minutes** of continuous network errors or 5xx.
- **On trip**: stops polling, calls `clearProbes()` (uninstalls every active probe), emits a `display.warn` for developers, and fires `addTelemetryDebug('Delivery API circuit breaker tripped', { reason })` for ops visibility. The trip is permanent for the page lifetime.

The 5-minute threshold is configurable via a new public init option:

```ts
datadogDebugger.init({
  clientToken: '…',
  service: 'my-app',
  maxUnreachableDuration: 60_000, // shut down after 1 min instead
})
```

`maxUnreachableDuration` must be a positive finite number; invalid values fall back to the 5-minute default (same defensive pattern as `pollInterval` and the probe budget rates).

## Test instructions

Unit tests cover the full behavior (see `packages/debugger/src/domain/deliveryApi.spec.ts`):

- Polling continues while failures last less than 5 minutes
- Polling stops after 5 minutes of continuous network failures
- Polling stops after 5 minutes of continuous 5xx responses
- 4xx responses trip immediately (no grace period)
- A successful response resets the failure window
- Active probes are cleared on trip
- `display.warn` is emitted on trip
- A configured `maxUnreachableDuration` is honored
- Invalid `maxUnreachableDuration` (e.g. `-1`) falls back to the default

```bash
yarn test:unit --spec packages/debugger/src/domain/deliveryApi.spec.ts
```

To exercise it manually, point a debugger-enabled sandbox at a proxy that returns 503 (or block the request in DevTools), set `maxUnreachableDuration: 10_000` for quick feedback, and observe the warning + `clearProbes` after the window elapses.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
