### PR TITLE
🐛 ignore symlinked BROWSER_SUPPORT.md in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,6 @@ yarn.lock
 /generated-docs
 /developer-extension/.output
 /developer-extension/.wxt
+
+# Symlinks (prettier would otherwise resolve and overwrite the target file or replace the symlink with a regular file)
+/packages/rum-slim/BROWSER_SUPPORT.md


### PR DESCRIPTION
## Motivation

`packages/rum-slim/BROWSER_SUPPORT.md` is tracked in git as a symlink (mode `120000`) pointing to `../rum/BROWSER_SUPPORT.md` — it is the only symlink in the entire repo.

Running `yarn format --write` (which runs `prettier --check .` / `--write .` over the whole repo) silently breaks this symlink in one of two ways depending on the user's git configuration:

- With `core.symlinks=true` (default on macOS/Linux), prettier resolves the symlink and overwrites `packages/rum/BROWSER_SUPPORT.md` — modifying a different package's docs from under us.
- With `core.symlinks=false`, the symlink is checked out as a plain text file containing the link path, and prettier replaces it with a regular file plus trailing newline — destroying the symlink locally.

Commit d509304b5 ("🎨 add trailing newline to rum-slim `BROWSER_SUPPORT.md` symlink") shows this has already snuck through once before.

## Changes

- Add `/packages/rum-slim/BROWSER_SUPPORT.md` to `.prettierignore`, with a comment explaining why so that any future symlinks get the same treatment.

Prettier has no built-in `--ignore-symlinks` flag, so `.prettierignore` is the simplest fix. There is only one tracked symlink today, so listing it explicitly is low overhead. If more symlinks appear later, we can revisit with a small wrapper that derives the list from `git ls-files -s`.

## Test instructions

1. Ensure the symlink exists locally:
   ```bash
   ls -la packages/rum-slim/BROWSER_SUPPORT.md
   # Expected: lrwxr-xr-x ... -> ../rum/BROWSER_SUPPORT.md
   ```
   If it shows as a regular file, your local repo has `core.symlinks=false`; recreate it with:
   ```bash
   rm packages/rum-slim/BROWSER_SUPPORT.md
   ln -s ../rum/BROWSER_SUPPORT.md packages/rum-slim/BROWSER_SUPPORT.md
   ```
2. Run `yarn format --write`.
3. Verify:
   - Output reports `All matched files use Prettier code style!` (no warning about `BROWSER_SUPPORT.md`).
   - `ls -la packages/rum-slim/BROWSER_SUPPORT.md` still shows the symlink.
   - `git status` shows no change to `packages/rum-slim/BROWSER_SUPPORT.md` (or `packages/rum/BROWSER_SUPPORT.md`).

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
