### PR TITLE
👷 scope debugger CODEOWNERS to the Node.js debugger team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,8 +14,8 @@ test/e2e/scenario/recorder/**                   @Datadog/rum-browser @Datadog/se
 /README.md    @Datadog/rum-browser @DataDog/documentation
 
 # Debugger
-packages/debugger                                               @Datadog/rum-browser @DataDog/debugger
-packages/debugger/README.md                                     @Datadog/rum-browser @DataDog/debugger @DataDog/documentation
-test/apps/instrumentation-overhead                              @Datadog/rum-browser @DataDog/debugger
-test/e2e/scenario/debugger.scenario.ts                          @Datadog/rum-browser @DataDog/debugger
-test/performance/scenarios/instrumentationOverhead.scenario.ts  @Datadog/rum-browser @DataDog/debugger
+packages/debugger                                               @Datadog/rum-browser @DataDog/debugger-nodejs
+packages/debugger/README.md                                     @Datadog/rum-browser @DataDog/debugger-nodejs @DataDog/documentation
+test/apps/instrumentation-overhead                              @Datadog/rum-browser @DataDog/debugger-nodejs
+test/e2e/scenario/debugger.scenario.ts                          @Datadog/rum-browser @DataDog/debugger-nodejs
+test/performance/scenarios/instrumentationOverhead.scenario.ts  @Datadog/rum-browser @DataDog/debugger-nodejs


### PR DESCRIPTION
## Motivation

Ownership of `packages/debugger` is currently assigned to the whole `@DataDog/debugger` team in `.github/CODEOWNERS`. In practice, this package is maintained by the sub-team responsible for the debugger code in the Node.js client library, not the entire debugger team. Scoping ownership accordingly avoids spurious review requests to people who don't work on the browser-side debugger package.

## Changes

Update `.github/CODEOWNERS` to replace `@DataDog/debugger` with the more specific `@DataDog/debugger-nodejs` for:

- `packages/debugger`
- `packages/debugger/README.md`
- `test/apps/instrumentation-overhead`
- `test/e2e/scenario/debugger.scenario.ts`
- `test/performance/scenarios/instrumentationOverhead.scenario.ts`

`@Datadog/rum-browser` (and `@DataDog/documentation` on the README) remain as co-owners. No code or behavior changes — this only affects GitHub review routing.

