### PR TITLE
🔊 enrich session lock error telemetry with operation and lifecycle context

### DIFF
--- a/packages/core/src/browser/addEventListener.ts
+++ b/packages/core/src/browser/addEventListener.ts
@@ -56,7 +56,10 @@ type EventMapFor<T> = T extends Window
       visibilitychange: Event
     }
   : T extends Document
-    ? DocumentEventMap
+    ? DocumentEventMap & {
+        // TS 4.9.5 does not define `prerenderingchange` on Document yet (Speculation Rules / Prerender2)
+        prerenderingchange: Event
+      }
     : T extends HTMLElement
       ? HTMLElementEventMap
       : T extends VisualViewport

--- a/packages/core/src/browser/lifecycleTracker.spec.ts
+++ b/packages/core/src/browser/lifecycleTracker.spec.ts
@@ -1,0 +1,80 @@
+import { createNewEvent, registerCleanupTask } from '../../test'
+import type { Configuration } from '../domain/configuration'
+import {
+  getLifecycleContext,
+  resetLifecycleTracker,
+  startLifecycleTracker,
+  type LifecycleContext,
+} from './lifecycleTracker'
+
+const configuration = {} as Configuration
+
+describe('lifecycleTracker', () => {
+  beforeEach(() => {
+    resetLifecycleTracker()
+    registerCleanupTask(() => resetLifecycleTracker())
+  })
+
+  it('reports no event before any fires', () => {
+    startLifecycleTracker(configuration)
+
+    const ctx = getLifecycleContext()
+    expect(ctx.lastLifecycleEvent).toBeUndefined()
+    expect(ctx.timeSinceLifecycleEvent).toBeUndefined()
+    expect(ctx.restoredFromBfcache).toBeFalse()
+    expect(ctx.wasPrerendered).toBeFalse()
+  })
+
+  it('captures the most recent lifecycle event', () => {
+    startLifecycleTracker(configuration)
+
+    window.dispatchEvent(createNewEvent('pagehide'))
+
+    const ctx = getLifecycleContext()
+    expect(ctx.lastLifecycleEvent).toBe('pagehide')
+    expect(ctx.timeSinceLifecycleEvent).toBeGreaterThanOrEqual(0)
+  })
+
+  it('overwrites lastLifecycleEvent on subsequent events', () => {
+    startLifecycleTracker(configuration)
+
+    window.dispatchEvent(createNewEvent('pagehide'))
+    window.dispatchEvent(createNewEvent('pageshow'))
+
+    expect(getLifecycleContext().lastLifecycleEvent).toBe('pageshow')
+  })
+
+  it('flips restoredFromBfcache when pageshow.persisted is true', () => {
+    startLifecycleTracker(configuration)
+
+    const event = createNewEvent('pageshow') as Event & { persisted?: boolean }
+    Object.defineProperty(event, 'persisted', { value: true })
+    window.dispatchEvent(event)
+
+    expect(getLifecycleContext().restoredFromBfcache).toBeTrue()
+  })
+
+  it('does not flip restoredFromBfcache on non-persisted pageshow', () => {
+    startLifecycleTracker(configuration)
+
+    window.dispatchEvent(createNewEvent('pageshow'))
+
+    expect(getLifecycleContext().restoredFromBfcache).toBeFalse()
+  })
+
+  it('is idempotent across multiple start calls', () => {
+    startLifecycleTracker(configuration)
+    startLifecycleTracker(configuration)
+
+    window.dispatchEvent(createNewEvent('visibilitychange'))
+
+    expect(getLifecycleContext().lastLifecycleEvent).toBe('visibilitychange')
+  })
+
+  it('returns a fresh snapshot every call', () => {
+    startLifecycleTracker(configuration)
+    const a: LifecycleContext = getLifecycleContext()
+    const b: LifecycleContext = getLifecycleContext()
+    expect(a).not.toBe(b)
+  })
+})

--- a/packages/core/src/browser/lifecycleTracker.ts
+++ b/packages/core/src/browser/lifecycleTracker.ts
@@ -1,0 +1,94 @@
+import type { Configuration } from '../domain/configuration'
+import { dateNow } from '../tools/utils/timeUtils'
+import { isWorkerEnvironment } from '../tools/globalObject'
+import { addEventListener, addEventListeners, DOM_EVENT } from './addEventListener'
+
+export type LifecycleEventName =
+  | 'visibilitychange'
+  | 'pagehide'
+  | 'pageshow'
+  | 'freeze'
+  | 'resume'
+  | 'beforeunload'
+  | 'prerenderingchange'
+
+export interface LifecycleContext {
+  lastLifecycleEvent: LifecycleEventName | undefined
+  timeSinceLifecycleEvent: number | undefined
+  restoredFromBfcache: boolean
+  wasPrerendered: boolean
+}
+
+let lastEvent: { name: LifecycleEventName; at: number } | undefined
+let restoredFromBfcache = false
+let wasPrerendered = false
+let started = false
+let stopListeners: (() => void) | undefined
+
+export function startLifecycleTracker(configuration: Configuration): void {
+  if (started || isWorkerEnvironment || typeof window === 'undefined') {
+    return
+  }
+  started = true
+
+  if (typeof document !== 'undefined' && (document as Document & { prerendering?: boolean }).prerendering) {
+    wasPrerendered = true
+  }
+
+  const { stop: stopWindowListeners } = addEventListeners(
+    configuration,
+    window,
+    [
+      DOM_EVENT.VISIBILITY_CHANGE,
+      DOM_EVENT.PAGE_HIDE,
+      DOM_EVENT.PAGE_SHOW,
+      DOM_EVENT.FREEZE,
+      DOM_EVENT.RESUME,
+      DOM_EVENT.BEFORE_UNLOAD,
+    ],
+    (event) => {
+      lastEvent = { name: event.type as LifecycleEventName, at: dateNow() }
+      if (event.type === DOM_EVENT.PAGE_SHOW && (event as PageTransitionEvent).persisted) {
+        restoredFromBfcache = true
+      }
+    },
+    { capture: true }
+  )
+
+  let stopPrerenderingListener: (() => void) | undefined
+  if (typeof document !== 'undefined' && 'prerendering' in document) {
+    stopPrerenderingListener = addEventListener(
+      configuration,
+      document,
+      'prerenderingchange',
+      () => {
+        wasPrerendered = true
+        lastEvent = { name: 'prerenderingchange', at: dateNow() }
+      },
+      { capture: true }
+    ).stop
+  }
+
+  stopListeners = () => {
+    stopWindowListeners()
+    stopPrerenderingListener?.()
+  }
+}
+
+export function getLifecycleContext(): LifecycleContext {
+  return {
+    lastLifecycleEvent: lastEvent?.name,
+    timeSinceLifecycleEvent: lastEvent ? dateNow() - lastEvent.at : undefined,
+    restoredFromBfcache,
+    wasPrerendered,
+  }
+}
+
+export function resetLifecycleTracker(): void {
+  stopListeners?.()
+  stopListeners = undefined
+  lastEvent = undefined
+  restoredFromBfcache = false
+  wasPrerendered = false
+  started = false
+}

--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -12,6 +12,7 @@ import {
   timeStampNow,
 } from '../../tools/utils/timeUtils'
 import { addEventListener, addEventListeners, DOM_EVENT } from '../../browser/addEventListener'
+import { startLifecycleTracker } from '../../browser/lifecycleTracker'
 import { clearInterval, clearTimeout, setInterval, setTimeout } from '../../tools/timer'
 import { mockable } from '../../tools/mockable'
 import { noop, throttle } from '../../tools/utils/functionUtils'
@@ -98,6 +99,8 @@ export async function startSessionManager(
     return
   }
 
+  startLifecycleTracker(configuration)
+
   const strategy = mockable(getSessionStoreStrategy)(configuration.sessionStoreStrategyType, configuration)
 
   const sessionContextHistory = createValueHistory<SessionContext>({
@@ -110,8 +113,8 @@ export async function startSessionManager(
   const { throttled: throttledExpandOrRenew, cancel: cancelExpandOrRenew } = throttle(() => {
     sessionExpired = false
     strategy
-      .setSessionState((state) => expandOrRenew(state, configuration))
-      .catch((error) => monitorError(new Error(`Error while expanding or renewing session on activity: ${error}`)))
+      .setSessionState((state) => expandOrRenew(state, configuration), 'expandOrRenewOnActivity')
+      .catch(monitorError)
   }, ONE_SECOND)
   stopCallbacks.push(cancelExpandOrRenew)
 
@@ -155,7 +158,7 @@ export async function startSessionManager(
       const initialState = initializeSession(currentState, configuration)
       state = expandOrRenew(initialState, configuration)
       return state
-    })
+    }, 'initialize')
     return state
   }
 
@@ -184,8 +187,8 @@ export async function startSessionManager(
             }
 
             return state
-          })
-          .catch((error) => monitorError(new Error(`Error while expiring session on timeout: ${error}`)))
+          }, 'expireOnTimeout')
+          .catch(monitorError)
       }, delay)
     }
   }
@@ -195,8 +198,8 @@ export async function startSessionManager(
       if (trackingConsentState.isGranted()) {
         sessionExpired = false
         strategy
-          .setSessionState((state) => expandOrRenew(state, configuration))
-          .catch((error) => monitorError(new Error(`Error while expanding or renewing session on consent: ${error}`)))
+          .setSessionState((state) => expandOrRenew(state, configuration), 'expandOrRenewOnConsent')
+          .catch(monitorError)
       } else {
         expire()
       }
@@ -210,15 +213,13 @@ export async function startSessionManager(
       })
       trackVisibility(configuration, () => {
         if (!sessionExpired) {
-          strategy
-            .setSessionState((state) => expandOnly(state))
-            .catch((error) => monitorError(new Error(`Error while expanding session on visibility: ${error}`)))
+          strategy.setSessionState((state) => expandOnly(state), 'expandOnVisibility').catch(monitorError)
         }
       })
       trackResume(configuration, () => {
         strategy
-          .setSessionState((state) => initializeSession(state, configuration))
-          .catch((error) => monitorError(new Error(`Error while initializing session on resume: ${error}`)))
+          .setSessionState((state) => initializeSession(state, configuration), 'initializeOnResume')
+          .catch(monitorError)
       })
     }
   }
@@ -243,9 +244,7 @@ export async function startSessionManager(
       expireObservable,
       expire,
       updateSessionState: (partialState) => {
-        strategy
-          .setSessionState((state) => ({ ...state, ...partialState }))
-          .catch((error) => monitorError(new Error(`Error while updating session state: ${error}`)))
+        strategy.setSessionState((state) => ({ ...state, ...partialState }), 'updateState').catch(monitorError)
       },
     }
   }
@@ -323,8 +322,8 @@ export async function startSessionManager(
           delete state.anonymousId
         }
         return getExpiredSessionState(state, configuration)
-      })
-      .catch((error) => monitorError(new Error(`Error while persisting expired session state: ${error}`)))
+      }, 'expire')
+      .catch(monitorError)
   }
 
   function buildSessionContext(sessionState: SessionState): SessionContext {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -66,7 +66,7 @@ describe('session in cookie strategy', () => {
     it('should read cookie, apply fn, and write back', async () => {
       const { strategy, mockCookie } = setupCookieStrategy()
 
-      await strategy.setSessionState((state) => ({ ...state, id: 'abc123' }))
+      await strategy.setSessionState((state) => ({ ...state, id: 'abc123' }), 'updateState')
 
       expect(mockCookie.getStoredValues()[0]).toContain('id=abc123')
     })
@@ -78,7 +78,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return { ...state, id: 'new-id' }
-      })
+      }, 'updateState')
 
       expect(capturedState).toEqual({})
     })
@@ -91,7 +91,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState!.id).toBe('123')
     })
@@ -99,7 +99,7 @@ describe('session in cookie strategy', () => {
     it('should add c=xxx to cookie on write', async () => {
       const { strategy, mockCookie } = setupCookieStrategy()
 
-      await strategy.setSessionState(() => ({ id: 'abc' }))
+      await strategy.setSessionState(() => ({ id: 'abc' }), 'updateState')
 
       expect(mockCookie.getStoredValues()[0]).toContain('c=0')
     })
@@ -112,7 +112,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return { ...state, id: 'test' }
-      })
+      }, 'updateState')
 
       expect(capturedState!.c).toBeUndefined()
     })
@@ -121,7 +121,7 @@ describe('session in cookie strategy', () => {
       const { strategy, mockCookie } = setupCookieStrategy()
       mockCookie.setAllValues(['id=123&c=0'])
 
-      await strategy.setSessionState(() => ({}))
+      await strategy.setSessionState(() => ({}), 'updateState')
 
       expect(mockCookie.getStoredValues()).toEqual([])
     })
@@ -156,7 +156,7 @@ describe('session in cookie strategy', () => {
       const subscription = strategy.sessionObservable.subscribe(spy)
       registerCleanupTask(() => subscription.unsubscribe())
 
-      await strategy.setSessionState(() => ({ id: '123' }))
+      await strategy.setSessionState(() => ({ id: '123' }), 'updateState')
       await collectAsyncCalls(spy, 1)
 
       expect(spy.calls.mostRecent().args[0].sessionState).toEqual({ id: '123' })
@@ -169,12 +169,12 @@ describe('session in cookie strategy', () => {
       void strategy.setSessionState((state) => {
         calls.push('first')
         return { ...state, id: 'first' }
-      })
+      }, 'updateState')
 
       await strategy.setSessionState((state) => {
         calls.push('second')
         return { ...state, id: 'second' }
-      })
+      }, 'updateState')
 
       expect(calls).toEqual(['first', 'second'])
       expect(mockCookie.getStoredValues()[0]).toContain('id=second')
@@ -190,7 +190,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState.id).toBe('456')
     })
@@ -203,7 +203,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState.id).toBe('123')
     })
@@ -213,7 +213,7 @@ describe('session in cookie strategy', () => {
     it('should use 1 year expiration when trackAnonymousUser=true', async () => {
       const { strategy, mockCookie } = setupCookieStrategy({ trackAnonymousUser: true })
 
-      await strategy.setSessionState(() => ({ id: '123', created: '0' }))
+      await strategy.setSessionState(() => ({ id: '123', created: '0' }), 'updateState')
 
       expect(mockCookie.getLastExpireDelay()).toBe(SESSION_COOKIE_EXPIRATION_DELAY)
     })
@@ -221,7 +221,7 @@ describe('session in cookie strategy', () => {
     it('should use 4h expiration when trackAnonymousUser=false', async () => {
       const { strategy, mockCookie } = setupCookieStrategy({ trackAnonymousUser: false })
 
-      await strategy.setSessionState(() => ({ id: '123', created: '0' }))
+      await strategy.setSessionState(() => ({ id: '123', created: '0' }), 'updateState')
 
       expect(mockCookie.getLastExpireDelay()).toBe(SESSION_TIME_OUT_DELAY)
     })
@@ -282,7 +282,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState!.id).toBe('legacy-id')
       expect(capturedState!.created).toBe('123')
@@ -297,7 +297,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState!.id).toBe('new-id')
     })
@@ -307,7 +307,7 @@ describe('session in cookie strategy', () => {
       const { strategy, mockCookie } = setupCookieStrategy()
 
       // First call triggers migration
-      await strategy.setSessionState((state) => state)
+      await strategy.setSessionState((state) => state, 'updateState')
 
       // Clear the new cookie to simulate empty state
       mockCookie.setAllValues([])
@@ -317,7 +317,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState).toEqual({})
     })
@@ -327,7 +327,7 @@ describe('session in cookie strategy', () => {
     it('should encode cookie options in the cookie value', async () => {
       const { strategy, mockCookie } = setupCookieStrategy({ usePartitionedCrossSiteSessionCookie: true })
 
-      await strategy.setSessionState(() => ({ id: '123' }))
+      await strategy.setSessionState(() => ({ id: '123' }), 'updateState')
 
       expect(mockCookie.getStoredValues()[0]).toMatch(/^id=123&c=1/)
     })
@@ -335,7 +335,7 @@ describe('session in cookie strategy', () => {
     it('should not encode cookie options in the cookie value if the session is empty', async () => {
       const { strategy, mockCookie } = setupCookieStrategy({ usePartitionedCrossSiteSessionCookie: true })
 
-      await strategy.setSessionState(() => ({}))
+      await strategy.setSessionState(() => ({}), 'updateState')
 
       expect(mockCookie.getStoredValues()).toEqual([])
     })

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -10,11 +10,19 @@ import { mockable } from '../../../tools/mockable'
 import { monitorError } from '../../../tools/monitor'
 import { addTelemetryError } from '../../telemetry'
 import { createCookieAccess } from '../../../browser/cookieAccess'
+import { clearTimeout, setTimeout } from '../../../tools/timer'
 import { dateNow, timeStampNow } from '../../../tools/utils/timeUtils'
 import type { Context } from '../../../tools/serialisation/context'
-import type { SessionStoreStrategy, SessionStoreStrategyType, SessionObservableEvent } from './sessionStoreStrategy'
+import { getLifecycleContext } from '../../../browser/lifecycleTracker'
+import type {
+  SessionStateOperation,
+  SessionStoreStrategy,
+  SessionStoreStrategyType,
+  SessionObservableEvent,
+} from './sessionStoreStrategy'
 import { SESSION_STORE_KEY, LEGACY_SESSION_STORE_KEY } from './sessionStoreStrategy'
 
+const LOCK_QUERY_TIMEOUT = 1000
 const SESSION_COOKIE_VERSION = 0
 
 export function selectCookieStrategy(initConfiguration: InitConfiguration): SessionStoreStrategyType | undefined {
@@ -62,21 +70,17 @@ export function initCookieStrategy(cookieOptions: CookieOptions, configuration: 
   }
 
   return {
-    async setSessionState(fn: (sessionState: SessionState) => SessionState): Promise<void> {
+    async setSessionState(
+      fn: (sessionState: SessionState) => SessionState,
+      operation: SessionStateOperation
+    ): Promise<void> {
       if (typeof navigator !== 'undefined' && navigator.locks) {
+        const lockRequestedAt = dateNow()
         await navigator.locks
           .request(SESSION_STORE_KEY, () => applyAndWrite(fn))
           .catch(async (error) => {
-            const context: Context = {
-              strategy: configuration.sessionStoreStrategyType?.type,
-              timeSinceInit: dateNow() - initTimestamp,
-              visibilityState: document.visibilityState,
-              hidden: document.hidden,
-              cookieStoreSupported: 'cookieStore' in window,
-              cookies: document.cookie,
-              cookieStore: (await cookieStore.getAll()).map((value) => value as Context),
-            }
-            addTelemetryError(new Error(`Error while expanding or renewing session on activity: ${error}`), context)
+            const context = await buildLockErrorContext(configuration, operation, initTimestamp, lockRequestedAt)
+            addTelemetryError(error, context)
             throw error
           })
       } else {
@@ -85,6 +89,80 @@ export function initCookieStrategy(cookieOptions: CookieOptions, configuration: 
       }
     },
     sessionObservable,
+  }
+}
+
+interface LockQuerySnapshot {
+  heldByOthers: number
+  pendingCount: number
+  isPending: boolean
+}
+
+async function queryLockSnapshot(): Promise<LockQuerySnapshot | 'timeout' | 'unavailable' | 'error'> {
+  if (typeof navigator === 'undefined' || !navigator.locks?.query) {
+    return 'unavailable'
+  }
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timeoutId = setTimeout(() => resolve('timeout'), LOCK_QUERY_TIMEOUT)
+  })
+  try {
+    const snapshot = await Promise.race([navigator.locks.query(), timeout])
+    if (snapshot === 'timeout') {
+      return 'timeout'
+    }
+    const held = snapshot.held ?? []
+    const pending = snapshot.pending ?? []
+    return {
+      heldByOthers: held.filter((lock) => lock.name === SESSION_STORE_KEY).length,
+      pendingCount: pending.filter((lock) => lock.name === SESSION_STORE_KEY).length,
+      isPending: pending.some((lock) => lock.name === SESSION_STORE_KEY),
+    }
+  } catch {
+    return 'error'
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+function getNavigationType(): string | undefined {
+  if (typeof performance === 'undefined' || typeof performance.getEntriesByType !== 'function') {
+    return undefined
+  }
+  // The document-load entry is what we want here ('back_forward' signals bfcache restore).
+  // Some Chromium builds expose extra entries for experimental soft navigations — index 0 is
+  // still the original document-load entry per the Performance Timeline ordering.
+  const entry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined
+  return entry?.type
+}
+
+function isInIframe(): boolean | undefined {
+  try {
+    return window !== window.top
+  } catch {
+    // Cross-origin access — definitely in an iframe
+    return true
+  }
+}
+
+async function buildLockErrorContext(
+  configuration: Configuration,
+  operation: SessionStateOperation,
+  initTimestamp: number,
+  lockRequestedAt: number
+): Promise<Context> {
+  return {
+    operation,
+    strategy: configuration.sessionStoreStrategyType?.type,
+    timeSinceInit: dateNow() - initTimestamp,
+    lockRequestDuration: dateNow() - lockRequestedAt,
+    visibilityState: document.visibilityState,
+    readyState: document.readyState,
+    inIframe: isInIframe(),
+    navigationType: getNavigationType(),
+    sessionCookies: getCookies(SESSION_STORE_KEY),
+    lockQuery: (await queryLockSnapshot()) as Context[string],
+    ...getLifecycleContext(),
   }
 }
 

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -28,7 +28,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
 
   describe('setSessionState', () => {
     it('should read current state from localStorage, apply fn, and write back', () => {
-      void strategy.setSessionState((state) => ({ ...state, id: 'test-id' }))
+      void strategy.setSessionState((state) => ({ ...state, id: 'test-id' }), 'updateState')
       expect(localStorage.getItem(SESSION_STORE_KEY)).toContain('id=test-id')
     })
 
@@ -36,7 +36,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       void strategy.setSessionState((state) => {
         expect(state).toEqual({})
         return { ...state, id: 'new-id' }
-      })
+      }, 'updateState')
     })
 
     it('should read existing state from localStorage', () => {
@@ -45,7 +45,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       void strategy.setSessionState((state) => {
         expect(state.id).toBe('existing')
         return { ...state, expire: '999' }
-      })
+      }, 'updateState')
     })
 
     it('should notify sessionObservable after write', async () => {
@@ -53,7 +53,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       const subscription = strategy.sessionObservable.subscribe(spy)
       registerCleanupTask(() => subscription.unsubscribe())
 
-      await strategy.setSessionState((state) => ({ ...state, id: 'test-id' }))
+      await strategy.setSessionState((state) => ({ ...state, id: 'test-id' }), 'updateState')
 
       expect(spy).toHaveBeenCalledOnceWith(
         jasmine.objectContaining({ sessionState: jasmine.objectContaining({ id: 'test-id' }) })
@@ -104,7 +104,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState!.id).toBe('legacy-id')
       expect(capturedState!.created).toBe('123')
@@ -118,7 +118,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState!.id).toBe('new-id')
     })
@@ -127,7 +127,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       localStorage.setItem(LEGACY_SESSION_STORE_KEY, 'id=legacy-id')
 
       // First call triggers migration
-      await strategy.setSessionState((state) => state)
+      await strategy.setSessionState((state) => state, 'updateState')
 
       // Clear the new key to simulate empty state
       localStorage.removeItem(SESSION_STORE_KEY)
@@ -137,7 +137,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       await strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       expect(capturedState).toEqual({})
     })

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -5,7 +5,12 @@ import type { Configuration } from '../../configuration'
 import { SessionPersistence } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
 import { isSessionInNotStartedState, toSessionString, toSessionState } from '../sessionState'
-import type { SessionStoreStrategy, SessionStoreStrategyType, SessionObservableEvent } from './sessionStoreStrategy'
+import type {
+  SessionStateOperation,
+  SessionStoreStrategy,
+  SessionStoreStrategyType,
+  SessionObservableEvent,
+} from './sessionStoreStrategy'
 import { SESSION_STORE_KEY, LEGACY_SESSION_STORE_KEY } from './sessionStoreStrategy'
 
 const LOCAL_STORAGE_TEST_KEY = '_dd_test_'
@@ -36,7 +41,10 @@ export function initLocalStorageStrategy(configuration: Configuration): SessionS
   let isFirstCall = true
 
   return {
-    async setSessionState(fn: (sessionState: SessionState) => SessionState): Promise<void> {
+    async setSessionState(
+      fn: (sessionState: SessionState) => SessionState,
+      _operation: SessionStateOperation
+    ): Promise<void> {
       let currentState = toSessionState(localStorage.getItem(SESSION_STORE_KEY))
 
       if (isFirstCall && isSessionInNotStartedState(currentState)) {

--- a/packages/core/src/domain/session/storeStrategies/sessionInMemory.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInMemory.spec.ts
@@ -17,7 +17,7 @@ describe('Memory SessionStoreStrategy', () => {
 
   describe('setSessionState', () => {
     it('should read current state, apply fn, and write back', () => {
-      void strategy.setSessionState((state) => ({ ...state, id: 'test-id' }))
+      void strategy.setSessionState((state) => ({ ...state, id: 'test-id' }), 'updateState')
 
       const globalObject = getGlobalObject<Record<string, { state?: SessionState }>>()
       expect(globalObject[MEMORY_SESSION_STORE_KEY]?.state?.id).toBe('test-id')
@@ -27,14 +27,14 @@ describe('Memory SessionStoreStrategy', () => {
       void strategy.setSessionState((state) => {
         expect(state).toEqual({})
         return { ...state, id: 'new-id' }
-      })
+      }, 'updateState')
     })
 
     it('should notify sessionObservable after write', async () => {
       const spy = jasmine.createSpy('observer')
       strategy.sessionObservable.subscribe(spy)
 
-      await strategy.setSessionState((state) => ({ ...state, id: 'test-id' }))
+      await strategy.setSessionState((state) => ({ ...state, id: 'test-id' }), 'updateState')
 
       expect(spy).toHaveBeenCalledOnceWith(
         jasmine.objectContaining({ sessionState: jasmine.objectContaining({ id: 'test-id' }) })
@@ -48,7 +48,7 @@ describe('Memory SessionStoreStrategy', () => {
       const spy = jasmine.createSpy('observer')
 
       strategy.sessionObservable.subscribe(spy)
-      await strategy2.setSessionState((state) => ({ ...state, id: 'from-strategy2' }))
+      await strategy2.setSessionState((state) => ({ ...state, id: 'from-strategy2' }), 'updateState')
 
       expect(spy).toHaveBeenCalledOnceWith(
         jasmine.objectContaining({ sessionState: jasmine.objectContaining({ id: 'from-strategy2' }) })
@@ -58,20 +58,20 @@ describe('Memory SessionStoreStrategy', () => {
 
   describe('isolation', () => {
     it('should shallow clone on read to prevent external mutation', () => {
-      void strategy.setSessionState(() => ({ id: 'original' }))
+      void strategy.setSessionState(() => ({ id: 'original' }), 'updateState')
 
       let capturedState: SessionState | undefined
       void strategy.setSessionState((state) => {
         capturedState = state
         return state
-      })
+      }, 'updateState')
 
       capturedState!.id = 'mutated'
 
       void strategy.setSessionState((state) => {
         expect(state.id).toBe('original')
         return state
-      })
+      }, 'updateState')
     })
   })
 })

--- a/packages/core/src/domain/session/storeStrategies/sessionInMemory.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInMemory.ts
@@ -3,7 +3,12 @@ import { Observable } from '../../../tools/observable'
 import { shallowClone } from '../../../tools/utils/objectUtils'
 import { SessionPersistence } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
-import type { SessionStoreStrategy, SessionStoreStrategyType, SessionObservableEvent } from './sessionStoreStrategy'
+import type {
+  SessionStateOperation,
+  SessionStoreStrategy,
+  SessionStoreStrategyType,
+  SessionObservableEvent,
+} from './sessionStoreStrategy'
 
 export const MEMORY_SESSION_STORE_KEY = '_DD_SESSION'
 
@@ -40,7 +45,10 @@ export function initMemorySessionStoreStrategy(): SessionStoreStrategy {
   }
 
   return {
-    async setSessionState(fn: (sessionState: SessionState) => SessionState): Promise<void> {
+    async setSessionState(
+      fn: (sessionState: SessionState) => SessionState,
+      _operation: SessionStateOperation
+    ): Promise<void> {
       const currentState = memorySession.state ?? {}
       const newState = shallowClone(fn(currentState))
       memorySession.state = newState

--- a/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
@@ -16,7 +16,17 @@ export interface SessionObservableEvent {
   sessionState: SessionState
 }
 
+export type SessionStateOperation =
+  | 'initialize'
+  | 'expandOrRenewOnActivity'
+  | 'expandOrRenewOnConsent'
+  | 'expandOnVisibility'
+  | 'initializeOnResume'
+  | 'expireOnTimeout'
+  | 'expire'
+  | 'updateState'
+
 export interface SessionStoreStrategy {
-  setSessionState(fn: (sessionState: SessionState) => SessionState): Promise<void>
+  setSessionState(fn: (sessionState: SessionState) => SessionState, operation: SessionStateOperation): Promise<void>
   sessionObservable: Observable<SessionObservableEvent>
 }


### PR DESCRIPTION
## Motivation

Session lock errors reported via telemetry currently lack the context needed to diagnose them. We don't know which call site triggered the failing `setSessionState`, what page lifecycle event preceded the failure, or what the state of the cookie store / Web Locks API was at the time.

## Changes

- Tag every `setSessionState` call with a `SessionStateOperation` label (activity, consent, visibility, resume, timeout, expire, initialize, updateState) so lock failures can be attributed to a specific call site.
- Add a lifecycle tracker that records the last page lifecycle event (visibilitychange, pagehide/show, freeze/resume, beforeunload, prerenderingchange) plus bfcache restore and prerender flags, and include it in cookie lock error telemetry.
- Capture additional cookie strategy diagnostics in error telemetry: lock request duration, `document.readyState`, iframe state, navigation type, raw session cookies, and a `navigator.locks.query` snapshot (with timeout) of held/pending locks.
- Forward the original lock error instead of wrapping it in a new `Error`, preserving the stack trace for `monitorError` / `addTelemetryError`.

## Test instructions

- Run unit tests: `yarn test:unit --spec packages/core/src/browser/lifecycleTracker.spec.ts` and `yarn test:unit --spec packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts`.
- In staging, trigger a session lock contention (e.g. concurrent tabs/iframes hammering the session cookie) and confirm the resulting telemetry error events include the new `operation`, `lifecycle`, `lockDuration`, `readyState`, `inIframe`, `navigationType`, `cookies`, and `locks` fields.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file