### PR TITLE
✅ debugger: complete entry-snapshot capture-decision tests

### DIFF
--- a/packages/debugger/src/domain/api.spec.ts
+++ b/packages/debugger/src/domain/api.spec.ts
@@ -220,8 +220,7 @@ describe('api', () => {
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
 
-    // TODO: Validate that this test is actually correct
-    it('should capture entry snapshot only for ENTRY evaluation with no condition', () => {
+    it('should capture both entry and return snapshots for ENTRY evaluation', () => {
       const probe: Probe = {
         id: 'test-probe',
         version: 0,
@@ -236,6 +235,46 @@ describe('api', () => {
       addProbe(probe)
 
       const probes = getProbes('TestClass;entrySnapshot')!
+      onEntry(probes, { name: 'obj' }, { arg: 'value' })
+      onReturn(probes, 'result', { name: 'obj' }, { arg: 'value' }, { local: 'data' })
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(snapshot.captures).toEqual({
+        entry: {
+          arguments: {
+            arg: { type: 'string', value: 'value' },
+            this: { type: 'Object', fields: { name: { type: 'string', value: 'obj' } } },
+          },
+        },
+        return: {
+          arguments: {
+            arg: { type: 'string', value: 'value' },
+            this: { type: 'Object', fields: { name: { type: 'string', value: 'obj' } } },
+          },
+          locals: {
+            local: { type: 'string', value: 'data' },
+            '@return': { type: 'string', value: 'result' },
+          },
+        },
+      })
+    })
+
+    it('should capture both entry and return snapshots for EXIT evaluation with no condition', () => {
+      const probe: Probe = {
+        id: 'test-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'exitSnapshotNoCondition' },
+        template: 'Test',
+        captureSnapshot: true,
+        capture: { maxReferenceDepth: 1 },
+        sampling: {},
+        evaluateAt: 'EXIT',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;exitSnapshotNoCondition')!
       onEntry(probes, { name: 'obj' }, { arg: 'value' })
       onReturn(probes, 'result', { name: 'obj' }, { arg: 'value' }, { local: 'data' })
 


### PR DESCRIPTION
## Motivation

The `api.spec.ts` test `"should capture entry snapshot only for ENTRY evaluation with no condition"` had a `// TODO: Validate that this test is actually correct` comment. On inspection the test's assertions were correct but its name was misleading — it actually verifies that **both** entry and return captures are produced, not "entry snapshot only". While clarifying this, I also noticed that the `shouldCaptureEntrySnapshot` decision matrix was not exhaustively covered: the `EXIT` + no-condition case had no test, even though it exercises the `!probe.condition` branch of the OR in `api.ts`.

## Changes

Test-only changes to `packages/debugger/src/domain/api.spec.ts`:

- Renamed `"should capture entry snapshot only for ENTRY evaluation with no condition"` → `"should capture both entry and return snapshots for ENTRY evaluation"` and removed the `TODO` comment. The assertions and probe configuration are unchanged.
- Added a new test `"should capture both entry and return snapshots for EXIT evaluation with no condition"` placed next to its `EXIT` + condition counterpart so the pair is easy to compare.

The three capture-decision tests now form a self-consistent triple covering every behaviorally-distinct configuration of `shouldCaptureEntrySnapshot = probe.captureSnapshot && (probe.evaluateAt === 'ENTRY' || !probe.condition)`:

| `evaluateAt` | condition | Entry captured? |
|---|---|---|
| `ENTRY` | irrelevant (short-circuits) | yes |
| `EXIT` | none | yes |
| `EXIT` | present | **no** |

A regression that collapsed the OR to just `evaluateAt === 'ENTRY'` would now be caught by the new test, where the previous test set would not have noticed.

## Test instructions

```bash
yarn test:unit --spec packages/debugger/src/domain/api.spec.ts
```

All 36 tests should pass.

## Checklist

- [x] Tested locally
- [ ] Tested on staging — N/A, test-only change with no runtime impact
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change. — N/A, unit-test-only change
- [ ] Updated documentation and/or relevant AGENTS.md file — N/A
