### PR TITLE
🐛 generalize @-prefix ref desugaring in debugger expressions

### DIFF
--- a/packages/debugger/src/domain/expression.ts
+++ b/packages/debugger/src/domain/expression.ts
@@ -5,7 +5,7 @@
  * Adapted from dd-trace-js/packages/dd-trace/src/debugger/devtools_client/condition.js
  */
 
-const identifierRegex = /^[@a-zA-Z_$][\w$]*$/
+const identifierRegex = /^(@[\w$]+|[a-zA-Z_$][\w$]*)$/
 
 // The following identifiers have purposefully not been included in this list:
 // - The reserved words `this` and `super` as they can have valid use cases as `ref` values

--- a/packages/debugger/test/expressionTestCases.ts
+++ b/packages/debugger/test/expressionTestCases.ts
@@ -141,6 +141,11 @@ export const references: TestCase[] = [
     expected: new SyntaxError('Illegal identifier: @(1)'),
     execute: false,
   },
+  {
+    ast: { ref: '@' },
+    expected: new SyntaxError('Illegal identifier: @'),
+    execute: false,
+  },
 ]
 
 export const propertyAccess: TestCase[] = [


### PR DESCRIPTION
## Motivation

The identifier regex used to validate `ref` values in debugger expressions previously allowed a bare `@`:

```js
const identifierRegex = /^[@a-zA-Z_$][\w$]*$/
```

Because the `@` was part of the leading character class and the rest of the pattern allowed zero characters, `{ ref: '@' }` passed validation even though it's not a valid identifier. It should be rejected with a `SyntaxError` like other malformed refs (e.g. `@x.y`, `@(1)`).

## Changes

- Tighten the regex so an `@` prefix requires at least one trailing word/`$` character:
  ```js
  const identifierRegex = /^(@[\w$]+|[a-zA-Z_$][\w$]*)$/
  ```
- Add a test case covering `{ ref: '@' }` → `SyntaxError: Illegal identifier: @`.

Mirrors the equivalent Node.js tracer fix in [DataDog/dd-trace-js#8628](https://github.com/DataDog/dd-trace-js/pull/8628).

## Test instructions

```
yarn test:unit --spec packages/debugger/src/domain/expression.spec.ts
```
