### PR TITLE
🐛 [RUM-11848] Guard window/location access for non-browser environments

### DIFF
--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -6,6 +6,7 @@ import {
   generateUUID,
 } from '../tools/utils/stringUtils'
 import { buildUrl } from '../tools/utils/urlPolyfill'
+import { globalObject } from '../tools/globalObject'
 
 export interface CookieOptions {
   secure?: boolean
@@ -75,7 +76,14 @@ export function deleteCookie(name: string, options?: CookieOptions) {
  * https://web.dev/same-site-same-origin/#site
  */
 let getCurrentSiteCache: string | undefined
-export function getCurrentSite(hostname = location.hostname, referrer = document.referrer): string | undefined {
+export function getCurrentSite(
+  hostname = globalObject.location?.hostname ?? '',
+  referrer = typeof document !== 'undefined' ? document.referrer : ''
+): string | undefined {
+  // Cookie probing requires document.cookie, which is not available in Web Workers or Node.js
+  if (typeof document === 'undefined') {
+    return undefined
+  }
   if (getCurrentSiteCache === undefined) {
     const defaultHostName = getCookieDefaultHostName(hostname, referrer)
     if (defaultHostName) {

--- a/packages/core/src/domain/context/storeContextManager.ts
+++ b/packages/core/src/domain/context/storeContextManager.ts
@@ -16,6 +16,11 @@ export function storeContextManager(
   productKey: string,
   customerDataType: CustomerDataType
 ) {
+  // window and localStorage are not available in Web Workers or Node.js environments
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+    return
+  }
+
   const storageKey = buildStorageKey(productKey, customerDataType)
 
   storageListeners.push(

--- a/packages/core/src/tools/utils/urlPolyfill.ts
+++ b/packages/core/src/tools/utils/urlPolyfill.ts
@@ -1,7 +1,7 @@
 import { globalObject } from '../globalObject'
 
 export function normalizeUrl(url: string) {
-  return buildUrl(url, location.href).href
+  return buildUrl(url, globalObject.location?.href).href
 }
 
 export function isValidUrl(url: string) {


### PR DESCRIPTION
## Motivation

The SDK crashes with `ReferenceError: location is not defined` and `window is not defined` when initialized in Web Workers or Node.js. Three code paths access browser globals without guards: `normalizeUrl()` uses bare `location.href`, `storeContextManager()` uses bare `window` and `localStorage`, and `getCurrentSite()` uses `location.hostname` in a default parameter.

~107 telemetry errors/week across v6.21.x and v7.1.0. [Telemetry link](https://dd-rum-telemetry.datadoghq.eu/logs?query=status%3Aerror%20service%3Abrowser-logs-sdk%20location%20is%20not%20defined).

Relates to [RUM-11848](https://datadoghq.atlassian.net/browse/RUM-11848).

## Changes

Each function now handles non-browser environments gracefully instead of crashing:

- `normalizeUrl()` uses `globalObject.location?.href` as base URL. For absolute URLs (the common case with `proxy`), the base is ignored anyway.
- `storeContextManager()` returns early when `window` or `localStorage` are unavailable. It becomes a silent no-op in workers/Node.
- `getCurrentSite()` uses safe defaults for `hostname` and `referrer` parameters instead of bare `location`/`document` access.

## Test instructions

1. `yarn dev`
2. Open the sandbox in a browser
3. Run this in the console to verify the SDK initializes in a Worker without errors:

```js
const workerCode = `
  importScripts(location.origin + '/datadog-logs.js');
  try {
    DD_LOGS.init({
      clientToken: 'test-token',
      site: 'datadoghq.eu',
      storeContextsAcrossPages: true,
    });
    DD_LOGS.logger.info('Hello from worker');
    self.postMessage({ status: 'ok' });
  } catch (e) {
    self.postMessage({ status: 'error', message: e.message });
  }
`;
const blob = new Blob([workerCode], { type: 'application/javascript' });
const worker = new Worker(URL.createObjectURL(blob));
worker.onmessage = (e) => { console.log('Worker result:', e.data); worker.terminate(); };
```

Expected: `{ status: 'ok' }`. Without the fix: `ReferenceError: window is not defined`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

[RUM-11848]: https://datadoghq.atlassian.net/browse/RUM-11848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ