### PR TITLE
🔊 Send source-code-context telemetry usage

### DIFF
--- a/packages/core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/core/src/domain/telemetry/telemetryEvent.types.ts
@@ -389,6 +389,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       unity_version?: string
       /**
+       * The version of MAUI used in a .NET MAUI application
+       */
+      maui_version?: string
+      /**
        * The threshold used for iOS App Hangs monitoring (in milliseconds)
        */
       app_hang_threshold?: number
@@ -447,7 +451,7 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        */
       sdk_version?: string
       /**
-       * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform'.
+       * The source of the SDK, e.g., 'browser', 'ios', 'android', 'flutter', 'react-native', 'unity', 'kotlin-multiplatform', 'maui'.
        */
       source?: string
       /**
@@ -545,6 +549,7 @@ export type TelemetryBrowserFeaturesUsage =
   | StopAction
   | StartResource
   | StopResource
+  | SourceCodeContext
 /**
  * Schema of mobile specific features usage
  */
@@ -589,6 +594,7 @@ export interface CommonTelemetryProperties {
     | 'kotlin-multiplatform'
     | 'electron'
     | 'rum-cpp'
+    | 'maui'
   /**
    * The version of the SDK generating the telemetry event
    */
@@ -968,6 +974,13 @@ export interface StopResource {
    * stopResource API
    */
   feature: 'stop-resource'
+  [k: string]: unknown
+}
+export interface SourceCodeContext {
+  /**
+   * DD_SOURCE_CODE_CONTEXT global for microfrontends
+   */
+  feature: 'source-code-context'
   [k: string]: unknown
 }
 export interface TrackWebView {

--- a/packages/rum-core/src/domain/contexts/sourceCodeContext.ts
+++ b/packages/rum-core/src/domain/contexts/sourceCodeContext.ts
@@ -1,4 +1,11 @@
-import { SKIPPED, computeStackTrace, objectEntries, addTelemetryError, HookNames } from '@datadog/browser-core'
+import {
+  SKIPPED,
+  computeStackTrace,
+  objectEntries,
+  addTelemetryError,
+  HookNames,
+  addTelemetryUsage,
+} from '@datadog/browser-core'
 import type { Hooks, DefaultRumEventAttributes, AssembleHookParams } from '../hooks'
 
 interface SourceCodeContext {
@@ -19,6 +26,7 @@ export function startSourceCodeContext(hooks: Hooks) {
     if (!browserWindow.DD_SOURCE_CODE_CONTEXT) {
       return
     }
+    addTelemetryUsage({ feature: 'source-code-context' })
 
     objectEntries(browserWindow.DD_SOURCE_CODE_CONTEXT).forEach(([stack, context]) => {
       const stackTrace = computeStackTrace({ stack })

--- a/packages/rum-core/src/rumEvent.types.ts
+++ b/packages/rum-core/src/rumEvent.types.ts
@@ -154,7 +154,7 @@ export type RumActionEvent = CommonProperties &
            */
           readonly height?: number
           /**
-           * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+           * Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
            */
           readonly permanent_id?: string
           [k: string]: unknown
@@ -321,6 +321,7 @@ export type RumErrorEvent = CommonProperties &
         | 'windows'
         | 'macos'
         | 'linux'
+        | 'maui'
       /**
        * Resource properties of the error
        */
@@ -1172,6 +1173,7 @@ export interface CommonProperties {
     | 'kotlin-multiplatform'
     | 'electron'
     | 'rum-cpp'
+    | 'maui'
   /**
    * View properties
    */
@@ -1525,6 +1527,7 @@ export interface ViewContainerSchema {
       | 'kotlin-multiplatform'
       | 'electron'
       | 'rum-cpp'
+      | 'maui'
     [k: string]: unknown
   }
   [k: string]: unknown


### PR DESCRIPTION
## Motivation

Measure customer adoption of the microfrontend source code attribution feature (`DD_SOURCE_CODE_CONTEXT` global). 

## Changes

- `packages/rum-core/src/domain/contexts/sourceCodeContext.ts`: call `addTelemetryUsage({ feature: 'source-code-context' })` when `window.DD_SOURCE_CODE_CONTEXT` is set
- Regenerated `telemetryEvent.types.ts` and `rumEvent.types.ts` from the updated `rum-events-format` schema (adds `SourceCodeContext` to `TelemetryBrowserFeaturesUsage`)

## Test instructions

1. `yarn dev`
2. Open `http://localhost:8080/test.html` (sets `window.DD_SOURCE_CODE_CONTEXT` before RUM init and configures telemetry sample rates to 100)
3. Look at Browser SDK extension event

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file