### PR TITLE
♻️ Update debugger generated code target to ES2020

### DIFF
--- a/packages/debugger/src/domain/deliveryApi.ts
+++ b/packages/debugger/src/domain/deliveryApi.ts
@@ -146,7 +146,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
         currentCursor = data.nextCursor
       }
 
-      for (const probeId of data.deletions || []) {
+      for (const probeId of data.deletions ?? []) {
         if (knownProbeIds.has(probeId)) {
           try {
             removeProbe(probeId)
@@ -157,7 +157,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
         }
       }
 
-      for (const probe of data.updates || []) {
+      for (const probe of data.updates ?? []) {
         if (!probe.id) {
           continue
         }

--- a/packages/debugger/src/domain/expression.spec.ts
+++ b/packages/debugger/src/domain/expression.spec.ts
@@ -156,7 +156,7 @@ describe('Expression language', () => {
 // Validate that all compiled expressions produce JavaScript compatible with the oldest target browser.
 // The expression compiler generates code as strings evaluated at runtime via new Function(),
 // bypassing TypeScript compilation and webpack transpilation. This test catches usage of syntax
-// not supported by older browsers (e.g., optional chaining ?., optional catch binding, nullish coalescing ??).
+// not supported by older browsers.
 describe('browser compatibility of generated code', () => {
   function assertECMAVersionCompatible(code: string, params: string[] = []) {
     const functionCode = `function f(${params.join(', ')}) { ${code} }`

--- a/packages/debugger/src/domain/expression.ts
+++ b/packages/debugger/src/domain/expression.ts
@@ -132,7 +132,7 @@ export function compile(node: ExpressionNode): string | number | boolean | null 
       try {
         ${compile(value as ExpressionNode)}
         return true
-      } catch (e) {
+      } catch {
         return false
       }
     })()`
@@ -302,7 +302,7 @@ function accessProperty(variable: string, keyOrIndex: string, allowMapAccess: bo
 function guardAgainstPropertyAccessSideEffects(variable: string, propertyName: string): string {
   return `((val, key) => {
     const desc = Object.getOwnPropertyDescriptor(val, key);
-    if (desc && desc.get !== undefined) {
+    if (desc?.get !== undefined) {
       throw new Error('Possibility of side effect')
     } else {
       return val[key]

--- a/test/unit/browsers.conf.ts
+++ b/test/unit/browsers.conf.ts
@@ -2,10 +2,10 @@
 
 import type { BrowserConfiguration } from '../browsers.conf'
 
-// The ECMAScript version supported by the oldest browser in the list below (Chrome 63 → ES2017).
+// The ECMAScript version supported by the oldest browser in the list below (Edge/Chrome 80 → ES2020).
 // Used by tests that validate runtime-generated code strings (e.g. the expression compiler) which
 // bypass TypeScript/webpack transpilation and must only use syntax supported by all target browsers.
-export const OLDEST_BROWSER_ECMA_VERSION = 2017
+export const OLDEST_BROWSER_ECMA_VERSION = 2020
 
 export const browserConfigurations: BrowserConfiguration[] = [
   {


### PR DESCRIPTION
## Motivation

The debugger expression compiler generates JavaScript strings that are evaluated at runtime via `new Function()`, so those strings bypass TypeScript/webpack transpilation. The compatibility test for this generated code was still pinned to ES2017, while the current browser test matrix now supports ES2020.

## Changes

Updates the generated-code compatibility target from ES2017 to ES2020.

Also modernizes a few debugger code paths where ES2020 syntax improves readability:
- Uses optional catch binding in generated expression code when the caught error is unused.
- Uses optional chaining when checking property descriptors for getter side effects.
- Uses nullish coalescing for optional Delivery API response arrays.

## Test instructions

Run:

```bash
yarn test:unit --spec packages/debugger/src/domain/expression.spec.ts
yarn test:unit --spec packages/debugger/src/domain/deliveryApi.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
