### PR TITLE
👷 Allow version bump titles in PR

### DIFF
--- a/scripts/check-pr-title.spec.ts
+++ b/scripts/check-pr-title.spec.ts
@@ -15,6 +15,12 @@ describe('isValidPrTitle', () => {
     assert.equal(isValidPrTitle('⚡ Speed up'), true)
   })
 
+  it('accepts version bump titles like v7.2.0', () => {
+    assert.equal(isValidPrTitle('v7.2.0'), true)
+    assert.equal(isValidPrTitle('v1.0.0'), true)
+    assert.equal(isValidPrTitle('v10.12.34'), true)
+  })
+
   it('rejects titles without any allowed emoji prefix', () => {
     assert.equal(isValidPrTitle('Add new feature'), false)
     assert.equal(isValidPrTitle('feat: add thing'), false)

--- a/scripts/check-pr-title.ts
+++ b/scripts/check-pr-title.ts
@@ -2,6 +2,10 @@ import { printError, printLog, runMain } from './lib/executionUtils.ts'
 import { GITMOJI, normalizeGitmoji } from './lib/gitmoji.ts'
 
 export function isValidPrTitle(title: string): boolean {
+  if (/^v\d+\.\d+\.\d+$/.test(title)) {
+    return true
+  }
+
   const normalized = normalizeGitmoji(title)
   return GITMOJI.some(({ emoji }) => normalized.startsWith(normalizeGitmoji(emoji)))
 }


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets. -->

We cannot merge release PRs such as https://github.com/DataDog/browser-sdk/pull/4679 because the "Lint PR title" job fails.

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links. Please highlight all the changes that you are not sure about (ex: AI agent generated) -->

- Add a guard that validates version bump PR titles
- Matching test case

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

```
> PR_TITLE="v7.2.0" node scripts/check-pr-title.ts  
PR title OK: v7.2.0
```

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
