### PR TITLE
👷 Add debugger bundle to deploy scripts

### DIFF
--- a/scripts/deploy/deploy.spec.ts
+++ b/scripts/deploy/deploy.spec.ts
@@ -77,11 +77,16 @@ describe('deploy', () => {
           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-v6.js',
         env,
       },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/debugger/bundle/datadog-debugger.js s3://browser-agent-artifacts-prod/datadog-debugger-v6.js',
+        env,
+      },
     ])
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v6.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v6.js,/datadog-rum-slim-v6.js`,
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v6.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v6.js,/datadog-rum-slim-v6.js,/datadog-debugger-v6.js`,
         env,
       },
     ])
@@ -115,10 +120,15 @@ describe('deploy', () => {
           'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/us1/v6/datadog-rum-slim.js',
         env,
       },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=14400, s-maxage=60 packages/debugger/bundle/datadog-debugger.js s3://browser-agent-artifacts-prod/us1/v6/datadog-debugger.js',
+        env,
+      },
     ])
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /us1/v6/datadog-logs.js,/us1/v6/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/datadog-rum.js,/us1/v6/datadog-rum-slim.js`,
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /us1/v6/datadog-logs.js,/us1/v6/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/us1/v6/datadog-rum.js,/us1/v6/datadog-rum-slim.js,/us1/v6/datadog-debugger.js`,
         env,
       },
     ])
@@ -152,11 +162,16 @@ describe('deploy', () => {
           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/datadog-rum-slim-staging.js',
         env,
       },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/debugger/bundle/datadog-debugger.js s3://browser-agent-artifacts-staging/datadog-debugger-staging.js',
+        env,
+      },
     ])
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /datadog-logs-staging.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-staging.js,/datadog-rum-slim-staging.js`,
+        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /datadog-logs-staging.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-staging.js,/datadog-rum-slim-staging.js,/datadog-debugger-staging.js`,
         env,
       },
     ])
@@ -189,11 +204,16 @@ describe('deploy', () => {
           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-canary.js',
         env,
       },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/debugger/bundle/datadog-debugger.js s3://browser-agent-artifacts-prod/datadog-debugger-canary.js',
+        env,
+      },
     ])
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-canary.js,/datadog-rum-slim-canary.js`,
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-canary.js,/datadog-rum-slim-canary.js,/datadog-debugger-canary.js`,
         env,
       },
     ])
@@ -226,11 +246,16 @@ describe('deploy', () => {
           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-prod/datadog-rum-slim-v7-canary.js',
         env,
       },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/debugger/bundle/datadog-debugger.js s3://browser-agent-artifacts-prod/datadog-debugger-v7-canary.js',
+        env,
+      },
     ])
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v7-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v7-canary.js,/datadog-rum-slim-v7-canary.js`,
+        command: `aws cloudfront create-invalidation --distribution-id EGB08BYCT1DD9 --paths /datadog-logs-v7-canary.js,/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/datadog-rum-v7-canary.js,/datadog-rum-slim-v7-canary.js,/datadog-debugger-v7-canary.js`,
         env,
       },
     ])
@@ -267,11 +292,16 @@ describe('deploy', () => {
           'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/rum-slim/bundle/datadog-rum-slim.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-rum-slim.js',
         env,
       },
+      {
+        command:
+          'aws s3 cp --cache-control max-age=900, s-maxage=60 packages/debugger/bundle/datadog-debugger.js s3://browser-agent-artifacts-staging/pull-request/123/datadog-debugger.js',
+        env,
+      },
     ])
 
     assert.deepEqual(getCloudfrontCommands(), [
       {
-        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /pull-request/123/datadog-logs.js,/pull-request/123/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/datadog-rum.js,/pull-request/123/datadog-rum-slim.js`,
+        command: `aws cloudfront create-invalidation --distribution-id E2FP11ZSCFD3EU --paths /pull-request/123/datadog-logs.js,/pull-request/123/chunks/datadogProfiler-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/chunks/datadogRecorder-${FAKE_CHUNK_HASH}-datadog-rum.js,/pull-request/123/datadog-rum.js,/pull-request/123/datadog-rum-slim.js,/pull-request/123/datadog-debugger.js`,
         env,
       },
     ])

--- a/scripts/deploy/lib/deploymentUtils.ts
+++ b/scripts/deploy/lib/deploymentUtils.ts
@@ -7,6 +7,7 @@ export const packages: Package[] = [
   { packageName: 'logs', service: 'browser-logs-sdk' },
   { packageName: 'rum', service: 'browser-rum-sdk' },
   { packageName: 'rum-slim', service: 'browser-rum-sdk' },
+  { packageName: 'debugger', service: 'browser-debugger-sdk' },
 ]
 
 // ex: datadog-rum-v4.js, chunks/datadogRecorder-8d8a8dfab6958424038f-datadog-rum.js

--- a/scripts/deploy/upload-source-maps.spec.ts
+++ b/scripts/deploy/upload-source-maps.spec.ts
@@ -112,6 +112,13 @@ describe('upload-source-maps', () => {
           command:
             'mv packages/rum-slim/bundle/datadog-rum-slim.js.map packages/rum-slim/bundle/datadog-rum-slim-v6.js.map',
         },
+        {
+          command: 'mv packages/debugger/bundle/datadog-debugger.js packages/debugger/bundle/datadog-debugger-v6.js',
+        },
+        {
+          command:
+            'mv packages/debugger/bundle/datadog-debugger.js.map packages/debugger/bundle/datadog-debugger-v6.js.map',
+        },
       ])
 
       // upload the source maps
@@ -129,6 +136,11 @@ describe('upload-source-maps', () => {
         {
           command:
             'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+          env,
+        },
+        {
+          command:
+            'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
           env,
         },
       ])
@@ -149,6 +161,11 @@ describe('upload-source-maps', () => {
       {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_ORG2_PROD,
       },
     ])
@@ -173,6 +190,11 @@ describe('upload-source-maps', () => {
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix /us1/v6 --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_PROD,
       },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix /us1/v6 --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
     ])
 
     assert.deepEqual(getOrg2SourceMapCommands(), [
@@ -189,6 +211,11 @@ describe('upload-source-maps', () => {
       {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net/us1/v6 --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net/us1/v6 --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_ORG2_PROD,
       },
     ])
@@ -217,6 +244,13 @@ describe('upload-source-maps', () => {
       {
         command:
           'mv packages/rum-slim/bundle/datadog-rum-slim.js.map packages/rum-slim/bundle/datadog-rum-slim-staging.js.map',
+      },
+      {
+        command: 'mv packages/debugger/bundle/datadog-debugger.js packages/debugger/bundle/datadog-debugger-staging.js',
+      },
+      {
+        command:
+          'mv packages/debugger/bundle/datadog-debugger.js.map packages/debugger/bundle/datadog-debugger-staging.js.map',
       },
     ])
 
@@ -252,6 +286,16 @@ describe('upload-source-maps', () => {
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_PROD,
       },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_STAGING,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
     ])
 
     assert.deepEqual(getOrg2SourceMapCommands(), [
@@ -268,6 +312,11 @@ describe('upload-source-maps', () => {
       {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_ORG2_PROD,
       },
     ])
@@ -297,6 +346,13 @@ describe('upload-source-maps', () => {
         command:
           'mv packages/rum-slim/bundle/datadog-rum-slim.js.map packages/rum-slim/bundle/datadog-rum-slim-canary.js.map',
       },
+      {
+        command: 'mv packages/debugger/bundle/datadog-debugger.js packages/debugger/bundle/datadog-debugger-canary.js',
+      },
+      {
+        command:
+          'mv packages/debugger/bundle/datadog-debugger.js.map packages/debugger/bundle/datadog-debugger-canary.js.map',
+      },
     ])
 
     // upload the source maps only to datadoghq.com
@@ -316,6 +372,11 @@ describe('upload-source-maps', () => {
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_PROD,
       },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
     ])
 
     assert.deepEqual(getOrg2SourceMapCommands(), [
@@ -332,6 +393,11 @@ describe('upload-source-maps', () => {
       {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_ORG2_PROD,
       },
     ])
@@ -362,6 +428,14 @@ describe('upload-source-maps', () => {
         command:
           'mv packages/rum-slim/bundle/datadog-rum-slim.js.map packages/rum-slim/bundle/datadog-rum-slim-v7-canary.js.map',
       },
+      {
+        command:
+          'mv packages/debugger/bundle/datadog-debugger.js packages/debugger/bundle/datadog-debugger-v7-canary.js',
+      },
+      {
+        command:
+          'mv packages/debugger/bundle/datadog-debugger.js.map packages/debugger/bundle/datadog-debugger-v7-canary.js.map',
+      },
     ])
 
     // upload the source maps only to datadoghq.com (same as plain 'canary')
@@ -381,6 +455,11 @@ describe('upload-source-maps', () => {
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_PROD,
       },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix / --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_PROD,
+      },
     ])
 
     assert.deepEqual(getOrg2SourceMapCommands(), [
@@ -397,6 +476,11 @@ describe('upload-source-maps', () => {
       {
         command:
           'datadog-ci sourcemaps upload packages/rum-slim/bundle --service browser-rum-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-rum-slim/ --repository-url https://www.github.com/datadog/browser-sdk',
+        env: ENV_ORG2_PROD,
+      },
+      {
+        command:
+          'datadog-ci sourcemaps upload packages/debugger/bundle --service browser-debugger-sdk --release-version dev --minified-path-prefix https://d20xtzwzcl0ceb.cloudfront.net --project-path @datadog/browser-debugger/ --repository-url https://www.github.com/datadog/browser-sdk',
         env: ENV_ORG2_PROD,
       },
     ])


### PR DESCRIPTION
## Motivation

Deploy scripts should publish the debugger bundle and upload its source maps for environments where the debugger package exists, without regressing historical v6 deployment coverage.

## Changes

- Add the debugger package to deployment package selection with `browser-debugger-sdk` as its source-map service.
- Replace the exported raw package array with `getPackages(version)` so versioned releases can skip packages introduced after the requested major version.
- Keep v6 deployment/source-map coverage unchanged while adding debugger expectations for staging, canary, v7 canary, and PR paths.

## Test instructions

- Run `node --test --experimental-test-module-mocks scripts/deploy/deploy.spec.ts scripts/deploy/upload-source-maps.spec.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
