### PR TITLE
♻️ unify endpoint URL building with buildEndpointUrl

### DIFF
--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -1,6 +1,6 @@
 import type { Payload } from '../../transport'
 import type { InitConfiguration } from './configuration'
-import { createEndpointBuilder } from './endpointBuilder'
+import { buildEndpointUrl, createEndpointBuilder } from './endpointBuilder'
 
 const DEFAULT_PAYLOAD = {} as Payload
 
@@ -126,6 +126,96 @@ describe('endpointBuilder', () => {
       const config = { ...initConfiguration, source: 'unity' as const }
       const endpoint = createEndpointBuilder(config, 'rum').build('fetch', DEFAULT_PAYLOAD)
       expect(endpoint).toContain('ddsource=unity')
+    })
+  })
+
+  describe('buildEndpointUrl', () => {
+    it('builds proxy URL from a string proxy', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: 'https://proxy.io/path',
+          site: undefined,
+          path: '/api/v2/rum',
+          parameters: 'foo=bar',
+        })
+      ).toBe('https://proxy.io/path?ddforward=%2Fapi%2Fv2%2Frum%3Ffoo%3Dbar')
+    })
+
+    it('normalizes a relative proxy URL', () => {
+      expect(buildEndpointUrl({ proxy: '/path', site: undefined, path: '/api/v2/rum', parameters: 'foo=bar' })).toBe(
+        `${location.origin}/path?ddforward=%2Fapi%2Fv2%2Frum%3Ffoo%3Dbar`
+      )
+    })
+
+    it('adds the subdomain forwarding hint when provided', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: 'https://proxy.io/path',
+          site: undefined,
+          path: '/api/v2/profiling/quota',
+          parameters: 'session_id=abc',
+          subdomain: 'quota',
+        })
+      ).toBe(
+        'https://proxy.io/path?ddforward=%2Fapi%2Fv2%2Fprofiling%2Fquota%3Fsession_id%3Dabc&ddforwardSubdomain=quota'
+      )
+    })
+
+    it('delegates URL creation to proxy function', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: ({ path, parameters, subdomain }) => `https://${subdomain}.proxy.test${path}?${parameters}`,
+          site: undefined,
+          path: '/api/v2/profiling/quota',
+          parameters: 'session_id=abc',
+          subdomain: 'quota',
+        })
+      ).toBe('https://quota.proxy.test/api/v2/profiling/quota?session_id=abc')
+    })
+
+    it('builds intake URL from the site when no proxy is configured', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: undefined,
+          site: 'datadoghq.com',
+          path: '/api/v2/rum',
+          parameters: 'foo=bar',
+        })
+      ).toBe('https://browser-intake-datadoghq.com/api/v2/rum?foo=bar')
+    })
+
+    it('defaults to US1 site when site is undefined', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: undefined,
+          site: undefined,
+          path: '/api/v2/rum',
+          parameters: 'foo=bar',
+        })
+      ).toBe('https://browser-intake-datadoghq.com/api/v2/rum?foo=bar')
+    })
+
+    it('omits the query separator when parameters are empty', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: undefined,
+          site: 'datadoghq.com',
+          path: '/api/v2/rum',
+          parameters: '',
+        })
+      ).toBe('https://browser-intake-datadoghq.com/api/v2/rum')
+    })
+
+    it('adds subdomain to the intake host', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: undefined,
+          site: 'datadoghq.com',
+          path: '/api/v2/profiling/quota',
+          parameters: 'session_id=abc',
+          subdomain: 'quota',
+        })
+      ).toBe('https://quota.browser-intake-datadoghq.com/api/v2/profiling/quota?session_id=abc')
     })
   })
 })

--- a/packages/core/src/domain/configuration/endpointBuilder.spec.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.spec.ts
@@ -173,6 +173,16 @@ describe('endpointBuilder', () => {
       ).toBe('https://quota.proxy.test/api/v2/profiling/quota?session_id=abc')
     })
 
+    it('falls back to empty parameters when calling proxy function', () => {
+      expect(
+        buildEndpointUrl({
+          proxy: ({ path, parameters }) => `https://proxy.test${path}?${parameters}`,
+          site: undefined,
+          path: '/api/v2/rum',
+        })
+      ).toBe('https://proxy.test/api/v2/rum?')
+    })
+
     it('builds intake URL from the site when no proxy is configured', () => {
       expect(
         buildEndpointUrl({

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -2,8 +2,9 @@ import type { Payload } from '../../transport'
 import { timeStampNow } from '../../tools/utils/timeUtils'
 import { normalizeUrl } from '../../tools/utils/urlPolyfill'
 import { generateUUID } from '../../tools/utils/stringUtils'
+import type { Site } from '../intakeSites'
 import { INTAKE_SITE_US1 } from '../intakeSites'
-import type { InitConfiguration } from './configuration'
+import type { InitConfiguration, ProxyFn } from './configuration'
 
 // replaced at build time
 declare const __BUILD_ENV__SDK_VERSION__: string
@@ -39,45 +40,59 @@ export function createEndpointBuilder(
   trackType: TrackType,
   extraParameters?: string[]
 ) {
-  const buildUrlWithParameters = createEndpointUrlWithParametersBuilder(initConfiguration, trackType)
-
   return {
     build(api: ApiType, payload: Payload) {
-      const parameters = buildEndpointParameters(initConfiguration, trackType, api, payload, extraParameters)
-      return buildUrlWithParameters(parameters)
+      return buildEndpointUrl({
+        proxy: initConfiguration.proxy,
+        site: initConfiguration.site,
+        path: `/api/v2/${trackType}`,
+        parameters: buildEndpointParameters(initConfiguration, trackType, api, payload, extraParameters),
+      })
     },
     trackType,
   }
 }
 
-/**
- * Create a function used to build a full endpoint url from provided parameters. The goal of this
- * function is to pre-compute some parts of the URL to avoid re-computing everything on every
- * request, as only parameters are changing.
- */
-function createEndpointUrlWithParametersBuilder(
-  initConfiguration: EndpointBuilderInitConfiguration,
-  trackType: TrackType
-): (parameters: string) => string {
-  const path = `/api/v2/${trackType}`
-  const proxy = initConfiguration.proxy
-  if (typeof proxy === 'string') {
-    const normalizedProxyUrl = normalizeUrl(proxy)
-    return (parameters) => `${normalizedProxyUrl}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}`
-  }
-  if (typeof proxy === 'function') {
-    return (parameters) => proxy({ path, parameters })
-  }
-  const host = buildEndpointHost(initConfiguration)
-  return (parameters) => `https://${host}${path}?${parameters}`
+export interface BuildEndpointUrlOptions {
+  proxy?: string | ProxyFn
+  site: Site | undefined
+  subdomain?: string
+  path: string
+  parameters: string
 }
 
-export function buildEndpointHost(initConfiguration: Omit<InitConfiguration, 'source'>) {
-  const { site = INTAKE_SITE_US1 } = initConfiguration
+export function buildEndpointUrl({
+  proxy,
+  site = INTAKE_SITE_US1,
+  path,
+  parameters,
+  subdomain,
+}: BuildEndpointUrlOptions): string {
+  let pathAndParameters = path
+  if (parameters) {
+    pathAndParameters += `?${parameters}`
+  }
+
+  if (typeof proxy === 'string') {
+    let url = `${normalizeUrl(proxy)}?ddforward=${encodeURIComponent(pathAndParameters)}`
+    if (subdomain) {
+      url += `&ddforwardSubdomain=${subdomain}`
+    }
+    return url
+  }
+
+  if (typeof proxy === 'function') {
+    return proxy({ path, parameters, subdomain })
+  }
 
   const domainParts = site.split('.')
   const extension = domainParts.pop()
-  return `browser-intake-${domainParts.join('-')}.${extension!}`
+  let domain = `browser-intake-${domainParts.join('-')}.${extension!}`
+  if (subdomain) {
+    domain = `${subdomain}.${domain}`
+  }
+
+  return `https://${domain}${pathAndParameters}`
 }
 
 /**

--- a/packages/core/src/domain/configuration/endpointBuilder.ts
+++ b/packages/core/src/domain/configuration/endpointBuilder.ts
@@ -58,14 +58,14 @@ export interface BuildEndpointUrlOptions {
   site: Site | undefined
   subdomain?: string
   path: string
-  parameters: string
+  parameters?: string
 }
 
 export function buildEndpointUrl({
   proxy,
   site = INTAKE_SITE_US1,
   path,
-  parameters,
+  parameters = '',
   subdomain,
 }: BuildEndpointUrlOptions): string {
   let pathAndParameters = path

--- a/packages/core/src/domain/configuration/index.ts
+++ b/packages/core/src/domain/configuration/index.ts
@@ -7,5 +7,5 @@ export {
   serializeConfiguration,
 } from './configuration'
 export type { EndpointBuilder, TrackType } from './endpointBuilder'
-export { createEndpointBuilder, buildEndpointHost } from './endpointBuilder'
+export { createEndpointBuilder, buildEndpointUrl } from './endpointBuilder'
 export { computeTransportConfiguration, isIntakeUrl } from './transportConfiguration'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@ export {
   TraceContextInjection,
   serializeConfiguration,
   isSampleRate,
-  buildEndpointHost,
+  buildEndpointUrl,
   isIntakeUrl,
   computeTransportConfiguration,
 } from './domain/configuration'

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -1,7 +1,6 @@
 import type { createContextManager, Context } from '@datadog/browser-core'
 import {
   display,
-  buildEndpointHost,
   mapValues,
   getCookie,
   addTelemetryMetrics,
@@ -9,6 +8,7 @@ import {
   monitorError,
   isIndexableObject,
   fetch,
+  buildEndpointUrl,
 } from '@datadog/browser-core'
 import { extractRegexMatch } from '../extractRegexMatch'
 import type { RumInitConfiguration } from './configuration'
@@ -321,7 +321,12 @@ export function buildEndpoint(configuration: RumInitConfiguration) {
     return configuration.remoteConfigurationProxy
   }
   const id = getRemoteConfigurationId(configuration)!
-  return `https://sdk-configuration.${buildEndpointHost(configuration)}/${REMOTE_CONFIGURATION_VERSION}/${encodeURIComponent(id)}.json`
+  return buildEndpointUrl({
+    site: configuration.site,
+    path: `/${REMOTE_CONFIGURATION_VERSION}/${encodeURIComponent(id)}.json`,
+    subdomain: 'sdk-configuration',
+    parameters: '',
+  })
 }
 
 function doBackgroundCacheSync(

--- a/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -325,7 +325,6 @@ export function buildEndpoint(configuration: RumInitConfiguration) {
     site: configuration.site,
     path: `/${REMOTE_CONFIGURATION_VERSION}/${encodeURIComponent(id)}.json`,
     subdomain: 'sdk-configuration',
-    parameters: '',
   })
 }
 

--- a/packages/rum/src/domain/profiling/quotaCheck.spec.ts
+++ b/packages/rum/src/domain/profiling/quotaCheck.spec.ts
@@ -117,7 +117,15 @@ describe('checkProfilingQuota', () => {
     interceptor.withFetch(backendResponse(true, 'quota_ok'))
     await checkProfilingQuota(mockRumConfiguration({ proxy: 'http://proxy.example.com' }), 'session-abc')
     expect(interceptor.requests[0].url).toBe(
-      'http://proxy.example.com?ddforward=%2Fapi%2Fv2%2Fprofiling%2Fquota%3Fsession_id%3Dsession-abc&ddforwardSubdomain=quota'
+      'http://proxy.example.com/?ddforward=%2Fapi%2Fv2%2Fprofiling%2Fquota%3Fsession_id%3Dsession-abc&ddforwardSubdomain=quota'
+    )
+  })
+
+  it('normalizes string proxy URLs', async () => {
+    interceptor.withFetch(backendResponse(true, 'quota_ok'))
+    await checkProfilingQuota(mockRumConfiguration({ proxy: '/proxy' }), 'session-abc')
+    expect(interceptor.requests[0].url).toBe(
+      `${location.origin}/proxy?ddforward=%2Fapi%2Fv2%2Fprofiling%2Fquota%3Fsession_id%3Dsession-abc&ddforwardSubdomain=quota`
     )
   })
 

--- a/packages/rum/src/domain/profiling/quotaCheck.ts
+++ b/packages/rum/src/domain/profiling/quotaCheck.ts
@@ -1,4 +1,4 @@
-import { fetch, setTimeout, clearTimeout, buildEndpointHost } from '@datadog/browser-core'
+import { fetch, setTimeout, clearTimeout, buildEndpointUrl } from '@datadog/browser-core'
 import type { RumConfiguration } from '@datadog/browser-rum-core'
 
 // Reason strings surfaced on RUM events. Backend reasons backend_unavailable and
@@ -29,21 +29,13 @@ function parseQuotaResult(body: unknown, httpStatusFallback: QuotaResult): Quota
 }
 
 function buildQuotaUrl(configuration: RumConfiguration, sessionId: string): string {
-  const path = '/api/v2/profiling/quota'
-  const parameters = `session_id=${sessionId}`
-  const proxy = configuration.proxy
-  const host = `quota.${buildEndpointHost({ site: configuration.site, clientToken: configuration.clientToken })}`
-
-  if (typeof proxy === 'string') {
-    // ddforwardSubdomain tells the proxy which intake subdomain to target.
-    return `${proxy}?ddforward=${encodeURIComponent(`${path}?${parameters}`)}&ddforwardSubdomain=quota`
-  }
-
-  if (typeof proxy === 'function') {
-    return proxy({ path, parameters, subdomain: 'quota' })
-  }
-
-  return `https://${host}${path}?${parameters}`
+  return buildEndpointUrl({
+    proxy: configuration.proxy,
+    site: configuration.site,
+    path: '/api/v2/profiling/quota',
+    parameters: `session_id=${sessionId}`,
+    subdomain: 'quota',
+  })
 }
 
 export function checkProfilingQuota(


### PR DESCRIPTION
## Motivation

Customers using proxy routing should get consistent and predictable intake behavior across Browser SDK features.  
This change improves consistency of URL construction so proxy routing, subdomain forwarding, and site-based fallback behave the same way in core ingestion paths, profiling quota checks, and remote configuration fetches.

## Changes

- unify endpoint URL construction through `buildEndpointUrl` in core configuration logic
- switch profiling quota endpoint generation to use the shared endpoint URL builder
- switch remote configuration endpoint generation to use the same shared builder (including `sdk-configuration` subdomain)
- extend endpoint URL tests to cover:
  - string and relative proxy URLs
  - subdomain forwarding with proxies
  - proxy function delegation
  - default-site fallback behavior
  - empty-parameters URL behavior
- add/adjust profiling quota tests to validate normalized proxy URL behavior

## Test instructions

1. Run the sandbox with a proxy path configured (for example `proxy: '/proxy'` in SDK init).
2. Open the sandbox in the browser and verify in Network that intake requests go through `/proxy` and include `ddforward`.
3. Verify profiling quota requests include `ddforwardSubdomain=quota` when proxying is enabled.
4. Disable proxy and verify requests target the expected Datadog intake host based on `site`.
5. Configure remote configuration (with an id) and verify the fetched endpoint uses the `sdk-configuration` subdomain path.
6. Validate that requests still succeed when query parameters are empty for endpoints that don’t require them.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
