### PR TITLE
🐛 Report debugger condition evaluation errors

### DIFF
--- a/packages/debugger/src/domain/activeEntries.ts
+++ b/packages/debugger/src/domain/activeEntries.ts
@@ -1,9 +1,11 @@
 import type { StackFrame } from './stacktrace'
+import type { EvaluationError } from './condition'
 
 export interface ActiveEntry {
   start: number
   timestamp?: number
   message?: string
+  evaluationErrors?: EvaluationError[]
   entry?: {
     arguments: Record<string, any>
   }

--- a/packages/debugger/src/domain/api.spec.ts
+++ b/packages/debugger/src/domain/api.spec.ts
@@ -150,6 +150,64 @@ describe('api', () => {
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
 
+    it('should not evaluate ENTRY condition when sampling budget is exceeded', () => {
+      const probe: Probe = {
+        id: 'test-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'entryConditionSamplingBudget' },
+        when: {
+          dsl: 'missing.value',
+          json: { getmember: [{ ref: 'missing' }, 'value'] },
+        },
+        template: 'Test',
+        captureSnapshot: true,
+        capture: {},
+        sampling: { snapshotsPerSecond: 0.5 },
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;entryConditionSamplingBudget')!
+      onEntry(probes, {}, { missing: { value: true } })
+      onReturn(probes, null, {}, { missing: { value: true } }, {})
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+
+      onEntry(probes, {}, {})
+      onReturn(probes, null, {}, {}, {})
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not evaluate EXIT condition when sampling budget is exceeded', () => {
+      const probe: Probe = {
+        id: 'test-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'exitConditionSamplingBudget' },
+        when: {
+          dsl: 'missing.value',
+          json: { getmember: [{ ref: 'missing' }, 'value'] },
+        },
+        template: 'Test',
+        captureSnapshot: true,
+        capture: {},
+        sampling: { snapshotsPerSecond: 0.5 },
+        evaluateAt: 'EXIT',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;exitConditionSamplingBudget')!
+      onEntry(probes, {}, { missing: { value: true } })
+      onReturn(probes, null, {}, { missing: { value: true } }, {})
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+
+      onEntry(probes, {}, {})
+      onReturn(probes, null, {}, {}, {})
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+    })
+
     it('should evaluate condition at ENTRY', () => {
       const probe: Probe = {
         id: 'test-probe',
@@ -316,6 +374,112 @@ describe('api', () => {
       const snapshot = payload.debugger.snapshot
       expect(snapshot.duration).toBe(10_000_000) // Should be in nanoseconds (10ms)
     })
+
+    it('should report ENTRY condition evaluation errors without capturing a snapshot', () => {
+      const probe: Probe = {
+        id: 'test-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'entryConditionError' },
+        when: {
+          dsl: 'missing.value',
+          json: { getmember: [{ ref: 'missing' }, 'value'] },
+        },
+        template: 'Should not be evaluated',
+        captureSnapshot: true,
+        capture: { maxReferenceDepth: 1 },
+        sampling: { snapshotsPerSecond: Infinity },
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;entryConditionError')!
+      onEntry(probes, {}, {})
+      onReturn(probes, null, {}, {}, {})
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(payload.message).toBeUndefined()
+      expect(snapshot.evaluationErrors).toEqual([
+        {
+          expr: 'missing.value',
+          message: jasmine.stringMatching(/^ReferenceError: /),
+        },
+      ])
+      expect(snapshot.duration).toBeUndefined()
+      expect(snapshot.captures).toBeUndefined()
+      expect(snapshot.stack).toBeUndefined()
+    })
+
+    it('should report EXIT condition evaluation errors without capturing a return snapshot', () => {
+      const probe: Probe = {
+        id: 'test-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'exitConditionError' },
+        when: {
+          dsl: 'missing.value',
+          json: { getmember: [{ ref: 'missing' }, 'value'] },
+        },
+        template: 'Should not be evaluated',
+        captureSnapshot: true,
+        capture: { maxReferenceDepth: 1 },
+        sampling: { snapshotsPerSecond: Infinity },
+        evaluateAt: 'EXIT',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;exitConditionError')!
+      onEntry(probes, {}, {})
+      onReturn(probes, null, {}, {}, {})
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(payload.message).toBeUndefined()
+      expect(snapshot.evaluationErrors).toEqual([
+        {
+          expr: 'missing.value',
+          message: jasmine.stringMatching(/^ReferenceError: /),
+        },
+      ])
+      expect(snapshot.captures).toBeUndefined()
+      expect(snapshot.stack).toBeUndefined()
+    })
+
+    it('should rate limit repeated condition evaluation errors', () => {
+      const clock = mockClock()
+      const probe: Probe = {
+        id: 'test-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'rateLimitedConditionError' },
+        when: {
+          dsl: 'missing.value',
+          json: { getmember: [{ ref: 'missing' }, 'value'] },
+        },
+        template: 'Should not be evaluated',
+        captureSnapshot: true,
+        capture: { maxReferenceDepth: 1 },
+        sampling: { snapshotsPerSecond: Infinity },
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;rateLimitedConditionError')!
+      onEntry(probes, {}, {})
+      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, {}, {})
+      onReturn(probes, null, {}, {}, {})
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+
+      clock.tick(5 * 60 * 1000)
+
+      onEntry(probes, {}, {})
+      onReturn(probes, null, {}, {}, {})
+      expect(mockBatchAdd).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('onThrow', () => {
@@ -435,6 +599,42 @@ describe('api', () => {
       onThrow(probes, error, {}, {})
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+    })
+
+    it('should report EXIT condition evaluation errors on throw without capturing a snapshot', () => {
+      const probe: Probe = {
+        id: 'test-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'throwConditionError' },
+        when: {
+          dsl: 'missing.value',
+          json: { getmember: [{ ref: 'missing' }, 'value'] },
+        },
+        template: 'Should not be evaluated',
+        captureSnapshot: true,
+        capture: { maxReferenceDepth: 1 },
+        sampling: { snapshotsPerSecond: Infinity },
+        evaluateAt: 'EXIT',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;throwConditionError')!
+      onEntry(probes, {}, {})
+      onThrow(probes, new Error('Test error'), {}, {})
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(payload.message).toBeUndefined()
+      expect(snapshot.evaluationErrors).toEqual([
+        {
+          expr: 'missing.value',
+          message: jasmine.stringMatching(/^ReferenceError: /),
+        },
+      ])
+      expect(snapshot.captures).toBeUndefined()
+      expect(snapshot.stack).toBeUndefined()
     })
 
     it('should handle onThrow without preceding onEntry', () => {

--- a/packages/debugger/src/domain/api.ts
+++ b/packages/debugger/src/domain/api.ts
@@ -6,6 +6,7 @@ import { capture, captureFields } from './capture'
 import type { CaptureContext } from './capture'
 import type { InitializedProbe } from './probes'
 import {
+  checkConditionErrorBudget,
   checkGlobalSnapshotBudget,
   hasProbeLifetimeBudgetRemaining,
   removeProbe,
@@ -16,7 +17,7 @@ import type { ActiveEntry } from './activeEntries'
 import { active } from './activeEntries'
 import { captureStackTrace, parseStackTrace } from './stacktrace'
 import { evaluateProbeMessage } from './template'
-import { evaluateProbeCondition } from './condition'
+import { evaluateProbeCondition, isConditionEvaluationError } from './condition'
 
 const globalObj = getGlobalObject<BrowserWindow>() // eslint-disable-line local-rules/disallow-side-effects
 
@@ -84,8 +85,21 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
       // Build context for condition and message evaluation
       const context = { ...args, this: self }
 
-      // Check condition - if it fails, don't evaluate or capture anything
-      if (!evaluateProbeCondition(probe, context)) {
+      try {
+        // Check condition - if it fails, don't evaluate or capture anything
+        if (!evaluateProbeCondition(probe, context)) {
+          // Still push to stack so onReturn/onThrow can pop it, but mark as skipped
+          stack.push(null)
+          continue
+        }
+      } catch (error) {
+        if (isConditionEvaluationError(error) && checkConditionErrorBudget(probe, start)) {
+          queueDebuggerSnapshot(probe, {
+            start,
+            timestamp: timeStampNow(),
+            evaluationErrors: [error.evaluationError],
+          })
+        }
         // Still push to stack so onReturn/onThrow can pop it, but mark as skipped
         stack.push(null)
         continue
@@ -174,7 +188,19 @@ export function onReturn(
         $dd_return: value,
       }
 
-      if (!evaluateProbeCondition(probe, context)) {
+      try {
+        if (!evaluateProbeCondition(probe, context)) {
+          continue
+        }
+      } catch (error) {
+        if (isConditionEvaluationError(error) && checkConditionErrorBudget(probe, end)) {
+          queueDebuggerSnapshot(probe, {
+            start: result.start,
+            timestamp: result.timestamp,
+            duration: result.duration,
+            evaluationErrors: [error.evaluationError],
+          })
+        }
         continue
       }
 
@@ -254,7 +280,19 @@ export function onThrow(probes: InitializedProbe[], error: Error, self: any, arg
         $dd_exception: error,
       }
 
-      if (!evaluateProbeCondition(probe, context)) {
+      try {
+        if (!evaluateProbeCondition(probe, context)) {
+          continue
+        }
+      } catch (error) {
+        if (isConditionEvaluationError(error) && checkConditionErrorBudget(probe, end)) {
+          queueDebuggerSnapshot(probe, {
+            start: result.start,
+            timestamp: result.timestamp,
+            duration: result.duration,
+            evaluationErrors: [error.evaluationError],
+          })
+        }
         continue
       }
 
@@ -329,9 +367,10 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
             type: probe.where.typeName,
           },
         },
+        evaluationErrors: result.evaluationErrors,
         stack: result.stack,
         language: 'javascript',
-        duration: result.duration! * 1e6, // to nanoseconds
+        duration: result.duration === undefined ? undefined : result.duration * 1e6, // to nanoseconds (might be undefined in case of eval errors)
         captures:
           result.entry || result.return
             ? {

--- a/packages/debugger/src/domain/condition.spec.ts
+++ b/packages/debugger/src/domain/condition.spec.ts
@@ -1,13 +1,6 @@
-import { display } from '@datadog/browser-core'
-import { evaluateProbeCondition, compileCondition } from './condition'
+import { evaluateProbeCondition, compileCondition, isConditionEvaluationError } from './condition'
 
 describe('condition', () => {
-  let displayErrorSpy: jasmine.Spy
-
-  beforeEach(() => {
-    displayErrorSpy = spyOn(display, 'error')
-  })
-
   describe('evaluateProbeCondition', () => {
     it('should return true when probe has no condition', () => {
       const probe: any = {}
@@ -84,31 +77,41 @@ describe('condition', () => {
       expect(evaluateProbeCondition(probe, { x: undefined })).toBe(false)
     })
 
-    it('should handle condition evaluation errors gracefully', () => {
+    it('should return an evaluation error when condition evaluation fails', () => {
       const probe: any = {
         id: 'test-probe',
+        when: {
+          dsl: 'nonExistent.property',
+        },
         condition: compileCondition('nonExistent.property'),
       }
 
-      // Should return true (fire probe) when condition evaluation fails
-      const result = evaluateProbeCondition(probe, {})
-      expect(result).toBe(true)
-
-      // Should log error
-      expect(displayErrorSpy).toHaveBeenCalledWith(
-        jasmine.stringContaining('Failed to evaluate condition for probe test-probe'),
-        jasmine.any(Error)
-      )
+      expect(() => evaluateProbeCondition(probe, {})).toThrowMatching((error) => {
+        expect(isConditionEvaluationError(error)).toBeTrue()
+        expect(isConditionEvaluationError(error) && error.evaluationError).toEqual({
+          expr: 'nonExistent.property',
+          message: jasmine.stringMatching(/^ReferenceError: /),
+        })
+        return true
+      })
     })
 
     it('should handle syntax errors in condition', () => {
       const probe: any = {
+        when: {
+          dsl: 'invalid syntax !!!',
+        },
         condition: compileCondition('invalid syntax !!!'),
       }
 
-      const result = evaluateProbeCondition(probe, {})
-      expect(result).toBe(true)
-      expect(displayErrorSpy).toHaveBeenCalled()
+      expect(() => evaluateProbeCondition(probe, {})).toThrowMatching((error) => {
+        expect(isConditionEvaluationError(error)).toBeTrue()
+        expect(isConditionEvaluationError(error) && error.evaluationError).toEqual({
+          expr: 'invalid syntax !!!',
+          message: jasmine.stringMatching(/^SyntaxError: /),
+        })
+        return true
+      })
     })
 
     it('should handle conditions with special variables', () => {

--- a/packages/debugger/src/domain/condition.ts
+++ b/packages/debugger/src/domain/condition.ts
@@ -1,5 +1,3 @@
-import { display } from '@datadog/browser-core'
-
 export interface CompiledCondition {
   evaluate: (contextKeys: string[]) => (...args: any[]) => boolean
   clearCache: () => void
@@ -7,7 +5,29 @@ export interface CompiledCondition {
 
 export interface ProbeWithCondition {
   id: string
+  when?: {
+    dsl: string
+  }
   condition?: CompiledCondition
+}
+
+export interface EvaluationError {
+  [key: string]: string
+  expr: string
+  message: string
+}
+
+export type ConditionEvaluationError = Error & { evaluationError: EvaluationError }
+
+export function createConditionEvaluationError(evaluationError: EvaluationError): ConditionEvaluationError {
+  const error = new Error(evaluationError.message) as ConditionEvaluationError
+  error.name = 'ConditionEvaluationError'
+  error.evaluationError = evaluationError
+  return error
+}
+
+export function isConditionEvaluationError(error: unknown): error is ConditionEvaluationError {
+  return error instanceof Error && error.name === 'ConditionEvaluationError' && 'evaluationError' in error
 }
 
 /**
@@ -49,6 +69,7 @@ export function compileCondition(condition: string): CompiledCondition {
  * @param probe - Probe configuration
  * @param context - Runtime context with variables
  * @returns True if condition passes (or no condition), false otherwise
+ * @throws ConditionEvaluationError when the condition cannot be evaluated
  */
 export function evaluateProbeCondition(probe: ProbeWithCondition, context: Record<string, any>): boolean {
   // If no condition, probe always fires
@@ -65,9 +86,13 @@ export function evaluateProbeCondition(probe: ProbeWithCondition, context: Recor
     const fn = probe.condition.evaluate(contextKeys)
     return Boolean(fn.call(thisValue, ...contextValues))
   } catch (e) {
-    // If condition evaluation fails, log error and let probe fire
-    // TODO: Handle error properly
-    display.error(`Failed to evaluate condition for probe ${probe.id}:`, e)
-    return true
+    throw createConditionEvaluationError({
+      expr: probe.when!.dsl,
+      message: formatConditionEvaluationError(e),
+    })
   }
+}
+
+function formatConditionEvaluationError(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error)
 }

--- a/packages/debugger/src/domain/probes.ts
+++ b/packages/debugger/src/domain/probes.ts
@@ -13,6 +13,7 @@ const DEFAULT_MAX_SNAPSHOTS_PER_SECOND_PER_PROBE = 1
 const DEFAULT_MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE = 5000
 const DEFAULT_MAX_SNAPSHOTS_PER_PROBE_LIFETIME = 1000
 const DEFAULT_MAX_NON_SNAPSHOTS_PER_PROBE_LIFETIME = 50000
+const DEFAULT_MS_BETWEEN_CONDITION_ERRORS = 5 * 60 * 1000
 
 // Global snapshot rate limiting
 let globalSnapshotSamplingRateWindowStart = 0
@@ -67,6 +68,7 @@ export interface InitializedProbe extends Probe {
   condition?: CompiledCondition
   msBetweenSampling: number
   lastCaptureMs: number
+  lastConditionErrorMs: number
   eventsSentInLifetime: number
   lifetimeBudgetWarningEmitted: boolean
 }
@@ -283,6 +285,15 @@ export function isProbeLifetimeBudgetExhausted(probe: InitializedProbe): boolean
   return probe.eventsSentInLifetime >= getMaxProbeLifetimeEvents(probe)
 }
 
+export function checkConditionErrorBudget(probe: InitializedProbe, now: number): boolean {
+  if (now - probe.lastConditionErrorMs < DEFAULT_MS_BETWEEN_CONDITION_ERRORS) {
+    return false
+  }
+
+  probe.lastConditionErrorMs = now
+  return true
+}
+
 /**
  * Initialize a probe by preprocessing template segments, conditions, and sampling
  *
@@ -346,6 +357,7 @@ export function initializeProbe(probe: Probe): asserts probe is InitializedProbe
       : currentProbeBudgetConfiguration.maxNonSnapshotsPerSecondPerProbe)
   ;(probe as InitializedProbe).msBetweenSampling = (1 / snapshotsPerSecond) * 1000 // Convert to milliseconds
   ;(probe as InitializedProbe).lastCaptureMs = -Infinity // Initialize to -Infinity to allow first call
+  ;(probe as InitializedProbe).lastConditionErrorMs = -Infinity
   ;(probe as InitializedProbe).eventsSentInLifetime = 0
   ;(probe as InitializedProbe).lifetimeBudgetWarningEmitted = false
 }


### PR DESCRIPTION
## Motivation

Condition evaluation errors currently make debugger probes fire as if the condition passed. This can lead to misleading probe results and unnecessary snapshot capture when the real issue is that the probe condition could not be evaluated.

## Changes

- Treat condition evaluation errors as condition failures instead of passing conditions.
- Report condition evaluation errors through `debugger.snapshot.evaluationErrors` so users can understand why their probe did not evaluate.
- Skip message evaluation, stack capture, and snapshot capture for condition-error-only results.
- Rate limit repeated condition evaluation error reports per probe to avoid spamming events in tight loops.
- Added unit coverage for ENTRY/EXIT condition errors, throw paths, rate limiting, no stack/capture behavior, and sampled-out condition behavior.

## Test instructions

Run:

`yarn test:unit --spec packages/debugger/src/domain/condition.spec.ts`

`yarn test:unit --spec packages/debugger/src/domain/api.spec.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
