### PR TITLE
🐛 Skip debugger probes with invalid conditions

### DIFF
--- a/packages/debugger/src/domain/probes.spec.ts
+++ b/packages/debugger/src/domain/probes.spec.ts
@@ -1,4 +1,4 @@
-import { display } from '@datadog/browser-core'
+import type { ErrorWithCause } from '@datadog/browser-core'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 import {
   initializeProbe,
@@ -209,8 +209,7 @@ describe('probes', () => {
       )
     })
 
-    it('should handle condition compilation errors', () => {
-      const displayErrorSpy = spyOn(display, 'error')
+    it('should not add probe when condition compilation fails', () => {
       const probe: Probe = {
         id: 'test-probe-1',
         version: 0,
@@ -227,12 +226,17 @@ describe('probes', () => {
         evaluateAt: 'EXIT',
       }
 
-      initializeProbe(probe)
+      let error: unknown
+      try {
+        addProbe(probe)
+      } catch (err) {
+        error = err
+      }
 
-      expect(displayErrorSpy).toHaveBeenCalledWith(
-        jasmine.stringContaining('Cannot compile condition'),
-        jasmine.any(Error)
-      )
+      expect(error).toEqual(jasmine.any(Error))
+      expect((error as Error).message).toContain('Cannot compile condition')
+      expect((error as ErrorWithCause).cause).toEqual(jasmine.any(TypeError))
+      expect(getProbes('TestClass;conditionError')).toBeUndefined()
     })
 
     it('should calculate msBetweenSampling for snapshot probes', () => {

--- a/packages/debugger/src/domain/probes.ts
+++ b/packages/debugger/src/domain/probes.ts
@@ -1,4 +1,5 @@
 import { display } from '@datadog/browser-core'
+import type { ErrorWithCause } from '@datadog/browser-core'
 import { clearActiveEntries } from './activeEntries'
 import { compile } from './expression'
 import { compileCondition } from './condition'
@@ -298,11 +299,12 @@ export function initializeProbe(probe: Probe): asserts probe is InitializedProbe
       ;(probe as InitializedProbe).condition = compileCondition(String(compile(probe.when.json)))
     }
   } catch (err) {
-    // TODO: Handle error properly
-    display.error(
-      `Cannot compile condition expression: ${probe.when!.dsl} (probe: ${probe.id}, version: ${probe.version})`,
-      err as Error
+    // TODO: Report to the debugger intake as a diagnostics message with state ERROR.
+    const conditionError = new Error(
+      `Cannot compile condition expression: ${probe.when!.dsl} (probe: ${probe.id}, version: ${probe.version})`
     )
+    ;(conditionError as ErrorWithCause).cause = err
+    throw conditionError
   }
 
   // Optimize for fast calculations when probe is hit


### PR DESCRIPTION
## Motivation

Debugger probes with invalid condition expressions were still installed after condition compilation failed. Those probes should be rejected until we can report the failure through debugger diagnostics.

## Changes

- Stop installing a probe when its condition expression cannot be compiled.
- Throw a contextual error that keeps the compiler error as `cause`, so the delivery API per-probe error handling can report it without interrupting remaining probe updates.
- Update the TODO to track sending this failure to the debugger intake as a diagnostics message with state `ERROR`.
- Update unit coverage to assert the invalid probe is not registered.

## Test instructions

Run:

```bash
yarn test:unit --spec packages/debugger/src/domain/probes.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
