### PR TITLE
🐛 Preserve in-flight debugger probe entries on removal

### DIFF
--- a/packages/debugger/src/domain/activeEntries.ts
+++ b/packages/debugger/src/domain/activeEntries.ts
@@ -21,13 +21,3 @@ export interface ActiveEntry {
   }
   exception?: Error
 }
-
-export const active = new Map<string, Array<ActiveEntry | null>>()
-
-export function clearActiveEntries(probeId?: string): void {
-  if (probeId !== undefined) {
-    active.delete(probeId)
-  } else {
-    active.clear()
-  }
-}

--- a/packages/debugger/src/domain/api.spec.ts
+++ b/packages/debugger/src/domain/api.spec.ts
@@ -912,6 +912,35 @@ describe('api', () => {
       expect(getProbes('TestClass;nonSnapshotLifetime')).toBeUndefined()
     })
 
+    it('should finish in-flight recursive entries after the lifetime budget is exhausted', () => {
+      initTransport({ maxNonSnapshotsPerProbeLifetime: 1 })
+
+      const probe: Probe = {
+        id: 'recursive-lifetime-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'recursiveLifetime' },
+        template: 'Test',
+        captureSnapshot: false,
+        capture: {},
+        sampling: { snapshotsPerSecond: Infinity },
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const probes = getProbes('TestClass;recursiveLifetime')!
+      onEntry(probes, {}, {})
+      onEntry(probes, {}, {})
+
+      onReturn(probes, null, {}, {}, {})
+      expect(getProbes('TestClass;recursiveLifetime')).toBeUndefined()
+
+      // The lifetime budget gates new entries, but already accepted in-flight
+      // entries still drain even if another frame exhausts the budget first.
+      onReturn(probes, null, {}, {}, {})
+      expect(mockBatchAdd).toHaveBeenCalledTimes(2)
+    })
+
     it('should reset the lifetime budget when a new probe version is delivered', () => {
       initTransport({ maxSnapshotsPerProbeLifetime: 1 })
 
@@ -933,9 +962,8 @@ describe('api', () => {
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
-      // A Remote Config delivery for an existing probe id replaces the old probe with
-      // the new version. After re-add, the new version should have a fresh budget.
-      removeProbe(probe.id)
+      // The old probe has reached its lifetime budget and was auto-unregistered.
+      // After re-add, the new version should have a fresh budget.
       addProbe({ ...probe, version: 1 })
 
       probes = getProbes('TestClass;versionedLifetime')!
@@ -1043,7 +1071,7 @@ describe('api', () => {
       }
     }
 
-    it('should discard in-flight entries when a probe is removed', () => {
+    it('should drain in-flight entries through the removed probe instance', () => {
       const probe = createProbe('cleanup-probe', 'cleanupTest')
       addProbe(probe)
 
@@ -1051,7 +1079,20 @@ describe('api', () => {
       onEntry(probes, {}, {})
 
       removeProbe('cleanup-probe')
+      onReturn(probes, null, {}, {}, {})
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+    })
+
+    it('should isolate in-flight entries from a replacement probe with the same id', () => {
+      const probe = createProbe('cleanup-probe', 'cleanupTest')
       addProbe(probe)
+
+      const probes = getProbes('TestClass;cleanupTest')!
+      onEntry(probes, {}, {})
+
+      removeProbe('cleanup-probe')
+      addProbe(createProbe('cleanup-probe', 'cleanupTest'))
 
       const newProbes = getProbes('TestClass;cleanupTest')!
       onReturn(newProbes, null, {}, {}, {})
@@ -1067,7 +1108,7 @@ describe('api', () => {
       onEntry(probes, {}, {})
 
       clearProbes()
-      addProbe(probe)
+      addProbe(createProbe('cleanup-probe', 'clearAllTest'))
 
       const newProbes = getProbes('TestClass;clearAllTest')!
       onReturn(newProbes, null, {}, {}, {})

--- a/packages/debugger/src/domain/api.ts
+++ b/packages/debugger/src/domain/api.ts
@@ -8,13 +8,12 @@ import type { InitializedProbe } from './probes'
 import {
   checkConditionErrorBudget,
   checkGlobalSnapshotBudget,
-  hasProbeLifetimeBudgetRemaining,
-  removeProbe,
+  enforceProbeLifetimeBudget,
+  recordProbeEventSent,
   resetProbeBudgetConfiguration,
   setProbeBudgetConfiguration,
 } from './probes'
 import type { ActiveEntry } from './activeEntries'
-import { active } from './activeEntries'
 import { captureStackTrace, parseStackTrace } from './stacktrace'
 import { evaluateProbeMessage } from './template'
 import { evaluateProbeCondition, isConditionEvaluationError } from './condition'
@@ -40,7 +39,6 @@ export function resetDebuggerTransport(): void {
   debuggerBatch = undefined
   debuggerConfig = undefined
   cachedDDtags = undefined
-  active.clear()
   resetProbeBudgetConfiguration()
 }
 
@@ -57,14 +55,8 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
 
   // TODO: A lot of repeated work performed for each probe that could be shared between probes
   for (const probe of probes) {
-    if (!hasProbeLifetimeBudgetRemaining(probe)) {
+    if (!enforceProbeLifetimeBudget(probe)) {
       continue
-    }
-
-    let stack = active.get(probe.id) // TODO: Should we use the functionId instead?
-    if (!stack) {
-      stack = []
-      active.set(probe.id, stack)
     }
 
     // Skip if sampling budget is exceeded
@@ -72,7 +64,7 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
       start - probe.lastCaptureMs < probe.msBetweenSampling ||
       !checkGlobalSnapshotBudget(start, probe.captureSnapshot)
     ) {
-      stack.push(null)
+      probe.activeEntries.push(null)
       continue
     }
 
@@ -89,7 +81,7 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
         // Check condition - if it fails, don't evaluate or capture anything
         if (!evaluateProbeCondition(probe, context)) {
           // Still push to stack so onReturn/onThrow can pop it, but mark as skipped
-          stack.push(null)
+          probe.activeEntries.push(null)
           continue
         }
       } catch (error) {
@@ -101,7 +93,7 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
           })
         }
         // Still push to stack so onReturn/onThrow can pop it, but mark as skipped
-        stack.push(null)
+        probe.activeEntries.push(null)
         continue
       }
 
@@ -120,12 +112,12 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
         },
       }
       if (captureCtx.timedOut) {
-        stack.push(null)
+        probe.activeEntries.push(null)
         continue
       }
     }
 
-    stack.push({
+    probe.activeEntries.push({
       start,
       timestamp,
       message,
@@ -154,23 +146,10 @@ export function onReturn(
 ): any {
   const end = performance.now()
   const captureCtx: CaptureContext = { deadline: performance.now() + SNAPSHOT_TIMEOUT_MS, timedOut: false }
-  let exhaustedProbeIds: string[] | undefined
 
   // TODO: A lot of repeated work performed for each probe that could be shared between probes
   for (const probe of probes) {
-    if (!hasProbeLifetimeBudgetRemaining(probe)) {
-      ;(exhaustedProbeIds ??= []).push(probe.id)
-      continue
-    }
-
-    const stack = active.get(probe.id) // TODO: Should we use the functionId instead?
-    if (!stack) {
-      continue // TODO: This shouldn't be possible, do we need it? Should we warn?
-    }
-    const result = stack.pop()
-    if (stack.length === 0) {
-      active.delete(probe.id)
-    }
+    const result = probe.activeEntries.pop()
     if (!result) {
       continue
     }
@@ -226,12 +205,6 @@ export function onReturn(
     queueDebuggerSnapshot(probe, result)
   }
 
-  if (exhaustedProbeIds) {
-    for (const id of exhaustedProbeIds) {
-      removeProbe(id)
-    }
-  }
-
   return value
 }
 
@@ -246,23 +219,10 @@ export function onReturn(
 export function onThrow(probes: InitializedProbe[], error: Error, self: any, args: Record<string, any> = {}): void {
   const end = performance.now()
   const captureCtx: CaptureContext = { deadline: performance.now() + SNAPSHOT_TIMEOUT_MS, timedOut: false }
-  let exhaustedProbeIds: string[] | undefined
 
   // TODO: A lot of repeated work performed for each probe that could be shared between probes
   for (const probe of probes) {
-    if (!hasProbeLifetimeBudgetRemaining(probe)) {
-      ;(exhaustedProbeIds ??= []).push(probe.id)
-      continue
-    }
-
-    const stack = active.get(probe.id) // TODO: Should we use the functionId instead?
-    if (!stack) {
-      continue // TODO: This shouldn't be possible, do we need it? Should we warn?
-    }
-    const result = stack.pop()
-    if (stack.length === 0) {
-      active.delete(probe.id)
-    }
+    const result = probe.activeEntries.pop()
     if (!result) {
       continue
     }
@@ -319,12 +279,6 @@ export function onThrow(probes: InitializedProbe[], error: Error, self: any, arg
     }
 
     queueDebuggerSnapshot(probe, result)
-  }
-
-  if (exhaustedProbeIds) {
-    for (const id of exhaustedProbeIds) {
-      removeProbe(id)
-    }
   }
 }
 
@@ -383,7 +337,7 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
   }
 
   debuggerBatch.add(payload)
-  probe.eventsSentInLifetime++
+  recordProbeEventSent(probe)
 }
 
 function getDebuggerDDtags(debuggerVersion: string): string {

--- a/packages/debugger/src/domain/probes.spec.ts
+++ b/packages/debugger/src/domain/probes.spec.ts
@@ -126,6 +126,79 @@ describe('probes', () => {
       // Should not throw when removing probe with static template (no clearCache method)
       expect(() => removeProbe('test-probe-1')).not.toThrow()
     })
+
+    it('should remove the exact initialized probe instance when passed a probe', () => {
+      const probe: Probe = {
+        id: 'test-probe-1',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'instanceTest' },
+        template: 'Static message',
+        captureSnapshot: false,
+        capture: {},
+        sampling: {},
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const initializedProbe = getProbes('TestClass;instanceTest')![0]
+      removeProbe(initializedProbe)
+
+      expect(getProbes('TestClass;instanceTest')).toBeUndefined()
+    })
+
+    it('should not remove a replacement probe when passed a stale probe instance', () => {
+      const staleProbe: Probe = {
+        id: 'test-probe-1',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'replacementTest' },
+        template: 'Stale message',
+        captureSnapshot: false,
+        capture: {},
+        sampling: {},
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(staleProbe)
+
+      const staleInitializedProbe = getProbes('TestClass;replacementTest')![0]
+      removeProbe('test-probe-1')
+      addProbe({
+        id: 'test-probe-1',
+        version: 1,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'replacementTest' },
+        template: 'Replacement message',
+        captureSnapshot: false,
+        capture: {},
+        sampling: {},
+        evaluateAt: 'ENTRY',
+      })
+
+      expect(() => removeProbe(staleInitializedProbe)).not.toThrow()
+      expect(getProbes('TestClass;replacementTest')).toEqual([jasmine.objectContaining({ version: 1 })])
+    })
+
+    it('should not throw when passed a stale probe instance that is no longer registered', () => {
+      const probe: Probe = {
+        id: 'test-probe-1',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'staleTest' },
+        template: 'Static message',
+        captureSnapshot: false,
+        capture: {},
+        sampling: {},
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const initializedProbe = getProbes('TestClass;staleTest')![0]
+      removeProbe('test-probe-1')
+
+      expect(() => removeProbe(initializedProbe)).not.toThrow()
+      expect(getProbes('TestClass;staleTest')).toBeUndefined()
+    })
   })
 
   describe('initializeProbe', () => {

--- a/packages/debugger/src/domain/probes.ts
+++ b/packages/debugger/src/domain/probes.ts
@@ -1,12 +1,12 @@
 import { display } from '@datadog/browser-core'
 import type { ErrorWithCause } from '@datadog/browser-core'
-import { clearActiveEntries } from './activeEntries'
 import { compile } from './expression'
 import { compileCondition } from './condition'
 import type { CompiledCondition } from './condition'
 import { templateRequiresEvaluation, compileSegments } from './template'
 import type { TemplateSegment, CompiledTemplate } from './template'
 import type { CaptureOptions } from './capture'
+import type { ActiveEntry } from './activeEntries'
 
 // Sampling rate limits
 const DEFAULT_MAX_SNAPSHOTS_PER_SECOND_GLOBALLY = 25
@@ -72,6 +72,7 @@ export interface InitializedProbe extends Probe {
   lastConditionErrorMs: number
   eventsSentInLifetime: number
   lifetimeBudgetWarningEmitted: boolean
+  activeEntries: Array<ActiveEntry | null>
 }
 
 // Pre-populate with a placeholder key to help V8 optimize property lookups.
@@ -164,42 +165,62 @@ export function getAllProbes(): InitializedProbe[] {
 }
 
 /**
- * Remove a probe from the registry
+ * Remove a probe from the registry.
  *
- * @param id - The probe ID
+ * Passing an initialized probe removes only that exact registered instance, so
+ * stale in-flight returns cannot remove a newer replacement with the same id.
  */
-export function removeProbe(id: string): void {
+export function removeProbe(id: string): void
+export function removeProbe(probe: InitializedProbe): void
+export function removeProbe(idOrProbe: string | InitializedProbe): void {
+  const id = typeof idOrProbe === 'string' ? idOrProbe : idOrProbe.id
+  const expectedProbe = typeof idOrProbe === 'string' ? undefined : idOrProbe
   const functionId = probeIdToFunctionId[id]
   if (!functionId) {
+    if (expectedProbe) {
+      // Identity-checked removal is best-effort: the in-flight probe instance
+      // may already have been removed or replaced by the delivery API.
+      return
+    }
     throw new Error(`Probe with id ${id} not found`)
   }
   const probes = activeProbes[functionId]
   if (!probes) {
+    if (expectedProbe) {
+      // The id mapping can outlive the probe array briefly for stale in-flight
+      // instances; there is nothing left for this instance to unregister.
+      return
+    }
     throw new Error(`Probes with function id ${functionId} not found`)
   }
   for (let i = 0; i < probes.length; i++) {
     const probe = probes[i]
-    if (probe.id === id) {
+    if (probe.id === id && (!expectedProbe || probe === expectedProbe)) {
       if (typeof probe.template === 'object' && probe.template !== null && probe.template.clearCache) {
         probe.template.clearCache()
       }
       if (typeof probe.condition === 'object' && probe.condition !== null && probe.condition.clearCache) {
         probe.condition.clearCache()
       }
-      probes.splice(i, 1)
-      // TODO: Gracefully drain in-flight entries instead of clearing them immediately.
-      // Deleting a probe can currently race with reentrant onEntry/onReturn invocations
-      // for the same probe — both delivery-driven removal and budget-based auto-unregistering
-      // can wipe the active stack while a deeper invocation is still in progress.
-      // A common concrete trigger is instrumenting a recursive function: if the inner
-      // frame is the one that exhausts the lifetime budget, the outer frame's pending
-      // entry is dropped and its snapshot is lost.
-      clearActiveEntries(id)
-      break
+      const remainingProbes = probes.slice(0, i).concat(probes.slice(i + 1))
+      if (remainingProbes.length === 0) {
+        delete activeProbes[functionId]
+      } else {
+        activeProbes[functionId] = remainingProbes
+      }
+      delete probeIdToFunctionId[id]
+      return
     }
   }
+  const hasReplacementWithSameId = expectedProbe && probes.some((probe) => probe.id === id)
+  if (hasReplacementWithSameId) {
+    // Stale in-flight instance: a replacement with the same id is already registered.
+    return
+  }
+
+  // No matching registered probe exists, so the id mapping is orphaned.
   delete probeIdToFunctionId[id]
-  if (probes.length === 0) {
+  if (activeProbes[functionId]?.length === 0) {
     delete activeProbes[functionId]
   }
 }
@@ -217,6 +238,10 @@ export function clearProbes(): void {
         if (typeof probe.condition === 'object' && probe.condition !== null && probe.condition.clearCache) {
           probe.condition.clearCache()
         }
+        // Unlike removeProbe(), clearProbes() is an aggressive teardown used by
+        // tests and the delivery API circuit breaker. Drop in-flight entries so
+        // stale captured probe instances cannot emit after the debugger is disabled.
+        probe.activeEntries.length = 0
       }
     }
   }
@@ -230,7 +255,6 @@ export function clearProbes(): void {
       delete probeIdToFunctionId[probeId]
     }
   }
-  clearActiveEntries()
   globalSnapshotSamplingRateWindowStart = 0
   snapshotsSampledWithinTheLastSecond = 0
 }
@@ -266,7 +290,7 @@ export function checkGlobalSnapshotBudget(now: number, captureSnapshot: boolean)
   return true
 }
 
-export function hasProbeLifetimeBudgetRemaining(probe: InitializedProbe): boolean {
+function hasProbeLifetimeBudgetRemaining(probe: InitializedProbe): boolean {
   if (isProbeLifetimeBudgetExhausted(probe)) {
     if (!probe.lifetimeBudgetWarningEmitted) {
       probe.lifetimeBudgetWarningEmitted = true
@@ -280,6 +304,22 @@ export function hasProbeLifetimeBudgetRemaining(probe: InitializedProbe): boolea
   }
 
   return true
+}
+
+export function enforceProbeLifetimeBudget(probe: InitializedProbe): boolean {
+  if (!hasProbeLifetimeBudgetRemaining(probe)) {
+    removeProbe(probe)
+    return false
+  }
+
+  return true
+}
+
+export function recordProbeEventSent(probe: InitializedProbe): void {
+  probe.eventsSentInLifetime++
+  if (isProbeLifetimeBudgetExhausted(probe)) {
+    removeProbe(probe)
+  }
 }
 
 export function isProbeLifetimeBudgetExhausted(probe: InitializedProbe): boolean {
@@ -362,6 +402,7 @@ export function initializeProbe(probe: Probe): asserts probe is InitializedProbe
   ;(probe as InitializedProbe).lastConditionErrorMs = -Infinity
   ;(probe as InitializedProbe).eventsSentInLifetime = 0
   ;(probe as InitializedProbe).lifetimeBudgetWarningEmitted = false
+  ;(probe as InitializedProbe).activeEntries = []
 }
 
 function normalizeProbeLifetimeLimit(limit: number | undefined, defaultLimit: number): number {


### PR DESCRIPTION
## Motivation

Removing a debugger probe used to clear its active entry stack immediately. For reentrant or recursive instrumented functions, this could drop an outer frame's pending snapshot if an inner frame exhausted the lifetime budget or if the probe was removed while the outer frame was still in flight.

## Changes

- Move active entry bookkeeping onto each initialized probe instance instead of a global map keyed by probe id.
- Let removed probe instances drain already accepted in-flight entries, while preventing future entries through the probe registry.
- Add identity-checked `removeProbe(probe)` behavior so stale in-flight probe instances cannot remove a newer replacement with the same probe id.
- Centralize lifetime budget transitions in `enforceProbeLifetimeBudget()` and `recordProbeEventSent()`.
- Document that `clearProbes()` remains aggressive teardown for tests and the delivery API circuit breaker.
- Add unit coverage for recursive lifetime-budget draining, replacement isolation, and the `removeProbe(probe)` overload contract.

## Test instructions

Run:

```bash
yarn test:unit --spec packages/debugger/src/domain/api.spec.ts --spec packages/debugger/src/domain/probes.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
