### PR TITLE
👷 Update BS Mobile Chrome Device

### DIFF
--- a/packages/rum-core/src/browser/scroll.spec.ts
+++ b/packages/rum-core/src/browser/scroll.spec.ts
@@ -20,8 +20,8 @@ describe('scroll', () => {
     it('normalized scroll matches initial behavior', () => {
       expect(getScrollX()).toBe(0)
       expect(getScrollY()).toBe(0)
-      expect(getScrollX()).toBe(window.scrollX || window.pageXOffset)
-      expect(getScrollY()).toBe(window.scrollY || window.pageYOffset)
+      expect(getScrollX()).toBe(Math.round(window.scrollX || window.pageXOffset))
+      expect(getScrollY()).toBe(Math.round(window.scrollY || window.pageYOffset))
     })
 
     it('normalized scroll updates when scrolled', () => {
@@ -31,8 +31,8 @@ describe('scroll', () => {
 
       expect(getScrollX()).toBe(0)
       expect(getScrollY()).toBe(100)
-      expect(getScrollX()).toBe(window.scrollX || window.pageXOffset)
-      expect(getScrollY()).toBe(window.scrollY || window.pageYOffset)
+      expect(getScrollX()).toBe(Math.round(window.scrollX || window.pageXOffset))
+      expect(getScrollY()).toBe(Math.round(window.scrollY || window.pageYOffset))
     })
   })
 })

--- a/test/unit/browsers.conf.ts
+++ b/test/unit/browsers.conf.ts
@@ -45,7 +45,7 @@ export const browserConfigurations: BrowserConfiguration[] = [
     sessionName: 'Chrome mobile',
     name: 'chrome',
     os: 'android',
-    osVersion: '12.0',
-    device: 'Google Pixel 6',
+    osVersion: '15.0',
+    device: 'Google Pixel 6 Pro',
   },
 ]

--- a/test/unit/browsers.conf.ts
+++ b/test/unit/browsers.conf.ts
@@ -45,7 +45,7 @@ export const browserConfigurations: BrowserConfiguration[] = [
     sessionName: 'Chrome mobile',
     name: 'chrome',
     os: 'android',
-    osVersion: '15.0',
-    device: 'Google Pixel 6 Pro',
+    osVersion: '12.0',
+    device: 'Google Pixel 6',
   },
 ]

--- a/test/unit/browsers.conf.ts
+++ b/test/unit/browsers.conf.ts
@@ -46,6 +46,6 @@ export const browserConfigurations: BrowserConfiguration[] = [
     name: 'chrome',
     os: 'android',
     osVersion: '12.0',
-    device: 'Google Pixel 6 Pro',
+    device: 'Google Pixel 6',
   },
 ]


### PR DESCRIPTION
## Motivation

Our current `chrome-mobile` config got deprecated.
<img width="2358" height="624" alt="image" src="https://github.com/user-attachments/assets/6b09da16-c1e9-428f-bdf0-547ed4571d32" />
> osVersion: '12.0',
> device: 'Google Pixel 6 Pro',

So we are moving to the following which is [supported](https://www.browserstack.com/list-of-browsers-and-platforms/js_testing)
> osVersion: '12.0',
> device: 'Google Pixel 6',


## Changes

1. Changes `browser.conf.ts`
2. Fixes failing scroll test by `Math.round` the `window.scroll`
<img width="704" height="167" alt="Screenshot 2026-05-28 at 12 01 07" src="https://github.com/user-attachments/assets/e9722d02-fd1d-4505-a909-8e5fd6b419d2" />



## Test instructions

CI should pass. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [X] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
