### PR TITLE
🐛 [PANA-7563] Fix maximum call stack exceeded error when processing mutations

### DIFF
--- a/packages/rum/src/domain/record/mutationBatch.ts
+++ b/packages/rum/src/domain/record/mutationBatch.ts
@@ -34,7 +34,9 @@ export function createMutationBatch(processMutationBatch: (mutations: RumMutatio
       if (pendingMutations.length === 0) {
         cancelScheduledFlush = requestIdleCallback(throttledFlush, { timeout: MUTATION_PROCESS_MAX_DELAY })
       }
-      pendingMutations.push(...mutations)
+      for (const mutation of mutations) {
+        pendingMutations.push(mutation)
+      }
     },
 
     flush,


### PR DESCRIPTION
## Motivation

When we are notified of a batch of mutations by `MutationObserver`, we push them onto a queue using code that looks like this:
```
pendingMutations.push(...mutation)
```

This passes each mutation as a separate argument to `Array#push()`, requiring stack space proportional to the number of mutations. If the number of mutations is huge, as it sometimes is, this can cause a `Maximum call stack exceeded` error to be fired.

## Changes

This PR makes us push each mutation onto the queue separately in a loop. This avoids the risk of generating a `Maximum call stack exceeded` error. While this is [a bit slower](https://benchmarklab.azurewebsites.net/Benchmarks/Show/35778/0/pushing-onto-an-array-in-a-loop-vs-pushing-with-the-spr#latest_results_block), it's still quite fast, so in practice there should be little downside to this change.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
