### PR TITLE
🧹 telemetry maintenance: drop unused instrumentation, bump expirations

### DIFF
--- a/packages/core/src/domain/session/sessionManager.ts
+++ b/packages/core/src/domain/session/sessionManager.ts
@@ -18,14 +18,11 @@ import { noop, throttle } from '../../tools/utils/functionUtils'
 import { generateUUID } from '../../tools/utils/stringUtils'
 import type { Configuration } from '../configuration'
 import type { TrackingConsentState } from '../trackingConsent'
-import { globalObject, isWorkerEnvironment } from '../../tools/globalObject'
+import { isWorkerEnvironment } from '../../tools/globalObject'
 import { display } from '../../tools/display'
 import { isSampled } from '../sampler'
 import { TelemetryMetrics, addTelemetryMetrics } from '../telemetry'
 import { monitorError } from '../../tools/monitor'
-import { getCookies } from '../../browser/cookie'
-import { ExperimentalFeature, isExperimentalFeatureEnabled } from '../../tools/experimentalFeatures'
-import { SESSION_STORE_KEY } from './storeStrategies/sessionStoreStrategy'
 import { SESSION_TIME_OUT_DELAY } from './sessionConstants'
 import type { SessionState } from './sessionState'
 import {
@@ -42,24 +39,10 @@ import { getSessionStoreStrategy, selectSessionStoreStrategyType } from './sessi
 export interface SessionManager {
   findSession: (startTime?: RelativeTime, options?: { returnInactive: boolean }) => SessionContext | undefined
   findTrackedSession: (startTime?: RelativeTime, options?: { returnInactive: boolean }) => SessionContext | undefined
-  renewObservable: Observable<SessionRenewalEvent | undefined>
+  renewObservable: Observable<void>
   expireObservable: Observable<void>
   expire: () => void
   updateSessionState: (state: Partial<SessionState>) => void
-}
-
-interface SessionDebugContext {
-  previousSession?: SessionContext
-  newState: SessionState
-  from: string
-  cookieValues: string[] | undefined
-  cookies: string[]
-  locksAvailable: boolean
-  cookieStoreAvailable: boolean
-}
-export interface SessionRenewalEvent {
-  expire: SessionDebugContext | undefined
-  renew: SessionDebugContext
 }
 
 export interface SessionContext {
@@ -89,9 +72,8 @@ export async function startSessionManager(
   trackingConsentState: TrackingConsentState
 ): Promise<SessionManager | undefined> {
   const startTime = relativeNow()
-  const renewObservable = new Observable<SessionRenewalEvent | undefined>()
+  const renewObservable = new Observable<void>()
   const expireObservable = new Observable<void>()
-  let expireContext: SessionDebugContext | undefined
 
   const sessionStoreStrategyType = await mockable(selectSessionStoreStrategyType)(configuration)
   if (!sessionStoreStrategyType) {
@@ -170,9 +152,9 @@ export async function startSessionManager(
   }
 
   function subscribeToSessionChanges() {
-    const subscription = strategy.sessionObservable.subscribe(({ cookieValues, sessionState }) => {
+    const subscription = strategy.sessionObservable.subscribe((sessionState) => {
       scheduleExpirationTimeout(sessionState)
-      handleStateChange(sessionState, { from: 'sessionObservable', cookieValues })
+      handleStateChange(sessionState)
     })
     stopCallbacks.push(() => subscription.unsubscribe())
   }
@@ -256,10 +238,7 @@ export async function startSessionManager(
     }
   }
 
-  function handleStateChange(
-    newState: SessionState,
-    { from, cookieValues }: { from: string; cookieValues?: string[] }
-  ) {
+  function handleStateChange(newState: SessionState) {
     const previousSession = sessionContextHistory.find()
     const hadSession = previousSession?.id !== undefined
     const hasSession = newState.id !== undefined
@@ -267,17 +246,6 @@ export async function startSessionManager(
 
     if (hadSession && (!hasSession || sessionIdChanged)) {
       // Session expired or replaced
-      if (isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_RENEWAL_DEBUG_CONTEXT)) {
-        expireContext = {
-          previousSession: previousSession && { ...previousSession },
-          newState: { ...newState },
-          from,
-          cookieValues,
-          cookies: getCookies(SESSION_STORE_KEY),
-          locksAvailable: Boolean(globalObject.navigator?.locks),
-          cookieStoreAvailable: Boolean(globalObject.cookieStore),
-        }
-      }
       sessionExpired = true
       expireObservable.notify()
       sessionContextHistory.closeActive(relativeNow())
@@ -290,22 +258,7 @@ export async function startSessionManager(
       }
       // New session appeared
       sessionContextHistory.add(buildSessionContext(newState), relativeNow())
-      renewObservable.notify(
-        isExperimentalFeatureEnabled(ExperimentalFeature.SESSION_RENEWAL_DEBUG_CONTEXT)
-          ? {
-              expire: expireContext,
-              renew: {
-                previousSession: previousSession && { ...previousSession },
-                newState: { ...newState },
-                from,
-                cookieValues,
-                cookies: getCookies(SESSION_STORE_KEY),
-                locksAvailable: Boolean(globalObject.navigator?.locks),
-                cookieStoreAvailable: Boolean(globalObject.cookieStore),
-              },
-            }
-          : undefined
-      )
+      renewObservable.notify()
     } else if (hadSession && hasSession && !sessionIdChanged) {
       // Same session,
       // Mutate the session context in the history for replay forced changes
@@ -321,7 +274,7 @@ export async function startSessionManager(
     if (!trackingConsentState.isGranted()) {
       delete expiredState.anonymousId
     }
-    handleStateChange(expiredState, { from: 'expire' })
+    handleStateChange(expiredState)
     // Persist to storage asynchronously
     strategy
       .setSessionState((state) => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -138,7 +138,7 @@ describe('session in cookie strategy', () => {
       mockCookie.simulateExternalChange('id=test&c=0')
       await collectAsyncCalls(spy, 1)
 
-      expect(spy.calls.mostRecent().args[0].sessionState.c).toBeUndefined()
+      expect(spy.calls.mostRecent().args[0].c).toBeUndefined()
     })
 
     it('should notify observable when cookie is cleared', async () => {
@@ -150,7 +150,7 @@ describe('session in cookie strategy', () => {
       mockCookie.simulateExternalChange('')
       await collectAsyncCalls(spy, 1)
 
-      expect(spy.calls.mostRecent().args[0]).toEqual({ cookieValues: [], sessionState: {} })
+      expect(spy.calls.mostRecent().args[0]).toEqual({})
     })
 
     it('should notify sessionObservable after write', async () => {
@@ -162,7 +162,7 @@ describe('session in cookie strategy', () => {
       await strategy.setSessionState(() => ({ id: '123' }), 'updateState')
       await collectAsyncCalls(spy, 1)
 
-      expect(spy.calls.mostRecent().args[0].sessionState).toEqual({ id: '123' })
+      expect(spy.calls.mostRecent().args[0]).toEqual({ id: '123' })
     })
 
     it('should queue setSessionState calls and process them sequentially', async () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -19,7 +19,6 @@ import { CookieApi, LEGACY_SESSION_STORE_KEY, SESSION_STORE_KEY } from './sessio
 import type {
   SessionStoreStrategy,
   SessionStoreStrategyType,
-  SessionObservableEvent,
   CookieSessionStoreStrategyType,
   SessionStateOperation,
 } from './sessionStoreStrategy'
@@ -56,7 +55,7 @@ export function initCookieStrategy(
   configuration: Configuration
 ): SessionStoreStrategy {
   const { cookieOptions, cookieApi } = sessionStoreStrategyType
-  const sessionObservable = new Observable<SessionObservableEvent>()
+  const sessionObservable = new Observable<SessionState>()
   const trackAnonymousUser = !!configuration.trackAnonymousUser
   const opts = encodeCookieOptions(cookieOptions)
   const cookieAccess = mockable(createCookieAccess)(cookieApi, configuration, cookieOptions)
@@ -66,7 +65,7 @@ export function initCookieStrategy(
     cookieAccess
       .getAll()
       .then((cookieValues) => {
-        sessionObservable.notify({ cookieValues, sessionState: findMatchingSessionState(cookieValues, opts) })
+        sessionObservable.notify(findMatchingSessionState(cookieValues, opts))
       })
       .catch((error) => monitorError(new Error(`Error while reading session cookies on change: ${error}`)))
   })

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -55,9 +55,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
 
       await strategy.setSessionState((state) => ({ ...state, id: 'test-id' }), 'updateState')
 
-      expect(spy).toHaveBeenCalledOnceWith(
-        jasmine.objectContaining({ sessionState: jasmine.objectContaining({ id: 'test-id' }) })
-      )
+      expect(spy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: 'test-id' }))
     })
   })
 
@@ -75,9 +73,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
       })
       window.dispatchEvent(event)
 
-      expect(spy).toHaveBeenCalledOnceWith(
-        jasmine.objectContaining({ sessionState: jasmine.objectContaining({ id: 'from-other-tab' }) })
-      )
+      expect(spy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: 'from-other-tab' }))
     })
 
     it('should ignore storage events for other keys', () => {

--- a/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -5,12 +5,7 @@ import type { Configuration } from '../../configuration'
 import { SessionPersistence } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
 import { isSessionInNotStartedState, toSessionString, toSessionState } from '../sessionState'
-import type {
-  SessionStateOperation,
-  SessionStoreStrategy,
-  SessionStoreStrategyType,
-  SessionObservableEvent,
-} from './sessionStoreStrategy'
+import type { SessionStateOperation, SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 import { SESSION_STORE_KEY, LEGACY_SESSION_STORE_KEY } from './sessionStoreStrategy'
 
 const LOCAL_STORAGE_TEST_KEY = '_dd_test_'
@@ -29,11 +24,11 @@ export function selectLocalStorageStrategy(): SessionStoreStrategyType | undefin
 }
 
 export function initLocalStorageStrategy(configuration: Configuration): SessionStoreStrategy {
-  const sessionObservable = new Observable<SessionObservableEvent>(
+  const sessionObservable = new Observable<SessionState>(
     (observable) =>
       addEventListener(configuration, window, 'storage', (event) => {
         if (event.key === SESSION_STORE_KEY && event.storageArea === localStorage) {
-          observable.notify({ sessionState: toSessionState(event.newValue) })
+          observable.notify(toSessionState(event.newValue))
         }
       }).stop
   )
@@ -55,7 +50,7 @@ export function initLocalStorageStrategy(configuration: Configuration): SessionS
       const newState = fn(currentState)
       localStorage.setItem(SESSION_STORE_KEY, toSessionString(newState))
       await Promise.resolve()
-      sessionObservable.notify({ sessionState: newState })
+      sessionObservable.notify(newState)
     },
     sessionObservable,
   }

--- a/packages/core/src/domain/session/storeStrategies/sessionInMemory.spec.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInMemory.spec.ts
@@ -37,9 +37,7 @@ describe('Memory SessionStoreStrategy', () => {
 
       await strategy.setSessionState((state) => ({ ...state, id: 'test-id' }), 'updateState')
 
-      expect(spy).toHaveBeenCalledOnceWith(
-        jasmine.objectContaining({ sessionState: jasmine.objectContaining({ id: 'test-id' }) })
-      )
+      expect(spy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: 'test-id' }))
     })
   })
 
@@ -51,9 +49,7 @@ describe('Memory SessionStoreStrategy', () => {
       strategy.sessionObservable.subscribe(spy)
       await strategy2.setSessionState((state) => ({ ...state, id: 'from-strategy2' }), 'updateState')
 
-      expect(spy).toHaveBeenCalledOnceWith(
-        jasmine.objectContaining({ sessionState: jasmine.objectContaining({ id: 'from-strategy2' }) })
-      )
+      expect(spy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: 'from-strategy2' }))
     })
   })
 

--- a/packages/core/src/domain/session/storeStrategies/sessionInMemory.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionInMemory.ts
@@ -3,12 +3,7 @@ import { Observable } from '../../../tools/observable'
 import { shallowClone } from '../../../tools/utils/objectUtils'
 import { SessionPersistence } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
-import type {
-  SessionStateOperation,
-  SessionStoreStrategy,
-  SessionStoreStrategyType,
-  SessionObservableEvent,
-} from './sessionStoreStrategy'
+import type { SessionStateOperation, SessionStoreStrategy, SessionStoreStrategyType } from './sessionStoreStrategy'
 
 export const MEMORY_SESSION_STORE_KEY = '_DD_SESSION'
 
@@ -34,14 +29,14 @@ export function initMemorySessionStoreStrategy(): SessionStoreStrategy {
   }
   const memorySession = globalObjectWithSession[MEMORY_SESSION_STORE_KEY]
 
-  const sessionObservable = new Observable<SessionObservableEvent>()
+  const sessionObservable = new Observable<SessionState>()
 
   // Wire the local observable to the shared onChange callback so that
   // multiple SDK instances (RUM + Logs) can observe each other's changes.
   const previousOnChange = memorySession.onChange
   memorySession.onChange = (state: SessionState) => {
     previousOnChange?.(state)
-    sessionObservable.notify({ sessionState: state })
+    sessionObservable.notify(state)
   }
 
   return {

--- a/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
+++ b/packages/core/src/domain/session/storeStrategies/sessionStoreStrategy.ts
@@ -22,11 +22,6 @@ export type SessionStoreStrategyType =
   | { type: typeof SessionPersistence.LOCAL_STORAGE }
   | { type: typeof SessionPersistence.MEMORY }
 
-export interface SessionObservableEvent {
-  cookieValues?: string[]
-  sessionState: SessionState
-}
-
 export type SessionStateOperation =
   | 'initialize'
   | 'expandOrRenewOnActivity'
@@ -39,5 +34,5 @@ export type SessionStateOperation =
 
 export interface SessionStoreStrategy {
   setSessionState(fn: (sessionState: SessionState) => SessionState, operation: SessionStateOperation): Promise<void>
-  sessionObservable: Observable<SessionObservableEvent>
+  sessionObservable: Observable<SessionState>
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,7 +51,7 @@ export {
 export { monitored, monitor, callMonitored, setDebugMode, monitorError } from './tools/monitor'
 export type { Subscription } from './tools/observable'
 export { Observable, BufferedObservable } from './tools/observable'
-export type { SessionManager, SessionContext, SessionRenewalEvent } from './domain/session/sessionManager'
+export type { SessionManager, SessionContext } from './domain/session/sessionManager'
 export { startSessionManager, startSessionManagerStub, stopSessionManager } from './domain/session/sessionManager'
 export {
   SESSION_TIME_OUT_DELAY, // Exposed for tests

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -15,7 +15,6 @@ import { objectHasValue } from './utils/objectUtils'
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
-  TOO_MANY_REQUESTS_INVESTIGATION = 'too_many_requests_investigation',
   SESSION_RENEWAL_DEBUG_CONTEXT = 'session_renewal_debug_context',
   PARTIAL_VIEW_UPDATES = 'partial_view_updates',
 }

--- a/packages/core/src/tools/experimentalFeatures.ts
+++ b/packages/core/src/tools/experimentalFeatures.ts
@@ -15,7 +15,6 @@ import { objectHasValue } from './utils/objectUtils'
 // eslint-disable-next-line no-restricted-syntax
 export enum ExperimentalFeature {
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
-  SESSION_RENEWAL_DEBUG_CONTEXT = 'session_renewal_debug_context',
   PARTIAL_VIEW_UPDATES = 'partial_view_updates',
 }
 

--- a/packages/core/test/fakeSessionStoreStrategy.ts
+++ b/packages/core/test/fakeSessionStoreStrategy.ts
@@ -1,9 +1,6 @@
 import { Observable } from '../src/tools/observable'
 import type { SessionState } from '../src/domain/session/sessionState'
-import type {
-  SessionStoreStrategy,
-  SessionObservableEvent,
-} from '../src/domain/session/storeStrategies/sessionStoreStrategy'
+import type { SessionStoreStrategy } from '../src/domain/session/storeStrategies/sessionStoreStrategy'
 
 export type FakeSessionStoreStrategy = SessionStoreStrategy & {
   setSessionState: jasmine.Spy<(fn: (state: SessionState) => SessionState) => Promise<void>>
@@ -15,7 +12,7 @@ export function createFakeSessionStoreStrategy({
   initialSession = {},
 }: { initialSession?: SessionState } = {}): FakeSessionStoreStrategy {
   let session: SessionState = initialSession
-  const sessionObservable = new Observable<SessionObservableEvent>()
+  const sessionObservable = new Observable<SessionState>()
 
   return {
     setSessionState: jasmine
@@ -23,7 +20,7 @@ export function createFakeSessionStoreStrategy({
       .and.callFake(async (fn: (state: SessionState) => SessionState): Promise<void> => {
         session = fn({ ...session })
         await Promise.resolve()
-        sessionObservable.notify({ sessionState: { ...session } })
+        sessionObservable.notify({ ...session })
       }),
     sessionObservable,
 
@@ -31,7 +28,7 @@ export function createFakeSessionStoreStrategy({
     getInternalState: () => ({ ...session }),
     simulateExternalChange: (state: SessionState) => {
       session = state
-      sessionObservable.notify({ sessionState: { ...session } })
+      sessionObservable.notify({ ...session })
     },
   }
 }

--- a/packages/rum-core/src/boot/startRum.spec.ts
+++ b/packages/rum-core/src/boot/startRum.spec.ts
@@ -1,4 +1,4 @@
-import type { RawError, Duration, BufferedData, SessionManager, SessionRenewalEvent } from '@datadog/browser-core'
+import type { RawError, Duration, BufferedData, SessionManager } from '@datadog/browser-core'
 import {
   Observable,
   toServerDuration,
@@ -87,7 +87,7 @@ describe('rum session', () => {
     expect(serverRumEvents.length).toEqual(2)
 
     sessionManager.setId('43')
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
     expect(serverRumEvents.length).toEqual(3)
 

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -74,7 +74,7 @@ export function startRum(
   lifeCycle.subscribe(LifeCycleEventType.RUM_EVENT_COLLECTED, (event) => sendToExtension('rum', event))
 
   sessionManager.expireObservable.subscribe(() => lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED))
-  sessionManager.renewObservable.subscribe((event) => lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, event))
+  sessionManager.renewObservable.subscribe(() => lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED))
 
   const reportError = (error: RawError) => {
     lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })

--- a/packages/rum-core/src/domain/contexts/viewHistory.spec.ts
+++ b/packages/rum-core/src/domain/contexts/viewHistory.spec.ts
@@ -1,4 +1,4 @@
-import type { RelativeTime, SessionRenewalEvent } from '@datadog/browser-core'
+import type { RelativeTime } from '@datadog/browser-core'
 import { relativeToClocks, CLEAR_OLD_VALUES_INTERVAL } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
@@ -136,7 +136,7 @@ describe('ViewHistory', () => {
       expect(viewHistory.findView(15 as RelativeTime)).toBeDefined()
       expect(viewHistory.findView(25 as RelativeTime)).toBeDefined()
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(viewHistory.findView(15 as RelativeTime)).toBeUndefined()
       expect(viewHistory.findView(25 as RelativeTime)).toBeUndefined()

--- a/packages/rum-core/src/domain/eventTracker.spec.ts
+++ b/packages/rum-core/src/domain/eventTracker.spec.ts
@@ -1,4 +1,4 @@
-import type { Duration, RelativeTime, TimeStamp, SessionRenewalEvent } from '@datadog/browser-core'
+import type { Duration, RelativeTime, TimeStamp } from '@datadog/browser-core'
 import { clocksNow } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
@@ -149,7 +149,7 @@ describe('eventTracker', () => {
 
       tracker.stopAll()
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(tracker.findId()).toEqual([])
     })

--- a/packages/rum-core/src/domain/lifeCycle.ts
+++ b/packages/rum-core/src/domain/lifeCycle.ts
@@ -1,11 +1,4 @@
-import type {
-  ClocksState,
-  Context,
-  Duration,
-  PageMayExitEvent,
-  RawError,
-  SessionRenewalEvent,
-} from '@datadog/browser-core'
+import type { ClocksState, Context, Duration, PageMayExitEvent, RawError } from '@datadog/browser-core'
 import { AbstractLifeCycle } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type { RawRumEvent, AssembledRumEvent } from '../rawRumEvent.types'
@@ -96,7 +89,7 @@ export interface LifeCycleEventMap {
   [LifeCycleEventTypeAsConst.REQUEST_STARTED]: RequestStartEvent
   [LifeCycleEventTypeAsConst.REQUEST_COMPLETED]: RequestCompleteEvent
   [LifeCycleEventTypeAsConst.SESSION_EXPIRED]: void
-  [LifeCycleEventTypeAsConst.SESSION_RENEWED]: SessionRenewalEvent | undefined
+  [LifeCycleEventTypeAsConst.SESSION_RENEWED]: void
   [LifeCycleEventTypeAsConst.PAGE_MAY_EXIT]: PageMayExitEvent
   [LifeCycleEventTypeAsConst.RAW_RUM_EVENT_COLLECTED]: RawRumEventCollectedData
   [LifeCycleEventTypeAsConst.RUM_EVENT_COLLECTED]: AssembledRumEvent

--- a/packages/rum-core/src/domain/resource/requestRegistry.spec.ts
+++ b/packages/rum-core/src/domain/resource/requestRegistry.spec.ts
@@ -1,7 +1,5 @@
 import type { Duration, RelativeTime, TimeStamp } from '@datadog/browser-core'
-import { addExperimentalFeatures, ExperimentalFeature, RequestType } from '@datadog/browser-core'
-import type { Clock, MockTelemetry } from '@datadog/browser-core/test'
-import { mockClock, startMockTelemetry } from '@datadog/browser-core/test'
+import { RequestType } from '@datadog/browser-core'
 import { createPerformanceEntry } from '../../../test'
 import { RumPerformanceEntryType } from '../../browser/performanceObservable'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
@@ -62,85 +60,6 @@ describe('RequestRegistry', () => {
       lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, createRequestCompleteEvent({ startTime: i }))
     }
     expect(requestRegistry.getMatchingRequest(createResourceEntry({ startTime: 0 }))).toBeUndefined()
-  })
-
-  describe('when the registry overflows', () => {
-    let telemetry: MockTelemetry
-    let lifeCycle: LifeCycle
-
-    beforeEach(() => {
-      telemetry = startMockTelemetry()
-      lifeCycle = new LifeCycle()
-      createRequestRegistry(lifeCycle)
-    })
-
-    it('fires "Too many requests" telemetry only once', async () => {
-      for (let i = 0; i < MAX_REQUESTS + 3; i++) {
-        lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, createRequestCompleteEvent({ startTime: i }))
-      }
-      expect(await telemetry.getEvents()).toEqual([jasmine.objectContaining({ message: 'Too many requests' })])
-    })
-
-    it('includes debug context when TOO_MANY_REQUESTS_INVESTIGATION is enabled', async () => {
-      const clock: Clock = mockClock()
-      addExperimentalFeatures([ExperimentalFeature.TOO_MANY_REQUESTS_INVESTIGATION])
-      let fetchCount = 0
-      let xhrCount = 0
-      let abortedCount = 0
-      let abortedOnStartCount = 0
-
-      // oldest request: created at t=0, FETCH, takes 50ms
-      lifeCycle.notify(
-        LifeCycleEventType.REQUEST_COMPLETED,
-        createRequestCompleteEvent({ startTime: 0, timeStamp: clock.timeStamp(0), duration: 50 as Duration })
-      )
-      fetchCount++
-
-      clock.tick(1000)
-
-      // 1 XHR request
-      lifeCycle.notify(
-        LifeCycleEventType.REQUEST_COMPLETED,
-        createRequestCompleteEvent({ startTime: MAX_REQUESTS - 1, type: RequestType.XHR })
-      )
-      xhrCount++
-
-      // aborted
-      lifeCycle.notify(
-        LifeCycleEventType.REQUEST_COMPLETED,
-        createRequestCompleteEvent({ startTime: MAX_REQUESTS, isAborted: true })
-      )
-      fetchCount++
-      abortedCount++
-
-      // aborted on start
-      lifeCycle.notify(
-        LifeCycleEventType.REQUEST_COMPLETED,
-        createRequestCompleteEvent({ startTime: MAX_REQUESTS, isAborted: true, isAbortedOnStart: true })
-      )
-      fetchCount++
-      abortedCount++
-      abortedOnStartCount++
-
-      // trigger requests until we reach the limit
-      while (fetchCount + xhrCount <= MAX_REQUESTS) {
-        lifeCycle.notify(LifeCycleEventType.REQUEST_COMPLETED, createRequestCompleteEvent({ startTime: 10 }))
-        fetchCount++
-      }
-
-      expect(await telemetry.getEvents()).toEqual([
-        jasmine.objectContaining({
-          message: 'Too many requests',
-          abortedCount,
-          abortedOnStartCount,
-          xhrCount,
-          fetchCount,
-          oldestRequestAge: 1000,
-          oldestRequestEndAge: 950,
-          withoutMatchingEntryCount: MAX_REQUESTS + 1,
-        }),
-      ])
-    })
   })
 
   function createRequestCompleteEvent({

--- a/packages/rum-core/src/domain/resource/requestRegistry.ts
+++ b/packages/rum-core/src/domain/resource/requestRegistry.ts
@@ -1,11 +1,3 @@
-import type { Context } from '@datadog/browser-core'
-import {
-  addTelemetryDebug,
-  ExperimentalFeature,
-  isExperimentalFeatureEnabled,
-  RequestType,
-  timeStampNow,
-} from '@datadog/browser-core'
 import type { RumPerformanceResourceTiming } from '../../browser/performanceObservable'
 import type { LifeCycle } from '../lifeCycle'
 import { LifeCycleEventType } from '../lifeCycle'
@@ -22,57 +14,12 @@ export const MAX_REQUESTS = 1000
 
 export function createRequestRegistry(lifeCycle: LifeCycle): RequestRegistry {
   const requests = new Set<RequestCompleteEvent>()
-  let tooManyRequestsReported = false
 
   const subscription = lifeCycle.subscribe(LifeCycleEventType.REQUEST_COMPLETED, (request) => {
     requests.add(request)
 
     if (requests.size > MAX_REQUESTS) {
-      const oldestRequest = requests.values().next().value!
-
-      if (!tooManyRequestsReported) {
-        tooManyRequestsReported = true
-
-        let debugContext: Context | undefined
-
-        if (isExperimentalFeatureEnabled(ExperimentalFeature.TOO_MANY_REQUESTS_INVESTIGATION)) {
-          let abortedCount = 0
-          let abortedOnStartCount = 0
-          let xhrCount = 0
-          let withoutMatchingEntryCount = 0
-          for (const r of requests) {
-            if (r.isAborted) {
-              abortedCount++
-            }
-            if (r.isAbortedOnStart) {
-              abortedOnStartCount++
-            }
-            if (r.type === RequestType.XHR) {
-              xhrCount++
-            }
-            const entries = performance.getEntriesByName(r.url, 'resource') as PerformanceResourceTiming[]
-            const hasMatchingEntry = entries.some((e) => e.startTime >= r.startClocks.relative)
-            if (!hasMatchingEntry) {
-              withoutMatchingEntryCount++
-            }
-          }
-          const oldestRequestAge = timeStampNow() - oldestRequest.startClocks.timeStamp
-          debugContext = {
-            abortedCount,
-            abortedOnStartCount,
-            xhrCount,
-            fetchCount: requests.size - xhrCount,
-            oldestRequestAge,
-            oldestRequestEndAge: oldestRequestAge - oldestRequest.duration,
-            withoutMatchingEntryCount,
-          }
-        }
-
-        // monitor-until: 2026-06-01, after early request collection is the default in v7
-        addTelemetryDebug('Too many requests', debugContext)
-      }
-
-      requests.delete(oldestRequest)
+      requests.delete(requests.values().next().value!)
     }
   })
 

--- a/packages/rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/rum-core/src/domain/resource/resourceCollection.ts
@@ -364,7 +364,7 @@ function filterHeaders(headers: Headers, matchers: MatchHeader[]): NetworkHeader
       display.warn(
         `Header "${lowerName}" value was truncated from ${capturedValue.length} to ${MAX_HEADER_VALUE_LENGTH} characters.`
       )
-      // monitor-until: 2026-05-23
+      // monitor-until: 2026-07-23
       addTelemetryDebug('Resource header value was truncated', {
         header_name: lowerName,
         original_length: capturedValue.length,
@@ -377,7 +377,7 @@ function filterHeaders(headers: Headers, matchers: MatchHeader[]): NetworkHeader
   })
 
   if (hasReachedMaxHeaderCount) {
-    // monitor-until: 2026-05-23
+    // monitor-until: 2026-07-23
     addTelemetryDebug('Maximum number of resource headers reached', {
       collectedHeaderCount,
       totalHeaderCount,

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -1,4 +1,4 @@
-import type { Duration, RelativeTime, SessionRenewalEvent } from '@datadog/browser-core'
+import type { Duration, RelativeTime } from '@datadog/browser-core'
 import { PageExitReason, timeStampNow, display, relativeToClocks, relativeNow } from '@datadog/browser-core'
 
 import type { Clock } from '@datadog/browser-core/test'
@@ -217,7 +217,7 @@ describe('view lifecycle', () => {
       expect(getViewCreateCount()).toBe(1)
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(getViewCreateCount()).toBe(2)
     })
@@ -226,7 +226,7 @@ describe('view lifecycle', () => {
       const { getViewUpdate, getViewUpdateCount } = viewTest
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(getViewUpdate(getViewUpdateCount() - 1).loadingType).toBe(ViewLoadingType.SESSION_RENEWAL)
     })
@@ -234,17 +234,17 @@ describe('view lifecycle', () => {
     it('should use the current view name, service and version for the new view', () => {
       const { getViewCreateCount, getViewCreate, startView } = viewTest
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       startView({ name: 'view 1', service: 'service 1', version: 'version 1' })
       startView({ name: 'view 2', service: 'service 2', version: 'version 2' })
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       startView({ name: 'view 3', service: 'service 3', version: 'version 3' })
       changeLocation('/bar')
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
       expect(getViewCreateCount()).toBe(8)
 

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -149,19 +149,13 @@ export function trackViews(
   }
 
   function startViewLifeCycle() {
-    lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, (event) => {
-      const context = currentView.contextManager.getContext()
-      if (event) {
-        context.is_session_renewal = true
-        context.renew_event = event as any
-      }
-
+    lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
       currentView = startNewView(ViewLoadingType.SESSION_RENEWAL, undefined, {
         // Renew view on session renewal
         name: currentView.name,
         service: currentView.service,
         version: currentView.version,
-        context,
+        context: currentView.contextManager.getContext(),
       })
     })
 

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -4,7 +4,6 @@ import type {
   DeflateWorkerAction,
   RawTelemetryEvent,
   SessionManager,
-  SessionRenewalEvent,
   Telemetry,
 } from '@datadog/browser-core'
 import { BridgeCapability, display, resetSampleDecisionCache } from '@datadog/browser-core'
@@ -373,7 +372,7 @@ describe('makeRecorderApi', () => {
           sessionManager.setId(LOW_HASH_UUID)
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
           expect(startRecordingSpy).not.toHaveBeenCalled()
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           await collectAsyncCalls(startRecordingSpy, 1)
 
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
@@ -385,7 +384,7 @@ describe('makeRecorderApi', () => {
           recorderApi.stop()
           sessionManager.setId(LOW_HASH_UUID)
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -401,7 +400,7 @@ describe('makeRecorderApi', () => {
           rumInit()
           sessionManager.setNotTracked()
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -417,7 +416,7 @@ describe('makeRecorderApi', () => {
         it('keeps not recording if startSessionReplayRecording was called', () => {
           rumInit()
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -438,7 +437,7 @@ describe('makeRecorderApi', () => {
           sessionManager.setId(HIGH_HASH_UUID)
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
           expect(stopRecordingSpy).toHaveBeenCalled()
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).toHaveBeenCalledTimes(1)
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         })
@@ -448,7 +447,7 @@ describe('makeRecorderApi', () => {
           rumInit()
           sessionManager.setId(HIGH_HASH_UUID)
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           triggerOnDomLoaded()
           expect(importRecorderSpy).toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
@@ -467,7 +466,7 @@ describe('makeRecorderApi', () => {
           sessionManager.setNotTracked()
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
           expect(stopRecordingSpy).toHaveBeenCalled()
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).toHaveBeenCalledTimes(1)
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
         })
@@ -484,7 +483,7 @@ describe('makeRecorderApi', () => {
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
           expect(stopRecordingSpy).toHaveBeenCalled()
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           await collectAsyncCalls(startRecordingSpy, 2)
 
           expect(importRecorderSpy).toHaveBeenCalledTimes(2)
@@ -498,7 +497,7 @@ describe('makeRecorderApi', () => {
           recorderApi.stop()
           expect(stopRecordingSpy).toHaveBeenCalledTimes(1)
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).toHaveBeenCalledTimes(1)
           expect(startRecordingSpy).toHaveBeenCalledTimes(1)
           expect(stopRecordingSpy).toHaveBeenCalledTimes(1)
@@ -515,7 +514,7 @@ describe('makeRecorderApi', () => {
           rumInit()
           sessionManager.setTracked()
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           await collectAsyncCalls(startRecordingSpy, 1)
 
           expect(startRecordingSpy).toHaveBeenCalled()
@@ -527,7 +526,7 @@ describe('makeRecorderApi', () => {
           recorderApi.stop()
           sessionManager.setTracked()
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
           expect(stopRecordingSpy).not.toHaveBeenCalled()
@@ -545,7 +544,7 @@ describe('makeRecorderApi', () => {
           sessionManager.setTracked()
           sessionManager.setId(HIGH_HASH_UUID)
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
           expect(stopRecordingSpy).not.toHaveBeenCalled()
@@ -561,7 +560,7 @@ describe('makeRecorderApi', () => {
         it('keeps not recording if startSessionReplayRecording was called', () => {
           rumInit()
           lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+          lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
           expect(importRecorderSpy).not.toHaveBeenCalled()
           expect(startRecordingSpy).not.toHaveBeenCalled()
           expect(stopRecordingSpy).not.toHaveBeenCalled()

--- a/packages/rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/rum/src/domain/profiling/profiler.spec.ts
@@ -6,7 +6,7 @@ import {
   VitalType,
   createHooks,
 } from '@datadog/browser-rum-core'
-import type { Duration, SessionRenewalEvent, ProfilerTrace } from '@datadog/browser-core'
+import type { Duration, ProfilerTrace } from '@datadog/browser-core'
 import {
   addDuration,
   clocksNow,
@@ -810,7 +810,7 @@ describe('profiler', () => {
     expect(interceptor.requests.length).toBe(1)
 
     // Notify that the session has been renewed
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
     // Wait for profiler to restart
     await waitForBoolean(() => profiler.isRunning())
@@ -847,7 +847,7 @@ describe('profiler', () => {
     await waitForBoolean(() => interceptor.requests.length >= 1)
     expect(interceptor.requests.length).toBe(1)
 
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
     await waitForBoolean(() => profiler.isRunning())
     expect(profilingContextManager.get()?.status).toBe('running')
 
@@ -859,7 +859,7 @@ describe('profiler', () => {
     await waitForBoolean(() => interceptor.requests.length >= 2)
     expect(interceptor.requests.length).toBe(2)
 
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
     await waitForBoolean(() => profiler.isRunning())
     expect(profilingContextManager.get()?.status).toBe('running')
 
@@ -889,7 +889,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('stopped')
 
     // Notify that the session has been renewed
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
     // Wait a bit to ensure profiler doesn't restart
     await new Promise((resolve) => setTimeout(resolve, 100))
@@ -920,7 +920,7 @@ describe('profiler', () => {
     // Session renews IMMEDIATELY - even before async data collection completes
     // This simulates the scenario where user activity triggers renewal
     // while data is still being collected in the background
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
     // The profiler should restart because the sync state was already 'stopped'
     // when SESSION_RENEWED fired
@@ -956,7 +956,7 @@ describe('profiler', () => {
     expect(profiler.isStopped()).toBe(true)
 
     // Session is renewed — start() is called synchronously, so no need to wait
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
     // Profiler should remain stopped - user's explicit stop should take priority over session expiration
     expect(profiler.isStopped()).toBe(true)
@@ -1118,7 +1118,7 @@ describe('profiler', () => {
     expect(profilingContextManager.get()?.status).toBe('stopped')
 
     // Session is renewed
-    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+    lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
 
     // Wait for profiler to restart
     await waitForBoolean(() => profiler.isRunning())
@@ -1314,7 +1314,7 @@ describe('profiler', () => {
       await waitForBoolean(() => profiler.isRunning())
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
       await waitForBoolean(() => profiler.isRunning())
 
       resolveOldQuota({ decision: 'quota_ko', reason: 'quota_exceeded' })
@@ -1343,7 +1343,7 @@ describe('profiler', () => {
 
       expect(callCount).toBe(1)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
       await waitForBoolean(() => profiler.isRunning())
 
       expect(callCount).toBe(2)
@@ -1362,7 +1362,7 @@ describe('profiler', () => {
       profiler.stop()
       expect(profiler.isStopped()).toBe(true)
 
-      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED, {} as SessionRenewalEvent)
+      lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
       await waitNextMicrotask()
 
       expect(profiler.isStopped()).toBe(true)


### PR DESCRIPTION
## Motivation

Routine maintenance of our internal telemetry: remove temporary instrumentation
that has served its purpose, and extend the expiration window for instrumentation
we still rely on. This keeps the SDK free of dead investigation code and avoids
prematurely dropping telemetry we still need.

## Changes

- Remove the "Too many requests" telemetry and its `too_many_requests_investigation` experimental flag
- Remove the session renewal debug context and its `session_renewal_debug_context` experimental flag, reverting the session store observables to emit a plain session state
- Postpone the resource headers telemetry expiration by a couple of months

## Test instructions

No user-facing change.
