### PR TITLE
✨RUM-16635 Add wildcard host pattern matching to WebView event bridge

### DIFF
--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -1,7 +1,7 @@
 import { mockEventBridge } from '../../test'
 import { DefaultPrivacyLevel } from '../domain/configuration'
 import type { BrowserWindowWithEventBridge } from './eventBridge'
-import { getEventBridge, canUseEventBridge, BridgeCapability, bridgeSupports } from './eventBridge'
+import { getEventBridge, canUseEventBridge, matchesWildcardPattern, BridgeCapability, bridgeSupports } from './eventBridge'
 
 describe('canUseEventBridge', () => {
   const allowedWebViewHosts = ['foo.bar']
@@ -31,45 +31,34 @@ describe('canUseEventBridge', () => {
   })
 })
 
+describe('matchesWildcardPattern', () => {
+  // prettier-ignore
+  const cases: Array<[string, string, boolean]> = [
+    // [host,                          pattern,                  expected]
+    ['app.shopist.io',                 '*.shopist.io',           true],
+    ['preview-abc.shopist.io',         '*.shopist.io',           true],
+    ['shopist.io',                     '*.shopist.io',           false], // apex not matched by subdomain wildcard
+    ['shopist.io',                     'shopist.io',             true],  // exact match
+    ['app.shopist.io',                 'shopist.io',             false], // exact only, no subdomain
+    ['preview-abc123.shopist.io',      'preview-*.shopist.io',   true],
+    ['app.shopist.io',                 'preview-*.shopist.io',   false],
+    ['evil.com',                       '*.shopist.io',           false],
+    ['anything.foo.anything.bar',      '*.foo.*.bar',            false], // multiple wildcards → invalid
+  ]
+
+  cases.forEach(([host, pattern, expected]) => {
+    it(`"${host}" against "${pattern}" → ${expected}`, () => {
+      expect(matchesWildcardPattern(host, pattern)).toBe(expected)
+    })
+  })
+})
+
 describe('canUseEventBridge with wildcard patterns', () => {
-  it('should match a wildcard subdomain pattern', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io'] })
+  it('should use wildcard matching when getAllowedWebViewHostPatterns is present', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io', 'shopist.io'] })
     expect(canUseEventBridge('app.shopist.io')).toBeTrue()
-    expect(canUseEventBridge('preview-abc.shopist.io')).toBeTrue()
-  })
-
-  it('should not match the apex domain with a wildcard subdomain pattern', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io'] })
-    expect(canUseEventBridge('shopist.io')).toBeFalse()
-  })
-
-  it('should match the apex domain with an exact pattern', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['shopist.io'] })
     expect(canUseEventBridge('shopist.io')).toBeTrue()
-    expect(canUseEventBridge('app.shopist.io')).toBeFalse()
-  })
-
-  it('should match a prefix wildcard pattern', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['preview-*.shopist.io'] })
-    expect(canUseEventBridge('preview-abc123.shopist.io')).toBeTrue()
-    expect(canUseEventBridge('app.shopist.io')).toBeFalse()
-  })
-
-  it('should match across multiple patterns', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['shopist.io', '*.shopist.io'] })
-    expect(canUseEventBridge('shopist.io')).toBeTrue()
-    expect(canUseEventBridge('app.shopist.io')).toBeTrue()
-  })
-
-  it('should not match an unrelated host', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io'] })
     expect(canUseEventBridge('evil.com')).toBeFalse()
-  })
-
-  it('should skip a pattern with more than one wildcard and still evaluate others', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['*.foo.*.bar', 'shopist.io'] })
-    expect(canUseEventBridge('shopist.io')).toBeTrue()
-    expect(canUseEventBridge('anything.foo.anything.bar')).toBeFalse()
   })
 
   it('should prefer wildcard path over legacy path when getAllowedWebViewHostPatterns is present', () => {

--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -31,6 +31,58 @@ describe('canUseEventBridge', () => {
   })
 })
 
+describe('canUseEventBridge with wildcard patterns', () => {
+  it('should match a wildcard subdomain pattern', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io'] })
+    expect(canUseEventBridge('app.shopist.io')).toBeTrue()
+    expect(canUseEventBridge('preview-abc.shopist.io')).toBeTrue()
+  })
+
+  it('should not match the apex domain with a wildcard subdomain pattern', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io'] })
+    expect(canUseEventBridge('shopist.io')).toBeFalse()
+  })
+
+  it('should match the apex domain with an exact pattern', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['shopist.io'] })
+    expect(canUseEventBridge('shopist.io')).toBeTrue()
+    expect(canUseEventBridge('app.shopist.io')).toBeFalse()
+  })
+
+  it('should match a prefix wildcard pattern', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['preview-*.shopist.io'] })
+    expect(canUseEventBridge('preview-abc123.shopist.io')).toBeTrue()
+    expect(canUseEventBridge('app.shopist.io')).toBeFalse()
+  })
+
+  it('should match across multiple patterns', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['shopist.io', '*.shopist.io'] })
+    expect(canUseEventBridge('shopist.io')).toBeTrue()
+    expect(canUseEventBridge('app.shopist.io')).toBeTrue()
+  })
+
+  it('should not match an unrelated host', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io'] })
+    expect(canUseEventBridge('evil.com')).toBeFalse()
+  })
+
+  it('should skip a pattern with more than one wildcard and still evaluate others', () => {
+    mockEventBridge({ allowedWebViewHostPatterns: ['*.foo.*.bar', 'shopist.io'] })
+    expect(canUseEventBridge('shopist.io')).toBeTrue()
+    expect(canUseEventBridge('anything.foo.anything.bar')).toBeFalse()
+  })
+
+  it('should prefer wildcard path over legacy path when getAllowedWebViewHostPatterns is present', () => {
+    mockEventBridge({ allowedWebViewHosts: ['legacy.com'], allowedWebViewHostPatterns: ['shopist.io'] })
+    expect(canUseEventBridge('shopist.io')).toBeTrue()
+    expect(canUseEventBridge('legacy.com')).toBeFalse()
+  })
+
+  it('should not detect when bridge is absent', () => {
+    expect(canUseEventBridge('shopist.io')).toBeFalse()
+  })
+})
+
 describe('event bridge send', () => {
   let sendSpy: jasmine.Spy<(msg: string) => void>
 

--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -1,7 +1,13 @@
 import { mockEventBridge } from '../../test'
 import { DefaultPrivacyLevel } from '../domain/configuration'
 import type { BrowserWindowWithEventBridge } from './eventBridge'
-import { getEventBridge, canUseEventBridge, matchesWildcardPattern, BridgeCapability, bridgeSupports } from './eventBridge'
+import {
+  getEventBridge,
+  canUseEventBridge,
+  matchesWildcardPattern,
+  BridgeCapability,
+  bridgeSupports,
+} from './eventBridge'
 
 describe('canUseEventBridge', () => {
   const allowedWebViewHosts = ['foo.bar']

--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -60,17 +60,18 @@ describe('matchesWildcardPattern', () => {
 })
 
 describe('canUseEventBridge with wildcard patterns', () => {
-  it('should use wildcard matching when getAllowedWebViewHostPatterns is present', () => {
-    mockEventBridge({ allowedWebViewHostPatterns: ['*.shopist.io', 'shopist.io'] })
+  it('should match wildcard entries in getAllowedWebViewHosts', () => {
+    mockEventBridge({ allowedWebViewHosts: ['*.shopist.io', 'shopist.io'] })
     expect(canUseEventBridge('app.shopist.io')).toBeTrue()
     expect(canUseEventBridge('shopist.io')).toBeTrue()
     expect(canUseEventBridge('evil.com')).toBeFalse()
   })
 
-  it('should prefer wildcard path over legacy path when getAllowedWebViewHostPatterns is present', () => {
-    mockEventBridge({ allowedWebViewHosts: ['legacy.com'], allowedWebViewHostPatterns: ['shopist.io'] })
-    expect(canUseEventBridge('shopist.io')).toBeTrue()
-    expect(canUseEventBridge('legacy.com')).toBeFalse()
+  it('should match plain and wildcard entries together', () => {
+    mockEventBridge({ allowedWebViewHosts: ['legacy.com', '*.shopist.io'] })
+    expect(canUseEventBridge('legacy.com')).toBeTrue()
+    expect(canUseEventBridge('app.shopist.io')).toBeTrue()
+    expect(canUseEventBridge('evil.com')).toBeFalse()
   })
 
   it('should not detect when bridge is absent', () => {

--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -2,13 +2,7 @@ import { mockEventBridge } from '../../test'
 import { display } from '../tools/display'
 import { DefaultPrivacyLevel } from '../domain/configuration'
 import type { BrowserWindowWithEventBridge } from './eventBridge'
-import {
-  getEventBridge,
-  canUseEventBridge,
-  matchesWildcardPattern,
-  BridgeCapability,
-  bridgeSupports,
-} from './eventBridge'
+import { getEventBridge, canUseEventBridge, matchesHostEntry, BridgeCapability, bridgeSupports } from './eventBridge'
 
 describe('canUseEventBridge', () => {
   const allowedWebViewHosts = ['foo.bar']
@@ -38,7 +32,7 @@ describe('canUseEventBridge', () => {
   })
 })
 
-describe('matchesWildcardPattern', () => {
+describe('matchesHostEntry', () => {
   // prettier-ignore
   const cases: Array<[string, string, boolean]> = [
     // [host,                          pattern,                  expected]
@@ -46,17 +40,17 @@ describe('matchesWildcardPattern', () => {
     ['preview-abc.shopist.io',         '*.shopist.io',           true],
     ['shopist.io',                     '*.shopist.io',           false], // apex not matched by subdomain wildcard
     ['shopist.io',                     'shopist.io',             true],  // exact match
-    ['app.shopist.io',                 'shopist.io',             false], // exact only, no subdomain
+    ['app.shopist.io',                 'shopist.io',             true],  // subdomain-suffix match
     ['preview-abc123.shopist.io',      'preview-*.shopist.io',   true],
     ['app.shopist.io',                 'preview-*.shopist.io',   false],
     ['evil.com',                       '*.shopist.io',           false],
-    ['app.shopist.io.evil.com',                       '*.shopist.io',                       false],
+    ['app.shopist.io.evil.com',        '*.shopist.io',           false],
     ['anything.foo.anything.bar',      '*.foo.*.bar',            false], // multiple wildcards → invalid
   ]
 
   cases.forEach(([host, pattern, expected]) => {
     it(`"${host}" against "${pattern}" → ${expected}`, () => {
-      expect(matchesWildcardPattern(host, pattern)).toBe(expected)
+      expect(matchesHostEntry(host, pattern)).toBe(expected)
     })
   })
 })

--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -50,6 +50,7 @@ describe('matchesWildcardPattern', () => {
     ['preview-abc123.shopist.io',      'preview-*.shopist.io',   true],
     ['app.shopist.io',                 'preview-*.shopist.io',   false],
     ['evil.com',                       '*.shopist.io',           false],
+    ['app.shopist.io.evil.com',                       '*.shopist.io',                       false],
     ['anything.foo.anything.bar',      '*.foo.*.bar',            false], // multiple wildcards → invalid
   ]
 

--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -1,4 +1,5 @@
 import { mockEventBridge } from '../../test'
+import { display } from '../tools/display'
 import { DefaultPrivacyLevel } from '../domain/configuration'
 import type { BrowserWindowWithEventBridge } from './eventBridge'
 import {
@@ -72,6 +73,16 @@ describe('canUseEventBridge with wildcard patterns', () => {
     expect(canUseEventBridge('legacy.com')).toBeTrue()
     expect(canUseEventBridge('app.shopist.io')).toBeTrue()
     expect(canUseEventBridge('evil.com')).toBeFalse()
+  })
+
+  it('should log an error and skip patterns with more than one wildcard', () => {
+    const displayErrorSpy = spyOn(display, 'error')
+    mockEventBridge({ allowedWebViewHosts: ['*.foo.*.bar', 'shopist.io'] })
+    expect(canUseEventBridge('shopist.io')).toBeTrue()
+    expect(canUseEventBridge('anything.foo.anything.bar')).toBeFalse()
+    expect(displayErrorSpy).toHaveBeenCalledWith(
+      'Invalid WebView host pattern "*.foo.*.bar": only one wildcard (*) is supported.'
+    )
   })
 
   it('should not detect when bridge is absent', () => {

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -52,26 +52,16 @@ export function bridgeSupports(capability: BridgeCapability): boolean {
 
 export function canUseEventBridge(currentHost = globalObject.location?.hostname): boolean {
   const bridge = getEventBridge()
-
-  return (
-    bridge?.getAllowedWebViewHosts().some((entry) => {
-      if (entry.includes('*') && entry.split('*').length !== 2) {
-        display.error(`Invalid WebView host pattern "${entry}": only one wildcard (*) is supported.`)
-        return false
-      }
-      return entry.includes('*')
-        ? matchesWildcardPattern(currentHost, entry)
-        : currentHost === entry || currentHost.endsWith(`.${entry}`)
-    }) ?? false
-  )
+  return bridge?.getAllowedWebViewHosts().some((entry) => matchesHostEntry(currentHost, entry)) ?? false
 }
 
-export function matchesWildcardPattern(host: string, pattern: string): boolean {
-  if (!pattern.includes('*')) {
-    return host === pattern
+export function matchesHostEntry(host: string, entry: string): boolean {
+  if (!entry.includes('*')) {
+    return host === entry || host.endsWith(`.${entry}`)
   }
-  const parts = pattern.split('*')
+  const parts = entry.split('*')
   if (parts.length !== 2) {
+    display.error(`Invalid WebView host pattern "${entry}": only one wildcard (*) is supported.`)
     return false
   }
   const [prefix, suffix] = parts

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -55,20 +55,15 @@ export function bridgeSupports(capability: BridgeCapability): boolean {
 
 export function canUseEventBridge(currentHost = globalObject.location?.hostname): boolean {
   const bridge = getEventBridge()
-  if (!bridge) {
-    return false
-  }
 
   if (typeof getEventBridgeGlobal()?.getAllowedWebViewHostPatterns === 'function') {
-    return bridge.getAllowedWebViewHostPatterns().some((pattern) => matchesWildcardPattern(currentHost, pattern))
+    return bridge?.getAllowedWebViewHostPatterns().some((pattern) => matchesWildcardPattern(currentHost, pattern)) ?? false
   }
 
-  return bridge
-    .getAllowedWebViewHosts()
-    .some((allowedHost) => currentHost === allowedHost || currentHost.endsWith(`.${allowedHost}`))
+  return bridge?.getAllowedWebViewHosts().some((allowedHost) => currentHost === allowedHost || currentHost.endsWith(`.${allowedHost}`)) ?? false
 }
 
-function matchesWildcardPattern(host: string, pattern: string): boolean {
+export function matchesWildcardPattern(host: string, pattern: string): boolean {
   if (!pattern.includes('*')) {
     return host === pattern
   }

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -55,7 +55,9 @@ export function bridgeSupports(capability: BridgeCapability): boolean {
 
 export function canUseEventBridge(currentHost = globalObject.location?.hostname): boolean {
   const bridge = getEventBridge()
-  if (!bridge) return false
+  if (!bridge) {
+    return false
+  }
 
   if (typeof getEventBridgeGlobal()?.getAllowedWebViewHostPatterns === 'function') {
     return bridge.getAllowedWebViewHostPatterns().some((pattern) => matchesWildcardPattern(currentHost, pattern))

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -10,7 +10,6 @@ export interface DatadogEventBridge {
   getPrivacyLevel?(): DefaultPrivacyLevel
   getIsTraceSampled?(): 'true' | 'false' | 'null'
   getAllowedWebViewHosts(): string
-  getAllowedWebViewHostPatterns?(): string
   send(msg: string): void
 }
 
@@ -38,9 +37,6 @@ export function getEventBridge<T, E>() {
     getAllowedWebViewHosts() {
       return JSON.parse(eventBridgeGlobal.getAllowedWebViewHosts()) as string[]
     },
-    getAllowedWebViewHostPatterns() {
-      return JSON.parse(eventBridgeGlobal.getAllowedWebViewHostPatterns?.() || '[]') as string[]
-    },
     send(eventType: T, event: E, viewId?: string) {
       const view = viewId ? { id: viewId } : undefined
       eventBridgeGlobal.send(JSON.stringify({ eventType, event, view }))
@@ -56,16 +52,14 @@ export function bridgeSupports(capability: BridgeCapability): boolean {
 export function canUseEventBridge(currentHost = globalObject.location?.hostname): boolean {
   const bridge = getEventBridge()
 
-  if (typeof getEventBridgeGlobal()?.getAllowedWebViewHostPatterns === 'function') {
-    return (
-      bridge?.getAllowedWebViewHostPatterns().some((pattern) => matchesWildcardPattern(currentHost, pattern)) ?? false
-    )
-  }
-
   return (
     bridge
       ?.getAllowedWebViewHosts()
-      .some((allowedHost) => currentHost === allowedHost || currentHost.endsWith(`.${allowedHost}`)) ?? false
+      .some((entry) =>
+        entry.includes('*')
+          ? matchesWildcardPattern(currentHost, entry)
+          : currentHost === entry || currentHost.endsWith(`.${entry}`)
+      ) ?? false
   )
 }
 

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -10,6 +10,7 @@ export interface DatadogEventBridge {
   getPrivacyLevel?(): DefaultPrivacyLevel
   getIsTraceSampled?(): 'true' | 'false' | 'null'
   getAllowedWebViewHosts(): string
+  getAllowedWebViewHostPatterns?(): string
   send(msg: string): void
 }
 
@@ -37,6 +38,9 @@ export function getEventBridge<T, E>() {
     getAllowedWebViewHosts() {
       return JSON.parse(eventBridgeGlobal.getAllowedWebViewHosts()) as string[]
     },
+    getAllowedWebViewHostPatterns() {
+      return JSON.parse(eventBridgeGlobal.getAllowedWebViewHostPatterns?.() || '[]') as string[]
+    },
     send(eventType: T, event: E, viewId?: string) {
       const view = viewId ? { id: viewId } : undefined
       eventBridgeGlobal.send(JSON.stringify({ eventType, event, view }))
@@ -51,13 +55,27 @@ export function bridgeSupports(capability: BridgeCapability): boolean {
 
 export function canUseEventBridge(currentHost = globalObject.location?.hostname): boolean {
   const bridge = getEventBridge()
+  if (!bridge) return false
 
-  return (
-    !!bridge &&
-    bridge
-      .getAllowedWebViewHosts()
-      .some((allowedHost) => currentHost === allowedHost || currentHost.endsWith(`.${allowedHost}`))
-  )
+  if (typeof getEventBridgeGlobal()?.getAllowedWebViewHostPatterns === 'function') {
+    return bridge.getAllowedWebViewHostPatterns().some((pattern) => matchesWildcardPattern(currentHost, pattern))
+  }
+
+  return bridge
+    .getAllowedWebViewHosts()
+    .some((allowedHost) => currentHost === allowedHost || currentHost.endsWith(`.${allowedHost}`))
+}
+
+function matchesWildcardPattern(host: string, pattern: string): boolean {
+  if (!pattern.includes('*')) {
+    return host === pattern
+  }
+  const parts = pattern.split('*')
+  if (parts.length !== 2) {
+    return false
+  }
+  const [prefix, suffix] = parts
+  return host.length >= prefix.length + suffix.length && host.startsWith(prefix) && host.endsWith(suffix)
 }
 
 function getEventBridgeGlobal() {

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -1,3 +1,4 @@
+import { display } from '../tools/display'
 import { globalObject } from '../tools/globalObject'
 import type { DefaultPrivacyLevel } from '../domain/configuration'
 
@@ -53,13 +54,15 @@ export function canUseEventBridge(currentHost = globalObject.location?.hostname)
   const bridge = getEventBridge()
 
   return (
-    bridge
-      ?.getAllowedWebViewHosts()
-      .some((entry) =>
-        entry.includes('*')
-          ? matchesWildcardPattern(currentHost, entry)
-          : currentHost === entry || currentHost.endsWith(`.${entry}`)
-      ) ?? false
+    bridge?.getAllowedWebViewHosts().some((entry) => {
+      if (entry.includes('*') && entry.split('*').length !== 2) {
+        display.error(`Invalid WebView host pattern "${entry}": only one wildcard (*) is supported.`)
+        return false
+      }
+      return entry.includes('*')
+        ? matchesWildcardPattern(currentHost, entry)
+        : currentHost === entry || currentHost.endsWith(`.${entry}`)
+    }) ?? false
   )
 }
 

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -57,10 +57,16 @@ export function canUseEventBridge(currentHost = globalObject.location?.hostname)
   const bridge = getEventBridge()
 
   if (typeof getEventBridgeGlobal()?.getAllowedWebViewHostPatterns === 'function') {
-    return bridge?.getAllowedWebViewHostPatterns().some((pattern) => matchesWildcardPattern(currentHost, pattern)) ?? false
+    return (
+      bridge?.getAllowedWebViewHostPatterns().some((pattern) => matchesWildcardPattern(currentHost, pattern)) ?? false
+    )
   }
 
-  return bridge?.getAllowedWebViewHosts().some((allowedHost) => currentHost === allowedHost || currentHost.endsWith(`.${allowedHost}`)) ?? false
+  return (
+    bridge
+      ?.getAllowedWebViewHosts()
+      .some((allowedHost) => currentHost === allowedHost || currentHost.endsWith(`.${allowedHost}`)) ?? false
+  )
 }
 
 export function matchesWildcardPattern(host: string, pattern: string): boolean {

--- a/packages/browser-core/test/emulate/mockEventBridge.ts
+++ b/packages/browser-core/test/emulate/mockEventBridge.ts
@@ -5,11 +5,13 @@ import { registerCleanupTask } from '../registerCleanupTask'
 
 export function mockEventBridge({
   allowedWebViewHosts = [window.location.hostname],
+  allowedWebViewHostPatterns,
   privacyLevel = DefaultPrivacyLevel.MASK,
   capabilities = [BridgeCapability.RECORDS],
   isTraceSampled,
 }: {
   allowedWebViewHosts?: string[]
+  allowedWebViewHostPatterns?: string[]
   privacyLevel?: DefaultPrivacyLevel
   capabilities?: BridgeCapability[]
   isTraceSampled?: boolean
@@ -17,6 +19,8 @@ export function mockEventBridge({
   const eventBridge: DatadogEventBridge = {
     send: (_msg: string) => undefined,
     getAllowedWebViewHosts: () => JSON.stringify(allowedWebViewHosts),
+    getAllowedWebViewHostPatterns:
+      allowedWebViewHostPatterns !== undefined ? () => JSON.stringify(allowedWebViewHostPatterns) : undefined,
     getCapabilities: () => JSON.stringify(capabilities),
     getPrivacyLevel: () => privacyLevel,
     getIsTraceSampled: isTraceSampled !== undefined ? () => String(isTraceSampled) as 'true' | 'false' : undefined,

--- a/packages/browser-core/test/emulate/mockEventBridge.ts
+++ b/packages/browser-core/test/emulate/mockEventBridge.ts
@@ -5,13 +5,11 @@ import { registerCleanupTask } from '../registerCleanupTask'
 
 export function mockEventBridge({
   allowedWebViewHosts = [window.location.hostname],
-  allowedWebViewHostPatterns,
   privacyLevel = DefaultPrivacyLevel.MASK,
   capabilities = [BridgeCapability.RECORDS],
   isTraceSampled,
 }: {
   allowedWebViewHosts?: string[]
-  allowedWebViewHostPatterns?: string[]
   privacyLevel?: DefaultPrivacyLevel
   capabilities?: BridgeCapability[]
   isTraceSampled?: boolean
@@ -19,8 +17,6 @@ export function mockEventBridge({
   const eventBridge: DatadogEventBridge = {
     send: (_msg: string) => undefined,
     getAllowedWebViewHosts: () => JSON.stringify(allowedWebViewHosts),
-    getAllowedWebViewHostPatterns:
-      allowedWebViewHostPatterns !== undefined ? () => JSON.stringify(allowedWebViewHostPatterns) : undefined,
     getCapabilities: () => JSON.stringify(capabilities),
     getPrivacyLevel: () => privacyLevel,
     getIsTraceSampled: isTraceSampled !== undefined ? () => String(isTraceSampled) as 'true' | 'false' : undefined,


### PR DESCRIPTION
## Motivation

Part of [RUM-15826](https://datadoghq.atlassian.net/browse/RUM-15826). iOS SDK counterpart https://github.com/DataDog/dd-sdk-ios/pull/2963.

## Changes

 Adds a new optional `getAllowedWebViewHostPatterns?()` method to the `DatadogEventBridge` interface. When present, `canUseEventBridge()` uses wildcard pattern matching via plain string operations instead of the legacy exact + subdomain-suffix path. 
 
Invalid patterns (more than one `*`) produce a `display.error` console warning so customers see an actionable signal. Old Browser SDK versions receiving wildcard entries from a new mobile SDK will silently ignore them (literal match fails) while plain host entries continue to bridge normally.

## Test instructions

CI should pass.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

[RUM-15826]: https://datadoghq.atlassian.net/browse/RUM-15826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ