### PR TITLE
📝 add code review guide for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Browser SDK for collecting Real User Monitoring (RUM) and logging data from web 
 
 ## Package Manager
 
-This project uses Yarn workspaces (v4.12.0). Never use `npm` or `npx`.
+This project uses Yarn workspaces (latest version). Never use `npm` or `npx`.
 
 ## Key Commands
 
@@ -75,6 +75,7 @@ scripts/             # Build, deploy, release automation
 
 For deeper context, see:
 
+- `docs/REVIEW.md` — what to look for (and what to skip) when reviewing a PR
 - `docs/DEVELOPMENT.md` — commit conventions, dependency management, schema generation, TS compatibility
 - `docs/CONVENTIONS.md` — coding style, file organization, size control
 - `docs/ARCHITECTURE.md` — package dependencies, data pipeline
@@ -130,5 +131,5 @@ To test with specific config options (e.g. `forwardErrorsToLogs: true`), just ed
 
 - Branch naming: `<username>/<feature>` (e.g., `john.doe/fix-session-bug`)
 - Always branch from `main` unless explicitly decided otherwise
-- PR title **must** follow commit message convention (see @docs/DEVELOPMENT.md)
+- PR title **must** follow commit message convention (see `docs/DEVELOPMENT.md`)
 - PR template at `.github/PULL_REQUEST_TEMPLATE.md` - use it for all PRs

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -92,6 +92,31 @@ Avoid polluting browser context or conflicting with customer own polyfills.
   }
   ```
 
+## Global object access
+
+Use `globalObject` from `@datadog/browser-core` instead of `window` or `globalThis`. It is typed
+as `GlobalObject`, a custom interface that marks browser APIs as optional when they are not
+available in all supported browsers or execution contexts (e.g. Web Workers). This makes
+availability checks explicit and type-safe.
+
+**Examples:**
+
+- **KO** to access browser globals directly
+
+  ```typescript
+  window.navigator.locks?.request('my-lock', doWork)
+  globalThis.cookieStore?.get('my-cookie')
+  ```
+
+- **OK** to use `globalObject`
+
+  ```typescript
+  import { globalObject } from '@datadog/browser-core'
+
+  globalObject.navigator.locks?.request('my-lock', doWork)
+  globalObject.cookieStore?.get('my-cookie')
+  ```
+
 ## File organization
 
 In the different packages, we try to split code relative to different concerns to ease discoverability and reusability:

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -41,6 +41,14 @@ Backward compatibility is a requirement — watch for unintentional breaking cha
 changes, renamed/removed event fields, changed default values, or a different shape passed to
 customer callbacks.
 
+### Browser API availability
+
+Browser APIs (e.g. `navigator.locks`, `navigator.sendBeacon`, `cookieStore`) may not exist in all
+supported browsers or execution contexts (iframes, Web Workers). Any call to a browser API not
+already established in the codebase must be guarded with an availability check.
+
+See "Global object access" in `docs/CONVENTIONS.md` for the recommended pattern.
+
 ### Documentation
 
 Public APIs require a TSDoc comment, including:

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -1,0 +1,73 @@
+# Code Review Guide (for agents)
+
+What to look for when reviewing a PR. Linters, formatter and type-checker already run in CI — don't
+repeat what they enforce. Focus on the project-specific concerns below.
+
+## Principles
+
+- **High signal only.** A wrong comment costs more than a missing one. If unsure, verify in the
+  codebase or use `question:`, not `issue:`/`suggestion:`.
+- **Check the existing pattern before flagging.** Code that looks wrong is often intentional and
+  used elsewhere — grep first.
+- **Don't restate code** or ask for comments that duplicate a clear name.
+- **Few strong comments** beat many nitpicks.
+
+## Comment style
+
+Use [Conventional Comments](https://conventionalcomments.org/) labels:
+
+- `praise:` — genuinely good (not filler).
+- `issue:` — a concrete bug/regression to fix.
+- `suggestion:` — a concrete improvement you're confident about.
+- `nitpick:` — trivial, non-blocking.
+- `thought:` / `question:` — when unsure; prefer over a wrong `issue:`/`suggestion:`.
+
+## What to look for
+
+### Bundle size
+
+The minifier mangles local/top-level names but **not property names or object keys**.
+
+- Long property/method/key names that ship to the bundle (e.g. `private veryLongDescriptiveProperty`)
+  — suggest shorter names. Local vars get minified, so ignore those.
+- Patterns that minify poorly: `class` where a closure works, `enum` vs `const enum` (see "Size
+  control" in `docs/CONVENTIONS.md`).
+- Dead abstractions: a one-call helper/wrapper/option adding bytes for no clear value.
+- In general, any pattern that achieves the same result with less code is welcome.
+
+### Backward compatibility
+
+Backward compatibility is a requirement — watch for unintentional breaking changes: public API
+changes, renamed/removed event fields, changed default values, or a different shape passed to
+customer callbacks.
+
+### Documentation
+
+Public APIs require a TSDoc comment, including:
+
+- a clear description,
+- at least one example,
+- the `@hidden` tag if experimental,
+- the `@internal` tag if internal.
+
+### Conventions (read the source doc, don't rely on memory)
+
+- Naming, dependency-as-parameter, file org, utils/specHelper scoping — `docs/CONVENTIONS.md`.
+- Public API rules (no `enum`, options object for customer callbacks) — `docs/CONVENTIONS.md`.
+- Telemetry usage scope and repo-wide rules — `AGENTS.md`.
+- Test patterns (`registerCleanupTask`, `collectAsyncCalls`, `mockable`) — `AGENTS.md` /
+  `docs/TESTING.md`.
+
+### Reuse over reinvention
+
+Prefer existing utilities/types over new ones (e.g. `globalObject` over raw `window`/`globalThis`,
+existing `Context` types, `*Utils` helpers).
+
+## Do NOT comment on
+
+- What Prettier/ESLint/`tsc` enforce (formatting, `prefer-template`, `prefer-optional-chain`, unused
+  vars, imports).
+- Auto-generated files: `CHANGELOG.md`, schema-generated `*.types.ts` (`DO NOT MODIFY`) — flag only
+  if edited by hand.
+- Comments/JSDoc that restate a clear name.
+- Speculative `null`/`undefined` guards without a concrete failing case.


### PR DESCRIPTION
## Motivation

We increasingly rely on AI agents — Codex in particular — to review PRs. This
adds a concise guide to get more value from them: steering their feedback
toward the project-specific concerns that matter most to us (bundle size,
backward compatibility, public API documentation) and away from what our
tooling already enforces.

## Changes

- Add `docs/REVIEW.md`: conventional-comment style, what to look for
  (bundle size, backward compatibility, TSDoc on public APIs, conventions,
  reuse) and what to skip because tooling already enforces it.
- Link it from `AGENTS.md`.

## Test instructions

Documentation-only change, no runtime impact. Review `docs/REVIEW.md` for
accuracy and tone.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file
