### PR TITLE
👷 Add 'dependencies' label to bump-chrome-version PRs

### DIFF
--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -66,10 +66,11 @@ export async function createGitHubRelease({ version, body }: GitHubReleaseParams
   })
 }
 
-export function createPullRequest(mainBranch: string) {
+export function createPullRequest(mainBranch: string, labels?: string[]) {
   using token = getGithubPullRequestToken()
   command`gh auth login --with-token`.withInput(token.value).run()
-  const pullRequestUrl = command`gh pr create --fill --base ${mainBranch}`.run()
+  const labelArgs = labels?.flatMap((label) => ['--label', label]) ?? []
+  const pullRequestUrl = command`gh pr create --fill --base ${mainBranch} ${labelArgs}`.run()
   return pullRequestUrl.trim()
 }
 

--- a/scripts/test/bump-chrome-version.ts
+++ b/scripts/test/bump-chrome-version.ts
@@ -55,7 +55,7 @@ runMain(async () => {
 
   printLog('Create PR...')
 
-  const pullRequestUrl = createPullRequest(MAIN_BRANCH)
+  const pullRequestUrl = createPullRequest(MAIN_BRANCH, ['dependencies'])
   printLog(`Chrome version bump PR created (from ${CURRENT_PACKAGE_VERSION} to ${packageVersion}).`)
 
   // used to share the pull request url to the notification jobs


### PR DESCRIPTION
## Motivation

The `bump-chrome-version` script creates PRs to update the Chrome version used in tests. These PRs should be labeled as `dependencies` so they can be handled by the same interrupt handler skill as other dependency update PRs.

## Changes

- Updated `createPullRequest()` in `scripts/lib/gitUtils.ts` to accept an optional `labels` parameter and pass them as `--label` flags to `gh pr create`
- Updated `bump-chrome-version.ts` to pass the `'dependencies'` label when creating its PR

## Test instructions

The change is in the CI script that bumps Chrome version. To verify:
1. Check that `createPullRequest` now accepts an optional `labels` argument
2. Confirm that `bump-chrome-version.ts` passes `['dependencies']` to `createPullRequest`

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file