### PR TITLE
⚗️ Add instrumentConstructor utility

### DIFF
--- a/packages/browser-core/src/index.ts
+++ b/packages/browser-core/src/index.ts
@@ -92,8 +92,8 @@ export { sendToExtension } from './tools/sendToExtension'
 export { runOnReadyState, asyncRunOnReadyState } from './browser/runOnReadyState'
 export { getZoneJsOriginalValue } from './tools/getZoneJsOriginalValue'
 export { mockable } from './tools/mockable'
-export type { InstrumentedMethodCall } from './tools/instrumentMethod'
-export { instrumentMethod, instrumentSetter } from './tools/instrumentMethod'
+export type { InstrumentedMethodCall, InstrumentedConstructorCall } from './tools/instrumentMethod'
+export { instrumentMethod, instrumentConstructor, instrumentSetter } from './tools/instrumentMethod'
 export {
   computeRawError,
   getFileFromStackTraceString,

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -199,6 +199,8 @@ describe('instrumentMethod', () => {
 })
 
 describe('instrumentConstructor', () => {
+  const THIRD_PARTY_CONSTRUCTOR_TAG = 42
+
   class MyClass {
     value: number
     constructor(value: number) {
@@ -237,6 +239,36 @@ describe('instrumentConstructor', () => {
     })
     expect(instance.value).toBe(42)
     expect(instance.getValue()).toBe(42)
+  })
+
+  it('allows other instrumentations from third parties', () => {
+    const container = { MyClass }
+    const instrumentationSpy = jasmine.createSpy()
+    instrumentConstructor(container, 'MyClass', instrumentationSpy)
+
+    thirdPartyConstructorWrap(container)
+
+    const instance = new container.MyClass(7) as MyClass & { thirdPartyTag: number }
+
+    expect(instance.value).toBe(7)
+    expect(instance.thirdPartyTag).toBe(THIRD_PARTY_CONSTRUCTOR_TAG)
+    expect(instrumentationSpy).toHaveBeenCalled()
+  })
+
+  it('computes the handling stack', () => {
+    const container = { MyClass }
+    const instrumentationSpy = jasmine.createSpy()
+    instrumentConstructor(container, 'MyClass', instrumentationSpy, { computeHandlingStack: true })
+
+    function foo() {
+      new container.MyClass(1)
+    }
+
+    foo()
+
+    expect(instrumentationSpy.calls.mostRecent().args[0].handlingStack).toEqual(
+      jasmine.stringMatching(/^HandlingStack: instrumented constructor\n {2}at foo @/)
+    )
   })
 
   it('does not call the instrumentation when the constructor is invoked without new', () => {
@@ -412,6 +444,37 @@ describe('instrumentConstructor', () => {
       expect(instance.value).toBe(5)
     })
 
+    describe('when the constructor has been instrumented by a third party', () => {
+      it('should preserve third party instrumentation after stop()', () => {
+        const container = { MyClass }
+        const { stop } = instrumentConstructor(container, 'MyClass', noop)
+
+        thirdPartyConstructorWrap(container)
+        const wrappedConstructor = container.MyClass
+
+        stop()
+
+        expect(container.MyClass).toBe(wrappedConstructor)
+      })
+
+      it('does not call the instrumentation when constructing after stop()', () => {
+        const container = { MyClass }
+        const instrumentationSpy = jasmine.createSpy()
+        const { stop } = instrumentConstructor(container, 'MyClass', instrumentationSpy)
+
+        thirdPartyConstructorWrap(container)
+
+        stop()
+
+        const instance = new container.MyClass(5) as MyClass & { thirdPartyTag: number }
+
+        expect(instrumentationSpy).not.toHaveBeenCalled()
+        expect(instance.value).toBe(5)
+        expect(instance.thirdPartyTag).toBe(THIRD_PARTY_CONSTRUCTOR_TAG)
+        expect(instance instanceof MyClass).toBeTrue()
+      })
+    })
+
     it('preserves new.target when constructing a subclass of the instrumented constructor after stop()', () => {
       const container = { MyClass }
       const { stop } = instrumentConstructor(container, 'MyClass', noop)
@@ -491,6 +554,22 @@ describe('instrumentConstructor', () => {
       expect(instance.x).toBe(2)
     })
   })
+
+  /**
+   * Wraps the current `MyClass` on `container` (typically the SDK-instrumented constructor) in a
+   * Proxy that still delegates construction, then tags instances — analogous to
+   * `thirdPartyInstrumentation` in the `instrumentMethod` suite.
+   */
+  function thirdPartyConstructorWrap(container: { MyClass: typeof MyClass }) {
+    const inner = container.MyClass
+    container.MyClass = new Proxy(inner, {
+      construct(target, argArray, newTarget) {
+        const instance = Reflect.construct(target, argArray, newTarget) as MyClass & { thirdPartyTag: number }
+        instance.thirdPartyTag = THIRD_PARTY_CONSTRUCTOR_TAG
+        return instance
+      },
+    })
+  }
 })
 
 describe('instrumentSetter', () => {

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -180,6 +180,72 @@ describe('instrumentMethod', () => {
     })
   })
 
+  describe('constructor support', () => {
+    class MyClass {
+      value: number
+      constructor(value: number) {
+        this.value = value
+      }
+
+      getValue() {
+        return this.value
+      }
+    }
+
+    it('works when the instrumented method is called with new', () => {
+      const container = { MyClass }
+      const instrumentationSpy = jasmine.createSpy()
+      instrumentMethod(container, 'MyClass', instrumentationSpy)
+
+      const instance = new container.MyClass(42)
+
+      expect(instrumentationSpy).toHaveBeenCalledOnceWith({
+        target: jasmine.any(MyClass),
+        parameters: [42],
+        onPostCall: jasmine.any(Function),
+        handlingStack: undefined,
+      })
+      expect(instance.value).toBe(42)
+      expect(instance.getValue()).toBe(42)
+    })
+
+    it('preserves instanceof on the constructed instance', () => {
+      const container = { MyClass }
+      instrumentMethod(container, 'MyClass', noop)
+
+      const instance = new container.MyClass(1)
+
+      expect(instance instanceof container.MyClass).toBeTrue()
+    })
+
+    it('passes the constructed instance to onPostCall', () => {
+      const container = { MyClass }
+      const postCallCallbackSpy = jasmine.createSpy()
+      instrumentMethod(container, 'MyClass', ({ onPostCall }) => onPostCall(postCallCallbackSpy))
+
+      const instance = new container.MyClass(7)
+
+      expect(postCallCallbackSpy).toHaveBeenCalledOnceWith(instance)
+      expect((postCallCallbackSpy.calls.mostRecent().args[0] as MyClass).value).toBe(7)
+    })
+
+    it('works correctly after stop() when a third party has re-instrumented', () => {
+      const container = { MyClass }
+      const { stop } = instrumentMethod(container, 'MyClass', noop)
+
+      // Third party wraps our instrumentation
+      const OurInstrumentation = container.MyClass
+      container.MyClass = class extends OurInstrumentation {}
+
+      stop()
+
+      const instance = new container.MyClass(99)
+
+      expect(instance instanceof MyClass).toBeTrue()
+      expect(instance.value).toBe(99)
+    })
+  })
+
   function thirdPartyInstrumentation(object: { method?: () => number; onevent?: () => void }) {
     const originalMethod = object.method
     if (typeof originalMethod === 'function') {

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -511,6 +511,26 @@ describe('instrumentConstructor', () => {
       const instance = new container.MyClass(2)
       expect(instance.constructor).toBe(MyClass)
     })
+
+    it('does not clobber prototype.constructor when a third party repoints it before stop()', () => {
+      const container = { MyClass }
+      const { stop } = instrumentConstructor(container, 'MyClass', noop)
+
+      function thirdPartyCanonicalCtor() {
+        /* third party keeps identity checks aligned with their wrapper */
+      }
+
+      // Simulate another layer repointing the shared prototype after our instrumentation.
+      const constructorDescriptor = Object.getOwnPropertyDescriptor(MyClass.prototype, 'constructor')!
+      Object.defineProperty(MyClass.prototype, 'constructor', {
+        ...constructorDescriptor,
+        value: thirdPartyCanonicalCtor,
+      })
+
+      stop()
+
+      expect(MyClass.prototype.constructor).toBe(thirdPartyCanonicalCtor)
+    })
   })
 
   /**

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -1,4 +1,4 @@
-import { mockClock, mockZoneJs } from '../../test'
+import { mockClock, mockZoneJs, registerCleanupTask } from '../../test'
 import type { Clock, MockZoneJs } from '../../test'
 import type { InstrumentedMethodCall } from './instrumentMethod'
 import { instrumentConstructor, instrumentMethod, instrumentSetter } from './instrumentMethod'
@@ -210,6 +210,19 @@ describe('instrumentConstructor', () => {
     }
   }
 
+  const initialMyClassPrototypeConstructor = Object.getOwnPropertyDescriptor(MyClass.prototype, 'constructor')!
+
+  beforeEach(() => {
+    // Several tests instrument without calling `stop()`; they share this `MyClass` and leave
+    // `MyClass.prototype.constructor` pointing at a stale wrapper, which breaks random-order runs.
+    Object.defineProperty(MyClass.prototype, 'constructor', {
+      configurable: initialMyClassPrototypeConstructor.configurable!,
+      enumerable: initialMyClassPrototypeConstructor.enumerable!,
+      writable: initialMyClassPrototypeConstructor.writable,
+      value: MyClass,
+    })
+  })
+
   it('calls the instrumentation when the constructor is called with new', () => {
     const container = { MyClass }
     const instrumentationSpy = jasmine.createSpy()
@@ -235,6 +248,16 @@ describe('instrumentConstructor', () => {
     // The instance is recognized both as the original class and as the instrumented value.
     expect(instance instanceof MyClass).toBeTrue()
     expect(instance instanceof container.MyClass).toBeTrue()
+  })
+
+  it('exposes the instrumented constructor as instance.constructor', () => {
+    const container = { MyClass }
+    const { stop } = instrumentConstructor(container, 'MyClass', noop)
+    registerCleanupTask(stop)
+
+    const instance = new container.MyClass(1)
+
+    expect(instance.constructor).toBe(container.MyClass)
   })
 
   it('preserves new.target as the original constructor for direct new calls', () => {
@@ -378,6 +401,62 @@ describe('instrumentConstructor', () => {
       expect(instance instanceof Sub).toBeTrue()
       expect(instance.extra()).toBe('sub')
       expect(instance.value).toBe(5)
+    })
+
+    it('restores the prototype constructor descriptor and prototype object identity after stop()', () => {
+      const container = { MyClass }
+      const prototypeObject = MyClass.prototype
+      const constructorDescriptorBefore = Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')!
+
+      const { stop } = instrumentConstructor(container, 'MyClass', noop)
+
+      expect(container.MyClass.prototype).toBe(prototypeObject)
+      expect(new container.MyClass(1).constructor).toBe(container.MyClass)
+
+      stop()
+
+      expect(container.MyClass).toBe(MyClass)
+      expect(MyClass.prototype).toBe(prototypeObject)
+      expect(Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')).toEqual(constructorDescriptorBefore)
+      expect(prototypeObject.constructor).toBe(MyClass)
+
+      const instance = new container.MyClass(2)
+      expect(instance.constructor).toBe(MyClass)
+    })
+
+    it('restores prototype.constructor after stop when the prototype had no own constructor descriptor', () => {
+      class NoOwnPrototypeConstructor {
+        x: number
+        constructor(x: number) {
+          this.x = x
+        }
+      }
+
+      const prototypeObject = NoOwnPrototypeConstructor.prototype
+      delete (prototypeObject as unknown as { constructor?: typeof NoOwnPrototypeConstructor }).constructor
+
+      expect(Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')).toBeUndefined()
+
+      const container = { NoOwnPrototypeConstructor }
+      const { stop } = instrumentConstructor(container, 'NoOwnPrototypeConstructor', noop)
+      registerCleanupTask(stop)
+
+      new container.NoOwnPrototypeConstructor(1)
+
+      stop()
+
+      expect(container.NoOwnPrototypeConstructor).toBe(NoOwnPrototypeConstructor)
+      expect(NoOwnPrototypeConstructor.prototype).toBe(prototypeObject)
+      expect(Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')).toEqual({
+        value: NoOwnPrototypeConstructor,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      })
+
+      const instance = new NoOwnPrototypeConstructor(2)
+      expect(instance.constructor).toBe(NoOwnPrototypeConstructor)
+      expect(instance.x).toBe(2)
     })
   })
 })

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -295,6 +295,18 @@ describe('instrumentConstructor', () => {
     expect(instance instanceof container.MyClass).toBeTrue()
   })
 
+  it('keeps the constructor prototype property non-writable after instrumentation', () => {
+    const originalPrototypeDescriptor = Object.getOwnPropertyDescriptor(MyClass, 'prototype')!
+    expect(originalPrototypeDescriptor.writable).toBeFalse()
+
+    const container = { MyClass }
+    const { stop } = instrumentConstructor(container, 'MyClass', noop)
+    registerCleanupTask(stop)
+
+    const instrumentedPrototypeDescriptor = Object.getOwnPropertyDescriptor(container.MyClass, 'prototype')!
+    expect(instrumentedPrototypeDescriptor.writable).toBeFalse()
+  })
+
   it('exposes the instrumented constructor as instance.constructor', () => {
     const container = { MyClass }
     const { stop } = instrumentConstructor(container, 'MyClass', noop)

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -356,6 +356,29 @@ describe('instrumentConstructor', () => {
       expect(instance instanceof MyClass).toBeTrue()
       expect(instance.value).toBe(5)
     })
+
+    it('preserves new.target when constructing a subclass of the instrumented constructor after stop()', () => {
+      const container = { MyClass }
+      const { stop } = instrumentConstructor(container, 'MyClass', noop)
+
+      // A third party extends our instrumented constructor while the SDK is active.
+      class Sub extends container.MyClass {
+        extra() {
+          return 'sub'
+        }
+      }
+
+      stop()
+
+      // Constructing the subclass now delegates to the stopped branch. It must still preserve the
+      // subclass as `new.target`, otherwise the instance is allocated with the original prototype
+      // and loses the subclass prototype methods.
+      const instance = new Sub(5)
+
+      expect(instance instanceof Sub).toBeTrue()
+      expect(instance.extra()).toBe('sub')
+      expect(instance.value).toBe(5)
+    })
   })
 })
 

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -220,6 +220,22 @@ describe('instrumentMethod', () => {
       expect(instance instanceof container.MyClass).toBeTrue()
     })
 
+    it('preserves static members on the instrumented constructor', () => {
+      class MyClassWithStaticMembers {
+        static staticNumber = 123
+
+        static staticMethod() {
+          return 'static-result'
+        }
+      }
+
+      const container = { MyClassWithStaticMembers }
+      instrumentMethod(container, 'MyClassWithStaticMembers', noop)
+
+      expect(container.MyClassWithStaticMembers.staticNumber).toBe(123)
+      expect(container.MyClassWithStaticMembers.staticMethod()).toBe('static-result')
+    })
+
     it('preserves instanceof when instrumented constructor is used as a base class', () => {
       const container = { MyClass }
       instrumentMethod(container, 'MyClass', noop)

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -220,6 +220,47 @@ describe('instrumentMethod', () => {
       expect(instance instanceof container.MyClass).toBeTrue()
     })
 
+    it('preserves new.target as the original constructor for direct new calls', () => {
+      let observedNewTarget: unknown
+      class TracksNewTarget {
+        constructor() {
+          observedNewTarget = new.target
+        }
+      }
+
+      const container = { TracksNewTarget }
+      instrumentMethod(container, 'TracksNewTarget', noop)
+
+      new container.TracksNewTarget()
+
+      // Without instrumentation, `new.target` in the constructor body is `TracksNewTarget`.
+      // Forwarding the wrapper as the Reflect.construct newTarget makes `new.target` the
+      // instrumentation function instead, which breaks subclass checks and similar patterns.
+      expect(observedNewTarget).toBe(TracksNewTarget)
+    })
+
+    it('preserves new.target as the subclass when extending the instrumented constructor', () => {
+      let observedNewTargetInOriginal: unknown
+      class Base {
+        constructor() {
+          observedNewTargetInOriginal = new.target
+        }
+      }
+
+      const container = { Base }
+      instrumentMethod(container, 'Base', noop)
+
+      class Sub extends container.Base {
+        constructor() {
+          super()
+        }
+      }
+
+      new Sub()
+
+      expect(observedNewTargetInOriginal).toBe(Sub)
+    })
+
     it('preserves static members on the instrumented constructor', () => {
       class MyClassWithStaticMembers {
         static staticNumber = 123

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -330,6 +330,25 @@ describe('instrumentConstructor', () => {
     expect(container.MyClassWithStaticMembers.staticMethod()).toBe('static-result')
   })
 
+  it('preserves the own prototype property descriptor on the instrumented constructor (writable must match original)', () => {
+    const container = { MyClass }
+    const originalDescriptor = Object.getOwnPropertyDescriptor(MyClass, 'prototype')!
+
+    expect(originalDescriptor.writable).toBe(false)
+
+    instrumentConstructor(container, 'MyClass', noop)
+
+    // Writable must match original
+    expect(Object.getOwnPropertyDescriptor(container.MyClass, 'prototype')).toEqual(
+      jasmine.objectContaining({
+        writable: originalDescriptor.writable,
+        configurable: originalDescriptor.configurable,
+        enumerable: originalDescriptor.enumerable,
+        value: MyClass.prototype,
+      })
+    )
+  })
+
   it('preserves instanceof when instrumented constructor is used as a base class', () => {
     const container = { MyClass }
     instrumentConstructor(container, 'MyClass', noop)

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -362,25 +362,6 @@ describe('instrumentConstructor', () => {
     expect(container.MyClassWithStaticMembers.staticMethod()).toBe('static-result')
   })
 
-  it('preserves the own prototype property descriptor on the instrumented constructor (writable must match original)', () => {
-    const container = { MyClass }
-    const originalDescriptor = Object.getOwnPropertyDescriptor(MyClass, 'prototype')!
-
-    expect(originalDescriptor.writable).toBe(false)
-
-    instrumentConstructor(container, 'MyClass', noop)
-
-    // Writable must match original
-    expect(Object.getOwnPropertyDescriptor(container.MyClass, 'prototype')).toEqual(
-      jasmine.objectContaining({
-        writable: originalDescriptor.writable,
-        configurable: originalDescriptor.configurable,
-        enumerable: originalDescriptor.enumerable,
-        value: MyClass.prototype,
-      })
-    )
-  })
-
   it('preserves instanceof when instrumented constructor is used as a base class', () => {
     const container = { MyClass }
     instrumentConstructor(container, 'MyClass', noop)
@@ -517,41 +498,6 @@ describe('instrumentConstructor', () => {
 
       const instance = new container.MyClass(2)
       expect(instance.constructor).toBe(MyClass)
-    })
-
-    it('restores prototype.constructor after stop when the prototype had no own constructor descriptor', () => {
-      class NoOwnPrototypeConstructor {
-        x: number
-        constructor(x: number) {
-          this.x = x
-        }
-      }
-
-      const prototypeObject = NoOwnPrototypeConstructor.prototype
-      delete (prototypeObject as unknown as { constructor?: typeof NoOwnPrototypeConstructor }).constructor
-
-      expect(Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')).toBeUndefined()
-
-      const container = { NoOwnPrototypeConstructor }
-      const { stop } = instrumentConstructor(container, 'NoOwnPrototypeConstructor', noop)
-      registerCleanupTask(stop)
-
-      new container.NoOwnPrototypeConstructor(1)
-
-      stop()
-
-      expect(container.NoOwnPrototypeConstructor).toBe(NoOwnPrototypeConstructor)
-      expect(NoOwnPrototypeConstructor.prototype).toBe(prototypeObject)
-      expect(Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')).toEqual({
-        value: NoOwnPrototypeConstructor,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      })
-
-      const instance = new NoOwnPrototypeConstructor(2)
-      expect(instance.constructor).toBe(NoOwnPrototypeConstructor)
-      expect(instance.x).toBe(2)
     })
   })
 

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -243,20 +243,34 @@ describe('instrumentMethod', () => {
       expect((postCallCallbackSpy.calls.mostRecent().args[0] as MyClass).value).toBe(7)
     })
 
-    it('works correctly after stop() when a third party has re-instrumented', () => {
+    it('constructs without calling the instrumentation after stop() when calling new Original()', () => {
       const container = { MyClass }
-      const { stop } = instrumentMethod(container, 'MyClass', noop)
-
-      // Third party wraps our instrumentation
-      const OurInstrumentation = container.MyClass
-      container.MyClass = class extends OurInstrumentation {}
+      const instrumentationSpy = jasmine.createSpy()
+      const { stop } = instrumentMethod(container, 'MyClass', instrumentationSpy)
 
       stop()
 
-      const instance = new container.MyClass(99)
+      const instance = new container.MyClass(5)
 
+      expect(instrumentationSpy).not.toHaveBeenCalled()
       expect(instance instanceof MyClass).toBeTrue()
-      expect(instance.value).toBe(99)
+      expect(instance.value).toBe(5)
+    })
+
+    it('constructs without calling the instrumentation after stop() when calling instrumentation reference', () => {
+      const container = { MyClass }
+      const instrumentationSpy = jasmine.createSpy()
+      const { stop } = instrumentMethod(container, 'MyClass', instrumentationSpy)
+
+      const OurInstrumentation = container.MyClass
+
+      stop()
+
+      const instance = new OurInstrumentation(5)
+
+      expect(instrumentationSpy).not.toHaveBeenCalled()
+      expect(instance instanceof MyClass).toBeTrue()
+      expect(instance.value).toBe(5)
     })
   })
 

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -201,28 +201,10 @@ describe('instrumentMethod', () => {
 describe('instrumentConstructor', () => {
   const THIRD_PARTY_CONSTRUCTOR_TAG = 42
 
-  class MyClass {
-    value: number
-    constructor(value: number) {
-      this.value = value
-    }
-
-    getValue() {
-      return this.value
-    }
-  }
-
-  const initialMyClassPrototypeConstructor = Object.getOwnPropertyDescriptor(MyClass.prototype, 'constructor')!
+  let MyClass: MyClassConstructor
 
   beforeEach(() => {
-    // Several tests instrument without calling `stop()`; they share this `MyClass` and leave
-    // `MyClass.prototype.constructor` pointing at a stale wrapper, which breaks random-order runs.
-    Object.defineProperty(MyClass.prototype, 'constructor', {
-      configurable: initialMyClassPrototypeConstructor.configurable!,
-      enumerable: initialMyClassPrototypeConstructor.enumerable!,
-      writable: initialMyClassPrototypeConstructor.writable,
-      value: MyClass,
-    })
+    MyClass = createMyClassFixture().MyClass
   })
 
   it('calls the instrumentation when the constructor is called with new', () => {
@@ -248,7 +230,7 @@ describe('instrumentConstructor', () => {
 
     thirdPartyConstructorWrap(container)
 
-    const instance = new container.MyClass(7) as MyClass & { thirdPartyTag: number }
+    const instance = new container.MyClass(7) as MyClassInstance & { thirdPartyTag: number }
 
     expect(instance.value).toBe(7)
     expect(instance.thirdPartyTag).toBe(THIRD_PARTY_CONSTRUCTOR_TAG)
@@ -394,11 +376,11 @@ describe('instrumentConstructor', () => {
     const instance = new container.MyClass(7)
 
     expect(postCallCallbackSpy).toHaveBeenCalledOnceWith(instance)
-    expect((postCallCallbackSpy.calls.mostRecent().args[0] as MyClass).value).toBe(7)
+    expect((postCallCallbackSpy.calls.mostRecent().args[0] as MyClassInstance).value).toBe(7)
   })
 
   it('does not instrument a constructor that does not exist', () => {
-    const container: { MyClass?: typeof MyClass } = {}
+    const container: { MyClass?: MyClassConstructor } = {}
 
     const { stop } = instrumentConstructor(container, 'MyClass', noop)
 
@@ -459,7 +441,7 @@ describe('instrumentConstructor', () => {
 
         stop()
 
-        const instance = new container.MyClass(5) as MyClass & { thirdPartyTag: number }
+        const instance = new container.MyClass(5) as MyClassInstance & { thirdPartyTag: number }
 
         expect(instrumentationSpy).not.toHaveBeenCalled()
         expect(instance.value).toBe(5)
@@ -534,20 +516,40 @@ describe('instrumentConstructor', () => {
   })
 
   /**
-   * Wraps the current `MyClass` on `container` (typically the SDK-instrumented constructor) in a
+   * Wraps the current `container.MyClass` (typically the SDK-instrumented constructor) in a
    * Proxy that still delegates construction, then tags instances — analogous to
    * `thirdPartyInstrumentation` in the `instrumentMethod` suite.
    */
-  function thirdPartyConstructorWrap(container: { MyClass: typeof MyClass }) {
+  function thirdPartyConstructorWrap(container: { MyClass: MyClassConstructor }) {
     const inner = container.MyClass
     container.MyClass = new Proxy(inner, {
       construct(target, argArray, newTarget) {
-        const instance = Reflect.construct(target, argArray, newTarget) as MyClass & { thirdPartyTag: number }
+        const instance = Reflect.construct(target, argArray, newTarget) as MyClassInstance & {
+          thirdPartyTag: number
+        }
         instance.thirdPartyTag = THIRD_PARTY_CONSTRUCTOR_TAG
         return instance
       },
     })
   }
+
+  function createMyClassFixture() {
+    class MyClass {
+      value: number
+      constructor(value: number) {
+        this.value = value
+      }
+
+      getValue() {
+        return this.value
+      }
+    }
+
+    return { MyClass }
+  }
+
+  type MyClassConstructor = ReturnType<typeof createMyClassFixture>['MyClass']
+  type MyClassInstance = InstanceType<MyClassConstructor>
 })
 
 describe('instrumentSetter', () => {

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -1,7 +1,7 @@
 import { mockClock, mockZoneJs } from '../../test'
 import type { Clock, MockZoneJs } from '../../test'
 import type { InstrumentedMethodCall } from './instrumentMethod'
-import { instrumentMethod, instrumentSetter } from './instrumentMethod'
+import { instrumentConstructor, instrumentMethod, instrumentSetter } from './instrumentMethod'
 import { noop } from './utils/functionUtils'
 
 describe('instrumentMethod', () => {
@@ -180,157 +180,6 @@ describe('instrumentMethod', () => {
     })
   })
 
-  describe('constructor support', () => {
-    class MyClass {
-      value: number
-      constructor(value: number) {
-        this.value = value
-      }
-
-      getValue() {
-        return this.value
-      }
-    }
-
-    it('works when the instrumented method is called with new', () => {
-      const container = { MyClass }
-      const instrumentationSpy = jasmine.createSpy()
-      instrumentMethod(container, 'MyClass', instrumentationSpy)
-
-      const instance = new container.MyClass(42)
-
-      expect(instrumentationSpy).toHaveBeenCalledOnceWith({
-        target: jasmine.any(MyClass),
-        parameters: [42],
-        onPostCall: jasmine.any(Function),
-        handlingStack: undefined,
-      })
-      expect(instance.value).toBe(42)
-      expect(instance.getValue()).toBe(42)
-    })
-
-    it('preserves instanceof on the constructed instance', () => {
-      const container = { MyClass }
-      instrumentMethod(container, 'MyClass', noop)
-
-      const instance = new container.MyClass(1)
-
-      // The instance is recognized both as the original class and as the instrumented value.
-      expect(instance instanceof MyClass).toBeTrue()
-      expect(instance instanceof container.MyClass).toBeTrue()
-    })
-
-    it('preserves new.target as the original constructor for direct new calls', () => {
-      let observedNewTarget: unknown
-      class TracksNewTarget {
-        constructor() {
-          observedNewTarget = new.target
-        }
-      }
-
-      const container = { TracksNewTarget }
-      instrumentMethod(container, 'TracksNewTarget', noop)
-
-      new container.TracksNewTarget()
-
-      // Without instrumentation, `new.target` in the constructor body is `TracksNewTarget`.
-      // Forwarding the wrapper as the Reflect.construct newTarget makes `new.target` the
-      // instrumentation function instead, which breaks subclass checks and similar patterns.
-      expect(observedNewTarget).toBe(TracksNewTarget)
-    })
-
-    it('preserves new.target as the subclass when extending the instrumented constructor', () => {
-      let observedNewTargetInOriginal: unknown
-      class Base {
-        constructor() {
-          observedNewTargetInOriginal = new.target
-        }
-      }
-
-      const container = { Base }
-      instrumentMethod(container, 'Base', noop)
-
-      class Sub extends container.Base {
-        constructor() {
-          super()
-        }
-      }
-
-      new Sub()
-
-      expect(observedNewTargetInOriginal).toBe(Sub)
-    })
-
-    it('preserves static members on the instrumented constructor', () => {
-      class MyClassWithStaticMembers {
-        static staticNumber = 123
-
-        static staticMethod() {
-          return 'static-result'
-        }
-      }
-
-      const container = { MyClassWithStaticMembers }
-      instrumentMethod(container, 'MyClassWithStaticMembers', noop)
-
-      expect(container.MyClassWithStaticMembers.staticNumber).toBe(123)
-      expect(container.MyClassWithStaticMembers.staticMethod()).toBe('static-result')
-    })
-
-    it('preserves instanceof when instrumented constructor is used as a base class', () => {
-      const container = { MyClass }
-      instrumentMethod(container, 'MyClass', noop)
-
-      // Third party wraps our instrumentation
-      const OurInstrumentation = container.MyClass
-      container.MyClass = class extends OurInstrumentation {}
-
-      const instance = new container.MyClass(99)
-      expect(instance instanceof container.MyClass).toBeTrue()
-    })
-
-    it('passes the constructed instance to onPostCall', () => {
-      const container = { MyClass }
-      const postCallCallbackSpy = jasmine.createSpy()
-      instrumentMethod(container, 'MyClass', ({ onPostCall }) => onPostCall(postCallCallbackSpy))
-
-      const instance = new container.MyClass(7)
-
-      expect(postCallCallbackSpy).toHaveBeenCalledOnceWith(instance)
-      expect((postCallCallbackSpy.calls.mostRecent().args[0] as MyClass).value).toBe(7)
-    })
-
-    it('constructs without calling the instrumentation after stop() when calling new Original()', () => {
-      const container = { MyClass }
-      const instrumentationSpy = jasmine.createSpy()
-      const { stop } = instrumentMethod(container, 'MyClass', instrumentationSpy)
-
-      stop()
-
-      const instance = new container.MyClass(5)
-
-      expect(instrumentationSpy).not.toHaveBeenCalled()
-      expect(instance instanceof MyClass).toBeTrue()
-      expect(instance.value).toBe(5)
-    })
-
-    it('constructs without calling the instrumentation after stop() when calling instrumentation reference', () => {
-      const container = { MyClass }
-      const instrumentationSpy = jasmine.createSpy()
-      const { stop } = instrumentMethod(container, 'MyClass', instrumentationSpy)
-
-      const OurInstrumentation = container.MyClass
-
-      stop()
-
-      const instance = new OurInstrumentation(5)
-
-      expect(instrumentationSpy).not.toHaveBeenCalled()
-      expect(instance instanceof MyClass).toBeTrue()
-      expect(instance.value).toBe(5)
-    })
-  })
-
   function thirdPartyInstrumentation(object: { method?: () => number; onevent?: () => void }) {
     const originalMethod = object.method
     if (typeof originalMethod === 'function') {
@@ -347,6 +196,167 @@ describe('instrumentMethod', () => {
       }
     }
   }
+})
+
+describe('instrumentConstructor', () => {
+  class MyClass {
+    value: number
+    constructor(value: number) {
+      this.value = value
+    }
+
+    getValue() {
+      return this.value
+    }
+  }
+
+  it('calls the instrumentation when the constructor is called with new', () => {
+    const container = { MyClass }
+    const instrumentationSpy = jasmine.createSpy()
+    instrumentConstructor(container, 'MyClass', instrumentationSpy)
+
+    const instance = new container.MyClass(42)
+
+    expect(instrumentationSpy).toHaveBeenCalledOnceWith({
+      parameters: [42],
+      onPostCall: jasmine.any(Function),
+      handlingStack: undefined,
+    })
+    expect(instance.value).toBe(42)
+    expect(instance.getValue()).toBe(42)
+  })
+
+  it('preserves instanceof on the constructed instance', () => {
+    const container = { MyClass }
+    instrumentConstructor(container, 'MyClass', noop)
+
+    const instance = new container.MyClass(1)
+
+    // The instance is recognized both as the original class and as the instrumented value.
+    expect(instance instanceof MyClass).toBeTrue()
+    expect(instance instanceof container.MyClass).toBeTrue()
+  })
+
+  it('preserves new.target as the original constructor for direct new calls', () => {
+    let observedNewTarget: unknown
+    class TracksNewTarget {
+      constructor() {
+        observedNewTarget = new.target
+      }
+    }
+
+    const container = { TracksNewTarget }
+    instrumentConstructor(container, 'TracksNewTarget', noop)
+
+    new container.TracksNewTarget()
+
+    // Without instrumentation, `new.target` in the constructor body is `TracksNewTarget`.
+    // Forwarding the wrapper as the Reflect.construct newTarget makes `new.target` the
+    // instrumentation function instead, which breaks subclass checks and similar patterns.
+    expect(observedNewTarget).toBe(TracksNewTarget)
+  })
+
+  it('preserves new.target as the subclass when extending the instrumented constructor', () => {
+    let observedNewTargetInOriginal: unknown
+    class Base {
+      constructor() {
+        observedNewTargetInOriginal = new.target
+      }
+    }
+
+    const container = { Base }
+    instrumentConstructor(container, 'Base', noop)
+
+    class Sub extends container.Base {
+      constructor() {
+        super()
+      }
+    }
+
+    new Sub()
+
+    expect(observedNewTargetInOriginal).toBe(Sub)
+  })
+
+  it('preserves static members on the instrumented constructor', () => {
+    class MyClassWithStaticMembers {
+      static staticNumber = 123
+
+      static staticMethod() {
+        return 'static-result'
+      }
+    }
+
+    const container = { MyClassWithStaticMembers }
+    instrumentConstructor(container, 'MyClassWithStaticMembers', noop)
+
+    expect(container.MyClassWithStaticMembers.staticNumber).toBe(123)
+    expect(container.MyClassWithStaticMembers.staticMethod()).toBe('static-result')
+  })
+
+  it('preserves instanceof when instrumented constructor is used as a base class', () => {
+    const container = { MyClass }
+    instrumentConstructor(container, 'MyClass', noop)
+
+    // Third party wraps our instrumentation
+    const OurInstrumentation = container.MyClass
+    container.MyClass = class extends OurInstrumentation {}
+
+    const instance = new container.MyClass(99)
+    expect(instance instanceof container.MyClass).toBeTrue()
+  })
+
+  it('passes the constructed instance to onPostCall', () => {
+    const container = { MyClass }
+    const postCallCallbackSpy = jasmine.createSpy()
+    instrumentConstructor(container, 'MyClass', ({ onPostCall }) => onPostCall(postCallCallbackSpy))
+
+    const instance = new container.MyClass(7)
+
+    expect(postCallCallbackSpy).toHaveBeenCalledOnceWith(instance)
+    expect((postCallCallbackSpy.calls.mostRecent().args[0] as MyClass).value).toBe(7)
+  })
+
+  it('does not instrument a constructor that does not exist', () => {
+    const container: { MyClass?: typeof MyClass } = {}
+
+    const { stop } = instrumentConstructor(container, 'MyClass', noop)
+
+    expect(container.MyClass).toBeUndefined()
+    expect(stop).toBe(noop)
+  })
+
+  describe('stop()', () => {
+    it('constructs without calling the instrumentation when calling new Original()', () => {
+      const container = { MyClass }
+      const instrumentationSpy = jasmine.createSpy()
+      const { stop } = instrumentConstructor(container, 'MyClass', instrumentationSpy)
+
+      stop()
+
+      const instance = new container.MyClass(5)
+
+      expect(instrumentationSpy).not.toHaveBeenCalled()
+      expect(instance instanceof MyClass).toBeTrue()
+      expect(instance.value).toBe(5)
+    })
+
+    it('constructs without calling the instrumentation when calling the instrumentation reference', () => {
+      const container = { MyClass }
+      const instrumentationSpy = jasmine.createSpy()
+      const { stop } = instrumentConstructor(container, 'MyClass', instrumentationSpy)
+
+      const OurInstrumentation = container.MyClass
+
+      stop()
+
+      const instance = new OurInstrumentation(5)
+
+      expect(instrumentationSpy).not.toHaveBeenCalled()
+      expect(instance instanceof MyClass).toBeTrue()
+      expect(instance.value).toBe(5)
+    })
+  })
 })
 
 describe('instrumentSetter', () => {

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -239,6 +239,19 @@ describe('instrumentConstructor', () => {
     expect(instance.getValue()).toBe(42)
   })
 
+  it('does not call the instrumentation when the constructor is invoked without new', () => {
+    const container = { MyClass }
+    const instrumentationSpy = jasmine.createSpy()
+    instrumentConstructor(container, 'MyClass', instrumentationSpy)
+
+    // Bare `[[Call]]` has no `new.target`; the original class constructor throws before any work.
+    expect(() => {
+      ;(container.MyClass as unknown as (value: number) => void)(42)
+    }).toThrow()
+
+    expect(instrumentationSpy).not.toHaveBeenCalled()
+  })
+
   it('preserves instanceof on the constructed instance', () => {
     const container = { MyClass }
     instrumentConstructor(container, 'MyClass', noop)

--- a/packages/browser-core/src/tools/instrumentMethod.spec.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.spec.ts
@@ -215,6 +215,20 @@ describe('instrumentMethod', () => {
 
       const instance = new container.MyClass(1)
 
+      // The instance is recognized both as the original class and as the instrumented value.
+      expect(instance instanceof MyClass).toBeTrue()
+      expect(instance instanceof container.MyClass).toBeTrue()
+    })
+
+    it('preserves instanceof when instrumented constructor is used as a base class', () => {
+      const container = { MyClass }
+      instrumentMethod(container, 'MyClass', noop)
+
+      // Third party wraps our instrumentation
+      const OurInstrumentation = container.MyClass
+      container.MyClass = class extends OurInstrumentation {}
+
+      const instance = new container.MyClass(99)
       expect(instance instanceof container.MyClass).toBeTrue()
     })
 

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -319,7 +319,21 @@ function preserveConstructorShape(instrumentation: (...args: any[]) => any, orig
 
   // Preserve the original prototype so that instanceof checks against the instrumented global work.
   // e.g. `new MyClass() instanceof MyClass` must remain true.
-  instrumentation.prototype = original.prototype
+  const originalPrototypeDescriptor = Object.getOwnPropertyDescriptor(original, 'prototype')
+  try {
+    if (originalPrototypeDescriptor) {
+      Object.defineProperty(instrumentation, 'prototype', {
+        value: original.prototype,
+        writable: originalPrototypeDescriptor.writable,
+        enumerable: originalPrototypeDescriptor.enumerable,
+        configurable: originalPrototypeDescriptor.configurable,
+      })
+    } else {
+      instrumentation.prototype = original.prototype
+    }
+  } catch {
+    instrumentation.prototype = original.prototype
+  }
 
   const prototypeObject = original.prototype as object
 

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -300,7 +300,7 @@ interface InstrumentationCallbacks<RESULT> {
 }
 
 /**
- * Copies the original constructor prototype and static members onto the instrumentation, so that
+ * Copies the original constructor prototype and other static members onto the instrumentation, so that
  * `instanceof` checks keep working and statics such as `WebSocket.OPEN` remain available while
  * instrumented.
  *
@@ -308,128 +308,36 @@ interface InstrumentationCallbacks<RESULT> {
  * before restoring the global property in `stop()`.
  */
 function preserveConstructorShape(instrumentation: AnyConstructor, original: AnyConstructor): () => void {
-  if (!original.prototype) {
-    return noop
-  }
-
-  copyOriginalPrototype(instrumentation, original)
-
-  const prototypeObject = original.prototype as object
-  const { rewired, savedConstructorDescriptor } = tryRewirePrototypeConstructor(prototypeObject, instrumentation)
-
-  copyOwnStaticsExceptBuiltins(original, instrumentation)
-
-  return () =>
-    restorePrototypeConstructor({
-      rewired,
-      prototypeObject,
-      savedConstructorDescriptor,
-      original,
-    })
-}
-
-// Preserve the original prototype so that instanceof checks against the instrumented global work.
-// e.g. `new MyClass() instanceof MyClass` must remain true.
-function copyOriginalPrototype(instrumentation: AnyConstructor, original: AnyConstructor): void {
-  const originalPrototypeDescriptor = Object.getOwnPropertyDescriptor(original, 'prototype')
-  try {
-    if (originalPrototypeDescriptor) {
-      Object.defineProperty(instrumentation, 'prototype', {
-        value: original.prototype,
-        writable: originalPrototypeDescriptor.writable,
-        enumerable: originalPrototypeDescriptor.enumerable,
-        configurable: originalPrototypeDescriptor.configurable,
-      })
-    } else {
-      instrumentation.prototype = original.prototype
-    }
-  } catch {
-    instrumentation.prototype = original.prototype
-  }
-}
-
-/*
- * Limitation: repointing `constructor` on this shared prototype affects every instance whose
- * `[[Prototype]]` is this object, including instances created before instrumentation, because
- * `constructor` is inherited rather than snapshotted per instance. Code that held `original` (or
- * whatever was in `prototype.constructor` before) as the canonical constructor and expects reference
- * equality to that value for the lifetime of the page can observe a behavior change while RUM is
- * active; restoring on `stop()` fixes this. In practice the SDK initializes as early as possible,
- * which narrows the window where pre-instrument instances exist.
- */
-function tryRewirePrototypeConstructor(
-  prototypeObject: object,
-  instrumentation: AnyConstructor
-): { rewired: boolean; savedConstructorDescriptor: PropertyDescriptor | undefined } {
-  const savedConstructorDescriptor = Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')
-
-  let rewired = false
-  try {
-    Object.defineProperty(prototypeObject, 'constructor', {
-      value: instrumentation,
-      writable: savedConstructorDescriptor?.writable ?? true,
-      enumerable: savedConstructorDescriptor?.enumerable ?? false,
-      configurable: true,
-    })
-    rewired = true
-  } catch {
-    // Some exotic builtins keep a non-configurable `constructor` on their prototype.
-  }
-  return { rewired, savedConstructorDescriptor }
-}
-
-const STATIC_COPY_EXCLUDED_KEYS = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
-
-/*
- * Limitation: only the original's *own* static members are copied. Statics inherited through the
- * constructor's prototype chain (e.g. `class Child extends Parent` where `Parent` defines statics)
- * are not preserved, since the instrumentation still inherits from `Function.prototype`. This is
- * acceptable for the globals we instrument (e.g. `WebSocket`, whose own statics are the only ones
- * that matter), but would need to delegate the static prototype chain to support subclassed
- * constructors with meaningful inherited statics.
- */
-function copyOwnStaticsExceptBuiltins(original: AnyConstructor, instrumentation: AnyConstructor): void {
+  /**
+   * Limitation: Only the original's *own* static members are copied. Statics inherited through the
+   * constructor's prototype chain (e.g. `class Child extends Parent` where `Parent` defines statics)
+   * are not preserved, since the instrumentation still inherits from `Function.prototype`. This is
+   * acceptable for the globals we instrument (e.g. `WebSocket`, whose own statics are the only ones
+   * that matter), but we would need to delegate the static prototype chain to support subclassed
+   * constructors with meaningful inherited statics.
+   */
   for (const key of ([] as PropertyKey[]).concat(
     Object.getOwnPropertyNames(original),
     Object.getOwnPropertySymbols(original)
   )) {
-    if (typeof key === 'string' && STATIC_COPY_EXCLUDED_KEYS.has(key)) {
-      continue
-    }
-    const descriptor = Object.getOwnPropertyDescriptor(original, key)
-    if (descriptor) {
-      Object.defineProperty(instrumentation, key, descriptor)
-    }
+    const descriptor = Object.getOwnPropertyDescriptor(original, key) as PropertyDescriptor
+    Object.defineProperty(instrumentation, key, descriptor)
   }
-}
 
-function restorePrototypeConstructor({
-  rewired,
-  prototypeObject,
-  savedConstructorDescriptor,
-  original,
-}: {
-  rewired: boolean
-  prototypeObject: object
-  savedConstructorDescriptor: PropertyDescriptor | undefined
-  original: AnyConstructor
-}): void {
-  if (!rewired) {
-    return
-  }
-  try {
-    if (savedConstructorDescriptor) {
-      Object.defineProperty(prototypeObject, 'constructor', savedConstructorDescriptor)
-    } else {
-      Object.defineProperty(prototypeObject, 'constructor', {
-        value: original,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      })
-    }
-  } catch {
-    // Best-effort: prototype.constructor may be non-configurable
+  /*
+   * Limitation: Repointing `constructor` on this shared prototype affects every instance whose
+   * `[[Prototype]]` is this object, including instances created before instrumentation, because
+   * `constructor` is inherited rather than snapshotted per instance. Code that held `original` (or
+   * whatever was in `prototype.constructor` before) as the canonical constructor and expects reference
+   * equality to that value for the lifetime of the page can observe a behavior change while RUM is
+   * active; restoring on `stop()` fixes this. In practice the SDK initializes as early as possible,
+   * which narrows the window where pre-instrument instances exist.
+   */
+  const originalConstructor = original.prototype.constructor
+  original.prototype.constructor = instrumentation
+
+  return () => {
+    original.prototype.constructor = originalConstructor
   }
 }
 

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -166,13 +166,13 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
  *    })
  *  })
  */
-export function instrumentConstructor<TARGET extends { [key: string]: any }, NAME extends keyof TARGET>(
-  target: TARGET,
-  name: NAME,
-  onPreCall: (this: null, callInfos: InstrumentedConstructorCall<TARGET[NAME]>) => void,
+export function instrumentConstructor<CONTAINER extends { [key: string]: any }, CONSTRUCTOR extends keyof CONTAINER>(
+  container: CONTAINER,
+  constructor: CONSTRUCTOR,
+  onPreCall: (this: null, callInfos: InstrumentedConstructorCall<CONTAINER[CONSTRUCTOR]>) => void,
   { computeHandlingStack }: { computeHandlingStack?: boolean } = {}
 ) {
-  const original = target[name]
+  const original = container[constructor]
 
   if (typeof original !== 'function') {
     return { stop: noop }
@@ -180,33 +180,36 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
 
   let restorePrototypeConstructor: () => void = noop
 
-  const { stop: replaceStop } = replaceWithInstrumentation(target, name, original, (isStopped) => {
-    const instrumentation = function (this: TARGET): ConstructorInstanceOf<TARGET[NAME]> {
+  const { stop: replaceStop } = replaceWithInstrumentation(container, constructor, original, (isStopped) => {
+    const instrumentation = function (this: unknown): ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]> {
       // Bare `[[Call]]` (no `new`): delegate through `[[Call]]` and skip `onPreCall`. Otherwise we
       // would notify instrumentation before the original rejects or returns, unlike the native
       // constructor (e.g. `WebSocket(url)` or `class {}()` without `new`).
       if (!new.target) {
-        return Reflect.apply(original, this, Array.from(arguments)) as ConstructorInstanceOf<TARGET[NAME]>
+        return Reflect.apply(original, this, Array.from(arguments)) as ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]>
       }
 
       // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
       // it through to Reflect.construct would expose the wrong new.target inside the original
       // body. If a subclass extends the wrapper, or a third party wraps us and their class is
       // instantiated, `new.target` is that outer constructor and must be preserved.
-      const constructNewTarget = new.target === instrumentation ? original : new.target
+      const newTarget = new.target === instrumentation ? original : new.target
 
       if (isStopped()) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return Reflect.construct(
           original,
-          arguments as unknown as ConstructorParametersOf<TARGET[NAME]>,
-          constructNewTarget
+          arguments as unknown as ConstructorParametersOf<CONTAINER[CONSTRUCTOR]>,
+          newTarget
         )
       }
 
-      const parameters = Array.from(arguments) as ConstructorParametersOf<TARGET[NAME]>
+      const parameters = Array.from(arguments) as ConstructorParametersOf<CONTAINER[CONSTRUCTOR]>
 
-      return notifyInstrumentation<InstrumentedConstructorCall<TARGET[NAME]>, ConstructorInstanceOf<TARGET[NAME]>>(
+      return notifyInstrumentation<
+        InstrumentedConstructorCall<CONTAINER[CONSTRUCTOR]>,
+        ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]>
+      >(
         onPreCall,
         {
           parameters,
@@ -214,13 +217,13 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
         },
         () =>
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          Reflect.construct(original, parameters, constructNewTarget)
+          Reflect.construct(original, parameters, newTarget)
       )
     }
 
     restorePrototypeConstructor = preserveConstructorShape(instrumentation as unknown as AnyConstructor, original)
 
-    return instrumentation as TARGET[NAME]
+    return instrumentation as CONTAINER[CONSTRUCTOR]
   })
 
   return {

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -121,7 +121,7 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
     ])
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const result = new.target ? Reflect.construct(original, parameters) : original.apply(this, parameters)
+    const result = new.target ? Reflect.construct(original, parameters, new.target) : original.apply(this, parameters)
 
     if (postCallCallback) {
       callMonitored(postCallCallback, null, [result])

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -210,7 +210,7 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
         onPreCall,
         {
           parameters,
-          handlingStack: computeHandlingStack ? createHandlingStack('instrumented method') : undefined,
+          handlingStack: computeHandlingStack ? createHandlingStack('instrumented constructor') : undefined,
         },
         () =>
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -3,6 +3,17 @@ import { callMonitored } from './monitor'
 import { noop } from './utils/functionUtils'
 import { createHandlingStack } from './stackTrace/handlingStack'
 
+/* Resolves parameters from either a call or construct signature, so instrumentMethod can handle
+ * both regular methods and constructors (e.g. `new WebSocket()`).
+ */
+type MethodParameters<T> = T extends new (...args: infer P) => any ? P : T extends (...args: infer P) => any ? P : never
+
+type MethodReturnType<T> = T extends new (...args: any[]) => infer R
+  ? R
+  : T extends (...args: any[]) => infer R
+    ? R
+    : never
+
 /**
  * Object passed to the callback of an instrumented method call. See `instrumentMethod` for more
  * info.
@@ -18,7 +29,7 @@ export interface InstrumentedMethodCall<TARGET extends { [key: string]: any }, M
    *
    * Note: if needed, parameters can be mutated by the instrumentation
    */
-  parameters: Parameters<TARGET[METHOD]>
+  parameters: MethodParameters<TARGET[METHOD]>
 
   /**
    * Registers a callback that will be called after the original method is called, with the method
@@ -33,7 +44,7 @@ export interface InstrumentedMethodCall<TARGET extends { [key: string]: any }, M
 }
 
 type PostCallCallback<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET> = (
-  result: ReturnType<TARGET[METHOD]>
+  result: MethodReturnType<TARGET[METHOD]>
 ) => void
 
 /**
@@ -85,13 +96,16 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
 
   let stopped = false
 
-  const instrumentation = function (this: TARGET): ReturnType<TARGET[METHOD]> {
+  const instrumentation = function (this: TARGET): MethodReturnType<TARGET[METHOD]> {
     if (stopped) {
+      if (new.target) {
+        return Reflect.construct(original, arguments as unknown as MethodParameters<TARGET[METHOD]>)
+      }
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
       return original.apply(this, arguments)
     }
 
-    const parameters = Array.from(arguments) as Parameters<TARGET[METHOD]>
+    const parameters = Array.from(arguments) as MethodParameters<TARGET[METHOD]>
 
     let postCallCallback: PostCallCallback<TARGET, METHOD> | undefined
 
@@ -107,7 +121,7 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
     ])
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const result = original.apply(this, parameters)
+    const result = new.target ? Reflect.construct(original, parameters) : original.apply(this, parameters)
 
     if (postCallCallback) {
       callMonitored(postCallCallback, null, [result])
@@ -115,6 +129,12 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return result
+  }
+
+  // Preserve the original prototype so that instanceof checks against the instrumented global work.
+  // e.g. `new window.WebSocket(url) instanceof window.WebSocket` must remain true.
+  if (typeof original === 'function' && original.prototype) {
+    instrumentation.prototype = original.prototype
   }
 
   targetPrototype[method] = instrumentation as TARGET[METHOD]

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -4,7 +4,7 @@ import { noop } from './utils/functionUtils'
 import { createHandlingStack } from './stackTrace/handlingStack'
 
 /* Resolves parameters from either a call or construct signature, so instrumentMethod can handle
- * both regular methods and constructors (e.g. `new WebSocket()`).
+ * both regular methods and constructors (e.g. `new MyClass()`).
  */
 type MethodParameters<T> = T extends new (...args: infer P) => any ? P : T extends (...args: infer P) => any ? P : never
 
@@ -142,7 +142,7 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
   }
 
   // Preserve the original prototype so that instanceof checks against the instrumented global work.
-  // e.g. `new window.WebSocket(url) instanceof window.WebSocket` must remain true.
+  // e.g. `new MyClass() instanceof MyClass` must remain true.
   if (typeof original === 'function' && original.prototype) {
     instrumentation.prototype = original.prototype
   }

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -114,31 +114,36 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
     }
   }
 
-  return replaceWithInstrumentation(
-    targetPrototype,
-    method,
-    original,
-    (isStopped) =>
-      function (this: TARGET): ReturnType<TARGET[METHOD]> {
-        if (isStopped()) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-          return original.apply(this, arguments)
-        }
+  let stopped = false
 
-        const parameters = Array.from(arguments) as Parameters<TARGET[METHOD]>
+  const instrumentation = function (this: TARGET): ReturnType<TARGET[METHOD]> {
+    if (stopped) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+      return original.apply(this, arguments)
+    }
 
-        return notifyInstrumentation<InstrumentedMethodCall<TARGET, METHOD>, ReturnType<TARGET[METHOD]>>(
-          onPreCall,
-          {
-            target: this,
-            parameters,
-            handlingStack: computeHandlingStack ? createHandlingStack('instrumented method') : undefined,
-          },
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call -- TARGET[METHOD] is any under the index signature; value is verified as a function above
-          () => original.apply(this, parameters)
-        )
-      } as TARGET[METHOD]
-  )
+    const parameters = Array.from(arguments) as Parameters<TARGET[METHOD]>
+
+    return notifyInstrumentation<InstrumentedMethodCall<TARGET, METHOD>, ReturnType<TARGET[METHOD]>>(
+      onPreCall,
+      {
+        target: this,
+        parameters,
+        handlingStack: computeHandlingStack ? createHandlingStack('instrumented method') : undefined,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call -- TARGET[METHOD] is any under the index signature; value is verified as a function above
+      () => original.apply(this, parameters)
+    )
+  } as TARGET[METHOD]
+
+  const { stop: restoreOriginal } = replaceWithInstrumentation(targetPrototype, method, original, instrumentation)
+
+  return {
+    stop: () => {
+      stopped = true
+      restoreOriginal()
+    },
+  }
 }
 
 /**
@@ -178,85 +183,74 @@ export function instrumentConstructor<CONTAINER extends { [key: string]: any }, 
     return { stop: noop }
   }
 
-  let restorePrototypeConstructor: () => void = noop
+  let stopped = false
 
-  const { stop: replaceStop } = replaceWithInstrumentation(container, constructor, original, (isStopped) => {
-    const instrumentation = function (this: unknown): ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]> {
-      // Bare `[[Call]]` (no `new`): delegate through `[[Call]]` and skip `onPreCall`. Otherwise we
-      // would notify instrumentation before the original rejects or returns, unlike the native
-      // constructor (e.g. `WebSocket(url)` or `class {}()` without `new`).
-      if (!new.target) {
-        return Reflect.apply(original, this, Array.from(arguments)) as ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]>
-      }
+  const instrumentation = function (this: unknown): ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]> {
+    // Bare `[[Call]]` (no `new`): delegate through `[[Call]]` and skip `onPreCall`. Otherwise we
+    // would notify instrumentation before the original rejects or returns, unlike the native
+    // constructor (e.g. `WebSocket(url)` or `class {}()` without `new`).
+    if (!new.target) {
+      return Reflect.apply(original, this, Array.from(arguments)) as ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]>
+    }
 
-      // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
-      // it through to Reflect.construct would expose the wrong new.target inside the original
-      // body. If a subclass extends the wrapper, or a third party wraps us and their class is
-      // instantiated, `new.target` is that outer constructor and must be preserved.
-      const newTarget = new.target === instrumentation ? original : new.target
+    // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
+    // it through to Reflect.construct would expose the wrong new.target inside the original
+    // body. If a subclass extends the wrapper, or a third party wraps us and their class is
+    // instantiated, `new.target` is that outer constructor and must be preserved.
+    const newTarget = new.target === instrumentation ? original : new.target
 
-      if (isStopped()) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return Reflect.construct(
-          original,
-          arguments as unknown as ConstructorParametersOf<CONTAINER[CONSTRUCTOR]>,
-          newTarget
-        )
-      }
-
-      const parameters = Array.from(arguments) as ConstructorParametersOf<CONTAINER[CONSTRUCTOR]>
-
-      return notifyInstrumentation<
-        InstrumentedConstructorCall<CONTAINER[CONSTRUCTOR]>,
-        ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]>
-      >(
-        onPreCall,
-        {
-          parameters,
-          handlingStack: computeHandlingStack ? createHandlingStack('instrumented constructor') : undefined,
-        },
-        () =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          Reflect.construct(original, parameters, newTarget)
+    if (stopped) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return Reflect.construct(
+        original,
+        arguments as unknown as ConstructorParametersOf<CONTAINER[CONSTRUCTOR]>,
+        newTarget
       )
     }
 
-    restorePrototypeConstructor = preserveConstructorShape(instrumentation as unknown as AnyConstructor, original)
+    const parameters = Array.from(arguments) as ConstructorParametersOf<CONTAINER[CONSTRUCTOR]>
 
-    return instrumentation as CONTAINER[CONSTRUCTOR]
-  })
+    return notifyInstrumentation<
+      InstrumentedConstructorCall<CONTAINER[CONSTRUCTOR]>,
+      ConstructorInstanceOf<CONTAINER[CONSTRUCTOR]>
+    >(
+      onPreCall,
+      {
+        parameters,
+        handlingStack: computeHandlingStack ? createHandlingStack('instrumented constructor') : undefined,
+      },
+      () =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        Reflect.construct(original, parameters, newTarget)
+    )
+  } as CONTAINER[CONSTRUCTOR]
+
+  const restorePrototypeConstructor = preserveConstructorShape(instrumentation, original)
+  const { stop: restoreOriginal } = replaceWithInstrumentation(container, constructor, original, instrumentation)
 
   return {
     stop: () => {
+      stopped = true
       restorePrototypeConstructor()
-      replaceStop()
+      restoreOriginal()
     },
   }
 }
 
 /**
- * Replaces `targetPrototype[method]` with the instrumentation built by `buildInstrumentation`, and
+ * Replaces `targetPrototype[method]` with the provided instrumentation and
  * returns a `stop` function restoring the original (unless a third party replaced us afterwards).
- *
- * `buildInstrumentation` receives an `isStopped` accessor so the wrapper can transparently delegate
- * to the original once the instrumentation has been stopped but consumers still hold a reference to
- * it.
  */
 function replaceWithInstrumentation<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET>(
   targetPrototype: TARGET,
   method: METHOD,
   original: TARGET[METHOD],
-  buildInstrumentation: (isStopped: () => boolean) => TARGET[METHOD]
+  instrumentation: TARGET[METHOD]
 ) {
-  let stopped = false
-
-  const instrumentation = buildInstrumentation(() => stopped)
-
   targetPrototype[method] = instrumentation
 
   return {
     stop: () => {
-      stopped = true
       // If the instrumentation has been removed by a third party, keep the last one
       if (targetPrototype[method] === instrumentation) {
         targetPrototype[method] = original

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -149,8 +149,9 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
  * restores the original constructor unless a third party replaced it afterwards.
  *
  * The wrapper preserves the original prototype (so `instanceof` keeps working), the original
- * `new.target` (so constructors that inspect it behave as if not instrumented), and the original
- * static members (e.g. `WebSocket.OPEN`).
+ * `new.target` (so constructors that inspect it behave as if not instrumented), the original
+ * static members (e.g. `WebSocket.OPEN`), and `instance.constructor ===` so checks like
+ * `new WebSocket(url).constructor === WebSocket` stay true.
  *
  * @see {@link preserveConstructorShape} for limitations on static members preservation.
  * @example
@@ -175,7 +176,9 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
     return { stop: noop }
   }
 
-  return replaceWithInstrumentation(target, name, original, (isStopped) => {
+  let restorePrototypeConstructor: () => void = noop
+
+  const { stop: replaceStop } = replaceWithInstrumentation(target, name, original, (isStopped) => {
     const instrumentation = function (this: TARGET): ConstructorInstanceOf<TARGET[NAME]> {
       // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
       // it through to Reflect.construct would expose the wrong new.target inside the original
@@ -206,10 +209,17 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
       )
     }
 
-    preserveConstructorShape(instrumentation, original)
+    restorePrototypeConstructor = preserveConstructorShape(instrumentation, original)
 
     return instrumentation as TARGET[NAME]
   })
+
+  return {
+    stop: () => {
+      restorePrototypeConstructor()
+      replaceStop()
+    },
+  }
 }
 
 /**
@@ -291,15 +301,42 @@ interface InstrumentationCallbacks<RESULT> {
  * acceptable for the globals we instrument (e.g. `WebSocket`, whose own statics are the only ones
  * that matter), but would need to delegate the static prototype chain to support subclassed
  * constructors with meaningful inherited statics.
+ *
+ * Returns a function that restores `prototype.constructor` to its prior descriptor; call it
+ * before restoring the global property in `stop()`.
  */
 function preserveConstructorShape(instrumentation: (...args: any[]) => any, original: (...args: any[]) => any) {
   if (!original.prototype) {
-    return
+    return noop
   }
 
   // Preserve the original prototype so that instanceof checks against the instrumented global work.
   // e.g. `new MyClass() instanceof MyClass` must remain true.
   instrumentation.prototype = original.prototype
+
+  const prototypeObject = original.prototype as object
+
+  // Limitation: repointing `constructor` on this shared prototype affects every instance whose
+  // [[Prototype]] is this object, including instances created before instrumentation, because
+  // `constructor` is inherited rather than snapshotted per instance. Code that held `original`
+  // (or whatever was in `prototype.constructor` before) as the canonical constructor and expects
+  // reference equality to that value for the lifetime of the page can observe a behavior change
+  // while RUM is active; restoring on `stop()` fixes this. Note, In practice the
+  // SDK initializes as early as possible, which narrows the window where pre-instrument instances
+  // exist.
+  const savedConstructorDescriptor = Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')
+  let rewiredPrototypeConstructor = false
+  try {
+    Object.defineProperty(prototypeObject, 'constructor', {
+      value: instrumentation,
+      writable: savedConstructorDescriptor?.writable ?? true,
+      enumerable: savedConstructorDescriptor?.enumerable ?? false,
+      configurable: true,
+    })
+    rewiredPrototypeConstructor = true
+  } catch {
+    // Some exotic builtins keep a non-configurable `constructor` on their prototype.
+  }
 
   // Preserve own static members (class fields, static methods, etc.) on the instrumented function.
   const excludedKeys = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
@@ -316,6 +353,26 @@ function preserveConstructorShape(instrumentation: (...args: any[]) => any, orig
     const descriptor = Object.getOwnPropertyDescriptor(original, key)
     if (descriptor) {
       Object.defineProperty(instrumentation, key, descriptor)
+    }
+  }
+
+  return () => {
+    if (!rewiredPrototypeConstructor) {
+      return
+    }
+    try {
+      if (savedConstructorDescriptor) {
+        Object.defineProperty(prototypeObject, 'constructor', savedConstructorDescriptor)
+      } else {
+        Object.defineProperty(prototypeObject, 'constructor', {
+          value: original,
+          writable: true,
+          enumerable: false,
+          configurable: true,
+        })
+      }
+    } catch {
+      // Best-effort: prototype.constructor may be non-configurable
     }
   }
 }

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -152,6 +152,7 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
  * `new.target` (so constructors that inspect it behave as if not instrumented), and the original
  * static members (e.g. `WebSocket.OPEN`).
  *
+ * @see {@link preserveConstructorShape} for limitations on static members preservation.
  * @example
  *
  *  instrumentConstructor(window, 'WebSocket', ({ parameters, onPostCall }) => {
@@ -283,6 +284,13 @@ interface InstrumentationCallbacks<RESULT> {
  * Copies the original constructor prototype and static members onto the instrumentation, so that
  * `instanceof` checks keep working and statics such as `WebSocket.OPEN` remain available while
  * instrumented.
+ *
+ * Limitation: only the original's *own* static members are copied. Statics inherited through the
+ * constructor's prototype chain (e.g. `class Child extends Parent` where `Parent` defines statics)
+ * are not preserved, since the instrumentation still inherits from `Function.prototype`. This is
+ * acceptable for the globals we instrument (e.g. `WebSocket`, whose own statics are the only ones
+ * that matter), but would need to delegate the static prototype chain to support subclassed
+ * constructors with meaningful inherited statics.
  */
 function preserveConstructorShape(instrumentation: (...args: any[]) => any, original: (...args: any[]) => any) {
   if (!original.prototype) {
@@ -293,7 +301,7 @@ function preserveConstructorShape(instrumentation: (...args: any[]) => any, orig
   // e.g. `new MyClass() instanceof MyClass` must remain true.
   instrumentation.prototype = original.prototype
 
-  // Preserve static members (class fields, static methods, etc.) on the instrumented function.
+  // Preserve own static members (class fields, static methods, etc.) on the instrumented function.
   const excludedKeys = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
   for (const key of Object.getOwnPropertyNames(original)) {
     if (excludedKeys.has(key)) {

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -176,9 +176,19 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
 
   return replaceWithInstrumentation(target, name, original, (isStopped) => {
     const instrumentation = function (this: TARGET): ConstructorInstanceOf<TARGET[NAME]> {
+      // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
+      // it through to Reflect.construct would expose the wrong new.target inside the original
+      // body. If a subclass extends the wrapper, or a third party wraps us and their class is
+      // `new`ed, `new.target` is that outer constructor and must be preserved.
+      const constructNewTarget = new.target === instrumentation ? original : new.target
+
       if (isStopped()) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return Reflect.construct(original, arguments as unknown as ConstructorParametersOf<TARGET[NAME]>)
+        return Reflect.construct(
+          original,
+          arguments as unknown as ConstructorParametersOf<TARGET[NAME]>,
+          constructNewTarget
+        )
       }
 
       const parameters = Array.from(arguments) as ConstructorParametersOf<TARGET[NAME]>
@@ -189,15 +199,9 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
           parameters,
           handlingStack: computeHandlingStack ? createHandlingStack('instrumented method') : undefined,
         },
-        () => {
-          // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
-          // it through to Reflect.construct would expose the wrong new.target inside the original
-          // body. If a subclass extends the wrapper, or a third party wraps us and their class is
-          // `new`ed, `new.target` is that outer constructor and must be preserved.
-          const constructNewTarget = new.target === instrumentation ? original : new.target
+        () =>
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          return Reflect.construct(original, parameters, constructNewTarget)
-        }
+          Reflect.construct(original, parameters, constructNewTarget)
       )
     }
 

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -3,17 +3,6 @@ import { callMonitored } from './monitor'
 import { noop } from './utils/functionUtils'
 import { createHandlingStack } from './stackTrace/handlingStack'
 
-/* Resolves parameters from either a call or construct signature, so instrumentMethod can handle
- * both regular methods and constructors (e.g. `new MyClass()`).
- */
-type MethodParameters<T> = T extends new (...args: infer P) => any ? P : T extends (...args: infer P) => any ? P : never
-
-type MethodReturnType<T> = T extends new (...args: any[]) => infer R
-  ? R
-  : T extends (...args: any[]) => infer R
-    ? R
-    : never
-
 /**
  * Object passed to the callback of an instrumented method call. See `instrumentMethod` for more
  * info.
@@ -29,7 +18,7 @@ export interface InstrumentedMethodCall<TARGET extends { [key: string]: any }, M
    *
    * Note: if needed, parameters can be mutated by the instrumentation
    */
-  parameters: MethodParameters<TARGET[METHOD]>
+  parameters: Parameters<TARGET[METHOD]>
 
   /**
    * Registers a callback that will be called after the original method is called, with the method
@@ -44,8 +33,35 @@ export interface InstrumentedMethodCall<TARGET extends { [key: string]: any }, M
 }
 
 type PostCallCallback<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET> = (
-  result: MethodReturnType<TARGET[METHOD]>
+  result: ReturnType<TARGET[METHOD]>
 ) => void
+
+type ConstructorParametersOf<CONSTRUCTOR> = CONSTRUCTOR extends new (...args: infer P) => any ? P : never
+type ConstructorInstanceOf<CONSTRUCTOR> = CONSTRUCTOR extends new (...args: any[]) => infer R ? R : never
+
+/**
+ * Object passed to the callback of an instrumented constructor call. See `instrumentConstructor`
+ * for more info.
+ */
+export interface InstrumentedConstructorCall<CONSTRUCTOR> {
+  /**
+   * The parameters with which the constructor was called.
+   *
+   * Note: if needed, parameters can be mutated by the instrumentation
+   */
+  parameters: ConstructorParametersOf<CONSTRUCTOR>
+
+  /**
+   * Registers a callback that will be called after the original constructor is called, with the
+   * constructed instance passed as argument.
+   */
+  onPostCall: (callback: (result: ConstructorInstanceOf<CONSTRUCTOR>) => void) => void
+
+  /**
+   * The stack trace of the constructor call.
+   */
+  handlingStack?: string
+}
 
 /**
  * Instruments a method on a object, calling the given callback before the original method is
@@ -67,6 +83,8 @@ type PostCallCallback<TARGET extends { [key: string]: any }, METHOD extends keyo
  * override it.
  * * if the event handler is set by a third party after us, we need to keep it in place when
  * removing ours.
+ *
+ * To instrument a constructor @see {@link instrumentConstructor}.
  *
  * @example
  *
@@ -94,78 +112,120 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
     }
   }
 
+  return replaceWithInstrumentation(
+    targetPrototype,
+    method,
+    original,
+    (isStopped) =>
+      function (this: TARGET): ReturnType<TARGET[METHOD]> {
+        if (isStopped()) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+          return original.apply(this, arguments)
+        }
+
+        const parameters = Array.from(arguments) as Parameters<TARGET[METHOD]>
+
+        return notifyInstrumentation<InstrumentedMethodCall<TARGET, METHOD>, ReturnType<TARGET[METHOD]>>(
+          onPreCall,
+          {
+            target: this,
+            parameters,
+            handlingStack: computeHandlingStack ? createHandlingStack('instrumented method') : undefined,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call -- TARGET[METHOD] is any under the index signature; value is verified as a function above
+          () => original.apply(this, parameters)
+        )
+      } as TARGET[METHOD]
+  )
+}
+
+/**
+ * Instruments a constructor on an object (typically a global, e.g. `window.WebSocket`), calling the
+ * given callback before the original constructor is invoked. The callback receives an object with
+ * information about the constructor call, and can register an `onPostCall` callback to be notified
+ * with the constructed instance.
+ *
+ * Like `instrumentMethod`, this is a "good citizen" regarding third party instrumentations: stopping
+ * restores the original constructor unless a third party replaced it afterwards.
+ *
+ * The wrapper preserves the original prototype (so `instanceof` keeps working), the original
+ * `new.target` (so constructors that inspect it behave as if not instrumented), and the original
+ * static members (e.g. `WebSocket.OPEN`).
+ *
+ * @example
+ *
+ *  instrumentConstructor(window, 'WebSocket', ({ parameters, onPostCall }) => {
+ *    console.log('Before constructing WebSocket with parameters', parameters)
+ *
+ *    onPostCall((instance) => {
+ *      console.log('Constructed WebSocket instance', instance)
+ *    })
+ *  })
+ */
+export function instrumentConstructor<TARGET extends { [key: string]: any }, NAME extends keyof TARGET>(
+  target: TARGET,
+  name: NAME,
+  onPreCall: (this: null, callInfos: InstrumentedConstructorCall<TARGET[NAME]>) => void,
+  { computeHandlingStack }: { computeHandlingStack?: boolean } = {}
+) {
+  const original = target[name]
+
+  if (typeof original !== 'function') {
+    return { stop: noop }
+  }
+
+  return replaceWithInstrumentation(target, name, original, (isStopped) => {
+    const instrumentation = function (this: TARGET): ConstructorInstanceOf<TARGET[NAME]> {
+      if (isStopped()) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return Reflect.construct(original, arguments as unknown as ConstructorParametersOf<TARGET[NAME]>)
+      }
+
+      const parameters = Array.from(arguments) as ConstructorParametersOf<TARGET[NAME]>
+
+      return notifyInstrumentation<InstrumentedConstructorCall<TARGET[NAME]>, ConstructorInstanceOf<TARGET[NAME]>>(
+        onPreCall,
+        {
+          parameters,
+          handlingStack: computeHandlingStack ? createHandlingStack('instrumented method') : undefined,
+        },
+        () => {
+          // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
+          // it through to Reflect.construct would expose the wrong new.target inside the original
+          // body. If a subclass extends the wrapper, or a third party wraps us and their class is
+          // `new`ed, `new.target` is that outer constructor and must be preserved.
+          const constructNewTarget = new.target === instrumentation ? original : new.target
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return Reflect.construct(original, parameters, constructNewTarget)
+        }
+      )
+    }
+
+    preserveConstructorShape(instrumentation, original)
+
+    return instrumentation as TARGET[NAME]
+  })
+}
+
+/**
+ * Replaces `targetPrototype[method]` with the instrumentation built by `buildInstrumentation`, and
+ * returns a `stop` function restoring the original (unless a third party replaced us afterwards).
+ *
+ * `buildInstrumentation` receives an `isStopped` accessor so the wrapper can transparently delegate
+ * to the original once the instrumentation has been stopped but consumers still hold a reference to
+ * it.
+ */
+function replaceWithInstrumentation<TARGET extends { [key: string]: any }, METHOD extends keyof TARGET>(
+  targetPrototype: TARGET,
+  method: METHOD,
+  original: TARGET[METHOD],
+  buildInstrumentation: (isStopped: () => boolean) => TARGET[METHOD]
+) {
   let stopped = false
 
-  const instrumentation = function (this: TARGET): MethodReturnType<TARGET[METHOD]> {
-    if (stopped) {
-      if (new.target) {
-        return Reflect.construct(original, arguments as unknown as MethodParameters<TARGET[METHOD]>)
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-      return original.apply(this, arguments)
-    }
+  const instrumentation = buildInstrumentation(() => stopped)
 
-    const parameters = Array.from(arguments) as MethodParameters<TARGET[METHOD]>
-
-    let postCallCallback: PostCallCallback<TARGET, METHOD> | undefined
-
-    callMonitored(onPreCall, null, [
-      {
-        target: this,
-        parameters,
-        onPostCall: (callback) => {
-          postCallCallback = callback
-        },
-        handlingStack: computeHandlingStack ? createHandlingStack('instrumented method') : undefined,
-      },
-    ])
-
-    let result: MethodReturnType<TARGET[METHOD]>
-
-    if (new.target) {
-      // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing it
-      // through to Reflect.construct would expose the wrong new.target inside the original body.
-      // If a subclass extends the wrapper, or a third party wraps us and their class is `new`ed,
-      // `new.target` is that outer constructor and must be preserved.
-      const constructNewTarget = new.target === instrumentation ? original : new.target
-      result = Reflect.construct(original, parameters, constructNewTarget)
-    } else {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- TARGET[METHOD] is any under the index signature; value is verified as a function above
-      result = original.apply(this, parameters)
-    }
-
-    if (postCallCallback) {
-      callMonitored(postCallCallback, null, [result])
-    }
-
-    return result
-  }
-
-  // Preserve the original prototype so that instanceof checks against the instrumented global work.
-  // e.g. `new MyClass() instanceof MyClass` must remain true.
-  if (typeof original === 'function' && original.prototype) {
-    instrumentation.prototype = original.prototype
-
-    // Preserve static members (class fields, static methods, etc.) on the instrumented function.
-    const excludedKeys = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
-    for (const key of Object.getOwnPropertyNames(original)) {
-      if (excludedKeys.has(key)) {
-        continue
-      }
-      const descriptor = Object.getOwnPropertyDescriptor(original, key)
-      if (descriptor) {
-        Object.defineProperty(instrumentation, key, descriptor)
-      }
-    }
-    for (const key of Object.getOwnPropertySymbols(original)) {
-      const descriptor = Object.getOwnPropertyDescriptor(original, key)
-      if (descriptor) {
-        Object.defineProperty(instrumentation, key, descriptor)
-      }
-    }
-  }
-
-  targetPrototype[method] = instrumentation as TARGET[METHOD]
+  targetPrototype[method] = instrumentation
 
   return {
     stop: () => {
@@ -175,6 +235,76 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
         targetPrototype[method] = original
       }
     },
+  }
+}
+
+/**
+ * Runs the pre-call callback (injecting the `onPostCall` registration), invokes the original
+ * method/constructor, then runs the registered post-call callback with the result.
+ *
+ * Note: the handling stack must be computed by the caller (at the topmost position of the call
+ * stack), so it is part of `baseCallInfo` rather than computed here.
+ */
+function notifyInstrumentation<CALL_INFO extends InstrumentationCallbacks<RESULT>, RESULT>(
+  onPreCall: (this: null, callInfo: CALL_INFO) => void,
+  baseCallInfo: Omit<CALL_INFO, 'onPostCall'>,
+  invokeOriginal: () => RESULT
+): RESULT {
+  let postCallCallback: ((result: RESULT) => void) | undefined
+
+  callMonitored(onPreCall, null, [
+    {
+      ...baseCallInfo,
+      onPostCall: (callback: (result: RESULT) => void) => {
+        postCallCallback = callback
+      },
+    } as CALL_INFO,
+  ])
+
+  const result = invokeOriginal()
+
+  if (postCallCallback) {
+    callMonitored(postCallCallback, null, [result])
+  }
+
+  return result
+}
+
+interface InstrumentationCallbacks<RESULT> {
+  onPostCall: (callback: (result: RESULT) => void) => void
+  handlingStack?: string
+}
+
+/**
+ * Copies the original constructor prototype and static members onto the instrumentation, so that
+ * `instanceof` checks keep working and statics such as `WebSocket.OPEN` remain available while
+ * instrumented.
+ */
+function preserveConstructorShape(instrumentation: (...args: any[]) => any, original: (...args: any[]) => any) {
+  if (!original.prototype) {
+    return
+  }
+
+  // Preserve the original prototype so that instanceof checks against the instrumented global work.
+  // e.g. `new MyClass() instanceof MyClass` must remain true.
+  instrumentation.prototype = original.prototype
+
+  // Preserve static members (class fields, static methods, etc.) on the instrumented function.
+  const excludedKeys = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
+  for (const key of Object.getOwnPropertyNames(original)) {
+    if (excludedKeys.has(key)) {
+      continue
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(original, key)
+    if (descriptor) {
+      Object.defineProperty(instrumentation, key, descriptor)
+    }
+  }
+  for (const key of Object.getOwnPropertySymbols(original)) {
+    const descriptor = Object.getOwnPropertyDescriptor(original, key)
+    if (descriptor) {
+      Object.defineProperty(instrumentation, key, descriptor)
+    }
   }
 }
 

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -145,10 +145,8 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
   // e.g. `new MyClass() instanceof MyClass` must remain true.
   if (typeof original === 'function' && original.prototype) {
     instrumentation.prototype = original.prototype
-  }
 
-  // Preserve static members (class fields, static methods, etc.) on the instrumented function.
-  if (typeof original === 'function') {
+    // Preserve static members (class fields, static methods, etc.) on the instrumented function.
     const excludedKeys = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
     for (const key of Object.getOwnPropertyNames(original)) {
       if (excludedKeys.has(key)) {

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -330,14 +330,14 @@ function preserveConstructorShape(instrumentation: AnyConstructor, original: Any
    * active; restoring on `stop()` fixes this. In practice the SDK initializes as early as possible,
    * which narrows the window where pre-instrument instances exist.
    */
-  const originalConstructor = original.prototype.constructor
-  original.prototype.constructor = instrumentation
+  const { stop: restoreOriginalConstructor } = replaceWithInstrumentation(
+    original.prototype,
+    'constructor',
+    original.prototype.constructor,
+    instrumentation
+  )
 
-  return () => {
-    if (original.prototype.constructor === instrumentation) {
-      original.prototype.constructor = originalConstructor
-    }
-  }
+  return restoreOriginalConstructor
 }
 
 export function instrumentSetter<TARGET extends { [key: string]: any }, PROPERTY extends keyof TARGET>(

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -180,10 +180,17 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
 
   const { stop: replaceStop } = replaceWithInstrumentation(target, name, original, (isStopped) => {
     const instrumentation = function (this: TARGET): ConstructorInstanceOf<TARGET[NAME]> {
+      // Bare `[[Call]]` (no `new`): delegate through `[[Call]]` and skip `onPreCall`. Otherwise we
+      // would notify instrumentation before the original rejects or returns, unlike the native
+      // constructor (e.g. `WebSocket(url)` or `class {}()` without `new`).
+      if (!new.target) {
+        return Reflect.apply(original, this, Array.from(arguments)) as ConstructorInstanceOf<TARGET[NAME]>
+      }
+
       // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing
       // it through to Reflect.construct would expose the wrong new.target inside the original
       // body. If a subclass extends the wrapper, or a third party wraps us and their class is
-      // `new`ed, `new.target` is that outer constructor and must be preserved.
+      // instantiated, `new.target` is that outer constructor and must be preserved.
       const constructNewTarget = new.target === instrumentation ? original : new.target
 
       if (isStopped()) {

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -137,6 +137,26 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
     instrumentation.prototype = original.prototype
   }
 
+  // Preserve static members (class fields, static methods, etc.) on the instrumented function.
+  if (typeof original === 'function') {
+    const excludedKeys = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
+    for (const key of Object.getOwnPropertyNames(original)) {
+      if (excludedKeys.has(key)) {
+        continue
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(original, key)
+      if (descriptor) {
+        Object.defineProperty(instrumentation, key, descriptor)
+      }
+    }
+    for (const key of Object.getOwnPropertySymbols(original)) {
+      const descriptor = Object.getOwnPropertyDescriptor(original, key)
+      if (descriptor) {
+        Object.defineProperty(instrumentation, key, descriptor)
+      }
+    }
+  }
+
   targetPrototype[method] = instrumentation as TARGET[METHOD]
 
   return {

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -39,6 +39,8 @@ type PostCallCallback<TARGET extends { [key: string]: any }, METHOD extends keyo
 type ConstructorParametersOf<CONSTRUCTOR> = CONSTRUCTOR extends new (...args: infer P) => any ? P : never
 type ConstructorInstanceOf<CONSTRUCTOR> = CONSTRUCTOR extends new (...args: any[]) => infer R ? R : never
 
+type AnyConstructor = abstract new (...args: any[]) => any
+
 /**
  * Object passed to the callback of an instrumented constructor call. See `instrumentConstructor`
  * for more info.
@@ -216,7 +218,7 @@ export function instrumentConstructor<TARGET extends { [key: string]: any }, NAM
       )
     }
 
-    restorePrototypeConstructor = preserveConstructorShape(instrumentation, original)
+    restorePrototypeConstructor = preserveConstructorShape(instrumentation as unknown as AnyConstructor, original)
 
     return instrumentation as TARGET[NAME]
   })
@@ -302,23 +304,33 @@ interface InstrumentationCallbacks<RESULT> {
  * `instanceof` checks keep working and statics such as `WebSocket.OPEN` remain available while
  * instrumented.
  *
- * Limitation: only the original's *own* static members are copied. Statics inherited through the
- * constructor's prototype chain (e.g. `class Child extends Parent` where `Parent` defines statics)
- * are not preserved, since the instrumentation still inherits from `Function.prototype`. This is
- * acceptable for the globals we instrument (e.g. `WebSocket`, whose own statics are the only ones
- * that matter), but would need to delegate the static prototype chain to support subclassed
- * constructors with meaningful inherited statics.
- *
  * Returns a function that restores `prototype.constructor` to its prior descriptor; call it
  * before restoring the global property in `stop()`.
  */
-function preserveConstructorShape(instrumentation: (...args: any[]) => any, original: (...args: any[]) => any) {
+function preserveConstructorShape(instrumentation: AnyConstructor, original: AnyConstructor): () => void {
   if (!original.prototype) {
     return noop
   }
 
-  // Preserve the original prototype so that instanceof checks against the instrumented global work.
-  // e.g. `new MyClass() instanceof MyClass` must remain true.
+  copyOriginalPrototype(instrumentation, original)
+
+  const prototypeObject = original.prototype as object
+  const { rewired, savedConstructorDescriptor } = tryRewirePrototypeConstructor(prototypeObject, instrumentation)
+
+  copyOwnStaticsExceptBuiltins(original, instrumentation)
+
+  return () =>
+    restorePrototypeConstructor({
+      rewired,
+      prototypeObject,
+      savedConstructorDescriptor,
+      original,
+    })
+}
+
+// Preserve the original prototype so that instanceof checks against the instrumented global work.
+// e.g. `new MyClass() instanceof MyClass` must remain true.
+function copyOriginalPrototype(instrumentation: AnyConstructor, original: AnyConstructor): void {
   const originalPrototypeDescriptor = Object.getOwnPropertyDescriptor(original, 'prototype')
   try {
     if (originalPrototypeDescriptor) {
@@ -334,19 +346,24 @@ function preserveConstructorShape(instrumentation: (...args: any[]) => any, orig
   } catch {
     instrumentation.prototype = original.prototype
   }
+}
 
-  const prototypeObject = original.prototype as object
-
-  // Limitation: repointing `constructor` on this shared prototype affects every instance whose
-  // [[Prototype]] is this object, including instances created before instrumentation, because
-  // `constructor` is inherited rather than snapshotted per instance. Code that held `original`
-  // (or whatever was in `prototype.constructor` before) as the canonical constructor and expects
-  // reference equality to that value for the lifetime of the page can observe a behavior change
-  // while RUM is active; restoring on `stop()` fixes this. Note, In practice the
-  // SDK initializes as early as possible, which narrows the window where pre-instrument instances
-  // exist.
+/*
+ * Limitation: repointing `constructor` on this shared prototype affects every instance whose
+ * `[[Prototype]]` is this object, including instances created before instrumentation, because
+ * `constructor` is inherited rather than snapshotted per instance. Code that held `original` (or
+ * whatever was in `prototype.constructor` before) as the canonical constructor and expects reference
+ * equality to that value for the lifetime of the page can observe a behavior change while RUM is
+ * active; restoring on `stop()` fixes this. In practice the SDK initializes as early as possible,
+ * which narrows the window where pre-instrument instances exist.
+ */
+function tryRewirePrototypeConstructor(
+  prototypeObject: object,
+  instrumentation: AnyConstructor
+): { rewired: boolean; savedConstructorDescriptor: PropertyDescriptor | undefined } {
   const savedConstructorDescriptor = Object.getOwnPropertyDescriptor(prototypeObject, 'constructor')
-  let rewiredPrototypeConstructor = false
+
+  let rewired = false
   try {
     Object.defineProperty(prototypeObject, 'constructor', {
       value: instrumentation,
@@ -354,15 +371,29 @@ function preserveConstructorShape(instrumentation: (...args: any[]) => any, orig
       enumerable: savedConstructorDescriptor?.enumerable ?? false,
       configurable: true,
     })
-    rewiredPrototypeConstructor = true
+    rewired = true
   } catch {
     // Some exotic builtins keep a non-configurable `constructor` on their prototype.
   }
+  return { rewired, savedConstructorDescriptor }
+}
 
-  // Preserve own static members (class fields, static methods, etc.) on the instrumented function.
-  const excludedKeys = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
-  for (const key of Object.getOwnPropertyNames(original)) {
-    if (excludedKeys.has(key)) {
+const STATIC_COPY_EXCLUDED_KEYS = new Set(['prototype', 'length', 'name', 'arguments', 'caller'])
+
+/*
+ * Limitation: only the original's *own* static members are copied. Statics inherited through the
+ * constructor's prototype chain (e.g. `class Child extends Parent` where `Parent` defines statics)
+ * are not preserved, since the instrumentation still inherits from `Function.prototype`. This is
+ * acceptable for the globals we instrument (e.g. `WebSocket`, whose own statics are the only ones
+ * that matter), but would need to delegate the static prototype chain to support subclassed
+ * constructors with meaningful inherited statics.
+ */
+function copyOwnStaticsExceptBuiltins(original: AnyConstructor, instrumentation: AnyConstructor): void {
+  for (const key of ([] as PropertyKey[]).concat(
+    Object.getOwnPropertyNames(original),
+    Object.getOwnPropertySymbols(original)
+  )) {
+    if (typeof key === 'string' && STATIC_COPY_EXCLUDED_KEYS.has(key)) {
       continue
     }
     const descriptor = Object.getOwnPropertyDescriptor(original, key)
@@ -370,31 +401,35 @@ function preserveConstructorShape(instrumentation: (...args: any[]) => any, orig
       Object.defineProperty(instrumentation, key, descriptor)
     }
   }
-  for (const key of Object.getOwnPropertySymbols(original)) {
-    const descriptor = Object.getOwnPropertyDescriptor(original, key)
-    if (descriptor) {
-      Object.defineProperty(instrumentation, key, descriptor)
-    }
-  }
+}
 
-  return () => {
-    if (!rewiredPrototypeConstructor) {
-      return
+function restorePrototypeConstructor({
+  rewired,
+  prototypeObject,
+  savedConstructorDescriptor,
+  original,
+}: {
+  rewired: boolean
+  prototypeObject: object
+  savedConstructorDescriptor: PropertyDescriptor | undefined
+  original: AnyConstructor
+}): void {
+  if (!rewired) {
+    return
+  }
+  try {
+    if (savedConstructorDescriptor) {
+      Object.defineProperty(prototypeObject, 'constructor', savedConstructorDescriptor)
+    } else {
+      Object.defineProperty(prototypeObject, 'constructor', {
+        value: original,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      })
     }
-    try {
-      if (savedConstructorDescriptor) {
-        Object.defineProperty(prototypeObject, 'constructor', savedConstructorDescriptor)
-      } else {
-        Object.defineProperty(prototypeObject, 'constructor', {
-          value: original,
-          writable: true,
-          enumerable: false,
-          configurable: true,
-        })
-      }
-    } catch {
-      // Best-effort: prototype.constructor may be non-configurable
-    }
+  } catch {
+    // Best-effort: prototype.constructor may be non-configurable
   }
 }
 

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -120,14 +120,24 @@ export function instrumentMethod<TARGET extends { [key: string]: any }, METHOD e
       },
     ])
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const result = new.target ? Reflect.construct(original, parameters, new.target) : original.apply(this, parameters)
+    let result: MethodReturnType<TARGET[METHOD]>
+
+    if (new.target) {
+      // When `new` is used on this instrumented property, `new.target` is this wrapper. Passing it
+      // through to Reflect.construct would expose the wrong new.target inside the original body.
+      // If a subclass extends the wrapper, or a third party wraps us and their class is `new`ed,
+      // `new.target` is that outer constructor and must be preserved.
+      const constructNewTarget = new.target === instrumentation ? original : new.target
+      result = Reflect.construct(original, parameters, constructNewTarget)
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- TARGET[METHOD] is any under the index signature; value is verified as a function above
+      result = original.apply(this, parameters)
+    }
 
     if (postCallCallback) {
       callMonitored(postCallCallback, null, [result])
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return result
   }
 

--- a/packages/browser-core/src/tools/instrumentMethod.ts
+++ b/packages/browser-core/src/tools/instrumentMethod.ts
@@ -340,7 +340,9 @@ function preserveConstructorShape(instrumentation: AnyConstructor, original: Any
   original.prototype.constructor = instrumentation
 
   return () => {
-    original.prototype.constructor = originalConstructor
+    if (original.prototype.constructor === instrumentation) {
+      original.prototype.constructor = originalConstructor
+    }
   }
 }
 

--- a/packages/browser-core/src/tools/stackTrace/handlingStack.ts
+++ b/packages/browser-core/src/tools/stackTrace/handlingStack.ts
@@ -14,6 +14,7 @@ export function createHandlingStack(
     | 'action'
     | 'error'
     | 'instrumented method'
+    | 'instrumented constructor'
     | 'log'
     | 'nuxt error'
     | 'react error'


### PR DESCRIPTION
## Motivation

In order to instrument WebSocket connections, we need to wrap the `WebSocket` constructor, so far the `instrumentMethod` only supports instrumenting regular methods. This PR adds another utility `instrumentConstructor` supporting the instrumentation of constructor functions.

## Changes

- Add an `instrumentConstructor` utility that supports instrumenting constructor functions
- Factorize logic between `instrumentMethod` and new `instrumentConstructor`utils
- Add exhaustive unit tests for `instrumentConstructor`

## Test instructions

`yarn test:unit --spec packages/core/src/tools/instrumentMethod.spec.ts`

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file