### PR TITLE
🔧 Sync rum-events-format with WebSocket resource schema

### DIFF
--- a/packages/browser-core/src/domain/resourceUtils.ts
+++ b/packages/browser-core/src/domain/resourceUtils.ts
@@ -8,6 +8,7 @@ export const ResourceType = {
   IMAGE: 'image',
   FONT: 'font',
   MEDIA: 'media',
+  WEBSOCKET: 'websocket',
   OTHER: 'other',
 } as const
 

--- a/packages/browser-rum-core/src/rawRumEvent.types.ts
+++ b/packages/browser-rum-core/src/rawRumEvent.types.ts
@@ -73,6 +73,7 @@ export interface RawRumResourceEvent {
     protocol?: string
     delivery_type?: DeliveryType
     graphql?: GraphQlMetadata
+    websocket?: WebSocketResourceProperties
     request?: ResourceRequest
     response?: ResourceResponse
   }
@@ -84,6 +85,29 @@ export interface RawRumResourceEvent {
     page_states?: PageStateServerEntry[]
   }
   context?: Context
+}
+
+export interface WebSocketResourceProperties {
+  connection_id: string
+  handshake_succeeded: boolean
+  start_time: TimeStamp
+  end_time: TimeStamp
+  start_view_id?: string
+  end_view_id?: string
+  tracking_end_reason: 'close_event' | 'session_end'
+  close_code?: number
+  close_reason?: string
+  was_clean?: boolean
+  messages_in: { count: number; size: number }
+  messages_out: { count: number; size: number }
+  time_to_first_message_in?: Duration
+  time_to_first_message_out?: Duration
+  last_message_at?: TimeStamp
+  longest_silence: Duration
+  idle_duration_before_close?: Duration
+  buffered_amount_max?: number
+  protocol?: string
+  setup_duration?: Duration
 }
 
 export type NetworkHeaders = Record<string, string>


### PR DESCRIPTION
## Motivation

Add the `websocket` resource type and its fields to the RUM event format so WebSocket connections can be reported as resource events.

> **Blocked:** depends on the upstream `rum-events-format` schema PR landing first. Kept in draft until then.

## Changes

- Bump the `rum-events-format` submodule to include the websocket resource sub-schema (`d6ba7f7` -> `a597e6d`).
- Regenerate `rumEvent.types.ts` and add the corresponding raw event shape in `rawRumEvent.types.ts`.
- Add `ResourceType.WEBSOCKET` to the core resource utils.

## Test instructions

`yarn typecheck`

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file