### PR TITLE
✨ Add trackWebSockets configuration option (default: false)

### DIFF
--- a/packages/browser-core/src/tools/experimentalFeatures.ts
+++ b/packages/browser-core/src/tools/experimentalFeatures.ts
@@ -16,6 +16,7 @@ import { objectHasValue } from './utils/objectUtils'
 export enum ExperimentalFeature {
   TRACK_INTAKE_REQUESTS = 'track_intake_requests',
   PARTIAL_VIEW_UPDATES = 'partial_view_updates',
+  TRACK_WEB_SOCKETS = 'track_web_sockets',
 }
 
 const enabledExperimentalFeatures: Set<ExperimentalFeature> = new Set()


### PR DESCRIPTION
## Motivation

Make WebSocket collection opt-in and gated behind an experimental feature flag.

## Changes

- Add the `trackWebSockets` init option (default `false`) to the RUM configuration.
- Add the `TRACK_WEB_SOCKETS` experimental feature flag.

## Test instructions

`yarn test:unit --spec packages/rum-core/src/domain/configuration/configuration.spec.ts`

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file