### PR TITLE
🔧 Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 bundle
 cjs
 esm


### PR DESCRIPTION
## Motivation

Avoid devs adding `.DS_Store` files to git + less of a visual mess when viewing `git status`.

## Changes

Add `.DS_Store` to `.gitignore`.
