### PR TITLE
🐛 Use Debugger SDK prefix for debugger logs

### DIFF
--- a/packages/browser-core/src/tools/display.ts
+++ b/packages/browser-core/src/tools/display.ts
@@ -17,7 +17,7 @@ export const ConsoleApiName = {
 
 export type ConsoleApiName = (typeof ConsoleApiName)[keyof typeof ConsoleApiName]
 
-interface Display {
+export interface Display {
   debug: typeof console.debug
   log: typeof console.log
   info: typeof console.info
@@ -43,13 +43,17 @@ Object.keys(ConsoleApiName).forEach((name) => {
 
 const PREFIX = 'Datadog Browser SDK:'
 
-export const display: Display = {
-  debug: originalConsoleMethods.debug.bind(globalConsole, PREFIX),
-  log: originalConsoleMethods.log.bind(globalConsole, PREFIX),
-  info: originalConsoleMethods.info.bind(globalConsole, PREFIX),
-  warn: originalConsoleMethods.warn.bind(globalConsole, PREFIX),
-  error: originalConsoleMethods.error.bind(globalConsole, PREFIX),
+export function createDisplay(prefix: string): Display {
+  return {
+    debug: originalConsoleMethods.debug.bind(globalConsole, prefix),
+    log: originalConsoleMethods.log.bind(globalConsole, prefix),
+    info: originalConsoleMethods.info.bind(globalConsole, prefix),
+    warn: originalConsoleMethods.warn.bind(globalConsole, prefix),
+    error: originalConsoleMethods.error.bind(globalConsole, prefix),
+  }
 }
+
+export const display: Display = createDisplay(PREFIX)
 
 export const DOCS_ORIGIN = 'https://docs.datadoghq.com'
 export const DOCS_TROUBLESHOOTING = `${DOCS_ORIGIN}/real_user_monitoring/browser/troubleshooting`

--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -1,6 +1,6 @@
-import { display } from '@datadog/browser-core'
 import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import { onEntry, onReturn, onThrow, initDebuggerTransport, resetDebuggerTransport } from './api'
+import { display } from './display'
 import { addProbe, removeProbe, getProbes, clearProbes } from './probes'
 import type { Probe } from './probes'
 
@@ -1437,7 +1437,7 @@ describe('api', () => {
         onReturn(probes, null, {}, {}, {})
       }).not.toThrow()
       expect(warnSpy).toHaveBeenCalledWith(
-        'Debugger transport is not initialized. Make sure DD_DEBUGGER.init() has been called.'
+        'Transport is not initialized. Make sure DD_DEBUGGER.init() has been called.'
       )
     })
   })

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -1,6 +1,6 @@
 import type { Batch, Context } from '@datadog/browser-core'
 
-import { timeStampNow, display, buildTag, generateUUID, globalObject } from '@datadog/browser-core'
+import { timeStampNow, buildTag, generateUUID, globalObject } from '@datadog/browser-core'
 import type { BrowserWindow, DebuggerInitConfiguration } from '../entries/main'
 import { capture, captureFields } from './capture'
 import type { CaptureContext } from './capture'
@@ -17,6 +17,7 @@ import type { ActiveEntry } from './activeEntries'
 import { captureStackTrace, parseStackTrace } from './stacktrace'
 import { evaluateProbeMessage } from './template'
 import { evaluateProbeCondition, isConditionEvaluationError } from './condition'
+import { display } from './display'
 
 const globalObj = globalObject as BrowserWindow
 
@@ -290,7 +291,7 @@ export function onThrow(probes: InitializedProbe[], error: Error, self: any, arg
  */
 function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): void {
   if (!debuggerBatch || !debuggerConfig) {
-    display.warn('Debugger transport is not initialized. Make sure DD_DEBUGGER.init() has been called.')
+    display.warn('Transport is not initialized. Make sure DD_DEBUGGER.init() has been called.')
     return
   }
 

--- a/packages/browser-debugger/src/domain/deliveryApi.spec.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.spec.ts
@@ -1,7 +1,8 @@
 import type { GlobalObject } from '@datadog/browser-core'
-import { display, globalObject } from '@datadog/browser-core'
+import { globalObject } from '@datadog/browser-core'
 import { registerCleanupTask, mockClock, replaceMockable } from '@datadog/browser-core/test'
 import type { Clock } from '@datadog/browser-core/test'
+import { display } from './display'
 import { getProbes, clearProbes } from './probes'
 import type { Probe } from './probes'
 import {

--- a/packages/browser-debugger/src/domain/deliveryApi.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.ts
@@ -2,7 +2,6 @@ import type { TimeoutId, Site } from '@datadog/browser-core'
 import {
   addTelemetryDebug,
   dateNow,
-  display,
   fetch,
   globalObject,
   isServerError,
@@ -11,6 +10,7 @@ import {
   clearInterval,
   INTAKE_SITE_US1,
 } from '@datadog/browser-core'
+import { display } from './display'
 import { addProbe, clearProbes, removeProbe } from './probes'
 import type { Probe } from './probes'
 
@@ -70,7 +70,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
   }
 
   if (pollIntervalId !== undefined) {
-    display.warn('Debugger: Delivery API polling already started')
+    display.warn('Delivery API polling already started')
     return
   }
 
@@ -122,7 +122,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
         } catch {
           // ignore
         }
-        display.error(`Debugger: Delivery API poll failed with status ${response.status}`, errorBody)
+        display.error(`Delivery API poll failed with status ${response.status}`, errorBody)
         // 408 (request timeout), 429 (rate limited), and 5xx are transient: they
         // only trip the breaker after the unreachable-duration window. Other 4xx
         // responses indicate a client/config issue (bad token, wrong service, …)
@@ -152,7 +152,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
             removeProbe(probeId)
             knownProbeIds.delete(probeId)
           } catch (err) {
-            display.error(`Debugger: Failed to remove probe ${probeId}:`, err as Error)
+            display.error(`Failed to remove probe ${probeId}:`, err as Error)
           }
         }
       }
@@ -174,7 +174,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
           addProbe(probe)
           knownProbeIds.add(probe.id)
         } catch (err) {
-          display.error(`Debugger: Failed to add probe ${probe.id}:`, err as Error)
+          display.error(`Failed to add probe ${probe.id}:`, err as Error)
         }
       }
     } catch (err) {
@@ -183,7 +183,7 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
       if (err instanceof DOMException && err.code === DOMException.ABORT_ERR) {
         return
       }
-      display.error('Debugger: Delivery API poll error:', err as Error)
+      display.error('Delivery API poll error:', err as Error)
       if (noteFailureAndCheckTrip(maxUnreachableDuration)) {
         tripCircuitBreaker('network error')
       }
@@ -250,7 +250,7 @@ function tripCircuitBreaker(reason: string): void {
   }
   tripped = true
   display.warn(
-    `Debugger: Delivery API circuit breaker tripped (${reason}). Disabling Live Debugger for the rest of the page lifetime.`
+    `Delivery API circuit breaker tripped (${reason}). Disabling Live Debugger for the rest of the page lifetime.`
   )
   // monitor-until: forever, to keep an eye on how often the Live Debugger gets disabled in the wild
   addTelemetryDebug('Delivery API circuit breaker tripped', { reason })

--- a/packages/browser-debugger/src/domain/display.spec.ts
+++ b/packages/browser-debugger/src/domain/display.spec.ts
@@ -1,0 +1,12 @@
+import { createDisplay, originalConsoleMethods } from '@datadog/browser-core'
+import { DEBUGGER_DISPLAY_PREFIX } from './display'
+
+describe('debugger display', () => {
+  it('should use the debugger SDK prefix', () => {
+    const warnSpy = spyOn(originalConsoleMethods, 'warn')
+
+    createDisplay(DEBUGGER_DISPLAY_PREFIX).warn('message')
+
+    expect(warnSpy).toHaveBeenCalledWith('Datadog Debugger SDK:', 'message')
+  })
+})

--- a/packages/browser-debugger/src/domain/display.ts
+++ b/packages/browser-debugger/src/domain/display.ts
@@ -1,0 +1,6 @@
+import type { Display } from '@datadog/browser-core'
+import { createDisplay } from '@datadog/browser-core'
+
+export const DEBUGGER_DISPLAY_PREFIX = 'Datadog Debugger SDK:'
+// eslint-disable-next-line local-rules/disallow-side-effects
+export const display: Display = createDisplay(DEBUGGER_DISPLAY_PREFIX)

--- a/packages/browser-debugger/src/domain/probes.ts
+++ b/packages/browser-debugger/src/domain/probes.ts
@@ -1,5 +1,5 @@
-import { display } from '@datadog/browser-core'
 import type { ErrorWithCause } from '@datadog/browser-core'
+import { display } from './display'
 import { compile } from './expression'
 import { compileCondition } from './condition'
 import type { CompiledCondition } from './condition'
@@ -295,7 +295,7 @@ function hasProbeLifetimeBudgetRemaining(probe: InitializedProbe): boolean {
     if (!probe.lifetimeBudgetWarningEmitted) {
       probe.lifetimeBudgetWarningEmitted = true
       display.warn(
-        `Debugger: Probe ${probe.id} version ${probe.version} reached max ${
+        `Probe ${probe.id} version ${probe.version} reached max ${
           probe.captureSnapshot ? 'snapshot' : 'non-snapshot'
         } events per lifetime: ${getMaxProbeLifetimeEvents(probe)}`
       )

--- a/packages/browser-debugger/src/entries/main.spec.ts
+++ b/packages/browser-debugger/src/entries/main.spec.ts
@@ -1,7 +1,7 @@
-import { display } from '@datadog/browser-core'
 import { registerCleanupTask, replaceMockableWithSpy } from '@datadog/browser-core/test'
 import { initDebuggerTransport } from '../domain/api'
 import { startDeliveryApiPolling } from '../domain/deliveryApi'
+import { display } from '../domain/display'
 import { startDebuggerBatch } from '../transport/startDebuggerBatch'
 import type { BrowserWindow } from './main'
 import { datadogDebugger } from './main'

--- a/packages/browser-debugger/src/entries/main.ts
+++ b/packages/browser-debugger/src/entries/main.ts
@@ -6,10 +6,11 @@
  * @see [Live Debugger Documentation](https://docs.datadoghq.com/tracing/live_debugger/)
  */
 
-import { defineGlobal, display, globalObject, makePublicApi, mockable } from '@datadog/browser-core'
+import { defineGlobal, globalObject, makePublicApi, mockable } from '@datadog/browser-core'
 import type { PublicApi, Site } from '@datadog/browser-core'
 import { initDebuggerTransport, onEntry, onReturn, onThrow } from '../domain/api'
 import { startDeliveryApiPolling } from '../domain/deliveryApi'
+import { display } from '../domain/display'
 import { getProbes } from '../domain/probes'
 import { startDebuggerBatch } from '../transport/startDebuggerBatch'
 
@@ -172,7 +173,7 @@ function resolveDebuggerVersion(initConfiguration: DebuggerInitConfiguration): s
     initConfiguration.version !== buildVersion
   ) {
     display.warn(
-      `Debugger: init version "${initConfiguration.version}" does not match the build-plugin version "${buildVersion}". Using the init version.`
+      `init version "${initConfiguration.version}" does not match the build-plugin version "${buildVersion}". Using the init version.`
     )
   }
 

--- a/packages/browser-debugger/src/transport/startDebuggerBatch.ts
+++ b/packages/browser-debugger/src/transport/startDebuggerBatch.ts
@@ -7,16 +7,16 @@ import {
   createIdentityEncoder,
   Observable,
   PageExitReason,
-  display,
   createEndpointBuilder,
 } from '@datadog/browser-core'
+import { display } from '../domain/display'
 
 export function startDebuggerBatch(initConfiguration: InitConfiguration): Batch {
   const debuggerEndpointBuilder = createEndpointBuilder({ ...initConfiguration, source: 'dd_debugger' }, 'debugger')
 
   const batch = createBatch({
     encoder: createIdentityEncoder(),
-    request: createHttpRequest([debuggerEndpointBuilder], (error) => display.error('Debugger transport error:', error)),
+    request: createHttpRequest([debuggerEndpointBuilder], (error) => display.error('transport error:', error)),
     flushController: createFlushController({
       pageMayExitObservable: createSimplePageMayExitObservable(),
       sessionExpireObservable: new Observable(),


### PR DESCRIPTION
## Motivation

Debugger console messages currently show up as `Datadog Browser SDK: Debugger: ...`, which is noisy and makes Live Debugger logs look like generic Browser SDK logs.

## Changes

- Add a reusable `createDisplay()` helper in browser-core while preserving the existing `display` behavior for other packages.
- Add a browser-debugger display wrapper using the `Datadog Debugger SDK:` prefix.
- Switch debugger warnings/errors to the debugger display and remove the redundant `Debugger:` text from message bodies.
- Update debugger display spies in unit tests and add focused coverage for the new prefix.

## Test instructions

- [x] `yarn test:unit --spec packages/browser-debugger/src/domain/display.spec.ts`
- [x] Checked edited files with IDE lint diagnostics
- [ ] Broader focused debugger specs were attempted but are currently blocked in this checkout by existing `@datadog/browser-core/test` resolution errors.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
