### PR TITLE
🐛 Ignore unsupported debugger probes

### DIFF
--- a/packages/browser-debugger/src/domain/deliveryApi.spec.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.spec.ts
@@ -186,7 +186,7 @@ describe('deliveryApi', () => {
       expect(probes![0].id).toBe('probe-1')
     })
 
-    it('should ignore unsupported probes from the updates array', async () => {
+    it('should ignore log probes without a method location', async () => {
       respondWith({
         nextCursor: 'cursor-1',
         updates: [
@@ -207,10 +207,23 @@ describe('deliveryApi', () => {
       expect(getProbes('undefined;undefined')).toBeUndefined()
     })
 
-    it('should ignore non-log probes from the updates array', async () => {
+    it('should ignore log probes without a where clause', async () => {
       respondWith({
         nextCursor: 'cursor-1',
-        updates: [makeProbe({ id: 'metric-probe', type: 'METRIC_PROBE' })],
+        updates: [{ id: 'log-probe-without-where', version: 1, type: 'LOG_PROBE' } as Probe],
+        deletions: [],
+      })
+
+      startDeliveryApiPolling(makeConfig())
+      await flushPromises()
+
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
+    it('should ignore non-log probes without requiring a method location', async () => {
+      respondWith({
+        nextCursor: 'cursor-1',
+        updates: [{ id: 'metric-probe', version: 1, type: 'METRIC_PROBE' } as Probe],
         deletions: [],
       })
 
@@ -218,6 +231,7 @@ describe('deliveryApi', () => {
       await flushPromises()
 
       expect(getProbes('test.js;testMethod')).toBeUndefined()
+      expect(errorSpy).not.toHaveBeenCalled()
     })
 
     it('should remove probes listed in deletions', async () => {

--- a/packages/browser-debugger/src/domain/deliveryApi.spec.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.spec.ts
@@ -186,6 +186,40 @@ describe('deliveryApi', () => {
       expect(probes![0].id).toBe('probe-1')
     })
 
+    it('should ignore unsupported probes from the updates array', async () => {
+      respondWith({
+        nextCursor: 'cursor-1',
+        updates: [
+          makeProbe({
+            id: 'line-probe',
+            where: {
+              sourceFile: 'packages/apps/live-debugger/toolkit/services/use-debugger-services.hook.ts',
+              lines: ['16'],
+            },
+          }),
+        ],
+        deletions: [],
+      })
+
+      startDeliveryApiPolling(makeConfig())
+      await flushPromises()
+
+      expect(getProbes('undefined;undefined')).toBeUndefined()
+    })
+
+    it('should ignore non-log probes from the updates array', async () => {
+      respondWith({
+        nextCursor: 'cursor-1',
+        updates: [makeProbe({ id: 'metric-probe', type: 'METRIC_PROBE' })],
+        deletions: [],
+      })
+
+      startDeliveryApiPolling(makeConfig())
+      await flushPromises()
+
+      expect(getProbes('test.js;testMethod')).toBeUndefined()
+    })
+
     it('should remove probes listed in deletions', async () => {
       // First poll: add the probe via the delivery API
       respondWith({

--- a/packages/browser-debugger/src/domain/deliveryApi.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.ts
@@ -234,7 +234,7 @@ function isTransientFailureStatus(status: number): boolean {
 }
 
 function isSupportedProbe(probe: Probe): boolean {
-  return probe.type === 'LOG_PROBE' && probe.where.typeName !== undefined && probe.where.methodName !== undefined
+  return probe.type === 'LOG_PROBE' && probe.where?.typeName !== undefined && probe.where.methodName !== undefined
 }
 
 /**

--- a/packages/browser-debugger/src/domain/deliveryApi.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.ts
@@ -170,6 +170,13 @@ export function startDeliveryApiPolling(config: DeliveryApiConfiguration): void 
           }
         }
 
+        if (!isSupportedProbe(probe)) {
+          // A probe should not change from supported to unsupported while keeping
+          // the same id, but guard against leaving stale state if it ever happens.
+          knownProbeIds.delete(probe.id)
+          continue
+        }
+
         try {
           addProbe(probe)
           knownProbeIds.add(probe.id)
@@ -224,6 +231,10 @@ export function clearDeliveryApiState(): void {
  */
 function isTransientFailureStatus(status: number): boolean {
   return isServerError(status) || status === 408 || status === 429
+}
+
+function isSupportedProbe(probe: Probe): boolean {
+  return probe.type === 'LOG_PROBE' && probe.where.typeName !== undefined && probe.where.methodName !== undefined
 }
 
 /**


### PR DESCRIPTION
## Motivation

The browser debugger runtime only supports log method probes today. Unsupported delivery API updates, such as line probes or non-log probe types, were accepted and could be registered under invalid or unsupported function ids even though they could not execute correctly.

## Changes

- Only register delivery API updates for `LOG_PROBE` probes that contain a method location (`where.typeName` and `where.methodName`).
- Silently ignore unsupported probe types and locations so they do not pollute the probe registry.
- Clear defensive known-probe state if an unsupported update ever reuses an existing probe id.
- Add unit coverage for ignoring a line-probe-shaped update and a non-log method probe.

## Test instructions

- `yarn test:unit --spec packages/browser-debugger/src/domain/deliveryApi.spec.ts`

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
