### PR TITLE
🐛 stop browser source leaking into Node-only scripts typecheck

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -40,6 +40,9 @@ export default defineConfig(
       'packages/*/esm',
       'test/**/dist',
       'test/**/.next',
+      // Test-app webpack configs are build tooling for fixtures, not part of the typed project graph
+      // (excluded from tsconfig.scripts.json). Without this, projectService fails to find a project.
+      'test/apps/*/webpack.*',
       'test/apps/react-heavy-spa',
       'test/apps/react-shopist-like',
       'test/apps/microfrontend',

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -15,5 +15,9 @@
     "checkJs": false,
     "allowImportingTsExtensions": true
   },
-  "include": ["scripts", "**/webpack.*.*", "test/envUtils.ts", "eslint.config.ts", "eslint-local-rules", "test/unit"]
+  "include": ["scripts", "**/webpack.*.*", "test/envUtils.ts", "eslint.config.ts", "eslint-local-rules", "test/unit"],
+  // `test/apps` is excluded (like in tsconfig.default.json): its generated `node_modules` contain
+  // `@datadog/webpack-plugin` types that import browser source, which would otherwise be pulled into
+  // this Node-only program via the `**/webpack.*.*` glob and fail for lack of DOM libs.
+  "exclude": ["test/apps"]
 }


### PR DESCRIPTION
## Motivation

Running `yarn typecheck` locally produces a flood of bogus errors (`Cannot find name 'window' / 'document' / 'CSSRule' / 'VisualViewport' ...`, 500+) once any test app has been installed locally — even on a clean `main`.

Root cause: `tsconfig.scripts.json` is Node-only (`lib: ["ES2024"]`, `types: ["node"]`, no DOM libs), but its `include` has `**/webpack.*.*`. That glob matches `test/apps/*/webpack.*` configs, which `import` `@datadog/webpack-plugin` — resolved from each test app's locally generated `node_modules`. The plugin's types pull `@datadog/browser-rum` browser source into the scripts program (via the workspace `paths` alias to `packages/browser-rum/src`), which then fails for lack of DOM libs.

It "works on a fresh clone / CI" only because the test apps' `node_modules` aren't installed there; anyone who has run the test apps locally hits it.

## Changes

- **`tsconfig.scripts.json`**: exclude `test/apps` (mirrors `tsconfig.default.json`, which already excludes it) so those webpack configs are no longer part of the scripts program.
- **`eslint.config.ts`**: ignore `test/apps/*/webpack.*`. Those files relied on the scripts tsconfig to be part of a project for `projectService` typed-linting; excluding them above would otherwise break lint with `file was not found by the project service`. This keeps `yarn lint` at the same baseline as `main`.

No source or runtime change — purely a typecheck/lint graph scoping fix.

## Test instructions

1. Install a test app locally so its `node_modules` exist (e.g. run a test app, or `yarn` inside `test/apps/microfrontend`).
2. On `main`: `yarn typecheck` → hundreds of `Cannot find name 'window'/...` errors.
3. On this branch: `yarn typecheck` → those errors are gone; `yarn lint` matches the `main` baseline (no new errors).
4. Confirm no DOM-using browser source is pulled into the scripts program:
   `yarn tsc -b tsconfig.scripts.json --noEmit --listFiles | grep -v node_modules | grep 'packages/browser-.*/src'` → only type-only `*.types.ts` remain.

> Note: a few unrelated, pre-existing local errors remain (e.g. a `react-router` clash from `sandbox/react-router-v7-demo/node_modules` and `react-router-app/app.tsx`, plus `setTimeout`/`NodeJS.Timeout` typing in two `browser-core` specs). These also stem from locally-generated nested `node_modules`, exist on `main` already, and are out of scope here.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file