### PR TITLE
♻️ Simplify debugger template evaluation

### DIFF
--- a/packages/browser-debugger/src/domain/condition.ts
+++ b/packages/browser-debugger/src/domain/condition.ts
@@ -1,6 +1,5 @@
 export interface CompiledCondition {
   evaluate: (contextKeys: string[]) => (...args: any[]) => boolean
-  clearCache: () => void
 }
 
 export interface ProbeWithCondition {
@@ -56,9 +55,6 @@ export function compileCondition(condition: string): CompiledCondition {
         functionCache.set(cacheKey, fn)
       }
       return fn
-    },
-    clearCache: () => {
-      functionCache.clear()
     },
   }
 }

--- a/packages/browser-debugger/src/domain/probes.spec.ts
+++ b/packages/browser-debugger/src/domain/probes.spec.ts
@@ -11,10 +11,6 @@ import {
 } from './probes'
 import type { Probe } from './probes'
 
-interface TemplateWithCache {
-  createFunction: (params: string[]) => (...args: any[]) => any
-}
-
 describe('probes', () => {
   beforeEach(() => {
     clearProbes()
@@ -43,9 +39,9 @@ describe('probes', () => {
       expect(retrieved).toEqual([
         jasmine.objectContaining({
           id: 'test-probe-1',
-          templateRequiresEvaluation: false,
         }),
       ])
+      expect(retrieved![0].evaluateTemplate).toBeUndefined()
     })
 
     it('should return undefined for non-existent probe', () => {
@@ -186,12 +182,12 @@ describe('probes', () => {
 
       expect(probe).toEqual(
         jasmine.objectContaining({
-          templateRequiresEvaluation: false,
           template: 'Static message',
           msBetweenSampling: jasmine.any(Number),
           lastCaptureMs: -Infinity,
         })
       )
+      expect(probe.evaluateTemplate).toBeUndefined()
     })
 
     it('should initialize probe with dynamic template', () => {
@@ -212,10 +208,8 @@ describe('probes', () => {
 
       expect(probe).toEqual(
         jasmine.objectContaining({
-          templateRequiresEvaluation: true,
-          template: {
-            createFunction: jasmine.any(Function),
-          },
+          template: '',
+          evaluateTemplate: jasmine.any(Function),
         })
       )
       expect(probe.segments).toBeUndefined() // Should be deleted after initialization
@@ -331,7 +325,7 @@ describe('probes', () => {
       expect(probe.msBetweenSampling).toBeLessThan(1) // 5000 per second = 0.2ms
     })
 
-    it('should cache compiled functions by context keys', () => {
+    it('should evaluate dynamic template with cached functions', () => {
       const probe: Probe = {
         id: 'test-probe-1',
         version: 0,
@@ -347,16 +341,8 @@ describe('probes', () => {
 
       initializeProbe(probe)
 
-      const template = probe.template as TemplateWithCache
-      const fn1 = template.createFunction(['x', 'y'])
-      const fn2 = template.createFunction(['x', 'y'])
-
-      // Should return the same cached function
-      expect(fn1).toBe(fn2)
-
-      const fn3 = template.createFunction(['x', 'z'])
-      // Different keys should create different function
-      expect(fn1).not.toBe(fn3)
+      expect(probe.evaluateTemplate!({ x: 1 })).toEqual(['1'])
+      expect(probe.evaluateTemplate!({ x: 2 })).toEqual(['2'])
     })
   })
 
@@ -394,7 +380,6 @@ describe('probes', () => {
       expect(getProbes('TestClass;clear1')).toBeUndefined()
       expect(getProbes('TestClass;clear2')).toBeUndefined()
     })
-
   })
 
   describe('checkGlobalSnapshotBudget', () => {

--- a/packages/browser-debugger/src/domain/probes.spec.ts
+++ b/packages/browser-debugger/src/domain/probes.spec.ts
@@ -13,7 +13,6 @@ import type { Probe } from './probes'
 
 interface TemplateWithCache {
   createFunction: (params: string[]) => (...args: any[]) => any
-  clearCache?: () => void
 }
 
 describe('probes', () => {
@@ -76,38 +75,6 @@ describe('probes', () => {
       expect(getProbes('TestClass;testMethod')).toBeUndefined()
     })
 
-    it('should clear function cache when removing probe with dynamic template', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'cacheTest' },
-        template: '',
-        segments: [{ dsl: 'x', json: { ref: 'x' } }],
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
-      addProbe(probe)
-      const retrieved = getProbes('TestClass;cacheTest')
-      const template = retrieved![0].template as TemplateWithCache
-
-      // Create some cached functions
-      template.createFunction(['x', 'y'])
-      template.createFunction(['x', 'z'])
-
-      // Spy on clearCache method
-      const clearCacheSpy = jasmine.createSpy('clearCache')
-      template.clearCache = clearCacheSpy
-
-      removeProbe('test-probe-1')
-
-      // Verify clearCache was called
-      expect(clearCacheSpy).toHaveBeenCalled()
-    })
-
     it('should handle removing probe with static template without errors', () => {
       const probe: Probe = {
         id: 'test-probe-1',
@@ -123,7 +90,7 @@ describe('probes', () => {
 
       addProbe(probe)
 
-      // Should not throw when removing probe with static template (no clearCache method)
+      // Should not throw when removing probe with static template
       expect(() => removeProbe('test-probe-1')).not.toThrow()
     })
 
@@ -248,7 +215,6 @@ describe('probes', () => {
           templateRequiresEvaluation: true,
           template: {
             createFunction: jasmine.any(Function),
-            clearCache: jasmine.any(Function),
           },
         })
       )
@@ -277,7 +243,6 @@ describe('probes', () => {
       expect(probe.condition).toEqual(
         jasmine.objectContaining({
           evaluate: jasmine.any(Function),
-          clearCache: jasmine.any(Function),
         })
       )
     })
@@ -430,68 +395,6 @@ describe('probes', () => {
       expect(getProbes('TestClass;clear2')).toBeUndefined()
     })
 
-    it('should clear function caches for all probes with dynamic templates', () => {
-      const probe1: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'clearCache1' },
-        template: '',
-        segments: [{ dsl: 'x', json: { ref: 'x' } }],
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
-      const probe2: Probe = {
-        id: 'test-probe-2',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'clearCache2' },
-        template: '',
-        segments: [{ dsl: 'y', json: { ref: 'y' } }],
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
-      const probe3: Probe = {
-        id: 'test-probe-3',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'clearCache3' },
-        template: 'Static message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
-      addProbe(probe1)
-      addProbe(probe2)
-      addProbe(probe3)
-
-      const template1 = getProbes('TestClass;clearCache1')![0].template as TemplateWithCache
-      const template2 = getProbes('TestClass;clearCache2')![0].template as TemplateWithCache
-
-      // Create some cached functions
-      template1.createFunction(['x'])
-      template2.createFunction(['y'])
-
-      // Spy on clearCache methods
-      const clearCache1Spy = jasmine.createSpy('clearCache1')
-      const clearCache2Spy = jasmine.createSpy('clearCache2')
-      template1.clearCache = clearCache1Spy
-      template2.clearCache = clearCache2Spy
-
-      clearProbes()
-
-      // Verify clearCache was called for both dynamic template probes
-      expect(clearCache1Spy).toHaveBeenCalled()
-      expect(clearCache2Spy).toHaveBeenCalled()
-    })
   })
 
   describe('checkGlobalSnapshotBudget', () => {

--- a/packages/browser-debugger/src/domain/probes.ts
+++ b/packages/browser-debugger/src/domain/probes.ts
@@ -196,12 +196,6 @@ export function removeProbe(idOrProbe: string | InitializedProbe): void {
   for (let i = 0; i < probes.length; i++) {
     const probe = probes[i]
     if (probe.id === id && (!expectedProbe || probe === expectedProbe)) {
-      if (typeof probe.template === 'object' && probe.template?.clearCache) {
-        probe.template.clearCache()
-      }
-      if (typeof probe.condition === 'object' && probe.condition?.clearCache) {
-        probe.condition.clearCache()
-      }
       const remainingProbes = probes.slice(0, i).concat(probes.slice(i + 1))
       if (remainingProbes.length === 0) {
         delete activeProbes[functionId]
@@ -232,12 +226,6 @@ export function clearProbes(): void {
   for (const probes of Object.values(activeProbes)) {
     if (probes) {
       for (const probe of probes) {
-        if (typeof probe.template === 'object' && probe.template?.clearCache) {
-          probe.template.clearCache()
-        }
-        if (typeof probe.condition === 'object' && probe.condition?.clearCache) {
-          probe.condition.clearCache()
-        }
         // Unlike removeProbe(), clearProbes() is an aggressive teardown used by
         // tests and the delivery API circuit breaker. Drop in-flight entries so
         // stale captured probe instances cannot emit after the debugger is disabled.
@@ -383,9 +371,6 @@ export function initializeProbe(probe: Probe): asserts probe is InitializedProbe
           functionCache.set(cacheKey, fn)
         }
         return fn
-      },
-      clearCache: () => {
-        functionCache.clear()
       },
     }
   }

--- a/packages/browser-debugger/src/domain/probes.ts
+++ b/packages/browser-debugger/src/domain/probes.ts
@@ -3,8 +3,8 @@ import { display } from './display'
 import { compile } from './expression'
 import { compileCondition } from './condition'
 import type { CompiledCondition } from './condition'
-import { templateRequiresEvaluation, compileSegments } from './template'
-import type { TemplateSegment, CompiledTemplate } from './template'
+import { browserInspect, templateRequiresEvaluation, compileSegments } from './template'
+import type { TemplateSegment } from './template'
 import type { CaptureOptions } from './capture'
 import type { ActiveEntry } from './activeEntries'
 
@@ -50,7 +50,7 @@ export interface Probe {
   type: string
   where: ProbeWhere
   when?: ProbeWhen
-  template: string | CompiledTemplate
+  template: string
   segments?: TemplateSegment[]
   captureSnapshot: boolean
   capture: CaptureOptions
@@ -64,9 +64,9 @@ export interface Probe {
 }
 
 export interface InitializedProbe extends Probe {
-  templateRequiresEvaluation: boolean
   functionId: string
   condition?: CompiledCondition
+  evaluateTemplate?: (context: Record<string, any>) => unknown[]
   msBetweenSampling: number
   lastCaptureMs: number
   lastConditionErrorMs: number
@@ -347,8 +347,7 @@ export function initializeProbe(probe: Probe): asserts probe is InitializedProbe
   }
 
   // Optimize for fast calculations when probe is hit
-  ;(probe as InitializedProbe).templateRequiresEvaluation = templateRequiresEvaluation(probe.segments)
-  if ((probe as InitializedProbe).templateRequiresEvaluation) {
+  if (templateRequiresEvaluation(probe.segments)) {
     const segmentsCode = compileSegments(probe.segments!)
 
     // Pre-build the function body so we avoid rebuilding this string on every probe hit.
@@ -358,20 +357,20 @@ export function initializeProbe(probe: Probe): asserts probe is InitializedProbe
     const fnBodyTemplate = `return ${segmentsCode};`
 
     // Cache compiled functions by context keys to avoid recreating them
-    const functionCache = new Map<string, (...args: any[]) => any[]>()
+    const functionCache = new Map<string, (...args: any[]) => unknown[]>()
 
-    // Store the template with a factory that caches functions
-    probe.template = {
-      createFunction: (contextKeys: string[]) => {
-        const cacheKey = contextKeys.join(',')
-        let fn = functionCache.get(cacheKey)
-        if (!fn) {
-          // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
-          fn = new Function('$dd_inspect', ...contextKeys, fnBodyTemplate) as (...args: any[]) => any[]
-          functionCache.set(cacheKey, fn)
-        }
-        return fn
-      },
+    ;(probe as InitializedProbe).evaluateTemplate = (context: Record<string, any>): unknown[] => {
+      const { this: thisValue, ...otherContext } = context
+      const contextKeys = Object.keys(otherContext)
+      const contextValues = Object.values(otherContext)
+      const cacheKey = contextKeys.join(',')
+      let fn = functionCache.get(cacheKey)
+      if (!fn) {
+        // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+        fn = new Function('$dd_inspect', ...contextKeys, fnBodyTemplate) as (...args: any[]) => unknown[]
+        functionCache.set(cacheKey, fn)
+      }
+      return fn.call(thisValue, browserInspect, ...contextValues)
     }
   }
   delete probe.segments

--- a/packages/browser-debugger/src/domain/template.spec.ts
+++ b/packages/browser-debugger/src/domain/template.spec.ts
@@ -211,7 +211,6 @@ describe('template', () => {
   describe('evaluateProbeMessage', () => {
     it('should return static template string when no evaluation needed', () => {
       const probe: any = {
-        templateRequiresEvaluation: false,
         template: 'Static message',
       }
       const result = evaluateProbeMessage(probe, {})
@@ -219,17 +218,8 @@ describe('template', () => {
     })
 
     it('should evaluate template with simple expressions', () => {
-      const template: any = {
-        createFunction: (keys: string[]) => {
-          expect(keys).toEqual(['x', 'y'])
-          // eslint-disable-next-line camelcase, @typescript-eslint/no-unused-vars
-          return ($dd_inspect: any, x: number, y: number) => [`x=${x}, y=${y}`]
-        },
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: (context: any) => [`x=${context.x}, y=${context.y}`],
       }
 
       const result = evaluateProbeMessage(probe, { x: 10, y: 20 })
@@ -237,22 +227,8 @@ describe('template', () => {
     })
 
     it('should handle segments with static and dynamic parts', () => {
-      const template: any = {
-        createFunction:
-          (keys: string[]) =>
-          // eslint-disable-next-line camelcase, @typescript-eslint/no-unused-vars
-          ($dd_inspect: any, ...values: any[]) => {
-            const context: any = {}
-            keys.forEach((key, i) => {
-              context[key] = values[i]
-            })
-            return ['Value: ', String(context.value)]
-          },
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: (context: any) => ['Value: ', String(context.value)],
       }
 
       const result = evaluateProbeMessage(probe, { value: 42 })
@@ -260,13 +236,8 @@ describe('template', () => {
     })
 
     it('should handle error objects in segments', () => {
-      const template: any = {
-        createFunction: () => () => [{ expr: 'bad.expr', message: 'TypeError: Cannot read property' }],
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: () => [{ expr: 'bad.expr', message: 'TypeError: Cannot read property' }],
       }
 
       const result = evaluateProbeMessage(probe, {})
@@ -274,13 +245,8 @@ describe('template', () => {
     })
 
     it('should handle non-string segments', () => {
-      const template: any = {
-        createFunction: () => () => [42, ' ', true, ' ', null],
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: () => [42, ' ', true, ' ', null],
       }
 
       const result = evaluateProbeMessage(probe, {})
@@ -295,27 +261,8 @@ describe('template', () => {
         { dsl: 'a', json: { ref: 'a' } },
       ]
 
-      // Compile the segments like initializeProbe does
-      const segmentsCode = compileSegments(segments)
-      const fnBodyTemplate = `return ${segmentsCode};`
-      const functionCache = new Map<string, (...args: any[]) => any[]>()
-
-      const template = {
-        createFunction: (contextKeys: string[]) => {
-          const cacheKey = contextKeys.join(',')
-          let fn = functionCache.get(cacheKey)
-          if (!fn) {
-            // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
-            fn = new Function('$dd_inspect', ...contextKeys, fnBodyTemplate) as (...args: any[]) => any[]
-            functionCache.set(cacheKey, fn)
-          }
-          return fn
-        },
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: evaluateSegments(segments),
       }
 
       const context = {
@@ -330,27 +277,8 @@ describe('template', () => {
     it('should handle templates without this context', () => {
       const segments = [{ str: 'Simple message with ' }, { dsl: 'a', json: { ref: 'a' } }]
 
-      // Compile the segments like initializeProbe does
-      const segmentsCode = compileSegments(segments)
-      const fnBodyTemplate = `return ${segmentsCode};`
-      const functionCache = new Map<string, (...args: any[]) => any[]>()
-
-      const template = {
-        createFunction: (contextKeys: string[]) => {
-          const cacheKey = contextKeys.join(',')
-          let fn = functionCache.get(cacheKey)
-          if (!fn) {
-            // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
-            fn = new Function('$dd_inspect', ...contextKeys, fnBodyTemplate) as (...args: any[]) => any[]
-            functionCache.set(cacheKey, fn)
-          }
-          return fn
-        },
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: evaluateSegments(segments),
       }
 
       // Context without 'this'
@@ -363,15 +291,10 @@ describe('template', () => {
     })
 
     it('should handle template evaluation errors', () => {
-      const template: any = {
-        createFunction: () => () => {
+      const probe: any = {
+        evaluateTemplate: () => {
           throw new Error('Evaluation failed')
         },
-      }
-
-      const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
       }
 
       const result = evaluateProbeMessage(probe, {})
@@ -380,13 +303,8 @@ describe('template', () => {
 
     it('should truncate long messages', () => {
       const longMessage = 'a'.repeat(10000)
-      const template: any = {
-        createFunction: () => () => [longMessage],
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: () => [longMessage],
       }
 
       const result = evaluateProbeMessage(probe, {})
@@ -395,17 +313,8 @@ describe('template', () => {
     })
 
     it('should use browserInspect for object values', () => {
-      const template: any = {
-        // eslint-disable-next-line camelcase
-        createFunction: () => ($dd_inspect: (value: any, options: any) => string, obj: any) => [
-          'Object: ',
-          $dd_inspect(obj, {}),
-        ],
-      }
-
       const probe: any = {
-        templateRequiresEvaluation: true,
-        template,
+        evaluateTemplate: (context: any) => ['Object: ', browserInspect(context.obj)],
       }
 
       const result = evaluateProbeMessage(probe, { obj: { a: 1, b: 2 } })
@@ -432,3 +341,17 @@ describe('template', () => {
     })
   })
 })
+
+function evaluateSegments(segments: Array<{ str?: string; dsl?: string; json?: any }>) {
+  const segmentsCode = compileSegments(segments)
+  const fnBodyTemplate = `return ${segmentsCode};`
+
+  return (context: Record<string, any>): unknown[] => {
+    const { this: thisValue, ...otherContext } = context
+    const contextKeys = Object.keys(otherContext)
+    const contextValues = Object.values(otherContext)
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    const fn = new Function('$dd_inspect', ...contextKeys, fnBodyTemplate) as (...args: any[]) => unknown[]
+    return fn.call(thisValue, browserInspect, ...contextValues)
+  }
+}

--- a/packages/browser-debugger/src/domain/template.ts
+++ b/packages/browser-debugger/src/domain/template.ts
@@ -14,7 +14,6 @@ export interface TemplateSegment {
 
 export interface CompiledTemplate {
   createFunction: (keys: string[]) => (...args: any[]) => any[]
-  clearCache?: () => void
 }
 
 // Options for browserInspect - controls how values are stringified

--- a/packages/browser-debugger/src/domain/template.ts
+++ b/packages/browser-debugger/src/domain/template.ts
@@ -6,14 +6,15 @@ import { compile } from './expression'
 
 const MAX_MESSAGE_LENGTH = 8 * 1024 // 8KB
 
+interface TemplateEvaluationError {
+  expr: string
+  message: string
+}
+
 export interface TemplateSegment {
   str?: string
   dsl?: string
   json?: any
-}
-
-export interface CompiledTemplate {
-  createFunction: (keys: string[]) => (...args: any[]) => any[]
 }
 
 // Options for browserInspect - controls how values are stringified
@@ -182,29 +183,9 @@ function inspectValueInternal(value: unknown, depthExceeded: boolean = false): s
   return browserInspectInternal(value, true)
 }
 
-/**
- * Evaluate compiled template with runtime context
- *
- * @param compiledTemplate - Template object with createFunction factory
- * @param context - Runtime context with variables
- * @returns Array of segment results (strings or error objects)
- */
-function evalCompiledTemplate(compiledTemplate: CompiledTemplate, context: Record<string, any>): any[] {
-  // Separate 'this' from other context variables
-  const { this: thisValue, ...otherContext } = context
-  const contextKeys = Object.keys(otherContext)
-  const contextValues = Object.values(otherContext)
-
-  // Create function with dynamic parameters (function body was pre-built during initialization)
-  const fn = compiledTemplate.createFunction(contextKeys)
-
-  // Execute with browserInspect and context values, binding 'this' context
-  return fn.call(thisValue, browserInspect, ...contextValues)
-}
-
 export interface ProbeWithTemplate {
-  templateRequiresEvaluation: boolean
-  template: CompiledTemplate | string
+  template: string
+  evaluateTemplate?: (context: Record<string, any>) => unknown[]
 }
 
 /**
@@ -217,15 +198,14 @@ export interface ProbeWithTemplate {
 export function evaluateProbeMessage(probe: ProbeWithTemplate, context: Record<string, any>): string {
   let message: string
 
-  if (probe.templateRequiresEvaluation) {
+  if (probe.evaluateTemplate) {
     try {
-      const segments = evalCompiledTemplate(probe.template as CompiledTemplate, context)
+      const segments = probe.evaluateTemplate(context)
       message = segments
         .map((seg) => {
           if (typeof seg === 'string') {
             return seg
-          } else if (seg && typeof seg === 'object' && seg.expr) {
-            // Error object from template evaluation
+          } else if (isTemplateEvaluationError(seg)) {
             return `{${seg.message}}`
           }
           return String(seg)
@@ -235,7 +215,7 @@ export function evaluateProbeMessage(probe: ProbeWithTemplate, context: Record<s
       message = `{Error: ${(e as Error).message}}`
     }
   } else {
-    message = probe.template as string
+    message = probe.template
   }
 
   // Truncate message if it exceeds maximum length
@@ -244,4 +224,8 @@ export function evaluateProbeMessage(probe: ProbeWithTemplate, context: Record<s
   }
 
   return message
+}
+
+function isTemplateEvaluationError(segment: any): segment is TemplateEvaluationError {
+  return segment?.expr !== undefined
 }


### PR DESCRIPTION
## Motivation

Simplify debugger template evaluation and remove unnecessary cache cleanup paths. The previous implementation stored compiled template cache objects on probes and explicitly cleared those caches when probes were removed, but the caches were already only reachable through the probe instance and could be garbage-collected with it. Moving evaluation behind an initialized-probe function keeps this behavior local to probe initialization and makes the runtime code easier to maintain.

## Changes

- Remove explicit cache clearing for probe conditions and dynamic templates when probes are removed or cleared.
- Replace the compiled template object stored in `probe.template` with an `evaluateTemplate(context)` function on initialized probes.
- Keep `probe.template` as the original template string after initialization.
- Update template/probe tests to cover the new evaluation shape instead of cache object internals.

## Test instructions

- `yarn test:unit --spec packages/browser-debugger/src/domain/template.spec.ts --spec packages/browser-debugger/src/domain/probes.spec.ts`
- `yarn typecheck`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
