### PR TITLE
✨ Add browser debugger Capture Expressions

### DIFF
--- a/packages/browser-core/src/tools/utils/arrayUtils.spec.ts
+++ b/packages/browser-core/src/tools/utils/arrayUtils.spec.ts
@@ -1,0 +1,26 @@
+import { mergeArrays } from './arrayUtils'
+
+describe('arrayUtils', () => {
+  describe('mergeArrays', () => {
+    it('should return undefined when both arrays are undefined', () => {
+      expect(mergeArrays(undefined, undefined)).toBeUndefined()
+    })
+
+    it('should return the current array when the next array is undefined or empty', () => {
+      const current = ['a']
+
+      expect(mergeArrays(current, undefined)).toBe(current)
+      expect(mergeArrays(current, [])).toBe(current)
+    })
+
+    it('should return the next array when the current array is undefined', () => {
+      const next = ['b']
+
+      expect(mergeArrays(undefined, next)).toBe(next)
+    })
+
+    it('should concatenate current and next arrays when both have values', () => {
+      expect(mergeArrays(['a'], ['b'])).toEqual(['a', 'b'])
+    })
+  })
+})

--- a/packages/browser-core/src/tools/utils/arrayUtils.ts
+++ b/packages/browser-core/src/tools/utils/arrayUtils.ts
@@ -13,3 +13,10 @@ export function removeItem<T>(array: T[], item: T) {
 export function isNonEmptyArray<T>(value: unknown): value is T[] {
   return Array.isArray(value) && value.length > 0
 }
+
+export function mergeArrays<T>(current: T[] | undefined, next: T[] | undefined): T[] | undefined {
+  if (!next?.length) {
+    return current
+  }
+  return current ? current.concat(next) : next
+}

--- a/packages/browser-debugger/src/domain/activeEntries.ts
+++ b/packages/browser-debugger/src/domain/activeEntries.ts
@@ -7,14 +7,13 @@ export interface ActiveEntry {
   timestamp?: number
   message?: string
   evaluationErrors?: EvaluationError[]
-  entry?: {
-    arguments: Record<string, any>
-  }
+  entry?: { arguments: Record<string, any> } | { captureExpressions: Record<string, any> }
   stack?: StackFrame[]
   duration?: number
   return?: {
     arguments?: Record<string, any>
     locals?: Record<string, any>
+    captureExpressions?: Record<string, any>
     throwable?: Throwable
   }
   exception?: unknown

--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -243,6 +243,98 @@ describe('api', () => {
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
 
+    it('should capture expressions at ENTRY', () => {
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          captureExpressions: [
+            { name: 'argValue', expr: { dsl: 'arg.value', json: { getmember: [{ ref: 'arg' }, 'value'] } } },
+            { name: 'limited', expr: { dsl: 'longString', json: { ref: 'longString' } }, capture: { maxLength: 3 } },
+          ],
+          sampling: { snapshotsPerSecond: Infinity },
+          evaluateAt: 'ENTRY',
+        })
+      )
+
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg, { arg: { value: 42 }, longString: 'abcdef' })
+      onReturn(probes, null, thisArg, { arg: { value: 42 }, longString: 'abcdef' })
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(snapshot.captures).toEqual({
+        entry: {
+          captureExpressions: {
+            argValue: { type: 'number', value: '42' },
+            limited: { type: 'string', value: 'abc', truncated: true, size: 6 },
+          },
+        },
+        return: undefined,
+      })
+    })
+
+    it('should capture expressions at EXIT with @return and locals', () => {
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          captureExpressions: [
+            { name: 'returnValue', expr: { dsl: '@return', json: { ref: '@return' } } },
+            { name: 'localValue', expr: { dsl: 'local.value', json: { getmember: [{ ref: 'local' }, 'value'] } } },
+          ],
+          sampling: { snapshotsPerSecond: Infinity },
+        })
+      )
+
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg)
+      onReturn(probes, { nested: 'return' }, thisArg, {}, { local: { value: 'data' } })
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(snapshot.captures).toEqual({
+        entry: undefined,
+        return: {
+          captureExpressions: {
+            returnValue: { type: 'Object', fields: { nested: { type: 'string', value: 'return' } } },
+            localValue: { type: 'string', value: 'data' },
+          },
+        },
+      })
+    })
+
+    it('should report capture expression evaluation errors without dropping successful expressions', () => {
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          captureExpressions: [
+            { name: 'existing', expr: { dsl: 'existing', json: { ref: 'existing' } } },
+            {
+              name: 'missing.value',
+              expr: { dsl: 'missing.value', json: { getmember: [{ ref: 'missing' }, 'value'] } },
+            },
+          ],
+          sampling: { snapshotsPerSecond: Infinity },
+          evaluateAt: 'ENTRY',
+        })
+      )
+
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg, { existing: 'value' })
+      onReturn(probes, null, thisArg, { existing: 'value' })
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(snapshot.captures.entry.captureExpressions).toEqual({
+        existing: { type: 'string', value: 'value' },
+      })
+      expect(snapshot.evaluationErrors).toEqual([
+        {
+          expr: 'missing.value',
+          message: jasmine.stringMatching(/^ReferenceError: /),
+        },
+      ])
+    })
+
     it('should capture both entry and return snapshots for ENTRY evaluation', () => {
       addProbe(createProbe({ evaluateAt: 'ENTRY' }))
 
@@ -632,6 +724,41 @@ describe('api', () => {
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
 
+    it('should capture expressions at EXIT with @exception', () => {
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          captureExpressions: [
+            {
+              name: 'exceptionMessage',
+              expr: { dsl: '@exception.message', json: { getmember: [{ ref: '@exception' }, 'message'] } },
+            },
+          ],
+          sampling: { snapshotsPerSecond: Infinity },
+        })
+      )
+
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg)
+      onThrow(probes, new Error('Test error'), thisArg)
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(snapshot.captures).toEqual({
+        entry: undefined,
+        return: {
+          arguments: undefined,
+          captureExpressions: {
+            exceptionMessage: { type: 'string', value: 'Test error' },
+          },
+          throwable: {
+            message: 'Test error',
+            stacktrace: jasmine.any(Array),
+          },
+        },
+      })
+    })
+
     it('should report EXIT condition evaluation errors on throw without capturing a snapshot', () => {
       addProbe(
         createProbe({
@@ -716,6 +843,27 @@ describe('api', () => {
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
     })
+
+    it('should apply the global snapshot rate limit to capture-expression probes', () => {
+      for (let i = 0; i < 30; i++) {
+        addProbe(
+          createProbe({
+            where: { typeName: 'test.js', methodName: `captureExpressionGlobal${i}` },
+            captureSnapshot: false,
+            captureExpressions: [{ name: 'x', expr: { dsl: 'x', json: { ref: 'x' } } }],
+            sampling: { snapshotsPerSecond: 5000 },
+          })
+        )
+      }
+
+      for (let i = 0; i < 30; i++) {
+        const probes = getProbes(`test.js;captureExpressionGlobal${i}`)!
+        onEntry(probes, thisArg, { x: i })
+        onReturn(probes, null, thisArg, { x: i })
+      }
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(25)
+    })
   })
 
   describe('configured per-second budgets', () => {
@@ -748,6 +896,25 @@ describe('api', () => {
       onReturn(probes, null, thisArg)
       onEntry(probes, thisArg)
       onReturn(probes, null, thisArg)
+
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+    })
+
+    it('should use the configured default snapshot per-probe rate limit for capture-expression probes', () => {
+      initTransport({ maxSnapshotsPerSecondPerProbe: 0.5 })
+
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          captureExpressions: [{ name: 'x', expr: { dsl: 'x', json: { ref: 'x' } } }],
+        })
+      )
+
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
+      onEntry(probes, thisArg, { x: 1 })
+      onReturn(probes, null, thisArg, { x: 1 })
+      onEntry(probes, thisArg, { x: 2 })
+      onReturn(probes, null, thisArg, { x: 2 })
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -1,7 +1,6 @@
 import type { Batch, Context } from '@datadog/browser-core'
 import { timeStampNow } from '@datadog/js-core/time'
-
-import { buildTag, generateUUID, globalObject } from '@datadog/browser-core'
+import { buildTag, generateUUID, globalObject, mergeArrays } from '@datadog/browser-core'
 import type { BrowserWindow, DebuggerInitConfiguration } from '../entries/main'
 import { capture, captureFields } from './capture'
 import type { CaptureContext } from './capture'
@@ -20,6 +19,7 @@ import { evaluateProbeMessage } from './template'
 import { evaluateProbeCondition, isConditionEvaluationError } from './condition'
 import { display } from './display'
 import { formatThrowable } from './error'
+import { evaluateCaptureExpressions } from './captureExpressions'
 
 const globalObj = globalObject as BrowserWindow
 
@@ -65,7 +65,7 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
     // Skip if sampling budget is exceeded
     if (
       start - probe.lastCaptureMs < probe.msBetweenSampling ||
-      !checkGlobalSnapshotBudget(start, probe.captureSnapshot)
+      !checkGlobalSnapshotBudget(start, isSnapshotProducingProbe(probe))
     ) {
       probe.activeEntries.push(null)
       continue
@@ -76,6 +76,8 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
 
     let timestamp: number | undefined
     let message: string | undefined
+    let entryCaptureExpressions: Record<string, any> | undefined
+    let evaluationErrors: ActiveEntry['evaluationErrors'] | undefined
     if (probe.evaluateAt === 'ENTRY') {
       // Build context for condition and message evaluation
       const context = { ...args, this: self }
@@ -102,11 +104,21 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
 
       timestamp = timeStampNow()
       message = evaluateProbeMessage(probe, context)
+
+      const captureExpressionsResult = evaluateCaptureExpressions(probe, context, captureCtx)
+      if (captureExpressionsResult) {
+        entryCaptureExpressions = captureExpressionsResult.values
+        evaluationErrors = captureExpressionsResult.evaluationErrors
+        if (captureCtx.timedOut) {
+          probe.activeEntries.push(null)
+          continue
+        }
+      }
     }
 
     // Special case for evaluateAt=EXIT with a condition: we only capture the return snapshot
     const shouldCaptureEntrySnapshot = probe.captureSnapshot && (probe.evaluateAt === 'ENTRY' || !probe.condition)
-    let entry: { arguments: Record<string, any> } | undefined
+    let entry: ActiveEntry['entry'] | undefined
     if (shouldCaptureEntrySnapshot) {
       entry = {
         arguments: captureArguments(args, self, probe.capture, captureCtx),
@@ -115,14 +127,19 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
         probe.activeEntries.push(null)
         continue
       }
+    } else if (entryCaptureExpressions) {
+      entry = {
+        captureExpressions: entryCaptureExpressions,
+      }
     }
 
     probe.activeEntries.push({
       start,
       timestamp,
       message,
+      evaluationErrors,
       entry,
-      stack: probe.captureSnapshot ? captureStackTrace(1) : undefined,
+      stack: isSnapshotProducingProbe(probe) ? captureStackTrace(1) : undefined,
     })
   }
 }
@@ -184,6 +201,19 @@ export function onReturn(
       }
 
       result.message = evaluateProbeMessage(probe, context)
+
+      if (!probe.captureSnapshot) {
+        const captureExpressionsResult = evaluateCaptureExpressions(probe, context, captureCtx)
+        if (captureExpressionsResult) {
+          result.return = {
+            captureExpressions: captureExpressionsResult.values,
+          }
+          result.evaluationErrors = mergeArrays(result.evaluationErrors, captureExpressionsResult.evaluationErrors)
+          if (captureCtx.timedOut) {
+            continue
+          }
+        }
+      }
     }
 
     if (probe.captureSnapshot) {
@@ -254,6 +284,19 @@ export function onThrow(probes: InitializedProbe[], error: unknown, self: any, a
       }
 
       result.message = evaluateProbeMessage(probe, context)
+
+      if (!probe.captureSnapshot) {
+        const captureExpressionsResult = evaluateCaptureExpressions(probe, context, captureCtx)
+        if (captureExpressionsResult) {
+          result.return = {
+            captureExpressions: captureExpressionsResult.values,
+          }
+          result.evaluationErrors = mergeArrays(result.evaluationErrors, captureExpressionsResult.evaluationErrors)
+          if (captureCtx.timedOut) {
+            continue
+          }
+        }
+      }
     }
 
     let throwArguments: Record<string, any> | undefined
@@ -265,6 +308,7 @@ export function onThrow(probes: InitializedProbe[], error: unknown, self: any, a
     }
 
     result.return = {
+      ...result.return,
       arguments: throwArguments,
       throwable: formatThrowable(error),
     }
@@ -369,6 +413,10 @@ function detectThreadName() {
     return 'web-worker'
   }
   return 'unknown'
+}
+
+function isSnapshotProducingProbe(probe: InitializedProbe): boolean {
+  return probe.captureSnapshot || (probe.compiledCaptureExpressions?.expressions.length ?? 0) > 0
 }
 
 declare const ServiceWorkerGlobalScope: typeof EventTarget

--- a/packages/browser-debugger/src/domain/captureExpressions.ts
+++ b/packages/browser-debugger/src/domain/captureExpressions.ts
@@ -1,0 +1,44 @@
+import { capture } from './capture'
+import type { CapturedValue, CaptureContext } from './capture'
+import type { EvaluationError } from './condition'
+import type { InitializedProbe } from './probes'
+
+export interface CaptureExpressionsResult {
+  values?: Record<string, CapturedValue>
+  evaluationErrors?: EvaluationError[]
+}
+
+export function evaluateCaptureExpressions(
+  probe: InitializedProbe,
+  context: Record<string, any>,
+  captureCtx: CaptureContext
+): CaptureExpressionsResult | undefined {
+  const compiledCaptureExpressions = probe.compiledCaptureExpressions
+  if (!compiledCaptureExpressions) {
+    return
+  }
+
+  const values: Record<string, CapturedValue> = {}
+  const evaluationErrors: EvaluationError[] = []
+
+  for (const { name, expression, capture: captureOptions } of compiledCaptureExpressions.expressions) {
+    try {
+      const value = compiledCaptureExpressions.evaluateExpression(expression, context)
+      values[name] = capture(value, captureOptions, captureCtx)
+    } catch (error) {
+      evaluationErrors.push({
+        expr: name,
+        message: formatCaptureExpressionEvaluationError(error),
+      })
+    }
+  }
+
+  return {
+    values: Object.keys(values).length ? values : undefined,
+    evaluationErrors: evaluationErrors.length ? evaluationErrors : undefined,
+  }
+}
+
+function formatCaptureExpressionEvaluationError(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+}

--- a/packages/browser-debugger/src/domain/deliveryApi.spec.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.spec.ts
@@ -211,6 +211,51 @@ describe('deliveryApi', () => {
       expect(getAllProbes()).toEqual([])
     })
 
+    it('should ignore log probes with both snapshot capture and capture expressions', async () => {
+      respondWith({
+        nextCursor: 'cursor-1',
+        updates: [
+          createProbe({
+            id: 'snapshot-and-capture-expressions',
+            captureSnapshot: true,
+            captureExpressions: [{ name: 'arg', expr: { dsl: 'arg', json: { ref: 'arg' } } }],
+          }),
+        ],
+        deletions: [],
+      })
+
+      startDeliveryApiPolling(makeConfig())
+      await flushPromises()
+
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
+    it('should log an error when a capture expression cannot be compiled', async () => {
+      respondWith({
+        nextCursor: 'cursor-1',
+        updates: [
+          createProbe({
+            id: 'invalid-capture-expression',
+            captureSnapshot: false,
+            captureExpressions: [
+              {
+                name: 'invalid expr',
+                expr: { dsl: 'not a valid identifier!', json: { ref: 'not a valid identifier!' } },
+              },
+            ],
+          }),
+        ],
+        deletions: [],
+      })
+
+      startDeliveryApiPolling(makeConfig())
+      await flushPromises()
+
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
+      expect(errorSpy).toHaveBeenCalledWith('Failed to add probe invalid-capture-expression:', jasmine.any(Error))
+    })
+
     it('should ignore log probes without a where clause', async () => {
       respondWith({
         nextCursor: 'cursor-1',

--- a/packages/browser-debugger/src/domain/deliveryApi.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.ts
@@ -234,7 +234,12 @@ function isTransientFailureStatus(status: number): boolean {
 }
 
 function isSupportedProbe(probe: Probe): boolean {
-  return probe.type === 'LOG_PROBE' && probe.where?.typeName !== undefined && probe.where.methodName !== undefined
+  return (
+    probe.type === 'LOG_PROBE' &&
+    probe.where?.typeName !== undefined &&
+    probe.where.methodName !== undefined &&
+    !(probe.captureSnapshot && probe.captureExpressions?.length)
+  )
 }
 
 /**

--- a/packages/browser-debugger/src/domain/probes.spec.ts
+++ b/packages/browser-debugger/src/domain/probes.spec.ts
@@ -13,6 +13,20 @@ import { createProbe } from './probe.specHelper'
 
 const DEFAULT_PROBE_FUNCTION_ID = 'test.js;testMethod'
 
+interface CaptureExpressionsWithCache {
+  expressions: Array<{
+    name: string
+    expression: string
+    capture: {
+      maxReferenceDepth?: number
+      maxCollectionSize?: number
+      maxFieldCount?: number
+      maxLength?: number
+    }
+  }>
+  evaluateExpression: (expression: string, context: Record<string, any>) => unknown
+}
+
 describe('probes', () => {
   beforeEach(() => {
     clearProbes()
@@ -204,6 +218,85 @@ describe('probes', () => {
 
       expect(probe.evaluateTemplate!({ x: 1 })).toEqual(['1'])
       expect(probe.evaluateTemplate!({ x: 2 })).toEqual(['2'])
+    })
+
+    it('should compile capture expressions with per-expression limits', () => {
+      const probe = createProbe({
+        captureSnapshot: false,
+        capture: { maxReferenceDepth: 3, maxCollectionSize: 4, maxFieldCount: 5, maxLength: 6 },
+        captureExpressions: [
+          { name: 'arg', expr: { dsl: 'arg', json: { ref: 'arg' } } },
+          {
+            name: 'obj.value',
+            expr: { dsl: 'obj.value', json: { getmember: [{ ref: 'obj' }, 'value'] } },
+            capture: { maxReferenceDepth: 1, maxLength: 2 },
+          },
+        ],
+      })
+
+      initializeProbe(probe)
+
+      const compiledCaptureExpressions = probe.compiledCaptureExpressions as CaptureExpressionsWithCache
+      expect(compiledCaptureExpressions.expressions.length).toBe(2)
+      expect(compiledCaptureExpressions.expressions[0]).toEqual(
+        jasmine.objectContaining({
+          name: 'arg',
+          expression: 'arg',
+          capture: { maxReferenceDepth: 3, maxCollectionSize: 4, maxFieldCount: 5, maxLength: 6 },
+        })
+      )
+      expect(compiledCaptureExpressions.expressions[1]).toEqual(
+        jasmine.objectContaining({
+          name: 'obj.value',
+          capture: { maxReferenceDepth: 1, maxCollectionSize: 4, maxFieldCount: 5, maxLength: 2 },
+        })
+      )
+      expect(compiledCaptureExpressions.expressions[1].expression).toContain('obj')
+      expect(compiledCaptureExpressions.expressions[1].expression).toContain('value')
+      expect(compiledCaptureExpressions.evaluateExpression('arg', { arg: 1 })).toBe(1)
+      expect(probe.captureExpressions).toBeUndefined()
+    })
+
+    it('should not compile capture expressions when the array is empty', () => {
+      const probe = createProbe({ captureSnapshot: false, captureExpressions: [] })
+
+      initializeProbe(probe)
+
+      expect(probe.compiledCaptureExpressions).toBeUndefined()
+    })
+
+    it('should throw when capture expression compilation fails', () => {
+      const probe = createProbe({
+        captureSnapshot: false,
+        captureExpressions: [
+          {
+            name: 'invalid expr',
+            expr: { dsl: 'not a valid identifier!', json: { ref: 'not a valid identifier!' } },
+          },
+        ],
+      })
+
+      let error: unknown
+      try {
+        initializeProbe(probe)
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toEqual(jasmine.any(Error))
+      expect((error as Error).message).toContain('Cannot compile capture expression: invalid expr')
+      expect((error as ErrorWithCause).cause).toEqual(jasmine.any(SyntaxError))
+    })
+
+    it('should not compile capture expressions when snapshot capture is enabled', () => {
+      const probe = createProbe({
+        captureSnapshot: true,
+        captureExpressions: [{ name: 'arg', expr: { dsl: 'arg', json: { ref: 'arg' } } }],
+      })
+
+      initializeProbe(probe)
+
+      expect(probe.compiledCaptureExpressions).toBeUndefined()
     })
   })
 

--- a/packages/browser-debugger/src/domain/probes.ts
+++ b/packages/browser-debugger/src/domain/probes.ts
@@ -8,6 +8,7 @@ import type { TemplateSegment } from './template'
 import { formatUnknownError } from './error'
 import type { CaptureOptions } from './capture'
 import type { ActiveEntry } from './activeEntries'
+import type { ExpressionNode } from './expression'
 
 // Sampling rate limits
 const DEFAULT_MAX_SNAPSHOTS_PER_SECOND_GLOBALLY = 25
@@ -45,6 +46,26 @@ export interface ProbeBudgetConfiguration {
   maxNonSnapshotsPerProbeLifetime?: number
 }
 
+export interface ProbeCaptureExpression {
+  name: string
+  expr: {
+    dsl: string
+    json: ExpressionNode
+  }
+  capture?: CaptureOptions
+}
+
+export interface CompiledCaptureExpression {
+  name: string
+  expression: string
+  capture: CaptureOptions
+}
+
+export interface CompiledCaptureExpressions {
+  expressions: CompiledCaptureExpression[]
+  evaluateExpression: (expression: string, context: Record<string, any>) => unknown
+}
+
 export interface Probe {
   id: string
   version: number
@@ -55,6 +76,7 @@ export interface Probe {
   segments?: TemplateSegment[]
   captureSnapshot: boolean
   capture: CaptureOptions
+  captureExpressions?: ProbeCaptureExpression[]
   sampling?: ProbeSampling
   evaluateAt: 'ENTRY' | 'EXIT'
   location?: {
@@ -68,6 +90,7 @@ export interface InitializedProbe extends Probe {
   functionId: string
   condition?: CompiledCondition
   evaluateTemplate?: (context: Record<string, any>) => unknown[]
+  compiledCaptureExpressions?: CompiledCaptureExpressions
   msBetweenSampling: number
   lastCaptureMs: number
   lastConditionErrorMs: number
@@ -256,7 +279,7 @@ export function clearProbes(): void {
  * @returns True if within budget, false if rate limited
  */
 export function checkGlobalSnapshotBudget(now: number, captureSnapshot: boolean): boolean {
-  // Only enforce global budget for probes that capture snapshots
+  // Only enforce global budget for probes that capture snapshots or capture expressions
   if (!captureSnapshot) {
     return true
   }
@@ -285,7 +308,7 @@ function hasProbeLifetimeBudgetRemaining(probe: InitializedProbe): boolean {
       probe.lifetimeBudgetWarningEmitted = true
       display.warn(
         `Probe ${probe.id} version ${probe.version} reached max ${
-          probe.captureSnapshot ? 'snapshot' : 'non-snapshot'
+          isSnapshotProducingProbe(probe) ? 'snapshot' : 'non-snapshot'
         } events per lifetime: ${getMaxProbeLifetimeEvents(probe)}`
       )
     }
@@ -357,33 +380,31 @@ export function initializeProbe(probe: Probe): asserts probe is InitializedProbe
     // EXIT probes there can be two (normal-return vs exception path).
     const fnBodyTemplate = `return ${segmentsCode};`
 
-    // Cache compiled functions by context keys to avoid recreating them
-    const functionCache = new Map<string, (...args: any[]) => unknown[]>()
-
-    ;(probe as InitializedProbe).evaluateTemplate = (context: Record<string, any>): unknown[] => {
-      const { this: thisValue, ...otherContext } = context
-      const contextKeys = Object.keys(otherContext)
-      const contextValues = Object.values(otherContext)
-      const cacheKey = contextKeys.join(',')
-      let fn = functionCache.get(cacheKey)
-      if (!fn) {
+    const getFunction = createCachedFunctionFactory(
+      (contextKeys: string[]) => contextKeys.join(','),
+      (contextKeys: string[]) =>
         // TODO: Avoid helper parameter shadowing if contextKeys contain reserved
         // helper names like $dd_inspect or $dd_format_error.
         // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
-        fn = new Function('$dd_inspect', '$dd_format_error', ...contextKeys, fnBodyTemplate) as (
-          ...args: any[]
-        ) => unknown[]
-        functionCache.set(cacheKey, fn)
-      }
-      return fn.call(thisValue, browserInspect, formatUnknownError, ...contextValues)
-    }
+        new Function('$dd_inspect', '$dd_format_error', ...contextKeys, fnBodyTemplate) as (...args: any[]) => unknown[]
+    )
+
+    ;(probe as InitializedProbe).evaluateTemplate = (context: Record<string, any>): unknown[] =>
+      callWithContext(context, (thisValue, contextKeys, contextValues) =>
+        getFunction(contextKeys).call(thisValue, browserInspect, formatUnknownError, ...contextValues)
+      )
   }
   delete probe.segments
+
+  if (!probe.captureSnapshot && probe.captureExpressions?.length) {
+    ;(probe as InitializedProbe).compiledCaptureExpressions = compileCaptureExpressions(probe)
+  }
+  delete probe.captureExpressions
 
   // Optimize for fast calculations when probe is hit - calculate sampling budget
   const snapshotsPerSecond =
     probe.sampling?.snapshotsPerSecond ??
-    (probe.captureSnapshot
+    (isSnapshotProducingProbe(probe)
       ? currentProbeBudgetConfiguration.maxSnapshotsPerSecondPerProbe
       : currentProbeBudgetConfiguration.maxNonSnapshotsPerSecondPerProbe)
   ;(probe as InitializedProbe).msBetweenSampling = (1 / snapshotsPerSecond) * 1000 // Convert to milliseconds
@@ -403,7 +424,81 @@ function normalizeProbeBudgetRate(rate: number | undefined, defaultRate: number)
 }
 
 function getMaxProbeLifetimeEvents(probe: InitializedProbe): number {
-  return probe.captureSnapshot
+  return isSnapshotProducingProbe(probe)
     ? currentProbeBudgetConfiguration.maxSnapshotsPerProbeLifetime
     : currentProbeBudgetConfiguration.maxNonSnapshotsPerProbeLifetime
+}
+
+function isSnapshotProducingProbe(probe: Probe): boolean {
+  return (
+    probe.captureSnapshot ||
+    (probe.captureExpressions?.length ??
+      (probe as InitializedProbe).compiledCaptureExpressions?.expressions.length ??
+      0) > 0
+  )
+}
+
+function compileCaptureExpressions(probe: Probe): CompiledCaptureExpressions {
+  const expressions: CompiledCaptureExpression[] = []
+  for (const captureExpression of probe.captureExpressions!) {
+    try {
+      expressions.push({
+        name: captureExpression.name,
+        expression: String(compile(captureExpression.expr.json)),
+        capture: {
+          maxReferenceDepth: captureExpression.capture?.maxReferenceDepth ?? probe.capture?.maxReferenceDepth,
+          maxCollectionSize: captureExpression.capture?.maxCollectionSize ?? probe.capture?.maxCollectionSize,
+          maxFieldCount: captureExpression.capture?.maxFieldCount ?? probe.capture?.maxFieldCount,
+          maxLength: captureExpression.capture?.maxLength ?? probe.capture?.maxLength,
+        },
+      })
+    } catch (err) {
+      const captureExpressionError = new Error(
+        `Cannot compile capture expression: ${captureExpression.name} (probe: ${probe.id}, version: ${probe.version})`
+      )
+      ;(captureExpressionError as ErrorWithCause).cause = err
+      throw captureExpressionError
+    }
+  }
+
+  const getFunction = createCachedFunctionFactory(
+    (contextKeys: string[], expression: string) => `${contextKeys.join(',')}:${expression}`,
+    (contextKeys: string[], expression: string) =>
+      // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+      new Function(...contextKeys, `return ${expression}`) as (...args: any[]) => unknown
+  )
+
+  return {
+    expressions,
+    evaluateExpression: (expression: string, context: Record<string, any>) =>
+      callWithContext(context, (thisValue, contextKeys, contextValues) =>
+        getFunction(contextKeys, expression).call(thisValue, ...contextValues)
+      ),
+  }
+}
+
+function callWithContext<T>(
+  context: Record<string, any>,
+  call: (thisValue: any, contextKeys: string[], contextValues: any[]) => T
+): T {
+  const { this: thisValue, ...otherContext } = context
+  const contextKeys = Object.keys(otherContext)
+  const contextValues = Object.values(otherContext)
+  return call(thisValue, contextKeys, contextValues)
+}
+
+function createCachedFunctionFactory<TFunction extends (...args: any[]) => any, TKeyParts extends unknown[]>(
+  getCacheKey: (...keyParts: TKeyParts) => string,
+  createFunction: (...keyParts: TKeyParts) => TFunction
+): (...keyParts: TKeyParts) => TFunction {
+  const functionCache = new Map<string, TFunction>()
+  return (...keyParts: TKeyParts) => {
+    const cacheKey = getCacheKey(...keyParts)
+    let fn = functionCache.get(cacheKey)
+    if (!fn) {
+      fn = createFunction(...keyParts)
+      functionCache.set(cacheKey, fn)
+    }
+    return fn
+  }
 }


### PR DESCRIPTION
## Motivation

Add Capture Expressions support to the browser debugger so method probes can capture named expression results without enabling full snapshot capture.

## Changes

- Add `captureExpressions` probe parsing/compilation for browser debugger probes.
- Evaluate Capture Expressions at the configured method phase (`ENTRY` or `EXIT`) and serialize them under `captures.entry.captureExpressions` or `captures.return.captureExpressions`.
- Treat Capture Expression probes as snapshot-producing for sampling, global limits, stack capture, and lifetime budgets.
- Reject Delivery API probes that combine `captureSnapshot` with `captureExpressions`.
- Add a shared `mergeArrays` utility in browser-core for optional array merging.
- Add unit coverage for compilation, invalid expressions, delivery filtering, entry/return/throw evaluation, evaluation errors, limits, and rate limiting.

## Test instructions

- `yarn test:unit --spec packages/browser-core/src/tools/utils/arrayUtils.spec.ts --spec packages/browser-debugger/src/domain/template.spec.ts --spec packages/browser-debugger/src/domain/probes.spec.ts --spec packages/browser-debugger/src/domain/api.spec.ts --spec packages/browser-debugger/src/domain/deliveryApi.spec.ts`
- `yarn typecheck`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
