### PR TITLE
🐛 Omit global this from debugger snapshots

### DIFF
--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -1,3 +1,4 @@
+import { globalObject } from '@datadog/browser-core'
 import { mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import { onEntry, onReturn, onThrow, initDebuggerTransport, resetDebuggerTransport } from './api'
 import { display } from './display'
@@ -87,6 +88,36 @@ describe('api', () => {
       expect(snapshot.captures.return.locals['@return']).toEqual({
         type: 'string',
         value: 'result',
+      })
+    })
+
+    it('should not capture this when it is the global object', () => {
+      const probe: Probe = {
+        id: 'global-this-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'globalThis' },
+        template: 'Test message',
+        captureSnapshot: true,
+        capture: { maxReferenceDepth: 1 },
+        sampling: { snapshotsPerSecond: 5000 },
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const args = { a: 1 }
+      const probes = getProbes('TestClass;globalThis')!
+      onEntry(probes, globalObject, args)
+      onReturn(probes, 'result', globalObject, args, {})
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+
+      expect(snapshot.captures.entry.arguments).toEqual({
+        a: { type: 'number', value: '1' },
+      })
+      expect(snapshot.captures.return.arguments).toEqual({
+        a: { type: 'number', value: '1' },
       })
     })
 
@@ -573,6 +604,37 @@ describe('api', () => {
           })
         )
       }
+    })
+
+    it('should not capture this for exceptions when it is the global object', () => {
+      const probe: Probe = {
+        id: 'global-this-throw-probe',
+        version: 0,
+        type: 'LOG_PROBE',
+        where: { typeName: 'TestClass', methodName: 'globalThisThrow' },
+        template: 'Test',
+        captureSnapshot: true,
+        capture: { maxReferenceDepth: 1 },
+        sampling: {},
+        evaluateAt: 'ENTRY',
+      }
+      addProbe(probe)
+
+      const args = { a: 1 }
+      const probes = getProbes('TestClass;globalThisThrow')!
+      onEntry(probes, globalObject, args)
+      onThrow(probes, new Error('Test error'), globalObject, args)
+
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+
+      expect(snapshot.captures.return.arguments).toEqual({
+        a: { type: 'number', value: '1' },
+      })
+      expect(snapshot.captures.return.throwable).toEqual({
+        message: 'Test error',
+        stacktrace: jasmine.any(Array),
+      })
     })
 
     it('should capture exception details', () => {

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -107,10 +107,7 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
     let entry: { arguments: Record<string, any> } | undefined
     if (shouldCaptureEntrySnapshot) {
       entry = {
-        arguments: {
-          ...captureFields(args, probe.capture, captureCtx),
-          this: capture(self, probe.capture, captureCtx),
-        },
+        arguments: captureArguments(args, self, probe.capture, captureCtx),
       }
       if (captureCtx.timedOut) {
         probe.activeEntries.push(null)
@@ -189,10 +186,7 @@ export function onReturn(
 
     if (probe.captureSnapshot) {
       result.return = {
-        arguments: {
-          ...captureFields(args, probe.capture, captureCtx),
-          this: capture(self, probe.capture, captureCtx),
-        },
+        arguments: captureArguments(args, self, probe.capture, captureCtx),
         locals: {
           ...captureFields(locals, probe.capture, captureCtx),
           '@return': capture(value, probe.capture, captureCtx),
@@ -262,10 +256,7 @@ export function onThrow(probes: InitializedProbe[], error: Error, self: any, arg
 
     let throwArguments: Record<string, any> | undefined
     if (probe.captureSnapshot) {
-      throwArguments = {
-        ...captureFields(args, probe.capture, captureCtx),
-        this: capture(self, probe.capture, captureCtx),
-      }
+      throwArguments = captureArguments(args, self, probe.capture, captureCtx)
       if (captureCtx.timedOut) {
         continue
       }
@@ -339,6 +330,19 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
 
   debuggerBatch.add(payload)
   recordProbeEventSent(probe)
+}
+
+function captureArguments(
+  args: Record<string, any>,
+  self: any,
+  captureOptions: InitializedProbe['capture'],
+  captureCtx: CaptureContext
+): Record<string, any> {
+  const fields = captureFields(args, captureOptions, captureCtx)
+  if (self !== globalObject) {
+    fields.this = capture(self, captureOptions, captureCtx)
+  }
+  return fields
 }
 
 function getDebuggerDDtags(debuggerVersion: string): string {

--- a/test/e2e/scenario/debugger.scenario.ts
+++ b/test/e2e/scenario/debugger.scenario.ts
@@ -149,7 +149,9 @@ test.describe('debugger', () => {
       const snapshot = (event.debugger as any).snapshot
       expect(snapshot.probe.id).toBe('test-probe-1')
       expect(snapshot.language).toBe('javascript')
-      expect(snapshot.duration).toBeGreaterThan(0)
+      expect(snapshot.duration).toBeGreaterThanOrEqual(0)
+      expect(snapshot.captures.entry.arguments.this).toBeUndefined()
+      expect(snapshot.captures.return.arguments.this).toBeUndefined()
     })
 
   createTest('capture function arguments and return value')


### PR DESCRIPTION
## Motivation

Debugger snapshots currently include `this` in captured arguments even when it points to the browser global object. That value is large, mostly redundant across instrumented calls if it points to the global object, and not useful as an implicit receiver capture.

## Changes

Skip `this` from full snapshot argument captures when it is the SDK `globalObject`.

This applies to entry, return, and thrown snapshots. Explicit capture expressions are unaffected, so a user can still capture `this` when they intentionally request it.

## Test instructions

Run:

`yarn test:unit --spec packages/browser-debugger/src/domain/api.spec.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
