### PR TITLE
🐛 Send partial snapshots after debugger capture timeout

### DIFF
--- a/packages/browser-debugger/src/domain/activeEntries.ts
+++ b/packages/browser-debugger/src/domain/activeEntries.ts
@@ -1,22 +1,19 @@
 import type { StackFrame } from './stacktrace'
 import type { EvaluationError } from './condition'
 import type { Throwable } from './error'
-import type { TimeoutCapturedValue } from './capture'
 
 type CapturedFields = Record<string, any>
-type CapturedArguments = CapturedFields | TimeoutCapturedValue
 
 interface ActiveEntryThrowable {
   throwable?: Throwable
 }
 
 type ActiveEntryEntry =
-  | { arguments: CapturedArguments; captureExpressions?: never }
-  | { arguments?: never; captureExpressions: CapturedFields }
+  { arguments: CapturedFields; captureExpressions?: never } | { arguments?: never; captureExpressions: CapturedFields }
 
 type ActiveEntryReturn =
   | (ActiveEntryThrowable & {
-      arguments: CapturedArguments
+      arguments: CapturedFields
       locals?: CapturedFields
       captureExpressions?: never
     })

--- a/packages/browser-debugger/src/domain/activeEntries.ts
+++ b/packages/browser-debugger/src/domain/activeEntries.ts
@@ -1,19 +1,22 @@
 import type { StackFrame } from './stacktrace'
 import type { EvaluationError } from './condition'
 import type { Throwable } from './error'
+import type { TimeoutCapturedValue } from './capture'
 
 type CapturedFields = Record<string, any>
+type CapturedArguments = CapturedFields | TimeoutCapturedValue
 
 interface ActiveEntryThrowable {
   throwable?: Throwable
 }
 
 type ActiveEntryEntry =
-  { arguments: CapturedFields; captureExpressions?: never } | { arguments?: never; captureExpressions: CapturedFields }
+  | { arguments: CapturedArguments; captureExpressions?: never }
+  | { arguments?: never; captureExpressions: CapturedFields }
 
 type ActiveEntryReturn =
   | (ActiveEntryThrowable & {
-      arguments: CapturedFields
+      arguments: CapturedArguments
       locals?: CapturedFields
       captureExpressions?: never
     })

--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -1212,6 +1212,19 @@ describe('api', () => {
   })
 
   describe('snapshot timeout', () => {
+    function hasTimeoutMarker(value: any): boolean {
+      if (!value || typeof value !== 'object') {
+        return false
+      }
+      if (value.notCapturedReason === 'timeout') {
+        return true
+      }
+      if (Array.isArray(value)) {
+        return value.some(hasTimeoutMarker)
+      }
+      return Object.values(value).some(hasTimeoutMarker)
+    }
+
     function createSnapshotProbe(methodName: string): Probe {
       return {
         id: `timeout-probe-${methodName}`,
@@ -1226,7 +1239,7 @@ describe('api', () => {
       }
     }
 
-    it('should drop snapshot when entry capture exceeds timeout', () => {
+    it('should send partial snapshot when entry capture exceeds timeout', () => {
       const probe = createSnapshotProbe('entryTimeout')
       addProbe(probe)
 
@@ -1247,15 +1260,13 @@ describe('api', () => {
       onEntry(probes, {}, { arg: deepObj })
       onReturn(probes, null, {}, { arg: deepObj }, {})
 
-      // The entry capture timed out, so onEntry pushed null.
-      // onReturn still gets an active entry from its own onEntry call, but
-      // the entry snapshot is dropped. The return capture has its own timeout.
-      // Since performance.now is still returning future values, the return
-      // capture also times out and no snapshot is sent.
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(hasTimeoutMarker(snapshot.captures.entry)).toBe(true)
     })
 
-    it('should drop snapshot when return capture exceeds timeout', () => {
+    it('should send partial snapshot when return capture exceeds timeout', () => {
       const probe = createSnapshotProbe('returnTimeout')
       addProbe(probe)
 
@@ -1277,10 +1288,13 @@ describe('api', () => {
 
       onReturn(probes, null, {}, { x: 1 }, { local: 'value' })
 
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(hasTimeoutMarker(snapshot.captures.return)).toBe(true)
     })
 
-    it('should drop snapshot when throw capture exceeds timeout', () => {
+    it('should send partial snapshot when throw capture exceeds timeout', () => {
       const probe = createSnapshotProbe('throwTimeout')
       addProbe(probe)
 
@@ -1302,7 +1316,11 @@ describe('api', () => {
 
       onThrow(probes, new Error('test'), {}, { x: 1 })
 
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(hasTimeoutMarker(snapshot.captures.return.arguments)).toBe(true)
+      expect(snapshot.captures.return.throwable.message).toBe('test')
     })
 
     it('should not affect non-snapshot probes', () => {
@@ -1353,18 +1371,18 @@ describe('api', () => {
       })
 
       const probes = getProbes('TestClass;entryLeakTest')!
-      // This onEntry will time out and push null
+      // This onEntry will time out but should still push the partial snapshot entry
       onEntry(probes, {}, { x: 1 })
 
-      // onReturn should handle the null entry gracefully (no snapshot sent)
+      // onReturn should pop the timed-out entry and send its partial snapshot
       shouldTimeout = false
       callCount = 0
       onReturn(probes, null, {}, { x: 1 }, {})
 
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
 
-    it('should skip subsequent snapshot probes after timeout but still process non-snapshot probes', () => {
+    it('should mark subsequent snapshot probes as timed out but still process non-snapshot probes', () => {
       const snapshotProbe1: Probe = {
         id: 'timeout-shared-1',
         version: 0,
@@ -1413,16 +1431,17 @@ describe('api', () => {
       })
 
       const probes = getProbes('TestClass;sharedDeadline')!
-      onEntry(probes, {}, { x: 1 })
-      onReturn(probes, null, {}, { x: 1 }, {})
+      onEntry(probes, {}, { x: { nested: 'value' } })
+      onReturn(probes, null, {}, { x: { nested: 'value' } }, {})
 
-      // The non-snapshot probe should still send, but both snapshot probes should be dropped
+      // All probes should still send, with snapshot probes marked as timed out
       const calls = mockBatchAdd.calls.allArgs()
-      expect(calls.length).toBe(1)
-      expect(calls[0][0].message).toBe('Non-snapshot probe')
+      expect(calls.length).toBe(3)
+      expect(calls[1][0].message).toBe('Non-snapshot probe')
+      expect(hasTimeoutMarker(calls[2][0].debugger.snapshot.captures)).toBe(true)
     })
 
-    it('should share deadline across probes so second snapshot probe exits immediately', () => {
+    it('should share deadline across probes and mark the second snapshot as timed out immediately', () => {
       const probe1 = createSnapshotProbe('sharedDeadline1')
       const probe2: Probe = {
         ...createSnapshotProbe('sharedDeadline2'),
@@ -1443,11 +1462,13 @@ describe('api', () => {
       })
 
       const probes = getProbes('TestClass;sharedDeadline1')!
-      onEntry(probes, {}, { x: 1 })
-      onReturn(probes, null, {}, { x: 1 }, {})
+      onEntry(probes, {}, { x: { nested: 'value' } })
+      onReturn(probes, null, {}, { x: { nested: 'value' } }, {})
 
-      // Both snapshot probes share the deadline -- neither should send
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      // Both snapshot probes share the deadline -- both should send partial snapshots
+      const calls = mockBatchAdd.calls.allArgs()
+      expect(calls.length).toBe(2)
+      expect(hasTimeoutMarker(calls[1][0].debugger.snapshot.captures)).toBe(true)
     })
   })
 

--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -1185,7 +1185,20 @@ describe('api', () => {
   })
 
   describe('snapshot timeout', () => {
-    it('should drop snapshot when entry capture exceeds timeout', () => {
+    function hasTimeoutMarker(value: any): boolean {
+      if (!value || typeof value !== 'object') {
+        return false
+      }
+      if (value.notCapturedReason === 'timeout') {
+        return true
+      }
+      if (Array.isArray(value)) {
+        return value.some(hasTimeoutMarker)
+      }
+      return Object.values(value).some(hasTimeoutMarker)
+    }
+
+    it('should send partial snapshot when entry capture exceeds timeout', () => {
       addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
       let callCount = 0
@@ -1205,15 +1218,13 @@ describe('api', () => {
       onEntry(probes, thisArg, { arg: deepObj })
       onReturn(probes, null, thisArg, { arg: deepObj })
 
-      // The entry capture timed out, so onEntry pushed null.
-      // onReturn still gets an active entry from its own onEntry call, but
-      // the entry snapshot is dropped. The return capture has its own timeout.
-      // Since performance.now is still returning future values, the return
-      // capture also times out and no snapshot is sent.
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(hasTimeoutMarker(snapshot.captures.entry)).toBe(true)
     })
 
-    it('should drop snapshot when return capture exceeds timeout', () => {
+    it('should send partial snapshot when return capture exceeds timeout', () => {
       addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
@@ -1234,10 +1245,13 @@ describe('api', () => {
 
       onReturn(probes, null, thisArg, { x: 1 }, { local: 'value' })
 
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(hasTimeoutMarker(snapshot.captures.return)).toBe(true)
     })
 
-    it('should drop snapshot when throw capture exceeds timeout', () => {
+    it('should send partial snapshot when throw capture exceeds timeout', () => {
       addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
@@ -1258,7 +1272,11 @@ describe('api', () => {
 
       onThrow(probes, new Error('test'), thisArg, { x: 1 })
 
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
+      const payload = mockBatchAdd.calls.mostRecent().args[0]
+      const snapshot = payload.debugger.snapshot
+      expect(hasTimeoutMarker(snapshot.captures.return.arguments)).toBe(true)
+      expect(snapshot.captures.return.throwable.message).toBe('test')
     })
 
     it('should not affect non-snapshot probes', () => {
@@ -1302,18 +1320,18 @@ describe('api', () => {
       })
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      // This onEntry will time out and push null
+      // This onEntry will time out but should still push the partial snapshot entry
       onEntry(probes, thisArg, { x: 1 })
 
-      // onReturn should handle the null entry gracefully (no snapshot sent)
+      // onReturn should pop the timed-out entry and send its partial snapshot
       shouldTimeout = false
       callCount = 0
       onReturn(probes, null, thisArg, { x: 1 })
 
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
 
-    it('should skip subsequent snapshot probes after timeout but still process non-snapshot probes', () => {
+    it('should mark subsequent snapshot probes as timed out but still process non-snapshot probes', () => {
       const snapshotProbe1 = createProbe({
         id: 'snapshot-probe-1',
         sampling: { snapshotsPerSecond: 5000 },
@@ -1342,16 +1360,20 @@ describe('api', () => {
       })
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, thisArg, { x: 1 })
-      onReturn(probes, null, thisArg, { x: 1 })
+      onEntry(probes, thisArg, { x: { nested: 'value' } })
+      onReturn(probes, null, thisArg, { x: { nested: 'value' } })
 
-      // The non-snapshot probe should still send, but both snapshot probes should be dropped
+      // All probes should still send, with snapshot probes marked as timed out
       const calls = mockBatchAdd.calls.allArgs()
-      expect(calls.length).toBe(1)
-      expect(calls[0][0].debugger.snapshot.probe.id).toBe(nonSnapshotProbe.id)
+      expect(calls.length).toBe(3)
+      expect(calls[1][0].debugger.snapshot.probe.id).toBe(nonSnapshotProbe.id)
+      expect(calls[2][0].debugger.snapshot.captures.entry.arguments).toEqual({
+        type: 'object',
+        notCapturedReason: 'timeout',
+      })
     })
 
-    it('should share deadline across probes so second snapshot probe exits immediately', () => {
+    it('should share deadline across probes and mark the second snapshot as timed out immediately', () => {
       addProbe(
         createProbe({
           id: 'timeout-probe-sharedDeadline1',
@@ -1376,11 +1398,16 @@ describe('api', () => {
       })
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, thisArg, { x: 1 })
-      onReturn(probes, null, thisArg, { x: 1 })
+      onEntry(probes, thisArg, { x: { nested: 'value' } })
+      onReturn(probes, null, thisArg, { x: { nested: 'value' } })
 
-      // Both snapshot probes share the deadline -- neither should send
-      expect(mockBatchAdd).not.toHaveBeenCalled()
+      // Both snapshot probes share the deadline, so the second probe should send a timeout marker immediately.
+      const calls = mockBatchAdd.calls.allArgs()
+      expect(calls.length).toBe(2)
+      expect(calls[1][0].debugger.snapshot.captures.entry.arguments).toEqual({
+        type: 'object',
+        notCapturedReason: 'timeout',
+      })
     })
   })
 

--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -1368,8 +1368,8 @@ describe('api', () => {
       expect(calls.length).toBe(3)
       expect(calls[1][0].debugger.snapshot.probe.id).toBe(nonSnapshotProbe.id)
       expect(calls[2][0].debugger.snapshot.captures.entry.arguments).toEqual({
-        type: 'object',
-        notCapturedReason: 'timeout',
+        x: { type: 'Object', notCapturedReason: 'timeout' },
+        this: { type: 'Object', notCapturedReason: 'timeout' },
       })
     })
 
@@ -1405,8 +1405,8 @@ describe('api', () => {
       const calls = mockBatchAdd.calls.allArgs()
       expect(calls.length).toBe(2)
       expect(calls[1][0].debugger.snapshot.captures.entry.arguments).toEqual({
-        type: 'object',
-        notCapturedReason: 'timeout',
+        x: { type: 'Object', notCapturedReason: 'timeout' },
+        this: { type: 'Object', notCapturedReason: 'timeout' },
       })
     })
   })

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -109,10 +109,6 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
       entry = {
         arguments: captureArguments(args, self, probe.capture, captureCtx),
       }
-      if (captureCtx.timedOut) {
-        probe.activeEntries.push(null)
-        continue
-      }
     }
 
     probe.activeEntries.push({
@@ -192,9 +188,6 @@ export function onReturn(
           '@return': capture(value, probe.capture, captureCtx),
         },
       }
-      if (captureCtx.timedOut) {
-        continue
-      }
     }
 
     queueDebuggerSnapshot(probe, result)
@@ -254,16 +247,8 @@ export function onThrow(probes: InitializedProbe[], error: Error, self: any, arg
       result.message = evaluateProbeMessage(probe, context)
     }
 
-    let throwArguments: Record<string, any> | undefined
-    if (probe.captureSnapshot) {
-      throwArguments = captureArguments(args, self, probe.capture, captureCtx)
-      if (captureCtx.timedOut) {
-        continue
-      }
-    }
-
     result.return = {
-      arguments: throwArguments,
+      arguments: probe.captureSnapshot ? captureArguments(args, self, probe.capture, captureCtx) : undefined,
       throwable: {
         message: error.message,
         stacktrace: parseStackTrace(error),

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -1,10 +1,10 @@
 import { globalObject } from '@datadog/js-core/util'
-import type { Batch, Context, ContextValue } from '@datadog/browser-core'
+import type { Batch, ContextValue } from '@datadog/browser-core'
 import { timeStampNow } from '@datadog/js-core/time'
 import { buildTag, generateUUID, mergeArrays } from '@datadog/browser-core'
 import type { BrowserWindow, DebuggerInitConfiguration } from '../entries/main'
-import { capture, captureFields, createTimeoutCapturedValue } from './capture'
-import type { CaptureContext, TimeoutCapturedValue } from './capture'
+import { capture, captureFields } from './capture'
+import type { CaptureContext } from './capture'
 import type { InitializedProbe } from './probes'
 import {
   checkConditionErrorBudget,
@@ -297,7 +297,7 @@ export function onThrow(probes: InitializedProbe[], error: unknown, self: any, a
       }
     }
 
-    let throwArguments: Record<string, any> | TimeoutCapturedValue | undefined
+    let throwArguments: Record<string, any> | undefined
     if (probe.captureSnapshot) {
       throwArguments = captureArguments(args, self, probe.capture, captureCtx)
     }
@@ -371,7 +371,7 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
     },
   }
 
-  debuggerBatch.add(payload as unknown as Context)
+  debuggerBatch.add(payload)
   recordProbeEventSent(probe)
 }
 
@@ -380,11 +380,7 @@ function captureArguments(
   self: any,
   captureOptions: InitializedProbe['capture'],
   captureCtx: CaptureContext
-): Record<string, any> | TimeoutCapturedValue {
-  if (captureCtx.timedOut) {
-    return createTimeoutCapturedValue(args)
-  }
-
+): Record<string, any> {
   const fields = captureFields(args, captureOptions, captureCtx)
   if (self !== globalObject) {
     fields.this = capture(self, captureOptions, captureCtx)

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -3,8 +3,8 @@ import type { Batch, Context, ContextValue } from '@datadog/browser-core'
 import { timeStampNow } from '@datadog/js-core/time'
 import { buildTag, generateUUID, mergeArrays } from '@datadog/browser-core'
 import type { BrowserWindow, DebuggerInitConfiguration } from '../entries/main'
-import { capture, captureFields } from './capture'
-import type { CaptureContext } from './capture'
+import { capture, captureFields, createTimeoutCapturedValue } from './capture'
+import type { CaptureContext, TimeoutCapturedValue } from './capture'
 import type { InitializedProbe } from './probes'
 import {
   checkConditionErrorBudget,
@@ -124,10 +124,6 @@ export function onEntry(probes: InitializedProbe[], self: any, args: Record<stri
       entry = {
         arguments: captureArguments(args, self, probe.capture, captureCtx),
       }
-      if (captureCtx.timedOut) {
-        probe.activeEntries.push(null)
-        continue
-      }
     } else if (entryCaptureExpressions) {
       entry = {
         captureExpressions: entryCaptureExpressions,
@@ -227,9 +223,6 @@ export function onReturn(
           '@return': capture(value, probe.capture, captureCtx),
         },
       }
-      if (captureCtx.timedOut) {
-        continue
-      }
     }
 
     queueDebuggerSnapshot(probe, result)
@@ -304,12 +297,9 @@ export function onThrow(probes: InitializedProbe[], error: unknown, self: any, a
       }
     }
 
-    let throwArguments: Record<string, any> | undefined
+    let throwArguments: Record<string, any> | TimeoutCapturedValue | undefined
     if (probe.captureSnapshot) {
       throwArguments = captureArguments(args, self, probe.capture, captureCtx)
-      if (captureCtx.timedOut) {
-        continue
-      }
     }
 
     const throwable = formatThrowable(error)
@@ -347,7 +337,7 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
       : undefined
   ) as ContextValue
 
-  const payload: Context = {
+  const payload = {
     message: result.message,
     service: debuggerConfig.service,
     ddtags: getDebuggerDDtags(version),
@@ -381,7 +371,7 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
     },
   }
 
-  debuggerBatch.add(payload)
+  debuggerBatch.add(payload as unknown as Context)
   recordProbeEventSent(probe)
 }
 
@@ -390,7 +380,11 @@ function captureArguments(
   self: any,
   captureOptions: InitializedProbe['capture'],
   captureCtx: CaptureContext
-): Record<string, any> {
+): Record<string, any> | TimeoutCapturedValue {
+  if (captureCtx.timedOut) {
+    return createTimeoutCapturedValue(args)
+  }
+
   const fields = captureFields(args, captureOptions, captureCtx)
   if (self !== globalObject) {
     fields.this = capture(self, captureOptions, captureCtx)

--- a/packages/browser-debugger/src/domain/capture.spec.ts
+++ b/packages/browser-debugger/src/domain/capture.spec.ts
@@ -664,17 +664,27 @@ describe('capture timeout', () => {
     maxLength: 255,
   }
 
-  it('should return timeout value with real type when already timed out', () => {
+  it('should still capture cheap values when already timed out', () => {
     const ctx: CaptureContext = { deadline: 0, timedOut: true }
 
-    expect(capture({ a: 1 }, defaultOpts, ctx)).toEqual({ type: 'object', notCapturedReason: 'timeout' })
-    expect(capture('hello', defaultOpts, ctx)).toEqual({ type: 'string', notCapturedReason: 'timeout' })
-    expect(capture(42, defaultOpts, ctx)).toEqual({ type: 'number', notCapturedReason: 'timeout' })
-    expect(capture(null, defaultOpts, ctx)).toEqual({ type: 'null', notCapturedReason: 'timeout' })
-    expect(capture(undefined, defaultOpts, ctx)).toEqual({ type: 'undefined', notCapturedReason: 'timeout' })
+    expect(capture('hello', defaultOpts, ctx)).toEqual({ type: 'string', value: 'hello' })
+    expect(capture(42, defaultOpts, ctx)).toEqual({ type: 'number', value: '42' })
+    expect(capture(null, defaultOpts, ctx)).toEqual({ type: 'null', isNull: true })
+    expect(capture(undefined, defaultOpts, ctx)).toEqual({ type: 'undefined' })
+    expect(capture(new Date('2026-01-01T00:00:00.000Z'), defaultOpts, ctx)).toEqual({
+      type: 'Date',
+      value: '2026-01-01T00:00:00.000Z',
+    })
   })
 
-  it('should stop traversing object properties when deadline is exceeded', () => {
+  it('should return timeout values for traversable values when already timed out', () => {
+    const ctx: CaptureContext = { deadline: 0, timedOut: true }
+
+    expect(capture({ a: 1 }, defaultOpts, ctx)).toEqual({ type: 'Object', notCapturedReason: 'timeout' })
+    expect(capture([1, 2], defaultOpts, ctx)).toEqual({ type: 'Array', notCapturedReason: 'timeout' })
+  })
+
+  it('should preserve object fields and mark nested values when the deadline is exceeded', () => {
     let callCount = 0
     const originalNow = performance.now.bind(performance)
     spyOn(performance, 'now').and.callFake(() => {
@@ -688,17 +698,21 @@ describe('capture timeout', () => {
       return Infinity
     })
 
-    const obj: Record<string, number> = {}
+    const obj: Record<string, { nested: string }> = {}
     for (let i = 0; i < 20; i++) {
-      obj[`field${i}`] = i
+      obj[`field${i}`] = { nested: 'value' }
     }
 
     const ctx: CaptureContext = { deadline: performance.now() + 10, timedOut: false }
     const result = capture(obj, defaultOpts, ctx)
 
     expect(ctx.timedOut).toBe(true)
-    const capturedFieldCount = Object.keys((result as any).fields || {}).length
-    expect(capturedFieldCount).toBeLessThan(20)
+    const fields = (result as any).fields
+    expect(Object.keys(fields).length).toBe(20)
+    expect(Object.values(fields).filter((value: any) => value.notCapturedReason === 'timeout').length).toBeGreaterThan(
+      1
+    )
+    expect((result as any).notCapturedReason).toBe('timeout')
   })
 
   it('should stop traversing array elements when deadline is exceeded', () => {
@@ -717,9 +731,33 @@ describe('capture timeout', () => {
 
     expect(ctx.timedOut).toBe(true)
     expect((result as any).elements.length).toBeLessThan(50)
+    expect((result as any).notCapturedReason).toBe('timeout')
   })
 
-  it('should stop captureFields traversal when deadline is exceeded', () => {
+  it('should mark maps as timed out when the traversal deadline is exceeded', () => {
+    let callCount = 0
+    spyOn(performance, 'now').and.callFake(() => {
+      callCount++
+      if (callCount <= 4) {
+        return 100
+      }
+      return Infinity
+    })
+
+    const map = new Map<number, { nested: string }>()
+    for (let i = 0; i < 50; i++) {
+      map.set(i, { nested: 'value' })
+    }
+
+    const ctx: CaptureContext = { deadline: 200, timedOut: false }
+    const result = capture(map, defaultOpts, ctx)
+
+    expect(ctx.timedOut).toBe(true)
+    expect((result as any).entries.length).toBeLessThan(50)
+    expect((result as any).notCapturedReason).toBe('timeout')
+  })
+
+  it('should preserve field names and mark nested values when the deadline is exceeded', () => {
     let callCount = 0
     spyOn(performance, 'now').and.callFake(() => {
       callCount++
@@ -729,15 +767,16 @@ describe('capture timeout', () => {
       return Infinity
     })
 
-    const obj: Record<string, number> = {}
+    const obj: Record<string, { nested: string }> = {}
     for (let i = 0; i < 20; i++) {
-      obj[`field${i}`] = i
+      obj[`field${i}`] = { nested: 'value' }
     }
 
     const ctx: CaptureContext = { deadline: 200, timedOut: false }
     const result = captureFields(obj, defaultOpts, ctx)
 
     expect(ctx.timedOut).toBe(true)
-    expect(Object.keys(result).length).toBeLessThan(20)
+    expect(Object.keys(result).length).toBe(20)
+    expect(Object.values(result).filter((value) => value.notCapturedReason === 'timeout').length).toBeGreaterThan(1)
   })
 })

--- a/packages/browser-debugger/src/domain/capture.spec.ts
+++ b/packages/browser-debugger/src/domain/capture.spec.ts
@@ -689,9 +689,8 @@ describe('capture timeout', () => {
     const originalNow = performance.now.bind(performance)
     spyOn(performance, 'now').and.callFake(() => {
       callCount++
-      // First call is the deadline check at the start of captureValue,
-      // subsequent calls are from isTimedOut checks during property iteration.
-      // Return past-deadline after a few calls to simulate timeout mid-traversal.
+      // The first call sets the deadline, the second checks the root object, and
+      // the third allows the first nested object to be captured.
       if (callCount <= 3) {
         return originalNow()
       }
@@ -712,6 +711,13 @@ describe('capture timeout', () => {
     expect(Object.values(fields).filter((value: any) => value.notCapturedReason === 'timeout').length).toBeGreaterThan(
       1
     )
+    expect(fields.field0).toEqual({
+      type: 'Object',
+      fields: {
+        nested: { type: 'string', value: 'value' },
+      },
+    })
+    expect(fields.field1).toEqual({ type: 'Object', notCapturedReason: 'timeout' })
     expect((result as any).notCapturedReason).toBe('timeout')
   })
 
@@ -778,5 +784,12 @@ describe('capture timeout', () => {
     expect(ctx.timedOut).toBe(true)
     expect(Object.keys(result).length).toBe(20)
     expect(Object.values(result).filter((value) => value.notCapturedReason === 'timeout').length).toBeGreaterThan(1)
+    expect(result.field0).toEqual({
+      type: 'Object',
+      fields: {
+        nested: { type: 'string', value: 'value' },
+      },
+    })
+    expect(result.field2).toEqual({ type: 'Object', notCapturedReason: 'timeout' })
   })
 })

--- a/packages/browser-debugger/src/domain/capture.ts
+++ b/packages/browser-debugger/src/domain/capture.ts
@@ -19,11 +19,6 @@ export interface CapturedValue {
   entries?: Array<[CapturedValue, CapturedValue]>
 }
 
-export interface TimeoutCapturedValue {
-  type: string
-  notCapturedReason: 'timeout'
-}
-
 /**
  * Mutable context threaded through the capture walker so that a single
  * `performance.now()` deadline can cooperatively abort deep traversals.
@@ -54,10 +49,6 @@ function isTimedOut(ctx: CaptureContext): boolean {
     return true
   }
   return false
-}
-
-export function createTimeoutCapturedValue(value: unknown): TimeoutCapturedValue {
-  return { type: value === null ? 'null' : typeof value, notCapturedReason: 'timeout' }
 }
 
 /**
@@ -119,10 +110,6 @@ function captureValue(
   maxLength: number,
   ctx: CaptureContext
 ): CapturedValue {
-  if (isTimedOut(ctx)) {
-    return createTimeoutCapturedValue(value)
-  }
-
   // Handle null first as typeof null === 'object'
   if (value === null) {
     return { type: 'null', isNull: true }
@@ -198,6 +185,9 @@ function captureFunction(
   if (depth >= maxReferenceDepth) {
     return { type: 'Function', notCapturedReason: 'depth' }
   }
+  if (isTimedOut(ctx)) {
+    return { type: 'Function', notCapturedReason: 'timeout' }
+  }
 
   return captureObjectProperties(
     fn as any,
@@ -224,7 +214,7 @@ function captureObject(
     return { type: getConstructorName(obj) ?? 'Object', notCapturedReason: 'depth' }
   }
 
-  // Built-in objects with specialized serialization
+  // Built-in leaf objects with cheap serialization
   if (obj instanceof Date) {
     try {
       return { type: 'Date', value: obj.toISOString() }
@@ -235,31 +225,9 @@ function captureObject(
   if (obj instanceof RegExp) {
     return { type: 'RegExp', value: obj.toString() }
   }
-  if (isError(obj)) {
-    return captureError(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
-  }
   if (obj instanceof Promise) {
     return { type: 'Promise', notCapturedReason: 'Promise state cannot be inspected' }
   }
-
-  // Collections
-  if (Array.isArray(obj)) {
-    return captureArray(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
-  }
-  if (obj instanceof Map) {
-    return captureMap(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
-  }
-  if (obj instanceof Set) {
-    return captureSet(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
-  }
-  if (obj instanceof WeakMap) {
-    return { type: 'WeakMap', notCapturedReason: 'WeakMap contents cannot be enumerated' }
-  }
-  if (obj instanceof WeakSet) {
-    return { type: 'WeakSet', notCapturedReason: 'WeakSet contents cannot be enumerated' }
-  }
-
-  // Binary data
   if (obj instanceof ArrayBuffer) {
     return captureArrayBuffer(obj)
   }
@@ -268,6 +236,12 @@ function captureObject(
   }
   if (obj instanceof DataView) {
     return captureDataView(obj)
+  }
+  if (obj instanceof WeakMap) {
+    return { type: 'WeakMap', notCapturedReason: 'WeakMap contents cannot be enumerated' }
+  }
+  if (obj instanceof WeakSet) {
+    return { type: 'WeakSet', notCapturedReason: 'WeakSet contents cannot be enumerated' }
   }
   if (ArrayBuffer.isView(obj) && !(obj instanceof DataView)) {
     return captureTypedArray(
@@ -279,6 +253,25 @@ function captureObject(
       maxLength,
       ctx
     )
+  }
+
+  // Keep cheap leaf serialization above this point, but stop before recursive/container capture.
+  if (isTimedOut(ctx)) {
+    return { type: getConstructorName(obj) ?? 'Object', notCapturedReason: 'timeout' }
+  }
+
+  // Potentially expensive objects with recursive serialization
+  if (isError(obj)) {
+    return captureError(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
+  }
+  if (Array.isArray(obj)) {
+    return captureArray(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
+  }
+  if (obj instanceof Map) {
+    return captureMap(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
+  }
+  if (obj instanceof Set) {
+    return captureSet(obj, depth, maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength, ctx)
   }
 
   // Custom objects
@@ -312,10 +305,6 @@ function captureObjectPropertiesFields(
 
   const fields: Record<string, CapturedValue> = {}
   for (const key of keysToCapture) {
-    if (isTimedOut(ctx)) {
-      break
-    }
-
     const keyStr = String(key)
     const keyName =
       typeof key === 'symbol' ? key.description || key.toString() : keyStr.includes('.') ? replaceDots(keyStr) : keyStr
@@ -362,7 +351,9 @@ function captureObjectProperties(
 
   const result: CapturedValue = { type: typeName, fields }
 
-  if (totalFields > maxFieldCount) {
+  if (ctx.timedOut) {
+    result.notCapturedReason = 'timeout'
+  } else if (totalFields > maxFieldCount) {
     result.notCapturedReason = 'fieldCount'
     result.size = totalFields
   }
@@ -392,7 +383,9 @@ function captureArray(
 
   const result: CapturedValue = { type: 'Array', elements }
 
-  if (totalSize > maxCollectionSize) {
+  if (ctx.timedOut) {
+    result.notCapturedReason = 'timeout'
+  } else if (totalSize > maxCollectionSize) {
     result.notCapturedReason = 'collectionSize'
     result.size = totalSize
   }
@@ -427,7 +420,9 @@ function captureMap(
 
   const result: CapturedValue = { type: 'Map', entries }
 
-  if (totalSize > maxCollectionSize) {
+  if (ctx.timedOut) {
+    result.notCapturedReason = 'timeout'
+  } else if (totalSize > maxCollectionSize) {
     result.notCapturedReason = 'collectionSize'
     result.size = totalSize
   }
@@ -459,7 +454,9 @@ function captureSet(
 
   const result: CapturedValue = { type: 'Set', elements }
 
-  if (totalSize > maxCollectionSize) {
+  if (ctx.timedOut) {
+    result.notCapturedReason = 'timeout'
+  } else if (totalSize > maxCollectionSize) {
     result.notCapturedReason = 'collectionSize'
     result.size = totalSize
   }
@@ -630,7 +627,9 @@ function captureTypedArray(
     },
   }
 
-  if (totalSize > maxCollectionSize) {
+  if (ctx.timedOut) {
+    result.notCapturedReason = 'timeout'
+  } else if (totalSize > maxCollectionSize) {
     result.notCapturedReason = 'collectionSize'
     result.size = totalSize
   }

--- a/packages/browser-debugger/src/domain/capture.ts
+++ b/packages/browser-debugger/src/domain/capture.ts
@@ -19,6 +19,11 @@ export interface CapturedValue {
   entries?: Array<[CapturedValue, CapturedValue]>
 }
 
+export interface TimeoutCapturedValue {
+  type: string
+  notCapturedReason: 'timeout'
+}
+
 /**
  * Mutable context threaded through the capture walker so that a single
  * `performance.now()` deadline can cooperatively abort deep traversals.
@@ -49,6 +54,10 @@ function isTimedOut(ctx: CaptureContext): boolean {
     return true
   }
   return false
+}
+
+export function createTimeoutCapturedValue(value: unknown): TimeoutCapturedValue {
+  return { type: value === null ? 'null' : typeof value, notCapturedReason: 'timeout' }
 }
 
 /**
@@ -111,7 +120,7 @@ function captureValue(
   ctx: CaptureContext
 ): CapturedValue {
   if (isTimedOut(ctx)) {
-    return { type: value === null ? 'null' : typeof value, notCapturedReason: 'timeout' }
+    return createTimeoutCapturedValue(value)
   }
 
   // Handle null first as typeof null === 'object'


### PR DESCRIPTION
## Motivation

Debugger snapshots were dropped when snapshot capture exceeded the timeout budget. This meant customers could miss useful partial snapshot data, including timeout markers that explain why capture is incomplete.

## Changes

- Continue delivering partial snapshots when entry, return, or throw capture exceeds the timeout budget.
- Keep argument captures as argument-name-to-value maps when a shared deadline is exhausted, matching the shape used for other captured variables.
- Continue serializing cheap leaf values after the deadline while preventing further recursive object and collection traversal.
- Mark partially captured objects, arrays, maps, sets, and typed arrays with `notCapturedReason: 'timeout'`.
- Extend unit coverage for partial captures and shared-deadline probes.

## Test instructions

- Run `yarn test:unit --spec packages/browser-debugger/src/domain/api.spec.ts --spec packages/browser-debugger/src/domain/capture.spec.ts`.
- Run `yarn typecheck`.
- Run ESLint and Prettier on the changed browser-debugger files.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
