### PR TITLE
✅ Simplify debugger probe test fixtures

### DIFF
--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -4,6 +4,9 @@ import { onEntry, onReturn, onThrow, initDebuggerTransport, resetDebuggerTranspo
 import { display } from './display'
 import { addProbe, removeProbe, getProbes, clearProbes } from './probes'
 import type { Probe } from './probes'
+import { createProbe } from './probe.specHelper'
+
+const DEFAULT_PROBE_FUNCTION_ID = 'test.js;testMethod'
 
 describe('api', () => {
   let mockBatchAdd: jasmine.Spy
@@ -38,22 +41,11 @@ describe('api', () => {
 
   describe('onEntry and onReturn', () => {
     it('should capture this inside arguments.fields', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'testMethod' },
-        template: 'Test message',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
       const self = { name: 'testObj' }
       const args = { a: 1, b: 2 }
-      const probes = getProbes('TestClass;testMethod')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, self, args)
       onReturn(probes, 'result', self, args, {})
 
@@ -92,21 +84,10 @@ describe('api', () => {
     })
 
     it('should not capture this when it is the global object', () => {
-      const probe: Probe = {
-        id: 'global-this-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'globalThis' },
-        template: 'Test message',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
       const args = { a: 1 }
-      const probes = getProbes('TestClass;globalThis')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, globalObject, args)
       onReturn(probes, 'result', globalObject, args, {})
 
@@ -122,23 +103,12 @@ describe('api', () => {
     })
 
     it('should capture entry and return for simple probe', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'testMethod' },
-        template: 'Test message',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
       const self = { name: 'test' }
       const args = { arg1: 'value1', arg2: 42 }
 
-      const probes = getProbes('TestClass;testMethod')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, self, args)
       const result = onReturn(probes, 'returnValue', self, args, {})
 
@@ -154,20 +124,13 @@ describe('api', () => {
 
     it('should skip probe if sampling budget exceeded', () => {
       // Use a very low sampling rate to ensure budget is exceeded
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'budgetTest' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: 0.5 }, // 0.5 per second = 2000ms between samples
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          sampling: { snapshotsPerSecond: 0.5 }, // 0.5 per second = 2000ms between samples
+        })
+      )
 
-      const probes = getProbes('TestClass;budgetTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // First call should work
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
@@ -182,24 +145,18 @@ describe('api', () => {
     })
 
     it('should not evaluate ENTRY condition when sampling budget is exceeded', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'entryConditionSamplingBudget' },
-        when: {
-          dsl: 'missing.value',
-          json: { getmember: [{ ref: 'missing' }, 'value'] },
-        },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: {},
-        sampling: { snapshotsPerSecond: 0.5 },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: 'missing.value',
+            json: { getmember: [{ ref: 'missing' }, 'value'] },
+          },
+          sampling: { snapshotsPerSecond: 0.5 },
+          evaluateAt: 'ENTRY',
+        })
+      )
 
-      const probes = getProbes('TestClass;entryConditionSamplingBudget')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, { missing: { value: true } })
       onReturn(probes, null, {}, { missing: { value: true } }, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -211,24 +168,17 @@ describe('api', () => {
     })
 
     it('should not evaluate EXIT condition when sampling budget is exceeded', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'exitConditionSamplingBudget' },
-        when: {
-          dsl: 'missing.value',
-          json: { getmember: [{ ref: 'missing' }, 'value'] },
-        },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: {},
-        sampling: { snapshotsPerSecond: 0.5 },
-        evaluateAt: 'EXIT',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: 'missing.value',
+            json: { getmember: [{ ref: 'missing' }, 'value'] },
+          },
+          sampling: { snapshotsPerSecond: 0.5 },
+        })
+      )
 
-      const probes = getProbes('TestClass;exitConditionSamplingBudget')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, { missing: { value: true } })
       onReturn(probes, null, {}, { missing: { value: true } }, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -240,24 +190,16 @@ describe('api', () => {
     })
 
     it('should evaluate condition at ENTRY', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'conditionEntry' },
+      const probe = createProbe({
         when: {
           dsl: 'x > 5',
           json: { gt: [{ ref: 'x' }, 5] },
         },
-        template: 'Condition passed',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
         evaluateAt: 'ENTRY',
-      }
+      })
       addProbe(probe)
 
-      let probes = getProbes('TestClass;conditionEntry')!
+      let probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should fire when condition passes
       onEntry(probes, {}, { x: 10 })
       onReturn(probes, null, {}, { x: 10 }, {})
@@ -267,7 +209,7 @@ describe('api', () => {
       addProbe(probe)
       mockBatchAdd.calls.reset()
 
-      probes = getProbes('TestClass;conditionEntry')!
+      probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should not fire when condition fails
       onEntry(probes, {}, { x: 3 })
       onReturn(probes, null, {}, { x: 3 }, {})
@@ -275,24 +217,15 @@ describe('api', () => {
     })
 
     it('should evaluate condition at EXIT with @return', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'conditionExit' },
+      const probe = createProbe({
         when: {
           dsl: '@return > 10',
           json: { gt: [{ ref: '@return' }, 10] },
         },
-        template: 'Return value check',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'EXIT',
-      }
+      })
       addProbe(probe)
 
-      let probes = getProbes('TestClass;conditionExit')!
+      let probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should fire when return value > 10
       onEntry(probes, {}, {})
       onReturn(probes, 15, {}, {}, {})
@@ -302,7 +235,7 @@ describe('api', () => {
       addProbe(probe)
       mockBatchAdd.calls.reset()
 
-      probes = getProbes('TestClass;conditionExit')!
+      probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should not fire when return value <= 10
       onEntry(probes, {}, {})
       onReturn(probes, 5, {}, {}, {})
@@ -310,20 +243,9 @@ describe('api', () => {
     })
 
     it('should capture both entry and return snapshots for ENTRY evaluation', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'entrySnapshot' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe({ evaluateAt: 'ENTRY' }))
 
-      const probes = getProbes('TestClass;entrySnapshot')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, { name: 'obj' }, { arg: 'value' })
       onReturn(probes, 'result', { name: 'obj' }, { arg: 'value' }, { local: 'data' })
 
@@ -350,20 +272,9 @@ describe('api', () => {
     })
 
     it('should capture both entry and return snapshots for EXIT evaluation with no condition', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'exitSnapshotNoCondition' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'EXIT',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;exitSnapshotNoCondition')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, { name: 'obj' }, { arg: 'value' })
       onReturn(probes, 'result', { name: 'obj' }, { arg: 'value' }, { local: 'data' })
 
@@ -390,24 +301,16 @@ describe('api', () => {
     })
 
     it('should only capture return snapshot for EXIT evaluation with condition', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'exitSnapshot' },
-        when: {
-          dsl: '@return === true',
-          json: { eq: [{ ref: '@return' }, true] },
-        },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'EXIT',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: '@return === true',
+            json: { eq: [{ ref: '@return' }, true] },
+          },
+        })
+      )
 
-      const probes = getProbes('TestClass;exitSnapshot')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, { arg: 'value' })
       onReturn(probes, true, {}, { arg: 'value' }, {})
 
@@ -420,20 +323,9 @@ describe('api', () => {
     it('should include duration in snapshot', () => {
       const clock = mockClock()
 
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'durationTest' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;durationTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
 
       clock.tick(10)
@@ -446,24 +338,18 @@ describe('api', () => {
     })
 
     it('should report ENTRY condition evaluation errors without capturing a snapshot', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'entryConditionError' },
-        when: {
-          dsl: 'missing.value',
-          json: { getmember: [{ ref: 'missing' }, 'value'] },
-        },
-        template: 'Should not be evaluated',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: 'missing.value',
+            json: { getmember: [{ ref: 'missing' }, 'value'] },
+          },
+          sampling: { snapshotsPerSecond: Infinity },
+          evaluateAt: 'ENTRY',
+        })
+      )
 
-      const probes = getProbes('TestClass;entryConditionError')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
 
@@ -483,24 +369,17 @@ describe('api', () => {
     })
 
     it('should report EXIT condition evaluation errors without capturing a return snapshot', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'exitConditionError' },
-        when: {
-          dsl: 'missing.value',
-          json: { getmember: [{ ref: 'missing' }, 'value'] },
-        },
-        template: 'Should not be evaluated',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'EXIT',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: 'missing.value',
+            json: { getmember: [{ ref: 'missing' }, 'value'] },
+          },
+          sampling: { snapshotsPerSecond: Infinity },
+        })
+      )
 
-      const probes = getProbes('TestClass;exitConditionError')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
 
@@ -520,24 +399,18 @@ describe('api', () => {
 
     it('should rate limit repeated condition evaluation errors', () => {
       const clock = mockClock()
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'rateLimitedConditionError' },
-        when: {
-          dsl: 'missing.value',
-          json: { getmember: [{ ref: 'missing' }, 'value'] },
-        },
-        template: 'Should not be evaluated',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: 'missing.value',
+            json: { getmember: [{ ref: 'missing' }, 'value'] },
+          },
+          sampling: { snapshotsPerSecond: Infinity },
+          evaluateAt: 'ENTRY',
+        })
+      )
 
-      const probes = getProbes('TestClass;rateLimitedConditionError')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       onEntry(probes, {}, {})
@@ -554,23 +427,12 @@ describe('api', () => {
 
   describe('onThrow', () => {
     it('should capture this inside arguments.fields for exceptions', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'throwTest' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
       const self = { name: 'testObj' }
       const args = { a: 1, b: 2 }
       const error = new Error('Test error')
-      const probes = getProbes('TestClass;throwTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, self, args)
       onThrow(probes, error, self, args)
 
@@ -607,21 +469,10 @@ describe('api', () => {
     })
 
     it('should not capture this for exceptions when it is the global object', () => {
-      const probe: Probe = {
-        id: 'global-this-throw-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'globalThisThrow' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
       const args = { a: 1 }
-      const probes = getProbes('TestClass;globalThisThrow')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, globalObject, args)
       onThrow(probes, new Error('Test error'), globalObject, args)
 
@@ -638,20 +489,9 @@ describe('api', () => {
     })
 
     it('should capture exception details', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'throwTest' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;throwTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const error = new Error('Test error')
       onEntry(probes, {}, { arg: 'value' })
       onThrow(probes, error, {}, { arg: 'value' })
@@ -677,24 +517,18 @@ describe('api', () => {
     })
 
     it('should evaluate EXIT condition with @exception', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'exceptionCondition' },
-        when: {
-          dsl: '@exception.message',
-          json: { getmember: [{ ref: '@exception' }, 'message'] },
-        },
-        template: 'Exception captured',
-        captureSnapshot: false,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'EXIT',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: '@exception.message',
+            json: { getmember: [{ ref: '@exception' }, 'message'] },
+          },
+          template: 'Exception captured',
+          captureSnapshot: false,
+        })
+      )
 
-      const probes = getProbes('TestClass;exceptionCondition')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const error = new Error('Test error')
       onEntry(probes, {}, {})
       onThrow(probes, error, {}, {})
@@ -703,24 +537,17 @@ describe('api', () => {
     })
 
     it('should report EXIT condition evaluation errors on throw without capturing a snapshot', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'throwConditionError' },
-        when: {
-          dsl: 'missing.value',
-          json: { getmember: [{ ref: 'missing' }, 'value'] },
-        },
-        template: 'Should not be evaluated',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'EXIT',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          when: {
+            dsl: 'missing.value',
+            json: { getmember: [{ ref: 'missing' }, 'value'] },
+          },
+          sampling: { snapshotsPerSecond: Infinity },
+        })
+      )
 
-      const probes = getProbes('TestClass;throwConditionError')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onThrow(probes, new Error('Test error'), {}, {})
 
@@ -739,20 +566,9 @@ describe('api', () => {
     })
 
     it('should handle onThrow without preceding onEntry', () => {
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'throwWithoutEntry' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;throwWithoutEntry')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const error = new Error('Test error')
       onThrow(probes, error, {}, {})
 
@@ -764,24 +580,18 @@ describe('api', () => {
     it('should respect global snapshot rate limit', () => {
       const probes: Probe[] = []
       for (let i = 0; i < 30; i++) {
-        const probe: Probe = {
+        const probe = createProbe({
           id: `probe-${i}`,
-          version: 0,
-          type: 'LOG_PROBE',
-          where: { typeName: 'TestClass', methodName: `method${i}` },
-          template: 'Test',
-          captureSnapshot: true,
-          capture: {},
+          where: { typeName: 'test.js', methodName: `method${i}` },
           sampling: { snapshotsPerSecond: 5000 },
-          evaluateAt: 'ENTRY',
-        }
+        })
         addProbe(probe)
         probes.push(probe)
       }
 
       // Try to fire 30 probes rapidly
       for (let i = 0; i < 30; i++) {
-        const probes = getProbes(`TestClass;method${i}`)!
+        const probes = getProbes(`test.js;method${i}`)!
         onEntry(probes, {}, {})
         onReturn(probes, null, {}, {}, {})
       }
@@ -794,22 +604,16 @@ describe('api', () => {
       initTransport({ maxSnapshotsPerSecondGlobally: 2 })
 
       for (let i = 0; i < 3; i++) {
-        const probe: Probe = {
+        const probe = createProbe({
           id: `configured-global-probe-${i}`,
-          version: 0,
-          type: 'LOG_PROBE',
-          where: { typeName: 'TestClass', methodName: `configuredGlobal${i}` },
-          template: 'Test',
-          captureSnapshot: true,
-          capture: {},
+          where: { typeName: 'test.js', methodName: `configuredGlobal${i}` },
           sampling: { snapshotsPerSecond: 5000 },
-          evaluateAt: 'ENTRY',
-        }
+        })
         addProbe(probe)
       }
 
       for (let i = 0; i < 3; i++) {
-        const probes = getProbes(`TestClass;configuredGlobal${i}`)!
+        const probes = getProbes(`test.js;configuredGlobal${i}`)!
         onEntry(probes, {}, {})
         onReturn(probes, null, {}, {}, {})
       }
@@ -822,20 +626,9 @@ describe('api', () => {
     it('should respect configured default snapshot per-probe rate limit', () => {
       initTransport({ maxSnapshotsPerSecondPerProbe: 0.5 })
 
-      const probe: Probe = {
-        id: 'configured-snapshot-rate-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'configuredSnapshotRate' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe({ sampling: undefined }))
 
-      const probes = getProbes('TestClass;configuredSnapshotRate')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       onEntry(probes, {}, {})
@@ -847,20 +640,14 @@ describe('api', () => {
     it('should respect configured default non-snapshot per-probe rate limit', () => {
       initTransport({ maxNonSnapshotsPerSecondPerProbe: 1 })
 
-      const probe: Probe = {
-        id: 'configured-non-snapshot-rate-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'configuredNonSnapshotRate' },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          sampling: undefined,
+        })
+      )
 
-      const probes = getProbes('TestClass;configuredNonSnapshotRate')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       onEntry(probes, {}, {})
@@ -874,23 +661,15 @@ describe('api', () => {
     it('should stop sending snapshot events after maxSnapshotsPerProbeLifetime', () => {
       initTransport({ maxSnapshotsPerProbeLifetime: 1 })
 
-      const probe: Probe = {
-        id: 'snapshot-lifetime-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'snapshotLifetime' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
+      const probe = createProbe({
         // Disable per-probe rate limiting so the second invocation exercises the
         // lifetime cap rather than the per-second cap.
         sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
+      })
       addProbe(probe)
 
       // First invocation: probe sends its single allowed event.
-      const probes = getProbes('TestClass;snapshotLifetime')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -900,7 +679,7 @@ describe('api', () => {
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
-      expect(getProbes('TestClass;snapshotLifetime')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should skip snapshot collection once the lifetime budget is exhausted', () => {
@@ -912,25 +691,18 @@ describe('api', () => {
         enumerable: true,
         get: getterSpy,
       })
-      const probe: Probe = {
-        id: 'snapshot-lifetime-collection-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'snapshotLifetimeCollection' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        // Disable per-probe rate limiting so the second invocation isn't sampled out
-        // by it — we want to exercise the lifetime cap, not the rate cap.
-        sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          // Disable per-probe rate limiting so the second invocation isn't sampled out
+          // by it — we want to exercise the lifetime cap, not the rate cap.
+          sampling: { snapshotsPerSecond: Infinity },
+        })
+      )
 
       // First invocation does the full pipeline: 2 reads from entry capture
       // (context spread + captureFields) + 1 read from return capture = 3 reads.
       // This exhausts the lifetime budget.
-      const probes = getProbes('TestClass;snapshotLifetimeCollection')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, args)
       onReturn(probes, null, {}, args, {})
 
@@ -945,23 +717,17 @@ describe('api', () => {
     it('should stop sending non-snapshot events after maxNonSnapshotsPerProbeLifetime', () => {
       initTransport({ maxNonSnapshotsPerProbeLifetime: 1 })
 
-      const probe: Probe = {
-        id: 'non-snapshot-lifetime-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'nonSnapshotLifetime' },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        // Disable per-probe rate limiting so the second invocation exercises the
-        // lifetime cap rather than the per-second cap.
-        sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          // Disable per-probe rate limiting so the second invocation exercises the
+          // lifetime cap rather than the per-second cap.
+          sampling: { snapshotsPerSecond: Infinity },
+        })
+      )
 
       // First invocation: probe sends its single allowed event.
-      const probes = getProbes('TestClass;nonSnapshotLifetime')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -971,31 +737,25 @@ describe('api', () => {
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
-      expect(getProbes('TestClass;nonSnapshotLifetime')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should finish in-flight recursive entries after the lifetime budget is exhausted', () => {
       initTransport({ maxNonSnapshotsPerProbeLifetime: 1 })
 
-      const probe: Probe = {
-        id: 'recursive-lifetime-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'recursiveLifetime' },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          sampling: { snapshotsPerSecond: Infinity },
+        })
+      )
 
-      const probes = getProbes('TestClass;recursiveLifetime')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onEntry(probes, {}, {})
 
       onReturn(probes, null, {}, {}, {})
-      expect(getProbes('TestClass;recursiveLifetime')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
 
       // The lifetime budget gates new entries, but already accepted in-flight
       // entries still drain even if another frame exhausts the budget first.
@@ -1006,20 +766,10 @@ describe('api', () => {
     it('should reset the lifetime budget when a new probe version is delivered', () => {
       initTransport({ maxSnapshotsPerProbeLifetime: 1 })
 
-      const probe: Probe = {
-        id: 'versioned-lifetime-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'versionedLifetime' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
+      const probe = createProbe({ sampling: { snapshotsPerSecond: 5000 } })
       addProbe(probe)
 
-      let probes = getProbes('TestClass;versionedLifetime')!
+      let probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -1028,7 +778,7 @@ describe('api', () => {
       // After re-add, the new version should have a fresh budget.
       addProbe({ ...probe, version: 1 })
 
-      probes = getProbes('TestClass;versionedLifetime')!
+      probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
@@ -1037,25 +787,14 @@ describe('api', () => {
     it('should not emit any event when the lifetime budget is zero', () => {
       initTransport({ maxSnapshotsPerProbeLifetime: 0 })
 
-      const probe: Probe = {
-        id: 'zero-budget-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'zeroBudget' },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
-      const probes = getProbes('TestClass;zeroBudget')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
-      expect(getProbes('TestClass;zeroBudget')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should still process sibling probes when one is removed mid-iteration', () => {
@@ -1068,34 +807,23 @@ describe('api', () => {
 
       // Disable per-probe rate limiting on both probes so the second invocation
       // exercises the lifetime cap rather than the per-second cap.
-      const probeA: Probe = {
+      const probeA = createProbe({
         id: 'sibling-probe-a',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'sibling' },
         template: 'A',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 1 },
         sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
-      const probeB: Probe = {
+      })
+      const probeB = createProbe({
         id: 'sibling-probe-b',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'sibling' },
         template: 'B',
         captureSnapshot: false,
-        capture: {},
         sampling: { snapshotsPerSecond: Infinity },
-        evaluateAt: 'ENTRY',
-      }
+      })
       addProbe(probeA)
       addProbe(probeB)
 
       // First invocation: both probes emit one event. probeA hits its cap (eventsSent=1,
       // max=1) but is not removed yet — the pre-call budget check still passed.
-      const probes = getProbes('TestClass;sibling')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
@@ -1104,85 +832,69 @@ describe('api', () => {
       // removal. probeB must still be processed in the same iteration even though
       // probeA gets spliced out of the probes array.
       mockBatchAdd.calls.reset()
-      const probesAfterFirst = getProbes('TestClass;sibling')!
+      const probesAfterFirst = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probesAfterFirst, {}, {})
       onReturn(probesAfterFirst, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
-      expect(getProbes('TestClass;sibling')).toEqual([jasmine.objectContaining({ id: 'sibling-probe-b' })])
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toEqual([jasmine.objectContaining({ id: 'sibling-probe-b' })])
 
       // probeB's stack entry must not leak: a third onReturn without onEntry is a no-op.
       mockBatchAdd.calls.reset()
-      const remainingProbes = getProbes('TestClass;sibling')!
+      const remainingProbes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onReturn(remainingProbes, null, {}, {}, {})
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
   })
 
   describe('active entries cleanup', () => {
-    function createProbe(id: string, methodName: string): Probe {
-      return {
-        id,
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-    }
-
     it('should drain in-flight entries through the removed probe instance', () => {
-      const probe = createProbe('cleanup-probe', 'cleanupTest')
+      const probe = createProbe()
       addProbe(probe)
 
-      const probes = getProbes('TestClass;cleanupTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
 
-      removeProbe('cleanup-probe')
+      removeProbe(probe.id)
       onReturn(probes, null, {}, {}, {})
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
 
     it('should isolate in-flight entries from a replacement probe with the same id', () => {
-      const probe = createProbe('cleanup-probe', 'cleanupTest')
+      const probe = createProbe()
       addProbe(probe)
 
-      const probes = getProbes('TestClass;cleanupTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
 
-      removeProbe('cleanup-probe')
-      addProbe(createProbe('cleanup-probe', 'cleanupTest'))
+      removeProbe(probe.id)
+      addProbe(createProbe({ id: probe.id }))
 
-      const newProbes = getProbes('TestClass;cleanupTest')!
+      const newProbes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onReturn(newProbes, null, {}, {}, {})
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
 
     it('should discard in-flight entries when all probes are cleared', () => {
-      const probe = createProbe('cleanup-probe', 'clearAllTest')
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;clearAllTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
 
       clearProbes()
-      addProbe(createProbe('cleanup-probe', 'clearAllTest'))
+      addProbe(createProbe())
 
-      const newProbes = getProbes('TestClass;clearAllTest')!
+      const newProbes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onReturn(newProbes, null, {}, {}, {})
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
 
     it('should not leak active entries after onReturn completes', () => {
-      const probe = createProbe('leak-probe', 'leakTest')
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;leakTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -1195,10 +907,9 @@ describe('api', () => {
     })
 
     it('should not leak active entries after onThrow completes', () => {
-      const probe = createProbe('throw-leak-probe', 'throwLeakTest')
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;throwLeakTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onThrow(probes, new Error('test'), {}, {})
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -1212,23 +923,8 @@ describe('api', () => {
   })
 
   describe('snapshot timeout', () => {
-    function createSnapshotProbe(methodName: string): Probe {
-      return {
-        id: `timeout-probe-${methodName}`,
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName },
-        template: 'Test',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 3 },
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-    }
-
     it('should drop snapshot when entry capture exceeds timeout', () => {
-      const probe = createSnapshotProbe('entryTimeout')
-      addProbe(probe)
+      addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
       let callCount = 0
       const realNow = performance.now.bind(performance)
@@ -1242,7 +938,7 @@ describe('api', () => {
         return realNow() + 20
       })
 
-      const probes = getProbes('TestClass;entryTimeout')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const deepObj = { level1: { level2: { level3: { level4: 'deep' } } } }
       onEntry(probes, {}, { arg: deepObj })
       onReturn(probes, null, {}, { arg: deepObj }, {})
@@ -1256,10 +952,9 @@ describe('api', () => {
     })
 
     it('should drop snapshot when return capture exceeds timeout', () => {
-      const probe = createSnapshotProbe('returnTimeout')
-      addProbe(probe)
+      addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
-      const probes = getProbes('TestClass;returnTimeout')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
 
       // Let onEntry succeed with real time
       onEntry(probes, {}, { x: 1 })
@@ -1281,10 +976,9 @@ describe('api', () => {
     })
 
     it('should drop snapshot when throw capture exceeds timeout', () => {
-      const probe = createSnapshotProbe('throwTimeout')
-      addProbe(probe)
+      addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
-      const probes = getProbes('TestClass;throwTimeout')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
 
       // Let onEntry succeed with real time
       onEntry(probes, {}, { x: 1 })
@@ -1306,18 +1000,12 @@ describe('api', () => {
     })
 
     it('should not affect non-snapshot probes', () => {
-      const probe: Probe = {
-        id: 'non-snapshot-timeout',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'nonSnapshot' },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(
+        createProbe({
+          captureSnapshot: false,
+          sampling: { snapshotsPerSecond: 5000 },
+        })
+      )
 
       // Spike performance.now to simulate slow execution
       let callCount = 0
@@ -1330,7 +1018,7 @@ describe('api', () => {
         return realNow() + 20
       })
 
-      const probes = getProbes('TestClass;nonSnapshot')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, {})
       onReturn(probes, null, {}, {}, {})
 
@@ -1338,8 +1026,7 @@ describe('api', () => {
     })
 
     it('should not leak active entries when entry capture times out', () => {
-      const probe = createSnapshotProbe('entryLeakTest')
-      addProbe(probe)
+      addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
       let shouldTimeout = true
       let callCount = 0
@@ -1352,7 +1039,7 @@ describe('api', () => {
         return realNow() + 20
       })
 
-      const probes = getProbes('TestClass;entryLeakTest')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // This onEntry will time out and push null
       onEntry(probes, {}, { x: 1 })
 
@@ -1365,39 +1052,19 @@ describe('api', () => {
     })
 
     it('should skip subsequent snapshot probes after timeout but still process non-snapshot probes', () => {
-      const snapshotProbe1: Probe = {
-        id: 'timeout-shared-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'sharedDeadline' },
-        template: 'Snapshot probe',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 3 },
+      const snapshotProbe1 = createProbe({
+        id: 'snapshot-probe-1',
         sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-      const nonSnapshotProbe: Probe = {
-        id: 'timeout-shared-2',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'sharedDeadline' },
-        template: 'Non-snapshot probe',
+      })
+      const nonSnapshotProbe = createProbe({
+        id: 'non-snapshot-probe',
         captureSnapshot: false,
-        capture: {},
         sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
-      const snapshotProbe2: Probe = {
-        id: 'timeout-shared-3',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'sharedDeadline' },
-        template: 'Second snapshot probe',
-        captureSnapshot: true,
-        capture: { maxReferenceDepth: 3 },
+      })
+      const snapshotProbe2 = createProbe({
+        id: 'snapshot-probe-2',
         sampling: { snapshotsPerSecond: 5000 },
-        evaluateAt: 'ENTRY',
-      }
+      })
       addProbe(snapshotProbe1)
       addProbe(nonSnapshotProbe)
       addProbe(snapshotProbe2)
@@ -1412,25 +1079,29 @@ describe('api', () => {
         return realNow() + 20
       })
 
-      const probes = getProbes('TestClass;sharedDeadline')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, { x: 1 })
       onReturn(probes, null, {}, { x: 1 }, {})
 
       // The non-snapshot probe should still send, but both snapshot probes should be dropped
       const calls = mockBatchAdd.calls.allArgs()
       expect(calls.length).toBe(1)
-      expect(calls[0][0].message).toBe('Non-snapshot probe')
+      expect(calls[0][0].debugger.snapshot.probe.id).toBe(nonSnapshotProbe.id)
     })
 
     it('should share deadline across probes so second snapshot probe exits immediately', () => {
-      const probe1 = createSnapshotProbe('sharedDeadline1')
-      const probe2: Probe = {
-        ...createSnapshotProbe('sharedDeadline2'),
-        id: 'timeout-probe-sharedDeadline2',
-        where: { typeName: 'TestClass', methodName: 'sharedDeadline1' },
-      }
-      addProbe(probe1)
-      addProbe(probe2)
+      addProbe(
+        createProbe({
+          id: 'timeout-probe-sharedDeadline1',
+          sampling: { snapshotsPerSecond: 5000 },
+        })
+      )
+      addProbe(
+        createProbe({
+          id: 'timeout-probe-sharedDeadline2',
+          sampling: { snapshotsPerSecond: 5000 },
+        })
+      )
 
       let callCount = 0
       const realNow = performance.now.bind(performance)
@@ -1442,7 +1113,7 @@ describe('api', () => {
         return realNow() + 20
       })
 
-      const probes = getProbes('TestClass;sharedDeadline1')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, {}, { x: 1 })
       onReturn(probes, null, {}, { x: 1 }, {})
 
@@ -1455,20 +1126,9 @@ describe('api', () => {
     it('should handle missing DD_RUM gracefully', () => {
       delete (window as any).DD_RUM
 
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'errorHandling' },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;errorHandling')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       expect(() => {
         onEntry(probes, {}, {})
         onReturn(probes, null, {}, {}, {})
@@ -1480,20 +1140,9 @@ describe('api', () => {
     it('should handle uninitialized debugger transport gracefully', () => {
       resetDebuggerTransport()
 
-      const probe: Probe = {
-        id: 'test-probe',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'errorHandling' },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const probes = getProbes('TestClass;errorHandling')!
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       expect(() => {
         onEntry(probes, {}, {})
         onReturn(probes, null, {}, {}, {})

--- a/packages/browser-debugger/src/domain/deliveryApi.spec.ts
+++ b/packages/browser-debugger/src/domain/deliveryApi.spec.ts
@@ -3,8 +3,7 @@ import { globalObject } from '@datadog/browser-core'
 import { registerCleanupTask, mockClock, replaceMockable } from '@datadog/browser-core/test'
 import type { Clock } from '@datadog/browser-core/test'
 import { display } from './display'
-import { getProbes, clearProbes } from './probes'
-import type { Probe } from './probes'
+import { getProbes, getAllProbes, clearProbes } from './probes'
 import {
   buildDeliveryApiUrl,
   startDeliveryApiPolling,
@@ -12,6 +11,9 @@ import {
   clearDeliveryApiState,
 } from './deliveryApi'
 import type { DeliveryApiConfiguration } from './deliveryApi'
+import { createProbe } from './probe.specHelper'
+
+const DEFAULT_PROBE_FUNCTION_ID = 'test.js;testMethod'
 
 describe('buildDeliveryApiUrl', () => {
   it('should default to datadoghq.com', () => {
@@ -172,29 +174,30 @@ describe('deliveryApi', () => {
     })
 
     it('should add probes from the updates array', async () => {
+      const probe = createProbe()
+
       respondWith({
         nextCursor: 'cursor-1',
-        updates: [makeProbe({ id: 'probe-1', version: 1 })],
+        updates: [probe],
         deletions: [],
       })
 
       startDeliveryApiPolling(makeConfig())
       await flushPromises()
 
-      const probes = getProbes('test.js;testMethod')
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)
       expect(probes).toBeDefined()
       expect(probes!.length).toBe(1)
-      expect(probes![0].id).toBe('probe-1')
+      expect(probes![0].id).toBe(probe.id)
     })
 
     it('should ignore log probes without a method location', async () => {
       respondWith({
         nextCursor: 'cursor-1',
         updates: [
-          makeProbe({
-            id: 'line-probe',
+          createProbe({
             where: {
-              sourceFile: 'packages/apps/live-debugger/toolkit/services/use-debugger-services.hook.ts',
+              sourceFile: 'test.js',
               lines: ['16'],
             },
           }),
@@ -205,13 +208,13 @@ describe('deliveryApi', () => {
       startDeliveryApiPolling(makeConfig())
       await flushPromises()
 
-      expect(getProbes('undefined;undefined')).toBeUndefined()
+      expect(getAllProbes()).toEqual([])
     })
 
     it('should ignore log probes without a where clause', async () => {
       respondWith({
         nextCursor: 'cursor-1',
-        updates: [{ id: 'log-probe-without-where', version: 1, type: 'LOG_PROBE' } as Probe],
+        updates: [{ ...createProbe(), where: undefined }],
         deletions: [],
       })
 
@@ -224,40 +227,42 @@ describe('deliveryApi', () => {
     it('should ignore non-log probes without requiring a method location', async () => {
       respondWith({
         nextCursor: 'cursor-1',
-        updates: [{ id: 'metric-probe', version: 1, type: 'METRIC_PROBE' } as Probe],
+        updates: [{ id: 'metric-probe', version: 1, type: 'METRIC_PROBE' }],
         deletions: [],
       })
 
       startDeliveryApiPolling(makeConfig())
       await flushPromises()
 
-      expect(getProbes('test.js;testMethod')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
       expect(errorSpy).not.toHaveBeenCalled()
     })
 
     it('should remove probes listed in deletions', async () => {
+      const probe = createProbe()
+
       // First poll: add the probe via the delivery API
       respondWith({
         nextCursor: 'cursor-1',
-        updates: [makeProbe({ id: 'probe-to-delete', version: 1 })],
+        updates: [probe],
         deletions: [],
       })
 
       startDeliveryApiPolling(makeConfig())
       await flushPromises()
-      expect(getProbes('test.js;testMethod')).toBeDefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeDefined()
 
       // Second poll: delete it
       respondWith({
         nextCursor: 'cursor-2',
         updates: [],
-        deletions: ['probe-to-delete'],
+        deletions: [probe.id],
       })
 
       clock.tick(5000)
       await flushPromises()
 
-      expect(getProbes('test.js;testMethod')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should send nextCursor in subsequent requests', async () => {
@@ -283,7 +288,7 @@ describe('deliveryApi', () => {
     it('should update existing probes when they appear in updates again', async () => {
       respondWith({
         nextCursor: 'cursor-1',
-        updates: [makeProbe({ id: 'probe-1', version: 1 })],
+        updates: [createProbe({ version: 1 })],
         deletions: [],
       })
 
@@ -292,14 +297,14 @@ describe('deliveryApi', () => {
 
       respondWith({
         nextCursor: 'cursor-2',
-        updates: [makeProbe({ id: 'probe-1', version: 2 })],
+        updates: [createProbe({ version: 2 })],
         deletions: [],
       })
 
       clock.tick(5000)
       await flushPromises()
 
-      const probes = getProbes('test.js;testMethod')
+      const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)
       expect(probes).toBeDefined()
       expect(probes!.length).toBe(1)
       expect(probes![0].version).toBe(2)
@@ -496,12 +501,12 @@ describe('deliveryApi', () => {
     it('should clear active probes when tripping', async () => {
       respondWith({
         nextCursor: 'cursor-1',
-        updates: [makeProbe({ id: 'probe-1', version: 1 })],
+        updates: [createProbe()],
         deletions: [],
       })
       startDeliveryApiPolling(makeConfig({ pollInterval: POLL_INTERVAL_MS }))
       await flushPromises()
-      expect(getProbes('test.js;testMethod')).toBeDefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeDefined()
 
       respondWithNetworkError()
       const ticks = Math.ceil(FIVE_MINUTES_MS / POLL_INTERVAL_MS) + 1
@@ -509,7 +514,7 @@ describe('deliveryApi', () => {
         await tickAndFlush(POLL_INTERVAL_MS)
       }
 
-      expect(getProbes('test.js;testMethod')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should honor a configured maxUnreachableDuration', async () => {
@@ -581,7 +586,7 @@ describe('deliveryApi', () => {
 
       // Breaker has tripped: polling stopped, probes cleared, and the in-flight
       // poll's signal must have been aborted.
-      expect(getProbes('test.js;testMethod')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
       expect(firstPollFetchOptions.signal!.aborted).toBeTrue()
       const callsAtTrip = fetchSpy.calls.count()
 
@@ -591,12 +596,12 @@ describe('deliveryApi', () => {
       resolveFirstPoll({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({ nextCursor: 'late', updates: [makeProbe({ id: 'late-probe' })], deletions: [] }),
+        json: () => Promise.resolve({ nextCursor: 'late', updates: [createProbe()], deletions: [] }),
         text: () => Promise.resolve(''),
       })
       await flushPromises()
 
-      expect(getProbes('test.js;testMethod')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
       // No new fetches should have been issued either.
       await tickAndFlush(POLL_INTERVAL_MS * 5)
       expect(fetchSpy.calls.count()).toBe(callsAtTrip)
@@ -620,20 +625,5 @@ describe('deliveryApi', () => {
 async function flushPromises() {
   for (let i = 0; i < 10; i++) {
     await Promise.resolve()
-  }
-}
-
-function makeProbe(overrides: Partial<Probe> = {}): Probe {
-  return {
-    id: 'probe-1',
-    version: 1,
-    type: 'LOG_PROBE',
-    where: { typeName: 'test.js', methodName: 'testMethod' },
-    template: 'Test message',
-    captureSnapshot: false,
-    capture: {},
-    sampling: {},
-    evaluateAt: 'ENTRY',
-    ...overrides,
   }
 }

--- a/packages/browser-debugger/src/domain/probe.specHelper.ts
+++ b/packages/browser-debugger/src/domain/probe.specHelper.ts
@@ -1,0 +1,16 @@
+import type { Probe } from './probes'
+
+export function createProbe(overrides: Partial<Probe> = {}): Probe {
+  return {
+    id: 'test-probe',
+    version: 0,
+    type: 'LOG_PROBE',
+    where: { typeName: 'test.js', methodName: 'testMethod' },
+    template: 'Test message',
+    captureSnapshot: true,
+    capture: { maxReferenceDepth: 3 },
+    sampling: { snapshotsPerSecond: 1 },
+    evaluateAt: 'EXIT',
+    ...overrides,
+  }
+}

--- a/packages/browser-debugger/src/domain/probes.spec.ts
+++ b/packages/browser-debugger/src/domain/probes.spec.ts
@@ -9,7 +9,9 @@ import {
   clearProbes,
   resetProbeBudgetConfiguration,
 } from './probes'
-import type { Probe } from './probes'
+import { createProbe } from './probe.specHelper'
+
+const DEFAULT_PROBE_FUNCTION_ID = 'test.js;testMethod'
 
 describe('probes', () => {
   beforeEach(() => {
@@ -21,24 +23,13 @@ describe('probes', () => {
 
   describe('addProbe and getProbes', () => {
     it('should add and retrieve a probe', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'test.js', methodName: 'testMethod' },
-        template: 'Test message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
+      const probe = createProbe()
       addProbe(probe)
-      const retrieved = getProbes('test.js;testMethod')
+      const retrieved = getProbes(DEFAULT_PROBE_FUNCTION_ID)
 
       expect(retrieved).toEqual([
         jasmine.objectContaining({
-          id: 'test-probe-1',
+          id: probe.id,
         }),
       ])
       expect(retrieved![0].evaluateTemplate).toBeUndefined()
@@ -52,137 +43,64 @@ describe('probes', () => {
 
   describe('removeProbe', () => {
     it('should remove a probe', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'testMethod' },
-        template: 'Test',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
+      const probe = createProbe()
       addProbe(probe)
-      expect(getProbes('TestClass;testMethod')).toBeDefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeDefined()
 
-      removeProbe('test-probe-1')
-      expect(getProbes('TestClass;testMethod')).toBeUndefined()
+      removeProbe(probe.id)
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should handle removing probe with static template without errors', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'staticTest' },
-        template: 'Static message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
+      const probe = createProbe()
       addProbe(probe)
 
       // Should not throw when removing probe with static template
-      expect(() => removeProbe('test-probe-1')).not.toThrow()
+      expect(() => removeProbe(probe.id)).not.toThrow()
     })
 
     it('should remove the exact initialized probe instance when passed a probe', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'instanceTest' },
-        template: 'Static message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(probe)
+      addProbe(createProbe())
 
-      const initializedProbe = getProbes('TestClass;instanceTest')![0]
+      const initializedProbe = getProbes(DEFAULT_PROBE_FUNCTION_ID)![0]
       removeProbe(initializedProbe)
 
-      expect(getProbes('TestClass;instanceTest')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should not remove a replacement probe when passed a stale probe instance', () => {
-      const staleProbe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'replacementTest' },
-        template: 'Stale message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-      addProbe(staleProbe)
+      const probe = createProbe()
+      addProbe(probe)
 
-      const staleInitializedProbe = getProbes('TestClass;replacementTest')![0]
-      removeProbe('test-probe-1')
-      addProbe({
-        id: 'test-probe-1',
-        version: 1,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'replacementTest' },
-        template: 'Replacement message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      })
+      const staleInitializedProbe = getProbes(DEFAULT_PROBE_FUNCTION_ID)![0]
+      removeProbe(probe.id)
+      addProbe(createProbe({ version: 1 }))
 
       expect(() => removeProbe(staleInitializedProbe)).not.toThrow()
-      expect(getProbes('TestClass;replacementTest')).toEqual([jasmine.objectContaining({ version: 1 })])
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toEqual([jasmine.objectContaining({ version: 1 })])
     })
 
     it('should not throw when passed a stale probe instance that is no longer registered', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'staleTest' },
-        template: 'Static message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
+      const probe = createProbe()
       addProbe(probe)
 
-      const initializedProbe = getProbes('TestClass;staleTest')![0]
-      removeProbe('test-probe-1')
+      const initializedProbe = getProbes(DEFAULT_PROBE_FUNCTION_ID)![0]
+      removeProbe(probe.id)
 
       expect(() => removeProbe(initializedProbe)).not.toThrow()
-      expect(getProbes('TestClass;staleTest')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
   })
 
   describe('initializeProbe', () => {
     it('should initialize probe with static template', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'initStatic' },
-        template: 'Static message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
+      const probe = createProbe()
 
       initializeProbe(probe)
 
       expect(probe).toEqual(
         jasmine.objectContaining({
-          template: 'Static message',
+          template: 'Test message',
           msBetweenSampling: jasmine.any(Number),
           lastCaptureMs: -Infinity,
         })
@@ -191,24 +109,16 @@ describe('probes', () => {
     })
 
     it('should initialize probe with dynamic template', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'initDynamic' },
-        template: '',
+      const probe = createProbe({
+        template: 'Value: {x}',
         segments: [{ str: 'Value: ' }, { dsl: 'x', json: { ref: 'x' } }],
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
+      })
 
       initializeProbe(probe)
 
       expect(probe).toEqual(
         jasmine.objectContaining({
-          template: '',
+          template: 'Value: {x}',
           evaluateTemplate: jasmine.any(Function),
         })
       )
@@ -216,21 +126,12 @@ describe('probes', () => {
     })
 
     it('should compile condition when present', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'conditionCompile' },
+      const probe = createProbe({
         when: {
           dsl: 'x > 5',
           json: { gt: [{ ref: 'x' }, 5] },
         },
-        template: 'Message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'EXIT',
-      }
+      })
 
       initializeProbe(probe)
 
@@ -242,25 +143,16 @@ describe('probes', () => {
     })
 
     it('should not add probe when condition compilation fails', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'conditionError' },
-        when: {
-          dsl: 'invalid',
-          json: { invalidOp: 'bad' } as any,
-        },
-        template: 'Message',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'EXIT',
-      }
-
       let error: unknown
       try {
-        addProbe(probe)
+        addProbe(
+          createProbe({
+            when: {
+              dsl: 'invalid',
+              json: { invalidOp: 'bad' } as any,
+            },
+          })
+        )
       } catch (err) {
         error = err
       }
@@ -268,21 +160,13 @@ describe('probes', () => {
       expect(error).toEqual(jasmine.any(Error))
       expect((error as Error).message).toContain('Cannot compile condition')
       expect((error as ErrorWithCause).cause).toEqual(jasmine.any(TypeError))
-      expect(getProbes('TestClass;conditionError')).toBeUndefined()
+      expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
 
     it('should calculate msBetweenSampling for snapshot probes', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'samplingCalc' },
-        template: 'Message',
-        captureSnapshot: true,
-        capture: {},
+      const probe = createProbe({
         sampling: { snapshotsPerSecond: 10 },
-        evaluateAt: 'ENTRY',
-      }
+      })
 
       initializeProbe(probe)
 
@@ -290,17 +174,9 @@ describe('probes', () => {
     })
 
     it('should use default sampling rate for snapshot probes without explicit rate', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'samplingDefault' },
-        template: 'Message',
-        captureSnapshot: true,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
+      const probe = createProbe({
+        sampling: undefined,
+      })
 
       initializeProbe(probe)
 
@@ -308,17 +184,10 @@ describe('probes', () => {
     })
 
     it('should use high default sampling rate for non-snapshot probes', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'samplingHigh' },
-        template: 'Message',
+      const probe = createProbe({
         captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
+        sampling: undefined,
+      })
 
       initializeProbe(probe)
 
@@ -326,18 +195,10 @@ describe('probes', () => {
     })
 
     it('should evaluate dynamic template with cached functions', () => {
-      const probe: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'cacheKeys' },
-        template: '',
+      const probe = createProbe({
+        template: '{x}',
         segments: [{ dsl: 'x', json: { ref: 'x' } }],
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
+      })
 
       initializeProbe(probe)
 
@@ -348,37 +209,13 @@ describe('probes', () => {
 
   describe('clearProbes', () => {
     it('should clear all probes', () => {
-      const probe1: Probe = {
-        id: 'test-probe-1',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'clear1' },
-        template: 'Test 1',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
-      const probe2: Probe = {
-        id: 'test-probe-2',
-        version: 0,
-        type: 'LOG_PROBE',
-        where: { typeName: 'TestClass', methodName: 'clear2' },
-        template: 'Test 2',
-        captureSnapshot: false,
-        capture: {},
-        sampling: {},
-        evaluateAt: 'ENTRY',
-      }
-
-      addProbe(probe1)
-      addProbe(probe2)
+      addProbe(createProbe({ where: { typeName: 'test.js', methodName: 'clear1' } }))
+      addProbe(createProbe({ where: { typeName: 'test.js', methodName: 'clear2' } }))
 
       clearProbes()
 
-      expect(getProbes('TestClass;clear1')).toBeUndefined()
-      expect(getProbes('TestClass;clear2')).toBeUndefined()
+      expect(getProbes('test.js;clear1')).toBeUndefined()
+      expect(getProbes('test.js;clear2')).toBeUndefined()
     })
   })
 

--- a/packages/browser-debugger/src/domain/probes.ts
+++ b/packages/browser-debugger/src/domain/probes.ts
@@ -54,7 +54,7 @@ export interface Probe {
   segments?: TemplateSegment[]
   captureSnapshot: boolean
   capture: CaptureOptions
-  sampling: ProbeSampling
+  sampling?: ProbeSampling
   evaluateAt: 'ENTRY' | 'EXIT'
   location?: {
     file?: string


### PR DESCRIPTION
## Motivation

Debugger domain specs were repeating full probe objects in many places, making tests noisy and harder to review. This also made it easy for test fixtures to drift from the probe shapes delivered by the UI/API.

## Changes

- Added a shared `createProbe()` spec helper for browser-debugger tests.
- Replaced repeated probe literals in API, delivery API, and probe registry specs with the helper.
- Kept overrides only where the test intentionally varies that property.
- Made `Probe.sampling` optional to match the delivery schema/backend contract and existing runtime fallback handling.
- Updated assertions to use shared default function ids or probe-derived ids instead of duplicated literals.

## Test instructions

- Run `yarn test:unit --spec "packages/browser-debugger/src/domain/{api,probes,deliveryApi}.spec.ts"`
- Verify the targeted debugger unit specs pass.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
