### PR TITLE
♻️ Align CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,14 +8,14 @@ packages/browser-rum/src/domain/record/**               @Datadog/rum-browser @Da
 packages/browser-rum/src/domain/segmentCollection/**    @Datadog/rum-browser @Datadog/session-replay-sdk
 packages/browser-rum/src/domain/*.ts                    @Datadog/rum-browser @Datadog/session-replay-sdk
 packages/browser-rum/test/record/**                     @Datadog/rum-browser @Datadog/session-replay-sdk
-test/e2e/scenario/recorder/**                   @Datadog/rum-browser @Datadog/session-replay-sdk
+test/e2e/scenario/recorder/**                           @Datadog/rum-browser @Datadog/session-replay-sdk
 
 # Docs
 /README.md    @Datadog/rum-browser @DataDog/documentation
 
 # Debugger
-packages/browser-debugger                                               @Datadog/rum-browser @DataDog/debugger-nodejs
-packages/browser-debugger/README.md                                     @Datadog/rum-browser @DataDog/debugger-nodejs @DataDog/documentation
+packages/browser-debugger                                       @Datadog/rum-browser @DataDog/debugger-nodejs
+packages/browser-debugger/README.md                             @Datadog/rum-browser @DataDog/debugger-nodejs @DataDog/documentation
 test/apps/instrumentation-overhead                              @Datadog/rum-browser @DataDog/debugger-nodejs
 test/e2e/scenario/debugger.scenario.ts                          @Datadog/rum-browser @DataDog/debugger-nodejs
 test/performance/scenarios/instrumentationOverhead.scenario.ts  @Datadog/rum-browser @DataDog/debugger-nodejs


### PR DESCRIPTION
## Motivation

Keep CODEOWNERS readable and consistently aligned after adding debugger ownership entries.

## Changes

Align the recorder and debugger CODEOWNERS rows so path patterns and owner lists line up with the surrounding entries. This is a formatting-only change.

## Test instructions

Not run; CODEOWNERS formatting-only change.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
