### PR TITLE
✅ Simplify debugger API spec call sites

### DIFF
--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -7,6 +7,7 @@ import type { Probe } from './probes'
 import { createProbe } from './probe.specHelper'
 
 const DEFAULT_PROBE_FUNCTION_ID = 'test.js;testMethod'
+const thisArg = {}
 
 describe('api', () => {
   let mockBatchAdd: jasmine.Spy
@@ -47,7 +48,7 @@ describe('api', () => {
       const args = { a: 1, b: 2 }
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, self, args)
-      onReturn(probes, 'result', self, args, {})
+      onReturn(probes, 'result', self, args)
 
       const payload = mockBatchAdd.calls.mostRecent().args[0]
       const snapshot = payload.debugger.snapshot
@@ -89,7 +90,7 @@ describe('api', () => {
       const args = { a: 1 }
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, globalObject, args)
-      onReturn(probes, 'result', globalObject, args, {})
+      onReturn(probes, 'result', globalObject, args)
 
       const payload = mockBatchAdd.calls.mostRecent().args[0]
       const snapshot = payload.debugger.snapshot
@@ -110,7 +111,7 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       onEntry(probes, self, args)
-      const result = onReturn(probes, 'returnValue', self, args, {})
+      const result = onReturn(probes, 'returnValue', self, args)
 
       expect(result).toBe('returnValue')
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -132,13 +133,13 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // First call should work
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       // Second immediate call should be skipped (less than 2000ms passed)
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       // Still only one call because sampling budget not refreshed
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -157,12 +158,12 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, { missing: { value: true } })
-      onReturn(probes, null, {}, { missing: { value: true } }, {})
+      onEntry(probes, thisArg, { missing: { value: true } })
+      onReturn(probes, null, thisArg, { missing: { value: true } })
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
@@ -179,12 +180,12 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, { missing: { value: true } })
-      onReturn(probes, null, {}, { missing: { value: true } }, {})
+      onEntry(probes, thisArg, { missing: { value: true } })
+      onReturn(probes, null, thisArg, { missing: { value: true } })
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
@@ -201,8 +202,8 @@ describe('api', () => {
 
       let probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should fire when condition passes
-      onEntry(probes, {}, { x: 10 })
-      onReturn(probes, null, {}, { x: 10 }, {})
+      onEntry(probes, thisArg, { x: 10 })
+      onReturn(probes, null, thisArg, { x: 10 })
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       clearProbes()
@@ -211,8 +212,8 @@ describe('api', () => {
 
       probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should not fire when condition fails
-      onEntry(probes, {}, { x: 3 })
-      onReturn(probes, null, {}, { x: 3 }, {})
+      onEntry(probes, thisArg, { x: 3 })
+      onReturn(probes, null, thisArg, { x: 3 })
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
 
@@ -227,8 +228,8 @@ describe('api', () => {
 
       let probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should fire when return value > 10
-      onEntry(probes, {}, {})
-      onReturn(probes, 15, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, 15, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       clearProbes()
@@ -237,8 +238,8 @@ describe('api', () => {
 
       probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // Should not fire when return value <= 10
-      onEntry(probes, {}, {})
-      onReturn(probes, 5, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, 5, thisArg)
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
 
@@ -311,8 +312,8 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, { arg: 'value' })
-      onReturn(probes, true, {}, { arg: 'value' }, {})
+      onEntry(probes, thisArg, { arg: 'value' })
+      onReturn(probes, true, thisArg, { arg: 'value' })
 
       const payload = mockBatchAdd.calls.mostRecent().args[0]
       const snapshot = payload.debugger.snapshot
@@ -326,11 +327,11 @@ describe('api', () => {
       addProbe(createProbe())
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
+      onEntry(probes, thisArg)
 
       clock.tick(10)
 
-      onReturn(probes, null, {}, {}, {})
+      onReturn(probes, null, thisArg)
 
       const payload = mockBatchAdd.calls.mostRecent().args[0]
       const snapshot = payload.debugger.snapshot
@@ -350,8 +351,8 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
       const payload = mockBatchAdd.calls.mostRecent().args[0]
@@ -380,8 +381,8 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
       const payload = mockBatchAdd.calls.mostRecent().args[0]
@@ -411,16 +412,16 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       clock.tick(5 * 60 * 1000)
 
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
     })
   })
@@ -493,8 +494,8 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const error = new Error('Test error')
-      onEntry(probes, {}, { arg: 'value' })
-      onThrow(probes, error, {}, { arg: 'value' })
+      onEntry(probes, thisArg, { arg: 'value' })
+      onThrow(probes, error, thisArg, { arg: 'value' })
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
@@ -520,8 +521,8 @@ describe('api', () => {
       addProbe(createProbe())
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onThrow(probes, 'Test error', {}, {})
+      onEntry(probes, thisArg)
+      onThrow(probes, 'Test error', thisArg)
 
       const payload = mockBatchAdd.calls.mostRecent().args[0]
       const snapshot = payload.debugger.snapshot
@@ -541,8 +542,8 @@ describe('api', () => {
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const iframeWindow = iframe.contentWindow as Window & { Error: ErrorConstructor }
       const error = new iframeWindow.Error('Iframe error')
-      onEntry(probes, {}, {})
-      onThrow(probes, error, {}, {})
+      onEntry(probes, thisArg)
+      onThrow(probes, error, thisArg)
 
       const payload = mockBatchAdd.calls.mostRecent().args[0]
       const snapshot = payload.debugger.snapshot
@@ -556,8 +557,8 @@ describe('api', () => {
       addProbe(createProbe())
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      expect(() => onThrow(probes, Object.create(null), {}, {})).not.toThrow()
+      onEntry(probes, thisArg)
+      expect(() => onThrow(probes, Object.create(null), thisArg)).not.toThrow()
 
       const payload = mockBatchAdd.calls.mostRecent().args[0]
       const snapshot = payload.debugger.snapshot
@@ -625,8 +626,8 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const error = new Error('Test error')
-      onEntry(probes, {}, {})
-      onThrow(probes, error, {}, {})
+      onEntry(probes, thisArg)
+      onThrow(probes, error, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
@@ -643,8 +644,8 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onThrow(probes, new Error('Test error'), {}, {})
+      onEntry(probes, thisArg)
+      onThrow(probes, new Error('Test error'), thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
       const payload = mockBatchAdd.calls.mostRecent().args[0]
@@ -665,7 +666,7 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const error = new Error('Test error')
-      onThrow(probes, error, {}, {})
+      onThrow(probes, error, thisArg)
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
@@ -687,8 +688,8 @@ describe('api', () => {
       // Try to fire 30 probes rapidly
       for (let i = 0; i < 30; i++) {
         const probes = getProbes(`test.js;method${i}`)!
-        onEntry(probes, {}, {})
-        onReturn(probes, null, {}, {}, {})
+        onEntry(probes, thisArg)
+        onReturn(probes, null, thisArg)
       }
 
       // Should only get 25 calls (global limit)
@@ -709,8 +710,8 @@ describe('api', () => {
 
       for (let i = 0; i < 3; i++) {
         const probes = getProbes(`test.js;configuredGlobal${i}`)!
-        onEntry(probes, {}, {})
-        onReturn(probes, null, {}, {}, {})
+        onEntry(probes, thisArg)
+        onReturn(probes, null, thisArg)
       }
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
@@ -724,10 +725,10 @@ describe('api', () => {
       addProbe(createProbe({ sampling: undefined }))
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
@@ -743,10 +744,10 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
@@ -765,14 +766,14 @@ describe('api', () => {
 
       // First invocation: probe sends its single allowed event.
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       // Second invocation: the lifetime budget is now exhausted. No new event should
       // be queued, and the probe should be auto-unregistered.
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
       expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
@@ -798,13 +799,13 @@ describe('api', () => {
       // (context spread + captureFields) + 1 read from return capture = 3 reads.
       // This exhausts the lifetime budget.
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, args)
-      onReturn(probes, null, {}, args, {})
+      onEntry(probes, thisArg, args)
+      onReturn(probes, null, thisArg, args)
 
       // Second invocation: both onEntry and onReturn detect the exhausted budget
       // up front and skip all capture work — no further reads from args.
-      onEntry(probes, {}, args)
-      onReturn(probes, null, {}, args, {})
+      onEntry(probes, thisArg, args)
+      onReturn(probes, null, thisArg, args)
 
       expect(getterSpy).toHaveBeenCalledTimes(3)
     })
@@ -823,14 +824,14 @@ describe('api', () => {
 
       // First invocation: probe sends its single allowed event.
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       // Second invocation: the lifetime budget is now exhausted. No new event should
       // be queued, and the probe should be auto-unregistered.
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
       expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
     })
@@ -846,15 +847,15 @@ describe('api', () => {
       )
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onEntry(probes, {}, {})
+      onEntry(probes, thisArg)
+      onEntry(probes, thisArg)
 
-      onReturn(probes, null, {}, {}, {})
+      onReturn(probes, null, thisArg)
       expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
 
       // The lifetime budget gates new entries, but already accepted in-flight
       // entries still drain even if another frame exhausts the budget first.
-      onReturn(probes, null, {}, {}, {})
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
     })
 
@@ -865,8 +866,8 @@ describe('api', () => {
       addProbe(probe)
 
       let probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       // The old probe has reached its lifetime budget and was auto-unregistered.
@@ -874,8 +875,8 @@ describe('api', () => {
       addProbe({ ...probe, version: 1 })
 
       probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
     })
 
@@ -885,8 +886,8 @@ describe('api', () => {
       addProbe(createProbe({ sampling: { snapshotsPerSecond: 5000 } }))
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
       expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toBeUndefined()
@@ -919,8 +920,8 @@ describe('api', () => {
       // First invocation: both probes emit one event. probeA hits its cap (eventsSent=1,
       // max=1) but is not removed yet — the pre-call budget check still passed.
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(2)
 
       // Second invocation: probeA's pre-call check now fails and it is queued for
@@ -928,15 +929,15 @@ describe('api', () => {
       // probeA gets spliced out of the probes array.
       mockBatchAdd.calls.reset()
       const probesAfterFirst = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probesAfterFirst, {}, {})
-      onReturn(probesAfterFirst, null, {}, {}, {})
+      onEntry(probesAfterFirst, thisArg)
+      onReturn(probesAfterFirst, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
       expect(getProbes(DEFAULT_PROBE_FUNCTION_ID)).toEqual([jasmine.objectContaining({ id: 'sibling-probe-b' })])
 
       // probeB's stack entry must not leak: a third onReturn without onEntry is a no-op.
       mockBatchAdd.calls.reset()
       const remainingProbes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onReturn(remainingProbes, null, {}, {}, {})
+      onReturn(remainingProbes, null, thisArg)
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
   })
@@ -947,10 +948,10 @@ describe('api', () => {
       addProbe(probe)
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
+      onEntry(probes, thisArg)
 
       removeProbe(probe.id)
-      onReturn(probes, null, {}, {}, {})
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
@@ -960,13 +961,13 @@ describe('api', () => {
       addProbe(probe)
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
+      onEntry(probes, thisArg)
 
       removeProbe(probe.id)
       addProbe(createProbe({ id: probe.id }))
 
       const newProbes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onReturn(newProbes, null, {}, {}, {})
+      onReturn(newProbes, null, thisArg)
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
@@ -975,13 +976,13 @@ describe('api', () => {
       addProbe(createProbe())
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
+      onEntry(probes, thisArg)
 
       clearProbes()
       addProbe(createProbe())
 
       const newProbes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onReturn(newProbes, null, {}, {}, {})
+      onReturn(newProbes, null, thisArg)
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
@@ -990,14 +991,14 @@ describe('api', () => {
       addProbe(createProbe())
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       mockBatchAdd.calls.reset()
 
       // A second onReturn without onEntry should not produce a snapshot
-      onReturn(probes, null, {}, {}, {})
+      onReturn(probes, null, thisArg)
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
 
@@ -1005,14 +1006,14 @@ describe('api', () => {
       addProbe(createProbe())
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onThrow(probes, new Error('test'), {}, {})
+      onEntry(probes, thisArg)
+      onThrow(probes, new Error('test'), thisArg)
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
 
       mockBatchAdd.calls.reset()
 
       // A second onThrow without onEntry should not produce a snapshot
-      onThrow(probes, new Error('test'), {}, {})
+      onThrow(probes, new Error('test'), thisArg)
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
   })
@@ -1035,8 +1036,8 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       const deepObj = { level1: { level2: { level3: { level4: 'deep' } } } }
-      onEntry(probes, {}, { arg: deepObj })
-      onReturn(probes, null, {}, { arg: deepObj }, {})
+      onEntry(probes, thisArg, { arg: deepObj })
+      onReturn(probes, null, thisArg, { arg: deepObj })
 
       // The entry capture timed out, so onEntry pushed null.
       // onReturn still gets an active entry from its own onEntry call, but
@@ -1052,7 +1053,7 @@ describe('api', () => {
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
 
       // Let onEntry succeed with real time
-      onEntry(probes, {}, { x: 1 })
+      onEntry(probes, thisArg, { x: 1 })
 
       // Now make performance.now jump forward so the return capture times out
       let callCount = 0
@@ -1065,7 +1066,7 @@ describe('api', () => {
         return realNow() + 20
       })
 
-      onReturn(probes, null, {}, { x: 1 }, { local: 'value' })
+      onReturn(probes, null, thisArg, { x: 1 }, { local: 'value' })
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
@@ -1076,7 +1077,7 @@ describe('api', () => {
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
 
       // Let onEntry succeed with real time
-      onEntry(probes, {}, { x: 1 })
+      onEntry(probes, thisArg, { x: 1 })
 
       // Now make performance.now jump forward so the throw capture times out
       let callCount = 0
@@ -1089,7 +1090,7 @@ describe('api', () => {
         return realNow() + 20
       })
 
-      onThrow(probes, new Error('test'), {}, { x: 1 })
+      onThrow(probes, new Error('test'), thisArg, { x: 1 })
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
@@ -1114,8 +1115,8 @@ describe('api', () => {
       })
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, {})
-      onReturn(probes, null, {}, {}, {})
+      onEntry(probes, thisArg)
+      onReturn(probes, null, thisArg)
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
     })
@@ -1136,12 +1137,12 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       // This onEntry will time out and push null
-      onEntry(probes, {}, { x: 1 })
+      onEntry(probes, thisArg, { x: 1 })
 
       // onReturn should handle the null entry gracefully (no snapshot sent)
       shouldTimeout = false
       callCount = 0
-      onReturn(probes, null, {}, { x: 1 }, {})
+      onReturn(probes, null, thisArg, { x: 1 })
 
       expect(mockBatchAdd).not.toHaveBeenCalled()
     })
@@ -1175,8 +1176,8 @@ describe('api', () => {
       })
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, { x: 1 })
-      onReturn(probes, null, {}, { x: 1 }, {})
+      onEntry(probes, thisArg, { x: 1 })
+      onReturn(probes, null, thisArg, { x: 1 })
 
       // The non-snapshot probe should still send, but both snapshot probes should be dropped
       const calls = mockBatchAdd.calls.allArgs()
@@ -1209,8 +1210,8 @@ describe('api', () => {
       })
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
-      onEntry(probes, {}, { x: 1 })
-      onReturn(probes, null, {}, { x: 1 }, {})
+      onEntry(probes, thisArg, { x: 1 })
+      onReturn(probes, null, thisArg, { x: 1 })
 
       // Both snapshot probes share the deadline -- neither should send
       expect(mockBatchAdd).not.toHaveBeenCalled()
@@ -1225,8 +1226,8 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       expect(() => {
-        onEntry(probes, {}, {})
-        onReturn(probes, null, {}, {}, {})
+        onEntry(probes, thisArg)
+        onReturn(probes, null, thisArg)
       }).not.toThrow()
 
       expect(mockBatchAdd).toHaveBeenCalledTimes(1)
@@ -1239,8 +1240,8 @@ describe('api', () => {
 
       const probes = getProbes(DEFAULT_PROBE_FUNCTION_ID)!
       expect(() => {
-        onEntry(probes, {}, {})
-        onReturn(probes, null, {}, {}, {})
+        onEntry(probes, thisArg)
+        onReturn(probes, null, thisArg)
       }).not.toThrow()
       expect(warnSpy).toHaveBeenCalledWith(
         'Transport is not initialized. Make sure DD_DEBUGGER.init() has been called.'


### PR DESCRIPTION
## Motivation

The debugger API specs often passed `{}` for placeholder `this`, `args`, or `locals` values. Those call sites were harder to read because it was not obvious which empty object represented which parameter.

## Changes

- Added a shared `thisArg` test fixture for placeholder `this` values.
- Removed redundant trailing empty objects where `onEntry`, `onReturn`, and `onThrow` already provide default values.
- Left meaningful object literals in place when they are part of the test data or expectations.

## Test instructions

- [x] `yarn test:unit --spec packages/browser-debugger/src/domain/api.spec.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
