### PR TITLE
👷 Freeze canary deployment by commenting out deploy-prod-canary CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,17 +353,17 @@ deploy-staging:
     - node ./scripts/deploy/deploy.ts staging staging root
     - node ./scripts/deploy/upload-source-maps.ts staging root
 
-deploy-prod-canary:
-  stage: deploy:canary
-  extends:
-    - .base-configuration
-    - .main
-  script:
-    - export BUILD_MODE=canary
-    - yarn
-    - yarn build:bundle
-    - node ./scripts/deploy/deploy.ts prod canary root
-    - node ./scripts/deploy/upload-source-maps.ts canary root
+# deploy-prod-canary:
+#   stage: deploy:canary
+#   extends:
+#     - .base-configuration
+#     - .main
+#   script:
+#     - export BUILD_MODE=canary
+#     - yarn
+#     - yarn build:bundle
+#     - node ./scripts/deploy/deploy.ts prod canary root
+#     - node ./scripts/deploy/upload-source-maps.ts canary root
 
 deploy-next-major-canary:
   stage: deploy

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,8 @@
 yarnPath: .yarn/releases/yarn-4.15.0.cjs
 defaultSemverRangePrefix: ''
 nodeLinker: node-modules
+approvedGitRepositories:
+  - "https://github.com/bcaudan/json-schema-to-typescript.git"
 
 # Gitlab artifacts are only supported folders relative to the repository. Disable global cache so yarn will store the cache in .yarn/cache.
 # See https://docs.gitlab.com/ee/ci/jobs/job_artifacts.html#create-job-artifacts

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,8 +1,6 @@
 yarnPath: .yarn/releases/yarn-4.15.0.cjs
 defaultSemverRangePrefix: ''
 nodeLinker: node-modules
-approvedGitRepositories:
-  - "https://github.com/bcaudan/json-schema-to-typescript.git"
 
 # Gitlab artifacts are only supported folders relative to the repository. Disable global cache so yarn will store the cache in .yarn/cache.
 # See https://docs.gitlab.com/ee/ci/jobs/job_artifacts.html#create-job-artifacts


### PR DESCRIPTION
## Motivation

Freeze canary deployments during the Dash event to avoid any unplanned releases to production.

## Changes

- Comment out the `deploy-prod-canary` CI job in `.gitlab-ci.yml` to disable automatic canary deployments

## Test instructions

No functional code changes — CI pipeline change only. Verify that the `deploy-prod-canary` stage no longer runs on new merges to `main`.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->