### PR TITLE
👷 Allow bcaudan/json-schema-to-typescript git dependency in Yarn hardened mode

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,8 @@
 yarnPath: .yarn/releases/yarn-4.15.0.cjs
 defaultSemverRangePrefix: ''
 nodeLinker: node-modules
+approvedGitRepositories:
+  - 'https://github.com/bcaudan/json-schema-to-typescript.git'
 
 # Gitlab artifacts are only supported folders relative to the repository. Disable global cache so yarn will store the cache in .yarn/cache.
 # See https://docs.gitlab.com/ee/ci/jobs/job_artifacts.html#create-job-artifacts


### PR DESCRIPTION
## Motivation

Yarn's hardened mode (used in this repo) blocks git-sourced dependencies unless they are explicitly approved. The `bcaudan/json-schema-to-typescript` fork is a git dependency that was blocked, causing CI to fail in hardened mode.

## Changes

- Add `approvedGitRepositories` entry in `.yarnrc.yml` to allow the `bcaudan/json-schema-to-typescript` git repository dependency.

## Test instructions

CI should pass with Yarn hardened mode enabled — no manual testing needed for this config-only change.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->