### PR TITLE
🐛 Restore sanitize toJSON hooks after failures

### DIFF
--- a/packages/browser-core/src/tools/serialisation/sanitize.spec.ts
+++ b/packages/browser-core/src/tools/serialisation/sanitize.spec.ts
@@ -226,6 +226,20 @@ describe('sanitize', () => {
       // Since toJSON throws, sanitize falls back to serialize property by property
       expect(sanitize(obj)).toEqual({ b: 42, toJSON: '[Function] faulty' })
     })
+
+    it('should restore prototype toJSON methods when sanitization throws', () => {
+      const toJSON = jasmine.createSpy('toJSON', () => 'Object').and.callThrough()
+      ;(Object.prototype as any).toJSON = toJSON
+      const obj = {
+        get x() {
+          throw new Error('Cannot sanitize')
+        },
+      }
+
+      expect(() => sanitize(obj)).toThrowError('Cannot sanitize')
+      expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'toJSON')).toBe(true)
+      delete (Object.prototype as any).toJSON
+    })
   })
 
   describe('maxSize verification', () => {

--- a/packages/browser-core/src/tools/serialisation/sanitize.ts
+++ b/packages/browser-core/src/tools/serialisation/sanitize.ts
@@ -58,58 +58,33 @@ export function sanitize(source: unknown, maxCharacterCount = SANITIZE_DEFAULT_M
   const restoreObjectPrototypeToJson = detachToJsonMethod(Object.prototype)
   const restoreArrayPrototypeToJson = detachToJsonMethod(Array.prototype)
 
-  // Initial call to sanitizeProcessor - will populate containerQueue if source is an Array or a plain Object
-  const containerQueue: ContainerElementToProcess[] = []
-  const visitedObjectsWithPath = new WeakMap<object, string>()
-  const sanitizedData = sanitizeProcessor(
-    source as ExtendedContextValue,
-    JSON_PATH_ROOT_ELEMENT,
-    undefined,
-    containerQueue,
-    visitedObjectsWithPath
-  )
-  const serializedSanitizedData = JSON.stringify(sanitizedData)
-  let accumulatedCharacterCount = serializedSanitizedData ? serializedSanitizedData.length : 0
+  try {
+    // Initial call to sanitizeProcessor - will populate containerQueue if source is an Array or a plain Object
+    const containerQueue: ContainerElementToProcess[] = []
+    const visitedObjectsWithPath = new WeakMap<object, string>()
+    const sanitizedData = sanitizeProcessor(
+      source as ExtendedContextValue,
+      JSON_PATH_ROOT_ELEMENT,
+      undefined,
+      containerQueue,
+      visitedObjectsWithPath
+    )
+    const serializedSanitizedData = JSON.stringify(sanitizedData)
+    let accumulatedCharacterCount = serializedSanitizedData ? serializedSanitizedData.length : 0
 
-  if (accumulatedCharacterCount > maxCharacterCount) {
-    warnOverCharacterLimit(maxCharacterCount, 'discarded', source)
-    return undefined
-  }
+    if (accumulatedCharacterCount > maxCharacterCount) {
+      warnOverCharacterLimit(maxCharacterCount, 'discarded', source)
+      return undefined
+    }
 
-  while (containerQueue.length > 0 && accumulatedCharacterCount < maxCharacterCount) {
-    const containerToProcess = containerQueue.shift()!
-    let separatorLength = 0 // 0 for the first element, 1 for subsequent elements
+    while (containerQueue.length > 0 && accumulatedCharacterCount < maxCharacterCount) {
+      const containerToProcess = containerQueue.shift()!
+      let separatorLength = 0 // 0 for the first element, 1 for subsequent elements
 
-    // Arrays and Objects have to be handled distinctly to ensure
-    // we do not pick up non-numerical properties from Arrays
-    if (Array.isArray(containerToProcess.source)) {
-      for (let key = 0; key < containerToProcess.source.length; key++) {
-        const targetData = sanitizeProcessor(
-          containerToProcess.source[key],
-          containerToProcess.path,
-          key,
-          containerQueue,
-          visitedObjectsWithPath
-        )
-
-        if (targetData !== undefined) {
-          accumulatedCharacterCount += JSON.stringify(targetData).length
-        } else {
-          // When an element of an Array (targetData) is undefined, it is serialized as null:
-          // JSON.stringify([undefined]) => '[null]' - This accounts for 4 characters
-          accumulatedCharacterCount += 4
-        }
-        accumulatedCharacterCount += separatorLength
-        separatorLength = 1
-        if (accumulatedCharacterCount > maxCharacterCount) {
-          warnOverCharacterLimit(maxCharacterCount, 'truncated', source)
-          break
-        }
-        ;(containerToProcess.target as ContextArray)[key] = targetData
-      }
-    } else {
-      for (const key in containerToProcess.source) {
-        if (Object.prototype.hasOwnProperty.call(containerToProcess.source, key)) {
+      // Arrays and Objects have to be handled distinctly to ensure
+      // we do not pick up non-numerical properties from Arrays
+      if (Array.isArray(containerToProcess.source)) {
+        for (let key = 0; key < containerToProcess.source.length; key++) {
           const targetData = sanitizeProcessor(
             containerToProcess.source[key],
             containerToProcess.path,
@@ -117,28 +92,55 @@ export function sanitize(source: unknown, maxCharacterCount = SANITIZE_DEFAULT_M
             containerQueue,
             visitedObjectsWithPath
           )
-          // When a property of an object has an undefined value, it will be dropped during serialization:
-          // JSON.stringify({a:undefined}) => '{}'
+
           if (targetData !== undefined) {
-            accumulatedCharacterCount +=
-              JSON.stringify(targetData).length + separatorLength + key.length + KEY_DECORATION_LENGTH
-            separatorLength = 1
+            accumulatedCharacterCount += JSON.stringify(targetData).length
+          } else {
+            // When an element of an Array (targetData) is undefined, it is serialized as null:
+            // JSON.stringify([undefined]) => '[null]' - This accounts for 4 characters
+            accumulatedCharacterCount += 4
           }
+          accumulatedCharacterCount += separatorLength
+          separatorLength = 1
           if (accumulatedCharacterCount > maxCharacterCount) {
             warnOverCharacterLimit(maxCharacterCount, 'truncated', source)
             break
           }
-          ;(containerToProcess.target as Context)[key] = targetData
+          ;(containerToProcess.target as ContextArray)[key] = targetData
+        }
+      } else {
+        for (const key in containerToProcess.source) {
+          if (Object.prototype.hasOwnProperty.call(containerToProcess.source, key)) {
+            const targetData = sanitizeProcessor(
+              containerToProcess.source[key],
+              containerToProcess.path,
+              key,
+              containerQueue,
+              visitedObjectsWithPath
+            )
+            // When a property of an object has an undefined value, it will be dropped during serialization:
+            // JSON.stringify({a:undefined}) => '{}'
+            if (targetData !== undefined) {
+              accumulatedCharacterCount +=
+                JSON.stringify(targetData).length + separatorLength + key.length + KEY_DECORATION_LENGTH
+              separatorLength = 1
+            }
+            if (accumulatedCharacterCount > maxCharacterCount) {
+              warnOverCharacterLimit(maxCharacterCount, 'truncated', source)
+              break
+            }
+            ;(containerToProcess.target as Context)[key] = targetData
+          }
         }
       }
     }
+
+    return sanitizedData
+  } finally {
+    // Rebind detached toJSON functions
+    restoreObjectPrototypeToJson()
+    restoreArrayPrototypeToJson()
   }
-
-  // Rebind detached toJSON functions
-  restoreObjectPrototypeToJson()
-  restoreArrayPrototypeToJson()
-
-  return sanitizedData
 }
 
 /**


### PR DESCRIPTION
## Motivation

`sanitize()` temporarily detaches `Object.prototype.toJSON` and `Array.prototype.toJSON` while cloning customer-provided data.

If sanitization throws before the normal return path, for example while reading an enumerable getter, those prototype `toJSON` methods were not restored. This can leave page prototypes modified after a failed sanitization attempt and affect later serialization.

## Changes

Wrap the sanitizer traversal in a `try/finally` so detached prototype `toJSON` methods are restored on both success and failure paths.

Add a regression test covering a throwing getter while `Object.prototype.toJSON` is detached.

## Test instructions

Run:

```bash
yarn test:unit --spec packages/browser-core/src/tools/serialisation/sanitize.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
