### PR TITLE
✅ Fix React router test state leak

### DIFF
--- a/packages/browser-rum-react/src/domain/reactRouter/createRouter.spec.ts
+++ b/packages/browser-rum-react/src/domain/reactRouter/createRouter.spec.ts
@@ -1,6 +1,8 @@
+import { registerCleanupTask } from '@datadog/browser-core/test'
 import { createMemoryRouter as createMemoryRouterV7 } from 'react-router-dom'
 import { createMemoryRouter as createMemoryRouterV6 } from 'react-router-dom-6'
 import { initializeReactPlugin } from '../../../test/initializeReactPlugin'
+import { resetReactPlugin } from '../reactPlugin'
 import { wrapCreateRouter } from './createRouter'
 import type { AnyRouter, AnyRouterSubscriber } from './types'
 
@@ -83,6 +85,11 @@ describe('wrapCreateRouter — initial error forwarding', () => {
   const errorOpts = { newErrors: { '0': new Error('loader error') }, deletedFetchers: [] }
   const normalOpts = { newErrors: null, deletedFetchers: [] }
   const noop = () => undefined
+
+  beforeEach(() => {
+    resetReactPlugin()
+    registerCleanupTask(resetReactPlugin)
+  })
 
   function buildFakeRouter(syncReplay?: typeof errorOpts) {
     let ourCallback: AnyRouterSubscriber | undefined


### PR DESCRIPTION
## Motivation

While investigating DataDog/browser-sdk#4750, the BrowserStack Firefox unit job failed with `TypeError: rumPublicApi.startView is not a function` in `reactPlugin.spec.ts`.

CI logs: https://gitlab.ddbuild.io/datadog/browser-sdk/-/jobs/1751673091

The failure was order-dependent: `wrapCreateRouter` regression tests could register pending React router `onRumInit` subscribers without clearing the React plugin global state, then a later spec initialized the plugin with a minimal fake public API.

## Changes

Reset the React plugin before the `wrapCreateRouter — initial error forwarding` regression tests and register cleanup afterward, so pending subscribers cannot leak into later randomized specs.

This only affects test isolation.

## Test instructions

`yarn test:unit --spec packages/browser-rum-react/src/domain/reactRouter/createRouter.spec.ts --spec packages/browser-rum-react/src/domain/reactPlugin.spec.ts --seed 11837`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
