### PR TITLE
♻️ Tighten debugger capture return types

### DIFF
--- a/packages/browser-debugger/src/domain/activeEntries.ts
+++ b/packages/browser-debugger/src/domain/activeEntries.ts
@@ -2,19 +2,42 @@ import type { StackFrame } from './stacktrace'
 import type { EvaluationError } from './condition'
 import type { Throwable } from './error'
 
+type CapturedFields = Record<string, any>
+
+interface ActiveEntryThrowable {
+  throwable?: Throwable
+}
+
+type ActiveEntryEntry =
+  | { arguments: CapturedFields; captureExpressions?: never }
+  | { arguments?: never; captureExpressions: CapturedFields }
+
+type ActiveEntryReturn =
+  | (ActiveEntryThrowable & {
+      arguments: CapturedFields
+      locals?: CapturedFields
+      captureExpressions?: never
+    })
+  | (ActiveEntryThrowable & {
+      arguments?: never
+      locals?: never
+      captureExpressions: CapturedFields
+    })
+  | (ActiveEntryThrowable & {
+      arguments?: never
+      locals?: never
+      captureExpressions?: never
+      throwable: NonNullable<ActiveEntryThrowable['throwable']>
+    })
+
 export interface ActiveEntry {
   start: number
   timestamp?: number
   message?: string
   evaluationErrors?: EvaluationError[]
-  entry?: { arguments: Record<string, any> } | { captureExpressions: Record<string, any> }
+  entry?: ActiveEntryEntry
   stack?: StackFrame[]
   duration?: number
-  return?: {
-    arguments?: Record<string, any>
-    locals?: Record<string, any>
-    captureExpressions?: Record<string, any>
-    throwable?: Throwable
-  }
+  return?: ActiveEntryReturn
   exception?: unknown
 }

--- a/packages/browser-debugger/src/domain/api.spec.ts
+++ b/packages/browser-debugger/src/domain/api.spec.ts
@@ -747,7 +747,6 @@ describe('api', () => {
       expect(snapshot.captures).toEqual({
         entry: undefined,
         return: {
-          arguments: undefined,
           captureExpressions: {
             exceptionMessage: { type: 'string', value: 'Test error' },
           },

--- a/packages/browser-debugger/src/domain/api.ts
+++ b/packages/browser-debugger/src/domain/api.ts
@@ -1,4 +1,4 @@
-import type { Batch, Context } from '@datadog/browser-core'
+import type { Batch, Context, ContextValue } from '@datadog/browser-core'
 import { timeStampNow } from '@datadog/js-core/time'
 import { buildTag, generateUUID, globalObject, mergeArrays } from '@datadog/browser-core'
 import type { BrowserWindow, DebuggerInitConfiguration } from '../entries/main'
@@ -205,8 +205,10 @@ export function onReturn(
       if (!probe.captureSnapshot) {
         const captureExpressionsResult = evaluateCaptureExpressions(probe, context, captureCtx)
         if (captureExpressionsResult) {
-          result.return = {
-            captureExpressions: captureExpressionsResult.values,
+          if (captureExpressionsResult.values) {
+            result.return = {
+              captureExpressions: captureExpressionsResult.values,
+            }
           }
           result.evaluationErrors = mergeArrays(result.evaluationErrors, captureExpressionsResult.evaluationErrors)
           if (captureCtx.timedOut) {
@@ -288,8 +290,10 @@ export function onThrow(probes: InitializedProbe[], error: unknown, self: any, a
       if (!probe.captureSnapshot) {
         const captureExpressionsResult = evaluateCaptureExpressions(probe, context, captureCtx)
         if (captureExpressionsResult) {
-          result.return = {
-            captureExpressions: captureExpressionsResult.values,
+          if (captureExpressionsResult.values) {
+            result.return = {
+              captureExpressions: captureExpressionsResult.values,
+            }
           }
           result.evaluationErrors = mergeArrays(result.evaluationErrors, captureExpressionsResult.evaluationErrors)
           if (captureCtx.timedOut) {
@@ -307,10 +311,13 @@ export function onThrow(probes: InitializedProbe[], error: unknown, self: any, a
       }
     }
 
-    result.return = {
-      ...result.return,
-      arguments: throwArguments,
-      throwable: formatThrowable(error),
+    const throwable = formatThrowable(error)
+    if (throwArguments) {
+      result.return = { arguments: throwArguments, throwable }
+    } else if (result.return?.captureExpressions) {
+      result.return = { captureExpressions: result.return.captureExpressions, throwable }
+    } else {
+      result.return = { throwable }
     }
 
     queueDebuggerSnapshot(probe, result)
@@ -330,6 +337,14 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
   }
 
   const version = globalObj.DD_DEBUGGER!.version
+  const captures = (
+    result.entry || result.return
+      ? {
+          entry: result.entry,
+          return: result.return,
+        }
+      : undefined
+  ) as ContextValue
 
   const payload: Context = {
     message: result.message,
@@ -360,13 +375,7 @@ function queueDebuggerSnapshot(probe: InitializedProbe, result: ActiveEntry): vo
         stack: result.stack,
         language: 'javascript',
         duration: result.duration === undefined ? undefined : result.duration * 1e6, // to nanoseconds (might be undefined in case of eval errors)
-        captures:
-          result.entry || result.return
-            ? {
-                entry: result.entry,
-                return: result.return,
-              }
-            : undefined,
+        captures,
       },
     },
   }


### PR DESCRIPTION
## Motivation

Debugger return captures are mutually exclusive: they contain either snapshot-captured arguments/locals or capture expressions. The current `ActiveEntry` type allowed both shapes to exist together, which made the in-memory model looser than the probe validation and capture code.

## Changes

Tighten `ActiveEntry` capture types so `entry` and `return` captures model snapshot fields and capture expressions as exclusive variants.

Keep `throwable` allowed alongside either return capture variant, since exception captures can include throwable metadata with snapshot captures or capture expressions.

Only assign `return.captureExpressions` when capture expression evaluation produced values, while still preserving evaluation errors.

Stop emitting `arguments: undefined` for capture-expression exception payloads.

## Test instructions

Run `yarn test:unit --spec packages/browser-debugger/src/domain/api.spec.ts`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
