### PR TITLE
Add browser rum nextjs npm metadata

### DIFF
--- a/packages/browser-rum-nextjs/package.json
+++ b/packages/browser-rum-nextjs/package.json
@@ -39,6 +39,10 @@
     "url": "https://github.com/DataDog/browser-sdk.git",
     "directory": "packages/browser-rum-nextjs"
   },
+  "homepage": "https://github.com/DataDog/browser-sdk/tree/main/packages/browser-rum-nextjs#readme",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "volta": {
     "extends": "../../package.json"
   },


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@datadog/browser-rum-nextjs`
- add npm `bugs.url` metadata pointing to the repository issue tracker

## Verification
- `node -e "const p=require('./packages/browser-rum-nextjs/package.json'); if(p.homepage!=='https://github.com/DataDog/browser-sdk/tree/main/packages/browser-rum-nextjs#readme') process.exit(1); if(p.bugs.url!=='https://github.com/DataDog/browser-sdk/issues') process.exit(1); console.log(JSON.stringify({name:p.name, homepage:p.homepage, bugs:p.bugs}))"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts ./packages/browser-rum-nextjs`