### PR TITLE
🐛 fix wrong framework name in angular router warning

### DIFF
--- a/packages/browser-rum-angular/src/domain/angularRouter/startAngularView.ts
+++ b/packages/browser-rum-angular/src/domain/angularRouter/startAngularView.ts
@@ -7,7 +7,7 @@ const PRIMARY_OUTLET = 'primary'
 export function startAngularView(root: RouteSnapshot, url: string) {
   onRumInit((configuration, rumPublicApi) => {
     if (!configuration.router) {
-      display.warn('`router: true` is missing from the react plugin configuration, the view will not be tracked.')
+      display.warn('`router: true` is missing from the angular plugin configuration, the view will not be tracked.')
       return
     }
 


### PR DESCRIPTION
## Motivation

the angular router warning wrongly mentions the `react` plugin 

## Changes

use `angular` instead of `react` in the warning message

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
