### PR TITLE
🔥 remove WeakSet fallback in mergeInto

### DIFF
--- a/packages/browser-core/src/tools/mergeInto.ts
+++ b/packages/browser-core/src/tools/mergeInto.ts
@@ -142,24 +142,12 @@ interface CircularReferenceChecker {
 }
 
 function createCircularReferenceChecker(): CircularReferenceChecker {
-  if (typeof WeakSet !== 'undefined') {
-    const set: WeakSet<any> = new WeakSet()
-    return {
-      hasAlreadyBeenSeen(value) {
-        const has = set.has(value)
-        if (!has) {
-          set.add(value)
-        }
-        return has
-      },
-    }
-  }
-  const array: any[] = []
+  const set = new WeakSet<any>()
   return {
     hasAlreadyBeenSeen(value) {
-      const has = array.indexOf(value) >= 0
+      const has = set.has(value)
       if (!has) {
-        array.push(value)
+        set.add(value)
       }
       return has
     },


### PR DESCRIPTION
## Motivation

the array fallback for environments without `WeakSet` is dead code , `WeakSet` is available in all supported browsers

## Changes

always use a `WeakSet` in `mergeInto`'s circular reference checker and remove the array fallback

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
