### PR TITLE
👷 Unfreeze canary deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,17 +353,17 @@ deploy-staging:
     - node ./scripts/deploy/deploy.ts staging staging root
     - node ./scripts/deploy/upload-source-maps.ts staging root
 
-# deploy-prod-canary:
-#   stage: deploy:canary
-#   extends:
-#     - .base-configuration
-#     - .main
-#   script:
-#     - export BUILD_MODE=canary
-#     - yarn
-#     - yarn build:bundle
-#     - node ./scripts/deploy/deploy.ts prod canary root
-#     - node ./scripts/deploy/upload-source-maps.ts canary root
+deploy-prod-canary:
+  stage: deploy:canary
+  extends:
+    - .base-configuration
+    - .main
+  script:
+    - export BUILD_MODE=canary
+    - yarn
+    - yarn build:bundle
+    - node ./scripts/deploy/deploy.ts prod canary root
+    - node ./scripts/deploy/upload-source-maps.ts canary root
 
 deploy-next-major-canary:
   stage: deploy


### PR DESCRIPTION
## Motivation

The Datadog dash freeze is lifted, so we can re-enable the canary deployment pipeline.

Reverts #4742 (commit 9581553e14bf876e7820b791fe1611c4116a08bb).

## Changes

Re-enables the `deploy-prod-canary` CI job in `.gitlab-ci.yml` by uncommenting it.

## Test instructions

N/A — CI pipeline change only.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file