### PR TITLE
🐛 [Profiler] Fix empty session ID & quota check on renew

### DIFF
--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
@@ -11,6 +11,8 @@ import {
   globalObject,
   DeflateEncoderStreamId,
   mockable,
+  isSampled,
+  correctedChildSampleRate,
 } from '@datadog/browser-core'
 
 import type { LifeCycle, RumConfiguration, TransportPayload, ViewHistory } from '@datadog/browser-rum-core'
@@ -71,6 +73,13 @@ export function createRumProfiler(
       instance.state === 'stopped' &&
       (instance.stateReason === 'session-expired' || instance.stateReason === 'quota_ko')
     ) {
+      const newSession = session.findTrackedSession()
+      if (
+        !newSession ||
+        !isSampled(newSession.id, correctedChildSampleRate(configuration.sessionSampleRate, configuration.profilingSampleRate))
+      ) {
+        return
+      }
       start()
     }
   })

--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
@@ -238,6 +238,7 @@ export function createRumProfiler(
       views: [],
       cleanupTasks,
       longTasks: [],
+      sessionId: session.findTrackedSession()?.id,
     }
 
     // Add last view entry
@@ -253,7 +254,7 @@ export function createRumProfiler(
     runningInstance.profiler.removeEventListener('samplebufferfull', handleSampleBufferFull)
 
     // Store instance data snapshot in local variables to use in async callback
-    const { startClocks, views } = runningInstance
+    const { startClocks, views, sessionId } = runningInstance
 
     // Stop current profiler to get trace
     runningInstance.profiler
@@ -288,7 +289,7 @@ export function createRumProfiler(
             views,
             sampleInterval: profilerConfiguration.sampleIntervalMs,
           }),
-          startClocks.relative
+          sessionId,
         )
       })
       .catch(monitorError)
@@ -356,8 +357,7 @@ export function createRumProfiler(
     instance.views.push(viewEntry)
   }
 
-  function handleProfilerTrace(trace: BrowserProfilerTrace, startTime: RelativeTime): void {
-    const sessionId = session.findTrackedSession(startTime)?.id
+  function handleProfilerTrace(trace: BrowserProfilerTrace, sessionId: string | undefined): void {
     const payload = assembleProfilingPayload(trace, configuration, sessionId)
 
     void transport.send(payload as unknown as TransportPayload)

--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
@@ -1,5 +1,4 @@
 import { elapsed, clocksOrigin, clocksNow } from '@datadog/js-core/time'
-import type { RelativeTime } from '@datadog/js-core/time'
 import type { Encoder, SessionManager, Profiler } from '@datadog/browser-core'
 import {
   addEventListener,
@@ -76,7 +75,10 @@ export function createRumProfiler(
       const newSession = session.findTrackedSession()
       if (
         !newSession ||
-        !isSampled(newSession.id, correctedChildSampleRate(configuration.sessionSampleRate, configuration.profilingSampleRate))
+        !isSampled(
+          newSession.id,
+          correctedChildSampleRate(configuration.sessionSampleRate, configuration.profilingSampleRate)
+        )
       ) {
         return
       }
@@ -289,7 +291,7 @@ export function createRumProfiler(
             views,
             sampleInterval: profilerConfiguration.sampleIntervalMs,
           }),
-          sessionId,
+          sessionId
         )
       })
       .catch(monitorError)

--- a/packages/browser-rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/browser-rum/src/domain/profiling/profiler.spec.ts
@@ -30,6 +30,8 @@ import {
   replaceMockable,
   createSessionManagerMock,
   replaceMockableWithSpy,
+  HIGH_HASH_UUID,
+  LOW_HASH_UUID,
 } from '@datadog/browser-core/test'
 import { mockRumConfiguration, mockViewHistory } from '../../../../browser-rum-core/test'
 import { mockProfiler } from '../../../test'
@@ -960,6 +962,43 @@ describe('profiler', () => {
     // Profiler should remain stopped - user's explicit stop should take priority over session expiration
     expect(profiler.isStopped()).toBe(true)
     expect(profilingContextManager.get()?.status).toBe('stopped')
+  })
+
+  it('should not restart profiling on session renewal when new session is not sampled for profiling', async () => {
+    mockProfiler(deepClone(mockedTrace))
+    const testLifeCycle = new LifeCycle()
+    const hooks = createHooks()
+    const profilingContextManager = startProfilingContext(hooks)
+    // Initial session uses LOW_HASH_UUID (sampled at any rate)
+    const sessionManager = createSessionManagerMock().setId(LOW_HASH_UUID)
+
+    const profiler = createRumProfiler(
+      mockRumConfiguration({ sessionSampleRate: 100, profilingSampleRate: 50 }),
+      testLifeCycle,
+      sessionManager,
+      profilingContextManager,
+      createIdentityEncoder,
+      mockViewHistory(),
+      { sampleIntervalMs: 10, collectIntervalMs: 60000, minProfileDurationMs: 0 }
+    )
+
+    // Start directly, simulating profilerApi.ts having validated the initial session
+    profiler.start()
+    await waitForBoolean(() => profiler.isRunning())
+
+    // Session expires
+    testLifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
+    expect(profiler.isStopped()).toBeTrue()
+
+    // Session renews with HIGH_HASH_UUID, which is not sampled at profilingSampleRate: 50
+    sessionManager.setId(HIGH_HASH_UUID)
+    testLifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(profiler.isStopped()).toBeTrue()
+
+    profiler.stop()
   })
 
   it('should not include long tasks outside the profiling window when clocks drift', async () => {

--- a/packages/browser-rum/src/domain/profiling/profiler.spec.ts
+++ b/packages/browser-rum/src/domain/profiling/profiler.spec.ts
@@ -1053,24 +1053,21 @@ describe('profiler', () => {
     expect(trace.longTasks[0].id).toBe('long-task-inside')
   })
 
-  it('should use the profiling start time when looking up the session id', async () => {
-    const clock = mockClock()
+  it('should use the session id at profiler instance start time, not at collection time', async () => {
     const { profiler, sessionManager } = setupProfiler()
-    const findTrackedSessionSpy = spyOn(sessionManager, 'findTrackedSession').and.callThrough()
 
     profiler.start()
-    expect(profiler.isRunning()).toBe(true)
+    await waitForBoolean(() => profiler.isRunning())
 
-    const expectedStartTime = relativeNow()
-
-    clock.tick(1000)
+    // Change session ID after profiler instance started
+    sessionManager.setId('changed-session-id')
 
     profiler.stop()
 
-    await waitNextMicrotask()
-    await waitNextMicrotask()
+    await waitForBoolean(() => interceptor.requests.length >= 1)
 
-    expect(findTrackedSessionSpy).toHaveBeenCalledWith(expectedStartTime)
+    const request = await readFormDataRequest<ProfileEventPayload>(interceptor.requests[0])
+    expect(request.event.session?.id).toBe('session-id-1')
   })
 
   describe('discard logic', () => {

--- a/packages/browser-rum/src/domain/profiling/types.ts
+++ b/packages/browser-rum/src/domain/profiling/types.ts
@@ -42,6 +42,8 @@ export interface RumProfilerRunningInstance extends RumProfilerEnrichmentData {
   readonly timeoutId: TimeoutId
   /** Clean-up tasks to execute after running the Profiler */
   readonly cleanupTasks: Array<() => void>
+  /** Session ID */
+  readonly sessionId: string | undefined
 }
 
 export type RumProfilerInstance = RumProfilerStoppedInstance | RumProfilerPausedInstance | RumProfilerRunningInstance


### PR DESCRIPTION
## Motivation

Profiles were being sent without a session ID: 
- The session ID was resolved at collection time via `findTrackedSession(startTime)`, but the session history may no longer contain the entry by then, resulting in an empty session ID in the profile payload.

Quotas were not enforced on renewal:
- On session renewal, the profiler restarted without re-checking whether the new session passes the profiling sampling rate, causing profiling to run for sessions that should not be sampled.

Relates to PROF-15036.

## Changes

- **Capture session ID at instance start time**: The session ID is now stored on `RumProfilerRunningInstance` when the profiler instance starts, and passed directly to `handleProfilerTrace` instead of being looked up by start time at collection.
- **Re-check sampling on session renewal**: The `SESSION_RENEWED` handler now validates the new session against `isSampled(newSession.id, correctedChildSampleRate(...))` before restarting the profiler.

## Test instructions

Unit test added: `should not restart profiling on session renewal when new session is not sampled for profiling` in `profiler.spec.ts`.

## Checklist

- [x] Tested locally
- [x] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file