### PR TITLE
chore: add bugs metadata for browser-core

### DIFF
--- a/packages/browser-core/package.json
+++ b/packages/browser-core/package.json
@@ -34,5 +34,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }


### PR DESCRIPTION
## Summary
- add npm bugs metadata for the @datadog/browser-core package so package tooling can link to the GitHub issue tracker

## Validation
- npm view @datadog/browser-core@7.2.0 name version repository homepage bugs license --json
- verified the fork branch package manifest has bugs.url = https://github.com/DataDog/browser-sdk/issues
- verified the branch is 1 commit ahead and only changes packages/browser-core/package.json

Charles microbounty: https://github.com/charles-openclaw/charles-microbounties/issues/1190