### PR TITLE
♻️ remove `allowUntrustedEvents` from internal configuration

### DIFF
--- a/developer-extension/src/panel/flushEvents.spec.ts
+++ b/developer-extension/src/panel/flushEvents.spec.ts
@@ -1,4 +1,3 @@
-import type { Configuration } from '@datadog/browser-core'
 import { registerCleanupTask } from '../../../packages/browser-core/test'
 import type { PageMayExitEvent } from '../../../packages/browser-core/src/browser/pageMayExitObservable'
 import { createPageMayExitObservable } from '../../../packages/browser-core/src/browser/pageMayExitObservable'
@@ -6,12 +5,10 @@ import { flushScript } from './flushEvents'
 
 describe('flushEvents', () => {
   let onExitSpy: jasmine.Spy<(event: PageMayExitEvent) => void>
-  let configuration: Configuration
 
   beforeEach(() => {
     onExitSpy = jasmine.createSpy()
-    configuration = {} as Configuration
-    registerCleanupTask(createPageMayExitObservable(configuration).subscribe(onExitSpy).unsubscribe)
+    registerCleanupTask(createPageMayExitObservable().subscribe(onExitSpy).unsubscribe)
   })
 
   it('flushes when the flush scripts evaluated', () => {

--- a/packages/browser-core/src/browser/addEventListener.spec.ts
+++ b/packages/browser-core/src/browser/addEventListener.spec.ts
@@ -1,17 +1,13 @@
-import type { Configuration } from '../domain/configuration'
 import { createNewEvent, mockZoneJs, registerCleanupTask } from '../../test'
 import type { MockZoneJs } from '../../test'
 import { noop } from '../tools/utils/functionUtils'
-import { addEventListener, DOM_EVENT, isEventSupported } from './addEventListener'
+import { addEventListener, DOM_EVENT, isEventSupported, setAllowUntrustedEvents } from './addEventListener'
 
 describe('addEventListener', () => {
-  let configuration: Configuration
-
   describe('Zone.js support', () => {
     let zoneJs: MockZoneJs
 
     beforeEach(() => {
-      configuration = { allowUntrustedEvents: false } as Configuration
       zoneJs = mockZoneJs()
     })
 
@@ -20,7 +16,7 @@ describe('addEventListener', () => {
       const eventTarget = document.createElement('div')
       zoneJs.replaceProperty(eventTarget, 'addEventListener', zoneJsPatchedAddEventListener)
 
-      addEventListener(configuration, eventTarget, DOM_EVENT.CLICK, noop)
+      addEventListener({}, eventTarget, DOM_EVENT.CLICK, noop)
       expect(zoneJsPatchedAddEventListener).not.toHaveBeenCalled()
     })
 
@@ -29,7 +25,7 @@ describe('addEventListener', () => {
       const eventTarget = document.createElement('div')
       zoneJs.replaceProperty(eventTarget, 'removeEventListener', zoneJsPatchedRemoveEventListener)
 
-      const { stop } = addEventListener(configuration, eventTarget, DOM_EVENT.CLICK, noop)
+      const { stop } = addEventListener({}, eventTarget, DOM_EVENT.CLICK, noop)
       stop()
       expect(zoneJsPatchedRemoveEventListener).not.toHaveBeenCalled()
     })
@@ -53,7 +49,7 @@ describe('addEventListener', () => {
     htmlDivElement.addEventListener = jasmine.createSpy()
     htmlDivElement.removeEventListener = jasmine.createSpy()
 
-    const { stop } = addEventListener({ allowUntrustedEvents: false }, htmlDivElement, DOM_EVENT.CLICK, noop)
+    const { stop } = addEventListener({}, htmlDivElement, DOM_EVENT.CLICK, noop)
 
     const event = createNewEvent(DOM_EVENT.CLICK)
     htmlDivElement.dispatchEvent(event)
@@ -78,7 +74,7 @@ describe('addEventListener', () => {
       removeEventListener: jasmine.createSpy(),
     } as unknown as HTMLElement
 
-    const { stop } = addEventListener({ allowUntrustedEvents: false }, customEventTarget, 'change', listener)
+    const { stop } = addEventListener({}, customEventTarget, 'change', listener)
     stop()
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -89,13 +85,13 @@ describe('addEventListener', () => {
 
   describe('Untrusted event', () => {
     beforeEach(() => {
-      configuration = { allowUntrustedEvents: false } as Configuration
+      setAllowUntrustedEvents(false)
     })
 
     it('should be ignored if __ddIsTrusted is absent', () => {
       const listener = jasmine.createSpy()
       const eventTarget = document.createElement('div')
-      addEventListener(configuration, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: undefined })
       eventTarget.dispatchEvent(event)
@@ -105,7 +101,7 @@ describe('addEventListener', () => {
     it('should be ignored if __ddIsTrusted is false', () => {
       const listener = jasmine.createSpy()
       const eventTarget = document.createElement('div')
-      addEventListener(configuration, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: false })
       eventTarget.dispatchEvent(event)
@@ -115,7 +111,7 @@ describe('addEventListener', () => {
     it('should not be ignored if __ddIsTrusted is true', () => {
       const listener = jasmine.createSpy()
       const eventTarget = document.createElement('div')
-      addEventListener(configuration, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: true })
       eventTarget.dispatchEvent(event)
@@ -123,16 +119,69 @@ describe('addEventListener', () => {
       expect(listener).toHaveBeenCalled()
     })
 
-    it('should not be ignored if allowUntrustedEvents is true', () => {
+    it('should not be ignored if setAllowUntrustedEvents(true) was called', () => {
       const listener = jasmine.createSpy()
       const eventTarget = document.createElement('div')
-      configuration = { allowUntrustedEvents: true } as Configuration
+      setAllowUntrustedEvents(true)
 
-      addEventListener(configuration, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: undefined })
       eventTarget.dispatchEvent(event)
 
+      expect(listener).toHaveBeenCalled()
+    })
+  })
+
+  describe('setAllowUntrustedEvents', () => {
+    let listener: jasmine.Spy
+    let eventTarget: HTMLElement
+
+    beforeEach(() => {
+      listener = jasmine.createSpy()
+      eventTarget = document.createElement('div')
+      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
+    })
+
+    function dispatchUntrustedClick() {
+      eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: undefined }))
+    }
+
+    it('passes untrusted events through before any SDK init (undefined state)', () => {
+      // allowUntrustedEventsFromConfiguration is undefined (reset between tests)
+      dispatchUntrustedClick()
+      expect(listener).toHaveBeenCalled()
+    })
+
+    it('filters untrusted events after setAllowUntrustedEvents(false)', () => {
+      setAllowUntrustedEvents(false)
+      dispatchUntrustedClick()
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('filters untrusted events after setAllowUntrustedEvents(undefined)', () => {
+      setAllowUntrustedEvents(undefined)
+      dispatchUntrustedClick()
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('allows untrusted events after setAllowUntrustedEvents(true)', () => {
+      setAllowUntrustedEvents(true)
+      dispatchUntrustedClick()
+      expect(listener).toHaveBeenCalled()
+    })
+
+    it('keeps the laxer value: once set to true, a subsequent false call has no effect', () => {
+      setAllowUntrustedEvents(true)
+      setAllowUntrustedEvents(false)
+      dispatchUntrustedClick()
+      expect(listener).toHaveBeenCalled()
+    })
+
+    it('can be upgraded from false to true', () => {
+      setAllowUntrustedEvents(false)
+      setAllowUntrustedEvents(true)
+      dispatchUntrustedClick()
       expect(listener).toHaveBeenCalled()
     })
   })

--- a/packages/browser-core/src/browser/addEventListener.spec.ts
+++ b/packages/browser-core/src/browser/addEventListener.spec.ts
@@ -16,7 +16,7 @@ describe('addEventListener', () => {
       const eventTarget = document.createElement('div')
       zoneJs.replaceProperty(eventTarget, 'addEventListener', zoneJsPatchedAddEventListener)
 
-      addEventListener({}, eventTarget, DOM_EVENT.CLICK, noop)
+      addEventListener(eventTarget, DOM_EVENT.CLICK, noop)
       expect(zoneJsPatchedAddEventListener).not.toHaveBeenCalled()
     })
 
@@ -25,7 +25,7 @@ describe('addEventListener', () => {
       const eventTarget = document.createElement('div')
       zoneJs.replaceProperty(eventTarget, 'removeEventListener', zoneJsPatchedRemoveEventListener)
 
-      const { stop } = addEventListener({}, eventTarget, DOM_EVENT.CLICK, noop)
+      const { stop } = addEventListener(eventTarget, DOM_EVENT.CLICK, noop)
       stop()
       expect(zoneJsPatchedRemoveEventListener).not.toHaveBeenCalled()
     })
@@ -49,7 +49,7 @@ describe('addEventListener', () => {
     htmlDivElement.addEventListener = jasmine.createSpy()
     htmlDivElement.removeEventListener = jasmine.createSpy()
 
-    const { stop } = addEventListener({}, htmlDivElement, DOM_EVENT.CLICK, noop)
+    const { stop } = addEventListener(htmlDivElement, DOM_EVENT.CLICK, noop)
 
     const event = createNewEvent(DOM_EVENT.CLICK)
     htmlDivElement.dispatchEvent(event)
@@ -74,7 +74,7 @@ describe('addEventListener', () => {
       removeEventListener: jasmine.createSpy(),
     } as unknown as HTMLElement
 
-    const { stop } = addEventListener({}, customEventTarget, 'change', listener)
+    const { stop } = addEventListener(customEventTarget, 'change', listener)
     stop()
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -91,7 +91,7 @@ describe('addEventListener', () => {
     it('should be ignored if __ddIsTrusted is absent', () => {
       const listener = jasmine.createSpy()
       const eventTarget = document.createElement('div')
-      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener(eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: undefined })
       eventTarget.dispatchEvent(event)
@@ -101,7 +101,7 @@ describe('addEventListener', () => {
     it('should be ignored if __ddIsTrusted is false', () => {
       const listener = jasmine.createSpy()
       const eventTarget = document.createElement('div')
-      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener(eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: false })
       eventTarget.dispatchEvent(event)
@@ -111,7 +111,7 @@ describe('addEventListener', () => {
     it('should not be ignored if __ddIsTrusted is true', () => {
       const listener = jasmine.createSpy()
       const eventTarget = document.createElement('div')
-      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener(eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: true })
       eventTarget.dispatchEvent(event)
@@ -124,7 +124,7 @@ describe('addEventListener', () => {
       const eventTarget = document.createElement('div')
       setAllowUntrustedEvents(true)
 
-      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener(eventTarget, DOM_EVENT.CLICK, listener)
 
       const event = createNewEvent(DOM_EVENT.CLICK, { __ddIsTrusted: undefined })
       eventTarget.dispatchEvent(event)
@@ -140,7 +140,7 @@ describe('addEventListener', () => {
     beforeEach(() => {
       listener = jasmine.createSpy()
       eventTarget = document.createElement('div')
-      addEventListener({}, eventTarget, DOM_EVENT.CLICK, listener)
+      addEventListener(eventTarget, DOM_EVENT.CLICK, listener)
     })
 
     function dispatchUntrustedClick() {

--- a/packages/browser-core/src/browser/addEventListener.ts
+++ b/packages/browser-core/src/browser/addEventListener.ts
@@ -92,13 +92,13 @@ type EventMapFor<T> = T extends Window
  * * returns a `stop` function to remove the listener
  */
 export function addEventListener<Target extends EventTarget, EventName extends keyof EventMapFor<Target> & string>(
-  configuration: { allowUntrustedEvents?: boolean | undefined },
+  _configuration: { allowUntrustedEvents?: boolean | undefined },
   eventTarget: Target,
   eventName: EventName,
   listener: (event: EventMapFor<Target>[EventName] & { type: EventName }) => void,
   options?: AddEventListenerOptions
 ) {
-  return addEventListeners(configuration, eventTarget, [eventName], listener, options)
+  return addEventListeners(_configuration, eventTarget, [eventName], listener, options)
 }
 
 /**
@@ -114,14 +114,14 @@ export function addEventListener<Target extends EventTarget, EventName extends k
  * * with `once: true`, the listener will be called at most once, even if different events are listened
  */
 export function addEventListeners<Target extends EventTarget, EventName extends keyof EventMapFor<Target> & string>(
-  configuration: { allowUntrustedEvents?: boolean | undefined },
+  _configuration: { allowUntrustedEvents?: boolean | undefined },
   eventTarget: Target,
   eventNames: EventName[],
   listener: (event: EventMapFor<Target>[EventName] & { type: EventName }) => void,
   { once, capture, passive }: AddEventListenerOptions = {}
 ) {
   const listenerWithMonitor = monitor((event: TrustableEvent) => {
-    if (!event.isTrusted && !event.__ddIsTrusted && !configuration.allowUntrustedEvents) {
+    if (!event.isTrusted && !event.__ddIsTrusted && allowUntrustedEventsFromConfiguration === false) {
       return
     }
     if (once) {
@@ -163,4 +163,17 @@ export function isEventSupported<Target extends EventTarget, EventName extends k
   } catch {
     return false
   }
+}
+
+let allowUntrustedEventsFromConfiguration: boolean | undefined
+
+export function setAllowUntrustedEvents(value: boolean | undefined) {
+  if (allowUntrustedEventsFromConfiguration === true) {
+    return // keep the laxer value (true)
+  }
+  allowUntrustedEventsFromConfiguration = value ?? false
+}
+
+export function resetAllowUntrustedEvents() {
+  allowUntrustedEventsFromConfiguration = undefined
 }

--- a/packages/browser-core/src/browser/addEventListener.ts
+++ b/packages/browser-core/src/browser/addEventListener.ts
@@ -92,13 +92,12 @@ type EventMapFor<T> = T extends Window
  * * returns a `stop` function to remove the listener
  */
 export function addEventListener<Target extends EventTarget, EventName extends keyof EventMapFor<Target> & string>(
-  _configuration: { allowUntrustedEvents?: boolean | undefined },
   eventTarget: Target,
   eventName: EventName,
   listener: (event: EventMapFor<Target>[EventName] & { type: EventName }) => void,
   options?: AddEventListenerOptions
 ) {
-  return addEventListeners(_configuration, eventTarget, [eventName], listener, options)
+  return addEventListeners(eventTarget, [eventName], listener, options)
 }
 
 /**
@@ -114,7 +113,6 @@ export function addEventListener<Target extends EventTarget, EventName extends k
  * * with `once: true`, the listener will be called at most once, even if different events are listened
  */
 export function addEventListeners<Target extends EventTarget, EventName extends keyof EventMapFor<Target> & string>(
-  _configuration: { allowUntrustedEvents?: boolean | undefined },
   eventTarget: Target,
   eventNames: EventName[],
   listener: (event: EventMapFor<Target>[EventName] & { type: EventName }) => void,
@@ -158,7 +156,7 @@ export function isEventSupported<Target extends EventTarget, EventName extends k
   }
 
   try {
-    addEventListener({}, eventTarget, eventName, noop).stop()
+    addEventListener(eventTarget, eventName, noop).stop()
     return true
   } catch {
     return false

--- a/packages/browser-core/src/browser/cookieAccess.spec.ts
+++ b/packages/browser-core/src/browser/cookieAccess.spec.ts
@@ -1,7 +1,6 @@
 import { ONE_MINUTE, dateNow } from '@datadog/js-core/time'
 import type { Clock } from '../../test'
 import { collectAsyncCalls, mockClock, registerCleanupTask, replaceMockable } from '../../test'
-import type { Configuration } from '../domain/configuration'
 import { display } from '../tools/display'
 import { globalObject } from '../tools/globalObject'
 import { detectVersion, isChromium } from '../tools/utils/browserDetection'
@@ -18,7 +17,6 @@ import {
 
 const COOKIE_NAME = 'test_cookie'
 const COOKIE_OPTIONS = { secure: false, crossSite: false, partitioned: false }
-const MOCK_CONFIGURATION = { allowUntrustedEvents: true } as Configuration
 
 function disableCookieStore() {
   replaceMockable(globalObject.cookieStore, undefined)
@@ -78,8 +76,7 @@ describe('cookieAccess', () => {
 
         return {
           clock,
-          createCookieAccess: (name: string, options: CookieOptions) =>
-            createCookieStoreAccess(name, options, MOCK_CONFIGURATION),
+          createCookieAccess: (name: string, options: CookieOptions) => createCookieStoreAccess(name, options),
           async flushObservable(this: void, spy: jasmine.Spy) {
             await collectAsyncCalls(spy, 1)
             // Reset the spy calls to avoid throwing on unexpected calls during teardown
@@ -245,10 +242,10 @@ describe('cookieAccess', () => {
       }
       const factory = jasmine.createSpy('factory').and.returnValue(access)
 
-      const result = await areCookiesAuthorized(factory, COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      const result = await areCookiesAuthorized(factory, COOKIE_OPTIONS)
 
       expect(result).toBe(true)
-      expect(factory).toHaveBeenCalledWith(jasmine.any(String), COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      expect(factory).toHaveBeenCalledWith(jasmine.any(String), COOKIE_OPTIONS)
     })
 
     it('returns false when the access cannot read back the test cookie', async () => {
@@ -258,7 +255,7 @@ describe('cookieAccess', () => {
         observable: null as any,
       }
 
-      const result = await areCookiesAuthorized(() => access, COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      const result = await areCookiesAuthorized(() => access, COOKIE_OPTIONS)
 
       expect(result).toBe(false)
     })
@@ -271,7 +268,7 @@ describe('cookieAccess', () => {
         observable: null as any,
       }
 
-      const result = await areCookiesAuthorized(() => access, COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      const result = await areCookiesAuthorized(() => access, COOKIE_OPTIONS)
 
       expect(result).toBe(false)
       expect(displayErrorSpy).toHaveBeenCalled()
@@ -288,7 +285,7 @@ describe('cookieAccess', () => {
         observable: null as any,
       }
 
-      await areCookiesAuthorized(() => access, COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      await areCookiesAuthorized(() => access, COOKIE_OPTIONS)
 
       expect(calls).toEqual([
         { value: 'test', expireDelay: jasmine.any(Number) as unknown as number },
@@ -298,7 +295,7 @@ describe('cookieAccess', () => {
 
     it('works with the real createDocumentCookieAccess', async () => {
       disableCookieStore()
-      const result = await areCookiesAuthorized(createDocumentCookieAccess, COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      const result = await areCookiesAuthorized(createDocumentCookieAccess, COOKIE_OPTIONS)
       expect(result).toBe(true)
     })
 
@@ -306,13 +303,13 @@ describe('cookieAccess', () => {
       if (!globalObject.cookieStore) {
         pending('CookieStore API not available')
       }
-      const result = await areCookiesAuthorized(createCookieStoreAccess, COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      const result = await areCookiesAuthorized(createCookieStoreAccess, COOKIE_OPTIONS)
       expect(result).toBe(true)
     })
 
     it('returns false when document.cookie is empty', async () => {
       spyOnProperty(document, 'cookie', 'get').and.returnValue('')
-      const result = await areCookiesAuthorized(createDocumentCookieAccess, COOKIE_OPTIONS, MOCK_CONFIGURATION)
+      const result = await areCookiesAuthorized(createDocumentCookieAccess, COOKIE_OPTIONS)
       expect(result).toBe(false)
     })
   })

--- a/packages/browser-core/src/browser/cookieAccess.ts
+++ b/packages/browser-core/src/browser/cookieAccess.ts
@@ -4,7 +4,6 @@ import { Observable } from '../tools/observable'
 import { mockable } from '../tools/mockable'
 import { display } from '../tools/display'
 import { generateUUID } from '../tools/utils/stringUtils'
-import type { Configuration } from '../domain/configuration'
 import { addTelemetryDebug } from '../domain/telemetry'
 import { globalObject } from '../tools/globalObject'
 import { addEventListener, DOM_EVENT, isEventSupported } from './addEventListener'
@@ -17,22 +16,17 @@ export interface CookieAccess {
   observable: Observable<void>
 }
 
-export type CookieAccessFactory = (
-  cookieName: string,
-  cookieOptions: CookieOptions,
-  configuration: Configuration
-) => CookieAccess
+export type CookieAccessFactory = (cookieName: string, cookieOptions: CookieOptions) => CookieAccess
 
 export async function areCookiesAuthorized(
   createAccess: CookieAccessFactory,
-  cookieOptions: CookieOptions,
-  configuration: Configuration
+  cookieOptions: CookieOptions
 ): Promise<boolean> {
   // Use a unique cookie name to avoid issues when the SDK is initialized multiple times during
   // the test cookie lifetime
   const testCookieName = `dd_cookie_test_${generateUUID()}`
   const testCookieValue = 'test'
-  const access = createAccess(testCookieName, cookieOptions, configuration)
+  const access = createAccess(testCookieName, cookieOptions)
   try {
     await access.getAllAndSet(() => ({ value: testCookieValue, expireDelay: ONE_MINUTE }))
     const values = await access.getAll()
@@ -49,14 +43,10 @@ export async function areCookiesAuthorized(
   }
 }
 
-export function createCookieStoreAccess(
-  cookieName: string,
-  cookieOptions: CookieOptions,
-  configuration: Configuration
-): CookieAccess {
+export function createCookieStoreAccess(cookieName: string, cookieOptions: CookieOptions): CookieAccess {
   const cookieStore = mockable(globalObject.cookieStore)!
   const observable = new Observable<void>(() => {
-    const listener = addEventListener(configuration, cookieStore, DOM_EVENT.CHANGE, (event) => {
+    const listener = addEventListener(cookieStore, DOM_EVENT.CHANGE, (event) => {
       // Based on our experimentation, we're assuming that entries for the same cookie cannot be in both the 'changed' and 'deleted' arrays.
       // However, due to ambiguity in the specification, we asked for clarification: https://github.com/WICG/cookie-store/issues/226
       const changeEvent =
@@ -115,11 +105,7 @@ export function createCookieStoreAccess(
 }
 
 export const WATCH_COOKIE_INTERVAL_DELAY = ONE_SECOND
-export function createDocumentCookieAccess(
-  cookieName: string,
-  cookieOptions: CookieOptions,
-  _configuration?: Configuration
-): CookieAccess {
+export function createDocumentCookieAccess(cookieName: string, cookieOptions: CookieOptions): CookieAccess {
   let previousCookieValues = getCookies(cookieName)
 
   const observable = new Observable<void>(() => {

--- a/packages/browser-core/src/browser/pageMayExitObservable.spec.ts
+++ b/packages/browser-core/src/browser/pageMayExitObservable.spec.ts
@@ -1,16 +1,13 @@
-import type { Configuration } from '../domain/configuration'
 import { createNewEvent, restorePageVisibility, setPageVisibility, registerCleanupTask } from '../../test'
 import type { PageMayExitEvent } from './pageMayExitObservable'
 import { PageExitReason, createPageMayExitObservable } from './pageMayExitObservable'
 
 describe('createPageMayExitObservable', () => {
   let onExitSpy: jasmine.Spy<(event: PageMayExitEvent) => void>
-  let configuration: Configuration
 
   beforeEach(() => {
     onExitSpy = jasmine.createSpy()
-    configuration = {} as Configuration
-    registerCleanupTask(createPageMayExitObservable(configuration).subscribe(onExitSpy).unsubscribe)
+    registerCleanupTask(createPageMayExitObservable().subscribe(onExitSpy).unsubscribe)
   })
 
   afterEach(() => {

--- a/packages/browser-core/src/browser/pageMayExitObservable.ts
+++ b/packages/browser-core/src/browser/pageMayExitObservable.ts
@@ -1,6 +1,5 @@
 import { Observable } from '../tools/observable'
 import { objectValues } from '../tools/utils/polyfills'
-import type { Configuration } from '../domain/configuration'
 import { isWorkerEnvironment } from '../tools/globalObject'
 import { addEventListeners, addEventListener, DOM_EVENT } from './addEventListener'
 
@@ -17,14 +16,13 @@ export interface PageMayExitEvent {
   reason: PageExitReason
 }
 
-export function createPageMayExitObservable(configuration: Configuration): Observable<PageMayExitEvent> {
+export function createPageMayExitObservable(): Observable<PageMayExitEvent> {
   return new Observable<PageMayExitEvent>((observable) => {
     if (isWorkerEnvironment) {
       // Page exit is not observable in worker environments (no window/document events)
       return
     }
     const { stop: stopListeners } = addEventListeners(
-      configuration,
       window,
       [DOM_EVENT.VISIBILITY_CHANGE, DOM_EVENT.FREEZE],
       (event) => {
@@ -45,7 +43,7 @@ export function createPageMayExitObservable(configuration: Configuration): Obser
       { capture: true }
     )
 
-    const stopBeforeUnloadListener = addEventListener(configuration, window, DOM_EVENT.BEFORE_UNLOAD, () => {
+    const stopBeforeUnloadListener = addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, () => {
       observable.notify({ reason: PageExitReason.UNLOADING })
     }).stop
 

--- a/packages/browser-core/src/browser/runOnReadyState.ts
+++ b/packages/browser-core/src/browser/runOnReadyState.ts
@@ -1,9 +1,7 @@
-import type { Configuration } from '../domain/configuration'
 import { noop } from '../tools/utils/functionUtils'
 import { DOM_EVENT, addEventListener } from './addEventListener'
 
 export function runOnReadyState(
-  configuration: Configuration,
   expectedReadyState: 'complete' | 'interactive',
   callback: () => void
 ): { stop: () => void } {
@@ -12,14 +10,11 @@ export function runOnReadyState(
     return { stop: noop }
   }
   const eventName = expectedReadyState === 'complete' ? DOM_EVENT.LOAD : DOM_EVENT.DOM_CONTENT_LOADED
-  return addEventListener(configuration, window, eventName, callback, { once: true })
+  return addEventListener(window, eventName, callback, { once: true })
 }
 
-export function asyncRunOnReadyState(
-  configuration: Configuration,
-  expectedReadyState: 'complete' | 'interactive'
-): Promise<void> {
+export function asyncRunOnReadyState(expectedReadyState: 'complete' | 'interactive'): Promise<void> {
   return new Promise((resolve) => {
-    runOnReadyState(configuration, expectedReadyState, resolve)
+    runOnReadyState(expectedReadyState, resolve)
   })
 }

--- a/packages/browser-core/src/browser/xhrObservable.spec.ts
+++ b/packages/browser-core/src/browser/xhrObservable.spec.ts
@@ -1,20 +1,18 @@
-import type { Configuration } from '../domain/configuration'
 import { withXhr, mockXhr } from '../../test'
 import type { Subscription } from '../tools/observable'
 import { noop } from '../tools/utils/functionUtils'
 import type { XhrCompleteContext, XhrContext } from './xhrObservable'
 import { initXhrObservable, resetXhrObservable } from './xhrObservable'
+import { setAllowUntrustedEvents } from './addEventListener'
 
 describe('xhr observable', () => {
   let requestsTrackingSubscription: Subscription
   let contextEditionSubscription: Subscription | undefined
   let requests: XhrCompleteContext[]
   let originalMockXhrSend: XMLHttpRequest['send']
-  let configuration: Configuration
 
   beforeEach(() => {
     mockXhr()
-    configuration = {} as Configuration
     // eslint-disable-next-line @typescript-eslint/unbound-method
     originalMockXhrSend = XMLHttpRequest.prototype.send
 
@@ -28,7 +26,7 @@ describe('xhr observable', () => {
   })
 
   function startTrackingRequests() {
-    requestsTrackingSubscription = initXhrObservable(configuration).subscribe((context) => {
+    requestsTrackingSubscription = initXhrObservable().subscribe((context) => {
       if (context.state === 'complete') {
         requests.push(context)
       }
@@ -227,7 +225,7 @@ describe('xhr observable', () => {
 
   it('should allow to enhance the context', (done) => {
     type CustomContext = XhrContext & { foo: string }
-    contextEditionSubscription = initXhrObservable(configuration).subscribe((rawContext) => {
+    contextEditionSubscription = initXhrObservable().subscribe((rawContext) => {
       const context = rawContext as CustomContext
       if (context.state === 'start') {
         context.foo = 'bar'
@@ -404,11 +402,7 @@ describe('xhr observable', () => {
     })
   })
 
-  describe('with conflicting allowUntrustedEvents policies across callers', () => {
-    // Reproduces the bug where the early bufferedData call to
-    // initXhrObservable({ allowUntrustedEvents: true }) creates the singleton
-    // and a later initXhrObservable(customerConfig) silently reuses it,
-    // discarding the customer's stricter policy.
+  describe('untrusted loadend events', () => {
     let policySubscription: Subscription
     let policyContexts: XhrContext[]
 
@@ -426,11 +420,9 @@ describe('xhr observable', () => {
       requestsTrackingSubscription = { unsubscribe: noop }
     })
 
-    it('does not emit completion for an untrusted loadend when the customer disallows it', (done) => {
-      // First caller (bufferedData) opts into untrusted events.
-      initXhrObservable({ allowUntrustedEvents: true })
-      // Second caller (customer config) opts out.
-      policySubscription = initXhrObservable({ allowUntrustedEvents: false }).subscribe((context) => {
+    it('does not emit completion for an untrusted loadend when disallowed', (done) => {
+      setAllowUntrustedEvents(false)
+      policySubscription = initXhrObservable().subscribe((context) => {
         policyContexts.push(context)
       })
 
@@ -449,9 +441,9 @@ describe('xhr observable', () => {
       })
     })
 
-    it('emits completion for an untrusted loadend when every caller allows it', (done) => {
-      initXhrObservable({ allowUntrustedEvents: true })
-      policySubscription = initXhrObservable({ allowUntrustedEvents: true }).subscribe((context) => {
+    it('emits completion for an untrusted loadend when allowed', (done) => {
+      setAllowUntrustedEvents(true)
+      policySubscription = initXhrObservable().subscribe((context) => {
         policyContexts.push(context)
       })
 

--- a/packages/browser-core/src/browser/xhrObservable.ts
+++ b/packages/browser-core/src/browser/xhrObservable.ts
@@ -34,15 +34,7 @@ export type XhrContext = XhrOpenContext | XhrStartContext | XhrCompleteContext
 let xhrObservable: Observable<XhrContext> | undefined
 const xhrContexts = new WeakMap<XMLHttpRequest, XhrContext>()
 
-// The singleton XHR observable applies the latest caller's allowUntrustedEvents
-// policy so that the customer's configuration overrides the early call from
-// bufferedData (which always opts in before the customer config is parsed).
-let allowUntrustedEvents: boolean | undefined
-
-export function initXhrObservable(configuration: { allowUntrustedEvents?: boolean | undefined } = {}) {
-  if (configuration.allowUntrustedEvents !== undefined) {
-    allowUntrustedEvents = configuration.allowUntrustedEvents
-  }
+export function initXhrObservable() {
   if (!xhrObservable) {
     xhrObservable = createXhrObservable()
   }
@@ -130,7 +122,7 @@ function sendXhr(
     observable.notify({ ...completeContext, state: 'complete' })
   }
 
-  const { stop: unsubscribeLoadEndListener } = addEventListener({ allowUntrustedEvents }, xhr, 'loadend', onEnd)
+  const { stop: unsubscribeLoadEndListener } = addEventListener(xhr, 'loadend', onEnd)
 
   observable.notify(startContext)
 }
@@ -149,5 +141,4 @@ function abortXhr({ target: xhr }: InstrumentedMethodCall<XMLHttpRequest, 'abort
  */
 export function resetXhrObservable() {
   xhrObservable = undefined
-  allowUntrustedEvents = undefined
 }

--- a/packages/browser-core/src/domain/bufferedData.ts
+++ b/packages/browser-core/src/domain/bufferedData.ts
@@ -49,7 +49,7 @@ export function startBufferingData() {
 
   subscribe(BufferedDataType.RUNTIME_ERROR, mockable(trackRuntimeError)())
   subscribe(BufferedDataType.FETCH, initFetchObservable())
-  subscribe(BufferedDataType.XHR, initXhrObservable({ allowUntrustedEvents: true }))
+  subscribe(BufferedDataType.XHR, initXhrObservable())
   subscribe(BufferedDataType.CONSOLE, initConsoleObservable(Object.values(ConsoleApiName)))
 
   return {

--- a/packages/browser-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-core/src/domain/configuration/configuration.spec.ts
@@ -144,27 +144,6 @@ describe('validateAndBuildConfiguration', () => {
     })
   })
 
-  describe('allowUntrustedEvents', () => {
-    it('defaults to false', () => {
-      expect(validateAndBuildConfiguration({ clientToken: 'yes' })!.allowUntrustedEvents).toBeFalse()
-    })
-
-    it('is set to provided value', () => {
-      expect(
-        validateAndBuildConfiguration({ clientToken: 'yes', allowUntrustedEvents: true })!.allowUntrustedEvents
-      ).toBeTrue()
-      expect(
-        validateAndBuildConfiguration({ clientToken: 'yes', allowUntrustedEvents: false })!.allowUntrustedEvents
-      ).toBeFalse()
-    })
-
-    it('the provided value is cast to boolean', () => {
-      expect(
-        validateAndBuildConfiguration({ clientToken: 'yes', allowUntrustedEvents: 'foo' as any })!.allowUntrustedEvents
-      ).toBeTrue()
-    })
-  })
-
   describe('trackingConsent', () => {
     it('defaults to "granted"', () => {
       expect(validateAndBuildConfiguration({ clientToken: 'yes' })!.trackingConsent).toBe(TrackingConsent.GRANTED)

--- a/packages/browser-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-core/src/domain/configuration/configuration.ts
@@ -300,7 +300,6 @@ export interface Configuration {
   version?: string | undefined
   env?: string | undefined
   silentMultipleInit: boolean
-  allowUntrustedEvents: boolean
   trackingConsent: TrackingConsent
   storeContextsAcrossPages: boolean
   trackAnonymousUser?: boolean
@@ -392,7 +391,6 @@ export function validateAndBuildConfiguration(
     version: initConfiguration.version ?? undefined,
     datacenter: initConfiguration.datacenter ?? undefined,
     silentMultipleInit: !!initConfiguration.silentMultipleInit,
-    allowUntrustedEvents: !!initConfiguration.allowUntrustedEvents,
     trackingConsent: initConfiguration.trackingConsent ?? TrackingConsent.GRANTED,
     trackAnonymousUser: initConfiguration.trackAnonymousUser ?? true,
     storeContextsAcrossPages: !!initConfiguration.storeContextsAcrossPages,

--- a/packages/browser-core/src/domain/context/storeContextManager.spec.ts
+++ b/packages/browser-core/src/domain/context/storeContextManager.spec.ts
@@ -1,4 +1,3 @@
-import type { Configuration } from '../configuration'
 import { createNewEvent } from '../../../test'
 import { DOM_EVENT } from '../../browser/addEventListener'
 import type { Context } from '../../tools/serialisation/context'
@@ -10,12 +9,6 @@ describe('storeContextManager', () => {
   const PRODUCT_KEY = 'fake'
   const CUSTOMER_DATA_TYPE = CustomerDataType.User
   const STORAGE_KEY = buildStorageKey(PRODUCT_KEY, CUSTOMER_DATA_TYPE)
-
-  let configuration: Configuration
-
-  beforeEach(() => {
-    configuration = {} as Configuration
-  })
 
   afterEach(() => {
     localStorage.clear()
@@ -97,7 +90,7 @@ describe('storeContextManager', () => {
     if (initialContext) {
       manager.setContext(initialContext)
     }
-    storeContextManager(configuration, manager, productKey, customerDataType)
+    storeContextManager(manager, productKey, customerDataType)
     return manager
   }
 })

--- a/packages/browser-core/src/domain/context/storeContextManager.ts
+++ b/packages/browser-core/src/domain/context/storeContextManager.ts
@@ -1,6 +1,5 @@
 import { addEventListener, DOM_EVENT } from '../../browser/addEventListener'
 import type { Context } from '../../tools/serialisation/context'
-import type { Configuration } from '../configuration'
 import { combine } from '../../tools/mergeInto'
 import { isEmptyObject } from '../../tools/utils/objectUtils'
 import type { ContextManager } from './contextManager'
@@ -11,7 +10,6 @@ const CONTEXT_STORE_KEY_PREFIX = '_dd_c'
 const storageListeners: Array<{ stop: () => void }> = []
 
 export function storeContextManager(
-  configuration: Configuration,
   contextManager: ContextManager,
   productKey: string,
   customerDataType: CustomerDataType
@@ -24,7 +22,7 @@ export function storeContextManager(
   const storageKey = buildStorageKey(productKey, customerDataType)
 
   storageListeners.push(
-    addEventListener(configuration, window, DOM_EVENT.STORAGE, ({ key }) => {
+    addEventListener(window, DOM_EVENT.STORAGE, ({ key }) => {
       if (storageKey === key) {
         synchronizeWithStorage()
       }

--- a/packages/browser-core/src/domain/contexts/accountContext.ts
+++ b/packages/browser-core/src/domain/contexts/accountContext.ts
@@ -19,7 +19,7 @@ export function startAccountContext(assembleHook: Hook<any, any>, configuration:
   const accountContextManager = buildAccountContextManager()
 
   if (configuration.storeContextsAcrossPages) {
-    storeContextManager(configuration, accountContextManager, productKey, CustomerDataType.Account)
+    storeContextManager(accountContextManager, productKey, CustomerDataType.Account)
   }
 
   assembleHook.register(() => {

--- a/packages/browser-core/src/domain/contexts/globalContext.ts
+++ b/packages/browser-core/src/domain/contexts/globalContext.ts
@@ -13,7 +13,7 @@ export function startGlobalContext(
   const globalContextManager = buildGlobalContextManager()
 
   if (configuration.storeContextsAcrossPages) {
-    storeContextManager(configuration, globalContextManager, productKey, CustomerDataType.GlobalContext)
+    storeContextManager(globalContextManager, productKey, CustomerDataType.GlobalContext)
   }
 
   assembleHook.register(() => {

--- a/packages/browser-core/src/domain/contexts/userContext.ts
+++ b/packages/browser-core/src/domain/contexts/userContext.ts
@@ -25,7 +25,7 @@ export function startUserContext(
   const userContextManager = buildUserContextManager()
 
   if (configuration.storeContextsAcrossPages) {
-    storeContextManager(configuration, userContextManager, productKey, CustomerDataType.User)
+    storeContextManager(userContextManager, productKey, CustomerDataType.User)
   }
 
   hook.register(({ eventType, startTime }) => {

--- a/packages/browser-core/src/domain/report/reportObservable.spec.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.spec.ts
@@ -1,7 +1,6 @@
 import type { MockCspEventListener, MockReportingObserver } from '../../../test'
 import { mockReportingObserver, mockCspEventListener, FAKE_CSP_VIOLATION_EVENT } from '../../../test'
 import type { Subscription } from '../../tools/observable'
-import type { Configuration } from '../configuration'
 import { ErrorHandling, ErrorSource } from '../error/error.types'
 import type { RawReportError } from './reportObservable'
 import { initReportObservable, RawReportType } from './reportObservable'
@@ -11,13 +10,11 @@ describe('report observable', () => {
   let cspEventListener: MockCspEventListener
   let consoleSubscription: Subscription
   let notifyReport: jasmine.Spy<(reportError: RawReportError) => void>
-  let configuration: Configuration
 
   beforeEach(() => {
     if (!window.ReportingObserver) {
       pending('ReportingObserver not supported')
     }
-    configuration = {} as Configuration
     reportingObserver = mockReportingObserver()
     cspEventListener = mockCspEventListener()
     notifyReport = jasmine.createSpy('notifyReport')
@@ -28,7 +25,7 @@ describe('report observable', () => {
   })
   ;[RawReportType.deprecation, RawReportType.intervention].forEach((type) => {
     it(`should notify ${type} reports`, () => {
-      consoleSubscription = initReportObservable(configuration, [type]).subscribe(notifyReport)
+      consoleSubscription = initReportObservable([type]).subscribe(notifyReport)
       reportingObserver.raiseReport(type)
 
       const [report] = notifyReport.calls.mostRecent().args
@@ -43,7 +40,7 @@ describe('report observable', () => {
   })
 
   it(`should compute stack for ${RawReportType.intervention}`, () => {
-    consoleSubscription = initReportObservable(configuration, [RawReportType.intervention]).subscribe(notifyReport)
+    consoleSubscription = initReportObservable([RawReportType.intervention]).subscribe(notifyReport)
     reportingObserver.raiseReport(RawReportType.intervention)
 
     const [report] = notifyReport.calls.mostRecent().args
@@ -53,7 +50,7 @@ describe('report observable', () => {
   })
 
   it(`should notify ${RawReportType.cspViolation}`, () => {
-    consoleSubscription = initReportObservable(configuration, [RawReportType.cspViolation]).subscribe(notifyReport)
+    consoleSubscription = initReportObservable([RawReportType.cspViolation]).subscribe(notifyReport)
     cspEventListener.dispatchEvent()
 
     expect(notifyReport).toHaveBeenCalledOnceWith({
@@ -72,7 +69,7 @@ describe('report observable', () => {
   it(`should not notify ${RawReportType.cspViolation} when the event is not supported`, () => {
     ;(EventTarget.prototype.addEventListener as jasmine.Spy).and.throwError('unsupported')
 
-    consoleSubscription = initReportObservable(configuration, [RawReportType.cspViolation]).subscribe(notifyReport)
+    consoleSubscription = initReportObservable([RawReportType.cspViolation]).subscribe(notifyReport)
     cspEventListener.dispatchEvent()
 
     expect(notifyReport).not.toHaveBeenCalled()

--- a/packages/browser-core/src/domain/report/reportObservable.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.ts
@@ -4,7 +4,6 @@ import { monitor } from '../../tools/monitor'
 import { mergeObservables, Observable } from '../../tools/observable'
 import { addEventListener, DOM_EVENT, isEventSupported } from '../../browser/addEventListener'
 import { safeTruncate } from '../../tools/utils/stringUtils'
-import type { Configuration } from '../configuration'
 import type { RawError } from '../error/error.types'
 import { ErrorHandling, ErrorSource } from '../error/error.types'
 import type { ReportType, InterventionReport, DeprecationReport } from './browser.types'
@@ -21,11 +20,11 @@ export type RawReportError = RawError & {
   originalError: SecurityPolicyViolationEvent | DeprecationReport | InterventionReport
 }
 
-export function initReportObservable(configuration: Configuration, apis: RawReportType[]) {
+export function initReportObservable(apis: RawReportType[]) {
   const observables: Array<Observable<RawReportError>> = []
 
   if (apis.includes(RawReportType.cspViolation)) {
-    observables.push(createCspViolationReportObservable(configuration))
+    observables.push(createCspViolationReportObservable())
   }
 
   const reportTypes = apis.filter((api: RawReportType): api is ReportType => api !== RawReportType.cspViolation)
@@ -58,14 +57,14 @@ function createReportObservable(reportTypes: ReportType[]) {
   })
 }
 
-function createCspViolationReportObservable(configuration: Configuration) {
+function createCspViolationReportObservable() {
   return new Observable<RawReportError>((observable) => {
     // Salesforce does not allow to add a securitypolicyviolation event listener. https://developer.salesforce.com/tools/lws-distortion-viewer
     if (!isEventSupported(document, DOM_EVENT.SECURITY_POLICY_VIOLATION)) {
       return
     }
 
-    const { stop } = addEventListener(configuration, document, DOM_EVENT.SECURITY_POLICY_VIOLATION, (event) => {
+    const { stop } = addEventListener(document, DOM_EVENT.SECURITY_POLICY_VIOLATION, (event) => {
       observable.notify(buildRawReportErrorFromCspViolation(event))
     })
 

--- a/packages/browser-core/src/domain/session/sessionManager.ts
+++ b/packages/browser-core/src/domain/session/sessionManager.ts
@@ -195,17 +195,17 @@ export async function startSessionManager(
     })
 
     if (!isWorkerEnvironment) {
-      trackActivity(configuration, () => {
+      trackActivity(() => {
         if (trackingConsentState.isGranted()) {
           throttledExpandOrRenew()
         }
       })
-      trackVisibility(configuration, () => {
+      trackVisibility(() => {
         if (!sessionExpired) {
           strategy.setSessionState((state) => expandOnly(state), 'expandOnVisibility').catch(monitorError)
         }
       })
-      trackResume(configuration, () => {
+      trackResume(() => {
         strategy
           .setSessionState((state) => initializeSession(state, configuration), 'initializeOnResume')
           .catch(monitorError)
@@ -335,9 +335,8 @@ export function stopSessionManager() {
   stopCallbacks = []
 }
 
-function trackActivity(configuration: Configuration, expandOrRenewSession: () => void) {
+function trackActivity(expandOrRenewSession: () => void) {
   const { stop } = addEventListeners(
-    configuration,
     window,
     [DOM_EVENT.CLICK, DOM_EVENT.TOUCH_START, DOM_EVENT.KEY_DOWN, DOM_EVENT.SCROLL],
     expandOrRenewSession,
@@ -346,14 +345,14 @@ function trackActivity(configuration: Configuration, expandOrRenewSession: () =>
   stopCallbacks.push(stop)
 }
 
-function trackVisibility(configuration: Configuration, expandSession: () => void) {
+function trackVisibility(expandSession: () => void) {
   const expandSessionWhenVisible = () => {
     if (document.visibilityState === 'visible') {
       expandSession()
     }
   }
 
-  const { stop } = addEventListener(configuration, document, DOM_EVENT.VISIBILITY_CHANGE, expandSessionWhenVisible)
+  const { stop } = addEventListener(document, DOM_EVENT.VISIBILITY_CHANGE, expandSessionWhenVisible)
   stopCallbacks.push(stop)
 
   const visibilityCheckInterval = setInterval(expandSessionWhenVisible, VISIBILITY_CHECK_DELAY)
@@ -362,7 +361,7 @@ function trackVisibility(configuration: Configuration, expandSession: () => void
   })
 }
 
-function trackResume(configuration: Configuration, cb: () => void) {
-  const { stop } = addEventListener(configuration, window, DOM_EVENT.RESUME, cb, { capture: true })
+function trackResume(cb: () => void) {
+  const { stop } = addEventListener(window, DOM_EVENT.RESUME, cb, { capture: true })
   stopCallbacks.push(stop)
 }

--- a/packages/browser-core/src/domain/session/sessionStore.ts
+++ b/packages/browser-core/src/domain/session/sessionStore.ts
@@ -75,7 +75,7 @@ export function getSessionStoreStrategy(
     case SessionPersistence.COOKIE:
       return initCookieStrategy(sessionStoreStrategyType, configuration)
     case SessionPersistence.LOCAL_STORAGE:
-      return initLocalStorageStrategy(configuration)
+      return initLocalStorageStrategy()
     case SessionPersistence.MEMORY:
       return initMemorySessionStoreStrategy()
   }

--- a/packages/browser-core/src/domain/session/storeStrategies/sessionInCookie.ts
+++ b/packages/browser-core/src/domain/session/storeStrategies/sessionInCookie.ts
@@ -33,11 +33,11 @@ export async function selectCookieStrategy(
     return undefined
   }
 
-  if (isCookieStoreSupported() && (await areCookiesAuthorized(createCookieStoreAccess, cookieOptions, configuration))) {
+  if (isCookieStoreSupported() && (await areCookiesAuthorized(createCookieStoreAccess, cookieOptions))) {
     return { type: SessionPersistence.COOKIE, cookieOptions, cookieApi: CookieApi.COOKIE_STORE }
   }
 
-  if (await areCookiesAuthorized(createDocumentCookieAccess, cookieOptions, configuration)) {
+  if (await areCookiesAuthorized(createDocumentCookieAccess, cookieOptions)) {
     return { type: SessionPersistence.COOKIE, cookieOptions, cookieApi: CookieApi.DOCUMENT_COOKIE }
   }
 
@@ -55,7 +55,7 @@ export function initCookieStrategy(
   const sessionObservable = new Observable<SessionState>()
   const trackAnonymousUser = !!configuration.trackAnonymousUser
   const opts = encodeCookieOptions(cookieOptions)
-  const cookieAccess = mockable(createCookieAccess)(cookieApi, configuration, cookieOptions)
+  const cookieAccess = mockable(createCookieAccess)(cookieApi, cookieOptions)
   let isFirstCall = true
 
   cookieAccess.observable.subscribe(() => {
@@ -117,13 +117,9 @@ function isContextGoingAwayError(error: unknown): boolean {
   return error.name === 'AbortError' || error.message.includes('no longer runnable')
 }
 
-export function createCookieAccess(
-  cookieApi: CookieApi,
-  configuration: Configuration,
-  cookieOptions: CookieOptions
-): CookieAccess {
+export function createCookieAccess(cookieApi: CookieApi, cookieOptions: CookieOptions): CookieAccess {
   return cookieApi === CookieApi.COOKIE_STORE
-    ? createCookieStoreAccess(SESSION_STORE_KEY, cookieOptions, configuration)
+    ? createCookieStoreAccess(SESSION_STORE_KEY, cookieOptions)
     : createDocumentCookieAccess(SESSION_STORE_KEY, cookieOptions)
 }
 

--- a/packages/browser-core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
+++ b/packages/browser-core/src/domain/session/storeStrategies/sessionInLocalStorage.spec.ts
@@ -1,11 +1,9 @@
 import { registerCleanupTask } from '../../../../test'
-import type { Configuration } from '../../configuration'
+import type { TrustableEvent } from '../../../browser/addEventListener'
 import type { SessionState } from '../sessionState'
 import { toSessionString } from '../sessionState'
 import { initLocalStorageStrategy, selectLocalStorageStrategy } from './sessionInLocalStorage'
 import { LEGACY_SESSION_STORE_KEY, SESSION_STORE_KEY } from './sessionStoreStrategy'
-
-const MOCK_CONFIGURATION = { allowUntrustedEvents: true } as Configuration
 
 describe('LocalStorage SessionStoreStrategy', () => {
   let strategy: ReturnType<typeof initLocalStorageStrategy>
@@ -13,7 +11,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
   beforeEach(() => {
     localStorage.removeItem(SESSION_STORE_KEY)
     localStorage.removeItem(LEGACY_SESSION_STORE_KEY)
-    strategy = initLocalStorageStrategy(MOCK_CONFIGURATION)
+    strategy = initLocalStorageStrategy()
     registerCleanupTask(() => {
       localStorage.removeItem(SESSION_STORE_KEY)
       localStorage.removeItem(LEGACY_SESSION_STORE_KEY)
@@ -71,6 +69,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
         newValue: toSessionString({ id: 'from-other-tab' }),
         storageArea: localStorage,
       })
+      ;(event as TrustableEvent).__ddIsTrusted = true
       window.dispatchEvent(event)
 
       expect(spy).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: 'from-other-tab' }))
@@ -86,6 +85,7 @@ describe('LocalStorage SessionStoreStrategy', () => {
         newValue: 'value',
         storageArea: localStorage,
       })
+      ;(event as TrustableEvent).__ddIsTrusted = true
       window.dispatchEvent(event)
 
       expect(spy).not.toHaveBeenCalled()

--- a/packages/browser-core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
+++ b/packages/browser-core/src/domain/session/storeStrategies/sessionInLocalStorage.ts
@@ -1,7 +1,6 @@
 import { generateUUID } from '../../../tools/utils/stringUtils'
 import { Observable } from '../../../tools/observable'
 import { addEventListener } from '../../../browser/addEventListener'
-import type { Configuration } from '../../configuration'
 import { SessionPersistence } from '../sessionConstants'
 import type { SessionState } from '../sessionState'
 import { isSessionInNotStartedState, toSessionString, toSessionState } from '../sessionState'
@@ -23,10 +22,10 @@ export function selectLocalStorageStrategy(): SessionStoreStrategyType | undefin
   }
 }
 
-export function initLocalStorageStrategy(configuration: Configuration): SessionStoreStrategy {
+export function initLocalStorageStrategy(): SessionStoreStrategy {
   const sessionObservable = new Observable<SessionState>(
     (observable) =>
-      addEventListener(configuration, window, 'storage', (event) => {
+      addEventListener(window, 'storage', (event) => {
         if (event.key === SESSION_STORE_KEY && event.storageArea === localStorage) {
           observable.notify(toSessionState(event.newValue))
         }

--- a/packages/browser-core/src/domain/telemetry/telemetry.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetry.ts
@@ -224,7 +224,7 @@ export function startTelemetryTransport(
         noop
       ),
       flushController: createFlushController({
-        pageMayExitObservable: createPageMayExitObservable(configuration),
+        pageMayExitObservable: createPageMayExitObservable(),
 
         // We don't use an actual session expire observable here, to make telemetry collection
         // independent of the session. This allows to start and send telemetry events earlier.

--- a/packages/browser-core/test/forEach.spec.ts
+++ b/packages/browser-core/test/forEach.spec.ts
@@ -10,6 +10,7 @@ import { resetInteractionCountPolyfill } from '../../browser-rum-core/src/domain
 import { resetMonitor } from '../src/tools/monitor'
 import { resetTelemetry } from '../src/domain/telemetry'
 import { resetSampleDecisionCache } from '../src/domain/sampler'
+import { resetAllowUntrustedEvents } from '../src/browser/addEventListener'
 import { startLeakDetection } from './leakDetection'
 import type { BuildEnvWindow } from './buildEnv'
 ;(window as unknown as BuildEnvWindow).__BUILD_ENV__SDK_VERSION__ = 'test'
@@ -41,6 +42,7 @@ afterEach(() => {
   resetSampleDecisionCache()
   resetExperimentalFeatures()
   resetManageResourceTimingBufferFull()
+  resetAllowUntrustedEvents()
 })
 
 function clearAllCookies() {

--- a/packages/browser-debugger/src/transport/startDebuggerBatch.ts
+++ b/packages/browser-debugger/src/transport/startDebuggerBatch.ts
@@ -42,8 +42,8 @@ function createSimplePageMayExitObservable(): Observable<PageMayExitEvent> {
       observable.notify({ reason: PageExitReason.UNLOADING })
     }
 
-    const visibilityListener = addEventListener({}, window, 'visibilitychange', onVisibilityChange, { capture: true })
-    const unloadListener = addEventListener({}, window, 'beforeunload', onBeforeUnload)
+    const visibilityListener = addEventListener(window, 'visibilitychange', onVisibilityChange, { capture: true })
+    const unloadListener = addEventListener(window, 'beforeunload', onBeforeUnload)
 
     return () => {
       visibilityListener.stop()

--- a/packages/browser-logs/src/boot/preStartLogs.ts
+++ b/packages/browser-logs/src/boot/preStartLogs.ts
@@ -21,6 +21,7 @@ import {
   TelemetryService,
   mockable,
   startTelemetrySessionContext,
+  setAllowUntrustedEvents,
 } from '@datadog/browser-core'
 import type { Hooks } from '../domain/hooks'
 import { createHooks } from '../domain/hooks'
@@ -84,6 +85,7 @@ export function createPreStartStrategy(
       }
       // Set the experimental feature flags as early as possible, so we can use them in most places
       initFeatureFlags(initConfiguration.enableExperimentalFeatures)
+      setAllowUntrustedEvents(initConfiguration.allowUntrustedEvents)
 
       if (canUseEventBridge()) {
         initConfiguration = overrideInitConfigurationForBridge(initConfiguration)

--- a/packages/browser-logs/src/boot/startLogs.ts
+++ b/packages/browser-logs/src/boot/startLogs.ts
@@ -43,7 +43,7 @@ export function startLogs(
   lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (log) => sendToExtension('logs', log))
 
   const reportError = startReportError(lifeCycle)
-  const pageMayExitObservable = createPageMayExitObservable(configuration)
+  const pageMayExitObservable = createPageMayExitObservable()
 
   // Start user and account context first to allow overrides from global context
   const assembleHook = hooks.assemble

--- a/packages/browser-logs/src/domain/report/reportCollection.ts
+++ b/packages/browser-logs/src/domain/report/reportCollection.ts
@@ -16,7 +16,7 @@ export interface ProvidedError {
 }
 
 export function startReportCollection(configuration: LogsConfiguration, lifeCycle: LifeCycle) {
-  const reportSubscription = initReportObservable(configuration, configuration.forwardReports).subscribe((rawError) => {
+  const reportSubscription = initReportObservable(configuration.forwardReports).subscribe((rawError) => {
     let message = rawError.message
     let error
     const status = rawError.originalError.type === 'deprecation' ? StatusType.warn : StatusType.error

--- a/packages/browser-rum-core/src/boot/preStartRum.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.ts
@@ -26,6 +26,7 @@ import {
   isWorkerEnvironment,
   startTelemetrySessionContext,
   addTelemetryDebug,
+  setAllowUntrustedEvents,
 } from '@datadog/browser-core'
 import type { Hooks } from '../domain/hooks'
 import { createHooks } from '../domain/hooks'
@@ -228,6 +229,7 @@ export function createPreStartStrategy(
       }
       // Set the experimental feature flags as early as possible, so we can use them in most places
       initFeatureFlags(initConfiguration.enableExperimentalFeatures)
+      setAllowUntrustedEvents(initConfiguration.allowUntrustedEvents)
 
       // Expose the initial configuration regardless of initialization success.
       cachedInitConfiguration = initConfiguration

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -594,11 +594,7 @@ export interface RumPublicApiOptions {
     source: string,
     onInitializationFailure: () => void
   ) => DeflateWorker | undefined
-  createDeflateEncoder?: (
-    configuration: RumConfiguration,
-    worker: DeflateWorker,
-    streamId: DeflateEncoderStreamId
-  ) => DeflateEncoder
+  createDeflateEncoder?: (worker: DeflateWorker, streamId: DeflateEncoderStreamId) => DeflateEncoder
   sdkName?: SdkName
 }
 
@@ -647,7 +643,7 @@ export function makeRumPublicApi(
     (configuration, sessionManager, deflateWorker, initialViewOptions, telemetry, hooks) => {
       const createEncoder =
         deflateWorker && options.createDeflateEncoder
-          ? (streamId: DeflateEncoderStreamId) => options.createDeflateEncoder!(configuration, deflateWorker, streamId)
+          ? (streamId: DeflateEncoderStreamId) => options.createDeflateEncoder!(deflateWorker, streamId)
           : createIdentityEncoder
 
       const startRumResult = mockable(startRum)(

--- a/packages/browser-rum-core/src/boot/startRum.ts
+++ b/packages/browser-rum-core/src/boot/startRum.ts
@@ -82,7 +82,7 @@ export function startRum(
     addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
   }
 
-  const pageMayExitObservable = createPageMayExitObservable(configuration)
+  const pageMayExitObservable = createPageMayExitObservable()
 
   if (!canUseEventBridge()) {
     const batch = startRumBatch(
@@ -154,14 +154,13 @@ export function startRumEventCollection(
   const cleanupTasks: Array<() => void> = []
 
   const domMutationObservable = createDOMMutationObservable()
-  const locationChangeObservable = createLocationChangeObservable(configuration)
+  const locationChangeObservable = createLocationChangeObservable()
   const { observable: windowOpenObservable, stop: stopWindowOpen } = createWindowOpenObservable()
   cleanupTasks.push(stopWindowOpen)
 
   const { assemble: assembleHook } = hooks
-
   startDefaultContext(assembleHook, configuration, sdkName)
-  const pageStateHistory = startPageStateHistory(assembleHook, configuration)
+  const pageStateHistory = startPageStateHistory(assembleHook)
   cleanupTasks.push(() => pageStateHistory.stop())
   const viewHistory = startViewHistory(lifeCycle)
   cleanupTasks.push(() => viewHistory.stop())
@@ -186,9 +185,9 @@ export function startRumEventCollection(
 
   const eventCollection = startEventCollection(lifeCycle)
 
-  const displayContext = startDisplayContext(assembleHook, configuration)
+  const displayContext = startDisplayContext(assembleHook)
   cleanupTasks.push(displayContext.stop)
-  const ciVisibilityContext = startCiVisibilityContext(configuration, assembleHook)
+  const ciVisibilityContext = startCiVisibilityContext(assembleHook)
   cleanupTasks.push(ciVisibilityContext.stop)
   startSyntheticsContext(assembleHook)
 
@@ -225,7 +224,7 @@ export function startRumEventCollection(
   const { stop: stopLongTaskCollection } = startLongTaskCollection(lifeCycle, configuration)
   cleanupTasks.push(stopLongTaskCollection)
 
-  const { addError } = startErrorCollection(lifeCycle, configuration, bufferedDataObservable)
+  const { addError } = startErrorCollection(lifeCycle, bufferedDataObservable)
 
   startRequestCollection(lifeCycle, configuration, sessionManager, userContext, accountContext, bufferedDataObservable)
 

--- a/packages/browser-rum-core/src/browser/cookieObservable.spec.ts
+++ b/packages/browser-rum-core/src/browser/cookieObservable.spec.ts
@@ -3,7 +3,6 @@ import { ONE_MINUTE } from '@datadog/js-core/time'
 import { deleteCookie, globalObject, setCookie } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../test'
 import { WATCH_COOKIE_INTERVAL_DELAY, createCookieObservable } from './cookieObservable'
 
 const COOKIE_NAME = 'cookie_name'
@@ -27,7 +26,7 @@ describe('cookieObservable', () => {
   })
 
   it('should notify observers on cookie change', async () => {
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+    const observable = createCookieObservable(COOKIE_NAME)
 
     const cookieChangePromise = new Promise((resolve) => {
       subscription = observable.subscribe(resolve)
@@ -52,7 +51,7 @@ describe('cookieObservable', () => {
 
   it('should notify observers on cookie change when cookieStore is not supported', () => {
     Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+    const observable = createCookieObservable(COOKIE_NAME)
 
     let cookieChange: string | undefined
     subscription = observable.subscribe((change) => (cookieChange = change))
@@ -65,7 +64,7 @@ describe('cookieObservable', () => {
 
   it('should not notify observers on cookie change when the cookie value as not changed when cookieStore is not supported', () => {
     Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+    const observable = createCookieObservable(COOKIE_NAME)
 
     setCookie(COOKIE_NAME, 'foo', COOKIE_DURATION)
 
@@ -80,7 +79,7 @@ describe('cookieObservable', () => {
 
   it('should not re-notify observers if the cookie has not changed since last notification when cookieStore is not supported', () => {
     Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+    const observable = createCookieObservable(COOKIE_NAME)
 
     const cookieChanges: Array<string | undefined> = []
     subscription = observable.subscribe((change) => cookieChanges.push(change))
@@ -94,7 +93,7 @@ describe('cookieObservable', () => {
 
   it('should notify observers on consecutive cookie changes when cookieStore is not supported', () => {
     Object.defineProperty(window, 'cookieStore', { get: () => undefined, configurable: true })
-    const observable = createCookieObservable(mockRumConfiguration(), COOKIE_NAME)
+    const observable = createCookieObservable(COOKIE_NAME)
 
     const cookieChanges: Array<string | undefined> = []
     subscription = observable.subscribe((change) => cookieChanges.push(change))

--- a/packages/browser-rum-core/src/browser/cookieObservable.ts
+++ b/packages/browser-rum-core/src/browser/cookieObservable.ts
@@ -1,5 +1,4 @@
 import { ONE_SECOND } from '@datadog/js-core/time'
-import type { Configuration } from '@datadog/browser-core'
 import {
   setInterval,
   clearInterval,
@@ -13,19 +12,17 @@ import {
 
 export type CookieObservable = ReturnType<typeof createCookieObservable>
 
-export function createCookieObservable(configuration: Configuration, cookieName: string) {
-  const detectCookieChangeStrategy = isCookieStoreSupported()
-    ? listenToCookieStoreChange(configuration)
-    : watchCookieFallback
+export function createCookieObservable(cookieName: string) {
+  const detectCookieChangeStrategy = isCookieStoreSupported() ? listenToCookieStoreChange() : watchCookieFallback
 
   return new Observable<string | undefined>((observable) =>
     detectCookieChangeStrategy(cookieName, (event) => observable.notify(event))
   )
 }
 
-function listenToCookieStoreChange(configuration: Configuration) {
+function listenToCookieStoreChange() {
   return (cookieName: string, callback: (event: string | undefined) => void) => {
-    const listener = addEventListener(configuration, globalObject.cookieStore!, DOM_EVENT.CHANGE, (event) => {
+    const listener = addEventListener(globalObject.cookieStore!, DOM_EVENT.CHANGE, (event) => {
       // Based on our experimentation, we're assuming that entries for the same cookie cannot be in both the 'changed' and 'deleted' arrays.
       // However, due to ambiguity in the specification, we asked for clarification: https://github.com/WICG/cookie-store/issues/226
       const changeEvent =

--- a/packages/browser-rum-core/src/browser/locationChangeObservable.spec.ts
+++ b/packages/browser-rum-core/src/browser/locationChangeObservable.spec.ts
@@ -1,6 +1,5 @@
 import { globalObject } from '@datadog/browser-core'
 import { buildLocation, registerCleanupTask, replaceMockable } from '@datadog/browser-core/test'
-import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { createLocationChangeObservable } from './locationChangeObservable'
 
 describe('locationChangeObservable', () => {
@@ -81,7 +80,7 @@ function setup() {
 
   history.pushState({}, '', '/foo')
 
-  const observable = createLocationChangeObservable({} as RumConfiguration)
+  const observable = createLocationChangeObservable()
   const observer = jasmine.createSpy('obs')
   const subscription = observable.subscribe(observer)
 

--- a/packages/browser-rum-core/src/browser/locationChangeObservable.ts
+++ b/packages/browser-rum-core/src/browser/locationChangeObservable.ts
@@ -7,19 +7,18 @@ import {
   Observable,
   shallowClone,
 } from '@datadog/browser-core'
-import type { RumConfiguration } from '../domain/configuration'
 
 export interface LocationChange {
   oldLocation: Readonly<Location>
   newLocation: Readonly<Location>
 }
 
-export function createLocationChangeObservable(configuration: RumConfiguration) {
+export function createLocationChangeObservable() {
   let currentLocation = shallowClone(getLocation())
 
   return new Observable<LocationChange>((observable) => {
-    const { stop: stopHistoryTracking } = trackHistory(configuration, onLocationChange)
-    const { stop: stopHashTracking } = trackHash(configuration, onLocationChange)
+    const { stop: stopHistoryTracking } = trackHistory(onLocationChange)
+    const { stop: stopHashTracking } = trackHash(onLocationChange)
 
     function onLocationChange() {
       if (currentLocation.href === getLocation().href) {
@@ -44,7 +43,7 @@ function getLocation() {
   return mockable(globalObject.location)
 }
 
-function trackHistory(configuration: RumConfiguration, onHistoryChange: () => void) {
+function trackHistory(onHistoryChange: () => void) {
   const { stop: stopInstrumentingPushState } = instrumentMethod(
     getHistoryInstrumentationTarget('pushState'),
     'pushState',
@@ -59,7 +58,7 @@ function trackHistory(configuration: RumConfiguration, onHistoryChange: () => vo
       onPostCall(onHistoryChange)
     }
   )
-  const { stop: removeListener } = addEventListener(configuration, window, DOM_EVENT.POP_STATE, onHistoryChange)
+  const { stop: removeListener } = addEventListener(window, DOM_EVENT.POP_STATE, onHistoryChange)
 
   return {
     stop: () => {
@@ -70,8 +69,8 @@ function trackHistory(configuration: RumConfiguration, onHistoryChange: () => vo
   }
 }
 
-function trackHash(configuration: RumConfiguration, onHashChange: () => void) {
-  return addEventListener(configuration, window, DOM_EVENT.HASH_CHANGE, onHashChange)
+function trackHash(onHashChange: () => void) {
+  return addEventListener(window, DOM_EVENT.HASH_CHANGE, onHashChange)
 }
 
 function getHistoryInstrumentationTarget(methodName: 'pushState' | 'replaceState') {

--- a/packages/browser-rum-core/src/browser/performanceObservable.spec.ts
+++ b/packages/browser-rum-core/src/browser/performanceObservable.spec.ts
@@ -2,12 +2,11 @@ import type { Subscription } from '@datadog/browser-core'
 import type { Duration } from '@datadog/js-core/time'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock } from '@datadog/browser-core/test'
-import { createPerformanceEntry, mockPerformanceObserver, mockRumConfiguration } from '../../test'
+import { createPerformanceEntry, mockPerformanceObserver } from '../../test'
 import { RumPerformanceEntryType, createPerformanceObservable } from './performanceObservable'
 
 describe('performanceObservable', () => {
   let performanceSubscription: Subscription | undefined
-  const configuration = mockRumConfiguration()
   const forbiddenUrl = 'https://forbidden.url/abce?ddsource=browser&dd-api-key=xxxx&dd-request-id=1234567890'
   const allowedUrl = 'https://allowed.url'
   let observableCallback: jasmine.Spy
@@ -24,7 +23,7 @@ describe('performanceObservable', () => {
 
   it('should notify performance resources', () => {
     const { notifyPerformanceEntries } = mockPerformanceObserver()
-    const performanceResourceObservable = createPerformanceObservable(configuration, {
+    const performanceResourceObservable = createPerformanceObservable({
       type: RumPerformanceEntryType.RESOURCE,
     })
     performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
@@ -35,7 +34,7 @@ describe('performanceObservable', () => {
 
   it('should not notify performance resources with intake url', () => {
     const { notifyPerformanceEntries } = mockPerformanceObserver()
-    const performanceResourceObservable = createPerformanceObservable(configuration, {
+    const performanceResourceObservable = createPerformanceObservable({
       type: RumPerformanceEntryType.RESOURCE,
     })
     performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
@@ -46,7 +45,7 @@ describe('performanceObservable', () => {
 
   it('should not notify performance resources with invalid duration', () => {
     const { notifyPerformanceEntries } = mockPerformanceObserver()
-    const performanceResourceObservable = createPerformanceObservable(configuration, {
+    const performanceResourceObservable = createPerformanceObservable({
       type: RumPerformanceEntryType.RESOURCE,
     })
     performanceSubscription = performanceResourceObservable.subscribe(observableCallback)
@@ -59,7 +58,7 @@ describe('performanceObservable', () => {
     const { notifyPerformanceEntries } = mockPerformanceObserver()
     notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.RESOURCE, { name: allowedUrl })])
 
-    const performanceResourceObservable = createPerformanceObservable(configuration, {
+    const performanceResourceObservable = createPerformanceObservable({
       type: RumPerformanceEntryType.RESOURCE,
       buffered: true,
     })

--- a/packages/browser-rum-core/src/browser/performanceObservable.ts
+++ b/packages/browser-rum-core/src/browser/performanceObservable.ts
@@ -1,7 +1,6 @@
 import type { RelativeTime, Duration } from '@datadog/js-core/time'
 import type { TimeoutId } from '@datadog/browser-core'
 import { addEventListener, Observable, setTimeout, clearTimeout, monitor } from '@datadog/browser-core'
-import type { RumConfiguration } from '../domain/configuration'
 import { hasValidResourceEntryDuration, isAllowedRequestUrl } from '../domain/resource/resourceUtils'
 
 type RumPerformanceObserverConstructor = new (callback: PerformanceObserverCallback) => RumPerformanceObserver
@@ -204,10 +203,11 @@ export interface EntryTypeToReturnType {
   [RumPerformanceEntryType.VISIBILITY_STATE]: RumFirstHiddenTiming
 }
 
-export function createPerformanceObservable<T extends RumPerformanceEntryType>(
-  configuration: RumConfiguration,
-  options: { type: T; buffered?: boolean; durationThreshold?: number }
-) {
+export function createPerformanceObservable<T extends RumPerformanceEntryType>(options: {
+  type: T
+  buffered?: boolean
+  durationThreshold?: number
+}) {
   return new Observable<Array<EntryTypeToReturnType[T]>>((observable) => {
     const handlePerformanceEntries = (entries: PerformanceEntryList) => {
       const rumPerformanceEntries = filterRumPerformanceEntries(entries as Array<EntryTypeToReturnType[T]>)
@@ -232,7 +232,7 @@ export function createPerformanceObservable<T extends RumPerformanceEntryType>(
     observer.observe(options)
     isObserverInitializing = false
 
-    manageResourceTimingBufferFull(configuration)
+    manageResourceTimingBufferFull()
 
     return () => {
       observer.disconnect()
@@ -242,10 +242,10 @@ export function createPerformanceObservable<T extends RumPerformanceEntryType>(
 }
 
 let resourceTimingBufferFullListener: { stop: () => void } | undefined
-function manageResourceTimingBufferFull(configuration: RumConfiguration) {
+function manageResourceTimingBufferFull() {
   if (!resourceTimingBufferFullListener && supportPerformanceObject() && 'addEventListener' in performance) {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1559377
-    resourceTimingBufferFullListener = addEventListener(configuration, performance, 'resourcetimingbufferfull', () => {
+    resourceTimingBufferFullListener = addEventListener(performance, 'resourcetimingbufferfull', () => {
       performance.clearResourceTimings()
     })
   }

--- a/packages/browser-rum-core/src/browser/viewportObservable.spec.ts
+++ b/packages/browser-rum-core/src/browser/viewportObservable.spec.ts
@@ -1,7 +1,6 @@
 import type { Subscription } from '@datadog/browser-core/src/tools/observable'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, createNewEvent, registerCleanupTask, waitAfterNextPaint } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../test'
 import type { ViewportDimension } from './viewportObservable'
 import { getViewportDimension, initViewportObservable } from './viewportObservable'
 
@@ -9,10 +8,9 @@ describe('viewportObservable', () => {
   let viewportSubscription: Subscription
   let viewportDimension: ViewportDimension
   let clock: Clock
-  const configuration = mockRumConfiguration()
 
   beforeEach(() => {
-    viewportSubscription = initViewportObservable(configuration).subscribe((dimension) => {
+    viewportSubscription = initViewportObservable().subscribe((dimension) => {
       viewportDimension = dimension
     })
     clock = mockClock()

--- a/packages/browser-rum-core/src/browser/viewportObservable.ts
+++ b/packages/browser-rum-core/src/browser/viewportObservable.ts
@@ -1,5 +1,4 @@
 import { Observable, throttle, addEventListener, DOM_EVENT } from '@datadog/browser-core'
-import type { RumConfiguration } from '../domain/configuration'
 
 export interface ViewportDimension {
   height: number
@@ -9,21 +8,20 @@ export interface ViewportDimension {
 
 let viewportObservable: Observable<ViewportDimension> | undefined
 
-export function initViewportObservable(configuration: RumConfiguration) {
+export function initViewportObservable() {
   if (!viewportObservable) {
-    viewportObservable = createViewportObservable(configuration)
+    viewportObservable = createViewportObservable()
   }
   return viewportObservable
 }
 
-export function createViewportObservable(configuration: RumConfiguration) {
+export function createViewportObservable() {
   return new Observable<ViewportDimension>((observable) => {
     const { throttled: updateDimension } = throttle(() => {
       observable.notify(getViewportDimension())
     }, 200)
 
-    return addEventListener(configuration, window, DOM_EVENT.RESIZE, updateDimension, { capture: true, passive: true })
-      .stop
+    return addEventListener(window, DOM_EVENT.RESIZE, updateDimension, { capture: true, passive: true }).stop
   })
 }
 

--- a/packages/browser-rum-core/src/domain/action/listenActionEvents.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/listenActionEvents.spec.ts
@@ -1,5 +1,4 @@
 import { createNewEvent } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../../test'
 import type { ActionEventsHooks } from './listenActionEvents'
 import { listenActionEvents } from './listenActionEvents'
 
@@ -15,7 +14,7 @@ describe('listenActionEvents', () => {
       onPointerUp: jasmine.createSpy(),
       onPointerDown: jasmine.createSpy().and.returnValue({}),
     }
-    ;({ stop: stopListenEvents } = listenActionEvents(mockRumConfiguration(), actionEventsHooks))
+    ;({ stop: stopListenEvents } = listenActionEvents(actionEventsHooks))
   })
 
   afterEach(() => {

--- a/packages/browser-rum-core/src/domain/action/listenActionEvents.ts
+++ b/packages/browser-rum-core/src/domain/action/listenActionEvents.ts
@@ -1,6 +1,5 @@
 import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 import type { RelativeTime } from '@datadog/js-core/time'
-import type { RumConfiguration } from '../configuration'
 
 export interface ExtraPointerEventFields {
   target: Element
@@ -18,10 +17,7 @@ export interface ActionEventsHooks<ClickContext> {
   onPointerUp: (context: ClickContext, event: MouseEventOnElement, getUserActivity: () => UserActivity) => void
 }
 
-export function listenActionEvents<ClickContext>(
-  configuration: RumConfiguration,
-  { onPointerDown, onPointerUp }: ActionEventsHooks<ClickContext>
-) {
+export function listenActionEvents<ClickContext>({ onPointerDown, onPointerUp }: ActionEventsHooks<ClickContext>) {
   let selectionEmptyAtPointerDown: boolean
   let userActivity: UserActivity = {
     selection: false,
@@ -32,7 +28,6 @@ export function listenActionEvents<ClickContext>(
 
   const listeners = [
     addEventListener(
-      configuration,
       window,
       DOM_EVENT.POINTER_DOWN,
       (event: PointerEvent) => {
@@ -50,7 +45,6 @@ export function listenActionEvents<ClickContext>(
     ),
 
     addEventListener(
-      configuration,
       window,
       DOM_EVENT.SELECTION_CHANGE,
       () => {
@@ -62,7 +56,6 @@ export function listenActionEvents<ClickContext>(
     ),
 
     addEventListener(
-      configuration,
       window,
       DOM_EVENT.SCROLL,
       () => {
@@ -72,7 +65,6 @@ export function listenActionEvents<ClickContext>(
     ),
 
     addEventListener(
-      configuration,
       window,
       DOM_EVENT.POINTER_UP,
       (event: PointerEvent) => {
@@ -87,7 +79,6 @@ export function listenActionEvents<ClickContext>(
     ),
 
     addEventListener(
-      configuration,
       window,
       DOM_EVENT.INPUT,
       () => {

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.ts
@@ -67,7 +67,7 @@ export function trackClickActions(
   const { stop: stopActionEventsListener } = listenActionEvents<{
     clickActionBase: ClickActionBase
     hadActivityOnPointerDown: () => boolean
-  }>(configuration, {
+  }>({
     onPointerDown: (pointerDownEvent) =>
       processPointerDown(configuration, lifeCycle, domMutationObservable, pointerDownEvent, windowOpenObservable),
     onPointerUp: ({ clickActionBase, hadActivityOnPointerDown }, startEvent, getUserActivity) => {

--- a/packages/browser-rum-core/src/domain/contexts/ciVisibilityContext.spec.ts
+++ b/packages/browser-rum-core/src/domain/contexts/ciVisibilityContext.spec.ts
@@ -1,5 +1,4 @@
 import type { RelativeTime } from '@datadog/js-core/time'
-import type { Configuration } from '@datadog/browser-core'
 import { display, Observable, createHook } from '@datadog/browser-core'
 import { mockCiVisibilityValues } from '../../../test'
 import type { CookieObservable } from '../../browser/cookieObservable'
@@ -24,7 +23,7 @@ describe('startCiVisibilityContext', () => {
   describe('assemble hook', () => {
     it('should set ci visibility context defined by Cypress global variables', () => {
       mockCiVisibilityValues('trace_id_value')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
 
       const defaultRumEventAttributes = hook.trigger({
         eventType: 'view',
@@ -44,7 +43,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should add the ci visibility context defined by global cookie', () => {
       mockCiVisibilityValues('trace_id_value', 'cookies')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
 
       const defaultRumEventAttributes = hook.trigger({
         eventType: 'view',
@@ -64,7 +63,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should update the ci visibility context when global cookie is updated', () => {
       mockCiVisibilityValues('trace_id_value', 'cookies')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
       cookieObservable.notify('trace_id_value_updated')
 
       const defaultRumEventAttributes = hook.trigger({
@@ -85,7 +84,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should not set ci visibility context if the Cypress global variable is undefined', () => {
       mockCiVisibilityValues(undefined)
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
 
       const defaultRumEventAttributes = hook.trigger({
         eventType: 'view',
@@ -97,7 +96,7 @@ describe('startCiVisibilityContext', () => {
 
     it('should not set ci visibility context if it is not a string', () => {
       mockCiVisibilityValues({ key: 'value' })
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
 
       const defaultRumEventAttributes = hook.trigger({
         eventType: 'view',
@@ -112,7 +111,7 @@ describe('startCiVisibilityContext', () => {
       mockCiVisibilityValues(undefined, 'globals-throws')
 
       expect(() => {
-        ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+        ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
       }).not.toThrow()
 
       const defaultRumEventAttributes = hook.trigger({
@@ -128,7 +127,7 @@ describe('startCiVisibilityContext', () => {
     it('should not emit a warning when Cypress.env returns a value', () => {
       const displaySpy = spyOn(display, 'warn')
       mockCiVisibilityValues('trace_id_value')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
 
       expect(displaySpy).not.toHaveBeenCalled()
     })
@@ -136,14 +135,14 @@ describe('startCiVisibilityContext', () => {
     it('should not emit a warning when the cookie is set', () => {
       const displaySpy = spyOn(display, 'warn')
       mockCiVisibilityValues('trace_id_value', 'cookies')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
 
       expect(displaySpy).not.toHaveBeenCalled()
     })
 
     it('should not emit a warning when Cypress is not present', () => {
       const displaySpy = spyOn(display, 'warn')
-      ;({ stop: stopCiVisibility } = startCiVisibilityContext({} as Configuration, hook, cookieObservable))
+      ;({ stop: stopCiVisibility } = startCiVisibilityContext(hook, cookieObservable))
 
       expect(displaySpy).not.toHaveBeenCalled()
     })

--- a/packages/browser-rum-core/src/domain/contexts/ciVisibilityContext.ts
+++ b/packages/browser-rum-core/src/domain/contexts/ciVisibilityContext.ts
@@ -1,4 +1,3 @@
-import type { Configuration } from '@datadog/browser-core'
 import { display, getInitCookie, SKIPPED } from '@datadog/browser-core'
 import { createCookieObservable } from '../../browser/cookieObservable'
 import type { AssembleHook, DefaultRumEventAttributes } from '../hooks'
@@ -13,9 +12,8 @@ export interface CiTestWindow extends Window {
 }
 
 export function startCiVisibilityContext(
-  configuration: Configuration,
   assembleHook: AssembleHook,
-  cookieObservable = createCookieObservable(configuration, CI_VISIBILITY_TEST_ID_COOKIE_NAME)
+  cookieObservable = createCookieObservable(CI_VISIBILITY_TEST_ID_COOKIE_NAME)
 ) {
   let testExecutionId = getInitCookie(CI_VISIBILITY_TEST_ID_COOKIE_NAME) || readCypressTraceId()
 

--- a/packages/browser-rum-core/src/domain/contexts/displayContext.spec.ts
+++ b/packages/browser-rum-core/src/domain/contexts/displayContext.spec.ts
@@ -1,6 +1,5 @@
 import type { RelativeTime } from '@datadog/js-core/time'
 import { createHook } from '@datadog/browser-core'
-import { mockRumConfiguration } from '../../../test'
 import type { AssembleHook, AssembleHookParams } from '../hooks'
 import type { DisplayContext } from './displayContext'
 import { startDisplayContext } from './displayContext'
@@ -24,7 +23,7 @@ describe('displayContext', () => {
 
   describe('assemble hook', () => {
     it('should set the display context', () => {
-      displayContext = startDisplayContext(hook, mockRumConfiguration())
+      displayContext = startDisplayContext(hook)
 
       const event = hook.trigger({
         eventType: 'view',

--- a/packages/browser-rum-core/src/domain/contexts/displayContext.ts
+++ b/packages/browser-rum-core/src/domain/contexts/displayContext.ts
@@ -1,12 +1,11 @@
 import { monitor } from '@datadog/browser-core'
-import type { RumConfiguration } from '../configuration'
 import type { ViewportDimension } from '../../browser/viewportObservable'
 import { getViewportDimension, initViewportObservable } from '../../browser/viewportObservable'
 import type { AssembleHook, DefaultRumEventAttributes } from '../hooks'
 
 export type DisplayContext = ReturnType<typeof startDisplayContext>
 
-export function startDisplayContext(assembleHook: AssembleHook, configuration: RumConfiguration) {
+export function startDisplayContext(assembleHook: AssembleHook) {
   let viewport: ViewportDimension | undefined
   // Use requestAnimationFrame to delay the calculation of viewport dimensions until after SDK initialization, preventing long tasks.
   const animationFrameId = requestAnimationFrame(
@@ -15,7 +14,7 @@ export function startDisplayContext(assembleHook: AssembleHook, configuration: R
     })
   )
 
-  const unsubscribeViewport = initViewportObservable(configuration).subscribe((viewportDimension) => {
+  const unsubscribeViewport = initViewportObservable().subscribe((viewportDimension) => {
     viewport = viewportDimension
   }).unsubscribe
 

--- a/packages/browser-rum-core/src/domain/contexts/pageStateHistory.spec.ts
+++ b/packages/browser-rum-core/src/domain/contexts/pageStateHistory.spec.ts
@@ -2,7 +2,7 @@ import type { RelativeTime, Duration, ServerDuration } from '@datadog/js-core/ti
 import { createHook } from '@datadog/browser-core'
 import type { Clock } from '../../../../browser-core/test'
 import { mockClock, registerCleanupTask } from '../../../../browser-core/test'
-import { createPerformanceEntry, mockPerformanceObserver, mockRumConfiguration } from '../../../test'
+import { createPerformanceEntry, mockPerformanceObserver } from '../../../test'
 import { RumEventType } from '../../rawRumEvent.types'
 import * as performanceObservable from '../../browser/performanceObservable'
 import type { AssembleHook, AssembleHookParams } from '../hooks'
@@ -12,7 +12,6 @@ import { PageState, startPageStateHistory } from './pageStateHistory'
 describe('pageStateHistory', () => {
   let clock: Clock
   let hook: AssembleHook
-  const configuration = mockRumConfiguration()
 
   beforeEach(() => {
     clock = mockClock()
@@ -24,7 +23,7 @@ describe('pageStateHistory', () => {
 
     beforeEach(() => {
       mockPerformanceObserver()
-      pageStateHistory = startPageStateHistory(hook, configuration)
+      pageStateHistory = startPageStateHistory(hook)
       registerCleanupTask(pageStateHistory.stop)
     })
 
@@ -69,7 +68,7 @@ describe('pageStateHistory', () => {
 
       beforeEach(() => {
         mockPerformanceObserver()
-        pageStateHistory = startPageStateHistory(hook, configuration)
+        pageStateHistory = startPageStateHistory(hook)
         registerCleanupTask(pageStateHistory.stop)
       })
 
@@ -147,7 +146,7 @@ describe('pageStateHistory', () => {
       it('should limit the number of page states added', () => {
         pageStateHistory.stop()
         const maxPageStateEntriesSelectable = 1
-        pageStateHistory = startPageStateHistory(hook, configuration, maxPageStateEntriesSelectable)
+        pageStateHistory = startPageStateHistory(hook, maxPageStateEntriesSelectable)
         registerCleanupTask(pageStateHistory.stop)
 
         pageStateHistory.addPageState(PageState.ACTIVE)
@@ -180,7 +179,7 @@ describe('pageStateHistory', () => {
 
       beforeEach(() => {
         mockPerformanceObserver()
-        pageStateHistory = startPageStateHistory(hook, configuration)
+        pageStateHistory = startPageStateHistory(hook)
         registerCleanupTask(pageStateHistory.stop)
       })
 
@@ -241,7 +240,7 @@ describe('pageStateHistory', () => {
         }),
       ])
 
-      pageStateHistory = startPageStateHistory(hook, configuration)
+      pageStateHistory = startPageStateHistory(hook)
       registerCleanupTask(pageStateHistory.stop)
 
       expect(pageStateHistory.wasInPageStateDuringPeriod(PageState.ACTIVE, 5 as RelativeTime, 5 as Duration)).toBeTrue()
@@ -255,7 +254,7 @@ describe('pageStateHistory', () => {
         supportedEntryTypes: [],
       })
 
-      pageStateHistory = startPageStateHistory(hook, configuration)
+      pageStateHistory = startPageStateHistory(hook)
       registerCleanupTask(pageStateHistory.stop)
 
       expect(

--- a/packages/browser-rum-core/src/domain/contexts/pageStateHistory.ts
+++ b/packages/browser-rum-core/src/domain/contexts/pageStateHistory.ts
@@ -7,7 +7,6 @@ import {
   addEventListeners,
   DOM_EVENT,
 } from '@datadog/browser-core'
-import type { RumConfiguration } from '../configuration'
 import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../browser/performanceObservable'
 import type { PageStateServerEntry } from '../../rawRumEvent.types'
 import { RumEventType } from '../../rawRumEvent.types'
@@ -41,7 +40,6 @@ export interface PageStateHistory {
 
 export function startPageStateHistory(
   assembleHook: AssembleHook,
-  configuration: RumConfiguration,
   maxPageStateEntriesSelectable = MAX_PAGE_STATE_ENTRIES_SELECTABLE
 ): PageStateHistory {
   const pageStateEntryHistory = createValueHistory<PageStateEntry>({
@@ -63,7 +61,6 @@ export function startPageStateHistory(
   addPageState(getPageState(), relativeNow())
 
   const { stop: stopEventListeners } = addEventListeners(
-    configuration,
     window,
     [
       DOM_EVENT.PAGE_SHOW,

--- a/packages/browser-rum-core/src/domain/error/errorCollection.ts
+++ b/packages/browser-rum-core/src/domain/error/errorCollection.ts
@@ -11,7 +11,6 @@ import {
   NonErrorPrefix,
   combine,
 } from '@datadog/browser-core'
-import type { RumConfiguration } from '../configuration'
 import type { RawRumErrorEvent } from '../../rawRumEvent.types'
 import { RumEventType } from '../../rawRumEvent.types'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
@@ -27,11 +26,7 @@ export interface ProvidedError {
   componentStack?: string
 }
 
-export function startErrorCollection(
-  lifeCycle: LifeCycle,
-  configuration: RumConfiguration,
-  bufferedDataObservable: Observable<BufferedData>
-) {
+export function startErrorCollection(lifeCycle: LifeCycle, bufferedDataObservable: Observable<BufferedData>) {
   const errorObservable = new Observable<RawError>()
 
   bufferedDataObservable.subscribe(({ data, type }) => {
@@ -42,7 +37,7 @@ export function startErrorCollection(
     }
   })
 
-  trackReportError(configuration, errorObservable)
+  trackReportError(errorObservable)
 
   errorObservable.subscribe((error) => lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error }))
 

--- a/packages/browser-rum-core/src/domain/error/trackReportError.spec.ts
+++ b/packages/browser-rum-core/src/domain/error/trackReportError.spec.ts
@@ -10,8 +10,6 @@ import {
   mockReportingObserver,
   registerCleanupTask,
 } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../../test'
-import type { RumConfiguration } from '../configuration'
 import { trackReportError } from './trackReportError'
 
 describe('trackReportError', () => {
@@ -20,13 +18,11 @@ describe('trackReportError', () => {
   let notifyLog: jasmine.Spy
   let reportingObserver: MockReportingObserver
   let cspEventListener: MockCspEventListener
-  let configuration: RumConfiguration
 
   beforeEach(() => {
     if (!window.ReportingObserver) {
       pending('ReportingObserver not supported')
     }
-    configuration = mockRumConfiguration()
     errorObservable = new Observable()
     notifyLog = jasmine.createSpy('notifyLog')
     reportingObserver = mockReportingObserver()
@@ -39,7 +35,7 @@ describe('trackReportError', () => {
   })
 
   it('should track reports', () => {
-    trackReportError(configuration, errorObservable)
+    trackReportError(errorObservable)
     reportingObserver.raiseReport('intervention')
 
     expect(notifyLog).toHaveBeenCalledWith({
@@ -54,7 +50,7 @@ describe('trackReportError', () => {
   })
 
   it('should track securitypolicyviolation', () => {
-    trackReportError(configuration, errorObservable)
+    trackReportError(errorObservable)
     cspEventListener.dispatchEvent()
 
     expect(notifyLog).toHaveBeenCalledWith({

--- a/packages/browser-rum-core/src/domain/error/trackReportError.ts
+++ b/packages/browser-rum-core/src/domain/error/trackReportError.ts
@@ -1,12 +1,9 @@
 import type { Observable, RawError } from '@datadog/browser-core'
 import { initReportObservable, RawReportType } from '@datadog/browser-core'
-import type { RumConfiguration } from '../configuration'
-
-export function trackReportError(configuration: RumConfiguration, errorObservable: Observable<RawError>) {
-  const subscription = initReportObservable(configuration, [
-    RawReportType.cspViolation,
-    RawReportType.intervention,
-  ]).subscribe((rawError) => errorObservable.notify(rawError))
+export function trackReportError(errorObservable: Observable<RawError>) {
+  const subscription = initReportObservable([RawReportType.cspViolation, RawReportType.intervention]).subscribe(
+    (rawError) => errorObservable.notify(rawError)
+  )
 
   return {
     stop: () => {

--- a/packages/browser-rum-core/src/domain/longTask/longTaskCollection.ts
+++ b/packages/browser-rum-core/src/domain/longTask/longTaskCollection.ts
@@ -22,7 +22,7 @@ export function startLongTaskCollection(lifeCycle: LifeCycle, configuration: Rum
     ? RumPerformanceEntryType.LONG_ANIMATION_FRAME
     : RumPerformanceEntryType.LONG_TASK
 
-  const subscription = createPerformanceObservable(configuration, {
+  const subscription = createPerformanceObservable({
     type: entryType,
     buffered: true,
   }).subscribe((entries) => {

--- a/packages/browser-rum-core/src/domain/requestCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/requestCollection.spec.ts
@@ -203,12 +203,7 @@ describe('collect xhr', () => {
         context.spanId = createSpanIdentifier()
       },
     }
-    ;({ stop: stopXhrTracking } = trackXhr(
-      lifeCycle,
-      mockRumConfiguration(),
-      tracerStub as Tracer,
-      bufferedDataObservable
-    ))
+    ;({ stop: stopXhrTracking } = trackXhr(lifeCycle, tracerStub as Tracer, bufferedDataObservable))
 
     registerCleanupTask(() => {
       stopXhrTracking()

--- a/packages/browser-rum-core/src/domain/requestCollection.ts
+++ b/packages/browser-rum-core/src/domain/requestCollection.ts
@@ -77,20 +77,15 @@ export function startRequestCollection(
   bufferedDataObservable: Observable<BufferedData>
 ) {
   const tracer = startTracer(configuration, sessionManager, userContext, accountContext)
-  trackXhr(lifeCycle, configuration, tracer, bufferedDataObservable)
+  trackXhr(lifeCycle, tracer, bufferedDataObservable)
   trackFetch(lifeCycle, configuration, tracer, bufferedDataObservable)
 }
 
-export function trackXhr(
-  lifeCycle: LifeCycle,
-  configuration: RumConfiguration,
-  tracer: Tracer,
-  bufferedDataObservable: Observable<BufferedData>
-) {
+export function trackXhr(lifeCycle: LifeCycle, tracer: Tracer, bufferedDataObservable: Observable<BufferedData>) {
   const subscriptions: Subscription[] = []
 
   subscriptions.push(
-    initXhrObservable(configuration).subscribe((context) => {
+    initXhrObservable().subscribe((context) => {
       if (context.state === 'start' && isAllowedRequestUrl(context.url)) {
         tracer.traceXhr(context, context.xhr)
         assignRequestIndex(context as RumXhrStartContext)

--- a/packages/browser-rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/browser-rum-core/src/domain/resource/resourceCollection.ts
@@ -51,7 +51,7 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Rum
   const taskQueue = mockable(createTaskQueue)()
   const requestRegistry = createRequestRegistry(lifeCycle)
 
-  const performanceResourceSubscription = createPerformanceObservable(configuration, {
+  const performanceResourceSubscription = createPerformanceObservable({
     type: RumPerformanceEntryType.RESOURCE,
     buffered: true,
   }).subscribe((entries) => {
@@ -80,7 +80,7 @@ export function startResourceCollection(lifeCycle: LifeCycle, configuration: Rum
     }
   })
 
-  const { stop: stopRunOnReadyState } = runOnReadyState(configuration, 'interactive', () => {
+  const { stop: stopRunOnReadyState } = runOnReadyState('interactive', () => {
     handleResource(() => assembleResource(getNavigationEntry(), undefined, configuration))
   })
 

--- a/packages/browser-rum-core/src/domain/view/bfCacheSupport.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/bfCacheSupport.spec.ts
@@ -1,13 +1,11 @@
 import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../../test'
 import { onBFCacheRestore } from './bfCacheSupport'
 
 describe('onBFCacheRestore', () => {
   it('should invoke the callback only for BFCache restoration and stop listening when stopped', () => {
-    const configuration = mockRumConfiguration()
     const callback = jasmine.createSpy('callback')
 
-    const stop = onBFCacheRestore(configuration, callback)
+    const stop = onBFCacheRestore(callback)
     registerCleanupTask(stop)
 
     window.dispatchEvent(createNewEvent('pageshow', { persisted: false }))

--- a/packages/browser-rum-core/src/domain/view/bfCacheSupport.ts
+++ b/packages/browser-rum-core/src/domain/view/bfCacheSupport.ts
@@ -1,12 +1,7 @@
-import type { Configuration } from '@datadog/browser-core'
 import { addEventListener, DOM_EVENT } from '@datadog/browser-core'
 
-export function onBFCacheRestore(
-  configuration: Configuration,
-  callback: (event: PageTransitionEvent) => void
-): () => void {
+export function onBFCacheRestore(callback: (event: PageTransitionEvent) => void): () => void {
   const { stop } = addEventListener(
-    configuration,
     window,
     DOM_EVENT.PAGE_SHOW,
     (event: PageTransitionEvent) => {

--- a/packages/browser-rum-core/src/domain/view/trackViews.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.ts
@@ -119,7 +119,7 @@ export function trackViews(
   let locationChangeSubscription: Subscription
   if (areViewsTrackedAutomatically) {
     locationChangeSubscription = renewViewOnLocationChange(locationChangeObservable)
-    stopOnBFCacheRestore = onBFCacheRestore(configuration, (pageshowEvent) => {
+    stopOnBFCacheRestore = onBFCacheRestore((pageshowEvent) => {
       currentView.end()
       const startClocks = relativeToClocks(pageshowEvent.timeStamp as RelativeTime)
       currentView = startNewView(ViewLoadingType.BF_CACHE, startClocks, undefined)

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackCommonViewMetrics.ts
@@ -48,7 +48,7 @@ export function trackCommonViewMetrics(
     }
   )
 
-  const { stop: stopScrollMetricsTracking } = trackScrollMetrics(configuration, viewStart, (newScrollMetrics) => {
+  const { stop: stopScrollMetricsTracking } = trackScrollMetrics(viewStart, (newScrollMetrics) => {
     commonViewMetrics.scroll = newScrollMetrics
   })
 

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackCumulativeLayoutShift.ts
@@ -70,7 +70,7 @@ export function trackCumulativeLayoutShift(
   })
 
   const slidingWindow = slidingSessionWindow()
-  const performanceSubscription = createPerformanceObservable(configuration, {
+  const performanceSubscription = createPerformanceObservable({
     type: RumPerformanceEntryType.LAYOUT_SHIFT,
     buffered: true,
   }).subscribe((entries) => {

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.spec.ts
@@ -3,7 +3,7 @@ import { clocksOrigin } from '@datadog/js-core/time'
 import { registerCleanupTask, restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
 import type { RumPerformanceEntry } from '../../../browser/performanceObservable'
 import { RumPerformanceEntryType } from '../../../browser/performanceObservable'
-import { createPerformanceEntry, mockPerformanceObserver, mockRumConfiguration } from '../../../../test'
+import { createPerformanceEntry, mockPerformanceObserver } from '../../../../test'
 import { FCP_MAXIMUM_DELAY, trackFirstContentfulPaint } from './trackFirstContentfulPaint'
 import { trackFirstHidden } from './trackFirstHidden'
 
@@ -15,8 +15,8 @@ describe('trackFirstContentfulPaint', () => {
     ;({ notifyPerformanceEntries } = mockPerformanceObserver())
 
     fcpCallback = jasmine.createSpy()
-    const firstHidden = trackFirstHidden(mockRumConfiguration(), clocksOrigin())
-    const firstContentfulPaint = trackFirstContentfulPaint(mockRumConfiguration(), firstHidden, fcpCallback)
+    const firstHidden = trackFirstHidden(clocksOrigin())
+    const firstContentfulPaint = trackFirstContentfulPaint(firstHidden, fcpCallback)
 
     registerCleanupTask(() => {
       firstHidden.stop()

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstContentfulPaint.ts
@@ -2,19 +2,14 @@ import type { RelativeTime, Duration } from '@datadog/js-core/time'
 import { ONE_MINUTE, elapsed, relativeNow } from '@datadog/js-core/time'
 import type { RumPerformancePaintTiming } from '../../../browser/performanceObservable'
 import { createPerformanceObservable, RumPerformanceEntryType } from '../../../browser/performanceObservable'
-import type { RumConfiguration } from '../../configuration'
 import type { FirstHidden } from './trackFirstHidden'
 
 // Discard FCP timings above a certain delay to avoid incorrect data
 // It happens in some cases like sleep mode or some browser implementations
 export const FCP_MAXIMUM_DELAY = 10 * ONE_MINUTE
 
-export function trackFirstContentfulPaint(
-  configuration: RumConfiguration,
-  firstHidden: FirstHidden,
-  callback: (fcpTiming: RelativeTime) => void
-) {
-  const performanceSubscription = createPerformanceObservable(configuration, {
+export function trackFirstContentfulPaint(firstHidden: FirstHidden, callback: (fcpTiming: RelativeTime) => void) {
+  const performanceSubscription = createPerformanceObservable({
     type: RumPerformanceEntryType.PAINT,
     buffered: true,
   }).subscribe((entries) => {

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstHidden.spec.ts
@@ -2,21 +2,20 @@ import type { RelativeTime, TimeStamp } from '@datadog/js-core/time'
 import { clocksOrigin } from '@datadog/js-core/time'
 import { DOM_EVENT } from '@datadog/browser-core'
 import { createNewEvent, restorePageVisibility, setPageVisibility } from '@datadog/browser-core/test'
-import { mockRumConfiguration, mockGlobalPerformanceBuffer } from '../../../../test'
+import { mockGlobalPerformanceBuffer } from '../../../../test'
 import type { GlobalPerformanceBufferMock } from '../../../../test'
 import { trackFirstHidden } from './trackFirstHidden'
 
 describe('trackFirstHidden', () => {
-  const configuration = mockRumConfiguration()
   let firstHidden: { timeStamp: RelativeTime; stop: () => void }
   let performanceBufferMock: GlobalPerformanceBufferMock
 
   function trackFirstHiddenWithDefaults({
-    configuration = mockRumConfiguration(),
     viewStart = clocksOrigin(),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     eventTarget = window as Window,
-  }): ReturnType<typeof trackFirstHidden> {
-    return trackFirstHidden(configuration, viewStart, eventTarget)
+  } = {}): ReturnType<typeof trackFirstHidden> {
+    return trackFirstHidden(viewStart, eventTarget)
   }
 
   afterEach(() => {
@@ -27,7 +26,7 @@ describe('trackFirstHidden', () => {
   describe('the page is initially hidden', () => {
     it('should return 0', () => {
       setPageVisibility('hidden')
-      firstHidden = trackFirstHiddenWithDefaults({ configuration })
+      firstHidden = trackFirstHiddenWithDefaults()
 
       expect(firstHidden.timeStamp).toBe(0 as RelativeTime)
     })
@@ -35,7 +34,7 @@ describe('trackFirstHidden', () => {
     it('should ignore events', () => {
       setPageVisibility('hidden')
       const eventTarget = createWindowEventTarget()
-      firstHidden = trackFirstHiddenWithDefaults({ configuration, eventTarget })
+      firstHidden = trackFirstHiddenWithDefaults({ eventTarget })
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.PAGE_HIDE, { timeStamp: 100 }))
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.VISIBILITY_CHANGE, { timeStamp: 100 }))
@@ -47,13 +46,13 @@ describe('trackFirstHidden', () => {
   describe('the page is initially visible', () => {
     it('should return Infinity if the page was not hidden yet', () => {
       setPageVisibility('visible')
-      firstHidden = trackFirstHiddenWithDefaults({ configuration })
+      firstHidden = trackFirstHiddenWithDefaults()
       expect(firstHidden.timeStamp).toBe(Infinity as RelativeTime)
     })
 
     it('should return the timestamp of the first pagehide event', () => {
       const eventTarget = createWindowEventTarget()
-      firstHidden = trackFirstHiddenWithDefaults({ configuration, eventTarget })
+      firstHidden = trackFirstHiddenWithDefaults({ eventTarget })
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.PAGE_HIDE, { timeStamp: 100 }))
 
@@ -62,7 +61,7 @@ describe('trackFirstHidden', () => {
 
     it('should return the timestamp of the first visibilitychange event if the page is hidden', () => {
       const eventTarget = createWindowEventTarget()
-      firstHidden = trackFirstHiddenWithDefaults({ configuration, eventTarget })
+      firstHidden = trackFirstHiddenWithDefaults({ eventTarget })
 
       setPageVisibility('hidden')
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.VISIBILITY_CHANGE, { timeStamp: 100 }))
@@ -72,7 +71,7 @@ describe('trackFirstHidden', () => {
 
     it('should ignore visibilitychange event if the page is visible', () => {
       const eventTarget = createWindowEventTarget()
-      firstHidden = trackFirstHiddenWithDefaults({ configuration, eventTarget })
+      firstHidden = trackFirstHiddenWithDefaults({ eventTarget })
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.VISIBILITY_CHANGE, { timeStamp: 100 }))
 
@@ -81,7 +80,7 @@ describe('trackFirstHidden', () => {
 
     it('should ignore subsequent events', () => {
       const eventTarget = createWindowEventTarget()
-      firstHidden = trackFirstHiddenWithDefaults({ configuration, eventTarget })
+      firstHidden = trackFirstHiddenWithDefaults({ eventTarget })
 
       eventTarget.dispatchEvent(createNewEvent(DOM_EVENT.PAGE_HIDE, { timeStamp: 100 }))
 
@@ -121,7 +120,7 @@ describe('trackFirstHidden', () => {
         startTime: 23219031,
       } as PerformanceEntry)
 
-      firstHidden = trackFirstHiddenWithDefaults({ configuration })
+      firstHidden = trackFirstHiddenWithDefaults()
       expect(firstHidden.timeStamp).toBe(23 as RelativeTime)
     })
 
@@ -135,7 +134,6 @@ describe('trackFirstHidden', () => {
       } as PerformanceEntry)
 
       firstHidden = trackFirstHiddenWithDefaults({
-        configuration,
         eventTarget: createWindowEventTarget(),
         viewStart: { relative: 100 as RelativeTime, timeStamp: 100 as TimeStamp },
       })
@@ -151,7 +149,7 @@ describe('trackFirstHidden', () => {
         startTime: 0,
       } as PerformanceEntry)
 
-      firstHidden = trackFirstHiddenWithDefaults({ configuration })
+      firstHidden = trackFirstHiddenWithDefaults()
       expect(firstHidden.timeStamp).toBe(0 as RelativeTime)
     })
   })

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackFirstHidden.ts
@@ -1,6 +1,5 @@
 import type { ClocksState, RelativeTime } from '@datadog/js-core/time'
 import { addEventListeners, DOM_EVENT, noop } from '@datadog/browser-core'
-import type { RumConfiguration } from '../../configuration'
 import { supportPerformanceTimingEvent, RumPerformanceEntryType } from '../../../browser/performanceObservable'
 
 export type FirstHidden = ReturnType<typeof trackFirstHidden>
@@ -9,11 +8,7 @@ export interface Options {
   viewStart: ClocksState
 }
 
-export function trackFirstHidden(
-  configuration: RumConfiguration,
-  viewStart: ClocksState,
-  eventTarget: Window = window
-) {
+export function trackFirstHidden(viewStart: ClocksState, eventTarget: Window = window) {
   if (document.visibilityState === 'hidden') {
     return { timeStamp: 0 as RelativeTime, stop: noop }
   }
@@ -32,7 +27,6 @@ export function trackFirstHidden(
   let timeStamp: RelativeTime = Infinity as RelativeTime
 
   const { stop } = addEventListeners(
-    configuration,
     eventTarget,
     [DOM_EVENT.PAGE_HIDE, DOM_EVENT.VISIBILITY_CHANGE],
     (event) => {

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackInitialViewMetrics.ts
@@ -21,14 +21,14 @@ export function trackInitialViewMetrics(
 ) {
   const initialViewMetrics: InitialViewMetrics = {}
 
-  const { stop: stopNavigationTracking } = trackNavigationTimings(configuration, (navigationTimings) => {
+  const { stop: stopNavigationTracking } = trackNavigationTimings((navigationTimings) => {
     setLoadEvent(navigationTimings.loadEvent)
     initialViewMetrics.navigationTimings = navigationTimings
     scheduleViewUpdate()
   })
 
-  const firstHidden = trackFirstHidden(configuration, viewStart)
-  const { stop: stopFCPTracking } = trackFirstContentfulPaint(configuration, firstHidden, (firstContentfulPaint) => {
+  const firstHidden = trackFirstHidden(viewStart)
+  const { stop: stopFCPTracking } = trackFirstContentfulPaint(firstHidden, (firstContentfulPaint) => {
     initialViewMetrics.firstContentfulPaint = firstContentfulPaint
     scheduleViewUpdate()
   })

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackInteractionToNextPaint.ts
@@ -72,11 +72,11 @@ export function trackInteractionToNextPaint(
   const { getViewInteractionCount, stopViewInteractionCount } = trackViewInteractionCount(viewLoadingType)
   const longestInteractions = trackLongestInteractions(getViewInteractionCount)
   const subPartsTracker = createSubPartsTracker(longestInteractions)
-  const firstInputSubscription = createPerformanceObservable(configuration, {
+  const firstInputSubscription = createPerformanceObservable({
     type: RumPerformanceEntryType.FIRST_INPUT,
     buffered: true,
   }).subscribe(handleEntries)
-  const eventSubscription = createPerformanceObservable(configuration, {
+  const eventSubscription = createPerformanceObservable({
     type: RumPerformanceEntryType.EVENT,
     // durationThreshold only impact PerformanceEventTiming entries used for INP computation which requires a threshold at 40 (default is 104ms)
     // cf: https://github.com/GoogleChrome/web-vitals/blob/3806160ffbc93c3c4abf210a167b81228172b31c/src/onINP.ts#L202-L210

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.spec.ts
@@ -58,7 +58,7 @@ describe('trackLargestContentfulPaint', () => {
       ])
     }
 
-    const firstHidden = trackFirstHidden(mockRumConfiguration(), clocksOrigin())
+    const firstHidden = trackFirstHidden(clocksOrigin())
     const largestContentfulPaint = trackLargestContentfulPaint(
       mockRumConfiguration(),
       firstHidden,

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackLargestContentfulPaint.ts
@@ -40,7 +40,6 @@ export function trackLargestContentfulPaint(
   // but the web-vitals reference implementation uses this as a safeguard.
   let firstInteractionTimestamp = Infinity
   const { stop: stopEventListener } = addEventListeners(
-    configuration,
     eventTarget,
     [DOM_EVENT.POINTER_DOWN, DOM_EVENT.KEY_DOWN],
     (event) => {
@@ -50,7 +49,7 @@ export function trackLargestContentfulPaint(
   )
 
   let biggestLcpSize = 0
-  const performanceLcpSubscription = createPerformanceObservable(configuration, {
+  const performanceLcpSubscription = createPerformanceObservable({
     type: RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT,
     buffered: true,
   }).subscribe((entries) => {

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackLoadingTime.ts
@@ -26,7 +26,7 @@ export function trackLoadingTime(
   let isWaitingForLoadEvent = loadType === ViewLoadingType.INITIAL_LOAD
   let isWaitingForActivityLoadingTime = true
   const loadingTimeCandidates: Duration[] = []
-  const firstHidden = trackFirstHidden(configuration, viewStart)
+  const firstHidden = trackFirstHidden(viewStart)
 
   function invokeCallbackIfAllCandidatesAreReceived() {
     if (!isWaitingForActivityLoadingTime && !isWaitingForLoadEvent && loadingTimeCandidates.length > 0) {

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackNavigationTimings.spec.ts
@@ -1,7 +1,7 @@
 import { type Duration, relativeNow, type RelativeTime } from '@datadog/js-core/time'
 import type { Clock } from '@datadog/browser-core/test'
 import { mockClock, registerCleanupTask, replaceMockable } from '@datadog/browser-core/test'
-import { mockDocumentReadyState, mockRumConfiguration } from '../../../../test'
+import { mockDocumentReadyState } from '../../../../test'
 import { getNavigationEntry } from '../../../browser/performanceUtils'
 import type { NavigationTimings, RelevantNavigationTiming } from './trackNavigationTimings'
 import { trackNavigationTimings } from './trackNavigationTimings'
@@ -38,7 +38,7 @@ describe('trackNavigationTimings', () => {
 
   it('notifies navigation timings after the load event', () => {
     replaceMockable(getNavigationEntry, () => FAKE_NAVIGATION_ENTRY)
-    ;({ stop } = trackNavigationTimings(mockRumConfiguration(), navigationTimingsCallback))
+    ;({ stop } = trackNavigationTimings(navigationTimingsCallback))
 
     clock.tick(0)
 
@@ -56,7 +56,7 @@ describe('trackNavigationTimings', () => {
       ...FAKE_NAVIGATION_ENTRY,
       responseStart: -1 as RelativeTime,
     }))
-    ;({ stop } = trackNavigationTimings(mockRumConfiguration(), navigationTimingsCallback))
+    ;({ stop } = trackNavigationTimings(navigationTimingsCallback))
 
     clock.tick(0)
 
@@ -68,7 +68,7 @@ describe('trackNavigationTimings', () => {
       ...FAKE_NAVIGATION_ENTRY,
       responseStart: (relativeNow() + 1) as RelativeTime,
     }))
-    ;({ stop } = trackNavigationTimings(mockRumConfiguration(), navigationTimingsCallback))
+    ;({ stop } = trackNavigationTimings(navigationTimingsCallback))
 
     clock.tick(0)
 
@@ -78,7 +78,7 @@ describe('trackNavigationTimings', () => {
   it('wait for the load event to provide navigation timing', () => {
     replaceMockable(getNavigationEntry, () => FAKE_NAVIGATION_ENTRY)
     mockDocumentReadyState()
-    ;({ stop } = trackNavigationTimings(mockRumConfiguration(), navigationTimingsCallback))
+    ;({ stop } = trackNavigationTimings(navigationTimingsCallback))
 
     clock.tick(0)
 
@@ -87,7 +87,7 @@ describe('trackNavigationTimings', () => {
 
   it('discard incomplete navigation timing', () => {
     replaceMockable(getNavigationEntry, () => FAKE_INCOMPLETE_NAVIGATION_ENTRY)
-    ;({ stop } = trackNavigationTimings(mockRumConfiguration(), navigationTimingsCallback))
+    ;({ stop } = trackNavigationTimings(navigationTimingsCallback))
 
     clock.tick(0)
 

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackNavigationTimings.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackNavigationTimings.ts
@@ -3,7 +3,6 @@ import type { Duration } from '@datadog/js-core/time'
 import { setTimeout, runOnReadyState, clearTimeout, mockable } from '@datadog/browser-core'
 import type { RumPerformanceNavigationTiming } from '../../../browser/performanceObservable'
 import { getNavigationEntry, sanitizeFirstByte } from '../../../browser/performanceUtils'
-import type { RumConfiguration } from '../../configuration'
 
 export interface NavigationTimings {
   domComplete: Duration
@@ -20,11 +19,8 @@ export type RelevantNavigationTiming = Pick<
   'domComplete' | 'domContentLoadedEventEnd' | 'domInteractive' | 'loadEventEnd' | 'responseStart'
 >
 
-export function trackNavigationTimings(
-  configuration: RumConfiguration,
-  callback: (timings: NavigationTimings) => void
-) {
-  return waitAfterLoadEvent(configuration, () => {
+export function trackNavigationTimings(callback: (timings: NavigationTimings) => void) {
+  return waitAfterLoadEvent(() => {
     const entry = mockable(getNavigationEntry)()
 
     if (!isIncompleteNavigation(entry)) {
@@ -47,9 +43,9 @@ function isIncompleteNavigation(entry: RelevantNavigationTiming) {
   return entry.loadEventEnd <= 0
 }
 
-function waitAfterLoadEvent(configuration: RumConfiguration, callback: () => void) {
+function waitAfterLoadEvent(callback: () => void) {
   let timeoutId: TimeoutId | undefined
-  const { stop: stopOnReadyState } = runOnReadyState(configuration, 'complete', () => {
+  const { stop: stopOnReadyState } = runOnReadyState('complete', () => {
     // Invoke the callback a bit after the actual load event, so the "loadEventEnd" timing is accurate
     timeoutId = setTimeout(() => callback())
   })

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackScrollMetrics.spec.ts
@@ -3,12 +3,11 @@ import type { Subscription } from '@datadog/browser-core'
 import { DOM_EVENT, Observable } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { createNewEvent, mockClock, registerCleanupTask } from '@datadog/browser-core/test'
-import { mockRumConfiguration } from '../../../../test'
 import type { ScrollMetrics, ScrollValues } from './trackScrollMetrics'
 import { createScrollValuesObservable, trackScrollMetrics } from './trackScrollMetrics'
 
 describe('createScrollValuesObserver', () => {
-  const scrollObservable = createScrollValuesObservable(mockRumConfiguration(), 0)
+  const scrollObservable = createScrollValuesObservable(0)
   let subscription: Subscription
 
   const newScroll = () => {
@@ -54,7 +53,6 @@ describe('trackScrollMetrics', () => {
     scrollMetricsCallback = jasmine.createSpy()
     clock = mockClock()
     trackScrollMetrics(
-      mockRumConfiguration(),
       { relative: 0 as RelativeTime, timeStamp: 0 as TimeStamp },
       scrollMetricsCallback,
       scrollObservable

--- a/packages/browser-rum-core/src/domain/view/viewMetrics/trackScrollMetrics.ts
+++ b/packages/browser-rum-core/src/domain/view/viewMetrics/trackScrollMetrics.ts
@@ -1,7 +1,6 @@
 import { ONE_SECOND, elapsed, relativeNow } from '@datadog/js-core/time'
 import type { Duration, ClocksState } from '@datadog/js-core/time'
 import { Observable, throttle, addEventListener, DOM_EVENT, monitor } from '@datadog/browser-core'
-import type { RumConfiguration } from '../../configuration'
 import { getScrollY } from '../../../browser/scroll'
 import { getViewportDimension } from '../../../browser/viewportObservable'
 
@@ -16,10 +15,9 @@ export interface ScrollMetrics {
 }
 
 export function trackScrollMetrics(
-  configuration: RumConfiguration,
   viewStart: ClocksState,
   callback: (scrollMetrics: ScrollMetrics) => void,
-  scrollValues = createScrollValuesObservable(configuration)
+  scrollValues = createScrollValuesObservable()
 ) {
   let maxScrollDepth = 0
   let maxScrollHeight = 0
@@ -77,10 +75,7 @@ export function computeScrollValues() {
   }
 }
 
-export function createScrollValuesObservable(
-  configuration: RumConfiguration,
-  throttleDuration = THROTTLE_SCROLL_DURATION
-): Observable<ScrollValues> {
+export function createScrollValuesObservable(throttleDuration = THROTTLE_SCROLL_DURATION): Observable<ScrollValues> {
   return new Observable<ScrollValues>((observable) => {
     function notify() {
       observable.notify(computeScrollValues())
@@ -96,7 +91,7 @@ export function createScrollValuesObservable(
     if (observerTarget) {
       resizeObserver.observe(observerTarget)
     }
-    const eventListener = addEventListener(configuration, window, DOM_EVENT.SCROLL, throttledNotify.throttled, {
+    const eventListener = addEventListener(window, DOM_EVENT.SCROLL, throttledNotify.throttled, {
       passive: true,
     })
 

--- a/packages/browser-rum-core/src/domain/waitPageActivityEnd.ts
+++ b/packages/browser-rum-core/src/domain/waitPageActivityEnd.ts
@@ -130,7 +130,7 @@ export function createPageActivityObservable(
         }
       }),
       windowOpenObservable.subscribe(notifyPageActivity),
-      createPerformanceObservable(configuration, { type: RumPerformanceEntryType.RESOURCE }).subscribe((entries) => {
+      createPerformanceObservable({ type: RumPerformanceEntryType.RESOURCE }).subscribe((entries) => {
         if (entries.some((entry) => !isExcludedUrl(configuration, entry.name))) {
           notifyPageActivity()
         }

--- a/packages/browser-rum/src/boot/datadogRecorder.spec.ts
+++ b/packages/browser-rum/src/boot/datadogRecorder.spec.ts
@@ -44,7 +44,7 @@ describe('startRecording', () => {
       sendOnExit: requestSendSpy,
     }
 
-    const deflateEncoder = createDeflateEncoder(configuration, worker!, DeflateEncoderStreamId.REPLAY)
+    const deflateEncoder = createDeflateEncoder(worker!, DeflateEncoderStreamId.REPLAY)
     const viewHistory = startViewHistory(lifeCycle)
     initialView(lifeCycle)
 

--- a/packages/browser-rum/src/boot/postStartStrategy.ts
+++ b/packages/browser-rum/src/boot/postStartStrategy.ts
@@ -69,7 +69,7 @@ export function createPostStartStrategy(
 
     const [startRecordingImpl] = await Promise.all([
       notifyWhenSettled(observable, { type: 'recorder-settled' }, lazyLoadRecorder()),
-      notifyWhenSettled(observable, { type: 'document-ready' }, asyncRunOnReadyState(configuration, 'interactive')),
+      notifyWhenSettled(observable, { type: 'document-ready' }, asyncRunOnReadyState('interactive')),
     ])
 
     if (status !== RecorderStatus.Starting) {

--- a/packages/browser-rum/src/boot/recorderApi.ts
+++ b/packages/browser-rum/src/boot/recorderApi.ts
@@ -87,7 +87,7 @@ export function makeRecorderApi(): RecorderApi {
         worker ??= startDeflateWorker(configuration, 'Datadog Session Replay', () => strategy.stop())
 
         if (worker) {
-          cachedDeflateEncoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+          cachedDeflateEncoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
         }
       }
       return cachedDeflateEncoder

--- a/packages/browser-rum/src/domain/deflate/deflateEncoder.spec.ts
+++ b/packages/browser-rum/src/domain/deflate/deflateEncoder.spec.ts
@@ -1,13 +1,11 @@
 import type { EncoderResult, Uint8ArrayBuffer } from '@datadog/browser-core'
 import { noop, DeflateEncoderStreamId } from '@datadog/browser-core'
-import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { MockWorker } from '../../../test'
 import { createDeflateEncoder } from './deflateEncoder'
 
 const OTHER_STREAM_ID = 10 as DeflateEncoderStreamId
 
 describe('createDeflateEncoder', () => {
-  const configuration = {} as RumConfiguration
   let worker: MockWorker
 
   const ENCODED_FOO = [102, 111, 111]
@@ -20,7 +18,7 @@ describe('createDeflateEncoder', () => {
 
   describe('write()', () => {
     it('invokes write callbacks', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       const writeCallbackSpy = jasmine.createSpy()
       encoder.write('foo', writeCallbackSpy)
       encoder.write('bar', writeCallbackSpy)
@@ -35,7 +33,7 @@ describe('createDeflateEncoder', () => {
     })
 
     it('marks the encoder as not empty', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       encoder.write('foo')
       expect(encoder.isEmpty).toBe(false)
     })
@@ -43,7 +41,7 @@ describe('createDeflateEncoder', () => {
 
   describe('finish()', () => {
     it('invokes the callback with the encoded data', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       const finishCallbackSpy = jasmine.createSpy<(result: EncoderResult<Uint8ArrayBuffer>) => void>()
       encoder.write('foo')
       encoder.write('bar')
@@ -60,7 +58,7 @@ describe('createDeflateEncoder', () => {
     })
 
     it('invokes the callback even if nothing has been written', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       const finishCallbackSpy = jasmine.createSpy<(result: EncoderResult<Uint8ArrayBuffer>) => void>()
       encoder.finish(finishCallbackSpy)
 
@@ -73,7 +71,7 @@ describe('createDeflateEncoder', () => {
     })
 
     it('cancels pending write callbacks', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       const writeCallbackSpy = jasmine.createSpy()
       encoder.write('foo', writeCallbackSpy)
       encoder.write('bar', writeCallbackSpy)
@@ -85,14 +83,14 @@ describe('createDeflateEncoder', () => {
     })
 
     it('marks the encoder as empty', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       encoder.write('foo')
       encoder.finish(noop)
       expect(encoder.isEmpty).toBe(true)
     })
 
     it('supports calling finish() while another finish() call is pending', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       const finishCallbackSpy = jasmine.createSpy<(result: EncoderResult<Uint8ArrayBuffer>) => void>()
       encoder.write('foo')
       encoder.finish(finishCallbackSpy)
@@ -125,7 +123,7 @@ describe('createDeflateEncoder', () => {
 
   describe('finishSync()', () => {
     it('returns the encoded data up to this point and any pending data', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       encoder.write('foo')
       encoder.write('bar')
 
@@ -141,7 +139,7 @@ describe('createDeflateEncoder', () => {
     })
 
     it('cancels pending write callbacks', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       const writeCallbackSpy = jasmine.createSpy()
       encoder.write('foo', writeCallbackSpy)
       encoder.write('bar', writeCallbackSpy)
@@ -153,14 +151,14 @@ describe('createDeflateEncoder', () => {
     })
 
     it('marks the encoder as empty', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       encoder.write('foo')
       encoder.finishSync()
       expect(encoder.isEmpty).toBe(true)
     })
 
     it('supports calling finishSync() while another finish() call is pending', () => {
-      const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
       const finishCallbackSpy = jasmine.createSpy<(result: EncoderResult<Uint8ArrayBuffer>) => void>()
       encoder.write('foo')
       encoder.finish(finishCallbackSpy)
@@ -181,9 +179,9 @@ describe('createDeflateEncoder', () => {
 
   it('ignores messages destined to other streams', () => {
     // Let's assume another encoder is sending something to the worker
-    createDeflateEncoder(configuration, worker, OTHER_STREAM_ID).write('foo', noop)
+    createDeflateEncoder(worker, OTHER_STREAM_ID).write('foo', noop)
 
-    const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+    const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
     const writeCallbackSpy = jasmine.createSpy()
     encoder.write('foo', writeCallbackSpy)
 
@@ -194,7 +192,7 @@ describe('createDeflateEncoder', () => {
   })
 
   it('unsubscribes from the worker responses come out of order', () => {
-    const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+    const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
     encoder.write('foo', noop)
     encoder.write('bar', noop)
 
@@ -205,7 +203,7 @@ describe('createDeflateEncoder', () => {
   })
 
   it('do not notify data twice when calling finishSync() then finish()', () => {
-    const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+    const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
     const finishCallbackSpy = jasmine.createSpy<(result: EncoderResult<Uint8ArrayBuffer>) => void>()
 
     encoder.write('foo')
@@ -225,7 +223,7 @@ describe('createDeflateEncoder', () => {
   })
 
   it('do not notify data twice when calling finishSync() then finishSync()', () => {
-    const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+    const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
 
     encoder.write('foo')
     encoder.finishSync()
@@ -235,7 +233,7 @@ describe('createDeflateEncoder', () => {
   })
 
   it('does not unsubscribe when there is no pending action', () => {
-    const encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+    const encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
 
     encoder.write('foo')
     encoder.finishSync()

--- a/packages/browser-rum/src/domain/deflate/deflateEncoder.ts
+++ b/packages/browser-rum/src/domain/deflate/deflateEncoder.ts
@@ -7,13 +7,8 @@ import type {
   Uint8ArrayBuffer,
 } from '@datadog/browser-core'
 import { addEventListener, concatBuffers } from '@datadog/browser-core'
-import type { RumConfiguration } from '@datadog/browser-rum-core'
 
-export function createDeflateEncoder(
-  configuration: RumConfiguration,
-  worker: DeflateWorker,
-  streamId: DeflateEncoderStreamId
-): DeflateEncoder {
+export function createDeflateEncoder(worker: DeflateWorker, streamId: DeflateEncoderStreamId): DeflateEncoder {
   let rawBytesCount = 0
   let compressedData: Uint8ArrayBuffer[] = []
   let compressedDataTrailer: Uint8ArrayBuffer
@@ -29,7 +24,6 @@ export function createDeflateEncoder(
 
   const expectedStreamId: number = streamId
   const { stop: removeMessageListener } = addEventListener(
-    configuration,
     worker,
     'message',
     ({ data: workerResponse }: MessageEvent<DeflateWorkerResponse>) => {

--- a/packages/browser-rum/src/domain/deflate/deflateWorker.ts
+++ b/packages/browser-rum/src/domain/deflate/deflateWorker.ts
@@ -90,11 +90,10 @@ export function getDeflateWorkerStatus() {
 export function doStartDeflateWorker(configuration: RumConfiguration, source: string) {
   try {
     const worker = mockable(createDeflateWorker)(configuration)
-    const { stop: removeErrorListener } = addEventListener(configuration, worker, 'error', (error) => {
+    const { stop: removeErrorListener } = addEventListener(worker, 'error', (error) => {
       onError(configuration, source, error)
     })
     const { stop: removeMessageListener } = addEventListener(
-      configuration,
       worker,
       'message',
       ({ data }: MessageEvent<DeflateWorkerResponse>) => {

--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
@@ -95,8 +95,8 @@ export function createRumProfiler(
 
     // Add global clean-up tasks for listeners that are not specific to a profiler instance (eg. visibility change, before unload)
     globalCleanupTasks.push(
-      addEventListener(configuration, window, DOM_EVENT.VISIBILITY_CHANGE, handleVisibilityChange).stop,
-      addEventListener(configuration, window, DOM_EVENT.BEFORE_UNLOAD, handleBeforeUnload).stop
+      addEventListener(window, DOM_EVENT.VISIBILITY_CHANGE, handleVisibilityChange).stop,
+      addEventListener(window, DOM_EVENT.BEFORE_UNLOAD, handleBeforeUnload).stop
     )
 
     // Start profiler instance

--- a/packages/browser-rum/src/domain/record/record.ts
+++ b/packages/browser-rum/src/domain/record/record.ts
@@ -67,12 +67,12 @@ export function record(options: RecordOptions): RecordAPI {
     trackMove(processRecord, scope),
     trackMouseInteraction(processRecord, scope),
     trackScroll(document, processRecord, scope),
-    trackViewportResize(processRecord, scope),
+    trackViewportResize(processRecord),
     trackInput(document, processRecord, scope),
     trackMediaInteraction(processRecord, scope),
     trackStyleSheet(processRecord, scope),
-    trackFocus(processRecord, scope),
-    trackVisualViewportResize(processRecord, scope),
+    trackFocus(processRecord),
+    trackVisualViewportResize(processRecord),
     trackViewEnd(lifeCycle, processRecord, flushMutations),
   ]
 

--- a/packages/browser-rum/src/domain/record/trackers/trackFocus.spec.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackFocus.spec.ts
@@ -1,7 +1,7 @@
 import { createNewEvent, registerCleanupTask } from '@datadog/browser-core/test'
 import { RecordType } from '../../../types'
 import type { EmitRecordCallback } from '../record.types'
-import { createRecordingScopeForTesting } from '../test/recordingScope.specHelper'
+import {} from '../test/recordingScope.specHelper'
 import { trackFocus } from './trackFocus'
 import type { Tracker } from './tracker.types'
 
@@ -11,7 +11,7 @@ describe('trackFocus', () => {
 
   beforeEach(() => {
     emitRecordCallback = jasmine.createSpy()
-    focusTracker = trackFocus(emitRecordCallback, createRecordingScopeForTesting())
+    focusTracker = trackFocus(emitRecordCallback)
     registerCleanupTask(() => {
       focusTracker.stop()
     })

--- a/packages/browser-rum/src/domain/record/trackers/trackFocus.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackFocus.ts
@@ -2,12 +2,11 @@ import { DOM_EVENT, addEventListeners } from '@datadog/browser-core'
 import { timeStampNow } from '@datadog/js-core/time'
 import type { FocusRecord } from '../../../types'
 import { RecordType } from '../../../types'
-import type { RecordingScope } from '../recordingScope'
 import type { EmitRecordCallback } from '../record.types'
 import type { Tracker } from './tracker.types'
 
-export function trackFocus(emitRecord: EmitRecordCallback<FocusRecord>, scope: RecordingScope): Tracker {
-  return addEventListeners(scope.configuration, window, [DOM_EVENT.FOCUS, DOM_EVENT.BLUR], () => {
+export function trackFocus(emitRecord: EmitRecordCallback<FocusRecord>): Tracker {
+  return addEventListeners(window, [DOM_EVENT.FOCUS, DOM_EVENT.BLUR], () => {
     emitRecord({
       data: { has_focus: document.hasFocus() },
       type: RecordType.Focus,

--- a/packages/browser-rum/src/domain/record/trackers/trackInput.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackInput.ts
@@ -20,7 +20,6 @@ export function trackInput(
   const isShadowRoot = target !== document
 
   const { stop: stopEventListeners } = addEventListeners(
-    scope.configuration,
     target,
     // The 'input' event bubbles across shadow roots, so we don't have to listen for it on shadow
     // roots since it will be handled by the event listener that we did add to the document. Only

--- a/packages/browser-rum/src/domain/record/trackers/trackMediaInteraction.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackMediaInteraction.ts
@@ -13,7 +13,6 @@ export function trackMediaInteraction(
   scope: RecordingScope
 ): Tracker {
   return addEventListeners(
-    scope.configuration,
     document,
     [DOM_EVENT.PLAY, DOM_EVENT.PAUSE],
     (event) => {

--- a/packages/browser-rum/src/domain/record/trackers/trackMouseInteraction.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackMouseInteraction.ts
@@ -62,7 +62,6 @@ export function trackMouseInteraction(
     })
   }
   return addEventListeners(
-    scope.configuration,
     document,
     Object.keys(eventTypeToMouseInteraction) as Array<keyof typeof eventTypeToMouseInteraction>,
     handler,

--- a/packages/browser-rum/src/domain/record/trackers/trackMove.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackMove.ts
@@ -46,7 +46,6 @@ export function trackMove(
   )
 
   const { stop: removeListener } = addEventListeners(
-    scope.configuration,
     document,
     [DOM_EVENT.MOUSE_MOVE, DOM_EVENT.TOUCH_MOVE],
     updatePosition,

--- a/packages/browser-rum/src/domain/record/trackers/trackScroll.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackScroll.ts
@@ -47,7 +47,7 @@ export function trackScroll(
     )
   }, SCROLL_OBSERVER_THRESHOLD)
 
-  const { stop: removeListener } = addEventListener(scope.configuration, target, DOM_EVENT.SCROLL, updatePosition, {
+  const { stop: removeListener } = addEventListener(target, DOM_EVENT.SCROLL, updatePosition, {
     capture: true,
     passive: true,
   })

--- a/packages/browser-rum/src/domain/record/trackers/trackViewportResize.spec.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackViewportResize.spec.ts
@@ -19,7 +19,7 @@ describe('trackViewportResize', () => {
     const scope = createRecordingScopeForTesting()
     takeFullSnapshotForTesting(scope)
 
-    viewportResizeTracker = trackVisualViewportResize(emitRecordCallback, scope)
+    viewportResizeTracker = trackVisualViewportResize(emitRecordCallback)
     registerCleanupTask(() => {
       viewportResizeTracker.stop()
     })

--- a/packages/browser-rum/src/domain/record/trackers/trackViewportResize.ts
+++ b/packages/browser-rum/src/domain/record/trackers/trackViewportResize.ts
@@ -7,20 +7,14 @@ import type { BrowserIncrementalSnapshotRecord, ViewportResizeData, VisualViewpo
 import { getVisualViewport } from '../viewports'
 import { assembleIncrementalSnapshot } from '../assembly'
 import type { EmitRecordCallback } from '../record.types'
-import type { RecordingScope } from '../recordingScope'
 import type { Tracker } from './tracker.types'
 
 const VISUAL_VIEWPORT_OBSERVER_THRESHOLD = 200
 
-export function trackViewportResize(
-  emitRecord: EmitRecordCallback<BrowserIncrementalSnapshotRecord>,
-  scope: RecordingScope
-): Tracker {
-  const viewportResizeSubscription = initViewportObservable(scope.configuration).subscribe(
-    (data: ViewportDimension) => {
-      emitRecord(assembleIncrementalSnapshot<ViewportResizeData>(IncrementalSource.ViewportResize, data))
-    }
-  )
+export function trackViewportResize(emitRecord: EmitRecordCallback<BrowserIncrementalSnapshotRecord>): Tracker {
+  const viewportResizeSubscription = initViewportObservable().subscribe((data: ViewportDimension) => {
+    emitRecord(assembleIncrementalSnapshot<ViewportResizeData>(IncrementalSource.ViewportResize, data))
+  })
 
   return {
     stop: () => {
@@ -29,10 +23,7 @@ export function trackViewportResize(
   }
 }
 
-export function trackVisualViewportResize(
-  emitRecord: EmitRecordCallback<VisualViewportRecord>,
-  scope: RecordingScope
-): Tracker {
+export function trackVisualViewportResize(emitRecord: EmitRecordCallback<VisualViewportRecord>): Tracker {
   const visualViewport = window.visualViewport
   if (!visualViewport) {
     return { stop: noop }
@@ -51,7 +42,6 @@ export function trackVisualViewportResize(
     }
   )
   const { stop: removeListener } = addEventListeners(
-    scope.configuration,
     visualViewport,
     [DOM_EVENT.RESIZE, DOM_EVENT.SCROLL],
     updateDimension,

--- a/packages/browser-rum/src/domain/segmentCollection/segment.spec.ts
+++ b/packages/browser-rum/src/domain/segmentCollection/segment.spec.ts
@@ -1,7 +1,6 @@
 import type { DeflateEncoder, Uint8ArrayBuffer } from '@datadog/browser-core'
 import type { TimeStamp } from '@datadog/js-core/time'
 import { noop, setDebugMode, DeflateEncoderStreamId } from '@datadog/browser-core'
-import type { RumConfiguration } from '@datadog/browser-rum-core'
 import { registerCleanupTask } from '@datadog/browser-core/test'
 import { MockWorker } from '../../../test'
 import type { CreationReason, BrowserRecord, SegmentContext, BrowserSegment, BrowserSegmentMetadata } from '../../types'
@@ -35,13 +34,12 @@ const ENCODED_META_BYTES_COUNT = 193 // this should stay accurate as long as les
 const TRAILER_BYTES_COUNT = 1
 
 describe('Segment', () => {
-  const configuration = {} as RumConfiguration
   let worker: MockWorker
   let encoder: DeflateEncoder
 
   beforeEach(() => {
     worker = new MockWorker()
-    encoder = createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+    encoder = createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
     setDebugMode(true)
 
     registerCleanupTask(() => {

--- a/packages/browser-rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/browser-rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -1,7 +1,7 @@
 import type { ClocksState } from '@datadog/js-core/time'
 import type { HttpRequest, HttpRequestEvent } from '@datadog/browser-core'
 import { DeflateEncoderStreamId, Observable, PageExitReason } from '@datadog/browser-core'
-import type { ViewHistory, ViewHistoryEntry, RumConfiguration } from '@datadog/browser-rum-core'
+import type { ViewHistory, ViewHistoryEntry } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
 import type { Clock } from '@datadog/browser-core/test'
 import {
@@ -46,7 +46,6 @@ describe('startSegmentCollection', () => {
   }
   let addRecord: (record: BrowserRecord) => void
   let context: SegmentContext | undefined
-  let configuration: RumConfiguration
 
   function addRecordAndFlushSegment(flushStrategy: () => void = emulatePageUnload) {
     // Make sure the segment is not empty
@@ -65,7 +64,6 @@ describe('startSegmentCollection', () => {
   }
 
   beforeEach(() => {
-    configuration = {} as RumConfiguration
     lifeCycle = new LifeCycle()
     worker = new MockWorker()
     httpRequestSpy = {
@@ -78,7 +76,7 @@ describe('startSegmentCollection', () => {
       lifeCycle,
       () => context,
       httpRequestSpy,
-      createDeflateEncoder(configuration, worker, DeflateEncoderStreamId.REPLAY)
+      createDeflateEncoder(worker, DeflateEncoderStreamId.REPLAY)
     ))
 
     registerCleanupTask(() => {


### PR DESCRIPTION
## Motivation

Passing the SDK configuration object through dozens of internal utility functions (event listeners, performance observers, navigation timings, scroll metrics, etc.) just to convey a single boolean flag (`allowUntrustedEvents`) added unnecessary boilerplate and made function signatures harder to read and test.

As we are moving toward tooling modularization and reusability, having to carry a "full" Configuration object just to use low level functions is impractical.

## Changes

- Introduce a `setAllowUntrustedEvents()` singleton in `addEventListener.ts`: the `allowUntrustedEvents` flag is now set once at SDK init time rather than threaded through every call site
- Remove the `configuration` parameter from internal utilities that no longer need it: `addEventListener`/`addEventListeners`, `startPageStateHistory`, `startErrorCollection`, `trackReportError`, `trackXhr`, `onBFCacheRestore`, `trackFirstHidden`, `trackFirstContentfulPaint`, `trackNavigationTimings`, `trackScrollMetrics`, `createScrollValuesObservable`, `createPerformanceObservable`, `runOnReadyState`, and several view metrics trackers
- Add `resetAllowUntrustedEvents()` called between unit tests so the singleton doesn't leak across specs

## Test instructions

Initialize the SDK with `allowUntrustedEvents: true`, then dispatch an event: the SDK should pick it up, as before.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
