### PR TITLE
✅ fail unit tests when unexpected console logs are detected in CI

### DIFF
--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -33,6 +33,10 @@ describe('canUseEventBridge', () => {
 })
 
 describe('matchesHostEntry', () => {
+  beforeEach(() => {
+    spyOn(display, 'error')
+  })
+
   // prettier-ignore
   const cases: Array<[string, string, boolean]> = [
     // [host,                          pattern,                  expected]

--- a/test/unit/karma.base.conf.js
+++ b/test/unit/karma.base.conf.js
@@ -5,6 +5,7 @@ import { getTestReportDirectory } from '../envUtils.ts'
 import jasmineSeedReporterPlugin from './jasmineSeedReporterPlugin.js'
 import karmaSkippedFailedReporterPlugin from './karmaSkippedFailedReporterPlugin.js'
 import karmaDuplicateTestNameReporterPlugin from './karmaDuplicateTestNameReporterPlugin.js'
+import karmaUnexpectedErrorLogReporterPlugin from './karmaUnexpectedErrorLogReporterPlugin.js'
 
 const webpackConfig = webpackBase({
   mode: 'development',
@@ -14,6 +15,9 @@ const webpackConfig = webpackBase({
 })
 
 const reporters = ['spec', 'jasmine-seed', 'karma-skipped-failed', 'karma-duplicate-test-name']
+if (process.env.CI) {
+  reporters.push('karma-unexpected-error-log')
+}
 
 const testReportDirectory = getTestReportDirectory()
 if (testReportDirectory) {
@@ -101,6 +105,7 @@ export default {
     jasmineSeedReporterPlugin,
     karmaSkippedFailedReporterPlugin,
     karmaDuplicateTestNameReporterPlugin,
+    karmaUnexpectedErrorLogReporterPlugin,
   ],
 
   // Running tests on low performance environments (ex: BrowserStack) can block JS execution for a

--- a/test/unit/karmaUnexpectedErrorLogReporterPlugin.js
+++ b/test/unit/karmaUnexpectedErrorLogReporterPlugin.js
@@ -1,0 +1,39 @@
+/**
+ * Karma reporter that fails any spec that produces an unexpected console log.
+ *
+ * Tests that intentionally trigger console output should spy on the relevant method beforehand,
+ * which prevents the call from reaching the browser console (and thus this reporter).
+ */
+function KarmaUnexpectedErrorLogReporter(logger) {
+  const log = logger.create('karma-unexpected-error-log')
+
+  // Logs are buffered here between two onSpecComplete calls
+  const pendingLogs = new Map() // browser.id -> string[]
+
+  this.onBrowserLog = (browser, message, type) => {
+    pendingLogs.getOrInsert(browser.id, []).push(`${type}: ${message}`)
+  }
+
+  this.onSpecComplete = (browser, result) => {
+    if (!pendingLogs.has(browser.id)) {
+      return
+    }
+    const logs = pendingLogs.get(browser.id)
+    pendingLogs.delete(browser.id)
+
+    for (const message of logs) {
+      const failure = `Unexpected console call: ${message}`
+      log.error(failure)
+      result.log.push(failure)
+    }
+    result.success = false
+    browser.lastResult.failed++
+  }
+}
+
+KarmaUnexpectedErrorLogReporter.$inject = ['logger']
+
+// eslint-disable-next-line import-x/no-default-export
+export default {
+  'reporter:karma-unexpected-error-log': ['type', KarmaUnexpectedErrorLogReporter],
+}


### PR DESCRIPTION
## Motivation

Test suites can silently produce console output (errors, warnings, logs) without anyone noticing,
masking bugs where production code logs unexpectedly. This makes it harder to catch regressions
where a code path that should be silent starts printing to the console.

## Changes

- Add a Karma reporter plugin (`karmaUnexpectedErrorLogReporterPlugin`) that intercepts any browser
  console call during a spec and fails the test if it wasn't intercepted by a spy first. Only
  active when `CI=true` to avoid disrupting local dev workflows.
- Fix the `matchesHostEntry` test suite: add a `spyOn(display, 'error')` in `beforeEach` to
  silence the expected error log produced by the multi-wildcard test cases.

## Test instructions

No visible behavior change in the browser — this is a test infrastructure change only.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file