### PR TITLE
👷 remove dead puppeteer-core ws resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,6 @@
     "webpack-dev-middleware": "8.0.3",
     "ws": "8.21.0"
   },
-  "resolutions": {
-    "puppeteer-core@npm:21.11.0/ws": "8.17.1"
-  },
   "volta": {
     "node": "26.2.0",
     "yarn": "4.15.0"


### PR DESCRIPTION
## Motivation

The `puppeteer-core@npm:21.11.0/ws` Yarn `resolutions` override is dead config. It was added by Renovate in #2992 (Sept 2024) to pin the `ws` transitive dependency nested under `puppeteer-core@21.11.0` to `8.17.1` (a known-good version at the time). `puppeteer-core` is now at `24.43.1`, so the selector `puppeteer-core@npm:21.11.0` matches nothing and the override has no effect.

## Changes

- Remove the `puppeteer-core@npm:21.11.0/ws` entry from `resolutions` in the root `package.json`. The `resolutions` block was otherwise empty, so it is removed entirely.

Verified that `yarn install` produces **no change to `yarn.lock`** (the override matched nothing), and `ws` still resolves to `8.21.0` / `~8.20.1` as before. Pure config cleanup, no dependency-graph impact.

## Test instructions

- `yarn install` — lockfile is unchanged.
- `grep "ws@" yarn.lock` — `ws` still resolves to `8.21.0` / `~8.20.1`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
