### PR TITLE
🐛 Tolerate an invalid view URL in the developer extension

### DIFF
--- a/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
+++ b/developer-extension/src/panel/components/tabs/eventsTab/eventRow.tsx
@@ -459,6 +459,10 @@ function Emphasis({ children }: { children: ReactNode }) {
   return <strong>{children}</strong>
 }
 
-function getViewName(view: { name?: string; url: string }) {
-  return view.name ?? new URL(view.url).pathname
+function getViewName(view: { name?: string; url: string }): string {
+  try {
+    return view.name ?? new URL(view.url).pathname
+  } catch {
+    return view.url ?? '<unknown view>'
+  }
 }


### PR DESCRIPTION
## Motivation

If a customer uses `beforeSend()` to set `view.url` to a value which is not actually a URL, it can cause the developer extension to crash, which makes debugging quite difficult.

## Changes

This PR catches the exception thrown in `getViewName()` from `new URL(view.url)` and applies a fallback view name.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
