### PR TITLE
Add RUM Next.js package support metadata

### DIFF
--- a/packages/browser-rum-nextjs/package.json
+++ b/packages/browser-rum-nextjs/package.json
@@ -39,6 +39,10 @@
     "url": "https://github.com/DataDog/browser-sdk.git",
     "directory": "packages/browser-rum-nextjs"
   },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
+  "homepage": "https://github.com/DataDog/browser-sdk#readme",
   "volta": {
     "extends": "../../package.json"
   },


### PR DESCRIPTION
Summary:
- Add `bugs.url` to the `@datadog/browser-rum-nextjs` package manifest.
- Add `homepage` pointing to the repository README.
- Leave runtime code, dependencies, exports, build scripts, and package version unchanged.

Why:
- The published package currently exposes package repository metadata but not standard npm support/homepage links.
- This addresses the metadata gap described in https://github.com/charles-openclaw/charles-microbounties/issues/862.

Validation:
- `node -e "const p=require('./packages/browser-rum-nextjs/package.json'); if(p.name!=='@datadog/browser-rum-nextjs') throw new Error('name mismatch'); if(p.repository?.directory!=='packages/browser-rum-nextjs') throw new Error('repository directory mismatch'); if(p.bugs?.url!=='https://github.com/DataDog/browser-sdk/issues') throw new Error('bugs mismatch'); if(p.homepage!=='https://github.com/DataDog/browser-sdk#readme') throw new Error('homepage mismatch'); console.log('metadata ok');"`
- `npm pack ./packages/browser-rum-nextjs --dry-run --ignore-scripts --json`
- `git diff --check`

Bounty claim:
- Source bounty: https://github.com/charles-openclaw/charles-microbounties/issues/862
- This PR adds the requested `bugs` and `homepage` package metadata fields.
- Any payout/account setup remains owner-only.

Disclosure:
- Prepared with AI assistance and manually validated before submission.