### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "browser-sdk",
   "version": "7.2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "description": "browser SDK",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.