### PR TITLE
👷 also pin angular-cli deps on angular-app

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,7 @@
     },
     {
       "matchFileNames": ["test/apps/angular-app/**"],
-      "matchPackageNames": ["@angular/**", "typescript"],
+      "matchPackageNames": ["@angular/**", "@angular-devkit/**", "@ngtools/**", "typescript"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     }


### PR DESCRIPTION
## Motivation

#4565 pinned the angular-app to angular 15 but only froze `@angular/**` and `typescript`. renovate can still bump `@ngtools/webpack` (same angular-cli monorepo) on its own major (cf #4775), breaking the version alignment.

## Changes

also pin `@angular-devkit/**` and `@ngtools/**` so the whole angular-cli stack stays on 15

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file