### PR TITLE
👷 Allow passing a full commit hash to `json-schemas --update`

### DIFF
--- a/scripts/json-schemas.ts
+++ b/scripts/json-schemas.ts
@@ -49,26 +49,36 @@ function printHelp() {
 Usage: node scripts/json-schemas.ts [options]
 
 Options:
-  --update <branch>  Update @datadog/rum-events-format to the latest commit on <branch> and run yarn install
+  --update <branch|commit>  Update @datadog/rum-events-format to the latest commit on <branch> (or a specific full commit hash) and run yarn install
   --build            Build json-schema-to-typescript and regenerate TypeScript types from JSON schemas
   --help, -h         Show this help message
 
 Examples:
-  node scripts/json-schemas.ts --update master --build  # Full sync (alias: yarn json-schemas:sync)
+  node scripts/json-schemas.ts --update master --build              # Full sync (alias: yarn json-schemas:sync)
+  node scripts/json-schemas.ts --update <40-char-hash> --build       # Sync to a specific commit
   node scripts/json-schemas.ts --build                  # Regenerate types only (alias: yarn json-schemas:generate)
 `)
 }
 
-async function update(branch: string) {
-  printLog(`Resolving latest commit on ${branch}...`)
-  const response = await fetchHandlingError(`https://api.github.com/repos/DataDog/rum-events-format/branches/${branch}`)
-  const {
-    commit: { sha: commitHash },
-  } = (await response.json()) as { commit: { sha: string } }
-  if (!commitHash) {
-    throw new Error(`Could not resolve branch ${branch}`)
+async function update(branchOrCommit: string) {
+  let commitHash: string
+  if (/^[0-9a-f]{40}$/.test(branchOrCommit)) {
+    commitHash = branchOrCommit
+    printLog(`Using provided commit hash: ${commitHash}`)
+  } else {
+    printLog(`Resolving latest commit on ${branchOrCommit}...`)
+    const response = await fetchHandlingError(
+      `https://api.github.com/repos/DataDog/rum-events-format/branches/${branchOrCommit}`
+    )
+    const {
+      commit: { sha },
+    } = (await response.json()) as { commit: { sha: string } }
+    if (!sha) {
+      throw new Error(`Could not resolve branch ${branchOrCommit}`)
+    }
+    commitHash = sha
+    printLog(`Latest commit: ${commitHash}`)
   }
-  printLog(`Latest commit: ${commitHash}`)
 
   await modifyFile(PACKAGE_JSON_PATH, (content) =>
     content.replace(


### PR DESCRIPTION
## Motivation

When working with a specific commit from `rum-events-format` (e.g. a commit that hasn't landed on any branch yet, or an exact reproducible reference), it was not possible to pass it directly to `json-schemas --update` — only a branch name was accepted, which always resolved to the latest tip of that branch.

Related PR: https://github.com/DataDog/rum-events-format/pull/393

## Changes

- `json-schemas --update` now accepts either a branch name or a full 40-character commit hash. When a hash is detected, the GitHub API call is skipped and the hash is used directly.

## Test instructions

Run with a branch name to verify existing behaviour is unchanged:
```
node scripts/json-schemas.ts --update master
```

Run with a full commit hash (grab one from `DataDog/rum-events-format`) to verify it is used directly without an API call:
```
node scripts/json-schemas.ts --update <40-char-hash>
```
Confirm `package.json` is updated to `DataDog/rum-events-format#commit=<that-hash>` in both cases.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
