### PR TITLE
👷 [RUM-16634] Require WebView wildcard to match at least one character

### DIFF
--- a/packages/browser-core/src/transport/eventBridge.spec.ts
+++ b/packages/browser-core/src/transport/eventBridge.spec.ts
@@ -50,6 +50,10 @@ describe('matchesHostEntry', () => {
     ['evil.com',                       '*.shopist.io',           false],
     ['app.shopist.io.evil.com',        '*.shopist.io',           false],
     ['anything.foo.anything.bar',      '*.foo.*.bar',            false], // multiple wildcards → invalid
+    ['preview-.shopist.io',            'preview-*.shopist.io',   false], // wildcard must match at least one character
+    ['.shopist.io',                    '*.shopist.io',           false], // wildcard must match at least one character
+    ['app.shopist.io',                 '*',                      true],  // bare "*" matches any host
+    ['shopist.io',                     '*',                      true],  // bare "*" matches any host
   ]
 
   cases.forEach(([host, pattern, expected]) => {

--- a/packages/browser-core/src/transport/eventBridge.ts
+++ b/packages/browser-core/src/transport/eventBridge.ts
@@ -65,7 +65,7 @@ export function matchesHostEntry(host: string, entry: string): boolean {
     return false
   }
   const [prefix, suffix] = parts
-  return host.length >= prefix.length + suffix.length && host.startsWith(prefix) && host.endsWith(suffix)
+  return host.length > prefix.length + suffix.length && host.startsWith(prefix) && host.endsWith(suffix)
 }
 
 function getEventBridgeGlobal() {


### PR DESCRIPTION
## Motivation

`matchesHostEntry` used `>=`, which let a `*` match zero characters (e.g. `preview-*.shopist.io` matched `preview-.shopist.io`). A wildcard should match at least one character.

## Changes

- `matchesHostEntry`: `>=` → `>`.
- A bare `*` still matches every non-empty host.
- Added test cases for the zero-char rejection and bare `*`.