### PR TITLE
chore: add npm bugs metadata to all published packages

### DIFF
--- a/packages/browser-core/package.json
+++ b/packages/browser-core/package.json
@@ -34,5 +34,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-debugger/package.json
+++ b/packages/browser-debugger/package.json
@@ -35,5 +35,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -40,5 +40,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum-angular/package.json
+++ b/packages/browser-rum-angular/package.json
@@ -44,5 +44,8 @@
     "@angular/platform-browser": "22.0.0",
     "@angular/router": "22.0.0",
     "rxjs": "7.8.2"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum-core/package.json
+++ b/packages/browser-rum-core/package.json
@@ -33,5 +33,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum-nextjs/package.json
+++ b/packages/browser-rum-nextjs/package.json
@@ -47,5 +47,8 @@
     "next": "16.2.7",
     "react": "19.2.7",
     "react-dom": "19.2.7"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum-nuxt/package.json
+++ b/packages/browser-rum-nuxt/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum-react/package.json
+++ b/packages/browser-rum-react/package.json
@@ -71,5 +71,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum-slim/package.json
+++ b/packages/browser-rum-slim/package.json
@@ -40,5 +40,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum-vue/package.json
+++ b/packages/browser-rum-vue/package.json
@@ -55,5 +55,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-rum/package.json
+++ b/packages/browser-rum/package.json
@@ -47,5 +47,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/browser-worker/package.json
+++ b/packages/browser-worker/package.json
@@ -30,5 +30,8 @@
   },
   "devDependencies": {
     "webpack": "5.107.2"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }

--- a/packages/js-core/package.json
+++ b/packages/js-core/package.json
@@ -32,5 +32,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
   }
 }


### PR DESCRIPTION
## Problem

All `@datadog/browser-*` packages are missing the `bugs` field in their `package.json` files.

```sh
npm view @datadog/browser-rum bugs    # empty
npm view @datadog/browser-logs bugs   # empty
npm view @datadog/browser-core bugs   # empty
# etc.
```

## Fix

Add `bugs.url` pointing to the GitHub issue tracker in all 13 published packages. Metadata-only change — no runtime behaviour is affected.