### PR TITLE
chore: add missing bugs metadata to browser packages

### DIFF
--- a/packages/browser-core/package.json
+++ b/packages/browser-core/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-core",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",

--- a/packages/browser-debugger/package.json
+++ b/packages/browser-debugger/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-debugger",
   "private": true,
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-logs",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-rum-angular/package.json
+++ b/packages/browser-rum-angular/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum-angular",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-rum-core/package.json
+++ b/packages/browser-rum-core/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum-core",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "types": "cjs/index.d.ts",

--- a/packages/browser-rum-nextjs/package.json
+++ b/packages/browser-rum-nextjs/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum-nextjs",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-rum-nuxt/package.json
+++ b/packages/browser-rum-nuxt/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum-nuxt",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-rum-react/package.json
+++ b/packages/browser-rum-react/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum-react",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-rum-slim/package.json
+++ b/packages/browser-rum-slim/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum-slim",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-rum-vue/package.json
+++ b/packages/browser-rum-vue/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum-vue",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-rum/package.json
+++ b/packages/browser-rum/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-rum",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "cjs/entries/main.js",
   "module": "esm/entries/main.js",
   "types": "cjs/entries/main.d.ts",

--- a/packages/browser-worker/package.json
+++ b/packages/browser-worker/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/browser-worker",
   "version": "7.3.0",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "main": "bundle/worker.js",
   "files": [
     "bundle/**/*.js",

--- a/packages/js-core/package.json
+++ b/packages/js-core/package.json
@@ -2,6 +2,9 @@
   "name": "@datadog/js-core",
   "version": "0.0.2",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/DataDog/browser-sdk/issues"
+  },
   "sideEffects": false,
   "exports": {
     "./time": {


### PR DESCRIPTION
This PR adds the missing  field to the npm metadata of all affected  packages, allowing users to easily find the issue tracker.

Fixed packages:
- @datadog/browser-core
- @datadog/browser-logs
- @datadog/browser-rum
- @datadog/browser-rum-core
- @datadog/browser-rum-react
- @datadog/browser-rum-angular
- @datadog/browser-rum-vue
- @datadog/browser-rum-nextjs
- @datadog/browser-rum-nuxt
- @datadog/browser-rum-slim
- @datadog/browser-worker
- @datadog/browser-debugger
- @datadog/js-core

Wallet (TON): UQAVD5f6XBxXDlK4SDbvRpq_btbnmniWroIXv55bvgFnceaz