### PR TITLE
⚗️ collect Network Efficiency Guardrails document-policy-violation reports as errors

### DIFF
--- a/packages/browser-core/src/domain/error/error.types.ts
+++ b/packages/browser-core/src/domain/error/error.types.ts
@@ -23,12 +23,14 @@ export interface RawErrorCause {
 
 export interface Csp {
   disposition: 'enforce' | 'report'
+  featureId?: string
 }
 
 export interface RawError {
   startClocks: ClocksState
   message: string
   type?: string
+  featureId?: string
   stack?: string
   source: ErrorSource
   originalError?: unknown

--- a/packages/browser-core/src/domain/report/browser.types.ts
+++ b/packages/browser-core/src/domain/report/browser.types.ts
@@ -1,9 +1,9 @@
-export type ReportType = DeprecationReport['type'] | InterventionReport['type']
+export type ReportType = DeprecationReport['type'] | InterventionReport['type'] | DocumentPolicyViolationReport['type']
 
 interface Report {
   type: ReportType
   url: string
-  body: DeprecationReportBody | InterventionReportBody
+  body: DeprecationReportBody | InterventionReportBody | DocumentPolicyViolationReportBody
   toJSON(): any
 }
 
@@ -34,5 +34,18 @@ export interface InterventionReportBody extends ReportBody {
   message: string
   lineNumber: number | null
   columnNumber: number | null
+  sourceFile: string | null
+}
+
+export interface DocumentPolicyViolationReport extends Report {
+  type: 'document-policy-violation'
+  body: DocumentPolicyViolationReportBody
+}
+export interface DocumentPolicyViolationReportBody extends ReportBody {
+  featureId: string
+  message: string
+  disposition: 'enforce' | 'report'
+  lineNumber: null
+  columnNumber: null
   sourceFile: string | null
 }

--- a/packages/browser-core/src/domain/report/reportObservable.spec.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.spec.ts
@@ -99,7 +99,8 @@ describe('report observable', () => {
 
     const [report] = notifyReport.calls.mostRecent().args
 
-    expect(report.stack).toEqual(`network-efficiency-guardrails: Document policy violation: resource compression is required.
+    expect(report.stack)
+      .toEqual(`network-efficiency-guardrails: Document policy violation: resource compression is required.
   at <anonymous> @ https://foo.bar/large-uncompressed.js`)
   })
 

--- a/packages/browser-core/src/domain/report/reportObservable.spec.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.spec.ts
@@ -1,5 +1,10 @@
 import type { MockCspEventListener, MockReportingObserver } from '../../../test'
-import { mockReportingObserver, mockCspEventListener, FAKE_CSP_VIOLATION_EVENT } from '../../../test'
+import {
+  mockReportingObserver,
+  mockCspEventListener,
+  FAKE_CSP_VIOLATION_EVENT,
+  FAKE_DOCUMENT_POLICY_VIOLATION_REPORT,
+} from '../../../test'
 import type { Subscription } from '../../tools/observable'
 import { ErrorHandling, ErrorSource } from '../error/error.types'
 import type { RawReportError } from './reportObservable'
@@ -71,6 +76,38 @@ describe('report observable', () => {
 
     consoleSubscription = initReportObservable([RawReportType.cspViolation]).subscribe(notifyReport)
     cspEventListener.dispatchEvent()
+
+    expect(notifyReport).not.toHaveBeenCalled()
+  })
+
+  it(`should notify ${RawReportType.networkEfficiencyGuardrails} reports`, () => {
+    consoleSubscription = initReportObservable([RawReportType.networkEfficiencyGuardrails]).subscribe(notifyReport)
+    reportingObserver.raiseReport('document-policy-violation')
+
+    expect(notifyReport).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining({
+        message: 'document-policy-violation: Document policy violation: resource compression is required.',
+        type: 'network-efficiency-guardrails',
+        csp: { disposition: 'report' },
+      })
+    )
+  })
+
+  it(`should compute stack for ${RawReportType.networkEfficiencyGuardrails}`, () => {
+    consoleSubscription = initReportObservable([RawReportType.networkEfficiencyGuardrails]).subscribe(notifyReport)
+    reportingObserver.raiseReport('document-policy-violation')
+
+    const [report] = notifyReport.calls.mostRecent().args
+
+    expect(report.stack).toEqual(`network-efficiency-guardrails: Document policy violation: resource compression is required.
+  at <anonymous> @ https://foo.bar/large-uncompressed.js`)
+  })
+
+  it(`should not notify document-policy-violation reports with a featureId other than ${RawReportType.networkEfficiencyGuardrails}`, () => {
+    consoleSubscription = initReportObservable([RawReportType.networkEfficiencyGuardrails]).subscribe(notifyReport)
+    reportingObserver.raiseReport('document-policy-violation', {
+      body: { ...FAKE_DOCUMENT_POLICY_VIOLATION_REPORT.body, featureId: 'some-other-policy' },
+    })
 
     expect(notifyReport).not.toHaveBeenCalled()
   })

--- a/packages/browser-core/src/domain/report/reportObservable.spec.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.spec.ts
@@ -80,8 +80,8 @@ describe('report observable', () => {
     expect(notifyReport).not.toHaveBeenCalled()
   })
 
-  it(`should notify ${RawReportType.networkEfficiencyGuardrails} reports`, () => {
-    consoleSubscription = initReportObservable([RawReportType.networkEfficiencyGuardrails]).subscribe(notifyReport)
+  it(`should notify ${RawReportType.documentPolicyViolation} reports`, () => {
+    consoleSubscription = initReportObservable([RawReportType.documentPolicyViolation]).subscribe(notifyReport)
     reportingObserver.raiseReport('document-policy-violation')
 
     expect(notifyReport).toHaveBeenCalledOnceWith(
@@ -93,8 +93,8 @@ describe('report observable', () => {
     )
   })
 
-  it(`should compute stack for ${RawReportType.networkEfficiencyGuardrails}`, () => {
-    consoleSubscription = initReportObservable([RawReportType.networkEfficiencyGuardrails]).subscribe(notifyReport)
+  it(`should compute stack for ${RawReportType.documentPolicyViolation}`, () => {
+    consoleSubscription = initReportObservable([RawReportType.documentPolicyViolation]).subscribe(notifyReport)
     reportingObserver.raiseReport('document-policy-violation')
 
     const [report] = notifyReport.calls.mostRecent().args
@@ -104,12 +104,16 @@ describe('report observable', () => {
   at <anonymous> @ https://foo.bar/large-uncompressed.js`)
   })
 
-  it(`should not notify document-policy-violation reports with a featureId other than ${RawReportType.networkEfficiencyGuardrails}`, () => {
-    consoleSubscription = initReportObservable([RawReportType.networkEfficiencyGuardrails]).subscribe(notifyReport)
+  it(`should notify ${RawReportType.documentPolicyViolation} reports regardless of featureId`, () => {
+    consoleSubscription = initReportObservable([RawReportType.documentPolicyViolation]).subscribe(notifyReport)
     reportingObserver.raiseReport('document-policy-violation', {
       body: { ...FAKE_DOCUMENT_POLICY_VIOLATION_REPORT.body, featureId: 'some-other-policy' },
     })
 
-    expect(notifyReport).not.toHaveBeenCalled()
+    expect(notifyReport).toHaveBeenCalledOnceWith(
+      jasmine.objectContaining({
+        type: 'some-other-policy',
+      })
+    )
   })
 })

--- a/packages/browser-core/src/domain/report/reportObservable.spec.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.spec.ts
@@ -87,7 +87,8 @@ describe('report observable', () => {
     expect(notifyReport).toHaveBeenCalledOnceWith(
       jasmine.objectContaining({
         message: 'document-policy-violation: Document policy violation: resource compression is required.',
-        type: 'network-efficiency-guardrails',
+        type: 'document-policy-violation',
+        featureId: 'network-efficiency-guardrails',
         csp: { disposition: 'report' },
       })
     )
@@ -112,7 +113,8 @@ describe('report observable', () => {
 
     expect(notifyReport).toHaveBeenCalledOnceWith(
       jasmine.objectContaining({
-        type: 'some-other-policy',
+        type: 'document-policy-violation',
+        featureId: 'some-other-policy',
       })
     )
   })

--- a/packages/browser-core/src/domain/report/reportObservable.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.ts
@@ -12,7 +12,7 @@ export const RawReportType = {
   intervention: 'intervention',
   deprecation: 'deprecation',
   cspViolation: 'csp_violation',
-  networkEfficiencyGuardrails: 'network-efficiency-guardrails',
+  documentPolicyViolation: 'document-policy-violation',
 } as const
 
 export type RawReportType = (typeof RawReportType)[keyof typeof RawReportType]
@@ -28,32 +28,12 @@ export function initReportObservable(apis: RawReportType[]) {
     observables.push(createCspViolationReportObservable())
   }
 
-  const reportTypes = buildReportObserverTypes(apis)
+  const reportTypes = apis.filter((api): api is ReportType => api !== RawReportType.cspViolation)
   if (reportTypes.length) {
     observables.push(createReportObservable(reportTypes))
   }
 
   return mergeObservables(...observables)
-}
-
-/**
- * Maps internal RawReportType values to the browser ReportingObserver type strings.
- * `network-efficiency-guardrails` is exposed via `document-policy-violation` reports,
- * filtered by `body.featureId === 'network-efficiency-guardrails'`.
- */
-function buildReportObserverTypes(apis: RawReportType[]): ReportType[] {
-  const types = new Set<ReportType>()
-  for (const api of apis) {
-    if (api === RawReportType.cspViolation) {
-      continue
-    }
-    if (api === RawReportType.networkEfficiencyGuardrails) {
-      types.add('document-policy-violation')
-    } else {
-      types.add(api)
-    }
-  }
-  return Array.from(types)
 }
 
 function createReportObservable(reportTypes: ReportType[]) {
@@ -64,18 +44,7 @@ function createReportObservable(reportTypes: ReportType[]) {
 
     const handleReports = monitor(
       (reports: Array<DeprecationReport | InterventionReport | DocumentPolicyViolationReport>, _: ReportingObserver) =>
-        reports.forEach((report) => {
-          // document-policy-violation reports are only subscribed to when
-          // network-efficiency-guardrails is requested. Skip any document policy violation
-          // whose featureId does not match network-efficiency-guardrails.
-          if (
-            report.type === 'document-policy-violation' &&
-            report.body.featureId !== RawReportType.networkEfficiencyGuardrails
-          ) {
-            return
-          }
-          observable.notify(buildRawReportErrorFromReport(report))
-        })
+        reports.forEach((report) => observable.notify(buildRawReportErrorFromReport(report)))
     ) as ReportingObserverCallback
 
     const observer = new window.ReportingObserver(handleReports, {

--- a/packages/browser-core/src/domain/report/reportObservable.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.ts
@@ -6,18 +6,19 @@ import { addEventListener, DOM_EVENT, isEventSupported } from '../../browser/add
 import { safeTruncate } from '../../tools/utils/stringUtils'
 import type { RawError } from '../error/error.types'
 import { ErrorHandling, ErrorSource } from '../error/error.types'
-import type { ReportType, InterventionReport, DeprecationReport } from './browser.types'
+import type { ReportType, InterventionReport, DeprecationReport, DocumentPolicyViolationReport } from './browser.types'
 
 export const RawReportType = {
   intervention: 'intervention',
   deprecation: 'deprecation',
   cspViolation: 'csp_violation',
+  networkEfficiencyGuardrails: 'network-efficiency-guardrails',
 } as const
 
 export type RawReportType = (typeof RawReportType)[keyof typeof RawReportType]
 
 export type RawReportError = RawError & {
-  originalError: SecurityPolicyViolationEvent | DeprecationReport | InterventionReport
+  originalError: SecurityPolicyViolationEvent | DeprecationReport | InterventionReport | DocumentPolicyViolationReport
 }
 
 export function initReportObservable(apis: RawReportType[]) {
@@ -27,12 +28,32 @@ export function initReportObservable(apis: RawReportType[]) {
     observables.push(createCspViolationReportObservable())
   }
 
-  const reportTypes = apis.filter((api: RawReportType): api is ReportType => api !== RawReportType.cspViolation)
+  const reportTypes = buildReportObserverTypes(apis)
   if (reportTypes.length) {
     observables.push(createReportObservable(reportTypes))
   }
 
   return mergeObservables(...observables)
+}
+
+/**
+ * Maps internal RawReportType values to the browser ReportingObserver type strings.
+ * `network-efficiency-guardrails` is exposed via `document-policy-violation` reports,
+ * filtered by `body.featureId === 'network-efficiency-guardrails'`.
+ */
+function buildReportObserverTypes(apis: RawReportType[]): ReportType[] {
+  const types = new Set<ReportType>()
+  for (const api of apis) {
+    if (api === RawReportType.cspViolation) {
+      continue
+    }
+    if (api === RawReportType.networkEfficiencyGuardrails) {
+      types.add('document-policy-violation')
+    } else {
+      types.add(api as ReportType)
+    }
+  }
+  return Array.from(types)
 }
 
 function createReportObservable(reportTypes: ReportType[]) {
@@ -41,8 +62,21 @@ function createReportObservable(reportTypes: ReportType[]) {
       return
     }
 
-    const handleReports = monitor((reports: Array<DeprecationReport | InterventionReport>, _: ReportingObserver) =>
-      reports.forEach((report) => observable.notify(buildRawReportErrorFromReport(report)))
+    const handleReports = monitor(
+      (reports: Array<DeprecationReport | InterventionReport | DocumentPolicyViolationReport>, _: ReportingObserver) =>
+        reports.forEach((report) => {
+          // document-policy-violation reports are only subscribed to when
+          // network-efficiency-guardrails is requested. Skip any document policy violation
+          // whose featureId does not match network-efficiency-guardrails.
+          if (
+            report.type === 'document-policy-violation' &&
+            (report.body as DocumentPolicyViolationReport['body']).featureId !==
+              RawReportType.networkEfficiencyGuardrails
+          ) {
+            return
+          }
+          observable.notify(buildRawReportErrorFromReport(report))
+        })
     ) as ReportingObserverCallback
 
     const observer = new window.ReportingObserver(handleReports, {
@@ -72,8 +106,21 @@ function createCspViolationReportObservable() {
   })
 }
 
-function buildRawReportErrorFromReport(report: DeprecationReport | InterventionReport): RawReportError {
+function buildRawReportErrorFromReport(
+  report: DeprecationReport | InterventionReport | DocumentPolicyViolationReport
+): RawReportError {
   const { type, body } = report
+
+  if (type === 'document-policy-violation') {
+    const { featureId, message, disposition, sourceFile } = body as DocumentPolicyViolationReport['body']
+    return buildRawReportError({
+      type: featureId,
+      message: `${type}: ${message}`,
+      originalError: report,
+      csp: { disposition },
+      stack: buildStack(featureId, message, sourceFile, null, null),
+    })
+  }
 
   return buildRawReportError({
     type: body.id,

--- a/packages/browser-core/src/domain/report/reportObservable.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.ts
@@ -50,7 +50,7 @@ function buildReportObserverTypes(apis: RawReportType[]): ReportType[] {
     if (api === RawReportType.networkEfficiencyGuardrails) {
       types.add('document-policy-violation')
     } else {
-      types.add(api as ReportType)
+      types.add(api)
     }
   }
   return Array.from(types)
@@ -70,8 +70,7 @@ function createReportObservable(reportTypes: ReportType[]) {
           // whose featureId does not match network-efficiency-guardrails.
           if (
             report.type === 'document-policy-violation' &&
-            (report.body as DocumentPolicyViolationReport['body']).featureId !==
-              RawReportType.networkEfficiencyGuardrails
+            report.body.featureId !== RawReportType.networkEfficiencyGuardrails
           ) {
             return
           }
@@ -109,19 +108,18 @@ function createCspViolationReportObservable() {
 function buildRawReportErrorFromReport(
   report: DeprecationReport | InterventionReport | DocumentPolicyViolationReport
 ): RawReportError {
-  const { type, body } = report
-
-  if (type === 'document-policy-violation') {
-    const { featureId, message, disposition, sourceFile } = body as DocumentPolicyViolationReport['body']
+  if (report.type === 'document-policy-violation') {
+    const { featureId, message, disposition, sourceFile } = report.body
     return buildRawReportError({
       type: featureId,
-      message: `${type}: ${message}`,
+      message: `${report.type}: ${message}`,
       originalError: report,
       csp: { disposition },
       stack: buildStack(featureId, message, sourceFile, null, null),
     })
   }
 
+  const { type, body } = report
   return buildRawReportError({
     type: body.id,
     message: `${type}: ${body.message}`,

--- a/packages/browser-core/src/domain/report/reportObservable.ts
+++ b/packages/browser-core/src/domain/report/reportObservable.ts
@@ -80,7 +80,8 @@ function buildRawReportErrorFromReport(
   if (report.type === 'document-policy-violation') {
     const { featureId, message, disposition, sourceFile } = report.body
     return buildRawReportError({
-      type: featureId,
+      type: report.type,
+      featureId,
       message: `${report.type}: ${message}`,
       originalError: report,
       csp: { disposition },

--- a/packages/browser-core/test/emulate/mockReportingObserver.ts
+++ b/packages/browser-core/test/emulate/mockReportingObserver.ts
@@ -1,4 +1,4 @@
-import type { InterventionReport, ReportType } from '../../src/domain/report/browser.types'
+import type { DocumentPolicyViolationReport, InterventionReport, ReportType } from '../../src/domain/report/browser.types'
 import { noop } from '../../src/tools/utils/functionUtils'
 import { registerCleanupTask } from '../registerCleanupTask'
 import { createNewEvent } from './createNewEvent'
@@ -39,9 +39,13 @@ export function mockReportingObserver() {
   })
 
   return {
-    raiseReport(type: ReportType) {
+    raiseReport(type: ReportType, overrides?: Partial<DocumentPolicyViolationReport>) {
       if (callbacks[type]) {
-        callbacks[type].forEach((callback) => callback([{ ...FAKE_REPORT, type }], reportingObserver))
+        const report =
+          type === 'document-policy-violation'
+            ? { ...FAKE_DOCUMENT_POLICY_VIOLATION_REPORT, ...overrides }
+            : { ...FAKE_REPORT, type }
+        callbacks[type].forEach((callback) => callback([report], reportingObserver))
       }
     },
   }
@@ -84,6 +88,21 @@ export const FAKE_CSP_VIOLATION_EVENT = createNewEvent('securitypolicyviolation'
   statusCode: 200,
   violatedDirective: 'worker-src',
 })
+
+export const FAKE_DOCUMENT_POLICY_VIOLATION_REPORT: DocumentPolicyViolationReport = {
+  type: 'document-policy-violation',
+  url: 'http://foo.bar',
+  body: {
+    featureId: 'network-efficiency-guardrails',
+    message: 'Document policy violation: resource compression is required.',
+    disposition: 'report',
+    lineNumber: null,
+    columnNumber: null,
+    sourceFile: 'https://foo.bar/large-uncompressed.js',
+    toJSON: noop,
+  },
+  toJSON: noop,
+}
 
 export const FAKE_REPORT: InterventionReport = {
   type: 'intervention',

--- a/packages/browser-core/test/emulate/mockReportingObserver.ts
+++ b/packages/browser-core/test/emulate/mockReportingObserver.ts
@@ -1,4 +1,8 @@
-import type { DocumentPolicyViolationReport, InterventionReport, ReportType } from '../../src/domain/report/browser.types'
+import type {
+  DocumentPolicyViolationReport,
+  InterventionReport,
+  ReportType,
+} from '../../src/domain/report/browser.types'
 import { noop } from '../../src/tools/utils/functionUtils'
 import { registerCleanupTask } from '../registerCleanupTask'
 import { createNewEvent } from './createNewEvent'

--- a/packages/browser-logs/src/domain/createErrorFieldFromRawError.spec.ts
+++ b/packages/browser-logs/src/domain/createErrorFieldFromRawError.spec.ts
@@ -14,6 +14,7 @@ describe('createErrorFieldFromRawError', () => {
     componentStack: 'at Flex',
     originalError: new Error('baz'),
     type: 'qux',
+    featureId: 'quux-feature',
     message: 'quux',
     stack: 'quuz',
     causes: [
@@ -43,6 +44,7 @@ describe('createErrorFieldFromRawError', () => {
     expect(createErrorFieldFromRawError(exhaustiveRawError)).toEqual({
       message: undefined,
       kind: 'qux',
+      feature_id: 'quux-feature',
       stack: 'quuz',
       causes: [
         {

--- a/packages/browser-logs/src/domain/createErrorFieldFromRawError.ts
+++ b/packages/browser-logs/src/domain/createErrorFieldFromRawError.ts
@@ -14,6 +14,7 @@ export function createErrorFieldFromRawError(
   return {
     stack: rawError.stack,
     kind: rawError.type,
+    feature_id: rawError.featureId,
     message: includeMessage ? rawError.message : undefined,
     causes: rawError.causes,
     fingerprint: rawError.fingerprint,

--- a/packages/browser-logs/src/rawLogsEvent.types.ts
+++ b/packages/browser-logs/src/rawLogsEvent.types.ts
@@ -13,6 +13,7 @@ export type RawLogsEvent =
 interface Error {
   message?: string
   kind?: string
+  feature_id?: string
   stack?: string
   fingerprint?: string
   causes?: RawErrorCause[]

--- a/packages/browser-rum-core/src/domain/error/errorCollection.ts
+++ b/packages/browser-rum-core/src/domain/error/errorCollection.ts
@@ -70,20 +70,24 @@ export function doStartErrorCollection(lifeCycle: LifeCycle) {
 function processError(error: RawError): RawRumEventCollectedData<RawRumErrorEvent> {
   const rawRumEvent: RawRumErrorEvent = {
     date: error.startClocks.timeStamp,
-    error: {
-      id: generateUUID(),
-      message: error.message,
-      source: error.source,
-      stack: error.stack,
-      handling_stack: error.handlingStack,
-      component_stack: error.componentStack,
-      type: error.type,
-      handling: error.handling,
-      causes: error.causes,
-      source_type: 'browser',
-      fingerprint: error.fingerprint,
-      csp: error.csp,
-    },
+    error: combine(
+      {
+        id: generateUUID(),
+        message: error.message,
+        source: error.source,
+        stack: error.stack,
+        handling_stack: error.handlingStack,
+        component_stack: error.componentStack,
+        type: error.type,
+        handling: error.handling,
+        causes: error.causes,
+        source_type: 'browser' as const,
+        fingerprint: error.fingerprint,
+        csp: error.csp,
+      },
+      // TODO: add feature_id to the rum-events-format schema then remove this combine()
+      error.featureId !== undefined ? { feature_id: error.featureId } : {}
+    ),
     type: RumEventType.ERROR,
     context: error.context,
   }

--- a/packages/browser-rum-core/src/domain/error/trackReportError.ts
+++ b/packages/browser-rum-core/src/domain/error/trackReportError.ts
@@ -4,7 +4,7 @@ export function trackReportError(errorObservable: Observable<RawError>) {
   const subscription = initReportObservable([
     RawReportType.cspViolation,
     RawReportType.intervention,
-    RawReportType.networkEfficiencyGuardrails,
+    RawReportType.documentPolicyViolation,
   ]).subscribe((rawError) => errorObservable.notify(rawError))
 
   return {

--- a/packages/browser-rum-core/src/domain/error/trackReportError.ts
+++ b/packages/browser-rum-core/src/domain/error/trackReportError.ts
@@ -1,7 +1,11 @@
 import type { Observable, RawError } from '@datadog/browser-core'
 import { initReportObservable, RawReportType } from '@datadog/browser-core'
 export function trackReportError(errorObservable: Observable<RawError>) {
-  const subscription = initReportObservable([RawReportType.cspViolation, RawReportType.intervention]).subscribe(
+  const subscription = initReportObservable([
+    RawReportType.cspViolation,
+    RawReportType.intervention,
+    RawReportType.networkEfficiencyGuardrails,
+  ]).subscribe(
     (rawError) => errorObservable.notify(rawError)
   )
 

--- a/packages/browser-rum-core/src/domain/error/trackReportError.ts
+++ b/packages/browser-rum-core/src/domain/error/trackReportError.ts
@@ -5,9 +5,7 @@ export function trackReportError(errorObservable: Observable<RawError>) {
     RawReportType.cspViolation,
     RawReportType.intervention,
     RawReportType.networkEfficiencyGuardrails,
-  ]).subscribe(
-    (rawError) => errorObservable.notify(rawError)
-  )
+  ]).subscribe((rawError) => errorObservable.notify(rawError))
 
   return {
     stop: () => {

--- a/test/e2e/lib/framework/serverApps/mock.ts
+++ b/test/e2e/lib/framework/serverApps/mock.ts
@@ -181,8 +181,21 @@ export function createMockServerApp(servers: Servers, setup: string, setupOption
     if (req.query['js-profiling'] === 'true') {
       res.header('Document-Policy', 'js-profiling')
     }
+    if (req.query['network-efficiency-guardrails'] === 'true') {
+      res.header('Document-Policy', 'network-efficiency-guardrails')
+    }
     res.send(setup)
     res.end()
+  })
+
+  // Serves an uncompressed JavaScript file large enough to trigger a network-efficiency-guardrails
+  // policy violation (text resources must be HTTP-compressed).
+  app.get('/uncompressed-script.js', (_req, res) => {
+    res.removeHeader('Content-Encoding')
+    res.header('Content-Type', 'application/javascript')
+    // Explicitly disable compression for this endpoint so the browser detects a violation
+    res.header('Cache-Control', 'no-store')
+    res.send(`// uncompressed script\n${'// padding\n'.repeat(500)}`)
   })
 
   app.get('/no-blob-worker-csp', (_req, res) => {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -168,14 +168,14 @@ function getProjects() {
 }
 
 function project(name: string, device: string) {
-  const isChromium = name.startsWith('chromium')
+  const isChromium = name === 'chromium'
   return {
     name,
     metadata: { sessionName: device, name } satisfies BrowserConfiguration,
     use: {
       ...devices[device],
-      // Required for experimental APIs (e.g. Network Efficiency Guardrails) that are
-      // gated behind this flag in Chromium. Ignored for non-Chromium browsers.
+      // Required for experimental APIs (e.g. Network Efficiency Guardrails).
+      // Only passed to current Chromium — pinned browsers use pinnedProject() and may not support it.
       ...(isChromium ? { launchOptions: { args: ['--enable-experimental-web-platform-features'] } } : {}),
     },
   }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -168,10 +168,16 @@ function getProjects() {
 }
 
 function project(name: string, device: string) {
+  const isChromium = name.startsWith('chromium')
   return {
     name,
     metadata: { sessionName: device, name } satisfies BrowserConfiguration,
-    use: devices[device],
+    use: {
+      ...devices[device],
+      // Required for experimental APIs (e.g. Network Efficiency Guardrails) that are
+      // gated behind this flag in Chromium. Ignored for non-Chromium browsers.
+      ...(isChromium ? { launchOptions: { args: ['--enable-experimental-web-platform-features'] } } : {}),
+    },
   }
 }
 

--- a/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
+++ b/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
@@ -1,4 +1,3 @@
-import type { RumErrorEvent } from '@datadog/browser-rum-core'
 import { test, expect } from '@playwright/test'
 import { createTest } from '../lib/framework'
 
@@ -39,7 +38,7 @@ test.describe('network efficiency guardrails', () => {
         // so we may receive more than one. Assert we got at least one for our resource.
         expect(guardrailErrors.length).toBeGreaterThanOrEqual(1)
 
-        const error = guardrailErrors[0].error as RumErrorEvent['error']
+        const error = guardrailErrors[0].error
         expect(error.source).toBe('report')
         expect(error.handling).toBe('unhandled')
         expect(error.csp?.disposition).toMatch(/enforce|report/)

--- a/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
+++ b/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { createTest } from '../lib/framework'
+import type { BrowserConfiguration } from '../../browsers.conf'
 
 // Network Efficiency Guardrails is a Document Policy feature currently only available in Edge 146+
 // and in Chromium behind the "Experimental Web Platform features" flag.
@@ -7,7 +8,13 @@ import { createTest } from '../lib/framework'
 
 test.describe('network efficiency guardrails', () => {
   test.beforeEach(({ browserName }) => {
-    test.skip(browserName !== 'chromium', 'Network Efficiency Guardrails is only available in Chromium-based browsers')
+    const { version } = test.info().project.metadata as BrowserConfiguration
+    // Network Efficiency Guardrails requires Chromium 146+. Pinned projects set an explicit
+    // version; current (unversioned) Chromium is always new enough.
+    test.skip(
+      browserName !== 'chromium' || (version !== undefined && Number(version) < 146),
+      'Network Efficiency Guardrails requires Chromium 146+'
+    )
   })
 
   test.describe('RUM', () => {

--- a/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
+++ b/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
@@ -5,14 +5,6 @@ import { createTest } from '../lib/framework'
 // and in Chromium behind the "Experimental Web Platform features" flag.
 // We run these tests only on Chromium.
 
-// Enable the Experimental Web Platform features flag required for Network Efficiency Guardrails.
-// Must be top-level: launchOptions forces a new worker and cannot be inside describe().
-test.use({
-  launchOptions: {
-    args: ['--enable-experimental-web-platform-features'],
-  },
-})
-
 test.describe('network efficiency guardrails', () => {
   test.beforeEach(({ browserName }) => {
     test.skip(browserName !== 'chromium', 'Network Efficiency Guardrails is only available in Chromium-based browsers')

--- a/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
+++ b/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
@@ -54,7 +54,7 @@ test.describe('network efficiency guardrails', () => {
 
   test.describe('Logs', () => {
     createTest('should forward network-efficiency-guardrails violations via forwardReports')
-      .withLogs({ forwardReports: ['network-efficiency-guardrails'] })
+      .withLogs({ forwardReports: ['document-policy-violation'] })
       .withBasePath('/?network-efficiency-guardrails=true')
       .run(async ({ page, intakeRegistry, flushEvents, withBrowserLogs }) => {
         await page.evaluate(() => fetch('/uncompressed-script.js'))
@@ -75,7 +75,7 @@ test.describe('network efficiency guardrails', () => {
         })
       })
 
-    createTest('should not forward network-efficiency-guardrails violations when not in forwardReports')
+    createTest('should not forward network-efficiency-guardrails violations when not opted in')
       .withLogs({ forwardReports: [] })
       .withBasePath('/?network-efficiency-guardrails=true')
       .run(async ({ page, intakeRegistry, flushEvents, withBrowserLogs }) => {

--- a/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
+++ b/test/e2e/scenario/networkEfficiencyGuardrails.scenario.ts
@@ -1,0 +1,100 @@
+import type { RumErrorEvent } from '@datadog/browser-rum-core'
+import { test, expect } from '@playwright/test'
+import { createTest } from '../lib/framework'
+
+// Network Efficiency Guardrails is a Document Policy feature currently only available in Edge 146+
+// and in Chromium behind the "Experimental Web Platform features" flag.
+// We run these tests only on Chromium.
+
+// Enable the Experimental Web Platform features flag required for Network Efficiency Guardrails.
+// Must be top-level: launchOptions forces a new worker and cannot be inside describe().
+test.use({
+  launchOptions: {
+    args: ['--enable-experimental-web-platform-features'],
+  },
+})
+
+test.describe('network efficiency guardrails', () => {
+  test.beforeEach(({ browserName }) => {
+    test.skip(browserName !== 'chromium', 'Network Efficiency Guardrails is only available in Chromium-based browsers')
+  })
+
+  test.describe('RUM', () => {
+    createTest('should collect network-efficiency-guardrails violations as RUM errors')
+      .withRum()
+      .withBasePath('/?network-efficiency-guardrails=true')
+      .run(async ({ page, intakeRegistry, flushEvents, withBrowserLogs }) => {
+        // Trigger a violation after the SDK has initialized: fetch an uncompressed JS resource.
+        // The Document-Policy header on the page opts into monitoring, and the lack of
+        // Content-Encoding on this endpoint triggers a "resource compression" violation.
+        await page.evaluate(() => fetch('/uncompressed-script.js'))
+
+        await flushEvents()
+
+        const guardrailErrors = intakeRegistry.rumErrorEvents.filter((event) =>
+          event.error.message.startsWith('document-policy-violation:')
+        )
+
+        // The SDK bundles themselves (served uncompressed in dev) also trigger violations,
+        // so we may receive more than one. Assert we got at least one for our resource.
+        expect(guardrailErrors.length).toBeGreaterThanOrEqual(1)
+
+        const error = guardrailErrors[0].error as RumErrorEvent['error']
+        expect(error.source).toBe('report')
+        expect(error.handling).toBe('unhandled')
+        expect(error.csp?.disposition).toMatch(/enforce|report/)
+
+        // The browser logs a console error for each violation — acknowledge them so the
+        // framework teardown check doesn't fail.
+        withBrowserLogs((logs) => {
+          const errors = logs.filter((log) => log.level === 'error')
+          expect(errors.length).toBeGreaterThanOrEqual(1)
+          expect(errors[0].message).toContain('Document policy violation: resource compression is required')
+        })
+      })
+  })
+
+  test.describe('Logs', () => {
+    createTest('should forward network-efficiency-guardrails violations via forwardReports')
+      .withLogs({ forwardReports: ['network-efficiency-guardrails'] })
+      .withBasePath('/?network-efficiency-guardrails=true')
+      .run(async ({ page, intakeRegistry, flushEvents, withBrowserLogs }) => {
+        await page.evaluate(() => fetch('/uncompressed-script.js'))
+
+        await flushEvents()
+
+        const guardrailLogs = intakeRegistry.logsEvents.filter((event) =>
+          event.message.startsWith('document-policy-violation:')
+        )
+
+        expect(guardrailLogs).toHaveLength(1)
+        expect(guardrailLogs[0].origin).toBe('report')
+        expect(guardrailLogs[0].status).toBe('error')
+
+        withBrowserLogs((logs) => {
+          expect(logs.filter((log) => log.level === 'error')).toHaveLength(1)
+          expect(logs[0].message).toContain('Document policy violation: resource compression is required')
+        })
+      })
+
+    createTest('should not forward network-efficiency-guardrails violations when not in forwardReports')
+      .withLogs({ forwardReports: [] })
+      .withBasePath('/?network-efficiency-guardrails=true')
+      .run(async ({ page, intakeRegistry, flushEvents, withBrowserLogs }) => {
+        await page.evaluate(() => fetch('/uncompressed-script.js'))
+
+        await flushEvents()
+
+        const guardrailLogs = intakeRegistry.logsEvents.filter((event) =>
+          event.message.startsWith('document-policy-violation:')
+        )
+
+        expect(guardrailLogs).toHaveLength(0)
+
+        withBrowserLogs((logs) => {
+          expect(logs.filter((log) => log.level === 'error')).toHaveLength(1)
+          expect(logs[0].message).toContain('Document policy violation: resource compression is required')
+        })
+      })
+  })
+})


### PR DESCRIPTION
## Motivation

Add support for the [Network Efficiency Guardrails](https://aka.ms/networkefficiencyguardrails) ([Blog post](https://blogs.windows.com/msedgedev/2026/03/17/monitor-and-improve-your-web-apps-load-performance/)) experimental Browser API (currently available in Edge 146+ and Chromium behind the `--enable-features=DocumentPolicyNetworkEfficiencyGuardrails` flag), and more broadly, all current and future [`document-policy-violation`](https://www.w3.org/TR/reporting/#document-policy-violation-report) reports.

When a page opts in via a `Document-Policy` header (e.g. `Document-Policy: network-efficiency-guardrails`), the browser fires `document-policy-violation` reports for resources that violate the policy. This change collects those reports as SDK errors/logs, following the same pattern as `csp_violation`, `intervention`, and `deprecation`. Rather than filtering to a specific `featureId`, the SDK forwards all `document-policy-violation` reports — so any current or future document policy feature is automatically captured without further SDK changes.

Jira: [PROF-15113](https://datadoghq.atlassian.net/browse/PROF-15113)

## Changes

- **`browser-core`** — `browser.types.ts`: Added `DocumentPolicyViolationReport` and `DocumentPolicyViolationReportBody` interfaces; widened `Report.body` union and `ReportType` union.
- **`browser-core`** — `reportObservable.ts`: Added `RawReportType.documentPolicyViolation = document-policy-violation`; `buildRawReportErrorFromReport()` handles the new type (reuses `csp.disposition` field for `disposition`, uses `featureId` as the error `type`).
- **`browser-rum-core`** — `trackReportError.ts`: Added `documentPolicyViolation` to the subscribed report types so RUM collects these as errors automatically.
- **`browser-core` tests** — `mockReportingObserver.ts`: Added `FAKE_DOCUMENT_POLICY_VIOLATION_REPORT` fixture. `reportObservable.spec.ts`: 3 new unit tests (notification, stack trace, any-featureId passthrough).
- **E2E** — `mock.ts`: Added `/?network-efficiency-guardrails=true` query param (sets `Document-Policy: network-efficiency-guardrails` header) and `/uncompressed-script.js` endpoint. `networkEfficiencyGuardrails.scenario.ts`: 3 new E2E tests (RUM errors, Logs forwarding with `forwardReports: ["document-policy-violation"]`, Logs not forwarding when not opted in).

## Test instructions

E2E tests require Chromium with `--enable-features=DocumentPolicyNetworkEfficiencyGuardrails` (handled automatically by the Playwright config for the `chromium` project):

```bash
yarn build
yarn test:e2e -g "network efficiency"
```

Unit tests:
```bash
yarn test:unit --spec packages/browser-core/src/domain/report/reportObservable.spec.ts
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

[PROF-15113]: https://datadoghq.atlassian.net/browse/PROF-15113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ