### PR TITLE
👷 Bump @datadog/js-core to 0.0.3

### DIFF
--- a/packages/browser-core/package.json
+++ b/packages/browser-core/package.json
@@ -23,7 +23,7 @@
     "directory": "packages/browser-core"
   },
   "dependencies": {
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "devDependencies": {
     "@types/pako": "2.0.4",

--- a/packages/browser-debugger/package.json
+++ b/packages/browser-debugger/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "repository": {
     "type": "git",

--- a/packages/browser-logs/package.json
+++ b/packages/browser-logs/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {
     "@datadog/browser-rum": "7.3.0"

--- a/packages/browser-rum-angular/package.json
+++ b/packages/browser-rum-angular/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
     "@datadog/browser-rum-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {
     "@angular/core": ">=15 <=22",

--- a/packages/browser-rum-core/package.json
+++ b/packages/browser-rum-core/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "devDependencies": {
     "ajv": "8.20.0"

--- a/packages/browser-rum-nextjs/package.json
+++ b/packages/browser-rum-nextjs/package.json
@@ -20,7 +20,7 @@
     "@datadog/browser-core": "7.3.0",
     "@datadog/browser-rum-core": "7.3.0",
     "@datadog/browser-rum-react": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {
     "next": ">=13.0.0",

--- a/packages/browser-rum-nuxt/package.json
+++ b/packages/browser-rum-nuxt/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
     "@datadog/browser-rum-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {
     "nuxt": "3 || 4",

--- a/packages/browser-rum-react/package.json
+++ b/packages/browser-rum-react/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
     "@datadog/browser-rum-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.64.0 <2",

--- a/packages/browser-rum-vue/package.json
+++ b/packages/browser-rum-vue/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
     "@datadog/browser-rum-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {
     "vue": "^3.5.0",

--- a/packages/browser-rum/package.json
+++ b/packages/browser-rum/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@datadog/browser-core": "7.3.0",
     "@datadog/browser-rum-core": "7.3.0",
-    "@datadog/js-core": "0.0.2"
+    "@datadog/js-core": "0.0.3"
   },
   "peerDependencies": {
     "@datadog/browser-logs": "7.3.0"

--- a/packages/js-core/package.json
+++ b/packages/js-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/js-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "Apache-2.0",
   "sideEffects": false,
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,7 +356,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/browser-core@workspace:packages/browser-core"
   dependencies:
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     "@types/pako": "npm:2.0.4"
     pako: "npm:2.1.0"
   languageName: unknown
@@ -367,7 +367,7 @@ __metadata:
   resolution: "@datadog/browser-debugger@workspace:packages/browser-debugger"
   dependencies:
     "@datadog/browser-core": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     acorn: "npm:8.16.0"
   languageName: unknown
   linkType: soft
@@ -377,7 +377,7 @@ __metadata:
   resolution: "@datadog/browser-logs@workspace:packages/browser-logs"
   dependencies:
     "@datadog/browser-core": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
   peerDependencies:
     "@datadog/browser-rum": 7.3.0
   peerDependenciesMeta:
@@ -397,7 +397,7 @@ __metadata:
     "@angular/router": "npm:22.0.0"
     "@datadog/browser-core": "npm:7.3.0"
     "@datadog/browser-rum-core": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     rxjs: "npm:7.8.2"
   peerDependencies:
     "@angular/core": ">=15 <=22"
@@ -411,7 +411,7 @@ __metadata:
   resolution: "@datadog/browser-rum-core@workspace:packages/browser-rum-core"
   dependencies:
     "@datadog/browser-core": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     ajv: "npm:8.20.0"
   languageName: unknown
   linkType: soft
@@ -423,7 +423,7 @@ __metadata:
     "@datadog/browser-core": "npm:7.3.0"
     "@datadog/browser-rum-core": "npm:7.3.0"
     "@datadog/browser-rum-react": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     "@types/react": "npm:19.2.17"
     next: "npm:16.2.7"
     react: "npm:19.2.7"
@@ -445,7 +445,7 @@ __metadata:
   dependencies:
     "@datadog/browser-core": "npm:7.3.0"
     "@datadog/browser-rum-core": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     vue: "npm:3.5.35"
     vue-router: "npm:5.1.0"
   peerDependencies:
@@ -472,7 +472,7 @@ __metadata:
   dependencies:
     "@datadog/browser-core": "npm:7.3.0"
     "@datadog/browser-rum-core": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     "@tanstack/react-router": "npm:1.170.15"
     "@types/react": "npm:19.2.17"
     "@types/react-dom": "npm:19.2.3"
@@ -522,7 +522,7 @@ __metadata:
   dependencies:
     "@datadog/browser-core": "npm:7.3.0"
     "@datadog/browser-rum-core": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     "@vue/test-utils": "npm:2.4.11"
     vue: "npm:3.5.35"
     vue-router: "npm:5.1.0"
@@ -548,7 +548,7 @@ __metadata:
     "@datadog/browser-core": "npm:7.3.0"
     "@datadog/browser-rum-core": "npm:7.3.0"
     "@datadog/browser-worker": "npm:7.3.0"
-    "@datadog/js-core": "npm:0.0.2"
+    "@datadog/js-core": "npm:0.0.3"
     "@types/pako": "npm:2.0.4"
     pako: "npm:2.1.0"
   peerDependencies:
@@ -591,7 +591,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/js-core@npm:0.0.2, @datadog/js-core@workspace:packages/js-core":
+"@datadog/js-core@npm:0.0.3, @datadog/js-core@workspace:packages/js-core":
   version: 0.0.0-use.local
   resolution: "@datadog/js-core@workspace:packages/js-core"
   languageName: unknown


### PR DESCRIPTION
## Motivation

Bump `@datadog/js-core` from `0.0.2` to `0.0.3` across all packages in the monorepo.

## Changes

- Bumped `@datadog/js-core` dependency version from `0.0.2` to `0.0.3` in all packages that depend on it (`browser-core`, `browser-debugger`, `browser-logs`, `browser-rum`, `browser-rum-core`, `browser-rum-angular`, `browser-rum-nextjs`, `browser-rum-nuxt`, `browser-rum-react`, `browser-rum-vue`)
- Bumped the `version` field in `packages/js-core/package.json` to `0.0.3`

## Test instructions

- No behavior change expected. Verify CI passes.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file