### PR TITLE
♻️ clean up `createBatch` API before migrating to js-core

### DIFF
--- a/packages/browser-core/src/browser/pageMayExitObservable.ts
+++ b/packages/browser-core/src/browser/pageMayExitObservable.ts
@@ -1,6 +1,6 @@
 import { Observable } from '../tools/observable'
 import { objectValues } from '../tools/utils/polyfills'
-import { isWorkerEnvironment } from '../tools/globalObject'
+import { globalObject } from '../tools/globalObject'
 import { addEventListeners, addEventListener, DOM_EVENT } from './addEventListener'
 
 export const PageExitReason = {
@@ -18,8 +18,9 @@ export interface PageMayExitEvent {
 
 export function createPageMayExitObservable(): Observable<PageMayExitEvent> {
   return new Observable<PageMayExitEvent>((observable) => {
-    if (isWorkerEnvironment) {
-      // Page exit is not observable in worker environments (no window/document events)
+    const window = globalObject.window
+    if (!window) {
+      // Page exit is not observable in non-browser environments
       return
     }
     const { stop: stopListeners } = addEventListeners(

--- a/packages/browser-core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
+++ b/packages/browser-core/src/domain/eventRateLimiter/createEventRateLimiter.spec.ts
@@ -1,8 +1,7 @@
-import { ONE_MINUTE, relativeToClocks } from '@datadog/js-core/time'
+import { ONE_MINUTE } from '@datadog/js-core/time'
 import type { Clock } from '../../../test'
 import { mockClock } from '../../../test'
 import { noop } from '../../tools/utils/functionUtils'
-import type { RawError } from '../error/error.types'
 import { createEventRateLimiter } from './createEventRateLimiter'
 import type { EventRateLimiter } from './createEventRateLimiter'
 
@@ -36,17 +35,13 @@ describe('createEventRateLimiter', () => {
     expect(eventLimiter.isLimitReached()).toBe(false)
   })
 
-  it('calls the "onLimitReached" callback with the raw "limit reached" error when the limit is reached', () => {
-    const onLimitReachedSpy = jasmine.createSpy<(rawError: RawError) => void>()
+  it('calls the "onLimitReached" callback with the "limit reached" message when the limit is reached', () => {
+    const onLimitReachedSpy = jasmine.createSpy<(message: string) => void>()
     eventLimiter = createEventRateLimiter('error', onLimitReachedSpy, limit)
 
     eventLimiter.isLimitReached()
     eventLimiter.isLimitReached()
-    expect(onLimitReachedSpy).toHaveBeenCalledOnceWith({
-      message: 'Reached max number of errors by minute: 1',
-      source: 'agent',
-      startClocks: relativeToClocks(clock.relative(0)),
-    })
+    expect(onLimitReachedSpy).toHaveBeenCalledOnceWith('Reached max number of errors by minute: 1')
   })
 
   it('returns false when called from the "onLimitReached" callback to bypass the limit for the "limit reached" error', () => {
@@ -63,7 +58,7 @@ describe('createEventRateLimiter', () => {
   })
 
   it('does not call the "onLimitReached" callback more than once when the limit is reached', () => {
-    const onLimitReachedSpy = jasmine.createSpy<(rawError: RawError) => void>()
+    const onLimitReachedSpy = jasmine.createSpy<(message: string) => void>()
     eventLimiter = createEventRateLimiter('error', onLimitReachedSpy, limit)
 
     eventLimiter.isLimitReached()

--- a/packages/browser-core/src/domain/eventRateLimiter/createEventRateLimiter.ts
+++ b/packages/browser-core/src/domain/eventRateLimiter/createEventRateLimiter.ts
@@ -1,7 +1,5 @@
-import { ONE_MINUTE, clocksNow } from '@datadog/js-core/time'
+import { ONE_MINUTE } from '@datadog/js-core/time'
 import { setTimeout } from '../../tools/timer'
-import type { RawError } from '../error/error.types'
-import { ErrorSource } from '../error/error.types'
 
 export type EventRateLimiter = ReturnType<typeof createEventRateLimiter>
 
@@ -10,7 +8,7 @@ const EVENT_RATE_LIMIT = 3000
 
 export function createEventRateLimiter(
   eventType: string,
-  onLimitReached: (limitError: RawError) => void,
+  onLimitReached: (message: string) => void,
   limit = EVENT_RATE_LIMIT
 ) {
   let eventCount = 0
@@ -33,11 +31,7 @@ export function createEventRateLimiter(
       if (eventCount === limit + 1) {
         allowNextEvent = true
         try {
-          onLimitReached({
-            message: `Reached max number of ${eventType}s by minute: ${limit}`,
-            source: ErrorSource.AGENT,
-            startClocks: clocksNow(),
-          })
+          onLimitReached(`Reached max number of ${eventType}s by minute: ${limit}`)
         } finally {
           allowNextEvent = false
         }

--- a/packages/browser-core/src/domain/telemetry/telemetry.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetry.ts
@@ -21,8 +21,7 @@ import { NonErrorPrefix } from '../error/error.types'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
 import { computeStackTrace } from '../../tools/stackTrace/computeStackTrace'
 import { getConnectivity } from '../connectivity'
-import { canUseEventBridge, createFlushController, getEventBridge, createBatch } from '../../transport'
-import { createPageMayExitObservable } from '../../browser/pageMayExitObservable'
+import { canUseEventBridge, getEventBridge, createBatch } from '../../transport'
 import { globalObject, isWorkerEnvironment } from '../../tools/globalObject'
 import { noop } from '../../tools/utils/functionUtils'
 import type { TelemetryEvent } from './telemetryEvent.types'
@@ -214,9 +213,6 @@ export function startTelemetryTransport(
       endpoints,
       // Ignore transport errors for telemetry
       reportError: noop,
-      flushController: createFlushController({
-        pageMayExitObservable: createPageMayExitObservable(),
-      }),
     })
     cleanupTasks.push(telemetryBatch.stop)
     const telemetrySubscription = telemetryObservable.subscribe(telemetryBatch.add)

--- a/packages/browser-core/src/domain/telemetry/telemetry.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetry.ts
@@ -28,7 +28,6 @@ import {
   getEventBridge,
   createBatch,
 } from '../../transport'
-import { createIdentityEncoder } from '../../tools/encoder'
 import { createPageMayExitObservable } from '../../browser/pageMayExitObservable'
 import { globalObject, isWorkerEnvironment } from '../../tools/globalObject'
 import { noop } from '../../tools/utils/functionUtils'
@@ -218,7 +217,6 @@ export function startTelemetryTransport(
       endpoints.push(replicaEndpoint)
     }
     const telemetryBatch = createBatch({
-      encoder: createIdentityEncoder(),
       request: createHttpRequest(
         endpoints,
         // Ignore transport errors for telemetry

--- a/packages/browser-core/src/domain/telemetry/telemetry.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetry.ts
@@ -216,10 +216,6 @@ export function startTelemetryTransport(
       reportError: noop,
       flushController: createFlushController({
         pageMayExitObservable: createPageMayExitObservable(),
-
-        // We don't use an actual session expire observable here, to make telemetry collection
-        // independent of the session. This allows to start and send telemetry events earlier.
-        sessionExpireObservable: new Observable(),
       }),
     })
     cleanupTasks.push(telemetryBatch.stop)

--- a/packages/browser-core/src/domain/telemetry/telemetry.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetry.ts
@@ -21,13 +21,7 @@ import { NonErrorPrefix } from '../error/error.types'
 import type { StackTrace } from '../../tools/stackTrace/computeStackTrace'
 import { computeStackTrace } from '../../tools/stackTrace/computeStackTrace'
 import { getConnectivity } from '../connectivity'
-import {
-  canUseEventBridge,
-  createFlushController,
-  createHttpRequest,
-  getEventBridge,
-  createBatch,
-} from '../../transport'
+import { canUseEventBridge, createFlushController, getEventBridge, createBatch } from '../../transport'
 import { createPageMayExitObservable } from '../../browser/pageMayExitObservable'
 import { globalObject, isWorkerEnvironment } from '../../tools/globalObject'
 import { noop } from '../../tools/utils/functionUtils'
@@ -217,11 +211,9 @@ export function startTelemetryTransport(
       endpoints.push(replicaEndpoint)
     }
     const telemetryBatch = createBatch({
-      request: createHttpRequest(
-        endpoints,
-        // Ignore transport errors for telemetry
-        noop
-      ),
+      endpoints,
+      // Ignore transport errors for telemetry
+      reportError: noop,
       flushController: createFlushController({
         pageMayExitObservable: createPageMayExitObservable(),
 

--- a/packages/browser-core/src/index.ts
+++ b/packages/browser-core/src/index.ts
@@ -66,6 +66,7 @@ export type {
   Payload,
   FlushEvent,
   FlushReason,
+  UrgentFlushReason,
 } from './transport'
 export {
   createHttpRequest,

--- a/packages/browser-core/src/transport/batch.spec.ts
+++ b/packages/browser-core/src/transport/batch.spec.ts
@@ -1,10 +1,11 @@
 import { Observable } from '..'
 import type { MockFlushController } from '../../test'
-import { createMockFlushController } from '../../test'
+import { createMockFlushController, replaceMockable } from '../../test'
 import { display } from '../tools/display'
 import type { Encoder } from '../tools/encoder'
 import { createIdentityEncoder } from '../tools/encoder'
 import { createBatch, MESSAGE_BYTES_LIMIT, type Batch } from './batch'
+import { createHttpRequest } from './httpRequest'
 import type { HttpRequest, HttpRequestEvent } from './httpRequest'
 
 describe('batch', () => {
@@ -31,7 +32,8 @@ describe('batch', () => {
     } satisfies HttpRequest
     flushController = createMockFlushController()
     encoder = createIdentityEncoder()
-    batch = createBatch({ encoder, request: transport, flushController })
+    replaceMockable(createHttpRequest, (() => transport) as unknown as typeof createHttpRequest)
+    batch = createBatch({ encoder, endpoints: [], reportError: () => undefined, flushController })
   })
 
   it('should send a message', () => {

--- a/packages/browser-core/src/transport/batch.spec.ts
+++ b/packages/browser-core/src/transport/batch.spec.ts
@@ -4,7 +4,9 @@ import { createMockFlushController, replaceMockable } from '../../test'
 import { display } from '../tools/display'
 import type { Encoder } from '../tools/encoder'
 import { createIdentityEncoder } from '../tools/encoder'
+import { createPageMayExitObservable } from '../browser/pageMayExitObservable'
 import { createBatch, MESSAGE_BYTES_LIMIT, type Batch } from './batch'
+import { createFlushController } from './flushController'
 import { createHttpRequest } from './httpRequest'
 import type { HttpRequest, HttpRequestEvent } from './httpRequest'
 
@@ -33,7 +35,9 @@ describe('batch', () => {
     flushController = createMockFlushController()
     encoder = createIdentityEncoder()
     replaceMockable(createHttpRequest, (() => transport) as unknown as typeof createHttpRequest)
-    batch = createBatch({ encoder, endpoints: [], reportError: () => undefined, flushController })
+    replaceMockable(createPageMayExitObservable, () => new Observable())
+    replaceMockable(createFlushController, () => flushController)
+    batch = createBatch({ encoder, endpoints: [], reportError: () => undefined })
   })
 
   it('should send a message', () => {

--- a/packages/browser-core/src/transport/batch.ts
+++ b/packages/browser-core/src/transport/batch.ts
@@ -8,7 +8,6 @@ import type { Encoder, EncoderResult } from '../tools/encoder'
 import { computeBytesCount, ONE_KIBI_BYTE } from '../tools/utils/byteUtils'
 import { mockable } from '../tools/mockable'
 import type { EndpointBuilder } from '../domain/configuration'
-import type { RawError } from '../domain/error/error.types'
 import { createHttpRequest } from './httpRequest'
 import type { Payload } from './httpRequest'
 import type { FlushController, FlushEvent } from './flushController'
@@ -30,7 +29,7 @@ export function createBatch({
 }: {
   encoder?: Encoder
   endpoints: EndpointBuilder[]
-  reportError: (error: RawError) => void
+  reportError: (message: string) => void
   flushController: FlushController
 }): Batch {
   const request = mockable(createHttpRequest)(endpoints, reportError)

--- a/packages/browser-core/src/transport/batch.ts
+++ b/packages/browser-core/src/transport/batch.ts
@@ -3,6 +3,7 @@ import type { Context } from '../tools/serialisation/context'
 import { objectValues } from '../tools/utils/polyfills'
 import { isPageExitReason } from '../browser/pageMayExitObservable'
 import { jsonStringify } from '../tools/serialisation/jsonStringify'
+import { createIdentityEncoder } from '../tools/encoder'
 import type { Encoder, EncoderResult } from '../tools/encoder'
 import { computeBytesCount, ONE_KIBI_BYTE } from '../tools/utils/byteUtils'
 import type { HttpRequest, Payload } from './httpRequest'
@@ -18,11 +19,11 @@ export interface Batch {
 }
 
 export function createBatch({
-  encoder,
+  encoder = createIdentityEncoder(),
   request,
   flushController,
 }: {
-  encoder: Encoder
+  encoder?: Encoder
   request: HttpRequest
   flushController: FlushController
 }): Batch {

--- a/packages/browser-core/src/transport/batch.ts
+++ b/packages/browser-core/src/transport/batch.ts
@@ -1,23 +1,27 @@
 import { DOCS_TROUBLESHOOTING, MORE_DETAILS, display } from '../tools/display'
 import type { Context } from '../tools/serialisation/context'
 import { objectValues } from '../tools/utils/polyfills'
-import { isPageExitReason } from '../browser/pageMayExitObservable'
+import { isPageExitReason, createPageMayExitObservable } from '../browser/pageMayExitObservable'
 import { jsonStringify } from '../tools/serialisation/jsonStringify'
 import { createIdentityEncoder } from '../tools/encoder'
 import type { Encoder, EncoderResult } from '../tools/encoder'
 import { computeBytesCount, ONE_KIBI_BYTE } from '../tools/utils/byteUtils'
 import { mockable } from '../tools/mockable'
 import type { EndpointBuilder } from '../domain/configuration'
+import type { Observable } from '../tools/observable'
 import { createHttpRequest } from './httpRequest'
 import type { Payload } from './httpRequest'
-import type { FlushController, FlushEvent } from './flushController'
+import { createFlushController } from './flushController'
+import type { FlushEvent, FlushReason, UrgentFlushReason } from './flushController'
 
 export const MESSAGE_BYTES_LIMIT = 256 * ONE_KIBI_BYTE
 
 export interface Batch {
-  flushController: FlushController
   add: (message: Context) => void
   upsert: (message: Context, key: string) => void
+  forceFlush: (reason: FlushReason) => void
+  prepareUrgentFlushObservable: Observable<UrgentFlushReason>
+  flushObservable: Observable<FlushEvent>
   stop: () => void
 }
 
@@ -25,14 +29,14 @@ export function createBatch({
   encoder = createIdentityEncoder(),
   endpoints,
   reportError,
-  flushController,
 }: {
   encoder?: Encoder
   endpoints: EndpointBuilder[]
   reportError: (message: string) => void
-  flushController: FlushController
 }): Batch {
   const request = mockable(createHttpRequest)(endpoints, reportError)
+  const pageMayExitObservable = mockable(createPageMayExitObservable)()
+  const flushController = mockable(createFlushController)({ pageMayExitObservable })
   let upsertBuffer: { [key: string]: string } = {}
   const flushSubscription = flushController.flushObservable.subscribe((event) => flush(event))
 
@@ -111,9 +115,11 @@ export function createBatch({
   }
 
   return {
-    flushController,
     add: addOrUpdate,
     upsert: addOrUpdate,
+    prepareUrgentFlushObservable: flushController.prepareUrgentFlushObservable,
+    forceFlush: flushController.forceFlush,
+    flushObservable: flushController.flushObservable,
     stop: flushSubscription.unsubscribe,
   }
 }

--- a/packages/browser-core/src/transport/batch.ts
+++ b/packages/browser-core/src/transport/batch.ts
@@ -6,7 +6,11 @@ import { jsonStringify } from '../tools/serialisation/jsonStringify'
 import { createIdentityEncoder } from '../tools/encoder'
 import type { Encoder, EncoderResult } from '../tools/encoder'
 import { computeBytesCount, ONE_KIBI_BYTE } from '../tools/utils/byteUtils'
-import type { HttpRequest, Payload } from './httpRequest'
+import { mockable } from '../tools/mockable'
+import type { EndpointBuilder } from '../domain/configuration'
+import type { RawError } from '../domain/error/error.types'
+import { createHttpRequest } from './httpRequest'
+import type { Payload } from './httpRequest'
 import type { FlushController, FlushEvent } from './flushController'
 
 export const MESSAGE_BYTES_LIMIT = 256 * ONE_KIBI_BYTE
@@ -20,13 +24,16 @@ export interface Batch {
 
 export function createBatch({
   encoder = createIdentityEncoder(),
-  request,
+  endpoints,
+  reportError,
   flushController,
 }: {
   encoder?: Encoder
-  request: HttpRequest
+  endpoints: EndpointBuilder[]
+  reportError: (error: RawError) => void
   flushController: FlushController
 }): Batch {
+  const request = mockable(createHttpRequest)(endpoints, reportError)
   let upsertBuffer: { [key: string]: string } = {}
   const flushSubscription = flushController.flushObservable.subscribe((event) => flush(event))
 

--- a/packages/browser-core/src/transport/flushController.spec.ts
+++ b/packages/browser-core/src/transport/flushController.spec.ts
@@ -15,15 +15,12 @@ describe('flushController', () => {
   let flushController: FlushController
   let flushSpy: jasmine.Spy<(event: FlushEvent) => void>
   let pageMayExitObservable: Observable<PageMayExitEvent>
-  let sessionExpireObservable: Observable<void>
 
   beforeEach(() => {
     clock = mockClock()
     pageMayExitObservable = new Observable()
-    sessionExpireObservable = new Observable()
     flushController = createFlushController({
       pageMayExitObservable,
-      sessionExpireObservable,
     })
     flushSpy = jasmine.createSpy()
     flushController.flushObservable.subscribe(flushSpy)
@@ -72,29 +69,29 @@ describe('flushController', () => {
     })
   })
 
-  describe('session expire', () => {
-    it('notifies when the session expires', () => {
+  describe('forceFlush', () => {
+    it('notifies when forceFlush is called', () => {
       flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
       flushController.notifyAfterAddMessage()
-      sessionExpireObservable.notify()
+      flushController.forceFlush('session_expire')
       expect(flushSpy).toHaveBeenCalled()
     })
 
-    it('flush reason should be "session_expire"', () => {
+    it('flush reason should be the provided reason', () => {
       flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
       flushController.notifyAfterAddMessage()
-      sessionExpireObservable.notify()
+      flushController.forceFlush('session_expire')
       expect(flushSpy.calls.first().args[0].reason).toBe('session_expire')
     })
 
     it('does not notify if no message was added', () => {
-      sessionExpireObservable.notify()
+      flushController.forceFlush('session_expire')
       expect(flushSpy).not.toHaveBeenCalled()
     })
 
-    it('notifies when the session expires even if no message have been fully added yet', () => {
+    it('notifies even if no message have been fully added yet', () => {
       flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
-      sessionExpireObservable.notify()
+      flushController.forceFlush('session_expire')
       expect(flushSpy).toHaveBeenCalled()
     })
   })

--- a/packages/browser-core/src/transport/flushController.spec.ts
+++ b/packages/browser-core/src/transport/flushController.spec.ts
@@ -100,11 +100,11 @@ describe('flushController', () => {
   })
 
   describe('bytes limit', () => {
-    it('uses the page exit reason as flush reason for intermediate flushes during page exit', () => {
+    it('uses the urgent reason as flush reason for intermediate flushes during page exit', () => {
       flushController.notifyBeforeAddMessage(SMALL_MESSAGE_BYTE_COUNT)
       flushController.notifyAfterAddMessage()
 
-      flushController.preparePageExitFlushObservable.subscribe(() => {
+      flushController.prepareUrgentFlushObservable.subscribe(() => {
         flushController.notifyBeforeAddMessage(BYTES_LIMIT)
       })
 

--- a/packages/browser-core/src/transport/flushController.ts
+++ b/packages/browser-core/src/transport/flushController.ts
@@ -95,9 +95,6 @@ export function createFlushController({ pageMayExitObservable }: FlushController
     flushObservable,
     prepareUrgentFlushObservable,
     forceFlush: flush,
-    get messagesCount() {
-      return currentMessagesCount
-    },
 
     /**
      * Notifies that a message will be added to a pool of pending messages waiting to be flushed.

--- a/packages/browser-core/src/transport/flushController.ts
+++ b/packages/browser-core/src/transport/flushController.ts
@@ -31,7 +31,6 @@ export interface FlushEvent {
 
 interface FlushControllerOptions {
   pageMayExitObservable: Observable<PageMayExitEvent>
-  sessionExpireObservable: Observable<void>
 }
 
 /**
@@ -39,7 +38,7 @@ interface FlushControllerOptions {
  * to happen. The implementation is designed to support both synchronous and asynchronous usages,
  * but relies on invariants described in each method documentation to keep a coherent state.
  */
-export function createFlushController({ pageMayExitObservable, sessionExpireObservable }: FlushControllerOptions) {
+export function createFlushController({ pageMayExitObservable }: FlushControllerOptions) {
   let forcedFlushReason: FlushReason | undefined
   const prepareUrgentFlushObservable = new Observable<UrgentFlushReason>()
   const pageMayExitSubscription = pageMayExitObservable.subscribe((event) => {
@@ -51,11 +50,9 @@ export function createFlushController({ pageMayExitObservable, sessionExpireObse
     }
     flush(event.reason)
   })
-  const sessionExpireSubscription = sessionExpireObservable.subscribe(() => flush('session_expire'))
 
   const flushObservable = new Observable<FlushEvent>(() => () => {
     pageMayExitSubscription.unsubscribe()
-    sessionExpireSubscription.unsubscribe()
   })
 
   let currentBytesCount = 0
@@ -97,6 +94,7 @@ export function createFlushController({ pageMayExitObservable, sessionExpireObse
   return {
     flushObservable,
     prepareUrgentFlushObservable,
+    forceFlush: flush,
     get messagesCount() {
       return currentMessagesCount
     },

--- a/packages/browser-core/src/transport/flushController.ts
+++ b/packages/browser-core/src/transport/flushController.ts
@@ -7,7 +7,8 @@ import type { TimeoutId } from '../tools/timer'
 import { clearTimeout, setTimeout } from '../tools/timer'
 import { RECOMMENDED_REQUEST_BYTES_LIMIT } from './httpRequest'
 
-export type FlushReason = PageExitReason | 'duration_limit' | 'bytes_limit' | 'messages_limit' | 'session_expire'
+export type UrgentFlushReason = PageExitReason
+export type FlushReason = UrgentFlushReason | 'duration_limit' | 'bytes_limit' | 'messages_limit' | 'session_expire'
 
 /**
  * flush automatically, aim to be lower than ALB connection timeout
@@ -40,11 +41,11 @@ interface FlushControllerOptions {
  */
 export function createFlushController({ pageMayExitObservable, sessionExpireObservable }: FlushControllerOptions) {
   let forcedFlushReason: FlushReason | undefined
-  const preparePageExitFlushObservable = new Observable<PageExitReason>()
+  const prepareUrgentFlushObservable = new Observable<UrgentFlushReason>()
   const pageMayExitSubscription = pageMayExitObservable.subscribe((event) => {
     forcedFlushReason = event.reason
     try {
-      preparePageExitFlushObservable.notify(event.reason)
+      prepareUrgentFlushObservable.notify(event.reason)
     } finally {
       forcedFlushReason = undefined
     }
@@ -95,7 +96,7 @@ export function createFlushController({ pageMayExitObservable, sessionExpireObse
 
   return {
     flushObservable,
-    preparePageExitFlushObservable,
+    prepareUrgentFlushObservable,
     get messagesCount() {
       return currentMessagesCount
     },

--- a/packages/browser-core/src/transport/httpRequest.ts
+++ b/packages/browser-core/src/transport/httpRequest.ts
@@ -2,7 +2,6 @@ import type { EndpointBuilder } from '../domain/configuration'
 import type { Context } from '../tools/serialisation/context'
 import { fetch } from '../browser/fetch'
 import { monitor, monitorError } from '../tools/monitor'
-import type { RawError } from '../domain/error/error.types'
 import { Observable } from '../tools/observable'
 import { ONE_KIBI_BYTE } from '../tools/utils/byteUtils'
 import { newRetryState, sendWithRetryStrategy } from './sendWithRetryStrategy'
@@ -72,7 +71,7 @@ export interface RetryInfo {
 
 export function createHttpRequest<Body extends Payload = Payload>(
   endpointBuilders: EndpointBuilder[],
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   bytesLimit: number = RECOMMENDED_REQUEST_BYTES_LIMIT
 ): HttpRequest<Body> {
   const observable = new Observable<HttpRequestEvent<Body>>()

--- a/packages/browser-core/src/transport/index.ts
+++ b/packages/browser-core/src/transport/index.ts
@@ -4,5 +4,5 @@ export type { BrowserWindowWithEventBridge, DatadogEventBridge } from './eventBr
 export { canUseEventBridge, bridgeSupports, getEventBridge, BridgeCapability } from './eventBridge'
 export type { Batch } from './batch'
 export { createBatch } from './batch'
-export type { FlushController, FlushEvent, FlushReason } from './flushController'
+export type { FlushController, FlushEvent, FlushReason, UrgentFlushReason } from './flushController'
 export { createFlushController, FLUSH_DURATION_LIMIT } from './flushController'

--- a/packages/browser-core/src/transport/sendWithRetryStrategy.spec.ts
+++ b/packages/browser-core/src/transport/sendWithRetryStrategy.spec.ts
@@ -1,6 +1,5 @@
 import { mockClock, setNavigatorOnLine } from '../../test'
 import type { Clock } from '../../test'
-import { ErrorSource } from '../domain/error/error.types'
 import { Observable } from '../tools/observable'
 import { ONE_MEBI_BYTE } from '../tools/utils/byteUtils'
 import type { RetryState } from './sendWithRetryStrategy'
@@ -166,12 +165,8 @@ describe('sendWithRetryStrategy', () => {
       expect(latestEvents()).toEqual([])
 
       sendMock.respondWith(0, { status: 200 })
-      expect(reportErrorSpy).toHaveBeenCalled()
-      expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
-        jasmine.objectContaining({
-          message: `Reached max logs events size queued for upload: ${MAX_QUEUE_BYTES_COUNT / ONE_MEBI_BYTE}MiB`,
-          source: ErrorSource.AGENT,
-        })
+      expect(reportErrorSpy).toHaveBeenCalledWith(
+        `Reached max logs events size queued for upload: ${MAX_QUEUE_BYTES_COUNT / ONE_MEBI_BYTE}MiB`
       )
       reportErrorSpy.calls.reset()
       expect(latestEvents()).toEqual([

--- a/packages/browser-core/src/transport/sendWithRetryStrategy.ts
+++ b/packages/browser-core/src/transport/sendWithRetryStrategy.ts
@@ -1,10 +1,8 @@
-import { ONE_MINUTE, ONE_SECOND, clocksNow } from '@datadog/js-core/time'
+import { ONE_MINUTE, ONE_SECOND } from '@datadog/js-core/time'
 import type { TrackType } from '../domain/configuration'
 import { setTimeout } from '../tools/timer'
 import { ONE_MEBI_BYTE, ONE_KIBI_BYTE } from '../tools/utils/byteUtils'
 import { isServerError } from '../tools/utils/responseUtils'
-import type { RawError } from '../domain/error/error.types'
-import { ErrorSource } from '../domain/error/error.types'
 import type { Observable } from '../tools/observable'
 import type { Payload, HttpRequestEvent, HttpResponse, BandwidthStats } from './httpRequest'
 
@@ -40,7 +38,7 @@ export function sendWithRetryStrategy<Body extends Payload>(
   state: RetryState<Body>,
   sendStrategy: SendStrategy<Body>,
   trackType: TrackType,
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   requestObservable: Observable<HttpRequestEvent<Body>>
 ) {
   if (
@@ -69,7 +67,7 @@ function scheduleRetry<Body extends Payload>(
   state: RetryState<Body>,
   sendStrategy: SendStrategy<Body>,
   trackType: TrackType,
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   requestObservable: Observable<HttpRequestEvent<Body>>
 ) {
   if (state.transportStatus !== TransportStatus.DOWN) {
@@ -124,15 +122,11 @@ function retryQueuedPayloads<Body extends Payload>(
   state: RetryState<Body>,
   sendStrategy: SendStrategy<Body>,
   trackType: TrackType,
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   requestObservable: Observable<HttpRequestEvent<Body>>
 ) {
   if (reason === RetryReason.AFTER_SUCCESS && state.queuedPayloads.isFull() && !state.queueFullReported) {
-    reportError({
-      message: `Reached max ${trackType} events size queued for upload: ${MAX_QUEUE_BYTES_COUNT / ONE_MEBI_BYTE}MiB`,
-      source: ErrorSource.AGENT,
-      startClocks: clocksNow(),
-    })
+    reportError(`Reached max ${trackType} events size queued for upload: ${MAX_QUEUE_BYTES_COUNT / ONE_MEBI_BYTE}MiB`)
     state.queueFullReported = true
   }
   const previousQueue = state.queuedPayloads

--- a/packages/browser-core/test/emulate/mockFlushController.ts
+++ b/packages/browser-core/test/emulate/mockFlushController.ts
@@ -29,6 +29,7 @@ export function createMockFlushController() {
     },
     flushObservable,
     prepareUrgentFlushObservable,
+    forceFlush: jasmine.createSpy<FlushController['forceFlush']>(),
     notifyFlush(reason: FlushReason = 'bytes_limit') {
       if (currentMessagesCount === 0) {
         throw new Error(

--- a/packages/browser-core/test/emulate/mockFlushController.ts
+++ b/packages/browser-core/test/emulate/mockFlushController.ts
@@ -9,7 +9,7 @@ export function createMockFlushController() {
   let currentMessagesCount = 0
   let currentBytesCount = 0
 
-  return {
+  const flushController = {
     notifyBeforeAddMessage: jasmine
       .createSpy<FlushController['notifyBeforeAddMessage']>()
       .and.callFake((messageBytesCount) => {
@@ -21,15 +21,19 @@ export function createMockFlushController() {
       .and.callFake((messageBytesCountDiff = 0) => {
         currentBytesCount += messageBytesCountDiff
       }),
+    flushObservable,
+    prepareUrgentFlushObservable,
+    forceFlush: jasmine.createSpy<FlushController['forceFlush']>(),
+  } satisfies FlushController
+
+  return {
+    ...flushController,
     get messagesCount() {
       return currentMessagesCount
     },
     get bytesCount() {
       return currentBytesCount
     },
-    flushObservable,
-    prepareUrgentFlushObservable,
-    forceFlush: jasmine.createSpy<FlushController['forceFlush']>(),
     notifyFlush(reason: FlushReason = 'bytes_limit') {
       if (currentMessagesCount === 0) {
         throw new Error(
@@ -49,5 +53,5 @@ export function createMockFlushController() {
         messagesCount,
       })
     },
-  } satisfies Record<any, any> & FlushController
+  }
 }

--- a/packages/browser-core/test/emulate/mockFlushController.ts
+++ b/packages/browser-core/test/emulate/mockFlushController.ts
@@ -1,12 +1,11 @@
 import { Observable } from '../../src/tools/observable'
-import type { PageExitReason } from '../../src/browser/pageMayExitObservable'
-import type { FlushEvent, FlushController, FlushReason } from '../../src/transport'
+import type { FlushEvent, FlushController, FlushReason, UrgentFlushReason } from '../../src/transport'
 
 export type MockFlushController = ReturnType<typeof createMockFlushController>
 
 export function createMockFlushController() {
   const flushObservable = new Observable<FlushEvent>()
-  const preparePageExitFlushObservable = new Observable<PageExitReason>()
+  const prepareUrgentFlushObservable = new Observable<UrgentFlushReason>()
   let currentMessagesCount = 0
   let currentBytesCount = 0
 
@@ -29,7 +28,7 @@ export function createMockFlushController() {
       return currentBytesCount
     },
     flushObservable,
-    preparePageExitFlushObservable,
+    prepareUrgentFlushObservable,
     notifyFlush(reason: FlushReason = 'bytes_limit') {
       if (currentMessagesCount === 0) {
         throw new Error(

--- a/packages/browser-debugger/src/entries/main.spec.ts
+++ b/packages/browser-debugger/src/entries/main.spec.ts
@@ -1,4 +1,5 @@
 import { registerCleanupTask, replaceMockableWithSpy } from '@datadog/browser-core/test'
+import { Observable } from '@datadog/browser-core'
 import { initDebuggerTransport } from '../domain/api'
 import { startDeliveryApiPolling } from '../domain/deliveryApi'
 import { display } from '../domain/display'
@@ -36,7 +37,8 @@ describe('datadogDebugger', () => {
   it('should default the init version from build-plugin metadata', async () => {
     browserWindow.__DD_LIVE_DEBUGGER_BUILD__ = { version: 'build-version' }
     replaceMockableWithSpy(startDebuggerBatch).and.callFake(() => ({
-      flushController: undefined as any,
+      flushObservable: new Observable(),
+      prepareUrgentFlushObservable: new Observable(),
       add: () => undefined,
       flush: () => undefined,
       forceFlush: () => undefined,
@@ -68,7 +70,8 @@ describe('datadogDebugger', () => {
   it('should warn when the explicit init version mismatches build-plugin metadata', async () => {
     browserWindow.__DD_LIVE_DEBUGGER_BUILD__ = { version: 'build-version' }
     replaceMockableWithSpy(startDebuggerBatch).and.callFake(() => ({
-      flushController: undefined as any,
+      flushObservable: new Observable(),
+      prepareUrgentFlushObservable: new Observable(),
       add: () => undefined,
       flush: () => undefined,
       forceFlush: () => undefined,

--- a/packages/browser-debugger/src/entries/main.spec.ts
+++ b/packages/browser-debugger/src/entries/main.spec.ts
@@ -39,6 +39,7 @@ describe('datadogDebugger', () => {
       flushController: undefined as any,
       add: () => undefined,
       flush: () => undefined,
+      forceFlush: () => undefined,
       stop: () => undefined,
       upsert: () => undefined,
     }))
@@ -70,6 +71,7 @@ describe('datadogDebugger', () => {
       flushController: undefined as any,
       add: () => undefined,
       flush: () => undefined,
+      forceFlush: () => undefined,
       stop: () => undefined,
       upsert: () => undefined,
     }))

--- a/packages/browser-debugger/src/transport/startDebuggerBatch.ts
+++ b/packages/browser-debugger/src/transport/startDebuggerBatch.ts
@@ -4,7 +4,6 @@ import {
   createBatch,
   createFlushController,
   createHttpRequest,
-  createIdentityEncoder,
   Observable,
   PageExitReason,
   createEndpointBuilder,
@@ -15,7 +14,6 @@ export function startDebuggerBatch(initConfiguration: InitConfiguration): Batch 
   const debuggerEndpointBuilder = createEndpointBuilder({ ...initConfiguration, source: 'dd_debugger' }, 'debugger')
 
   const batch = createBatch({
-    encoder: createIdentityEncoder(),
     request: createHttpRequest([debuggerEndpointBuilder], (error) => display.error('transport error:', error)),
     flushController: createFlushController({
       pageMayExitObservable: createSimplePageMayExitObservable(),

--- a/packages/browser-debugger/src/transport/startDebuggerBatch.ts
+++ b/packages/browser-debugger/src/transport/startDebuggerBatch.ts
@@ -3,7 +3,6 @@ import {
   addEventListener,
   createBatch,
   createFlushController,
-  createHttpRequest,
   Observable,
   PageExitReason,
   createEndpointBuilder,
@@ -14,7 +13,8 @@ export function startDebuggerBatch(initConfiguration: InitConfiguration): Batch 
   const debuggerEndpointBuilder = createEndpointBuilder({ ...initConfiguration, source: 'dd_debugger' }, 'debugger')
 
   const batch = createBatch({
-    request: createHttpRequest([debuggerEndpointBuilder], (error) => display.error('transport error:', error)),
+    endpoints: [debuggerEndpointBuilder],
+    reportError: (error) => display.error('transport error:', error),
     flushController: createFlushController({
       pageMayExitObservable: createSimplePageMayExitObservable(),
       sessionExpireObservable: new Observable(),

--- a/packages/browser-debugger/src/transport/startDebuggerBatch.ts
+++ b/packages/browser-debugger/src/transport/startDebuggerBatch.ts
@@ -14,7 +14,7 @@ export function startDebuggerBatch(initConfiguration: InitConfiguration): Batch 
 
   const batch = createBatch({
     endpoints: [debuggerEndpointBuilder],
-    reportError: (error) => display.error('transport error:', error),
+    reportError: (message) => display.error('transport error:', message),
     flushController: createFlushController({
       pageMayExitObservable: createSimplePageMayExitObservable(),
       sessionExpireObservable: new Observable(),

--- a/packages/browser-debugger/src/transport/startDebuggerBatch.ts
+++ b/packages/browser-debugger/src/transport/startDebuggerBatch.ts
@@ -1,50 +1,12 @@
-import type { InitConfiguration, PageMayExitEvent, Batch } from '@datadog/browser-core'
-import {
-  addEventListener,
-  createBatch,
-  createFlushController,
-  Observable,
-  PageExitReason,
-  createEndpointBuilder,
-} from '@datadog/browser-core'
+import type { InitConfiguration, Batch } from '@datadog/browser-core'
+import { createBatch, createEndpointBuilder } from '@datadog/browser-core'
 import { display } from '../domain/display'
 
 export function startDebuggerBatch(initConfiguration: InitConfiguration): Batch {
   const debuggerEndpointBuilder = createEndpointBuilder({ ...initConfiguration, source: 'dd_debugger' }, 'debugger')
 
-  const batch = createBatch({
+  return createBatch({
     endpoints: [debuggerEndpointBuilder],
     reportError: (message) => display.error('transport error:', message),
-    flushController: createFlushController({
-      pageMayExitObservable: createSimplePageMayExitObservable(),
-    }),
-  })
-
-  return batch
-}
-
-function createSimplePageMayExitObservable(): Observable<PageMayExitEvent> {
-  return new Observable<PageMayExitEvent>((observable) => {
-    if (typeof window === 'undefined') {
-      return
-    }
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'hidden') {
-        observable.notify({ reason: PageExitReason.HIDDEN })
-      }
-    }
-
-    const onBeforeUnload = () => {
-      observable.notify({ reason: PageExitReason.UNLOADING })
-    }
-
-    const visibilityListener = addEventListener(window, 'visibilitychange', onVisibilityChange, { capture: true })
-    const unloadListener = addEventListener(window, 'beforeunload', onBeforeUnload)
-
-    return () => {
-      visibilityListener.stop()
-      unloadListener.stop()
-    }
   })
 }

--- a/packages/browser-debugger/src/transport/startDebuggerBatch.ts
+++ b/packages/browser-debugger/src/transport/startDebuggerBatch.ts
@@ -17,7 +17,6 @@ export function startDebuggerBatch(initConfiguration: InitConfiguration): Batch 
     reportError: (message) => display.error('transport error:', message),
     flushController: createFlushController({
       pageMayExitObservable: createSimplePageMayExitObservable(),
-      sessionExpireObservable: new Observable(),
     }),
   })
 

--- a/packages/browser-logs/src/boot/startLogs.ts
+++ b/packages/browser-logs/src/boot/startLogs.ts
@@ -1,7 +1,6 @@
 import type { BufferedObservable, BufferedData, SessionManager } from '@datadog/browser-core'
 import {
   sendToExtension,
-  createPageMayExitObservable,
   canUseEventBridge,
   startAccountContext,
   startGlobalContext,
@@ -43,7 +42,6 @@ export function startLogs(
   lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (log) => sendToExtension('logs', log))
 
   const reportError = startReportError(lifeCycle)
-  const pageMayExitObservable = createPageMayExitObservable()
 
   // Start user and account context first to allow overrides from global context
   const assembleHook = hooks.assemble
@@ -64,13 +62,7 @@ export function startLogs(
   startLogsAssembly(configuration, lifeCycle, assembleHook, getCommonContext, reportError)
 
   if (!canUseEventBridge()) {
-    const { stop: stopLogsBatch } = startLogsBatch(
-      configuration,
-      lifeCycle,
-      reportError,
-      pageMayExitObservable,
-      sessionManager
-    )
+    const { stop: stopLogsBatch } = startLogsBatch(configuration, lifeCycle, reportError, sessionManager)
     cleanupTasks.push(() => stopLogsBatch())
   } else {
     startLogsBridge(lifeCycle)

--- a/packages/browser-logs/src/domain/assembly.spec.ts
+++ b/packages/browser-logs/src/domain/assembly.spec.ts
@@ -342,13 +342,7 @@ describe('logs limitation', () => {
 
       expect(serverLogs.length).toEqual(1)
       expect(serverLogs[0].message).toBe('foo')
-      expect(reportErrorSpy).toHaveBeenCalledTimes(1)
-      expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
-        jasmine.objectContaining({
-          message,
-          source: ErrorSource.AGENT,
-        })
-      )
+      expect(reportErrorSpy).toHaveBeenCalledWith(message)
     })
 
     it(`does not take discarded ${status} logs into account (message: "${message}")`, () => {
@@ -397,12 +391,7 @@ describe('logs limitation', () => {
       expect(serverLogs.length).toEqual(2)
       expect(serverLogs[0].message).toEqual('foo')
       expect(serverLogs[1].message).toEqual('baz')
-      expect(reportErrorSpy).toHaveBeenCalledTimes(1)
-      expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
-        jasmine.objectContaining({
-          source: ErrorSource.AGENT,
-        })
-      )
+      expect(reportErrorSpy).toHaveBeenCalledWith(message)
     })
 
     it(`allows to send logs with a different status when reaching the limit (message: "${message}")`, () => {
@@ -423,12 +412,7 @@ describe('logs limitation', () => {
       expect(serverLogs.length).toEqual(2)
       expect(serverLogs[0].message).toEqual('foo')
       expect(serverLogs[1].message).toEqual('baz')
-      expect(reportErrorSpy).toHaveBeenCalledTimes(1)
-      expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
-        jasmine.objectContaining({
-          source: ErrorSource.AGENT,
-        })
-      )
+      expect(reportErrorSpy).toHaveBeenCalledWith(message)
     })
   })
 
@@ -445,11 +429,6 @@ describe('logs limitation', () => {
 
     expect(serverLogs.length).toEqual(1)
     expect(serverLogs[0].message).toEqual('foo')
-    expect(reportErrorSpy).toHaveBeenCalledTimes(1)
-    expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
-      jasmine.objectContaining({
-        source: ErrorSource.AGENT,
-      })
-    )
+    expect(reportErrorSpy).toHaveBeenCalledWith('Reached max number of customs by minute: 1')
   })
 })

--- a/packages/browser-logs/src/domain/assembly.ts
+++ b/packages/browser-logs/src/domain/assembly.ts
@@ -1,4 +1,4 @@
-import type { Context, EventRateLimiter, RawError } from '@datadog/browser-core'
+import type { Context, EventRateLimiter } from '@datadog/browser-core'
 import { ErrorSource, buildTags, createEventRateLimiter } from '@datadog/browser-core'
 import { toRelativeTime } from '@datadog/js-core/time'
 import { DISCARDED } from '@datadog/js-core/assembly'
@@ -16,7 +16,7 @@ export function startLogsAssembly(
   lifeCycle: LifeCycle,
   hook: AssembleHook,
   getCommonContext: () => CommonContext,
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   eventRateLimit?: number
 ) {
   const statusWithCustom = (STATUSES as string[]).concat(['custom'])

--- a/packages/browser-logs/src/domain/reportError.ts
+++ b/packages/browser-logs/src/domain/reportError.ts
@@ -1,20 +1,20 @@
-import type { RawError } from '@datadog/browser-core'
 import { ErrorSource, addTelemetryDebug } from '@datadog/browser-core'
+import { timeStampNow } from '@datadog/js-core/time'
 import type { LifeCycle } from './lifeCycle'
 import { LifeCycleEventType } from './lifeCycle'
 import { StatusType } from './logger/isAuthorized'
 
 export function startReportError(lifeCycle: LifeCycle) {
-  return (error: RawError) => {
+  return (message: string) => {
     lifeCycle.notify(LifeCycleEventType.RAW_LOG_COLLECTED, {
       rawLogsEvent: {
-        message: error.message,
-        date: error.startClocks.timeStamp,
+        message,
+        date: timeStampNow(),
         origin: ErrorSource.AGENT,
         status: StatusType.error,
       },
     })
     // monitor-until: forever, to keep an eye on the errors reported to customers
-    addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
+    addTelemetryDebug('Error reported to customer', { 'error.message': message })
   }
 }

--- a/packages/browser-logs/src/transport/startLogsBatch.ts
+++ b/packages/browser-logs/src/transport/startLogsBatch.ts
@@ -5,7 +5,6 @@ import {
   createReplicaEndpointBuilder,
   createFlushController,
   createHttpRequest,
-  createIdentityEncoder,
 } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
@@ -26,7 +25,6 @@ export function startLogsBatch(
   }
 
   const batch = createBatch({
-    encoder: createIdentityEncoder(),
     request: createHttpRequest(endpoints, reportError),
     flushController: createFlushController({
       pageMayExitObservable,

--- a/packages/browser-logs/src/transport/startLogsBatch.ts
+++ b/packages/browser-logs/src/transport/startLogsBatch.ts
@@ -1,10 +1,5 @@
-import type { Context, Observable, PageMayExitEvent, SessionManager } from '@datadog/browser-core'
-import {
-  createBatch,
-  createEndpointBuilder,
-  createReplicaEndpointBuilder,
-  createFlushController,
-} from '@datadog/browser-core'
+import type { Context, SessionManager } from '@datadog/browser-core'
+import { createBatch, createEndpointBuilder, createReplicaEndpointBuilder } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
 import { LifeCycleEventType } from '../domain/lifeCycle'
@@ -14,7 +9,6 @@ export function startLogsBatch(
   configuration: LogsConfiguration,
   lifeCycle: LifeCycle,
   reportError: (message: string) => void,
-  pageMayExitObservable: Observable<PageMayExitEvent>,
   sessionManager: SessionManager
 ) {
   const endpoints = [createEndpointBuilder(configuration, 'logs')]
@@ -23,12 +17,8 @@ export function startLogsBatch(
     endpoints.push(replicaEndpoint)
   }
 
-  const batch = createBatch({
-    endpoints,
-    reportError,
-    flushController: createFlushController({ pageMayExitObservable }),
-  })
-  sessionManager.expireObservable.subscribe(() => batch.flushController.forceFlush('session_expire'))
+  const batch = createBatch({ endpoints, reportError })
+  sessionManager.expireObservable.subscribe(() => batch.forceFlush('session_expire'))
 
   lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (serverLogsEvent: LogsEvent & Context) => {
     batch.add(serverLogsEvent)

--- a/packages/browser-logs/src/transport/startLogsBatch.ts
+++ b/packages/browser-logs/src/transport/startLogsBatch.ts
@@ -26,11 +26,9 @@ export function startLogsBatch(
   const batch = createBatch({
     endpoints,
     reportError,
-    flushController: createFlushController({
-      pageMayExitObservable,
-      sessionExpireObservable: sessionManager.expireObservable,
-    }),
+    flushController: createFlushController({ pageMayExitObservable }),
   })
+  sessionManager.expireObservable.subscribe(() => batch.flushController.forceFlush('session_expire'))
 
   lifeCycle.subscribe(LifeCycleEventType.LOG_COLLECTED, (serverLogsEvent: LogsEvent & Context) => {
     batch.add(serverLogsEvent)

--- a/packages/browser-logs/src/transport/startLogsBatch.ts
+++ b/packages/browser-logs/src/transport/startLogsBatch.ts
@@ -4,7 +4,6 @@ import {
   createEndpointBuilder,
   createReplicaEndpointBuilder,
   createFlushController,
-  createHttpRequest,
 } from '@datadog/browser-core'
 import type { LogsConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
@@ -25,7 +24,8 @@ export function startLogsBatch(
   }
 
   const batch = createBatch({
-    request: createHttpRequest(endpoints, reportError),
+    endpoints,
+    reportError,
     flushController: createFlushController({
       pageMayExitObservable,
       sessionExpireObservable: sessionManager.expireObservable,

--- a/packages/browser-logs/src/transport/startLogsBatch.ts
+++ b/packages/browser-logs/src/transport/startLogsBatch.ts
@@ -1,4 +1,4 @@
-import type { Context, Observable, PageMayExitEvent, RawError, SessionManager } from '@datadog/browser-core'
+import type { Context, Observable, PageMayExitEvent, SessionManager } from '@datadog/browser-core'
 import {
   createBatch,
   createEndpointBuilder,
@@ -13,7 +13,7 @@ import type { LogsEvent } from '../logsEvent.types'
 export function startLogsBatch(
   configuration: LogsConfiguration,
   lifeCycle: LifeCycle,
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   pageMayExitObservable: Observable<PageMayExitEvent>,
   sessionManager: SessionManager
 ) {

--- a/packages/browser-rum-core/src/boot/startRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/startRum.spec.ts
@@ -1,6 +1,6 @@
 import { ONE_SECOND, toServerDuration, relativeNow } from '@datadog/js-core/time'
 import type { Duration } from '@datadog/js-core/time'
-import type { RawError, BufferedData, SessionManager } from '@datadog/browser-core'
+import type { BufferedData, SessionManager } from '@datadog/browser-core'
 import { Observable, findLast, noop, createIdentityEncoder, BufferedObservable } from '@datadog/browser-core'
 import type { Clock, SessionManagerMock } from '@datadog/browser-core/test'
 import {
@@ -33,7 +33,7 @@ function startRumStub(
   lifeCycle: LifeCycle,
   configuration: RumConfiguration,
   sessionManager: SessionManager,
-  reportError: (error: RawError) => void
+  reportError: (message: string) => void
 ) {
   const hooks = createHooks()
 

--- a/packages/browser-rum-core/src/boot/startRum.ts
+++ b/packages/browser-rum-core/src/boot/startRum.ts
@@ -96,8 +96,8 @@ export function startRum(
       sessionManager.expireObservable,
       createEncoder
     )
-    const preparePageExitSubscription = batch.flushController.preparePageExitFlushObservable.subscribe((reason) => {
-      lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason })
+    const preparePageExitSubscription = batch.flushController.prepareUrgentFlushObservable.subscribe((reason) => {
+      lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, reason)
     })
     cleanupTasks.push(() => preparePageExitSubscription.unsubscribe())
     cleanupTasks.push(() => batch.stop())
@@ -105,7 +105,7 @@ export function startRum(
   } else {
     startRumEventBridge(lifeCycle)
     const pageMayExitSubscription = pageMayExitObservable.subscribe((event) => {
-      lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, event)
+      lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, event.reason)
     })
     cleanupTasks.push(() => pageMayExitSubscription.unsubscribe())
   }

--- a/packages/browser-rum-core/src/boot/startRum.ts
+++ b/packages/browser-rum-core/src/boot/startRum.ts
@@ -85,25 +85,17 @@ export function startRum(
     addTelemetryDebug('Error reported to customer', { 'error.message': message })
   }
 
-  const pageMayExitObservable = createPageMayExitObservable()
-
   if (!canUseEventBridge()) {
-    const batch = startRumBatch(
-      configuration,
-      lifeCycle,
-      reportError,
-      pageMayExitObservable,
-      sessionManager.expireObservable,
-      createEncoder
-    )
-    const preparePageExitSubscription = batch.flushController.prepareUrgentFlushObservable.subscribe((reason) => {
+    const batch = startRumBatch(configuration, lifeCycle, reportError, sessionManager.expireObservable, createEncoder)
+    const preparePageExitSubscription = batch.prepareUrgentFlushObservable.subscribe((reason) => {
       lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, reason)
     })
     cleanupTasks.push(() => preparePageExitSubscription.unsubscribe())
     cleanupTasks.push(() => batch.stop())
-    startCustomerDataTelemetry(telemetry, lifeCycle, batch.flushController.flushObservable)
+    startCustomerDataTelemetry(telemetry, lifeCycle, batch.flushObservable)
   } else {
     startRumEventBridge(lifeCycle)
+    const pageMayExitObservable = createPageMayExitObservable()
     const pageMayExitSubscription = pageMayExitObservable.subscribe((event) => {
       lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, event.reason)
     })

--- a/packages/browser-rum-core/src/boot/startRum.ts
+++ b/packages/browser-rum-core/src/boot/startRum.ts
@@ -1,6 +1,5 @@
 import type {
   Observable,
-  RawError,
   DeflateEncoderStreamId,
   Encoder,
   BufferedData,
@@ -17,7 +16,9 @@ import {
   startGlobalContext,
   startUserContext,
   startTabContext,
+  ErrorSource,
 } from '@datadog/browser-core'
+import { clocksNow } from '@datadog/js-core/time'
 import { createDOMMutationObservable } from '../browser/domMutationObservable'
 import { createWindowOpenObservable } from '../browser/windowOpenObservable'
 import { startInternalContext } from '../domain/contexts/internalContext'
@@ -76,10 +77,12 @@ export function startRum(
   sessionManager.expireObservable.subscribe(() => lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED))
   sessionManager.renewObservable.subscribe(() => lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED))
 
-  const reportError = (error: RawError) => {
-    lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
+  const reportError = (message: string) => {
+    lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, {
+      error: { message, source: ErrorSource.AGENT, startClocks: clocksNow() },
+    })
     // monitor-until: forever, to keep an eye on the errors reported to customers
-    addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
+    addTelemetryDebug('Error reported to customer', { 'error.message': message })
   }
 
   const pageMayExitObservable = createPageMayExitObservable()
@@ -149,7 +152,7 @@ export function startRumEventCollection(
   initialViewOptions: ViewOptions | undefined,
   bufferedDataObservable: Observable<BufferedData>,
   sdkName: SdkName | undefined,
-  reportError: (error: RawError) => void
+  reportError: (message: string) => void
 ) {
   const cleanupTasks: Array<() => void> = []
 

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.spec.ts
@@ -224,9 +224,7 @@ describe('trackClickActions', () => {
 
     clock.tick(12)
 
-    lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, {
-      reason: PageExitReason.HIDDEN,
-    })
+    lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.HIDDEN)
 
     expect(events.length).toBe(1)
     expect(events[0].duration).toBe(12 as Duration)

--- a/packages/browser-rum-core/src/domain/action/trackClickActions.ts
+++ b/packages/browser-rum-core/src/domain/action/trackClickActions.ts
@@ -62,7 +62,7 @@ export function trackClickActions(
   let currentClickChain: ClickChain | undefined
 
   lifeCycle.subscribe(LifeCycleEventType.VIEW_ENDED, stopClickChain)
-  lifeCycle.subscribe(LifeCycleEventType.PAGE_MAY_EXIT, stopClickChain)
+  lifeCycle.subscribe(LifeCycleEventType.PREPARE_URGENT_FLUSH, stopClickChain)
 
   const { stop: stopActionEventsListener } = listenActionEvents<{
     clickActionBase: ClickActionBase
@@ -207,7 +207,7 @@ function startClickAction(
     click.stop(endClocks.timeStamp)
   })
 
-  const pageMayExitSubscription = lifeCycle.subscribe(LifeCycleEventType.PAGE_MAY_EXIT, () => {
+  const pageMayExitSubscription = lifeCycle.subscribe(LifeCycleEventType.PREPARE_URGENT_FLUSH, () => {
     click.stop(timeStampNow())
   })
 

--- a/packages/browser-rum-core/src/domain/assembly.spec.ts
+++ b/packages/browser-rum-core/src/domain/assembly.spec.ts
@@ -1,7 +1,7 @@
 import { ONE_MINUTE, relativeToClocks } from '@datadog/js-core/time'
 import type { TimeStamp, ClocksState, RelativeTime } from '@datadog/js-core/time'
 import type { SessionManager } from '@datadog/browser-core'
-import { ErrorSource, display, startGlobalContext, startTabContext } from '@datadog/browser-core'
+import { display, startGlobalContext, startTabContext } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { registerCleanupTask, mockClock, createSessionManagerMock } from '@datadog/browser-core/test'
 import { createRawRumEvent, mockRumConfiguration, mockViewHistory, noopRecorderApi } from '../../test'
@@ -575,13 +575,7 @@ describe('rum assembly', () => {
 
         expect(serverRumEvents.length).toBe(1)
         expect(serverRumEvents[0].date).toBe(100)
-        expect(reportErrorSpy).toHaveBeenCalledTimes(1)
-        expect(reportErrorSpy.calls.argsFor(0)[0]).toEqual(
-          jasmine.objectContaining({
-            message,
-            source: ErrorSource.AGENT,
-          })
-        )
+        expect(reportErrorSpy).toHaveBeenCalledWith(message)
       })
 
       it(`does not take discarded ${eventType} events into account`, () => {

--- a/packages/browser-rum-core/src/domain/assembly.ts
+++ b/packages/browser-rum-core/src/domain/assembly.ts
@@ -1,4 +1,4 @@
-import type { RawError, EventRateLimiter } from '@datadog/browser-core'
+import type { EventRateLimiter } from '@datadog/browser-core'
 import { isEmptyObject, display, createEventRateLimiter, buildTags } from '@datadog/browser-core'
 import { DISCARDED } from '@datadog/js-core/assembly'
 import { combine } from '@datadog/js-core/util'
@@ -57,7 +57,7 @@ export function startRumAssembly(
   configuration: RumConfiguration,
   lifeCycle: LifeCycle,
   assembleHook: AssembleHook,
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   eventRateLimit?: number
 ) {
   const eventRateLimiters = {

--- a/packages/browser-rum-core/src/domain/lifeCycle.ts
+++ b/packages/browser-rum-core/src/domain/lifeCycle.ts
@@ -1,5 +1,5 @@
 import type { ClocksState, Duration } from '@datadog/js-core/time'
-import type { Context, PageMayExitEvent, RawError } from '@datadog/browser-core'
+import type { Context, RawError, UrgentFlushReason } from '@datadog/browser-core'
 import { AbstractLifeCycle } from '@datadog/browser-core'
 import type { RumEventDomainContext } from '../domainContext.types'
 import type { RawRumEvent, AssembledRumEvent } from '../rawRumEvent.types'
@@ -35,7 +35,7 @@ export const enum LifeCycleEventType {
   // on the same domain.
   SESSION_EXPIRED,
   SESSION_RENEWED,
-  PAGE_MAY_EXIT,
+  PREPARE_URGENT_FLUSH,
   RAW_RUM_EVENT_COLLECTED,
   RUM_EVENT_COLLECTED,
   RAW_ERROR_COLLECTED,
@@ -69,7 +69,7 @@ declare const LifeCycleEventTypeAsConst: {
   REQUEST_COMPLETED: LifeCycleEventType.REQUEST_COMPLETED
   SESSION_EXPIRED: LifeCycleEventType.SESSION_EXPIRED
   SESSION_RENEWED: LifeCycleEventType.SESSION_RENEWED
-  PAGE_MAY_EXIT: LifeCycleEventType.PAGE_MAY_EXIT
+  PREPARE_URGENT_FLUSH: LifeCycleEventType.PREPARE_URGENT_FLUSH
   RAW_RUM_EVENT_COLLECTED: LifeCycleEventType.RAW_RUM_EVENT_COLLECTED
   RUM_EVENT_COLLECTED: LifeCycleEventType.RUM_EVENT_COLLECTED
   RAW_ERROR_COLLECTED: LifeCycleEventType.RAW_ERROR_COLLECTED
@@ -91,7 +91,7 @@ export interface LifeCycleEventMap {
   [LifeCycleEventTypeAsConst.REQUEST_COMPLETED]: RequestCompleteEvent
   [LifeCycleEventTypeAsConst.SESSION_EXPIRED]: void
   [LifeCycleEventTypeAsConst.SESSION_RENEWED]: void
-  [LifeCycleEventTypeAsConst.PAGE_MAY_EXIT]: PageMayExitEvent
+  [LifeCycleEventTypeAsConst.PREPARE_URGENT_FLUSH]: UrgentFlushReason
   [LifeCycleEventTypeAsConst.RAW_RUM_EVENT_COLLECTED]: RawRumEventCollectedData
   [LifeCycleEventTypeAsConst.RUM_EVENT_COLLECTED]: AssembledRumEvent
   [LifeCycleEventTypeAsConst.RAW_ERROR_COLLECTED]: {

--- a/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.spec.ts
@@ -345,7 +345,7 @@ describe('view lifecycle', () => {
 
         expect(getViewEndCount()).toEqual(0)
 
-        lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: exitReason })
+        lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, exitReason)
 
         expect(getViewEndCount()).toEqual(0)
       })
@@ -356,7 +356,7 @@ describe('view lifecycle', () => {
 
       expect(getViewUpdateCount()).toEqual(1)
 
-      lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
+      lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.UNLOADING)
 
       expect(getViewUpdateCount()).toEqual(2)
     })
@@ -366,7 +366,7 @@ describe('view lifecycle', () => {
 
       expect(getViewCreateCount()).toEqual(1)
 
-      lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
+      lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.UNLOADING)
 
       expect(getViewCreateCount()).toEqual(1)
     })
@@ -374,7 +374,7 @@ describe('view lifecycle', () => {
     it('should not set the view as inactive on unloading', () => {
       const { getViewUpdate, getViewUpdateCount } = viewTest
 
-      lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
+      lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.UNLOADING)
 
       expect(getViewUpdate(getViewUpdateCount() - 1).isActive).toBe(true)
     })

--- a/packages/browser-rum-core/src/domain/view/trackViews.ts
+++ b/packages/browser-rum-core/src/domain/view/trackViews.ts
@@ -279,8 +279,8 @@ function newView(
   // Session keep alive
   const keepAliveIntervalId = setInterval(triggerViewUpdate, SESSION_KEEP_ALIVE_INTERVAL)
 
-  const pageMayExitSubscription = lifeCycle.subscribe(LifeCycleEventType.PAGE_MAY_EXIT, (pageMayExitEvent) => {
-    if (pageMayExitEvent.reason === PageExitReason.UNLOADING) {
+  const pageMayExitSubscription = lifeCycle.subscribe(LifeCycleEventType.PREPARE_URGENT_FLUSH, (reason) => {
+    if (reason === PageExitReason.UNLOADING) {
       triggerViewUpdate()
     }
   })

--- a/packages/browser-rum-core/src/transport/formDataTransport.ts
+++ b/packages/browser-rum-core/src/transport/formDataTransport.ts
@@ -1,18 +1,13 @@
-import type {
-  Uint8ArrayBuffer,
-  Encoder,
-  EncoderResult,
-  DeflateEncoderStreamId,
-  RawError,
-  Context,
-} from '@datadog/browser-core'
+import type { Uint8ArrayBuffer, Encoder, EncoderResult, DeflateEncoderStreamId, Context } from '@datadog/browser-core'
 import {
   addTelemetryDebug,
   createEndpointBuilder,
   createHttpRequest,
   jsonStringify,
   objectEntries,
+  ErrorSource,
 } from '@datadog/browser-core'
+import { clocksNow } from '@datadog/js-core/time'
 import type { RumConfiguration } from '../domain/configuration'
 import type { LifeCycle } from '../domain/lifeCycle'
 import { LifeCycleEventType } from '../domain/lifeCycle'
@@ -35,11 +30,13 @@ export function createFormDataTransport<T extends TransportPayload>(
   createEncoder: (streamId: DeflateEncoderStreamId) => Encoder,
   streamId: DeflateEncoderStreamId
 ) {
-  const reportError = (error: RawError) => {
-    lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
+  const reportError = (message: string) => {
+    lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, {
+      error: { message, source: ErrorSource.AGENT, startClocks: clocksNow() },
+    })
 
     // monitor-until: forever, to keep an eye on the errors reported to customers
-    addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
+    addTelemetryDebug('Error reported to customer', { 'error.message': message })
   }
 
   const httpRequest = createHttpRequest([createEndpointBuilder(configuration, 'profile')], reportError)

--- a/packages/browser-rum-core/src/transport/startRumBatch.ts
+++ b/packages/browser-rum-core/src/transport/startRumBatch.ts
@@ -80,11 +80,9 @@ export function startRumBatch(
     encoder: createEncoder(DeflateEncoderStreamId.RUM),
     endpoints,
     reportError,
-    flushController: createFlushController({
-      pageMayExitObservable,
-      sessionExpireObservable,
-    }),
+    flushController: createFlushController({ pageMayExitObservable }),
   })
+  sessionExpireObservable.subscribe(() => batch.flushController.forceFlush('session_expire'))
 
   let lastSentView: RumViewEvent | undefined
   let viewUpdatesSinceCheckpoint = 0

--- a/packages/browser-rum-core/src/transport/startRumBatch.ts
+++ b/packages/browser-rum-core/src/transport/startRumBatch.ts
@@ -1,7 +1,6 @@
-import type { Observable, PageMayExitEvent, Encoder, Context } from '@datadog/browser-core'
+import type { Observable, Encoder, Context } from '@datadog/browser-core'
 import {
   createBatch,
-  createFlushController,
   DeflateEncoderStreamId,
   isExperimentalFeatureEnabled,
   ExperimentalFeature,
@@ -66,7 +65,6 @@ export function startRumBatch(
   configuration: RumConfiguration,
   lifeCycle: LifeCycle,
   reportError: (message: string) => void,
-  pageMayExitObservable: Observable<PageMayExitEvent>,
   sessionExpireObservable: Observable<void>,
   createEncoder: (streamId: DeflateEncoderStreamId) => Encoder
 ) {
@@ -80,9 +78,8 @@ export function startRumBatch(
     encoder: createEncoder(DeflateEncoderStreamId.RUM),
     endpoints,
     reportError,
-    flushController: createFlushController({ pageMayExitObservable }),
   })
-  sessionExpireObservable.subscribe(() => batch.flushController.forceFlush('session_expire'))
+  sessionExpireObservable.subscribe(() => batch.forceFlush('session_expire'))
 
   let lastSentView: RumViewEvent | undefined
   let viewUpdatesSinceCheckpoint = 0

--- a/packages/browser-rum-core/src/transport/startRumBatch.ts
+++ b/packages/browser-rum-core/src/transport/startRumBatch.ts
@@ -2,7 +2,6 @@ import type { Observable, RawError, PageMayExitEvent, Encoder, Context } from '@
 import {
   createBatch,
   createFlushController,
-  createHttpRequest,
   DeflateEncoderStreamId,
   isExperimentalFeatureEnabled,
   ExperimentalFeature,
@@ -79,7 +78,8 @@ export function startRumBatch(
 
   const batch = createBatch({
     encoder: createEncoder(DeflateEncoderStreamId.RUM),
-    request: createHttpRequest(endpoints, reportError),
+    endpoints,
+    reportError,
     flushController: createFlushController({
       pageMayExitObservable,
       sessionExpireObservable,

--- a/packages/browser-rum-core/src/transport/startRumBatch.ts
+++ b/packages/browser-rum-core/src/transport/startRumBatch.ts
@@ -1,4 +1,4 @@
-import type { Observable, RawError, PageMayExitEvent, Encoder, Context } from '@datadog/browser-core'
+import type { Observable, PageMayExitEvent, Encoder, Context } from '@datadog/browser-core'
 import {
   createBatch,
   createFlushController,
@@ -65,7 +65,7 @@ export function assembleViewUpdateEvent(
 export function startRumBatch(
   configuration: RumConfiguration,
   lifeCycle: LifeCycle,
-  reportError: (error: RawError) => void,
+  reportError: (message: string) => void,
   pageMayExitObservable: Observable<PageMayExitEvent>,
   sessionExpireObservable: Observable<void>,
   createEncoder: (streamId: DeflateEncoderStreamId) => Encoder

--- a/packages/browser-rum/src/boot/datadogRecorder.spec.ts
+++ b/packages/browser-rum/src/boot/datadogRecorder.spec.ts
@@ -276,7 +276,7 @@ describe('startRecording', () => {
 })
 
 function flushSegment(lifeCycle: LifeCycle) {
-  lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
+  lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.UNLOADING)
 }
 
 function createRandomString(minLength: number) {

--- a/packages/browser-rum/src/boot/datadogRecorder.ts
+++ b/packages/browser-rum/src/boot/datadogRecorder.ts
@@ -1,11 +1,13 @@
-import type { RawError, HttpRequest, DeflateEncoder, Telemetry, SessionManager } from '@datadog/browser-core'
+import type { HttpRequest, DeflateEncoder, Telemetry, SessionManager } from '@datadog/browser-core'
 import {
   createHttpRequest,
   addTelemetryDebug,
   canUseEventBridge,
   noop,
   createEndpointBuilder,
+  ErrorSource,
 } from '@datadog/browser-core'
+import { clocksNow } from '@datadog/js-core/time'
 import type { LifeCycle, ViewHistory, RumConfiguration } from '@datadog/browser-rum-core'
 import { LifeCycleEventType } from '@datadog/browser-rum-core'
 
@@ -27,10 +29,12 @@ export function startRecording(
 ) {
   const cleanupTasks: Array<() => void> = []
 
-  const reportError = (error: RawError) => {
-    lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, { error })
+  const reportError = (message: string) => {
+    lifeCycle.notify(LifeCycleEventType.RAW_ERROR_COLLECTED, {
+      error: { message, source: ErrorSource.AGENT, startClocks: clocksNow() },
+    })
     // monitor-until: forever, to keep an eye on the errors reported to customers
-    addTelemetryDebug('Error reported to customer', { 'error.message': error.message })
+    addTelemetryDebug('Error reported to customer', { 'error.message': message })
   }
 
   const replayRequest =

--- a/packages/browser-rum/src/domain/segmentCollection/segmentCollection.spec.ts
+++ b/packages/browser-rum/src/domain/segmentCollection/segmentCollection.spec.ts
@@ -56,7 +56,7 @@ describe('startSegmentCollection', () => {
   }
 
   function emulatePageUnload() {
-    lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.UNLOADING })
+    lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.UNLOADING)
   }
 
   function readMostRecentMetadata(spy: jasmine.Spy<HttpRequest['send']>) {
@@ -155,7 +155,7 @@ describe('startSegmentCollection', () => {
 
     describe('flush when the page exits because it gets hidden', () => {
       function emulatePageHidden() {
-        lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.HIDDEN })
+        lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.HIDDEN)
       }
 
       it('uses `httpRequest.sendOnExit` when sending the segment', () => {
@@ -172,7 +172,7 @@ describe('startSegmentCollection', () => {
 
     describe('flush when the page exits because it gets frozen', () => {
       function emulatePageFrozen() {
-        lifeCycle.notify(LifeCycleEventType.PAGE_MAY_EXIT, { reason: PageExitReason.FROZEN })
+        lifeCycle.notify(LifeCycleEventType.PREPARE_URGENT_FLUSH, PageExitReason.FROZEN)
       }
 
       it('uses `httpRequest.sendOnExit` when sending the segment', () => {

--- a/packages/browser-rum/src/domain/segmentCollection/segmentCollection.ts
+++ b/packages/browser-rum/src/domain/segmentCollection/segmentCollection.ts
@@ -99,9 +99,9 @@ export function doStartSegmentCollection(
   })
 
   const { unsubscribe: unsubscribePageMayExit } = lifeCycle.subscribe(
-    LifeCycleEventType.PAGE_MAY_EXIT,
-    (pageMayExitEvent) => {
-      flushSegment(pageMayExitEvent.reason as FlushReason)
+    LifeCycleEventType.PREPARE_URGENT_FLUSH,
+    (reason) => {
+      flushSegment(reason as FlushReason)
     }
   )
 


### PR DESCRIPTION
## Motivation

In preparation for moving `createBatch` to `js-core`, this PR reduces the
number of abstractions it leaks to callers. Previously, every entry-point
(`startLogsBatch`, `startRumBatch`, `startTelemetryTransport`, …) had to
manually wire up `HttpRequest`, `FlushController`, and `PageMayExitObservable`
— details that are really internal to the batch machinery. Internalizing them
makes `createBatch` a self-contained, easy-to-use primitive, and reduces the
surface that js-core would need to expose.

## Changes

- Make `encoder` optional, defaulting to `createIdentityEncoder`
- Internalize `HttpRequest` creation (callers now pass `endpoints` + `reportError`)
- Simplify `reportError` to accept a plain message string instead of a `RawError`, so we don't have to expose `RawError` (yet)
- Rename `PAGE_MAY_EXIT` lifecycle event to `PREPARE_URGENT_FLUSH` to better reflect its semantics and make it slightly more runtime agnostic
- Replace `sessionExpireObservable` on `FlushController` with a `forceFlush(reason)` method, so callers drive flush timing without being wired into the controller
- Internalize `FlushController` and `PageMayExitObservable`; `Batch` now exposes `forceFlush`, `flushObservable`, and `prepareUrgentFlushObservable` directly

## Test instructions

This is a pure refactoring — verify that the SDK initialises and sends events normally by loading the sandbox (`yarn dev` → `http://localhost:8080`) and checking that RUM and log events are dispatched as expected.

## Checklist

- [x] Tested locally
- [x] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
