### PR TITLE
🐛 Fix flaky stylesheet rules test

### DIFF
--- a/packages/browser-rum/src/domain/record/record.spec.ts
+++ b/packages/browser-rum/src/domain/record/record.spec.ts
@@ -1,7 +1,7 @@
 import { DefaultPrivacyLevel, findLast, noop } from '@datadog/browser-core'
 import type { RumConfiguration, ViewCreatedEvent } from '@datadog/browser-rum-core'
 import { LifeCycle, LifeCycleEventType } from '@datadog/browser-rum-core'
-import { createNewEvent, collectAsyncCalls, registerCleanupTask } from '@datadog/browser-core/test'
+import { createNewEvent, collectAsyncCalls, mockClock, registerCleanupTask } from '@datadog/browser-core/test'
 import { recordsPerFullSnapshot } from '../../../test'
 import type {
   AddNodeChange,
@@ -34,7 +34,8 @@ describe('record', () => {
     })
   })
 
-  it('captures stylesheet rules', async () => {
+  it('captures stylesheet rules', () => {
+    const clock = mockClock()
     const styleElement = appendElement('<style></style>') as HTMLStyleElement
 
     startRecording()
@@ -53,61 +54,23 @@ describe('record', () => {
       styleSheet.insertRule('body { color: #ccc; }')
     }, 10)
 
-    await collectAsyncCalls(emitSpy, recordsPerFullSnapshot() + 6)
+    clock.tick(10)
 
-    const records = getEmittedRecords()
-    let i = 0
+    const styleSheetRuleData = getEmittedRecords()
+      .filter(
+        (record): record is BrowserIncrementalSnapshotRecord =>
+          record.type === RecordType.IncrementalSnapshot && record.data.source === IncrementalSource.StyleSheetRule
+      )
+      .map((record) => record.data)
 
-    expect(records[i++].type).toEqual(RecordType.Meta)
-    expect(records[i++].type).toEqual(RecordType.Focus)
-    expect(records[i++].type).toEqual(RecordType.FullSnapshot)
-
-    if (window.visualViewport) {
-      expect(records[i++].type).toEqual(RecordType.VisualViewport)
-    }
-
-    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-      jasmine.objectContaining({
-        source: IncrementalSource.StyleSheetRule,
-        adds: [{ rule: 'body { background: #000; }', index: undefined }],
-      })
-    )
-    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-      jasmine.objectContaining({
-        source: IncrementalSource.StyleSheetRule,
-        adds: [{ rule: 'body { background: #111; }', index: undefined }],
-      })
-    )
-    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-      jasmine.objectContaining({
-        source: IncrementalSource.StyleSheetRule,
-        removes: [{ index: 0 }],
-      })
-    )
-    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-      jasmine.objectContaining({
-        source: IncrementalSource.StyleSheetRule,
-        adds: [{ rule: 'body { color: #fff; }', index: undefined }],
-      })
-    )
-    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-    expect((records[i++] as BrowserIncrementalSnapshotRecord).data).toEqual(
-      jasmine.objectContaining({
-        source: IncrementalSource.StyleSheetRule,
-        removes: [{ index: 0 }],
-      })
-    )
-    expect(records[i].type).toEqual(RecordType.IncrementalSnapshot)
-    expect((records[i] as BrowserIncrementalSnapshotRecord).data).toEqual(
-      jasmine.objectContaining({
-        source: IncrementalSource.StyleSheetRule,
-        adds: [{ rule: 'body { color: #ccc; }', index: undefined }],
-      })
-    )
+    expect(styleSheetRuleData).toEqual([
+      jasmine.objectContaining({ adds: [{ rule: 'body { background: #000; }', index: undefined }] }),
+      jasmine.objectContaining({ adds: [{ rule: 'body { background: #111; }', index: undefined }] }),
+      jasmine.objectContaining({ removes: [{ index: 0 }] }),
+      jasmine.objectContaining({ adds: [{ rule: 'body { color: #fff; }', index: undefined }] }),
+      jasmine.objectContaining({ removes: [{ index: 0 }] }),
+      jasmine.objectContaining({ adds: [{ rule: 'body { color: #ccc; }', index: undefined }] }),
+    ])
   })
 
   it('flushes pending mutation records before taking a full snapshot', async () => {


### PR DESCRIPTION
## Motivation

The `captures stylesheet rules` test in `record.spec.ts` is flaky. Let's try to fix that.

## Changes

There are two factors that seem to contribute to this test's flakiness:
1. It uses the real `setTimeout()`, rather than a mock clock, so it's sensitive to sometimes-unpredictable timing in CI.
2. It expects an exact sequence of records, instead of just checking that all of the records it expects are present. If another tracker happens to emit a record that's not part of the assertion, the test fails.

This PR fixes both issues:
1. The test has been converted to use `mockClock()`.
2. The test now filters the records it receives, and only asserts against the kinds of records it's actually interested in.

Locally, the new version seems to be solid; I'm hoping this will fix the flakiness in CI.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
