### PR TITLE
📝 add deterministic sampling warning to v7.0.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,11 @@ This is the v7 major release. It removes deprecated options and legacy code path
 - **Higher-quality data** — deterministic sampling (consistent decisions across products), aborted requests no longer polluting error metrics, and a new `session_renewal` view loading type to better understand session boundaries.
 - **A cleaner API** — deprecated options and beta flags removed; what's left is the supported, stable surface going forward.
 
+> [!WARNING]
+> Upgrading to v7 introduces deterministic sampling for distributed traces based on the RUM session ID. As a result, under RUM without Limits, the likelihood to index sessions that had sampled associated traces is significantly increased — meaning more traces will now be retained by your existing Cross-Product Retention Filters RUMxAPM, even without any configuration change.
+>
+> If you have cross-product Retention Filters (e.g. RUM-linked APM traces), you may see an **increase in the volume of indexed spans**, which could lead to **higher costs**. We recommend reviewing your Retention Filter configuration and estimated span volume after upgrading.
+
 **Migrating from v6:**
 
 - Follow the [v6 → v7 migration guide](https://github.com/DataDog/documentation/blob/8ed5928d4cf04351f6ec6f6e8d605267def58351/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md) in the Datadog documentation.


### PR DESCRIPTION
## Motivation

When upgrading to v7, users with RUM-linked APM cross-product Retention Filters may unexpectedly see an increase in indexed span volume — and therefore higher costs — due to the new deterministic sampling behavior introduced in v7. This is not called out anywhere in the v7.0.0 changelog, so users may be caught off-guard.

## Changes

- Add a `[!WARNING]` callout in the v7.0.0 changelog section explaining that deterministic sampling may increase the volume of indexed spans for users with RUMxAPM Retention Filters, and recommending they review their configuration before upgrading.

## Test instructions

Open the `CHANGELOG.md` on GitHub and verify the warning renders correctly as a callout block in the v7.0.0 section.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file
