### PR TITLE
✨ Rename feature operation APIs to operation

### DIFF
--- a/packages/browser-rum-core/src/boot/preStartRum.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.ts
@@ -40,7 +40,7 @@ import {
   serializeRumConfiguration,
 } from '../domain/configuration'
 import type { ViewOptions } from '../domain/view/trackViews'
-import type { FeatureOperationOptions, FailureReason } from '../domain/vital/vitalCollection'
+import type { OperationOptions, FailureReason } from '../domain/vital/vitalCollection'
 import { callPluginsMethod } from '../domain/plugins'
 import { startTrackingConsentContext } from '../domain/contexts/trackingConsentContext'
 import type { StartRumResult } from './startRum'
@@ -208,14 +208,14 @@ export function createPreStartStrategy(
   const addOperationStepVital = (
     name: string,
     stepType: 'start' | 'end',
-    options?: FeatureOperationOptions,
+    options?: OperationOptions,
     failureReason?: FailureReason
   ) => {
     bufferApiCalls.notify((startRumResult) =>
       startRumResult.addOperationStepVital(
         sanitize(name)!,
         stepType,
-        sanitize(options) as FeatureOperationOptions,
+        sanitize(options) as OperationOptions,
         sanitize(failureReason) as FailureReason | undefined
       )
     )

--- a/packages/browser-rum-core/src/boot/rumPublicApi.spec.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.spec.ts
@@ -1019,7 +1019,7 @@ describe('rum public api', () => {
     })
   })
 
-  describe('startFeatureOperation', () => {
+  describe('startOperation', () => {
     it('should call addOperationStepVital on the startRum result with start status', async () => {
       const addOperationStepVitalSpy = jasmine.createSpy()
       const { rumPublicApi } = makeRumPublicApiWithDefaults({
@@ -1028,7 +1028,7 @@ describe('rum public api', () => {
         },
       })
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      rumPublicApi.startFeatureOperation('foo', { operationKey: '00000000-0000-0000-0000-000000000000' })
+      rumPublicApi.startOperation('foo', { operationKey: '00000000-0000-0000-0000-000000000000' })
       await collectAsyncCalls(addOperationStepVitalSpy, 1)
       expect(addOperationStepVitalSpy).toHaveBeenCalledWith(
         'foo',
@@ -1042,7 +1042,7 @@ describe('rum public api', () => {
     })
   })
 
-  describe('succeedFeatureOperation', () => {
+  describe('succeedOperation', () => {
     it('should call addOperationStepVital on the startRum result with end status', async () => {
       const addOperationStepVitalSpy = jasmine.createSpy()
       const { rumPublicApi } = makeRumPublicApiWithDefaults({
@@ -1051,7 +1051,7 @@ describe('rum public api', () => {
         },
       })
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      rumPublicApi.succeedFeatureOperation('foo', { operationKey: '00000000-0000-0000-0000-000000000000' })
+      rumPublicApi.succeedOperation('foo', { operationKey: '00000000-0000-0000-0000-000000000000' })
       await collectAsyncCalls(addOperationStepVitalSpy, 1)
       expect(addOperationStepVitalSpy).toHaveBeenCalledWith(
         'foo',
@@ -1064,7 +1064,7 @@ describe('rum public api', () => {
     })
   })
 
-  describe('failFeatureOperation', () => {
+  describe('failOperation', () => {
     it('should call addOperationStepVital on the startRum result with end status and failure reason', async () => {
       const addOperationStepVitalSpy = jasmine.createSpy()
       const { rumPublicApi } = makeRumPublicApiWithDefaults({
@@ -1073,7 +1073,7 @@ describe('rum public api', () => {
         },
       })
       rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
-      rumPublicApi.failFeatureOperation('foo', 'error', { operationKey: '00000000-0000-0000-0000-000000000000' })
+      rumPublicApi.failOperation('foo', 'error', { operationKey: '00000000-0000-0000-0000-000000000000' })
       await collectAsyncCalls(addOperationStepVitalSpy, 1)
       expect(addOperationStepVitalSpy).toHaveBeenCalledWith(
         'foo',
@@ -1081,6 +1081,46 @@ describe('rum public api', () => {
         { operationKey: '00000000-0000-0000-0000-000000000000' },
         'error'
       )
+    })
+  })
+
+  describe('deprecated *FeatureOperation aliases', () => {
+    it('startFeatureOperation should forward with start status and still expose a handlingStack', async () => {
+      const addOperationStepVitalSpy = jasmine.createSpy()
+      const { rumPublicApi } = makeRumPublicApiWithDefaults({
+        startRumResult: { addOperationStepVital: addOperationStepVitalSpy },
+      })
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      rumPublicApi.startFeatureOperation('foo')
+      await collectAsyncCalls(addOperationStepVitalSpy, 1)
+      expect(addOperationStepVitalSpy).toHaveBeenCalledWith(
+        'foo',
+        'start',
+        { handlingStack: jasmine.any(String) },
+        undefined
+      )
+    })
+
+    it('succeedFeatureOperation should forward with end status', async () => {
+      const addOperationStepVitalSpy = jasmine.createSpy()
+      const { rumPublicApi } = makeRumPublicApiWithDefaults({
+        startRumResult: { addOperationStepVital: addOperationStepVitalSpy },
+      })
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      rumPublicApi.succeedFeatureOperation('foo')
+      await collectAsyncCalls(addOperationStepVitalSpy, 1)
+      expect(addOperationStepVitalSpy).toHaveBeenCalledWith('foo', 'end', undefined, undefined)
+    })
+
+    it('failFeatureOperation should forward with end status and failure reason', async () => {
+      const addOperationStepVitalSpy = jasmine.createSpy()
+      const { rumPublicApi } = makeRumPublicApiWithDefaults({
+        startRumResult: { addOperationStepVital: addOperationStepVitalSpy },
+      })
+      rumPublicApi.init(DEFAULT_INIT_CONFIGURATION)
+      rumPublicApi.failFeatureOperation('foo', 'error')
+      await collectAsyncCalls(addOperationStepVitalSpy, 1)
+      expect(addOperationStepVitalSpy).toHaveBeenCalledWith('foo', 'end', undefined, 'error')
     })
   })
 

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -513,28 +513,60 @@ export interface RumPublicApi extends PublicApi {
   stopDurationVital: (name: string, options?: DurationVitalOptions) => void
 
   /**
-   * Start a feature operation.
+   * Start an operation.
    *
-   * Call {@link succeedFeatureOperation} or {@link failFeatureOperation} with the same name (and optional
+   * Call {@link succeedOperation} or {@link failOperation} with the same name (and optional
    * `operationKey`) to send a RUM vital event marking the end of the operation.
    *
-   * @category Vital - Feature Operation
+   * @category Vital - Operation
    * @param name - Name of the operation
    * @param options - Options for the operation (operationKey, context, description)
    * @example
    * ```ts
-   * datadogRum.startFeatureOperation('checkout')
+   * datadogRum.startOperation('checkout')
    * // ... perform the operation
-   * datadogRum.succeedFeatureOperation('checkout')
+   * datadogRum.succeedOperation('checkout')
    * ```
+   */
+  startOperation: (name: string, options?: FeatureOperationOptions) => void
+
+  /**
+   * Mark an operation as successful.
+   *
+   * Sends a RUM vital event marking the end of the operation started with {@link startOperation}.
+   *
+   * @category Vital - Operation
+   * @param name - Name of the operation
+   * @param options - Options for the operation (operationKey, context, description)
+   */
+  succeedOperation: (name: string, options?: FeatureOperationOptions) => void
+
+  /**
+   * Mark an operation as failed.
+   *
+   * Sends a RUM vital event marking the end of the operation started with {@link startOperation}.
+   *
+   * @category Vital - Operation
+   * @param name - Name of the operation
+   * @param failureReason - Reason for the failure
+   * @param options - Options for the operation (operationKey, context, description)
+   */
+  failOperation: (name: string, failureReason: FailureReason, options?: FeatureOperationOptions) => void
+
+  /**
+   * Start a feature operation.
+   *
+   * @deprecated Use {@link startOperation} instead.
+   * @category Vital - Feature Operation
+   * @param name - Name of the operation
+   * @param options - Options for the operation (operationKey, context, description)
    */
   startFeatureOperation: (name: string, options?: FeatureOperationOptions) => void
 
   /**
    * Mark a feature operation as successful.
    *
-   * Sends a RUM vital event marking the end of the operation started with {@link startFeatureOperation}.
-   *
+   * @deprecated Use {@link succeedOperation} instead.
    * @category Vital - Feature Operation
    * @param name - Name of the operation
    * @param options - Options for the operation (operationKey, context, description)
@@ -544,8 +576,7 @@ export interface RumPublicApi extends PublicApi {
   /**
    * Mark a feature operation as failed.
    *
-   * Sends a RUM vital event marking the end of the operation started with {@link startFeatureOperation}.
-   *
+   * @deprecated Use {@link failOperation} instead.
    * @category Vital - Feature Operation
    * @param name - Name of the operation
    * @param failureReason - Reason for the failure
@@ -969,7 +1000,7 @@ export function makeRumPublicApi(
       })
     }),
 
-    startFeatureOperation: (name, options) => {
+    startOperation: (name, options) => {
       const handlingStack = createHandlingStack('vital')
       callMonitored(() => {
         addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'start' })
@@ -977,15 +1008,23 @@ export function makeRumPublicApi(
       })
     },
 
-    succeedFeatureOperation: monitor((name, options) => {
+    succeedOperation: monitor((name, options) => {
       addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'succeed' })
       strategy.addOperationStepVital(name, 'end', options)
     }),
 
-    failFeatureOperation: monitor((name, failureReason, options) => {
+    failOperation: monitor((name, failureReason, options) => {
       addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'fail' })
       strategy.addOperationStepVital(name, 'end', options, failureReason)
     }),
+
+    // Deprecated aliases — kept for backwards compatibility, forward to the renamed APIs above.
+    startFeatureOperation: (name, options) => rumPublicApi.startOperation(name, options),
+
+    succeedFeatureOperation: (name, options) => rumPublicApi.succeedOperation(name, options),
+
+    failFeatureOperation: (name, failureReason, options) => rumPublicApi.failOperation(name, failureReason, options),
+
     DEFAULT_TRACKED_RESOURCE_HEADERS,
   })
 

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -1020,7 +1020,13 @@ export function makeRumPublicApi(
     }),
 
     // Deprecated aliases — kept for backwards compatibility, forward to the renamed APIs above.
-    startFeatureOperation: (name, options) => rumPublicApi.startOperation(name, options),
+    startFeatureOperation: (name, options) => {
+      const handlingStack = createHandlingStack('vital')
+      callMonitored(() => {
+        addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'start' })
+        strategy.addOperationStepVital(name, 'start', { ...options, handlingStack })
+      })
+    },
 
     succeedFeatureOperation: (name, options) => rumPublicApi.succeedOperation(name, options),
 

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -45,6 +45,7 @@ import type { ViewOptions } from '../domain/view/trackViews'
 import type {
   AddDurationVitalOptions,
   DurationVitalOptions,
+  OperationOptions,
   FeatureOperationOptions,
   FailureReason,
 } from '../domain/vital/vitalCollection'
@@ -528,7 +529,7 @@ export interface RumPublicApi extends PublicApi {
    * datadogRum.succeedOperation('checkout')
    * ```
    */
-  startOperation: (name: string, options?: FeatureOperationOptions) => void
+  startOperation: (name: string, options?: OperationOptions) => void
 
   /**
    * Mark an operation as successful.
@@ -539,7 +540,7 @@ export interface RumPublicApi extends PublicApi {
    * @param name - Name of the operation
    * @param options - Options for the operation (operationKey, context, description)
    */
-  succeedOperation: (name: string, options?: FeatureOperationOptions) => void
+  succeedOperation: (name: string, options?: OperationOptions) => void
 
   /**
    * Mark an operation as failed.
@@ -551,7 +552,7 @@ export interface RumPublicApi extends PublicApi {
    * @param failureReason - Reason for the failure
    * @param options - Options for the operation (operationKey, context, description)
    */
-  failOperation: (name: string, failureReason: FailureReason, options?: FeatureOperationOptions) => void
+  failOperation: (name: string, failureReason: FailureReason, options?: OperationOptions) => void
 
   /**
    * Start a feature operation.

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -556,8 +556,8 @@ export interface RumPublicApi extends PublicApi {
   /**
    * Start a feature operation.
    *
-   * @deprecated Use {@link startOperation} instead.
    * @category Vital - Feature Operation
+   * @deprecated Use {@link startOperation} instead.
    * @param name - Name of the operation
    * @param options - Options for the operation (operationKey, context, description)
    */
@@ -566,8 +566,8 @@ export interface RumPublicApi extends PublicApi {
   /**
    * Mark a feature operation as successful.
    *
-   * @deprecated Use {@link succeedOperation} instead.
    * @category Vital - Feature Operation
+   * @deprecated Use {@link succeedOperation} instead.
    * @param name - Name of the operation
    * @param options - Options for the operation (operationKey, context, description)
    */
@@ -576,8 +576,8 @@ export interface RumPublicApi extends PublicApi {
   /**
    * Mark a feature operation as failed.
    *
-   * @deprecated Use {@link failOperation} instead.
    * @category Vital - Feature Operation
+   * @deprecated Use {@link failOperation} instead.
    * @param name - Name of the operation
    * @param failureReason - Reason for the failure
    * @param options - Options for the operation (operationKey, context, description)

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -1020,6 +1020,7 @@ export function makeRumPublicApi(
     }),
 
     // Deprecated aliases — kept for backwards compatibility, forward to the renamed APIs above.
+    // TODO: remove in the next major version (RUM-16921).
     startFeatureOperation: (name, options) => {
       const handlingStack = createHandlingStack('vital')
       callMonitored(() => {

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -733,6 +733,24 @@ export function makeRumPublicApi(
     })
   }
 
+  const startOperation: RumPublicApi['startOperation'] = (name, options) => {
+    const handlingStack = createHandlingStack('vital')
+    callMonitored(() => {
+      addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'start' })
+      strategy.addOperationStepVital(name, 'start', { ...options, handlingStack })
+    })
+  }
+
+  const succeedOperation: RumPublicApi['succeedOperation'] = monitor((name, options) => {
+    addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'succeed' })
+    strategy.addOperationStepVital(name, 'end', options)
+  })
+
+  const failOperation: RumPublicApi['failOperation'] = monitor((name, failureReason, options) => {
+    addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'fail' })
+    strategy.addOperationStepVital(name, 'end', options, failureReason)
+  })
+
   const rumPublicApi: RumPublicApi = makePublicApi<RumPublicApi>({
     init: (initConfiguration) => {
       const errorStack = new Error().stack
@@ -1001,37 +1019,15 @@ export function makeRumPublicApi(
       })
     }),
 
-    startOperation: (name, options) => {
-      const handlingStack = createHandlingStack('vital')
-      callMonitored(() => {
-        addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'start' })
-        strategy.addOperationStepVital(name, 'start', { ...options, handlingStack })
-      })
-    },
-
-    succeedOperation: monitor((name, options) => {
-      addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'succeed' })
-      strategy.addOperationStepVital(name, 'end', options)
-    }),
-
-    failOperation: monitor((name, failureReason, options) => {
-      addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'fail' })
-      strategy.addOperationStepVital(name, 'end', options, failureReason)
-    }),
+    startOperation,
+    succeedOperation,
+    failOperation,
 
     // Deprecated aliases — kept for backwards compatibility, forward to the renamed APIs above.
     // TODO: remove in the next major version (RUM-16921).
-    startFeatureOperation: (name, options) => {
-      const handlingStack = createHandlingStack('vital')
-      callMonitored(() => {
-        addTelemetryUsage({ feature: 'add-operation-step-vital', action_type: 'start' })
-        strategy.addOperationStepVital(name, 'start', { ...options, handlingStack })
-      })
-    },
-
-    succeedFeatureOperation: (name, options) => rumPublicApi.succeedOperation(name, options),
-
-    failFeatureOperation: (name, failureReason, options) => rumPublicApi.failOperation(name, failureReason, options),
+    startFeatureOperation: startOperation,
+    succeedFeatureOperation: succeedOperation,
+    failFeatureOperation: failOperation,
 
     DEFAULT_TRACKED_RESOURCE_HEADERS,
   })

--- a/packages/browser-rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/browser-rum-core/src/domain/vital/vitalCollection.ts
@@ -35,9 +35,11 @@ export interface DurationVitalOptions extends VitalOptions {
   vitalKey?: string
 }
 
-export interface FeatureOperationOptions extends VitalOptions {
+export interface OperationOptions extends VitalOptions {
   operationKey?: string
 }
+
+export type FeatureOperationOptions = OperationOptions
 
 export type FailureReason = 'error' | 'abandoned' | 'other'
 
@@ -104,7 +106,7 @@ export function startVitalCollection(lifeCycle: LifeCycle, pageStateHistory: Pag
   function addOperationStepVital(
     name: string,
     stepType: 'start' | 'end',
-    options?: FeatureOperationOptions & { handlingStack?: string },
+    options?: OperationOptions & { handlingStack?: string },
     failureReason?: FailureReason
   ) {
     const { operationKey, context, description, handlingStack } = options || {}

--- a/packages/browser-rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/browser-rum-core/src/domain/vital/vitalCollection.ts
@@ -39,7 +39,8 @@ export interface OperationOptions extends VitalOptions {
   operationKey?: string
 }
 
-export type FeatureOperationOptions = OperationOptions
+/** @deprecated Use {@link OperationOptions} instead. */
+export interface FeatureOperationOptions extends OperationOptions {}
 
 export type FailureReason = 'error' | 'abandoned' | 'other'
 

--- a/packages/browser-rum-core/src/domain/vital/vitalCollection.ts
+++ b/packages/browser-rum-core/src/domain/vital/vitalCollection.ts
@@ -40,7 +40,7 @@ export interface OperationOptions extends VitalOptions {
 }
 
 /** @deprecated Use {@link OperationOptions} instead. */
-export interface FeatureOperationOptions extends OperationOptions {}
+export type FeatureOperationOptions = OperationOptions
 
 export type FailureReason = 'error' | 'abandoned' | 'other'
 

--- a/packages/browser-rum-core/src/index.ts
+++ b/packages/browser-rum-core/src/index.ts
@@ -68,6 +68,7 @@ export type {
   DurationVitalStart,
   AddDurationVitalOptions,
   DurationVitalOptions,
+  OperationOptions,
   FeatureOperationOptions,
   FailureReason,
 } from './domain/vital/vitalCollection'

--- a/packages/browser-rum-slim/src/entries/main.ts
+++ b/packages/browser-rum-slim/src/entries/main.ts
@@ -33,6 +33,7 @@ export type {
   StartRecordingOptions,
   AddDurationVitalOptions,
   DurationVitalOptions,
+  OperationOptions,
   FeatureOperationOptions,
   FailureReason,
   ActionOptions,

--- a/packages/browser-rum/src/entries/main.ts
+++ b/packages/browser-rum/src/entries/main.ts
@@ -43,6 +43,7 @@ export type {
   StartRecordingOptions,
   AddDurationVitalOptions,
   DurationVitalOptions,
+  OperationOptions,
   FeatureOperationOptions,
   FailureReason,
   ActionOptions,

--- a/test/apps/microfrontend/common.ts
+++ b/test/apps/microfrontend/common.ts
@@ -62,7 +62,7 @@ export function createApp(id: string, title: string, borderColor: string) {
   })
 
   createButton(container, 'feature-operation', () => {
-    window.DD_RUM.startFeatureOperation(`${id}-feature-operation`)
+    window.DD_RUM.startOperation(`${id}-feature-operation`)
   })
 
   createButton(container, 'view', () => {

--- a/test/apps/microfrontend/types.d.ts
+++ b/test/apps/microfrontend/types.d.ts
@@ -4,7 +4,7 @@ interface Window {
     addAction: (name: string, context?: any) => void
     startDurationVital: (name: string, options?: { vitalKey?: string }) => void
     stopDurationVital: (name: string, options?: { vitalKey?: string }) => void
-    startFeatureOperation: (name: string) => void
+    startOperation: (name: string) => void
     startView: (options: { name: string }) => void
   }
 }

--- a/test/e2e/scenario/microfrontend.scenario.ts
+++ b/test/e2e/scenario/microfrontend.scenario.ts
@@ -182,13 +182,13 @@ test.describe('microfrontend', () => {
           expect(event?.context?.handlingStack).toMatch(HANDLING_STACK_REGEX)
         })
 
-      createTest('expose handling stack for DD_RUM.startFeatureOperation')
+      createTest('expose handling stack for DD_RUM.startOperation')
         .withRum({ ...RUM_CONFIG })
         .withRumInit((configuration) => {
           window.DD_RUM!.init(configuration)
 
           function testHandlingStack() {
-            window.DD_RUM!.startFeatureOperation('test-operation')
+            window.DD_RUM!.startOperation('test-operation')
           }
 
           testHandlingStack()
@@ -410,7 +410,7 @@ test.describe('microfrontend', () => {
           ])
         })
 
-      createTest('feature operations should have service and version from source code context')
+      createTest('operations should have service and version from source code context')
         .withRum({ ...RUM_CONFIG })
         .withSetup(microfrontendSetup)
         .run(async ({ intakeRegistry, flushEvents, page }) => {

--- a/test/e2e/scenario/rum/vitals.scenario.ts
+++ b/test/e2e/scenario/rum/vitals.scenario.ts
@@ -48,7 +48,7 @@ test.describe('vital collection', () => {
     .withRum()
     .run(async ({ flushEvents, intakeRegistry, page }) => {
       await page.evaluate(() => {
-        window.DD_RUM!.startFeatureOperation('foo')
+        window.DD_RUM!.startOperation('foo')
       })
       await flushEvents()
 


### PR DESCRIPTION
## Motivation

iOS, Android and the Electron SDK have renamed the feature operation APIs by dropping the "feature" prefix (`startFeatureOperation` → `startOperation`, etc.). The Browser SDK is still exposing the old name.

## Changes

- Add `startOperation` / `succeedOperation` / `failOperation` as the public operation APIs.
- Keep `startFeatureOperation` / `succeedFeatureOperation` / `failFeatureOperation` as `@deprecated` aliases that forward to the new methods — **non-breaking**, existing callers keep working.
- `failureReason` parameter is unchanged.

## Test instructions

```ts
datadogRum.startOperation('checkout', { operationKey: 'k' })
datadogRum.failOperation('checkout', 'error', { operationKey: 'k' })
```
Both should emit an `operation_step` vital (`start`, then `end` with `failure_reason: 'error'`). The deprecated `*FeatureOperation` names still work identically.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
