### PR TITLE
🔧 set ephemeral:false for staging branches

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -8,6 +8,7 @@ schema-version: v1
 kind: integration-branch
 name: $CURRENT_STAGING
 team: rum-browser
+ephemeral: false
 update_automatically: false # update_automatically is updating the integration branch on a schedule, instead we're updating it in a CI job for any commit to the base branch.
 reset_pattern: '' # use `staging-reset.js` instead so that a new staging branch is created weekly
 contacts:


### PR DESCRIPTION
## Motivation

`ephemeral` will default to `true` soon. We want to keep our staging branches

## Changes

Explicitly set `ephemeral: false`

## Test instructions

<!-- How can the reviewer test this change? Include relevant steps to reproduce the issue, if any. -->

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
