### PR TITLE
✅ Stabilize Nuxt E2E apps with preview and explicit ports

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -96,11 +96,12 @@ const baseWebServers = [
     name: 'nuxt app',
     stdout: 'pipe' as const,
     cwd: path.join(__dirname, '../apps/nuxt-app'),
-    command: isLocal ? 'yarn dev' : 'yarn start',
-    env: { NO_COLOR: '1' },
+    // `nuxt dev` shares one vite-node IPC server; parallel Playwright workers can trigger
+    // intermittent EINVAL / aborted navigations. Preview matches CI and tolerates concurrency.
+    command: 'yarn start',
+    env: { NO_COLOR: '1', PORT: '3100', NITRO_PORT: '3100' },
     wait: {
-      // yarn dev logs:   "➜ Local:  http://localhost:PORT"
-      // yarn start logs: "Listening on http://[::]:PORT"
+      // yarn preview logs: "Listening on http://[::]:PORT" (or localhost in some versions)
       stdout: /(?:Local:\s+http:\/\/localhost|Listening on http:\/\/(?:\[[^\]]+\]|[^:]+)):(?<nuxt_app_port>\d+)/,
     },
   },
@@ -108,8 +109,8 @@ const baseWebServers = [
     name: 'nuxt vue router v4 app',
     stdout: 'pipe' as const,
     cwd: path.join(__dirname, '../apps/nuxt-vue-router-v4-app'),
-    command: isLocal ? 'yarn dev' : 'yarn start',
-    env: { NO_COLOR: '1', PORT: '3001', NITRO_PORT: '3001' },
+    command: 'yarn start',
+    env: { NO_COLOR: '1', PORT: '3200', NITRO_PORT: '3200' },
     wait: {
       stdout:
         /(?:Local:\s+http:\/\/localhost|Listening on http:\/\/(?:\[[^\]]+\]|[^:]+)):(?<nuxt_vue_router_v4_app_port>\d+)/,


### PR DESCRIPTION
## Motivation

Nuxt plugin E2E tests could fail locally with `page.goto` `net::ERR_ABORTED` and Nuxt dev logs showing `connect EINVAL` on the vite-node Unix socket. That path is stressed when Playwright runs workers in parallel against `nuxt dev`, which shares a single vite-node IPC server.

## Changes

- Serve both Nuxt test apps with `yarn start` (`nuxt preview`) in `test/e2e/playwright.config.ts` for all environments (same as CI), instead of `yarn dev` locally.
- Set explicit `PORT` / `NITRO_PORT` for each app (`3100` for `nuxt-app`, `3200` for `nuxt-vue-router-v4-app`) so preview does not bind default 3000/3001 and collide with other processes.

## Test instructions

1. `yarn build:apps --app nuxt-app --app nuxt-vue-router-v4-app` (preview needs `.output`).
2. `yarn test:e2e test/e2e/scenario/plugins/nuxtPlugin.scenario.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

Made with [Cursor](https://cursor.com)