### PR TITLE
🐛 [VULN-81506] fix prototype pollution via mergeInto and tryJsonParse

### DIFF
--- a/packages/browser-core/src/domain/context/storeContextManager.spec.ts
+++ b/packages/browser-core/src/domain/context/storeContextManager.spec.ts
@@ -77,6 +77,12 @@ describe('storeContextManager', () => {
     expect(localStorage.getItem(buildStorageKey(PRODUCT_KEY, CustomerDataType.GlobalContext))).toBe('{"qux":"qix"}')
   })
 
+  it('should return empty context when localStorage contains invalid JSON', () => {
+    localStorage.setItem(STORAGE_KEY, 'not valid json')
+    const manager = createStoredContextManager()
+    expect(manager.getContext()).toEqual({})
+  })
+
   function createStoredContextManager({
     initialContext,
     productKey = PRODUCT_KEY,

--- a/packages/browser-core/src/domain/context/storeContextManager.ts
+++ b/packages/browser-core/src/domain/context/storeContextManager.ts
@@ -1,7 +1,7 @@
 import { combine } from '@datadog/js-core/util'
 import { addEventListener, DOM_EVENT } from '../../browser/addEventListener'
 import type { Context } from '../../tools/serialisation/context'
-import { isEmptyObject } from '../../tools/utils/objectUtils'
+import { isEmptyObject, tryJsonParse } from '../../tools/utils/objectUtils'
 import type { ContextManager } from './contextManager'
 import type { CustomerDataType } from './contextConstants'
 
@@ -45,7 +45,7 @@ export function storeContextManager(
 
   function getFromStorage() {
     const rawContext = localStorage.getItem(storageKey)
-    return rawContext ? (JSON.parse(rawContext) as Context) : {}
+    return rawContext ? (tryJsonParse<Context>(rawContext) ?? {}) : {}
   }
 }
 

--- a/packages/browser-core/src/tools/utils/objectUtils.spec.ts
+++ b/packages/browser-core/src/tools/utils/objectUtils.spec.ts
@@ -1,4 +1,4 @@
-import { getConstructorName } from './objectUtils'
+import { getConstructorName, tryJsonParse } from './objectUtils'
 
 describe('objectUtils', () => {
   describe('getConstructorName', () => {
@@ -37,6 +37,27 @@ describe('objectUtils', () => {
     it('should return undefined when the constructor name is not a non-empty string', () => {
       expect(getConstructorName({ constructor: { name: '' } })).toBeUndefined()
       expect(getConstructorName({ constructor: { name: 42 } })).toBeUndefined()
+    })
+  })
+
+  describe('tryJsonParse', () => {
+    it('should parse valid JSON', () => {
+      expect(tryJsonParse('{"a":1}')).toEqual({ a: 1 })
+    })
+
+    it('should return undefined for invalid JSON', () => {
+      expect(tryJsonParse('not json')).toBeUndefined()
+    })
+
+    it('should strip __proto__ key', () => {
+      const result = tryJsonParse('{"a":1,"__proto__":{"injected":true}}')
+      expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBeFalse()
+      expect(({} as any).injected).toBeUndefined()
+    })
+
+    it('should strip nested __proto__ key', () => {
+      tryJsonParse('{"a":{"__proto__":{"injected":true}}}')
+      expect(({} as any).injected).toBeUndefined()
     })
   })
 })

--- a/packages/browser-core/src/tools/utils/objectUtils.ts
+++ b/packages/browser-core/src/tools/utils/objectUtils.ts
@@ -1,6 +1,9 @@
+// Prevent prototype pollution: __proto__ as an own property in parsed JSON can corrupt Object.prototype
+const stripDangerousKeys = (key: string, value: unknown) => (key === '__proto__' ? undefined : value)
+
 export function tryJsonParse<T = unknown>(text: string): T | undefined {
   try {
-    return JSON.parse(text) as T
+    return JSON.parse(text, stripDangerousKeys) as T
   } catch {
     // ignore
   }

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
@@ -1,4 +1,5 @@
 import { timeStampNow } from '@datadog/js-core/time'
+import { tryJsonParse } from '@datadog/browser-core'
 import type { TimeStamp } from '@datadog/js-core/time'
 import type { RumRemoteConfiguration } from './remoteConfiguration'
 
@@ -57,11 +58,8 @@ export function createConfigurationCache({ remoteConfigurationId }: { remoteConf
         return { status: 'miss' }
       }
 
-      let parsed: unknown
-
-      try {
-        parsed = JSON.parse(raw)
-      } catch {
+      const parsed = tryJsonParse(raw)
+      if (parsed === undefined) {
         this.remove()
 
         return { status: 'error' }

--- a/packages/js-core/src/util/mergeInto.spec.ts
+++ b/packages/js-core/src/util/mergeInto.spec.ts
@@ -103,6 +103,25 @@ describe('combine', () => {
   })
 })
 
+describe('prototype pollution guards', () => {
+  afterEach(() => {
+    delete (Object.prototype as any).injected
+    delete (Object.prototype as any).polluted
+  })
+
+  it('should not pollute Object.prototype via __proto__', () => {
+    const source = JSON.parse('{"__proto__":{"injected":true}}')
+    mergeInto({}, source)
+    expect(({} as any).injected).toBeUndefined()
+  })
+
+  it('should not pollute Object.prototype via nested __proto__', () => {
+    const source = JSON.parse('{"a":{"__proto__":{"injected":true}}}')
+    mergeInto({}, source)
+    expect(({} as any).injected).toBeUndefined()
+  })
+})
+
 describe('deepClone', () => {
   it('should pass-through primitive values', () => {
     expect(deepClone('test')).toBe('test')

--- a/packages/js-core/src/util/mergeInto.ts
+++ b/packages/js-core/src/util/mergeInto.ts
@@ -70,7 +70,8 @@ function mergeIntoInternal<D, S>(
 
   const merged = getType(destination) === 'object' ? (destination as Record<any, any>) : {}
   for (const key in source) {
-    if (Object.prototype.hasOwnProperty.call(source, key)) {
+    // Skip __proto__: it resolves to Object.prototype via [[Get]], enabling prototype pollution
+    if (Object.prototype.hasOwnProperty.call(source, key) && key !== '__proto__') {
       merged[key] = mergeIntoInternal(merged[key], source[key], circularReferenceChecker)
     }
   }


### PR DESCRIPTION
## Motivation

`mergeInto` performed a recursive deep merge without guarding against `__proto__`, making it possible for external input to corrupt `Object.prototype`. 

## Changes

- Make `mergeInto` safe against prototype pollution by skipping `__proto__` during recursive merge
- Ensure `tryJsonParse` never returns objects carrying `__proto__` as an own property
- Harden `storeContextManager` and `remoteConfigurationCache` against malformed or untrusted localStorage data

## Behavioral changes

`mergeInto` (and `combine`, `deepClone`) now silently drops the `__proto__` key. `tryJsonParse` strips it from parsed JSON.

## Test instructions

```bash
yarn test:unit
```

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file