### PR TITLE
🐛 fix empty private regions deployment step

### DIFF
--- a/scripts/deploy/deploy-prod-dc.spec.ts
+++ b/scripts/deploy/deploy-prod-dc.spec.ts
@@ -2,8 +2,9 @@ import assert from 'node:assert/strict'
 import path from 'node:path'
 import { beforeEach, before, after, describe, it, mock, type Mock } from 'node:test'
 import { browserSdkVersion } from '../lib/browserSdkVersion.ts'
+import { mockDatacenters, resetDatacenterCache } from '../lib/datacenter.ts'
 import type { CommandDetail } from './lib/testHelpers.ts'
-import { mockModule, mockCommandImplementation, mockFetchHandlingError } from './lib/testHelpers.ts'
+import { mockModule, mockCommandImplementation, mockFetchHandlingError, MOCK_DATACENTERS } from './lib/testHelpers.ts'
 
 const currentBrowserSdkVersionMajor = browserSdkVersion.split('.')[0]
 
@@ -33,6 +34,7 @@ describe('deploy-prod-dc', () => {
   })
 
   beforeEach(() => {
+    mockDatacenters(MOCK_DATACENTERS)
     commands = mockCommandImplementation(commandMock)
     checkTelemetryErrorsCalls = []
     checkTelemetryErrorsMock.mock.mockImplementation((datacenters: string[], version: string) => {
@@ -46,8 +48,8 @@ describe('deploy-prod-dc', () => {
   })
 
   after(() => {
-    // Restore original Date.now
     Date.now = originalDateNow
+    resetDatacenterCache()
   })
 
   it('should deploy a given datacenter', async () => {
@@ -101,6 +103,14 @@ describe('deploy-prod-dc', () => {
       { command: 'node ./scripts/deploy/deploy.ts prod v6 prtest00,prtest01' },
       { command: 'node ./scripts/deploy/upload-source-maps.ts v6 prtest00,prtest01' },
     ])
+  })
+
+  it('should skip deployment when no private regions exist', async () => {
+    mockDatacenters(MOCK_DATACENTERS.filter((dc) => dc.type !== 'private'))
+
+    await runScript('./deploy-prod-dc.ts', 'v6', 'private-regions')
+
+    assert.strictEqual(commands.length, 0)
   })
 
   it('should deploy gov datacenters to the root upload path and skip all telemetry error checks', async () => {

--- a/scripts/deploy/deploy-prod-dc.ts
+++ b/scripts/deploy/deploy-prod-dc.ts
@@ -35,10 +35,17 @@ export async function main(...args: string[]): Promise<void> {
   })
 
   const version = positionals[0]
-  const datacenters = await getDatacenters(positionals[1])
+  const datacenterGroup = positionals[1]
 
-  if (!datacenters) {
+  if (!datacenterGroup) {
     throw new Error('DATACENTER argument is required')
+  }
+
+  const datacenters = await getDatacenters(datacenterGroup)
+
+  if (datacenters.length === 0) {
+    printLog('No datacenters found, skipping deployment.')
+    return
   }
 
   // Skip all telemetry error checks for gov datacenter deployments

--- a/scripts/deploy/lib/testHelpers.ts
+++ b/scripts/deploy/lib/testHelpers.ts
@@ -1,4 +1,5 @@
 import { mock, type Mock } from 'node:test'
+import type { Datacenter } from '../../lib/datacenter.ts'
 
 export async function mockModule(modulePath: string, mockObject: Record<string, any>): Promise<void> {
   const moduleExports = await import(modulePath)
@@ -83,16 +84,18 @@ export function mockCommandImplementation(mockFn: Mock<(...args: any[]) => void>
   return commands
 }
 
-export const MOCK_DATACENTER_RESPONSE = [
-  { name: 'ap1.prod.dog', site: 'ap1.datadoghq.com' },
-  { name: 'ap2.prod.dog', site: 'ap2.datadoghq.com' },
-  { name: 'eu1.prod.dog', site: 'datadoghq.eu' },
-  { name: 'us1.prod.dog', site: 'datadoghq.com' },
-  { name: 'us3.prod.dog', site: 'us3.datadoghq.com' },
-  { name: 'us5.prod.dog', site: 'us5.datadoghq.com' },
-  { name: 'prtest00.prod.dog', site: 'prtest00.datadoghq.com' },
-  { name: 'prtest01.prod.dog', site: 'prtest01.datadoghq.com' },
+export const MOCK_DATACENTERS: Datacenter[] = [
+  { name: 'ap1', site: 'ap1.datadoghq.com', type: 'minor' },
+  { name: 'ap2', site: 'ap2.datadoghq.com', type: 'minor' },
+  { name: 'eu1', site: 'datadoghq.eu', type: 'major' },
+  { name: 'us1', site: 'datadoghq.com', type: 'major' },
+  { name: 'us3', site: 'us3.datadoghq.com', type: 'minor' },
+  { name: 'us5', site: 'us5.datadoghq.com', type: 'minor' },
+  { name: 'prtest00', site: 'prtest00.datadoghq.com', type: 'private' },
+  { name: 'prtest01', site: 'prtest01.datadoghq.com', type: 'private' },
 ]
+
+const MOCK_DATACENTER_RESPONSE = MOCK_DATACENTERS.map((dc) => ({ name: `${dc.name}.prod.dog`, site: dc.site }))
 
 type FetchMockHandler = (url: string, options?: RequestInit) => Promise<Response> | undefined
 

--- a/scripts/lib/datacenter.ts
+++ b/scripts/lib/datacenter.ts
@@ -40,6 +40,14 @@ export async function getDatacenterMetadata(name: string): Promise<Datacenter | 
 
 let cachedDatacentersPromise: Promise<Datacenter[]> | undefined
 
+export function mockDatacenters(datacenters: Datacenter[]): void {
+  cachedDatacentersPromise = Promise.resolve(datacenters)
+}
+
+export function resetDatacenterCache(): void {
+  cachedDatacentersPromise = undefined
+}
+
 export function getAllDatacentersMetadata(): Promise<Datacenter[]> {
   if (cachedDatacentersPromise) {
     return cachedDatacentersPromise


### PR DESCRIPTION
## Motivation

The `step-2_deploy-prod-private-regions` CI job was failing because the runtime-metadata-service no longer returns any private-region datacenters (those with a `pr` prefix). The resolved datacenter list was empty, which caused:

1. An empty string passed as the `uploadPathTypes` argument to subprocesses
2. `deploy.ts` uploading files to a wrong S3 path (`//v7/…` instead of `<dc>/v7/…`)
3. `upload-source-maps.ts` crashing with `"No datacenter metadata found for "`

## Changes

- Skip deployment gracefully when the resolved datacenter list is empty (private regions may return in the future)
- Validate the `DATACENTER` argument upfront before any async work
- Add `mockDatacenters()`, `resetDatacenterCache()` to `datacenter.ts` so tests can inject mock data via the cache directly

## Test instructions

The CI pipeline re-run on a release will exercise the fix.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file