### PR TITLE
✨ Use optional MatchHeader name to account for default headers

### DIFF
--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -586,7 +586,9 @@ export interface RumPublicApi extends PublicApi {
   failFeatureOperation: (name: string, failureReason: FailureReason, options?: FeatureOperationOptions) => void
 
   /**
-   * List of default headers used by the {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders} option. See configuration example for extending them.
+   * List of default headers used by the {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders} option.
+   *
+   * @deprecated Use `{ includeDefaults: true }` as an entry in the `trackResourceHeaders` array instead.
    */
   DEFAULT_TRACKED_RESOURCE_HEADERS: typeof DEFAULT_TRACKED_RESOURCE_HEADERS
 }

--- a/packages/browser-rum-core/src/boot/rumPublicApi.ts
+++ b/packages/browser-rum-core/src/boot/rumPublicApi.ts
@@ -588,7 +588,7 @@ export interface RumPublicApi extends PublicApi {
   /**
    * List of default headers used by the {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders} option.
    *
-   * @deprecated Use `{ includeDefaults: true }` as an entry in the `trackResourceHeaders` array instead.
+   * @deprecated You can now omit `name` from a MatchHeader entry to include default headers.
    */
   DEFAULT_TRACKED_RESOURCE_HEADERS: typeof DEFAULT_TRACKED_RESOURCE_HEADERS
 }

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -431,22 +431,40 @@ describe('validateAndBuildRumConfiguration', () => {
         expect(result).toEqual(DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })))
       })
 
-      it('expands { includeDefaults: true } to the default headers', () => {
+      it('accepts a MatchHeader without name for default headers', () => {
         const result = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          trackResourceHeaders: [{ includeDefaults: true }],
+          trackResourceHeaders: [{}],
         })!.trackResourceHeaders
 
-        expect(result).toEqual(DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })))
+        expect(result).toEqual([{}])
       })
 
-      it('combines { includeDefaults: true } with custom matchers in array order', () => {
+      it('preserves location when name is absent', () => {
         const result = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          trackResourceHeaders: [{ includeDefaults: true }, { name: 'x-custom' }],
+          trackResourceHeaders: [{ location: 'response' }],
         })!.trackResourceHeaders
 
-        expect(result).toEqual([...DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })), { name: 'x-custom' }])
+        expect(result).toEqual([{ location: 'response' }])
+      })
+
+      it('combines default header matcher with custom matchers in array order', () => {
+        const result = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackResourceHeaders: [{}, { name: 'x-custom' }],
+        })!.trackResourceHeaders
+
+        expect(result).toEqual([{}, { name: 'x-custom' }])
+      })
+
+      it('treats undefined name like absent name', () => {
+        const result = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackResourceHeaders: [{ name: undefined }],
+        })!.trackResourceHeaders
+
+        expect(result).toEqual([{}])
       })
 
       it('accepts a MatchHeader with only name', () => {
@@ -536,21 +554,26 @@ describe('validateAndBuildRumConfiguration', () => {
         })!.trackResourceHeaders
 
         expect(result).toEqual([{ name: 'x-valid' }, { name: 'x-also-valid' }])
-        expect(displayWarnSpy).toHaveBeenCalledOnceWith(
-          "trackResourceHeaders[1] should be a MatchHeader object with a 'name' property"
-        )
+        expect(displayWarnSpy).toHaveBeenCalledOnceWith('trackResourceHeaders[1] should be a MatchHeader object')
       })
 
-      it('warns and skips item without name', () => {
+      it('accepts a MatchHeader without name', () => {
         const result = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,
-          trackResourceHeaders: [{ url: 'https://example.com' } as any],
+          trackResourceHeaders: [{ url: 'https://example.com' }],
+        })!.trackResourceHeaders
+
+        expect(result).toEqual([{ url: 'https://example.com' }])
+      })
+
+      it('warns and skips item with invalid name', () => {
+        const result = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackResourceHeaders: [{ name: 42 as any }],
         })!.trackResourceHeaders
 
         expect(result).toEqual([])
-        expect(displayWarnSpy).toHaveBeenCalledOnceWith(
-          "trackResourceHeaders[0] should be a MatchHeader object with a 'name' property"
-        )
+        expect(displayWarnSpy).toHaveBeenCalledOnceWith('trackResourceHeaders[0].name should be a MatchOption')
       })
 
       it('warns and skips item with invalid url', () => {

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -431,6 +431,24 @@ describe('validateAndBuildRumConfiguration', () => {
         expect(result).toEqual(DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })))
       })
 
+      it('expands { includeDefaults: true } to the default headers', () => {
+        const result = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackResourceHeaders: [{ includeDefaults: true }],
+        })!.trackResourceHeaders
+
+        expect(result).toEqual(DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })))
+      })
+
+      it('combines { includeDefaults: true } with custom matchers in array order', () => {
+        const result = validateAndBuildRumConfiguration({
+          ...DEFAULT_INIT_CONFIGURATION,
+          trackResourceHeaders: [{ includeDefaults: true }, { name: 'x-custom' }],
+        })!.trackResourceHeaders
+
+        expect(result).toEqual([...DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })), { name: 'x-custom' }])
+      })
+
       it('accepts a MatchHeader with only name', () => {
         const result = validateAndBuildRumConfiguration({
           ...DEFAULT_INIT_CONFIGURATION,

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -22,31 +22,7 @@ export const DEFAULT_PROPAGATOR_TYPES: PropagatorType[] = ['tracecontext', 'data
 
 /**
  * Default list of headers collected on resource events when {@link RumInitConfiguration.trackResourceHeaders | trackResourceHeaders}
- * is set to `true`. Re-exported by the `@datadog/browser-rum` and `@datadog/browser-rum-slim` packages, and exposed on the
- * `DD_RUM` global object when the SDK is loaded via the CDN, so it can be referenced when building a custom matcher list.
- *
- * @example NPM
- * ```ts
- * import { datadogRum, DEFAULT_TRACKED_RESOURCE_HEADERS } from '@datadog/browser-rum'
- *
- * datadogRum.init({
- *   // ...
- *   trackResourceHeaders: [
- *     ...DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
- *     { name: 'x-request-id' },
- *   ],
- * })
- * ```
- * @example CDN
- * ```ts
- * DD_RUM.init({
- *   // ...
- *   trackResourceHeaders: [
- *     ...DD_RUM.DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
- *     { name: 'x-request-id' },
- *   ],
- * })
- * ```
+ * is set to `true`.
  */
 export const DEFAULT_TRACKED_RESOURCE_HEADERS = [
   'cache-control',
@@ -283,11 +259,9 @@ export interface RumInitConfiguration extends InitConfiguration {
    *
    * - `true`: collect {@link DEFAULT_TRACKED_RESOURCE_HEADERS} for all URLs, both directions
    * - `MatchHeader[]`: each {@link MatchHeader} targets a header name, with optional URL scope
-   * (`url`), value extraction (`extractor`), and `location`. By default, both request and
-   * response headers are captured; set `location` to `'request'` or `'response'` to restrict
-   * to one.
-   * - `{ includeDefaults: true }` (as an array entry): expands to {@link DEFAULT_TRACKED_RESOURCE_HEADERS}
-   * in place, so the defaults can be combined with custom matchers without listing them manually.
+   * (`url`), value extraction (`extractor`), and `location`. When `name` is omitted, the matcher
+   * applies to {@link DEFAULT_TRACKED_RESOURCE_HEADERS}. By default, both request and response
+   * headers are captured; set `location` to `'request'` or `'response'` to restrict to one.
    *
    * Headers whose names match a built-in sensitive-data pattern are always dropped, regardless
    * of the configured matchers. The pattern blocks headers whose names contain: `token`, `cookie`,
@@ -298,7 +272,10 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @defaultValue false (disabled)
    * @example
    * // Collect default headers plus custom ones for all URLs
-   * trackResourceHeaders: [{ includeDefaults: true }, { name: 'x-request-id' }]
+   * trackResourceHeaders: [{}, { name: 'x-request-id' }]
+   * @example
+   * // Collect default headers from responses only
+   * trackResourceHeaders: [{ location: 'response' }]
    * @example
    * // URL-scoped rule: capture specific response headers only for calls to /api
    * trackResourceHeaders: [{ url: /\/api\//, name: 'cache-control', location: 'response' }]
@@ -306,7 +283,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * // Extract a partial value from a header
    * trackResourceHeaders: [{ url: /\/api\//, name: 'server-timing', extractor: /dur=(\d+)/, location: 'response' }]
    */
-  trackResourceHeaders?: boolean | Array<MatchHeader | { includeDefaults: true }> | undefined
+  trackResourceHeaders?: boolean | MatchHeader[] | undefined
 
   /**
    * Enables collection of long task events.
@@ -385,7 +362,7 @@ export interface GraphQlUrlOption {
 
 export interface MatchHeader {
   url?: MatchOption
-  name: MatchOption
+  name?: MatchOption
   extractor?: RegExp
   location?: 'request' | 'response' | 'any'
 }
@@ -588,10 +565,6 @@ function validateAndBuildGraphQlOptions(initConfiguration: RumInitConfiguration)
 
 const VALID_HEADER_LOCATIONS = ['request', 'response', 'any']
 
-function shouldIncludeDefaultHeaders(item: MatchHeader | { includeDefaults: true }): item is { includeDefaults: true } {
-  return isIndexableObject(item) && item.includeDefaults === true
-}
-
 function validateAndBuildTrackResourceHeaders(initConfiguration: RumInitConfiguration): MatchHeader[] {
   const option = initConfiguration.trackResourceHeaders
 
@@ -616,12 +589,12 @@ function validateAndBuildTrackResourceHeaders(initConfiguration: RumInitConfigur
   const result: MatchHeader[] = []
 
   option.forEach((item, index) => {
-    if (shouldIncludeDefaultHeaders(item)) {
-      DEFAULT_TRACKED_RESOURCE_HEADERS.forEach((name) => result.push({ name }))
+    if (!isIndexableObject(item)) {
+      display.warn(`trackResourceHeaders[${index}] should be a MatchHeader object`)
       return
     }
-    if (!isIndexableObject(item) || !isMatchOption(item.name)) {
-      display.warn(`trackResourceHeaders[${index}] should be a MatchHeader object with a 'name' property`)
+    if (item.name !== undefined && !isMatchOption(item.name)) {
+      display.warn(`trackResourceHeaders[${index}].name should be a MatchOption`)
       return
     }
     if (item.url !== undefined && !isMatchOption(item.url)) {
@@ -632,14 +605,18 @@ function validateAndBuildTrackResourceHeaders(initConfiguration: RumInitConfigur
       display.warn(`trackResourceHeaders[${index}].extractor should be a RegExp`)
       return
     }
-    if (item.location !== undefined && !VALID_HEADER_LOCATIONS.includes(item.location)) {
+    if (
+      item.location !== undefined &&
+      (typeof item.location !== 'string' || !VALID_HEADER_LOCATIONS.includes(item.location))
+    ) {
       display.warn(`trackResourceHeaders[${index}].location should be 'request', 'response', or 'any'`)
       return
     }
 
+    const { name, ...rest } = item
     result.push({
-      ...item,
-      name: typeof item.name === 'string' ? item.name.toLowerCase() : item.name,
+      ...rest,
+      ...(name !== undefined ? { name: typeof name === 'string' ? name.toLowerCase() : name } : {}),
     })
   })
 

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -286,6 +286,8 @@ export interface RumInitConfiguration extends InitConfiguration {
    * (`url`), value extraction (`extractor`), and `location`. By default, both request and
    * response headers are captured; set `location` to `'request'` or `'response'` to restrict
    * to one.
+   * - `{ includeDefaults: true }` (as an array entry): expands to {@link DEFAULT_TRACKED_RESOURCE_HEADERS}
+   * in place, so the defaults can be combined with custom matchers without listing them manually.
    *
    * Headers whose names match a built-in sensitive-data pattern are always dropped, regardless
    * of the configured matchers. The pattern blocks headers whose names contain: `token`, `cookie`,
@@ -296,10 +298,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @defaultValue false (disabled)
    * @example
    * // Collect default headers plus custom ones for all URLs
-   * trackResourceHeaders: [
-   *   ...DEFAULT_TRACKED_RESOURCE_HEADERS.map((h) => ({ name: h })),
-   *   { name: 'x-request-id' },
-   * ]
+   * trackResourceHeaders: [{ includeDefaults: true }, { name: 'x-request-id' }]
    * @example
    * // URL-scoped rule: capture specific response headers only for calls to /api
    * trackResourceHeaders: [{ url: /\/api\//, name: 'cache-control', location: 'response' }]
@@ -307,7 +306,7 @@ export interface RumInitConfiguration extends InitConfiguration {
    * // Extract a partial value from a header
    * trackResourceHeaders: [{ url: /\/api\//, name: 'server-timing', extractor: /dur=(\d+)/, location: 'response' }]
    */
-  trackResourceHeaders?: boolean | MatchHeader[] | undefined
+  trackResourceHeaders?: boolean | Array<MatchHeader | { includeDefaults: true }> | undefined
 
   /**
    * Enables collection of long task events.
@@ -589,6 +588,10 @@ function validateAndBuildGraphQlOptions(initConfiguration: RumInitConfiguration)
 
 const VALID_HEADER_LOCATIONS = ['request', 'response', 'any']
 
+function shouldIncludeDefaultHeaders(item: MatchHeader | { includeDefaults: true }): item is { includeDefaults: true } {
+  return isIndexableObject(item) && item.includeDefaults === true
+}
+
 function validateAndBuildTrackResourceHeaders(initConfiguration: RumInitConfiguration): MatchHeader[] {
   const option = initConfiguration.trackResourceHeaders
 
@@ -613,6 +616,10 @@ function validateAndBuildTrackResourceHeaders(initConfiguration: RumInitConfigur
   const result: MatchHeader[] = []
 
   option.forEach((item, index) => {
+    if (shouldIncludeDefaultHeaders(item)) {
+      DEFAULT_TRACKED_RESOURCE_HEADERS.forEach((name) => result.push({ name }))
+      return
+    }
     if (!isIndexableObject(item) || !isMatchOption(item.name)) {
       display.warn(`trackResourceHeaders[${index}] should be a MatchHeader object with a 'name' property`)
       return

--- a/packages/browser-rum-core/src/domain/resource/resourceCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/resource/resourceCollection.spec.ts
@@ -749,6 +749,27 @@ describe('resourceCollection', () => {
       expect(event.resource.response!.headers!['content-type']).toBeUndefined()
     })
 
+    it('should collect default headers when name is absent', () => {
+      setupResourceCollection({ trackResourceHeaders: [{ location: 'response' }] })
+
+      notifyRequest({
+        request: {
+          type: RequestType.FETCH,
+          response: new Response('', {
+            headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache', 'X-Other': 'ignored' },
+          }),
+        },
+      })
+
+      const event = rawRumEvents[0].rawRumEvent as RawRumResourceEvent
+      expect(event.resource.response).toEqual({
+        headers: {
+          'content-type': 'text/html',
+          'cache-control': 'no-cache',
+        },
+      })
+    })
+
     describe('forbidden headers', () => {
       const forbiddenHeaders = [
         'authorization',

--- a/packages/browser-rum-core/src/domain/resource/resourceCollection.ts
+++ b/packages/browser-rum-core/src/domain/resource/resourceCollection.ts
@@ -10,6 +10,7 @@ import {
   safeTruncate,
   setTimeout,
 } from '@datadog/browser-core'
+import type { MatchOption } from '@datadog/browser-core'
 import type { Duration } from '@datadog/js-core/time'
 import { elapsed, relativeToClocks, toServerDuration } from '@datadog/js-core/time'
 import { combine } from '@datadog/js-core/util'
@@ -19,6 +20,7 @@ import type { RumResourceEventDomainContext } from '../../domainContext.types'
 import type { NetworkHeaders, RawRumResourceEvent, ResourceRequest, ResourceResponse } from '../../rawRumEvent.types'
 import { RumEventType } from '../../rawRumEvent.types'
 import type { MatchHeader, RumConfiguration } from '../configuration'
+import { DEFAULT_TRACKED_RESOURCE_HEADERS } from '../configuration'
 import { startEventTracker } from '../eventTracker'
 import { extractRegexMatch } from '../extractRegexMatch'
 import type { LifeCycle, RawRumEventCollectedData } from '../lifeCycle'
@@ -387,6 +389,8 @@ const FORBIDDEN_HEADER_PATTERN =
   /(token|cookie|secret|authorization|(api|secret|access|app).?key|(client|connecting|real).?ip|forwarded)/
 const MAX_HEADER_COUNT = 100
 const MAX_HEADER_VALUE_LENGTH = 128
+const defaultHeadersMatchOption: MatchOption = (headerName) =>
+  (DEFAULT_TRACKED_RESOURCE_HEADERS as readonly string[]).includes(headerName)
 
 function filterHeaders(headers: Headers, matchers: MatchHeader[]): NetworkHeaders | undefined {
   const result: NetworkHeaders = {}
@@ -409,7 +413,7 @@ function filterHeaders(headers: Headers, matchers: MatchHeader[]): NetworkHeader
       return
     }
 
-    const matchHeader = matchers.find((m) => matchList([m.name], lowerName))
+    const matchHeader = matchers.find((m) => matchList([m.name ?? defaultHeadersMatchOption], lowerName))
     if (!matchHeader) {
       return
     }

--- a/test/e2e/scenario/rum/resources.scenario.ts
+++ b/test/e2e/scenario/rum/resources.scenario.ts
@@ -476,13 +476,10 @@ test.describe('resource headers with trackResourceHeaders', () => {
       expect(fetchEvent!.resource.response?.headers?.['cache-control']).toBeUndefined()
     })
 
-  createTest('collect default and custom headers using DEFAULT_TRACKED_RESOURCE_HEADERS pattern')
+  createTest('collect default and custom headers using optional name matcher')
     .withRum()
     .withRumInit((configuration) => {
-      configuration.trackResourceHeaders = [
-        ...window.DD_RUM!.DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
-        { name: 'x-request-id' },
-      ]
+      configuration.trackResourceHeaders = [{}, { name: 'x-request-id' }]
       window.DD_RUM!.init(configuration)
     })
     .run(async ({ intakeRegistry, flushEvents, page }) => {


### PR DESCRIPTION
## Motivation

Enabling `trackResourceHeaders` with custom matchers while still collecting the built-in defaults previously required spreading `DEFAULT_TRACKED_RESOURCE_HEADERS` manually:

```ts
trackResourceHeaders: [
  ...DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name })),
  { name: 'x-request-id' },
]
```

This is verbose and forces customers to import (NPM) or reference (CDN) the `DEFAULT_TRACKED_RESOURCE_HEADERS` constant. This change adds an ergonomic way to pull in the defaults inline, by making `name` optional on a `MatchHeader` entry.

## Changes

- **`MatchHeader` type** (`configuration.ts`): `name` is now optional. A matcher without `name` targets the built-in default headers instead of a specific one, and can still be scoped with `url`, `location`, etc.
- **Validation** (`configuration.ts`): `validateAndBuildTrackResourceHeaders` now accepts entries without `name` as-is (instead of expanding them at config-build time), only validating `name` when present. Warning messages were adjusted accordingly (e.g. `trackResourceHeaders[0].name should be a MatchOption`).
- **Header filtering** (`resourceCollection.ts`): `filterHeaders` falls back to a `defaultHeadersMatchOption` (checks membership in `DEFAULT_TRACKED_RESOURCE_HEADERS`) when a matcher's `name` is absent, so the expansion now happens at collection time rather than at config validation time.
- **TSDoc**: documented that omitting `name` targets the default headers, with an example combining it with `location: 'response'`.
- **Deprecation**: marked the `DEFAULT_TRACKED_RESOURCE_HEADERS` field on the `DD_RUM` public API as `@deprecated`, now pointing to the optional-`name` matcher instead of the previously introduced `{ includeDefaults: true }` sentinel (which this commit replaces before it shipped). The field/value is kept to avoid a breaking change.
- **Tests**: updated/added cases for a bare `{}` matcher, `{ location: 'response' }` without `name`, combining it with a custom matcher, and `name: undefined` being treated like an absent `name`.
- **E2E**: updated the resources scenario to use `[{}, { name: 'x-request-id' }]` instead of spreading `DEFAULT_TRACKED_RESOURCE_HEADERS`.

New usage:

```ts
trackResourceHeaders: [{}, { name: 'x-request-id' }]
```

## Test instructions

### Automated

```bash
yarn test:unit --spec packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
yarn test:unit --spec packages/browser-rum-core/src/domain/resource/resourceCollection.spec.ts
yarn typecheck
yarn lint
```

### Manual (end-to-end)

Start the dev server and create a temporary sandbox page that combines a bare (default-headers) matcher with a custom matcher:

```bash
yarn dev-server start

cat > sandbox/test-default-headers.html << 'HTML'
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>Test default headers matcher</title>
    <script src="/datadog-rum.js"></script>
    <script>
      DD_RUM.init({
        clientToken: 'xxx',
        applicationId: 'xxx',
        proxy: '/proxy',
        trackResources: true,
        trackResourceHeaders: [{}, { name: 'x-custom-header' }],
      })
      function makeRequest() {
        fetch('/datadog-rum.js', { headers: { 'x-custom-header': 'hello' } })
      }
    </script>
  </head>
  <body>
    <button id="fetch-btn" onclick="makeRequest()">Fetch</button>
  </body>
</html>
HTML
```

Then exercise it (dev-server URL from `yarn dev-server status`):

```bash
yarn dev-server intake clear
agent-browser open http://localhost:8081/test-default-headers.html
agent-browser click '#fetch-btn'
# wait for the fetch's PerformanceResourceTiming, then flush
agent-browser reload
yarn dev-server intake rum-resources \
  | jq -c 'select(.resource.type=="fetch") | {request_headers: .resource.request.headers, response_headers: .resource.response.headers}'
```

Expected output — the custom matcher (`x-custom-header`) is captured on the request **and** the default headers (`content-type`, `content-length`, …) are captured on the response:

```json
{"request_headers":{"x-custom-header":"hello"},"response_headers":{"content-type":"text/javascript; charset=utf-8","content-length":"2429864"}}
```

Cleanup:

```bash
yarn dev-server stop
rm sandbox/test-default-headers.html
```

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file
