### PR TITLE
📝 update AGENTS.md monorepo structure to reflect current packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,17 +50,27 @@ yarn format
 
 ```
 packages/
-├── core/           # Shared utilities (Observable, configuration, transport)
-├── rum-core/       # Core RUM functionality
-├── rum/            # Full RUM package
-├── rum-slim/       # Lightweight RUM
-├── rum-react/      # React integration
-├── logs/           # Browser logging
-└── worker/         # Web Worker support
+├── browser-core/           # Shared utilities (Observable, configuration, transport)
+├── browser-rum-core/       # Core RUM functionality
+├── browser-rum/            # Full RUM package
+├── browser-rum-slim/       # Lightweight RUM
+├── browser-rum-react/      # React integration
+├── browser-rum-angular/    # Angular integration
+├── browser-rum-vue/        # Vue integration
+├── browser-rum-nextjs/     # Next.js integration
+├── browser-rum-nuxt/       # Nuxt integration
+├── browser-logs/           # Browser logging
+├── browser-worker/         # Web Worker support
+├── browser-debugger/       # Live Debugger (capture function snapshots without code changes)
+└── js-core/                # Runtime-agnostic core utilities shared across Datadog JS SDKs
 
-developer-extension/ # Chrome DevTools extension
+developer-extension/  # Chrome DevTools extension
 
-docs/                # Repository documentation
+remote-configuration/ # Remote configuration schema (mirrors internal repo)
+
+sandbox/              # Local dev sandbox (served by `yarn dev` at localhost:8080)
+
+docs/                 # Repository documentation
 
 test/
 ├── apps/            # Test apps for E2E and performance testing


### PR DESCRIPTION
## Motivation

The `AGENTS.md` monorepo structure section was out of date: package names have been
renamed with a `browser-` prefix and several new packages/folders have been added,
causing AI agents (and new contributors) to reference paths that no longer exist.

## Changes

- Updated all package directory names to match the current `browser-` prefix naming
- Added missing packages: `browser-debugger`, `browser-rum-angular`, `browser-rum-vue`, `browser-rum-nextjs`, `browser-rum-nuxt`, `js-core`
- Added missing top-level folders: `remote-configuration/`, `sandbox/`

## Test instructions

N/A — documentation-only change.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file