### PR TITLE
👷 Make json-schemas sync reliable: authenticate API requests and format output deterministically

### DIFF
--- a/scripts/json-schemas.ts
+++ b/scripts/json-schemas.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path'
 import { parseArgs } from 'node:util'
 
 import type jsonSchemaToTypescriptModule from 'json-schema-to-typescript'
-import { resolveConfig } from 'prettier'
+import { format, resolveConfig } from 'prettier'
 
 import { printLog, printWarning, runMain, fetchHandlingError } from './lib/executionUtils.ts'
 import { command } from './lib/command.ts'
@@ -120,11 +120,15 @@ async function build() {
     const compiledTypes = await compileFromFile(schemaPath, {
       cwd: path.dirname(schemaPath),
       bannerComment: '/**\n * DO NOT MODIFY IT BY HAND. Run `yarn json-schemas:sync` instead.\n*/',
-      style: prettierConfig || {},
+      // Skip json-schema-to-typescript's internal prettier pass: it resolves an ambient
+      // prettier that can differ between environments. Format with the repo's pinned prettier
+      // below instead, so the output is deterministic and matches `prettier --check .`.
+      format: false,
       ...options,
     })
     printLog(`Writing ${typesPath}...`)
-    fs.writeFileSync(absoluteTypesPath, compiledTypes)
+    const formattedTypes = await format(compiledTypes, { ...prettierConfig, parser: 'typescript' })
+    fs.writeFileSync(absoluteTypesPath, formattedTypes)
   }
 
   printLog('Done.')

--- a/scripts/json-schemas.ts
+++ b/scripts/json-schemas.ts
@@ -5,7 +5,7 @@ import { parseArgs } from 'node:util'
 import type jsonSchemaToTypescriptModule from 'json-schema-to-typescript'
 import { resolveConfig } from 'prettier'
 
-import { printLog, runMain, fetchHandlingError } from './lib/executionUtils.ts'
+import { printLog, printWarning, runMain, fetchHandlingError } from './lib/executionUtils.ts'
 import { command } from './lib/command.ts'
 import { modifyFile } from './lib/filesUtils.ts'
 import { SCHEMAS } from './lib/generatedSchemaTypes.ts'
@@ -67,8 +67,24 @@ async function update(branchOrCommit: string) {
     printLog(`Using provided commit hash: ${commitHash}`)
   } else {
     printLog(`Resolving latest commit on ${branchOrCommit}...`)
+    // Unauthenticated GitHub API requests are limited to 60/hour per IP, which is easily exhausted
+    // behind a shared NAT. Authenticate with the user's `gh` CLI token to get the 5000/hour limit.
+    let token = ''
+    try {
+      token = command`gh auth token`.run().trim()
+    } catch {
+      printWarning(
+        'Could not get a token from `gh auth token`; issuing unauthenticated GitHub requests (limited to 60/hour per IP).'
+      )
+    }
     const response = await fetchHandlingError(
-      `https://api.github.com/repos/DataDog/rum-events-format/branches/${branchOrCommit}`
+      `https://api.github.com/repos/DataDog/rum-events-format/branches/${branchOrCommit}`,
+      {
+        headers: {
+          ...(token ? { Authorization: `token ${token}` } : {}),
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }
     )
     const {
       commit: { sha },


### PR DESCRIPTION
## Motivation

Two issues made `yarn json-schemas:sync` unreliable:

1. **Rate limiting** — the branch-resolution step resolves the latest `rum-events-format` commit through an **unauthenticated** GitHub REST API call, capped at **60/hour per IP**. Behind a shared corporate NAT that budget is consumed by everyone on the same address, so the sync fails with HTTP **403**:

   ```
   API rate limit exceeded for <ip>. ... Authenticated requests get a higher rate limit.
   x-ratelimit-limit: 60   x-ratelimit-remaining: 0
   ```

2. **Non-deterministic formatting** — `json-schema-to-typescript` formats the generated `*.types.ts` files with whatever prettier it resolves at runtime, which differs between environments (e.g. a nested prettier left by a prior fork build locally vs. a freshly built fork in CI). In CI this collapsed union types onto a single line, so the `check-schemas` job reported a diff against the committed (repo-prettier-formatted) files and failed.

## Changes

Both changes are in `scripts/json-schemas.ts`:

- **Authenticate GitHub requests**: resolve the branch using the developer's existing `gh` CLI token (authenticated limit: 5000/hour). Try `gh auth token`; on success attach an `Authorization: token …` header (style matches the existing call in `scripts/lib/gitUtils.ts`). If `gh` is missing or the user isn't logged in, print a warning and fall back to the previous unauthenticated behavior rather than failing. No env-var setup is required.
- **Deterministic formatting**: skip json-schema-to-typescript's internal prettier pass (`format: false`) and format the compiled output with the repo's pinned prettier (`parser: 'typescript'`) before writing. Generation is now identical across environments and matches `prettier --check .`, so `check-schemas` stays green.

(The PR also includes a routine `rum-events-format` schema bump produced by running the now-reliable sync end-to-end.)

## Test instructions

1. **Auth — happy path** (logged into `gh`):
   ```bash
   node scripts/json-schemas.ts --update master
   ```
   Resolves the latest commit with no 403.
2. **Auth — fallback path** (simulate `gh` unavailable):
   ```bash
   d=$(mktemp -d); printf '#!/bin/sh\nexit 1\n' > "$d/gh"; chmod +x "$d/gh"
   PATH="$d:$PATH" node scripts/json-schemas.ts --update master
   ```
   Prints the warning and proceeds with an unauthenticated request instead of crashing.
3. **Formatting determinism**: from a clean tree, regenerate and confirm no diff:
   ```bash
   yarn json-schemas:generate && git diff --stat   # expect: no changes
   ```
   Then force a fresh generator build (the original CI failure mode) and repeat:
   ```bash
   rm -rf node_modules/json-schema-to-typescript/dist node_modules/json-schema-to-typescript/node_modules/prettier
   yarn json-schemas:generate && git diff --stat   # still expect: no changes
   ```
4. Run the CI check end-to-end (from a clean tree): `node scripts/check-schemas.ts` exits 0.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)