### PR TITLE
✨ add support for `remote_configuration_id` in view events

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=02c94b31a2676458a156ed627f3edcd87254beb7",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.9",

--- a/packages/browser-core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetryEvent.types.ts
@@ -482,6 +482,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        * Whether the beta encode cookie options is enabled
        */
       beta_encode_cookie_options?: boolean
+      /**
+       * Whether the beta partial view updates feature is enabled
+       */
+      beta_enable_view_updates?: boolean
       [k: string]: unknown
     }
     [k: string]: unknown

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -397,6 +397,7 @@ export interface RumConfiguration extends Configuration {
   profilingSampleRate: number
   propagateTraceBaggage: boolean
   allowedGraphQlUrls: GraphQlUrlOption[]
+  remoteConfigurationId: string | undefined
 }
 
 export function validateAndBuildRumConfiguration(
@@ -474,6 +475,7 @@ export function validateAndBuildRumConfiguration(
     profilingSampleRate: initConfiguration.profilingSampleRate ?? 0,
     propagateTraceBaggage: initConfiguration.propagateTraceBaggage !== false,
     allowedGraphQlUrls,
+    remoteConfigurationId: getRemoteConfigurationId(initConfiguration),
     ...baseConfiguration,
   }
 }

--- a/packages/browser-rum-core/src/domain/view/viewCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/view/viewCollection.spec.ts
@@ -113,6 +113,7 @@ describe('viewCollection', () => {
         replay_stats: undefined,
         configuration: {
           start_session_replay_recording_manually: jasmine.any(Boolean),
+          remote_configuration_id: undefined,
         },
         cls: undefined,
       },
@@ -237,6 +238,26 @@ describe('viewCollection', () => {
         (rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent)._dd.configuration
           .start_session_replay_recording_manually
       ).toBe(true)
+    })
+  })
+
+  describe('with configuration.remote_configuration_id', () => {
+    it('should include the remote configuration id when configured', () => {
+      setupViewCollection({ remoteConfigurationId: 'foo' })
+      lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, VIEW)
+
+      expect(
+        (rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent)._dd.configuration.remote_configuration_id
+      ).toBe('foo')
+    })
+
+    it('should be undefined when remote configuration is not used', () => {
+      setupViewCollection({ remoteConfigurationId: undefined })
+      lifeCycle.notify(LifeCycleEventType.VIEW_UPDATED, VIEW)
+
+      expect(
+        (rawRumEvents[rawRumEvents.length - 1].rawRumEvent as RawRumViewEvent)._dd.configuration.remote_configuration_id
+      ).toBeUndefined()
     })
   })
 

--- a/packages/browser-rum-core/src/domain/view/viewCollection.ts
+++ b/packages/browser-rum-core/src/domain/view/viewCollection.ts
@@ -90,6 +90,7 @@ function processViewUpdate(
         : undefined,
       configuration: {
         start_session_replay_recording_manually: configuration.startSessionReplayRecordingManually,
+        remote_configuration_id: configuration.remoteConfigurationId,
       },
     },
     date: view.startClocks.timeStamp,

--- a/packages/browser-rum-core/src/rawRumEvent.types.ts
+++ b/packages/browser-rum-core/src/rawRumEvent.types.ts
@@ -170,6 +170,7 @@ export interface RawRumViewEvent {
     }
     configuration: {
       start_session_replay_recording_manually: boolean
+      remote_configuration_id?: string
     }
   }
   device?: {

--- a/packages/browser-rum-core/src/rumEvent.types.ts
+++ b/packages/browser-rum-core/src/rumEvent.types.ts
@@ -513,6 +513,15 @@ export type RumErrorEvent = CommonProperties &
        * Profiling context
        */
       profiling?: ProfilingInternalContextSchema
+      /**
+       * Mapping of source file URLs to their debug IDs for source map deobfuscation
+       */
+      readonly debug_ids?: {
+        /**
+         * Debug ID (UUID) for the source file
+         */
+        [k: string]: string
+      }
       [k: string]: unknown
     }
     [k: string]: unknown
@@ -637,6 +646,15 @@ export type RumLongTaskEvent = CommonProperties &
        * Profiling context
        */
       profiling?: ProfilingInternalContextSchema
+      /**
+       * Mapping of source file URLs to their debug IDs for source map deobfuscation
+       */
+      readonly debug_ids?: {
+        /**
+         * Debug ID (UUID) for the source file
+         */
+        [k: string]: string
+      }
       [k: string]: unknown
     }
     [k: string]: unknown
@@ -919,70 +937,7 @@ export type RumViewEvent = CommonProperties &
       }
       [k: string]: unknown
     }
-    /**
-     * Internal properties
-     */
     readonly _dd: {
-      /**
-       * Version of the update of the view event
-       */
-      readonly document_version: number
-      /**
-       * List of the page states during the view
-       */
-      readonly page_states?: {
-        /**
-         * Page state name
-         */
-        readonly state: 'active' | 'passive' | 'hidden' | 'frozen' | 'terminated'
-        /**
-         * Duration in ns between start of the view and start of the page state
-         */
-        readonly start: number
-        [k: string]: unknown
-      }[]
-      /**
-       * Debug metadata for Replay Sessions
-       */
-      replay_stats?: {
-        /**
-         * The number of records produced during this view lifetime
-         */
-        records_count?: number
-        /**
-         * The number of segments sent during this view lifetime
-         */
-        segments_count?: number
-        /**
-         * The total size in bytes of the segments sent during this view lifetime
-         */
-        segments_total_raw_size?: number
-        [k: string]: unknown
-      }
-      /**
-       * Additional information of the reported Cumulative Layout Shift
-       */
-      readonly cls?: {
-        /**
-         * Pixel ratio of the device where the layout shift was reported
-         */
-        readonly device_pixel_ratio?: number
-        [k: string]: unknown
-      }
-      /**
-       * Subset of the SDK configuration options in use during its execution
-       */
-      readonly configuration?: {
-        /**
-         * Whether session replay recording configured to start manually
-         */
-        readonly start_session_replay_recording_manually?: boolean
-        [k: string]: unknown
-      }
-      /**
-       * Profiling context
-       */
-      profiling?: ProfilingInternalContextSchema
       [k: string]: unknown
     }
     [k: string]: unknown
@@ -998,16 +953,6 @@ export type RumViewUpdateEvent = ViewContainerSchema &
      * RUM event type
      */
     readonly type: 'view_update'
-    /**
-     * Internal properties
-     */
-    readonly _dd?: {
-      /**
-       * Version of the update of the view event
-       */
-      readonly document_version: number
-      [k: string]: unknown
-    }
     [k: string]: unknown
   }
 export type RumVitalEvent = RumVitalDurationEvent | RumVitalOperationStepEvent
@@ -1657,6 +1602,26 @@ export interface ProfilingInternalContextSchema {
     | 'failed-to-lazy-load'
     | 'missing-document-policy-header'
     | 'unexpected-exception'
+  /**
+   * The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+   *
+   * Possible values:
+   * - `quota_ok`: Quota check passed.
+   * - `quota_exceeded`: The organization has exceeded its profiling quota.
+   * - `org_disabled`: The organization has profiling disabled.
+   * - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+   * - `undefined`: The quota reason is undefined.
+   * - `timeout`: The quota check timed out on the client side.
+   * - `api-error`: An API error occurred on the client side.
+   */
+  readonly quota_reason?:
+    | 'quota_ok'
+    | 'quota_exceeded'
+    | 'org_disabled'
+    | 'backend_unavailable'
+    | 'undefined'
+    | 'timeout'
+    | 'api-error'
   [k: string]: unknown
 }
 /**
@@ -2043,6 +2008,76 @@ export interface ViewProperties {
       readonly max_scroll_height_time: number
       [k: string]: unknown
     }
+    [k: string]: unknown
+  }
+  /**
+   * Internal properties
+   */
+  readonly _dd?: {
+    /**
+     * Version of the update of the view event
+     */
+    readonly document_version: number
+    /**
+     * List of the page states during the view
+     */
+    readonly page_states?: {
+      /**
+       * Page state name
+       */
+      readonly state: 'active' | 'passive' | 'hidden' | 'frozen' | 'terminated'
+      /**
+       * Duration in ns between start of the view and start of the page state
+       */
+      readonly start: number
+      [k: string]: unknown
+    }[]
+    /**
+     * Debug metadata for Replay Sessions
+     */
+    replay_stats?: {
+      /**
+       * The number of records produced during this view lifetime
+       */
+      records_count?: number
+      /**
+       * The number of segments sent during this view lifetime
+       */
+      segments_count?: number
+      /**
+       * The total size in bytes of the segments sent during this view lifetime
+       */
+      segments_total_raw_size?: number
+      [k: string]: unknown
+    }
+    /**
+     * Additional information of the reported Cumulative Layout Shift
+     */
+    readonly cls?: {
+      /**
+       * Pixel ratio of the device where the layout shift was reported
+       */
+      readonly device_pixel_ratio?: number
+      [k: string]: unknown
+    }
+    /**
+     * Subset of the SDK configuration options in use during its execution
+     */
+    readonly configuration?: {
+      /**
+       * Whether session replay recording configured to start manually
+       */
+      readonly start_session_replay_recording_manually?: boolean
+      /**
+       * The id of the remote configuration applied to the SDK, if any
+       */
+      readonly remote_configuration_id?: string
+      [k: string]: unknown
+    }
+    /**
+     * Profiling context
+     */
+    profiling?: ProfilingInternalContextSchema
     [k: string]: unknown
   }
   [k: string]: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,10 +601,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=02c94b31a2676458a156ed627f3edcd87254beb7":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=02c94b31a2676458a156ed627f3edcd87254beb7"
-  checksum: 10c0/4a14c1afb23b3e4a0f631f8a1f077d6abab913c82f1145e1585002b488038b00ed19ce16c8840c20c7d94e5d113bc43c48bbb69f46038533cd53d3ebbcbc74c5
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd"
+  checksum: 10c0/745ee1b338aa0bbdeec2b2cff464525da4842912b76007e778c34e61581d40cabc12c3c232861b071d187224bef706b9ab0402515b165be7e2b51082dacd8002
   languageName: node
   linkType: hard
 
@@ -3930,7 +3930,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=02c94b31a2676458a156ed627f3edcd87254beb7"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.9"


### PR DESCRIPTION
## Motivation

Currently we have no per-session signal in the collected data showing whether a customer actually has Remote Configuration enabled. Surfacing the remote configuration id on view events lets us determine RC adoption directly from events.                                     

## Changes

Resolve remoteConfigurationId onto RumConfiguration (via the existing helper) and emit it as `remote_configuration_id` inside  `_dd.configuration` on view events.

## Test instructions

1. add `remote-config.json` file to sandbox directory
2. update parameters, passed to `DD_RUM.init` adding `remoteConfiguration: { id: 'remote-config-test' }`, `remoteConfigurationProxy: '/remote-config.json'`
3. check that `_dd.configuration.remote_configuration_id` is sent in a view event and has a value of `remote-config-test`

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
