### PR TITLE
👷 sign chrome-bump commits with commit-headless

### DIFF
--- a/.github/chainguard/self.gitlab.commit.sts.yaml
+++ b/.github/chainguard/self.gitlab.commit.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: 'project_path:DataDog/browser-sdk:ref_type:branch:ref:main'
+
+claim_pattern:
+  project_path: 'DataDog/browser-sdk'
+  ref_type: 'branch'
+  ref: 'main'
+
+permissions:
+  contents: write

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   CURRENT_STAGING: staging-27
   APP: 'browser-sdk'
-  CURRENT_CI_IMAGE: 116
+  CURRENT_CI_IMAGE: 117
   BUILD_STABLE_REGISTRY: 'registry.ddbuild.io'
   CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$APP:$CURRENT_CI_IMAGE'
   GIT_REPOSITORY: 'git@github.com:DataDog/browser-sdk.git'

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o 
 # DD Octo STS to get security token
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.8.1@sha256:eb2895829cdcb1f41cc4fc9d1f3f329c7d8f6fa72b0e8bb915d8195717e02bfa /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
 
+# Commit Headless to create signed (Verified) commits from CI bots
+COPY --from=registry.ddbuild.io/commit-headless /commit-headless /usr/local/bin/commit-headless
+
 RUN apt-get update && apt-get install -y jq
 
 # Webdriverio deps

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -90,6 +90,7 @@ export function pushSignedCommit(branch: string): void {
   using token = getGithubCommitToken()
   command`commit-headless push -T DataDog/browser-sdk --branch ${branch} --create-branch --head-sha ${headSha} --reset`
     .withEnvironment({ GITHUB_TOKEN: token.value })
+    .withLogs()
     .run()
   command`git branch --set-upstream-to=origin/${branch} ${branch}`.run()
 }

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -77,9 +77,10 @@ export function createPullRequest(mainBranch: string, labels?: string[]) {
 
 /**
  * Push the current HEAD commit to a new remote branch as a signed (Verified) commit, using
- * commit-headless to create it through the GitHub API instead of a plain `git push`. The local
- * branch is then made to track the newly created remote branch, so callers (e.g. `gh pr create`)
- * don't attempt an unsigned push of their own.
+ * commit-headless to create it through the GitHub API instead of a plain `git push`. Since the
+ * remote commit is re-signed, its SHA differs from the local one: `--reset` resets the local
+ * branch to it, so callers (e.g. `gh pr create`) see it as fully pushed and don't attempt an
+ * unsigned push of their own.
  */
 export function pushSignedCommit(branch: string): void {
   // `--create-branch` has no default branch point, so `--head-sha` must be given explicitly: the
@@ -87,10 +88,9 @@ export function pushSignedCommit(branch: string): void {
   const headSha = command`git rev-parse HEAD^`.run().trim()
 
   using token = getGithubCommitToken()
-  command`commit-headless push -T DataDog/browser-sdk --branch ${branch} --create-branch --head-sha ${headSha}`
+  command`commit-headless push -T DataDog/browser-sdk --branch ${branch} --create-branch --head-sha ${headSha} --reset`
     .withEnvironment({ GITHUB_TOKEN: token.value })
     .run()
-  command`git fetch --no-tags origin ${branch}`.run()
   command`git branch --set-upstream-to=origin/${branch} ${branch}`.run()
 }
 

--- a/scripts/lib/gitUtils.ts
+++ b/scripts/lib/gitUtils.ts
@@ -6,6 +6,7 @@ import {
   getGithubReadToken,
   getGithubReleaseToken,
   getGithubPullRequestToken,
+  getGithubCommitToken,
   type OctoStsToken,
 } from './secrets.ts'
 import { FetchError, fetchHandlingError, findError } from './executionUtils.ts'
@@ -72,6 +73,25 @@ export function createPullRequest(mainBranch: string, labels?: string[]) {
   const labelArgs = labels?.flatMap((label) => ['--label', label]) ?? []
   const pullRequestUrl = command`gh pr create --fill --base ${mainBranch} ${labelArgs}`.run()
   return pullRequestUrl.trim()
+}
+
+/**
+ * Push the current HEAD commit to a new remote branch as a signed (Verified) commit, using
+ * commit-headless to create it through the GitHub API instead of a plain `git push`. The local
+ * branch is then made to track the newly created remote branch, so callers (e.g. `gh pr create`)
+ * don't attempt an unsigned push of their own.
+ */
+export function pushSignedCommit(branch: string): void {
+  // `--create-branch` has no default branch point, so `--head-sha` must be given explicitly: the
+  // parent of HEAD, i.e. the commit the local branch was created from.
+  const headSha = command`git rev-parse HEAD^`.run().trim()
+
+  using token = getGithubCommitToken()
+  command`commit-headless push -T DataDog/browser-sdk --branch ${branch} --create-branch --head-sha ${headSha}`
+    .withEnvironment({ GITHUB_TOKEN: token.value })
+    .run()
+  command`git fetch --no-tags origin ${branch}`.run()
+  command`git branch --set-upstream-to=origin/${branch} ${branch}`.run()
 }
 
 export function getLastCommonCommit(baseBranch: string): string {

--- a/scripts/lib/secrets.ts
+++ b/scripts/lib/secrets.ts
@@ -34,6 +34,13 @@ export function getGithubReadToken() {
   return new OctoStsToken('read')
 }
 
+/**
+ * This token is scoped to main branch only.
+ */
+export function getGithubCommitToken() {
+  return new OctoStsToken('commit')
+}
+
 export function getOrg2ApiKey(): string {
   return getSecretKey('ci.browser-sdk.datadog_ci_api_key')
 }

--- a/scripts/test/bump-chrome-version.ts
+++ b/scripts/test/bump-chrome-version.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { printLog, runMain, fetchHandlingError } from '../lib/executionUtils.ts'
 import { command } from '../lib/command.ts'
 import { CI_FILE, replaceCiFileVariable } from '../lib/filesUtils.ts'
-import { initGitConfig, createPullRequest } from '../lib/gitUtils.ts'
+import { initGitConfig, createPullRequest, pushSignedCommit } from '../lib/gitUtils.ts'
 
 const REPOSITORY = process.env.GIT_REPOSITORY
 const MAIN_BRANCH = process.env.MAIN_BRANCH
@@ -51,7 +51,7 @@ runMain(async () => {
 
   command`git add ${CI_FILE}`.run()
   command`git commit -m ${commitMessage}`.run()
-  command`git push origin ${chromeVersionBranch}`.run()
+  pushSignedCommit(chromeVersionBranch)
 
   printLog('Create PR...')
 


### PR DESCRIPTION
## Motivation

The chrome-bump CI job pushed its version-bump commit directly with `git push`, producing an unverified commit on the created branch. This currently works because we have admin rights to bypass the signed-commit policy on the repo, but we're about to lose that bypass — so CI-generated commits need to be properly signed (Verified) going forward.

## Changes

- Add a `commit` OctoSTS scope (main branch only) and a chainguard policy (`self.gitlab.commit.sts.yaml`) authorizing it for the GitLab CI job
- Install `commit-headless` in the CI image (Dockerfile) to create signed (Verified) commits through the GitHub API
- Add `pushSignedCommit()` in `gitUtils.ts`, which pushes HEAD as a new remote branch via `commit-headless push` and points the local branch at it, so a later `gh pr create` doesn't attempt its own unsigned push
- Use `pushSignedCommit()` in `bump-chrome-version.ts` instead of `git push`
- Bump `CURRENT_CI_IMAGE` to 117 for the updated Dockerfile

## Test instructions

It's hard to test before merging, but when it's merged we can:

- Manually run the `bump-chrome-version-scheduled` GitLab CI job with `CHROME_PACKAGE_VERSION` overridden to an old version (e.g. a version with a lower major than what's currently released), so the job detects a newer Chrome version and creates a bump PR
- Verify the job pushes a **Verified** commit on the new `bump-chrome-version-to-<major>` branch
- Verify the resulting PR is opened correctly against `main`
- Close the test PR/branch afterwards (no need to merge it)

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
