### PR TITLE
🐛 fix bundle size increase threshold never triggering

### DIFF
--- a/scripts/bundle-size/lib/bundleSizes.ts
+++ b/scripts/bundle-size/lib/bundleSizes.ts
@@ -6,7 +6,7 @@ import { fetchPerformanceMetrics } from './fetchPerformanceMetrics.ts'
 import { markdownArray, type Pr } from './reportAsAPrComment.ts'
 
 // The value is set to 5% as it's around 10 times the average value for small PRs.
-const SIZE_INCREASE_THRESHOLD = 5
+const SIZE_INCREASE_THRESHOLD = 0.05
 
 export async function computeAndReportBundleSizes(pr?: Pr) {
   const localBundleSizes = extractUncompressedBundleSizes(calculateBundleSizes())

--- a/scripts/bundle-size/lib/bundleSizes.ts
+++ b/scripts/bundle-size/lib/bundleSizes.ts
@@ -84,7 +84,7 @@ export function formatBundleSizes({
   })
 
   if (highIncreaseDetected) {
-    message += `\n⚠️ The increase is particularly high and exceeds ${SIZE_INCREASE_THRESHOLD}%. Please check the changes.`
+    message += `\n⚠️ The increase is particularly high and exceeds ${formatPercentage(SIZE_INCREASE_THRESHOLD)}. Please check the changes.`
   }
 
   return message


### PR DESCRIPTION
## Motivation

The bundle-size PR comment never flags a size increase. The warning was meant to fire at +5% growth but never does.

## Changes

`percentageChange` is a ratio (`0.05` = 5%), but it was compared against `SIZE_INCREASE_THRESHOLD = 5`, i.e. +500% — so the ⚠️ status and the "exceeds 5%" warning were effectively dead. The table itself was fine since the Δ% column is formatted separately. Set the threshold to `0.05`.

## Test instructions

Hard to test without a real +5% bundle bump. Reviewable by reading the diff.

## Checklist

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file