### PR TITLE
✨ [RUM-139] Add CSP trusted-types support

### DIFF
--- a/packages/browser-rum/src/domain/deflate/deflateWorker.ts
+++ b/packages/browser-rum/src/domain/deflate/deflateWorker.ts
@@ -43,7 +43,11 @@ type DeflateWorkerState =
 export type CreateDeflateWorker = typeof createDeflateWorker
 
 export function createDeflateWorker(configuration: RumConfiguration): DeflateWorker {
-  return new Worker(configuration.workerUrl || URL.createObjectURL(new Blob([__BUILD_ENV__WORKER_STRING__])))
+  return new Worker(
+    getWorkerTrustedTypePolicy().createScriptURL(
+      configuration.workerUrl || URL.createObjectURL(new Blob([__BUILD_ENV__WORKER_STRING__]))
+    )
+  )
 }
 
 let state: DeflateWorkerState = { status: DeflateWorkerStatus.Nil }
@@ -149,4 +153,26 @@ function onError(configuration: RumConfiguration, source: string, error: unknown
       stream_id: streamId,
     })
   }
+}
+
+// Trusted Types are not yet in TypeScript lib
+interface WindowWithTrustedTypes {
+  trustedTypes?: {
+    createPolicy(name: string, policy: TrustedTypesPolicy): TrustedTypesPolicy
+  }
+}
+
+interface TrustedTypesPolicy {
+  createScriptURL(url: string): string
+}
+
+let workerTrustedTypePolicyCache: TrustedTypesPolicy | undefined
+function getWorkerTrustedTypePolicy(): TrustedTypesPolicy {
+  if (!workerTrustedTypePolicyCache) {
+    const trustedTypes = (window as WindowWithTrustedTypes).trustedTypes
+    workerTrustedTypePolicyCache = trustedTypes
+      ? trustedTypes.createPolicy('datadog-worker', { createScriptURL: (url) => url })
+      : { createScriptURL: (url) => url }
+  }
+  return workerTrustedTypePolicyCache
 }

--- a/test/e2e/lib/framework/serverApps/mock.ts
+++ b/test/e2e/lib/framework/serverApps/mock.ts
@@ -197,6 +197,21 @@ export function createMockServerApp(servers: Servers, setup: string, setupOption
     res.end()
   })
 
+  app.get('/trusted-types-csp', (_req, res) => {
+    res.header(
+      'Content-Security-Policy',
+      [
+        `connect-src ${servers.datadogHttpApi.origin} ${servers.base.origin} ${servers.crossOrigin.origin} https://quota.browser-intake-datadoghq.com`,
+        `script-src 'self' 'unsafe-inline' ${servers.crossOrigin.origin}`,
+        "worker-src blob: 'self'",
+        "require-trusted-types-for 'script'",
+        'trusted-types datadog-chunks datadog-worker',
+      ].join(';')
+    )
+    res.send(setup)
+    res.end()
+  })
+
   app.get(/datadog-(?<packageName>[a-z-]*)\.js/, (req, res) => {
     const { originalUrl, params } = req
 

--- a/test/e2e/scenario/transport.scenario.ts
+++ b/test/e2e/scenario/transport.scenario.ts
@@ -100,5 +100,39 @@ test.describe('transport', () => {
           expect(cspDocLog, "'CSP doc' log").toBeTruthy()
         })
       })
+
+    createTest('workerUrl initialization parameter')
+      .withRum({ compressIntakeRequests: true, workerUrl: '/worker.js' })
+      .withBasePath('/no-blob-worker-csp')
+      .run(async ({ intakeRegistry, flushEvents }) => {
+        await flushEvents()
+        expect(intakeRegistry.rumRequests.length).toBeGreaterThan(0)
+      })
+
+    test.describe('Trusted Types CSP', () => {
+      createTest('supports Trusted Types CSP with compression worker')
+        .withRum({ compressIntakeRequests: true })
+        .withBasePath('/trusted-types-csp')
+        .run(async ({ flushEvents, intakeRegistry }) => {
+          await flushEvents()
+          expect(intakeRegistry.rumRequests.length).toBeGreaterThan(0)
+        })
+
+      createTest('supports Trusted Types CSP with workerUrl')
+        .withRum({ compressIntakeRequests: true, workerUrl: '/worker.js' })
+        .withBasePath('/trusted-types-csp')
+        .run(async ({ intakeRegistry, flushEvents }) => {
+          await flushEvents()
+          expect(intakeRegistry.rumRequests.length).toBeGreaterThan(0)
+        })
+
+      createTest('supports Trusted Types CSP with session replay chunk')
+        .withRum({ sessionReplaySampleRate: 100 })
+        .withBasePath('/trusted-types-csp')
+        .run(async ({ flushEvents, intakeRegistry }) => {
+          await flushEvents()
+          expect(intakeRegistry.rumRequests.length).toBeGreaterThan(0)
+        })
+    })
   })
 })

--- a/webpack.base.ts
+++ b/webpack.base.ts
@@ -32,6 +32,9 @@ export default ({
     path: path.resolve('./bundle'),
     chunkFormat: 'module',
     chunkLoading: 'import',
+    trustedTypes: {
+      policyName: 'datadog-chunks',
+    },
   },
   target: ['web', 'es2020'],
   devtool: false,


### PR DESCRIPTION
## Motivation

When a customer uses `require-trusted-types-for 'script'` in their CSP, two things break. The compression worker fails because `new Worker(url)` with a plain string is blocked. The session replay recorder fails because Webpack loads lazy chunks by setting `scriptElement.src = url`, which is also blocked. Both produce `TrustedScriptURL` violations and the SDK bails out.

Fixes https://github.com/DataDog/browser-sdk/issues/3506. Jira: [RUM-139](https://datadoghq.atlassian.net/browse/RUM-139).

## Changes

Two fixes, one for each broken path.

For Webpack chunks: added `output.trustedTypes: { policyName: 'datadog-chunks' }` in `webpack.base.ts`. Webpack 5 has built-in support for this and handles the `createPolicy` / fallback logic on its own.

For the worker: added `getWorkerTrustedTypePolicy()` in `deflateWorker.ts` that creates a `datadog-worker` policy and wraps the URL through `createScriptURL()` before passing it to `new Worker()`. Falls back to a no-op passthrough in browsers without trusted types support.

Two separate policies are needed because Webpack creates and owns its policy internally, so we can't reuse it. And you can't create two policies with the same name by default (the spec blocks it unless `allow-duplicates` is in the CSP).

The third broken path from the ticket, the async CDN snippet's `.src = url` assignment, is not covered here. That one needs a documentation workaround rather than a code change.

## Test instructions

```bash
yarn test:e2e -g "Trusted Types"
```

Or to test manually: start the dev server, open a page served with `require-trusted-types-for 'script'; trusted-types datadog-chunks datadog-worker` headers, and initialize RUM with `compressIntakeRequests: true` and `sessionReplaySampleRate: 100`. There should be no CSP violations in the console and both the worker (blob URL) and recorder chunk should load.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

[RUM-139]: https://datadoghq.atlassian.net/browse/RUM-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ