### PR TITLE
✨ Add CDN default headers

### DIFF
--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -59,6 +59,8 @@ export const DEFAULT_TRACKED_RESOURCE_HEADERS = [
   'content-length',
   'server-timing',
   'x-cache',
+  'cf-cache-status',
+  'x-vercel-cache',
 ] as const
 
 /**


### PR DESCRIPTION
## Motivation

The RUM backend's shared-cache detection reads the `x-cache`, `cf-cache-status`, and `x-vercel-cache` response headers to flag `cache_reason=shared_cache_hit`. Only `x-cache` was collected by default, so Cloudflare and Vercel CDN traffic was invisible to that detection.

## Changes

- Added `cf-cache-status` and `x-vercel-cache` to `DEFAULT_TRACKED_RESOURCE_HEADERS`
- Customers using `trackResourceHeaders: true` will now automatically collect these headers, no config change required on their end.

## Test instructions

- `yarn test:unit --spec packages/browser-rum-core/src/domain/configuration/configuration.spec.ts` — existing test asserting `trackResourceHeaders: true` resolves to `DEFAULT_TRACKED_RESOURCE_HEADERS.map((name) => ({ name }))` covers the updated list.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file