### PR TITLE
✅ Avoid frontdoor access in Salesforce e2e tests.

### DIFF
--- a/test/e2e/lib/framework/buildSalesforceLwcUrl.ts
+++ b/test/e2e/lib/framework/buildSalesforceLwcUrl.ts
@@ -1,4 +1,5 @@
 import { createSign } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
 
 import {
   getSfLwcClientId,
@@ -9,39 +10,77 @@ import {
 
 const salesforceHomePath = '/lightning/app/c__SF_LWC_App/page/home'
 
-// The frontdoor.jsp OTP expires in ~1 minute, so the URL must be generated at test time —
-// not at suite startup — to guarantee a valid token when the test actually navigates.
-// This functions is similar to the one in scripts/salesforce-lwc-app.ts, but it is not using the sf CLI so we can call it at test time.
+interface SalesforceLwcSession {
+  instanceUrl: string
+  accessToken: string
+}
+
+let salesforceLwcSession: Promise<SalesforceLwcSession> | undefined
+
+// The session is fetched once per test run and reused across tests to avoid re-authenticating
+// (JWT or CLI) for every test.
+export function getSalesforceLwcSession(): Promise<SalesforceLwcSession> {
+  salesforceLwcSession ??= buildSalesforceLwcSession()
+  return salesforceLwcSession
+}
+
 export async function buildSalesforceLwcUrl(): Promise<string> {
-  if (!getSfLwcClientId() || !getSfLwcInstanceUrl() || !getSfLwcJwtPrivateKey() || !getSfLwcUsername()) {
-    console.error('Salesforce credentials are not set')
-    return ''
+  const { instanceUrl } = await getSalesforceLwcSession()
+  return new URL(salesforceHomePath, instanceUrl).href
+}
+
+async function buildSalesforceLwcSession(): Promise<SalesforceLwcSession> {
+  try {
+    return await buildSalesforceLwcJwtSession()
+  } catch (error) {
+    const cliSession = buildSalesforceLwcCliSession()
+    if (cliSession) {
+      return cliSession
+    }
+    throw error
   }
+}
+
+async function buildSalesforceLwcJwtSession(): Promise<SalesforceLwcSession> {
+  const clientId = getSfLwcClientId()
   const instanceUrl = getSfLwcInstanceUrl()
-  const privateKey = Buffer.from(getSfLwcJwtPrivateKey(), 'base64').toString('utf8')
-  const accessToken = await getAccessToken(getSfLwcClientId(), getSfLwcUsername(), instanceUrl, privateKey)
+  const jwtPrivateKey = getSfLwcJwtPrivateKey()
+  const username = getSfLwcUsername()
 
-  const path = new URL(salesforceHomePath, 'https://salesforce.local')
-
-  const response = await fetch(`${instanceUrl}/services/oauth2/singleaccess`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      access_token: accessToken,
-      redirect_uri: `${path.pathname}${path.search}`,
-    }),
-  })
-
-  if (!response.ok) {
-    throw new Error(`UI Bridge API failed (${response.status}): ${await response.text()}`)
+  if (!clientId || !instanceUrl || !jwtPrivateKey || !username) {
+    throw new Error('Salesforce credentials are not set')
   }
 
-  const json = (await response.json()) as Record<string, string>
-  const frontdoorUri = json['frontdoor_uri']
-  if (!frontdoorUri) {
-    throw new Error('UI Bridge API response missing frontdoor_uri')
+  const privateKey = Buffer.from(jwtPrivateKey, 'base64').toString('utf8')
+  const accessToken = await getAccessToken(clientId, username, instanceUrl, privateKey)
+  return { instanceUrl, accessToken }
+}
+
+// Fallback for local development: reuse the `sf` CLI session already authenticated via
+// `yarn salesforce:deploy-app` / `yarn salesforce:get-url`, instead of requiring JWT credentials.
+function buildSalesforceLwcCliSession(): SalesforceLwcSession | undefined {
+  const alias = process.env.SF_ORG_ALIAS ?? 'sf-lwc-ci'
+
+  try {
+    const accessTokenOutput = execFileSync(
+      'sf',
+      ['org', 'auth', 'show-access-token', '--target-org', alias, '--json'],
+      {
+        encoding: 'utf8',
+      }
+    )
+    const orgDisplayOutput = execFileSync('sf', ['org', 'display', '--target-org', alias, '--json'], {
+      encoding: 'utf8',
+    })
+    const accessTokenJson = JSON.parse(accessTokenOutput) as { result: { accessToken: string } }
+    const orgDisplayJson = JSON.parse(orgDisplayOutput) as { result: { instanceUrl: string } }
+    return {
+      accessToken: accessTokenJson.result.accessToken,
+      instanceUrl: orgDisplayJson.result.instanceUrl,
+    }
+  } catch {
+    return undefined
   }
-  return frontdoorUri
 }
 
 async function getAccessToken(

--- a/test/e2e/lib/framework/createTest.ts
+++ b/test/e2e/lib/framework/createTest.ts
@@ -23,7 +23,7 @@ import {
   VUE_ROUTER_APP_PORT,
   VUE_ROUTER_V4_APP_PORT,
 } from '../helpers/playwright'
-import { buildSalesforceLwcUrl } from './buildSalesforceLwcUrl'
+import { buildSalesforceLwcUrl, getSalesforceLwcSession } from './buildSalesforceLwcUrl'
 import { IntakeRegistry } from './intakeRegistry'
 import { flushEvents } from './flushEvents'
 import type { Servers } from './httpServers'
@@ -472,6 +472,21 @@ function declareTest(title: string, setupOptions: SetupOptions, factory: SetupFa
           contentType: 'application/javascript',
         })
       })
+
+      // Set the session cookie directly instead of navigating through the frontdoor.jsp OTP
+      // flow, which is more prone to flakiness and expires ~1 minute after being generated.
+      const { accessToken, instanceUrl } = await getSalesforceLwcSession()
+      await context.addCookies([
+        {
+          name: 'sid',
+          value: accessToken,
+          domain: new URL(instanceUrl).hostname,
+          path: '/',
+          httpOnly: true,
+          secure: true,
+          sameSite: 'Lax',
+        },
+      ])
 
       if (setupOptions.rum) {
         await page.addInitScript(

--- a/test/e2e/scenario/salesforce/salesforceLwc.scenario.ts
+++ b/test/e2e/scenario/salesforce/salesforceLwc.scenario.ts
@@ -10,12 +10,6 @@ test.use({
   launchOptions: { args: ['--disable-web-security'] },
 })
 
-// All tests authenticate as the same Salesforce user via the JWT bearer + UI Bridge
-// (frontdoor/singleaccess) flow. Running them concurrently across workers races
-// that single user's session and can invalidate each other's frontdoor URLs, so
-// force this file to run serially in one worker.
-test.describe.configure({ mode: 'serial' })
-
 const salesforceRumConfiguration = {
   trackViewsManually: true,
   trackLongTasks: true,


### PR DESCRIPTION
## Motivation

Before we got the Salesforce OAuth access token with JWT, and use it to navigate to frontdoor. But now Salesforce asks us to add a passkey which breaks the flow. 

## Changes

Change the `buildSalesforceLwcUrl` function to get the access token but put that token in the sid cookie and navigate to the LWC app. 
This also allows us to run the tests in parallel so it's an improvement.

## Test instructions

CI should pass. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
