### PR TITLE
✅ Skip Salesforce LWC tests

### DIFF
--- a/test/e2e/scenario/salesforce/salesforceLwc.scenario.ts
+++ b/test/e2e/scenario/salesforce/salesforceLwc.scenario.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 import { createTest } from '../../lib/framework'
 
 // Skip non chromium browsers because --disable-web-security is chromium-only.
-test.skip(() => test.info().project.name !== 'chromium', 'Salesforce app is tested on chromium only')
+test.skip(true, 'Skip until we fix the frontdoor authentication')
 
 // Bypass CSP and CORS restrictions in the Salesforce app.
 test.use({


### PR DESCRIPTION
## Motivation

Salesforce setup is requiring a passkey which is breaking E2E tests. Skip those tests until we can fix it. 

## Changes

Skips Salesforce e2e tests. 

## Test instructions

CI should pass. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
