### PR TITLE
♻️ [RUM-16925] switch debug_ids to recommended URL/Debug-ID array format

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=31cc845ba1cb52086a25424de86731c316b2385e",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.9",

--- a/packages/browser-core/src/domain/error/error.spec.ts
+++ b/packages/browser-core/src/domain/error/error.spec.ts
@@ -161,7 +161,7 @@ describe('computeRawError', () => {
       handling: ErrorHandling.HANDLED,
     })
 
-    expect(formatted.debugIds).toEqual({ [url]: 'debug-id-1' })
+    expect(formatted.debugIds).toEqual([{ url, id: 'debug-id-1' }])
   })
 
   it('should not attach debug IDs when the error has no stack', () => {
@@ -252,7 +252,10 @@ describe('computeRawError', () => {
         handling: ErrorHandling.HANDLED,
       })
 
-      expect(formatted.debugIds).toEqual({ [url]: 'debug-id-1', [causeUrl]: 'debug-id-cause' })
+      expect(formatted.debugIds).toEqual([
+        { url, id: 'debug-id-1' },
+        { url: causeUrl, id: 'debug-id-cause' },
+      ])
     })
 
     it('should return undefined causes when error has no cause', () => {

--- a/packages/browser-core/src/domain/error/error.types.ts
+++ b/packages/browser-core/src/domain/error/error.types.ts
@@ -1,5 +1,6 @@
 import type { ClocksState } from '@datadog/js-core/time'
 import type { Context } from '../../tools/serialisation/context'
+import type { DebugIdEntry } from '../sourceCodeContext'
 
 // TS v4.6 introduced Error.cause[1] typed as `Error`. TS v4.8 changed Error.cause to be
 // `unknown`[2].
@@ -39,7 +40,7 @@ export interface RawError {
   fingerprint?: string
   csp?: Csp
   context?: Context
-  debugIds?: { [url: string]: string }
+  debugIds?: DebugIdEntry[]
 }
 
 export const ErrorSource = {

--- a/packages/browser-core/src/domain/sourceCodeContext.spec.ts
+++ b/packages/browser-core/src/domain/sourceCodeContext.spec.ts
@@ -20,7 +20,10 @@ describe('buildDebugIdByUrl', () => {
       [makeStack(thirdUrl)]: { ddDebugId: 'id-3' },
     })
 
-    expect(buildDebugIdByUrl([url, otherUrl])).toEqual({ [url]: 'id-1', [otherUrl]: 'id-2' })
+    expect(buildDebugIdByUrl([url, otherUrl])).toEqual([
+      { url, id: 'id-1' },
+      { url: otherUrl, id: 'id-2' },
+    ])
   })
 
   it('should return undefined for a URL not in DD_SOURCE_CODE_CONTEXT', () => {
@@ -38,7 +41,7 @@ describe('buildDebugIdByUrl', () => {
       [`Error: ctx\n    at top (${url}:1:1)\n    at deeper (${otherUrl}:2:2)`]: { ddDebugId: 'id-1' },
     })
 
-    expect(buildDebugIdByUrl([url])).toEqual({ [url]: 'id-1' })
+    expect(buildDebugIdByUrl([url])).toEqual([{ url, id: 'id-1' }])
     expect(buildDebugIdByUrl([otherUrl])).toBeUndefined()
   })
 
@@ -51,7 +54,13 @@ describe('buildDebugIdByUrl', () => {
     // Context added later
     mock.addEntry(makeStack(url), { service: 'late-service', ddDebugId: 'late-id' })
 
-    expect(buildDebugIdByUrl([url])).toEqual({ [url]: 'late-id' })
+    expect(buildDebugIdByUrl([url])).toEqual([{ url, id: 'late-id' }])
+  })
+
+  it('should deduplicate repeated URLs', () => {
+    mockSourceCodeContext({ [makeStack(url)]: { ddDebugId: 'id-1' } })
+
+    expect(buildDebugIdByUrl([url, url])).toEqual([{ url, id: 'id-1' }])
   })
 })
 

--- a/packages/browser-core/src/domain/sourceCodeContext.ts
+++ b/packages/browser-core/src/domain/sourceCodeContext.ts
@@ -1,6 +1,5 @@
 import { globalObject } from '@datadog/js-core/util'
 import { computeStackTrace } from '../tools/stackTrace/computeStackTrace'
-import { isEmptyObject } from '../tools/utils/objectUtils'
 import { addTelemetryUsage } from './telemetry'
 
 /**
@@ -63,19 +62,30 @@ function syncSourceCodeContext() {
   }
 }
 
-export function buildDebugIdByUrl(urls: string[]): { [url: string]: string } | undefined {
+export interface DebugIdEntry {
+  url: string
+  id: string
+}
+
+export function buildDebugIdByUrl(urls: string[]): DebugIdEntry[] | undefined {
   syncSourceCodeContext()
 
-  const debugIdByUrl: { [url: string]: string } = {}
+  const seenUrls = new Set<string>()
+  const debugIds: DebugIdEntry[] = []
 
   for (const url of urls) {
+    if (seenUrls.has(url)) {
+      continue
+    }
+    seenUrls.add(url)
+
     const debugId = contextByUrl.get(url)?.ddDebugId
     if (debugId !== undefined) {
-      debugIdByUrl[url] = debugId
+      debugIds.push({ url, id: debugId })
     }
   }
 
-  return isEmptyObject(debugIdByUrl) ? undefined : debugIdByUrl
+  return debugIds.length ? debugIds : undefined
 }
 
 export function getSourceCodeContext(url: string): SourceCodeContextEntry | undefined {

--- a/packages/browser-core/src/index.ts
+++ b/packages/browser-core/src/index.ts
@@ -101,6 +101,7 @@ export {
 } from './domain/error/error'
 export { NonErrorPrefix } from './domain/error/error.types'
 export { buildDebugIdByUrl, getSourceCodeContext } from './domain/sourceCodeContext'
+export type { DebugIdEntry } from './domain/sourceCodeContext'
 export type { Context, ContextArray, ContextValue } from './tools/serialisation/context'
 export { getCookie, getInitCookie, setCookie, deleteCookie, resetInitCookies } from './browser/cookie'
 export { isCookieStoreSupported } from './browser/cookieAccess'

--- a/packages/browser-logs/src/domain/createErrorFieldFromRawError.spec.ts
+++ b/packages/browser-logs/src/domain/createErrorFieldFromRawError.spec.ts
@@ -37,7 +37,7 @@ describe('createErrorFieldFromRawError', () => {
     context: {
       foo: 'bar',
     },
-    debugIds: {},
+    debugIds: [],
   }
 
   it('creates an error field from a raw error', () => {

--- a/packages/browser-rum-core/src/domain/assembly.spec.ts
+++ b/packages/browser-rum-core/src/domain/assembly.spec.ts
@@ -229,11 +229,10 @@ describe('rum assembly', () => {
       describe('_dd.debug_ids', () => {
         const url = 'http://path/to/redact/app.js'
 
-        const redactDebugIdUrls = (debugIds: { [url: string]: string }) => {
-          Object.keys(debugIds).forEach((debugIdUrl) => {
-            if (debugIdUrl.includes('path/to/redact')) {
-              debugIds['redacted-url'] = debugIds[debugIdUrl]
-              delete debugIds[debugIdUrl]
+        const redactDebugIdUrls = (debugIds: Array<{ url: string; id: string }>) => {
+          debugIds.forEach((entry) => {
+            if (entry.url.includes('path/to/redact')) {
+              entry.url = 'redacted-url'
             }
           })
         }
@@ -249,11 +248,11 @@ describe('rum assembly', () => {
 
           notifyRawRumEvent(lifeCycle, {
             rawRumEvent: createRawRumEvent(RumEventType.ERROR, {
-              _dd: { debug_ids: { [url]: 'debug-id' } },
+              _dd: { debug_ids: [{ url, id: 'debug-id' }] },
             }),
           })
 
-          expect((serverRumEvents[0] as any)._dd.debug_ids).toEqual({ 'redacted-url': 'debug-id' })
+          expect((serverRumEvents[0] as any)._dd.debug_ids).toEqual([{ url: 'redacted-url', id: 'debug-id' }])
         })
 
         it('should allow redaction of the url in _dd.debug_ids on long task events', () => {
@@ -267,11 +266,11 @@ describe('rum assembly', () => {
 
           notifyRawRumEvent(lifeCycle, {
             rawRumEvent: createRawRumEvent(RumEventType.LONG_TASK, {
-              _dd: { debug_ids: { [url]: 'debug-id' } },
+              _dd: { debug_ids: [{ url, id: 'debug-id' }] },
             }),
           })
 
-          expect((serverRumEvents[0] as any)._dd.debug_ids).toEqual({ 'redacted-url': 'debug-id' })
+          expect((serverRumEvents[0] as any)._dd.debug_ids).toEqual([{ url: 'redacted-url', id: 'debug-id' }])
         })
       })
 

--- a/packages/browser-rum-core/src/domain/assembly.ts
+++ b/packages/browser-rum-core/src/domain/assembly.ts
@@ -33,7 +33,7 @@ const MODIFIABLE_FIELD_PATHS_BY_EVENT: Record<AssembledRumEvent['type'], Modifia
     'error.handling_stack': 'string',
     'error.resource.url': 'string',
     'error.fingerprint': 'string',
-    '_dd.debug_ids': 'object',
+    '_dd.debug_ids': 'array',
   },
   [RumEventType.RESOURCE]: {
     ...COMMON_MODIFIABLE_FIELD_PATHS,
@@ -51,7 +51,7 @@ const MODIFIABLE_FIELD_PATHS_BY_EVENT: Record<AssembledRumEvent['type'], Modifia
     ...COMMON_MODIFIABLE_FIELD_PATHS,
     'long_task.scripts[].source_url': 'string',
     'long_task.scripts[].invoker': 'string',
-    '_dd.debug_ids': 'object',
+    '_dd.debug_ids': 'array',
   },
   [RumEventType.VITAL]: COMMON_MODIFIABLE_FIELD_PATHS,
 }

--- a/packages/browser-rum-core/src/domain/error/errorCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/error/errorCollection.spec.ts
@@ -223,7 +223,7 @@ describe('error collection', () => {
         startClocks: { relative: 1234 as RelativeTime, timeStamp: 123456789 as TimeStamp },
       })
 
-      expect((rawRumEvents[0].rawRumEvent as RawRumErrorEvent)._dd).toEqual({ debug_ids: { [url]: debugId } })
+      expect((rawRumEvents[0].rawRumEvent as RawRumErrorEvent)._dd).toEqual({ debug_ids: [{ url, id: debugId }] })
     })
 
     it('should include handling stack', () => {

--- a/packages/browser-rum-core/src/domain/limitModification.ts
+++ b/packages/browser-rum-core/src/domain/limitModification.ts
@@ -2,7 +2,7 @@ import { sanitize, objectEntries } from '@datadog/browser-core'
 import type { Context } from '@datadog/browser-core'
 import { deepClone, getType } from '@datadog/js-core/util'
 
-export type ModifiableFieldPaths = Record<string, 'string' | 'object'>
+export type ModifiableFieldPaths = Record<string, 'string' | 'object' | 'array'>
 
 /**
  * Allows declaring and enforcing modifications to specific fields of an object.
@@ -29,7 +29,12 @@ export function limitModification<T extends Context, Result>(
   return result
 }
 
-function setValueAtPath(object: unknown, clone: unknown, pathSegments: string[], fieldType: 'string' | 'object') {
+function setValueAtPath(
+  object: unknown,
+  clone: unknown,
+  pathSegments: string[],
+  fieldType: 'string' | 'object' | 'array'
+) {
   const [field, ...restPathSegments] = pathSegments
 
   if (field === '[]') {
@@ -55,7 +60,7 @@ function setNestedValue(
   object: Record<string, unknown>,
   field: string,
   value: unknown,
-  fieldType: 'string' | 'object'
+  fieldType: 'string' | 'object' | 'array'
 ) {
   if (object[field] === value) {
     return
@@ -67,6 +72,8 @@ function setNestedValue(
     object[field] = sanitize(value)
   } else if (fieldType === 'object' && (newType === 'undefined' || newType === 'null')) {
     object[field] = {}
+  } else if (fieldType === 'array' && (newType === 'undefined' || newType === 'null')) {
+    object[field] = []
   }
 }
 

--- a/packages/browser-rum-core/src/domain/longTask/longTaskCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/longTask/longTaskCollection.spec.ts
@@ -98,9 +98,9 @@ describe('longTaskCollection', () => {
 
       notifyPerformanceEntries([createPerformanceEntry(RumPerformanceEntryType.LONG_ANIMATION_FRAME)])
 
-      expect((rawRumEvents[0].rawRumEvent as RawRumLongAnimationFrameEvent)._dd.debug_ids).toEqual({
-        'http://example.com/script.js': debugId,
-      })
+      expect((rawRumEvents[0].rawRumEvent as RawRumLongAnimationFrameEvent)._dd.debug_ids).toEqual([
+        { url: 'http://example.com/script.js', id: debugId },
+      ])
     })
 
     it('should not attach debug_ids when no script url matches the source code context', () => {

--- a/packages/browser-rum-core/src/rawRumEvent.types.ts
+++ b/packages/browser-rum-core/src/rawRumEvent.types.ts
@@ -7,6 +7,7 @@ import type {
   DefaultPrivacyLevel,
   Csp,
   Context,
+  DebugIdEntry,
 } from '@datadog/browser-core'
 import type { GraphQlMetadata } from './domain/resource/graphql'
 import type { PageState } from './domain/contexts/pageStateHistory'
@@ -143,7 +144,7 @@ export interface RawRumErrorEvent {
     csp?: Csp
   }
   _dd?: {
-    debug_ids?: { [url: string]: string }
+    debug_ids?: DebugIdEntry[]
   }
   view?: {
     in_foreground: boolean
@@ -349,7 +350,7 @@ export interface RawRumLongAnimationFrameEvent {
   }
   _dd: {
     discarded: boolean
-    debug_ids?: { [url: string]: string }
+    debug_ids?: DebugIdEntry[]
   }
 }
 

--- a/packages/browser-rum-core/src/rumEvent.types.ts
+++ b/packages/browser-rum-core/src/rumEvent.types.ts
@@ -516,12 +516,17 @@ export type RumErrorEvent = CommonProperties &
       /**
        * Mapping of source file URLs to their debug IDs for source map deobfuscation
        */
-      readonly debug_ids?: {
+      debug_ids?: {
+        /**
+         * URL of the source file
+         */
+        url: string
         /**
          * Debug ID (UUID) for the source file
          */
-        [k: string]: string
-      }
+        id: string
+        [k: string]: unknown
+      }[]
       [k: string]: unknown
     }
     [k: string]: unknown
@@ -649,12 +654,17 @@ export type RumLongTaskEvent = CommonProperties &
       /**
        * Mapping of source file URLs to their debug IDs for source map deobfuscation
        */
-      readonly debug_ids?: {
+      debug_ids?: {
+        /**
+         * URL of the source file
+         */
+        url: string
         /**
          * Debug ID (UUID) for the source file
          */
-        [k: string]: string
-      }
+        id: string
+        [k: string]: unknown
+      }[]
       [k: string]: unknown
     }
     [k: string]: unknown

--- a/test/e2e/scenario/microfrontend.scenario.ts
+++ b/test/e2e/scenario/microfrontend.scenario.ts
@@ -455,13 +455,13 @@ test.describe('microfrontend', () => {
         // We assert the chunk with toMatchObject instead of toEqual to allow those extras.
 
         // frame 0 -> app1 expose chunk (app1.ts + common.ts).
-        expect(intakeRegistry.rumErrorEvents[0]._dd?.debug_ids).toMatchObject({
-          [`${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`]: APP1_DEBUG_ID,
-        })
+        expect(intakeRegistry.rumErrorEvents[0]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([{ url: `${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`, id: APP1_DEBUG_ID }])
+        )
         // frame 0 -> app2 expose chunk (app2.ts + common.ts)
-        expect(intakeRegistry.rumErrorEvents[1]._dd?.debug_ids).toMatchObject({
-          [`${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`]: APP2_DEBUG_ID,
-        })
+        expect(intakeRegistry.rumErrorEvents[1]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([{ url: `${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`, id: APP2_DEBUG_ID }])
+        )
 
         withBrowserLogs((browserLogs) => {
           expect(browserLogs).toHaveLength(2)
@@ -491,13 +491,13 @@ test.describe('microfrontend', () => {
         // We assert the chunk with toMatchObject instead of toEqual to allow those extras.
 
         // script 0 -> app1 expose chunk (app1.ts + common.ts)
-        expect(longTaskEvents[0]._dd?.debug_ids).toMatchObject({
-          [`${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`]: APP1_DEBUG_ID,
-        })
+        expect(longTaskEvents[0]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([{ url: `${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`, id: APP1_DEBUG_ID }])
+        )
         // script 0 -> app2 expose chunk (app2.ts + common.ts)
-        expect(longTaskEvents[1]._dd?.debug_ids).toMatchObject({
-          [`${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`]: APP2_DEBUG_ID,
-        })
+        expect(longTaskEvents[1]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([{ url: `${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`, id: APP2_DEBUG_ID }])
+        )
       })
 
     createTest('errors spanning multiple chunks should have a debug_id for each chunk in the stack')
@@ -514,15 +514,19 @@ test.describe('microfrontend', () => {
         // We assert the chunk with toMatchObject instead of toEqual to allow those extras.
 
         // frame 0 (throw) -> shared lib chunk (boom), frame 1 (caller) -> app1 expose chunk
-        expect(intakeRegistry.rumErrorEvents[0]._dd?.debug_ids).toMatchObject({
-          [`${baseUrl}microfrontend/chunks/${LIB_EXPOSE_CHUNK}`]: LIB_DEBUG_ID,
-          [`${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`]: APP1_DEBUG_ID,
-        })
+        expect(intakeRegistry.rumErrorEvents[0]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([
+            { url: `${baseUrl}microfrontend/chunks/${LIB_EXPOSE_CHUNK}`, id: LIB_DEBUG_ID },
+            { url: `${baseUrl}microfrontend/chunks/${APP1_EXPOSE_CHUNK}`, id: APP1_DEBUG_ID },
+          ])
+        )
         // same shared lib debug ID, merged with app2's own chunk
-        expect(intakeRegistry.rumErrorEvents[1]._dd?.debug_ids).toMatchObject({
-          [`${baseUrl}microfrontend/chunks/${LIB_EXPOSE_CHUNK}`]: LIB_DEBUG_ID,
-          [`${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`]: APP2_DEBUG_ID,
-        })
+        expect(intakeRegistry.rumErrorEvents[1]._dd?.debug_ids).toEqual(
+          expect.arrayContaining([
+            { url: `${baseUrl}microfrontend/chunks/${LIB_EXPOSE_CHUNK}`, id: LIB_DEBUG_ID },
+            { url: `${baseUrl}microfrontend/chunks/${APP2_EXPOSE_CHUNK}`, id: APP2_DEBUG_ID },
+          ])
+        )
 
         withBrowserLogs((browserLogs) => {
           expect(browserLogs).toHaveLength(2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,10 +601,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=31cc845ba1cb52086a25424de86731c316b2385e":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd"
-  checksum: 10c0/745ee1b338aa0bbdeec2b2cff464525da4842912b76007e778c34e61581d40cabc12c3c232861b071d187224bef706b9ab0402515b165be7e2b51082dacd8002
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=31cc845ba1cb52086a25424de86731c316b2385e"
+  checksum: 10c0/23133c77ad86eac92b578ab6d2f6d9ed6383c32e3cb96750d3f2fec8f3a4080506a463e43b6fa2ca252624450d51c26f729fa6dd703e1ada291cf6d0681f5845
   languageName: node
   linkType: hard
 
@@ -3930,7 +3930,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=ae1f25f83ed299d8e6026255469f6d020796dbfd"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=31cc845ba1cb52086a25424de86731c316b2385e"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.9"


### PR DESCRIPTION
## Summary
- `_dd.debug_ids` on RUM error and long task/LoAF events now serializes as an array of `{ url, id }` entries instead of a `{ [url]: id }` map, per the [recommended format](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/6863128158/Debug+_id+data+format) — the map shape was discouraged because keys containing dots get split into nested objects by the event platform.
- Bumped `@datadog/rum-events-format` pin to `31cc845` (already merged upstream) and regenerated `rumEvent.types.ts` via `yarn json-schemas:sync`.
- `buildDebugIdByUrl()` in `sourceCodeContext.ts` now returns `DebugIdEntry[] | undefined` instead of a map (same name/signature otherwise).
- Added `'array'` as a valid `ModifiableFieldPaths` type so `beforeSend` redaction still works on `_dd.debug_ids`.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] Updated unit tests in `sourceCodeContext.spec.ts`, `error.spec.ts`, `errorCollection.spec.ts`, `longTaskCollection.spec.ts`, `assembly.spec.ts`, `createErrorFieldFromRawError.spec.ts` — all green
- [x] Updated E2E assertions in `microfrontend.scenario.ts` to match the array shape