### PR TITLE
🐛 Use unknown type for addReactError error parameter

### DIFF
--- a/packages/browser-rum-react/src/domain/error/addReactError.ts
+++ b/packages/browser-rum-react/src/domain/error/addReactError.ts
@@ -34,7 +34,10 @@ export function addReactError(error: unknown, info: ErrorInfo) {
         handlingStack,
         componentStack: info.componentStack ?? undefined,
         startClocks,
-        context: { ...(error as Error & { dd_context?: Context }).dd_context, framework: 'react' },
+        context: {
+          ...(typeof error === 'object' && error !== null ? (error as { dd_context?: Context }).dd_context : undefined),
+          framework: 'react',
+        },
       })
     })
   })

--- a/packages/browser-rum-react/src/domain/error/addReactError.ts
+++ b/packages/browser-rum-react/src/domain/error/addReactError.ts
@@ -24,7 +24,7 @@ import { onRumStart } from '../reactPlugin'
  * // ...
  * ```
  */
-export function addReactError(error: Error, info: ErrorInfo) {
+export function addReactError(error: unknown, info: ErrorInfo) {
   const handlingStack = createHandlingStack('react error')
   const startClocks = clocksNow()
   onRumStart((addError) => {


### PR DESCRIPTION
## Motivation

`addError` already accepts `error: unknown` — `addReactError` should match. React 19's `onUncaughtError` callback types the error as `unknown` (anything can be thrown in JS), so calling `addReactError` directly from it produces a type error today.

Fixes #4858.

## Changes

Widens the `error` parameter in `addReactError` from `Error` to `unknown`, aligning it with the existing `addError` signature. The implementation is unchanged — the cast `(error as Error & { dd_context?: Context })` already handles narrowing when accessing error properties.

## Test instructions

1. Run `yarn test:unit --spec packages/browser-rum-react/src/domain/error/addReactError.spec.ts`.
2. All 2 tests should pass.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file