### PR TITLE
🔧 Add react V7 to git ignored test applications

### DIFF
--- a/test/apps/.gitignore
+++ b/test/apps/.gitignore
@@ -1,6 +1,7 @@
 allowed-tracking-origin/
 invalid-tracking-origin/
 react-router-v6-app/
+react-router-v7-app/
 vue-router-v4-app/
 nuxt-vue-router-v4-app/
 cdn-extension/


### PR DESCRIPTION
## Motivation

After [Update react-router monorepo](https://github.com/DataDog/browser-sdk/pull/4846) we build V8, V7 and V6. But we are not ignoring the V7 test application. 

## Changes

Add `react-router-v7-app/` to test apps `.gitignore`

## Test instructions

CI should pass. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
