### PR TITLE
✨ Extend remote configuration supported parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=31cc845ba1cb52086a25424de86731c316b2385e",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=4ed60cbe47c30afcef051481a035adf88161d4b7",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.9",

--- a/packages/browser-rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.spec.ts
@@ -32,7 +32,6 @@ import type { RumPublicApi, RumPublicApiOptions, Strategy } from './rumPublicApi
 import type { StartRumResult } from './startRum'
 import type { DoStartRum } from './preStartRum'
 import { createPreStartStrategy } from './preStartRum'
-import { CACHE_VERSION } from '../domain/configuration/remoteConfigurationCache'
 
 const DEFAULT_INIT_CONFIGURATION = { applicationId: 'xxx', clientToken: 'xxx' }
 const INVALID_INIT_CONFIGURATION = { clientToken: 'yes' } as RumInitConfiguration
@@ -550,7 +549,7 @@ describe('preStartRum', () => {
         it('should start the SDK with the cached configuration on cache hit', async () => {
           localStorage.setItem(
             CACHE_KEY,
-            JSON.stringify({ version: CACHE_VERSION, config: { rum: { sessionSampleRate: 75 } }, fetchedAt: 1000 })
+            JSON.stringify({ version: 2, config: { rum: { sessionSampleRate: 75 } }, fetchedAt: 1000 })
           )
           const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
 

--- a/packages/browser-rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.spec.ts
@@ -32,6 +32,7 @@ import type { RumPublicApi, RumPublicApiOptions, Strategy } from './rumPublicApi
 import type { StartRumResult } from './startRum'
 import type { DoStartRum } from './preStartRum'
 import { createPreStartStrategy } from './preStartRum'
+import { CACHE_VERSION } from '../domain/configuration/remoteConfigurationCache'
 
 const DEFAULT_INIT_CONFIGURATION = { applicationId: 'xxx', clientToken: 'xxx' }
 const INVALID_INIT_CONFIGURATION = { clientToken: 'yes' } as RumInitConfiguration
@@ -549,7 +550,7 @@ describe('preStartRum', () => {
         it('should start the SDK with the cached configuration on cache hit', async () => {
           localStorage.setItem(
             CACHE_KEY,
-            JSON.stringify({ version: 1, config: { sessionSampleRate: 75 }, fetchedAt: 1000 })
+            JSON.stringify({ version: CACHE_VERSION, config: { rum: { sessionSampleRate: 75 } }, fetchedAt: 1000 })
           )
           const { strategy, doStartRumSpy } = createPreStartStrategyWithDefaults()
 

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -757,7 +757,7 @@ describe('remoteConfiguration', () => {
       })
     })
 
-    it('should apply the new RFC fields when present in the rum section', () => {
+    it('should apply telemetrySampleRate, trackResources, trackLongTasks, and actionNameAttribute from the rum section', () => {
       const result = applyRemoteConfiguration(
         DEFAULT_INIT_CONFIGURATION,
         {

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -117,7 +117,19 @@ describe('remoteConfiguration', () => {
       })
     })
 
-    it('should throw an error if the remote config does not contain rum config', async () => {
+    it('should succeed if the remote config contains only a profiling section', async () => {
+      interceptor.withFetch(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ profiling: { sampleRate: 10 } }),
+        })
+      )
+
+      const fetchResult = await fetchRemoteConfiguration(configuration)
+      expect(fetchResult).toEqual({ ok: true, value: { profiling: { sampleRate: 10 } } })
+    })
+
+    it('should return an error if the remote config does not contain rum or profiling', async () => {
       interceptor.withFetch(() =>
         Promise.resolve({
           ok: true,

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -6,13 +6,14 @@ import { appendElement } from '../../../test'
 import type { RumInitConfiguration } from './configuration'
 import {
   type RumRemoteConfiguration,
+  type RemoteConfiguration,
   initMetrics,
   applyRemoteConfiguration,
   buildEndpoint,
   fetchRemoteConfiguration,
   getRemoteConfiguration,
 } from './remoteConfiguration'
-import { buildCacheKey } from './remoteConfigurationCache'
+import { buildCacheKey, CACHE_VERSION } from './remoteConfigurationCache'
 
 const DEFAULT_INIT_CONFIGURATION: RumInitConfiguration = {
   clientToken: 'xxx',
@@ -82,10 +83,12 @@ describe('remoteConfiguration', () => {
       expect(fetchResult).toEqual({
         ok: true,
         value: {
-          applicationId: 'xxx',
-          sessionSampleRate: 50,
-          sessionReplaySampleRate: 50,
-          defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
+          rum: {
+            applicationId: 'xxx',
+            sessionSampleRate: 50,
+            sessionReplaySampleRate: 50,
+            defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
+          },
         },
       })
     })
@@ -150,7 +153,12 @@ describe('remoteConfiguration', () => {
         ...actual,
       }
       expect(
-        applyRemoteConfiguration(DEFAULT_INIT_CONFIGURATION, rumRemoteConfiguration, supportedContextManagers, metrics)
+        applyRemoteConfiguration(
+          DEFAULT_INIT_CONFIGURATION,
+          { rum: rumRemoteConfiguration },
+          supportedContextManagers,
+          metrics
+        )
       ).toEqual({
         ...DEFAULT_INIT_CONFIGURATION,
         applicationId: 'yyy',
@@ -188,7 +196,12 @@ describe('remoteConfiguration', () => {
         defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
       }
       expect(
-        applyRemoteConfiguration(DEFAULT_INIT_CONFIGURATION, rumRemoteConfiguration, supportedContextManagers, metrics)
+        applyRemoteConfiguration(
+          DEFAULT_INIT_CONFIGURATION,
+          { rum: rumRemoteConfiguration },
+          supportedContextManagers,
+          metrics
+        )
       ).toEqual({
         applicationId: 'yyy',
         clientToken: 'xxx',
@@ -749,8 +762,8 @@ describe('remoteConfiguration', () => {
   describe('async loading (getRemoteConfiguration)', () => {
     const REMOTE_CONFIGURATION_ID = 'rc-test-id'
     const CACHE_KEY = buildCacheKey(REMOTE_CONFIGURATION_ID)
-    const FRESH_RUM_CONFIG: RumRemoteConfiguration = { applicationId: 'fresh-app' }
-    const CACHED_RUM_CONFIG: RumRemoteConfiguration = { applicationId: 'cached-app' }
+    const FRESH_RUM_CONFIG: RemoteConfiguration = { rum: { applicationId: 'fresh-app' } }
+    const CACHED_RUM_CONFIG: RemoteConfiguration = { rum: { applicationId: 'cached-app' } }
 
     let initConfiguration: RumInitConfiguration
     let supportedContextManagers: {
@@ -760,12 +773,12 @@ describe('remoteConfiguration', () => {
     let interceptor: ReturnType<typeof interceptRequests>
     let displaySpy: jasmine.Spy
 
-    function withCachedEntry(config: RumRemoteConfiguration) {
-      localStorage.setItem(CACHE_KEY, JSON.stringify({ version: 1, config, fetchedAt: 1000 }))
+    function withCachedEntry(config: RemoteConfiguration) {
+      localStorage.setItem(CACHE_KEY, JSON.stringify({ version: CACHE_VERSION, config, fetchedAt: 1000 }))
     }
 
-    function withFetchSuccess(config: RumRemoteConfiguration = FRESH_RUM_CONFIG) {
-      interceptor.withFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ rum: config }) }))
+    function withFetchSuccess(config: RemoteConfiguration = FRESH_RUM_CONFIG) {
+      interceptor.withFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve(config) }))
     }
 
     function withFetchFailure() {
@@ -832,7 +845,7 @@ describe('remoteConfiguration', () => {
 
       const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!)
       expect(stored.config).toEqual(FRESH_RUM_CONFIG)
-      expect(stored.version).toBe(1)
+      expect(stored.version).toBe(CACHE_VERSION)
     })
 
     it('should not overwrite cache when background fetch fails', async () => {
@@ -858,7 +871,7 @@ describe('remoteConfiguration', () => {
 
       function withFetchSuccessReturningSpy() {
         return interceptor.withFetch(() =>
-          Promise.resolve({ ok: true, json: () => Promise.resolve({ rum: FRESH_RUM_CONFIG }) })
+          Promise.resolve({ ok: true, json: () => Promise.resolve(FRESH_RUM_CONFIG) })
         )
       }
     })

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -756,6 +756,38 @@ describe('remoteConfiguration', () => {
         )
       })
     })
+
+    it('should apply the new RFC fields when present in the rum section', () => {
+      const result = applyRemoteConfiguration(
+        DEFAULT_INIT_CONFIGURATION,
+        {
+          rum: {
+            applicationId: 'xxx',
+            trackResources: false,
+            trackLongTasks: false,
+            telemetrySampleRate: 10,
+            actionNameAttribute: 'data-label',
+          },
+        },
+        supportedContextManagers,
+        metrics
+      )
+      expect(result.trackResources).toBeFalse()
+      expect(result.trackLongTasks).toBeFalse()
+      expect(result.telemetrySampleRate).toBe(10)
+      expect(result.actionNameAttribute).toBe('data-label')
+    })
+
+    it('should apply profiling.sampleRate and skip rum fields when only profiling is present', () => {
+      const result = applyRemoteConfiguration(
+        DEFAULT_INIT_CONFIGURATION,
+        { profiling: { sampleRate: 25 } },
+        supportedContextManagers,
+        metrics
+      )
+      expect(result.profilingSampleRate).toBe(25)
+      expect(result.sessionSampleRate).toBe(DEFAULT_INIT_CONFIGURATION.sessionSampleRate)
+    })
   })
 
   describe('buildEndpoint', () => {

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.spec.ts
@@ -870,9 +870,7 @@ describe('remoteConfiguration', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1)
 
       function withFetchSuccessReturningSpy() {
-        return interceptor.withFetch(() =>
-          Promise.resolve({ ok: true, json: () => Promise.resolve(FRESH_RUM_CONFIG) })
-        )
+        return interceptor.withFetch(() => Promise.resolve({ ok: true, json: () => Promise.resolve(FRESH_RUM_CONFIG) }))
       }
     })
 

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -19,13 +19,20 @@ import { CACHE_STATUS_TO_METRIC_MAP, createConfigurationCache } from './remoteCo
 export type RemoteConfiguration = RumSdkConfig
 export type RumRemoteConfiguration = Exclude<RemoteConfiguration['rum'], undefined>
 const REMOTE_CONFIGURATION_VERSION = 'v1'
-const SUPPORTED_FIELDS: Array<keyof RumInitConfiguration> = [
+const SUPPORTED_RUM_FIELDS: Array<keyof RumInitConfiguration> = [
   'applicationId',
   'service',
   'env',
   'version',
   'sessionSampleRate',
   'sessionReplaySampleRate',
+  'telemetrySampleRate',
+  'trackAnonymousUser',
+  'trackUserInteractions',
+  'trackResources',
+  'trackLongTasks',
+  'traceContextInjection',
+  'actionNameAttribute',
   'defaultPrivacyLevel',
   'enablePrivacyForActionName',
   'traceSampleRate',
@@ -86,15 +93,16 @@ export async function fetchAndApplyRemoteConfiguration(
 
 export function applyRemoteConfiguration(
   initConfiguration: RumInitConfiguration,
-  rumRemoteConfiguration: RumRemoteConfiguration & { [key: string]: unknown },
+  remoteConfiguration: RemoteConfiguration,
   supportedContextManagers: SupportedContextManagers,
   metrics: ReturnType<typeof initMetrics>
 ): RumInitConfiguration {
+  const rumRemoteConfiguration = remoteConfiguration.rum as RumRemoteConfiguration & { [key: string]: unknown }
   // intents:
   // - explicitly set each supported field to limit risk in case an attacker can create configurations
   // - check the existence in the remote config to avoid clearing a provided init field
   const appliedConfiguration = { ...initConfiguration } as RumInitConfiguration & { [key: string]: unknown }
-  SUPPORTED_FIELDS.forEach((option: string) => {
+  SUPPORTED_RUM_FIELDS.forEach((option: string) => {
     if (option in rumRemoteConfiguration) {
       appliedConfiguration[option] = resolveConfigurationProperty(rumRemoteConfiguration[option])
     }
@@ -104,6 +112,9 @@ export function applyRemoteConfiguration(
       resolveContextProperty(supportedContextManagers[context], rumRemoteConfiguration[context])
     }
   })
+  if (remoteConfiguration.profiling?.sampleRate !== undefined) {
+    appliedConfiguration.profilingSampleRate = remoteConfiguration.profiling.sampleRate
+  }
   return appliedConfiguration
 
   // share context to access metrics
@@ -282,7 +293,7 @@ function extractValue(extractor: SerializedRegex, candidate: string) {
   return extractRegexMatch(candidate, resolvedExtractor)
 }
 
-type FetchRemoteConfigurationResult = { ok: true; value: RumRemoteConfiguration } | { ok: false; error: Error }
+type FetchRemoteConfigurationResult = { ok: true; value: RemoteConfiguration } | { ok: false; error: Error }
 
 export async function fetchRemoteConfiguration(
   configuration: RumInitConfiguration
@@ -303,7 +314,7 @@ export async function fetchRemoteConfiguration(
   if (remoteConfiguration.rum) {
     return {
       ok: true,
-      value: remoteConfiguration.rum,
+      value: remoteConfiguration,
     }
   }
   return {

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -311,7 +311,7 @@ export async function fetchRemoteConfiguration(
     }
   }
   const remoteConfiguration: RemoteConfiguration = await response.json()
-  if (remoteConfiguration.rum) {
+  if (remoteConfiguration.rum || remoteConfiguration.profiling) {
     return {
       ok: true,
       value: remoteConfiguration,

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.ts
@@ -97,21 +97,23 @@ export function applyRemoteConfiguration(
   supportedContextManagers: SupportedContextManagers,
   metrics: ReturnType<typeof initMetrics>
 ): RumInitConfiguration {
-  const rumRemoteConfiguration = remoteConfiguration.rum as RumRemoteConfiguration & { [key: string]: unknown }
   // intents:
   // - explicitly set each supported field to limit risk in case an attacker can create configurations
   // - check the existence in the remote config to avoid clearing a provided init field
   const appliedConfiguration = { ...initConfiguration } as RumInitConfiguration & { [key: string]: unknown }
-  SUPPORTED_RUM_FIELDS.forEach((option: string) => {
-    if (option in rumRemoteConfiguration) {
-      appliedConfiguration[option] = resolveConfigurationProperty(rumRemoteConfiguration[option])
-    }
-  })
-  ;(Object.keys(supportedContextManagers) as Array<keyof SupportedContextManagers>).forEach((context) => {
-    if (rumRemoteConfiguration[context] !== undefined) {
-      resolveContextProperty(supportedContextManagers[context], rumRemoteConfiguration[context])
-    }
-  })
+  if (remoteConfiguration.rum) {
+    const rumRemoteConfiguration = remoteConfiguration.rum as RumRemoteConfiguration & { [key: string]: unknown }
+    SUPPORTED_RUM_FIELDS.forEach((option: string) => {
+      if (option in rumRemoteConfiguration) {
+        appliedConfiguration[option] = resolveConfigurationProperty(rumRemoteConfiguration[option])
+      }
+    })
+    ;(Object.keys(supportedContextManagers) as Array<keyof SupportedContextManagers>).forEach((context) => {
+      if (rumRemoteConfiguration[context] !== undefined) {
+        resolveContextProperty(supportedContextManagers[context], rumRemoteConfiguration[context])
+      }
+    })
+  }
   if (remoteConfiguration.profiling?.sampleRate !== undefined) {
     appliedConfiguration.profilingSampleRate = remoteConfiguration.profiling.sampleRate
   }

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.types.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfiguration.types.ts
@@ -38,6 +38,15 @@ export type DynamicOption =
  */
 export interface RumSdkConfig {
   /**
+   * Profiling feature Remote Configuration properties
+   */
+  profiling?: {
+    /**
+     * The percentage of users profiled
+     */
+    sampleRate?: number
+  }
+  /**
    * RUM feature Remote Configuration properties
    */
   rum?: {
@@ -94,6 +103,34 @@ export interface RumSdkConfig {
      * The percentage of sessions with RUM & Session Replay pricing tracked
      */
     sessionReplaySampleRate?: number
+    /**
+     * The percentage of telemetry events sampled
+     */
+    telemetrySampleRate?: number
+    /**
+     * Whether to track anonymous users
+     */
+    trackAnonymousUser?: boolean
+    /**
+     * Whether to automatically collect user actions
+     */
+    trackUserInteractions?: boolean
+    /**
+     * Whether to collect resource events
+     */
+    trackResources?: boolean
+    /**
+     * Whether to collect long task events
+     */
+    trackLongTasks?: boolean
+    /**
+     * Controls when tracing headers are injected
+     */
+    traceContextInjection?: 'all' | 'sampled'
+    /**
+     * HTML attribute used as the RUM action name
+     */
+    actionNameAttribute?: string
     /**
      * Session replay default privacy level
      */

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.spec.ts
@@ -1,14 +1,16 @@
 import { registerCleanupTask, mockClock } from '@datadog/browser-core/test'
 import type { Clock } from '@datadog/browser-core/test'
-import type { RumRemoteConfiguration } from './remoteConfiguration'
+import type { RemoteConfiguration } from './remoteConfiguration'
 import { buildCacheKey, createConfigurationCache, CACHE_VERSION, CACHE_KEY_PREFIX } from './remoteConfigurationCache'
 
 const REMOTE_CONFIGURATION_ID = 'test-id'
 const CACHE_KEY = `${CACHE_KEY_PREFIX}${REMOTE_CONFIGURATION_ID}`
 
-const VALID_CONFIG: RumRemoteConfiguration = {
-  applicationId: 'app-id',
-  sessionSampleRate: 50,
+const VALID_CONFIG: RemoteConfiguration = {
+  rum: {
+    applicationId: 'app-id',
+    sessionSampleRate: 50,
+  },
 }
 
 describe('remoteConfigurationCache', () => {
@@ -143,10 +145,10 @@ describe('remoteConfigurationCache', () => {
       it('should overwrite a previously stored entry', () => {
         const cache = createConfigurationCache({ remoteConfigurationId: REMOTE_CONFIGURATION_ID })
 
-        cache.write({ applicationId: 'first' })
-        cache.write({ applicationId: 'second' })
+        cache.write({ rum: { applicationId: 'first' } })
+        cache.write({ rum: { applicationId: 'second' } })
 
-        expect(cache.read()).toEqual({ status: 'hit', config: { applicationId: 'second' } })
+        expect(cache.read()).toEqual({ status: 'hit', config: { rum: { applicationId: 'second' } } })
       })
 
       it('should silently swallow localStorage.setItem errors', () => {

--- a/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
+++ b/packages/browser-rum-core/src/domain/configuration/remoteConfigurationCache.ts
@@ -1,14 +1,14 @@
 import { timeStampNow } from '@datadog/js-core/time'
 import { tryJsonParse } from '@datadog/browser-core'
 import type { TimeStamp } from '@datadog/js-core/time'
-import type { RumRemoteConfiguration } from './remoteConfiguration'
+import type { RemoteConfiguration } from './remoteConfiguration'
 
-export const CACHE_VERSION = 1
+export const CACHE_VERSION = 2
 export const CACHE_KEY_PREFIX = 'dd_rc_'
 
 interface CachedRemoteConfiguration {
   version: number
-  config: RumRemoteConfiguration
+  config: RemoteConfiguration
   fetchedAt: TimeStamp
 }
 
@@ -18,7 +18,7 @@ export type CacheReadResult =
   | {
       status: Exclude<CacheReadStatus, 'hit'>
     }
-  | { status: Extract<CacheReadStatus, 'hit'>; config: RumRemoteConfiguration }
+  | { status: Extract<CacheReadStatus, 'hit'>; config: RemoteConfiguration }
 
 export const CACHE_STATUS_TO_METRIC_MAP: Record<CacheReadStatus, 'success' | 'missing' | 'failure'> = {
   hit: 'success',
@@ -80,7 +80,7 @@ export function createConfigurationCache({ remoteConfigurationId }: { remoteConf
         // Ignore
       }
     },
-    write(config: RumRemoteConfiguration) {
+    write(config: RemoteConfiguration) {
       const entry: CachedRemoteConfiguration = {
         version: CACHE_VERSION,
         config,

--- a/remote-configuration/rum-sdk-config.json
+++ b/remote-configuration/rum-sdk-config.json
@@ -138,6 +138,19 @@
     }
   },
   "properties": {
+    "profiling": {
+      "type": "object",
+      "description": "Profiling feature Remote Configuration properties",
+      "additionalProperties": false,
+      "properties": {
+        "sampleRate": {
+          "type": "number",
+          "description": "The percentage of users profiled",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
     "rum": {
       "type": "object",
       "description": "RUM feature Remote Configuration properties",
@@ -172,6 +185,37 @@
           "description": "The percentage of sessions with RUM & Session Replay pricing tracked",
           "minimum": 0,
           "maximum": 100
+        },
+        "telemetrySampleRate": {
+          "type": "number",
+          "description": "The percentage of telemetry events sampled",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "trackAnonymousUser": {
+          "type": "boolean",
+          "description": "Whether to track anonymous users"
+        },
+        "trackUserInteractions": {
+          "type": "boolean",
+          "description": "Whether to automatically collect user actions"
+        },
+        "trackResources": {
+          "type": "boolean",
+          "description": "Whether to collect resource events"
+        },
+        "trackLongTasks": {
+          "type": "boolean",
+          "description": "Whether to collect long task events"
+        },
+        "traceContextInjection": {
+          "type": "string",
+          "description": "Controls when tracing headers are injected",
+          "enum": ["all", "sampled"]
+        },
+        "actionNameAttribute": {
+          "type": "string",
+          "description": "HTML attribute used as the RUM action name"
         },
         "defaultPrivacyLevel": {
           "type": "string",

--- a/test/e2e/scenario/rum/remoteConfiguration.scenario.ts
+++ b/test/e2e/scenario/rum/remoteConfiguration.scenario.ts
@@ -266,8 +266,8 @@ test.describe('remote configuration', () => {
           (key) => JSON.parse(localStorage.getItem(key)!) as { version: number; config: object },
           CACHE_KEY
         )
-        expect(stored.version).toBe(1)
-        expect(stored.config).toEqual({ applicationId: RC_APP_ID, sessionSampleRate: 1 })
+        expect(stored.version).toBe(2)
+        expect(stored.config).toEqual({ rum: { applicationId: RC_APP_ID, sessionSampleRate: 1 } })
       })
 
     createTest('should resolve an option value from a cookie')
@@ -494,7 +494,7 @@ test.describe('remote configuration', () => {
  * outer one wraps it as a valid JS string literal with proper escaping.
  */
 function seedCache(remoteConfig: RemoteConfiguration) {
-  const entry = JSON.stringify({ version: 1, config: remoteConfig.rum, fetchedAt: 1000 })
+  const entry = JSON.stringify({ version: 2, config: remoteConfig, fetchedAt: 1000 })
   return html`<script>
     localStorage.setItem('${CACHE_KEY}', ${JSON.stringify(entry)})
   </script>`

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,10 +599,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=31cc845ba1cb52086a25424de86731c316b2385e":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=4ed60cbe47c30afcef051481a035adf88161d4b7":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=31cc845ba1cb52086a25424de86731c316b2385e"
-  checksum: 10c0/23133c77ad86eac92b578ab6d2f6d9ed6383c32e3cb96750d3f2fec8f3a4080506a463e43b6fa2ca252624450d51c26f729fa6dd703e1ada291cf6d0681f5845
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=4ed60cbe47c30afcef051481a035adf88161d4b7"
+  checksum: 10c0/16677d35d476ba78fbf8cd37f0367577a839dcdfa29edbbe195ddae2511d6d22746aaaef894bc7bedd747e9163551dfc4bb27e8595fbfcee7d4ca41ac800fed3
   languageName: node
   linkType: hard
 
@@ -3943,7 +3943,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=31cc845ba1cb52086a25424de86731c316b2385e"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=4ed60cbe47c30afcef051481a035adf88161d4b7"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.9"


### PR DESCRIPTION
## Motivation

The multi-platform RFC defines the full set of fields that should be remotely configurable for the browser SDK. We were only handling a subset. This adds the missing ones from the RFC browser table marked as "\[Product\] Keep".

## Changes

Added 7 new fields to `SUPPORTED_RUM_FIELDS`: `telemetrySampleRate`, `trackAnonymousUser`, `trackUserInteractions`, `trackResources`, `trackLongTasks`, `traceContextInjection`, and `actionNameAttribute`.

Also added support for `profiling.sampleRate`, which lives in a separate top-level namespace in the schema (not under `rum`). To handle this, `applyRemoteConfiguration` now receives the full `RemoteConfiguration` instead of just the `rum` part. The cache format changed accordingly, so `CACHE_VERSION` is bumped to 2.

`logs.*` fields (`forwardErrorsToLogs`, `forwardConsoleLogs`, `forwardReports`) are not included here. They belong to `browser-logs`, not `browser-rum-core`, and need a separate approach to avoid a double fetch.

RFC: https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/6675005886/RFC+-+Remote+Configuration+Parameters

## Test instructions

1. Set up a remote configuration with one of the new fields, e.g. `trackResources: false`
2. Initialize the SDK with that remote config ID
3. Verify the field is applied (resources should not be collected)
4. Check that fields not present in the remote config keep their init values

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file