### PR TITLE
🐛 Add react-router-v8 to tsconfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -33,6 +33,7 @@
       "@datadog/browser-rum-react/internal": ["./packages/browser-rum-react/src/entries/internal"],
       "@datadog/browser-rum-react/react-router-v6": ["./packages/browser-rum-react/src/entries/reactRouterV6"],
       "@datadog/browser-rum-react/react-router-v7": ["./packages/browser-rum-react/src/entries/reactRouterV7"],
+      "@datadog/browser-rum-react/react-router-v8": ["./packages/browser-rum-react/src/entries/reactRouterV8"],
       "@datadog/browser-rum-react/tanstack-router": ["./packages/browser-rum-react/src/entries/tanstackRouter"],
 
       "@datadog/browser-rum-vue": ["./packages/browser-rum-vue/src/entries/main"],


### PR DESCRIPTION
## Motivation

Rum-Events-Format CI is failing on `typecheck` [example](https://github.com/DataDog/rum-events-format/actions/runs/29412491361/job/87352552041), [example2](https://github.com/DataDog/rum-events-format/actions/runs/29405406027/job/87319527633?pr=409).

In CI, the typecheck job does not run `yarn build` first, so `packages/browser-rum-react/cjs` does not exist. 
`TypeScript cannot resolve @datadog/browser-rum-react/react-router-v8`

<img width="1130" height="191" alt="Screenshot 2026-07-15 at 14 48 24" src="https://github.com/user-attachments/assets/b3170e1e-39cf-403d-9dea-b88f6f62629e" />


## Changes

Add the missing react-router-v8 path alias in tsconfig.base.json

## Test instructions

Run locally:
`mv packages/browser-rum-react/cjs/tmp/browser-rum-react-cjs`
`mv packages/browser-rum-react/esm/tmp/browser-rum-react-esm`
`yarn typecheck`
You will see the job fail.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
