### PR TITLE
🐛 Keep primitive values unchanged during sanitization

### DIFF
--- a/packages/browser-core/src/tools/serialisation/sanitize.spec.ts
+++ b/packages/browser-core/src/tools/serialisation/sanitize.spec.ts
@@ -182,6 +182,26 @@ describe('sanitize', () => {
   })
 
   describe('toJson functions handling', () => {
+    it('should not use toJSON functions inherited by primitive values', () => {
+      const stringPrototype = String.prototype as { toJSON?: () => unknown }
+      const originalToJSON = stringPrototype.toJSON
+      const toJSON = jasmine.createSpy().and.returnValue({})
+      stringPrototype.toJSON = toJSON
+      registerCleanupTask(() => {
+        if (originalToJSON) {
+          stringPrototype.toJSON = originalToJSON
+        } else {
+          delete stringPrototype.toJSON
+        }
+      })
+
+      const value = '{"foo":"bar"}'
+
+      expect(sanitize(value)).toBe(value)
+      expect(sanitize({ value })).toEqual({ value })
+      expect(toJSON).not.toHaveBeenCalled()
+    })
+
     it('should use toJSON functions if available on root object', () => {
       const toJSON = jasmine.createSpy('toJSON', () => 'Specific').and.callThrough()
       const obj = { a: 1, b: 2, toJSON }

--- a/packages/browser-core/src/tools/serialisation/sanitize.spec.ts
+++ b/packages/browser-core/src/tools/serialisation/sanitize.spec.ts
@@ -202,6 +202,14 @@ describe('sanitize', () => {
       expect(toJSON).not.toHaveBeenCalled()
     })
 
+    it('should use toJSON methods defined on functions', () => {
+      const toJSON = jasmine.createSpy().and.returnValue({ foo: 'bar' })
+      const value = Object.assign(() => undefined, { toJSON })
+
+      expect(sanitize(value)).toEqual({ foo: 'bar' })
+      expect(toJSON).toHaveBeenCalledTimes(1)
+    })
+
     it('should use toJSON functions if available on root object', () => {
       const toJSON = jasmine.createSpy('toJSON', () => 'Specific').and.callThrough()
       const obj = { a: 1, b: 2, toJSON }

--- a/packages/browser-core/src/tools/serialisation/sanitize.ts
+++ b/packages/browser-core/src/tools/serialisation/sanitize.ts
@@ -252,8 +252,13 @@ function sanitizeEvent(event: Event): SanitizedEvent {
  *
  */
 function tryToApplyToJSON(value: ExtendedContextValue) {
+  // Primitive values are sanitized directly and should not use inherited toJSON methods.
+  if ((typeof value !== 'object' || value === null) && typeof value !== 'function') {
+    return value
+  }
+
   const object = value as ObjectWithToJsonMethod
-  if (object && typeof object.toJSON === 'function') {
+  if (typeof object.toJSON === 'function') {
     try {
       return object.toJSON() as ExtendedContextValue
     } catch {


### PR DESCRIPTION
## Motivation

Primitive values should follow the primitive sanitization path even when their prototypes define `toJSON`.

## Changes

- Ignore inherited `toJSON` methods on primitive values.
- Add unit coverage for root and nested values.

## Test instructions

`yarn test:unit --spec packages/browser-core/src/tools/serialisation/sanitize.spec.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file