### PR TITLE
✨ Enable WebSocket resource tracking behind a beta option

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.9",

--- a/packages/browser-core/src/domain/telemetry/telemetryEvent.types.ts
+++ b/packages/browser-core/src/domain/telemetry/telemetryEvent.types.ts
@@ -483,6 +483,10 @@ export type TelemetryConfigurationEvent = CommonTelemetryProperties & {
        * Whether the beta partial view updates feature is enabled
        */
       beta_enable_view_updates?: boolean
+      /**
+       * Whether the beta track WebSockets feature is enabled
+       */
+      beta_track_web_sockets?: boolean
       [k: string]: unknown
     }
     [k: string]: unknown

--- a/packages/browser-rum-core/src/boot/startRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/startRum.spec.ts
@@ -1,7 +1,15 @@
 import { ONE_SECOND, toServerDuration, relativeNow } from '@datadog/js-core/time'
 import type { Duration } from '@datadog/js-core/time'
 import type { BufferedData, SessionManager } from '@datadog/browser-core'
-import { Observable, findLast, noop, createIdentityEncoder, BufferedObservable } from '@datadog/browser-core'
+import {
+  Observable,
+  findLast,
+  noop,
+  createIdentityEncoder,
+  BufferedObservable,
+  addExperimentalFeatures,
+  ExperimentalFeature,
+} from '@datadog/browser-core'
 import type { Clock, SessionManagerMock } from '@datadog/browser-core/test'
 import {
   createNewEvent,
@@ -232,5 +240,74 @@ describe('view events', () => {
       (serverRumEvent): serverRumEvent is RumViewEvent => serverRumEvent.type === RumEventType.VIEW
     )!
     expect(lastRumViewEvent._dd.sdk_name).toBe('rum')
+  })
+})
+
+describe('WebSocket resource collection activation', () => {
+  it('starts when betaTrackWebSockets is enabled and resources are tracked', () => {
+    const originalWebSocket = window.WebSocket
+    const { stop } = startRumStub(
+      new LifeCycle(),
+      mockRumConfiguration({ trackResources: true, betaTrackWebSockets: true }),
+      createSessionManagerMock(),
+      noop
+    )
+    registerCleanupTask(stop)
+
+    expect(window.WebSocket).not.toBe(originalWebSocket)
+  })
+
+  it('starts when the experimental flag is enabled and resources are tracked', () => {
+    addExperimentalFeatures([ExperimentalFeature.TRACK_WEBSOCKETS])
+    const originalWebSocket = window.WebSocket
+    const { stop } = startRumStub(
+      new LifeCycle(),
+      mockRumConfiguration({ trackResources: true, betaTrackWebSockets: false }),
+      createSessionManagerMock(),
+      noop
+    )
+    registerCleanupTask(stop)
+
+    expect(window.WebSocket).not.toBe(originalWebSocket)
+  })
+
+  it('does not start when neither enablement mechanism is active', () => {
+    const originalWebSocket = window.WebSocket
+    const { stop } = startRumStub(
+      new LifeCycle(),
+      mockRumConfiguration({ trackResources: true, betaTrackWebSockets: false }),
+      createSessionManagerMock(),
+      noop
+    )
+    registerCleanupTask(stop)
+
+    expect(window.WebSocket).toBe(originalWebSocket)
+  })
+
+  it('does not start from the beta option when resource tracking is disabled', () => {
+    const originalWebSocket = window.WebSocket
+    const { stop } = startRumStub(
+      new LifeCycle(),
+      mockRumConfiguration({ trackResources: false, betaTrackWebSockets: true }),
+      createSessionManagerMock(),
+      noop
+    )
+    registerCleanupTask(stop)
+
+    expect(window.WebSocket).toBe(originalWebSocket)
+  })
+
+  it('does not start from the experimental flag when resource tracking is disabled', () => {
+    addExperimentalFeatures([ExperimentalFeature.TRACK_WEBSOCKETS])
+    const originalWebSocket = window.WebSocket
+    const { stop } = startRumStub(
+      new LifeCycle(),
+      mockRumConfiguration({ trackResources: false, betaTrackWebSockets: false }),
+      createSessionManagerMock(),
+      noop
+    )
+    registerCleanupTask(stop)
+
+    expect(window.WebSocket).toBe(originalWebSocket)
   })
 })

--- a/packages/browser-rum-core/src/boot/startRum.ts
+++ b/packages/browser-rum-core/src/boot/startRum.ts
@@ -224,7 +224,10 @@ export function startRumEventCollection(
 
   const vitalCollection = startVitalCollection(lifeCycle, pageStateHistory)
 
-  if (isExperimentalFeatureEnabled(ExperimentalFeature.TRACK_WEBSOCKETS) && configuration.trackResources) {
+  if (
+    configuration.trackResources &&
+    (configuration.betaTrackWebSockets || isExperimentalFeatureEnabled(ExperimentalFeature.TRACK_WEBSOCKETS))
+  ) {
     const webSocketCollection = startWebSocketCollection(lifeCycle, viewHistory, vitalCollection.addDurationVital)
     cleanupTasks.push(webSocketCollection.stop)
   }

--- a/packages/browser-rum-core/src/domain/assembly.spec.ts
+++ b/packages/browser-rum-core/src/domain/assembly.spec.ts
@@ -1,7 +1,7 @@
 import { ONE_MINUTE, relativeToClocks } from '@datadog/js-core/time'
 import type { TimeStamp, ClocksState, RelativeTime } from '@datadog/js-core/time'
 import type { SessionManager } from '@datadog/browser-core'
-import { display, startGlobalContext, startTabContext } from '@datadog/browser-core'
+import { display, ResourceType, startGlobalContext, startTabContext } from '@datadog/browser-core'
 import type { Clock } from '@datadog/browser-core/test'
 import { registerCleanupTask, mockClock, createSessionManagerMock } from '@datadog/browser-core/test'
 import { createRawRumEvent, mockRumConfiguration, mockViewHistory, noopRecorderApi } from '../../test'
@@ -16,6 +16,7 @@ import type { RumConfiguration } from './configuration'
 import type { ViewHistory } from './contexts/viewHistory'
 import { startSessionContext } from './contexts/sessionContext'
 import { createHooks } from './hooks'
+import { WEBSOCKET_CONNECTING_VITAL_NAME } from './resource/webSocketCollection'
 
 describe('rum assembly', () => {
   describe('beforeSend', () => {
@@ -208,6 +209,29 @@ describe('rum assembly', () => {
 
           expect(serverRumEvents[0].context!.foo).toBe('bar')
         })
+
+        it('should allow beforeSend to add protocols to the websocket-connecting vital context', () => {
+          const protocols = ['chat.v1']
+          const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+            partialConfiguration: {
+              beforeSend: (event) => {
+                if (event.type === RumEventType.VITAL && event.vital.name === WEBSOCKET_CONNECTING_VITAL_NAME) {
+                  event.context.protocols = protocols
+                }
+                return true
+              },
+            },
+          })
+
+          notifyRawRumEvent(lifeCycle, {
+            rawRumEvent: createRawRumEvent(RumEventType.VITAL, {
+              vital: { name: WEBSOCKET_CONNECTING_VITAL_NAME },
+              context: { url: 'wss://example.com/socket' },
+            }),
+          })
+
+          expect(serverRumEvents[0].context!.protocols).toEqual(protocols)
+        })
       })
 
       describe('allowed customer provided field', () => {
@@ -353,6 +377,34 @@ describe('rum assembly', () => {
           expect(resource.response!.headers!['x-powered-by']).toBeUndefined()
           expect(resource.response!.headers!['content-type']).toBe('text/html')
         })
+      })
+
+      it('should allow beforeSend to redact the WebSocket resource protocol', () => {
+        const { lifeCycle, serverRumEvents } = setupAssemblyTestWithDefaults({
+          partialConfiguration: {
+            beforeSend: (event) => {
+              if (event.type === RumEventType.RESOURCE) {
+                const webSocket = event.resource.websocket as { protocol?: string } | undefined
+                if (webSocket) {
+                  webSocket.protocol = '[REDACTED]'
+                }
+              }
+              return true
+            },
+          },
+        })
+
+        notifyRawRumEvent(lifeCycle, {
+          rawRumEvent: createRawRumEvent(RumEventType.RESOURCE, {
+            resource: {
+              type: ResourceType.WEBSOCKET,
+              websocket: { protocol: 'credential-bearing-protocol' },
+            },
+          }),
+        })
+
+        const resource = serverRumEvents[0] as RumResourceEvent
+        expect((resource.resource.websocket as { protocol?: string }).protocol).toBe('[REDACTED]')
       })
 
       it('should reject modification of field not sensitive, context or customer provided', () => {

--- a/packages/browser-rum-core/src/domain/assembly.ts
+++ b/packages/browser-rum-core/src/domain/assembly.ts
@@ -42,6 +42,7 @@ const MODIFIABLE_FIELD_PATHS_BY_EVENT: Record<AssembledRumEvent['type'], Modifia
     'resource.request.headers': 'object',
     'resource.response.headers': 'object',
     'resource.websocket.close_reason': 'string',
+    'resource.websocket.protocol': 'string',
   },
   [RumEventType.ACTION]: {
     ...COMMON_MODIFIABLE_FIELD_PATHS,

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -410,6 +410,19 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
+  describe('betaTrackWebSockets', () => {
+    it('defaults to false', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.betaTrackWebSockets).toBeFalse()
+    })
+
+    it('is true when the option is enabled', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, betaTrackWebSockets: true })!
+          .betaTrackWebSockets
+      ).toBeTrue()
+    })
+  })
+
   describe('trackResourceHeaders', () => {
     describe('disabled', () => {
       it('defaults to empty array', () => {
@@ -833,6 +846,7 @@ describe('serializeRumConfiguration', () => {
       propagateTraceBaggage: true,
       trackResourceHeaders: true,
       betaEnableViewUpdates: true,
+      betaTrackWebSockets: true,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -848,7 +862,9 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
             // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
-            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration'
+            // TODO: report `betaTrackWebSockets` as `beta_track_web_sockets` once the generated telemetry
+            // schema declares it; then remove it here and serialize it in `serializeRumConfiguration`.
+            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration' | 'betaTrackWebSockets'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.spec.ts
@@ -846,7 +846,7 @@ describe('serializeRumConfiguration', () => {
       propagateTraceBaggage: true,
       trackResourceHeaders: true,
       betaEnableViewUpdates: true,
-      betaTrackWebSockets: true,
+      betaTrackWebSockets: false,
     }
 
     type MapRumInitConfigurationKey<Key extends string> = Key extends keyof InitConfiguration
@@ -862,9 +862,7 @@ describe('serializeRumConfiguration', () => {
           ? 'track_long_task' // We forgot the s, keeping this for backward compatibility
           : // The following options are not reported as telemetry. Please avoid adding more of them.
             // `remoteConfiguration` is covered by the legacy `remote_configuration_id` field.
-            // TODO: report `betaTrackWebSockets` as `beta_track_web_sockets` once the generated telemetry
-            // schema declares it; then remove it here and serialize it in `serializeRumConfiguration`.
-            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration' | 'betaTrackWebSockets'
+            Key extends 'applicationId' | 'subdomain' | 'remoteConfiguration'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an
@@ -905,6 +903,7 @@ describe('serializeRumConfiguration', () => {
       profiling_sample_rate: 42,
       track_resource_headers: 'default_headers',
       beta_enable_view_updates: true,
+      beta_track_web_sockets: false,
     })
   })
 })

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -352,6 +352,18 @@ export interface RumInitConfiguration extends InitConfiguration {
    * @category Beta
    */
   betaEnableViewUpdates?: boolean | undefined
+
+  /**
+   * Enables collection of WebSocket resource events.
+   *
+   * Warning: enabling this option introduces WebSocket resource events to the `beforeSend` hook.
+   * Their domain context is WebSocket-specific and does not contain the XHR, Fetch, or performance
+   * entry fields available on regular resource events. Narrow the context using the existing
+   * `isManual` and `isWebSocket` discriminants before accessing those fields.
+   *
+   * @category Beta
+   */
+  betaTrackWebSockets?: boolean | undefined
 }
 
 export type HybridInitConfiguration = Omit<RumInitConfiguration, 'applicationId' | 'clientToken'>
@@ -396,6 +408,7 @@ export interface RumConfiguration extends Configuration {
   startSessionReplayRecordingManually: boolean
   trackUserInteractions: boolean
   betaEnableViewUpdates: boolean
+  betaTrackWebSockets: boolean
   trackViewsManually: boolean
   trackResources: boolean
   trackResourceHeaders: MatchHeader[]
@@ -469,6 +482,7 @@ export function validateAndBuildRumConfiguration(
     compressIntakeRequests: !!initConfiguration.compressIntakeRequests,
     trackUserInteractions: !!(initConfiguration.trackUserInteractions ?? true),
     betaEnableViewUpdates: !!initConfiguration.betaEnableViewUpdates,
+    betaTrackWebSockets: !!initConfiguration.betaTrackWebSockets,
     trackViewsManually: !!initConfiguration.trackViewsManually,
     trackResources: !!(initConfiguration.trackResources ?? true),
     trackResourceHeaders: validateAndBuildTrackResourceHeaders(initConfiguration),

--- a/packages/browser-rum-core/src/domain/configuration/configuration.ts
+++ b/packages/browser-rum-core/src/domain/configuration/configuration.ts
@@ -713,6 +713,7 @@ export function serializeRumConfiguration(configuration: RumInitConfiguration) {
     use_remote_configuration_proxy: !!configuration.remoteConfigurationProxy,
     track_resource_headers: getTrackResourceHeadersTelemetryValue(configuration.trackResourceHeaders),
     beta_enable_view_updates: configuration.betaEnableViewUpdates,
+    beta_track_web_sockets: configuration.betaTrackWebSockets,
     ...baseSerializedConfiguration,
   } satisfies RawTelemetryConfiguration
 }

--- a/packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts
@@ -142,6 +142,25 @@ describe('webSocketCollection', () => {
     expect(webSocket.bufferedAmountMax).toBe(bufferedAmount)
   })
 
+  it('removes query parameters from the completed WebSocket URL', () => {
+    const url = 'wss://example.com:8443/path/socket%3Froom?token=secret&tenant=acme'
+
+    startTracking()
+    notifyConnecting(0, url)
+    notifyClosed(10, 1000, 'bye', true)
+
+    expect(completed[0].url).toBe('wss://example.com:8443/path/socket%3Froom')
+  })
+
+  it('keeps the server-negotiated protocol on the completed event', () => {
+    startTracking()
+    notifyConnecting(0, 'wss://example.com/socket', undefined, ['auth-token', 'chat.v1'])
+    notifyOpen(5, 'chat.v1')
+    notifyClosed(10, 1000, 'bye', true)
+
+    expect(completed[0].protocol).toBe('chat.v1')
+  })
+
   it('generates a unique connection_id per connection', () => {
     startTracking()
     notifyConnecting()
@@ -402,7 +421,7 @@ describe('webSocketCollection', () => {
       expect(addDurationVital).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: completed[0].connectionId }))
     })
 
-    it('includes url, protocols, and startViewId in the vital context', () => {
+    it('includes the sanitized URL and startViewId without constructor protocols', () => {
       const startView = 0
       const relativeStartView = clock.relative(startView)
       const viewByRelative: Record<number, ViewHistoryEntry> = {
@@ -413,21 +432,35 @@ describe('webSocketCollection', () => {
         startTime !== undefined ? viewByRelative[startTime as number] : undefined
       )
       const addDurationVital = jasmine.createSpy<(vital: DurationVital) => void>()
-      const url = 'wss://example.com/socket'
-      const protocols = ['chat.v1', 'json']
 
       startTracking(viewHistory, addDurationVital)
-      notifyConnecting(startView, url, undefined, protocols)
+      notifyConnecting(startView, 'wss://example.com/socket?token=secret&tenant=acme', undefined, [
+        'auth-token',
+        'chat.v1',
+      ])
 
       expect(addDurationVital).toHaveBeenCalledOnceWith(
         jasmine.objectContaining({
           context: {
-            url,
-            protocols,
+            url: 'wss://example.com/socket',
             startViewId: 'view-start',
           },
         })
       )
+      const context = addDurationVital.calls.mostRecent().args[0].context
+      expect('protocols' in context).toBeFalse()
+    })
+
+    ;(['auth-token', ['auth-token', 'chat.v1']] as Array<string | string[]>).forEach((protocols) => {
+      it(`does not include constructor protocols in the vital context when provided as ${typeof protocols === 'string' ? 'a string' : 'an array'}`, () => {
+        const addDurationVital = jasmine.createSpy<(vital: DurationVital) => void>()
+        startTracking(mockViewHistory(), addDurationVital)
+
+        notifyConnecting(0, 'wss://example.com/socket', undefined, protocols)
+
+        const context = addDurationVital.calls.mostRecent().args[0].context
+        expect('protocols' in context).toBeFalse()
+      })
     })
   })
 

--- a/packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts
+++ b/packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts
@@ -9,12 +9,19 @@ import type { ViewHistoryEntry } from '../contexts/viewHistory'
 import { LifeCycle, LifeCycleEventType } from '../lifeCycle'
 import type { DurationVital } from '../vital/vitalCollection'
 import type { WebSocketCompleteEvent } from './webSocketCollection'
-import { startWebSocketCollection, trackWebSocket, WEBSOCKET_CONNECTING_VITAL_NAME } from './webSocketCollection'
+import {
+  startWebSocketCollection,
+  trackWebSocket,
+  WEBSOCKET_CLOSED_VITAL_NAME,
+  WEBSOCKET_CONNECTING_VITAL_NAME,
+} from './webSocketCollection'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 describe('webSocketCollection', () => {
   let lifeCycle: LifeCycle
   let wsObservable: Observable<WebSocketContext>
-  let completed: WebSocketCompleteEvent[]
+  let webSocketCompleteEvents: WebSocketCompleteEvent[]
   let wsInstance: WebSocket
   let clock: Clock
 
@@ -22,10 +29,10 @@ describe('webSocketCollection', () => {
     clock = mockClock()
     lifeCycle = new LifeCycle()
     wsObservable = new Observable<WebSocketContext>()
-    completed = []
+    webSocketCompleteEvents = []
     wsInstance = {} as WebSocket
     lifeCycle.subscribe(LifeCycleEventType.WEBSOCKET_COMPLETED, (webSocket) => {
-      completed.push(webSocket)
+      webSocketCompleteEvents.push(webSocket)
     })
   })
 
@@ -92,23 +99,23 @@ describe('webSocketCollection', () => {
       notifyConnecting()
       notifyOpen(10)
       notifyClosed(40, 1000, 'bye', true)
-      expect(completed[0].handshakeSucceeded).toBeTrue()
+      expect(webSocketCompleteEvents[0].handshakeSucceeded).toBeTrue()
 
       notifyConnecting()
       notifyOpen(10)
       tracker.flushOpenConnections('session_end')
-      expect(completed[1].handshakeSucceeded).toBeTrue()
+      expect(webSocketCompleteEvents[1].handshakeSucceeded).toBeTrue()
     })
 
     it('is false when the open event never fired before completion', () => {
       const tracker = startTracking()
       notifyConnecting()
       notifyClosed(25, 1006, 'abnormal', false)
-      expect(completed[0].handshakeSucceeded).toBeFalse()
+      expect(webSocketCompleteEvents[0].handshakeSucceeded).toBeFalse()
 
       notifyConnecting()
       tracker.flushOpenConnections('session_end')
-      expect(completed[1].handshakeSucceeded).toBeFalse()
+      expect(webSocketCompleteEvents[1].handshakeSucceeded).toBeFalse()
     })
   })
 
@@ -128,8 +135,8 @@ describe('webSocketCollection', () => {
     notifyMessageOut(30, messageOutSize, bufferedAmount)
     notifyClosed(40, closeCode, closeReason, true)
 
-    expect(completed.length).toBe(1)
-    const webSocket = completed[0]
+    expect(webSocketCompleteEvents.length).toBe(1)
+    const webSocket = webSocketCompleteEvents[0]
 
     expect(webSocket.trackingEndReason).toBe('close_event')
     expect(webSocket.closeCode).toBe(closeCode)
@@ -149,7 +156,7 @@ describe('webSocketCollection', () => {
     notifyConnecting(0, url)
     notifyClosed(10, 1000, 'bye', true)
 
-    expect(completed[0].url).toBe('wss://example.com:8443/path/socket%3Froom')
+    expect(webSocketCompleteEvents[0].url).toBe('wss://example.com:8443/path/socket%3Froom')
   })
 
   it('keeps the server-negotiated protocol on the completed event', () => {
@@ -158,20 +165,20 @@ describe('webSocketCollection', () => {
     notifyOpen(5, 'chat.v1')
     notifyClosed(10, 1000, 'bye', true)
 
-    expect(completed[0].protocol).toBe('chat.v1')
+    expect(webSocketCompleteEvents[0].protocol).toBe('chat.v1')
   })
 
   it('generates a unique connection_id per connection', () => {
     startTracking()
     notifyConnecting()
     notifyClosed(1, 1000, 'reason_a', true)
-    const firstId = completed[0].connectionId
+    const firstId = webSocketCompleteEvents[0].connectionId
 
     wsInstance = {} as WebSocket
     notifyConnecting()
     notifyClosed(1, 1000, 'reason_b', true)
 
-    expect(completed[1].connectionId).not.toBe(firstId)
+    expect(webSocketCompleteEvents[1].connectionId).not.toBe(firstId)
   })
 
   it('tracks overlapping connections independently with unique connection_ids', () => {
@@ -199,24 +206,26 @@ describe('webSocketCollection', () => {
     wsInstance = wsA
     notifyClosed(30, 1000, 'bye-a', true)
 
-    expect(completed.length).toBe(1)
-    expect(completed[0].url).toBe(urlA)
-    expect(completed[0].messagesIn).toEqual({ count: 1, size: 10 })
-    expect(completed[0].trackingEndReason).toBe('close_event')
+    expect(webSocketCompleteEvents.length).toBe(1)
+    expect(webSocketCompleteEvents[0].url).toBe(urlA)
+    expect(webSocketCompleteEvents[0].messagesIn).toEqual({ count: 1, size: 10 })
+    expect(webSocketCompleteEvents[0].trackingEndReason).toBe('close_event')
 
     wsInstance = wsB
     notifyMessageOut(35, 5)
     notifyClosed(40, 1000, 'bye-b', true)
 
-    expect(completed.length).toBe(2)
-    expect(completed[1].url).toBe(urlB)
-    expect(completed[1].messagesIn).toEqual({ count: 1, size: 20 })
-    expect(completed[1].messagesOut).toEqual({ count: 1, size: 5 })
-    expect(completed[1].trackingEndReason).toBe('close_event')
-    expect(completed[1].connectionId).not.toBe(completed[0].connectionId)
+    expect(webSocketCompleteEvents.length).toBe(2)
+    expect(webSocketCompleteEvents[1].url).toBe(urlB)
+    expect(webSocketCompleteEvents[1].messagesIn).toEqual({ count: 1, size: 20 })
+    expect(webSocketCompleteEvents[1].messagesOut).toEqual({ count: 1, size: 5 })
+    expect(webSocketCompleteEvents[1].trackingEndReason).toBe('close_event')
+    expect(webSocketCompleteEvents[1].connectionId).not.toBe(webSocketCompleteEvents[0].connectionId)
 
-    expect(completed[0].startClocks.relative).toBeLessThan(completed[1].startClocks.relative)
-    expect(completed[1].endClocks.relative).toBeGreaterThan(completed[0].endClocks.relative)
+    expect(webSocketCompleteEvents[0].startClocks.relative).toBeLessThan(
+      webSocketCompleteEvents[1].startClocks.relative
+    )
+    expect(webSocketCompleteEvents[1].endClocks.relative).toBeGreaterThan(webSocketCompleteEvents[0].endClocks.relative)
   })
 
   it('records firstMessageInOffset / firstMessageOutOffset as offsets from open', () => {
@@ -232,7 +241,7 @@ describe('webSocketCollection', () => {
     notifyMessageOut(firstMessageOutAt, 1)
     notifyClosed(30, 1000, 'bye', true)
 
-    const webSocket = completed[0]
+    const webSocket = webSocketCompleteEvents[0]
     expect(webSocket.firstMessageInOffset).toBe((firstMessageInAt - openAt) as Duration)
     expect(webSocket.firstMessageOutOffset).toBe((firstMessageOutAt - openAt) as Duration)
   })
@@ -246,7 +255,7 @@ describe('webSocketCollection', () => {
     notifyMessageIn(75, 1) // gap 25
     notifyClosed(100, 1000, 'bye', true)
 
-    expect(completed[0].longestInboundSilence).toBe(30 as Duration)
+    expect(webSocketCompleteEvents[0].longestInboundSilence).toBe(30 as Duration)
   })
 
   it('ignores message-out when computing longestInboundSilence', () => {
@@ -258,7 +267,7 @@ describe('webSocketCollection', () => {
     notifyMessageIn(130, 1) // gap from last in (20) to 130
     notifyClosed(200, 1000, 'bye', true)
 
-    expect(completed[0].longestInboundSilence).toBe(110 as Duration)
+    expect(webSocketCompleteEvents[0].longestInboundSilence).toBe(110 as Duration)
   })
 
   it('records inboundIdleDurationBeforeClose from last message-in to close', () => {
@@ -271,7 +280,7 @@ describe('webSocketCollection', () => {
     notifyMessageIn(lastMessageInAt, 1)
     notifyClosed(closeAt, 1000, 'bye', true)
 
-    expect(completed[0].inboundIdleDurationBeforeClose).toBe((closeAt - lastMessageInAt) as Duration)
+    expect(webSocketCompleteEvents[0].inboundIdleDurationBeforeClose).toBe((closeAt - lastMessageInAt) as Duration)
   })
 
   it('leaves inboundIdleDurationBeforeClose and lastMessageInAt undefined when no message was received', () => {
@@ -281,8 +290,8 @@ describe('webSocketCollection', () => {
     notifyMessageOut(30, 1)
     notifyClosed(50, 1000, 'bye', true)
 
-    expect(completed[0].lastMessageInAt).toBeUndefined()
-    expect(completed[0].inboundIdleDurationBeforeClose).toBeUndefined()
+    expect(webSocketCompleteEvents[0].lastMessageInAt).toBeUndefined()
+    expect(webSocketCompleteEvents[0].inboundIdleDurationBeforeClose).toBeUndefined()
   })
 
   it('records setupDuration as elapsed time from connecting to open', () => {
@@ -297,7 +306,7 @@ describe('webSocketCollection', () => {
     notifyOpen(openAt, '', openClocks)
     notifyClosed(40, 1000, 'bye', true)
 
-    expect(completed[0].setupDuration).toBe(expectedSetupDuration)
+    expect(webSocketCompleteEvents[0].setupDuration).toBe(expectedSetupDuration)
   })
 
   it('records setupDuration as elapsed time from connecting to close when open never fires', () => {
@@ -313,7 +322,7 @@ describe('webSocketCollection', () => {
     notifyConnecting(startAt, 'wss://example.com/socket', startClocks)
     notifyClosed(closeAt, closeCode, closeReason, false, closeClocks)
 
-    expect(completed[0].setupDuration).toBe(expectedSetupDuration)
+    expect(webSocketCompleteEvents[0].setupDuration).toBe(expectedSetupDuration)
   })
 
   it('records setupDuration on session_end flush when the connection never opened', () => {
@@ -321,7 +330,7 @@ describe('webSocketCollection', () => {
     notifyConnecting()
     tracker.flushOpenConnections('session_end')
 
-    const webSocket = completed[0]
+    const webSocket = webSocketCompleteEvents[0]
     expect(webSocket.setupDuration).toBe(elapsed(webSocket.startClocks.timeStamp, webSocket.endClocks.timeStamp))
   })
 
@@ -336,7 +345,7 @@ describe('webSocketCollection', () => {
     notifyMessageOut(40, 1, 50)
     notifyClosed(50, 1000, 'bye', true)
 
-    expect(completed[0].bufferedAmountMax).toBe(peakBufferedAmount)
+    expect(webSocketCompleteEvents[0].bufferedAmountMax).toBe(peakBufferedAmount)
   })
 
   it('captures startViewId and endViewId from viewHistory', () => {
@@ -356,7 +365,7 @@ describe('webSocketCollection', () => {
     notifyConnecting()
     notifyClosed(startViewB, 1000, 'bye', true)
 
-    const webSocket = completed[0]
+    const webSocket = webSocketCompleteEvents[0]
     expect(webSocket.startViewId).toBe('view-A')
     expect(webSocket.endViewId).toBe('view-B')
   })
@@ -369,12 +378,12 @@ describe('webSocketCollection', () => {
 
     tracker.flushOpenConnections('session_end')
 
-    expect(completed.length).toBe(1)
-    expect(completed[0].trackingEndReason).toBe('session_end')
-    expect(completed[0].handshakeSucceeded).toBeTrue()
-    expect(completed[0].closeCode).toBeUndefined()
-    expect(completed[0].closeReason).toBeUndefined()
-    expect(completed[0].wasClean).toBeUndefined()
+    expect(webSocketCompleteEvents.length).toBe(1)
+    expect(webSocketCompleteEvents[0].trackingEndReason).toBe('session_end')
+    expect(webSocketCompleteEvents[0].handshakeSucceeded).toBeTrue()
+    expect(webSocketCompleteEvents[0].closeCode).toBeUndefined()
+    expect(webSocketCompleteEvents[0].closeReason).toBeUndefined()
+    expect(webSocketCompleteEvents[0].wasClean).toBeUndefined()
   })
 
   it('does not finalize twice when close arrives after flushOpenConnections', () => {
@@ -384,8 +393,8 @@ describe('webSocketCollection', () => {
     tracker.flushOpenConnections('session_end')
     notifyClosed(20, 1000, 'bye', true)
 
-    expect(completed.length).toBe(1)
-    expect(completed[0].trackingEndReason).toBe('session_end')
+    expect(webSocketCompleteEvents.length).toBe(1)
+    expect(webSocketCompleteEvents[0].trackingEndReason).toBe('session_end')
   })
 
   it('stop() unsubscribes from the observable and ignores further events', () => {
@@ -394,7 +403,7 @@ describe('webSocketCollection', () => {
     tracker.stop()
     notifyClosed(20, 1000, 'bye', true)
 
-    expect(completed.length).toBe(0)
+    expect(webSocketCompleteEvents.length).toBe(0)
   })
 
   describe('websocket-connecting vital', () => {
@@ -412,16 +421,21 @@ describe('webSocketCollection', () => {
       )
     })
 
-    it('uses the same id as the subsequent WEBSOCKET_COMPLETED connectionId', () => {
+    it('uses a fresh UUID as the vital id and the connectionId in the context', () => {
       const addDurationVital = jasmine.createSpy<(vital: DurationVital) => void>()
       startTracking(mockViewHistory(), addDurationVital)
       notifyConnecting()
       notifyClosed(1, 1000, 'bye', true)
 
-      expect(addDurationVital).toHaveBeenCalledOnceWith(jasmine.objectContaining({ id: completed[0].connectionId }))
+      const vital = addDurationVital.calls.first().args[0]
+      expect(vital.id).not.toBe(webSocketCompleteEvents[0].connectionId)
+      expect(vital.id).toMatch(UUID_PATTERN)
+      expect(vital.context).toEqual(
+        jasmine.objectContaining({ connection_id: webSocketCompleteEvents[0].connectionId })
+      )
     })
 
-    it('includes the sanitized URL and startViewId without constructor protocols', () => {
+    it('includes the sanitized URL and connection_id, without constructor protocols', () => {
       const startView = 0
       const relativeStartView = clock.relative(startView)
       const viewByRelative: Record<number, ViewHistoryEntry> = {
@@ -438,17 +452,13 @@ describe('webSocketCollection', () => {
         'auth-token',
         'chat.v1',
       ])
+      notifyClosed(1, 1000, 'bye', true)
 
-      expect(addDurationVital).toHaveBeenCalledOnceWith(
-        jasmine.objectContaining({
-          context: {
-            url: 'wss://example.com/socket',
-            startViewId: 'view-start',
-          },
-        })
-      )
-      const context = addDurationVital.calls.mostRecent().args[0].context
-      expect('protocols' in context).toBeFalse()
+      const vital = addDurationVital.calls.first().args[0]
+      expect(vital.context).toEqual({
+        url: 'wss://example.com/socket',
+        connection_id: webSocketCompleteEvents[0].connectionId,
+      })
     })
 
     ;(['auth-token', ['auth-token', 'chat.v1']] as Array<string | string[]>).forEach((protocols) => {
@@ -461,6 +471,48 @@ describe('webSocketCollection', () => {
         const context = addDurationVital.calls.mostRecent().args[0].context
         expect('protocols' in context).toBeFalse()
       })
+    })
+  })
+
+  describe('websocket-closed vital', () => {
+    it('emits a duration-0 vital at close time on a close event', () => {
+      const addDurationVital = jasmine.createSpy<(vital: DurationVital) => void>()
+      startTracking(mockViewHistory(), addDurationVital)
+      notifyConnecting()
+      notifyClosed(40, 1000, 'bye', true)
+
+      const connectingVital = addDurationVital.calls.argsFor(0)[0]
+      const closedVital = addDurationVital.calls.argsFor(1)[0]
+
+      expect(closedVital.name).toBe(WEBSOCKET_CLOSED_VITAL_NAME)
+      expect(closedVital.type).toBe(VitalType.DURATION)
+      expect(closedVital.duration).toBe(0 as Duration)
+      expect(closedVital.startClocks).toEqual(webSocketCompleteEvents[0].endClocks)
+      expect(closedVital.context).toEqual({
+        url: webSocketCompleteEvents[0].url,
+        connection_id: webSocketCompleteEvents[0].connectionId,
+      })
+      expect(closedVital.context.connection_id).toBe(connectingVital.context.connection_id)
+    })
+
+    it('emits a duration-0 vital at flush time on a session_end flush', () => {
+      const addDurationVital = jasmine.createSpy<(vital: DurationVital) => void>()
+      const tracker = startTracking(mockViewHistory(), addDurationVital)
+      notifyConnecting()
+      tracker.flushOpenConnections('session_end')
+
+      const connectingVital = addDurationVital.calls.argsFor(0)[0]
+      const closedVital = addDurationVital.calls.argsFor(1)[0]
+
+      expect(closedVital.name).toBe(WEBSOCKET_CLOSED_VITAL_NAME)
+      expect(closedVital.type).toBe(VitalType.DURATION)
+      expect(closedVital.duration).toBe(0 as Duration)
+      expect(closedVital.startClocks).toEqual(webSocketCompleteEvents[0].endClocks)
+      expect(closedVital.context).toEqual({
+        url: webSocketCompleteEvents[0].url,
+        connection_id: webSocketCompleteEvents[0].connectionId,
+      })
+      expect(closedVital.context.connection_id).toBe(connectingVital.context.connection_id)
     })
   })
 
@@ -520,12 +572,12 @@ describe('webSocketCollection', () => {
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
 
-      expect(completed.length).toBe(1)
-      expect(completed[0].trackingEndReason).toBe('session_end')
-      expect(completed[0].handshakeSucceeded).toBeFalse()
-      expect(completed[0].closeCode).toBeUndefined()
-      expect(completed[0].closeReason).toBeUndefined()
-      expect(completed[0].wasClean).toBeUndefined()
+      expect(webSocketCompleteEvents.length).toBe(1)
+      expect(webSocketCompleteEvents[0].trackingEndReason).toBe('session_end')
+      expect(webSocketCompleteEvents[0].handshakeSucceeded).toBeFalse()
+      expect(webSocketCompleteEvents[0].closeCode).toBeUndefined()
+      expect(webSocketCompleteEvents[0].closeReason).toBeUndefined()
+      expect(webSocketCompleteEvents[0].wasClean).toBeUndefined()
     })
 
     it('ignores further WebSocket events from the same instance after stop()', () => {
@@ -533,11 +585,11 @@ describe('webSocketCollection', () => {
       notifyConnecting()
       collection.stop()
 
-      const eventCountAfterStop = completed.length
+      const eventCountAfterStop = webSocketCompleteEvents.length
 
       notifyClosed(1000, 1000, 'bye', true)
 
-      expect(completed.length).toBe(eventCountAfterStop)
+      expect(webSocketCompleteEvents.length).toBe(eventCountAfterStop)
     })
 
     it('ignores further WebSocket events from the same instance after the session expires', () => {
@@ -548,16 +600,16 @@ describe('webSocketCollection', () => {
 
       lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED)
 
-      expect(completed.length).toBe(1)
-      expect(completed[0].trackingEndReason).toBe('session_end')
-      expect(completed[0].messagesOut).toEqual({ count: 1, size: 10 })
+      expect(webSocketCompleteEvents.length).toBe(1)
+      expect(webSocketCompleteEvents[0].trackingEndReason).toBe('session_end')
+      expect(webSocketCompleteEvents[0].messagesOut).toEqual({ count: 1, size: 10 })
 
       notifyMessageOut(40, 7)
       notifyClosed(50, 1000, 'bye', true)
 
-      expect(completed.length).toBe(1)
-      expect(completed[0].trackingEndReason).toBe('session_end')
-      expect(completed[0].messagesOut).toEqual({ count: 1, size: 10 })
+      expect(webSocketCompleteEvents.length).toBe(1)
+      expect(webSocketCompleteEvents[0].trackingEndReason).toBe('session_end')
+      expect(webSocketCompleteEvents[0].messagesOut).toEqual({ count: 1, size: 10 })
     })
   })
 })

--- a/packages/browser-rum-core/src/domain/resource/webSocketCollection.ts
+++ b/packages/browser-rum-core/src/domain/resource/webSocketCollection.ts
@@ -10,6 +10,7 @@ import { LifeCycleEventType } from '../lifeCycle'
 import type { DurationVital } from '../vital/vitalCollection'
 
 export const WEBSOCKET_CONNECTING_VITAL_NAME = 'websocket-connecting'
+export const WEBSOCKET_CLOSED_VITAL_NAME = 'websocket-closed'
 
 export type WebSocketTrackingEndReason = 'close_event' | 'session_end'
 
@@ -92,6 +93,27 @@ export function trackWebSocket(
 ): WebSocketConnectionTracker {
   const webSocketRegistry = new Map<WebSocket, WebSocketConnection>()
 
+  function completeConnection(
+    webSocket: WebSocketConnection,
+    endInfo: { at: ClocksState; code?: number; reason?: string; wasClean?: boolean },
+    reason: WebSocketTrackingEndReason
+  ) {
+    const completedEvent = buildCompletedEvent(webSocket, endInfo, reason, viewHistory)
+    lifeCycle.notify(LifeCycleEventType.WEBSOCKET_COMPLETED, completedEvent)
+
+    addDurationVital({
+      id: generateUUID(),
+      name: WEBSOCKET_CLOSED_VITAL_NAME,
+      type: VitalType.DURATION,
+      startClocks: completedEvent.endClocks,
+      duration: 0 as Duration,
+      context: sanitize({
+        url: completedEvent.url,
+        connection_id: completedEvent.connectionId,
+      }),
+    })
+  }
+
   const subscription = webSocketContextObservable.subscribe((context) => {
     switch (context.state) {
       case 'connecting': {
@@ -112,14 +134,14 @@ export function trackWebSocket(
         webSocketRegistry.set(context.instance, webSocket)
 
         addDurationVital({
-          id: connectionId,
+          id: generateUUID(),
           name: WEBSOCKET_CONNECTING_VITAL_NAME,
           type: VitalType.DURATION,
           startClocks: context.startClocks,
           duration: 0 as Duration,
           context: sanitize({
             url,
-            startViewId,
+            connection_id: connectionId,
           }),
         })
         return
@@ -175,10 +197,7 @@ export function trackWebSocket(
 
         webSocketRegistry.delete(context.instance)
 
-        lifeCycle.notify(
-          LifeCycleEventType.WEBSOCKET_COMPLETED,
-          buildCompletedEvent(webSocket, context, 'close_event', viewHistory)
-        )
+        completeConnection(webSocket, context, 'close_event')
 
         return
       }
@@ -190,10 +209,7 @@ export function trackWebSocket(
       const at = clocksNow()
 
       webSocketRegistry.forEach((webSocket) => {
-        lifeCycle.notify(
-          LifeCycleEventType.WEBSOCKET_COMPLETED,
-          buildCompletedEvent(webSocket, { at }, reason, viewHistory)
-        )
+        completeConnection(webSocket, { at }, reason)
       })
 
       webSocketRegistry.clear()

--- a/packages/browser-rum-core/src/domain/resource/webSocketCollection.ts
+++ b/packages/browser-rum-core/src/domain/resource/webSocketCollection.ts
@@ -2,6 +2,7 @@ import type { Observable, WebSocketContext } from '@datadog/browser-core'
 import { generateUUID, initWebSocketObservable, sanitize } from '@datadog/browser-core'
 import type { ClocksState, Duration, TimeStamp } from '@datadog/js-core/time'
 import { clocksNow, elapsed } from '@datadog/js-core/time'
+import { buildUrl } from '@datadog/js-core/util'
 import { VitalType } from '../../rawRumEvent.types'
 import type { ViewHistory } from '../contexts/viewHistory'
 import type { LifeCycle } from '../lifeCycle'
@@ -96,10 +97,11 @@ export function trackWebSocket(
       case 'connecting': {
         const connectionId = generateUUID()
         const startViewId = viewHistory.findView(context.startClocks.relative)?.id
+        const url = sanitizeWebSocketUrl(context.url)
         const webSocket: WebSocketConnection = {
           webSocket: context.instance,
           connectionId,
-          url: context.url,
+          url,
           startClocks: context.startClocks,
           startViewId,
           messagesIn: { count: 0, size: 0 },
@@ -116,8 +118,7 @@ export function trackWebSocket(
           startClocks: context.startClocks,
           duration: 0 as Duration,
           context: sanitize({
-            url: context.url,
-            protocols: context.protocols,
+            url,
             startViewId,
           }),
         })
@@ -202,6 +203,12 @@ export function trackWebSocket(
       webSocketRegistry.clear()
     },
   }
+}
+
+function sanitizeWebSocketUrl(url: string) {
+  const sanitizedUrl = buildUrl(url)
+  sanitizedUrl.search = ''
+  return sanitizedUrl.href
 }
 
 function recordMessageTiming(webSocket: WebSocketConnection, at: ClocksState, direction: 'in' | 'out') {

--- a/test/e2e/scenario/rum/websockets.scenario.ts
+++ b/test/e2e/scenario/rum/websockets.scenario.ts
@@ -20,7 +20,7 @@ type RumResourceEventWithWebSocket = RumResourceEvent & {
 }
 
 test.describe('rum websockets', () => {
-  createTest('collect websocket-connecting vital and websocket resource when the connection closes')
+  createTest('collect websocket vitals and websocket resource when the connection closes')
     .withRum({ enableExperimentalFeatures: ['track_websockets'] })
     .withBody(WebSocketPage.testBody())
     .run(async ({ intakeRegistry, flushEvents, page }) => {
@@ -35,12 +35,17 @@ test.describe('rum websockets', () => {
       const connectingVital = intakeRegistry.rumVitalEvents.find((e) => e.vital.name === 'websocket-connecting')
       expect(connectingVital).toBeDefined()
 
+      const closedVital = intakeRegistry.rumVitalEvents.find((e) => e.vital.name === 'websocket-closed')
+      expect(closedVital).toBeDefined()
+
       const rumEvent = getLastRumResourceEventWithWebSocket(intakeRegistry.rumResourceEvents)
       expect(rumEvent).toBeDefined()
 
       const { websocket } = rumEvent!.resource
 
-      expect(websocket.connection_id).toBe(connectingVital!.vital.id)
+      expect(websocket.connection_id).toBe(connectingVital!.context!.connection_id)
+      expect(closedVital!.context!.connection_id).toBe(websocket.connection_id)
+      expect(closedVital!.date).toBe(websocket.end_time)
       expect(websocket.tracking_end_reason).toBe('close_event')
       expect(websocket.messages_out.count).toBe(1)
       expect(websocket.messages_out.size).toBe(DEFAULT_WS_OUT_MESSAGE.length)
@@ -165,6 +170,9 @@ test.describe('rum websockets', () => {
 
       const connectingVital = intakeRegistry.rumVitalEvents.find((e) => e.vital.name === 'websocket-connecting')
       expect(connectingVital).toBeUndefined()
+
+      const closedVital = intakeRegistry.rumVitalEvents.find((e) => e.vital.name === 'websocket-closed')
+      expect(closedVital).toBeUndefined()
 
       const wsResources = getWebSocketResources(intakeRegistry.rumResourceEvents)
       expect(wsResources).toHaveLength(0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,10 +701,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4"
-  checksum: 10c0/831a49695bbe7908a2e7a95b7359ee54adaafd485eae5b3910f04c273b4953efe15ff2d4f66517bdced1c72363eebba53208bd1bd61fc35edd1977f1545dd285
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3"
+  checksum: 10c0/b8306ceac7e936a517dc2cce03d9c6e0b8db9206433214d36eeae0d2e2e7089feec8c4f7c5f077eb4edf45d8abbbbbaa45808fc0a52b46c6f711e0d924221744
   languageName: node
   linkType: hard
 
@@ -6272,7 +6272,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=e18f1d3b6a018f00061239bf14fbfb748c9538a3"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.9"


### PR DESCRIPTION
## Motivation

WebSocket resource tracking was previously gated behind an internal experimental feature flag only. We want to let interested customers opt in directly via configuration while the feature is still stabilizing, ahead of general availability.

Some web applications might use the query string of the WebSocket URL to pass authentication tokens or smuggle it in the `Sec-WebSocket-Protocol` header via the `protocols` param. The changes also include some safe guards: don't capture the query string of WebSocket URLs, nor the `protocols` param, by default we still capture the selected protocol from the server (unlikely that it contains sensitive data), but this can be redacted by the host application if needed.

Note: PR https://github.com/DataDog/browser-sdk/pull/4903 was merged into this one to introduce a `websocket-closed` vital events when the connection terminates.

## Changes

- Add a `betaTrackWebSockets` init configuration option that enables WebSocket resource collection (in addition to the existing `TRACK_WEBSOCKETS` experimental flag).
- Wire up `startRumEventCollection` to start the WebSocket collection when either the beta option or the experimental flag is enabled, provided `trackResources` is also on.
- Sanitize WebSocket metadata sent to the backend/`beforeSend`:
  - Strip query parameters from the WebSocket URL before it's used for the connection URL and the `websocket-connecting` vital context.
  - Drop constructor-provided `protocols` from the vital context (only the server-negotiated protocol is now surfaced on the completed resource event).
  - Make `resource.websocket.protocol` modifiable from `beforeSend` (alongside the existing `resource.websocket.close_reason`) so customers can redact it if needed.

## Test instructions

- `yarn test:unit --spec packages/browser-rum-core/src/boot/startRum.spec.ts`
- `yarn test:unit --spec packages/browser-rum-core/src/domain/assembly.spec.ts`
- `yarn test:unit --spec packages/browser-rum-core/src/domain/configuration/configuration.spec.ts`
- `yarn test:unit --spec packages/browser-rum-core/src/domain/resource/webSocketCollection.spec.ts`
- Manually: init RUM with `betaTrackWebSockets: true` and `trackResources: true`, open a WebSocket connection with query params/protocols in the URL, and confirm the emitted resource/vital events have a sanitized URL and no leaked protocols/credentials.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file