### PR TITLE
🐛 Avoid BigInt exponentiation in sampling

### DIFF
--- a/packages/browser-core/src/domain/sampler.ts
+++ b/packages/browser-core/src/domain/sampler.ts
@@ -59,7 +59,8 @@ export function sampleUsingKnuthFactor(identifier: bigint, sampleRate: number): 
   // numbers in the end, and Number(2n**64n-1n) === Number(2n**64n).
   const knuthFactor = 1111111111111111111n
   // Avoid `**` as it can be downleveled to `Math.pow`, which does not support BigInts.
-  const twoPow64 = BigInt('0x10000000000000000')
+  // eslint-disable-next-line no-bitwise
+  const twoPow64 = 1n << 64n
   const hash = (identifier * knuthFactor) % twoPow64
   return Number(hash) <= (sampleRate / 100) * Number(twoPow64)
 }

--- a/packages/browser-core/src/domain/sampler.ts
+++ b/packages/browser-core/src/domain/sampler.ts
@@ -58,7 +58,8 @@ export function sampleUsingKnuthFactor(identifier: bigint, sampleRate: number): 
   // BigInt arithmetic to write. In practice this does not matter, as we are using floating point
   // numbers in the end, and Number(2n**64n-1n) === Number(2n**64n).
   const knuthFactor = 1111111111111111111n
-  const twoPow64 = 2n ** 64n
+  // Avoid `**` as it can be downleveled to `Math.pow`, which does not support BigInts.
+  const twoPow64 = BigInt('0x10000000000000000')
   const hash = (identifier * knuthFactor) % twoPow64
   return Number(hash) <= (sampleRate / 100) * Number(twoPow64)
 }


### PR DESCRIPTION
## Motivation

Some build targets downlevel BigInt exponentiation to `Math.pow`, which does not support BigInt operands and can make sampling fail at runtime.

## Changes

Replace the exponentiation with an equivalent BigInt constant.

## Test instructions

Run `yarn test:unit --spec packages/browser-core/src/domain/sampler.spec.ts`.

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file
