### PR TITLE
🐛 Update session replay sandbox URL and cookie name in developer extension

### DIFF
--- a/developer-extension/src/common/packagesUrlConstants.ts
+++ b/developer-extension/src/common/packagesUrlConstants.ts
@@ -3,11 +3,8 @@ export const DEV_LOGS_URL = `${DEV_SERVER_ORIGIN}/datadog-logs.js`
 export const DEV_RUM_SLIM_URL = `${DEV_SERVER_ORIGIN}/datadog-rum-slim.js`
 export const DEV_RUM_URL = `${DEV_SERVER_ORIGIN}/datadog-rum.js`
 
-// To follow web-ui development, this version will need to be manually updated from time to time.
-// When doing that, be sure to update types and implement any protocol changes.
-export const PROD_REPLAY_SANDBOX_VERSION = '0.138.0'
 export const PROD_REPLAY_SANDBOX_ORIGIN = 'https://session-replay-datadoghq.com'
-export const PROD_REPLAY_SANDBOX_URL = `${PROD_REPLAY_SANDBOX_ORIGIN}/${PROD_REPLAY_SANDBOX_VERSION}/index.html`
+export const PROD_REPLAY_SANDBOX_URL = `${PROD_REPLAY_SANDBOX_ORIGIN}/static-app/index.html`
 
 export const DEV_REPLAY_SANDBOX_ORIGIN = 'https://localhost:8443'
-export const DEV_REPLAY_SANDBOX_URL = `${DEV_REPLAY_SANDBOX_ORIGIN}/static-apps/replay-sandbox/public/index.html`
+export const DEV_REPLAY_SANDBOX_URL = `${DEV_REPLAY_SANDBOX_ORIGIN}/static-apps/session-replay-sandbox/public/index.html`

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -72,15 +72,17 @@ async function getInfos(): Promise<SdkInfos> {
           }))
         }
 
-        const cookieRawValue = document.cookie
-          .split(';')
-          .map(cookie => cookie.match(/(\\S*?)=(.*)/)?.slice(1) || [])
-          .find(([name, _]) => name === '_dd_s')
-          ?.[1]
-
+        const cookies = new Map(
+          document.cookie
+            .split(';')
+            .map(cookie => cookie.match(/(\\S*?)=(.*)/)?.slice(1))
+            .filter(cookie => cookie !== undefined)
+        );
+        const cookieRawValue = cookies.get('_dd_s_v2') ?? cookies.get('_dd_s');
         const cookie = cookieRawValue && Object.fromEntries(
           cookieRawValue.split('&').map(value => value.split('='))
         )
+
         const rum = window.DD_RUM && {
           version: window.DD_RUM?.version,
           config: serializeWithFunctions(window.DD_RUM?.getInitConfiguration?.()),
@@ -88,12 +90,14 @@ async function getInfos(): Promise<SdkInfos> {
           globalContext: window.DD_RUM?.getGlobalContext?.(),
           user: window.DD_RUM?.getUser?.(),
         }
+
         const logs = window.DD_LOGS && {
           version: window.DD_LOGS?.version,
           config: serializeWithFunctions(window.DD_LOGS?.getInitConfiguration?.()),
           globalContext: window.DD_LOGS?.getGlobalContext?.(),
           user: window.DD_LOGS?.getUser?.(),
         }
+
         return { rum, logs, cookie }
       `
     )) as SdkInfos

--- a/developer-extension/src/panel/hooks/useSdkInfos.ts
+++ b/developer-extension/src/panel/hooks/useSdkInfos.ts
@@ -60,7 +60,7 @@ async function getInfos(): Promise<SdkInfos> {
       `
         // Helper to serialize objects while preserving function metadata
         function serializeWithFunctions(obj) {
-          return JSON.parse(JSON.stringify(obj, function(key, value) {
+          const stringified = JSON.stringify(obj, function(key, value) {
             if (typeof value === 'function') {
               return {
                 __type: 'function',
@@ -69,7 +69,11 @@ async function getInfos(): Promise<SdkInfos> {
               }
             }
             return value
-          }))
+          })
+          if (stringified === undefined) {
+            return stringified
+          }
+          return JSON.parse(stringified)
         }
 
         const cookies = new Map(


### PR DESCRIPTION
## Motivation

The developer extension needs some updates to reflect recent changes in the SDK and in the Datadog web UI.

## Changes

* The session replay sandbox's URL has changed; the reference in the developer extension has been updated. (Note that the new URL is unversioned; we'll reintroduce versioning via another mechanism soon.)
* The new cookie name for browser SDK v7 is now supported in the developer extension.
* A configuration property with a value of `undefined` no longer causes the developer extension to throw an exception internally. (I happened to notice this issue while fixing the other two problems.)

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [x] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
