### PR TITLE
♻️ Add explicit delete method to CookieAccess

### DIFF
--- a/packages/browser-core/src/browser/cookieAccess.spec.ts
+++ b/packages/browser-core/src/browser/cookieAccess.spec.ts
@@ -230,6 +230,33 @@ describe('cookieAccess', () => {
           expect(spy).toHaveBeenCalledTimes(1)
         })
       })
+
+      describe('delete', () => {
+        it('should remove the cookie value', async () => {
+          const { createCookieAccess, setCookieWithCleanup } = setup()
+          await setCookieWithCleanup(COOKIE_NAME, 'value1', ONE_MINUTE)
+
+          const cookieAccess = createCookieAccess(COOKIE_NAME, COOKIE_OPTIONS)
+          await cookieAccess.delete()
+
+          expect(await cookieAccess.getAll()).toEqual([])
+        })
+
+        it('should notify the observable', async () => {
+          const { createCookieAccess, flushObservable, setCookieWithCleanup } = setup()
+          await setCookieWithCleanup(COOKIE_NAME, 'value1', ONE_MINUTE)
+
+          const cookieAccess = createCookieAccess(COOKIE_NAME, COOKIE_OPTIONS)
+          const spy = jasmine.createSpy('observer')
+          const subscription = cookieAccess.observable.subscribe(spy)
+          registerCleanupTask(() => subscription.unsubscribe())
+
+          await cookieAccess.delete()
+          await flushObservable(spy)
+
+          expect(spy).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   }
 
@@ -238,6 +265,7 @@ describe('cookieAccess', () => {
       const access: CookieAccess = {
         getAll: jasmine.createSpy('getAll').and.returnValue(Promise.resolve(['test'])),
         getAllAndSet: jasmine.createSpy('getAllAndSet').and.returnValue(Promise.resolve()),
+        delete: jasmine.createSpy('delete').and.returnValue(Promise.resolve()),
         observable: null as any,
       }
       const factory = jasmine.createSpy('factory').and.returnValue(access)
@@ -252,6 +280,7 @@ describe('cookieAccess', () => {
       const access: CookieAccess = {
         getAll: () => Promise.resolve([]),
         getAllAndSet: () => Promise.resolve(),
+        delete: () => Promise.resolve(),
         observable: null as any,
       }
 
@@ -265,6 +294,7 @@ describe('cookieAccess', () => {
       const access: CookieAccess = {
         getAll: () => Promise.resolve([]),
         getAllAndSet: () => Promise.reject(new Error('boom')),
+        delete: () => Promise.resolve(),
         observable: null as any,
       }
 
@@ -275,22 +305,17 @@ describe('cookieAccess', () => {
     })
 
     it('cleans up the test cookie after the check', async () => {
-      const calls: Array<{ value: string; expireDelay: number }> = []
+      const deleteSpy = jasmine.createSpy('delete').and.returnValue(Promise.resolve())
       const access: CookieAccess = {
         getAll: () => Promise.resolve(['test']),
-        getAllAndSet: (cb) => {
-          calls.push(cb([]))
-          return Promise.resolve()
-        },
+        getAllAndSet: () => Promise.resolve(),
+        delete: deleteSpy,
         observable: null as any,
       }
 
       await areCookiesAuthorized(() => access, COOKIE_OPTIONS)
 
-      expect(calls).toEqual([
-        { value: 'test', expireDelay: jasmine.any(Number) as unknown as number },
-        { value: '', expireDelay: 0 },
-      ])
+      expect(deleteSpy).toHaveBeenCalled()
     })
 
     it('works with the real createDocumentCookieAccess', async () => {

--- a/packages/browser-core/src/browser/cookieAccess.ts
+++ b/packages/browser-core/src/browser/cookieAccess.ts
@@ -7,12 +7,13 @@ import { display } from '../tools/display'
 import { generateUUID } from '../tools/utils/stringUtils'
 import { addTelemetryDebug } from '../domain/telemetry'
 import { addEventListener, DOM_EVENT, isEventSupported } from './addEventListener'
-import { getCookies, setCookie } from './cookie'
+import { deleteCookie, getCookies, setCookie } from './cookie'
 import type { CookieOptions } from './cookie'
 
 export interface CookieAccess {
   getAll(): Promise<string[]>
   getAllAndSet(cb: (value: string[]) => { value: string; expireDelay: number }): Promise<void>
+  delete(): Promise<void>
   observable: Observable<void>
 }
 
@@ -40,7 +41,7 @@ export async function areCookiesAuthorized(
     return false
   } finally {
     try {
-      await access.getAllAndSet(() => ({ value: '', expireDelay: 0 }))
+      await access.delete()
     } catch {
       // Best-effort cleanup
     }
@@ -67,6 +68,15 @@ export function createCookieStoreAccess(cookieName: string, cookieOptions: Cooki
     async getAll() {
       const items = await cookieStore.getAll(cookieName)
       return items.map((item) => item.value)
+    },
+
+    delete() {
+      return cookieStore.delete({
+        name: cookieName,
+        domain: cookieOptions.domain,
+        path: '/',
+        partitioned: cookieOptions.partitioned,
+      })
     },
 
     async getAllAndSet(cb: (value: string[]) => { value: string; expireDelay: number }) {
@@ -143,6 +153,12 @@ export function createDocumentCookieAccess(cookieName: string, cookieOptions: Co
       setCookie(cookieName, value, expireDelay, cookieOptions)
       await Promise.resolve()
       notifyCookieValueIfChanged([value])
+    },
+
+    async delete() {
+      deleteCookie(cookieName, cookieOptions)
+      await Promise.resolve()
+      notifyCookieValueIfChanged([])
     },
 
     observable,

--- a/packages/browser-core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
+++ b/packages/browser-core/src/domain/session/storeStrategies/sessionInCookie.spec.ts
@@ -27,6 +27,11 @@ function createMockCookieAccess() {
         observable.notify()
         return Promise.resolve()
       },
+      delete(): Promise<void> {
+        storedValues = []
+        observable.notify()
+        return Promise.resolve()
+      },
       observable,
     },
     mockCookie: {


### PR DESCRIPTION
## Motivation

Fixes #4885

`areCookiesAuthorized` cleaned up its test cookie by calling `getAllAndSet(() => ({ value: '', expireDelay: 0 }))`, i.e. setting an already-expired cookie rather than actually deleting it. This works in most browsers, but Firefox does not reliably delete expired cookies (see https://bugzilla.mozilla.org/show_bug.cgi?id=576347), so the test cookie could stick around forever there.

## Changes

- Add an explicit `delete()` method to the `CookieAccess` interface, implemented for both `createCookieStoreAccess` (via `cookieStore.delete()`) and `createDocumentCookieAccess` (via `deleteCookie`)
- Use `access.delete()` in `areCookiesAuthorized`'s cleanup instead of the expired-cookie workaround

## Test instructions

- `yarn test:unit --spec packages/browser-core/src/browser/cookieAccess.spec.ts`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->