### PR TITLE
✨ [RUM-17395] Add debug_ids to profiler wall-time trace for sourcemap unminification

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "woke": "scripts/cli woke"
   },
   "devDependencies": {
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=4ed60cbe47c30afcef051481a035adf88161d4b7",
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4",
     "@eslint/js": "10.0.1",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@microsoft/api-extractor": "7.58.9",

--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.spec.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.spec.ts
@@ -31,6 +31,7 @@ import {
   replaceMockableWithSpy,
   HIGH_HASH_UUID,
   LOW_HASH_UUID,
+  mockSourceCodeContext,
 } from '@datadog/browser-core/test'
 import { mockRumConfiguration, mockViewHistory } from '../../../../browser-rum-core/test'
 import { mockProfiler } from '../../../test'
@@ -69,13 +70,17 @@ describe('profiler', () => {
 
   let lifeCycle = new LifeCycle()
 
-  function setupProfiler(currentView?: ViewHistoryEntry, profilerConfigOverrides?: Partial<RUMProfilerConfiguration>) {
+  function setupProfiler(
+    currentView?: ViewHistoryEntry,
+    profilerConfigOverrides?: Partial<RUMProfilerConfiguration>,
+    traceOverrides?: Partial<ProfilerTrace>
+  ) {
     const sessionManager = createSessionManagerMock().setId('session-id-1')
     lifeCycle = new LifeCycle()
     const hooks = createHooks()
     const profilingContextManager: ProfilingContextManager = startProfilingContext(hooks)
 
-    const mockProfilerTrace: ProfilerTrace = deepClone(mockedTrace)
+    const mockProfilerTrace: ProfilerTrace = { ...deepClone(mockedTrace), ...traceOverrides }
 
     const mockedRumProfilerTrace: BrowserProfilerTrace = Object.assign(mockProfilerTrace, {
       startClocks: {
@@ -197,6 +202,33 @@ describe('profiler', () => {
     expect(payload.profile.session).toEqual({ id: 'session-id-1' })
     expect(payload.trace.stacks).toEqual(mockedRumProfilerTrace.stacks)
     expect(payload.trace.samples).toEqual(mockedRumProfilerTrace.samples)
+  })
+
+  it('should attach debugIds resolved from the source code context for trace resources', async () => {
+    const url = 'http://example.com/resource1.js'
+    mockSourceCodeContext({ [`Error: ctx\n    at fn (${url}:1:1)`]: { ddDebugId: 'debug-id-1' } })
+
+    const { profiler } = setupProfiler(undefined, undefined, { resources: [url] })
+
+    profiler.start()
+    await waitForBoolean(() => profiler.isRunning())
+    profiler.stop()
+    await waitForBoolean(() => emitPayloadSpy.calls.count() >= 1)
+
+    const payload = emitPayloadSpy.calls.argsFor(0)[0]
+    expect(payload.trace.debugIds).toEqual([{ resourceId: 0, debugId: 'debug-id-1' }])
+  })
+
+  it('should omit debugIds when no trace resource matches the source code context', async () => {
+    const { profiler } = setupProfiler()
+
+    profiler.start()
+    await waitForBoolean(() => profiler.isRunning())
+    profiler.stop()
+    await waitForBoolean(() => emitPayloadSpy.calls.count() >= 1)
+
+    const payload = emitPayloadSpy.calls.argsFor(0)[0]
+    expect(payload.trace.debugIds).toBeUndefined()
   })
 
   it('should pause profiling collection on hidden visibility and restart on visible visibility', async () => {

--- a/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
+++ b/packages/browser-rum/src/domain/profiling/datadogProfiler.ts
@@ -35,6 +35,7 @@ import { createActionHistory } from './actionHistory'
 import { createVitalHistory } from './vitalHistory'
 import { checkProfilingQuota } from './quotaCheck'
 import type { QuotaReason } from './quotaCheck'
+import { buildProfilerDebugIds } from './profilerDebugIds'
 
 export const DEFAULT_RUM_PROFILER_CONFIGURATION: RUMProfilerConfiguration = {
   sampleIntervalMs: 10, // Sample stack trace every 10ms
@@ -304,6 +305,7 @@ export function createRumProfiler(
             vitals,
             views,
             sampleInterval: profilerConfiguration.sampleIntervalMs,
+            debugIds: buildProfilerDebugIds(trace.resources),
           }),
           sessionId
         )

--- a/packages/browser-rum/src/domain/profiling/profilerDebugIds.spec.ts
+++ b/packages/browser-rum/src/domain/profiling/profilerDebugIds.spec.ts
@@ -1,0 +1,42 @@
+import { mockSourceCodeContext } from '@datadog/browser-core/test'
+import { buildProfilerDebugIds } from './profilerDebugIds'
+
+describe('buildProfilerDebugIds', () => {
+  it('should resolve matching resources to { resourceId, debugId }', () => {
+    const url = 'http://example.com/resource1.js'
+    mockSourceCodeContext({ [`Error: ctx\n    at fn (${url}:1:1)`]: { ddDebugId: 'debug-id-1' } })
+
+    expect(buildProfilerDebugIds([url])).toEqual([{ resourceId: 0, debugId: 'debug-id-1' }])
+  })
+
+  it('should skip resources with no debug ID', () => {
+    const matched = 'http://example.com/resource1.js'
+    const unmatched = 'http://example.com/resource2.js'
+    mockSourceCodeContext({ [`Error: ctx\n    at fn (${matched}:1:1)`]: { ddDebugId: 'debug-id-1' } })
+
+    expect(buildProfilerDebugIds([unmatched, matched])).toEqual([{ resourceId: 1, debugId: 'debug-id-1' }])
+  })
+
+  it('should preserve resource indices when some resources are unmatched', () => {
+    const first = 'http://example.com/resource1.js'
+    const second = 'http://example.com/resource2.js'
+    const third = 'http://example.com/resource3.js'
+    mockSourceCodeContext({
+      [`Error: ctx\n    at fn (${first}:1:1)`]: { ddDebugId: 'debug-id-1' },
+      [`Error: ctx\n    at fn (${third}:1:1)`]: { ddDebugId: 'debug-id-3' },
+    })
+
+    expect(buildProfilerDebugIds([first, second, third])).toEqual([
+      { resourceId: 0, debugId: 'debug-id-1' },
+      { resourceId: 2, debugId: 'debug-id-3' },
+    ])
+  })
+
+  it('should return undefined when nothing resolves', () => {
+    expect(buildProfilerDebugIds(['http://example.com/resource1.js'])).toBeUndefined()
+  })
+
+  it('should return undefined for an empty resources array', () => {
+    expect(buildProfilerDebugIds([])).toBeUndefined()
+  })
+})

--- a/packages/browser-rum/src/domain/profiling/profilerDebugIds.ts
+++ b/packages/browser-rum/src/domain/profiling/profilerDebugIds.ts
@@ -1,11 +1,13 @@
-import { getSourceCodeContext } from '@datadog/browser-core'
+import { buildDebugIdByUrl } from '@datadog/browser-core'
 import type { ResourceDebugId } from '../../types'
 
 export function buildProfilerDebugIds(resources: string[]): ResourceDebugId[] | undefined {
+  const debugIdByUrl = new Map(buildDebugIdByUrl(resources)?.map((entry) => [entry.url, entry.id]))
+
   const debugIds: ResourceDebugId[] = []
 
   resources.forEach((url, resourceId) => {
-    const debugId = getSourceCodeContext(url)?.ddDebugId
+    const debugId = debugIdByUrl.get(url)
     if (debugId !== undefined) {
       debugIds.push({ resourceId, debugId })
     }

--- a/packages/browser-rum/src/domain/profiling/profilerDebugIds.ts
+++ b/packages/browser-rum/src/domain/profiling/profilerDebugIds.ts
@@ -1,0 +1,15 @@
+import { getSourceCodeContext } from '@datadog/browser-core'
+import type { ResourceDebugId } from '../../types'
+
+export function buildProfilerDebugIds(resources: string[]): ResourceDebugId[] | undefined {
+  const debugIds: ResourceDebugId[] = []
+
+  resources.forEach((url, resourceId) => {
+    const debugId = getSourceCodeContext(url)?.ddDebugId
+    if (debugId !== undefined) {
+      debugIds.push({ resourceId, debugId })
+    }
+  })
+
+  return debugIds.length ? debugIds : undefined
+}

--- a/packages/browser-rum/src/types/profiling.ts
+++ b/packages/browser-rum/src/types/profiling.ts
@@ -133,6 +133,10 @@ export interface BrowserProfilerTrace {
    */
   readonly resources: string[]
   /**
+   * Mapping of profiler resources to their debug IDs for source map deobfuscation.
+   */
+  readonly debugIds?: ResourceDebugId[]
+  /**
    * An array of profiler frames.
    */
   readonly frames: ProfilerFrame[]
@@ -167,6 +171,19 @@ export interface BrowserProfilerTrace {
    * List of detected navigation entries.
    */
   readonly views: RumViewEntry[]
+}
+/**
+ * Association between a profiler resource and its debug ID.
+ */
+export interface ResourceDebugId {
+  /**
+   * Index in the trace.resources array.
+   */
+  readonly resourceId: number
+  /**
+   * Debug ID (UUID) for the resource, used for source map deobfuscation.
+   */
+  readonly debugId: string
 }
 /**
  * Schema of a profiler frame from the JS Self-Profiling API.

--- a/test/e2e/scenario/microfrontend.scenario.ts
+++ b/test/e2e/scenario/microfrontend.scenario.ts
@@ -29,6 +29,16 @@ const LOGS_CONFIG: Partial<LogsInitConfiguration> = {
   },
 }
 
+// Debug IDs are derived from each chunk's content hash, so they're stable across rebuilds
+// (regenerate these constants if app source/deps change). The shared `lib` remote is its own chunk,
+// so its debug ID is the same for every app.
+const APP1_EXPOSE_CHUNK = '__federation_expose_app1-0b975610772143724d2f-app1.js'
+const APP1_DEBUG_ID = '33164643-dc2f-4bf0-8440-b443adfa15c3'
+const APP2_EXPOSE_CHUNK = '__federation_expose_app2-8042c1cdfd7c71d0bf47-app2.js'
+const APP2_DEBUG_ID = 'cb80d79d-2dfc-4bc0-9872-92b454fb59e1'
+const LIB_EXPOSE_CHUNK = '__federation_expose_lib-c0a8a100340f04ff2712-lib.js'
+const LIB_DEBUG_ID = '4564c6ea-a5bb-4355-968a-7de8d685fe65'
+
 test.describe('microfrontend', () => {
   test.describe('RUM service and version attribution', () => {
     test.describe('with beforeSend', () => {
@@ -431,16 +441,6 @@ test.describe('microfrontend', () => {
   })
 
   test.describe('RUM debug_id attribution', () => {
-    // Debug IDs are derived from each chunk's content hash, so they're stable across rebuilds
-    // (regenerate these constants if app source/deps change). The shared `lib` remote is its own chunk,
-    // so its debug ID is the same for every app.
-    const APP1_EXPOSE_CHUNK = '__federation_expose_app1-0b975610772143724d2f-app1.js'
-    const APP1_DEBUG_ID = '33164643-dc2f-4bf0-8440-b443adfa15c3'
-    const APP2_EXPOSE_CHUNK = '__federation_expose_app2-8042c1cdfd7c71d0bf47-app2.js'
-    const APP2_DEBUG_ID = 'cb80d79d-2dfc-4bc0-9872-92b454fb59e1'
-    const LIB_EXPOSE_CHUNK = '__federation_expose_lib-c0a8a100340f04ff2712-lib.js'
-    const LIB_DEBUG_ID = '4564c6ea-a5bb-4355-968a-7de8d685fe65'
-
     createTest('runtime errors should have debug_id from source code context')
       .withRum(RUM_CONFIG)
       .withSetup(microfrontendSetup)
@@ -531,6 +531,40 @@ test.describe('microfrontend', () => {
         withBrowserLogs((browserLogs) => {
           expect(browserLogs).toHaveLength(2)
         })
+      })
+  })
+
+  test.describe('RUM profiling debug_id attribution', () => {
+    test.beforeEach(({ browserName }) => {
+      test.skip(browserName !== 'chromium', 'JS Profiling API is only available in Chromium')
+    })
+
+    createTest('profiling should have debug_id from source code context')
+      .withRum({ ...RUM_CONFIG, profilingSampleRate: 100 })
+      .withBasePath('/?js-profiling=true')
+      .withSetup(microfrontendSetup)
+      .run(async ({ intakeRegistry, flushEvents, page }) => {
+        await page.click('#app1-loaf')
+        await page.click('#app2-loaf')
+        await flushEvents()
+
+        expect(intakeRegistry.profileRequests).toHaveLength(1)
+
+        const trace = intakeRegistry.profileRequests[0].trace
+        // Microfrontend chunks are served from a cross-origin host, so their resource URL
+        // doesn't share `baseUrl`'s origin - match by chunk filename instead.
+        const app1ResourceId = trace.resources.findIndex((url: string) => url.endsWith(APP1_EXPOSE_CHUNK))
+        const app2ResourceId = trace.resources.findIndex((url: string) => url.endsWith(APP2_EXPOSE_CHUNK))
+
+        expect(app1ResourceId).toBeGreaterThan(-1)
+        expect(app2ResourceId).toBeGreaterThan(-1)
+
+        expect(trace.debugIds).toEqual(
+          expect.arrayContaining([
+            { resourceId: app1ResourceId, debugId: APP1_DEBUG_ID },
+            { resourceId: app2ResourceId, debugId: APP2_DEBUG_ID },
+          ])
+        )
       })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,10 +599,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/rum-events-format@DataDog/rum-events-format#commit=4ed60cbe47c30afcef051481a035adf88161d4b7":
+"@datadog/rum-events-format@DataDog/rum-events-format#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4":
   version: 0.0.0
-  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=4ed60cbe47c30afcef051481a035adf88161d4b7"
-  checksum: 10c0/16677d35d476ba78fbf8cd37f0367577a839dcdfa29edbbe195ddae2511d6d22746aaaef894bc7bedd747e9163551dfc4bb27e8595fbfcee7d4ca41ac800fed3
+  resolution: "@datadog/rum-events-format@https://github.com/DataDog/rum-events-format.git#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4"
+  checksum: 10c0/831a49695bbe7908a2e7a95b7359ee54adaafd485eae5b3910f04c273b4953efe15ff2d4f66517bdced1c72363eebba53208bd1bd61fc35edd1977f1545dd285
   languageName: node
   linkType: hard
 
@@ -3943,7 +3943,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "browser-sdk@workspace:."
   dependencies:
-    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=4ed60cbe47c30afcef051481a035adf88161d4b7"
+    "@datadog/rum-events-format": "DataDog/rum-events-format#commit=02a3fbe611005aec9e3530201412ac71bf34c1e4"
     "@eslint/js": "npm:10.0.1"
     "@jsdevtools/coverage-istanbul-loader": "npm:3.0.5"
     "@microsoft/api-extractor": "npm:7.58.9"


### PR DESCRIPTION
## Motivation

Un-minify profiler stack frames across micro frontends, same as Error/LoAF events already do via `_dd.debug_ids`.

## Changes

`wall-time.json` now includes a `debugIds` array mapping each resource index to its debug ID:

```jsonc
{
  "resources": ["https://service-a.js", "https://service-b.js"],
  "debugIds": [{ "resourceId": 0, "debugId": "5f4b4d0a-3f9a-4b86-9f53-8f7e9a5c7d21" }]
}
```

- Resolved via the existing debug-ID source-code-context lookup, same as Error/LoAF events.

## Test instructions

`yarn test:unit --spec "packages/browser-rum/src/domain/profiling/**/*.spec.ts"`

## Checklist

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file