### PR TITLE
🐛 [rum-nuxt] Fix Nuxt post-hydration error handling

### DIFF
--- a/packages/browser-rum-nuxt/src/domain/error/setupNuxtErrorHandling.spec.ts
+++ b/packages/browser-rum-nuxt/src/domain/error/setupNuxtErrorHandling.spec.ts
@@ -27,6 +27,70 @@ describe('setupNuxtErrorHandling', () => {
     expect(hookSpy).toHaveBeenCalledWith('app:error', jasmine.any(Function))
   })
 
+  it("stops calling Nuxt's default error handler after hydration", () => {
+    const reportErrorSpy = jasmine.createSpy()
+    const originalErrorHandlerSpy = jasmine.createSpy() as jasmine.Spy & { __nuxt_default?: true }
+    originalErrorHandlerSpy.__nuxt_default = true
+    let suspenseResolveCallback!: () => void
+    const nuxtApp = {
+      vueApp: {
+        config: {
+          errorHandler: originalErrorHandlerSpy,
+        },
+      },
+      hook: jasmine.createSpy().and.callFake((name: string, callback: () => void) => {
+        if (name === 'app:suspense:resolve') {
+          suspenseResolveCallback = callback
+        }
+      }),
+    } as unknown as NuxtApp
+
+    setupNuxtErrorHandling(nuxtApp, reportErrorSpy)
+
+    const initialError = new Error('initial')
+    const errorHandler = nuxtApp.vueApp.config.errorHandler as NonNullable<App['config']['errorHandler']>
+    errorHandler(initialError, null, 'mounted hook')
+    suspenseResolveCallback()
+
+    const postHydrationError = new Error('post hydration')
+    errorHandler(postHydrationError, null, 'native event handler')
+
+    expect(reportErrorSpy.calls.allArgs()).toEqual([
+      [initialError, null, 'mounted hook'],
+      [postHydrationError, null, 'native event handler'],
+    ])
+    expect(originalErrorHandlerSpy).toHaveBeenCalledOnceWith(initialError, null, 'mounted hook')
+  })
+
+  it('keeps calling a custom original error handler after hydration', () => {
+    const reportErrorSpy = jasmine.createSpy()
+    const originalErrorHandlerSpy = jasmine.createSpy()
+    let suspenseResolveCallback!: () => void
+    const nuxtApp = {
+      vueApp: {
+        config: {
+          errorHandler: originalErrorHandlerSpy,
+        },
+      },
+      hook: jasmine.createSpy().and.callFake((name: string, callback: () => void) => {
+        if (name === 'app:suspense:resolve') {
+          suspenseResolveCallback = callback
+        }
+      }),
+    } as unknown as NuxtApp
+
+    setupNuxtErrorHandling(nuxtApp, reportErrorSpy)
+
+    suspenseResolveCallback()
+
+    const error = new Error('oops')
+    const errorHandler = nuxtApp.vueApp.config.errorHandler as NonNullable<App['config']['errorHandler']>
+    errorHandler(error, null, 'mounted hook')
+
+    expect(reportErrorSpy).toHaveBeenCalledOnceWith(error, null, 'mounted hook')
+    expect(originalErrorHandlerSpy).toHaveBeenCalledOnceWith(error, null, 'mounted hook')
+  })
+
   it('deduplicates the same error between Vue and app:error hooks', () => {
     const reportErrorSpy = jasmine.createSpy()
     let appErrorCallback!: (err: unknown) => void

--- a/packages/browser-rum-nuxt/src/domain/error/setupNuxtErrorHandling.spec.ts
+++ b/packages/browser-rum-nuxt/src/domain/error/setupNuxtErrorHandling.spec.ts
@@ -29,13 +29,13 @@ describe('setupNuxtErrorHandling', () => {
 
   it("stops calling Nuxt's default error handler after hydration", () => {
     const reportErrorSpy = jasmine.createSpy()
-    const originalErrorHandlerSpy = jasmine.createSpy() as jasmine.Spy & { __nuxt_default?: true }
-    originalErrorHandlerSpy.__nuxt_default = true
+    const nuxtDefaultErrorHandlerSpy = jasmine.createSpy() as jasmine.Spy & { __nuxt_default?: true }
+    nuxtDefaultErrorHandlerSpy.__nuxt_default = true
     let suspenseResolveCallback!: () => void
     const nuxtApp = {
       vueApp: {
         config: {
-          errorHandler: originalErrorHandlerSpy,
+          errorHandler: nuxtDefaultErrorHandlerSpy,
         },
       },
       hook: jasmine.createSpy().and.callFake((name: string, callback: () => void) => {
@@ -50,6 +50,7 @@ describe('setupNuxtErrorHandling', () => {
     const initialError = new Error('initial')
     const errorHandler = nuxtApp.vueApp.config.errorHandler as NonNullable<App['config']['errorHandler']>
     errorHandler(initialError, null, 'mounted hook')
+
     suspenseResolveCallback()
 
     const postHydrationError = new Error('post hydration')
@@ -59,17 +60,17 @@ describe('setupNuxtErrorHandling', () => {
       [initialError, null, 'mounted hook'],
       [postHydrationError, null, 'native event handler'],
     ])
-    expect(originalErrorHandlerSpy).toHaveBeenCalledOnceWith(initialError, null, 'mounted hook')
+    expect(nuxtDefaultErrorHandlerSpy).toHaveBeenCalledOnceWith(initialError, null, 'mounted hook')
   })
 
-  it('keeps calling a custom original error handler after hydration', () => {
+  it('keeps calling a custom error handler after hydration', () => {
     const reportErrorSpy = jasmine.createSpy()
-    const originalErrorHandlerSpy = jasmine.createSpy()
+    const customErrorHandlerSpy = jasmine.createSpy()
     let suspenseResolveCallback!: () => void
     const nuxtApp = {
       vueApp: {
         config: {
-          errorHandler: originalErrorHandlerSpy,
+          errorHandler: customErrorHandlerSpy,
         },
       },
       hook: jasmine.createSpy().and.callFake((name: string, callback: () => void) => {
@@ -88,7 +89,7 @@ describe('setupNuxtErrorHandling', () => {
     errorHandler(error, null, 'mounted hook')
 
     expect(reportErrorSpy).toHaveBeenCalledOnceWith(error, null, 'mounted hook')
-    expect(originalErrorHandlerSpy).toHaveBeenCalledOnceWith(error, null, 'mounted hook')
+    expect(customErrorHandlerSpy).toHaveBeenCalledOnceWith(error, null, 'mounted hook')
   })
 
   it('deduplicates the same error between Vue and app:error hooks', () => {

--- a/packages/browser-rum-nuxt/src/domain/error/setupNuxtErrorHandling.ts
+++ b/packages/browser-rum-nuxt/src/domain/error/setupNuxtErrorHandling.ts
@@ -6,6 +6,7 @@ import { callMonitored, createHandlingStack } from '@datadog/browser-core'
 export interface NuxtApp {
   vueApp: App
   hook(name: 'app:error', callback: (err: unknown) => void): void
+  hook(name: 'app:suspense:resolve', callback: () => void): void
 }
 
 export type NuxtErrorReporter = (error: unknown, instance: ComponentPublicInstance | null, info: string) => void
@@ -39,14 +40,30 @@ export function setupNuxtErrorHandling(nuxtApp: NuxtApp, reportError: NuxtErrorR
   // Wrap existing errorHandler rather than replacing it, so Nuxt's own
   // handleVueError (which drives the error page) is still called.
   const original = nuxtApp.vueApp.config.errorHandler
+  let shouldCallOriginal = true
+
+  nuxtApp.hook('app:suspense:resolve', () => {
+    if (isNuxtDefaultErrorHandler(original)) {
+      shouldCallOriginal = false
+    }
+  })
+
   nuxtApp.vueApp.config.errorHandler = (error, instance, info) => {
     deduplicatedReportError(error, instance, info)
-    original?.(error, instance, info)
+    if (shouldCallOriginal) {
+      original?.(error, instance, info)
+    }
   }
 
   nuxtApp.hook('app:error', (err) => {
     deduplicatedReportError(err, null, '')
   })
+}
+
+// https://github.com/nuxt/nuxt/blob/83aa474239388738b611e2b2fd9151936a041a93/packages/nuxt/src/app/entry.ts#L62-L74
+// Follows what Nuxt does internally to determine if the error handler is the default one.
+function isNuxtDefaultErrorHandler(errorHandler: App['config']['errorHandler']) {
+  return !!errorHandler && '__nuxt_default' in errorHandler && errorHandler.__nuxt_default === true
 }
 
 function deduplicateByError(func: NuxtErrorReporter) {

--- a/test/e2e/scenario/plugins/nuxtPlugin.scenario.ts
+++ b/test/e2e/scenario/plugins/nuxtPlugin.scenario.ts
@@ -101,7 +101,7 @@ test.describe('plugin: nuxt error', () => {
             expect(browserLogs.filter((log) => log.level === 'error').length).toBeGreaterThan(0)
           })
         })
-      createTest('should not render the full-page error for non-fatal client errors after hydration')
+      createTest('should not render the 500 Internal Server Error page for non-fatal client errors after hydration')
         .withBasePath('/error-test')
         .withRum()
         .withNuxtApp(routerVersion)
@@ -109,6 +109,8 @@ test.describe('plugin: nuxt error', () => {
           // Wait for hydration (app:suspense:resolve) to complete: only the initial render is
           // allowed to trigger the full-page error.
           await page.click('[data-testid="trigger-error"]')
+          // Verify that the 500 error page is not rendered.
+          // This is proven by showing that we are still in the same page and the button is still visible.
           await expect(page.locator('h1')).toHaveText('Error Page')
           await expect(page.getByTestId('trigger-error')).toBeVisible()
           await expect(page.getByTestId('error-handled')).toBeVisible()

--- a/test/e2e/scenario/plugins/nuxtPlugin.scenario.ts
+++ b/test/e2e/scenario/plugins/nuxtPlugin.scenario.ts
@@ -101,6 +101,23 @@ test.describe('plugin: nuxt error', () => {
             expect(browserLogs.filter((log) => log.level === 'error').length).toBeGreaterThan(0)
           })
         })
+      createTest('should not render the full-page error for non-fatal client errors after hydration')
+        .withBasePath('/error-test')
+        .withRum()
+        .withNuxtApp(routerVersion)
+        .run(async ({ page, flushEvents, intakeRegistry }) => {
+          // Wait for hydration (app:suspense:resolve) to complete: only the initial render is
+          // allowed to trigger the full-page error.
+          await page.click('[data-testid="trigger-error"]')
+          await expect(page.locator('h1')).toHaveText('Error Page')
+          await expect(page.getByTestId('trigger-error')).toBeVisible()
+          await expect(page.getByTestId('error-handled')).toBeVisible()
+
+          await flushEvents()
+
+          const errorEvents = intakeRegistry.rumErrorEvents.filter((e) => e.error.source === 'custom')
+          expect(errorEvents).toHaveLength(1)
+        })
     })
   }
 })


### PR DESCRIPTION
## Motivation

[Issue](https://github.com/DataDog/browser-sdk/issues/4890).

Nuxt installs its default `vueApp.config.errorHandler` during initial rendering and removes it after hydration on `app:suspense:resolve`, as long as the handler was not overridden.

The Nuxt RUM plugin wraps that handler before hydration, which prevents Nuxt’s identity check from removing it. As a result, client-side Vue errors triggered after hydration keep delegating to Nuxt’s default error handler and render the full-page error.vue, even though Nuxt would normally only log them to the console.

## Changes

 - Stop delegating to Nuxt’s default error handler after `app:suspense:resolve`.
 - Continue reporting Vue errors to RUM after hydration.
 - Preserve the original behavior before hydration so initial render/startup errors can still trigger Nuxt’s error page.
 - Keep delegating to custom original Vue error handlers after hydration.
 - Add unit coverage for Nuxt default handler gating and custom handler preservation.
 - Added e2e test.

## Test instructions

1. Checkout main.
2. Start the Nuxt test app.
3. Open the Nuxt error test page without RUM.
4. Click `Trigger Error`.
5. Confirm the error is only logged to the console and the app does not render the Nuxt error page.
6. Open the same page with: `?rum-config={"applicationId":"test","clientToken":"test","site":"datadoghq.com"}`
7. Click `Trigger Error`.
8. On main, confirm the app renders the Nuxt 500 Internal Server Error page.
9. With this fix, confirm the error is reported to RUM but the app stays on the page and only logs the error to the console.

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [x] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
