### PR TITLE
📝 Add salesforce readme

### DIFF
--- a/packages/browser-rum-slim/src/salesforce/README.md
+++ b/packages/browser-rum-slim/src/salesforce/README.md
@@ -28,7 +28,7 @@ You should also enable [Lightning Web Security][1] in the Salesforce org.
 Finally, you need the [Datadog RUM Salesforce Bundle][2]. Download it into your Salesforce project's static resources folder, for example:
 
 ```shell
-curl -o staticresources/datadog_rum_salesforce.js https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum-salesforce.js
+curl -o staticresources/datadog_rum.js https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum-salesforce.js
 ```
 
 Once you have these, follow one of the deployment paths below:
@@ -219,7 +219,7 @@ Expose the component to the Lightning Utility Bar, then add it to your app's Uti
 </LightningComponentBundle>
 ```
 
-`flexipages/MyApp_UtilityBar.flexipage-meta.xml`
+Add the following `componentInstance` excerpt to your app's existing Utility Bar FlexiPage metadata, for example in `flexipages/MyApp_UtilityBar.flexipage-meta.xml`.
 
 ```xml
 <componentInstance>
@@ -231,27 +231,27 @@ Expose the component to the Lightning Utility Bar, then add it to your app's Uti
   <componentInstanceProperties>
     <name>applicationId</name>
     <type>String</type>
-    <value><YOUR_DATADOG_APPLICATION_ID></value>
+    <value>YOUR_DATADOG_APPLICATION_ID</value>
   </componentInstanceProperties>
   <componentInstanceProperties>
     <name>clientToken</name>
     <type>String</type>
-    <value><YOUR_DATADOG_CLIENT_TOKEN></value>
+    <value>YOUR_DATADOG_CLIENT_TOKEN</value>
   </componentInstanceProperties>
   <componentInstanceProperties>
     <name>site</name>
     <type>String</type>
-    <value><YOUR_DATADOG_SITE></value>
+    <value>YOUR_DATADOG_SITE</value>
   </componentInstanceProperties>
   <componentInstanceProperties>
     <name>service</name>
     <type>String</type>
-    <value><YOUR_SERVICE_NAME></value>
+    <value>YOUR_SERVICE_NAME</value>
   </componentInstanceProperties>
   <componentInstanceProperties>
     <name>env</name>
     <type>String</type>
-    <value><YOUR_ENV_NAME></value>
+    <value>YOUR_ENV_NAME</value>
   </componentInstanceProperties>
   <componentName>datadogInit</componentName>
   <identifier>datadogInit</identifier>

--- a/packages/browser-rum-slim/src/salesforce/README.md
+++ b/packages/browser-rum-slim/src/salesforce/README.md
@@ -209,8 +209,8 @@ Expose the component to the Lightning Utility Bar, then add it to your app's Uti
   </targets>
   <targetConfigs>
     <targetConfig targets="lightning__UtilityBar">
-      <property name="applicationId" type="String" label="Application ID" />
-      <property name="clientToken" type="String" label="Client Token" />
+      <property name="applicationId" type="String" label="Application ID" required="true" />
+      <property name="clientToken" type="String" label="Client Token" required="true" />
       <property name="site" type="String" label="Site" />
       <property name="service" type="String" label="Service" />
       <property name="env" type="String" label="Env" />
@@ -333,19 +333,19 @@ Use the following trusted site configuration for US1:
 
 For non-US1 Datadog sites, use the intake endpoint for the correct [Datadog site][4].
 
-### 4. Add the Head Markup script
+### 4. Add the Head Markup
 
 In Experience Builder:
 
 1. Go to **Settings > Advanced**.
 2. Open **Head Markup**.
 3. Click **Edit Head Markup**.
-4. Paste the following script.
+4. Paste the following markup.
 5. Replace the placeholder values with your Datadog RUM configuration.
 
 ```html
-<script src="/sfsites/c/resource/datadog_rum"></script>
-<script>
+<x-oasis-script src="/sfsites/c/resource/datadog_rum"></x-oasis-script>
+<x-oasis-script>
   window.DD_RUM.onReady(function () {
     window.DD_RUM.init({
       applicationId: '<YOUR_DATADOG_APPLICATION_ID>',
@@ -360,7 +360,7 @@ In Experience Builder:
       trackUserInteractions: true,
     })
   })
-</script>
+</x-oasis-script>
 ```
 
 ### 5. Publish the Experience Cloud site

--- a/packages/browser-rum-slim/src/salesforce/README.md
+++ b/packages/browser-rum-slim/src/salesforce/README.md
@@ -1,60 +1,125 @@
-# Salesforce Lightning RUM
+# Salesforce Integration
 
-This entrypoint is intended for Salesforce Lightning and LWC applications.
+## Overview
 
-## Recommended LWC Setup
+Instrument Salesforce Lightning Apps and Experience Cloud sites with Datadog Real User Monitoring using the Datadog RUM Salesforce bundle.
+
+This guide covers three deployment paths, plus a feature support reference:
+
+- **[Lightning Apps](#lightning-apps)**: Use a custom Lightning Web Component loaded from the Utility Bar.
+- **[Experience Cloud Head Markup](#experience-cloud-head-markup)**: Add the Datadog RUM initialization script directly to Head Markup.
+- **[Experience Cloud Theme/Layout LWC](#experience-cloud-themelayout-lwc)**: Add a custom Lightning Web Component to an Experience Builder page, shared region, or theme/layout area.
+- **[Feature Support](#salesforce-feature-support-matrix)**: Review supported features for the Datadog integration.
+
+**Note**: Use only one deployment path per Salesforce app or Experience Cloud site.
+
+## Setup
+
+You will need the following Datadog RUM values:
+
+- A Datadog RUM Application ID
+- A Datadog RUM Client Token
+- A Datadog site, such as `datadoghq.com`
+
+You can get those values in Datadog under **Digital Experience > Real User Monitoring > Manage Applications > Set Up Manually**.
+
+You should also enable [Lightning Web Security][1] in the Salesforce org.
+
+Finally, you need the [Datadog RUM Salesforce Bundle][2]. Download it into your Salesforce project's static resources folder, for example:
+
+```shell
+curl -o staticresources/datadog_rum_salesforce.js https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum-salesforce.js
+```
+
+Once you have these, follow one of the deployment paths below:
+
+- **[Lightning Apps](#lightning-apps)**: Use a custom Lightning Web Component loaded from the Utility Bar.
+- **[Experience Cloud Head Markup](#experience-cloud-head-markup)**: Add the Datadog RUM initialization script directly to Head Markup.
+- **[Experience Cloud Theme/Layout LWC](#experience-cloud-themelayout-lwc)**: Add a custom Lightning Web Component to an Experience Builder page, shared region, or theme/layout area.
+
+## Lightning Apps
+
+Use this path for Salesforce LWC applications.
+
+This path uses:
+
+- A Salesforce Static Resource for the Datadog Salesforce RUM bundle.
+- A CSP Trusted Site for the Datadog browser intake endpoint.
+- A custom Lightning Web Component.
+- A Utility Bar configuration with eager loading enabled.
 
 ### 1. Add the static resource
 
-Copy `packages/browser-rum-slim/bundle/datadog-rum-salesforce.js` into your Salesforce project as
-`staticresources/datadog_rum_salesforce.js`.
+Copy the Datadog Salesforce RUM bundle into your Salesforce project and register it as a static resource.
 
-Create the accompanying metadata file `staticresources/datadog_rum_salesforce.resource-meta.xml`:
+Suggested configuration:
+
+- Static Resource Name: `datadog_rum`
+- File location: `staticresources/datadog_rum.js`
+- Metadata location: `staticresources/datadog_rum.resource-meta.xml`
+
+XML configuration:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
-    <cacheControl>Public</cacheControl>
-    <contentType>application/javascript</contentType>
+  <cacheControl>Public</cacheControl>
+  <contentType>application/javascript</contentType>
 </StaticResource>
 ```
 
-### 2. Add the CSP trusted site
+If you configure this through the Salesforce UI:
 
-Create a CSP trusted site metadata file under `cspTrustedSites/`, for example `cspTrustedSites/browser_intake_datadoghq_com.cspTrustedSite-meta.xml`:
+1. Go to **Setup > Static Resources**.
+2. Click **New**.
+3. Set **Name** to `datadog_rum`.
+4. Upload the Salesforce RUM JavaScript bundle.
+5. Set **Cache Control** to `Public`.
+6. Save the static resource.
+
+### 2. Add the CSP Trusted Site
+
+Allow Salesforce's Content Security Policy to connect to the Datadog browser intake endpoint. Without this configuration, the browser may block RUM events from being sent to Datadog.
+
+Suggested configuration:
+
+- File location: `cspTrustedSites/browser_intake_datadoghq_com.cspTrustedSite-meta.xml`
+
+XML configuration:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <CspTrustedSite xmlns="http://soap.sforce.com/2006/04/metadata">
-    <canAccessCamera>false</canAccessCamera>
-    <canAccessMicrophone>false</canAccessMicrophone>
-    <context>All</context>
-    <description>Datadog browser RUM intake for US1</description>
-    <endpointUrl>https://browser-intake-datadoghq.com</endpointUrl>
-    <isActive>true</isActive>
-    <isApplicableToConnectSrc>true</isApplicableToConnectSrc>
-    <isApplicableToFontSrc>false</isApplicableToFontSrc>
-    <isApplicableToFrameSrc>false</isApplicableToFrameSrc>
-    <isApplicableToImgSrc>false</isApplicableToImgSrc>
-    <isApplicableToMediaSrc>false</isApplicableToMediaSrc>
-    <isApplicableToStyleSrc>false</isApplicableToStyleSrc>
+  <context>All</context>
+  <description>Datadog browser RUM intake for US1</description>
+  <endpointUrl>https://browser-intake-datadoghq.com</endpointUrl>
+  <isActive>true</isActive>
+  <isApplicableToConnectSrc>true</isApplicableToConnectSrc>
 </CspTrustedSite>
 ```
 
-### 3. Create the LWC component
+For non-US1 Datadog sites, update `endpointUrl` to match the correct Datadog browser intake endpoint for your region.
 
-Create a new LWC component under `lwc/datadogInit/`. A LWC bundle requires an HTML template, so first create `lwc/datadogInit/datadogInit.html`:
+### 3. Create the Datadog init component
+
+Create a Lightning Web Component that loads the Datadog Browser SDK and manually starts views as users navigate within the Lightning application.
+
+A Lightning Web Component bundle requires an HTML template. Create the following file first.
+
+File location: `lwc/datadogInit/datadogInit.html`
 
 ```html
 <template></template>
 ```
 
-Then create `lwc/datadogInit/datadogInit.js`:
+### 4. Add the component JavaScript
 
-```js
+File location: `lwc/datadogInit/datadogInit.js`
+
+```javascript
 import { LightningElement, api, wire } from 'lwc'
 import { NavigationMixin, CurrentPageReference } from 'lightning/navigation'
-import datadogRumSalesforce from '@salesforce/resourceUrl/datadog_rum_salesforce'
+import datadogRum from '@salesforce/resourceUrl/datadog_rum'
 import { loadScript } from 'lightning/platformResourceLoader'
 
 let datadogInitialization
@@ -103,7 +168,7 @@ export default class DatadogInit extends NavigationMixin(LightningElement) {
   }
 
   loadDatadogRum() {
-    return loadScript(this, datadogRumSalesforce).then(() => {
+    return loadScript(this, datadogRum).then(() => {
       const initConfig = {
         applicationId: this.applicationId,
         clientToken: this.clientToken,
@@ -127,111 +192,417 @@ export default class DatadogInit extends NavigationMixin(LightningElement) {
 }
 ```
 
-Also create the required component metadata file `lwc/datadogInit/datadogInit.js-meta.xml` to expose it to the utility bar:
+### 5. Add to Utility Bar
+
+Expose the component to the Lightning Utility Bar, then add it to your app's Utility Bar with `eager` set to `true`.
+
+`lwc/datadogInit/datadogInit.js-meta.xml`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
-    <isExposed>true</isExposed>
-    <targets>
-        <target>lightning__UtilityBar</target>
-    </targets>
-    <targetConfigs>
-        <targetConfig targets="lightning__UtilityBar">
-            <property name="applicationId" type="String" required="true" label="Application ID" />
-            <property name="clientToken" type="String" required="true" label="Client Token" />
-            <property name="site" type="String" required="true" label="Site" default="datadoghq.com" />
-            <property name="service" type="String" label="Service" />
-            <property name="env" type="String" label="Environment" />
-        </targetConfig>
-    </targetConfigs>
+  <apiVersion>64.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Datadog Init</masterLabel>
+  <targets>
+    <target>lightning__UtilityBar</target>
+  </targets>
+  <targetConfigs>
+    <targetConfig targets="lightning__UtilityBar">
+      <property name="applicationId" type="String" label="Application ID" />
+      <property name="clientToken" type="String" label="Client Token" />
+      <property name="site" type="String" label="Site" />
+      <property name="service" type="String" label="Service" />
+      <property name="env" type="String" label="Env" />
+    </targetConfig>
+  </targetConfigs>
 </LightningComponentBundle>
 ```
 
-### 4. Add the component to a Lightning App
-
-Add `datadogInit` to your app's utility bar via a flexipage metadata file. Set `eager` to `true` so the component initializes immediately on page load.
-
-If your app already has a utility bar, edit its existing flexipage file under `flexipages/`. If it does not, create one — for example `flexipages/MyApp_UtilityBar.flexipage-meta.xml`.
+`flexipages/MyApp_UtilityBar.flexipage-meta.xml`
 
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>applicationId</name>
-                    <value>YOUR_APPLICATION_ID</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>clientToken</name>
-                    <value>YOUR_CLIENT_TOKEN</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>site</name>
-                    <value>datadoghq.com</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>service</name>
-                    <value>your-service-name</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>env</name>
-                    <value>production</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>eager</name>
-                    <type>decorator</type>
-                    <value>true</value>
-                </componentInstanceProperties>
-                <componentName>datadogInit</componentName>
-                <identifier>datadogInit</identifier>
-            </componentInstance>
-        </itemInstances>
-        <name>utilityItems</name>
-        <type>Region</type>
-    </flexiPageRegions>
-    <!-- ... rest of your flexipage definition ... -->
-</FlexiPage>
+<componentInstance>
+  <componentInstanceProperties>
+    <name>eager</name>
+    <type>decorator</type>
+    <value>true</value>
+  </componentInstanceProperties>
+  <componentInstanceProperties>
+    <name>applicationId</name>
+    <type>String</type>
+    <value><YOUR_DATADOG_APPLICATION_ID></value>
+  </componentInstanceProperties>
+  <componentInstanceProperties>
+    <name>clientToken</name>
+    <type>String</type>
+    <value><YOUR_DATADOG_CLIENT_TOKEN></value>
+  </componentInstanceProperties>
+  <componentInstanceProperties>
+    <name>site</name>
+    <type>String</type>
+    <value><YOUR_DATADOG_SITE></value>
+  </componentInstanceProperties>
+  <componentInstanceProperties>
+    <name>service</name>
+    <type>String</type>
+    <value><YOUR_SERVICE_NAME></value>
+  </componentInstanceProperties>
+  <componentInstanceProperties>
+    <name>env</name>
+    <type>String</type>
+    <value><YOUR_ENV_NAME></value>
+  </componentInstanceProperties>
+  <componentName>datadogInit</componentName>
+  <identifier>datadogInit</identifier>
+</componentInstance>
 ```
 
-## Salesforce Feature Support
+### 6. Validate the Lightning app installation
 
-| Feature                | Supported                      |
-| ---------------------- | ------------------------------ |
-| **View Events**        |                                |
-| Initial View           | ✅                             |
-| Manual Tracking        | ✅                             |
-| Navigation Timings     | ✅                             |
-| Web Vitals             | ✅                             |
-| Automatic Tracking     | ✅⚠️ Supported with workaround |
-| Loading Time           | ✅⚠️(1)                        |
-| **Resource Events**    |                                |
-| Fetch Resources        | ✅⚠️(2)                        |
-| XHR Resources          | ✅⚠️(2)                        |
-| Other Resources        | ✅                             |
-| APM Correlation        | ✅⚠️(2)                        |
-| **Action Events**      |                                |
-| Custom Actions         | ✅                             |
-| Click Actions          | ✅                             |
-| Frustration Signals    | ✅                             |
-| Selectors              | ✅⚠️(3)                        |
-| Action Name            | ✅⚠️(2)                        |
-| Loading Time           | ✅⚠️(1)                        |
-| **Error Events**       |                                |
-| Console Error          | ✅                             |
-| Custom Errors          | ✅                             |
-| Runtime Errors         | ✅⚠️(4)                        |
-| `onUnhandledRejection` | ❌                             |
-| CSP Violation          | ❌                             |
-| **Other**              |                                |
-| Vital Events           | ✅                             |
-| Long Task Events       | ✅                             |
-| Session Replay         | ❌                             |
+After deploying the component:
 
-1. Loading time ends when no pending network requests are detected. Under LWS the SDK may not observe all pending fetch/XHR requests, causing loading time to end prematurely or be absent.
-2. Events are collected, but `beforeSend` context will not include the response payload (`context.response`, `context.xhr`, `context.responseBody`) as these objects are inaccessible within the LWS sandbox.
-3. Due to shadow boundaries, the SDK might receive the component host as `event.target` instead of the actual clicked element.
-4. Direct synchronous errors can reach the SDK through `window.onerror`, but in the Lightning shell they may be redacted as "Script error." with no original error object, URL, line, or stack available to the SDK.
+1. Open the Lightning app.
+2. Open browser developer tools.
+3. Confirm that the Datadog static resource loads successfully.
+4. Confirm there are no CSP errors for the Datadog browser intake endpoint.
+5. Navigate between Lightning pages.
+6. In Datadog RUM Explorer, filter by the configured service and env.
+7. Confirm that view events are created when navigation occurs.
+
+## Experience Cloud Head Markup
+
+Use this path for Experience Cloud sites where you can add custom JavaScript through Head Markup. This is usually the most direct Experience Cloud approach because the SDK loads at the page level and does not rely on the Salesforce Utility Bar.
+
+This path uses:
+
+- A Salesforce Static Resource for the Datadog Salesforce RUM bundle.
+- Experience Cloud CSP configuration.
+- A Head Markup script that loads the SDK and tracks route changes.
+
+### 1. Add the static resource
+
+Copy the Datadog Salesforce RUM bundle into your Salesforce project and register it as a static resource.
+
+Suggested configuration:
+
+- Static Resource Name: `datadog_rum`
+- File location: `staticresources/datadog_rum.js`
+- Metadata location: `staticresources/datadog_rum.resource-meta.xml`
+
+XML configuration:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+  <cacheControl>Public</cacheControl>
+  <contentType>application/javascript</contentType>
+</StaticResource>
+```
+
+If you configure this through the Salesforce UI:
+
+1. Go to **Setup > Static Resources**.
+2. Click **New**.
+3. Set **Name** to `datadog_rum`.
+4. Upload the Salesforce RUM JavaScript bundle.
+5. Set **Cache Control** to `Public`.
+6. Save the static resource.
+
+### 2. Open the Experience Cloud site in Builder
+
+1. Go to **Setup > Apps > App Manager**.
+2. Search for your Experience Cloud application.
+3. Click **Manage**.
+4. When the page loads, click **Builder**.
+
+### 3. Configure CSP for the Datadog intake endpoint
+
+In Experience Builder:
+
+1. Go to **Settings > Security & Privacy**.
+2. Change the security level from **Strict CSP** to **Relaxed CSP**.
+3. Add the Datadog browser intake endpoint as a trusted site.
+
+Use the following trusted site configuration for US1:
+
+| Field | Value                                  |
+| ----- | -------------------------------------- |
+| Name  | `browser_intake_datadoghq_com`         |
+| URL   | `https://browser-intake-datadoghq.com` |
+
+For non-US1 Datadog sites, use the intake endpoint for the correct [Datadog site][4].
+
+### 4. Add the Head Markup script
+
+In Experience Builder:
+
+1. Go to **Settings > Advanced**.
+2. Open **Head Markup**.
+3. Click **Edit Head Markup**.
+4. Paste the following script.
+5. Replace the placeholder values with your Datadog RUM configuration.
+
+```html
+<script src="/sfsites/c/resource/datadog_rum"></script>
+<script>
+  window.DD_RUM.onReady(function () {
+    window.DD_RUM.init({
+      applicationId: '<YOUR_DATADOG_APPLICATION_ID>',
+      clientToken: '<YOUR_DATADOG_CLIENT_TOKEN>',
+      site: '<YOUR_DATADOG_SITE>',
+      env: '<YOUR_ENV_NAME>',
+      service: '<YOUR_SERVICE_NAME>',
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 0,
+      trackLongTasks: true,
+      trackResources: true,
+      trackUserInteractions: true,
+    })
+  })
+</script>
+```
+
+### 5. Publish the Experience Cloud site
+
+After adding the Head Markup script:
+
+1. Save the Head Markup configuration.
+2. Publish the Experience Cloud site.
+3. Open the published site in a new browser session.
+4. Confirm that the Datadog static resource loads.
+5. Confirm that no CSP errors appear in the browser console.
+6. Navigate between site pages.
+7. Confirm that RUM view events appear in Datadog.
+
+## Experience Cloud Theme/Layout LWC
+
+Use this path when you want to instrument an Experience Cloud site with a Lightning Web Component instead of Head Markup.
+
+This path is useful when:
+
+- Head Markup is unavailable.
+- You want to place the initializer in a shared region, template, page layout, or theme/layout area.
+- You want to reuse the LWC-based implementation pattern across Salesforce surfaces.
+
+Unlike Lightning Apps, Experience Cloud does not use the Utility Bar. The `datadogInit` component must be placed somewhere that loads on every page where RUM should run:
+
+- For lightweight installations, expose the component as an Experience Builder page component and place it in a shared region that appears across the site.
+- For custom LWR theme layouts, include the initializer inside your existing custom theme layout wrapper.
+
+This path uses:
+
+- A Salesforce Static Resource for the Datadog Salesforce RUM bundle.
+- Experience Cloud CSP configuration.
+- A custom Lightning Web Component exposed to Experience Builder.
+- Placement in a shared site region, page template, or theme/layout area.
+
+### 1. Add the static resource
+
+Copy the Datadog Salesforce RUM bundle into your Salesforce project and register it as a static resource.
+
+Suggested configuration:
+
+- Static Resource Name: `datadog_rum`
+- File location: `staticresources/datadog_rum.js`
+- Metadata location: `staticresources/datadog_rum.resource-meta.xml`
+
+XML configuration:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+  <cacheControl>Public</cacheControl>
+  <contentType>application/javascript</contentType>
+</StaticResource>
+```
+
+If you configure this through the Salesforce UI:
+
+1. Go to **Setup > Static Resources**.
+2. Click **New**.
+3. Set **Name** to `datadog_rum`.
+4. Upload the Salesforce RUM JavaScript bundle.
+5. Set **Cache Control** to `Public`.
+6. Save the static resource.
+
+### 2. Configure CSP for the Datadog intake endpoint
+
+In Experience Builder:
+
+1. Go to **Settings > Security & Privacy**.
+2. Change the security level from **Strict CSP** to **Relaxed CSP**.
+3. Add the Datadog browser intake endpoint as a trusted site.
+
+Use the following trusted site configuration for US1:
+
+| Field | Value                                  |
+| ----- | -------------------------------------- |
+| Name  | `browser_intake_datadoghq_com`         |
+| URL   | `https://browser-intake-datadoghq.com` |
+
+For non-US1 Datadog sites, use the intake endpoint for the correct [Datadog site][4].
+
+### 3. Create the Datadog init component
+
+Create an LWC that loads the Datadog Browser SDK and manually starts views as users navigate within the Experience Cloud site.
+
+A Lightning Web Component bundle requires an HTML template.
+
+File location: `lwc/datadogInit/datadogInit.html`
+
+```html
+<template></template>
+```
+
+### 4. Add the component JavaScript
+
+File location: `lwc/datadogInit/datadogInit.js`
+
+```javascript
+import { LightningElement, wire } from 'lwc'
+import { NavigationMixin, CurrentPageReference } from 'lightning/navigation'
+import datadogRum from '@salesforce/resourceUrl/datadog_rum'
+import { loadScript } from 'lightning/platformResourceLoader'
+
+let datadogInitialization
+let lastStartedUrl
+
+export default class DatadogInit extends NavigationMixin(LightningElement) {
+  connectedCallback() {
+    this.initialize()
+  }
+
+  @wire(CurrentPageReference)
+  handleCurrentPageReference(pageReference) {
+    if (!pageReference) {
+      return
+    }
+
+    this.initialize()
+
+    if (window.DD_RUM) {
+      this.startViewForPageReference(pageReference)
+    }
+  }
+
+  startViewForPageReference(pageReference) {
+    const urlPromise = this[NavigationMixin.GenerateUrl](pageReference)
+    urlPromise.then((url) => {
+      if (url === lastStartedUrl) {
+        return
+      }
+      lastStartedUrl = url
+      const absoluteUrl = new URL(url, window.location.origin).href
+      window.DD_RUM.startView({ name: url, url: absoluteUrl })
+    })
+  }
+
+  initialize() {
+    if (!datadogInitialization) {
+      datadogInitialization = this.loadDatadogRum()
+    }
+  }
+
+  loadDatadogRum() {
+    return loadScript(this, datadogRum).then(() => {
+      const initConfig = {
+        applicationId: '<YOUR_DATADOG_APPLICATION_ID>',
+        clientToken: '<YOUR_DATADOG_CLIENT_TOKEN>',
+        env: '<YOUR_ENV_NAME>',
+        service: '<YOUR_SERVICE_NAME>',
+        site: '<YOUR_DATADOG_SITE>',
+        trackViewsManually: true,
+        trackEarlyRequests: true,
+        trackLongTasks: true,
+        trackResources: true,
+        trackUserInteractions: true,
+      }
+      window.DD_RUM.init(initConfig)
+      lastStartedUrl = window.location.pathname + window.location.search + window.location.hash
+      window.DD_RUM.startView({
+        name: lastStartedUrl,
+        url: window.location.href,
+      })
+    })
+  }
+}
+```
+
+### 5. Add to Experience Builder
+
+Expose the component to Experience Builder and place it in a shared region, page template, global header, global footer, or theme/layout area that loads on every page.
+
+`lwc/datadogInit/datadogInit.js-meta.xml`
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>64.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Datadog Init</masterLabel>
+  <targets>
+    <target>lightningCommunity__Page</target>
+    <target>lightningCommunity__Default</target>
+  </targets>
+</LightningComponentBundle>
+```
+
+### 6. Validate the Theme/Layout LWC installation
+
+After publishing the site:
+
+1. Open the Experience Cloud site in a new browser session.
+2. Open browser developer tools.
+3. Confirm that the Datadog static resource loads successfully.
+4. Confirm there are no CSP errors for the Datadog browser intake endpoint.
+5. Navigate between site pages.
+6. Confirm that RUM view events appear in Datadog.
+
+If the component is accidentally added multiple times, the global initialization guard prevents duplicate SDK initialization, but the component should still be placed only once for clarity and maintainability.
+
+## Salesforce Feature Support Matrix
+
+The following table outlines SDK feature support within the Lightning Web Security (LWS) sandbox environment.
+
+| Feature Area        | Supported   | Notes                                                                     |
+| ------------------- | ----------- | ------------------------------------------------------------------------- |
+| **View Events**     |             |                                                                           |
+| Initial View        | Yes         | Automatic on init.                                                        |
+| Manual Tracking     | Yes         | Supported through `startView`.                                            |
+| Navigation Timings  | Yes         | Collected via performance API.                                            |
+| Web Vitals          | Yes         |                                                                           |
+| **Resource Events** |             |                                                                           |
+| Fetch / XHR         | Limited (2) | Context payload inaccessible.                                             |
+| Other Resources     | Yes         | CSS, images, etc.                                                         |
+| APM Correlation     | Limited (2) | Requires header injection.                                                |
+| **Action Events**   |             |                                                                           |
+| Custom Actions      | Yes         | Supported through `addAction`. (5) Not supported on the Head Markup path. |
+| Click Actions       | Yes         | (3) Shadow DOM boundaries apply.                                          |
+| Frustration Signals | Yes         |                                                                           |
+| Loading Time        | Limited (1) | Network detection may be incomplete.                                      |
+| **Error Events**    |             |                                                                           |
+| Console / Custom    | Yes         | Captured via instrumentation. (5) Not supported on the Head Markup path.  |
+| Runtime Errors      | Limited (4) | Often redacted as "Script error."                                         |
+| Unhandled Rejection | No          | Event not supported in LWS.                                               |
+| **Other**           |             |                                                                           |
+| Vital Events        | Yes         |                                                                           |
+| Long Task Events    | Yes         |                                                                           |
+| Session Replay      | No          | DOM/Worker constraints prevent support.                                   |
+
+Footnotes:
+
+1. **Loading Time**: Ends when no pending network requests are detected. LWS may hide some fetch/XHR activity.
+2. **Limited Context**: Inaccessible sandbox objects mean `beforeSend` cannot access response bodies or full XHR objects.
+3. **Selectors**: Due to shadow boundaries, `event.target` may reflect the component host rather than the inner element.
+4. **Runtime Errors**: Errors passing through the Lightning shell may lose stack traces and original error objects.
+5. **Head Markup limitation**: The Experience Cloud Head Markup path has no component context to call `addAction` or `addError`, so custom actions and custom error tracking are not supported there.
+
+## Troubleshooting
+
+Need help? Contact [Datadog Support][3].
+
+[1]: https://help.salesforce.com/s/articleView?id=sf.lwc_lwsec_enable.htm
+[2]: https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum-salesforce.js
+[3]: https://docs.datadoghq.com/help/
+[4]: https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site

--- a/packages/browser-rum-slim/src/salesforce/README.md
+++ b/packages/browser-rum-slim/src/salesforce/README.md
@@ -344,22 +344,27 @@ In Experience Builder:
 5. Replace the placeholder values with your Datadog RUM configuration.
 
 ```html
-<x-oasis-script src="/sfsites/c/resource/datadog_rum"></x-oasis-script>
-<x-oasis-script>
-  window.DD_RUM.onReady(function () {
-    window.DD_RUM.init({
-      applicationId: '<YOUR_DATADOG_APPLICATION_ID>',
-      clientToken: '<YOUR_DATADOG_CLIENT_TOKEN>',
-      site: '<YOUR_DATADOG_SITE>',
-      env: '<YOUR_ENV_NAME>',
-      service: '<YOUR_SERVICE_NAME>',
-      sessionSampleRate: 100,
-      sessionReplaySampleRate: 0,
-      trackLongTasks: true,
-      trackResources: true,
-      trackUserInteractions: true,
-    })
-  })
+<x-oasis-script hidden>
+  ;(function () {
+    var datadogScript = document.createElement('script')
+    datadogScript.src = '/sfsites/c/resource/datadog_rum'
+    datadogScript.onload = function () {
+      window.DD_RUM.onReady(function () {
+        window.DD_RUM.init({
+          applicationId: '<YOUR_DATADOG_APPLICATION_ID>',
+          clientToken: '<YOUR_DATADOG_CLIENT_TOKEN>',
+          site: '<YOUR_DATADOG_SITE>',
+          env: '<YOUR_ENV_NAME>',
+          service: '<YOUR_SERVICE_NAME>',
+          sessionSampleRate: 100,
+          trackLongTasks: true,
+          trackResources: true,
+          trackUserInteractions: true,
+        })
+      })
+    }
+    document.head.appendChild(datadogScript)
+  })()
 </x-oasis-script>
 ```
 


### PR DESCRIPTION
## Motivation

Until we publish documentation, we need the tile to point somewhere. [PR](https://github.com/DataDog/integrations-extras/pull/3058) the idea is to make the tile point here.
In other integrations we point to npm which is the same as the readme of the integration but in this case we don't publish to npm.

## Changes

Updates `salesforce/readme.md`

## Test instructions

CI should pass. 

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [ ] Tested locally
- [ ] Tested on staging
- [ ] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [x] Updated documentation and/or relevant AGENTS.md file

<!-- Also, please read the contribution guidelines: https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md -->
