### PR TITLE
🔊 Track plugin usage via telemetry

### DIFF
--- a/packages/browser-rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.spec.ts
@@ -22,6 +22,7 @@ import {
   replaceMockable,
   replaceMockableWithSpy,
   createStartSessionManagerMock,
+  startMockTelemetry,
 } from '@datadog/browser-core/test'
 import type { HybridInitConfiguration, RumInitConfiguration } from '../domain/configuration'
 import type { ViewOptions } from '../domain/view/trackViews'
@@ -594,6 +595,22 @@ describe('preStartRum', () => {
           initConfiguration,
           publicApi: PUBLIC_API,
         })
+      })
+
+      it('reports a telemetry usage event for each plugin', async () => {
+        const telemetry = startMockTelemetry()
+        const pluginA = { name: 'plugin-a' }
+        const pluginB = { name: 'plugin-b' }
+        const { strategy } = createPreStartStrategyWithDefaults()
+        strategy.init({ ...DEFAULT_INIT_CONFIGURATION, plugins: [pluginA, pluginB] }, PUBLIC_API)
+
+        const events = await telemetry.getEvents()
+        expect(events).toEqual(
+          jasmine.arrayContaining([
+            jasmine.objectContaining({ type: 'usage', usage: { feature: 'use-plugin', plugin_name: 'plugin-a' } }),
+            jasmine.objectContaining({ type: 'usage', usage: { feature: 'use-plugin', plugin_name: 'plugin-b' } }),
+          ])
+        )
       })
 
       it('plugins can edit the init configuration prior to validation', async () => {

--- a/packages/browser-rum-core/src/boot/preStartRum.ts
+++ b/packages/browser-rum-core/src/boot/preStartRum.ts
@@ -1,6 +1,6 @@
 import { timeStampNow, clocksNow } from '@datadog/js-core/time'
 import type { TimeStamp } from '@datadog/js-core/time'
-import type { TrackingConsentState, DeflateWorker, Context, Telemetry, SessionManager } from '@datadog/browser-core'
+import type { TrackingConsentState, DeflateWorker, Context, Telemetry, SessionManager, RawTelemetryUsage } from '@datadog/browser-core'
 import {
   BufferedObservable,
   display,
@@ -11,6 +11,7 @@ import {
   getEventBridge,
   initFeatureFlags,
   addTelemetryConfiguration,
+  addTelemetryUsage,
   CustomerContextKey,
   buildAccountContextManager,
   buildGlobalContextManager,
@@ -242,6 +243,10 @@ export function createPreStartStrategy(
       }
 
       callPluginsMethod(initConfiguration.plugins, 'onInit', { initConfiguration, publicApi })
+
+      initConfiguration.plugins?.forEach((plugin) => {
+        addTelemetryUsage({ feature: 'use-plugin', plugin_name: plugin.name } as unknown as RawTelemetryUsage)
+      })
 
       const hasRemoteConfiguration = getRemoteConfigurationId(initConfiguration)
 


### PR DESCRIPTION
## Motivation

Plugins are already captured in configuration telemetry via `serializeRumConfiguration`, but that only tells us what was configured before validation. There's no way to query which plugins customers have registered from usage telemetry. This adds a `use-plugin` event per plugin at init time.

## Changes

Calls `addTelemetryUsage({ feature: 'use-plugin', plugin_name })` for each entry in `initConfiguration.plugins`, right after `callPluginsMethod`. The cast to `RawTelemetryUsage` is needed because `use-plugin` isn't in the `rum-events-format` schema yet. A follow-up PR there will let us drop the cast once the type is generated.

## Test instructions

1. `yarn test:unit --spec packages/browser-rum-core/src/boot/preStartRum.spec.ts`

## Checklist

<!-- By submitting this test, you confirm the following: -->

- [x] Tested locally
- [ ] Tested on staging
- [x] Added unit tests for this change.
- [ ] Added e2e/integration tests for this change.
- [ ] Updated documentation and/or relevant AGENTS.md file